### PR TITLE
ENH: Add fit_sequence method.

### DIFF
--- a/statsmodels/base/tests/test_optimize.py
+++ b/statsmodels/base/tests/test_optimize.py
@@ -1,3 +1,4 @@
+import numpy as np
 from numpy.testing import assert_
 from statsmodels.base.optimizer import (_fit_newton, _fit_nm,
                                         _fit_bfgs, _fit_cg,
@@ -20,7 +21,7 @@ def dummy_score(x):
     return 2*x
 
 def dummy_hess(x):
-    return [[2]]
+    return np.array([[2]])
 
 def test_full_output_false():
     # just a smoke test


### PR DESCRIPTION
Makes it possible to specify a sequence of optimizers. I'm not wild about adding another method, but it's the cleanest optionwise so far. We could just allow method in `fit` to take the same as `solvers` in `fit_sequence`. Docs would get long and option keywords like `maxiter` would be ignored though.

There's a lot of boilerplate code copy and pasted between `fit` and `fit_method`.  Should probably refactor this to avoid it.

TODO: If we switch to the `scipy.optimize.minimize` interface, which we now have in our minimum scipy, we can use also specify arbitrary optimizers for any model, which could be really cool.

Example usage:

```
data = sm.datasets.randhie.load()
exog = sm.add_constant(data.exog, prepend=False)
mod = sm.Probit(data.endog, data.exog)

res1 = mod.fit_sequence([('bfgs', 2), ('powell', 2), ('cg', 4)])

res2 = mod.fit_sequence([dict(method='bfgs', maxiter=2), 
                        dict(method='powell', maxiter=2), 
                        dict(method='newton')], full_output=False, disp=0)
```
- [ ] add to release notes
- [ ] add tests
- [ ] add examples
- [ ] refactor for DRY
- [ ] decide on API
- [ ] generalize fit_regularized methods as part of this?
