### PR TITLE
fix typo

### DIFF
--- a/docs/themes/statsmodels/indexsidebar.html
+++ b/docs/themes/statsmodels/indexsidebar.html
@@ -21,7 +21,7 @@ Documentation for the current development version is <a href="http://statsmodels
   <input type="submit" name="sub" value="Subscribe" style="margin-left:15px"/>
 </form>
 <p style="font-size:1em">
-    Grab the souce from <a href="https://github.com/statsmodels/statsmodels/">Github</a>.
+    Grab the source from <a href="https://github.com/statsmodels/statsmodels/">Github</a>.
     Report bugs to the <a href="https://github.com/statsmodels/statsmodels/issues">Issue Tracker</a>.
     Have a look at our <a href="{{ pathto('dev/index') }}">Developer</a> and <a href = "{{ pathto('dev/roadmap_todo') }}">Get Involved</a> Pages.
 </p>


### PR DESCRIPTION
disambiguation dilemma between "sauce" and "source"
