### PR TITLE
ENH: add cov_type fixed_scale to linear model

### DIFF
--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -962,7 +962,10 @@ class LikelihoodModelResults(Results):
 
     @cache_readonly
     def llf(self):
-        return self.model.loglike(self.params)
+        if hasattr(self, 'cov_type') and self.cov_type != 'nonrobust':
+            return np.nan
+        else:
+            return self.model.loglike(self.params)
 
     @cache_readonly
     def bse(self):

--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -962,10 +962,7 @@ class LikelihoodModelResults(Results):
 
     @cache_readonly
     def llf(self):
-        if hasattr(self, 'cov_type') and self.cov_type != 'nonrobust':
-            return np.nan
-        else:
-            return self.model.loglike(self.params)
+        return self.model.loglike(self.params)
 
     @cache_readonly
     def bse(self):

--- a/statsmodels/regression/linear_model.py
+++ b/statsmodels/regression/linear_model.py
@@ -1636,10 +1636,8 @@ class RegressionResults(base.LikelihoodModelResults):
                           'robust covariance, proceeding anyway',
                           InvalidTestWarning)
 
-        llf_full = (self.llf if not np.isnan(self.llf) else
-                    self.model.loglike(self.params))
-        llf_restr = (restricted.llf if not np.isnan(restricted.llf) else
-                    restricted.model.loglike(restricted.params))
+        llf_full = self.llf
+        llf_restr = restricted.llf
         df_full = self.df_resid
         df_restr = restricted.df_resid
 

--- a/statsmodels/regression/linear_model.py
+++ b/statsmodels/regression/linear_model.py
@@ -1636,8 +1636,10 @@ class RegressionResults(base.LikelihoodModelResults):
                           'robust covariance, proceeding anyway',
                           InvalidTestWarning)
 
-        llf_full = self.llf
-        llf_restr = restricted.llf
+        llf_full = (self.llf if not np.isnan(self.llf) else
+                    self.model.loglike(self.params))
+        llf_restr = (restricted.llf if not np.isnan(restricted.llf) else
+                    restricted.model.loglike(restricted.params))
         df_full = self.df_resid
         df_restr = restricted.df_resid
 

--- a/statsmodels/regression/linear_model.py
+++ b/statsmodels/regression/linear_model.py
@@ -1778,7 +1778,13 @@ class RegressionResults(base.LikelihoodModelResults):
         # TODO: this should be outsourced in a function so we can reuse it in
         #       other models
         # TODO: make it DRYer   repeated code for checking kwds
-        if cov_type in ('HC0', 'HC1', 'HC2', 'HC3'):
+        if cov_type in ['fixed scale', 'fixed_scale']:
+            res.cov_kwds['description'] = ('Standard Errors are based on ' +
+                                           'fixed scale')
+
+            res.cov_kwds['scale'] = scale = kwds.get('scale', 1.)
+            res.cov_params_default = scale * res.normalized_cov_params
+        elif cov_type in ('HC0', 'HC1', 'HC2', 'HC3'):
             if kwds:
                 raise ValueError('heteroscedasticity robust covarians ' +
                                  'does not use keywords')

--- a/statsmodels/regression/linear_model.py
+++ b/statsmodels/regression/linear_model.py
@@ -1658,6 +1658,8 @@ class RegressionResults(base.LikelihoodModelResults):
         use_t : bool
             If true, then the t distribution is used for inference.
             If false, then the normal distribution is used.
+            If `use_t` is None, then an appropriate default is used, which is
+            `true` if the cov_type is nonrobust, and `false` in all other cases.
         kwds : depends on cov_type
             Required or optional arguments for robust covariance calculation.
             see Notes below
@@ -1675,6 +1677,8 @@ class RegressionResults(base.LikelihoodModelResults):
         The following covariance types and required or optional arguments are
         currently available:
 
+        - 'fixed scale' and optional keyword argument 'scale' which uses
+            a predefined scale estimate with default equal to one.
         - 'HC0', 'HC1', 'HC2', 'HC3' and no keyword arguments:
             heteroscedasticity robust covariance
         - 'HAC' and keywords

--- a/statsmodels/regression/tests/test_robustcov.py
+++ b/statsmodels/regression/tests/test_robustcov.py
@@ -766,3 +766,35 @@ class TestWLSOLSRobustSmall(object):
             ft2 = res2.f_test(mat)
             assert_allclose(ft1.fvalue, ft2.fvalue, rtol=1e-13)
             assert_allclose(ft1.pvalue, ft2.pvalue, rtol=1e-12)
