### PR TITLE
Actually use dangling libraries=['m'] in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -410,7 +410,8 @@ for name, data in ext_data.items():
     obj = Extension('statsmodels.%s.%s' % (destdir, name),
                     sources=sources,
                     depends=data.get('depends', []),
-                    include_dirs=include)
+                    include_dirs=include,
+                    libraries=libraries)
 
     extensions.append(obj)
 


### PR DESCRIPTION
On line 380:

```
libraries = ['m'] if 'win32' not in sys.platform else []
```

doesn't get used.

I'm not sure how necessary the `libraries = ['m']` inclusion is. What linux distributions don't include libc math? See http://docs.cython.org/src/tutorial/external.html#dynamic-linking for details.
