### PR TITLE
Fix a docstring in KDEMultivariateConditional.

### DIFF
--- a/statsmodels/nonparametric/kernel_density.py
+++ b/statsmodels/nonparametric/kernel_density.py
@@ -340,7 +340,7 @@ class KDEMultivariateConditional(GenericKDE):
     Conditional multivariate kernel density estimator.
 
     Calculates ``P(Y_1,Y_2,...Y_n | X_1,X_2...X_m) =
-    P(X_1, X_2,...X_n, Y_1, Y_2,..., Y_m)/P(Y_1, Y_2,..., Y_m)``.
+    P(X_1, X_2,...X_n, Y_1, Y_2,..., Y_m)/P(X_1, X_2,..., X_m)``.
     The conditional density is by definition the ratio of the two densities,
     see [1]_.
 


### PR DESCRIPTION
The docstring for `KDEMultivariateConditional` says:

```
Calculates ``P(Y_1,Y_2,...Y_n | X_1,X_2...X_m) =
P(X_1, X_2,...X_n, Y_1, Y_2,..., Y_m)/P(Y_1, Y_2,..., Y_m)``.
The conditional density is by definition the ratio of the two densities,
see [1]_.
```

Of course, this is wrong. Presumably the divisor should be `P(X_1, X_2,..., X_m)`.
