### PR TITLE
BUG: Format and decode errors in Python 2.6

### DIFF
--- a/statsmodels/datasets/utils.py
+++ b/statsmodels/datasets/utils.py
@@ -184,7 +184,7 @@ def _get_data(base_url, dataname, cache, extension="csv"):
         else:
             raise err
 
-    data = data.decode('utf-8', errors='strict')
+    data = data.decode('utf-8', 'strict')
     return StringIO(data), from_cache
 
 
@@ -196,7 +196,7 @@ def _get_dataset_meta(dataname, package, cache):
     data, _ = _urlopen_cached(index_url, cache)
     #Python 3
     if sys.version[0] == '3':  # pragma: no cover
-        data = data.decode('utf-8', errors='strict')
+        data = data.decode('utf-8', 'strict')
     index = read_csv(StringIO(data))
     idx = np.logical_and(index.Item == dataname, index.Package == package)
     dataset_meta = index.ix[idx]

--- a/statsmodels/tools/grouputils.py
+++ b/statsmodels/tools/grouputils.py
@@ -308,7 +308,7 @@ def _make_hierarchical_index(index, names):
 def _make_generic_names(index):
     n_names = len(index.names)
     pad = str(len(str(n_names)))  # number of digits
-    return [("group{:0"+pad+"}").format(i) for i in range(n_names)]
+    return [("group{0:0"+pad+"}").format(i) for i in range(n_names)]
 
 
 class Grouping(object):


### PR DESCRIPTION
Fixes two small errors on Python 2.6
- Improper use of keyword arguments in format, e.g errors='strict'
- Improper use of position-less format string
