### PR TITLE
Score/LM conditional moment tests

### DIFF
--- a/statsmodels/base/_parameter_inference.py
+++ b/statsmodels/base/_parameter_inference.py
@@ -70,9 +70,9 @@ def _lm_robust(score, R, Ainv, B, V=None):
         else:
             inner = R.dot(V).dot(R.T)
 
-    #lm_stat2 = wscore.dot(np.linalg.pinv(inner).dot(wscore))
-    # Let's assume inner is invertible, TODO: check if usecase for pinv exists
-    lm_stat = wscore.dot(np.linalg.solve(inner, wscore))
+        #lm_stat2 = wscore.dot(np.linalg.pinv(inner).dot(wscore))
+        # Let's assume inner is invertible, TODO: check if usecase for pinv exists
+        lm_stat = wscore.dot(np.linalg.solve(inner, wscore))
     pval = stats.chi2.sf(lm_stat, k_constraints)
     return lm_stat, pval, k_constraints
 

--- a/statsmodels/base/_parameter_inference.py
+++ b/statsmodels/base/_parameter_inference.py
@@ -1,0 +1,245 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Wed May 30 15:11:09 2018
+
+@author: josef
+"""
+
+import time
+import numpy as np
+from scipy import stats
+
+from statsmodels.regression.linear_model import OLS
+from statsmodels.genmod.generalized_linear_model import GLM
+from statsmodels.genmod import families
+import statsmodels.stats._diagnostic_other as diao
+
+
+# this is a copy from stats._diagnostic_other
+def _lm_robust(score, R, Ainv, B, V=None):
+    '''general formula for score/LM test
+
+    generalized score or lagrange multiplier test for implicit constraints
+
+    `r(params) = 0`, with gradient `R = d r / d params`
+
+    linear constraints are given by `R params - q = 0`
+
+    It is assumed that all arrays are evaluated at the constrained estimates.
+
+
+    Parameters
+    ----------
+    score : ndarray, 1-D
+        derivative of objective function at estimated parameters
+        of constrained model
+    constraint_matrix R : ndarray
+        Linear restriction matrix or Jacobian of nonlinear constraints
+    hessian_inv, Ainv : ndarray, symmetric, square
+        inverse of second derivative of objective function
+        TODO: could be OPG or any other estimator if information matrix
+        equality holds
+    cov_score B :  ndarray, symmetric, square
+        covariance matrix of the score. This is the inner part of a sandwich
+        estimator.
+    cov_params V :  ndarray, symmetric, square
+        covariance of full parameter vector evaluated at constrained parameter
+        estimate. This can be specified instead of cov_score B.
+
+    Returns
+    -------
+    lm_stat : float
+        score/lagrange multiplier statistic
+
+    Notes
+    -----
+
+    '''
+    k_constraints = np.linalg.matrix_rank(R)
+    tmp = R.dot(Ainv)
+    wscore = tmp.dot(score)  # C Ainv score
+
+    if B is None and V is None:
+        # only Ainv is given, so we assume information matrix identity holds
+        # computational short cut, should be same if Ainv == inv(B)
+        lm_stat = score.dot(Ainv.dot(score))
+    else:
+        # information matrix identity does not hold
+        if V is None:
+            inner = tmp.dot(B).dot(tmp.T)
+        else:
+            inner = R.dot(V).dot(R.T)
+
+    #lm_stat2 = wscore.dot(np.linalg.pinv(inner).dot(wscore))
+    # Let's assume inner is invertible, TODO: check if usecase for pinv exists
+    lm_stat = wscore.dot(np.linalg.solve(inner, wscore))
+    pval = stats.chi2.sf(lm_stat, k_constraints)
+    return lm_stat, pval, k_constraints
+
+
+def score_test(self, exog_extra=None, params_constrained=None,
+               hypothesis='joint', cov_type=None, cov_kwds=None,
+               k_constraints=None, observed=True):
+    """score test for restrictions or for omitted variables
+
+    Null Hypothesis : constraints are satisfied
+
+    Alternative Hypothesis : at least one of the constraints does not hold
+
+    This allows to specify restricted and unrestricted model properties in
+    three different ways
+
+    - fit_constrained result: model contains score and hessian function for
+      the full, unrestricted model, but the parameter estimate in the results
+      instance are for the restricted model. This is the case if the model
+      was estimated with fit_constrained.
+    - restricted model with variable addition: If exog_extra is not None, then
+      it is assumed that the current model is a model with zero restrictions
+      and the unrestricted model is given by adding exog_extra as additional
+      explanatory variables.
+    - unrestricted model with restricted parameters explicitly provided. If
+      params_constrained is not None, then the model is assumed to be for the
+      unrestricted model, but the provided parameters are for the restricted
+      model.
+      TODO: This will currently only work for `nonrobust` cov_type, otherwise
+      we will also need the restriction matrix.
+
+
+    Parameters
+    ----------
+    exog_extra : None or array_like
+        Explanatory variables that are jointly tested for inclusion in the
+        model, i.e. omitted variables.
+    params_constrained : array_like
+        estimated parameter of the restricted model. This can be the
+        parameter estimate for the current when testing for omitted
+        variables.
+    hypothesis : str, 'joint' (default) or 'separate'
+        If hypothesis is 'joint', then the chisquare test results for the
+        joint hypothesis that all constraints hold is returned.
+        If hypothesis is 'joint', then z-test results for each constraint
+        is returned.
+        This is currently only implemented for cov_type="nonrobust".
+    cov_type : str
+        Warning: only partially implemented so far, currently only "nonrobust"
+        and "HC0" are supported.
+        If cov_type is None, then the cov_type specified in fit for the Wald
+        tests is used.
+        If the cov_type argument is not None, then it will be used instead of
+        the Wald cov_type given in fit.
+    k_constraints : int or None
+        Number of constraints that were used in the estimation of params
+        restricted relative to the number of exog in the model.
+        This must be provided if no exog_extra are given. If exog_extra is
+        not None, then k_constraints is assumed to be zero if it is None.
+    observed : bool
+        If True, then the observed Hessian is used in calculating the
+        covariance matrix of the score. If false then the expected
+        information matrix is used. This currently only applies to GLM where
+        EIM is available.
+        Warning: This option might still change.
+
+    Returns
+    -------
+    chi2_stat : float
+        chisquare statistic for the score test
+    p-value : float
+        P-value of the score test based on the chisquare distribution.
+    df : int
+        Degrees of freedom used in the p-value calculation. This is equal
+        to the number of constraints.
+
+    Notes
+    -----
+    not yet verified for case with scale not equal to 1.
+
+    cov_type is 'nonrobust':
+
+    The covariance matrix for the score is based on the Hessian, i.e.
+    observed information matrix or optionally on the expected information
+    matrix.
+
+    cov_type is 'HC0'
+
+    """
+    # TODO: we are computing unnecessary things for cov_type nonrobust
+    model = self.model
+    nobs = model.nobs
+    if params_constrained is None:
+        params_constrained = self.params
+    cov_type = cov_type if cov_type is not None else self.cov_type
+    r_matrix = None
+
+    if exog_extra is None:
+
+        if hasattr(self, 'constraints'):
+            k_constraints = self.constraints.coefs.shape[0]
+            r_matrix = self.constraints.coefs
+        else:
+            if k_constraints is None:
+                raise ValueError('if exog_extra is None, then k_constraints'
+                                 'needs to be given')
+
+        score = model.score(params_constrained)
+        score_obs = model.score_obs(params_constrained)
+        hessian = model.hessian(params_constrained, observed=observed)
+
+    else:
+        if cov_type == 'V':
+            raise ValueError('if exog_extra is not None, then cov_type cannot '
+                             'be V')
+        if hasattr(self, 'constraints'):
+            raise NotImplementedError('if exog_extra is not None, then self'
+                                      'should not be a constrained fit result')
+        exog_extra = np.asarray(exog_extra)
+        k_constraints = 0
+        ex = np.column_stack((model.exog, exog_extra))
+        k_constraints += ex.shape[1] - model.exog.shape[1]
+        # TODO use diag instead of full np.eye
+        r_matrix = np.eye(len(self.params) + k_constraints)[-k_constraints:]
+
+        score_factor = model.score_factor(params_constrained)
+        score_obs = (score_factor[:, None] * ex)
+        score = score_obs.sum(0)
+        hessian_factor = model.hessian_factor(params_constrained,
+                                             observed=observed)
+        hessian = -np.dot(ex.T * hessian_factor, ex)
+
+    if cov_type == 'nonrobust':
+        cov_score_test = -hessian
+    elif cov_type.upper() == 'HC0':
+        hinv = -np.linalg.inv(hessian)
+        cov_score = nobs * np.cov(score_obs.T)
+        # temporary to try out
+        lm = _lm_robust(score, r_matrix, hinv, cov_score, V=None)
+        return lm
+        # alternative is to use only the center, but it is singular
+        # https://github.com/statsmodels/statsmodels/pull/2096#issuecomment-393646205
+        # cov_score_test_inv = cov_lm_robust(score, r_matrix, hinv,
+        #                                   cov_score, V=None)
+    elif cov_type.upper() == 'V':
+        # TODO: this doesn't work, V in fit_constrained results is singular
+        # we need cov_params without the zeros in it
+        hinv = -np.linalg.inv(hessian)
+        cov_score = nobs * np.cov(score_obs.T)
+        V = self.cov_params_default
+        # temporary to try out
+        chi2stat = _lm_robust(score, r_matrix, hinv, cov_score, V=V)
+        pval = stats.chi2.sf(chi2stat, k_constraints)
+        return chi2stat, pval
+    else:
+        raise NotImplementedError('only cov_type "nonrobust" is available')
+
+    if hypothesis == 'joint':
+        chi2stat = score.dot(np.linalg.solve(cov_score_test, score[:, None]))
+        pval = stats.chi2.sf(chi2stat, k_constraints)
+        # return a stats results instance instead?  Contrast?
+        return chi2stat, pval, k_constraints
+    elif hypothesis == 'separate':
+        diff = score
+        bse = np.sqrt(np.diag(cov_score_test))
+        stat = diff / bse
+        pval = stats.norm.sf(np.abs(stat))*2
+        return stat, pval
+    else:
+        raise NotImplementedError('only hypothesis "joint" is available')

--- a/statsmodels/base/_parameter_inference.py
+++ b/statsmodels/base/_parameter_inference.py
@@ -164,11 +164,17 @@ def score_test(self, exog_extra=None, params_constrained=None,
     """
     # TODO: we are computing unnecessary things for cov_type nonrobust
     model = self.model
-    nobs = model.nobs
+    nobs = model.endog.shape[0] # model.nobs
+    # discrete Poisson does not have nobs
     if params_constrained is None:
         params_constrained = self.params
     cov_type = cov_type if cov_type is not None else self.cov_type
     r_matrix = None
+
+    if observed is False:
+        hess_kwd = {'observed': False}
+    else:
+        hess_kwd = {}
 
     if exog_extra is None:
 
