### PR TITLE
REF/ENH RLM and robust scale for almost perfect prediction

### DIFF
--- a/statsmodels/robust/norms.py
+++ b/statsmodels/robust/norms.py
@@ -619,7 +619,7 @@ class Hampel(RobustNorm):
 
             rho(z) = a*(b + c - a)                  for \|z\| > c
         """
-        np.fabs(z)
+        z = np.fabs(z)
         z_isscalar = np.isscalar(z)
         z = np.atleast_1d(z)
         a = self.a; b = self.b; c = self.c
@@ -627,8 +627,8 @@ class Hampel(RobustNorm):
         t34 = ~(t1 | t2 )
         v = np.zeros(z.shape, float)
         v[t1] = z[t1]**2 * 0.5
-        v[t2] = (a * z[t2] - a**2 * 0.5)
-        v[t3] = a * (c - z[t2])**2  / (c - b) * (-0.5)
+        v[t2] = (a * (z[t2] - a) + a**2 * 0.5)
+        v[t3] = a * (c - z[t3])**2  / (c - b) * (-0.5)
         v[t34] += a * (b + c - a) * 0.5
 
         if z_isscalar:
@@ -663,7 +663,7 @@ class Hampel(RobustNorm):
         t1, t2, t3 = self._subset(z)
         s = np.sign(z)
         z = np.fabs(z)
-        v = s * (t1 * z +
+        v =  (t1 * z*s +
                  t2 * a*s +
                  t3 * a*s * (c - z) / (c - b))
         return v
@@ -747,7 +747,8 @@ class TukeyBiweight(RobustNorm):
             rho(z) = 0                              for \|z\| > R
         """
         subset = self._subset(z)
-        return -(1 - (z / self.c)**2)**3 * subset * self.c**2 / 6.
+        factor = self.c**2 / 6.
+        return -(1 - (z / self.c)**2)**3 * subset * factor + factor
 
     def psi(self, z):
         """

--- a/statsmodels/robust/norms.py
+++ b/statsmodels/robust/norms.py
@@ -619,15 +619,22 @@ class Hampel(RobustNorm):
 
             rho(z) = a*(b + c - a)                  for \|z\| > c
         """
-
-        z = np.fabs(z)
+        np.fabs(z)
+        z_isscalar = np.isscalar(z)
+        z = np.atleast_1d(z)
         a = self.a; b = self.b; c = self.c
         t1, t2, t3 = self._subset(z)
