### PR TITLE
WIP/BUG: fixed ProbPlot class and tests to work with general distributions

### DIFF
--- a/statsmodels/graphics/_probscale.py
+++ b/statsmodels/graphics/_probscale.py
@@ -86,7 +86,6 @@ def _sig_figs(val, nsf, expthresh=5):
         else:
             out = str(round(val, nsf))
 
-
     return out
 
 

--- a/statsmodels/graphics/_probscale.py
+++ b/statsmodels/graphics/_probscale.py
@@ -1,0 +1,178 @@
+import numpy as np
+import matplotlib
+from matplotlib.transforms import Transform
+from matplotlib.scale import ScaleBase
+from matplotlib.ticker import (
+    FixedLocator,
+    NullLocator,
+    Formatter,
+    NullFormatter,
+    FuncFormatter
+)
+import matplotlib.pyplot as plt
+from scipy import stats
+
+
+def _get_probs(nobs):
+    '''Returns the x-axis labels for a probability plot based
+    on the number of observations (`nobs`)
+    '''
+    order = int(np.floor(np.log10(nobs)))
+    base_probs = np.array([10., 20., 30., 40., 50., 60., 70., 80., 90.])
+
+    axis_probs = base_probs.copy()
+    for n in range(order):
+        if n <= 2:
+            lower_fringe = np.array([1., 2., 5.])
+            upper_fringe = np.array([5., 8., 9.])
+        else:
+            lower_fringe = np.array([1.])
+            upper_fringe = np.array([9.])
+
+        new_lower = lower_fringe/10.**(n)
+        new_upper = upper_fringe/10.**(n) + axis_probs.max()
+        axis_probs = np.hstack([new_lower, axis_probs, new_upper])
+
+    return axis_probs
+
+
+def _sig_figs(val, nsf, expthresh=5):
+    '''Formats a number into a string with the correct number of sig figs.
+
+    Parameters
+    -------s---
+    val : numeric
+        the number you want to round
+    nsf : int
+        the number of sig figs it should have
+
+    Example
+    -------
+    >>> print(_sig_figs(1247.15, 3))
+    1250
+    >>> print(_sig_figs(1247.15, 7))
+    1247.150
+
+    '''
+    # check on the number provided
+    if not np.isfinite(val):
+        raise ValueError("`val` must be a finite number")
+
+    else:
+
+        # check on the _sig_figs
+        if nsf < 1:
+            raise ValueError("number of sig figs must be greater than zero!")
+
+        # logic to do all of the rounding
+        elif val != 0.0:
+            order = np.floor(np.log10(np.abs(val)))
+
+            if -1.0 * expthresh <= order <= expthresh:
+                decimal_places = int(nsf - 1 - order)
+
+                if decimal_places <= 0:
+                    out = '{0:,.0f}'.format(round(val, decimal_places))
+
+                else:
+                    fmt = '{0:,.%df}' % decimal_places
+                    out = fmt.format(val)
+
+            else:
+                decimal_places = nsf - 1
+                fmt = '{0:.%de}' % decimal_places
+                out = fmt.format(val)
+
+        else:
+            out = str(round(val, nsf))
+
+
+    return out
+
+
+class ProbFormatter(Formatter):
+    def __call__(self, x, pos=None):
+        if x < 10:
+            out = _sig_figs(x, 1)
+        elif x <= 99:
+            out =  _sig_figs(x, 2)
+        else:
+            order = np.ceil(np.round(np.abs(np.log10(100 - x)), 6))
+            out = _sig_figs(x, order + 2)
+
+        return '{}'.format(out)
+
+
+class ProbTransform(Transform):
+    input_dims = 1
+    output_dims = 1
+    is_separable = True
+    has_inverse = True
+
+    def __init__(self, dist):
+        Transform.__init__(self)
+        self.dist = dist
+
+    def transform_non_affine(self, a):
+        return self.dist.ppf(a / 100.)
+
+    def inverted(self):
+        return InvertedProbTransform(self.dist)
+
+
+class InvertedProbTransform(Transform):
+    input_dims = 1
+    output_dims = 1
+    is_separable = True
+    has_inverse = True
+
+    def __init__(self, dist):
+        self.dist = dist
+        Transform.__init__(self)
+
+    def transform_non_affine(self, a):
+        return self.dist.cdf(a) * 100.
+
+    def inverted(self):
+        return ProbTransform(self.dist)
+
+
+class ProbScale(ScaleBase):
+    """
+    A probability scale.  Care is taken so non-positive
+    values are not plotted.
+
+    For computational efficiency (to push as much as possible to Numpy
+    C code in the common cases), this scale provides different
+    transforms depending on the base of the logarithm:
+
+    """
+    name = 'prob'
+
+    def __init__(self, axis, **kwargs):
+        self.dist = kwargs.pop('dist', stats.norm)
+        self._transform = ProbTransform(self.dist)
+
+    def set_default_locators_and_formatters(self, axis):
+        """
+        Set the locators and formatters to specialized versions for
+        log scaling.
+        """
+        axis.set_major_locator(FixedLocator(_get_probs(1e10)))
+        axis.set_major_formatter(FuncFormatter(ProbFormatter()))
+        axis.set_minor_locator(NullLocator())
+        axis.set_minor_formatter(NullFormatter())
+
+    def get_transform(self):
+        """
+        Return a :class:`~matplotlib.transforms.Transform` instance
+        appropriate for the given logarithm base.
+        """
+        return self._transform
+
+    def limit_range_for_scale(self, vmin, vmax, minpos):
+        """
+        Limit the domain to positive values.
+        """
+        return (vmin <= 0.0 and minpos or vmin,
+                vmax <= 0.0 and minpos or vmax)

