### PR TITLE
FIX: Cython indices error

### DIFF
--- a/statsmodels/tsa/statespace/_statespace.pyx.in
+++ b/statsmodels/tsa/statespace/_statespace.pyx.in
@@ -835,7 +835,7 @@ cdef {{cython_type}} {{prefix}}inverse_cholesky({{prefix}}KalmanFilter kfilter, 
         # by hand
         for i in range(kfilter.k_endog):
             for j in range(i):
-                kfilter._forecast_error_fac[i,j] = kfilter._forecast_error_fac[j,i]
+                kfilter.forecast_error_fac[i,j] = kfilter.forecast_error_fac[j,i]
 
 
     # Get `tmp2` and `tmp3` via matrix multiplications


### PR DESCRIPTION
Fixes #2253. Bug caused by memoryview indexing (`array[i,j]`) used on pointer variable in little-used option. Corrected by referring to the memoryview rather than the pointer.