### PR TITLE
BUG fix lowess sort when nans closes #946

### DIFF
--- a/statsmodels/nonparametric/smoothers_lowess.py
+++ b/statsmodels/nonparametric/smoothers_lowess.py
@@ -158,7 +158,7 @@ def lowess(endog, exog, frac=2.0/3.0, it=3, delta=0.0, is_sorted=False,
 
     if not is_sorted:
         # Sort both inputs according to the ascending order of x values
-        sort_index = np.argsort(exog)
+        sort_index = np.argsort(x)
         x = np.array(x[sort_index])
         y = np.array(y[sort_index])
 


### PR DESCRIPTION
a bug in sorting when there were nans, see #946

with a few more unit tests for options
