### PR TITLE
Adding Cronbach Alpha (Output format needs to be checked)

### DIFF
--- a/statsmodels/stats/inter_rater.py
+++ b/statsmodels/stats/inter_rater.py
@@ -192,6 +192,48 @@ def to_table(data, bins=None):
 
     return tt[0], bins_
 
+def CronbachAlpha(itemscores):
+    '''Compute Cronbach's Alpha
+
+    Parameters
+    ----------
+    itemscores : array_like
+
+        n*p array or dataframe, n subjects and p items
+
+    Returns
+    -------
+    Calpha : float
+
+        To interpret the output the rule of George, D., & Mallery, P. (2003)
+        can be used
+        > .9 (Excellent),
+        > .8 (Good),
+        >.7 (Acceptable),
+        > .6 (Questionable),
+        > .5(Poor), and < .5 (Unacceptable)
+
+    Notes
+    -------
+    Cronbach's Alpha is the most commonly used measure of internal consistency.
+    One problem might be Cronbach's Alpha is not robust against missing data.
+    
+    TO DO: May need function to omitted missing values
+    
+    References
+    ----------
+    Wikipedia
+    '''
+
+    itemscores = np.asarray(itemscores)
+    itemvars = itemscores.var(axis=1, ddof=1)
+    tscores = itemscores.sum(axis=0)
+    nitems = len(itemscores)
+    calpha = nitems / (nitems-1) * (1 - itemvars.sum() / tscores.var(ddof=1))
+
+    return calpha
+
+
 def fleiss_kappa(table):
     '''Fleiss' kappa multi-rater agreement measure
 


### PR DESCRIPTION
Added Cronbach Alpha function with improve code from

https://github.com/statsmodels/statsmodels/issues/1272

Still may need a function to omit arrays with NaN.

Don't know how you guys want the return options but someone might want to adjust the return values since R yields something like:

Cronbach's Alpha = calpha
Sample size = nitems
Number of items = len(tscores)
