### PR TITLE
BUG include_package_data for install closes #907

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -520,4 +520,5 @@ if __name__ == "__main__":
           cmdclass = cmdclass,
           packages = packages,
           package_data = package_data,
+          include_package_data=True,
           **setuptools_kwargs)


### PR DESCRIPTION
includes data files in the installation see #907

(pushed by accident to statsmodels instead of josef.pkt)
