### PR TITLE
Unindent 'hasconst' parameter heading in models doc

### DIFF
--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -27,8 +27,7 @@ _model_params_doc = """
 _missing_param_doc = """missing : str
         Available options are 'none', 'drop', and 'raise'. If 'none', no nan
         checking is done. If 'drop', any observations with nans are dropped.
-        If 'raise', an error is raised. Default is 'none.'
-        """
+        If 'raise', an error is raised. Default is 'none.'"""
 _extra_param_doc = """hasconst : None or bool
         Indicates whether the RHS includes a user-supplied constant. If True,
         a constant is not checked for and k_constant is set to 1 and all


### PR DESCRIPTION
Minor change in docs.

Not sure if `_extra_param_doc` should be changed
to be consistent.
