### PR TITLE
ENH: Add gradient-based optimization for fitting GLM's

### DIFF
--- a/statsmodels/genmod/families/family.py
+++ b/statsmodels/genmod/families/family.py
@@ -214,7 +214,7 @@ class Family(object):
 
     def loglike(self, endog, mu, scale=1.):
         """
-        The log-likelihood function expressed as a function of the fitted mean response.
+        The log-likelihood function in terms of the fitted mean response.
 
         Parameters
         ----------
@@ -352,7 +352,7 @@ class Poisson(Family):
 
     def loglike(self, endog, mu, scale=1.):
         """
-        The log-likelihood function for the Poisson exponential family expressed as a function of the fitted mean response.
+        The log-likelihood function in terms of the fitted mean response.
 
         Parameters
         ----------
@@ -486,7 +486,7 @@ class Gaussian(Family):
 
     def loglike(self, endog, mu, scale=1.):
         """
-        The log-likelihood function for the Gaussian exponential family expressed as a function of the fitted mean response.
+        The log-likelihood in terms of the fitted mean response.
 
         Parameters
         ----------
@@ -651,7 +651,7 @@ class Gamma(Family):
 
     def loglike(self, endog, mu, scale=1.):
         """
-        The log-likelihood function for the Gamma exponential family expressed as a function of the fitted mean response.
+        The log-likelihood function in terms of the fitted mean response.
 
         Parameters
         ----------
@@ -873,7 +873,7 @@ class Binomial(Family):
 
     def loglike(self, endog, mu, scale=1.):
         """
-        The log-likelihood function for the Binomial exponential family expressed as a function of the fitted mean response.
+        The log-likelihood function in terms of the fitted mean response.
 
         Parameters
         ----------
@@ -1050,7 +1050,7 @@ class InverseGaussian(Family):
 
     def loglike(self, endog, mu, scale=1.):
         """
-        The log-likelihood function for the inverse Gaussian distribution expressed as a function of the fitted mean response.
+        The log-likelihood function in terms of the fitted mean response.
 
         Parameters
         ----------
@@ -1252,7 +1252,7 @@ class NegativeBinomial(Family):
 
     def loglike(self, endog, mu, scale):
         """
-        The log-likelihood function for the negative binomial family expressed as a function of the fitted mean response.
+        The log-likelihood function in terms of the fitted mean response.
 
         Parameters
         ----------

--- a/statsmodels/genmod/families/family.py
+++ b/statsmodels/genmod/families/family.py
@@ -214,8 +214,7 @@ class Family(object):
 
     def loglike(self, endog, mu, scale=1.):
         """
-        The log-likelihood function expressed as a function of the
-        fitted mean response.
+        The log-likelihood function expressed as a function of the fitted mean response.
 
         Parameters
         ----------
@@ -353,8 +352,7 @@ class Poisson(Family):
 
     def loglike(self, endog, mu, scale=1.):
         """
-        The log-likelihood function for the Poisson exponential family
-        expressed as a function of the fitted mean response.
+        The log-likelihood function for the Poisson exponential family expressed as a function of the fitted mean response.
 
         Parameters
         ----------
@@ -488,8 +486,7 @@ class Gaussian(Family):
 
     def loglike(self, endog, mu, scale=1.):
         """
-        The log-likelihood function for the Gaussian exponential
-        family expressed as a function of the fitted mean response.
+        The log-likelihood function for the Gaussian exponential family expressed as a function of the fitted mean response.
 
         Parameters
         ----------
@@ -654,8 +651,7 @@ class Gamma(Family):
 
     def loglike(self, endog, mu, scale=1.):
         """
-        The log-likelihood function for the Gamma exponential family
-        expressed as a function of the fitted mean response.
+        The log-likelihood function for the Gamma exponential family expressed as a function of the fitted mean response.
 
         Parameters
         ----------
@@ -877,8 +873,7 @@ class Binomial(Family):
 
     def loglike(self, endog, mu, scale=1.):
         """
-        The log-likelihood function for the Binomial exponential
-        family expressed as a function of the fitted mean response.
+        The log-likelihood function for the Binomial exponential family expressed as a function of the fitted mean response.
 
         Parameters
         ----------
