### PR TITLE
DOC: Fixed links to Rdatasets

### DIFF
--- a/docs/source/gettingstarted.rst
+++ b/docs/source/gettingstarted.rst
@@ -33,7 +33,7 @@ Data
 ----
 
 We download the `Guerry dataset
-<http://vincentarelbundock.github.com/Rdatasets/doc/Guerry.html>`_, a
+<http://vincentarelbundock.github.com/Rdatasets/doc/HistData/Guerry.html>`_, a
 collection of historical data used in support of Andre-Michel Guerry's 1833
 *Essay on the Moral Statistics of France*. The data set is hosted online in
 comma-separated values format (CSV) by the `Rdatasets
@@ -43,7 +43,7 @@ We could download the file locally and then load it using ``read_csv``, but
 
 .. ipython:: python
 
-    url = "http://vincentarelbundock.github.com/Rdatasets/csv/Guerry.csv"
+    url = "http://vincentarelbundock.github.com/Rdatasets/csv/HistData/Guerry.csv"
     #the next two lines are not necessary with a recent version of pandas
     from urllib2 import urlopen
     url = urlopen(url)

--- a/examples/example_gmle.py
+++ b/examples/example_gmle.py
@@ -71,14 +71,14 @@ class NBin(GenericLikelihoodModel):
 #Usage Example
 #-------------
 
-#The `Medpar <http://vincentarelbundock.github.com/Rdatasets/doc/medpar.html>`_
+#The `Medpar <http://vincentarelbundock.github.com/Rdatasets/doc/COUNT/medpar.html>`_
 #dataset is hosted in CSV format at the `Rdatasets repository
 #<http://vincentarelbundock.github.com/Rdatasets>`_. We use the ``read_csv``
 #function from the `Pandas library <http://pandas.pydata.org>`_ to load the data
 #in memory. We then print the first few columns:
 
 import pandas as pd
-url = 'http://vincentarelbundock.github.com/Rdatasets/csv/medpar.csv'
+url = 'http://vincentarelbundock.github.com/Rdatasets/csv/COUNT/medpar.csv'
 medpar = pd.read_csv(url)
 medpar.head()
 
@@ -115,7 +115,7 @@ res.aic
 #To ensure that the above results are sound, we compare them to results
 # obtained using the MASS implementation for R::
 #
-#    url = 'http://vincentarelbundock.github.com/Rdatasets/csv/medpar.csv'
+#    url = 'http://vincentarelbundock.github.com/Rdatasets/csv/COUNT/medpar.csv'
 #    medpar = read.csv(url)
 #    f = los~factor(type)+hmo+white
 #

--- a/examples/ipynb/example_gmle.ipynb
+++ b/examples/ipynb/example_gmle.ipynb
@@ -102,7 +102,7 @@
       "Usage Example\n",
       "-------------\n",
       "\n",
-      "The [Medpar](http://vincentarelbundock.github.com/Rdatasets/doc/medpar.html)\n",
+      "The [Medpar](http://vincentarelbundock.github.com/Rdatasets/doc/COUNT/medpar.html)\n",
       "dataset is hosted in CSV format at the [Rdatasets repository](http://vincentarelbundock.github.com/Rdatasets). We use the ``read_csv``\n",
       "function from the [Pandas library](http://pandas.pydata.org) to load the data\n",
       "in memory. We then print the first few columns: \n"
@@ -113,7 +113,7 @@
      "collapsed": false,
      "input": [
       "import pandas as pd\n",
-      "url = 'http://vincentarelbundock.github.com/Rdatasets/csv/medpar.csv'\n",
+      "url = 'http://vincentarelbundock.github.com/Rdatasets/csv/COUNT/medpar.csv'\n",
       "medpar = pd.read_csv(url)\n",
       "medpar.head()"
      ],
@@ -204,7 +204,7 @@
       "To ensure that the above results are sound, we compare them to results\n",
       "obtained using the MASS implementation for R:\n",
       "\n",
-      "    url = 'http://vincentarelbundock.github.com/Rdatasets/csv/medpar.csv'\n",
+      "    url = 'http://vincentarelbundock.github.com/Rdatasets/csv/COUNT/medpar.csv'\n",
       "    medpar = read.csv(url)\n",
       "    f = los~factor(type)+hmo+white\n",
       "    \n",

--- a/statsmodels/sandbox/examples/example_nbin.py
+++ b/statsmodels/sandbox/examples/example_nbin.py
@@ -233,8 +233,8 @@ from numpy.testing import assert_almost_equal
 import pandas
 import patsy
 from urllib2 import urlopen
-medpar = pandas.read_csv(urlopen('http://vincentarelbundock.github.com/Rdatasets/csv/medpar.csv'))
-mdvis = pandas.read_csv(urlopen('http://vincentarelbundock.github.com/Rdatasets/csv/mdvis.csv'))
+medpar = pandas.read_csv(urlopen('http://vincentarelbundock.github.com/Rdatasets/csv/COUNT/medpar.csv'))
+mdvis = pandas.read_csv(urlopen('http://vincentarelbundock.github.com/Rdatasets/csv/COUNT/mdvis.csv'))
 
 # NB-2
 '''


### PR DESCRIPTION
Rdatasets now groups datasets in subfolders based on the package with with they were originally distributed. This PR adjusts the links used in some of the examples.

Note that I do not intend to make any more changes to the Rdatasets directory structure, so hard-linking to files in the future shouldn't be a problem.  
