### PR TITLE
Added bw_method to sm.graphics.violinplot + default colors?

### DIFF
--- a/statsmodels/graphics/boxplots.py
+++ b/statsmodels/graphics/boxplots.py
@@ -14,7 +14,7 @@ __all__ = ['violinplot', 'beanplot']
 
 
 def violinplot(data, ax=None, labels=None, positions=None, side='both',
-               show_boxplot=True, plot_opts={}):
+               show_boxplot=True, bw_method=None, plot_opts={}):
     """Make a violin plot of each dataset in the `data` sequence.
 
     A violin plot is a boxplot combined with a kernel density estimate of the
@@ -136,6 +136,7 @@ def violinplot(data, ax=None, labels=None, positions=None, side='both',
     # Plot violins.
     for pos_data, pos in zip(data, positions):
         xvals, violin = _single_violin(ax, pos, pos_data, width, side,
+                                       bw_method,
                                        plot_opts)
 
     if show_boxplot:
@@ -147,7 +148,7 @@ def violinplot(data, ax=None, labels=None, positions=None, side='both',
     return fig
 
 
-def _single_violin(ax, pos, pos_data, width, side, plot_opts):
+def _single_violin(ax, pos, pos_data, width, side, bw_method, plot_opts):
     """"""
 
     def _violin_range(pos_data, plot_opts):
@@ -169,7 +170,7 @@ def _single_violin(ax, pos, pos_data, width, side, plot_opts):
 
     pos_data = np.asarray(pos_data)
     # Kernel density estimate for data at this position.
-    kde = gaussian_kde(pos_data)
+    kde = gaussian_kde(pos_data, bw_method=bw_method)
 
     # Create violin for pos, scaled to the available space.
     xvals = _violin_range(pos_data, plot_opts)


### PR DESCRIPTION
Hello there,
I have a homebrewed version of this (also based off of the same code!) but it allows the user to specify the bandwidth method. So in this PR, I added the ability to change the bandwidth method. It's currently with the regular args because I didn't think this is a plot argument, but rather an estimation argument. Suggestions?

Here are some examples: http://nbviewer.ipython.org/gist/olgabot/7915540

Besides the bandwidth method, can the default facecolor also be changed? The yellow is rather ugly, and I'd much prefer something from colorbrewer: http://bl.ocks.org/mbostock/5577023

Thanks,
Olga

PS Initially I was going to add this to `pandas` (https://github.com/pydata/pandas/issues/5676) but since `statsmodels` already has most of the code, this seemed like a more natural choice.