@@ -1055,9 +1050,7 @@ class InverseGaussian(Family):
 
     def loglike(self, endog, mu, scale=1.):
         """
-        The log-likelihood function for the inverse Gaussian
-        distribution expressed as a function of the fitted mean
-        response.
+        The log-likelihood function for the inverse Gaussian distribution expressed as a function of the fitted mean response.
 
         Parameters
         ----------
@@ -1259,8 +1252,7 @@ class NegativeBinomial(Family):
 
     def loglike(self, endog, mu, scale):
         """
-        The log-likelihood function for the negative binomial family
-        expressed as a function of the fitted mean response.
+        The log-likelihood function for the negative binomial family expressed as a function of the fitted mean response.
 
         Parameters
         ----------

--- a/statsmodels/genmod/families/links.py
+++ b/statsmodels/genmod/families/links.py
@@ -76,7 +76,7 @@ class Link(object):
 
         Notes
         -----
-        This reference implementation gives the correct result but it
+        This reference implementation gives the correct result but is
         inefficient, so it can be overriden in subclasses.
 
         Parameters
@@ -89,7 +89,7 @@ class Link(object):
         The value of the derivative of the inverse of the link function
 
         """
-        return 1/self.deriv(self.inverse(z))
+        return 1 / self.deriv(self.inverse(z))
 
 
 class Logit(Link):
@@ -207,6 +207,22 @@ class Logit(Link):
         return t/(1 + t)**2
 
 
+    def deriv2(self, p):
+        """
+        Second derivative of the logit function.
+
+        Parameters
+        ----------
+        p : array-like
+            probabilities
+
+        Returns
+        -------
+        The value of the second derivative of the logit function
+        """
+        v = p * (1 - p)
+        return (2*p - 1) / v**2
+
 class logit(Logit):
     pass
 
@@ -251,12 +267,15 @@ class Power(Link):
         g(p) = x**self.power
         """
 
-        return np.power(p, self.power)
+        # TODO: not sure if this is a good idea...
+        p = np.clip(p, 1e-10, 1e10)
+
+        z = np.power(p, self.power)
+        return z
 
     def inverse(self, z):
         """
         Inverse of the power transform link function
-
 
         Parameters
         ----------
@@ -272,7 +291,11 @@ class Power(Link):
         -----
         g^(-1)(z`) = `z`**(1/`power`)
         """
-        return np.power(z, 1. / self.power)
+        # TODO: not sure if this is a good idea...
+        z = np.clip(z, 1e-10, 1e10)
+
+        p = np.power(z, 1. / self.power)
+        return p
 
     def deriv(self, p):
         """
@@ -293,6 +316,26 @@ class Power(Link):
         g'(`p`) = `power` * `p`**(`power` - 1)
         """
         return self.power * np.power(p, self.power - 1)
+
+    def deriv2(self, p):
+        """
+        Second derivative of the power transform
+
+        Parameters
+        ----------
+        p : array-like
+            Mean parameters
+
+        Returns
+        --------
+        g''(p) : array
+            Second derivative of the power transform of `p`
+
+        Notes
+        -----
+        g''(`p`) = `power` * (`power` - 1) * `p`**(`power` - 2)
+        """
+        return self.power * (self.power - 1) * np.power(p, self.power - 2)
 
     def inverse_deriv(self, z):
         """
@@ -437,10 +480,31 @@ class Log(Link):
 
         Notes
         -----
-        g(x) = 1/x
+        g'(x) = 1/x
         """
         p = self._clean(p)
         return 1. / p
+
+    def deriv2(self, p):
+        """
+        Second derivative of the log transform link function
+
+        Parameters
+        ----------
+        p : array-like
+            Mean parameters
+
+        Returns
+        -------
+        g''(p) : array
+            Second derivative of log transform of x
+
+        Notes
+        -----
+        g''(x) = -1/x^2
+        """
+        p = self._clean(p)
+        return -1. / p**2
 
     def inverse_deriv(self, z):
         """
@@ -553,12 +617,14 @@ class CDFLink(Logit):
         return 1. / self.dbn.pdf(self.dbn.ppf(p))
 
     def deriv2(self, p):
-        """Second derivative of the link function g''(p)
+        """
+        Second derivative of the link function g''(p)
 
         implemented through numerical differentiation
         """
         from statsmodels.tools.numdiff import approx_fprime
-        # Note: speciaf function for norm.ppf does not support complex
+        p = np.atleast_1d(p)
+        # Note: special function for norm.ppf does not support complex
         return np.diag(approx_fprime(p, self.deriv, centered=True))
 
     def inverse_deriv(self, z):
