### PR TITLE
Update of sandbox doc

### DIFF
--- a/docs/source/sandbox.rst
+++ b/docs/source/sandbox.rst
@@ -50,14 +50,15 @@ series analysis. Most of the models and function have been moved to
 Moving Window Statistics
 """"""""""""""""""""""""
 
+Most moving window statistics, like rolling mean, moments (up to 4th order), min,
+max, mean, and variance, are covered by the functions for `Moving (rolling)
+statistics/moments <http://pandas.pydata.org/pandas-docs/stable/computation.html#moving-rolling-statistics-moments>`_ in Pandas.
+
+
 .. autosummary::
    :toctree: generated/
 
-   tsa.movmean
-   tsa.movmoment
-   tsa.movorder
    tsa.movstat
-   tsa.movvar
 
 
 


### PR DESCRIPTION
In the documentation to sandbox.rst, I eliminated the references to 
- tsa.movmean
- tsa.movmoment
- tsa.movorder
- tsa.movvar
  and instead included a comment and a link to the corresponding Pandas-functions.
  Left "tsa.movstat", as I am unsure if it is covered by Pandas.
  Also, this is my first commit, so I wanted to do something small.