-        v = (t1 * z**2 * 0.5 +
-             t2 * (a * z - a**2 * 0.5) +
-             t3 * (a * (c * z - z**2 * 0.5) / (c - b) - 7 * a**2 / 6.) +
-             (1 - t1 + t2 + t3) * a * (b + c - a))
-        return v
+        t34 = ~(t1 | t2 )
+        v = np.zeros(z.shape, float)
+        v[t1] = z[t1]**2 * 0.5
+        v[t2] = (a * z[t2] - a**2 * 0.5)
+        v[t3] = a * (c - z[t2])**2  / (c - b) * (-0.5)
+        v[t34] += a * (b + c - a) * 0.5
+
+        if z_isscalar:
+            return v[0]
+        else:
+            return v
 
     def psi(self, z):
         """

--- a/statsmodels/robust/robust_linear_model.py
+++ b/statsmodels/robust/robust_linear_model.py
@@ -282,6 +282,11 @@ class RLM(base.LikelihoodModel):
         converged = 0
         while not converged:
             self.weights = self.M.weights(wls_results.resid/self.scale)
+            if self.scale == 0:
+                # only for case when scale is exactly zero
+                # there could also be problems if scale is close to zero
+                # assumes we get nans only where resid == 0
+                self.weights[np.isnan(self.weights)] = 1.
             wls_results = lm.WLS(self.endog, self.exog,
                                  weights=self.weights).fit()
             if update_scale is True:

--- a/statsmodels/robust/robust_linear_model.py
+++ b/statsmodels/robust/robust_linear_model.py
@@ -417,7 +417,7 @@ class RLMResults(base.LikelihoodModelResults):
         self.nobs = model.nobs
         self._cache = resettable_cache()
         #for remove_data
-        self.data_in_cache = ['sresid']
+        self.data_in_cache = ['sresid', 'rho']
 
         self.cov_params_default = self.bcov_scaled
         #TODO: "pvals" should come from chisq on bse?

--- a/statsmodels/robust/robust_linear_model.py
+++ b/statsmodels/robust/robust_linear_model.py
@@ -280,6 +280,17 @@ class RLM(base.LikelihoodModel):
         history = self._update_history(wls_results, history, conv)
         iteration = 1
         converged = 0
+
+        if wls_results.scale == 0:
+            # handle case where we have perfect prediction immediately
+            # extra check, once we have scale == 0
+            # this could be relevant if we allow for start_weights`with zeros
+            if (wls_results.resid == 0).all():
+                converged = True
+                if np.isnan(self.scale):
+                    # in case self._estimate_scale returned nan
+                    self.scale = 0
+
         while not converged:
             self.weights = self.M.weights(wls_results.resid/self.scale)
             if self.scale == 0:

--- a/statsmodels/robust/robust_linear_model.py
+++ b/statsmodels/robust/robust_linear_model.py
@@ -315,6 +315,7 @@ class RLM(base.LikelihoodModel):
         results.fit_options = dict(cov=cov.upper(), scale_est=scale_est,
                                    norm=self.M.__class__.__name__, conv=conv)
         #norm is not changed in fit, no old state
+        results.wls_results = wls_results
 
         #doing the next causes exception
         #self.cov = self.scale_est = None #reset for additional fits
@@ -418,6 +419,7 @@ class RLMResults(base.LikelihoodModelResults):
         self._cache = resettable_cache()
         #for remove_data
         self.data_in_cache = ['sresid', 'rho']
+        self._data_attr = ['wls_results']
 
         self.cov_params_default = self.bcov_scaled
         #TODO: "pvals" should come from chisq on bse?

--- a/statsmodels/robust/robust_linear_model.py
+++ b/statsmodels/robust/robust_linear_model.py
@@ -536,6 +536,25 @@ class RLMResults(base.LikelihoodModelResults):
         bicr = 2 * self.rho_sum + k_vars * np.log(nobs)
         return bicr
 
+    # TODO: this should go into LikelihoodModel but needs checking across models
+    def wald_null(self):
+        # wald test that all slope coefficients are zero
+        # TODO Note: this will not work when params are 2d
+        #      not clear about tsa models
+        # next part copied from RegressionResults fvalue
+        k_params = self.params.size
+        mat = np.eye(k_params)
+        const_idx = self.model.data.const_idx
+        # TODO: What if model includes implicit constant, e.g. all dummies but no constant regressor?
+        # TODO: Restats as LM test by projecting orthogonalizing to constant?
+        if self.model.data.k_constant == 1:
+            # assume const_idx exists
+            idx = range(k_params)
+            idx.pop(const_idx)
+            mat = mat[idx]  # remove constant
+        wt = self.wald_test(mat)
+        return wt
+
     def remove_data(self):
         super(self.__class__, self).remove_data()
         #self.model.history['sresid'] = None

--- a/statsmodels/robust/robust_linear_model.py
+++ b/statsmodels/robust/robust_linear_model.py
@@ -287,6 +287,8 @@ class RLM(base.LikelihoodModel):
             # this could be relevant if we allow for start_weights`with zeros
             if (wls_results.resid == 0).all():
                 converged = True
+                # TODO: Problem, we skip the while loop, set attributes?
+                self.weights = wls_results.model.weights # all ones
                 if np.isnan(self.scale):
                     # in case self._estimate_scale returned nan
                     self.scale = 0

--- a/statsmodels/robust/scale.py
+++ b/statsmodels/robust/scale.py
@@ -126,7 +126,7 @@ class Huber(object):
             est_mu = False
 
         if initscale is None:
-            scale = mad(a - mu, axis=axis, center=0)
+            scale = mad(a - np.expand_dims(mu, axis), axis=axis, center=0)
         else:
             scale = initscale
         scale = tools.unsqueeze(scale, axis, a.shape)

--- a/statsmodels/robust/scale.py
+++ b/statsmodels/robust/scale.py
@@ -224,6 +224,13 @@ class HuberScale(object):
                     Gaussian.cdf(self.d)-.5 - self.d/(np.sqrt(2*np.pi))*\
                     np.exp(-.5*self.d**2))
         s = mad(resid, center=0)
+        if s == 0:
+            # lower bound on s for winsorized mean
+            n_outliers = (resid != 0).mean() # fraction of outliers
+            # standard deviation for winsorized outliers
+            # without bias correction, but divided by two to reduce
+            s = self.d * np.sqrt(n_outliers) / 2
+
         subset = lambda x: np.less(np.fabs(resid/x),self.d)
         chi = lambda s: subset(s)*(resid/s)**2/2+(1-subset(s))*(self.d**2/2)
         scalehist = [np.inf,s]

--- a/statsmodels/robust/scale.py
+++ b/statsmodels/robust/scale.py
@@ -223,7 +223,7 @@ class HuberScale(object):
         h = (df_resid)/nobs*(self.d**2 + (1-self.d**2)*\
                     Gaussian.cdf(self.d)-.5 - self.d/(np.sqrt(2*np.pi))*\
                     np.exp(-.5*self.d**2))
-        s = mad(resid)
+        s = mad(resid, center=0)
         subset = lambda x: np.less(np.fabs(resid/x),self.d)
         chi = lambda s: subset(s)*(resid/s)**2/2+(1-subset(s))*(self.d**2/2)
         scalehist = [np.inf,s]

--- a/statsmodels/robust/scale.py
+++ b/statsmodels/robust/scale.py
@@ -122,7 +122,7 @@ class Huber(object):
             est_mu = True
         else:
             n = a.shape[0]
-            mu = mu
+            mu = np.asarray(mu)
             est_mu = False
 
         if initscale is None:
@@ -220,7 +220,7 @@ class HuberScale(object):
         self.maxiter = maxiter
 
     def __call__(self, df_resid, nobs, resid):
-        h = (df_resid)/nobs*(self.d**2 + (1-self.d**2)*\
+        h = df_resid * 1. /nobs*(self.d**2 + (1-self.d**2)*\
                     Gaussian.cdf(self.d)-.5 - self.d/(np.sqrt(2*np.pi))*\
                     np.exp(-.5*self.d**2))
         s = mad(resid, center=0)

--- a/statsmodels/robust/scale.py
+++ b/statsmodels/robust/scale.py
@@ -126,7 +126,7 @@ class Huber(object):
             est_mu = False
 
         if initscale is None:
-            scale = mad(a, axis=axis)
+            scale = mad(a - mu, axis=axis, center=0)
         else:
             scale = initscale
         scale = tools.unsqueeze(scale, axis, a.shape)

--- a/statsmodels/robust/tests/check_rlm_perfect_prediction.py
+++ b/statsmodels/robust/tests/check_rlm_perfect_prediction.py
@@ -1,0 +1,92 @@
+# -*- coding: utf-8 -*-
+"""Script to check the behavior of all RLM version for perfect prediction
+or almost perfect prediction
+
+check is whether `fail` is empty
+
+
+Created on Mon Jan 27 08:47:53 2014
+Author: Josef Perktold
+"""
+
+import numpy as np
+
+from statsmodels.robust.robust_linear_model import RLM
+import statsmodels.robust.scale as rscale
+import statsmodels.robust.norms as rnorms
+
+norm_names = ['AndrewWave', 'Hampel', 'HuberT', 'LeastSquares', 'RamsayE',
+              'TrimmedMean', 'TukeyBiweight']
+# 'RobustNorm' is super class
+norms = [getattr(rnorms, ni) for ni in norm_names]
+
+scale_names = ['mad', 'Gaussian', 'Huber', 'HuberScale']
+# note: 'mad' is a string keyword in RLM.fit, not a scale instance
+scales = ['mad', rscale.HuberScale(), rscale.HuberScale(d=1.5)]
+# scales not usable rscale.Gaussian() incorrect interface,
+#                   rscale.Huber estimates mean by default
+scales2 = [rscale.mad, rscale.Huber(), rscale.HuberScale(), rscale.HuberScale(d=1.5)]
+
+y1 = np.array([27.01, 27.01, 28.5, 27.01, 27.04])
+y2 = np.array([ 0,  0,  0,  0,  0,  0, -1,  1])
+y3 = 4 + np.array([ 0,  0,  0,  0,  0,  0, -1.5,  1])
+y4 = 4. + np.zeros(10)
+
+endogs = [y1 - 27 + 4, 4 + y2, y3, y4]#[:-1]
+
+
+y = y1
+rlm = RLM(y, np.ones(len(y)), M=rnorms.TukeyBiweight())
+res = rlm.fit(scale_est=rscale.HuberScale())
+print res.params, res.bse, res.scale
+
+success = []
+fail = []
+for norm in norms:
+    for scale in scales:
+        for y in endogs:
+            try:
+                rlm = RLM(y, np.ones(len(y)), M=norm())
+                res = rlm.fit(scale_est=scale)
+                #print res.params, res.bse, res.scale
+                success.append([norm, scale, res.params, res.bse, res.scale])
+            except Exception as e:
+                fail.append([y, norm, scale, res.params, res.bse, res.scale])
+                print '   using  ', norm, scale
+                print e
+
+
+rlm = RLM(y, np.ones(len(y)), M=rnorms.HuberT())
+res = rlm.fit(scale_est=rscale.HuberScale())
+
+print 'params'
+print(np.array([r[2] for r in success]).reshape(-1, len(endogs)))
+print '\nscale'
+print(np.array([r[4] for r in success]).reshape(-1, len(endogs)))
+print '\nbse'
+print(np.array([r[3] for r in success]).reshape(-1, len(endogs)))
+
+
+success = []
+fail = []
+for scale in scales2:
+    for y in (endogs + [np.arange(5)] + [yi - yi.mean() for yi in endogs]):
+        try:
+            if isinstance(scale, rscale.HuberScale):
+                res = scale(len(y) - 1., len(y), y) # BUG requires float
+            elif isinstance(scale, rscale.Huber):
+                res = scale(y, mu=np.array(0))[1]
+            else:
+                res = scale(y)
+            #print res.params, res.bse, res.scale
+            success.append([y, scale, res])
+        except Exception as e:
+            fail.append([y, scale])
+            print '   using  ', scale, y
+            print e
+
+print fail
+print '\nscale'
+scale_estimates = np.array([r[2] for r in success]).reshape(-1, len(endogs))
+print(scale_estimates)
+print '\n numbe of nan scales', np.isnan(scale_estimates).sum()

--- a/statsmodels/robust/tests/check_rlm_perfect_prediction.py
+++ b/statsmodels/robust/tests/check_rlm_perfect_prediction.py
@@ -73,9 +73,9 @@ for scale in scales2:
     for y in (endogs + [np.arange(5)] + [yi - yi.mean() for yi in endogs]):
         try:
             if isinstance(scale, rscale.HuberScale):
-                res = scale(len(y) - 1., len(y), y) # BUG requires float
+                res = scale(len(y) - 1, len(y), y)
             elif isinstance(scale, rscale.Huber):
-                res = scale(y, mu=np.array(0))[1]
+                res = scale(y, mu=0)[1]
             else:
                 res = scale(y)
             #print res.params, res.bse, res.scale

--- a/statsmodels/robust/tests/test_rlm.py
+++ b/statsmodels/robust/tests/test_rlm.py
@@ -3,7 +3,7 @@ Test functions for sm.rlm
 """
 
 import numpy as np
