### PR TITLE
MAINT: fix some test and style issues with tsa.filters.hp_filter.

### DIFF
--- a/statsmodels/tsa/filters/hp_filter.py
+++ b/statsmodels/tsa/filters/hp_filter.py
@@ -1,10 +1,10 @@
 from __future__ import absolute_import
 
 from scipy import sparse
-from scipy.sparse import dia_matrix, eye as speye
 from scipy.sparse.linalg import spsolve
 import numpy as np
 from ._utils import _maybe_get_pandas_wrapper
+
 
 def hpfilter(X, lamb=1600):
     """
@@ -82,10 +82,10 @@ def hpfilter(X, lamb=1600):
     if X.ndim > 1:
         X = X.squeeze()
     nobs = len(X)
-    I = speye(nobs,nobs)
+    I = sparse.eye(nobs,nobs)
     offsets = np.array([0,1,2])
     data = np.repeat([[1.],[-2.],[1.]], nobs, axis=1)
-    K = dia_matrix((data, offsets), shape=(nobs-2,nobs))
+    K = sparse.dia_matrix((data, offsets), shape=(nobs-2,nobs))
 
     import scipy
     if (X.dtype != np.dtype('<f8') and
@@ -101,6 +101,7 @@ def hpfilter(X, lamb=1600):
         trend = spsolve(I+lamb*K.T.dot(K), X)
     else:
         trend = spsolve(I+lamb*K.T.dot(K), X, use_umfpack=use_umfpack)
+
     cycle = X-trend
     if _pandas_wrapper is not None:
         return _pandas_wrapper(cycle), _pandas_wrapper(trend)

--- a/statsmodels/tsa/filters/tests/test_filters.py
+++ b/statsmodels/tsa/filters/tests/test_filters.py
@@ -614,7 +614,7 @@ class TestFilters(object):
         cls.datana = DataFrame(data, DatetimeIndex(start='1/1/1951',
                                                   periods=len(data),
                                                   freq='Q'))
-        from .results import filter_results
+        from statsmodels.tsa.filters.tests.results import filter_results
         cls.expected = filter_results
 
     def test_convolution(self):
@@ -676,8 +676,8 @@ class TestFilters(object):
         expected = self.expected.recurse_init_na
         np.testing.assert_almost_equal(res, expected)
 
-        np.testing.assert_raises(ValueError, recursive_filter, x,
-                                 [.75, .25, .5], [150, 100])
+        assert_raises(ValueError, recursive_filter, x,
+                      [.75, .25, .5], [150, 100])
 
     def test_pandas(self):
         start = datetime(1951, 3, 31)

--- a/statsmodels/tsa/filters/tests/test_filters.py
+++ b/statsmodels/tsa/filters/tests/test_filters.py
@@ -614,7 +614,7 @@ class TestFilters(object):
         cls.datana = DataFrame(data, DatetimeIndex(start='1/1/1951',
                                                   periods=len(data),
                                                   freq='Q'))
-        from statsmodels.tsa.filters.tests.results import filter_results
+        from .results import filter_results
         cls.expected = filter_results
 
     def test_convolution(self):


### PR DESCRIPTION
The issue with relative import of test results is that it breaks running the tests in that file (with ``nose.runmodule``). This pattern is used in lots of places in the test suite. I can fix them all up if you agree with the change.

Other fixes are pyflakes/pep8.