### PR TITLE
ENH GEE equivalence class covariance structure enhancements

### DIFF
--- a/statsmodels/genmod/cov_struct.py
+++ b/statsmodels/genmod/cov_struct.py
@@ -983,9 +983,6 @@ class Equivalence(CovStruct):
     level of the `pairs` dictionary to force the corresponding
     covariance to be zero.
 
-    The `pairs` dictionary is modified by the function so the user
-    should pass a copy if it is needed elsewhere.
-
     Examples
     --------
     The following sets up the `pairs` dictionary for a model with two
@@ -1010,7 +1007,9 @@ class Equivalence(CovStruct):
             raise ValueError("Equivalence cov_struct accepts only one of `pairs` and `labels`")
 
         if pairs is not None:
-            self.pairs = pairs
+            import copy
+            self.pairs = copy.deepcopy(pairs)
+
         if labels is not None:
             self.labels = np.asarray(labels)
 
@@ -1090,8 +1089,6 @@ class Equivalence(CovStruct):
                         i1 = i1[jj]
                         i2 = i2[jj]
                         pairs[g_lb][clabel] = (i1, i2)
-
-        self.pairs = pairs
 
 
     def initialize(self, model):

--- a/statsmodels/genmod/cov_struct.py
+++ b/statsmodels/genmod/cov_struct.py
@@ -1007,6 +1007,9 @@ class Equivalence(CovStruct):
         if (pairs is not None) and (labels is not None):
             raise ValueError("Equivalence cov_struct accepts only one of `pairs` and `labels`")
 
+        if self.model.weights is not None:
+            warnings.warn("weights not implemented for equalence cov_struct, using unweighted covariance estimate")
+
         if pairs is not None:
             import copy
             self.pairs = copy.deepcopy(pairs)

--- a/statsmodels/genmod/cov_struct.py
+++ b/statsmodels/genmod/cov_struct.py
@@ -1012,7 +1012,7 @@ class Equivalence(CovStruct):
         if pairs is not None:
             self.pairs = pairs
         if labels is not None:
-            self.labels = labels
+            self.labels = np.asarray(labels)
 
         self.as_cor = as_cor
 

--- a/statsmodels/genmod/cov_struct.py
+++ b/statsmodels/genmod/cov_struct.py
@@ -1,6 +1,7 @@
 from statsmodels.compat.python import iterkeys, itervalues, zip, range
 from statsmodels.stats.correlation_tools import cov_nearest
 import numpy as np