-from numpy.testing import assert_almost_equal, assert_allclose
+from numpy.testing import assert_almost_equal, assert_allclose, assert_equal
 from scipy import stats
 import statsmodels.api as sm
 from statsmodels.robust.robust_linear_model import RLM
@@ -188,6 +188,13 @@ class TestRlmBisquare(TestRlm):
         wt = self.res1.wald_test(np.eye(4)[2])
         assert_almost_equal(np.squeeze(wt.statistic), statistic, decimal)
         assert_almost_equal(wt.pvalue, pvalue, decimal)
+
+        # consistency test, check wald_null returns same as wald_test
+        wt1 = self.res1.wald_test(np.eye(4)[:-1])
+        wt0 = self.res1.wald_null()
+        assert_almost_equal(wt0.statistic, wt1.statistic, decimal)
+        assert_almost_equal(wt0.pvalue, wt1.pvalue, decimal)
+        assert_equal(wt0.distribution, 'chi2')
 
 
 class TestRlmAndrews(TestRlm):

--- a/statsmodels/robust/tests/test_rlm.py
+++ b/statsmodels/robust/tests/test_rlm.py
@@ -196,6 +196,21 @@ class TestRlmBisquare(TestRlm):
         assert_almost_equal(wt0.pvalue, wt1.pvalue, decimal)
         assert_equal(wt0.distribution, 'chi2')
 
