### PR TITLE
Test: Test GLM IRLS vs Newton using all links

### DIFF
--- a/statsmodels/genmod/generalized_linear_model.py
+++ b/statsmodels/genmod/generalized_linear_model.py
@@ -732,16 +732,16 @@ class GLM(base.LikelihoodModel):
         using the scipy gradient optimizers.
         """
 
-        if max_start_irls > 0:
+        if (max_start_irls > 0) and (start_params is None):
             irls_rslt = self._fit_irls(start_params=start_params, maxiter=maxiter,
                                        tol=tol, scale=scale, cov_type=cov_type,
                                        cov_kwds=cov_kwds, use_t=use_t, **kwargs)
             start_params = irls_rslt.params
 
-        # TODO: pass more into fit here
         rslt = super(GLM, self).fit(start_params=start_params, tol=tol,
                                     maxiter=maxiter, full_output=full_output,
                                     method=method, disp=disp, **kwargs)
+
         self.mu = self.predict(rslt.params)
         self.scale = self.estimate_scale(self.mu)
 

--- a/statsmodels/genmod/generalized_linear_model.py
+++ b/statsmodels/genmod/generalized_linear_model.py
@@ -631,9 +631,9 @@ class GLM(base.LikelihoodModel):
         else:
             return self.family.fitted(linpred)
 
-    def fit(self, start_params=None, maxiter=100, method='IRLS',
-            tol=1e-8, scale=None, cov_type='nonrobust', cov_kwds=None,
-            use_t=None, full_output=True, disp=False, **kwargs):
+    def fit(self, start_params=None, maxiter=100, method='IRLS', tol=1e-8,
+            scale=None, cov_type='nonrobust', cov_kwds=None, use_t=None,
+            full_output=True, disp=False, max_start_irls=3, **kwargs):
         """
         Fits a generalized linear model for a given family.
 
@@ -673,6 +673,10 @@ class GLM(base.LikelihoodModel):
         disp : bool, optional
             Set to True to print convergence messages.  Not used if method is
             IRLS.
+        max_start_irls : int
+            The number of IRLS iterations used to obtain starting
+            values for gradient optimization.  Only relevant if
+            `method` is set to something other than 'IRLS'.
 
         Notes
         -----
@@ -714,16 +718,25 @@ class GLM(base.LikelihoodModel):
                                       tol=tol, scale=scale,
                                       full_output=full_output,
                                       disp=disp, cov_type=cov_type,
-                                      cov_kwds=cov_kwds, use_t=use_t, **kwargs)
+                                      cov_kwds=cov_kwds, use_t=use_t,
+                                      max_start_irls=max_start_irls,
+                                      **kwargs)
 
     def _fit_gradient(self, start_params=None, method="newton",
                       maxiter=100, tol=1e-8, full_output=True,
                       disp=True, scale=None, cov_type='nonrobust',
-                      cov_kwds=None, use_t=None, **kwargs):
+                      cov_kwds=None, use_t=None, max_start_irls=3,
+                      **kwargs):
         """
         Fits a generalized linear model for a given family iteratively
         using the scipy gradient optimizers.
         """
