### PR TITLE
ENH/BUG Various GEE improvements

### DIFF
--- a/statsmodels/genmod/cov_struct.py
+++ b/statsmodels/genmod/cov_struct.py
@@ -775,22 +775,16 @@ class GlobalOddsRatio(CategoricalCovStruct):
 
             # Number of subjects in this group
             m = int(len(v) / self._ncut)
+            i1, i2 = np.tril_indices(m, -1)
 
             cpp1 = {}
-            # Loop over distinct subject pairs
-            for i1 in range(m):
-                for i2 in range(i1):
-                    # Loop over cut point pairs
-                    for k1 in range(self._ncut):
-                        for k2 in range(k1+1):
-                            if (k2, k1) not in cpp1:
-                                cpp1[(k2, k1)] = []
-                            j1 = i1*self._ncut + k1
-                            j2 = i2*self._ncut + k2
-                            cpp1[(k2, k1)].append([j2, j1])
+            for k1 in range(self._ncut):
+                for k2 in range(k1+1):
+                    jj = np.zeros((len(i1), 2), dtype=np.int64)
+                    jj[:, 0] = i1*self._ncut + k1
+                    jj[:, 1] = i2*self._ncut + k2
+                    cpp1[(k2, k1)] = jj
 
-            for k in cpp1.keys():
-                cpp1[k] = np.asarray(cpp1[k])
             cpp.append(cpp1)
 
         self.cpp = cpp

--- a/statsmodels/genmod/cov_struct.py
+++ b/statsmodels/genmod/cov_struct.py
@@ -797,7 +797,8 @@ class GlobalOddsRatio(CategoricalCovStruct):
 
         # Initialize the dependence parameters
         self.crude_or = self.observed_crude_oddsratio()
-        self.dep_params = self.crude_or
+        if self.model.update_dep:
+            self.dep_params = self.crude_or
 
 
     def pooled_odds_ratio(self, tables):

--- a/statsmodels/genmod/cov_struct.py
+++ b/statsmodels/genmod/cov_struct.py
@@ -693,7 +693,37 @@ class Autoregressive(CovStruct):
                 self.dep_params)
 
 
-class GlobalOddsRatio(CovStruct):
+class CategoricalCovStruct(CovStruct):
+    """
+    Parent class for covariance structure for categorical data models.
+
+    Attributes
+    ----------
+    nlevel : int
+        The number of distinct levels for the outcome variable.
+    ibd : list
+        A list whose i^th element ibd[i] is a sequence of integer
+        pairs (a,b), where endog_li[i][a:b] is the subvector of binary
+        indicators derived from the same ordinal value.
+    """
+
+    def initialize(self, model):
+
+        super(CategoricalCovStruct, self).initialize(model)
+
+        self.nlevel = len(model.endog_values)
+        self._ncut = self.nlevel - 1
+
+        ibd = []
+        for v in model.endog_li:
+            jj = np.arange(0, len(v) + 1, self._ncut)
+            ibd1 = np.hstack((jj[0:-1][:, None], jj[1:][:, None]))
+            ibd1 = [(jj[k], jj[k + 1]) for k in range(len(jj) - 1)]
+            ibd.append(ibd1)
+        self.ibd = ibd
+
+
+class GlobalOddsRatio(CategoricalCovStruct):
     """
     Estimate the global odds ratio for a GEE with ordinal or nominal
     data.
@@ -727,6 +757,7 @@ class GlobalOddsRatio(CovStruct):
         self.endog_type = endog_type
         self.dep_params = 0.
 
+
     def initialize(self, model):
 
         super(GlobalOddsRatio, self).initialize(model)
@@ -734,35 +765,24 @@ class GlobalOddsRatio(CovStruct):
         if self.model.weights is not None:
             warnings.warn("weights not implemented for GlobalOddsRatio cov_struct, using unweighted covariance estimate")
 
-        self.nlevel = len(model.endog_values)
-        self.ncut = self.nlevel - 1
-
-        ibd = []
-        for v in model.endog_li:
-            jj = np.arange(0, len(v) + 1, self.ncut)
-            ibd1 = np.hstack((jj[0:-1][:, None], jj[1:][:, None]))
-            ibd1 = [(jj[k], jj[k + 1]) for k in range(len(jj) - 1)]
-            ibd.append(ibd1)
-        self.ibd = ibd
-
         # Need to restrict to between-subject pairs
         cpp = []
         for v in model.endog_li:
 
             # Number of subjects in this group
-            m = int(len(v) / self.ncut)
+            m = int(len(v) / self._ncut)
 
             cpp1 = {}
             # Loop over distinct subject pairs
             for i1 in range(m):
                 for i2 in range(i1):
                     # Loop over cut point pairs
-                    for k1 in range(self.ncut):
+                    for k1 in range(self._ncut):
                         for k2 in range(k1+1):
                             if (k2, k1) not in cpp1:
                                 cpp1[(k2, k1)] = []
-                            j1 = i1*self.ncut + k1
-                            j2 = i2*self.ncut + k2
+                            j1 = i1*self._ncut + k1
+                            j2 = i2*self._ncut + k2
                             cpp1[(k2, k1)].append([j2, j1])
 
             for k in cpp1.keys():
@@ -803,11 +823,13 @@ class GlobalOddsRatio(CovStruct):
 
         return np.exp(log_pooled_or)
 
+
     def covariance_matrix(self, expected_value, index):
 
         vmat = self.get_eyy(expected_value, index)
         vmat -= np.outer(expected_value, expected_value)
         return vmat, False
+
 
     def observed_crude_oddsratio(self):
         """