@@ -182,7 +188,7 @@ def score_test(self, exog_extra=None, params_constrained=None,
 
         score = model.score(params_constrained)
         score_obs = model.score_obs(params_constrained)
-        hessian = model.hessian(params_constrained, observed=observed)
+        hessian = model.hessian(params_constrained, **hess_kwd)
 
     else:
         if cov_type == 'V':
@@ -202,7 +208,7 @@ def score_test(self, exog_extra=None, params_constrained=None,
         score_obs = (score_factor[:, None] * ex)
         score = score_obs.sum(0)
         hessian_factor = model.hessian_factor(params_constrained,
-                                             observed=observed)
+                                              **hess_kwd)
         hessian = -np.dot(ex.T * hessian_factor, ex)
 
     if cov_type == 'nonrobust':

--- a/statsmodels/genmod/tests/test_score_test.py
+++ b/statsmodels/genmod/tests/test_score_test.py
@@ -1,0 +1,87 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Thu May 31 15:39:15 2018
+
+Author: Josef Perktold
+"""
+
+
+import numpy as np
+from numpy.testing import assert_allclose
+from scipy import stats
+
+from statsmodels.regression.linear_model import OLS
+from statsmodels.genmod.generalized_linear_model import GLM
+from statsmodels.genmod import families
+import statsmodels.stats._diagnostic_other as diao
+from statsmodels.base._parameter_inference import score_test
+
+
+class TestScoreTest(object):
+    # compares score to wald, and regression test for pvalues
+    rtol_ws = 5e-3
+    atol_ws = 0
+    dispersed = False  # Poisson correctly specified
+    # regression numbers
+    res_pvalue = [0.31786373532550893, 0.32654081685271297]
+
+    @classmethod
+    def setup_class(cls):
+        nobs, k_vars = 500, 5
+
+        np.random.seed(786452)
+        x = np.random.randn(nobs, k_vars)
+        x[:, 0] = 1
+        x2 = np.random.randn(nobs, 2)
+        xx = np.column_stack((x, x2))
+
+        if cls.dispersed:
+            het = np.random.randn(nobs)
+            y = np.random.poisson(np.exp(x.sum(1) * 0.5 + het))
+            #y_mc = np.random.negative_binomial(np.exp(x.sum(1) * 0.5), 2)
+        else:
+            y = np.random.poisson(np.exp(x.sum(1) * 0.5))
+
+        cls.exog_extra = x2
+        cls.model_full = GLM(y, xx, family=families.Poisson())
+        cls.model_drop = GLM(y, x, family=families.Poisson())
+
+    def test_wald_score(self):
+        mod_full = self.model_full
+        mod_drop = self.model_drop
+        restriction = 'x5=0, x6=0'
+        res_full = mod_full.fit()
+        res_constr = mod_full.fit_constrained('x5=0, x6=0')
+        res_drop = mod_drop.fit()
+
+        wald = res_full.wald_test(restriction)
+        lm_constr = np.hstack(score_test(res_constr))
+        lm_extra = np.hstack(score_test(res_drop, exog_extra=self.exog_extra))
+
+        res_wald = np.hstack([wald.statistic.squeeze(), wald.pvalue, [wald.df_denom]])
+        assert_allclose(lm_constr, res_wald, rtol=self.rtol_ws, atol=self.atol_ws)
+        assert_allclose(lm_extra, res_wald, rtol=self.rtol_ws, atol=self.atol_ws)
+        assert_allclose(lm_constr, lm_extra, rtol=1e-12, atol=1e-14)
+        # regression number
+        assert_allclose(lm_constr[1], self.res_pvalue[0], rtol=1e-12, atol=1e-14)
+
+        cov_type='HC0'
+        res_full_hc = mod_full.fit(cov_type=cov_type, start_params=res_full.params)
+        wald = res_full_hc.wald_test(restriction)
+        lm_constr = np.hstack(score_test(res_constr, cov_type=cov_type))
+        lm_extra = np.hstack(score_test(res_drop, exog_extra=self.exog_extra,
+                                        cov_type=cov_type))
+
+        res_wald = np.hstack([wald.statistic.squeeze(), wald.pvalue, [wald.df_denom]])
+        assert_allclose(lm_constr, res_wald, rtol=self.rtol_ws, atol=self.atol_ws)
+        assert_allclose(lm_extra, res_wald, rtol=self.rtol_ws, atol=self.atol_ws)
+        assert_allclose(lm_constr, lm_extra, rtol=1e-13)
+        # regression number
+        assert_allclose(lm_constr[1], self.res_pvalue[1], rtol=1e-12, atol=1e-14)
+
+
+class TestScoreTestDispersed(TestScoreTest):
+    rtol_ws = 0.11
+    atol_ws = 0.015
+    dispersed = True  # Poisson is mis-specified
+    res_pvalue = [5.412978775609189e-14, 0.05027602575743518]

--- a/statsmodels/genmod/tests/test_score_test.py
+++ b/statsmodels/genmod/tests/test_score_test.py
@@ -36,6 +36,7 @@ class TestScoreTest(object):
                              [ 0.14935018,  0.88127732],
                              [ 0.14841761,  0.8820132 ],
                              [ 0.22836064,  0.81936588]])
+    res_disptest_g = [0.052247629593715761, 0.81919738867722225]
 
     @classmethod
     def setup_class(cls):
@@ -107,6 +108,15 @@ class TestScoreTest(object):
         res_drop = self.model_drop.fit()
         res_test = diao.dispersion_poisson(res_drop)
         assert_allclose(res_test[0], self.res_disptest, rtol=1e-6, atol=1e-14)
+        # constant only dispersion
+        ex = np.ones((res_drop.model.endog.shape[0], 1))
+        # ex = np.column_stack((np.ones(res_drop.model.endog.shape[0]),
+        #                      res_drop.predict()))  # or **2
+        # dispersion_poisson_generic might not be correct
+        # or not clear what the alternative hypothesis is
+        # choosing different `ex` implies different alternative hypotheses
+        res_test = diao.dispersion_poisson_generic(res_drop, ex)
+        assert_allclose(res_test, self.res_disptest_g, rtol=1e-6, atol=1e-14)
 
 
 class TestScoreTestDispersed(TestScoreTest):
@@ -122,6 +132,7 @@ class TestScoreTestDispersed(TestScoreTest):
                              [  4.53940519e+00,   5.64131397e-06],
                              [  2.98154154e+00,   2.86801135e-03],
                              [  4.27569194e+00,   1.90544551e-05]])
+    res_disptest_g = [17.670784788586968, 2.6262956791721383e-05]
 
 
 class TestScoreTestPoisson(TestScoreTest):
@@ -140,6 +151,7 @@ class TestScoreTestPoisson(TestScoreTest):
                              [ 0.14935018,  0.88127732],
                              [ 0.14841761,  0.8820132 ],
                              [ 0.22836064,  0.81936588]])
+    res_disptest_g = [0.052247629593715761, 0.81919738867722225]
 
     @classmethod
     def setup_class(cls):
@@ -180,3 +192,4 @@ class TestScoreTestPoissonDispersed(TestScoreTestPoisson):
                              [  4.53940519e+00,   5.64131397e-06],
                              [  2.98154154e+00,   2.86801135e-03],
                              [  4.27569194e+00,   1.90544551e-05]])
+    res_disptest_g = [17.670784788586968, 2.6262956791721383e-05]

--- a/statsmodels/genmod/tests/test_score_test.py
+++ b/statsmodels/genmod/tests/test_score_test.py
@@ -29,6 +29,13 @@ class TestScoreTest(object):
     # regression numbers
     res_pvalue = [0.31786373532550893, 0.32654081685271297]
     skip_wooldridge = False
+    res_disptest = np.array([[ 0.13927919,  0.44461477],
+                             [ 0.13927919,  0.44461477],
+                             [ 0.21295545,  0.41568086],
+                             [ 0.14935018,  0.88127732],
+                             [ 0.14935018,  0.88127732],
+                             [ 0.14841761,  0.8820132 ],
+                             [ 0.22836064,  0.81936588]])
 
     @classmethod
     def setup_class(cls):
@@ -96,6 +103,11 @@ class TestScoreTest(object):
             # smoke test
             lm_wooldridge.summary()
 
+    def test_dispersion(self):
+        res_drop = self.model_drop.fit()
+        res_test = diao.dispersion_poisson(res_drop)
+        assert_allclose(res_test[0], self.res_disptest, rtol=1e-6, atol=1e-14)
+
 
 class TestScoreTestDispersed(TestScoreTest):
     rtol_ws = 0.11
@@ -103,6 +115,13 @@ class TestScoreTestDispersed(TestScoreTest):
     rtol_wooldridge = 0.03
     dispersed = True  # Poisson is mis-specified
     res_pvalue = [5.412978775609189e-14, 0.05027602575743518]
+    res_disptest = np.array([[  1.26473634e+02,   0.00000000e+00],
+                             [  1.26473634e+02,   0.00000000e+00],
+                             [  1.19393621e+02,   0.00000000e+00],
+                             [  4.53940519e+00,   5.64131397e-06],
+                             [  4.53940519e+00,   5.64131397e-06],
+                             [  2.98154154e+00,   2.86801135e-03],
+                             [  4.27569194e+00,   1.90544551e-05]])
 
 
 class TestScoreTestPoisson(TestScoreTest):
@@ -113,7 +132,14 @@ class TestScoreTestPoisson(TestScoreTest):
     dispersed = False  # Poisson correctly specified
     # regression numbers
     res_pvalue = [0.31786373532550893, 0.32654081685271297]
-    skip_wooldridge = True
+    skip_wooldridge = False
+    res_disptest = np.array([[ 0.13927919,  0.44461477],
+                             [ 0.13927919,  0.44461477],
+                             [ 0.21295545,  0.41568086],
+                             [ 0.14935018,  0.88127732],
+                             [ 0.14935018,  0.88127732],
+                             [ 0.14841761,  0.8820132 ],
+                             [ 0.22836064,  0.81936588]])
 
     @classmethod
     def setup_class(cls):
@@ -147,3 +173,10 @@ class TestScoreTestPoissonDispersed(TestScoreTestPoisson):
     rtol_wooldridge = 0.03
     dispersed = True  # Poisson is mis-specified
     res_pvalue = [5.412978775609189e-14, 0.05027602575743518]
+    res_disptest = np.array([[  1.26473634e+02,   0.00000000e+00],
+                             [  1.26473634e+02,   0.00000000e+00],
+                             [  1.19393621e+02,   0.00000000e+00],
+                             [  4.53940519e+00,   5.64131397e-06],
+                             [  4.53940519e+00,   5.64131397e-06],
+                             [  2.98154154e+00,   2.86801135e-03],
+                             [  4.27569194e+00,   1.90544551e-05]])

--- a/statsmodels/stats/_diagnostic_other.py
+++ b/statsmodels/stats/_diagnostic_other.py
@@ -1,0 +1,679 @@
+# -*- coding: utf-8 -*-
+"""Score, lagrange multiplier and conditional moment tests
+robust to misspecification or without specification of higher moments
+
+Created on Thu Oct 30 00:42:38 2014
+
+Author: Josef Perktold
+License: BSD-3
+
+Notes
+-----
+
+This module is a mixture of very general and very specific functions for
+hypothesis testing in general models, targeted mainly to non-normal models.
+
+Some of the options or versions of these tests are mainly intented for
+cross-checking and to replicate different examples in references.
+
+We need clean versions with good defaults for those functions that are
+intended for the user.
+
+
+References
+----------
+general:
+
+Wooldridge
+Cameron and Trivedi
+Wooldridge, and Cameron Trivedi also cover the special cases for GLM/LEF
+White
+Pagan and Vella
+Newey and McFadden
+Davidson and MacKinnon
+
+GLM:
+
+Boos
+Breslow 1990
+
+
+Poisson:
+...
+
+
+
+"""
+
+import numpy as np
+from scipy import stats
+
+from statsmodels.regression.linear_model import OLS
+
+
+class ResultsGeneric(object):
+
+
+    def __init__(self, **kwds):
+        self.__dict__.update(kwds)
+
+
+class TestResults(ResultsGeneric):
+
+
+    def summary(self):
+        txt = 'Specification Test (LM, score)\n'
+        stat = [self.c1, self.c2, self.c3]
+        pval = [self.pval1, self.pval2, self.pval3]
+        description = ['nonrobust', 'dispersed', 'HC']
+
+        for row in zip(description, stat, pval):
+            txt += '%-12s  statistic = %6.4f  pvalue = %6.5f\n' % row
+
+        txt += '\nAssumptions:\n'
+        txt += 'nonrobust: variance is correctly specified\n'
+        txt += 'dispersed: variance correctly specified up to scale factor\n'
+        txt += 'HC       : robust to any heteroscedasticity\n'
+        txt += 'test is not robust to correlation across observations'
+
+
+        return txt
+
+def lm_test_glm(result, exog_extra, mean_deriv=None):
+    '''score/lagrange multiplier test for GLM
+
+    Wooldridge procedure for test of mean function in GLM
+
+    Parameters
+    ----------
+    results : GLMResults instance
+        results instance with the constrained model
+    exog_extra : ndarray or None
+        additional exogenous variables for variable addition test
+        This can be set to None if mean_deriv is provided.
+    mean_deriv : None or ndarray
+        Extra moment condition that correspond to the partial derivative of
+        a mean function with respect to some parameters.
+
+    Returns
+    -------
+    test_results : Results instance
+        The results instance has the following attributes which are score
+        statistic and p-value for 3 versions of the score test.
+
+        c1, pval1 : nonrobust score_test results
+        c2, pval2 : score test results robust to over or under dispersion
+        c3, pval3 : score test results fully robust to any heteroscedasticity
+
+        The test results instance also has a simple summary method.
+
+    Notes
+    -----
+    TODO: add `df` to results and make df detection more robust
+
+    This implements the auxiliary regression procedure of Wooldridge,
+    implemented based on the presentation in chapter 8 in Handbook of ...
+
+
+    References
+    ----------
+    Wooldridge
+    Wooldridge
+    and more Wooldridge
+
+    '''
+
+
+    if hasattr(result, '_result'):
+        res = result._result
+    else:
+        res = result
+
+    mod = result.model
+    nobs = mod.endog.shape[0]
+
+    #mean_func = mod.family.link.inverse
+    dlinkinv = mod.family.link.inverse_deriv
+
+    # derivative of mean function w.r.t. beta (linear params)
+    dm = lambda x, linpred: dlinkinv(linpred)[:,None] * x
+
+    var_func = mod.family.variance
+
+    x = result.model.exog
+    x2 = exog_extra
+
+    # test omitted
+    lin_pred = res.predict(linear=True)
+    dm_incl = dm(x, lin_pred)
+    if x2 is not None:
+        dm_excl = dm(x2, lin_pred)
+        if mean_deriv is not None:
+            # allow both and stack
+            dm_excl = np.column_stack((dm_excl, mean_deriv))
+    elif mean_deriv is not None:
+        dm_excl = mean_deriv
+    else:
+        raise ValueError('either exog_extra or mean_deriv have to be provided')
+
+    # TODO check for rank or redundant, note OLS calculates the rank
+    k_constraint = dm_excl.shape[1]
+
+    v = var_func(res.fittedvalues)
+    std = np.sqrt(v)
+    res_ols1 = OLS(res.resid_response / std, np.column_stack((dm_incl, dm_excl)) / std[:, None]).fit()
+
+    # case: nonrobust assumes variance implied by distribution is correct
+    c1 = res_ols1.ess
+    pval1 = stats.chi2.sf(c1, k_constraint)
+    #print c1, stats.chi2.sf(c1, 2)
+
+    # case: robust to dispersion
+    c2 = nobs * res_ols1.rsquared
+    pval2 = stats.chi2.sf(c2, k_constraint)
+    #print c2, stats.chi2.sf(c2, 2)
+
+    # case: robust to heteroscedasticity
+    from statsmodels.stats.multivariate_tools import partial_project
+    pp = partial_project(dm_excl / std[:,None], dm_incl / std[:,None])
+    resid_p = res.resid_response / std
+    res_ols3 = OLS(np.ones(nobs), pp.resid * resid_p[:,None]).fit()
+    #c3 = nobs * res_ols3.rsquared   # this is Wooldridge
+    c3b = res_ols3.ess  # simpler if endog is ones
+    pval3 = stats.chi2.sf(c3b, k_constraint)
+
+    tres = TestResults(c1=c1, pval1=pval1,
+                       c2=c2, pval2=pval2,
+                       c3=c3b, pval3=pval3)
+
+    return tres
+
+
+
+def lm_robust(score, R, Ainv, B, V=None):
+    '''general formula for score/LM test
+
+    generalized score or lagrange multiplier test for implicit constraints
+
+    `r(params) = 0`, with gradient `R = d r / d params`
+
+    linear constraints are given by `R params - q = 0`
+
+    It is assumed that all arrays are evaluated at the constrained estimates.
+
+
+    Parameters
+    ----------
+    score : ndarray, 1-D
+        derivative of objective function at estimated parameters
+        of constrained model
+    constraint_matrix R : ndarray
+        Linear restriction matrix or Jacobian of nonlinear constraints
+    hessian_inv, Ainv : ndarray, symmetric, square
+        inverse of second derivative of objective function
+        TODO: could be OPG or any other estimator if information matrix
+        equality holds
+    cov_score B :  ndarray, symmetric, square
+        covariance matrix of the score. This is the inner part of a sandwich
+        estimator.
+    cov_params V :  ndarray, symmetric, square
+        covariance of full parameter vector evaluated at constrained parameter
+        estimate. This can be specified instead of cov_score B.
+
+    Returns
+    -------
+    lm_stat : float
+        score/lagrange multiplier statistic
+
+    Notes
+    -----
+
+    '''
+
+    tmp = R.dot(Ainv)
+    wscore = tmp.dot(score)  # C Ainv score
+
+    if B is None and V is None:
+        # only Ainv is given, so we assume information matrix identity holds
+        # computational short cut, should be same if Ainv == inv(B)
+        lm_stat = score.dot(Ainv.dot(score))
+    else:
+        # information matrix identity does not hold
+        if V is None:
+            inner = tmp.dot(B).dot(tmp.T)
+        else:
+            inner = R.dot(V).dot(R.T)
+
+        #lm_stat2 = wscore.dot(np.linalg.pinv(inner).dot(wscore))
+        # Let's assume inner is invertible, TODO: check if usecase for pinv exists
+        lm_stat = wscore.dot(np.linalg.solve(inner, wscore))
+
+    return lm_stat#, lm_stat2
+
+
+def lm_robust_subset(score, k_constraints, score_deriv, cov_score):
+    '''general formula for score/LM test
+
+    generalized score or lagrange multiplier test for constraints on a subset
+    of parameters
+
+    `params_1 = value`, where params_1 is a subset of the unconstrained
+    parameter vector.
+
+    It is assumed that all arrays are evaluated at the constrained estimates.
+
+
+    Parameters
+    ----------
+    score : ndarray, 1-D
+        derivative of objective function at estimated parameters
+        of constrained model
+    k_constraint: int
+        number of constraints
+    score_deriv : ndarray, symmetric, square
+        inverse of second derivative of objective function
+        TODO: could be OPG or any other estimator if information matrix
+        equality holds
+    cov_score B :  ndarray, symmetric, square
+        covariance matrix of the score. This is the inner part of a sandwich
+        estimator.
+    not cov_params V :  ndarray, symmetric, square
+        covariance of full parameter vector evaluated at constrained parameter
+        estimate. This can be specified instead of cov_score B.
+
+    Returns
+    -------
+    lm_stat : float
+        score/lagrange multiplier statistic
+
+    Notes
+    -----
+
+    The implementation is based on Boos 1992 section 4.1. The same derivation
+    is also in other articles and in text books.
+
+    '''
+
+    # Notation in Boos
+    # score `S = sum (s_i)
+    # score_obs `s_i`
+    # score_deriv `I` is derivative of score (hessian)
+    # `D` is covariance matrix of score, OPG product given independent observations
+
+    #k_params = len(score)
+
+    # submatrices of score_deriv/hessian
+    # these are I22 and I12 in Boos
+    h_uu = score_deriv[-k_constraints:, -k_constraints:]
+    h_cu = score_deriv[:k_constraints, -k_constraints:]
+
+    # TODO: pinv or solve ?
+    tmp_proj = h_cu.dot(np.linalg.inv(h_uu))
+    tmp = np.column_stack(np.eye(k_constraints), tmp_proj)
+
+    cov_score_constraints = tmp.dot(cov_score.dot(tmp))
+
+
+    #lm_stat2 = wscore.dot(np.linalg.pinv(inner).dot(wscore))
+    # Let's assume inner is invertible, TODO: check if usecase for pinv exists
+    lm_stat = score.dot(np.linalg.solve(cov_score_constraints, score))
+    pval = stats.chi2.sf(lm_stat, k_constraints)
+
+    # check second calculation Boos referencing Kent 1982 and Engle 1984
+    # we can use this when robust_cov_params of full model is available
+    h_inv = np.linalg.inv(score_deriv)
+    v = h_inv.dot(cov_score.dot(h_inv)) # this is robust cov_params
+    v_cc = v[:k_constraints, :k_constraints]
+    h_cc = score_deriv[:k_constraints, :k_constraints]
+    # brute force calculation:
+    h_resid_cu = h_cc - h_cu.dot(np.linalg.solve(h_uu, h_cu))
+    cov_s_c = h_resid_cu.dot(v_cc.dot(h_resid_cu))
+    diff = np.max(np.abs(cov_s_c - cov_score_constraints))
+    return lm_stat, pval, diff#, lm_stat2
+
+
+def lm_robust_subset_parts(score, k_constraints,
+                           score_deriv_uu, score_deriv_cu,
+                           cov_score_cc, cov_score_cu, cov_score_uu):
+    """robust generalized score tests on subset of parameters
+
+    This is the same as lm_robust_subset with arguments in parts of
+    partitioned matrices.
+    This can be useful, when we have the parts based on different estimation
+    procedures, i.e. when we don't have the full unconstrained model.
+
+    Calculates mainly the covariance of the constraint part of the score.
+
+    TODO: these function should just return the covariance of the score
+    instead of calculating the score/lm test.
+
+    Implementation similar to lm_robust_subset based on Boos 1992, section 4.1
+    """
+
+    tmp_proj = np.linalg.solve(score_deriv_uu, score_deriv_cu)
+    tmp = tmp_proj.dot(cov_score_cu)
+
+    cov = cov_score_cc
+    cov -= tmp_proj
+    cov -= tmp_proj.T
+    cov += tmp.dot(tmp_proj.T)
+
+    lm_stat = score.dot(np.linalg.solve(cov, score))
+    pval = stats.chi2.sf(lm_stat, k_constraints)
+    return lm_stat, pval
+
+
+def lm_robust_reparameterized(score, params_deriv,
+                           score_deriv, cov_score):
+    """robust generalized score test for transformed parameters
+
+    The parameters are given by a nonlinear transformation of the estimated
+    reduced parameters
+
+    `params = g(params_reduced)`  with jacobian `G = d g / d params_reduced`
+
+    score and other arrays are for full parameter space `params`
+
+    Boos 1992, section 4.4
+    """
+    # Boos notation
+    # params_deriv G
+
+    k_params, k_constraints = params_deriv.shape
+
+    G = params_deriv  # shortcut alias
+
+    tmp_c0 = np.linalg.solve(G.dot(score_deriv.dot(G)))
+    tmp_c1 = score_deriv.dot(G.dot(tmp_c0.dot(G)))
+    tmp_c = np.eye(k_params) - tmp_c1
+
+    cov = tmp_c.dot(cov_score.dot(tmp_c))  # warning: reduced rank
+
+    lm_stat = score.dot(np.linalg.pinv(cov).dot(score))
+    pval = stats.chi2.sf(lm_stat, k_constraints)
+    return lm_stat, pval
+
+
+def dispersion_poisson(results):
+    """Score/LM type tests for Poisson variance assumptions
+
+    Null Hypothesis is
+
+    H0: var(y) = E(y) and assuming E(y) is correctly specified
+    H1: var(y) ~= E(y)
+
+    The tests are based on the constrained model, i.e. the Poisson model.
+    The tests differ in their assumed alternatives, and in their maintained
+    assumptions.
+
+    Parameters
+    ----------
+    results : Poisson results instance
+        TODO: currently uses GLMResults properties
+        this can be either a discrete Poisson or a GLM with family Poisson
+        results instance
+
+    """
+    from scipy import stats
+
+    if hasattr(results, '_results'):
+        results = results._results
+
+    endog = results.model.endog
+    nobs = endog.shape[0]   #TODO: use attribute, may need to be added
+    fitted = results.predict(results.params)
+    fitted = results.fittedvalues
+    #this assumes Poisson
+    resid2 = results.resid_response**2
+    var_resid_endog = (resid2 - endog)
+    var_resid_fitted = (resid2 - fitted)
+    std1 = np.sqrt(2 * (fitted**2).sum())
+
+    var_resid_endog_sum = var_resid_endog.sum()
+    dean_a = var_resid_fitted.sum() / std1
+    dean_b = var_resid_endog_sum / std1
+    dean_c = (var_resid_endog / fitted).sum() / np.sqrt(2 * nobs)
+
+    pval_dean_a = stats.norm.sf(np.abs(dean_a))
+    pval_dean_b = stats.norm.sf(np.abs(dean_b))
+    pval_dean_c = stats.norm.sf(np.abs(dean_c))
+
+    results_all = [[dean_a, pval_dean_a],
+                   [dean_b, pval_dean_b],
+                   [dean_c, pval_dean_c]]
+    description = [['Dean A', 'mu (1 + a mu)'],
+                   ['Dean B', 'mu (1 + a mu)'],
+                   ['Dean C', 'mu (1 + a)']]
+
+    # Cameron Trived auxiliary regression page 78 count book 1989
+    endog_v = var_resid_endog / fitted
+    res_ols_nb2 = OLS(endog_v, fitted).fit(use_t=False)
+    stat_ols_nb2 = res_ols_nb2.tvalues[0]
+    pval_ols_nb2 = res_ols_nb2.pvalues[0]
+    results_all.append([stat_ols_nb2, pval_ols_nb2])
+    description.append(['CT nb2', 'mu (1 + a mu)'])
+
+    res_ols_nb1 = OLS(endog_v, fitted).fit(use_t=False)
+    stat_ols_nb1 = res_ols_nb1.tvalues[0]
+    pval_ols_nb1 = res_ols_nb1.pvalues[0]
+    results_all.append([stat_ols_nb1, pval_ols_nb1])
+    description.append(['CT nb1', 'mu (1 + a)'])
+
+    endog_v = var_resid_endog / fitted
+    res_ols_nb2 = OLS(endog_v, fitted).fit(cov_type='HC1', use_t=False)
+    stat_ols_hc1_nb2 = res_ols_nb2.tvalues[0]
+    pval_ols_hc1_nb2 = res_ols_nb2.pvalues[0]
+    results_all.append([stat_ols_hc1_nb2, pval_ols_hc1_nb2])
+    description.append(['CT nb2 HC1', 'mu (1 + a mu)'])
+
+    res_ols_nb1 = OLS(endog_v, np.ones(len(endog_v))).fit(cov_type='HC1', use_t=False)
+    stat_ols_hc1_nb1 = res_ols_nb1.tvalues[0]
+    pval_ols_hc1_nb1 = res_ols_nb1.pvalues[0]
+    results_all.append([stat_ols_hc1_nb1, pval_ols_hc1_nb1])
+    description.append(['CT nb1 HC1', 'mu (1 + a)'])
+
+
+    return np.array(results_all), description
+
+
+def dispersion_poisson_generic(results, exog_new_test, exog_new_control=None,
+                               include_score=False, use_endog=True,
+                               cov_type='HC1', cov_kwds=None, use_t=False):
+    """A variable addition test for the variance function
+
+    This uses an artificial regression to calculate a variant of an LM or
+    generalized score test for the specification of the variance assumption
+    in a Poisson model. The performed test is a Wald test on the coefficients
+    of the `exog_new_test`.
+
+
+
+    """
+    from scipy import stats
+
+    if hasattr(results, '_results'):
+        results = results._results
+
+    endog = results.model.endog
+    nobs = endog.shape[0]   #TODO: use attribute, may need to be added
+    #fitted = results.predict(results.params) #for discrete.Poisson
+    fitted = results.fittedvalues
+    #this assumes Poisson
+    resid2 = results.resid_response**2
+    if use_endog:
+        var_resid = (resid2 - endog)
+    else:
+        var_resid = (resid2 - fitted)
+
+    endog_v = var_resid / fitted
+
+    k_constraints = exog_new_test.shape[1]
+    ex_list = [exog_new_test]
+    if include_score:
+        score_obs = results.model.score_obs(results.params)
+        ex_list.append(score_obs)
+
+    if exog_new_control is not None:
+        ex_list.append(score_obs)
+
+    if len(ex_list) > 1:
+        ex = np.column_stack(ex_list)
+        use_wald = True
+    else:
+        ex = ex_list[0]  # no control variables in exog
+        use_wald = False
+
+    res_ols = OLS(endog_v, ex).fit(cov_type=cov_type, cov_kwds=cov_kwds,
+                  use_t=use_t)
+
+    if use_wald:
+        # we have controls and need to test coefficients
+        k_vars = ex.shape[1]
+        constraints = np.eye(k_constraints, k_vars)
+        ht = res_ols.wald_test(constraints)
+        stat_ols = ht.statistic
+        pval_ols = ht.pvalue
+    else:
+        # we don't have controls and can use overall fit
+        nobs = endog_v.shape[0]
+        stat_ols = nobs * res_ols.rsquared
+        pval_ols = stats.chi2.sf(stat_ols, k_constraints)
+
+    return stat_ols, pval_ols
+
+
+
+def conditional_moment_test_generic(mom_test, mom_test_deriv,
+                                    mom_incl, mom_incl_deriv,
+                                    var_mom_all=None,
+                                    cov_type='OPG', cov_kwds=None):
+    """generic conditional moment test
+
+    This is mainly intended as internal function in support of diagnostic
+    and specification tests. It has no conversion and checking of correct
+    arguments.
+
+    Parameters
+    ----------
+    mom_test : ndarray, 2-D (nobs, k_constraints)
+        moment conditions that will be tested to be zero
+    mom_test_deriv : ndarray, 2-D, square (k_constraints, k_constraints)
+        derivative of moment conditions under test with respect to the
+        parameters of the model summed over observations.
+    mom_incl : ndarray, 2-D (nobs, k_params)
+        moment conditions that where use in estimation, assumed to be zero
+        This is score_obs in the case of (Q)MLE
+    mom_incl_deriv : ndarray, 2-D, square (k_params, k_params)
+        derivative of moment conditions of estimator summed over observations
+        This is the information matrix or Hessian in the case of (Q)MLE.
+    var_mom_all : None, or ndarray, 2-D, (k, k) with k = k_constraints + k_params
+        Expected product or variance of the joint (column_stacked) moment
+        conditions. The stacking should have the variance of the moment
+        conditions under test in the first k_constraint rows and columns.
+        If it is not None, then it will be estimated based on cov_type.
+        I think: This is the Hessian of the extended or alternative model
+        under full MLE and score test assuming information matrix identity holds.
+
+    Returns
+    -------
+    results
+
+
+    Notes
+    -----
+    TODO: cov_type other than OPG is missing
+    initial implementation based on Cameron Trived countbook 1998 p.48, p.56
+
+    also included: mom_incl can be None if expected mom_test_deriv is zero.
+
+    References
+    ----------
+    Cameron and Trivedi 1998 count book
+    Wooldridge ???
+    Pagan and Vella 1989
+
+    """
+    if cov_type != 'OPG':
+        raise NotImplementedError
+
+    k_constraints = mom_test.shape[1]
+
+    if mom_incl is None:
+        # assume mom_test_deriv is zero, do not include effect of mom_incl
+        if var_mom_all is None:
+            var_cm = mom_test.T.dot(mom_test)
+        else:
+            var_cm = var_mom_all
+
+    else:
+        # take into account he effect of parameter estimates on mom_test
+        if var_mom_all is None:
+            mom_all = np.column_stack((mom_test, mom_incl))
+            # TODO: replace with inner sandwich covariance estimator
+            var_mom_all = mom_all.T.dot(mom_all)
+
+        tmp = mom_test_deriv.dot(np.linalg.pinv(mom_incl_deriv))
+        h = np.column_stack((np.eye(k_constraints, tmp)))
+
+    var_cm = h.dot(var_mom_all.dot(h.T))
+
+    # calculate test results with chisquare
+    var_cm_inv = np.linalg.pinv(var_cm)
+    mom_test_sum = mom_test.sum(0)
+    statistic = mom_test_sum.dot(var_cm_inv.dot(mom_test_sum))
+    pval = stats.chi2.sf(statistic, k_constraints)
+
+    # normal test of individual components
+    se = np.sqrt(np.diag(var_cm))
+    tvalues = mom_test_sum / se
+    pvalues = stats.norm.sf(np.abs(tvalues))
+
+    res = ResultsGeneric(var_cm=var_cm,
+                         stat_cmt=statistic,
+                         pval_cmt=pval,
+                         tvalues=tvalues,
+                         pvalues=pvalues)
+
+    return res
+
+
+def conditional_moment_test_regression(mom_test, mom_test_deriv=None,
+                                    mom_incl=None, mom_incl_deriv=None,
+                                    var_mom_all=None, demean=False,
+                                    cov_type='OPG', cov_kwds=None):
+    """generic conditional moment test based artificial regression
+
+    this is very experimental, no options implemented yet
+
+    so far
+    OPG regression, or
+    artificial regression with Robust Wald test
+
+    The latter is (as far as I can see) the same as an overidentifying test
+    in GMM where the test statistic is the value of the GMM objective function
+    and it is assumed that parameters were estimated with optimial GMM, i.e.
+    the weight matrix equal to the expectation of the score variance.
+
+    """
+    # so far coded from memory
+    nobs, k_constraints = mom_test.shape
+
+    endog = np.ones(nobs)
+    if mom_incl is not None:
+        ex = np.column_stack((mom_test, mom_incl))
+    else:
+        ex = mom_test
+    if demean:
+        ex -= ex.mean(0)
+    if cov_type == 'OPG':
+        res = OLS(endog, ex).fit()
+
+        statistic = nobs * res.rsquared
+        pval = stats.chi2.sf(statistic, k_constraints)
+    else:
+        res = OLS(endog, ex).fit(cov_type=cov_type, cov_kwds=cov_kwds)
+        tres = res.wald_test(np.eye(ex.shape[1]))
+        statistic = tres.statistic
+        pval = tres.pvalue
+
+    return statistic, pval

--- a/statsmodels/stats/_diagnostic_other.py
+++ b/statsmodels/stats/_diagnostic_other.py
@@ -579,20 +579,19 @@ def dispersion_poisson_generic(results, exog_new_test, exog_new_control=None,
     in a Poisson model. The performed test is a Wald test on the coefficients
     of the `exog_new_test`.
 
-
+    Warning: insufficiently tested, especially for options
 
     """
-    from scipy import stats
 
     if hasattr(results, '_results'):
         results = results._results
 
     endog = results.model.endog
     nobs = endog.shape[0]   #TODO: use attribute, may need to be added
-    #fitted = results.predict(results.params) #for discrete.Poisson
-    fitted = results.fittedvalues
-    #this assumes Poisson
+    # fitted = results.fittedvalues  # generic has linpred as fittedvalues
+    fitted = results.predict()
     resid2 = results.resid_response**2
+    #the following assumes Poisson
     if use_endog:
         var_resid = (resid2 - endog)
     else:
@@ -629,7 +628,8 @@ def dispersion_poisson_generic(results, exog_new_test, exog_new_control=None,
     else:
         # we don't have controls and can use overall fit
         nobs = endog_v.shape[0]
-        stat_ols = nobs * res_ols.rsquared
+        rsquared_noncentered = 1 - res_ols.ssr/res_ols.uncentered_tss
+        stat_ols = nobs * rsquared_noncentered
         pval_ols = stats.chi2.sf(stat_ols, k_constraints)
 
     return stat_ols, pval_ols

--- a/statsmodels/stats/_diagnostic_other.py
+++ b/statsmodels/stats/_diagnostic_other.py
@@ -160,8 +160,8 @@ def lm_test_glm(result, exog_extra, mean_deriv=None):
 
     # TODO check for rank or redundant, note OLS calculates the rank
     k_constraint = dm_excl.shape[1]
-
-    v = var_func(res.fittedvalues)
+    fittedvalues = res.predict()  # discrete has linpred instead of mean
+    v = var_func(fittedvalues)
     std = np.sqrt(v)
     res_ols1 = OLS(res.resid_response / std, np.column_stack((dm_incl, dm_excl)) / std[:, None]).fit()
 
@@ -404,7 +404,6 @@ def lm_robust_subset(score, k_constraints, score_deriv, cov_score):
 
     cov_score_constraints = tmp.dot(cov_score.dot(tmp.T))
 
-
     #lm_stat2 = wscore.dot(np.linalg.pinv(inner).dot(wscore))
     # Let's assume inner is invertible, TODO: check if usecase for pinv exists
     lm_stat = score.dot(np.linalg.solve(cov_score_constraints, score))
@@ -512,8 +511,8 @@ def dispersion_poisson(results):
 
     endog = results.model.endog
     nobs = endog.shape[0]   #TODO: use attribute, may need to be added
-    fitted = results.predict(results.params)
-    fitted = results.fittedvalues
+    fitted = results.predict()
+    #fitted = results.fittedvalues  # discrete has linear prediction
     #this assumes Poisson
     resid2 = results.resid_response**2
     var_resid_endog = (resid2 - endog)

--- a/statsmodels/stats/_diagnostic_other.py
+++ b/statsmodels/stats/_diagnostic_other.py
@@ -20,34 +20,148 @@ We need clean versions with good defaults for those functions that are
 intended for the user.
 
 
+
 References
 ----------
-general:
 
-Wooldridge
-Cameron and Trivedi
-Wooldridge, and Cameron Trivedi also cover the special cases for GLM/LEF
-White
-Pagan and Vella
-Newey and McFadden
-Davidson and MacKinnon
+The following references are collected after my intitial implementation and is
+most likely not exactly what I used.
 
-GLM:
+The main articles on which the functions are directly based upon, are Boos 1992,
+Tauchen 1985 and Whitney 1985a. Wooldrige artificial regression is
+based on several articles and his text book.
+Background reading are the textbooks by Cameron and Trivedi, Wooldridge and
+Davidson and MacKinnon.
+Newey and MacFadden 1994 provide some of the theoretical background.
 
-Boos
-Breslow 1990
+Poisson dispersion tests are based on Dean 1992 and articles and text books by
+Cameron and Trivedi.
+
+The references currently do not include the literature on LM-test for
+specification and diagnostic testing, like Pagan, Bera, Bera and Yoon and
+many others, except those for the Poisson excess dispersion case and Pagan
+and Vella.
 
 
-Poisson:
-...
+Boos, Dennis D. 1992. “On Generalized Score Tests.” The American Statistician 46
+(4): 327–33. https://doi.org/10.2307/2685328.
 
+Breslow, Norman. 1989. “Score Tests in Overdispersed GLM’s.” In Statistical
+Modelling, edited by Adriano Decarli, Brian J. Francis, Robert Gilchrist, and
+Gilg U. H. Seeber, 64–74. Lecture Notes in Statistics 57. Springer New York.
+http://link.springer.com/chapter/10.1007/978-1-4612-3680-1_8.
 
+Breslow, Norman. 1990. “Tests of Hypotheses in Overdispersed Poisson Regression
+and Other Quasi- Likelihood Models.” Journal of the American Statistical
+Association 85 (410): 565–71. https://doi.org/10.2307/2289799.
+
+Cameron, A. Colin, and Pravin K. Trivedi. 1986. “Econometric Models Based on
+Count Data. Comparisons and Applications of Some Estimators and Tests.” Journal
+of Applied Econometrics 1 (1): 29–53. https://doi.org/10.1002/jae.3950010104.
+
+Cameron, A. Colin, and Pravin K. Trivedi. 1990a. “Conditional Moment Tests and
+Orthogonal Polynomials.” Indiana University, Department of Economics, Working
+Paper, 90–051.
+
+Cameron, A. Colin, and Pravin K. Trivedi. 1990b. “Regression-Based Tests for
+Overdispersion in the Poisson Model.” Journal of Econometrics 46 (3): 347–64.
+https://doi.org/10.1016/0304-4076(90)90014-K.
+
+Cameron, A. Colin, and Pravin K. Trivedi. Microeconometrics: methods and
+applications. Cambridge university press, 2005.
+
+Cameron, A. Colin, and Pravin K. Trivedi. Regression analysis of count data.
+Vol. 53. Cambridge university press, 2013.
+
+Davidson, Russell, and James G. MacKinnon. 1981. “Several Tests for Model
+Specification in the Presence of Alternative Hypotheses.” Econometrica 49 (3):
+781–93. https://doi.org/10.2307/1911522.
+
+Davidson, Russell, and James G. MacKinnon. 1990. “Specification Tests Based on
+Artificial Regressions.” Journal of the American Statistical Association 85
+(409): 220–27. https://doi.org/10.2307/2289548.
+
+Davidson, Russell, and James G. MacKinnon. 1991. “Artificial Regressions and C
+(α) Tests.” Economics Letters 35 (2): 149–53.
+https://doi.org/10.1016/0165-1765(91)90162-E.
+
+Davidson, Russell, and James G. MacKinnon. Econometric theory and methods. Vol.
+5. New York: Oxford University Press, 2004.
+
+Dean, C. B. 1992. “Testing for Overdispersion in Poisson and Binomial Regression
+Models.” Journal of the American Statistical Association 87 (418): 451–57.
+https://doi.org/10.2307/2290276.
+
+Dean, C., and J. F. Lawless. 1989. “Tests for Detecting Overdispersion in
+Poisson Regression Models.” Journal of the American Statistical Association 84
+(406): 467–72. https://doi.org/10.2307/2289931.
+
+Newey, Whitney K. 1985a. “Generalized Method of Moments Specification Testing.”
+Journal of Econometrics 29 (3): 229–56.
+https://doi.org/10.1016/0304-4076(85)90154-X.
+
+Newey, Whitney K. 1985b. “Maximum Likelihood Specification Testing and
+Conditional Moment Tests.” Econometrica 53 (5): 1047–70.
+https://doi.org/10.2307/1911011.
+
+Newey, Whitney K. and Kenneth D. West. 1987. “Hypothesis Testing with Efficient
+Method of Moments Estimation.” International Economic Review 28 (3): 777–87.
+https://doi.org/10.2307/2526578.
+
+Newey, Whitney K. and Daniel McFadden. 1994 "Large sample estimation and
+hypothesis testing." Handbook of econometrics 4: 2111-2245.
+
+Pagan, Adrian, and Frank Vella. 1989. “Diagnostic Tests for Models Based on
+Individual Data: A Survey.” Journal of Applied Econometrics 4 (S1): S29–59.
+https://doi.org/10.1002/jae.3950040504.
+
+Tauchen, George. 1985. “Diagnostic Testing and Evaluation of Maximum Likelihood
+Models.” Journal of Econometrics 30 (1–2): 415–43.
+https://doi.org/10.1016/0304-4076(85)90149-6.
+
+White, Halbert. 1981. “Consequences and Detection of Misspecified Nonlinear
+Regression Models.” Journal of the American Statistical Association 76 (374):
+419–33. https://doi.org/10.2307/2287845.
+
+White, Halbert. 1983. “Maximum Likelihood Estimation of Misspecified Models.”
+Econometrica 51 (2): 513. https://doi.org/10.2307/1912004.
+
+White, Halbert. 1994. Estimation, Inference and Specification Analysis.
+Cambridge: Cambridge University Press. https://doi.org/10.1017/CCOL0521252806.
+
+Wooldridge, Jeffrey M. 1991. “Specification Testing and Quasi-Maximum-
+Likelihood Estimation.” Journal of Econometrics 48 (1–2): 29–55.
+https://doi.org/10.1016/0304-4076(91)90031-8.
+
+Wooldridge, Jeffrey M. 1990. “A Unified Approach to Robust, Regression-Based
+Specification Tests.” Econometric Theory 6 (1): 17–43.
+
+Wooldridge, Jeffrey M. 1991a. “On the Application of Robust, Regression- Based
+Diagnostics to Models of Conditional Means and Conditional Variances.” Journal
+of Econometrics 47 (1): 5–46. https://doi.org/10.1016/0304-4076(91)90076-P.
+
+Wooldridge, Jeffrey M. 1991b. “On the Application of Robust, Regression- Based
+Diagnostics to Models of Conditional Means and Conditional Variances.” Journal
+of Econometrics 47 (1): 5–46. https://doi.org/10.1016/0304-4076(91)90076-P.
+
+Wooldridge, Jeffrey M. 1991c. “Specification Testing and Quasi-Maximum-
+Likelihood Estimation.” Journal of Econometrics 48 (1–2): 29–55.
+https://doi.org/10.1016/0304-4076(91)90031-8.
+
+Wooldridge, Jeffrey M. 1994. “On the Limits of GLM for Specification Testing: A
+Comment on Gurmu and Trivedi.” Econometric Theory 10 (2): 409–18.
+https://doi.org/10.2307/3532875.
+
+Wooldridge, Jeffrey M. 1997. “Quasi-Likelihood Methods for Count Data.” Handbook
+of Applied Econometrics 2: 352–406.
+
+Wooldridge, Jeffrey M. Econometric analysis of cross section and panel data. MIT
+press, 2010.
 
 """
 
 import numpy as np
 from scipy import stats
-
 
 from statsmodels.tools.decorators import cache_readonly
 from statsmodels.regression.linear_model import OLS
@@ -61,7 +175,6 @@ class ResultsGeneric(object):
 
 
 class TestResults(ResultsGeneric):
-
 
     def summary(self):
         txt = 'Specification Test (LM, score)\n'
@@ -78,8 +191,8 @@ class TestResults(ResultsGeneric):
         txt += 'HC       : robust to any heteroscedasticity\n'
         txt += 'test is not robust to correlation across observations'
 
-
         return txt
+
 
 def lm_test_glm(result, exog_extra, mean_deriv=None):
     '''score/lagrange multiplier test for GLM
@@ -114,17 +227,17 @@ def lm_test_glm(result, exog_extra, mean_deriv=None):
     TODO: add `df` to results and make df detection more robust
 
     This implements the auxiliary regression procedure of Wooldridge,
-    implemented based on the presentation in chapter 8 in Handbook of ...
-
+    implemented based on the presentation in chapter 8 in Handbook of
+    Applied Econometrics 2.
 
     References
     ----------
-    Wooldridge
-    Wooldridge
-    and more Wooldridge
+    Wooldridge, Jeffrey M. 1997. “Quasi-Likelihood Methods for Count Data.”
+    Handbook of Applied Econometrics 2: 352–406.
+
+    and other articles and text book by Wooldridge
 
     '''
-
 
     if hasattr(result, '_result'):
         res = result._result
@@ -191,7 +304,6 @@ def lm_test_glm(result, exog_extra, mean_deriv=None):
     return tres
 
 
-
 def cm_test_robust(resid, resid_deriv, instruments, weights=1):
     '''score/lagrange multiplier of Wooldridge
 
@@ -224,13 +336,11 @@ def cm_test_robust(resid, resid_deriv, instruments, weights=1):
 
     Notes
     -----
-
     This implements the auxiliary regression procedure of Wooldridge,
     implemented based on procedure 2.1 in Wooldridge 1990.
 
     Wooldridge allows for multivariate conditional moments (`resid`)
     TODO: check dimensions for multivariate case for extension
-
 
     References
     ----------
@@ -247,7 +357,6 @@ def cm_test_robust(resid, resid_deriv, instruments, weights=1):
 
 
     nobs = resid.shape[0]
-
 
     from statsmodels.stats.multivariate_tools import partial_project
 
@@ -271,14 +380,13 @@ def cm_test_robust(resid, resid_deriv, instruments, weights=1):
 
     # for checking, this corresponds to nobs * rsquared of auxiliary regression
     stat2 = OLS(np.ones(nobs), moms_test).fit().ess
-
-
     pval = stats.chi2.sf(stat, k_constraint)
 
     return stat, pval, stat2
 
 
-def lm_robust(score, R, Ainv, B, V=None):
+def lm_robust(score, constraint_matrix, score_deriv_inv, cov_score,
+              cov_params=None):
     '''general formula for score/LM test
 
     generalized score or lagrange multiplier test for implicit constraints
@@ -288,7 +396,6 @@ def lm_robust(score, R, Ainv, B, V=None):
     linear constraints are given by `R params - q = 0`
 
     It is assumed that all arrays are evaluated at the constrained estimates.
-
 
     Parameters
     ----------
@@ -317,6 +424,8 @@ def lm_robust(score, R, Ainv, B, V=None):
     -----
 
     '''
+    # shorthand alias
+    R, Ainv, B, V = constraint_matrix, score_deriv_inv, cov_score, cov_params
 
     tmp = R.dot(Ainv)
     wscore = tmp.dot(score)  # C Ainv score
@@ -339,7 +448,7 @@ def lm_robust(score, R, Ainv, B, V=None):
     return lm_stat#, lm_stat2
 
 
-def lm_robust_subset(score, k_constraints, score_deriv, cov_score):
+def lm_robust_subset(score, k_constraints, score_deriv_inv, cov_score):
     '''general formula for score/LM test
 
     generalized score or lagrange multiplier test for constraints on a subset
@@ -350,7 +459,6 @@ def lm_robust_subset(score, k_constraints, score_deriv, cov_score):
 
     It is assumed that all arrays are evaluated at the constrained estimates.
 
-
     Parameters
     ----------
     score : ndarray, 1-D
@@ -358,7 +466,7 @@ def lm_robust_subset(score, k_constraints, score_deriv, cov_score):
         of constrained model
     k_constraint: int
         number of constraints
-    score_deriv : ndarray, symmetric, square
+    score_deriv_inv : ndarray, symmetric, square
         inverse of second derivative of objective function
         TODO: could be OPG or any other estimator if information matrix
         equality holds
@@ -373,10 +481,11 @@ def lm_robust_subset(score, k_constraints, score_deriv, cov_score):
     -------
     lm_stat : float
         score/lagrange multiplier statistic
+    p-value : float
+        p-value of the LM test based on chisquare distribution
 
     Notes
     -----
-
     The implementation is based on Boos 1992 section 4.1. The same derivation
     is also in other articles and in text books.
 
@@ -395,8 +504,8 @@ def lm_robust_subset(score, k_constraints, score_deriv, cov_score):
     # submatrices of score_deriv/hessian
     # these are I22 and I12 in Boos
     #h_uu = score_deriv[-k_constraints:, -k_constraints:]
-    h_uu = score_deriv[:-k_constraints, :-k_constraints]
-    h_cu = score_deriv[-k_constraints:, :-k_constraints]
+    h_uu = score_deriv_inv[:-k_constraints, :-k_constraints]
+    h_cu = score_deriv_inv[-k_constraints:, :-k_constraints]
 
     # TODO: pinv or solve ?
     tmp_proj = h_cu.dot(np.linalg.inv(h_uu))
@@ -411,7 +520,8 @@ def lm_robust_subset(score, k_constraints, score_deriv, cov_score):
 
 #     # check second calculation Boos referencing Kent 1982 and Engle 1984
 #     # we can use this when robust_cov_params of full model is available
-#     h_inv = np.linalg.inv(score_deriv)
+#     #h_inv = np.linalg.inv(score_deriv)
+#     hinv = score_deriv_inv
 #     v = h_inv.dot(cov_score.dot(h_inv)) # this is robust cov_params
 #     v_cc = v[:k_constraints, :k_constraints]
 #     h_cc = score_deriv[:k_constraints, :k_constraints]
@@ -434,6 +544,41 @@ def lm_robust_subset_parts(score, k_constraints,
 
     Calculates mainly the covariance of the constraint part of the score.
 
+    Parameters
+    ----------
+    score : ndarray, 1-D
+        derivative of objective function at estimated parameters
+        of constrained model. These is the score component for the restricted
+        part under hypothesis. The unconstrained part of the score is assumed
+        to be zero.
+    k_constraint: int
+        number of constraints
+    score_deriv_uu : ndarray, symmetric, square
+        first derivative of moment equation or second derivative of objective
+        function for the unconstrained part
+        TODO: could be OPG or any other estimator if information matrix
+        equality holds
+    score_deriv_cu : ndarray
+        first cross derivative of moment equation or second cross
+        derivative of objective function between.
+    cov_score_cc :  ndarray
+        covariance matrix of the score for the unconstrained part.
+        This is the inner part of a sandwich estimator.
+    cov_score_cu :  ndarray
+        covariance matrix of the score for the off-diagonal block, i.e.
+        covariance between constrained and unconstrained part.
+    cov_score_uu :  ndarray
+        covariance matrix of the score for the unconstrained part.
+
+    Returns
+    -------
+    lm_stat : float
+        score/lagrange multiplier statistic
+    p-value : float
+        p-value of the LM test based on chisquare distribution
+
+    Notes
+    -----
     TODO: these function should just return the covariance of the score
     instead of calculating the score/lm test.
 
@@ -455,8 +600,7 @@ def lm_robust_subset_parts(score, k_constraints,
     return lm_stat, pval
 
 
-def lm_robust_reparameterized(score, params_deriv,
-                           score_deriv, cov_score):
+def lm_robust_reparameterized(score, params_deriv, score_deriv, cov_score):
     """robust generalized score test for transformed parameters
 
     The parameters are given by a nonlinear transformation of the estimated
@@ -466,6 +610,30 @@ def lm_robust_reparameterized(score, params_deriv,
 
     score and other arrays are for full parameter space `params`
 
+    Parameters
+    ----------
+    score : ndarray, 1-D
+        derivative of objective function at estimated parameters
+        of constrained model
+    params_deriv: ndarray
+        Jacobian G of the parameter trasnformation
+    score_deriv: ndarray, symmetric, square
+        second derivative of objective function
+        TODO: could be OPG or any other estimator if information matrix
+        equality holds
+    cov_score B :  ndarray, symmetric, square
+        covariance matrix of the score. This is the inner part of a sandwich
+        estimator.
+
+    Returns
+    -------
+    lm_stat : float
+        score/lagrange multiplier statistic
+    p-value : float
+        p-value of the LM test based on chisquare distribution
+
+    Notes
+    -----
     Boos 1992, section 4.3, expression for T_{GS} just before example 6
     """
     # Boos notation
@@ -502,12 +670,19 @@ def dispersion_poisson(results):
     Parameters
     ----------
     results : Poisson results instance
-        TODO: currently uses GLMResults properties
-        this can be either a discrete Poisson or a GLM with family Poisson
-        results instance
+        This can be a results instance for either a discrete Poisson or a GLM
+        with family Poisson.
+
+    Returns
+    -------
+    res : ndarray, shape (7, 2)
+       each row contains the test statistic and p-value for one of the 7 tests
+       computed here.
+    description : 2-D list of strings
+       Each test has two strings a descriptive name and a string for the
+       alternative hypothesis.
 
     """
-    from scipy import stats
 
     if hasattr(results, '_results'):
         results = results._results
@@ -559,12 +734,12 @@ def dispersion_poisson(results):
     results_all.append([stat_ols_hc1_nb2, pval_ols_hc1_nb2])
     description.append(['CT nb2 HC1', 'mu (1 + a mu)'])
 
-    res_ols_nb1 = OLS(endog_v, np.ones(len(endog_v))).fit(cov_type='HC1', use_t=False)
+    res_ols_nb1 = OLS(endog_v, np.ones(len(endog_v))).fit(cov_type='HC1',
+                                                          use_t=False)
     stat_ols_hc1_nb1 = res_ols_nb1.tvalues[0]
     pval_ols_hc1_nb1 = res_ols_nb1.pvalues[0]
     results_all.append([stat_ols_hc1_nb1, pval_ols_hc1_nb1])
     description.append(['CT nb1 HC1', 'mu (1 + a)'])
-
 
     return np.array(results_all), description
 
@@ -664,12 +839,12 @@ def conditional_moment_test_generic(mom_test, mom_test_deriv,
         conditions under test in the first k_constraint rows and columns.
         If it is not None, then it will be estimated based on cov_type.
         I think: This is the Hessian of the extended or alternative model
-        under full MLE and score test assuming information matrix identity holds.
+        under full MLE and score test assuming information matrix identity
+        holds.
 
     Returns
     -------
     results
-
 
     Notes
     -----
@@ -771,7 +946,6 @@ def conditional_moment_test_regression(mom_test, mom_test_deriv=None,
     return statistic, pval
 
 
-
 class CMTNewey(object):
     """generic moment test for GMM
 
@@ -780,7 +954,6 @@ class CMTNewey(object):
     This is based on Newey 1985 on GMM.
     Lemma 1:
     Theorem 1
-
 
     The main method is `chisquare` which returns the result of the
     conditional moment test.
@@ -806,7 +979,6 @@ class CMTNewey(object):
         defines a Linear combination of moments that have expected value equal
         to zero under the Null hypothesis.
 
-
     Notes
     -----
     The one letter names in Newey 1985 are
@@ -830,14 +1002,12 @@ class CMTNewey(object):
     assumes it in the following. Lemma 1 in both articles are essentially the
     same assuming D = H' W.
 
-
     References
     ----------
     - Newey 1985a, Generalized Method of Moment specification testing,
       Journal of Econometrics
     - Newey 1985b, Maximum Likelihood Specification Testing and Conditional
       Moment Tests, Econometrica
-
 
     """
 
@@ -859,7 +1029,6 @@ class CMTNewey(object):
         # assuming full rank of L'
         self.k_constraints = self.transf_mt.shape[0]
 
-
     @cache_readonly
     def asy_transf_params(self):
 
@@ -871,7 +1040,6 @@ class CMTNewey(object):
         #res = np.linalg.pinv(htw.dot(moments_deriv)).dot(htw)
         return -res
 
-
     @cache_readonly
     def project_w(self):
         # P_w = I - H (H' W H)^{-1} H' W
@@ -880,7 +1048,6 @@ class CMTNewey(object):
         res = moments_deriv.dot(self.asy_transf_params)
         res += np.eye(res.shape[0])
         return res
-
 
     @cache_readonly
     def asy_transform_mom_constraints(self):
@@ -908,11 +1075,9 @@ class CMTNewey(object):
 
         return transf.dot(self.asy_cov_moments).dot(transf.T)
 
-
     @cache_readonly
     def rank_cov_mom_constraints(self):
         return np.linalg.matrix_rank(self.cov_mom_constraints)
-
 
     def ztest(self):
         """statistic, p-value and degrees of freedom of separate moment test
@@ -930,7 +1095,6 @@ class CMTNewey(object):
         pval = stats.norm.sf(np.abs(stat))*2
         return stat, pval
 
-
     @cache_readonly
     def chisquare(self):
         """statistic, p-value and degrees of freedom of joint moment test
@@ -941,7 +1105,6 @@ class CMTNewey(object):
         # Newey uses a generalized inverse
         stat = diff.T.dot(np.linalg.pinv(cov).dot(diff))
         df = self.rank_cov_mom_constraints
-        from scipy import stats
         pval = stats.chi2.sf(stat, df)  # Theorem 1
         return stat, pval, df
 
@@ -955,7 +1118,6 @@ class CMTTauchen(object):
     conditional moment test.
 
     Warning: name of class and of methods will likely be changed
-
 
     Parameters
     ----------
@@ -988,7 +1150,6 @@ class CMTTauchen(object):
         self.k_params = score.shape[-1]
         self.k_moments_all = self.k_params + self.k_moments_test
 
-
     @cache_readonly
     def cov_params_all(self):
         m_deriv = np.zeros((self.k_moments_all, self.k_moments_all))
@@ -1003,7 +1164,6 @@ class CMTTauchen(object):
     @cache_readonly
     def cov_mom_constraints(self):
         return self.cov_params_all[self.k_params:, self.k_params:]
-
 
     @cache_readonly
     def rank_cov_mom_constraints(self):
@@ -1026,7 +1186,6 @@ class CMTTauchen(object):
         pval = stats.norm.sf(np.abs(stat))*2
         return stat, pval
 
-
     @cache_readonly
     def chisquare(self):
         """statistic, p-value and degrees of freedom of joint moment test
@@ -1039,6 +1198,5 @@ class CMTTauchen(object):
         #df = self.k_moments_test
         # We allow for redundant mom_constraints:
         df = self.rank_cov_mom_constraints
-        from scipy import stats
         pval = stats.chi2.sf(stat, df)
         return stat, pval, df

--- a/statsmodels/stats/tests/test_diagnostic_other.py
+++ b/statsmodels/stats/tests/test_diagnostic_other.py
@@ -8,7 +8,6 @@ License: BSD-3
 
 """
 
-
 import numpy as np
 from numpy.testing import assert_allclose
 
@@ -27,13 +26,11 @@ class CheckCMT(object):
             assert_allclose(actual, expected[:np.size(actual)], rtol=1e-13,
                             err_msg=msg)
 
-
     def test_scorehc0(self):
         expected = self.results_hc0
         for msg, actual in self.res_hc0():
             assert_allclose(actual, expected[:np.size(actual)], rtol=1e-13,
                             err_msg=msg)
-
 
     def test_scoreopg(self):
         expected = self.results_opg
@@ -69,7 +66,6 @@ class TestCMTOLS(CheckCMT):
         cls.results_score = (1.6857659627548, 0.43046770240535, 2)
         cls.results_hc0 = (1.6385932313952, 0.4407415561953, 2)
         cls.results_opg = (1.72226002418488, 0.422684174119544, 2.0)
-
 
     @classmethod    # TODO: a better structure ?
     def attach_moment_conditions(self):
@@ -112,7 +108,6 @@ class TestCMTOLS(CheckCMT):
         self.weights = weights
         self.L = L
 
-
     def res_score(self):
         res_ols = self.res_ols
         nobs = self.nobs
@@ -124,7 +119,6 @@ class TestCMTOLS(CheckCMT):
         weights = self.weights
         L = self.L
         x = self.exog_full  # for auxiliary regression only
-
 
         res_all = []
 
@@ -139,7 +133,6 @@ class TestCMTOLS(CheckCMT):
                               np.linalg.inv(cov_moms), cov_moms)
         res_all.append(('score mle', tres))
 
-
         tres = CMTNewey(moms, cov_moms, cov_moms[:,:-2], weights, L).chisquare
         res_all.append(('Newey', tres))
 
@@ -147,9 +140,7 @@ class TestCMTOLS(CheckCMT):
                           cov_moms[-2:, :-2], cov_moms).chisquare
         res_all.append(('Tauchen', tres))
 
-
         return res_all
-
 
     def res_opg(self):
         res_ols = self.res_ols
@@ -163,7 +154,6 @@ class TestCMTOLS(CheckCMT):
         x = self.exog_full
 
         res_ols2_hc0 = OLS(res_ols.model.endog, x).fit(cov_type='HC0')
-
 
         res_all = []
 
@@ -186,16 +176,15 @@ class TestCMTOLS(CheckCMT):
         res_all.append(('score subset QMLE', tres))
 
         tres = diao.lm_robust(moms, np.eye(moms.shape[0])[-2:],
-                              np.linalg.inv(covm), covm, V=None)
+                              np.linalg.inv(covm), covm, cov_params=None)
         res_all.append(('scoreB QMLE', tres))
 
         tres = diao.lm_robust(moms, np.eye(moms.shape[0])[-2:],
-                              np.linalg.inv(covm), None, V=np.linalg.inv(covm))
+                              np.linalg.inv(covm), None,
+                              cov_params=np.linalg.inv(covm))
         res_all.append(('scoreV QMLE', tres))
 
-
         return res_all
-
 
     def res_hc0(self):
         res_ols = self.res_ols
@@ -211,9 +200,7 @@ class TestCMTOLS(CheckCMT):
         x0 = res_ols.model.exog
         x1 = self.exog_add
 
-
         res_all = []
-
 
         tres = diao.cm_test_robust(resid=res_ols.resid, resid_deriv=x0,
                                    instruments=x1, weights=1)
@@ -231,17 +218,21 @@ class TestCMTOLS(CheckCMT):
         res_all.append(('score subset QMLE', tres))
 
         tres = diao.lm_robust(moms, np.eye(moms.shape[0])[-2:],
-                              np.linalg.inv(cov_moms), covm, V=None)
+                              np.linalg.inv(cov_moms), covm)
         res_all.append(('scoreB QMLE', tres))
 
         # need sandwich cov_params V
         Ainv = np.linalg.inv(cov_moms)
         vv = Ainv.dot(covm).dot(Ainv)
         tres = diao.lm_robust(moms, np.eye(moms.shape[0])[-2:],
-                              np.linalg.inv(cov_moms), None, V=vv)
+                              np.linalg.inv(cov_moms), None,
+                              cov_params=vv)
         res_all.append(('scoreV QMLE', tres))
 