+        # LR-type test, one example against SAS
+        lambda_ = 0.7977
+        S2 = 0.9378
+        chi2_statistic = 1.18
+        chi2_pvalue = 0.2782
+
+        # drop the last non-constant variable
+        keep = range(self.data.exog.shape[1])
+        del keep[2]
+        res_re = RLM(self.data.endog, self.data.exog[:, keep],
+                     M=sm.robust.norms.TukeyBiweight()).fit()
+        lrtt1 = self.res1.compare_lrtype(res_re)
+        assert_almost_equal(lrtt1.statistic, chi2_statistic, 2)
+        assert_almost_equal(lrtt1.pvalue, chi2_pvalue, decimal)
+
 
 class TestRlmAndrews(TestRlm):
     def __init__(self):

--- a/statsmodels/robust/tests/test_rlm.py
+++ b/statsmodels/robust/tests/test_rlm.py
@@ -183,6 +183,13 @@ class TestRlmBisquare(TestRlm):
         assert_almost_equal(self.res1.bic, bic, decimal)
         assert_almost_equal(self.res1.deviance, deviance, decimal)
 
+        statistic = 0.8092,
+        pvalue=0.3683
+        wt = self.res1.wald_test(np.eye(4)[2])
+        assert_almost_equal(np.squeeze(wt.statistic), statistic, decimal)
+        assert_almost_equal(wt.pvalue, pvalue, decimal)
+
+
 class TestRlmAndrews(TestRlm):
     def __init__(self):
         results = RLM(self.data.endog, self.data.exog,

--- a/statsmodels/robust/tests/test_rlm.py
+++ b/statsmodels/robust/tests/test_rlm.py
@@ -171,6 +171,17 @@ class TestRlmBisquare(TestRlm):
         from results.results_rlm import BiSquare
         self.res2 = BiSquare()
 
+    def test_other(self):
+        # reference numbers are from SAS manual
+        rsquared = 0.6659
+        aic = 29.5231
+        bic = 36.3361
+        deviance = 125.7905
+        decimal = 4
+        assert_almost_equal(self.res1.rsquared, rsquared, decimal)
+        assert_almost_equal(self.res1.aic, aic, decimal)
+        assert_almost_equal(self.res1.bic, bic, decimal)
+        assert_almost_equal(self.res1.deviance, deviance, decimal)
 
 class TestRlmAndrews(TestRlm):
     def __init__(self):

--- a/statsmodels/robust/tests/test_rlm_perfect_prediction.py
+++ b/statsmodels/robust/tests/test_rlm_perfect_prediction.py
@@ -80,10 +80,12 @@ def test_scale_perfect():
     # robust scale estimators for perfect and almost perfect prediction case
     # test if no exceptions are raised and params is close to center/median
 
+    endogs2 = (endogs + [np.arange(5)] + [yi - yi.mean() for yi in endogs])
+    endogs2 = (endogs + [2 + np.arange(5)] + [yi - np.median(yi) for yi in endogs])
     success = []
     fail = []
     for scale in scales2:
-        for y in (endogs + [np.arange(5)] + [yi - yi.mean() for yi in endogs]):
+        for y in endogs2:
             try:
                 if isinstance(scale, rscale.HuberScale):
                     res = scale(len(y) - 1, len(y), y)
@@ -100,6 +102,7 @@ def test_scale_perfect():
                     print e
 
     scale_estimates = np.array([r[2] for r in success]).reshape(-1, len(endogs))
+
     # regression test, currently two cases with nan scale in HuberScale
     assert_equal(np.isnan(scale_estimates).sum(), 2)
     assert_equal(len(fail), 0)
@@ -117,8 +120,10 @@ def test_scale_perfect():
            [ 0.,  0.   , -0., -0.,  4.924,  2.77 , np.nan,  4.779, 0.157],
            [ 0.,  0.   , -0., -0.,  4.359,  0.671,  5.518,  3.104, np.nan]]).T
 
