### PR TITLE
BF+TEST: fixes, checks and tests for isestimable

### DIFF
--- a/statsmodels/tools/tests/test_tools.py
+++ b/statsmodels/tools/tests/test_tools.py
@@ -4,7 +4,9 @@ Test functions for models.tools
 
 import numpy as np
 from numpy.random import standard_normal
-from numpy.testing import *
+from numpy.testing import (assert_equal, assert_array_equal,
+                           assert_almost_equal, assert_string_equal, TestCase)
+from nose.tools import (assert_true, assert_false, assert_raises)
 
 from statsmodels.datasets import longley
 from statsmodels.tools import tools
@@ -62,6 +64,37 @@ class TestTools(TestCase):
         Y = tools.fullrank(X)
         self.assertEquals(Y.shape, (40,8))
         self.assertEquals(tools.rank(Y), 8)
+
+
+def test_estimable():
+    rng = np.random.RandomState(20120713)
+    N, P = (40, 10)
+    X = rng.normal(size=(N, P))
+    C = rng.normal(size=(1, P))
+    isestimable = tools.isestimable
+    assert_true(isestimable(C, X))
+    assert_true(isestimable(np.eye(P), X))
+    for row in np.eye(P):
+        assert_true(isestimable(row, X))
+    X = np.ones((40, 2))
+    assert_true(isestimable([1, 1], X))
+    assert_false(isestimable([1, 0], X))
+    assert_false(isestimable([0, 1], X))
+    assert_false(isestimable(np.eye(2), X))
+    halfX = rng.normal(size=(N, 5))
+    X = np.hstack([halfX, halfX])
+    assert_false(isestimable(np.hstack([np.eye(5), np.zeros((5, 5))]), X))
+    assert_false(isestimable(np.hstack([np.zeros((5, 5)), np.eye(5)]), X))
+    assert_true(isestimable(np.hstack([np.eye(5), np.eye(5)]), X))
+    # Test array-like for design
+    XL = X.tolist()
+    assert_true(isestimable(np.hstack([np.eye(5), np.eye(5)]), XL))
+    # Test ValueError for incorrect number of columns
+    X = rng.normal(size=(N, 5))
+    for n in range(1, 4):
+        assert_raises(ValueError, isestimable, np.ones((n,)), X)
+    assert_raises(ValueError, isestimable, np.eye(4), X)
+
 
 class TestCategoricalNumerical(object):
     #TODO: use assert_raises to check that bad inputs are taken care of

--- a/statsmodels/tools/tools.py
+++ b/statsmodels/tools/tools.py
@@ -328,18 +328,47 @@ def add_constant(data, prepend=False):
                     usemask=False, asrecarray = return_rec)
     return data
 
+
 def isestimable(C, D):
+    """ True if (Q, P) contrast `C` is estimable for (N, P) design `D`
+
+    From an Q x P contrast matrix `C` and an N x P design matrix `D`, checks if
+    the contrast `C` is estimable by looking at the rank of ``vstack([C,D])``
+    and verifying it is the same as the rank of `D`.
+
+    Parameters
+    ----------
+    C : (Q, P) array-like
+        contrast matrix. If `C` has is 1 dimensional assume shape (1, P)
+    D: (N, P) array-like
+        design matrix
+
+    Returns
+    -------
+    tf : bool
+        True if the contrast `C` is estimable on design `D`
+
+    Examples
+    --------
+    >>> D = np.array([[1, 1, 1, 0, 0, 0],
+    ...               [0, 0, 0, 1, 1, 1],
+    ...               [1, 1, 1, 1, 1, 1]]).T
+    >>> isestimable([1, 0, 0], D)
+    False
+    >>> isestimable([1, -1, 0], D)
+    True
     """
-    From an q x p contrast matrix C and an n x p design matrix D, checks
-    if the contrast C is estimable by looking at the rank of vstack([C,D]) and
-    verifying it is the same as the rank of D.
-    """
+    C = np.asarray(C)
+    D = np.asarray(D)
     if C.ndim == 1:
-        C.shape = (C.shape[0], 1)
+        C = C[None, :]
+    if C.shape[1] != D.shape[1]:
+        raise ValueError('Contrast should have %d columns' % D.shape[1])
     new = np.vstack([C, D])
     if rank(new) != rank(D):
         return False
     return True
+
 
 def recipr(X):
     """


### PR DESCRIPTION
`isestimable` was assuming a column vector for a 1D contrast, rather
than a row vector as required.  It was writing to C.shape which could
modify the object passed by the caller.  Add more informative message
about wrong dimensions.  Generalize to array-like.  Add tests.