@@ -600,11 +666,28 @@ class cauchy(CDFLink):
 
     cauchy is an alias of CDFLink with dbn=scipy.stats.cauchy
     """
+
     def __init__(self):
         super(cauchy, self).__init__(dbn=scipy.stats.cauchy)
 
+    def deriv2(self, p):
+        """
+        Second derivative of the Cauchy link function.
 
-# TODO: CLogLog is untested
+        Parameters
+        ----------
+        p: array-like
+            Probabilities
+
+        Returns
+        -------
+        g'(p) : array
+           Value of the derivative of Cauchy link function at `p`
+        """
+        a = np.pi * (p - 0.5)
+        d2 = 2 * np.pi**2 * np.sin(a) / np.cos(a)**3
+        return d2
+
 class CLogLog(Logit):
     """
     The complementary log-log transform
@@ -674,10 +757,30 @@ class CLogLog(Logit):
 
         Notes
         -----
-        g'(p) = - 1 / (log(p) * p)
+        g'(p) = - 1 / ((p-1)*log(1-p))
         """
         p = self._clean(p)
         return 1. / ((p - 1) * (np.log(1 - p)))
+
+    def deriv2(self, p):
+        """
+        Second derivative of the C-Log-Log ink function
+
+        Parameters
+        ----------
+        p : array-like
+            Mean parameters
+
+        Returns
+        -------
+        g''(p) : array
+           The second derivative of the CLogLog link function
+        """
+        p = self._clean(p)
+        fl = np.log(1 - p)
+        d2 = -1 / ((1 - p)**2 * fl)
+        d2 *= 1 + 1 / fl
+        return d2
 
     def inverse_deriv(self, z):
         """
@@ -786,6 +889,28 @@ class NegativeBinomial(object):
         g'(x) = 1/(x+alpha*x^2)
         '''
         return 1/(p + self.alpha * p**2)
+
+    def deriv2(self,p):
+        '''
+        Second derivative of the negative binomial link function.
+
+        Parameters
+        ----------
+        p : array-like
+            Mean parameters
+
+        Returns
+        -------
+        g'(p) : array
+            The derivative of the negative binomial transform link function
+
+        Notes
+        -----
+        g'(x) = 1/(x+alpha*x^2)
+        '''
+        numer = -(1 + 2 * self.alpha * p)
+        denom = (p + self.alpha * p**2)**2
+        return numer / denom
 
     def inverse_deriv(self, z):
         '''

--- a/statsmodels/genmod/families/links.py
+++ b/statsmodels/genmod/families/links.py
@@ -267,9 +267,6 @@ class Power(Link):
         g(p) = x**self.power
         """
 
-        # TODO: not sure if this is a good idea...
-        p = np.clip(p, 1e-10, 1e10)
-
         z = np.power(p, self.power)
         return z
 
@@ -291,8 +288,6 @@ class Power(Link):
         -----
         g^(-1)(z`) = `z`**(1/`power`)
         """
-        # TODO: not sure if this is a good idea...
-        z = np.clip(z, 1e-10, 1e10)
 
         p = np.power(z, 1. / self.power)
         return p

--- a/statsmodels/genmod/families/tests/test_link.py
+++ b/statsmodels/genmod/families/tests/test_link.py
@@ -5,6 +5,7 @@ from statsmodels.compat.python import range
 import numpy as np
 from numpy.testing import assert_allclose, assert_equal
 import statsmodels.genmod.families as families
+from statsmodels.tools import numdiff as nd
 
 # Family instances
 links = families.links
@@ -23,19 +24,79 @@ Links = [logit, inverse_power, sqrt, inverse_squared, identity, log, probit, cau
          cloglog, negbinom]
 
 
-def test_inverse():
+def get_domainvalue(link):
+    """
+    Get a value in the domain for a given family.
+    """
+    z = -np.log(np.random.uniform(0, 1))
+    if type(link) == type(cloglog): # prone to overflow
+        z = min(z, 3)
+    elif type(link) == type(negbinom): # domain is negative numbers
+        z = -z
+    return z
 
-    ## Logic check that link.inverse(link) is the identity
+def test_inverse():
+    """
+    Logic check that link.inverse(link) and link(link.inverse) are the
+    identity.
+    """
+
+    np.random.seed(3285)
+
     for link in Links:
         for k in range(10):
