### PR TITLE
Regression plots issues including #2227

### DIFF
--- a/docs/source/release/version0.7.rst
+++ b/docs/source/release/version0.7.rst
@@ -38,12 +38,19 @@ sandbox.  This change bring a number of new features, including:
    dta = dta.dropna()
 
    pca_model = PCA(dta.T, standardize=False, demean=True)
-
    pca_model.plot_scree()
 
-*Note* : A function version is also available which is compatible with the 
-call in the sandbox.  The function version is just a thin wrapper around the 
+*Note* : A function version is also available which is compatible with the
+call in the sandbox.  The function version is just a thin wrapper around the
 class-based PCA implementation.
+
+Regression graphics for GLM/GEE
+-------------------------------
+
+Added variable plots, partial residual plots, and CERES residual plots
+are available for GLM and GEE models by calling the methods
+`plot_added_variable`, `plot_partial_residuals`, and
+`plot_ceres_residuals` that are attached to the results classes.
 
 Other important new features
 ----------------------------

--- a/statsmodels/genmod/generalized_estimating_equations.py
+++ b/statsmodels/genmod/generalized_estimating_equations.py
@@ -1505,7 +1505,7 @@ class GEEResults(base.LikelihoodModelResults):
     plot_partial_residuals.__doc__ = _plot_partial_residuals_doc % {
         'extra_params_doc' : ''}
 
