### PR TITLE
ENH: add cov_p option to f_test, t_test, cov_params

### DIFF
--- a/scikits/statsmodels/regression/tests/test_cov.py
+++ b/scikits/statsmodels/regression/tests/test_cov.py
@@ -1,0 +1,40 @@
+"""Example: minimal OLS
+
+"""
+
+import numpy as np
+import scikits.statsmodels.api as sm
+
+from numpy.testing import assert_almost_equal
+
+def test_HC_use():
+    np.random.seed(0)
+    nsample = 100
+    x = np.linspace(0,10, 100)
+    X = sm.add_constant(np.column_stack((x, x**2)), prepend=False)
+    beta = np.array([1, 0.1, 10])
+    y = np.dot(X, beta) + np.random.normal(size=nsample)
+
+    results = sm.OLS(y, X).fit()
+
+    #test cov_params
+    idx = np.array([1,2])
+    #need to call HC0_se to have cov_HC0 available
+    results.HC0_se
+    cov12 = results.cov_params(column=[1,2], cov_p=results.cov_HC0)
+    assert_almost_equal(cov12, results.cov_HC0[idx[:,None], idx], decimal=15)
+
+    #test t_test
+    tvals = results.params/results.HC0_se
+    ttest = results.t_test(np.eye(3), cov_p=results.cov_HC0)
+    assert_almost_equal(ttest.tvalue, tvals, decimal=14)
+    assert_almost_equal(ttest.sd, results.HC0_se, decimal=14)
+
+    #test f_test
+    ftest = results.f_test(np.eye(3)[:-1], cov_p=results.cov_HC0)
+    slopes = results.params[:-1]
+    idx = np.array([0,1])
+    cov_slopes = results.cov_HC0[idx[:,None], idx]
+    fval = np.dot(slopes, np.linalg.inv(cov_slopes).dot(slopes))/len(idx)
+    assert_almost_equal(ftest.fvalue, fval, decimal=12)
+


### PR DESCRIPTION
simplest version of adding additional keywords to f_test, t_test and cov_params in LikelihoodModelResults to allow the use of different estimates of the covariance matrix of the parameter estimates.

example

```
>>> results.HC0_se
array([ 0.12207437,  0.01226039,  0.24712809])
>>> results.cov_HC0
array([[ 0.01490215, -0.00144069, -0.02428962],
       [-0.00144069,  0.00015032,  0.00199825],
       [-0.02428962,  0.00199825,  0.06107229]])
>>> results.cov_params(column=[1,2], cov_p=results.cov_HC0)
array([[ 0.00015032,  0.00199825],
       [ 0.00199825,  0.06107229]])

>>> print results.t_test(np.eye(3), cov_p=results.cov_HC0)
<T test: effect=array([ 1.14923315,  0.08383825,  9.7349984 ]), sd=array([ 0.12207437,  0.01226039,  0.24712809]), t=array([  9.41420514,   6.83813843,  39.3925202 ]), p=array([ 0.,  0.,  0.]), df_denom=97>

>>> print results.f_test(np.eye(3)[:-1], cov_p=results.cov_HC0)
<F test: F=array([[ 1766.19326312]]), p=[[ 0.]], df_denom=97, df_num=2>
>>> 
```

possible enhancement, that is not implemented, is to allow the robust covariance matrices also be supplied by a string cov='HC0', however that gets a bit messy if additional parameters are required, e.g. for cluster robust SE we need to know the group identity, but for standard case it might be convenient.