@@ -847,6 +869,7 @@ class GlobalOddsRatio(CovStruct):
 
         return self.pooled_odds_ratio(list(itervalues(tables)))
 
+
     def get_eyy(self, endog_expval, index):
         """
         Returns a matrix V such that V[i,j] is the joint probability
@@ -872,14 +895,13 @@ class GlobalOddsRatio(CovStruct):
         for bdl in ibd:
             evy = endog_expval[bdl[0]:bdl[1]]
             if self.endog_type == "ordinal":
-                eyr = np.outer(evy, np.ones(len(evy)))
-                eyc = np.outer(np.ones(len(evy)), evy)
-                vmat[bdl[0]:bdl[1], bdl[0]:bdl[1]] = \
-                    np.where(eyr < eyc, eyr, eyc)
+                vmat[bdl[0]:bdl[1], bdl[0]:bdl[1]] =\
+                    np.minimum.outer(evy, evy)
             else:
                 vmat[bdl[0]:bdl[1], bdl[0]:bdl[1]] = np.diag(evy)
 
         return vmat
+
 
     def update(self, params):
         """
@@ -932,6 +954,69 @@ class GlobalOddsRatio(CovStruct):
     def summary(self):
 
         return "Global odds ratio: %.3f\n" % self.dep_params
+
+
+
+class OrdinalIndependence(CategoricalCovStruct):
+    """
+    An independence covariance structure for ordinal models.
+
+    The working covariance between indicators derived from different
+    observations is zero.  The working covariance between indicators
+    derived form a common observation is determined from their current
+    mean values.
+
+    There are no parameters to estimate in this covariance structure.
+    """
+
+    def covariance_matrix(self, expected_value, index):
+
+        ibd = self.ibd[index]
+        n = len(expected_value)
+        vmat = np.zeros((n, n))
+
+        for bdl in ibd:
+            ev = expected_value[bdl[0]:bdl[1]]
+            vmat[bdl[0]:bdl[1], bdl[0]:bdl[1]] =\
+                      np.minimum.outer(ev, ev) - np.outer(ev, ev)
+
+        return vmat, False
+
+
+    # Nothing to update
+    def update(self, params):
+        pass
+
+
+class NominalIndependence(CategoricalCovStruct):
+    """
+    An independence covariance structure for nominal models.
+
+    The working covariance between indicators derived from different
+    observations is zero.  The working covariance between indicators
+    derived form a common observation is determined from their current
+    mean values.
+
+    There are no parameters to estimate in this covariance structure.
+    """
+
+    def covariance_matrix(self, expected_value, index):
+
+        ibd = self.ibd[index]
+        n = len(expected_value)
+        vmat = np.zeros((n, n))
+
+        for bdl in ibd:
+            ev = expected_value[bdl[0]:bdl[1]]
+            vmat[bdl[0]:bdl[1], bdl[0]:bdl[1]] =\
+                      np.diag(ev) - np.outer(ev, ev)
+
+        return vmat, False
+
+
+    # Nothing to update
+    def update(self, params):
+        pass
 
 
 class Equivalence(CovStruct):

--- a/statsmodels/genmod/generalized_estimating_equations.py
+++ b/statsmodels/genmod/generalized_estimating_equations.py
@@ -534,17 +534,16 @@ class GEE(base.Model):
                 self._offset_exposure = self.constraint.offset_increment().copy()
             self.exog = self.constraint.reduced_exog()
 