-    def plot_ceres_residuals(self, focus_exog, frac=None, cond_means=None,
+    def plot_ceres_residuals(self, focus_exog, frac=0.66, cond_means=None,
                              ax=None):
         # Docstring attached below
 

--- a/statsmodels/genmod/generalized_linear_model.py
+++ b/statsmodels/genmod/generalized_linear_model.py
@@ -1146,7 +1146,7 @@ class GLMResults(base.LikelihoodModelResults):
     plot_partial_residuals.__doc__ = _plot_partial_residuals_doc % {
         'extra_params_doc' : ''}
 
-    def plot_ceres_residuals(self, focus_exog, frac=None, cond_means=None,
+    def plot_ceres_residuals(self, focus_exog, frac=0.66, cond_means=None,
                              ax=None):
         # Docstring attached below
 

--- a/statsmodels/genmod/tests/test_gee.py
+++ b/statsmodels/genmod/tests/test_gee.py
@@ -28,6 +28,31 @@ import statsmodels.api as sm
 from scipy.stats.distributions import norm
 from patsy import dmatrices
 
+try:
+    import matplotlib.pyplot as plt  #makes plt available for test functions
+    have_matplotlib = True
+except:
+    have_matplotlib = False
+
+pdf_output = False
+
+if pdf_output:
+    from matplotlib.backends.backend_pdf import PdfPages
+    pdf = PdfPages("test_glm.pdf")
+else:
+    pdf = None
+
+def close_or_save(pdf, fig):
+    if pdf_output:
+        pdf.savefig(fig)
+    plt.close(fig)
+
+def teardown_module():
+    if have_matplotlib:
+        plt.close('all')
+        if pdf_output:
+            pdf.close()
+
 def load_data(fname, icept=True):
     """
     Load a data set from the results directory.  The data set should
@@ -1357,6 +1382,9 @@ class TestGEEMultinomialCovType(CheckConsistency):
         check_wrapper(rslt2)
 
 def test_plots():
+
+    if not have_matplotlib:
+        raise nose.SkipTest('No tests here')
 
     np.random.seed(378)
     exog = np.random.normal(size=100)

--- a/statsmodels/genmod/tests/test_gee.py
+++ b/statsmodels/genmod/tests/test_gee.py
@@ -1384,9 +1384,6 @@ class TestGEEMultinomialCovType(CheckConsistency):
 @dec.skipif(not have_matplotlib)
 def test_plots():
 
-    if not have_matplotlib:
-        raise nose.SkipTest('No tests here')
-
     np.random.seed(378)
     exog = np.random.normal(size=100)
     endog = np.random.normal(size=(100, 2))

--- a/statsmodels/genmod/tests/test_gee.py
+++ b/statsmodels/genmod/tests/test_gee.py
@@ -14,7 +14,7 @@ import numpy as np
 import os
 
 from numpy.testing import (assert_almost_equal, assert_equal, assert_allclose,
-                           assert_array_less, assert_raises, assert_)
+                           assert_array_less, assert_raises, assert_, dec)
 from statsmodels.genmod.generalized_estimating_equations import (GEE,
      OrdinalGEE, NominalGEE, NominalGEEResults, OrdinalGEEResults,
      NominalGEEResultsWrapper, OrdinalGEEResultsWrapper)
@@ -1381,6 +1381,7 @@ class TestGEEMultinomialCovType(CheckConsistency):
 
         check_wrapper(rslt2)
 
+@dec.skipif(not have_matplotlib)
 def test_plots():
 
     if not have_matplotlib:

--- a/statsmodels/genmod/tests/test_glm.py
+++ b/statsmodels/genmod/tests/test_glm.py
@@ -24,6 +24,30 @@ DECIMAL_2 = 2
 DECIMAL_1 = 1
 DECIMAL_0 = 0
 
+try:
+    import matplotlib.pyplot as plt  #makes plt available for test functions
+    have_matplotlib = True
+except:
+    have_matplotlib = False
+
+pdf_output = False
+
+if pdf_output:
+    from matplotlib.backends.backend_pdf import PdfPages
+    pdf = PdfPages("test_glm.pdf")
+else:
+    pdf = None
+
+def close_or_save(pdf, fig):
+    if pdf_output:
+        pdf.savefig(fig)
+    plt.close(fig)
+
+def teardown_module():
+    plt.close('all')
+    if pdf_output:
+        pdf.close()
+
 class CheckModelResultsMixin(object):
     '''
     res2 should be either the results from RModelWrap
@@ -805,22 +829,50 @@ def test_formula_missing_exposure():
 
 def test_plots():
 
-    np.random.seed(378)
-    exog = np.random.normal(size=100)
-    endog = np.random.normal(size=(100, 2))
+    if not have_matplotlib:
+        raise nose.SkipTest('No tests here')
 
-    model = sm.GLM(exog, endog)
+    np.random.seed(378)
+    n = 200
+    exog = np.random.normal(size=(n, 2))
+    lin_pred = exog[:, 0] + exog[:, 1]**2
+    prob = 1 / (1 + np.exp(-lin_pred))
+    endog = 1 * (np.random.uniform(size=n) < prob)
+
+    model = sm.GLM(endog, exog, family=sm.families.Binomial())
     result = model.fit()
 
     import matplotlib.pyplot as plt
+    import pandas as pd
+    from statsmodels.graphics.regressionplots import add_lowess
 
-    # Smoke tests
-    fig = result.plot_added_variable(1)
-    plt.close(fig)
-    fig = result.plot_partial_residuals(1)
-    plt.close(fig)
-    fig = result.plot_ceres_residuals(1)
-    plt.close(fig)
+    # array interface
+    for j in 0,1:
+        fig = result.plot_added_variable(j)
+        add_lowess(fig.axes[0], frac=0.5)
+        close_or_save(pdf, fig)
+        fig = result.plot_partial_residuals(j)
+        add_lowess(fig.axes[0], frac=0.5)
+        close_or_save(pdf, fig)
+        fig = result.plot_ceres_residuals(j)
+        add_lowess(fig.axes[0], frac=0.5)
+        close_or_save(pdf, fig)
+
+    # formula interface
+    data = pd.DataFrame({"y": endog, "x1": exog[:, 0], "x2": exog[:, 1]})
+    model = sm.GLM.from_formula("y ~ x1 + x2", data, family=sm.families.Binomial())
+    result = model.fit()
+    for j in 0,1:
+        xname = ["x1", "x2"][j]
+        fig = result.plot_added_variable(xname)
+        add_lowess(fig.axes[0], frac=0.5)
+        close_or_save(pdf, fig)
+        fig = result.plot_partial_residuals(xname)
+        add_lowess(fig.axes[0], frac=0.5)
+        close_or_save(pdf, fig)
+        fig = result.plot_ceres_residuals(xname)
+        add_lowess(fig.axes[0], frac=0.5)
+        close_or_save(pdf, fig)
 
 def gen_endog(lin_pred, family_class, link, binom_version=0):
 

--- a/statsmodels/genmod/tests/test_glm.py
+++ b/statsmodels/genmod/tests/test_glm.py
@@ -7,7 +7,7 @@ from statsmodels.compat import range
 import os
 import numpy as np
 from numpy.testing import (assert_almost_equal, assert_equal, assert_raises,
-                           assert_allclose, assert_, assert_array_less)
+                           assert_allclose, assert_, assert_array_less, dec)
 from scipy import stats
 import statsmodels.api as sm
 from statsmodels.genmod.generalized_linear_model import GLM
@@ -828,10 +828,8 @@ def test_formula_missing_exposure():
                   exposure=exposure, family=family)
 
 
+@dec.skipif(not have_matplotlib)
 def test_plots():
-
-    if not have_matplotlib:
-        raise nose.SkipTest('No tests here')
 
     np.random.seed(378)
     n = 200

--- a/statsmodels/genmod/tests/test_glm.py
+++ b/statsmodels/genmod/tests/test_glm.py
@@ -44,9 +44,10 @@ def close_or_save(pdf, fig):
     plt.close(fig)
 
 def teardown_module():
-    plt.close('all')
-    if pdf_output:
-        pdf.close()
+    if have_matplotlib:
+        plt.close('all')
+        if pdf_output:
+            pdf.close()
 
 class CheckModelResultsMixin(object):
     '''

--- a/statsmodels/graphics/_regressionplots_doc.py
+++ b/statsmodels/graphics/_regressionplots_doc.py
@@ -55,9 +55,8 @@ _plot_ceres_residuals_doc = """\
         indicating the variable whose role in the regression is to be
         assessed.
     frac : float
-        Map from column numbers to lowess tuning parameters for the
-        adjusted model used in the CERES analysis.  Not used if
-        `cond_means` is provided.
+        Lowess tuning parameter for the adjusted model used in the
+        CERES analysis.  Not used if `cond_means` is provided.
     cond_means : array-like, optional
         If provided, the columns of this array span the space of the
         conditional means E[exog | focus exog], where exog ranges over

--- a/statsmodels/graphics/regressionplots.py
+++ b/statsmodels/graphics/regressionplots.py
@@ -924,7 +924,7 @@ def plot_ceres_residuals(results, focus_exog, frac=None, cond_means=None,
 plot_ceres_residuals.__doc__ = _plot_ceres_residuals_doc % {
     'extra_params_doc' : "results: object\n\tResults for a fitted regression model"}
 
-def ceres_resids(results, focus_exog, frac=None, cond_means=None):
+def ceres_resids(results, focus_exog, frac=None, cond_means=None, cond_mean_tol=1e-5):
     """
     Calculate the CERES residuals (Conditional Expectation Partial
     Residuals) for a fitted model.
@@ -946,6 +946,9 @@ def ceres_resids(results, focus_exog, frac=None, cond_means=None):
         this is an empty nx0 array, the conditional means are
         treated as being zero.  If None, the conditional means are
         estimated.
+    cond_mean_tol : float
+        Tolerance used for excluding colinear columns when estimating
+        the conditional means.
 
     Returns
     -------
@@ -996,7 +999,7 @@ def ceres_resids(results, focus_exog, frac=None, cond_means=None):
             nm1 = np.sum(cf_fit**2)
             nm2 = np.sum(cf**2)
             nmd = (nm2 - nm1) / nm2
-            if nmd > 1e-5:
+            if nmd > cond_mean_tol:
                 new_exog = np.concatenate((new_exog, cf[:, None]), axis=1)
     else:
         new_exog = np.concatenate((new_exog, cond_means), axis=1)


### PR DESCRIPTION
This PR adds checks for matplotlib in regression plot tests for GLM and GEE.

In addition:

* It fixes a bug in the regression plot GLM/GEE results methods that occurs when calling from a model fit by a formula.

* It handles more carefully the conditional mean calculation for CERES residuals to avoid creating
a design matrix with redundant columns.

* Mention this new feature in the 0.7 release notes.

