### PR TITLE
BUG: fix ytick positions closes #1561

### DIFF
--- a/statsmodels/sandbox/stats/multicomp.py
+++ b/statsmodels/sandbox/stats/multicomp.py
@@ -760,6 +760,7 @@ class TukeyHSDResults(object):
         ax1.set_ylim([-1, self._multicomp.ngroups])
         ax1.set_xlim([np.min(minrange) - r / 10., np.max(maxrange) + r / 10.])
         ax1.set_yticklabels(np.insert(self.groupsunique.astype(str), 0, ''))
+        ax1.set_yticks(np.arange(-1, len(means)+1))
         ax1.set_xlabel(xlabel if xlabel is not None else '')
         ax1.set_ylabel(ylabel if ylabel is not None else '')
         return fig


### PR DESCRIPTION
Fix for ytick positions are not at the correct position, closes #1561

solutions thanks to @thomas-haslwanter

works correctly in ipython notebook of #1561