+
+        if max_start_irls > 0:
+            irls_rslt = self._fit_irls(start_params=start_params, maxiter=maxiter,
+                                       tol=tol, scale=scale, cov_type=cov_type,
+                                       cov_kwds=cov_kwds, use_t=use_t, **kwargs)
+            start_params = irls_rslt.params
 
         # TODO: pass more into fit here
         rslt = super(GLM, self).fit(start_params=start_params, tol=tol,

--- a/statsmodels/genmod/tests/test_glm.py
+++ b/statsmodels/genmod/tests/test_glm.py
@@ -804,28 +804,28 @@ def test_plots():
     fig = result.plot_ceres_residuals(1)
     plt.close(fig)
 
-def gen_endog(lin_pred, family_name):
+def gen_endog(lin_pred, family_class, link):
 
-    if family_name == "binomial":
-        probs = 1 / (1 + np.exp(-lin_pred))
-        endog = 1*(np.random.uniform(size=len(lin_pred)) < probs)
-    elif family_name == "poisson":
-        lam = np.exp(lin_pred)
-        endog = np.random.poisson(lam)
-    elif family_name == "gamma":
-        lam = np.exp(lin_pred / 4)
-        endog = np.random.gamma(2, lam)
-    elif family_name == "gaussian":
-        endog = lin_pred + np.random.normal(size=len(lin_pred))
-    elif family_name == "negbinom":
+    np.random.seed(872)
+
+    fam = sm.families
+
+    mu = link().inverse(lin_pred)
+
+    if family_class == fam.Binomial:
+        endog = 1*(np.random.uniform(size=len(lin_pred)) < mu)
+    elif family_class == fam.Poisson:
+        endog = np.random.poisson(mu)
+    elif family_class == fam.Gamma:
+        endog = np.random.gamma(2, mu)
+    elif family_class == fam.Gaussian:
+        endog = mu + np.random.normal(size=len(lin_pred))
+    elif family_class == fam.NegativeBinomial:
         from scipy.stats.distributions import nbinom
-        lam = np.exp(lin_pred)
-        endog = nbinom.rvs(lam, 0.5)
-    elif family_name == "inverse_gaussian":
+        endog = nbinom.rvs(mu, 0.5)
+    elif family_class == fam.InverseGaussian:
         from scipy.stats.distributions import invgauss
-        lin_pred = 2 + (lin_pred - 2) / 4.
-        lam = 1 / np.sqrt(lin_pred)
-        endog = invgauss.rvs(lam)
+        endog = invgauss.rvs(mu)
     else:
         raise ValueError
 
@@ -855,42 +855,85 @@ def test_gradient_irls():
     Compare the results when using gradient optimization and IRLS.
     """
 
+    # TODO: Some of the non-canonical links are quite sensitive to the
+    # input data.  The tests here suggest that there are no
+    # fundamental errors in the code.  Better support is needed to
+    # detect non-convergence and optimization failures.
+
+    # TODO: Find working examples for inverse_square link
+
     np.random.seed(87342)
 
-    families = [sm.families.Binomial(), sm.families.Poisson(),
-                sm.families.Gamma(), sm.families.NegativeBinomial(),
-                sm.families.Gaussian(), sm.families.InverseGaussian()]
-    fnames = ["binomial", "poisson", "gamma", "negbinom", "gaussian",
-              "inverse_gaussian"]
+    fam = sm.families
+    lnk = sm.families.links
+    families = [(fam.Binomial, [lnk.logit, lnk.probit, lnk.cloglog, lnk.log, lnk.cauchy]),
+                (fam.Poisson, [lnk.log, lnk.identity, lnk.sqrt]),
+                (fam.Gamma, [lnk.log, lnk.identity, lnk.inverse_power]),
+                (fam.Gaussian, [lnk.identity, lnk.log, lnk.inverse_power]),
+                (fam.InverseGaussian, [lnk.log, lnk.identity, lnk.inverse_power, lnk.inverse_squared]),
+                (fam.NegativeBinomial, [lnk.log, lnk.inverse_power, lnk.inverse_squared, lnk.identity])]
 
     n = 100
     p = 3
     exog = np.random.normal(size=(n, p))
     exog[:, 0] = 1
-    lin_pred = 1 + exog.sum(1)
 
-    for family, family_name in zip(families, fnames):
+    for family_class, family_links in families:
 
-        endog = gen_endog(lin_pred, family_name)
+       for link in family_links:
+           print((family_class, link))
+           if (family_class, link) == (fam.Poisson, lnk.identity):
+               lin_pred = 20 + exog.sum(1)
+           elif (family_class, link) == (fam.Binomial, lnk.log):
+               lin_pred = -1 + exog.sum(1) / 8
+           elif (family_class, link) == (fam.Poisson, lnk.sqrt):
+               lin_pred = 2 + exog.sum(1)
+           elif (family_class, link) == (fam.InverseGaussian, lnk.log):
+               lin_pred = -1 + exog.sum(1)
+           elif (family_class, link) == (fam.InverseGaussian, lnk.identity):
+               lin_pred = 20 + 5*exog.sum(1)
+               lin_pred = np.clip(lin_pred, 1e-4, np.inf)
+           elif (family_class, link) == (fam.InverseGaussian, lnk.inverse_squared):
+               lin_pred = 0.5 + exog.sum(1) / 5
+               continue
+           elif (family_class, link) == (fam.InverseGaussian, lnk.inverse_power):
+               lin_pred = 1 + exog.sum(1) / 5
+           elif (family_class, link) == (fam.NegativeBinomial, lnk.identity):
+               lin_pred = 20 + 5*exog.sum(1)
+               lin_pred = np.clip(lin_pred, 1e-4, np.inf)
+           elif (family_class, link) == (fam.NegativeBinomial, lnk.inverse_squared):
+               lin_pred = 0.1 + np.random.uniform(size=exog.shape[0])**4
+               continue
+           elif (family_class, link) == (fam.NegativeBinomial, lnk.inverse_power):
+               lin_pred = 1 + exog.sum(1) / 5
+           else:
+               lin_pred = np.random.uniform(size=exog.shape[0])
 
-        mod_irls = sm.GLM(endog, exog, family=family)
-        rslt_irls = mod_irls.fit(method="IRLS")
+           endog = gen_endog(lin_pred, family_class, link)
 
-        mod_gradient = sm.GLM(endog, exog, family=family)
-        mod_irls.score(rslt_irls.params)
-        rslt_gradient = mod_gradient.fit(start_params=rslt_irls.params, method="newton")
+           mod_irls = sm.GLM(endog, exog, family=family_class(link=link))
+           rslt_irls = mod_irls.fit(method="IRLS")
 
-        assert_allclose(rslt_gradient.params,
-                        rslt_irls.params, rtol=1e-6, atol=1e-6,
-                        err_msg=family_name + " params")
+           mod_gradient = sm.GLM(endog, exog, family=family_class(link=link))
+           rslt_gradient = mod_gradient.fit(start_params=rslt_irls.params, method="newton")
 
-        gradient_bse = rslt_gradient.bse
-        if family_name == "negbinom":
-            ehess = mod_gradient.hessian(rslt_gradient.params, observed=False)
-            gradient_bse = np.sqrt(-np.diag(np.linalg.inv(ehess)))
-        assert_allclose(gradient_bse, rslt_irls.bse, rtol=1e-6,
-                        atol=1e-6, err_msg=family_name + " SE")
+           assert_allclose(rslt_gradient.params,
+                           rslt_irls.params, rtol=1e-6, atol=1e-6,
+                           err_msg=str(family_class) + " params")
 
+           assert_allclose(rslt_gradient.llf, rslt_irls.llf,
+                           rtol=1e-6, atol=1e-6, err_msg=str(family_class) + " params")
+
+           assert_allclose(rslt_gradient.scale, rslt_irls.scale,
+                           rtol=1e-6, atol=1e-6, err_msg=str(family_class) + " params")
+
+           # Get the standard errors using expected information.
+           gradient_bse = rslt_gradient.bse
+           ehess = mod_gradient.hessian(rslt_gradient.params, observed=False)
+           gradient_bse = np.sqrt(-np.diag(np.linalg.inv(ehess)))
+
+           assert_allclose(gradient_bse, rslt_irls.bse, rtol=1e-6,
+                           atol=1e-6, err_msg=str(family_class) + " SE")
 
 
 if __name__=="__main__":

--- a/statsmodels/genmod/tests/test_glm.py
+++ b/statsmodels/genmod/tests/test_glm.py
@@ -861,12 +861,7 @@ def test_gradient_irls():
     Compare the results when using gradient optimization and IRLS.
     """
 
-    # TODO: Some of the non-canonical links are quite sensitive to the
-    # input data.  The tests here suggest that there are no
-    # fundamental errors in the code.  Better support is needed to
-    # detect non-convergence and optimization failures.
-
-    # TODO: Find working examples for inverse_square link
+    # TODO: Find working examples for inverse_squared link
 
     np.random.seed(87342)
 
@@ -923,24 +918,29 @@ def test_gradient_irls():
                mod_irls = sm.GLM(endog, exog, family=family_class(link=link))
                rslt_irls = mod_irls.fit(method="IRLS")
 
-               mod_gradient = sm.GLM(endog, exog, family=family_class(link=link))
-               rslt_gradient = mod_gradient.fit(method="newton")
+               # Try with and without starting values.
+               for max_start_irls, start_params in (0, rslt_irls.params), (1, None):
 
-               assert_allclose(rslt_gradient.params,
-                               rslt_irls.params, rtol=1e-6, atol=1e-6)
+                   mod_gradient = sm.GLM(endog, exog, family=family_class(link=link))
+                   rslt_gradient = mod_gradient.fit(max_start_irls=max_start_irls,
+                                                    start_params=start_params,
+                                                    method="newton")
 
-               assert_allclose(rslt_gradient.llf, rslt_irls.llf,
-                               rtol=1e-6, atol=1e-6)
+                   assert_allclose(rslt_gradient.params,
+                                   rslt_irls.params, rtol=1e-6, atol=1e-6)
 
-               assert_allclose(rslt_gradient.scale, rslt_irls.scale,
-                               rtol=1e-6, atol=1e-6)
+                   assert_allclose(rslt_gradient.llf, rslt_irls.llf,
+                                   rtol=1e-6, atol=1e-6)
 
-               # Get the standard errors using expected information.
-               gradient_bse = rslt_gradient.bse
-               ehess = mod_gradient.hessian(rslt_gradient.params, observed=False)
-               gradient_bse = np.sqrt(-np.diag(np.linalg.inv(ehess)))
+                   assert_allclose(rslt_gradient.scale, rslt_irls.scale,
+                                   rtol=1e-6, atol=1e-6)
 
-               assert_allclose(gradient_bse, rslt_irls.bse, rtol=1e-6, atol=1e-6)
+                   # Get the standard errors using expected information.
+                   gradient_bse = rslt_gradient.bse
+                   ehess = mod_gradient.hessian(rslt_gradient.params, observed=False)
+                   gradient_bse = np.sqrt(-np.diag(np.linalg.inv(ehess)))
+
+                   assert_allclose(gradient_bse, rslt_irls.bse, rtol=1e-6, atol=1e-6)
 
 
 if __name__=="__main__":

--- a/statsmodels/genmod/tests/test_glm.py
+++ b/statsmodels/genmod/tests/test_glm.py
@@ -924,7 +924,7 @@ def test_gradient_irls():
                rslt_irls = mod_irls.fit(method="IRLS")
 
                mod_gradient = sm.GLM(endog, exog, family=family_class(link=link))
-               rslt_gradient = mod_gradient.fit(start_params=rslt_irls.params, method="newton")
+               rslt_gradient = mod_gradient.fit(method="newton")
 
                assert_allclose(rslt_gradient.params,
                                rslt_irls.params, rtol=1e-6, atol=1e-6)


### PR DESCRIPTION
This fills some gaps in the GLM test code.  For (almost) every valid link for every family we test the IRLS results versus the Newton's method results (comparing params, bse, llf, and scale).

Mostly things look good.  For some non-canonical links the results are very sensitive to the input data, but I was eventually able to find something that worked, except for the inverse_square link.  This suggests that the calculations in the code are OK.  However we should look into having better support for difficult cases.  

Another issue is that we only get agreement between IRLS and Newton when using the expected information to calculate bse after the Newton fit.  But the default is the observed information.  Thus most users will see a difference when they make the comparison (although the difference seems to only occur for certain, mostly non-canonical links).

This is partly in response to discussion in #1961.  I don't think there are any fundamental problems with the code for the negative binomial family.  exp_lin_pred is just a temporary used to hold something that would otherwise be calculated twice.  It is not assumed to be the mean.

Another thing I noted is that the docstring says that cloglog is a valid link for Negative binomial, but I'm not sure about this, and I was not able to come up with a convergent example.

