### PR TITLE
CLN: Simplify add_constant and add_trend

### DIFF
--- a/statsmodels/tools/data.py
+++ b/statsmodels/tools/data.py
@@ -113,3 +113,10 @@ def _is_using_patsy(endog, exog):
     # we get this when a structured array is passed through a formula
     return (is_design_matrix(endog) and
             (is_design_matrix(exog) or exog is None))
+
+
+def _is_recarray(data):
+    """
+    Returns true if data is a recarray
+    """
+    return isinstance(data, np.core.recarray)

--- a/statsmodels/tools/tests/test_tools.py
+++ b/statsmodels/tools/tests/test_tools.py
@@ -31,7 +31,7 @@ class TestTools(TestCase):
     def test_add_constant_has_constant1d(self):
         x = np.ones(5)
         x = tools.add_constant(x, has_constant='skip')
-        assert_equal(x, np.ones(5))
+        assert_equal(x, np.ones((5,1)))
 
         assert_raises(ValueError, tools.add_constant, x, has_constant='raise')
 

--- a/statsmodels/tools/tools.py
+++ b/statsmodels/tools/tools.py
@@ -253,10 +253,14 @@ def add_constant(data, prepend=True, has_constant='skip'):
 
     Returns
     -------
-    data : array
+    data : array, recarray or DataFrame
         The original values with a constant (column of ones) as the first or
-        last column.
+        last column. Returned value depends on input type.
 
+    Notes
+    -----
+    When the input is recarray or a pandas Series or DataFrame, the added
+    column's name is 'const'.
     """
     is_recarray = _is_recarray(data)
     if _is_using_pandas(data, None) or is_recarray:
@@ -290,9 +294,9 @@ def add_constant(data, prepend=True, has_constant='skip'):
         else:
             data['const'] = const
     else:
-        data = np.column_stack((data, np.ones((data.shape[0], 1))))
-        if prepend:
-            return np.roll(data, 1, 1)
+        order = 1 if prepend else -1
+        data = [np.ones((data.shape[0], 1)), data]
+        data = np.column_stack(data[::order])
 
     if is_recarray:
         data = data.to_records(index=False, convert_datetime64=False)

--- a/statsmodels/tools/tools.py
+++ b/statsmodels/tools/tools.py
@@ -9,7 +9,6 @@ from scipy.linalg import svdvals
 from statsmodels.datasets import webuse
 from statsmodels.tools.data import _is_using_pandas, _is_recarray
 from statsmodels.compat.numpy import np_matrix_rank
-from pandas import DataFrame
 
 
 def _make_dictnames(tmp_arr, offset=0):
@@ -262,46 +261,8 @@ def add_constant(data, prepend=True, has_constant='skip'):
     When the input is recarray or a pandas Series or DataFrame, the added
     column's name is 'const'.
     """
-    is_recarray = _is_recarray(data)
-    if _is_using_pandas(data, None) or is_recarray:
-        from pandas import Series, DataFrame
-
-        if is_recarray:
-            data = DataFrame.from_records(data)
-        elif isinstance(data, Series):
-            data = DataFrame(data)
-        else:
-            data = data.copy()
-    else:
-        data = np.asarray(data)
-
-    var0 = data.var(0) == 0
-    if np.any(var0):
-        if has_constant == 'raise':
-            raise ValueError("data already contains a constant.")
-        elif has_constant == 'skip':
-            return data
-        elif has_constant == 'add':
-            pass
-        else:
-            raise ValueError("Option {0} not understood for "
-                             "has_constant.".format(has_constant))
-
-    const = np.ones((data.shape[0], 1))
-    if _is_using_pandas(data, None):
-        if prepend:
-            data.insert(0, 'const', const)
-        else:
-            data['const'] = const
-    else:
-        order = 1 if prepend else -1
-        data = [np.ones((data.shape[0], 1)), data]
-        data = np.column_stack(data[::order])
-
-    if is_recarray:
-        data = data.to_records(index=False, convert_datetime64=False)
-
-    return data
+    from statsmodels.tsa.tsatools import add_trend
+    return add_trend(data, trend='c', prepend=prepend, has_constant=has_constant)
 
 
 def isestimable(C, D):

