### PR TITLE
BUG: Fix proportions allpairs #1493

### DIFF
--- a/statsmodels/stats/proportion.py
+++ b/statsmodels/stats/proportion.py
@@ -730,7 +730,7 @@ def proportions_chisquare_allpairs(count, nobs, multitest_method='hs'):
     Yates continuity correction is not available.
     '''
     #all_pairs = lmap(list, lzip(*np.triu_indices(4, 1)))
-    all_pairs = lzip(*np.triu_indices(4, 1))
+    all_pairs = lzip(*np.triu_indices(len(count), 1))
     pvals = [proportions_chisquare(count[list(pair)], nobs[list(pair)])[1]
                for pair in all_pairs]
     return AllPairsResults(pvals, all_pairs, multitest_method=multitest_method)

--- a/statsmodels/stats/tests/test_proportion.py
+++ b/statsmodels/stats/tests/test_proportion.py
@@ -82,6 +82,17 @@ class CheckProportionMixin(object):
         assert_almost_equal(pptd.pvals_raw, ppt.pvals_raw[:len(self.nobs) - 1],
                             decimal=13)
 
+
+    def test_number_pairs_1493(self):
+        ppt = smprop.proportions_chisquare_allpairs(self.n_success[:3],
+                                                    self.nobs[:3],
+                                                    multitest_method=None)
+
+        assert_equal(len(ppt.pvals_raw), 3)
+        idx = [0, 1, 3]
+        assert_almost_equal(ppt.pvals_raw, self.res_ppt_pvals_raw[idx])
+
+
 class TestProportion(CheckProportionMixin):
     def setup(self):
         self.n_success = np.array([ 73,  90, 114,  75])


### PR DESCRIPTION
fixes hardcoded number of pairs in statsmodels.stats.proportion.proportions_chisquare_allpairs
closes #1493