--- a/statsmodels/graphics/gofplots.py
+++ b/statsmodels/graphics/gofplots.py
@@ -130,7 +130,7 @@ class ProbPlot(object):
         self._distargs = distargs
 
         self._fit = fit
-        if isinstance(dist, basestring):
+        if isinstance(dist, string_types):
             self._userdist = getattr(stats, dist)
         else:
             self._userdist = dist

--- a/statsmodels/graphics/gofplots.py
+++ b/statsmodels/graphics/gofplots.py
@@ -230,7 +230,6 @@ class ProbPlot(object):
         line : str {'45', 's', 'r', q'} or None, optional
             Options for the reference line to which the data is compared:
 
-<<<<<<< HEAD
             - '45' - 45-degree line
             - 's' - standardized line, the expected order statistics are scaled
               by the standard deviation of the given sample and have the mean
@@ -239,17 +238,6 @@ class ProbPlot(object):
             - 'q' - A line is fit through the quartiles.
             - None - by default no reference line is added to the plot.
 
-=======
-              - '45' - 45-degree line
-              - 's' - standardized line, the expected order statistics are scaled
-                by the standard deviation of the given sample and have the mean
-                added to them
-              - 'r' - A regression line is fit
-              - 'q' - A line is fit through the quartiles.
-              - None - by default no reference line is added to the plot.
-              - If True a reference line is drawn on the graph. The default is to
-                fit a line via OLS regression.
->>>>>>> BUG: fixed ProbPlot class and tests to work better with general distributions
         other : `ProbPlot` instance, array-like, or None, optional
             If provided, the sample quantiles of this `ProbPlot` instance are
             plotted against the sample quantiles of the `other` `ProbPlot`
@@ -267,6 +255,7 @@ class ProbPlot(object):
         fig : Matplotlib figure instance
             If `ax` is None, the created figure. Otherwise the figure to which
             `ax` is connected.
+
         """
         if other is not None:
             check_other = isinstance(other, ProbPlot)
@@ -315,7 +304,6 @@ class ProbPlot(object):
         line : str {'45', 's', 'r', q'} or None, optional
             Options for the reference line to which the data is compared:
 
-<<<<<<< HEAD
             - '45' - 45-degree line
             - 's' - standardized line, the expected order statistics are scaled
               by the standard deviation of the given sample and have the mean
@@ -324,17 +312,6 @@ class ProbPlot(object):
             - 'q' - A line is fit through the quartiles.
             - None - by default no reference line is added to the plot.
 
-=======
-              - '45' - 45-degree line
-              - 's' - standardized line, the expected order statistics are scaled
-                by the standard deviation of the given sample and have the mean
-                added to them
-              - 'r' - A regression line is fit
-              - 'q' - A line is fit through the quartiles.
-              - None - by default no reference line is added to the plot.
-              - If True a reference line is drawn on the graph. The default is to
-                fit a line via OLS regression.
->>>>>>> BUG: fixed ProbPlot class and tests to work better with general distributions
         other : `ProbPlot` instance, array-like, or None, optional
             If provided, the sample quantiles of this `ProbPlot` instance are
             plotted against the sample quantiles of the `other` `ProbPlot`
@@ -352,6 +329,7 @@ class ProbPlot(object):
         fig : Matplotlib figure instance
             If `ax` is None, the created figure. Otherwise the figure to which
             `ax` is connected.
+
         """
         if other is not None:
             check_other = isinstance(other, ProbPlot)
@@ -400,7 +378,6 @@ class ProbPlot(object):
         line : str {'45', 's', 'r', q'} or None, optional
             Options for the reference line to which the data is compared:
 
-<<<<<<< HEAD
             - '45' - 45-degree line
             - 's' - standardized line, the expected order statistics are scaled
               by the standard deviation of the given sample and have the mean
@@ -409,17 +386,6 @@ class ProbPlot(object):
             - 'q' - A line is fit through the quartiles.
             - None - by default no reference line is added to the plot.
 
-=======
-              - '45' - 45-degree line
-              - 's' - standardized line, the expected order statistics are scaled
-                by the standard deviation of the given sample and have the mean
-                added to them
-              - 'r' - A regression line is fit
-              - 'q' - A line is fit through the quartiles.
-              - None - by default no reference line is added to the plot.
-              - If True a reference line is drawn on the graph. The default is to
-                fit a line via OLS regression.
->>>>>>> BUG: fixed ProbPlot class and tests to work better with general distributions
         exceed : boolean, optional
 
              - If False (default) the raw sample quantiles are plotted against
@@ -439,6 +405,7 @@ class ProbPlot(object):
         fig : Matplotlib figure instance
             If `ax` is None, the created figure. Otherwise the figure to which
             `ax` is connected.
+
         """
         scaled_quantiles = self.dist.dist.ppf(self.theoretical_percentiles, *self.distargs)
         if exceed:
@@ -590,7 +557,6 @@ def qqplot_2samples(data1, data2, xlabel=None, ylabel=None, line=None,
     line : str {'45', 's', 'r', q'} or None
         Options for the reference line to which the data is compared:
 
-<<<<<<< HEAD
         - '45' - 45-degree line
         - 's' - standardized line, the expected order statistics are scaled
           by the standard deviation of the given sample and have the mean
@@ -598,17 +564,6 @@ def qqplot_2samples(data1, data2, xlabel=None, ylabel=None, line=None,
         - 'r' - A regression line is fit
         - 'q' - A line is fit through the quartiles.
         - None - by default no reference line is added to the plot.
-=======
-          - '45' - 45-degree line
-          - 's' - standardized line, the expected order statistics are scaled
-            by the standard deviation of the given sample and have the mean
-            added to them
-          - 'r' - A regression line is fit
-          - 'q' - A line is fit through the quartiles.
-          - None - by default no reference line is added to the plot.
-          - If True a reference line is drawn on the graph. The default is to
-            fit a line via OLS regression.
->>>>>>> BUG: fixed ProbPlot class and tests to work better with general distributions
 
     ax : Matplotlib AxesSubplot instance, optional
         If given, this subplot is used to plot in instead of a new figure being
@@ -689,6 +644,7 @@ def qqline(ax, line, x=None, y=None, dist=None, fmt='r-'):
     Notes
     -----
     There is no return value. The line is plotted on the given `ax`.
+
     """
     if line == '45':
         end_pts = lzip(ax.get_xlim(), ax.get_ylim())
@@ -705,7 +661,7 @@ def qqline(ax, line, x=None, y=None, dist=None, fmt='r-'):
         # could use ax.lines[0].get_xdata(), get_ydata(),
         # but don't know axes are 'clean'
         y = OLS(y, add_constant(x)).fit().fittedvalues
-        lineartist, = ax.plot(x,y,fmt)
+        lineartist, = ax.plot(x, y, fmt)
 
     elif line == 's':
         m,b = y.std(), y.mean()
@@ -745,13 +701,14 @@ def plotting_pos(nobs, a):
     Notes
     -----
     The plotting positions are given by (i - a)/(nobs - 2*a + 1) for i in
-    range(0,nobs+1)
+    range(0, nobs+1)
 
     See also
     --------
     scipy.stats.mstats.plotting_positions
+
     """
-    return (np.arange(1.,nobs+1) - a)/(nobs- 2*a + 1)
+    return (np.arange(1., nobs+1) - a) / (nobs - 2*a + 1)
 
 
 def _fmt_probplot_axis(ax, dist, nobs, distargs=()):
@@ -772,6 +729,7 @@ def _fmt_probplot_axis(ax, dist, nobs, distargs=()):
     Returns
     -------
     There is no return value. This operates on `ax` in place
+
     """
     _check_for_ppf(dist)
 

--- a/statsmodels/graphics/tests/test__probscale.py
+++ b/statsmodels/graphics/tests/test__probscale.py
@@ -1,0 +1,176 @@
+import nose.tools as nt
+import numpy as np
+import numpy.testing as nptest
+
+import statsmodels.api as sm
+from statsmodels.graphics._probscale import (
+    _sig_figs,
+    _get_probs,
+    ProbFormatter,
+    ProbTransform,
+    ProbScale,
+    InvertedProbTransform
+)
+from scipy import stats
+
+
+class test__get_probs(object):
+    @nt.nottest
+    def compare_probs(self, N, expected):
+        probs = _get_probs(N)
+        nptest.assert_array_almost_equal(probs, expected, decimal=6)
+
+    def test_Order1(self):
+        N = 7
+        expected = np.array([10, 20, 30, 40, 50, 60, 70, 80, 90], dtype=float)
+        self.compare_probs(N, expected)
+
+    def test_Order2(self):
+        N = 77
+        expected = np.array([1, 2, 5, 10, 20, 30, 40, 50,
+                             60, 70, 80, 90, 95, 98, 99], dtype=float)
+        self.compare_probs(N, expected)
+
+    def test_Order3(self):
+        N = 378
+        expected = np.array([0.1, 0.2, 0.5, 1, 2, 5, 10, 20, 30, 40, 50,
+                             60, 70, 80, 90, 95, 98, 99, 99.5, 99.8, 99.9])
+        self.compare_probs(N, expected)
+
+    def test_Order6(self):
+        N = 4.5e6
+        expected = np.array([
+            1.0000e-05, 1.00000e-04, 1.000000e-03,
+            1.0000e-02, 2.00000e-02, 5.000000e-02,
+            1.0000e-01, 2.00000e-01, 5.000000e-01,
+            1.0000e+00, 2.00000e+00, 5.000000e+00,
+            1.0000e+01, 2.00000e+01, 3.000000e+01,
+            4.0000e+01, 5.00000e+01, 6.000000e+01,
+            7.0000e+01, 8.00000e+01, 9.000000e+01,
+            9.5000e+01, 9.80000e+01, 9.900000e+01,
+            9.9500e+01, 9.98000e+01, 9.990000e+01,
+            9.9950e+01, 9.99800e+01, 9.999000e+01,
+            9.9999e+01, 9.99999e+01, 9.999999e+01
+        ])
+        self.compare_probs(N, expected)
+
+
+class base__sig_figs_Mixin(object):
+    def teardown(self):
+        pass
+
+    def test_baseline(self):
+        nt.assert_equal(_sig_figs(self.x, 3), self.known_3)
+        nt.assert_equal(_sig_figs(self.x, 4), self.known_4)
+
+    def test_trailing_zeros(self):
+        nt.assert_equal(_sig_figs(self.x, 8), self.known_8)
+
+    @nptest.raises(ValueError)
+    def test_sigFigs_zero_n(self):
+        _sig_figs(self.x, 0)
+
+    @nptest.raises(ValueError)
+    def test_sigFigs_negative_n(self):
+        _sig_figs(self.x, -1)
+
+
+class test__sig_figs_gt1(base__sig_figs_Mixin):
+    def setup(self):
+        self.x = 1234.56
+        self.known_3 = '1,230'
+        self.known_4 = '1,235'
+        self.known_8 = '1,234.5600'
+        self.known_exp3 = '1.23e+08'
+        self.factor = 10**5
+
+
+class test__sig_figs_lt1(base__sig_figs_Mixin):
+    def setup(self):
+        self.x = 0.123456
+        self.known_3 = '0.123'
+        self.known_4 = '0.1235'
+        self.known_8 = '0.12345600'
+        self.known_exp3 = '1.23e-07'
+        self.factor = 10**-6
+
+
+class test_ProbFormatter(object):
+    def setup(self):
+        self.pf = ProbFormatter()
+
+    @nt.nottest
+    def compare_formats(self, val, known):
+        nt.assert_equal(self.pf(val), known)
+
+    def test_lt001(self):
+        self.compare_formats(0.0002, '0.0002')
+        self.compare_formats(0.00078, '0.0008')
+
+    def test_lt1(self):
+        self.compare_formats(0.1, '0.1')
+        self.compare_formats(0.512,'0.5')
+
+    def test_lt10(self):
+        self.compare_formats(3, '3')
+        self.compare_formats(9, '9')
+
+    def test_lt99(self):
+        self.compare_formats(24, '24')
+        self.compare_formats(98, '98')
+        self.compare_formats(99, '99')
+
+    def test_gt99(self):
+        self.compare_formats(99.9, '99.9')
+        self.compare_formats(99.9995, '99.9995')
+        self.compare_formats(99.9981, '99.998')
+
+
+class base_transformMixin(object):
+    def test_transform_non_affine_array(self):
+        nptest.assert_array_almost_equal(
+            self.transform.transform_non_affine(self.array),
+            self.known_transformed_array,
+            decimal=4
+        )
+
+    def test_transform_non_affine_scalar(self):
+        nt.assert_equal(
+            self.transform.transform_non_affine(self.scalar),
+            self.known_transformed_scalar
+        )
+
+    def test_inverted(self):
+        transinv = self.transform.inverted()
+        nt.assert_equal(type(transinv), type(self.known_inverted))
+        nt.assert_equal(transinv.dist, self.known_inverted.dist)
+
+
+class test_ProbTransform_Norm(base_transformMixin):
+    def setup(self):
+        self.dist = stats.norm
+        self.transform = ProbTransform(self.dist)
+        self.array = _get_probs(8)
+        self.known_transformed_array = np.array([
+            -1.28155157, -0.84162123, -0.52440051, -0.2533471 ,  0.,
+            0.2533471 ,  0.52440051,  0.84162123,  1.28155157
+        ])
+        self.scalar = 50.0
+        self.known_transformed_scalar = 0.0
+        self.known_inverted = InvertedProbTransform(self.dist)
+
+
+class test_InvertedProbTransform_Norm(base_transformMixin):
+    def setup(self):
+        self.dist = stats.norm
+        self.transform = InvertedProbTransform(self.dist)
+        self.array = np.arange(-3, 3.1, 0.5)
+        self.known_transformed_array = np.array([
+             0.1349898 ,   0.62096653,   2.27501319,   6.68072013,
+            15.86552539,  30.85375387,  50.        ,  69.14624613,
+            84.13447461,  93.31927987,  97.72498681,  99.37903347,  99.8650102
+        ])
+        self.scalar = 0.
+        self.known_transformed_scalar = 50.
+        self.known_inverted = ProbTransform(self.dist)
+

--- a/statsmodels/graphics/tests/test_gofplots.py
+++ b/statsmodels/graphics/tests/test_gofplots.py
@@ -120,13 +120,14 @@ class TestProbPlotLongelyNoFit(BaseProbplotMixin):
         self.data.exog = sm.add_constant(self.data.exog, prepend=False)
         self.mod_fit = sm.OLS(self.data.endog, self.data.exog).fit()
         self.prbplt = sm.ProbPlot(
-            self.mod_fit.resid, 
-            dist=stats.t, 
-            distargs=(4,), 
+            self.mod_fit.resid,
+            dist=stats.t,
+            distargs=(4,),
             fit=False
         )
         self.line = 'r'
         self.base_setup()
+
 
 class TestProbPlotLongelyWithFit(BaseProbplotMixin):
     def setup(self):
@@ -135,9 +136,9 @@ class TestProbPlotLongelyWithFit(BaseProbplotMixin):
         self.data.exog = sm.add_constant(self.data.exog, prepend=False)
         self.mod_fit = sm.OLS(self.data.endog, self.data.exog).fit()
         self.prbplt = sm.ProbPlot(
-            self.mod_fit.resid, 
-            dist=stats.t, 
-            distargs=(4,), 
+            self.mod_fit.resid,
+            dist=stats.t,
+            distargs=(4,),
             fit=True
         )
         self.line = 'r'

--- a/statsmodels/graphics/tests/test_gofplots.py
+++ b/statsmodels/graphics/tests/test_gofplots.py
@@ -20,6 +20,12 @@ class BaseProbplotMixin(object):
             self.fig, self.ax = plt.subplots()
         self.other_array = np.random.normal(size=self.prbplt.data.shape)
         self.other_prbplot = sm.ProbPlot(self.other_array)
+        self.plot_options = dict(
+            marker='d',
+            markerfacecolor='cornflowerblue',
+            markeredgecolor='white',
+            alpha=0.5
+        )
 
     def teardown(self):
         if have_matplotlib:
@@ -27,92 +33,113 @@ class BaseProbplotMixin(object):
 
     @dec.skipif(not have_matplotlib)
     def test_qqplot(self):
-        self.fig = self.prbplt.qqplot(ax=self.ax, line=self.line)
+        self.fig = self.prbplt.qqplot(ax=self.ax, line=self.line,
+                                        plot_options=self.plot_options)
 
     @dec.skipif(not have_matplotlib)
     def test_ppplot(self):
-        self.fig = self.prbplt.ppplot(ax=self.ax, line=self.line)
+        self.fig = self.prbplt.ppplot(ax=self.ax, line=self.line,
+                                        plot_options=self.plot_options)
 
     @dec.skipif(not have_matplotlib)
     def test_probplot(self):
-        self.fig = self.prbplt.probplot(ax=self.ax, line=self.line)
+        self.fig = self.prbplt.probplot(ax=self.ax, line=self.line,
+                                        plot_options=self.plot_options)
 
     @dec.skipif(not have_matplotlib)
     def test_qqplot_other_array(self):
         self.fig = self.prbplt.qqplot(ax=self.ax, line=self.line,
-                                        other=self.other_array)
+                                        other=self.other_array,
+                                        plot_options=self.plot_options)
     @dec.skipif(not have_matplotlib)
     def test_ppplot_other_array(self):
         self.fig = self.prbplt.ppplot(ax=self.ax, line=self.line,
-                                        other=self.other_array)
+                                        other=self.other_array,
+                                        plot_options=self.plot_options)
     @dec.skipif(not have_matplotlib)
