### PR TITLE
REF temporary, test failures, issue warning instead causing error

### DIFF
--- a/statsmodels/graphics/gofplots.py
+++ b/statsmodels/graphics/gofplots.py
@@ -379,6 +379,11 @@ class ProbPlot(object):
             If `ax` is None, the created figure.  Otherwise the figure to which
             `ax` is connected.
         """
+        oth = plotkwargs.pop('other', None)
+        if oth is not None:
+            import warnings
+            warnings.warn('other is not implemented in probplot')
+
         if exceed:
             fig, ax = _do_plot(self.theoretical_quantiles[::-1],
                                self.sorted_data,


### PR DESCRIPTION
 see #1407

removes `other` from plotkwargs in probplot to silence the test errors

temporary fix
