### PR TITLE
Correction to CDFlink derivative

### DIFF
--- a/statsmodels/genmod/families/links.py
+++ b/statsmodels/genmod/families/links.py
@@ -468,14 +468,10 @@ class CDFLink(Logit):
 
         Notes
         -----
-        g'(`p`) = 1./ `dbn`.pdf(`p`)
+        g'(`p`) = 1./ `dbn`.pdf(`dbn`.ppf(`p`))
         """
-# Or is it
-#        g'(`p`) = 1/`dbn`.pdf(`dbn`.ppf(`p`))
-#TODO: make sure this is correct.
-#can we just have a numerical approximation?
         p = self._clean(p)
-        return 1. / self.dbn.pdf(p)
+        return 1. / self.dbn.pdf(self.dbn.ppf(p))
 
 #probit = CDFLink()
 class probit(CDFLink):


### PR DESCRIPTION
Derivative of CDF-based link function requires transformation of mean before evaluation of PDF.
