### PR TITLE
Wald anova

### DIFF
--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -1409,8 +1409,58 @@ class LikelihoodModelResults(Results):
 
     def wald_test_terms(self, skip_single=False, extra_constraints=None,
                    combine_terms=None):
-        """create a sequence of wald tests similar to ANOVA type 3 tables
+        """
+        Compute a sequence of Wald tests for terms over multiple columns
 
+        This computes joined Wald tests for the hypothesis that all
+        coefficients corresponding to a `term` are zero.
+
+        `Terms` are defined by the underlying formula or by string matching.
+
+        Parameters
+        ----------
+        skip_single : boolean
+            If true, then terms that consist only of a single column and,
+            therefore, refers only to a single parameter is skipped.
+            If false, then all terms are included.
+        extra_constraints : ndarray
+            not tested yet
+        combine_terms : None or list of strings
+            Each string in this list is matched to the name of the terms or
+            the name of the exogenous variables. All columns whose name
+            includes that string are combined in one joint test.
+
+        Returns
+        -------
+        test_result : result instance
+            The result instance contains `table` which is a pandas DataFrame
+            with the test results: test statistic, degrees of freedom and
+            pvalues.
+
+        Examples
+        --------
+        >>> res_ols = ols("np.log(Days+1) ~ C(Duration, Sum)*C(Weight, Sum)",
+                          data).fit()
+        >>> res_ols.wald_test_terms()
+        <class 'statsmodels.stats.contrast.ANOVAWaldResult'>
+                                                  F             PR(>F)  df
+        Intercept                        279.754525  2.37985521351e-22   1
+        C(Duration, Sum)                   5.367071    0.0245738436636   1
+        C(Weight, Sum)                    12.432445  3.99943118767e-05   2
+        C(Duration, Sum):C(Weight, Sum)    0.176002      0.83912310946   2
+
+        >>> res_poi = Poisson.from_formula("Days ~ C(Weight) * C(Duration)",
+                                           data).fit(cov_type='HC0')
+        >>> wt = res_poi.wald_test_terms(skip_single=False,
+                                         combine_terms=['Duration', 'Weight'])
+        >>> print(wt)
+                                    chi2          PR(>chi2)  df
+        Intercept              15.695625  7.43960374424e-05   1
+        C(Weight)              16.132616  0.000313940174705   2
+        C(Duration)             1.009147     0.315107378931   1
+        C(Weight):C(Duration)   0.216694     0.897315972824   2
+        Duration               11.187849     0.010752286833   3
+        Weight                 30.263368  4.32586407145e-06   4
 
         """
         # lazy import

--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -1442,25 +1442,25 @@ class LikelihoodModelResults(Results):
         >>> res_ols = ols("np.log(Days+1) ~ C(Duration, Sum)*C(Weight, Sum)",
                           data).fit()
         >>> res_ols.wald_test_terms()
-        <class 'statsmodels.stats.contrast.ANOVAWaldResult'>
-                                                  F             PR(>F)  df
-        Intercept                        279.754525  2.37985521351e-22   1
-        C(Duration, Sum)                   5.367071    0.0245738436636   1
-        C(Weight, Sum)                    12.432445  3.99943118767e-05   2
-        C(Duration, Sum):C(Weight, Sum)    0.176002      0.83912310946   2
+        <class 'statsmodels.stats.contrast.WaldTestResults'>
+                                                  F                P>F  df constraint  df denom
+        Intercept                        279.754525  2.37985521351e-22              1        51
+        C(Duration, Sum)                   5.367071    0.0245738436636              1        51
+        C(Weight, Sum)                    12.432445  3.99943118767e-05              2        51
+        C(Duration, Sum):C(Weight, Sum)    0.176002      0.83912310946              2        51
 
         >>> res_poi = Poisson.from_formula("Days ~ C(Weight) * C(Duration)",
                                            data).fit(cov_type='HC0')
         >>> wt = res_poi.wald_test_terms(skip_single=False,
                                          combine_terms=['Duration', 'Weight'])
         >>> print(wt)
-                                    chi2          PR(>chi2)  df
-        Intercept              15.695625  7.43960374424e-05   1
-        C(Weight)              16.132616  0.000313940174705   2
-        C(Duration)             1.009147     0.315107378931   1
-        C(Weight):C(Duration)   0.216694     0.897315972824   2
-        Duration               11.187849     0.010752286833   3
-        Weight                 30.263368  4.32586407145e-06   4
+                                    chi2             P>chi2  df constraint
+        Intercept              15.695625  7.43960374424e-05              1
+        C(Weight)              16.132616  0.000313940174705              2
+        C(Duration)             1.009147     0.315107378931              1
+        C(Weight):C(Duration)   0.216694     0.897315972824              2
+        Duration               11.187849     0.010752286833              3
+        Weight                 30.263368  4.32586407145e-06              4
 
         """
         # lazy import