--- a/statsmodels/tools/tools.py
+++ b/statsmodels/tools/tools.py
@@ -7,7 +7,7 @@ import numpy.lib.recfunctions as nprf
 import numpy.linalg as L
 from scipy.linalg import svdvals
 from statsmodels.datasets import webuse
-from statsmodels.tools.data import _is_using_pandas
+from statsmodels.tools.data import _is_using_pandas, _is_recarray
 from statsmodels.compat.numpy import np_matrix_rank
 from pandas import DataFrame
 
@@ -233,107 +233,70 @@ def categorical(data, col=None, dictnames=False, drop=False, ):
             raise IndexError("The index %s is not understood" % col)
 
 
-def _series_add_constant(data, prepend, has_constant):
-    const = np.ones_like(data)
-    if data.var() == 0:
-        if has_constant == 'raise':
-            raise ValueError("data already contains a constant.")
-        elif has_constant == 'skip':
-            return data
-        elif has_constant == 'add':
-            pass
-        else:
-            raise ValueError("Option {0} not understood for "
-                             "has_constant.".format(has_constant))
-    if not prepend:
-        columns = [data.name, 'const']
-    else:
-        columns = ['const', data.name]
-    results = DataFrame({data.name : data, 'const' : const}, columns=columns)
-    return results
-
-
-def _dataframe_add_constant(data, prepend, has_constant):
-    # check for const.
-    if np.any(data.var(0) == 0):
-        if has_constant == 'raise':
-            raise ValueError("data already contains a constant.")
-        elif has_constant == 'skip':
-            return data
-        elif has_constant == 'add':
-            pass
-        else:
-            raise ValueError("Option {0} not understood for "
-                             "has_constant.".format(has_constant))
-    if prepend:
-        data.insert(0, 'const', 1)
-    else:
-        data['const'] = 1
-    return data
-
-
-def _pandas_add_constant(data, prepend, has_constant):
-    from pandas import Series
-    if isinstance(data, Series):
-        return _series_add_constant(data, prepend, has_constant)
-    else:
-        return _dataframe_add_constant(data, prepend, has_constant)
-
-
 # TODO: add an axis argument to this for sysreg
 def add_constant(data, prepend=True, has_constant='skip'):
     """
-    This appends a column of ones to an array if prepend==False.
+    Adds a column of ones to an array
 
     Parameters
     ----------
     data : array-like
         `data` is the column-ordered design matrix
     prepend : bool
-        True and the constant is prepended rather than appended.
+        If true, the constant is in the first column.  Else the constant is
+        appended (last column).
     has_constant : str {'raise', 'add', 'skip'}
-        Behavior if `data` already has a constant. The default will return
+        Behavior if ``data'' already has a constant. The default will return
         data without adding another constant. If 'raise', will raise an
         error if a constant is present. Using 'add' will duplicate the
-        constant, if one is present. Has no effect for structured or
-        recarrays. There is no checking for a constant in this case.
+        constant, if one is present.
 
     Returns
     -------
     data : array
-        The original array with a constant (column of ones) as the first or
+        The original values with a constant (column of ones) as the first or
         last column.
+
     """
-    if _is_using_pandas(data, None):
-        # work on a copy
-        return _pandas_add_constant(data.copy(), prepend, has_constant)
+    is_recarray = _is_recarray(data)
+    if _is_using_pandas(data, None) or is_recarray:
+        from pandas import Series, DataFrame
+
+        if is_recarray:
+            data = DataFrame.from_records(data)
+        elif isinstance(data, Series):
+            data = DataFrame(data)
+        else:
+            data = data.copy()
     else:
         data = np.asarray(data)
