### PR TITLE
ENH: Re-use effects if model fit with QR

### DIFF
--- a/statsmodels/regression/linear_model.py
+++ b/statsmodels/regression/linear_model.py
@@ -130,15 +130,17 @@ class RegressionModel(base.LikelihoodModel):
             beta = np.dot(self.pinv_wexog, endog)
 
         elif method == "qr":
-            if ((not hasattr(self, '_exog_Q')) or
+            if ((not hasattr(self, 'exog_Q')) or
                 (not hasattr(self, 'normalized_cov_params'))):
                 Q, R = np.linalg.qr(exog)
-                self._exog_Q, self._exog_R = Q, R
+                self.exog_Q, self.exog_R = Q, R
                 self.normalized_cov_params = np.linalg.inv(np.dot(R.T, R))
             else:
-                Q, R = self._exog_Q, self._exog_R
+                Q, R = self.exog_Q, self.exog_R
 
-            beta = np.linalg.solve(R,np.dot(Q.T,endog))
+            # used in ANOVA
+            self.effects = effects = np.dot(Q.T, endog)
+            beta = np.linalg.solve(R, effects)
 
             # no upper triangular solve routine in numpy/scipy?
         if isinstance(self, OLS):

--- a/statsmodels/stats/anova.py
+++ b/statsmodels/stats/anova.py
@@ -106,8 +106,10 @@ def anova1_lm_single(model, endog, exog, nobs, design_info, table, n_rows, test,
     Use of this function is discouraged. Use anova_lm instead.
     """
     #maybe we should rethink using pinv > qr in OLS/linear models?
-    q,r = np.linalg.qr(exog)
-    effects = np.dot(q.T, endog)
+    effects = getattr(model, 'effects', None)
+    if effects is None:
+        q,r = np.linalg.qr(exog)
+        effects = np.dot(q.T, endog)
 
     arr = np.zeros((len(design_info.terms), len(design_info.column_names)))
     slices = [design_info.slice(name) for name in design_info.term_names]


### PR DESCRIPTION
Just something I remembered. Reuse effects if we have them. Probably not super important, but it's nice to have. Might consider changing default method to QR in linear model fit too.
