### PR TITLE
BUG: fix warning arguments in GenericLikelihoodModel

### DIFF
--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -825,7 +825,7 @@ class GenericLikelihoodModel(LikelihoodModel):
             else:
                 # I don't want to raise after we have already fit()
                 import warnings
-                warnings.warn(UserWarning, 'more exog_names than parameters')
+                warnings.warn('more exog_names than parameters', UserWarning)
 
         return genericmlefit
     #fit.__doc__ += LikelihoodModel.fit.__doc__

--- a/statsmodels/miscmodels/tests/test_poisson.py
+++ b/statsmodels/miscmodels/tests/test_poisson.py
@@ -170,5 +170,10 @@ class TestPoissonZi(CompareMixin):
         #assert_almost_equal(self.res.tval[:-1], self.res_glm.t()[1:], self.decimal)
 
 
-
+    def test_exog_names_warning(self):
+        mod = self.res.model
+        mod1 = PoissonOffsetGMLE(mod.endog, mod.exog, offset=mod.offset)
+        from numpy.testing import assert_warns
+        mod1.data.xnames = mod1.data.xnames * 2
+        assert_warns(UserWarning, mod1.fit)
 


### PR DESCRIPTION
fix a warning, wrong argument sequence

with unittest

(not most warnings are not tested)