-    if not data.dtype.names:
-        var0 = data.var(0) == 0
-        if np.any(var0):
-            if has_constant == 'raise':
-                raise ValueError("data already contains a constant.")
-            elif has_constant == 'skip':
-                return data
-            elif has_constant == 'add':
-                pass
-            else:
-                raise ValueError("Option {0} not understood for "
-                                 "has_constant.".format(has_constant))
+
+    var0 = data.var(0) == 0
+    if np.any(var0):
+        if has_constant == 'raise':
+            raise ValueError("data already contains a constant.")
+        elif has_constant == 'skip':
+            return data
+        elif has_constant == 'add':
+            pass
+        else:
+            raise ValueError("Option {0} not understood for "
+                             "has_constant.".format(has_constant))
+
+    const = np.ones((data.shape[0], 1))
+    if _is_using_pandas(data, None):
+        if prepend:
+            data.insert(0, 'const', const)
+        else:
+            data['const'] = const
+    else:
         data = np.column_stack((data, np.ones((data.shape[0], 1))))
         if prepend:
             return np.roll(data, 1, 1)
-    else:
-        return_rec = data.__class__ is np.recarray
-        if prepend:
-            ones = np.ones((data.shape[0], 1), dtype=[('const', float)])
-            data = nprf.append_fields(ones, data.dtype.names,
-                                      [data[i] for i in data.dtype.names],
-                                      usemask=False, asrecarray=return_rec)
-        else:
-            data = nprf.append_fields(data, 'const', np.ones(data.shape[0]),
-                                      usemask=False, asrecarray=return_rec)
+
+    if is_recarray:
+        data = data.to_records(index=False, convert_datetime64=False)
+
     return data
 
 

--- a/statsmodels/tsa/tests/test_tsa_tools.py
+++ b/statsmodels/tsa/tests/test_tsa_tools.py
@@ -505,7 +505,7 @@ class TestAddTrend(unittest.TestCase):
         assert_raises(ValueError, tools.add_trend, X=df, trend='ct', has_constant='raise')
 
         skipped = tools.add_trend(self.c, trend='c')
-        assert_equal(skipped, self.c)
+        assert_equal(skipped, self.c[:,None])
 
         skipped_const = tools.add_trend(self.c, trend='ct', has_constant='skip')
         expected = np.vstack((self.c, self.t)).T
@@ -519,6 +519,13 @@ class TestAddTrend(unittest.TestCase):
         expected = np.vstack((self.c, self.c, self.t)).T
         assert_equal(added, expected)
 
+    def test_mixed_recarray(self):
+        dt = np.dtype([('c0', np.float64), ('c1', np.int8), ('c2', 'S4')])
+        ra = np.array([(1.0, 1, 'aaaa'), (1.1, 2, 'bbbb')], dtype=dt).view(np.recarray)
+        added = tools.add_trend(ra, trend='ct')
+        dt = np.dtype([('c0', np.float64), ('c1', np.int8), ('c2', 'S4'), ('const', np.float64), ('trend', np.float64)])
+        expected = np.array([(1.0, 1, 'aaaa', 1.0, 1.0), (1.1, 2, 'bbbb', 1.0, 2.0)], dtype=dt).view(np.recarray)
+        assert_equal(added, expected)
 
     def test_dataframe_duplicate(self):
         df = pd.DataFrame(self.arr_2d, columns=['const', 'trend'])

