### PR TITLE
DOC: add missing documentation for demean of acovf function

### DIFF
--- a/statsmodels/tsa/stattools.py
+++ b/statsmodels/tsa/stattools.py
@@ -276,9 +276,11 @@ def acovf(x, unbiased=False, demean=True, fft=False):
     Parameters
     ----------
     x : array
-       time series data
+        time series data
     unbiased : bool
-       if True, then denominators is n-k, otherwise n
+        if True, then denominators is n-k, otherwise n
+    demean : bool
+        if True, then subtract the mean x from each element of x
     fft : bool
         If True, use FFT convolution.  This method should be preferred
         for long time series.


### PR DESCRIPTION
When reviewing the acovf function I noticed that the demean parameter didn't have documentation.  Also, I cleaned up the indention a bit.
