### PR TITLE
WIP: Work on fixing scale in GLM #2351

### DIFF
--- a/statsmodels/genmod/families/family.py
+++ b/statsmodels/genmod/families/family.py
@@ -524,11 +524,6 @@ class Gaussian(Family):
             (1/2.)*log(2*pi*`scale`))
         """
 
-        va = scale * self.variance(mu)
-        sresid = (endog - mu)**2 / va
-        llf = -np.sum(np.log(2 * np.pi * va)) / 2
-        llf -= np.sum(sresid) / 2
-
         # FIXME: This is the profile likelihood after optimizing
         # scale.  Note that this implicitly uses the MLE for scale,
         # not the unbiased estimate accounting for the model df.  Also
@@ -536,12 +531,11 @@ class Gaussian(Family):
         if isinstance(self.link, L.Power) and self.link.power == 1:
             # Recalculate the scale as the MLE
             scale = np.sum((endog - mu)**2) / len(endog)
-            va = scale * self.variance(mu)
-            sresid = (endog - mu)**2 / va
-            llf = -np.sum(np.log(2 * np.pi * va)) / 2
-            llf -= np.sum(sresid) / 2
-            return llf
 
+        va = scale * self.variance(mu)
+        sresid = (endog - mu)**2 / va
+        llf = -np.sum(np.log(2 * np.pi * va)) / 2
+        llf -= np.sum(sresid) / 2
         return llf
 
 

--- a/statsmodels/genmod/families/family.py
+++ b/statsmodels/genmod/families/family.py
@@ -509,28 +509,10 @@ class Gaussian(Family):
 
         Notes
         -----
-
-        TODO: this is unclear and will need to be updated contingent
-        on what we do below.
-
-        If the link is the identity link function then the
-        loglikelihood function is the same as the classical OLS model.
-        llf = -(nobs/2)*(log(SSR) + (1 + log(2*pi/nobs)))
-        where SSR = sum((endog-link^(-1)(mu))**2)
-
-        If the links is not the identity link then the loglikelihood
-        function is defined as
+        The loglikelihood function is defined as
         llf = sum((`endog`*`mu`-`mu`**2/2)/`scale` - `endog`**2/(2*`scale`) - \
             (1/2.)*log(2*pi*`scale`))
         """
-
-        # FIXME: This is the profile likelihood after optimizing
-        # scale.  Note that this implicitly uses the MLE for scale,
-        # not the unbiased estimate accounting for the model df.  Also
-        # if scale is passed as an argument it is ignored.
-        if isinstance(self.link, L.Power) and self.link.power == 1:
-            # Recalculate the scale as the MLE
-            scale = np.sum((endog - mu)**2) / len(endog)
 
         va = scale * self.variance(mu)
         sresid = (endog - mu)**2 / va


### PR DESCRIPTION
#2351

The issue in loglike seems to be whether the scale parameter is the MLE or the unbiased method of moments estimate.  The calculations were a bit convoluted, but it boils down to this difference.  

For the current code, if using the power family with exponent 1 we ignore the provided scale parameter and implicitly replace it with the MLE.  If instead we try to use the provided scale parameter, tests fail because the provided scale is the unbiased estimate not the MLE.

I implemented a simple calculation of the loglike value that in my view should be the only thing there.  The older code in the "if" block is needed to get the tests to pass in the special case of power link with exponent 1. We should rewrite the tests so the code in the if block can be removed.

I also fixed unrelated issues in the deviance and resid_deviance methods.