-    def t_est_probplot_other_array(self):
+    def test_probplot_other_array(self):
         self.fig = self.prbplt.probplot(ax=self.ax, line=self.line,
-                                        other=self.other_array)
+                                        plot_options=self.plot_options)
 
     @dec.skipif(not have_matplotlib)
     def test_qqplot_other_prbplt(self):
         self.fig = self.prbplt.qqplot(ax=self.ax, line=self.line,
-                                        other=self.other_prbplot)
+                                        other=self.other_prbplot,
+                                        plot_options=self.plot_options)
     @dec.skipif(not have_matplotlib)
     def test_ppplot_other_prbplt(self):
         self.fig = self.prbplt.ppplot(ax=self.ax, line=self.line,
-                                        other=self.other_prbplot)
+                                        other=self.other_prbplot,
+                                        plot_options=self.plot_options)
     @dec.skipif(not have_matplotlib)
-    def t_est_probplot_other_prbplt(self):
+    def test_probplot_other_prbplt(self):
         self.fig = self.prbplt.probplot(ax=self.ax, line=self.line,
-                                        other=self.other_prbplot)
+                                        plot_options=self.plot_options)
 
     @dec.skipif(not have_matplotlib)
     def test_qqplot_custom_labels(self):
         self.fig = self.prbplt.qqplot(ax=self.ax, line=self.line,
                                       xlabel='Custom X-Label',
-                                      ylabel='Custom Y-Label')
+                                      ylabel='Custom Y-Label',
+                                      plot_options=self.plot_options)
 
     @dec.skipif(not have_matplotlib)
     def test_ppplot_custom_labels(self):
         self.fig = self.prbplt.ppplot(ax=self.ax, line=self.line,
                                       xlabel='Custom X-Label',
-                                      ylabel='Custom Y-Label')
+                                      ylabel='Custom Y-Label',
+                                      plot_options=self.plot_options)
 
     @dec.skipif(not have_matplotlib)
     def test_probplot_custom_labels(self):
         self.fig = self.prbplt.probplot(ax=self.ax, line=self.line,
                                         xlabel='Custom X-Label',
-                                        ylabel='Custom Y-Label')
+                                        ylabel='Custom Y-Label',
+                                        plot_options=self.plot_options)
 
     @dec.skipif(not have_matplotlib)
     def test_qqplot_pltkwargs(self):
         self.fig = self.prbplt.qqplot(ax=self.ax, line=self.line,
-                                      marker='d',
-                                      markerfacecolor='cornflowerblue',
-                                      markeredgecolor='white',
-                                      alpha=0.5)
+                                      plot_options=self.plot_options)
 
     @dec.skipif(not have_matplotlib)
     def test_ppplot_pltkwargs(self):
         self.fig = self.prbplt.ppplot(ax=self.ax, line=self.line,
-                                      marker='d',
-                                      markerfacecolor='cornflowerblue',
-                                      markeredgecolor='white',
-                                      alpha=0.5)
+                                      plot_options=self.plot_options)
 
     @dec.skipif(not have_matplotlib)
     def test_probplot_pltkwargs(self):
         self.fig = self.prbplt.probplot(ax=self.ax, line=self.line,
-                                        marker='d',
-                                        markerfacecolor='cornflowerblue',
-                                        markeredgecolor='white',
-                                        alpha=0.5)
+                                        plot_options=self.plot_options)
 
 
-class TestProbPlotLongely(BaseProbplotMixin):
+class TestProbPlotLongelyNoFit(BaseProbplotMixin):
     def setup(self):
         np.random.seed(5)
         self.data = sm.datasets.longley.load()
         self.data.exog = sm.add_constant(self.data.exog, prepend=False)
         self.mod_fit = sm.OLS(self.data.endog, self.data.exog).fit()