-        # Convert the data to the internal representation, which is a
-        # list of arrays, corresponding to the groups.
-        group_labels = sorted(set(self.groups))
-        group_indices = dict((s, []) for s in group_labels)
-        for i in range(len(self.endog)):
-            group_indices[self.groups[i]].append(i)
-        for k in iterkeys(group_indices):
-            group_indices[k] = np.asarray(group_indices[k])
-        self.group_indices = group_indices
+        # Create list of row indices for each group
+        group_labels, ix = np.unique(self.groups, return_inverse=True)
+        se = pd.Series(index=np.arange(len(ix)))
+        gb = se.groupby(ix).groups
+        dk = [(lb, np.asarray(gb[k])) for k,lb in enumerate(group_labels)]
+        self.group_indices = dict(dk)
         self.group_labels = group_labels
 
+        # Convert the data to the internal representation, which is a
+        # list of arrays, corresponding to the groups.
         self.endog_li = self.cluster_list(self.endog)
         self.exog_li = self.cluster_list(self.exog)
 

--- a/statsmodels/genmod/generalized_estimating_equations.py
+++ b/statsmodels/genmod/generalized_estimating_equations.py
@@ -35,9 +35,8 @@ import statsmodels.regression.linear_model as lm
 import statsmodels.base.wrapper as wrap
 
 from statsmodels.genmod import families
-from statsmodels.genmod.cov_struct import (Independence,
-                                           GlobalOddsRatio,
-                                           CovStruct)
+from statsmodels.genmod import cov_struct as cov_structs
+
 import statsmodels.genmod.families.varfuncs as varfuncs
 from statsmodels.genmod.families.links import Link
 
@@ -494,9 +493,9 @@ class GEE(base.Model):
 
         # Handle the cov_struct argument
         if cov_struct is None:
-            cov_struct = Independence()
+            cov_struct = cov_structs.Independence()
         else:
-            if not issubclass(cov_struct.__class__, CovStruct):
+            if not issubclass(cov_struct.__class__, cov_structs.CovStruct):
                 raise ValueError("GEE: `cov_struct` must be a genmod "
                                  "cov_struct instance")
 
@@ -1857,6 +1856,9 @@ class OrdinalGEE(GEE):
             if not isinstance(family, families.Binomial):
                 raise ValueError("ordinal GEE must use a Binomial family")
 
+        if cov_struct is None:
+            cov_struct = cov_structs.OrdinalIndependence()
+
         endog, exog, groups, time, offset = self.setup_ordinal(endog,
                                        exog, groups, time, offset)
 
@@ -2088,6 +2090,9 @@ class NominalGEE(GEE):
 
         if family is None:
             family = _Multinomial(self.ncut+1)
