### PR TITLE
TST: TestProbitCG increase bound for fcalls closes #1690

### DIFF
--- a/statsmodels/discrete/tests/test_discrete.py
+++ b/statsmodels/discrete/tests/test_discrete.py
@@ -378,7 +378,7 @@ class TestProbitCG(CheckBinaryResults):
                                                      maxiter=500, gtol=1e-08,
                                                      disp=0)
 
-        assert_array_less(cls.res1.mle_retvals['fcalls'], 70)
+        assert_array_less(cls.res1.mle_retvals['fcalls'], 100)
 
 
 class TestProbitNCG(CheckBinaryResults):


### PR DESCRIPTION
increase fcalls bound to 100
should make nipy Debian and Snake Charmer tests pass
see #1690