-        self.prbplt = sm.ProbPlot(self.mod_fit.resid, stats.t, distargs=(4,))
+        self.prbplt = sm.ProbPlot(
+            self.mod_fit.resid, 
+            dist=stats.t, 
+            distargs=(4,), 
+            fit=False
+        )
+        self.line = 'r'
+        self.base_setup()
+
+class TestProbPlotLongelyWithFit(BaseProbplotMixin):
+    def setup(self):
+        np.random.seed(5)
+        self.data = sm.datasets.longley.load()
+        self.data.exog = sm.add_constant(self.data.exog, prepend=False)
+        self.mod_fit = sm.OLS(self.data.endog, self.data.exog).fit()
+        self.prbplt = sm.ProbPlot(
+            self.mod_fit.resid, 
+            dist=stats.t, 
+            distargs=(4,), 
+            fit=True
+        )
         self.line = 'r'
         self.base_setup()
 
@@ -135,11 +162,11 @@ class TestProbPlotRandomNormalWithFit(BaseProbplotMixin):
         self.base_setup()
 
 
-class TestProbPlotRandomNormalLocScale(BaseProbplotMixin):
+class TestProbPlotRandomNormalFullDist(BaseProbplotMixin):
     def setup(self):
         np.random.seed(5)
         self.data = np.random.normal(loc=8.25, scale=3.25, size=37)
