### PR TITLE
BLD: Fix build issue on some versions of easy_install.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,11 @@ import sys
 import subprocess
 import re
 
+# temporarily redirect config directory to prevent matplotlib importing
+# testing that for writeable directory which results in sandbox error in
+# certain easy_install versions
+os.environ["MPLCONFIGDIR"] = "."
+
 # may need to work around setuptools bug by providing a fake Pyrex
 try:
     import Cython


### PR DESCRIPTION
This also needs to be backported to maintenance. Will hold off on merging until we're ready for 0.5.1 to see how we want to handle this.
