### PR TITLE
TST: enable tests for llf after change to WLS.loglike see #1170

### DIFF
--- a/statsmodels/regression/tests/test_glsar_gretl.py
+++ b/statsmodels/regression/tests/test_glsar_gretl.py
@@ -360,7 +360,7 @@ class TestGLSARGretl(object):
         #TODO
 
         assert_almost_equal(res.ssr, result_gretl_g1['ssr'][1], decimal=2)
-        #assert_almost_equal(res.llf, result_gretl_g1['llf'][1], decimal=7) #not in gretl
+        assert_almost_equal(res.llf, result_gretl_g1['llf'][1], decimal=4) #not in gretl
         assert_almost_equal(res.rsquared, result_gretl_g1['rsquared'][1], decimal=6) #FAIL
         assert_almost_equal(res.rsquared_adj, result_gretl_g1['rsquared_adj'][1], decimal=6) #FAIL
         assert_almost_equal(np.sqrt(res.mse_resid), result_gretl_g1['mse_resid_sqrt'][1], decimal=5)

--- a/statsmodels/regression/tests/test_glsar_stata.py
+++ b/statsmodels/regression/tests/test_glsar_stata.py
@@ -52,6 +52,8 @@ class TestGLSARCorc(CheckStataResultsPMixin):
     def test_rho(self):
         assert_almost_equal(self.res.model.rho, self.results.rho, 3)  # pylint: disable-msg=E1101
 
+        assert_almost_equal(self.res.llf, self.results.ll, 4)
+
 
 if __name__=="__main__":
     import nose


### PR DESCRIPTION
This enables tests that were commented out.

It is supposed to go in after fixing WLS.loglike as discussed in #1170

I cannot find the commit for WLS.loglike in any of bashtage's PRs right now.
If the change is not included in any of bashtage's PRs, I will make a separate PR, that also fixes the failing tests because we will use a different definition or normalization than Stata.

the tests don't fail with current master:

I had changed GLSAR to subclass GLS instead of WLS which has the correct loglike
GLSHet which subclasses WLS doesn't have unit tests yet. (I didn't find a direct equivalent in Stata or R, IIRC)
