### PR TITLE
Local FDR, estimation of null Z-score distribution

### DIFF
--- a/statsmodels/stats/multitest.py
+++ b/statsmodels/stats/multitest.py
@@ -493,8 +493,7 @@ def local_fdr(zscores, p0=1.0, null_density=None, deg=7,
     zbins = (bins[:-1] + bins[1:]) / 2
 
     # The design matrix at bin centers
-    dmat = [(zbins**k)[:,None] for k in range(0, deg + 1)]
-    dmat = np.concatenate(dmat, axis=1)
+    dmat = np.vander(zbins, deg + 1)
 
     # Use this to get starting values for Poisson regression
     md = OLS(np.log(1 + zhist), dmat).fit()
@@ -503,8 +502,7 @@ def local_fdr(zscores, p0=1.0, null_density=None, deg=7,
     md = GLM(zhist, dmat, family=families.Poisson()).fit(start_params=md.params)
 
     # The design matrix for all Z-scores
-    dmat_full = [(zscores**k)[:,None] for k in range(0, deg + 1)]
-    dmat_full = np.concatenate(dmat_full, axis=1)
+    dmat_full = np.vander(zscores, deg + 1)
 
     # The height of the estimated marginal density of Z-scores,
     # evaluated at every observed Z-score.

--- a/statsmodels/stats/multitest.py
+++ b/statsmodels/stats/multitest.py
@@ -457,7 +457,7 @@ def local_fdr(zscores, p0=1.0, null_density=None, deg=7,
         A vector of Z-scores
     p0 : float
         The assumed proportion of true null hypotheses
-    null_density : function (real to positive real)
+    null_density : function mapping reals to positive reals
         The density of null Z-scores; if None, use standard normal
     deg : integer
         The maximum exponent in the polynomial expansion of the
@@ -475,6 +475,17 @@ def local_fdr(zscores, p0=1.0, null_density=None, deg=7,
     ----------
     B Efron (2008).  Microarrays, Empirical Bayes, and the Two-Groups
     Model.  Statistical Science 23:1, 1-22.
+
+    Examples
+    --------
+    Basic use:
+
+    >>> fdr = local_fdr(zscores)
+
+    Example using an empirical null distribution estimated from the data:
+
+    >>> null = EmpiricalNull(zscores)
+    >>> fdr = local_fdr(zscores, null_density=null.pdf)
     """
 
     from statsmodels.genmod.generalized_linear_model import GLM

--- a/statsmodels/stats/multitest.py
+++ b/statsmodels/stats/multitest.py
@@ -478,11 +478,11 @@ def local_fdr(zscores, p0=1.0, null_density=None, deg=7,
 
     Examples
     --------
-    Basic use:
+    Basic use (the null Z-scores are taken to be standard normal):
 
     >>> fdr = local_fdr(zscores)
 
-    Example using an empirical null distribution estimated from the data:
+    Use an empirical null distribution estimated from the data:
 
     >>> null = EmpiricalNull(zscores)
     >>> fdr = local_fdr(zscores, null_density=null.pdf)
@@ -547,7 +547,7 @@ class EmpiricalNull(object):
         The observed Z-scores.
     null_lb : float
         Z-scores between `null_lb` and `null_lb` are all considered to be
-        from the true null hypotheses.
+        true null hypotheses.
     null_ub : float
         See `null_lb`.
     estimate_mean : bool
@@ -576,6 +576,12 @@ class EmpiricalNull(object):
     ----------
     B Efron (2008).  Microarrays, Empirical Bayes, and the Two-Groups
     Model.  Statistical Science 23:1, 1-22.
+
+    Notes
+    -----
+    See also:
+
+    http://nipy.org/nipy/labs/enn.html#nipy.algorithms.statistics.empirical_pvalue.NormalEmpiricalNull.fdr
     """
 
     def __init__(self, zscores, null_lb=-1, null_ub=1, estimate_mean=True,
@@ -607,11 +613,18 @@ class EmpiricalNull(object):
 
         from scipy.stats.distributions import norm
 
+
         def fun(params):
             """
-            Negative likelihood of z-scores, parameterized as mean, scale
-            of Gaussian family, and proportion of true nulls.  Follows
-            section 4 of Efron 2008.
+            Negative log-likelihood of z-scores.
+
+            The function has three arguments, packed into a vector:
+
+            mean : location parameter
+            logscale : log of the scale parameter
+            logitprop : logit of the proportion of true nulls
+
+            The implementation follows section 4 from Efron 2008.
             """
 
             d0, s0, p0 = xform(params)

--- a/statsmodels/stats/tests/test_multi.py
+++ b/statsmodels/stats/tests/test_multi.py
@@ -18,8 +18,11 @@ from numpy.testing import (assert_almost_equal, assert_equal, assert_,
                           assert_allclose)
 
 from statsmodels.stats.multitest import (multipletests, fdrcorrection,
-                                         fdrcorrection_twostage)
+                                         fdrcorrection_twostage,
+                                         empirical_null,
+                                         local_fdr)
 from statsmodels.stats.multicomp import tukeyhsd
+from scipy.stats.distributions import norm
 
 pval0 = np.array([0.838541367553 , 0.642193923795 , 0.680845947633 ,
         0.967833824309 , 0.71626938238 , 0.177096952723 , 5.23656777208e-005 ,
@@ -348,3 +351,37 @@ def test_tukeyhsd():
     assert_almost_equal(confint, res[:, 1:3], decimal=2)
     assert_equal(reject, res[:, 3]<0.05)
 
+
+def test_local_fdr():
+
+    # Create a mixed population of Z-scores: 1000 standard normal and
+    # 20 uniformly distributed between 3 and 4.
+    grid = np.linspace(0.001, 0.999, 1000)
+    z0 = norm.ppf(grid)
+    z1 = np.linspace(3, 4, 20)
+    zs = np.concatenate((z0, z1))
+
+    # Exact local FDR for U(3, 4) component.
+    f1 = np.exp(-z1**2 / 2) / np.sqrt(2*np.pi)
+    r = len(z1) / (len(z0) + len(z1))
+    f1 /= (1 - r) * f1 + r
+
+    fdr = local_fdr(zs)
+    fdr1 = fdr[len(z0):]
+
+    assert_allclose(f1, fdr1, rtol=0.05, atol=0.1)
+
+
+def test_empirical_null():
+
+    # Create a mixed population of Z-scores: 1000 standard normal and
+    # 20 uniformly distributed between 3 and 4.
+    grid = np.linspace(0.001, 0.999, 1000)
+    z0 = norm.ppf(grid)
+    z1 = np.linspace(3, 4, 20)
+    zs = np.concatenate((z0, z1))
+    mean0, scale0, prob0, f0 = empirical_null(zs, estimate_prob=True)
+
+    assert_allclose(mean0, 0, atol=1e-5, rtol=1e-5)
+    assert_allclose(scale0, 1, atol=1e-5, rtol=1e-2)
+    assert_allclose(prob0, 0.98, atol=1e-5, rtol=1e-2)

--- a/statsmodels/stats/tests/test_multi.py
+++ b/statsmodels/stats/tests/test_multi.py
@@ -363,7 +363,7 @@ def test_local_fdr():
 
     # Exact local FDR for U(3, 4) component.
     f1 = np.exp(-z1**2 / 2) / np.sqrt(2*np.pi)
-    r = len(z1) / (len(z0) + len(z1))
+    r = len(z1) / float(len(z0) + len(z1))
     f1 /= (1 - r) * f1 + r
 
     fdr = local_fdr(zs)

--- a/statsmodels/stats/tests/test_multi.py
+++ b/statsmodels/stats/tests/test_multi.py
@@ -19,7 +19,7 @@ from numpy.testing import (assert_almost_equal, assert_equal, assert_,
 
 from statsmodels.stats.multitest import (multipletests, fdrcorrection,
                                          fdrcorrection_twostage,
-                                         empirical_null,
+                                         EmpiricalNull,
                                          local_fdr)
 from statsmodels.stats.multicomp import tukeyhsd
 from scipy.stats.distributions import norm
@@ -380,8 +380,13 @@ def test_empirical_null():
     z0 = norm.ppf(grid)
     z1 = np.linspace(3, 4, 20)
     zs = np.concatenate((z0, z1))
-    mean0, scale0, prob0, f0 = empirical_null(zs, estimate_prob=True)
+    emp_null = EmpiricalNull(zs, estimate_prob=True)
 
-    assert_allclose(mean0, 0, atol=1e-5, rtol=1e-5)
-    assert_allclose(scale0, 1, atol=1e-5, rtol=1e-2)
-    assert_allclose(prob0, 0.98, atol=1e-5, rtol=1e-2)
+    assert_allclose(emp_null.mean0, 0, atol=1e-5, rtol=1e-5)
+    assert_allclose(emp_null.scale0, 1, atol=1e-5, rtol=1e-2)
+    assert_allclose(emp_null.prob0, 0.98, atol=1e-5, rtol=1e-2)
+
+    # smoke tests
+    emp_null.pdf(0.)
+    emp_null.pdf(np.r_[-1, 0, 1])
+


### PR DESCRIPTION
This PR implements two techniques from the paper:

B Efron (2008).  Microarrays, Empirical Bayes, and the Two-Groups Model.  Statistical Science 23:1, 1-22.                                                                               

The ``local_fdr`` function calculates local False Discovery rates from Z-scores.  We could possibly implement this as an option within ``multipletests``, but it's nice to have the option to operate on z-scores rather than p-values, which ``mutlipletests`` does not allow.

The  ``empirical_null`` function estimates a non-standard normal distribution based on a set of Z-scores that consists of an unknown mixture of null and non-null hypotheses.  It uses a likelihood-based version of the "central matching" idea.

See also #1371.