### PR TITLE
BLD: apt get dependencies from Neurodebian, whitespace cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,8 +34,8 @@ install:
     - sudo apt-key adv --recv-keys --keyserver pgp.mit.edu 2649A5A9
     - sudo apt-get update -qq
     - sudo apt-get install $PYTHON-dateutil
-    - sudo apt-get install $PYTHON-pandas
-    - sudo apt-get install $PYTHON-pandas-lib
+    - sudo apt-get --no-install-recommends install $PYTHON-pandas
+    - sudo apt-get --no-install-recommends install $PYTHON-pandas-lib
     - sudo easy_install$PYSUF -U patsy
 script:
     - sudo $PYTHON setup.py install


### PR DESCRIPTION
try to use binaries with apt get from Neurodebian for both python 2 and python 3
pandas and dateutil 

pandas is slow
dateutil fails to install very often
