### PR TITLE
ENH: allow generalized irf fevd calculations

### DIFF
--- a/statsmodels/tsa/vector_ar/irf.py
+++ b/statsmodels/tsa/vector_ar/irf.py
@@ -54,7 +54,7 @@ class BaseIRAnalysis(object):
         if svar:
             self.svar_irfs = model.svar_ma_rep(periods, P=P)
         else:
-            self.orth_irfs = model.orth_ma_rep(periods)
+            self.orth_irfs = model.orth_ma_rep(periods, P=P)
 
         self.cum_effects = self.irfs.cumsum(axis=0)
         if svar:


### PR DESCRIPTION
this makes currently only one change to choose the matrix for the forecast error variance decomposition in VAR

see thread on mailing list
https://groups.google.com/d/msg/pystatsmodels/BqMqOIghN78/A3CpDH6_h5AJ

This reproduces the results for an example with generalized fevd, but I don't know about other changes that would be useful.
Looks innocent since it doesn't change anything in the default case, AFAICS
