### PR TITLE
Address a test failure w/ scipy.stats.distributions named arguments

### DIFF
--- a/statsmodels/sandbox/distributions/extras.py
+++ b/statsmodels/sandbox/distributions/extras.py
@@ -835,6 +835,7 @@ class TransfTwo_gen(distributions.rv_continuous):
                          # possible to freeze the underlying distribution
 
         super(TransfTwo_gen,self).__init__(a=a, b=b, name = name,
+                                shapes = kls.shapes,
                                 longname = longname, extradoc = extradoc)
 
     def _rvs(self, *args):
@@ -935,6 +936,7 @@ def derivminus(x):
 
 def negsquarefunc(x):
     return -np.power(x,2)
+
 
 
 negsquarenormalg = TransfTwo_gen(stats.norm, negsquarefunc, inverseplus, inverseminus,
@@ -1227,6 +1229,8 @@ def mvnormcdf(upper, mu, cov, lower=None,  **kwds):
     #v/np.sqrt(np.atleast_2d(np.diag(covv)))/np.sqrt(np.atleast_2d(np.diag(covv))).T
 
     return mvstdnormcdf(lower, upper, corr, **kwds)
+
+
 
 
 if __name__ == '__main__':

--- a/statsmodels/sandbox/distributions/tests/testtransf.py
+++ b/statsmodels/sandbox/distributions/tests/testtransf.py
@@ -84,12 +84,11 @@ class Test_Transf2(object):
             #The below fails on the SPARC box with scipy 10.1
             #(lognormalg, stats.lognorm(1)),
             #transf2
-            (squarenormalg, stats.chi2(1)),
-            (absnormalg, stats.halfnorm),
-            (absnormalg, stats.foldnorm(1e-5)),  #try frozen
-            #(negsquarenormalg, 1-stats.chi2),  # won't work as distribution
+           (squarenormalg, stats.chi2(1)),
+           (absnormalg, stats.halfnorm),
+           (absnormalg, stats.foldnorm(1e-5)),  #try frozen
+           #(negsquarenormalg, 1-stats.chi2),  # won't work as distribution
             (squaretg(10), stats.f(1, 10))]      #try both frozen
-
 
         l,s = 0.0, 1.0
         self.ppfq = [0.1,0.5,0.9]
@@ -137,6 +136,8 @@ class Test_Transf2(object):
             assert_almost_equal(s1[2:], s2[2:],
                                 decimal=2, #lognorm for kurtosis
                                 err_msg='stats '+d1.name+d2.name)
+
+
 
     def test_equivalent_negsq(self):
         #special case negsquarenormalg


### PR DESCRIPTION
A recent PR in scipy.stats allowing using named arguments for distributions (https://github.com/scipy/scipy/pull/2588 and https://github.com/rgommers/scipy/tree/pr/2588) brings in a failure in `statsmodels.sandbox.distributions.tests.testtransf.Test_Transf2.test_equivalent`. 

This PR fixes the failure, at least superficially: the test passes, but it really needs to be reviewed by somebody who's familiar with the `TransfTwo_gen` code. The fix here assumes that the attribute `shape` of the `TransfTwo_gen` class is intended to correspond to the `shapes` attribute of the `stats.rv_continuous` (note the singular/plural shape/shapes). 
