### PR TITLE
Add drop_omitted to summary_col

### DIFF
--- a/statsmodels/iolib/summary2.py
+++ b/statsmodels/iolib/summary2.py
@@ -435,7 +435,7 @@ def summary_col(results, float_format='%.4f', model_names=[], stars=False,
     regressor_order : list of strings
         list of names of the regressors in the desired order. All regressors
         not specified will be appended to the end of the list.
-    drop_ommitted : bool
+    drop_omitted : bool
         Includes regressors that are not specified in regressor_order. If False,
         regressors not specified will be appended to end of the list. If True,
         only regressors in regressors_list will be included.

--- a/statsmodels/iolib/summary2.py
+++ b/statsmodels/iolib/summary2.py
@@ -468,8 +468,8 @@ def summary_col(results, float_format='%.4f', model_names=[], stars=False,
         summ = summ.reindex(f(order))
         summ.index = [x[:-4] for x in summ.index]
         
-    if drop_omitted:
-        summ = summ.loc[regressor_order]
+        if drop_omitted:
+            summ = summ.loc[regressor_order]
 
     idx = pd.Series(lrange(summ.shape[0])) %2 == 1
     summ.index = np.where(idx, '', summ.index.get_level_values(0))

--- a/statsmodels/iolib/summary2.py
+++ b/statsmodels/iolib/summary2.py
@@ -411,7 +411,7 @@ def _make_unique(list_of_names):
 
 
 def summary_col(results, float_format='%.4f', model_names=[], stars=False,
-        info_dict=None, regressor_order=[],drop_ommitted=False):
+        info_dict=None, regressor_order=[],drop_omitted=False):
     '''Summarize multiple results instances side-by-side (coefs and SEs)
 
     Parameters
@@ -469,7 +469,7 @@ def summary_col(results, float_format='%.4f', model_names=[], stars=False,
         summ.index = [x[:-4] for x in summ.index]
         
     if drop_omitted:
-        summ = summ.loc[regressors]
+        summ = summ.loc[regressor_order]
 
     idx = pd.Series(lrange(summ.shape[0])) %2 == 1
     summ.index = np.where(idx, '', summ.index.get_level_values(0))

--- a/statsmodels/iolib/summary2.py
+++ b/statsmodels/iolib/summary2.py
@@ -411,7 +411,7 @@ def _make_unique(list_of_names):
 
 
 def summary_col(results, float_format='%.4f', model_names=[], stars=False,
-        info_dict=None, regressor_order=[]):
+        info_dict=None, regressor_order=[],drop_ommitted=False):
     '''Summarize multiple results instances side-by-side (coefs and SEs)
 
     Parameters
@@ -435,6 +435,10 @@ def summary_col(results, float_format='%.4f', model_names=[], stars=False,
     regressor_order : list of strings
         list of names of the regressors in the desired order. All regressors
         not specified will be appended to the end of the list.
+    drop_ommitted : bool
+        Includes regressors that are not specified in regressor_order. If False,
+        regressors not specified will be appended to end of the list. If True,
+        only regressors in regressors_list will be included.
     '''
 
     if not isinstance(results, list):
@@ -463,6 +467,9 @@ def summary_col(results, float_format='%.4f', model_names=[], stars=False,
         summ.index = f(np.unique(varnames))
         summ = summ.reindex(f(order))
         summ.index = [x[:-4] for x in summ.index]
+        
+    if drop_omitted:
+        summ = summ.loc[regressors]
 
     idx = pd.Series(lrange(summ.shape[0])) %2 == 1
     summ.index = np.where(idx, '', summ.index.get_level_values(0))


### PR DESCRIPTION
Adds `drop_omitted` as boolean option to `summary_col` that will slice the resulting table to only include the regressors specified in `regressor_order`.
