### PR TITLE
VAR DOC typo

### DIFF
--- a/docs/source/vector_ar.rst
+++ b/docs/source/vector_ar.rst
@@ -132,7 +132,7 @@ Plotting input time series:
 
 ::
 
-    >>> model.plot()
+    >>> results.plot()
 
 .. plot:: plots/var_plot_input.py
 
@@ -140,7 +140,7 @@ Plotting time series autocorrelation function:
 
 ::
 
-    >>> model.plot_acorr()
+    >>> results.plot_acorr()
 
 .. plot:: plots/var_plot_acorr.py
 


### PR DESCRIPTION
Fixing a typo on the VAR documentation.  The docs had `model.plot()` and `model.plot_acorr()`, where it should be `results.plot()` and `results.plot_acorr()`.

Link to the page: http://statsmodels.sourceforge.net/stable/vector_ar.html#model-fitting
