### PR TITLE
BUG: tsa fix adfuller

### DIFF
--- a/statsmodels/tsa/stattools.py
+++ b/statsmodels/tsa/stattools.py
@@ -60,7 +60,6 @@ def _autolag(mod, endog, exog, startlag, maxlag, method, modargs=(),
 
     results = {}
     method = method.lower()
-    #print 'startlag, maxlag', startlag, maxlag, exog.shape
     for lag in range(startlag, startlag+maxlag+1):
         mod_instance = mod(endog, exog[:,:lag], *modargs)
         results[lag] = mod_instance.fit()
@@ -198,7 +197,6 @@ def adfuller(x, maxlag=None, regression="c", autolag='AIC',
         #from Greene referencing Schwert 1989
         maxlag = int(round(12. * np.power(nobs/100., 1/4.)))
 
-    #print 'maxlag', maxlag
     xdiff = np.diff(x)
     xdall = lagmat(xdiff[:,None], maxlag, trim='both', original='in')
     nobs = xdall.shape[0]
@@ -214,9 +212,9 @@ def adfuller(x, maxlag=None, regression="c", autolag='AIC',
         else:
             fullRHS = xdall
         startlag = fullRHS.shape[1] - xdall.shape[1] + 1 # 1 for level
-        #print 'startlag', startlag, xdall.shape, fullRHS.shape
-        #search for lag length with highest information criteria
+        #search for lag length with smallest information criteria
         #Note: use the same number of observations to have comparable IC
+        #aic and bic: smaller is better
 
         if not regresults:
             icbest, bestlag = _autolag(OLS, xdshort, fullRHS, startlag,
@@ -256,12 +254,13 @@ def adfuller(x, maxlag=None, regression="c", autolag='AIC',
             "10%" : critvalues[2]}
     if store:
         resstore.resols = resols
+        resstore.maxlag = maxlag
         resstore.usedlag = usedlag
         resstore.adfstat = adfstat
         resstore.critvalues = critvalues
         resstore.nobs = nobs
-        resstore.H0 = "The coefficient on the lagged level equals 1"
-        resstore.HA = "The coefficient on the lagged level < 1"
+        resstore.H0 = "The coefficient on the lagged level equals 1 - unit root"
+        resstore.HA = "The coefficient on the lagged level < 1 - stationary"
         resstore.icbest = icbest
         return adfstat, pvalue, critvalues, resstore
     else:

--- a/statsmodels/tsa/tests/test_adfuller_lag.py
+++ b/statsmodels/tsa/tests/test_adfuller_lag.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+"""Test for autolag of adfuller, unitroot_adf
+
+Created on Wed May 30 21:39:46 2012
+Author: Josef Perktold
+"""
+
+import numpy as np
+from numpy.testing import assert_equal, assert_almost_equal
+import statsmodels.tsa.stattools as tsast
+from statsmodels.datasets import macrodata
+
+def test_adf_autolag():
+    #see issue #246
+    #this is mostly a unit test
+    d2 = macrodata.load().data
+
+    for k_trend, tr in enumerate(['nc', 'c', 'ct', 'ctt']):
+        #[None:'nc', 0:'c', 1:'ct', 2:'ctt']
+        x = np.log(d2['realgdp'])
+        xd = np.diff(x)
+
+        #check exog
+        adf3 = tsast.adfuller(x, maxlag=None, autolag='aic',
+                              regression=tr, store=True, regresults=True)
+        st2 = adf3[-1]
+
+        assert_equal(len(st2.autolag_results), 14 + 1)  #+1 for lagged level
+        for l, res in sorted(st2.autolag_results.iteritems())[:5]:
+            lag = l-k_trend
+            #assert correct design matrices in _autolag
+            assert_equal(res.model.exog[-10:,k_trend], x[-11:-1])
+            assert_equal(res.model.exog[-1,k_trend+1:], xd[-lag:-1][::-1])
+            #min-ic lag of dfgls in Stata is also 2, or 9 for maic with notrend
+            assert_equal(st2.usedlag, 2)
+
+        #same result with lag fixed at usedlag of autolag
+        adf2 = tsast.adfuller(x, maxlag=2, autolag=None, regression=tr)
+        assert_almost_equal(adf3[:2], adf2[:2], decimal=12)
+
+
+    tr = 'c'
+    #check maxlag with autolag
+    adf3 = tsast.adfuller(x, maxlag=5, autolag='aic',
+                          regression=tr, store=True, regresults=True)
+    assert_equal(len(adf3[-1].autolag_results), 5 + 1)
+    adf3 = tsast.adfuller(x, maxlag=0, autolag='aic',
+                          regression=tr, store=True, regresults=True)
+    assert_equal(len(adf3[-1].autolag_results), 0 + 1)


### PR DESCRIPTION
issue #246

autolag in adfuller, unitroot_adf was broken

fixed and added unittest, 
no functional verified test since Stata doesn't have it for dfuller, but similar to dfgls

not nice: number of returns depends on options
waits for statistical test return refactoring
