### PR TITLE
Update boxplots.py

### DIFF
--- a/statsmodels/graphics/boxplots.py
+++ b/statsmodels/graphics/boxplots.py
@@ -139,7 +139,10 @@ def violinplot(data, ax=None, labels=None, positions=None, side='both',
                                        plot_opts)
 
     if show_boxplot:
-        ax.boxplot(data, notch=1, positions=positions, vert=1)
+        if np.ndim(data) == 2 : 
+            ax.boxplot(data.T, notch=1, positions=positions, vert=1)
+        else : 
+            ax.boxplot(data, notch=1, positions=positions, vert=1)
 
     # Set ticks and tick labels of horizontal axis.
     _set_ticks_labels(ax, data, labels, positions, plot_opts)


### PR DESCRIPTION
Boxplot is broken when you use np.array instead of a list of array

The issue is it does not tell you it is broken (even if the docstring is explicit about data being list of array)

For instance  : 

sm.graphics.violinplot(np.random.normal(size=[5,1000]))

will return a graph with 5 violins each corresponding to 1000 data points and 5 boxplot corresponding to 5 data points, leaving 995 X 5 data points unplotted. 
Either it should crash and tell you to use a list of array, either it should work.

I propose to ckeck if data as 2 dimensions. If so, transpose it so its representation is coherent with the violin plot.
