### PR TITLE
BUG: clustered cov fails when groups are 2d vector. Closes #2168

### DIFF
--- a/statsmodels/base/covtype.py
+++ b/statsmodels/base/covtype.py
@@ -183,6 +183,10 @@ def get_robustcov_results(self, cov_type='HC1', use_t=None, **kwds):
         groups = kwds['groups']
         if not hasattr(groups, 'shape'):
             groups = np.asarray(groups).T
+
+        if groups.ndim >= 2:
+            groups = groups.squeeze()
+
         res.cov_kwds['groups'] = groups
         use_correction = kwds.get('use_correction', True)
         res.cov_kwds['use_correction'] = use_correction
@@ -195,6 +199,9 @@ def get_robustcov_results(self, cov_type='HC1', use_t=None, **kwds):
                                              use_correction=use_correction)
 
         elif groups.ndim == 2:
+            if hasattr(groups, 'values'):
+                groups = groups.values
+
             if adjust_df:
                 # need to find number of groups
                 # duplicate work

--- a/statsmodels/regression/linear_model.py
+++ b/statsmodels/regression/linear_model.py
@@ -1813,6 +1813,10 @@ class RegressionResults(base.LikelihoodModelResults):
             groups = kwds['groups']
             if not hasattr(groups, 'shape'):
                 groups = np.asarray(groups).T
+
+            if groups.ndim >= 2:
+                groups = groups.squeeze()
+
             res.cov_kwds['groups'] = groups
             use_correction = kwds.get('use_correction', True)
             res.cov_kwds['use_correction'] = use_correction
@@ -1825,6 +1829,9 @@ class RegressionResults(base.LikelihoodModelResults):
                                                  use_correction=use_correction)
 
             elif groups.ndim == 2:
+                if hasattr(groups, 'values'):
+                    groups = groups.values
+
                 if adjust_df:
                     # need to find number of groups
                     # duplicate work

--- a/statsmodels/regression/tests/test_robustcov.py
+++ b/statsmodels/regression/tests/test_robustcov.py
@@ -9,7 +9,9 @@ Author: Josef Perktold
 import numpy as np
 from scipy import stats
 
-from numpy.testing import assert_allclose, assert_equal, assert_warns
+from numpy.testing import (assert_allclose, assert_equal, assert_warns,
+                           assert_raises)
+
 
 from statsmodels.regression.linear_model import OLS, WLS
 import statsmodels.stats.sandwich_covariance as sw
@@ -379,6 +381,45 @@ class TestOLSRobustCluster2(CheckOLSRobustCluster, CheckOLSRobustNewMixin):
         self.rtol = 1e-6
         self.rtolh = 1e-10
 
+
+class TestOLSRobustCluster2Input(CheckOLSRobustCluster, CheckOLSRobustNewMixin):
+    # compare with `reg cluster`
+
+    def setup(self):
+        import pandas as pd
+        fat_array = self.groups.reshape(-1, 1)
+        fat_groups = pd.DataFrame(fat_array)
+
+        res_ols = self.res1.get_robustcov_results('cluster',
+                                                  groups=fat_groups,
+                                                  use_correction=True,
+                                                  use_t=True)
+        self.res3 = self.res1
+        self.res1 = res_ols
+        self.bse_robust = res_ols.bse
+        self.cov_robust = res_ols.cov_params()
+        cov1 = sw.cov_cluster(self.res1, self.groups, use_correction=True)
+        se1 =  sw.se_cov(cov1)
+        self.bse_robust2 = se1
+        self.cov_robust2 = cov1
+        self.small = True
+        self.res2 = res2.results_cluster
+
+        self.rtol = 1e-6
+        self.rtolh = 1e-10
+
+    def test_too_many_groups(self):
+        long_groups = self.groups.reshape(-1, 1)
+        groups3 = np.hstack((long_groups, long_groups, long_groups))
+        assert_raises(ValueError, self.res1.get_robustcov_results,'cluster',
+                      groups=groups3, use_correction=True, use_t=True)
+
+    def test_2way_dataframe(self):
+        import pandas as pd
+        long_groups = self.groups.reshape(-1, 1)
+        groups2 = pd.DataFrame(np.hstack((long_groups, long_groups)))
+        res = self.res1.get_robustcov_results(
+            'cluster', groups=groups2, use_correction=True, use_t=True)
 
 class TestOLSRobustCluster2Fit(CheckOLSRobustCluster, CheckOLSRobustNewMixin):
     # copy, past uses fit method


### PR DESCRIPTION
fixes #2168,  
cov_type cluster fails if groups has extra dimension, missing squeeze