### PR TITLE
DOC: Add link to notebook and crosslink ref. Closes #924.

### DIFF
--- a/tools/nbgenerate.py
+++ b/tools/nbgenerate.py
@@ -299,7 +299,8 @@ if __name__ == '__main__':
                 with io.open(new_html, "w", encoding="utf-8") as f:
                     f.write(title_cell["source"]+u"\n")
                     f.write(u"="*len(title_cell["source"])+u"\n\n")
-                    f.write(notebook_template.substitute(body=html_out))
+                    f.write(notebook_template.substitute(name=fname_only,
+                                                         body=html_out))
             hash_funcs.update_hash_dict(filehash, fname_only)
     except Exception, err:
         raise err

--- a/tools/notebook_output_template.py
+++ b/tools/notebook_output_template.py
@@ -1,6 +1,10 @@
 from string import Template
 
 notebook_template = Template("""
+.. _$name_notebook:
+
+`Link to Notebook GitHub <https://github.com/statsmodels/statsmodels/tree/master/examples/notebooks/$name.ipynb>`_
+
 .. raw:: html
 
 $body


### PR DESCRIPTION
Adds a link to github and a sphinx crossref. Each notebook example is now crosslinkable with a `:ref:`filename_notebook``
