### PR TITLE
Fixed bug in uniform kernel

### DIFF
--- a/statsmodels/sandbox/nonparametric/kernels.py
+++ b/statsmodels/sandbox/nonparametric/kernels.py
@@ -280,7 +280,7 @@ class CustomKernel(object):
 
 class Uniform(CustomKernel):
     def __init__(self, h=1.0):
-        CustomKernel.__init__(self, shape=lambda x: 0.5, h=h,
+        CustomKernel.__init__(self, shape=lambda x: 0.5 * np.ones(x.shape), h=h,
                               domain=[-1.0, 1.0], norm = 1.0)
         self._L2Norm = 0.5
 


### PR DESCRIPTION
The previous implementation returned a scalar instead of an array (in contrast to all other kernels) and made, for example, KDEUniform's fit method fail.

Example for the bug:

``` python
data = np.random.randn(10)
kde = sm.nonparametric.KDEUnivariate(data)
kde.fit(kernel='uni', bw=1.0, gridsize=10, fft=False)
```

``` python.traceback
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-13-7439ff8c314e> in <module>()
      1 data = np.random.randn(10)
      2 kde = sm.nonparametric.KDEUnivariate(data)
----> 3 kde.fit(kernel='uni', bw=1.0, gridsize=10, fft=False)

/home/xxx/anaconda/envs/py33/lib/python3.3/site-packages/statsmodels/nonparametric/kde.py in fit(self, kernel, bw, fft, weights, gridsize, adjust, cut, clip)
    144             density, grid, bw = kdensity(endog, kernel=kernel, bw=bw,
    145                     adjust=adjust, weights=weights, gridsize=gridsize,
--> 146                     clip=clip, cut=cut)
    147         self.density = density
    148         self.support = grid

/home/xxx/anaconda/envs/py33/lib/python3.3/site-packages/statsmodels/nonparametric/kde.py in kdensity(X, kernel, bw, weights, gridsize, adjust, clip, cut, retgrid)
    361         domain_mask = (k < z_lo) | (k > z_high)
    362         k = kern(k) # estimate density
--> 363         k[domain_mask] = 0
    364     else:
    365         k = kern(k) # estimate density

TypeError: 'float' object does not support item assignment
```

This "test" passes after the fix; I don't have time right now to go beyond it.
