### PR TITLE
TST: Make Matplotlib optional

### DIFF
--- a/statsmodels/genmod/tests/test_gee.py
+++ b/statsmodels/genmod/tests/test_gee.py
@@ -1392,8 +1392,6 @@ def test_plots():
     model = sm.GEE(exog, endog, groups)
     result = model.fit()
 
-    import matplotlib.pyplot as plt
-
     # Smoke tests
     fig = result.plot_added_variable(1)
     plt.close(fig)

--- a/statsmodels/tools/pca.py
+++ b/statsmodels/tools/pca.py
@@ -6,7 +6,6 @@ Modified by Kevin Sheppard
 from __future__ import print_function, division
 
 import numpy as np
-import matplotlib.pyplot as plt
 import pandas as pd
 
 from statsmodels.compat.python import range
@@ -693,6 +692,8 @@ class PCA(object):
         fig : figure
             Handle to the figure
         """
+        # Local import since mpl is optional
+        import matplotlib.pyplot as plt
         plt.figure()
         ncomp = self._ncomp if ncomp is None else ncomp
         vals = np.asarray(self.eigenvals)
@@ -744,6 +745,8 @@ class PCA(object):
         fig : figure
             Handle to the figure
         """
+        # Local import since mpl is optional
+        import matplotlib.pyplot as plt
         plt.figure()
         ncomp = 10 if ncomp is None else ncomp
         ncomp = min(ncomp, self._ncomp)

--- a/statsmodels/tools/pca.py
+++ b/statsmodels/tools/pca.py
@@ -672,36 +672,39 @@ class PCA(object):
         self.ic = pd.DataFrame(self.ic, columns=['IC_p1', 'IC_p2', 'IC_p3'])
         self.ic.index.name = 'ncomp'
 
-    def plot_scree(self, ncomp=None, log_scale=True, cumulative=False):
+    def plot_scree(self, ncomp=None, log_scale=True, cumulative=False, ax=None):
         """
         Plot of the ordered eigenvalues
 
         Parameters
         ----------
         ncomp : int, optional
-            Number of components ot include in the plot.  It None, will
+            Number of components ot include in the plot.  If None, will
             included the same as the number of components computed
         log_scale : boot, optional
             Flag indicating whether ot use a log scale for the y-axis
         cumulative : bool, optional
             Flag indicating whether to plot the eigenvalues or cumulative
             eigenvalues
+        ax : Matplotlib axes instance, optional
+            An axes on which to draw the graph.  If omitted, new a figure
+            is created
 
         Returns
         -------
         fig : figure
             Handle to the figure
         """
-        # Local import since mpl is optional
-        import matplotlib.pyplot as plt
-        plt.figure()
+        import statsmodels.graphics.utils as gutils
+
+        fig, ax = gutils.create_mpl_ax(ax)
+
         ncomp = self._ncomp if ncomp is None else ncomp
         vals = np.asarray(self.eigenvals)
         vals = vals[:self._ncomp]
         if cumulative:
             vals = np.cumsum(vals)
 
-        ax = plt.subplot(1, 1, 1)
         if log_scale:
             ax.set_yscale('log')
         ax.plot(np.arange(ncomp), vals[: ncomp], 'bo')
@@ -724,42 +727,43 @@ class PCA(object):
         ax.set_title('Scree Plot')
         ax.set_ylabel('Eigenvalue')
         ax.set_xlabel('Component Number')
-        fig = ax.get_figure()
         fig.tight_layout()
 
-        plt.draw()
         return fig
 
-    def plot_rsquare(self, ncomp=None):
+    def plot_rsquare(self, ncomp=None, ax=None):
         """
         Box plots of the individual series R-square against the number of PCs
 
         Parameters
         ----------
         ncomp : int, optional
-            Number of components ot include in the plot.  It None, will
+            Number of components ot include in the plot.  If None, will
             plot the minimum of 10 or the number of computed components
+        ax : Matplotlib axes instance, optional
+            An axes on which to draw the graph.  If omitted, new a figure
+            is created
 
         Returns
         -------
         fig : figure
             Handle to the figure
         """
-        # Local import since mpl is optional
-        import matplotlib.pyplot as plt
-        plt.figure()
+        import statsmodels.graphics.utils as gutils
+
+        fig, ax = gutils.create_mpl_ax(ax)
+
         ncomp = 10 if ncomp is None else ncomp
         ncomp = min(ncomp, self._ncomp)
         # R2s in rows, series in columns
         r2s = 1.0 - self._ess_indiv / self._tss_indiv
         r2s = r2s[1:]
         r2s = r2s[:ncomp]
-        bp = plt.boxplot(r2s.T)
-        ax = bp['boxes'][0].get_axes()
+        ax.boxplot(r2s.T)
         ax.set_title('Individual Input $R^2$')
         ax.set_ylabel('$R^2$')
         ax.set_xlabel('Number of Included Principal Components')
-        fig = ax.get_figure()
+
         return fig
 
 

--- a/statsmodels/tools/tests/test_pca.py
+++ b/statsmodels/tools/tests/test_pca.py
@@ -190,6 +190,7 @@ class TestPCA(TestCase):
         assert_raises(ValueError, PCA, self.x, tol=2.0)
         assert_raises(ValueError, PCA, np.nan * np.ones((200,100)), tol=2.0)
 
+    @skipif(missing_matplotlib)
     def test_pandas(self):
         pc = PCA(pd.DataFrame(self.x))
         pc1 = PCA(self.x)

--- a/statsmodels/tools/tests/test_pca.py
+++ b/statsmodels/tools/tests/test_pca.py
@@ -5,7 +5,14 @@ import warnings
 
 import numpy as np
 from numpy.testing import assert_allclose, assert_equal, assert_raises
+from numpy.testing.decorators import skipif
 import pandas as pd
+
+try:
+    import matplotlib.pyplot as plt
+    missing_matplotlib = False
+except ImportError:
+    missing_matplotlib = True
 
 from statsmodels.tools.pca import PCA
 from statsmodels.tools.tests.results.datamlw import data, princomp1, princomp2
@@ -43,6 +50,7 @@ class TestPCA(TestCase):
         b = rs.standard_gamma(lam, size=(k, n)) / lam
         cls.x_wide = f.dot(b) + e
 
+    @skipif(missing_matplotlib)
     def test_smoke_plot_and_repr(self):
         pc = PCA(self.x)
         fig = pc.plot_scree()


### PR DESCRIPTION
PCA incorrectly imported matplotlib which is not mandatory.  Also removes
unneeded import in GEE test.