### PR TITLE
Doc edit link

### DIFF
--- a/docs/themes/statsmodels/sourcelink.html
+++ b/docs/themes/statsmodels/sourcelink.html
@@ -12,7 +12,7 @@
   <ul class="this-page-menu">
     <li><a href="{{ pathto('_sources/' + sourcename, true)|e }}"
            rel="nofollow">{{ _('Show Source') }}</a></li>
-    <li><a href="{{ https://github.com/statsmodels/statsmodels/tree/master/docs/source + sourcename, true)|e }}"
+    <li><a href="{{ https://github.com/statsmodels/statsmodels/edit/master/docs/source/ + sourcename, true)|e }}"
            rel="nofollow">{{ _('Edit / Correct on GitHub') }}</a></li>
   </ul>
 {%- endif %}


### PR DESCRIPTION
Usually, one notices an error / idea for improvement while reading the docs during the actual coding.

So I though such small glitches could be fixed right-away.

Thus I added an edit link next to the show source link.

I still see one thing we need to improve but I do not know how:
What happens with the pages that are auto-generated by Sphinx?
Like the examples.

Can we prevent Sphinx from adding the respective link by using a conditional check?

Here, my knowledge of templating ends...
