### PR TITLE
ENH/BUG: add update _init_keys (still test failure)

### DIFF
--- a/statsmodels/tsa/statespace/sarimax.py
+++ b/statsmodels/tsa/statespace/sarimax.py
@@ -506,7 +506,7 @@ class SARIMAX(MLEModel):
 
         # Set the default results class to be SARIMAXResults
         kwargs.setdefault('results_class', SARIMAXResults)
-
+        self._init_kwargs = kwargs  # store to recreate model
         # Initialize the statespace
         super(SARIMAX, self).__init__(
             endog, exog=exog, k_states=k_states, k_posdef=k_posdef, **kwargs
@@ -530,6 +530,18 @@ class SARIMAX(MLEModel):
                  'enforce_stationarity', 'enforce_invertibility',
                  'hamilton_representation'] + list(kwargs.keys())
         # TODO: I think the kwargs or not attached, need to recover from ???
+
+
+    def _get_init_kwds(self):
+        # this is a temporary fixup because exposure has been transformed
+        # see #1609
+        kwds = super(SARIMAX, self)._get_init_kwds()
+        kwds['endog'] = self.orig_endog
+        kwds['exog'] = self.orig_exog
+        if self.initialization == 'approximate_diffuse':
+            import warnings
+            warnings.warn('not all init keys or initialization is available yet')
+        return kwds
 
 
     def initialize(self):

--- a/statsmodels/tsa/statespace/sarimax.py
+++ b/statsmodels/tsa/statespace/sarimax.py
@@ -526,7 +526,7 @@ class SARIMAX(MLEModel):
         # update _init_keys attached by super
         self._init_keys += ['order',  'seasonal_order', 'trend',
                  'measurement_error', 'time_varying_regression',
-                 'mle_regression' 'simple_differencing',
+                 'mle_regression', 'simple_differencing',
                  'enforce_stationarity', 'enforce_invertibility',
                  'hamilton_representation'] + list(kwargs.keys())
         # TODO: I think the kwargs or not attached, need to recover from ???

--- a/statsmodels/tsa/statespace/sarimax.py
+++ b/statsmodels/tsa/statespace/sarimax.py
@@ -523,6 +523,15 @@ class SARIMAX(MLEModel):
         if k_diffuse_states == 0:
             self.initialize_stationary()
 
+        # update _init_keys attached by super
+        self._init_keys += ['order',  'seasonal_order', 'trend',
+                 'measurement_error', 'time_varying_regression',
+                 'mle_regression' 'simple_differencing',
+                 'enforce_stationarity', 'enforce_invertibility',
+                 'hamilton_representation'] + list(kwargs.keys())
+        # TODO: I think the kwargs or not attached, need to recover from ???
+
+
     def initialize(self):
         """
         Initialize the SARIMAX model.

--- a/statsmodels/tsa/statespace/tests/test_sarimax.py
+++ b/statsmodels/tsa/statespace/tests/test_sarimax.py
@@ -618,8 +618,9 @@ class SARIMAXCoverageTest(object):
 
         kwargs = self.model._get_init_kwds()
         endog = mod1.endog.squeeze() # test failures
-        endog = mod1.data.orig_endog
-        model2 = sarimax.SARIMAX(endog, mod1.exog, **kwargs)
+        endog = mod1.orig_endog
+        exog = mod1.orig_exog
+        model2 = sarimax.SARIMAX(endog, exog, **kwargs)
         model2.update(self.true_params)
         res1 = self.model.filter()
         res2 = model2.filter()

--- a/statsmodels/tsa/statespace/tests/test_sarimax.py
+++ b/statsmodels/tsa/statespace/tests/test_sarimax.py
@@ -617,7 +617,9 @@ class SARIMAXCoverageTest(object):
         mod1.update(self.true_params)  # test with side effect ?
 
         kwargs = self.model._get_init_kwds()
-        model2 = sarimax.SARIMAX(mod1.endog.squeeze(), mod1.exog, **kwargs)
+        endog = mod1.endog.squeeze() # test failures
+        endog = mod1.data.orig_endog
+        model2 = sarimax.SARIMAX(endog, mod1.exog, **kwargs)
         model2.update(self.true_params)
         res1 = self.model.filter()
         res2 = model2.filter()

--- a/statsmodels/tsa/statespace/tests/test_sarimax.py
+++ b/statsmodels/tsa/statespace/tests/test_sarimax.py
@@ -612,6 +612,18 @@ class SARIMAXCoverageTest(object):
         # Just make sure that no exceptions are thrown during summary
         self.result.summary()
 
+    def test_init_keys_replicate(self):
+        mod1 = self.model
+        mod1.update(self.true_params)  # test with side effect ?
+
+        kwargs = self.model._get_init_kwds()
+        model2 = sarimax.SARIMAX(mod1.endog.squeeze(), mod1.exog, **kwargs)
+        model2.update(self.true_params)
+        res1 = self.model.filter()
+        res2 = model2.filter()
+        assert_allclose(res2.llf, res1.llf, rtol=1e-13)
+
+
 class Test_ar(SARIMAXCoverageTest):
     # // AR: (p,0,0) x (0,0,0,0)
     # arima wpi, arima(3,0,0) noconstant vce(oim)

--- a/statsmodels/tsa/statespace/tests/test_sarimax.py
+++ b/statsmodels/tsa/statespace/tests/test_sarimax.py
@@ -616,10 +616,21 @@ class SARIMAXCoverageTest(object):
         mod1 = self.model
         mod1.update(self.true_params)  # test with side effect ?
 
+        if mod1.initialization == 'approximate_diffuse':
+            raise SkipTest('known failure: init_keys incomplete')
         kwargs = self.model._get_init_kwds()
-        endog = mod1.endog.squeeze() # test failures
-        endog = mod1.orig_endog
-        exog = mod1.orig_exog
+        # TODO: current limitations #2259 comments
+        #endog = mod1.endog.squeeze() # test failures, endog may be transformed
+        # this works
+        #endog = mod1.orig_endog
+        #exog = mod1.orig_exog
+
+        # in SARIMAX endog, exog will always be in kwargs but not in other models
+        if 'endog' in kwargs:
+            endog = kwargs.pop('endog')
+        if 'exog' in kwargs:
+            exog = kwargs.pop('exog')
+
         model2 = sarimax.SARIMAX(endog, exog, **kwargs)
         model2.update(self.true_params)
         res1 = self.model.filter()
@@ -928,6 +939,8 @@ class Test_arma_diffuse(SARIMAXCoverageTest):
     # save_results 24
     def __init__(self, *args, **kwargs):
         kwargs['order'] = (3,0,2)
+        # TODO: diffuse initialization not supported through keywords #2259
+        kwargs['initial_variance'] = 1e9
         super(Test_arma_diffuse, self).__init__(23, *args, **kwargs)
         self.model.initialize_approximate_diffuse(1e9)
 


### PR DESCRIPTION
see #2252 followup state space, SARIMAX

recreating a model, motivation: #1093

the current design for this is to define 
- `_init_keys` attribute list of keyword keys in `__init__` and 
- `_get_init_kwds` method to return dictionary with init keys and values. generic version is attached in `base`, can be used to overwrite specific values (e.g. log exposure in count and glm)

The problem is that here `endog` is transformed in some cases.

still test failures, I don't define and use specialized `_get_init_kwds` method yet