-            p = np.random.uniform() # In domain for all families
-            d = p - link.inverse(link(p))
-            assert_allclose(d, 0, atol=1e-8)
+            p = np.random.uniform(0, 1) # In domain for all families
+            d = link.inverse(link(p))
+            assert_allclose(d, p, atol=1e-8)
 
+            z = get_domainvalue(link)
+            d = link(link.inverse(z))
+            assert_allclose(d, z, atol=1e-8)
+
+
+def test_deriv():
+    """
+    Check link function derivatives using numeric differentiation.
+    """
+
+    np.random.seed(24235)
+
+    for link in Links:
+        for k in range(10):
+            p = np.random.uniform(0, 1)
+            d = link.deriv(p)
+            da = nd.approx_fprime(np.r_[p], link)
+            assert_allclose(d, da, rtol=1e-6, atol=1e-6)
+
+
+def test_deriv2():
+    """
+    Check link function second derivatives using numeric
+    differentiation.
+    """
+
+    np.random.seed(24235)
+
+    for link in Links:
+        # TODO: Resolve errors with the numeric derivatives
+        if type(link) == type(probit):
+            continue
+        for k in range(10):
+            p = np.random.uniform(0, 1)
+            p = np.clip(p, 0.01, 0.99)
+            if type(link) == type(cauchy):
+                p = np.clip(p, 0.03, 0.97)
+            d = link.deriv2(p)
+            da = nd.approx_fprime(np.r_[p], link.deriv)
+            assert_allclose(d, da, rtol=1e-6, atol=1e-6)
 
 def test_inverse_deriv():
+    """
+    Logic check that inverse_deriv equals 1/link.deriv(link.inverse)
+    """
 
-    ## Logic check that inverse_deriv equals 1/link.deriv(link.inverse)
+    np.random.seed(24235)
+
     for link in Links:
         for k in range(10):
             z = -np.log(np.random.uniform()) # In domain for all families

--- a/statsmodels/genmod/families/tests/test_link.py
+++ b/statsmodels/genmod/families/tests/test_link.py
@@ -47,11 +47,11 @@ def test_inverse():
         for k in range(10):
             p = np.random.uniform(0, 1) # In domain for all families
             d = link.inverse(link(p))
-            assert_allclose(d, p, atol=1e-8)
+            assert_allclose(d, p, atol=1e-8, err_msg=str(link))
 
             z = get_domainvalue(link)
             d = link(link.inverse(z))
-            assert_allclose(d, z, atol=1e-8)
+            assert_allclose(d, z, atol=1e-8, err_msg=str(link))
 
 
 def test_deriv():
@@ -66,7 +66,8 @@ def test_deriv():
             p = np.random.uniform(0, 1)
             d = link.deriv(p)
             da = nd.approx_fprime(np.r_[p], link)
-            assert_allclose(d, da, rtol=1e-6, atol=1e-6)
+            assert_allclose(d, da, rtol=1e-6, atol=1e-6,
+                            err_msg=str(link))
 
 
 def test_deriv2():
@@ -88,7 +89,8 @@ def test_deriv2():
                 p = np.clip(p, 0.03, 0.97)
             d = link.deriv2(p)
             da = nd.approx_fprime(np.r_[p], link.deriv)
-            assert_allclose(d, da, rtol=1e-6, atol=1e-6)
+            assert_allclose(d, da, rtol=1e-6, atol=1e-6,
+                            err_msg=str(link))
 
 def test_inverse_deriv():
     """
@@ -102,7 +104,8 @@ def test_inverse_deriv():
             z = -np.log(np.random.uniform()) # In domain for all families
             d = link.inverse_deriv(z)
             f = 1 / link.deriv(link.inverse(z))
-            assert_allclose(d, f, rtol=1e-8, atol=1e-10)
+            assert_allclose(d, f, rtol=1e-8, atol=1e-10,
+                            err_msg=str(link))
 
 
 def test_invlogit_stability():

--- a/statsmodels/genmod/families/varfuncs.py
+++ b/statsmodels/genmod/families/varfuncs.py
@@ -266,6 +266,14 @@ class NegativeBinomial(object):
         p = self._clean(mu)
         return p + self.alpha*p**2
 
+    def deriv(self, mu):
+        """
+        Derivative of the negative binomial variance function.
+        """
+
+        p = self._clean(mu)
+        return 1 + 2 * self.alpha * p
+
 nbinom = NegativeBinomial()
 nbinom.__doc__ = """
 Negative Binomial variance function.

