### PR TITLE
REF/BUG: add _get_init_kwds to GLM to handle exposure

### DIFF
--- a/statsmodels/genmod/generalized_linear_model.py
+++ b/statsmodels/genmod/generalized_linear_model.py
@@ -255,6 +255,16 @@ class GLM(base.LikelihoodModel):
             if offset.shape[0] != endog.shape[0]:
                 raise ValueError("offset is not the same length as endog")
 
+
+    def _get_init_kwds(self):
+        # this is a temporary fixup because exposure has been transformed
+        # see #1609, copied from discrete_model.CountModel
+        kwds = super(GLM, self)._get_init_kwds()
+        if 'exposure' in kwds and kwds['exposure'] is not None:
+            kwds['exposure'] = np.exp(kwds['exposure'])
+        return kwds
+
+
     def loglike_mu(self, mu, scale=1.):
         """
         Evaluate the log-likelihood for a generalized linear model.

--- a/statsmodels/genmod/tests/test_glm.py
+++ b/statsmodels/genmod/tests/test_glm.py
@@ -628,6 +628,16 @@ class TestGlmPoissonOffset(CheckModelResultsMixin):
                    offset=offset2).fit()
         assert_almost_equal(mod1.params, mod2.params)
 
+        # test recreating model
+        mod1_ = mod1.model
+        kwds = mod1_._get_init_kwds()
+        assert_allclose(kwds['exposure'], exposure, rtol=1e-14)
+        assert_allclose(kwds['offset'], mod1_.offset, rtol=1e-14)
+        mod3 = mod1_.__class__(mod1_.endog, mod1_.exog, **kwds)
+        assert_allclose(mod3.exposure, mod1_.exposure, rtol=1e-14)
+        assert_allclose(mod3.offset, mod1_.offset, rtol=1e-14)
+
+
     def test_predict(self):
         np.random.seed(382304)
         endog = np.random.randint(0, 10, 100)
@@ -784,6 +794,7 @@ def test_formula_missing_exposure():
                   exposure=exposure, family=family)
     assert_raises(ValueError, GLM, df.Foo, df[['constant', 'Bar']],
                   exposure=exposure, family=family)
+
 
 def test_plots():
 


### PR DESCRIPTION
closes #2019

this allows the recreation of GLM models with exposure, same solution as for discrete CountModel.

replaces #2104  to be backwards compatible and consistent across models

However, exposure needs to change, see #2175 and other issues