### PR TITLE
Updated CronbachAlpha from pull #1273

### DIFF
--- a/statsmodels/stats/inter_rater.py
+++ b/statsmodels/stats/inter_rater.py
@@ -192,6 +192,43 @@ def to_table(data, bins=None):
 
     return tt[0], bins_
 
+def cronbach_alpha(itemscores):
+    '''Compute Cronbach's Alpha
+    Parameters
+    ----------
+    itemscores : array_like
+        n*p array or dataframe, n subjects and p items
+    Returns
+    -------
+    Calpha : float
+        To interpret the output the rule of George, D., & Mallery, P. (2003)
+        can be used
+        > .9 (Excellent),
+        > .8 (Good),
+        > .7 (Acceptable),
+        > .6 (Questionable),
+        > .5(Poor), and < .5 (Unacceptable)
+
+    Notes
+    -----
+    Cronbach's Alpha is the most commonly used measure of internal consistency.
+    One problem might be Cronbach's Alpha is not robust against missing data.
+
+
+    References
+    ----------
+    Wikipedia
+    '''
+
+    itemscores = np.asarray(itemscores)
+    itemscores = itemscores[~np.isnan(itemscores).any(axis = 1)]
+    itemvars = itemscores.var(axis = 1, ddof = 1)
+    tscores = itemscores.sum(axis = 0)
+    nitems = len(itemscores)
+    calpha = nitems / (nitems - 1.) * (1 - itemvars.sum() / tscores.var(ddof = 1))
+
+    return calpha
+    
 def fleiss_kappa(table):
     '''Fleiss' kappa multi-rater agreement measure
 


### PR DESCRIPTION
Updated code from 
https://github.com/statsmodels/statsmodels/pull/1273

Fixes:
*Fixed code for pep-8 style and recommendations from dengemann and josef-pkt (I think)
*Added setting to take out np.Nan arrays

Still needed: 
Summary (I don't know what people want)
Cronbach's Alpha = calpha
Sample size = nitems
Number of items = len(tscores)

Test code:

```
###########Test################
import numpy as np
import pandas as pd

# For normal numpy arrays
itemscores = [[1,2,3,5,4,1],
              [3,6,5,6,4,1]]

print "Cronbach alpha = ", cronbach_alpha(itemscores)

# For arrays with Nan values (they should be dropped)
itemscoresNAN = [[1,2,3,5,4,1],
              [3,6,5,6,4,1],
              [3,6,5,6,np.nan,1]]

print "Cronbach alpha Nan = ", cronbach_alpha(itemscoresNAN)

#Pandas dataframe

df = pd.DataFrame({'TFD' : ['A', 'b', 'C','D','E','F'],
                    'Data1' : [1,2,3,5,4,1],
                    'Data2' : [3,6,5,6,4,1]}).set_index('TFD')
df=df.transpose()
print "Cronbach alpha (pd) = ", cronbach_alpha(df)
```
