### PR TITLE
ENH: Add abstract class for returning test results.

### DIFF
--- a/statsmodels/stats/tools.py
+++ b/statsmodels/stats/tools.py
@@ -1,0 +1,82 @@
+from collections import OrderedDict
+
+from statsmodels.tools.decorators import nottest
+
+#TODO: Allow options to set digits, control output, etc. of summary
+
+def _check_order(order, keys):
+    for i in order:
+        if i not in keys:
+            raise ValueError(("order is incorrectly specified: {} not in "
+                              "keys").format(i))
+
+@nottest
+class TestResult:
+    def __init__(self, doc, null, alternative, order=None, **kwargs):
+        kwargs.update({'null_hypothesis' : 'H0: {}'.format(null)})
+        kwargs.update({'alt_hypothesis' : 'HA: {}'.format(alternative)})
+        self.__dict__  = kwargs
+        self.null_hypothesis = "H0: {}".format(null)
+        self.alt_hypothesis = "HA: {}".format(alternative)
+        if order is not None:
+            _check_order(order, self.__dict__.keys())
+        else:
+            order = self.__dict__.keys()
+        self._order = order
+        self.__doc__ = doc
+
+    def __getitem__(self, key):
+        try:
+            return getattr(self, key)
+        except AttributeError:
+            raise KeyError("Key not found: {}".format(key))
+
+    def summary(self):
+        smry = 'Null Hypothesis: {}\n'.format(self.null_hypothesis)
+        smry += 'Alternative Hypothesis: {}\n'.format(self.alt_hypothesis)
+        for key in self._order:
+            smry += '{}: {}\n'.format(str(key), str(self[key]))
+        return smry
+
+if __name__ == "__main__":
+    import statsmodels.api as sm
+
+    data = sm.datasets.macrodata.load_pandas()
+    x = data.data['realgdp']
+    y = data.data['infl']
+    res = sm.tsa.adfuller(x, regression='c', autolag=None, maxlag=4)
+    d = res[-1]
+    res = res[:-1]
+    res = dict(zip(
+            ['adf', 'pvalue', 'usedlag', 'nobs'], res))
+
+    doc = """
+    Attributes
+    ----------
+    adf : float
+        Test statistic
+    pvalue : float
+        MacKinnon's approximate p-value based on MacKinnon (1994)
+    usedlag : int
+        Number of lags used.
+    nobs : int
+        Number of observations used for the ADF regression and calculation of
+        the critical values.
+    critical values : dict
+        Critical values for the test statistic at the 1 %, 5 %, and 10 % levels.
+        Based on MacKinnon (2010)
+    icbest : float
+        The maximized information criterion if autolag is not None.
+    regresults : RegressionResults instance
+        The
+    resstore : (optional) instance of ResultStore
+        an instance of a dummy class with results attached as attributes
+
+    """
+
+    res.update(d)
+    nice_result = TestResult(doc, 'There is a unit root.',
+                             'There is no unit root', ['adf', 'pvalue',
+                                                       'usedlag', 'nobs',
+                                                       '10%', '5%', '1%'],
+                             **res)

--- a/statsmodels/tsa/diagnostic.py
+++ b/statsmodels/tsa/diagnostic.py
@@ -1,0 +1,100 @@
+import numpy as np
+from scipy import stats
+
+from statsmodels.stats.tools import TestResult
+from statsmodels.tsa.stattools import acf
+from statsmodels.tools.decorators import nottest
+
+
+@nottest
+def acorr_box_test(x, nlags, df=0, boxpierce=False):
+    r"""
+    Ljung-Box or Box-Pierce test for no autocorrelation
+
+    Parameters
+    ----------
+    x : array-like
+        Data to test for autocorrelation. Usually regression residuals.
+    lags : int
+        The returned statistic will be based on this many lags.
+    df : int
+        Degrees of freedom correction. If `x' is based on model residuals,
+        should be the number of parameters fit for the model. For example,
+        if residuals come from an ARMA model, df should be the number of AR
+        coefficients plus the number of MA coefficients.
+    boxpierce : bool
+        If True, returns the Box-Pierce test statistic. If False, returns
+        the Ljung-Box. See notes. Default is False.
+
+    Returns
+    -------
+    results : TestResults object
+        An object containing relevant test statistics
+
+    Notes
+    -----
+    The Ljung-Box test statistic is
+
+    .. math::
+
+       Q = nobs * (nobs + 2) * \sum_{k=1}^(nlags)\frac{\rho_k^2}{nobs - k}
+
+    where :math:`\rho_k` is the sample autocorrelation at lag :math:`k`.
+    :math:`Q` is assumed to be distributed :math:`\chi^2_` with
+    :math:`nlags-df` degrees of freedom.
+
+    The Box-Pierce test statistic is
+
+    .. math::
+
+       Q = n * \sum_{k=1}^{nlags}\rho^2_k
+
+    The Ljung-Box statistic is preferred for all sample sizes.
+    """
+    x = np.asarray(x)
+    nobs = float(len(x))
+    lags = np.arange(1, nlags + 1)
+
+    acf_p = acf(x, nlags=nlags, fft=True)[1:]  # drop lag 0
+    if not boxpierce:
+        q_stat = nobs * (nobs + 2) * np.sum(acf_p**2 / (nobs - lags))
+    else:
+        q_stat = nobs * np.sum(acf_p ** 2)
+    p_value = stats.chi2.sf(q_stat, nlags - df)
+
+    return_doc = """
+    Ljung-Box or Box-Pierce Test Results
+
+    Attributes
+    ----------
+    q_stat : float
+        Ljung-Box test statistic
+    p_value : float
+        p-value of the test statistic
+    """
+
+    return TestResult(return_doc, "The series is random.",
+                      "The series is not independently distributed.",
+                      order=["q_stat", "p_value"], q_stat=q_stat,
+                      p_value=p_value)
+
+if __name__ == "__main__":
+    import statsmodels.api as sm
+    from statsmodels.tsa.arima_process import arma_generate_sample
+    np.random.seed(12345)
+    y = arma_generate_sample([1, .75, .35], [1, .25], nsample=100)
+
+    # order identification
+    order_select = sm.tsa.arma_order_select_ic(y)
+    print order_select.bic_min_order
+
+    # model validation
+    mod = sm.tsa.ARMA(y, (2, 1)).fit(trend='nc')
+
+    mod.arroots
+    mod.maroots # really close to the unit circle
+
+    resid = mod.resid
+
+    box_test = acorr_box_test(resid, 10, 3)
+    print box_test.summary()


### PR DESCRIPTION
Food for thought? Alternatively, we could have a wrapper that returns a DataFrame similar to the ANOVA results.

Run the file to see output for Augmented Dickey Fuller for example.
