### PR TITLE
BUG: Fixes for 2.6 test failures, replacing astype(str) with apply(str)

### DIFF
--- a/statsmodels/graphics/tests/test_tsaplots.py
+++ b/statsmodels/graphics/tests/test_tsaplots.py
@@ -32,7 +32,7 @@ def test_plot_acf():
 @dec.skipif(not have_matplotlib)
 def test_plot_month():
     dta = sm.datasets.elnino.load_pandas().data
-    dta['YEAR'] = dta.YEAR.astype(int).astype(str)
+    dta['YEAR'] = dta.YEAR.astype(int).apply(str)
     dta = dta.set_index('YEAR').T.unstack()
     dates = map(lambda x : pd.datetools.parse('1 '+' '.join(x)),
                                             dta.index.values)
@@ -59,8 +59,8 @@ def test_plot_month():
 @dec.skipif(not have_matplotlib)
 def test_plot_quarter():
     dta = sm.datasets.macrodata.load_pandas().data
-    dates = map('Q'.join, zip(dta.year.astype(int).astype(str),
-                              dta.quarter.astype(int).astype(str)))
+    dates = map('Q'.join, zip(dta.year.astype(int).apply(str),
+                              dta.quarter.astype(int).apply(str)))
 
     # test dates argument
     quarter_plot(dta.unemp.values, dates)


### PR DESCRIPTION
Simple fix for 2 test failures on 2.6.  See

https://travis-ci.org/bashtage/statsmodels/builds/21917286

build 209.1.  Build 209 uses the travis-miniconda to test against 2.6, but this branch uses the older build config.
