### PR TITLE
BLD: do not install *.pyx *.c  MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-global-include *.csv *.py *.txt *.pyx *.c
+global-include *.csv *.py *.txt
 #scikits*.*
 include MANIFEST.in
 
@@ -44,4 +44,4 @@ include statsmodels/stats/libqsturng/LICENSE.txt
 include statsmodels/regression/tests/results/leverage_influence_ols_nostars.txt
 
 
-global-exclude *~ *.swp  *.pyc *.bak
+global-exclude *~ *.swp  *.pyc *.bak *.pyx


### PR DESCRIPTION
remove *.pyx *.c  MANIFEST.in

this should fix and close #1195  cython pyximport tries to recompile the statsmodels extensions
