### PR TITLE
BUG: LikelihoodModelResults.pvalues use df_resid_inference

### DIFF
--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -885,7 +885,8 @@ class LikelihoodModelResults(Results):
     @cache_readonly
     def pvalues(self):
         if self.use_t:
-            return stats.t.sf(np.abs(self.tvalues), self.df_resid)*2
+            df_resid = getattr(self, 'df_resid_inference', self.df_resid)
+            return stats.t.sf(np.abs(self.tvalues), df_resid)*2
         else:
             return stats.norm.sf(np.abs(self.tvalues))*2
 

--- a/statsmodels/regression/tests/test_robustcov.py
+++ b/statsmodels/regression/tests/test_robustcov.py
@@ -405,6 +405,16 @@ class TestOLSRobustCluster2Fit(CheckOLSRobustCluster, CheckOLSRobustNewMixin):
         self.rtolh = 1e-10
 
 
+    def test_basic_inference(self):
+        res1 = self.res1
+        res2 = self.res2
+        rtol = 1e-7
+        assert_allclose(res1.params, res2.params, rtol=1e-8)
+        assert_allclose(res1.bse, res2.bse, rtol=rtol)
+        assert_allclose(res1.pvalues, res2.pvalues, rtol=rtol, atol=1e-20)
+        ci = res2.params_table[:, 4:6]
+        assert_allclose(res1.conf_int(), ci, rtol=5e-7, atol=1e-20)
+
 
 class TestOLSRobustCluster2Large(CheckOLSRobustCluster, CheckOLSRobustNewMixin):
     # compare with `reg cluster`


### PR DESCRIPTION
closes #1903

pvalues didn't use `df_resid_inference` which is used to separate it from `df_resid` in cluster robust standard errors.

adds one unit test for pvalues and conf_int

comment to unit tests
all sandwich unit tests should test the full results, which they don't do for the new `fit` options
tests needs streamlining. I'm not even sure how much each of the versions of choosing covariances and use_t are tested.
some asserts might be duplicated, see CheckOLSRobustNewMixin
