### PR TITLE
BUG pandas 0.15 compatibility in grouputils labels

### DIFF
--- a/statsmodels/tools/grouputils.py
+++ b/statsmodels/tools/grouputils.py
@@ -374,7 +374,12 @@ class Grouping(object):
             # Compat code for the labels -> codes change in pandas 0.15
             # FIXME: use .codes directly when we don't want to support pandas < 0.15
             tmp = pd.Categorical(self.index)
-            return getattr(tmp, "codes", tmp.labels)[None]
+            try:
+                labl = tmp.labels
+            except AttributeError:
+                labl = tmp.codes
+
+            return labl[None]
 
 
     @property


### PR DESCRIPTION
fix pandas compatibility for Categorical.labels with pandas master and 0.15

this is a correction to #1884
