### PR TITLE
REF: Results.predict convert to array and adjust shape

### DIFF
--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -995,6 +995,14 @@ class Results(object):
             from patsy import dmatrix
             exog = dmatrix(self.model.data.orig_exog.design_info.builder,
                     exog)
+
+        if exog is not None:
+            exog = np.asarray(exog)
+            if exog.ndim == 1 and (self.model.exog.ndim == 1 or
+                                   self.model.exog.shape[1] == 1):
+                exog = exog[:, None]
+            exog = np.atleast_2d(exog) # needed in count model shape[1]
+
         return self.model.predict(self.params, exog, *args, **kwargs)
 
 


### PR DESCRIPTION
Results.predict
convert to ndarray, and check and adjust shape, with unit_tests

closes #1032
supersedes #1178

I tried to let pandas through, but it doesn't help. np.dot for example returns an ndarray.
I left the commented out code for testing DataFrame in the generic tests, but it needs special handling on before return.
I don't know if we have any wrapper code for predict. I didn't see any.

Some comments on the requirements
- CountModels require 2d even if it's only a single prediction because of exog.shape[1]
- single regressor (OLS example) needs reshape to column_vector as in AR(MA)
- I'm not sure we always have model.exog as 2d, so I check also for 1d model.exog
- I didn't find self.data.k_exog or self.model.data.k_exog, so I did a model.exog.shape check directly