--- a/statsmodels/tsa/tests/test_tsa_tools.py
+++ b/statsmodels/tsa/tests/test_tsa_tools.py
@@ -2,14 +2,12 @@
 
 '''
 import unittest
-from nose.tools import assert_raises
-
 from statsmodels.compat.python import zip
 
+import numpy as np
+from numpy.testing import assert_array_almost_equal, assert_equal, assert_raises
 import pandas as pd
 from pandas.util.testing import assert_frame_equal
-import numpy as np
-from numpy.testing import assert_array_almost_equal, assert_equal
 
 import statsmodels.api as sm
 import statsmodels.tsa.stattools as tsa
@@ -390,6 +388,125 @@ def test_detrend():
                               [[-0.5, 0.5], [-0.5, 0.5], [-0.5, 0.5],
                                [-0.5, 0.5], [-0.5, 0.5]])
 
+class TestAddTrend(unittest.TestCase):
+    @classmethod
+    def setup_class(cls):
+        cls.n = 200
+        cls.arr_1d = np.arange(float(cls.n))
+        cls.arr_2d = np.tile(np.arange(float(cls.n))[:, None], 2)
+        cls.c = np.ones(cls.n)
+        cls.t = np.arange(1.0, cls.n + 1)
+
+    def test_series(self):
+        s = pd.Series(self.arr_1d)
+        appended = tools.add_trend(s)
+        expected = pd.DataFrame(s)
+        expected['const'] = self.c
+        assert_frame_equal(expected, appended)
+
+        prepended = tools.add_trend(s, prepend=True)
+        expected = pd.DataFrame(s)
+        expected.insert(0, 'const', self.c)
+        assert_frame_equal(expected, prepended)
+
+        s = pd.Series(self.arr_1d)
+        appended = tools.add_trend(s, trend='ct')
+        expected = pd.DataFrame(s)
+        expected['const'] = self.c
+        expected['trend'] = self.t
+        assert_frame_equal(expected, appended)
+
+    def test_dataframe(self):
+        df = pd.DataFrame(self.arr_2d)
+        appended = tools.add_trend(df)
+        expected = df.copy()
+        expected['const'] = self.c
+        assert_frame_equal(expected, appended)
+
+        prepended = tools.add_trend(df, prepend=True)
+        expected = df.copy()
+        expected.insert(0, 'const', self.c)
+        assert_frame_equal(expected, prepended)
+
+        df = pd.DataFrame(self.arr_2d)
+        appended = tools.add_trend(df, trend='t')
+        expected = df.copy()
+        expected['trend'] = self.t
+        assert_frame_equal(expected, appended)
+
+        df = pd.DataFrame(self.arr_2d)
+        appended = tools.add_trend(df, trend='ctt')
+        expected = df.copy()
+        expected['const'] = self.c
+        expected['trend'] = self.t
+        expected['trend_squared'] = self.t ** 2
+        assert_frame_equal(expected, appended)
+
+    def test_recarray(self):
+        recarray = pd.DataFrame(self.arr_2d).to_records(index=False, convert_datetime64=False)
+        appended = tools.add_trend(recarray)
+        expected = pd.DataFrame(self.arr_2d)
+        expected['const'] = self.c
+        expected = expected.to_records(index=False, convert_datetime64=False)
+        assert_equal(expected, appended)
+
+        prepended = tools.add_trend(recarray, prepend=True)
+        expected = pd.DataFrame(self.arr_2d)
+        expected.insert(0, 'const', self.c)
+        expected = expected.to_records(index=False, convert_datetime64=False)
+        assert_equal(expected, prepended)
+
+        appended = tools.add_trend(recarray, trend='ctt')
+        expected = pd.DataFrame(self.arr_2d)
+        expected['const'] = self.c
+        expected['trend'] = self.t
+        expected['trend_squared'] = self.t ** 2
+        expected = expected.to_records(index=False, convert_datetime64=False)
+        assert_equal(expected, appended)
+
+    def test_duplicate_const(self):
+        assert_raises(ValueError, tools.add_trend, X=self.c, trend='c', has_constant='raise')
+        assert_raises(ValueError, tools.add_trend, X=self.c, trend='ct', has_constant='raise')
+        df = pd.DataFrame(self.c)
+        assert_raises(ValueError, tools.add_trend, X=df, trend='c', has_constant='raise')
+        assert_raises(ValueError, tools.add_trend, X=df, trend='ct', has_constant='raise')
+
+        skipped = tools.add_trend(self.c, trend='c')
+        assert_equal(skipped, self.c)
+
+        skipped_const = tools.add_trend(self.c, trend='ct', has_constant='skip')
+        expected = np.vstack((self.c, self.t)).T
+        assert_equal(skipped_const, expected)
+
+        added = tools.add_trend(self.c, trend='c', has_constant='add')
+        expected = np.vstack((self.c, self.c)).T
+        assert_equal(added, expected)
+
+        added = tools.add_trend(self.c, trend='ct', has_constant='add')
+        expected = np.vstack((self.c, self.c, self.t)).T
+        assert_equal(added, expected)
+
+
+    def test_dataframe_duplicate(self):
+        df = pd.DataFrame(self.arr_2d, columns=['const', 'trend'])
+        tools.add_trend(df, trend='ct')
+        tools.add_trend(df, trend='ct', prepend=True)
+
+    def test_array(self):
+        base = np.vstack((self.arr_1d, self.c, self.t, self.t ** 2)).T
+        assert_equal(tools.add_trend(self.arr_1d), base[:, :2])
+        assert_equal(tools.add_trend(self.arr_1d, trend='t'), base[:, [0, 2]])
+        assert_equal(tools.add_trend(self.arr_1d, trend='ct'), base[:, :3])
+        assert_equal(tools.add_trend(self.arr_1d, trend='ctt'), base)
+
+        base = np.hstack((self.c[:, None], self.t[:, None], self.t[:, None] ** 2, self.arr_2d))
+        assert_equal(tools.add_trend(self.arr_2d, prepend=True), base[:, [0, 3, 4]])
+        assert_equal(tools.add_trend(self.arr_2d, trend='t', prepend=True), base[:, [1, 3, 4]])
+        assert_equal(tools.add_trend(self.arr_2d, trend='ct', prepend=True), base[:, [0, 1, 3, 4]])
+        assert_equal(tools.add_trend(self.arr_2d, trend='ctt', prepend=True), base)
+
+    def test_unknown_trend(self):
+        assert_raises(ValueError, tools.add_trend, X=self.arr_1d, trend='unknown')
 
 if __name__ == '__main__':
     import nose

--- a/statsmodels/tsa/tests/test_tsa_tools.py
+++ b/statsmodels/tsa/tests/test_tsa_tools.py
@@ -498,11 +498,11 @@ class TestAddTrend(unittest.TestCase):
         assert_equal(expected, appended)
 
     def test_duplicate_const(self):
-        assert_raises(ValueError, tools.add_trend, X=self.c, trend='c', has_constant='raise')
-        assert_raises(ValueError, tools.add_trend, X=self.c, trend='ct', has_constant='raise')
+        assert_raises(ValueError, tools.add_trend, x=self.c, trend='c', has_constant='raise')
+        assert_raises(ValueError, tools.add_trend, x=self.c, trend='ct', has_constant='raise')
         df = pd.DataFrame(self.c)
-        assert_raises(ValueError, tools.add_trend, X=df, trend='c', has_constant='raise')
-        assert_raises(ValueError, tools.add_trend, X=df, trend='ct', has_constant='raise')
+        assert_raises(ValueError, tools.add_trend, x=df, trend='c', has_constant='raise')
+        assert_raises(ValueError, tools.add_trend, x=df, trend='ct', has_constant='raise')
 
         skipped = tools.add_trend(self.c, trend='c')
         assert_equal(skipped, self.c[:,None])
@@ -546,7 +546,7 @@ class TestAddTrend(unittest.TestCase):
         assert_equal(tools.add_trend(self.arr_2d, trend='ctt', prepend=True), base)
 
     def test_unknown_trend(self):
-        assert_raises(ValueError, tools.add_trend, X=self.arr_1d, trend='unknown')
+        assert_raises(ValueError, tools.add_trend, x=self.arr_1d, trend='unknown')
 
 if __name__ == '__main__':
     import nose

--- a/statsmodels/tsa/tsatools.py
+++ b/statsmodels/tsa/tsatools.py
@@ -33,6 +33,13 @@ def add_trend(X, trend="c", prepend=False, has_constant='skip'):
         constant. 'skip' will return the data without change. 'skip' is the
         default.
 
+    Returns
+    -------
+    y : array, recarray or DataFrame
+        The original data with the additional trend columns.  If x is a
+        recarray or pandas Series or DataFrame, then the trend column names
+        are 'const', 'trend' and 'trend_squared'.
+
     Notes
     -----
     Returns columns as ["ctt","ct","c"] whenever applicable. There is currently
@@ -40,7 +47,7 @@ def add_trend(X, trend="c", prepend=False, has_constant='skip'):
 
     See also
     --------
-    statsmodels.add_constant
+    statsmodels.tools.add_constant
     """
     # TODO: could be generalized for trend of aribitrary order
     trend = trend.lower()
@@ -77,13 +84,16 @@ def add_trend(X, trend="c", prepend=False, has_constant='skip'):
     trendarr = np.fliplr(trendarr)
     if trend == "t":
         trendarr = trendarr[:, 1]
+    # Constant if all have same value and non-zero
+    x_has_constant = np.any(np.logical_and(np.any(np.ptp(np.asanyarray(X), axis=0) == 0, axis=0),
+                                           np.all(X != 0.0, axis=0)))
 
-    if "c" in trend and np.any(np.ptp(np.asanyarray(X), axis=0) == 0):
+    if "c" in trend and x_has_constant:
         if has_constant == 'raise':
             raise ValueError("X already contains a constant")
         elif has_constant == 'add':
             pass
-        elif has_constant == 'skip' and trend == "ct":
+        else:
             trendarr = trendarr[:, 1]
 
     order = 1 if prepend else -1

--- a/statsmodels/tsa/tsatools.py
+++ b/statsmodels/tsa/tsatools.py
@@ -228,8 +228,10 @@ def add_lag(x, col=None, lags=1, drop=False, insert=True):
         return np.column_stack((x[lags:,first_cols],ndlags,
                     x[lags:,last_cols]))
 
+
 def detrend(x, order=1, axis=0):
-    '''detrend an array with a trend of given order along axis 0 or 1
+    """
+    Detrend an array with a trend of given order along axis 0 or 1
 
     Parameters
     ----------
@@ -248,25 +250,20 @@ def detrend(x, order=1, axis=0):
     detrended data series : ndarray
         The detrended series is the residual of the linear regression of the
         data on the trend of given order.
-
-
-    '''
-    x = np.asarray(x)
+    """
+    if x.ndim == 2 and int(axis) == 1:
+        x = x.T
+    elif x.ndim > 2:
+        raise NotImplementedError('x.ndim > 2 is not implemented until it is needed')
+    # could use a polynomial, but this should work also with 2d x, but maybe not yet
     nobs = x.shape[0]
