### PR TITLE
expose version as __version__

### DIFF
--- a/statsmodels/__init__.py
+++ b/statsmodels/__init__.py
@@ -75,3 +75,8 @@ class NoseWrapper(Tester):
             t = NumpyTestProgram(argv=argv, exit=False, plugins=plugins)
         return t.result
 test = NoseWrapper().test
+
+try:
+	from .version import version as __version__
+except ImportError:
+	__version__ = 'not-yet-built'


### PR DESCRIPTION
**version** is conventionally present in nearly all python modules
(e.g. numpy, scipy, pandas, ...)

and please cherry pick into master
