### PR TITLE
Covariate effect plot

### DIFF
--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -37,7 +37,7 @@ _extra_param_doc = """
         False, a constant is not checked for and k_constant is set to 0.
 """
 
-_covariate_effect_plot_doc ="""\
+_plot_covariate_effects_doc ="""\
     Plot the fitted mean function in terms of a single 'focus'
     covariate, holding the values of the other covariates fixed at
     specified points.
@@ -73,7 +73,7 @@ _covariate_effect_plot_doc ="""\
     >>> new_exog = []
     >>> new_exog.append(np.percentile(exog, 25, axis=0)
     >>> new_exog.append(np.percentile(exog, 75, axis=0)
-    >>> fig = result.covariate_effect_plot(2, new_exog)
+    >>> fig = result.plot_covariate_effecs(2, new_exog)
 
     Similar to the previous example, using formulas:
 
@@ -84,7 +84,7 @@ _covariate_effect_plot_doc ="""\
     >>> new_exog[0] = [np.percentile(df[v], 25) for v in df.columns]
     >>> new_exog[1] = [np.percentile(df[v], 75) for v in df.columns]
     >>> new_exog = [Series(x, index=df.columns) for x in new_exog]
-    >>> fig = result.covariate_effect_plot('x2', new_exog)
+    >>> fig = result.plot_covariate_effects('x2', new_exog)
 
     Notes
     -----
@@ -797,17 +797,17 @@ class Results(object):
 
         return self.model.predict(self.params, exog, *args, **kwargs)
 
-    def covariate_effect_plot(self, focus_var, exog, n_points=50,
-                              ax=None):
+    def plot_covariate_effects(self, focus_var, exog, n_points=50,
+                               ax=None):
 
         from statsmodels.graphics import regressionplots
 
-        return regressionplots.covariate_effect_plot(self, focus_var,
-                                                     exog,
-                                                     n_points=n_points,
-                                                     ax=ax)
+        return regressionplots.plot_covariate_effects(self, focus_var,
+                                                      exog,
+                                                      n_points=n_points,
+                                                      ax=ax)
 
-    covariate_effect_plot.__doc__ = _covariate_effect_plot_doc % {
+    plot_covariate_effects.__doc__ = _plot_covariate_effects_doc % {
         'extra_params_doc': ''}
 
 

--- a/statsmodels/graphics/regressionplots.py
+++ b/statsmodels/graphics/regressionplots.py
@@ -24,7 +24,7 @@ from statsmodels.base import model
 __all__ = ['plot_fit', 'plot_regress_exog', 'plot_partregress', 'plot_ccpr',
            'plot_regress_exog', 'plot_partregress_grid', 'plot_ccpr_grid',
            'add_lowess', 'add_hist', 'abline_plot', 'influence_plot',
-           'plot_leverage_resid2', 'covariate_effect_plot']
+           'plot_leverage_resid2', 'plot_covariate_effects']
 
 
 #TODO: consider moving to influence module
@@ -876,8 +876,8 @@ def plot_leverage_resid2(results, alpha=.05, label_kwargs={}, ax=None,
     ax.margins(.075, .075)
     return fig
 
-def covariate_effect_plot(results, focus_var, exog, n_points=50,
-                          ax=None):
+def plot_covariate_effects(results, focus_var, exog, n_points=50,
+                           ax=None):
 
     fig, ax = utils.create_mpl_ax(ax)
 
@@ -948,5 +948,5 @@ def covariate_effect_plot(results, focus_var, exog, n_points=50,
 
     return fig
 
-covariate_effect_plot.__doc__ = model._covariate_effect_plot_doc % {
+plot_covariate_effects.__doc__ = model._plot_covariate_effects_doc % {
     'extra_params_doc': "results: object\n\tResults for a fitted regression model"}

--- a/statsmodels/graphics/tests/test_regressionplots.py
+++ b/statsmodels/graphics/tests/test_regressionplots.py
@@ -9,7 +9,7 @@ import statsmodels.api as sm
 from statsmodels.graphics.regressionplots import (plot_fit, plot_ccpr,
                   plot_partregress, plot_regress_exog, abline_plot,
                   plot_partregress_grid, plot_ccpr_grid, add_lowess,
-                  covariate_effect_plot, add_hist)
+                  plot_covariate_effects, add_hist)
 from pandas import Series, DataFrame
 from numpy.testing import dec
 
@@ -231,8 +231,8 @@ class TestCovariateEffectPlot(object):
 
                     exog_str, new_exog = self.get_new_exog(new_exog_type)
 
-                    fig = covariate_effect_plot(self.results, focus_var,
-                                                exog=new_exog)
+                    fig = plot_covariate_effects(self.results, focus_var,
+                                                 exog=new_exog)
 
                     ax = fig.get_axes()[0]
                     if show_hist:
@@ -306,8 +306,8 @@ class TestCovariateEffectPlotPandas(object):
 
                     exog_str, new_exog = self.get_new_exog(new_exog_type)
 
-                    fig = covariate_effect_plot(self.results, focus_var,
-                                                exog=new_exog)
+                    fig = plot_covariate_effects(self.results, focus_var,
+                                                 exog=new_exog)
 
                     ax = fig.get_axes()[0]
                     if show_hist:


### PR DESCRIPTION
This PR adds a plotting method to the base results class. It should be useful for any regression model that has endog and exog and that implements the predict method. The plot displays the fitted mean response against the value of one "focus" covariate, holding the other "control" covariates fixed at given values. There are two different ways to specify how the "control" covariates are fixed.
