### PR TITLE
ENH: Enhancements for models created with formulas  

### DIFF
--- a/statsmodels/base/data.py
+++ b/statsmodels/base/data.py
@@ -58,6 +58,8 @@ class ModelData(object):
                  **kwargs):
         if 'design_info' in kwargs:
             self.design_info = kwargs.pop('design_info')
+        if 'formula' in kwargs:
+            self.formula = kwargs.pop('formula')
         if missing != 'none':
             arrays, nan_idx = self.handle_missing(endog, exog, missing,
                                                   **kwargs)
@@ -77,6 +79,26 @@ class ModelData(object):
         self._handle_constant(hasconst)
         self._check_integrity()
         self._cache = resettable_cache()
+
+    def __getstate__(self):
+        from copy import copy
+        d = copy(self.__dict__)
+        if "design_info" in d:
+            del d["design_info"]
+            d["restore_design_info"] = True
+        return d
+
+    def __setstate__(self, d):
+        if "restore_design_info" in d:
+            # NOTE: there may be a more performant way to do this
+            from patsy import dmatrices
+            depth = 1  # hmm, have to have same eval env in calling ns
+            data = d['orig_endog'].join(d['orig_exog'])
+            _, design = dmatrices(d['formula'], data, depth,
+                                  return_type='dataframe')
+            self.design_info = design.design_info
+            del d["restore_design_info"]
+        self.__dict__.update(d)
 
     def _handle_constant(self, hasconst):
         if hasconst is not None:

--- a/statsmodels/base/data.py
+++ b/statsmodels/base/data.py
@@ -56,6 +56,8 @@ class ModelData(object):
 
     def __init__(self, endog, exog=None, missing='none', hasconst=None,
                  **kwargs):
+        if 'design_info' in kwargs:
+            self.design_info = kwargs.pop('design_info')
         if missing != 'none':
             arrays, nan_idx = self.handle_missing(endog, exog, missing,
                                                   **kwargs)

--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -62,8 +62,9 @@ class Model(object):
         self.exog = self.data.exog
         self.endog = self.data.endog
         self._data_attr = []
-        self._data_attr.extend(['exog', 'endog', 'data.exog', 'data.endog',
-                                'data.orig_endog', 'data.orig_exog'])
+        self._data_attr.extend(['exog', 'endog', 'data.exog', 'data.endog'])
+        if 'formula' not in kwargs:  # won't be able to unpickle without these
+            self._data_attr.extend(['data.orig_endog', 'data.orig_exog'])
         # store keys for extras if we need to recreate model instance
         # we don't need 'missing', maybe we need 'hasconst'
         self._init_keys = list(kwargs.keys())
@@ -84,7 +85,7 @@ class Model(object):
         data = handle_data(endog, exog, missing, hasconst, **kwargs)
         # kwargs arrays could have changed, easier to just attach here
         for key in kwargs:
-            if key == 'design_info':  # leave this attached to data
+            if key in ['design_info', 'formula']:  # leave attached to data
                 continue
             # pop so we don't start keeping all these twice or references
             try:
@@ -151,6 +152,7 @@ class Model(object):
                                             missing=missing)
         kwargs.update({'missing_idx': missing_idx,
                        'missing': missing,
+                       'formula': formula,  # attach formula for unpckling
                        'design_info': design_info})
         mod = cls(endog, exog, *args, **kwargs)
         mod.formula = formula

--- a/statsmodels/base/tests/test_data.py
+++ b/statsmodels/base/tests/test_data.py
@@ -850,7 +850,8 @@ def test_formula_missing_extra_arrays():
 
     formula = 'y_missing ~ X_missing'
 
-    (endog, exog), missing_idx = handle_formula_data(data, None, formula,
+    ((endog, exog),
+     missing_idx, design_info) = handle_formula_data(data, None, formula,
                                                      depth=2,
                                                      missing='drop')
 
@@ -863,7 +864,8 @@ def test_formula_missing_extra_arrays():
     assert_equal(data_nona[['constant', 'X']].values, model_data.exog)
     assert_equal(data_nona['weights'].values, model_data.weights)
 
-    (endog, exog), missing_idx = handle_formula_data(data, None, formula,
+    ((endog, exog),
+     missing_idx, design_info) = handle_formula_data(data, None, formula,
                                                      depth=2,
                                                      missing='drop')
     weights_2d = np.random.randn(10, 10)
@@ -878,7 +880,8 @@ def test_formula_missing_extra_arrays():
     assert_equal(data.ix[good_idx, ['constant', 'X']], model_data2.exog)
     assert_equal(weights_2d[good_idx][:, good_idx], model_data2.weights)
 
-    (endog, exog), missing_idx = handle_formula_data(data, None, formula,
+    ((endog, exog),
+     missing_idx, design_info) = handle_formula_data(data, None, formula,
                                                      depth=2,
                                                      missing='drop')
     kwargs.update({'weights': weights_wrong_size,

--- a/statsmodels/formula/formulatools.py
+++ b/statsmodels/formula/formulatools.py
@@ -71,7 +71,12 @@ def handle_formula_data(Y, X, formula, depth=0, missing='drop'):
     missing_mask = getattr(na_action, 'missing_mask', None)
     if not np.any(missing_mask):
         missing_mask = None
-    return result, missing_mask
+    if len(result) > 1:  # have RHS design
+        design_info = result[1].design_info  # detach it from DataFrame
+    else:
+        design_info = None
+    # NOTE: is there ever a case where we'd need LHS design_info?
+    return result, missing_mask, design_info
 
 
 def _remove_intercept_patsy(terms):

--- a/statsmodels/regression/tests/test_regression.py
+++ b/statsmodels/regression/tests/test_regression.py
@@ -1053,6 +1053,20 @@ def test_formula_missing_cat():
                   data=dta, missing='raise')
 
 
+def test_missing_formula_predict():
+    # see 2171
+    nsample = 30
+
+    data = pandas.DataFrame({'x': np.linspace(0, 10, nsample)})
+    null = pandas.DataFrame({'x': np.array([np.nan])})
+    data = pandas.concat([data, null])
+    beta = np.array([1, 0.1])
+    e = np.random.normal(size=nsample+1)
+    data['y'] = beta[0] + beta[1] * data['x'] + e
+    model = OLS.from_formula('y ~ x', data=data)
+    fit = model.fit()
+    pred = fit.predict(exog=data[:-1])
+
 if __name__=="__main__":
 
     import nose

--- a/statsmodels/stats/anova.py
+++ b/statsmodels/stats/anova.py
@@ -60,7 +60,7 @@ def anova_single(model, **kwargs):
     nobs = exog.shape[0]
 
     response_name = model.model.endog_names
-    design_info = model.model.data.orig_exog.design_info
+    design_info = model.model.data.design_info
     exog_names = model.model.exog_names
     # +1 for resids
     n_rows = (len(design_info.terms) - _has_intercept(design_info) + 1)


### PR DESCRIPTION
Will close #2171 and #1263. Two warts, if a model is created with a formula, we have to pickle the orig_endog and orig_exog otherwise we can't recreate the builder. There may be a better way to do this, we could probably reduce the data to a compact form e.g., so that categorical variables have all the unique categories, but I'm punting on this. The other wart is that I'm not trying to pickle the evaluation environment. I think we probably could try to do something here, but I think it's a fine compromise for now to let users deal with this. 

- move design_info
- add keywords and extra return (to handle_formula_data) to attach formula
- add get and set pickling state

backwards incompatible for internal code.