-        tres = diao.conditional_moment_test_generic(moms_obs[:, -2:], cov_moms[-2:, :-2], moms_obs[:,:-2], cov_moms[:-2, :-2])#, covm)
+        tres = diao.conditional_moment_test_generic(moms_obs[:, -2:],
+                                                    cov_moms[-2:, :-2],
+                                                    moms_obs[:,:-2],
+                                                    cov_moms[:-2, :-2])
         tres_ = (tres.stat_cmt, tres.pval_cmt)
         res_all.append(('cmt', tres_))
 
@@ -265,7 +256,6 @@ class TestCMTOLS(CheckCMT):
                                      cov_score_cu, cov_score_uu)
 
         res_all.append(('score subset_parts QMLE', tres))
-
 
         params_deriv = np.eye(x.shape[1], x.shape[1] - 2)
         #params_deriv[[-2, -1], [-2, -1]] = 0

--- a/statsmodels/stats/tests/test_diagnostic_other.py
+++ b/statsmodels/stats/tests/test_diagnostic_other.py
@@ -254,4 +254,28 @@ class TestCMTOLS(CheckCMT):
         tres_ = (tres.stat_cmt, tres.pval_cmt)
         res_all.append(('cmt', tres_))
 
+        score_deriv_uu = cov_moms[:-2, :-2]
+        score_deriv_cu = cov_moms[-2:, :-2]
+        cov_score_cc = covm[-2:, -2:]
+        cov_score_cu = covm[-2:, :-2]
+        cov_score_uu = covm[:-2, :-2]
+        moms[-2:], 2, cov_moms, covm
+        tres = diao.lm_robust_subset_parts(moms[-2:], 2, score_deriv_uu,
+                                     score_deriv_cu, cov_score_cc,
+                                     cov_score_cu, cov_score_uu)
+
+        res_all.append(('score subset_parts QMLE', tres))
+
+
+        params_deriv = np.eye(x.shape[1], x.shape[1] - 2)
+        #params_deriv[[-2, -1], [-2, -1]] = 0
+        score = moms
+        score_deriv = cov_moms
+        cov_score = covm
+
+        tres = diao.lm_robust_reparameterized(score, params_deriv,
+                           score_deriv, cov_score)
+
+        res_all.append(('score reparam QMLE', tres))
+
         return res_all