+
+        if cov_struct is None:
+            cov_struct = cov_structs.NominalIndependence()
 
         super(NominalGEE, self).__init__(endog, exog, groups,
                  time, family, cov_struct, missing, offset, dep_data,

--- a/statsmodels/genmod/tests/test_gee.py
+++ b/statsmodels/genmod/tests/test_gee.py
@@ -27,6 +27,7 @@ import statsmodels.formula.api as smf
 import statsmodels.api as sm
 from scipy.stats.distributions import norm
 from patsy import dmatrices
+import warnings
 
 try:
     import matplotlib.pyplot as plt  #makes plt available for test functions
@@ -167,6 +168,7 @@ class TestGEE(object):
 
         assert_allclose(marg.margeff, np.r_[-0.41197961], rtol=1e-5)
         assert_allclose(marg.margeff_se, np.r_[0.1379962], rtol=1e-6)
+
 
     def test_margins_poisson(self):
         """
@@ -744,8 +746,15 @@ class TestGEE(object):
 
         df = pd.DataFrame({"y": y, "groups": groups, "x1": x1, "x2": x2})
 
+        # smoke test
         model = OrdinalGEE.from_formula("y ~ 0 + x1 + x2", groups, data=df)
         result = model.fit()
+
+        # smoke test
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            model = NominalGEE.from_formula("y ~ 0 + x1 + x2", groups, data=df)
+            result = model.fit()
 
 
     def test_ordinal_independence(self):
@@ -771,9 +780,11 @@ class TestGEE(object):
         x = np.random.normal(size=(n,1))
 
         # smoke test
-        nmi = sm.cov_struct.NominalIndependence()
-        model1 = NominalGEE(y, x, groups, cov_struct=nmi)
-        result1 = model1.fit()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            nmi = sm.cov_struct.NominalIndependence()
+            model1 = NominalGEE(y, x, groups, cov_struct=nmi)
+            result1 = model1.fit()
 
 
     def test_nominal(self):
@@ -1252,7 +1263,10 @@ class TestGEE(object):
         # Smoke test
         eq = sm.cov_struct.Equivalence(labels=labels, return_cov=True)
         model1 = sm.GEE(endog, exog, groups, cov_struct=eq)
-        result1 = model1.fit(maxiter=2)
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')
+            result1 = model1.fit(maxiter=2)
+
 
 class CheckConsistency(object):
 

--- a/statsmodels/genmod/tests/test_gee.py
+++ b/statsmodels/genmod/tests/test_gee.py
@@ -732,6 +732,50 @@ class TestGEE(object):
         assert_equal(type(rslt), OrdinalGEEResultsWrapper)
         assert_equal(type(rslt._results), OrdinalGEEResults)
 
+
+    def test_ordinal_formula(self):
+
+        np.random.seed(434)
+        n = 40
+        y = np.random.randint(0, 3, n)
+        groups = np.arange(n)
+        x1 = np.random.normal(size=n)
+        x2 = np.random.normal(size=n)
+
+        df = pd.DataFrame({"y": y, "groups": groups, "x1": x1, "x2": x2})
+
+        model = OrdinalGEE.from_formula("y ~ 0 + x1 + x2", groups, data=df)
+        result = model.fit()
+
+
+    def test_ordinal_independence(self):
+
+        np.random.seed(434)
+        n = 40
+        y = np.random.randint(0, 3, n)
+        groups = np.kron(np.arange(n/2), np.r_[1, 1])
+        x = np.random.normal(size=(n,1))
+
+        # smoke test
+        odi = sm.cov_struct.OrdinalIndependence()
+        model1 = OrdinalGEE(y, x, groups, cov_struct=odi)
+        result1 = model1.fit()
+
+
+    def test_nominal_independence(self):
+
+        np.random.seed(434)
+        n = 40
+        y = np.random.randint(0, 3, n)
+        groups = np.kron(np.arange(n/2), np.r_[1, 1])
+        x = np.random.normal(size=(n,1))
+
+        # smoke test
+        nmi = sm.cov_struct.NominalIndependence()
+        model1 = NominalGEE(y, x, groups, cov_struct=nmi)
+        result1 = model1.fit()
+
+
     def test_nominal(self):
 
         endog, exog, groups = load_data("gee_nominal_1.csv",

--- a/statsmodels/genmod/tests/test_gee.py
+++ b/statsmodels/genmod/tests/test_gee.py
@@ -891,6 +891,47 @@ class TestGEE(object):
                                  decimal=6)
              # print(mdf.params)
 
+    def test_groups(self):
+        # Test various group structures (nonconsecutive, different
+        # group sizes, not ordered, string labels)
+
+        n = 40
+        x = np.random.normal(size=(n, 2))
+        y = np.random.normal(size=n)
+
+        # groups with unequal group sizes
+        groups = np.kron(np.arange(n/4), np.ones(4))
+        groups[8:12] = 3
+        groups[34:36] = 9
+
+        model1 = GEE(y, x, groups=groups)
+        result1 = model1.fit()
+
+        # Unordered groups
+        ix = np.random.permutation(n)
+        y1 = y[ix]
+        x1 = x[ix, :]
+        groups1 = groups[ix]
+
+        model2 = GEE(y1, x1, groups=groups1)
+        result2 = model2.fit()
+
+        assert_allclose(result1.params, result2.params)
+        assert_allclose(result1.tvalues, result2.tvalues)
+
+        # group labels are strings
+        mp = {}
+        import string
+        for j,g in enumerate(set(groups)):
+            mp[g] = string.ascii_letters[j:j+4]
+        groups2 = [mp[x] for x in groups]
+
+        model3 = GEE(y, x, groups=groups2)
+        result3 = model3.fit()
+
+        assert_allclose(result1.params, result3.params)
+        assert_allclose(result1.tvalues, result3.tvalues)
+
 
     def test_compare_OLS(self):
         #Gaussian GEE with independence correlation should agree

--- a/statsmodels/genmod/tests/test_gee.py
+++ b/statsmodels/genmod/tests/test_gee.py
@@ -924,7 +924,7 @@ class TestGEE(object):
         import string
         for j,g in enumerate(set(groups)):
             mp[g] = string.ascii_letters[j:j+4]
-        groups2 = [mp[x] for x in groups]
+        groups2 = [mp[g] for g in groups]
 
         model3 = GEE(y, x, groups=groups2)
         result3 = model3.fit()


### PR DESCRIPTION
* Fix a bug that raised an exception when fitting ordinal and nominal GEE models with formulas

* Add two parameter-free covariance structures for nominal or ordinal data that are independent except between indicators derived from the same observation

* Refactor categorical covariance structures to descend from abstract base class

* Privatize ncut

* Move starting values calculations for categorical models in subclasses

* (Hopefully) accelerate GlobalOddsRatio by using outer minimum to replace two temporary arrays


