### PR TITLE
BUG: array too long, raises exception with newer numpy closes #967

### DIFF
--- a/statsmodels/nonparametric/smoothers_lowess.py
+++ b/statsmodels/nonparametric/smoothers_lowess.py
@@ -171,7 +171,7 @@ def lowess(endog, exog, frac=2.0/3.0, it=3, delta=0.0, is_sorted=False,
         # rebuild yfitted with original indices
         # a bit messy: y might have been selected twice
         if not is_sorted:
-            yfitted_ = np.empty_like(endog)
+            yfitted_ = np.empty_like(y)
             yfitted_.fill(np.nan)
             yfitted_[sort_index] = yfitted
             yfitted = yfitted_


### PR DESCRIPTION
see issue #967 for test failures with newer numpy

in older numpy excess elements were ignored (in assignment to a part of an array), numbers were correct.
Fix in this PR creates the array in the right size (without excess elements, that were nan in this case)

```
>>> x = np.zeros(5)
>>> x[np.arange(5)<3] = np.ones(4)
>>> x
array([ 1.,  1.,  1.,  0.,  0.])
>>> np.__version__
'1.5.1'
```

```
>>> numpy.__version__
'1.7.1'

>>> x = np.zeros(5)
>>> x[np.arange(5)<3] = np.ones(4)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: NumPy boolean array indexing assignment cannot assign 4 input values to the 3 output values where
the mask is true
```
