### PR TITLE
BUG: GLM link warnings

### DIFF
--- a/statsmodels/genmod/families/family.py
+++ b/statsmodels/genmod/families/family.py
@@ -279,7 +279,7 @@ class Poisson(Family):
     links = [L.log, L.identity, L.sqrt]
     variance = V.mu
     valid = [0, np.inf]
-    safe_links = [L.log,]
+    safe_links = [L.Log,]
 
     def __init__(self, link=L.log):
         self.variance = Poisson.variance
@@ -579,7 +579,7 @@ class Gamma(Family):
 
     links = [L.log, L.identity, L.inverse_power]
     variance = V.mu_squared
-    safe_links = [L.log,]
+    safe_links = [L.Log,]
 
     def __init__(self, link=L.inverse_power):
         self.variance = Gamma.variance
@@ -740,7 +740,7 @@ class Binomial(Family):
     variance = V.binary  # this is not used below in an effort to include n
 
     # Other safe links, e.g. cloglog and probit are subclasses
-    safe_links = [L.logit, L.CDFLink]
+    safe_links = [L.Logit, L.CDFLink]
 
     def __init__(self, link=L.logit):  # , n=1.):
         # TODO: it *should* work for a constant n>1 actually, if data_weights
@@ -1001,7 +1001,7 @@ class InverseGaussian(Family):
 
     links = [L.inverse_squared, L.inverse_power, L.identity, L.log]
     variance = V.mu_cubed
-    safe_links = [L.log,]
+    safe_links = [L.Log,]
 
     def __init__(self, link=L.inverse_squared):
         self.variance = InverseGaussian.variance
@@ -1143,7 +1143,7 @@ class NegativeBinomial(Family):
     # TODO: add the ability to use the power links with an if test
     # similar to below
     variance = V.nbinom
-    safe_links = [L.log,]
+    safe_links = [L.Log,]
 
     def __init__(self, link=L.log, alpha=1.):
         self.alpha = alpha

--- a/statsmodels/genmod/families/family.py
+++ b/statsmodels/genmod/families/family.py
@@ -1001,7 +1001,7 @@ class InverseGaussian(Family):
 
     links = [L.inverse_squared, L.inverse_power, L.identity, L.log]
     variance = V.mu_cubed
-    safe_links = [L.Log,]
+    safe_links = [L.inverse_squared, L.Log,]
 
     def __init__(self, link=L.inverse_squared):
         self.variance = InverseGaussian.variance

--- a/statsmodels/genmod/tests/test_glm.py
+++ b/statsmodels/genmod/tests/test_glm.py
@@ -407,8 +407,10 @@ class TestGlmGamma(CheckModelResultsMixin):
         from .results.results_glm import Scotvote
         data = load()
         data.exog = add_constant(data.exog, prepend=False)
-        res1 = GLM(data.endog, data.exog, \
-                    family=sm.families.Gamma()).fit()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            res1 = GLM(data.endog, data.exog,
+                       family=sm.families.Gamma()).fit()
         self.res1 = res1
 #        res2 = RModel(data.endog, data.exog, r.glm, family=r.Gamma)
         res2 = Scotvote()
@@ -446,8 +448,10 @@ class TestGlmGammaIdentity(CheckModelResultsMixin):
 
         from .results.results_glm import CancerIdentity
         res2 = CancerIdentity()
-        self.res1 = GLM(res2.endog, res2.exog,
-            family=sm.families.Gamma(link=sm.families.links.identity)).fit()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            self.res1 = GLM(res2.endog, res2.exog,
+                            family=sm.families.Gamma(link=sm.families.links.identity)).fit()
         self.res2 = res2
 
 #    def setup(self):
@@ -534,9 +538,11 @@ class TestGlmInvgaussIdentity(CheckModelResultsMixin):
 
         from .results.results_glm import Medpar1
         data = Medpar1()
-        self.res1 = GLM(data.endog, data.exog,
-            family=sm.families.InverseGaussian(link=\
-            sm.families.links.identity)).fit()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            self.res1 = GLM(data.endog, data.exog,
+                            family=sm.families.InverseGaussian(
+                                link=sm.families.links.identity)).fit()
         from .results.results_glm import InvGaussIdentity
         self.res2 = InvGaussIdentity()
 

--- a/statsmodels/genmod/tests/test_glm.py
+++ b/statsmodels/genmod/tests/test_glm.py
@@ -15,6 +15,7 @@ from statsmodels.tools.tools import add_constant
 from statsmodels.tools.sm_exceptions import PerfectSeparationError
 from statsmodels.discrete import discrete_model as discrete
 from nose import SkipTest
+import warnings
 
 # Test Precisions
 DECIMAL_4 = 4
@@ -915,13 +916,17 @@ def test_gradient_irls():
 
                endog = gen_endog(lin_pred, family_class, link, binom_version)
 
-               mod_irls = sm.GLM(endog, exog, family=family_class(link=link))
+               with warnings.catch_warnings():
+                   warnings.simplefilter("ignore")
+                   mod_irls = sm.GLM(endog, exog, family=family_class(link=link))
                rslt_irls = mod_irls.fit(method="IRLS")
 
                # Try with and without starting values.
                for max_start_irls, start_params in (0, rslt_irls.params), (1, None):
 
-                   mod_gradient = sm.GLM(endog, exog, family=family_class(link=link))
+                   with warnings.catch_warnings():
+                       warnings.simplefilter("ignore")
+                       mod_gradient = sm.GLM(endog, exog, family=family_class(link=link))
                    rslt_gradient = mod_gradient.fit(max_start_irls=max_start_irls,
                                                     start_params=start_params,
                                                     method="newton")


### PR DESCRIPTION
This fixes a minor bug in GLM link warnings (added in #2208) that led to safe links raising unnecessary warnings.  The bug is due safe_links containing aliases log, logit, etc. rather than the parent classes Log, Logit, which means that links such as cloglog which are subclasses of, say, Logit are not recognized as being subclasses of logit.

Also silence warnings in tests when we are deliberately testing unsafe links.

Resolves problems discussed in #2222.