### PR TITLE
BUG/BLD: exclude sandbox in relative path, not absolute

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -443,9 +443,10 @@ def get_data_files():
                                                                   "*.dta"]})
     # add all the tests and results files
     for r, ds, fs in os.walk(pjoin(curdir, "statsmodels")):
-        if r.endswith('results') and 'sandbox' not in r:
-            data_files.update({relpath(r, start=curdir).replace(sep, ".") : ["*.csv",
-                                                               "*.txt"]})
+        r_ = relpath(r, start=curdir)
+        if r_.endswith('results') and 'sandbox' not in r_:
+            data_files.update({r_.replace(sep, ".") : ["*.csv",
+                                                       "*.txt"]})
 
     return data_files
 


### PR DESCRIPTION
Closes https://github.com/statsmodels/statsmodels/issues/1457

I didn't see any tests for `setup.py`, so I didn't include any. I can write a test for this function in a new file if you want. I've manually tested on a Mac for python 2.7 and 3.3
