### PR TITLE
BUG: make `group_sums` more mem efficient. Closes #2169.

### DIFF
--- a/statsmodels/stats/sandwich_covariance.py
+++ b/statsmodels/stats/sandwich_covariance.py
@@ -102,6 +102,7 @@ Statistics 90, no. 3 (2008): 414–427.
 
 """
 from statsmodels.compat.python import range
+import pandas as pd
 import numpy as np
 
 from statsmodels.tools.grouputils import Group
@@ -433,6 +434,11 @@ def group_sums(x, group):
     '''
 
     #TODO: transpose return in group_sum, need test coverage first
+
+    # re-label groups or bincount takes too much memory
+    if np.max(group) > 2 * x.shape[0]:
+        group = pd.factorize(group)[0]
+
     return np.array([np.bincount(group, weights=x[:, col])
                             for col in range(x.shape[1])])
 

--- a/statsmodels/tools/grouputils.py
+++ b/statsmodels/tools/grouputils.py
@@ -99,6 +99,11 @@ def group_sums(x, group, use_bincount=True):
         raise ValueError('not implemented yet')
 
     if use_bincount:
+
+        # re-label groups or bincount takes too much memory
+        if np.max(group) > 2 * x.shape[0]:
+            group = pd.factorize(group)[0]
+
         return np.array([np.bincount(group, weights=x[:, col])
                          for col in range(x.shape[1])])
     else:


### PR DESCRIPTION
The way this is set up should make refactoring easier (removing `group_sum` from `sandwich_covariance` in favor of the one in `grouputils`). I found `pd.factorize` to be an order of magnitude faster than `np.unique` on large arrays, so I went with that.