### PR TITLE
BLD: Made build extensions more flexible

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -332,15 +332,12 @@ ext_data = dict(
 
 extensions = []
 for name, data in ext_data.items():
-    sources = [data['name']]
+    data['sources'] = data.get('sources', []) + [data['name']]
+
     destdir = ".".join(os.path.dirname(data["name"]).split("/"))
+    data.pop('name')
 
-    sources.extend(data.get('sources', []))
-
-    obj = Extension('%s.%s' % (destdir, name),
-                    sources=sources,
-                    depends=data.get('depends', []),
-                    include_dirs=data.get('include', []))
+    obj = Extension('%s.%s' % (destdir, name), **data)
 
     extensions.append(obj)
 


### PR DESCRIPTION
I need to include 'libraries' and 'libraries_lib' arguments to the `Extension( ... )` setup for #1698. This pull request just allows each extension to define additional **kwargs in the Extension call.
