### PR TITLE
ENH: Allow ARMA(0,0) and ARIMA(0,d,0) models with constant/trend models to be estimated

### DIFF
--- a/statsmodels/tsa/arima_model.py
+++ b/statsmodels/tsa/arima_model.py
@@ -1146,8 +1146,7 @@ class ARMAResults(tsbase.TimeSeriesModelResults):
         Akaike Information Criterion
         :math:`-2*llf+2* df_model`
         where `df_model` includes all AR parameters, MA parameters, constant
-        terms parameters on constant terms and, when the model is estimated
-        using MLE, the variance parameter.
+        terms parameters on constant terms and the variance.
     arparams : array
         The parameters associated with the AR coefficients in the model.
     arroots : array
@@ -1247,9 +1246,7 @@ class ARMAResults(tsbase.TimeSeriesModelResults):
         k_ma = model.k_ma
         self.k_ma = k_ma
         df_model = k_exog + k_trend + k_ar + k_ma
-        self._ic_df_model = df_model
-        if k_ma > 0 or k_ar > 0 or model.method.lower().find("mle") > 0:
-            self._ic_df_model += 1
+        self._ic_df_model = df_model + 1
         self.df_model = df_model
         self.df_resid = self.nobs - df_model
         self._cache = resettable_cache()

--- a/statsmodels/tsa/tests/test_arima.py
+++ b/statsmodels/tsa/tests/test_arima.py
@@ -1,4 +1,5 @@
 import numpy as np
+from nose.tools import nottest
 from numpy.testing import (assert_almost_equal, assert_equal, assert_,
                            assert_raises, dec, TestCase)
 import statsmodels.sandbox.tsa.fftarma as fa
@@ -1912,7 +1913,10 @@ class TestARMA00(TestCase):
         predictions = self.arma_00_res.predict()
         assert_almost_equal(self.y.mean() * np.ones_like(predictions), predictions)
 
+    @nottest
     def test_information_criteria(self):
+        # This test is invalid since the ICs differ due to df_model differences
+        # between OLS and ARIMA
         res = self.arma_00_res
         y = self.y
         ols_res = OLS(y, np.ones_like(y)).fit()


### PR DESCRIPTION
- Allows ARMA and ARIMA with only exogenous or constant terms
- Changed the IC to match the definition in OLS as well as most other sources (see, e.g. 23.2 of http://gretl.sourceforge.net/gretl-help/gretl-guide.pdf).  The currently produces a large number of failures.  Would be useful to check source for baseline results **Note**: All differ by a term which has no impact on model selection.
- Still needs test for pure exogenous models

Does **_not_** try to implement "parameterless" models.
