### PR TITLE
ENH: Add grouping utilities code

### DIFF
--- a/statsmodels/tools/grouputils.py
+++ b/statsmodels/tools/grouputils.py
@@ -329,7 +329,10 @@ class Grouping(object):
         '''
         if isinstance(index, (Index, MultiIndex)):
             if names is not None:
-                index.set_names(names, inplace=True)
+                if hasattr(index, 'set_names'): # newer pandas
+                    index.set_names(names, inplace=True)
+                else:
+                    index.names = names
             self.index = index
         else:  # array-like
             if _is_hierarchical(index):
@@ -338,7 +341,10 @@ class Grouping(object):
                 self.index = Index(index, name=names)
             if names is None:
                 names = _make_generic_names(self.index)
-                self.index.set_names(names, inplace=True)
+                if hasattr(self.index, 'set_names'):
+                    self.index.set_names(names, inplace=True)
+                else:
+                    self.index.names = names
 
         self.nobs = len(self.index)
         self.slices = None

--- a/statsmodels/tools/tests/test_grouputils.py
+++ b/statsmodels/tools/tests/test_grouputils.py
@@ -26,7 +26,8 @@ class CheckGrouping(object):
         np.testing.assert_(not index.equals(self.grouping.index))
 
         # make sure it copied
-        np.testing.assert_(not sorted_data.equals(self.data))
+        if hasattr(sorted_data, 'equals'): # newer pandas
+            np.testing.assert_(not sorted_data.equals(self.data))
 
         # 2d arrays
         sorted_data, index = self.grouping.sort(self.data.values)
@@ -41,7 +42,8 @@ class CheckGrouping(object):
         expected_sorted_data = series.sort_index()
         ptesting.assert_series_equal(sorted_data, expected_sorted_data)
         np.testing.assert_(isinstance(sorted_data, pd.Series))
-        np.testing.assert_(not sorted_data.equals(series))
+        if hasattr(sorted_data, 'equals'):
+            np.testing.assert_(not sorted_data.equals(series))
 
         # 1d array
         array = series.values


### PR DESCRIPTION
Pulled out the grouputils stuff from #1133. This stuff is generally useful, if not exactly what we'll need in each case. I found myself re-implementing some of this functionality in the survival stuff. Better to have it in master to iterate on.

There's a missing function `group_demean` in there. I assume these were written by @josef-pkt given that they're pure numpy and notes to self docs ;). Do you have this lying around somewhere? // cc @vincentarelbundock
