### PR TITLE
REF numpy >1.9 compatibility, indexing into empty slice closes #1754

### DIFF
--- a/statsmodels/regression/linear_model.py
+++ b/statsmodels/regression/linear_model.py
@@ -2115,7 +2115,7 @@ class OLSResults(RegressionResults):
         params = np.copy(self.params)
         opt_fun_inst = _ELRegOpts() # to store weights
         if len(param_nums) == len(params):
-            llr = opt_fun_inst._opt_nuis_regress(b0_vals,
+            llr = opt_fun_inst._opt_nuis_regress([],
                                     param_nums=param_nums,
                                     endog=self.model.endog,
                                     exog=self.model.exog,


### PR DESCRIPTION
numpy > 1.9 will not allow anymore to assign different shaped array into slices
see #1754 details on numpy mailing list

no unittests added, is already covered
