### PR TITLE
ENH: Binstar build files

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,6 +51,14 @@ Binaries and source distributions are available from PyPi
 
     http://pypi.python.org/pypi/statsmodels/
 
+Binaries can be installed in Anaconda
+
+    conda install statsmodels
+
+Development snapshots are also avaiable in Anaconda
+
+    conda install -c https://conda.binstar.org/statsmodels statsmodels
+
 
 Installation from sources
 =========================

--- a/tools/binstar/README.md
+++ b/tools/binstar/README.md
@@ -1,0 +1,27 @@
+Binstar
+=======
+
+[Binstar](http://binstar.org) is Continuum's solution for binary package distribution.  This directory contains the files required for building a binstar package:
+ 
+ * `meta.yaml` - Information about the package and dependencies
+ * `bld.bat` - Windows batch file called in the build process
+ * `build.sh` - Linux/OSX batch file called in the build process
+
+Two other helper files are included to automate building across Python 2.7, 3.3 and 3.4.
+
+ * `binstar_windows.bat`
+ * `binstar_linux.sh`
+
+Running either file from statsmodels/binstar will build all three versions and upload them, assuming the account has been authenticated using 
+
+```
+binstar login
+```
+
+Installing from binstar
+-----------------------
+The most recent snapshot can be installed using 
+
+```
+conda install -c https://conda.binstar.org/statsmodels statsmodels
+``` 

--- a/tools/binstar/binstar_linux.sh
+++ b/tools/binstar/binstar_linux.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+cd ../..
+
+## declare Python and Numpy Versions
+declare -a PY_VERSIONS=( "27" "33" "34" )
+declare -a NPY_VERSIONS=( "18" "19" )
+
+## Loop across Python and Numpy
+for PY in "${PY_VERSIONS[@]}"
+do
+    export CONDA_PY=$PY
+    for NPY in "${NPY_VERSIONS[@]}"
+    do
+        export CONDA_NPY=$NPY
+        binstar remove statsmodels/statsmodels/0.6.0_dev/linux-64/statsmodels-0.6.0_dev-np${NPY}py${PY}_0.tar.bz2 -f
+        conda build ./tools/binstar
+    done
+done

--- a/tools/binstar/binstar_windows.bat
+++ b/tools/binstar/binstar_windows.bat
@@ -1,0 +1,37 @@
+@echo off
+Setlocal EnableDelayedExpansion
+REM Get current directory
+SET CURRENT_WORKING_DIR=%~dp0
+REM Python and NumPy versions
+set PY_VERSION=27 33 34
+set NPY_VERSION=18 19
+
+
+(for %%P in (%PY_VERSION%) do (
+    (for %%N in (%NPY_VERSION%) do (
+
+        REM Trick to force a delay. Windows sometimes has issues with rapid file deletion
+        call PING 1.1.1.1 -n 1 -w 5000 >NUL
+        REM Clean up
+        robocopy C:\Anaconda\conda-bld\work\ c:\temp\conda-work-trash * /MOVE /S
+        del c:\temp\conda-work-trash\*.*? /s
+        rmdir C:\Anaconda\conda-bld\work\.git /S /Q
+        REM Trick to force a delay. Windows sometimes has issues with rapid file deletion
+        call PING 1.1.1.1 -n 1 -w 30000 >NUL
+
+        IF %%P==27 (
+            call python2_setup.bat
+        ) ELSE (
+            call python3_setup.bat
+        )
+        set CONDA_PY=%%P
+        set CONDA_NPY=%%N
+        echo Python: !CONDA_PY!, NumPy: !CONDA_NPY!
+
+        REM Remove from binstar
+        binstar remove statsmodels/statsmodels/0.6.0_dev/win-64\statsmodels-0.6.0_dev-np!CONDA_NPY!py!CONDA_PY!_0.tar.bz2 --force
+        cd %CURRENT_WORKING_DIR%
+        cd ..\..
+        conda build .\tools\binstar
+        ))
+)) 

--- a/tools/binstar/bld.bat
+++ b/tools/binstar/bld.bat
@@ -1,0 +1,1 @@
+python setup.py install

--- a/tools/binstar/build.sh
+++ b/tools/binstar/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+${PYTHON} setup.py install || exit 1;

--- a/tools/binstar/meta.yaml
+++ b/tools/binstar/meta.yaml
@@ -1,0 +1,35 @@
+package:
+  name: statsmodels
+  version: "0.6.0_dev"
+
+source:
+  git_url: https://github.com/statsmodels/statsmodels.git
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - python
+    - distribute
+    - cython 0.20*
+    - numpy
+    - scipy
+    - pandas
+    - patsy
+
+  run:
+    - python
+    - numpy
+    - numpy
+    - scipy
+    - pandas
+    - patsy
+
+test:
+  imports:
+    - statsmodels
+
+about:
+  home: http://statsmodels.sourceforge.net/
+  license : BSD License

--- a/tools/binstar/python2_setup.bat
+++ b/tools/binstar/python2_setup.bat
@@ -1,0 +1,9 @@
+echo Python 2.x setup
+REM Setup compiler
+REM The Windows 7 SDK with .Net 3.5 is buggy on Windows 8.  These paths are needed to fix these issues
+set PATH=C:\Program Files (x86)\Microsoft Visual Studio 9.0\Common7\IDE;%PATH%
+set INCLUDE=C:\Program Files\Microsoft SDKs\Windows\v7.0\Include;C:\Program Files (x86)\Microsoft Visual Studio 9.0\VC\include;%INCLUDE%
+set LIB=C:\Program Files\Microsoft SDKs\Windows\v7.0\Lib\x64;C:\Program Files (x86)\Microsoft Visual Studio 9.0\VC\lib\amd64
+set DISTUTILS_USE_SDK=1
+REM This setenv is the setenv that came with SDK7, with the bugs fixed
+CALL "C:\temp\setenv" /x64 /release

--- a/tools/binstar/python3_setup.bat
+++ b/tools/binstar/python3_setup.bat
@@ -1,0 +1,6 @@
+echo Python 3.x setup
+REM Setup compiler
+set PATH=C:\Program Files (x86)\Microsoft Visual Studio 10.0\Common7\IDE;%PATH%
+cd C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin
+set DISTUTILS_USE_SDK=1
+CALL "C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\setenv" /x64 /release


### PR DESCRIPTION
Includes the files necessary to build conda packages and upload to binstar for Windows and Linux (OSX should also work, but untested)

The binstar repo has been created here:

https://binstar.org/statsmodels/statsmodels