-    assert_allclose(scale_estimates, scale_regression, atol=0.0005)
+    #assert_allclose(scale_estimates, scale_regression, atol=0.0005)
+    if DEBUG:
+        return scale_estimates
 
 if __name__ == '__main__':
     test_rlm_perfect()
-    test_scale_perfect()
+    sc = test_scale_perfect()

--- a/statsmodels/robust/tests/test_rlm_perfect_prediction.py
+++ b/statsmodels/robust/tests/test_rlm_perfect_prediction.py
@@ -1,0 +1,124 @@
+# -*- coding: utf-8 -*-
+"""Script to check the behavior of all RLM version for perfect prediction
+or almost perfect prediction
+
+currently
+- RLM: no exceptions and no nan params
+- RLM: some nans in bse if scale == 0
+- scale estimates: no exceptions, two nan if scale == 0
+
+Created on Mon Jan 27 08:47:53 2014
+Author: Josef Perktold
+"""
+
+import numpy as np
+from numpy.testing import assert_allclose, assert_equal
+
+from statsmodels.robust.robust_linear_model import RLM
+import statsmodels.robust.scale as rscale
+import statsmodels.robust.norms as rnorms
+
+DEBUG = False
+
+norm_names = ['AndrewWave', 'Hampel', 'HuberT', 'LeastSquares', 'RamsayE',
+              'TrimmedMean', 'TukeyBiweight']
+# 'RobustNorm' is super class
+norms = [getattr(rnorms, ni) for ni in norm_names]
+
+scale_names = ['mad', 'Gaussian', 'Huber', 'HuberScale']
+# note: 'mad' is a string keyword in RLM.fit, not a scale instance
+scales = ['mad', rscale.HuberScale(), rscale.HuberScale(d=1.5)]
+# scales not usable rscale.Gaussian() incorrect interface,
+#                   rscale.Huber estimates mean by default
+scales2 = [rscale.mad, rscale.Huber(), rscale.HuberScale(), rscale.HuberScale(d=1.5)]
+
+y1 = np.array([27.01, 27.01, 28.5, 27.01, 27.04])
+y2 = np.array([ 0,  0,  0,  0,  0,  0, -1,  1])
+y3 = 4 + np.array([ 0,  0,  0,  0,  0,  0, -1.5,  1])
+y4 = 4. + np.zeros(10)
+
+endogs = [y1 - 27 + 4, 4 + y2, y3, y4]
+
+def test_rlm_perfect():
+    # RLM for perfect and almost perfect prediction case
+    # test if no exceptions are raised and params is close to center/median
+    success = []
+    fail = []
+    for norm in norms:
+        for scale in scales:
+            for y in endogs:
+                try:
+                    rlm = RLM(y, np.ones(len(y)), M=norm())
+                    res = rlm.fit(scale_est=scale)
+                    success.append([norm, scale, res.params, res.bse, res.scale])
+                except Exception as e:
+                    fail.append([y, norm, scale, res.params, res.bse, res.scale])
+                    if DEBUG:
+                        print '   using  ', norm, scale
+                        print e
+
+    params_all = np.array([r[2] for r in success]).reshape(-1, len(endogs))
+    scale_all = np.array([r[4] for r in success]).reshape(-1, len(endogs))
+    bse_all = np.array([r[3] for r in success]).reshape(-1, len(endogs))
+
+    # asymmetric "outliers" can still affect the mean estimate
+    assert_allclose(params_all, 4, atol=0.32)
+    assert_equal(len(fail), 0)
+    assert_equal(np.isnan(scale_all).sum(), 0)
+    # TODO: check bse has 3 nans and the last column (y4) is all nan
+
+    if DEBUG:
+        print 'params'
+        print(params_all)
+        print '\nscale'
+        print(scale_all)
+        print '\nbse'
+        print(bse_all)
+
+
+def test_scale_perfect():
+    # robust scale estimators for perfect and almost perfect prediction case
+    # test if no exceptions are raised and params is close to center/median
+
+    success = []
+    fail = []
+    for scale in scales2:
+        for y in (endogs + [np.arange(5)] + [yi - yi.mean() for yi in endogs]):
+            try:
+                if isinstance(scale, rscale.HuberScale):
+                    res = scale(len(y) - 1, len(y), y)
+                elif isinstance(scale, rscale.Huber):
+                    res = scale(y, mu=0)[1]
+                else:
+                    res = scale(y)
+                #print res.params, res.bse, res.scale
+                success.append([y, scale, res])
+            except Exception as e:
+                fail.append([y, scale])
+                if DEBUG:
+                    print '   using  ', scale, y
+                    print e
+
+    scale_estimates = np.array([r[2] for r in success]).reshape(-1, len(endogs))
+    # regression test, currently two cases with nan scale in HuberScale
+    assert_equal(np.isnan(scale_estimates).sum(), 2)
+    assert_equal(len(fail), 0)
+
+    if DEBUG:
+        print fail
+        print '\nscale'
+        print(scale_estimates)
+        print '\n number of nan scales', np.isnan(scale_estimates).sum()
+
+    # values for regression test, printed so rows are datasets
+    scale_regression = np.array([
+           [ 0.,  1.483,  0., -0., -0.   ,  4.312,  0.541,  4.884, 0.639],
+           [ 0.,  0.   , -0., -0., -0.   ,  4.264,  0.686,  4.832, 0.023],
+           [ 0.,  0.   , -0., -0.,  4.924,  2.77 , np.nan,  4.779, 0.157],
+           [ 0.,  0.   , -0., -0.,  4.359,  0.671,  5.518,  3.104, np.nan]]).T
+
+    assert_allclose(scale_estimates, scale_regression, atol=0.0005)
+
+if __name__ == '__main__':
+    test_rlm_perfect()
+    test_scale_perfect()

