### PR TITLE
TST: fix _infer_freq for pandas .14+ compat

### DIFF
--- a/statsmodels/tsa/base/datetools.py
+++ b/statsmodels/tsa/base/datetools.py
@@ -281,8 +281,9 @@ def _add_datetimes(dates):
     return reduce(lambda x, y: y+x, dates)
 
 def _infer_freq(dates):
-    if hasattr(dates, "freqstr"):
-        return dates.freqstr
+    maybe_freqstr = getattr(dates, 'freqstr', None)
+    if maybe_freqstr is not None:
+        return maybe_freqstr
     try:
         from pandas.tseries.api import infer_freq
         freq = infer_freq(dates)


### PR DESCRIPTION
closes https://github.com/statsmodels/statsmodels/issues/1822
some discussion over at pandas: https://github.com/pydata/pandas/issues/7922

Basically pandas 0.14 fixed a bug with DatetimeIndex's raising an AttributeError if you
tried to access its freqstr attribute when it doesn't have a frequency.
The tests previously relied on having the freqstr attribute implying that freqstr was not None.
