### PR TITLE
Memoize calculation of column widths in SimpleTable

### DIFF
--- a/statsmodels/iolib/table.py
+++ b/statsmodels/iolib/table.py
@@ -338,7 +338,7 @@ class SimpleTable(list):
             if isinstance(v, list):
                 call_args.append((k, tuple(v)))
             elif isinstance(v, dict):
-                call_args.append((k, sorted(v.items())))
+                call_args.append((k, tuple(sorted(v.items()))))
             else:
                 call_args.append((k, v))
         key = tuple(call_args)


### PR DESCRIPTION
Fix for #1385. Assumes that the formatting information values are either a hashable type of a list of hashable types.
