### PR TITLE
DOC: minor git typo

### DIFF
--- a/docs/source/dev/git_notes.rst
+++ b/docs/source/dev/git_notes.rst
@@ -231,7 +231,7 @@ git will know that it can safely delete your branch::
 
 Then you can just do::
 
-    git -d shiny-new-feature
+    git branch -d shiny-new-feature
 
 Make sure you use a lower-case -d. That way, git will complain if your feature
 branch has not actually been merged. The branch will still exist on github


### PR DESCRIPTION
Ana Martínez Pardo anamartinezpardo@gmail.com
1:12 PM (11 minutes ago)

to pystatsmodels 
I found a minimal error in developers page [1]:
Instead of:
        git -d shiny-new-feature
I think it should be:
        git branch -d shiny-new-feature
As here [2]
Where is the best place to report it?

[1] http://statsmodels.sourceforge.net/devel/dev/git_notes.html#github#Deleting%20Branches%C2%B6
[2] http://git-scm.com/book/en/Git-Branching-Branch-Management
