### PR TITLE
TST fix test to avoid nans in exog if missing are ignored

### DIFF
--- a/statsmodels/base/tests/test_data.py
+++ b/statsmodels/base/tests/test_data.py
@@ -525,7 +525,7 @@ class TestMissingArray(object):
         np.testing.assert_array_equal(data.exog, X)
 
     def test_none(self):
-        data = sm_data.handle_data(self.y, self.X, 'none')
+        data = sm_data.handle_data(self.y, self.X, 'none', hasconst=False)
         np.testing.assert_array_equal(data.endog, self.y)
         np.testing.assert_array_equal(data.exog, self.X)
 
@@ -594,7 +594,7 @@ class TestMissingPandas(object):
         ptesting.assert_frame_equal(data.orig_exog, self.X.ix[idx])
 
     def test_none(self):
-        data = sm_data.handle_data(self.y, self.X, 'none')
+        data = sm_data.handle_data(self.y, self.X, 'none', hasconst=False)
         np.testing.assert_array_equal(data.endog, self.y.values)
         np.testing.assert_array_equal(data.exog, self.X.values)
 

--- a/statsmodels/tsa/tests/test_arima.py
+++ b/statsmodels/tsa/tests/test_arima.py
@@ -1764,6 +1764,7 @@ def test_arimax():
     assert_almost_equal(res.model.loglike(np.array(params)), stata_llf, 6)
 
     X = dta.diff()
+    X.iloc[0] = 0
     res = ARIMA(y, (2, 1, 1), X).fit(disp=False)
 
     # gretl won't estimate this - looks like maybe a bug on their part,


### PR DESCRIPTION
 see #2308

this fixes the unit tests

this does no solve the underlying problem that `missing='ignore'` might cause invalid linalg operations (and could crash or hang with some versions of BLAS/LAPACK)

see #2311 to add missing handling to the constant detection method (useful if used standalone), see my comments to #2311 

------------

question based on fixing the arimax test: do we have proper missing handling for initial conditions?.  nan was introduced by `exog.diff()` (by user/test not by ARIMA)
-> new issue #2338