### PR TITLE
TST: Check internet availability before running tests

### DIFF
--- a/statsmodels/compat/python.py
+++ b/statsmodels/compat/python.py
@@ -18,7 +18,7 @@ if PY3:
     pickle = cPickle
     import urllib.request
     import urllib.parse
-    from urllib.request import HTTPError, urlretrieve
+    from urllib.request import HTTPError, urlretrieve, URLError
     import io
     bytes = bytes
     str = str
@@ -131,6 +131,7 @@ else:
     urljoin = urlparse.urljoin
     urlencode = urllib.urlencode
     HTTPError = urllib2.HTTPError
+    URLError = urllib2.URLError
     string_types = basestring
 
     input = raw_input

--- a/statsmodels/datasets/__init__.py
+++ b/statsmodels/datasets/__init__.py
@@ -6,4 +6,4 @@ from . import (anes96, cancer, committee, ccard, copper, cpunish, elnino,
                engel, grunfeld, longley, macrodata, modechoice, nile, randhie,
                scotland, spector, stackloss, star98, strikes, sunspots, fair,
                heart, statecrime, co2, fertility)
-from .utils import get_rdataset, get_data_home, clear_data_home, webuse
+from .utils import get_rdataset, get_data_home, clear_data_home, webuse, check_internet

--- a/statsmodels/datasets/tests/test_utils.py
+++ b/statsmodels/datasets/tests/test_utils.py
@@ -1,7 +1,7 @@
 import os
 import sys
-from statsmodels.datasets import get_rdataset, webuse
-from numpy.testing import assert_, assert_array_equal
+from statsmodels.datasets import get_rdataset, webuse, check_internet
+from numpy.testing import assert_, assert_array_equal, dec
 
 cur_dir = os.path.dirname(os.path.abspath(__file__))
 
@@ -18,8 +18,9 @@ def test_get_rdataset():
         duncan = get_rdataset("Duncan", "car", cache=cur_dir)
         assert_(duncan.from_cache)
 
-# temporarily disabled because some test servers don't have internet
-def t_est_webuse():
+internet_available = check_internet()
+@dec.skipif(not internet_available)
+def test_webuse():
     # test copied and adjusted from iolib/tests/test_foreign
     from statsmodels.iolib.tests.results.macrodata import macrodata_result as res2
     #base_gh = "http://github.com/statsmodels/statsmodels/raw/master/statsmodels/datasets/macrodata/"
@@ -27,9 +28,8 @@ def t_est_webuse():
     res1 = webuse('macrodata', baseurl=base_gh, as_df=False)
     assert_array_equal(res1 == res2, True)
 
-
-# temporarily disabled because some test servers don't have internet
-def t_est_webuse_pandas():
+@dec.skipif(not internet_available)
+def test_webuse_pandas():
     # test copied and adjusted from iolib/tests/test_foreign
     from pandas.util.testing import assert_frame_equal
     from statsmodels.datasets import macrodata

--- a/statsmodels/datasets/utils.py
+++ b/statsmodels/datasets/utils.py
@@ -1,5 +1,6 @@
-from statsmodels.compat.python import (range, StringIO, urlopen, HTTPError,
-                                       lrange, cPickle, urljoin, BytesIO)
+from statsmodels.compat.python import (range, StringIO, urlopen,
+                                       HTTPError, URLError, lrange,
+                                       cPickle, urljoin, BytesIO)
 import sys
 import shutil
 from os import environ
@@ -326,3 +327,11 @@ def clear_data_home(data_home=None):
     """Delete all the content of the data home cache."""
     data_home = get_data_home(data_home)
     shutil.rmtree(data_home)
+
+def check_internet():
+    """Check if internet is available"""
+    try:
+        urlopen("https://github.com")
+    except URLError as err:
+        return False
+    return True


### PR DESCRIPTION
This kind of reverts https://github.com/statsmodels/statsmodels/pull/2241 to run tests only if internet is available.
The approach is pretty naive, so feel free to reject.