### PR TITLE
DOC: Add robust skewness and kurtosis to docs

### DIFF
--- a/docs/source/stats.rst
+++ b/docs/source/stats.rst
@@ -30,6 +30,10 @@ Residual Diagnostics and Specification Tests
    durbin_watson
    jarque_bera
    omni_normtest
+   medcouple
+   robust_skewness
+   robust_kurtosis
+   expected_robust_kurtosis
 
 .. currentmodule:: statsmodels.stats.diagnostic
 


### PR DESCRIPTION
Adds medcouple, robust skewness and kurtosis and expected kurtosis to the docs

closes #2174
[skip ci]