--- a/statsmodels/genmod/generalized_linear_model.py
+++ b/statsmodels/genmod/generalized_linear_model.py
@@ -633,7 +633,8 @@ class GLM(base.LikelihoodModel):
 
     def fit(self, start_params=None, maxiter=100, method='IRLS',
             tol=1e-8, full_output=True, disp=False, scale=None,
-            cov_type='nonrobust', cov_kwds=None, use_t=None):
+            cov_type='nonrobust', cov_kwds=None, use_t=None,
+            **kwargs):
         """
         Fits a generalized linear model for a given family.
 

--- a/statsmodels/genmod/generalized_linear_model.py
+++ b/statsmodels/genmod/generalized_linear_model.py
@@ -255,7 +255,7 @@ class GLM(base.LikelihoodModel):
         """
         return self.family.loglike(mu, self.endog, self.exog, scale)
 
-    def loglike(self, params, scale=1.):
+    def loglike(self, params, scale=None):
         """
         Evaluate the log-likelihood for a generalized linear model.
         """

--- a/statsmodels/genmod/generalized_linear_model.py
+++ b/statsmodels/genmod/generalized_linear_model.py
@@ -632,19 +632,25 @@ class GLM(base.LikelihoodModel):
             return self.family.fitted(linpred)
 
     def fit(self, start_params=None, maxiter=100, method='IRLS',
-            tol=1e-8, full_output=True, disp=False, scale=None,
-            cov_type='nonrobust', cov_kwds=None, use_t=None,
-            **kwargs):
+            tol=1e-8, scale=None, cov_type='nonrobust', cov_kwds=None,
+            use_t=None, full_output=True, disp=False, **kwargs):
         """
         Fits a generalized linear model for a given family.
 
         parameters
         ----------
+        start_params : array-like, optional
+            Initial guess of the solution for the loglikelihood maximization.
+            The default is family-specific and is given by the
+            ``family.starting_mu(endog)``. If start_params is given then the
+            initial mean will be calculated as ``np.dot(exog, start_params)``.
         maxiter : int, optional
             Default is 100.
         method : string
             Default is 'IRLS' for iteratively reweighted least squares.
             Otherwise gradient optimization is used.
+        tol : float
+            Convergence tolerance.  Default is 1e-8.
         scale : string or float, optional
             `scale` can be 'X2', 'dev', or a float
             The default value is None, which uses `X2` for Gamma, Gaussian,
@@ -652,8 +658,13 @@ class GLM(base.LikelihoodModel):
             `X2` is Pearson's chi-square divided by `df_resid`.
             The default is 1 for the Binomial and Poisson families.
             `dev` is the deviance divided by df_resid
-        tol : float
-            Convergence tolerance.  Default is 1e-8.
+        cov_type : string
+            The type of parameter estimate covariance matrix to compute.
+        cov_kwds : dict-like
+            Extra arguments for calculating the covariance of the parameter
+            estimates.
+        use_t : bool
+            If True, the Student t-distribution is used for inference.
         full_output : bool, optional
             Set to True to have all available output in the Results object's
             mle_retvals attribute. The output is dependent on the solver.
@@ -662,11 +673,6 @@ class GLM(base.LikelihoodModel):
         disp : bool, optional
             Set to True to print convergence messages.  Not used if method is
             IRLS.
-        start_params : array-like, optional
-            Initial guess of the solution for the loglikelihood maximization.
-            The default is family-specific and is given by the
-            ``family.starting_mu(endog)``. If start_params is given then the
-            initial mean will be calculated as ``np.dot(exog, start_params)``.
 
         Notes
         -----

--- a/statsmodels/genmod/generalized_linear_model.py
+++ b/statsmodels/genmod/generalized_linear_model.py
@@ -642,8 +642,8 @@ class GLM(base.LikelihoodModel):
         maxiter : int, optional
             Default is 100.
         method : string
-            Default is 'IRLS' for iteratively reweighted least squares.  This
-            is currently the only method available for GLM fit.
+            Default is 'IRLS' for iteratively reweighted least squares.
+            Otherwise gradient optimization is used.
         scale : string or float, optional
             `scale` can be 'X2', 'dev', or a float
             The default value is None, which uses `X2` for Gamma, Gaussian,

--- a/statsmodels/genmod/generalized_linear_model.py
+++ b/statsmodels/genmod/generalized_linear_model.py
@@ -700,7 +700,7 @@ class GLM(base.LikelihoodModel):
         if method.lower() == "irls":
             return self._fit_irls(start_params=start_params, maxiter=maxiter,
                                   tol=tol, scale=scale, cov_type=cov_type,
-                                  cov_kwds=cov_kwds, use_t=use_t)
+                                  cov_kwds=cov_kwds, use_t=use_t, **kwargs)
         else:
             return self._fit_gradient(start_params=start_params,
                                       method=method,
@@ -708,12 +708,12 @@ class GLM(base.LikelihoodModel):
                                       tol=tol, scale=scale,
                                       full_output=full_output,
                                       disp=disp, cov_type=cov_type,
-                                      cov_kwds=cov_kwds, use_t=use_t)
+                                      cov_kwds=cov_kwds, use_t=use_t, **kwargs)
 
     def _fit_gradient(self, start_params=None, method="newton",
                       maxiter=100, tol=1e-8, full_output=True,
                       disp=True, scale=None, cov_type='nonrobust',
-                      cov_kwds=None, use_t=None):
+                      cov_kwds=None, use_t=None, **kwargs):
         """
         Fits a generalized linear model for a given family iteratively
         using the scipy gradient optimizers.