-        self.prbplt = sm.ProbPlot(self.data, loc=8.25, scale=3.25)
+        self.prbplt = sm.ProbPlot(self.data, dist=stats.norm(loc=8.5, scale=3.0))
         self.line = '45'
         self.base_setup()
 
@@ -150,7 +177,7 @@ class TestTopLevel(object):
         self.data.exog = sm.add_constant(self.data.exog, prepend=False)
         self.mod_fit = sm.OLS(self.data.endog, self.data.exog).fit()
         self.res = self.mod_fit.resid
-        self.prbplt = sm.ProbPlot(self.mod_fit.resid, stats.t, distargs=(4,))
+        self.prbplt = sm.ProbPlot(self.mod_fit.resid, dist=stats.t, distargs=(4,))
         self.other_array = np.random.normal(size=self.prbplt.data.shape)
         self.other_prbplot = sm.ProbPlot(self.other_array)
 

--- a/statsmodels/graphics/tests/test_gofplots.py
+++ b/statsmodels/graphics/tests/test_gofplots.py
@@ -1,10 +1,11 @@
 import numpy as np
-from numpy.testing import dec
+import numpy.testing as nptest
 
 import statsmodels.api as sm
 from statsmodels.graphics.gofplots import qqplot, qqline, ProbPlot
