### PR TITLE
BUG: added exception if bw=0 for KDEUnivariate

### DIFF
--- a/statsmodels/nonparametric/bandwidths.py
+++ b/statsmodels/nonparametric/bandwidths.py
@@ -169,7 +169,12 @@ def select_bandwidth(x, bw, kernel):
         raise ValueError("Bandwidth %s not understood" % bw)
 #TODO: uncomment checks when we have non-rule of thumb bandwidths for diff. kernels
 #    if kernel == "gauss":
-    return bandwidth_funcs[bw](x, kernel)
+    bandwidth = bandwidth_funcs[bw](x, kernel)
+    if bandwidth == 0:
+        # eventually this can fall back on another selection criterion.
+        raise  RuntimeError("KDE bandwidth computed as 0. Cannot build density estimate.")
+    else: 
+        return bandwidth
 #    else:
 #        raise ValueError("Only Gaussian Kernels are currently supported")
 

--- a/statsmodels/nonparametric/tests/test_kernel_density.py
+++ b/statsmodels/nonparametric/tests/test_kernel_density.py
@@ -113,6 +113,13 @@ class TestKDEUnivariate(MyTest):
         npt.assert_allclose(kde_vals0, kde_expected,
                             atol=1e-6)
 
+    def test_all_samples_same_location_bw(self):
+        
+        X = np.ones(100)
+        kde = nparam.KDEUnivariate(X)
+        kde.fit()
+        assert(kde.bw != 0.0)
+
 
 
 class TestKDEMultivariate(MyTest):

--- a/statsmodels/nonparametric/tests/test_kernel_density.py
+++ b/statsmodels/nonparametric/tests/test_kernel_density.py
@@ -117,8 +117,7 @@ class TestKDEUnivariate(MyTest):
         
         X = np.ones(100)
         kde = nparam.KDEUnivariate(X)
-        kde.fit()
-        assert(kde.bw != 0.0)
+        npt.assert_raises(RuntimeError, kde.fit)
 
 
 


### PR DESCRIPTION
Fix for issue #1708

Have put the fix in `bandwidths.py`. I think the layout of the bandwidth selection needs to be changed, but this way the fix is stored externally to KDE so we  don't miss it when (if?) we reorganize.
