### PR TITLE
FIX: avoid zero division and log0 in loglike calculation

### DIFF
--- a/statsmodels/genmod/families/family.py
+++ b/statsmodels/genmod/families/family.py
@@ -826,9 +826,9 @@ class Binomial(Family):
                                np.log(1 - mu + 1e-200))
 
         else:
-            return 2 * np.sum(self.n * (endog * np.log(endog/mu + 1e-200) +
+            return 2 * np.sum(self.n * (endog * np.log(endog/(mu + 1e-200) + 1e-200) +
                                         (1 - endog) * np.log((1 - endog) /
-                                                             (1 - mu) +
+                                                             (1 - mu + 1e-200) +
                                                              1e-200)))
 
     def resid_dev(self, endog, mu, scale=1.):
@@ -873,8 +873,8 @@ class Binomial(Family):
                                                          (1 - mu)))/scale
         else:
             return (np.sign(endog - mu) *
-                    np.sqrt(2 * self.n * (endog * np.log(endog/mu + 1e-200) +
-                            (1 - endog) * np.log((1 - endog)/(1 - mu) +
+                    np.sqrt(2 * self.n * (endog * np.log(endog/(mu + 1e-200) + 1e-200) +
+                            (1 - endog) * np.log((1 - endog)/(1 - mu + 1e-200) +
                                                  1e-200)))/scale)
 
     def loglike(self, endog, mu, scale=1.):
@@ -911,15 +911,15 @@ class Binomial(Family):
         """
 
         if np.shape(self.n) == () and self.n == 1:
-            return scale * np.sum(endog * np.log(mu/(1 - mu) + 1e-200) +
-                                  np.log(1 - mu))
+            return scale * np.sum(endog * np.log(mu/(1 - mu + 1e-200) + 1e-200) +
+                                  np.log(1 - mu + 1e-200))
         else:
             y = endog * self.n  # convert back to successes
             return scale * np.sum(special.gammaln(self.n + 1) -
                                   special.gammaln(y + 1) -
                                   special.gammaln(self.n - y + 1) + y *
-                                  np.log(mu/(1 - mu)) + self.n *
-                                  np.log(1 - mu))
+                                  np.log(mu/(1 - mu + 1e-200) + 1e-200) + self.n *
+                                  np.log(1 - mu + 1e-200))
 
     def resid_anscombe(self, endog, mu):
         '''


### PR DESCRIPTION
In some cases, fitted value (mu) can be rounded off to 0 or 1 in Binomial GLM, and it causes zero division and log0. So added a very small number "1e-200" to them to avoid resulting NaN.

This approach is followed by following fix:
- https://bugs.launchpad.net/statsmodels/+bug/680077   issue gh #42 on 
