### PR TITLE
Minor fix: conv argument can be resid, not sresid

### DIFF
--- a/statsmodels/robust/robust_linear_model.py
+++ b/statsmodels/robust/robust_linear_model.py
@@ -178,7 +178,7 @@ class RLM(base.LikelihoodModel):
         history['scale'].append(tmp_results.scale)
         if conv == 'dev':
             history['deviance'].append(self.deviance(tmp_results))
-        elif conv == 'sresid':
+        elif conv == 'resid':
             history['sresid'].append(tmp_results.resid/tmp_results.scale)
         elif conv == 'weights':
             history['weights'].append(tmp_results.model.weights)


### PR DESCRIPTION
This is a minor issue i ran into.  The conv argument to the fit method would be 'resid', not 'sresid'.

thanks!
