### PR TITLE
Prediction interval

### DIFF
--- a/statsmodels/examples/ex_predict_results.py
+++ b/statsmodels/examples/ex_predict_results.py
@@ -56,3 +56,19 @@ assert_allclose(pred_res2.se_obs, prstd, rtol=1e-13)
 assert_allclose(ci2, np.column_stack((iv_l, iv_u)), rtol=1e-13)
 
 print pred_res2.summary_frame().head()
+
+res_wls_n = mod_wls.fit(use_t=False)
+pred_wls_n = res_wls_n.get_prediction()
+print(pred_wls_n.summary_frame().head())
+
+from statsmodels.genmod.generalized_linear_model import GLM
+
+w_sqrt = np.sqrt(w)
+mod_glm = GLM(y/w_sqrt, X/w_sqrt[:,None])
+res_glm = mod_glm.fit()
+pred_glm = res_glm.get_prediction()
+print(pred_glm.summary_frame().head())
+
+res_glm_t = mod_glm.fit(use_t=True)
+pred_glm_t = res_glm_t.get_prediction()
+print(pred_glm_t.summary_frame().head())

--- a/statsmodels/examples/ex_predict_results.py
+++ b/statsmodels/examples/ex_predict_results.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Sat Dec 20 12:01:13 2014
+
+Author: Josef Perktold
+License: BSD-3
+
+"""
+
+import numpy as np
+from statsmodels.regression.linear_model import OLS, WLS
+
+from statsmodels.sandbox.regression.predstd import wls_prediction_std
+from statsmodels.regression._prediction import get_prediction
+
+
+# from example wls.py
+
+nsample = 50
+x = np.linspace(0, 20, nsample)
+X = np.column_stack((x, (x - 5)**2))
+from statsmodels.tools.tools import add_constant
+X = add_constant(X)
+beta = [5., 0.5, -0.01]
+sig = 0.5
+w = np.ones(nsample)
+w[nsample * 6/10:] = 3
+y_true = np.dot(X, beta)
+e = np.random.normal(size=nsample)
+y = y_true + sig * w * e
+X = X[:,[0,1]]
+
+
+# ### WLS knowing the true variance ratio of heteroscedasticity
+
+mod_wls = WLS(y, X, weights=1./w)
+res_wls = mod_wls.fit()
+
+
+
+prstd, iv_l, iv_u = wls_prediction_std(res_wls)
+pred_res = get_prediction(res_wls)
+ci = pred_res.conf_int(obs=True)
+
+from numpy.testing import assert_allclose
+assert_allclose(pred_res.se_obs, prstd, rtol=1e-13)
+assert_allclose(ci, np.column_stack((iv_l, iv_u)), rtol=1e-13)
+
+print pred_res.summary_frame().head()
+
+pred_res2 = res_wls.get_prediction()
+ci2 = pred_res2.conf_int(obs=True)
+
+from numpy.testing import assert_allclose
+assert_allclose(pred_res2.se_obs, prstd, rtol=1e-13)
+assert_allclose(ci2, np.column_stack((iv_l, iv_u)), rtol=1e-13)
+
+print pred_res2.summary_frame().head()

--- a/statsmodels/genmod/generalized_linear_model.py
+++ b/statsmodels/genmod/generalized_linear_model.py
@@ -32,6 +32,8 @@ from statsmodels.graphics._regressionplots_doc import (
     _plot_partial_residuals_doc,
     _plot_ceres_residuals_doc)
 
+# need import in module instead of lazily to copy `__doc__`
+from . import _prediction as pred
 
 from statsmodels.tools.sm_exceptions import PerfectSeparationError
 
@@ -1106,6 +1108,32 @@ class GLMResults(base.LikelihoodModelResults):
     @cache_readonly
     def bic(self):
         return self.deviance - self.df_resid*np.log(self.nobs)
+
+
+    def get_prediction(self, exog=None, exposure=None, offset=None,
+                       transform=True, linear=False,
+                       row_labels=None):
+
+        import statsmodels.regression._prediction as linpred
+
+        pred_kwds = {'exposure': exposure, 'offset': offset, 'linear': True}
+
+        # two calls to a get_prediction duplicates exog generation if patsy
+        res_linpred = linpred.get_prediction(self, exog=exog, transform=transform,
+                              row_labels=row_labels, pred_kwds=pred_kwds)
+
+        pred_kwds['linear'] = False
+        res = pred.get_prediction_glm(self, exog=exog, transform=transform,
+                                      row_labels=row_labels,
+                                      linpred=res_linpred,
+                                      link=self.model.family.link,
+                                      pred_kwds=pred_kwds)
+
+        return res
+
+
+    get_prediction.__doc__ = pred.get_prediction_glm.__doc__
+
 
     def remove_data(self):
         #GLM has alias/reference in result instance

--- a/statsmodels/regression/_prediction.py
+++ b/statsmodels/regression/_prediction.py
@@ -1,0 +1,175 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Fri Dec 19 11:29:18 2014
+
+Author: Josef Perktold
+License: BSD-3
+
+"""
+
+import numpy as np
+from scipy import stats
+
+# this is similar to ContrastResults after t_test, partially copied and adjusted
+class PredictionResults(object):
+
+    def __init__(self, predicted_mean, var_pred_mean, var_resid,
+                 df=None, dist=None, row_labels=None):
+        self.predicted_mean = predicted_mean
+        self.var_pred_mean = var_pred_mean
+        self.df = df
+        self.var_resid = var_resid
+        self.row_labels = row_labels
+
+        if dist is None or dist == 'norm':
+            self.dist = stats.norm
+            self.dist_args = ()
+        elif dist == 't':
+            self.dist = stats.t
+            self.dist_args = (self.df,)
+        else:
+            self.dist = dist
+            self.dist_args = ()
+
+    @property
+    def se_obs(self):
+        return np.sqrt(self.var_pred_mean + self.var_resid)
+
+    @property
+    def se_mean(self):
+        return np.sqrt(self.var_pred_mean)
+
+    def conf_int(self, obs=False, alpha=0.05):
+        """
+        Returns the confidence interval of the value, `effect` of the constraint.
+
+        This is currently only available for t and z tests.
+
+        Parameters
+        ----------
+        alpha : float, optional
+            The significance level for the confidence interval.
+            ie., The default `alpha` = .05 returns a 95% confidence interval.
+
+        Returns
+        -------
+        ci : ndarray, (k_constraints, 2)
+            The array has the lower and the upper limit of the confidence
+            interval in the columns.
+
+        """
+
+        se = self.se_obs if obs else self.se_mean
+
+        q = self.dist.ppf(1 - alpha / 2., *self.dist_args)
+        lower = self.predicted_mean - q * se
+        upper = self.predicted_mean + q * se
+        return np.column_stack((lower, upper))
+
+
+    def summary_frame(self, what='all', alpha=0.05):
+        # TODO: finish and cleanup
+        import pandas as pd
+        from collections import OrderedDict
+        ci_obs = self.conf_int(alpha=alpha, obs=True) # need to split
+        ci_mean = self.conf_int(alpha=alpha, obs=False)
+        to_include = OrderedDict()
+        to_include['mean'] = self.predicted_mean
+        to_include['mean_se'] = self.se_mean
+        to_include['mean_ci_lower'] = ci_mean[:, 0]
+        to_include['mean_ci_upper'] = ci_mean[:, 1]
+        to_include['obs_ci_lower'] = ci_obs[:, 0]
+        to_include['obs_ci_upper'] = ci_obs[:, 1]
+
+        self.table = to_include
+        #OrderedDict doesn't work to preserve sequence
+        # pandas dict doesn't handle 2d_array
+        #data = np.column_stack(list(to_include.values()))
+        #names = ....
+        res = pd.DataFrame(to_include, index=self.row_labels,
+                           columns=to_include.keys())
+        return res
+
+
+def get_prediction(self, exog=None, transform=True, weights=None,
+                   row_labels=None, **kwds):
+    """
+    compute prediction results
+
+    Parameters
+    ----------
+    exog : array-like, optional
+        The values for which you want to predict.
+    transform : bool, optional
+        If the model was fit via a formula, do you want to pass
+        exog through the formula. Default is True. E.g., if you fit
+        a model y ~ log(x1) + log(x2), and transform is True, then
+        you can pass a data structure that contains x1 and x2 in
+        their original form. Otherwise, you'd need to log the data
+        first.
+    weights : array_like, optional
+        Weights interpreted as in WLS, used for the variance of the predicted
+        residual.
+    args, kwargs :
+        Some models can take additional arguments or keywords, see the
+        predict method of the model for the details.
+
+    Returns
+    -------
+    prediction_results : instance
+        The prediction results instance contains prediction and prediction
+        variance and can on demand calculate confidence intervals and summary
+        tables for the prediction of the mean and of new observations.
+
+    """
+
+    ### prepare exog and row_labels, based on base Results.predict
+    if transform and hasattr(self.model, 'formula') and exog is not None:
+        from patsy import dmatrix
+        exog = dmatrix(self.model.data.orig_exog.design_info.builder,
+                       exog)
+
+    if exog is not None:
+        if row_labels is None:
+            if hasattr(exog, 'index'):
+                row_labels = exog.index
+            else:
+                row_labels = None
+
+        exog = np.asarray(exog)
+        if exog.ndim == 1 and (self.model.exog.ndim == 1 or
+                               self.model.exog.shape[1] == 1):
+            exog = exog[:, None]
+        exog = np.atleast_2d(exog)  # needed in count model shape[1]
+    else:
+        exog = self.model.exog
+        if weights is None:
+            weights = getattr(self.model, 'weights', None)
+
+        if row_labels is None:
+            row_labels = getattr(self.model.data, 'row_labels', None)
+
+    # need to handle other arrays, TODO: is delegating to model possible ?
+    if weights is not None:
+        weights = np.asarray(weights)
+        if (weights.size > 1 and
+           (weights.ndim != 1 or weights.shape[0] == exog.shape[1])):
+            raise ValueError('weights has wrong shape')
+
+    ### end
+
+    predicted_mean = self.model.predict(self.params, exog, **kwds)
+
+    covb = self.cov_params()
+    var_pred_mean = (exog * np.dot(covb, exog.T).T).sum(1)
+
+    # TODO: check that we have correct scale, Refactor scale #???
+    var_resid = self.scale / weights # self.mse_resid / weights
+    # special case for now:
+    if self.cov_type == 'fixed scale':
+        var_resid = self.cov_kwds['scale'] / weights
+
+    dist = ['norm', 't'][self.use_t]
+    return PredictionResults(predicted_mean, var_pred_mean, var_resid,
+                             df=self.df_resid, dist=dist,
+                             row_labels=row_labels)

