### PR TITLE
TST: fix bug in test for test_monotone_fn_inverter

### DIFF
--- a/statsmodels/distributions/tests/test_ecdf.py
+++ b/statsmodels/distributions/tests/test_ecdf.py
@@ -37,6 +37,7 @@ class TestDistributions(npt.TestCase):
     def test_monotone_fn_inverter(self):
         x = [6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
         fn = lambda x : 1./x
+        y = fn(np.array(x))
         f = monotone_fn_inverter(fn, x)
         npt.assert_array_equal(f.y, x[::-1])
         npt.assert_array_equal(f.x, y[::-1])


### PR DESCRIPTION
y was not defined resulted in test failure
