### PR TITLE
BUG: summary2 use float_format

### DIFF
--- a/statsmodels/iolib/summary2.py
+++ b/statsmodels/iolib/summary2.py
@@ -541,7 +541,7 @@ def _df_to_simpletable(df, align='r', float_format="%.4f", header=True,
 
 def _simple_tables(tables, settings, pad_col=None, pad_index=None):
     simple_tables = []
-    float_format = '%.4f'
+    float_format = settings[1]['float_format']
     if pad_col is None:
         pad_col = [0] * len(tables)
     if pad_index is None:


### PR DESCRIPTION
 when creating `_simple_tables` setting float_format is ignored
 see #1964

However, this is incomplete as fix, since there are three dictionaries in `settings`, that have been appended in different methods or functions.

Should there only be one, or is this on purpose?