--- a/statsmodels/regression/linear_model.py
+++ b/statsmodels/regression/linear_model.py
@@ -55,6 +55,7 @@ from statsmodels.emplike.elregress import _ELRegOpts
 import warnings
 from statsmodels.tools.sm_exceptions import InvalidTestWarning
 
+# need import in module instead of lazily to copy `__doc__`
 from . import _prediction as pred
 
 def _get_sigma(sigma, nobs):

--- a/statsmodels/regression/linear_model.py
+++ b/statsmodels/regression/linear_model.py
@@ -55,6 +55,8 @@ from statsmodels.emplike.elregress import _ELRegOpts
 import warnings
 from statsmodels.tools.sm_exceptions import InvalidTestWarning
 
+from . import _prediction as pred
+
 def _get_sigma(sigma, nobs):
     """
     Returns sigma (matrix, nobs by nobs) for GLS and the inverse of its
@@ -1900,6 +1902,15 @@ class RegressionResults(base.LikelihoodModelResults):
             res.df_resid_inference = n_groups - 1
 
         return res
+
+
+    def get_prediction(self, exog=None, transform=True, weights=None,
+                       row_labels=None, **kwds):
+
+        return pred.get_prediction(self, exog=exog, transform=transform,
+                              weights=weights, row_labels=row_labels, **kwds)
+
+    get_prediction.__doc__ = pred.get_prediction.__doc__
 
 
     def summary(self, yname=None, xname=None, title=None, alpha=.05):

--- a/statsmodels/regression/tests/tests_predict.py
+++ b/statsmodels/regression/tests/tests_predict.py
@@ -157,3 +157,38 @@ class TestWLSPrediction(object):
 
         sf2 = pred_res2.summary_frame()
         assert_equal(sf2.columns.tolist(), col_names)
+
+
+    def test_glm(self):
+        # prelimnimary, getting started with basic test for GLM.get_prediction
+        from statsmodels.genmod.generalized_linear_model import GLM
+
+        res_wls = self.res_wls
+        mod_wls = res_wls.model
+        y, X, wi = mod_wls.endog, mod_wls.exog, mod_wls.weights
+
+        w_sqrt = np.sqrt(wi)  # notation wi is weights, `w` is var
+        mod_glm = GLM(y * w_sqrt, X * w_sqrt[:,None])
+
+        # compare using t distribution
+        res_glm = mod_glm.fit(use_t=True)
+        pred_glm = res_glm.get_prediction()
+        sf_glm = pred_glm.summary_frame()
+
+        pred_res_wls = res_wls.get_prediction()
+        sf_wls = pred_res_wls.summary_frame()
+        n_compare = 30   # in glm with predict wendog
+        assert_allclose(sf_glm.values[:n_compare],
+                        sf_wls.values[:n_compare, :4])
+
+        # compare using normal distribution
+
+        res_glm = mod_glm.fit() # default use_t=False
+        pred_glm = res_glm.get_prediction()
+        sf_glm = pred_glm.summary_frame()
+
+        res_wls = mod_wls.fit(use_t=False)
+        pred_res_wls = res_wls.get_prediction()
+        sf_wls = pred_res_wls.summary_frame()
+        assert_allclose(sf_glm.values[:n_compare],
+                        sf_wls.values[:n_compare, :4])


### PR DESCRIPTION
adding `get_prediction` to linear_model RegressionResults

everything is written in standalone function for reuse in other models, but some things are linear model specific. (It's not a generic function.)

main issue for regression.linear model #719 
also several discussions on mailing list

SUMMary issue for extension to other models #2150 
some implementation discussion for wrapping #2145 


**Status**

so far mainly the basic outline, I'm trying to get that settled first
I didn't check much of the details yet. 
unit test against old sandbox function.
now also method for GLM with link handling, conf_int is endpoint-transformation, see #938

PR also contains `statsmodels.genmod._prediction.params_transform_univariate`, currently as a helper function for simple non-linear prediction
useful for #2235 add `eform` for exponentiated parameters

