### PR TITLE
Results Class for tukeyhsd, added confidence interval plotting functionality 

### DIFF
--- a/statsmodels/examples/try_tukey_hsd.py
+++ b/statsmodels/examples/try_tukey_hsd.py
@@ -161,7 +161,7 @@ res4 = tukeyhsd4.tukeyhsd()
 print res4
 try:
     import matplotlib.pyplot as plt
-    fig = res4.compute_plot_intervals("USA")
+    fig = res4.plot_simultaneous("USA")
     plt.show()
 except Exception as e:
     print e

--- a/statsmodels/stats/tests/test_pairwise.py
+++ b/statsmodels/stats/tests/test_pairwise.py
@@ -243,7 +243,7 @@ class TestTuckeyHSD4(CheckTuckeyHSDMixin):
         self.groups = cyl_labels
         self.alpha = 0.05
         self.setup_class_()
-        self.res.compute_intervals()
+        self.res._simultaneous_ci()
 
         #from Matlab
         self.halfwidth2 = np.array([1.5228335685980883, 0.9794949704444682, 0.78673802805533644, 


### PR DESCRIPTION
In response to issue #789, created a results class `TukeyHSDResults` that more concisely contains the output of a tukey honesty significant difference test from the `MultiComparison` class. This class now contains all the raw output that MultiComparison.tukeyhsd() used to, plus a couple extras. The Hochberg interval plotting i discussed is also contained within this new class, such that the expected workflow would be something like:

``` python
mc = MultiComparison(data, groups)
results = mc.tukeyhsd()
print results #the summary table we were used to before
results.compute_plot_intervals()
```

The current workflow is also compatible with the `pairwise_tukey` function.
