### PR TITLE
BUG: Handle combo of pandas 0.8.0 and dateutils 1.5.0

### DIFF
--- a/statsmodels/tsa/base/datetools.py
+++ b/statsmodels/tsa/base/datetools.py
@@ -159,11 +159,12 @@ def date_parser(timestr, parserinfo=None, **kwargs):
         month, day = 12, 31
         year = int(timestr)
     else:
-        if hasattr(pandas_datetools, 'parser'):
-
+        if (hasattr(pandas_datetools, 'parser') and
+            not callable(pandas_datetools.parser)):
+            # exists in 0.8.0 pandas, but it's the class not the module
             return pandas_datetools.parser.parse(timestr, parserinfo,
                                                  **kwargs)
-        else: # older pandas version didn't import this into namespace
+        else: # 0.8.1 pandas version didn't import this into namespace
             from dateutil import parser
             return parser.parse(timestr, parserinfo, **kwargs)
 


### PR DESCRIPTION
Pandas 0.8.0 imported dateutil.parser while 0.8.1 did not. It imporeted the class though and not the module. This should fix this failure on wheezy (even though technically we don't support pandas 0.8.0 I guess we do now.)