+from statsmodels.graphics import gofplots
 from scipy import stats
-
+import nose.tools as nt
 
 try:
     import matplotlib.pyplot as plt
@@ -31,83 +32,83 @@ class BaseProbplotMixin(object):
         if have_matplotlib:
             plt.close('all')
 
-    @dec.skipif(not have_matplotlib)
+    @nptest.dec.skipif(not have_matplotlib)
     def test_qqplot(self):
         self.fig = self.prbplt.qqplot(ax=self.ax, line=self.line,
                                         plot_options=self.plot_options)
 
-    @dec.skipif(not have_matplotlib)
+    @nptest.dec.skipif(not have_matplotlib)
     def test_ppplot(self):
         self.fig = self.prbplt.ppplot(ax=self.ax, line=self.line,
                                         plot_options=self.plot_options)
 
-    @dec.skipif(not have_matplotlib)
+    @nptest.dec.skipif(not have_matplotlib)
     def test_probplot(self):
         self.fig = self.prbplt.probplot(ax=self.ax, line=self.line,
                                         plot_options=self.plot_options)
 
-    @dec.skipif(not have_matplotlib)
+    @nptest.dec.skipif(not have_matplotlib)
     def test_qqplot_other_array(self):
         self.fig = self.prbplt.qqplot(ax=self.ax, line=self.line,
                                         other=self.other_array,
                                         plot_options=self.plot_options)
-    @dec.skipif(not have_matplotlib)
+    @nptest.dec.skipif(not have_matplotlib)
     def test_ppplot_other_array(self):
         self.fig = self.prbplt.ppplot(ax=self.ax, line=self.line,
                                         other=self.other_array,
                                         plot_options=self.plot_options)
-    @dec.skipif(not have_matplotlib)
+    @nptest.dec.skipif(not have_matplotlib)
     def test_probplot_other_array(self):
         self.fig = self.prbplt.probplot(ax=self.ax, line=self.line,
                                         plot_options=self.plot_options)
 
-    @dec.skipif(not have_matplotlib)
+    @nptest.dec.skipif(not have_matplotlib)
     def test_qqplot_other_prbplt(self):
         self.fig = self.prbplt.qqplot(ax=self.ax, line=self.line,
                                         other=self.other_prbplot,
                                         plot_options=self.plot_options)
-    @dec.skipif(not have_matplotlib)
+    @nptest.dec.skipif(not have_matplotlib)
     def test_ppplot_other_prbplt(self):
         self.fig = self.prbplt.ppplot(ax=self.ax, line=self.line,
                                         other=self.other_prbplot,
                                         plot_options=self.plot_options)
