### PR TITLE
BLD TravisCI use python-dateutil package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ install:
          sudo python3 setup.py install ;
          cd .. ;
       else
+         sudo apt-get install $PYTHON-dateutil ;
          sudo apt-get install cython ;
       fi
     - sudo easy_install$PYSUF -U pandas


### PR DESCRIPTION
see https://groups.google.com/group/pystatsmodels/browse_thread/thread/8f2bd2a5e8591db5?hl=en

network access to labix to download python-dateutil often fails
