### PR TITLE
ENH: Improve error message for pandas objects without dates in index

### DIFF
--- a/statsmodels/tsa/base/tests/test_base.py
+++ b/statsmodels/tsa/base/tests/test_base.py
@@ -1,0 +1,8 @@
+from pandas import Series
+from statsmodels.tsa.base.tsa_model import TimeSeriesModel
+import numpy.testing as npt
+
+def test_pandas_nodates_index():
+    from statsmodels.datasets import sunspots
+    y = sunspots.load_pandas().data.SUNACTIVITY
+    npt.assert_raises(ValueError, TimeSeriesModel, y)

--- a/statsmodels/tsa/base/tsa_model.py
+++ b/statsmodels/tsa/base/tsa_model.py
@@ -52,6 +52,10 @@ class TimeSeriesModel(base.LikelihoodModel):
             dates = self._data.row_labels
 
         if dates is not None:
+            if (not isinstance(dates[0], datetime.datetime) and
+                    isinstance(self._data, data.PandasData)):
+                raise ValueError("Given a pandas object and the index does "
+                                 "not contain dates")
             if not freq:
                 try:
                     freq = datetools._infer_freq(dates)


### PR DESCRIPTION
I think this is the right thing to do. Will close #315.