+import pandas as pd
 from scipy import linalg as spl
 from collections import defaultdict
 from statsmodels.tools.sm_exceptions import (ConvergenceWarning,
@@ -139,7 +140,6 @@ class CovStruct(object):
         """
 
         vmat, is_cor = self.covariance_matrix(expval, index)
-
         if is_cor:
             vmat *= np.outer(stdev, stdev)
 
@@ -954,9 +954,22 @@ class Equivalence(CovStruct):
       one triangle of each covariance matrix should be included.
       Positions where j1 and j2 have the same value are variance
       parameters.
+    labels : array-like
+      An array of labels such that every distinct pair of labels
+      defines an equivalence class.  Either `labels` or `pairs` must
+      be provided.  When the two labels in a pair are equal two
+      equivalence classes are defined: one for the diagonal elements
+      (corresponding to variances) and one for the off-diagonal
+      elements (corresponding to covariances).
+    as_cor : boolean
+      If True, returns an estimate of the correlation matrix, otherwise
+      returns an estimate of the covariance matrix.
 
     Notes
     -----
+    Using `labels` to define the class is much easier than using
+    `pairs`, but is less general.
+
     Any pair of values not contained in `pairs` will be assigned zero
     covariance.
 
@@ -964,6 +977,14 @@ class Equivalence(CovStruct):
     matrix.  They are not updated if missing data are present.  When
     using this covariance structure, missing data should be removed
     before constructing the model.
+
+    If using `labels`, after a model is defined using the covariance
+    structure it is possible to remove a label pair from the second
+    level of the `pairs` dictionary to force the corresponding
+    covariance to be zero.
+
+    The `pairs` dictionary is modified by the function so the user
+    should pass a copy if it is needed elsewhere.
 
     Examples
     --------
@@ -978,36 +999,123 @@ class Equivalence(CovStruct):
     >> pairs[1][2] = 3 + np.tril_indices(3, -1)
     """
 
-    def __init__(self, pairs):
+    def __init__(self, pairs=None, labels=None, as_cor=True):
 
         super(Equivalence, self).__init__()
 
+        if (pairs is None) and (labels is None):
+            raise ValueError("Equivalence cov_struct requires either `pairs` or `labels`")
+
+        if (pairs is not None) and (labels is not None):
+            raise ValueError("Equivalence cov_struct accepts only one of `pairs` and `labels`")
+
+        if pairs is not None:
+            self.pairs = pairs
+        if labels is not None:
+            self.labels = labels
+
+        self.as_cor = as_cor
+
+    def _make_pairs(self, i, j):
+        """
+        Create arrays `i_`, `j_` containing all unique ordered pairs of elements in `i` and `j`.
+
+        The arrays `i` and `j` must be one-dimensional containing non-negative integers.
+        """
+
+        mat = np.zeros((len(i)*len(j), 2), dtype=np.int32)
+
+        # Create the pairs and order them
+        f = np.ones(len(j))
+        mat[:, 0] = np.kron(f, i).astype(np.int32)
+        f = np.ones(len(i))
+        mat[:, 1] = np.kron(j, f).astype(np.int32)
+        mat.sort(1)
+
+        # Remove repeated rows
+        dtype = np.dtype((np.void, mat.dtype.itemsize * mat.shape[1]))
+        bmat = np.ascontiguousarray(mat).view(dtype)
+        _, idx = np.unique(bmat, return_index=True)
+        mat = mat[idx, :]
+
+        return mat[:, 0], mat[:, 1]
+
+    def _pairs_from_labels(self):
+
+        from collections import defaultdict
+        pairs = defaultdict(lambda : defaultdict(lambda : None))
+
+        model = self.model
+
+        df = pd.DataFrame({"labels": self.labels, "groups": model.groups})
+        gb = df.groupby(["groups", "labels"])
+
+        ulabels = np.unique(self.labels)
+
+        for g_ix, g_lb in enumerate(model.group_labels):
+
+            # Loop over label pairs
+            for lx1 in range(len(ulabels)):
+                for lx2 in range(lx1+1):
+
+                    lb1 = ulabels[lx1]
+                    lb2 = ulabels[lx2]
+
+                    try:
+                        i1 = gb.groups[(g_lb, lb1)]
+                        i2 = gb.groups[(g_lb, lb2)]
+                    except KeyError:
+                        continue
+
+                    i1, i2 = self._make_pairs(i1, i2)
+
+                    clabel = str(lb1) + "/" + str(lb2)
+
+                    # Variance parameters belong in their own equiv class.
+                    jj = np.flatnonzero(i1 == i2)
+                    if len(jj) > 0:
+                        clabelv = clabel + "/v"
+                        pairs[g_lb][clabelv] = (i1[jj], i2[jj])
+
+                    # Covariance parameters
+                    jj = np.flatnonzero(i1 != i2)
+                    if len(jj) > 0:
+                        i1 = i1[jj]
+                        i2 = i2[jj]
+                        pairs[g_lb][clabel] = (i1, i2)
+
         self.pairs = pairs
 
-        # Initialize so that any pair containing a variance parameter
-        # has value 1.
-        self.dep_params = defaultdict(lambda : 0.)
-        for gp in self.pairs:
-            for lb in self.pairs[gp]:
-                j1, j2 = self.pairs[gp][lb]
-                if np.any(j1 == j2):
-                    self.dep_params[lb] = 1
 
     def initialize(self, model):
-        """
-        Start indexing from 0 within each group.
-        """
 
         super(Equivalence, self).initialize(model)
 
+        if not hasattr(self, 'pairs'):
+            self._pairs_from_labels()
+
+        # Initialize so that any equivalence class containing a
+        # variance parameter has value 1.
+        self.dep_params = defaultdict(lambda : 0.)
+        self._var_classes = set([])
+        for gp in self.model.group_labels:
+            for lb in self.pairs[gp]:
+                j1, j2 = self.pairs[gp][lb]
+                if np.any(j1 == j2):
+                    if not np.all(j1 == j2):
+                        warnings.warn("equivalence class contains both variance and covariance parameters")
+                    self._var_classes.add(lb)
+                    self.dep_params[lb] = 1
+
+        # Need to start indexing at 0 within each group.
         # rx maps olds indices to new indices
         rx = -1 * np.ones(len(self.model.endog), dtype=np.int32)
-        for gp in self.model.group_labels:
-            ii = self.model.group_indices[gp]
+        for g_ix, g_lb in enumerate(self.model.group_labels):
+            ii = self.model.group_indices[g_lb]
             rx[ii] = np.arange(len(ii), dtype=np.int32)
 
         # Reindex
-        for gp in self.pairs.keys():
+        for gp in self.model.group_labels:
             for lb in self.pairs[gp].keys():
                 a, b = self.pairs[gp][lb]
                 self.pairs[gp][lb] = (rx[a], rx[b])
@@ -1017,35 +1125,48 @@ class Equivalence(CovStruct):
         endog = self.model.endog_li
         varfunc = self.model.family.variance
         cached_means = self.model.cached_means
-        dep_params = defaultdict(lambda : [0., 0])
+        dep_params = defaultdict(lambda : [0., 0., 0., 0])
         dim = len(params)
 
-        for gp in range(self.model.num_group):
-            expval, _ = cached_means[gp]
+        for k, gp in enumerate(self.model.group_labels):
+            expval, _ = cached_means[k]
             stdev = np.sqrt(varfunc(expval))
-            resid = (endog[gp] - expval) / stdev
+            resid = (endog[k] - expval) / stdev
             for lb in self.pairs[gp].keys():
+                if self.as_cor and lb in self._var_classes:
+                    continue
                 jj = self.pairs[gp][lb]
                 dep_params[lb][0] += np.sum(resid[jj[0]] * resid[jj[1]])
-                dep_params[lb][1] += len(jj[0])
+                if self.as_cor:
+                    dep_params[lb][1] += np.sum(resid[jj[0]]**2)
+                    dep_params[lb][2] += np.sum(resid[jj[1]]**2)
+                dep_params[lb][3] += len(jj[0])
 
-        for lb in dep_params.keys():
-            dep_params[lb] = dep_params[lb][0] / (dep_params[lb][1] - dim)
+        if self.as_cor:
+            for lb in dep_params.keys():
+                den = np.sqrt(dep_params[lb][1] * dep_params[lb][2])
+                dep_params[lb] = dep_params[lb][0] / den
+            for lb in self._var_classes:
+                dep_params[lb] = 1.
+        else:
+            for lb in dep_params.keys():
+                dep_params[lb] = dep_params[lb][0] / (dep_params[lb][3] - dim)
 
         self.dep_params = dep_params
 
     def covariance_matrix(self, expval, index):
         dim = len(expval)
         cmat = np.zeros((dim, dim))
+        g_lb = self.model.group_labels[index]
 
-        for lb in self.pairs[index].keys():
-            j1, j2 = self.pairs[index][lb]
+        for lb in self.pairs[g_lb].keys():
+            j1, j2 = self.pairs[g_lb][lb]
             cmat[j1, j2] = self.dep_params[lb]
 
         cmat = cmat + cmat.T
         np.fill_diagonal(cmat, cmat.diagonal() / 2)
 
-        return cmat, False
+        return cmat, self.as_cor
 
     update.__doc__ = CovStruct.update.__doc__
     covariance_matrix.__doc__ = CovStruct.covariance_matrix.__doc__

--- a/statsmodels/genmod/cov_struct.py
+++ b/statsmodels/genmod/cov_struct.py
@@ -1007,9 +1007,6 @@ class Equivalence(CovStruct):
         if (pairs is not None) and (labels is not None):
             raise ValueError("Equivalence cov_struct accepts only one of `pairs` and `labels`")
 
-        if self.model.weights is not None:
-            warnings.warn("weights not implemented for equalence cov_struct, using unweighted covariance estimate")
-
         if pairs is not None:
             import copy
             self.pairs = copy.deepcopy(pairs)
@@ -1100,6 +1097,9 @@ class Equivalence(CovStruct):
     def initialize(self, model):
 
         super(Equivalence, self).initialize(model)
+
+        if self.model.weights is not None:
+            warnings.warn("weights not implemented for equalence cov_struct, using unweighted covariance estimate")
 
         if not hasattr(self, 'pairs'):
             self._pairs_from_labels()

--- a/statsmodels/genmod/cov_struct.py
+++ b/statsmodels/genmod/cov_struct.py
@@ -1033,8 +1033,14 @@ class Equivalence(CovStruct):
         mat.sort(1)
 
         # Remove repeated rows
-        dtype = np.dtype((np.void, mat.dtype.itemsize * mat.shape[1]))
-        bmat = np.ascontiguousarray(mat).view(dtype)
+        try:
+            dtype = np.dtype((np.void, mat.dtype.itemsize * mat.shape[1]))
+            bmat = np.ascontiguousarray(mat).view(dtype)
+        except TypeError:
+            # workaround for old numpy that can't call unique with complex
+            # dtypes
+            np.random.seed(4234)
+            bmat = np.dot(mat, np.random.uniform(size=mat.shape[1]))
         _, idx = np.unique(bmat, return_index=True)
         mat = mat[idx, :]
 

--- a/statsmodels/genmod/cov_struct.py
+++ b/statsmodels/genmod/cov_struct.py
@@ -1125,7 +1125,8 @@ class Equivalence(CovStruct):
         endog = self.model.endog_li
         varfunc = self.model.family.variance
         cached_means = self.model.cached_means
-        dep_params = defaultdict(lambda : [0., 0., 0., 0])
+        dep_params = defaultdict(lambda : [0., 0., 0.])
+        n_pairs = defaultdict(lambda : 0)
         dim = len(params)
 
         for k, gp in enumerate(self.model.group_labels):
@@ -1140,7 +1141,7 @@ class Equivalence(CovStruct):
                 if self.as_cor:
                     dep_params[lb][1] += np.sum(resid[jj[0]]**2)
                     dep_params[lb][2] += np.sum(resid[jj[1]]**2)
-                dep_params[lb][3] += len(jj[0])
+                n_pairs[lb] += len(jj[0])
 
         if self.as_cor:
             for lb in dep_params.keys():
@@ -1150,9 +1151,10 @@ class Equivalence(CovStruct):
                 dep_params[lb] = 1.
         else:
             for lb in dep_params.keys():
-                dep_params[lb] = dep_params[lb][0] / (dep_params[lb][3] - dim)
+                dep_params[lb] = dep_params[lb][0] / (n_pairs[lb] - dim)
 
         self.dep_params = dep_params
+        self.n_pairs = n_pairs
 
     def covariance_matrix(self, expval, index):
         dim = len(expval)

--- a/statsmodels/genmod/cov_struct.py
+++ b/statsmodels/genmod/cov_struct.py
@@ -1036,12 +1036,13 @@ class Equivalence(CovStruct):
         try:
             dtype = np.dtype((np.void, mat.dtype.itemsize * mat.shape[1]))
             bmat = np.ascontiguousarray(mat).view(dtype)
+            _, idx = np.unique(bmat, return_index=True)
         except TypeError:
             # workaround for old numpy that can't call unique with complex
             # dtypes
             np.random.seed(4234)
             bmat = np.dot(mat, np.random.uniform(size=mat.shape[1]))
-        _, idx = np.unique(bmat, return_index=True)
+            _, idx = np.unique(bmat, return_index=True)
         mat = mat[idx, :]
 
         return mat[:, 0], mat[:, 1]

--- a/statsmodels/genmod/tests/test_gee.py
+++ b/statsmodels/genmod/tests/test_gee.py
@@ -1133,11 +1133,16 @@ class TestGEE(object):
             model2 = sm.GEE(endog, exog, groups, cov_struct=ec)
             result2 = model2.fit()
 
-            # Use large atol/rtol since there are some small differences in the results
-            # due to degree of freedom differences.
-            assert_allclose(result1.params, result2.params, atol=1e-3, rtol=1e-3)
-            assert_allclose(result1.bse, result2.bse, atol=1e-3, rtol=1e-3)
-            assert_allclose(result1.scale, result2.scale, atol=1e-3, rtol=1e-3)
+            # Use large atol/rtol for the correlation case since there
+            # are some small differences in the results due to degree
+            # of freedom differences.
+            if return_cov == True:
+                atol, rtol = 1e-6, 1e-6
+            else:
+                atol, rtol = 1e-3, 1e-3
+            assert_allclose(result1.params, result2.params, atol=atol, rtol=rtol)
+            assert_allclose(result1.bse, result2.bse, atol=atol, rtol=rtol)
+            assert_allclose(result1.scale, result2.scale, atol=atol, rtol=rtol)
 
     def test_equivalence_from_pairs(self):
 

--- a/statsmodels/genmod/tests/test_gee.py
+++ b/statsmodels/genmod/tests/test_gee.py
@@ -1127,14 +1127,9 @@ class TestGEE(object):
         model1 = sm.GEE(endog, exog, groups, cov_struct=ex)
         result1 = model1.fit()
 
-        import copy
-
         for as_cor in False, True:
 
-            # This is changed inside the constructor so can't be re-used.
-            pairsc = copy.deepcopy(pairs)
-
-            ec = sm.cov_struct.Equivalence(pairsc, as_cor=as_cor)
+            ec = sm.cov_struct.Equivalence(pairs, as_cor=as_cor)
             model2 = sm.GEE(endog, exog, groups, cov_struct=ec)
             result2 = model2.fit()
 

--- a/statsmodels/genmod/tests/test_gee.py
+++ b/statsmodels/genmod/tests/test_gee.py
@@ -1176,8 +1176,9 @@ class TestGEE(object):
                     ixs.add(ky)
 
         # Smoke test
-        result1 = model1.fit()
-
+        eq = sm.cov_struct.Equivalence(labels=labels, return_cov=True)
+        model1 = sm.GEE(endog, exog, groups, cov_struct=eq)
+        result1 = model1.fit(maxiter=2)
 
 class CheckConsistency(object):
 

--- a/statsmodels/genmod/tests/test_gee.py
+++ b/statsmodels/genmod/tests/test_gee.py
@@ -1127,12 +1127,14 @@ class TestGEE(object):
         model1 = sm.GEE(endog, exog, groups, cov_struct=ex)
         result1 = model1.fit()
 
-        for as_cor in False, True:
+        for return_cov in False, True:
 
-            ec = sm.cov_struct.Equivalence(pairs, as_cor=as_cor)
+            ec = sm.cov_struct.Equivalence(pairs, return_cov=return_cov)
             model2 = sm.GEE(endog, exog, groups, cov_struct=ec)
             result2 = model2.fit()
 
+            # Use large atol/rtol since there are some small differences in the results
+            # due to degree of freedom differences.
             assert_allclose(result1.params, result2.params, atol=1e-3, rtol=1e-3)
             assert_allclose(result1.bse, result2.bse, atol=1e-3, rtol=1e-3)
             assert_allclose(result1.scale, result2.scale, atol=1e-3, rtol=1e-3)
@@ -1150,7 +1152,7 @@ class TestGEE(object):
         labels = np.kron(np.arange(5), np.ones(10)).astype(np.int32)
         labels = labels[np.random.permutation(len(labels))]
 
-        eq = sm.cov_struct.Equivalence(labels=labels, as_cor=False)
+        eq = sm.cov_struct.Equivalence(labels=labels, return_cov=True)
         model1 = sm.GEE(endog, exog, groups, cov_struct=eq)
 
         # Call this directly instead of letting init do it to get the
@@ -1172,6 +1174,9 @@ class TestGEE(object):
                     ky = (a, b)
                     assert(ky not in ixs)
                     ixs.add(ky)
+
+        # Smoke test
+        result1 = model1.fit()
 
 
 class CheckConsistency(object):


### PR DESCRIPTION
This PR has two main parts:

1. The equivalence classes can now be specified using a vector of labels, rather than by providing the pairs dictionary directly.  This is not as general, but much easier when it can be used.  For example, if there are two labels 'a' and 'b', the free parameters to be estimated are: cov(a, b), cov(a, a), cov(b, b), var(a) and var(b).  In this case cov(a, a) refers to the covariance between two different observations in the same group that fall into label class 'a', whereas var(a) is the variance.  cov(a, a) will generally be smaller than var(a).  An application where this would be useful is a situation where there are repeated measures on subjects, say of two biomarkers A and B measured at 3 time points, with 2 technical replicates at each time point.  Then there would be a covariance parameter between each A(s) and A(t) (with s and t denoting time), between each B(s) and B(t), and between each A(s) and B(t).  This is 6 + 6 + 9 parameters if I am counting right (there are more parameters for the A/B combinations since the order matters).

2. There is an option to calculate either the covariance or the correlation matrix.  Internally, GEE takes the correlation matrix and converts it to a covariance matrix by multiplying by the corresponding estimates of the standard deviation.  These estimates come from the mean structure (via the family varfunc).  Alternatively, we can estimate variances directly from the data, and pass the covariance matrix to GEE (which then does not rescale it).  Experience to date suggests that the two approaches generally perform similarly.  Intuition suggests that if the variance function is correctly specified (i.e. if the hypothesized mean/variance relationship holds), then it would be a bit more efficient to pass GEE a correlation function rather than trying to estimate the variance parameters directly.  But if there is unmodeled heteroscedasticity it may be picked up in the estimated covariance structure and provide a bit of robustness.  So given all this, I think it makes sense to provide the option to go either way.

Note also the addition of the n_pairs attribute to make it easy to see how much data is available to estimate each variance/covariance parameter.

