### PR TITLE
Changed links to examples wiki page

### DIFF
--- a/docs/source/examples/index.rst
+++ b/docs/source/examples/index.rst
@@ -8,7 +8,7 @@ started with ``statsmodels``.
 
 Each of these examples is also made available in
 IPython Notebook format on the `examples wiki page
-<https://github.com/statsmodels/statsmodels/wiki/Examples:-user-contributions>`_.
+<https://github.com/statsmodels/statsmodels/wiki/Examples>`_.
 Of course, you can edit the examples wiki page freely; please add any example,
 tutorial or cool `statsmodels` trick you feel is worth sharing. Thanks for
 helping us make this resource more useful!
@@ -16,7 +16,7 @@ helping us make this resource more useful!
 The script files for these examples and the notebooks are available in the
 top level examples folder in the source distribution.
 
-`Examples wiki page <https://github.com/statsmodels/statsmodels/wiki/Examples:-user-contributions>`_
+`Examples wiki page <https://github.com/statsmodels/statsmodels/wiki/Examples>`_
 
 The Examples
 ------------


### PR DESCRIPTION
When clicking on the current Examples wiki link you go to a "Create New Page" form on GitHub. Instead I expected to see an existing page with a list of links to notebooks.

Don't know if this is deliberate, but it's confusing the way it is now.
