### PR TITLE
BUG: Correctly index ma params for q != 1 and step > 1

### DIFF
--- a/statsmodels/tsa/arima_model.py
+++ b/statsmodels/tsa/arima_model.py
@@ -124,7 +124,7 @@ def _arma_predict_out_of_sample(params, steps, errors, p, q, k_trend, k_exog,
 
     for i in range(min(q,steps-1)):
         fcast = mu[i] + np.dot(arparams,endog[i:i+p]) + \
-                      np.dot(maparams,resid[i:i+q])
+                np.dot(maparams[:q-i],resid[i:i+q])
         forecast[i] = fcast
         endog[i+p] = fcast
 


### PR DESCRIPTION
This fixes #440, but I'm not closing it because this needs tests. They take forever to write, so I'm leaving this for later.
