### PR TITLE
TST: webuse test try http location see #2233

### DIFF
--- a/statsmodels/datasets/tests/test_utils.py
+++ b/statsmodels/datasets/tests/test_utils.py
@@ -22,7 +22,8 @@ def test_get_rdataset():
 def test_webuse():
     # test copied and adjusted from iolib/tests/test_foreign
     from statsmodels.iolib.tests.results.macrodata import macrodata_result as res2
-    base_gh = "http://github.com/statsmodels/statsmodels/raw/master/statsmodels/datasets/macrodata/"
+    #base_gh = "http://github.com/statsmodels/statsmodels/raw/master/statsmodels/datasets/macrodata/"
+    base_gh = "http://statsmodels.sourceforge.net/devel/_static/"
     res1 = webuse('macrodata', baseurl=base_gh, as_df=False)
     assert_array_equal(res1 == res2, True)
 


### PR DESCRIPTION
try to work around Ubuntu python xy testing problems, see issue #2233 

this should now be using http instead of https

If this still causes an error, then we add a skip-test