### PR TITLE
ENH: Always use unicode.

### DIFF
--- a/statsmodels/datasets/utils.py
+++ b/statsmodels/datasets/utils.py
@@ -184,9 +184,7 @@ def _get_data(base_url, dataname, cache, extension="csv"):
         else:
             raise err
 
-    #Python 3, always decode as unicode
-    if sys.version[0] == '3':  # pragma: no cover
-        data = data.decode('utf-8', errors='strict')
+    data = data.decode('utf-8', errors='strict')
     return StringIO(data), from_cache
 
 


### PR DESCRIPTION
I don't really know why we were only decoding to unicode in Python 3 only. Just make sure that everything is in unicode. Should fix any remaining issues with docstring display.
