### PR TITLE
BUG: numerical precision in resid_pearson with perfect fit #1229

### DIFF
--- a/statsmodels/regression/linear_model.py
+++ b/statsmodels/regression/linear_model.py
@@ -1253,8 +1253,9 @@ class RegressionResults(base.LikelihoodModelResults):
 
         if not hasattr(self, 'resid'):
             raise ValueError('Method requires residuals.')
-        if np.all(np.abs(self.wresid) <= 0.0):
-            # This is a very exact check, does not account for numerical error
+        eps = np.finfo(self.wresid.dtype).eps
+        if np.sqrt(self.scale) < 10 * eps * self.model.endog.mean():
+            # don't divide if scale is zero close to numerical precision
             from warnings import warn
             warn("All residuals are 0, cannot compute normed residuals.")
             return self.wresid

--- a/statsmodels/regression/tests/test_regression.py
+++ b/statsmodels/regression/tests/test_regression.py
@@ -241,7 +241,8 @@ class TestOLS(CheckRegressionResults):
         with warnings.catch_warnings(record=True):
             y = self.res1.model.endog
             res = OLS(y,y).fit()
-            assert_equal(res.wresid, res.resid_pearson)
+            assert_allclose(res.scale, 0, atol=1e-20)
+            assert_allclose(res.wresid, res.resid_pearson, atol=5e-11)
 
 
 class TestRTO(CheckRegressionResults):


### PR DESCRIPTION
supersedes #1227

see #1229 numerical precision of resid with perfect fit
