### PR TITLE
BUG: boxplot: add asarray, plot_grids merge conflict leading underline?

### DIFF
--- a/scikits/statsmodels/graphics/boxplots.py
+++ b/scikits/statsmodels/graphics/boxplots.py
@@ -165,6 +165,7 @@ def _single_violin(ax, pos, pos_data, width, side, plot_opts):
         x_upper = kde.dataset.max() + s
         return np.linspace(x_lower, x_upper, 100)
 
+    pos_data = np.asarray(pos_data)
     # Kernel density estimate for data at this position.
     kde = gaussian_kde(pos_data)
 

--- a/scikits/statsmodels/graphics/plot_grids.py
+++ b/scikits/statsmodels/graphics/plot_grids.py
@@ -111,7 +111,7 @@ def scatter_ellipse(data, level=0.9, varnames=None, ell_kwds=None,
                 level = [level]
             for alpha in level:
                 _make_ellipse(dmean[idx], dcov[idx[:,None], idx], ax, level=alpha,
-                         color='k')
+                         **ell_kwds_)
 
             if add_titles:
                 ax.set_title('%s-%s' % (varnames[i], varnames[j]))


### PR DESCRIPTION
use asarray, fixes bug with pandas series in some version of numpy and scipy gaussian_kde
