### PR TITLE
ENH: family: add option to turn of valid link check, or warn. 

### DIFF
--- a/statsmodels/genmod/generalized_estimating_equations.py
+++ b/statsmodels/genmod/generalized_estimating_equations.py
@@ -1942,6 +1942,7 @@ class Multinomial(Family):
             distribution.
         """
 
+        self.invalid_link = 'raise'
         self.ncut = nlevels - 1
         self.link = MultinomialLogit(self.ncut)
 


### PR DESCRIPTION
see #1509

add option: `invalid_link : string in ['raise' 'warn', 'ignore']`   to turn exception into warning or ignore

needed to allow the GLM equivalent for Probit in #1870
#1509 also includes other options to improve how links are specified, that are not addressed here.

Also, binomial should allow probit and CDFLink, which are also not included here.
