### PR TITLE
Single Exponential Smoothning

### DIFF
--- a/statsmodels/tsa/Expsmooth.py
+++ b/statsmodels/tsa/Expsmooth.py
@@ -1,0 +1,74 @@
+'''
+contains
+--------
+Exponential Smoothing
+Holt Winters Exponential smoothing
+
+
+
+License: BSD-3
+
+
+TODO
+----
+[]Add Holt double Exponential smoothing
+[]Add time series decomposition
+[]Fix Holt Winters Additive model (just an if statement and change
+                                    seasonal calculation from division to
+                                    addition)
+[]Add/improve Forcasting for Holt Winters to take multiple variables
+  []Add confidence intervals to forcast
+[]Add solver to fit Holt Winters parameters
+[]Improve data summary RMS error, Sum of Square Residual,
+'''
+
+import numpy as np
+
+def ExpSmoothing(y, alpha, forecast=None):
+    '''
+    Brown's simple exponential smoothing
+    Parameters
+    ----------
+    y: array
+        Time series data
+
+    alpha:  float
+        Smoothing factor between 0 and 1. Alpha can be calculated using
+        Method of least squares
+    forecast: int
+        Number of periods ahead. Forcast with bootstrapping method
+        s_t+1 = y_origin*a + (1-a)s_t
+
+    Returns
+    -------
+    weighted data: array
+        Data that is filtered using
+        y_t = a * y_t + a * (1-a)^1 * y_t-1 +... + a*(1-a)^n * y_t-n
+
+
+    References
+    ----------
+    Wikipedia
+    Forecasting based on NIST equation for Bootstrapping
+    http://www.itl.nist.gov/div898/handbook/pmc/section4/pmc432.htm#Single%20Exponential%20Smoothing%20with
+    
+    
+    '''
+    #Initialize data
+    y = np.asarray(y)
+
+    ylen = len(y)
+    weights = alpha * ((1 - alpha)**np.arange(0, ylen))
+    wdata = y * weights
+    if forecast >= 0:
+        fdata = np.zeros(forecast+1)
+        fdata[0] = wdata[ylen - 1]
+        for i in range(forecast):
+            f = fdata[i]
+            fdata[i + 1] = alpha * y[ylen - 1] + (1 - alpha) * f
+        fdata = np.delete(fdata, 0)
+        wdata = np.append(wdata, fdata)
+        return wdata
+    else:
+        return wdata
+


### PR DESCRIPTION
Since I somehow accidentally deleted the last file in https://github.com/statsmodels/statsmodels/pull/1274 but still have the code 
I decided to start from scratch and make the code in Pep8 style and focus on each individual Exponential smoothing (single double and triple) separately.
This will address https://github.com/statsmodels/statsmodels/issues/512 and  https://github.com/pydata/pandas/issues/2143

This code works good and can forecast for x amount of periods ahead using a bootstrapping method.

Improvements that are needed: .
*An solver for the alpha value using mean square error something like`sum(y-wdata)/len(y)`

*the Summary part needs RMS, Sum of squares residuals, AIC/AICc/BIC, Log-Likelihood, Swartz Criterion, average mean square error, Hanna-Quinn.

Here is what Eviews uses
http://www.eviews.com/EViews8/ev8ecets_n.html

Here is a set of test data to try

```
############Test######################
y = [47, 36, 12, 4, 84, 26, 37, 40, 72, 22]
print 'Exp=', ExpSmoothing(y, .5)

###forcasting
print 'forcast 10=', ExpSmoothing(y, .5, forecast = 10)
```

There is also working code in the answers to test against (without forcasting) here:
http://stackoverflow.com/questions/12726432/using-python-for-time-series-analysis-and-forecasting
