### PR TITLE
ECDF and step functions conventions

### DIFF
--- a/scikits/statsmodels/distributions/tests/test_ecdf.py
+++ b/scikits/statsmodels/distributions/tests/test_ecdf.py
@@ -19,9 +19,17 @@ class TestDistributions(npt.TestCase):
         y = np.zeros((2, 2))
         self.assertRaises(ValueError, StepFunction, x, y)
 
-    def test_StepFunctionAtValueOn(self):
+    def test_StepFunctionValueSideRight(self):
         x = np.arange(20)
         y = np.arange(20)
-        f = StepFunction(x, y, step_at_value=True)
+        f = StepFunction(x, y, side='right')
         npt.assert_almost_equal(f( np.array([[3.2,4.5],[24,-3.1],[3.0, 4.0]])),
                                              [[ 3, 4], [19, 0],  [3, 4]])
+
+    def test_StepFunctionRepeatedValues(self):
+        x = [1, 1, 2, 2, 2, 3, 3, 3, 4, 5]
+        y = [6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
+        f = StepFunction(x, y)
+        npt.assert_almost_equal(f([1, 2, 3, 4, 5]), [0, 7, 10, 13, 14])
+        f2 = StepFunction(x, y, side='right')
+        npt.assert_almost_equal(f2([1, 2, 3, 4, 5]), [7, 10, 13, 14, 15])


### PR DESCRIPTION
Step functions are conventionally defined with the step point as part of the previous interval. On the other hand, CDF are defined such that the step point is part of the following interval.

The StepFunction can now handle the CDF convention, and the ECDF uses it. 

This pull request follows Issue #103