--- a/statsmodels/stats/tests/test_diagnostic_other.py
+++ b/statsmodels/stats/tests/test_diagnostic_other.py
@@ -1,0 +1,257 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for generic score/LM tests and conditional moment tests
+
+Created on Mon Nov 17 08:44:06 2014
+
+Author: Josef Perktold
+License: BSD-3
+
+"""
+
+
+import numpy as np
+from numpy.testing import assert_allclose
+
+from statsmodels.regression.linear_model import OLS
+from statsmodels.stats._diagnostic_other import CMTNewey, CMTTauchen
+import statsmodels.stats._diagnostic_other  as diao
+
+
+class CheckCMT(object):
+
+    def test_score(self):
+        expected = self.results_score
+        for msg, actual in self.res_score():
+            # not all cases provide all 3 elements,
+            # TODO: fix API, returns of functions
+            assert_allclose(actual, expected[:np.size(actual)], rtol=1e-13,
+                            err_msg=msg)
+
+
+    def test_scorehc0(self):
+        expected = self.results_hc0
+        for msg, actual in self.res_hc0():
+            assert_allclose(actual, expected[:np.size(actual)], rtol=1e-13,
+                            err_msg=msg)
+
+
+    def test_scoreopg(self):
+        expected = self.results_opg
+        for msg, actual in self.res_opg():
+            assert_allclose(actual, expected[:np.size(actual)], rtol=1e-13,
+                            err_msg=msg)
+
+
+class TestCMTOLS(CheckCMT):
+
+    @classmethod
+    def setup_class(cls):
+
+        np.random.seed(864259)
+
+        nobs, k_vars = 100, 4
+        sig_e = 1
+        x0 = np.random.randn(nobs, k_vars)
+        x0[:,0] = 1
+        y_true = x0.sum(1)
+        y = y_true + sig_e * np.random.randn(nobs)
+
+        x1 = np.random.randn(nobs, 2)
+        x = np.column_stack((x0, x1))
+
+        cls.exog_full = x
+        cls.exog_add = x1
+        cls.res_ols = OLS(y, x0).fit()
+
+        cls.attach_moment_conditions()
+
+        # results from initial run, not reference package (drooped 2 digits)
+        cls.results_score = (1.6857659627548, 0.43046770240535, 2)
+        cls.results_hc0 = (1.6385932313952, 0.4407415561953, 2)
+        cls.results_opg = (1.72226002418488, 0.422684174119544, 2.0)
+
+
+    @classmethod    # TODO: a better structure ?
+    def attach_moment_conditions(self):
+        res_ols = self.res_ols
+        # assumes x = column_stack([x0, x1])
+        x = self.exog_full
+        #x0 = self.res_ols.model.exog  # not used here
+        x1 = self.exog_add
+
+        nobs, k_constraints = x1.shape
+
+        # TODO: cleanup after initial copy past
+        moms_obs = res_ols.resid[:, None] * x
+        moms = moms_obs.sum(0)
+        cov_moms =  res_ols.mse_resid * x.T.dot(x) #np.linalg.inv(x.T.dot(x))
+        cov_moms *=  res_ols.df_resid / nobs
+
+        # weights used for GMM to replicate OLS
+        weights = np.linalg.inv(cov_moms)
+        # we don't use last two variables
+        weights[:, -k_constraints:] = 0
+        weights[-k_constraints:, :] = 0
+
+        k_moms = moms.shape[0]
+        # TODO: Newey has different versions that all produce the same result
+        #       in example
+        L = np.eye(k_moms)[-k_constraints:] #.dot(np.linalg.inv(cov_moms))
+
+        moms_deriv = cov_moms[:, :-k_constraints]
+
+        covm = moms_obs.T.dot(moms_obs)
+
+        #attach
+        self.nobs = nobs
+        self.moms = moms
+        self.moms_obs = moms_obs
+        self.cov_moms = cov_moms
+        self.covm = covm
+        self.moms_deriv = moms_deriv
+        self.weights = weights
+        self.L = L
+
+
+    def res_score(self):
+        res_ols = self.res_ols
+        nobs = self.nobs
+        moms = self.moms
+        moms_obs = self.moms_obs
+        cov_moms = self.cov_moms
+        covm = self.covm
+        moms_deriv = self.moms_deriv
+        weights = self.weights
+        L = self.L
+        x = self.exog_full  # for auxiliary regression only
+
+
+        res_all = []
+
+        # auxiliary regression
+        stat = nobs * OLS(res_ols.resid, x).fit().rsquared
+        res_all.append(('ols R2', stat))
+
+        stat = moms.dot(np.linalg.solve(cov_moms, moms))
+        res_all.append(('score simple', stat))
+
+        tres = diao.lm_robust(moms, np.eye(moms.shape[0])[-2:],
+                              np.linalg.inv(cov_moms), cov_moms)
+        res_all.append(('score mle', tres))
+
+
+        tres = CMTNewey(moms, cov_moms, cov_moms[:,:-2], weights, L).chisquare
+        res_all.append(('Newey', tres))
+
+        tres = CMTTauchen(moms[:-2], cov_moms[:-2, :-2], moms[-2:],
+                          cov_moms[-2:, :-2], cov_moms).chisquare
+        res_all.append(('Tauchen', tres))
+
+
+        return res_all
+
+
+    def res_opg(self):
+        res_ols = self.res_ols
+        nobs = self.nobs
+        moms = self.moms
+        moms_obs = self.moms_obs
+        covm = self.covm
+        moms_deriv = self.moms_deriv
+        weights = self.weights
+        L = self.L
+        x = self.exog_full
+
+        res_ols2_hc0 = OLS(res_ols.model.endog, x).fit(cov_type='HC0')
+
+
+        res_all = []
+
+        # auxiliary regression
+        ones = np.ones(nobs)
+        stat = nobs * OLS(ones, moms_obs).fit().rsquared
+        res_all.append(('ols R2', stat))
+
+        tres = res_ols2_hc0.compare_lm_test(res_ols, demean=False)
+        res_all.append(('comp_lm uc', tres))
+
+        tres = CMTNewey(moms, covm, covm[:,:-2], weights, L).chisquare
+        res_all.append(('Newey', tres))
+
+        tres = CMTTauchen(moms[:-2], covm[:-2, :-2], moms[-2:], covm[-2:, :-2],
+                          covm).chisquare
+        res_all.append(('Tauchen', tres))
+
+        tres = diao.lm_robust_subset(moms[-2:], 2, covm, covm)
+        res_all.append(('score subset QMLE', tres))
+
+        tres = diao.lm_robust(moms, np.eye(moms.shape[0])[-2:],
+                              np.linalg.inv(covm), covm, V=None)
+        res_all.append(('scoreB QMLE', tres))
+
+        tres = diao.lm_robust(moms, np.eye(moms.shape[0])[-2:],
+                              np.linalg.inv(covm), None, V=np.linalg.inv(covm))
+        res_all.append(('scoreV QMLE', tres))
+
+
+        return res_all
+
+
+    def res_hc0(self):
+        res_ols = self.res_ols
+        nobs = self.nobs
+        moms = self.moms
+        moms_obs = self.moms_obs
+        cov_moms = self.cov_moms   # Hessian with scale
+        covm = self.covm
+        moms_deriv = self.moms_deriv
+        weights = self.weights
+        L = self.L
+
+        x0 = res_ols.model.exog
+        x1 = self.exog_add
+
+
+        res_all = []
+
+
+        tres = diao.cm_test_robust(resid=res_ols.resid, resid_deriv=x0,
+                                   instruments=x1, weights=1)
+        # TODO: extra return and no df in cm_test_robust Wooldridge
+        res_all.append(('Wooldridge', tres[:2]))
+
+        tres = CMTNewey(moms, covm, moms_deriv, weights, L).chisquare
+        res_all.append(('Newey', tres))
+
+        tres = CMTTauchen(moms[:-2], cov_moms[:-2, :-2], moms[-2:],
+                          cov_moms[-2:, :-2], covm).chisquare
+        res_all.append(('Tauchen', tres))
+
+        tres = diao.lm_robust_subset(moms[-2:], 2, cov_moms, covm)
+        res_all.append(('score subset QMLE', tres))
+
+        tres = diao.lm_robust(moms, np.eye(moms.shape[0])[-2:],
+                              np.linalg.inv(cov_moms), covm, V=None)
+        res_all.append(('scoreB QMLE', tres))
+
+        # need sandwich cov_params V
+        Ainv = np.linalg.inv(cov_moms)
+        vv = Ainv.dot(covm).dot(Ainv)
+        tres = diao.lm_robust(moms, np.eye(moms.shape[0])[-2:],
+                              np.linalg.inv(cov_moms), None, V=vv)
+        res_all.append(('scoreV QMLE', tres))
+
+        tres = diao.conditional_moment_test_generic(moms_obs[:, -2:], cov_moms[-2:, :-2], moms_obs[:,:-2], cov_moms[:-2, :-2])#, covm)
+        tres_ = (tres.stat_cmt, tres.pval_cmt)
+        res_all.append(('cmt', tres_))
+
+        # using unscaled hessian instead of scaled
+        x = self.exog_full
+        hess_unscaled = x.T.dot(x)
+        tres = diao.conditional_moment_test_generic(moms_obs[:, -2:],
+                    hess_unscaled[-2:, :-2], moms_obs[:,:-2],
+                    hess_unscaled[:-2, :-2])#, covm)
+        tres_ = (tres.stat_cmt, tres.pval_cmt)
+        res_all.append(('cmt', tres_))
+
+        return res_all


### PR DESCRIPTION
first round of adding generic robust score/LM and conditional moment tests

see #2041 for summary issue

most generic tests have unit tests for OLS case
some generic functions are untested
also includes GLM specific cm/lmtest, and Poisson over/under dispersion tests, no test coverage

I might want to merge this with only variable addition as verified use case and leave other applications and extensions for another PR.

Note: efficient GMM (with optimal weighting matrix): weighting matrix is irrelevant if we estimate with exactly identified model. However, Newey West say that the optimization like (Q)MLE or M-estimator with constraints is not efficient. (refering to CMT in Newey 1985 GMM versus Newey/West efficient GMM)
### TODO
- needs a GLM case as unit test
- needs examples and unit tests for hypothesis on variances and error correlation.
### Extensions

For the next two it is not clear yet whether the generic/general case can handle those. My guess is that it should be covered already.
- nuisance parameters under alternative hypothesis, 
  example Wooldridge variance tests in GLM/LEF joint with mean
- locally mis-specified alternative, Bera and Yoon
  This looks just like a test on only some of the overidentifying restrictions but partialling out all other alternatives, but I haven't verified that yet.
- cov_type: we don't have a simple function yet to calculate robust covariances standalone
- other extensions are to use this to implement specific functions
