### PR TITLE
REF: Let subclasses keep kwds attached to data.

### DIFF
--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -59,19 +59,20 @@ class Model(object):
         self.k_constant = self.data.k_constant
         self.exog = self.data.exog
         self.endog = self.data.endog
-        # kwargs arrays could have changed, easier to just attach here
-        for key in kwargs:
-            # pop so we don't start keeping all these twice or references
-            try:
-                setattr(self, key, self.data.__dict__.pop(key))
-            except KeyError: # panel already pops keys in data handling
-                pass
         self._data_attr = []
         self._data_attr.extend(['exog', 'endog', 'data.exog', 'data.endog',
                                 'data.orig_endog', 'data.orig_exog'])
 
     def _handle_data(self, endog, exog, missing, hasconst, **kwargs):
-        return handle_data(endog, exog, missing, hasconst, **kwargs)
+        data = handle_data(endog, exog, missing, hasconst, **kwargs)
+        # kwargs arrays could have changed, easier to just attach here
+        for key in kwargs:
+            # pop so we don't start keeping all these twice or references
+            try:
+                setattr(self, key, data.__dict__.pop(key))
+            except KeyError:  # panel already pops keys in data handling
+                pass
+        return data
 
     @classmethod
     def from_formula(cls, formula, data, subset=None, *args, **kwargs):


### PR DESCRIPTION
Allow subclasses to choose what the data attribute keeps attached and what it doesn't.