-    @dec.skipif(not have_matplotlib)
+    @nptest.dec.skipif(not have_matplotlib)
     def test_probplot_other_prbplt(self):
         self.fig = self.prbplt.probplot(ax=self.ax, line=self.line,
                                         plot_options=self.plot_options)
 
-    @dec.skipif(not have_matplotlib)
+    @nptest.dec.skipif(not have_matplotlib)
     def test_qqplot_custom_labels(self):
         self.fig = self.prbplt.qqplot(ax=self.ax, line=self.line,
                                       xlabel='Custom X-Label',
                                       ylabel='Custom Y-Label',
                                       plot_options=self.plot_options)
 
-    @dec.skipif(not have_matplotlib)
+    @nptest.dec.skipif(not have_matplotlib)
     def test_ppplot_custom_labels(self):
         self.fig = self.prbplt.ppplot(ax=self.ax, line=self.line,
                                       xlabel='Custom X-Label',
                                       ylabel='Custom Y-Label',
                                       plot_options=self.plot_options)
 
-    @dec.skipif(not have_matplotlib)
+    @nptest.dec.skipif(not have_matplotlib)
     def test_probplot_custom_labels(self):
         self.fig = self.prbplt.probplot(ax=self.ax, line=self.line,
                                         xlabel='Custom X-Label',
                                         ylabel='Custom Y-Label',
                                         plot_options=self.plot_options)
 
-    @dec.skipif(not have_matplotlib)
+    @nptest.dec.skipif(not have_matplotlib)
     def test_qqplot_pltkwargs(self):
         self.fig = self.prbplt.qqplot(ax=self.ax, line=self.line,
                                       plot_options=self.plot_options)
 
-    @dec.skipif(not have_matplotlib)
+    @nptest.dec.skipif(not have_matplotlib)
     def test_ppplot_pltkwargs(self):
         self.fig = self.prbplt.ppplot(ax=self.ax, line=self.line,
                                       plot_options=self.plot_options)
 
-    @dec.skipif(not have_matplotlib)
+    @nptest.dec.skipif(not have_matplotlib)
     def test_probplot_pltkwargs(self):
         self.fig = self.prbplt.probplot(ax=self.ax, line=self.line,
                                         plot_options=self.plot_options)
@@ -186,20 +187,189 @@ class TestTopLevel(object):
         if have_matplotlib:
             plt.close('all')
 
-    @dec.skipif(not have_matplotlib)
+    @nptest.dec.skipif(not have_matplotlib)
     def test_qqplot(self):
         fig = sm.qqplot(self.res, line='r')
 
-    @dec.skipif(not have_matplotlib)
+    @nptest.dec.skipif(not have_matplotlib)
     def test_qqplot_2samples_ProbPlotObjects(self):
         # also tests all values for line
         for line in ['r', 'q', '45', 's']:
             # test with `ProbPlot` instances
             fig = sm.qqplot_2samples(self.prbplt, self.other_prbplot,
                                      line=line)
-    @dec.skipif(not have_matplotlib)
+    @nptest.dec.skipif(not have_matplotlib)
     def test_qqplot_2samples_arrays(self):
         # also tests all values for line
         for line in ['r', 'q', '45', 's']:
             # test with arrays
             fig = sm.qqplot_2samples(self.res, self.other_array, line=line)