@@ -722,7 +722,7 @@ class GLM(base.LikelihoodModel):
         # TODO: pass more into fit here
         rslt = super(GLM, self).fit(start_params=start_params, tol=tol,
                                     maxiter=maxiter, full_output=full_output,
-                                    method=method, disp=disp)
+                                    method=method, disp=disp, **kwargs)
         self.mu = self.predict(rslt.params)
         self.scale = self.estimate_scale(self.mu)
 
@@ -746,7 +746,7 @@ class GLM(base.LikelihoodModel):
 
     def _fit_irls(self, start_params=None, maxiter=100, tol=1e-8,
                   scale=None, cov_type='nonrobust', cov_kwds=None,
-                  use_t=None):
+                  use_t=None, **kwargs):
         """
         Fits a generalized linear model for a given family using
         iteratively reweighted least squares (IRLS).

--- a/statsmodels/genmod/tests/test_glm.py
+++ b/statsmodels/genmod/tests/test_glm.py
@@ -863,13 +863,16 @@ def test_gradient_irls():
         rslt_gradient = mod_gradient.fit(start_params=rslt_irls.params, method="newton")
 
         assert_allclose(rslt_gradient.params,
-                        rslt_irls.params, rtol=1e-6, atol=1e-6)
+                        rslt_irls.params, rtol=1e-6, atol=1e-6,
+                        err_msg=family_name + " params")
 
-        # TODO: figure out why this fails
-        if family_name != "negbinom":
-            assert_allclose(rslt_gradient.bse,
-                            rslt_irls.bse, rtol=1e-6, atol=1e-6)
->>>>>>> Add gradient-based optimization for fitting GLM's
+        gradient_bse = rslt_gradient.bse
+        if family_name == "negbinom":
+            ehess = mod_gradient.hessian(rslt_gradient.params, observed=False)
+            gradient_bse = np.sqrt(-np.diag(np.linalg.inv(ehess)))
+        assert_allclose(gradient_bse, rslt_irls.bse, rtol=1e-6,
+                        atol=1e-6, err_msg=family_name + " SE")
+
 
 
 if __name__=="__main__":

--- a/statsmodels/genmod/tests/test_glm.py
+++ b/statsmodels/genmod/tests/test_glm.py
@@ -832,6 +832,24 @@ def gen_endog(lin_pred, family_name):
     return endog
 
 
+def test_summary():
+    """
+    Smoke test for summary.
+    """
+
+    np.random.seed(4323)
+
+    n = 100
+    exog = np.random.normal(size=(n, 2))
+    exog[:, 0] = 1
+    endog = np.random.normal(size=n)
+
+    for method in "irls", "cg":
+        fa = sm.families.Gaussian()
+        model = sm.GLM(endog, exog, family=fa)
+        rslt = model.fit(method=method)
+        s = rslt.summary()
+
 def test_gradient_irls():
     """
     Compare the results when using gradient optimization and IRLS.

