### PR TITLE
add support for NaNs in acovf, acf, pacf

### DIFF
--- a/statsmodels/tsa/stattools.py
+++ b/statsmodels/tsa/stattools.py
@@ -330,6 +330,8 @@ def acovf(x, unbiased=False, demean=True, fft=False, missing='none'):
     if demean and deal_with_masked:
         # whether 'drop' or 'conservative':
         xo = x - x.sum()/notmask_int.sum()
+        if missing=='conservative':
+            xo[~notmask_bool] = 0
     elif demean:
         xo = x - x.mean()
     else:

--- a/statsmodels/tsa/tests/test_stattools.py
+++ b/statsmodels/tsa/tests/test_stattools.py
@@ -10,6 +10,7 @@ from numpy import genfromtxt#, concatenate
 from statsmodels.datasets import macrodata, sunspots
 from pandas import Series, Index, DataFrame
 import os
+from statsmodels.base.data import MissingDataError
 
 
 DECIMAL_8 = 8
@@ -164,7 +165,47 @@ class TestACF_FFT(CheckCorrGram):
     def test_qstat(self):
         #todo why is res1/qstat 1 short
         assert_almost_equal(self.res1[1], self.qstat, DECIMAL_3)
+        
+class TestACFMissing(CheckCorrGram):
+    """
+    Test Autocorrelation Function using Missing
+    """
+    def __init__(self):
+        self.x = np.concatenate((np.array([np.nan]),self.x))
+        self.acf = self.results['acvar'] # drop and conservative
+        self.qstat = self.results['Q1']
+        self.res_drop = acf(self.x, nlags=40, qstat=True, alpha=.05, 
+                            missing='drop')
+        self.res_conservative = acf(self.x, nlags=40, qstat=True, alpha=.05, 
+                                    missing='conservative')       
+        self.acf_none = np.empty(40) * np.nan # lags 1 to 40 inclusive
+        self.qstat_none = np.empty(40) * np.nan
+        self.res_none = acf(self.x, nlags=40, qstat=True, alpha=.05,
+                        missing='none')
+    
+    def test_raise(self):
+        assert_raises(MissingDataError, acf, self.x, nlags=40, 
+                      qstat=True, alpha=.05, missing='raise')
+                      
+    def test_acf_none(self):
+        assert_almost_equal(self.res_none[0][1:41], self.acf_none, DECIMAL_8)
+    
+    def test_acf_drop(self):
+        assert_almost_equal(self.res_drop[0][1:41], self.acf, DECIMAL_8)
+    
+    def test_acf_conservative(self):
+        assert_almost_equal(self.res_conservative[0][1:41], self.acf, 
+                            DECIMAL_8)
 
+    def test_qstat_none(self):
+        #todo why is res1/qstat 1 short
+        assert_almost_equal(self.res_none[2], self.qstat_none, DECIMAL_3)
+    
+# how to do this test? the correct q_stat depends on whether nobs=len(x) is 
+# used when x contains NaNs or whether nobs<len(x) when x contains NaNs
+#    def test_qstat_drop(self):
+#        assert_almost_equal(self.res_drop[2][:40], self.qstat, DECIMAL_3)
+        
 
 class TestPACF(CheckCorrGram):
     def __init__(self):


### PR DESCRIPTION
Add some NaN-handling in statsmodels.tsa.stattools
Followed syntax in statsmodels.tsa.ar_model.AR
With reference to this PR: https://github.com/statsmodels/statsmodels/issues/322
And to this discussion: https://groups.google.com/forum/#!msg/pystatsmodels/Nr8E-dPQSsA/vWeAFT5F0_AJ
I had to comment out the import of Bunch in line 9, because it kept giving me an ImportError
