### PR TITLE
notebook examples title cell

### DIFF
--- a/examples/notebooks/example_quantreg.ipynb
+++ b/examples/notebooks/example_quantreg.ipynb
@@ -1,6 +1,6 @@
 {
  "metadata": {
-  "name": "example_quantreg"
+  "name": ""
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -8,10 +8,17 @@
   {
    "cells": [
     {
+     "cell_type": "heading",
+     "level": 1,
+     "metadata": {},
+     "source": [
+      "Quantile regression"
+     ]
+    },
+    {
      "cell_type": "markdown",
      "metadata": {},
      "source": [
-      "# Quantile regression\n",
       "\n",
       "This example page shows how to use ``statsmodels``' ``QuantReg`` class to replicate parts of the analysis published in \n",
       "\n",

--- a/examples/notebooks/example_regression_diagnostics.ipynb
+++ b/examples/notebooks/example_regression_diagnostics.ipynb
@@ -8,11 +8,17 @@
   {
    "cells": [
     {
+     "cell_type": "heading",
+     "level": 1,
+     "metadata": {},
+     "source": [
+      "Regression diagnostics"
+     ]
+    },
+    {
      "cell_type": "markdown",
      "metadata": {},
      "source": [
-      "# Regression diagnostics\n",
-      "\n",
       "This example file shows how to use a few of the ``statsmodels`` regression diagnostic tests in a real-life context. You can learn about more tests and find out more information abou the tests here on the [Regression Diagnostics page.](http://statsmodels.sourceforge.net/stable/diagnostic.html) \n",
       "\n",
       "Note that most of the tests described here only return a tuple of numbers, without any annotation. A full description of outputs is always included in the docstring and in the online ``statsmodels`` documentation. For presentation purposes, we use the ``zip(name,test)`` construct to pretty-print short descriptions in the examples below."


### PR DESCRIPTION
`nbgenerate.py` requires the title of notebook examples to be in a cell marked as "heading". The two notebooks I moved in my last PR didn't have that and so were doing something strange during docs build. This should fix this problem. 

I built the docs locally using IPython 1.0 (good job on that, BTW, @jseabold) and all looks fine. This is a trivial fix, so I'll merge if I don't see opposition within the next couple days. 
