### PR TITLE
BUG fix more ix indexing cases for pandas compat

### DIFF
--- a/statsmodels/sandbox/regression/tests/test_gmm.py
+++ b/statsmodels/sandbox/regression/tests/test_gmm.py
@@ -29,8 +29,8 @@ def get_griliches76_data():
     for yr in years:
         griliches76_data['D_%i' %yr] = np.zeros(N)
         for i in range(N):
-            if griliches76_data['year'][i] == yr:
-                griliches76_data['D_%i' %yr][i] = 1
+            if griliches76_data.ix[i, 'year'] == yr:
+                griliches76_data.ix[i, 'D_%i' %yr] = 1
             else:
                 pass
 

--- a/statsmodels/stats/anova.py
+++ b/statsmodels/stats/anova.py
@@ -128,9 +128,9 @@ def anova1_lm_single(model, endog, exog, nobs, design_info, table, n_rows, test,
     table.index = Index(index + ['Residual'])
     table.ix[index, ['df', 'sum_sq']] = np.c_[arr[~idx].sum(1), sum_sq]
     if test == 'F':
-        table[:n_rows][test] = ((table['sum_sq']/table['df'])/
+        table.ix[:n_rows, test] = ((table['sum_sq']/table['df'])/
                                 (model.ssr/model.df_resid))
-        table[:n_rows][pr_test] = stats.f.sf(table["F"], table["df"],
+        table.ix[:n_rows, pr_test] = stats.f.sf(table["F"], table["df"],
                                 model.df_resid)
 
     # fill in residual
@@ -353,7 +353,7 @@ def anova_lm(*args, **kwargs):
 
     table["ssr"] = lmap(getattr, args, ["ssr"]*n_models)
     table["df_resid"] = lmap(getattr, args, ["df_resid"]*n_models)
-    table.ix[1:]["df_diff"] = -np.diff(table["df_resid"].values)
+    table.ix[1:, "df_diff"] = -np.diff(table["df_resid"].values)
     table["ss_diff"] = -table["ssr"].diff()
     if test == "F":
         table["F"] = table["ss_diff"] / table["df_diff"] / scale


### PR DESCRIPTION
two pandas compatibility changes for double indexing ix[..][..] were missed before
test_gmm and stats.anova

based on Warnings running with pandas master

closes #1891
