### PR TITLE
BUG: var irf cov_alpha for trend and no constant

### DIFF
--- a/statsmodels/tsa/vector_ar/var_model.py
+++ b/statsmodels/tsa/vector_ar/var_model.py
@@ -970,8 +970,8 @@ class VARResults(VARProcess):
         """
         Estimated covariance matrix of model coefficients ex intercept
         """
-        # drop intercept
-        return self.cov_params[self.neqs:, self.neqs:]
+        # drop intercept and trend
+        return self.cov_params[self.k_trend*self.neqs:, self.k_trend*self.neqs:]
 
     @cache_readonly
     def _cov_sigma(self):


### PR DESCRIPTION
closes #1636 

fix as proposed in comment of #1636 
unittests approximately verify correct irf.sterr()

(This PR took me some time to prepare because I ran into other VAR bugs)