### PR TITLE
TST: adjust precision, CI Debian, Ubuntu testing

### DIFF
--- a/statsmodels/base/tests/test_generic_methods.py
+++ b/statsmodels/base/tests/test_generic_methods.py
@@ -74,12 +74,12 @@ class CheckGenericMixin(object):
         # check default use_t
         pvals = [res.wald_test(np.eye(k_vars)[k], use_f=use_t).pvalue
                                                    for k in range(k_vars)]
-        assert_allclose(pvals, res.pvalues, rtol=5e-10)
+        assert_allclose(pvals, res.pvalues, rtol=5e-10, atol=1e-25)
 
         # sutomatic use_f based on results class use_t
         pvals = [res.wald_test(np.eye(k_vars)[k]).pvalue
                                                    for k in range(k_vars)]
-        assert_allclose(pvals, res.pvalues, rtol=5e-10)
+        assert_allclose(pvals, res.pvalues, rtol=5e-10, atol=1e-25)
 
 
 

--- a/statsmodels/regression/tests/test_robustcov.py
+++ b/statsmodels/regression/tests/test_robustcov.py
@@ -49,7 +49,7 @@ class CheckOLSRobust(object):
             assert_allclose(tt.pvalue, res2.pvalues, rtol=5 * rtol)
         else:
             pval = stats.norm.sf(np.abs(tt.tvalue)) * 2
-            assert_allclose(pval, res2.pvalues, rtol=5 * rtol)
+            assert_allclose(pval, res2.pvalues, rtol=5 * rtol, atol=1e-25)
 
         ft = res1.f_test(mat[:-1], cov_p=self.cov_robust)
         if self.small:

--- a/statsmodels/sandbox/regression/tests/test_gmm.py
+++ b/statsmodels/sandbox/regression/tests/test_gmm.py
@@ -645,7 +645,7 @@ class CheckIV2SLS(object):
         hausm = res1.spec_hausman()
         # hausman uses se2 = ssr / nobs, no df correction
         assert_allclose(hausm[0], res2.hausman['DWH'], rtol=1e-11, atol=0)
-        assert_allclose(hausm[1], res2.hausman['DWHp'], rtol=1e-10, atol=0)
+        assert_allclose(hausm[1], res2.hausman['DWHp'], rtol=1e-10, atol=1e-25)
 
 
     def test_smoke(self):

--- a/statsmodels/tools/tests/test_grouputils.py
+++ b/statsmodels/tools/tests/test_grouputils.py
@@ -108,8 +108,8 @@ class CheckGrouping(object):
                                             level=0)
         expected = self.data.reset_index().groupby(names[0]).mean()[
                                                     self.data.columns]
-        np.testing.assert_array_equal(transformed_slices,
-                                      expected.values)
+        np.testing.assert_allclose(transformed_slices, expected.values,
+                                   rtol=1e-12, atol=1e-25)
 
         if len(names) > 1:
             transformed_slices = self.grouping.transform_slices(
@@ -119,8 +119,8 @@ class CheckGrouping(object):
             expected = self.data.reset_index().groupby(names[1]
                                                        ).mean()[
                                                         self.data.columns]
-            np.testing.assert_array_equal(transformed_slices,
-                                          expected.values)
+            np.testing.assert_allclose(transformed_slices, expected.values,
+                                       rtol=1e-12, atol=1e-25)
 
     def test_dummies_groups(self):
         # smoke test, calls dummy_sparse under the hood


### PR DESCRIPTION
nipy  Debian and pythonxy Ubuntu test failures

lower required precision (from very high)