+
+    def test_fixed_scale(self):
+        cov_type = 'fixed_scale'
+        kwds = {}
+        res1 = self.res_ols.get_robustcov_results(cov_type, **kwds)
+        res2 = self.res_wls.get_robustcov_results(cov_type, **kwds)
+        assert_allclose(res1.params, res2.params, rtol=1e-13)
+        assert_allclose(res1.cov_params(), res2.cov_params(), rtol=1e-13)
+        assert_allclose(res1.bse, res2.bse, rtol=1e-13)
+        assert_allclose(res1.pvalues, res2.pvalues, rtol=1e-13)
+
+        tt = res2.t_test(np.eye(len(res2.params)),
+                         cov_p=res2.normalized_cov_params)
+        assert_allclose(res2.cov_params(), res2.normalized_cov_params,
+                        rtol=1e-13)
+        assert_allclose(res2.bse, tt.sd, rtol=1e-13)
+        assert_allclose(res2.pvalues, tt.pvalue, rtol=1e-13)
+        assert_allclose(res2.tvalues, tt.tvalue, rtol=1e-13)
+
+        # using cov_type in fit
+        mod = self.res_wls.model
+        mod3 = WLS(mod.endog, mod.exog, weights=mod.weights)
+        res3 = mod3.fit(cov_type=cov_type, cov_kwds=kwds)
+        tt = res3.t_test(np.eye(len(res3.params)),
+                         cov_p=res3.normalized_cov_params)
+        assert_allclose(res3.cov_params(), res3.normalized_cov_params,
+                        rtol=1e-13)
+        assert_allclose(res3.bse, tt.sd, rtol=1e-13)
+        assert_allclose(res3.pvalues, tt.pvalue, rtol=1e-13)
+        assert_allclose(res3.tvalues, tt.tvalue, rtol=1e-13)
+
+

--- a/statsmodels/regression/tests/test_robustcov.py
+++ b/statsmodels/regression/tests/test_robustcov.py
@@ -798,3 +798,27 @@ class TestWLSOLSRobustSmall(object):
         assert_allclose(res3.tvalues, tt.tvalue, rtol=1e-13)
 
 
+def test_cov_type_fixed_scale():
+    # this is a unit test from scipy curvefit for `absolute_sigma` keyword
+    xdata = np.array([0, 1, 2, 3, 4, 5])
+    ydata = np.array([1, 1, 5, 7, 8, 12])
+    sigma = np.array([1, 2, 1, 2, 1, 2])
+
+    xdata = np.column_stack((xdata, np.ones(len(xdata))))
+    weights = 1. / sigma**2
+
+    res = WLS(ydata, xdata, weights=weights).fit()
+    assert_allclose(res.bse, [0.20659803, 0.57204404], rtol=1e-3)
+
+    res = WLS(ydata, xdata, weights=weights).fit()
+    assert_allclose(res.bse, [0.20659803, 0.57204404], rtol=1e-3)
+
+    res = WLS(ydata, xdata, weights=weights).fit(cov_type='fixed scale')
+    assert_allclose(res.bse, [0.30714756, 0.85045308], rtol=1e-3)
+
+    res = WLS(ydata, xdata, weights=weights / 9.).fit(cov_type='fixed scale')
+    assert_allclose(res.bse, [3*0.30714756, 3*0.85045308], rtol=1e-3)
+
+    res = WLS(ydata, xdata, weights=weights).fit(cov_type='fixed scale',
+                                                  cov_kwds={'scale':9})
+    assert_allclose(res.bse, [3*0.30714756, 3*0.85045308], rtol=1e-3)


### PR DESCRIPTION
closes #2142  (I opened that issue for the record and to link to the mailing list discussions)

cov_type that allows fixing the scale in the linear model.
main use_case is when weights in WLS are actual inverse variances

see discussions on mailing list

Todo:

- check other results
  - llf uses MLE scale
  - AIC, ... ?
- docstring
- example
- unit tests for scale kwd

DONE except for llf/loglike which needs refactoring, in all 3 linear regression models 

Questions:  
Should we change the default to `use_t=False`?  answer on mailing list: Yes
I think so, but IIRC we don't do it now as part of cov_type.  (`use_t` was part of cov_type but is now mostly a separate, independent keyword.)
correction: we already have `use_t=False` as default for every cov_type except `'nonrobust'`, set in `RegresssionResults.__init__`  - nothing to do in this PR

Do we want to overwrite the `scale` attribute? 
It's not necessary for cov_params and a bit of a pain to change - issues for unrelated refactoring.
skip this for now. this depends on other uses of the scale attribute

Follow-up question

Where do we put the relevant chisquare gof test, which only applies in the case of `fixed scale`?