--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -1407,7 +1407,7 @@ class LikelihoodModelResults(Results):
                                    distribution='chi2', distargs=(J,))
 
 
-    def wald_anova(self, skip_single=False, extra_constraints=None,
+    def wald_test_terms(self, skip_single=False, extra_constraints=None,
                    combine_terms=None):
         """create a sequence of wald tests similar to ANOVA type 3 tables
 

--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -1427,7 +1427,7 @@ class LikelihoodModelResults(Results):
             raise ValueError('no constraints, nothing to do')
 
 
-        identity = np.eye(result.model.exog.shape[1])
+        identity = np.eye(len(result.params))
         constraints = []
         combined = defaultdict(list)
         for term in design_info.terms:

--- a/statsmodels/base/tests/test_generic_methods.py
+++ b/statsmodels/base/tests/test_generic_methods.py
@@ -374,6 +374,21 @@ class TestWaldAnovaOLS(CheckAnovaMixin):
         cls.res = mod.fit(use_t=False)
 
 
+    def test_noformula(self):
+        endog = self.res.model.endog
+        exog = self.res.model.data.orig_exog
+        del exog.design_info
+
+        res = sm.OLS(endog, exog).fit()
+        wa = res.wald_anova(skip_single=True,
+                            combine_terms=['Duration', 'Weight'])
+        eye = np.eye(len(res.params))
+        c_weight = eye[2:6]
+        c_duration = eye[[1, 4, 5]]
+
+        compare_waldres(res, wa, [c_duration, c_weight])
+
+
 class TestWaldAnovaOLSF(CheckAnovaMixin):
 
     @classmethod
@@ -383,7 +398,6 @@ class TestWaldAnovaOLSF(CheckAnovaMixin):
 
         mod = ols("np.log(Days+1) ~ C(Duration, Sum)*C(Weight, Sum)", cls.data)
         cls.res = mod.fit()  # default use_t=True
-
 
 
 class TestWaldAnovaGLM(CheckAnovaMixin):
@@ -430,6 +444,16 @@ class TestWaldAnovaNegBin1(CheckAnovaMixin):
                                             loglike_method='nb1')
         cls.res = mod.fit(cov_type='HC0')
 
+
+class T_estWaldAnovaOLSNoFormula(object):
+
+    @classmethod
+    def initialize(cls):
+        from statsmodels.formula.api import ols, glm, poisson
+        from statsmodels.discrete.discrete_model import Poisson
+
+        mod = ols("np.log(Days+1) ~ C(Duration, Sum)*C(Weight, Sum)", cls.data)
+        cls.res = mod.fit()  # default use_t=True
 
 
 if __name__ == '__main__':

--- a/statsmodels/base/tests/test_generic_methods.py
+++ b/statsmodels/base/tests/test_generic_methods.py
@@ -331,7 +331,7 @@ class CheckAnovaMixin(object):
 
     def test_combined(self):
         res = self.res
-        wa = res.wald_anova(skip_single=False, combine_terms=['Duration', 'Weight'])
+        wa = res.wald_test_terms(skip_single=False, combine_terms=['Duration', 'Weight'])
         eye = np.eye(len(res.params))
         c_const = eye[0]
         c_w = eye[[2,3]]
@@ -346,7 +346,7 @@ class CheckAnovaMixin(object):
     def test_categories(self):
         # test only multicolumn terms
         res = self.res
-        wa = res.wald_anova(skip_single=True)
+        wa = res.wald_test_terms(skip_single=True)
         eye = np.eye(len(res.params))
         c_w = eye[[2,3]]
         c_dw = eye[[4,5]]
@@ -380,8 +380,8 @@ class TestWaldAnovaOLS(CheckAnovaMixin):
         del exog.design_info
 
         res = sm.OLS(endog, exog).fit()
-        wa = res.wald_anova(skip_single=True,
-                            combine_terms=['Duration', 'Weight'])
+        wa = res.wald_test_terms(skip_single=True,
+                                 combine_terms=['Duration', 'Weight'])
         eye = np.eye(len(res.params))
         c_weight = eye[2:6]
         c_duration = eye[[1, 4, 5]]

--- a/statsmodels/base/tests/test_generic_methods.py
+++ b/statsmodels/base/tests/test_generic_methods.py
@@ -374,6 +374,18 @@ class TestWaldAnovaOLS(CheckAnovaMixin):
         cls.res = mod.fit(use_t=False)
 
 
+class TestWaldAnovaOLSF(CheckAnovaMixin):
+
+    @classmethod
+    def initialize(cls):
+        from statsmodels.formula.api import ols, glm, poisson
+        from statsmodels.discrete.discrete_model import Poisson
+
+        mod = ols("np.log(Days+1) ~ C(Duration, Sum)*C(Weight, Sum)", cls.data)
+        cls.res = mod.fit()  # default use_t=True
+
+
+
 class TestWaldAnovaGLM(CheckAnovaMixin):
 
     @classmethod

--- a/statsmodels/base/tests/test_generic_methods.py
+++ b/statsmodels/base/tests/test_generic_methods.py
@@ -337,7 +337,7 @@ class CheckAnovaMixin(object):
         c_w = eye[[2,3]]
         c_d = eye[1]
         c_dw = eye[[4,5]]
-        c_weight = eye[2:]
+        c_weight = eye[2:6]
         c_duration = eye[[1, 4, 5]]
 
         compare_waldres(res, wa, [c_const, c_d, c_w, c_dw, c_duration, c_weight])
@@ -391,8 +391,33 @@ class TestWaldAnovaPoisson(CheckAnovaMixin):
     def initialize(cls):
         from statsmodels.discrete.discrete_model import Poisson
 
-        mod = Poisson.from_formula("np.log(Days+1) ~ C(Duration, Sum)*C(Weight, Sum)", cls.data)
+        mod = Poisson.from_formula("Days ~ C(Duration, Sum)*C(Weight, Sum)", cls.data)
         cls.res = mod.fit(cov_type='HC0')
+
+
+class TestWaldAnovaNegBin(CheckAnovaMixin):
+
+    @classmethod
+    def initialize(cls):
+        from statsmodels.discrete.discrete_model import NegativeBinomial
+
+        formula = "Days ~ C(Duration, Sum)*C(Weight, Sum)"
+        mod = NegativeBinomial.from_formula(formula, cls.data,
+                                            loglike_method='nb2')
+        cls.res = mod.fit()
+
+
+class TestWaldAnovaNegBin1(CheckAnovaMixin):
+
+    @classmethod
+    def initialize(cls):
+        from statsmodels.discrete.discrete_model import NegativeBinomial
+
+        formula = "Days ~ C(Duration, Sum)*C(Weight, Sum)"
+        mod = NegativeBinomial.from_formula(formula, cls.data,
+                                            loglike_method='nb1')
+        cls.res = mod.fit(cov_type='HC0')
+
 
 
 if __name__ == '__main__':

--- a/statsmodels/base/tests/test_generic_methods.py
+++ b/statsmodels/base/tests/test_generic_methods.py
@@ -361,6 +361,25 @@ def compare_waldres(res, wa, constrasts):
         assert_allclose(wa.table.values[i, 1], wt.pvalue)
         df = c.shape[0] if c.ndim == 2 else 1
         assert_equal(wa.table.values[i, 2], df)
+        # attributes
+        assert_allclose(wa.statistic[i], wt.statistic)
+        assert_allclose(wa.pvalues[i], wt.pvalue)
+        assert_equal(wa.df_constraints[i], df)
+        if res.use_t:
+            assert_equal(wa.df_denom[i], res.df_resid)
+
+    col_names = wa.col_names
+    if res.use_t:
+        assert_equal(wa.distribution, 'F')
+        assert_equal(col_names[0], 'F')
+        assert_equal(col_names[1], 'P>F')
+    else:
+        assert_equal(wa.distribution, 'chi2')
+        assert_equal(col_names[0], 'chi2')
+        assert_equal(col_names[1], 'P>chi2')
+
+    # SMOKETEST
+    wa.summary_frame()
 
 
 class TestWaldAnovaOLS(CheckAnovaMixin):

--- a/statsmodels/examples/ex_wald_anova.py
+++ b/statsmodels/examples/ex_wald_anova.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+"""Example for wald_test for terms - `wald_anova`
+
+Created on Mon Dec 15 11:19:23 2014
+
+Author: Josef Perktold
+License: BSD-3
+
+"""
+
+import numpy as np
+
+from statsmodels.formula.api import ols, glm, poisson
+from statsmodels.discrete.discrete_model import Poisson
+
+import statsmodels.stats.tests.test_anova as ttmod
+
+test = ttmod.TestAnova3()
+test.setupClass()
+
+data = test.data.drop([0,1,2])
+res_ols = ols("np.log(Days+1) ~ C(Duration, Sum)*C(Weight, Sum)", data).fit(use_t=False)
+
+res_glm = glm("np.log(Days+1) ~ C(Duration, Sum)*C(Weight, Sum)",
+                        data).fit()
+
+res_poi = Poisson.from_formula("Days ~ C(Weight) * C(Duration)", data).fit(cov_type='HC0')
+res_poi_2 = poisson("Days ~ C(Weight) + C(Duration)", data).fit(cov_type='HC0')
+
+print('\nOLS')
+print(res_ols.wald_anova())
+print('\nGLM')
+print(res_glm.wald_anova(skip_single=False, combine_terms=['Duration', 'Weight']))
+print('\nPoisson 1')
+print(res_poi.wald_anova(skip_single=False, combine_terms=['Duration', 'Weight']))
+print('\nPoisson 2')
+print(res_poi_2.wald_anova(skip_single=False))

--- a/statsmodels/examples/ex_wald_anova.py
+++ b/statsmodels/examples/ex_wald_anova.py
@@ -28,10 +28,21 @@ res_poi = Poisson.from_formula("Days ~ C(Weight) * C(Duration)", data).fit(cov_t
 res_poi_2 = poisson("Days ~ C(Weight) + C(Duration)", data).fit(cov_type='HC0')
 
 print('\nOLS')
-print(res_ols.wald_anova())
+print(res_ols.wald_test_terms())
 print('\nGLM')
-print(res_glm.wald_anova(skip_single=False, combine_terms=['Duration', 'Weight']))
+print(res_glm.wald_test_terms(skip_single=False, combine_terms=['Duration', 'Weight']))
 print('\nPoisson 1')
-print(res_poi.wald_anova(skip_single=False, combine_terms=['Duration', 'Weight']))
+print(res_poi.wald_test_terms(skip_single=False, combine_terms=['Duration', 'Weight']))
 print('\nPoisson 2')
-print(res_poi_2.wald_anova(skip_single=False))
+print(res_poi_2.wald_test_terms(skip_single=False))
+
+from statsmodels.discrete.discrete_model import NegativeBinomial
+res_nb2 = NegativeBinomial.from_formula("Days ~ C(Weight) * C(Duration)", data).fit()
+print('\nNegative Binomial nb2')
+print(res_nb2.wald_test_terms(skip_single=False))
+
+res_nb1 = NegativeBinomial.from_formula("Days ~ C(Weight) * C(Duration)", data,
+                                        loglike_method='nb1').fit(cov_type='HC0')
+print('\nNegative Binomial nb2')
+print(res_nb1.wald_test_terms(skip_single=False))
+

--- a/statsmodels/stats/contrast.py
+++ b/statsmodels/stats/contrast.py
@@ -343,3 +343,16 @@ def contrastfromcols(L, D, pseudo=None):
         C = np.dot(pseudo, Lp).T
 
     return np.squeeze(C)
+
+
+# TODO: this is currently a minimal version, stub
+class ANOVAWaldResult(object):
+
+    def __init__(self, table):
+        self.table = table
+
+    def __str__(self):
+        return self.table.to_string()
+
+    def __repr__(self):
+        return str(self.__class__) + '\n' + self.__str__()

--- a/statsmodels/stats/contrast.py
+++ b/statsmodels/stats/contrast.py
@@ -27,6 +27,7 @@ class ContrastResults(object):
         if F is not None:
             self.distribution = 'F'
             self.fvalue = F
+            self.statistic = self.fvalue
             self.df_denom = df_denom
             self.df_num = df_num
             self.dist = fdist

--- a/statsmodels/stats/contrast.py
+++ b/statsmodels/stats/contrast.py
@@ -347,13 +347,67 @@ def contrastfromcols(L, D, pseudo=None):
 
 
 # TODO: this is currently a minimal version, stub
-class ANOVAWaldResult(object):
+class WaldTestResults(object):
+    # for F and chi2 tests of joint hypothesis, mainly for vectorized
 
-    def __init__(self, table):
+    def __init__(self, statistic, distribution, dist_args, table=None,
+                 pvalues=None):
         self.table = table
 
+        self.distribution = distribution
+        self.statistic = statistic
+        #self.sd = sd
+        self.dist_args = dist_args
+
+        # The following is because I don't know which we want
+        if table is not None:
+            self.statistic = table['statistic'].values
+            self.pvalues = table['pvalue'].values
+            self.df_constraints = table['df_constraint'].values
+            if self.distribution == 'F':
+                self.df_denom = table['df_denom'].values
+
+        else:
+            if self.distribution is 'chi2':
+                self.dist = stats.chi2
+                self.df_constraints = self.dist_args[0]  # assumes tuple
+                # using dist_args[0] is a bit dangerous,
+            elif self.distribution is 'F':
+                self.dist = stats.f
+                self.df_constraints, self.df_denom = self.dist_args
+
+            else:
+                raise ValueError('only F and chi2 are possible distribution')
+
+            if pvalues is None:
+                self.pvalues = self.dist.sf(np.abs(statistic), *dist_args)
+            else:
+                self.pvalues = pvalues
+
+    @property
+    def col_names(self):
+        """column names for summary table
+        """
+
+        pr_test = "P>%s" % self.distribution
+        col_names = [self.distribution, pr_test, 'df constraint']
+        if self.distribution == 'F':
+            col_names.append('df denom')
+        return col_names
+
+    def summary_frame(self):
+        # needs to be a method for consistency
+        if hasattr(self, '_dframe'):
+            return self._dframe
+        # rename the column nambes, but don't copy data
+        renaming = dict(zip(self.table.columns, self.col_names))
+        self.dframe = self.table.rename(columns=renaming)
+        return self.dframe
+
+
     def __str__(self):
-        return self.table.to_string()
+        return self.summary_frame().to_string()
+
 
     def __repr__(self):
         return str(self.__class__) + '\n' + self.__str__()


### PR DESCRIPTION
wald test for terms that go over several columns

basic version tested for OLS, GLM and Poisson,  use_t=False only
It's not an ANOVA table, we ignore sum of squares or equivalent.

not clear: name of method, currently is `wald_anova`, alternative `wald_test_terms`  ??? DONE
    I settled on `wald_test_terms` as the more explicit term.

**missing**

- [x] unit tests for use_t=True, i.e. F instead of chi2
- [x] handling of extra parameters, as in NegativeBinomial (not checked yet)
- [x] improvements to test results class
- [x] unit tests for cases when no formula is available

- ignored for now: Multinomial where several things don't work

**extension**

- multi-equation models as in BetaRegression, and others to come

**open**

should we add `wald_null` ?  
hypothesis: all slope coefficients are zero, only constant is non-zero


------------

**Design for results class**

still a bit messy, creates table DataFrame similar to `lm_anova` from where the design was initially taken.
partially adjusted the results class to have standard attributes: `statistic`, `pvalues`, `df_xxx`, `distribution` (name)
needs a follow-up when we have settled on the design for these methods