### PR TITLE
Fix test gmm poisson

### DIFF
--- a/statsmodels/sandbox/regression/tests/test_gmm_poisson.py
+++ b/statsmodels/sandbox/regression/tests/test_gmm_poisson.py
@@ -17,7 +17,6 @@ from statsmodels.sandbox.regression import gmm
 from numpy.testing import assert_allclose, assert_equal
 from statsmodels.compatnp.np_compat import NumpyVersion
 
-SCIPY_GT_12 = NumpyVersion(scipy.version.short_version) > '0.12.0'
 
 def get_data():
     import os
@@ -91,7 +90,6 @@ class CheckGMM(object):
     q_tol = [5e-6, 1e-9]
     j_tol = [5e-5, 1e-9]
 
-    @skipif(SCIPY_GT_12,"Known failure with SciPy > 0.12")
     def test_basic(self):
         res1, res2 = self.res1, self.res2
         # test both absolute and relative difference
@@ -103,7 +101,6 @@ class CheckGMM(object):
         assert_allclose(res1.bse, res2.bse, rtol=rtol, atol=0)
         assert_allclose(res1.bse, res2.bse, rtol=0, atol=atol)
 
-    @skipif(SCIPY_GT_12,"Known failure with SciPy > 0.12")
     def test_other(self):
         res1, res2 = self.res1, self.res2
         rtol,  atol = self.q_tol


### PR DESCRIPTION
fixes the test failures on scipy >= 0.13   in #1420

use log-linear OLS as starting values for GMM-Poisson