--- a/statsmodels/stats/contrast.py
+++ b/statsmodels/stats/contrast.py
@@ -106,8 +106,9 @@ class ContrastResults(object):
                    (`self.fvalue`, self.pvalue, self.df_denom, self.df_num)
         else:
             # generic
-            return '<Wald test: statistic=%s, p-value=%s>' % \
-                   (self.statistic, self.pvalue)
+            name = getattr(self, 'name', 'Wald test')
+            return '<%s: statistic=%s, p-value=%s>' % \
+                   (name, self.statistic, self.pvalue)
 
 
     def summary_frame(self, xname=None, alpha=0.05):


### PR DESCRIPTION
see #55

This makes the code more robust for the cases where we have almost perfect prediction, or where mad of the sample or residual is zero.

There are also small fixes to missing asarray and integer division in robust/scale

The code adds some extra calculation `if scale == 0:`

Explicit, verifying test for `HuberScale` are still missing. I get the same results with an independent new implementation.
New unit tests include a "sanity" check for all norm, scale combinations: 
no exceptions, params is reasonably (no nan, close to median) estimated in RLM in all examples
a few nans in bse, and in standalone scale estimates for some corner cases

**update**

This now includes also some other fixes and enhancements:
- BUG robust.norms.Hampel.rho was incorrect
- BUG robust.norms.Hampel.psi had a `sign` error 
  (this should have caused problems in existing code, for some values in the negative range)
- REF robust.norms.TukeyBiweight shift function so that rho(0) == 0
- ENH: add rsquared, aic, bic, deviance to RLMResults (based on SAS manual)
- ENH: compare_lrtype  LR/Ftest like test for nested models

for scale
- BUG: robust.scale.Huber use mu if given

**TODO**
- regression test for robust scale with almost perfect prediction is outdated, 
  needs another check and new regression numbers.
- add comment to compare_lrtype 
  Maronna, Martin and Yohai 2006 p.106 use empirical cdf for chi2_factor 
  problem
  MMY don't divide by df
  (only test case against SAS has df=1, so we cannot verify)
  Hampel et all 2005 (1986?) p.346 divide by df and by nobs
