### PR TITLE
Add _repr_html_ method to Summary object to get HTML view in IPython notebook

### DIFF
--- a/scikits/statsmodels/iolib/summary.py
+++ b/scikits/statsmodels/iolib/summary.py
@@ -724,11 +724,7 @@ def summary_return(tables, return_fmt='text'):
             table.extend(part)
         return table.as_latex_tabular()
     elif return_fmt == 'html':
-        import copy
-        table = copy.deepcopy(tables[0])
-        for part in tables[1:]:
-            table.extend(part)
-        return table.as_html()
+        return "\n".join(table.as_html() for table in tables)
     else:
         raise ValueError('available output formats are text, csv, latex, html')
 


### PR DESCRIPTION
With this, calling `results.summary()` in the IPython notebook produces an HTML view of the results.

Before and after shot: http://i.imgur.com/byIfO.png

The HTML it produces could use some tweaking, but I thought I'd get some thoughts before I dive into that code.
