### PR TITLE
TST: support new pandas 0.8.0 frequency inference API

### DIFF
--- a/statsmodels/tsa/base/datetools.py
+++ b/statsmodels/tsa/base/datetools.py
@@ -218,6 +218,13 @@ def _add_datetimes(dates):
     return reduce(lambda x, y: y+x, dates)
 
 def _infer_freq(dates):
+    try:
+        from pandas.tseries.api import infer_freq
+        freq = infer_freq(dates)
+        return _pandas_mapping.get(freq, freq)
+    except ImportError:
+        pass
+
     timedelta = datetime.timedelta
     nobs = min(len(dates), 6)
     if nobs == 1:
@@ -239,3 +246,10 @@ def _infer_freq(dates):
         return 'A'
     else:
         return
+
+_pandas_mapping = {
+    'A-DEC': 'A',
+    'Q-DEC': 'Q',
+    'W-SUN': 'W'
+}
+

--- a/statsmodels/tsa/base/tests/test_datetools.py
+++ b/statsmodels/tsa/base/tests/test_datetools.py
@@ -60,17 +60,18 @@ def test_infer_freq():
     a = DateRange(d1, d2, offset=_freq_to_pandas['A']).values
     q = DateRange(d1, d2, offset=_freq_to_pandas['Q']).values
 
-    npt.assert_string_equal(_infer_freq(b), 'B')
-    npt.assert_string_equal(_infer_freq(d), 'D')
-    npt.assert_string_equal(_infer_freq(w), 'W')
-    npt.assert_string_equal(_infer_freq(m), 'M')
-    npt.assert_string_equal(_infer_freq(a), 'A')
-    npt.assert_string_equal(_infer_freq(q), 'Q')
-    npt.assert_string_equal(_infer_freq(b[2:4]), 'B')
-    npt.assert_string_equal(_infer_freq(b[:2]), 'D')
-    npt.assert_string_equal(_infer_freq(d[:2]), 'D')
-    npt.assert_string_equal(_infer_freq(w[:2]), 'W')
-    npt.assert_string_equal(_infer_freq(m[:2]), 'M')
-    npt.assert_string_equal(_infer_freq(a[:2]), 'A')
-    npt.assert_string_equal(_infer_freq(q[:2]), 'Q')
+    assert _infer_freq(b[2:5]) == 'B'
+    assert _infer_freq(b[:3]) == 'D'
+
+    assert _infer_freq(b) == 'B'
+    assert _infer_freq(d) == 'D'
+    assert _infer_freq(w) == 'W'
+    assert _infer_freq(m) == 'M'
+    assert _infer_freq(a) == 'A'
+    assert _infer_freq(q) == 'Q'
+    assert _infer_freq(d[:3]) == 'D'
+    assert _infer_freq(w[:3]) == 'W'
+    assert _infer_freq(m[:3]) == 'M'
+    assert _infer_freq(a[:3]) == 'A'
+    assert _infer_freq(q[:3]) == 'Q'
 


### PR DESCRIPTION
With these changes all the TSA tests pass. We'll need to do more work this summer to better integrate the new pandas timeseries APIs prior to 0.5.0. Should close #226
