### PR TITLE
BUG: add _ctor_param to TransfGen distributions

### DIFF
--- a/statsmodels/sandbox/distributions/extras.py
+++ b/statsmodels/sandbox/distributions/extras.py
@@ -738,6 +738,16 @@ class TransfTwo_gen(distributions.rv_continuous):
                                 shapes = kls.shapes,
                                 longname = longname, extradoc = extradoc)
 
+        # add enough info for self.freeze() to be able to reconstruct the instance
+        try:
+            self._ctor_param.update(dict(kls=kls, func=func,
+                    funcinvplus=funcinvplus, funcinvminus=funcinvminus,
+                    derivplus=derivplus, derivminus=derivminus,
+                    shape=self.shape))
+        except AttributeError:
+            # scipy < 0.14 does not have this, ignore and do nothing
+            pass
+
     def _rvs(self, *args):
         self.kls._size = self._size   #size attached to self, not function argument
         return self.func(self.kls._rvs(*args))

--- a/statsmodels/sandbox/distributions/tests/testtransf.py
+++ b/statsmodels/sandbox/distributions/tests/testtransf.py
@@ -91,7 +91,7 @@ class Test_Transf2(object):
            (absnormalg, stats.halfnorm),
            (absnormalg, stats.foldnorm(1e-5)),  #try frozen
            #(negsquarenormalg, 1-stats.chi2),  # won't work as distribution
-           #(squaretg(10), stats.f(1, 10))  # disable temporarily see #1864
+           (squaretg(10), stats.f(1, 10))
             ]      #try both frozen
 
         l,s = 0.0, 1.0


### PR DESCRIPTION
so that they can be frozen with scipy >= 0.14.
see scipy gh-3852, statsmodels gh-1865
