### PR TITLE
Fix bug causing problems with profile likelihood analysis

### DIFF
--- a/statsmodels/regression/mixed_linear_model.py
+++ b/statsmodels/regression/mixed_linear_model.py
@@ -2091,7 +2091,7 @@ class MixedLMResults(base.LikelihoodModelResults):
 
             # Shrink the covariance parameters until a PSD covariance
             # matrix is obtained.
-            dg = np.diag(cov_re)
+            dg = np.diag(cov_re).copy()
             success = False
             for ks in range(50):
                 try:


### PR DESCRIPTION
This should resolve #2102, at least in the given example.  I didn't realize that numpy.diag returns a reference.

Most users of 0.6.1 will never encounter this, because it only comes in to play when the starting values along the profile are outside the domain of PSD matrices.  The second notebook example is extremely close to the boundary, which leads to failures on some machines (it seems to work on others).