### PR TITLE
added intersphinx to pandas io module

### DIFF
--- a/docs/source/iolib.rst
+++ b/docs/source/iolib.rst
@@ -9,7 +9,7 @@ Input-Output :mod:`iolib`
 reader for STATA files, a class for generating tables for printing in several
 formats and two helper functions for pickling.
 
-Users can also leverage the powerful input/output functions provided by ``pandas`` (a ``statsmodels`` dependency). Among other things, ``pandas`` allows reading and writing to Excel, CSV, and HDF5 (PyTables). http://pandas.sourceforge.net/io.html
+Users can also leverage the powerful input/output functions provided by :py:mod:pandas.io (a ``statsmodels`` dependency). Among other things, ``pandas`` allows reading and writing to Excel, CSV, and HDF5 (PyTables). http://pandas.sourceforge.net/io.html
 
 Examples
 --------


### PR DESCRIPTION
Please test this quickly.

I do not have the sphinx docs locally set up.

It should point to 
https://github.com/pydata/pandas/tree/master/pandas/io