+
+
+class test_check_dist(object):
+    def test_good(self):
+        gofplots._check_dist(stats.norm)
+
+    @nt.raises(ValueError)
+    def test_bad(self):
+        gofplots._check_dist('junk')
+
+
+class test__do_plot(object):
+    def setup(self):
+        self.fig, self.ax = plt.subplots()
+        self.x = [0.2, 0.6, 2.0, 4.5, 10.0, 50.0, 83.0, 99.1, 99.7]
+        self.y = [1.2, 1.4, 1.7, 2.1, 3.2, 3.7, 4.5, 5.1, 6.3]
+        self.full_options = {
+            'marker': 's',
+            'markerfacecolor': 'cornflowerblue',
+            'markeredgecolor': 'firebrick',
+            'markeredgewidth': 1.25,
+            'linestyle': '--'
+        }
+        self.step_options = {
+            'linestyle': '-',
+            'where': 'mid'
+        }
+
+    def teardown(self):
+        plt.close('all')
+
+    def test_baseline(self):
+        fig, ax = gofplots._do_plot(self.x, self.y)
+        nt.assert_true(isinstance(fig, plt.Figure))
+        nt.assert_true(isinstance(ax, plt.Axes))
+        nt.assert_not_equal(self.fig, fig)
+        nt.assert_not_equal(self.ax, ax)
+
+    def test_with_ax(self):
+        fig, ax = gofplots._do_plot(self.x, self.y, ax=self.ax)
+        nt.assert_true(isinstance(fig, plt.Figure))
+        nt.assert_true(isinstance(ax, plt.Axes))
+        nt.assert_equal(self.fig, fig)
+        nt.assert_equal(self.ax, ax)
+
+    def test_plot_full_options(self):
+        fig, ax = gofplots._do_plot(self.x, self.y, ax=self.ax, step=False,
+                                    plot_options=self.full_options)
+
+    def test_step_baseline(self):
+        fig, ax = gofplots._do_plot(self.x, self.y, ax=self.ax, step=True,
+                                    plot_options=self.step_options)
+
+    def test_step_full_options(self):
+        fig, ax = gofplots._do_plot(self.x, self.y, ax=self.ax, step=True,
+                                    plot_options=self.full_options)
+
+    def test_plot_qq_line(self):
+        fig, ax= gofplots._do_plot(self.x, self.y, ax=self.ax, line='r')
+
+    def test_step_qq_line(self):
+        fig, ax= gofplots._do_plot(self.x, self.y, ax=self.ax,
+                                   step=True, line='r')
+
+
+class test_qqline(object):
+    def setup(self):
+        self.fig, self.ax = plt.subplots()
+
+        np.random.seed(0)
+        self.x = sorted(np.random.normal(loc=2.9, scale=1.2, size=37))
+        self.y = sorted(np.random.normal(loc=3.0, scale=1.1, size=37))
+        self.ax.plot(self.x, self.y, 'ko')
+        self.lineoptions = {'linewidth': 2, 'dashes': (10, 1 ,3 ,4),
+                            'color': 'green'}
+        self.fmt = 'bo-'
+
+    @nt.raises(ValueError)
+    def test_badline(self):
+        qqline(self.ax, 'junk')
+
+    @nt.raises(ValueError)
+    def test_non45_no_x(self):
+        qqline(self.ax, 's', y=self.y)
+
+    @nt.raises(ValueError)
+    def test_non45_no_y(self):
+        qqline(self.ax, 's', x=self.x)
+
+    @nt.raises(ValueError)
+    def test_non45_no_x_no_y(self):
+        qqline(self.ax, 's')
+
+    def teardown(self):
+        plt.close('all')
+
+    def test_45(self):
+        l = qqline(self.ax, '45')
+        nt.assert_true(isinstance(l, plt.Line2D))
+
+    def test_45_fmt(self):
+        l = qqline(self.ax, '45', fmt=self.fmt)
+
+    def test_45_fmt_lineoptions(self):
+        l = qqline(self.ax, '45', fmt=self.fmt, **self.lineoptions)
+
+    def test_r(self):
+        l = qqline(self.ax, 'r', x=self.x, y=self.y)
+        nt.assert_true(isinstance(l, plt.Line2D))
+
+    def test_r_fmt(self):
+        l = qqline(self.ax, 'r', x=self.x, y=self.y, fmt=self.fmt)
+
+    def test_r_fmt_lineoptions(self):
+        l = qqline(self.ax, 'r', x=self.x, y=self.y, fmt=self.fmt, **self.lineoptions)
+
+    def test_s(self):
+        l = qqline(self.ax, 's', x=self.x, y=self.y)
+        nt.assert_true(isinstance(l, plt.Line2D))
+
+    def test_s_fmt(self):
+        l = qqline(self.ax, 's', x=self.x, y=self.y, fmt=self.fmt)
+
+    def test_s_fmt_lineoptions(self):
+        l = qqline(self.ax, 's', x=self.x, y=self.y, fmt=self.fmt, **self.lineoptions)
+
+    def test_q(self):
+        l = qqline(self.ax, 'q', dist=stats.norm, x=self.x, y=self.y)
+        nt.assert_true(isinstance(l, plt.Line2D))
+
+    def test_q_fmt(self):
+        l = qqline(self.ax, 'q', dist=stats.norm, x=self.x, y=self.y, fmt=self.fmt)
+
+    def test_q_fmt_lineoptions(self):
+        l = qqline(self.ax, 'q', dist=stats.norm, x=self.x, y=self.y, fmt=self.fmt, **self.lineoptions)
+
+
+class test_plotting_pos(object):
+    def setup(self):
+        self.N = 13
+        self.data = np.arange(self.N)
+
+    @nt.nottest
+    def do_test(self, alpha,  beta):
+        smpp = gofplots.plotting_pos(self.N, a=alpha, b=beta)
+        sppp = stats.mstats.plotting_positions(
+            self.data, alpha=alpha, beta=beta
+        )
+
+        nptest.assert_array_almost_equal(smpp, sppp, decimal=5)
+
+    def test_weibull(self):
+        self.do_test(0, 0)
+
+    def test_lininterp(self):
+        self.do_test(0, 1)
+
+    def test_piecewise(self):
+        self.do_test(0.5, 0.5)
+
+    def test_approx_med_unbiased(self):
+        self.do_test(1./3., 1./3.)
+
+    def test_cunnane(self):
+        self.do_test(0.4, 0.4)
+
+
+
+


### PR DESCRIPTION
Unsurprisingly, most of what I did to get this point was to simplify things.

[Here's a notebook](http://nbviewer.ipython.org/gist/phobson/24904a4a765b5d74dc5e) showing how things are working so far. It shows off creating `ProbPlot` objects with three different distributions:
1. Lognormal
2. beta
3. t
4. normal

It also creates the object three different ways:
1. Simple: provide data, unfrozen distribution, minimal distribution parameters (`distargs`)
2. More specific: provide data, frozen distribution, minimal distribution parameters (`distargs`)
3. "Automatic": provide data, unfrozen distribution, tell the class to fit the distribution

Not all the plots are perfect. But we're getting close.
- [x] Add option to use `ax.step` instead of `ax.plot`
- [x] confirm that `distargs` are not needed with a frozen distribution
- [x] look into the "binary" nature of `t` probplots when `fit=False`
- [x] beef up the testing and examples for the `qqlines`

[Updated notebook](http://nbviewer.ipython.org/gist/phobson/24904a4a765b5d74dc5e)
