### PR TITLE
TST: Add testing against NumPy 1.9 and matplotlib 1.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,9 +39,10 @@ matrix:
   - python: 2.7
     env:
     - PYTHON=3.4
-    - NUMPY=1.8
+    - NUMPY=1.9
     - SCIPY=0.14
     - PANDAS=0.14
+    - MATPLOTLIB=1.4
   - python: 2.7
     env:
     - PYTHON=2.7


### PR DESCRIPTION
Change to travis config to include NumPy 1.9 and matplotlib 1.4 testing
