### PR TITLE
set dtype of det_cov_params to np.float in _res_loo  issue  #2148

### DIFF
--- a/statsmodels/stats/outliers_influence.py
+++ b/statsmodels/stats/outliers_influence.py
@@ -547,7 +547,7 @@ class OLSInfluence(object):
 
         params = np.zeros_like(exog)
         mse_resid = np.zeros_like(endog)
-        det_cov_params = np.zeros_like(endog)
+        det_cov_params = np.zeros_like(endog, dtype=np.float)
 
         cv_iter = LeaveOneOut(self.nobs)
         for inidx, outidx in cv_iter:


### PR DESCRIPTION
dtype of det_cov_params is np.int, values of det of cov_params are
frequently less than 1 and geting set to zero, change dtype to np.float
so they aren't lost

see issue #2148