### PR TITLE
REF: put type check for ndarray on top of data inspection

### DIFF
--- a/statsmodels/base/data.py
+++ b/statsmodels/base/data.py
@@ -290,7 +290,9 @@ def handle_data(endog, exog):
     if isinstance(exog, (list, tuple)):
         exog = np.asarray(exog)
 
-    if data_util._is_using_pandas(endog, exog):
+    if data_util._is_using_ndarray_type(endog, exog):
+        klass = ModelData
+    elif data_util._is_using_pandas(endog, exog):
         klass = PandasData
     elif data_util._is_using_larry(endog, exog):
         klass = LarryData

--- a/statsmodels/tools/data.py
+++ b/statsmodels/tools/data.py
@@ -81,6 +81,10 @@ def interpret_data(data, colnames=None, rownames=None):
 def struct_to_ndarray(arr):
     return arr.view((float, len(arr.dtype.names)))
 
+def _is_using_ndarray_type(endog, exog):
+    return (type(endog) is np.ndarray and
+            (type(exog) is np.ndarray or exog is None))
+
 def _is_using_ndarray(endog, exog):
     return (isinstance(endog, np.ndarray) and
             (isinstance(exog, np.ndarray) or exog is None))


### PR DESCRIPTION
put check for exog and endog of type ndarray first in the wrapper datastructure check

works, but not urgent, 

written to track down some slowdown in the tests, which was however unrelated (scipy.linalg.pinv2)