--- a/statsmodels/genmod/tests/test_glm.py
+++ b/statsmodels/genmod/tests/test_glm.py
@@ -804,6 +804,73 @@ def test_plots():
     fig = result.plot_ceres_residuals(1)
     plt.close(fig)
 
+def gen_endog(lin_pred, family_name):
+
+    if family_name == "binomial":
+        probs = 1 / (1 + np.exp(-lin_pred))
+        endog = 1*(np.random.uniform(size=len(lin_pred)) < probs)
+    elif family_name == "poisson":
+        lam = np.exp(lin_pred)
+        endog = np.random.poisson(lam)
+    elif family_name == "gamma":
+        lam = np.exp(lin_pred / 4)
+        endog = np.random.gamma(2, lam)
+    elif family_name == "gaussian":
+        endog = lin_pred + np.random.normal(size=len(lin_pred))
+    elif family_name == "negbinom":
+        from scipy.stats.distributions import nbinom
+        lam = np.exp(lin_pred)
+        endog = nbinom.rvs(lam, 0.5)
+    elif family_name == "inverse_gaussian":
+        from scipy.stats.distributions import invgauss
+        lin_pred = 2 + (lin_pred - 2) / 4.
+        lam = 1 / np.sqrt(lin_pred)
+        endog = invgauss.rvs(lam)
+    else:
+        raise ValueError
+
+    return endog
+
+
+def test_gradient_irls():
+    """
+    Compare the results when using gradient optimization and IRLS.
+    """
+
+    np.random.seed(87342)
+
+    families = [sm.families.Binomial(), sm.families.Poisson(),
+                sm.families.Gamma(), sm.families.NegativeBinomial(),
+                sm.families.Gaussian(), sm.families.InverseGaussian()]
+    fnames = ["binomial", "poisson", "gamma", "negbinom", "gaussian",
+              "inverse_gaussian"]
+
+    n = 2000
+    p = 3
+    exog = np.random.normal(size=(n, p))
+    exog[:, 0] = 1
+    lin_pred = 1 + exog.sum(1)
+
+    for family, family_name in zip(families, fnames):
+
+        endog = gen_endog(lin_pred, family_name)
+
+        mod_irls = sm.GLM(endog, exog, family=family)
+        rslt_irls = mod_irls.fit(method="IRLS")
+
+        mod_gradient = sm.GLM(endog, exog, family=family)
+        mod_irls.score(rslt_irls.params)
+        rslt_gradient = mod_gradient.fit(start_params=rslt_irls.params, method="newton")
+
+        assert_allclose(rslt_gradient.params,
+                        rslt_irls.params, rtol=1e-6, atol=1e-6)
+
+        # TODO: figure out why this fails
+        if family_name != "negbinom":
+            assert_allclose(rslt_gradient.bse,
+                            rslt_irls.bse, rtol=1e-6, atol=1e-6)
+>>>>>>> Add gradient-based optimization for fitting GLM's
+
 
 if __name__=="__main__":
     #run_module_suite()

--- a/statsmodels/genmod/tests/test_glm.py
+++ b/statsmodels/genmod/tests/test_glm.py
@@ -863,7 +863,7 @@ def test_gradient_irls():
     fnames = ["binomial", "poisson", "gamma", "negbinom", "gaussian",
               "inverse_gaussian"]
 
-    n = 2000
+    n = 100
     p = 3
     exog = np.random.normal(size=(n, p))
     exog[:, 0] = 1


### PR DESCRIPTION
closes #1736 and #1958, see also #1788 

This is a PR to allow GLM's to be fit using scipy optimizers.  It also fills some other gaps and corrects a few inconsistencies in the GLM implementation.  Here are the main points:

* The method keyword argument to fit can be IRLS (as before), or the name of any scipy optimizer.

* Several deriv2 implementations that were missing in family.py were falling back to numerical differentiation, which leads to issues with run time and big inaccuracies in some cases.  I have added most of the missing analytic deriv2 functions.

* I added tests for most of the links and associated functions (inverses, derivatives, etc.).

* I resolved inconsistencies in some of the signatures for the negative binomial family.

* I added a likelihood function that takes params as an argument, renaming the likelihood that takes the fitted means as loglike_mu.

* I added tests comparing IRLS fits to Newton fits for 6 families.  The tests all run clean for me.