-    if order == 0:
-        return x - np.expand_dims(x.mean(axis), axis)
-    else:
-        if x.ndim == 2 and lrange(2)[axis]==1:
-            x = x.T
-        elif x.ndim > 2:
-            raise NotImplementedError('x.ndim>2 is not implemented until it is needed')
-        #could use a polynomial, but this should work also with 2d x, but maybe not yet
-        trends = np.vander(np.arange(nobs).astype(float), N=order+1)
-        beta = np.linalg.lstsq(trends, x)[0]
-        resid = x - np.dot(trends, beta)
-        if x.ndim == 2 and lrange(2)[axis]==1:
-            resid = resid.T
-        return resid
+    trends = np.vander(np.arange(float(nobs)), N=order + 1)
+    beta = np.linalg.pinv(trends).dot(x)
+    resid = x - np.dot(trends, beta)
+    if x.ndim == 2 and int(axis) == 1:
+        resid = resid.T
+
+    return resid
 
 
 def lagmat(x, maxlag, trim='forward', original='ex', use_pandas=False):

--- a/statsmodels/tsa/tsatools.py
+++ b/statsmodels/tsa/tsatools.py
@@ -277,11 +277,16 @@ def detrend(x, order=1, axis=0):
         x = x.T
     elif x.ndim > 2:
         raise NotImplementedError('x.ndim > 2 is not implemented until it is needed')
-    # could use a polynomial, but this should work also with 2d x, but maybe not yet
+
     nobs = x.shape[0]
-    trends = np.vander(np.arange(float(nobs)), N=order + 1)
-    beta = np.linalg.pinv(trends).dot(x)
-    resid = x - np.dot(trends, beta)
+    if order == 0:
+        # Special case demean
+        resid = x - x.mean(axis=0)
+    else:
+        trends = np.vander(np.arange(float(nobs)), N=order + 1)
+        beta = np.linalg.pinv(trends).dot(x)
+        resid = x - np.dot(trends, beta)
+
     if x.ndim == 2 and int(axis) == 1:
         resid = resid.T
 


### PR DESCRIPTION
Simplified these two functions to handle NumPy arrays and recarrays as
well as pandas Series and DataFrames.  Removed bugs in add_trend.
Added complete test coverage for both functions.