### PR TITLE
ENH Handle corner case in mosaic plot

### DIFF
--- a/statsmodels/graphics/mosaicplot.py
+++ b/statsmodels/graphics/mosaicplot.py
@@ -41,7 +41,7 @@ def _normalize_split(proportion):
         raise ValueError("proportions should be positive,"
                           "given value: {}".format(proportion))
     if np.allclose(proportion, 0):
-        raise ValueError("at least one proportion should be"
+        raise ValueError("at least one proportion should be "
                           "greater than zero".format(proportion))
     # ok, data are meaningful, so go on
     if len(proportion) < 2:
@@ -376,6 +376,12 @@ def _statistical_coloring(data):
     return props
 
 
+def _get_position(x, w, h, W):
+    if W == 0:
+        return x
+    return (x + w / 2.0) * w * h / W
+
+
 def _create_labels(rects, horizontal, ax, rotation):
     """find the position of the label for each value of each category
 
@@ -444,8 +450,8 @@ def _create_labels(rects, horizontal, ax, rotation):
 
             vals = list(itervalues(subset))
             W = sum(w * h for (x, y, w, h) in vals)
-            x_lab = sum((x + w / 2.0) * w * h / W for (x, y, w, h) in vals)
-            y_lab = sum((y + h / 2.0) * w * h / W for (x, y, w, h) in vals)
+            x_lab = sum(_get_position(x, w, h, W) for (x, y, w, h) in vals)
+            y_lab = sum(_get_position(y, h, w, W) for (x, y, w, h) in vals)
             #now base on the ordering, select which position to keep
             #needs to be written in a more general form of 4 level are enough?
             #should give also the horizontal and vertical alignment


### PR DESCRIPTION
mosaic plots fail for me when using the pdf backend on tables in which one or more columns is entirely zero.  It turns out that the failure is only due to calculations in the label positioning yielding nan due to division by zero, which causes problems in the pdf and perhaps other (but not all) matplotlib backends.

The label positioning issue is easily fixed by catching the divide by zero and using an alternate position for the label.

There is a more general issue with lack of support for tables containing a row with all zeros.  This seems to be more intrinsic to the way the algorithm works so I don't want to tackle that now.  Also, the zero-row failure gives an informative error message, whereas the failure addressed here is very hard to track down (at least in pdf mode, it doesn't fail until the plot is written to the file, and the stack trace totally bypasses statsmodels code).
