### PR TITLE
BUG: Remove unwanted init key for OLS

### DIFF
--- a/statsmodels/regression/linear_model.py
+++ b/statsmodels/regression/linear_model.py
@@ -681,10 +681,8 @@ class OLS(WLS):
     def __init__(self, endog, exog=None, missing='none', hasconst=None):
         super(OLS, self).__init__(endog, exog, missing=missing,
                                   hasconst=hasconst)
-        print self._init_keys
         if "weights" in self._init_keys:
             self._init_keys.remove("weights")
-        print self._init_keys
 
     def loglike(self, params):
         """


### PR DESCRIPTION
Simple PR to remove an inappropriate init_key from OLS.  Closes #1957. 
