### PR TITLE
OSL Example: redundant cell in example removed

### DIFF
--- a/examples/notebooks/ols.ipynb
+++ b/examples/notebooks/ols.ipynb
@@ -77,24 +77,6 @@
      "cell_type": "markdown",
      "metadata": {},
      "source": [
-      "Inspect data:"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "X = sm.add_constant(X)\n",
-      "y = np.dot(X, beta) + e"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
       "Fit and summary:"
      ]
     },


### PR DESCRIPTION
Noticed that code cells 3 and 4 are the same for the [ordinary least squares example](http://statsmodels.sourceforge.net/devel/examples/notebooks/generated/ols.html)

![osl_redundant_cell](https://cloud.githubusercontent.com/assets/2342749/3077009/8b2a2a3a-e40d-11e3-8765-6cc3adf9d814.png)
