### PR TITLE
ENH: Print dateutil version.

### DIFF
--- a/statsmodels/tools/print_version.py
+++ b/statsmodels/tools/print_version.py
@@ -69,6 +69,13 @@ def show_versions():
         print("pandas: Not installed")
 
     try:
+        import dateutil
+        print("    dateutil: %s (%s)" % (safe_version(dateutil),
+                                     dirname(dateutil.__file__)))
+    except ImportError:
+        print("    dateutil: not installed")
+
+    try:
         import patsy
         print("patsy: %s (%s)" % (safe_version(patsy),
                                   dirname(patsy.__file__)))


### PR DESCRIPTION
The wheezy failure is coming from dateutil, but it works for 2.1. Looks like wheezy might still be on 1.5.
