### PR TITLE
ENH: make correct python variable names

### DIFF
--- a/tools/topy.R
+++ b/tools/topy.R
@@ -110,9 +110,12 @@ mkhtest <- function(ht, name, distr="f") {
     cat("\n\n")
 }
 
-mkarray2 <- function(X, name) {
+mkarray2 <- function(X, name, sanitize=FALSE) {
     indent = "    "
-    cat(sanitize_name(name)); cat(" = np.array([\n"); cat(X, sep=", ", fill=76, labels=indent); cat(indent); cat("])")
+    if (sanitize) {
+    cat(sanitize_name(name)); cat(" = np.array([\n"); cat(X, sep=", ", fill=76, labels=indent); cat(indent); cat("])") }
+    else{
+    cat(name); cat(" = np.array([\n"); cat(X, sep=", ", fill=76, labels=indent); cat(indent); cat("])") }
     if (is.matrix(X)) {
         i <- as.character(nrow(X))
         j <- as.character(ncol(X))


### PR DESCRIPTION
Make correct python variable names

```
> name <- "I am a Pr(<10).R name"
> sanitize_name(name)
[1] "I_am_a_Pr10_R_name"
```
