### PR TITLE
ENH: penalized MLE

### DIFF
--- a/statsmodels/base/_penalized.py
+++ b/statsmodels/base/_penalized.py
@@ -103,7 +103,11 @@ class PenalizedMixin(object):
 
         hess = super(PenalizedMixin, self).hessian(params)
         if pen_weight != 0:
-            hess -= np.diag(pen_weight * self.penal.deriv2(params))
+            h = self.penal.deriv2(params)
+            if h.ndim == 1:
+                hess -= np.diag(pen_weight * h)
+            else:
+                hess -= pen_weight * h
 
         return hess
 

--- a/statsmodels/base/_penalized.py
+++ b/statsmodels/base/_penalized.py
@@ -19,9 +19,11 @@ class PenalizedMixin(object):
 
     """
 
-    def __init__(self, *args, penal=None, **kwds):
+    def __init__(self, *args, **kwds):
         super(PenalizedMixin, self).__init__(*args, **kwds)
 
+        penal = kwds.pop('penal', None)
+        # I keep the following instead of adding default in pop for future changes
         if penal is None:
             # TODO: switch to unpenalized by default
             self.penal = SCADSmoothed(0.1, c0=0.0001)

--- a/statsmodels/base/_penalized.py
+++ b/statsmodels/base/_penalized.py
@@ -31,7 +31,12 @@ class PenalizedMixin(object):
             self.penal = penal
 
         # TODO: define pen_weight as average pen_weight? i.e. per observation
-        self.pen_weight = len(self.endog) #100.
+        # I would have prefered len(self.endog) * kwds.get('pen_weight', 1)
+        # or use pen_weight_factor in signature
+        self.pen_weight =  kwds.get('pen_weight', len(self.endog))
+
+        self._init_keys.extend(['penal', 'pen_weight'])
+
 
 
     def loglike(self, params, pen_weight=None):
@@ -138,7 +143,7 @@ class PenalizedMixin(object):
             if drop_index.any():
                 # todo : trim kwyword doesn't work, why not?
                 #res_aux = self.fit_constrained(rmat, trim=False)
-                res_aux = self._fit_zeros(keep_index)
+                res_aux = self._fit_zeros(keep_index, **kwds)
                 return res_aux
             else:
                 return res

--- a/statsmodels/base/_penalized.py
+++ b/statsmodels/base/_penalized.py
@@ -129,6 +129,7 @@ class PenalizedMixin(object):
             # temporary standin, only works for Poisson and GLM,
             # and is computationally inefficient
             drop_index = np.nonzero(np.abs(res.params) < 1e-4) [0]
+            keep_index = np.nonzero(np.abs(res.params) > 1e-4) [0]
             rmat = np.eye(len(res.params))[drop_index]
 
             # calling fit_constrained raise
@@ -136,7 +137,8 @@ class PenalizedMixin(object):
             # fit_constrained is calling fit, recursive endless loop
             if drop_index.any():
                 # todo : trim kwyword doesn't work, why not?
-                res_aux = self.fit_constrained(rmat, trim=False)
+                #res_aux = self.fit_constrained(rmat, trim=False)
+                res_aux = self._fit_zeros(keep_index)
                 return res_aux
             else:
                 return res

--- a/statsmodels/base/_penalized.py
+++ b/statsmodels/base/_penalized.py
@@ -1,0 +1,144 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Sun May 10 08:23:48 2015
+
+Author: Josef Perktold
+License: BSD-3
+"""
+
+import numpy as np
+from ._penalties import SCADSmoothed
+
+class PenalizedMixin(object):
+    """Mixin class for Maximum Penalized Likelihood
+
+
+    TODO: missing **kwds or explicit keywords
+
+    TODO: do we really need `pen_weight` keyword in likelihood methods?
+
+    """
+
+    def __init__(self, *args, penal=None, **kwds):
+        super(PenalizedMixin, self).__init__(*args, **kwds)
+
+        if penal is None:
+            # TODO: switch to unpenalized by default
+            self.penal = SCADSmoothed(0.1, c0=0.0001)
+        else:
+            self.penal = penal
+
+        # TODO: define pen_weight as average pen_weight? i.e. per observation
+        self.pen_weight = len(self.endog) #100.
+
+
+    def loglike(self, params, pen_weight=None):
+        if pen_weight is None:
+            pen_weight = self.pen_weight
+
+        llf = super(PenalizedMixin, self).loglike(params)
+        if pen_weight != 0:
+            llf -= pen_weight * self.penal.func(params)
+
+        return llf
+
+
+    def loglikeobs(self, params, pen_weight=None):
+        if pen_weight is None:
+            pen_weight = self.pen_weight
+
+        llf = super(PenalizedMixin, self).loglikeobs(params)
+        nobs_llf = float(llf.shape[0])
+
+        if pen_weight != 0:
+            llf -= pen_weight / nobs_llf * self.penal.func(params)
+
+        return llf
+
+
+    def score(self, params, pen_weight=None):
+        if pen_weight is None:
+            pen_weight = self.pen_weight
+
+        sc = super(PenalizedMixin, self).score(params)
+        if pen_weight != 0:
+            sc -= pen_weight * self.penal.grad(params)
+
+        return sc
+
+
+    def scoreobs(self, params, pen_weight=None):
+        if pen_weight is None:
+            pen_weight = self.pen_weight
+
+        sc = super(PenalizedMixin, self).scoreobs(params)
+        nobs_sc = float(sc.shape[0])
+        if pen_weight != 0:
+            sc -= pen_weight / nobs_sc  * self.penal.grad(params)
+
+        return sc
+
+
+    def hessian_(self, params, pen_weight=None):
+        if pen_weight is None:
+            pen_weight = self.pen_weight
+            loglike = self.loglike
+        else:
+            loglike = lambda p: self.loglike(p, pen_weight=pen_weight)
+
+        from statsmodels.tools.numdiff import approx_hess
+        return approx_hess(params, loglike)
+
+
+    def hessian(self, params, pen_weight=None):
+        if pen_weight is None:
+            pen_weight = self.pen_weight
+
+        hess = super(PenalizedMixin, self).hessian(params)
+        if pen_weight != 0:
+            hess -= np.diag(pen_weight * self.penal.deriv2(params))
+
+        return hess
+
+
+    def fit(self, method=None, trim=None, **kwds):
+        # If method is None, then we choose a default method ourselves
+
+        # TODO: temporary hack, need extra fit kwds
+        # we need to rule out fit methods in a model that will not work with
+        # penalization
+        if hasattr(self, 'family'):  # assume this identifies GLM
+            kwds.update({'max_start_irls' : 0})
+
+        # currently we use `bfgs` by default
+        if method is None:
+            method = 'bfgs'
+
+        if trim is None:
+            trim = False  # see below infinite recursion in `fit_constrained
+
+        res = super(PenalizedMixin, self).fit(method=method, **kwds)
+
+        if trim is False:
+            # note boolean check for "is False" not evaluates to False
+            return res
+        else:
+            # TODO: make it penal function dependent
+            # temporary standin, only works for Poisson and GLM,
+            # and is computationally inefficient
+            drop_index = np.nonzero(np.abs(res.params) < 1e-4) [0]
+            rmat = np.eye(len(res.params))[drop_index]
+
+            # calling fit_constrained raise
+            # "RuntimeError: maximum recursion depth exceeded in __instancecheck__"
+            # fit_constrained is calling fit, recursive endless loop
+            if drop_index.any():
+                # todo : trim kwyword doesn't work, why not?
+                res_aux = self.fit_constrained(rmat, trim=False)
+                return res_aux
+            else:
+                return res
+
+
+
+

--- a/statsmodels/base/_penalties.py
+++ b/statsmodels/base/_penalties.py
@@ -110,12 +110,175 @@ class PseudoHuber(Penalty):
         v = np.sqrt(1 + (params / self.dlt)**2)
         v -= 1
         v *= self.dlt**2
-        return np.sum(self.wts * self.alpha * v)
+        return np.sum(self.wts * self.alpha * v, 0)
 
     def grad(self, params):
         v = np.sqrt(1 + (params / self.dlt)**2)
         return params * self.wts * self.alpha / v
 
+
+class SCAD(Penalty):
+    """
+    The SCAD penalty of Fan and Li
+    """
+
+    def __init__(self, tau, c=3.7, wts=None):
+        if wts is None:
+            self.weights = 1.
+        else:
+            self.weights = wts
+        self.tau = tau
+        self.c = c
+
+    def func(self, params):
+
+        # 3 segments in absolute value
+        tau = self.tau
+        p_abs = np.atleast_1d(np.abs(params))
+        res = np.empty(p_abs.shape)#, p_abs.dtype)
+        res.fill(np.nan)
+        mask1 = p_abs < tau
+        mask3 = p_abs >= self.c * tau
+        res[mask1] = tau * p_abs[mask1]
+        mask2 = ~mask1 & ~mask3
+        p_abs2 = p_abs[mask2]
+        #tmp = (tau * p_abs2**2 - 2 * self.c * p_abs2 + tau**2)
+        tmp = (p_abs2**2 - 2 * self.c * tau * p_abs2 + tau**2)
+        res[mask2] = -tmp / (2 * (self.c - 1))
+        #res[mask3] = (self.c + 1) / 2. * p_abs[mask3]**2
+        res[mask3] = (self.c + 1) * tau**2 / 2.
+
+        return (self.weights * res).sum(0)
+
+    def grad(self, params):
+
+        # 3 segments in absolute value
+        tau = self.tau
+        p = np.atleast_1d(params)
+        p_abs = np.abs(p)
+        p_sign = np.sign(p)
+        res = np.empty(p_abs.shape)#, p_abs.dtype)
+        res.fill(np.nan)
+
+        mask1 = p_abs < tau
+        mask3 = p_abs >= self.c * tau
+        mask2 = ~mask1 & ~mask3
+        res[mask1] = p_sign[mask1] * tau
+        #tmp = p_sign[mask2] * (tau * p_abs[mask2] - self.c)
+        tmp = p_sign[mask2] * (p_abs[mask2] - self.c * tau)
+        res[mask2] = -tmp / (self.c - 1)
+        res[mask3] = 0#(self.c + 1)
+
+        return self.weights * res
+
+
+    def deriv2(self, params):
+        """Second derivative of function
+
+        Warning: Not checked, possible problems in multivariate case
+        This returns scalar or vector in same shape as params, not a square Hessian.
+
+        """
+
+        # 3 segments in absolute value
+        tau = self.tau
+        p = np.atleast_1d(params)
+        p_abs = np.abs(p)
+        p_sign = np.sign(p)
+        res = np.zeros(p_abs.shape)#, p_abs.dtype)
+
+        mask1 = p_abs < tau
+        mask3 = p_abs >= self.c * tau
+        mask2 = ~mask1 & ~mask3
+
+        res[mask2] = -p_sign[mask2] / (self.c - 1)
+
+        return self.weights * res
+
+
+class SCADSmoothed(SCAD):
+    """
+    The SCAD penalty of Fan and Li, quadratically smoothed around zero
+
+    This follows Fan and Li 2001 equation (3.7).
+
+    Parameterization follows Boo, Johnson, Li and Tan 2011
+
+
+    TODO: Use delegation instead of subclassing, so smoothing can be added to all
+    penalty classes.
+
+    """
+
+    def __init__(self, tau, c=3.7, c0=None, wts=None):
+        if wts is None:
+            self.weights = 1.
+        else:
+            self.weights = wts
+        self.alpha = 1.
+        self.tau = tau
+        self.c = c
+        self.c0 = c0 if c0 is not None else tau * 0.1
+        if self.c0 > tau:
+            raise ValueError('c0 cannot be larger than tau')
+
+        # get coefficients for quadratic approximation
+        c0 = self.c0
+        deriv_c0 = super(SCADSmoothed, self).grad(c0)
+        value_c0 = super(SCADSmoothed, self).func(c0)
+        self.aq1 = value_c0 - 0.5 * deriv_c0 * c0
+        self.aq2 = 0.5 * deriv_c0 / c0
+
+
+    def func(self, params):
+
+        # need to temporarily override weights for call to super
+        weights = self.weights
+        self.weights = 1.
+        value = super(SCADSmoothed, self).func(params[None, ...])
+        self.weights = weights
+
+        #change the segment corrsponding to quadratic approximation
+        p_abs = np.atleast_1d(np.abs(params))
+        mask = p_abs < self.c0
+        p_abs_masked = p_abs[mask]
+        value[mask] = self.aq1 + self.aq2 * p_abs_masked**2
+
+        return (self.weights * value).sum(0)
+
+
+    def grad(self, params):
+
+        # need to temporarily override weights for call to super
+        weights = self.weights
+        self.weights = 1.
+        value = super(SCADSmoothed, self).grad(params)
+        self.weights = weights
+
+        #change the segment corrsponding to quadratic approximation
+        p = np.atleast_1d(params)
+        mask = np.abs(p) < self.c0
+        value[mask] = 2 * self.aq2 * p[mask]
+
+        return value
+
+
+    def deriv2(self, params):
+
+        # need to temporarily override weights for call to super
+        weights = self.weights
+        self.weights = 1.
+        value = super(SCADSmoothed, self).deriv2(params)
+        self.weights = weights
+
+        #change the segment corrsponding to quadratic approximation
+        p = np.atleast_1d(params)
+        #p_abs = np.abs(p)
+        mask = np.abs(p) < self.c0
+        #p_abs_masked = p_abs[mask]
+        value[mask] = 2 * self.aq2
+
+        return value
 
 class CovariancePenalty(object):
 

--- a/statsmodels/base/_penalties.py
+++ b/statsmodels/base/_penalties.py
@@ -260,7 +260,7 @@ class SCADSmoothed(SCAD):
         mask = np.abs(p) < self.c0
         value[mask] = 2 * self.aq2 * p[mask]
 
-        return value
+        return weights * value
 
 
     def deriv2(self, params):

--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -547,6 +547,9 @@ class LikelihoodModel(Model):
             res.mle_retvals['iterations'] = res_constr.mle_retvals.get(
                                                             'iterations', np.nan)
             res.mle_retvals['converged'] = res_constr.mle_retvals['converged']
+            # overwrite all settings
+            #res.mle_retvals.update(res_constr.mle_retvals)  #not yet
+            res.mle_settings.update(res_constr.mle_settings)
 
 
         k_params = len(res._results.params)

--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -474,6 +474,108 @@ class LikelihoodModel(Model):
         return mlefit
 
 
+    def _fit_zeros(self, keep_index=None, start_params=None, return_auxiliary=False, **fit_kwds):
+        """experimental fit the model subject to zero constraints
+
+        Intended for internal use cases until we know what we need.
+        API will need to change to handle models with two exog.
+
+        This is essentially a simplified version of `fit_constrained`, and does not need
+        to use `offset`.
+
+        The estimation creates a new model with transformed design matrix,
+        exog, and converts the results back to the original parameterization.
+
+        Some subclasses could use a more efficient calculation than using a new model.
+
+        Parameters
+        ----------
+        keep_index : array_like (int or bool) or slice
+            variables that should be dropped.
+        start_params : None or array_like
+            starting values for the optimization. `start_params` needs to be
+            given in the original parameter space and are internally
+            transformed.
+        **fit_kwds : keyword arguments
+            fit_kwds are used in the optimization of the transformed model.
+
+        Returns
+        -------
+        results : Results instance
+
+        """
+
+        # not all models support start_params, drop if None, hide them in fit_kwds
+        if start_params is not None:
+            fit_kwds['start_params'] = start_params
+
+        # build auxiliary model and fit
+        init_kwds = self._get_init_kwds()
+        mod_constr = self.__class__(self.endog, self.exog[:, keep_index], **init_kwds)
+        res_constr = mod_constr.fit(**fit_kwds)
+
+        # create dummy results Instance, TODO: wire up properly
+        # TODO: this could be moved into separate private method if needed
+        # discrete L1 fit_regularized doens't reestimate AFAICS
+        #res = self.fit(maxiter=0, method='nm', disp=0,
+        # RLM doesn't have method, disp nor warn_convergence keywords
+        # OLS, WLS swallows extra kwds with **kwargs, but doesn't have method='nm'
+        try:
+            res = self.fit(maxiter=0, disp=0, method='nm',
+                           warn_convergence=False) # we get a wrapper back
+        except (TypeError, ValueError):
+            res = self.fit()
+
+        # Warning: make sure we are not just changing the wrapper instead of results #2400
+        if hasattr(res_constr.model, 'scale'):
+            # GLM problem, see #2399
+            res.model.scale = res._results.scale = res_constr.model.scale
+
+        if hasattr(res_constr, 'mle_retvals'):
+            # not available for not scipy optimization, e.g. glm irls
+            res.mle_retvals['fcall'] = res_constr.mle_retvals.get('fcall', np.nan)
+            res.mle_retvals['iterations'] = res_constr.mle_retvals.get(
+                                                            'iterations', np.nan)
+            res.mle_retvals['converged'] = res_constr.mle_retvals['converged']
+
+        # wee need to append index of extra params to keep_index as in NegativeBinomial
+        if hasattr(self, 'k_extra') and self.k_extra > 0:
+            # we cannot change the original, TODO: should we add keep_index_params?
+            import copy
+            keep_index = copy.copy(keep_index)
+            keep_index.extend(list(range(len(res.params)))[-self.k_extra:])
+
+        res._results.params[...] = 0
+        res._results.params[keep_index] = res_constr.params
+        # TODO: sandwiches, add cov_params_default ?
+        # fanxy indexing requires integer attay
+        keep_index = np.array(keep_index)
+        res._results.normalized_cov_params[...] = 0
+        res._results.normalized_cov_params[keep_index[:, None], keep_index] = res_constr.normalized_cov_params
+        k_constr = res_constr.df_resid - res._results.df_resid
+        res._results.keep_index = keep_index
+        res._results.df_resid = res_constr.df_resid
+        res._results.df_model = res_constr.df_model
+
+        res._results.k_constr = k_constr
+        res._results.results_constrained = res_constr
+
+        # special temporary workaround for RLM
+        # need to be able to override robust covariances
+        if hasattr(res.model, 'M'):
+            del res._results._cache['resid']
+            del res._results._cache['fittedvalues']
+            del res._results._cache['sresid']
+            cov = res._results._cache['bcov_scaled']
+            # inplace adjustment
+            cov[...] = 0
+            cov[keep_index[:, None], keep_index] = res_constr.bcov_scaled
+            res._results.cov_params_default = cov
+
+
+        return res
+
+
 #TODO: the below is unfinished
 class GenericLikelihoodModel(LikelihoodModel):
     """

--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -474,7 +474,8 @@ class LikelihoodModel(Model):
         return mlefit
 
 
-    def _fit_zeros(self, keep_index=None, start_params=None, return_auxiliary=False, **fit_kwds):
+    def _fit_zeros(self, keep_index=None, start_params=None, return_auxiliary=False,
+                   k_params=None, **fit_kwds):
         """experimental fit the model subject to zero constraints
 
         Intended for internal use cases until we know what we need.
@@ -496,6 +497,8 @@ class LikelihoodModel(Model):
             starting values for the optimization. `start_params` needs to be
             given in the original parameter space and are internally
             transformed.
+        k_params : int or None
+            If None, then we try to infer from start_params or model.
         **fit_kwds : keyword arguments
             fit_kwds are used in the optimization of the transformed model.
 
@@ -516,6 +519,7 @@ class LikelihoodModel(Model):
         # not all models support start_params, drop if None, hide them in fit_kwds
         if start_params is not None:
             fit_kwds['start_params'] = start_params[keep_index_p]
+            k_params = len(start_params) # ignore k_params in this case, or verify consisteny?
 
         # build auxiliary model and fit
         init_kwds = self._get_init_kwds()
@@ -524,6 +528,15 @@ class LikelihoodModel(Model):
         #switch name, only need keep_index for params belos
         keep_index = keep_index_p
 
+        if k_params is None:
+            k_params = self.exog.shape[1]
+            k_params += getattr(self, 'k_extra', 0)
+
+
+        params_full = np.zeros(k_params)
+        params_full[keep_index] = res_constr.params
+
+
         # create dummy results Instance, TODO: wire up properly
         # TODO: this could be moved into separate private method if needed
         # discrete L1 fit_regularized doens't reestimate AFAICS
@@ -531,8 +544,10 @@ class LikelihoodModel(Model):
         # RLM doesn't have method, disp nor warn_convergence keywords
         # OLS, WLS swallows extra kwds with **kwargs, but doesn't have method='nm'
         try:
-            res = self.fit(maxiter=0, disp=0, method='nm',
-                           warn_convergence=False) # we get a wrapper back
+            # Note: addding full_output=False causes currently exceptions
+            res = self.fit(maxiter=0, disp=0, method='nm', skip_hessian=True,
+                           warn_convergence=False, start_params=params_full)
+            # we get a wrapper back
         except (TypeError, ValueError):
             res = self.fit()
 
@@ -542,19 +557,17 @@ class LikelihoodModel(Model):
             res.model.scale = res._results.scale = res_constr.model.scale
 
         if hasattr(res_constr, 'mle_retvals'):
+            res.mle_retvals = res_constr.mle_retvals
             # not available for not scipy optimization, e.g. glm irls
-            res.mle_retvals['fcall'] = res_constr.mle_retvals.get('fcall', np.nan)
-            res.mle_retvals['iterations'] = res_constr.mle_retvals.get(
-                                                            'iterations', np.nan)
-            res.mle_retvals['converged'] = res_constr.mle_retvals['converged']
+#             res.mle_retvals['fcall'] = res_constr.mle_retvals.get('fcall', np.nan)
+#             res.mle_retvals['iterations'] = res_constr.mle_retvals.get(
+#                                                             'iterations', np.nan)
+#             res.mle_retvals['converged'] = res_constr.mle_retvals['converged']
             # overwrite all settings
             #res.mle_retvals.update(res_constr.mle_retvals)  #not yet
             res.mle_settings.update(res_constr.mle_settings)
 
-
-        k_params = len(res._results.params)
-        res._results.params[...] = 0
-        res._results.params[keep_index] = res_constr.params
+        res._results.params = params_full
         if not hasattr(res._results, 'normalized_cov_param') or res._results.normalized_cov_param is None:
             res._results.normalized_cov_params = np.zeros((k_params, k_params))
         else:

--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -504,15 +504,25 @@ class LikelihoodModel(Model):
         results : Results instance
 
         """
+        # wee need to append index of extra params to keep_index as in NegativeBinomial
+        if hasattr(self, 'k_extra') and self.k_extra > 0:
+            # we cannot change the original, TODO: should we add keep_index_params?
+            keep_index = np.array(keep_index, copy=True)
+            keep_index_p = np.concatenate((keep_index,
+                                           list(range(self.exog.shape[1] + self.k_extra))[-self.k_extra:]))
+        else:
+            keep_index_p = keep_index
 
         # not all models support start_params, drop if None, hide them in fit_kwds
         if start_params is not None:
-            fit_kwds['start_params'] = start_params
+            fit_kwds['start_params'] = start_params[keep_index_p]
 
         # build auxiliary model and fit
         init_kwds = self._get_init_kwds()
         mod_constr = self.__class__(self.endog, self.exog[:, keep_index], **init_kwds)
         res_constr = mod_constr.fit(**fit_kwds)
+        #switch name, only need keep_index for params belos
+        keep_index = keep_index_p
 
         # create dummy results Instance, TODO: wire up properly
         # TODO: this could be moved into separate private method if needed
@@ -538,21 +548,23 @@ class LikelihoodModel(Model):
                                                             'iterations', np.nan)
             res.mle_retvals['converged'] = res_constr.mle_retvals['converged']
 
-        # wee need to append index of extra params to keep_index as in NegativeBinomial
-        if hasattr(self, 'k_extra') and self.k_extra > 0:
-            # we cannot change the original, TODO: should we add keep_index_params?
-            import copy
-            keep_index = copy.copy(keep_index)
-            keep_index.extend(list(range(len(res.params)))[-self.k_extra:])
 
+        k_params = len(res._results.params)
         res._results.params[...] = 0
         res._results.params[keep_index] = res_constr.params
+        if not hasattr(res._results, 'normalized_cov_param') or res._results.normalized_cov_param is None:
+            res._results.normalized_cov_params = np.zeros((k_params, k_params))
+        else:
+            res._results.normalized_cov_params[...] = 0
+
         # TODO: sandwiches, add cov_params_default ?
         # fanxy indexing requires integer attay
         keep_index = np.array(keep_index)
-        res._results.normalized_cov_params[...] = 0
         res._results.normalized_cov_params[keep_index[:, None], keep_index] = res_constr.normalized_cov_params
         k_constr = res_constr.df_resid - res._results.df_resid
+        if hasattr(res_constr, 'cov_params_default'):
+            res._results.cov_params_default = np.zeros((k_params, k_params))
+            res._results.cov_params_default[keep_index[:, None], keep_index] = res_constr.cov_params_default
         res._results.keep_index = keep_index
         res._results.df_resid = res_constr.df_resid
         res._results.df_model = res_constr.df_model
@@ -574,6 +586,18 @@ class LikelihoodModel(Model):
 
 
         return res
+
+
+    def _fit_collinear(self, atol=1e-14, rtol=1e-13, **kwds):
+
+        # ------ copied from PR #2380 remove when merged
+        x = self.exog
+        tol = atol + rtol * x.var(0)
+        r = np.linalg.qr(x, mode='r')
+        mask = np.abs(r.diagonal()) < np.sqrt(tol)
+        #idx_collinear = np.where(mask)[0]
+        idx_keep = np.where(~mask)[0]
+        return self._fit_zeros(keep_index=idx_keep, **kwds)
 
 
 #TODO: the below is unfinished

--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -581,6 +581,10 @@ class LikelihoodModel(Model):
         if hasattr(res_constr, 'cov_params_default'):
             res._results.cov_params_default = np.zeros((k_params, k_params))
             res._results.cov_params_default[keep_index[:, None], keep_index] = res_constr.cov_params_default
+        if hasattr(res_constr, 'cov_type'):
+            res._results.cov_type = res_constr.cov_type
+            res._results.cov_kwds = res_constr.cov_kwds
+
         res._results.keep_index = keep_index
         res._results.df_resid = res_constr.df_resid
         res._results.df_model = res_constr.df_model

--- a/statsmodels/base/tests/test_generic_methods.py
+++ b/statsmodels/base/tests/test_generic_methods.py
@@ -257,9 +257,10 @@ class CheckGenericMixin(object):
 
         if use_start_params:
             start_params = np.zeros(k_vars + k_extra)
+            method =  self.results.mle_settings['optimizer']  #string not mutable
             sp =  self.results.mle_settings['start_params'].copy()
             start_params[keep_index_p] = sp #self.results.params
-            res1 = mod._fit_collinear(start_params=start_params)
+            res1 = mod._fit_collinear(start_params=start_params, method=method)
         else:
             res1 = mod._fit_collinear()
 

--- a/statsmodels/base/tests/test_generic_methods.py
+++ b/statsmodels/base/tests/test_generic_methods.py
@@ -287,17 +287,17 @@ class CheckGenericMixin(object):
 
         if hasattr(res1, 'resid'):
             # discrete models, Logit don't have `resid` yet
-            assert_allclose(res1.resid, res2.resid, rtol=1e-10)
+            assert_allclose(res1.resid, res2.resid, rtol=1e-6, atol=1e-13)
 
         ex = res1.model.exog.mean(0)
         predicted1 = res1.predict(ex)
         predicted2 = res2.predict(ex[keep_index])
-        assert_allclose(predicted1, predicted2, rtol=1e-10)
+        assert_allclose(predicted1, predicted2, rtol=1e-8, atol=1e-13)
 
         ex = res1.model.exog[:5]
         predicted1 = res1.predict(ex)
         predicted2 = res2.predict(ex[:, keep_index])
-        assert_allclose(predicted1, predicted2, rtol=1e-10)
+        assert_allclose(predicted1, predicted2, rtol=1e-8, atol=1e-13)
 
 
 

--- a/statsmodels/base/tests/test_generic_methods.py
+++ b/statsmodels/base/tests/test_generic_methods.py
@@ -159,6 +159,66 @@ class CheckGenericMixin(object):
 #             assert_allclose(predicted, fitted, rtol=1e-12)
 
 
+    def test_zero_constrained(self):
+        # not completely generic yet
+        if (isinstance(self.results.model, (sm.GEE))):#, sm.OLS, sm.WLS))):
+            raise SkipTest
+
+        use_start_params = not isinstance(self.results.model, (sm.RLM, sm.OLS, sm.WLS,
+                                                               sm.NegativeBinomial))
+        self.use_start_params = use_start_params  # attach for _get_constrained
+
+        keep_index = list(range(self.results.model.exog.shape[1]))
+        # index for params might include extra params
+        keep_index_p = list(range(self.results.params.shape[0]))
+        drop_index = [1]
+        for i in drop_index:
+            del keep_index[i]
+            del keep_index_p[i]
+
+        if use_start_params:
+            res1 = self.results.model._fit_zeros(keep_index,
+                                                 start_params=self.results.params[keep_index])
+        else:
+            res1 = self.results.model._fit_zeros(keep_index)
+
+        res2 = self._get_constrained(keep_index, keep_index_p)
+
+        assert_allclose(res1.params[keep_index_p], res2.params, rtol=1e-10)
+        assert_allclose(res1.params[drop_index], 0, rtol=1e-10)
+        assert_allclose(res1.bse[keep_index_p], res2.bse, rtol=1e-10)
+        assert_allclose(res1.bse[drop_index], 0, rtol=1e-10)
+        assert_allclose(res1.tvalues[keep_index_p], res2.tvalues, rtol=1e-10)
+        assert_allclose(res1.pvalues[keep_index_p], res2.pvalues, rtol=1e-10)
+
+        if hasattr(res1, 'resid'):
+            # discrete models, Logit don't have `resid` yet
+            assert_allclose(res1.resid, res2.resid, rtol=1e-10)
+
+        ex = self.results.model.exog.mean(0)
+        predicted1 = res1.predict(ex)
+        predicted2 = res2.predict(ex[keep_index])
+        assert_allclose(predicted1, predicted2, rtol=1e-10)
+
+        ex = self.results.model.exog[:5]
+        predicted1 = res1.predict(ex)
+        predicted2 = res2.predict(ex[:, keep_index])
+        assert_allclose(predicted1, predicted2, rtol=1e-10)
+
+
+    def _get_constrained(self, keep_index, keep_index_p):
+        # override in some test classes, no fit_kwds yet, e.g. cov_type
+        mod2 = self.results.model
+        mod_cls = mod2.__class__
+        init_kwds = mod2._get_init_kwds()
+        mod = mod_cls(mod2.endog, mod2.exog[:, keep_index], **init_kwds)
+        if self.use_start_params:
+            res = mod.fit(start_params=self.results.params[keep_index_p])
+        else:
+            res = mod.fit()
+        return res
+
+
 #########  subclasses for individual models, unchanged from test_shrink_pickle
 # TODO: check if setup_class is faster than setup
 
@@ -181,6 +241,11 @@ class TestGenericOLSOneExog(CheckGenericMixin):
         np.random.seed(987689)
         y = x + np.random.randn(x.shape[0])
         self.results = sm.OLS(y, x).fit()
+
+    def test_zero_constrained(self):
+        # override, we cannot remove the only regressor
+        #raise SkipTest
+        pass
 
 
 class TestGenericWLS(CheckGenericMixin):
@@ -208,6 +273,7 @@ class TestGenericPoisson(CheckGenericMixin):
 
         #TODO: temporary, fixed in master
         self.predict_kwds = dict(exposure=1, offset=0)
+
 
 class TestGenericNegativeBinomial(CheckGenericMixin):
 

--- a/statsmodels/base/tests/test_generic_methods.py
+++ b/statsmodels/base/tests/test_generic_methods.py
@@ -260,7 +260,7 @@ class CheckGenericMixin(object):
             method =  self.results.mle_settings['optimizer']  #string not mutable
             sp =  self.results.mle_settings['start_params'].copy()
             start_params[keep_index_p] = sp #self.results.params
-            res1 = mod._fit_collinear(start_params=start_params, method=method)
+            res1 = mod._fit_collinear(start_params=start_params, method=method, disp=0)
         else:
             res1 = mod._fit_collinear()
 
@@ -287,17 +287,17 @@ class CheckGenericMixin(object):
 
         if hasattr(res1, 'resid'):
             # discrete models, Logit don't have `resid` yet
-            assert_allclose(res1.resid, res2.resid, rtol=1e-6, atol=1e-13)
+            assert_allclose(res1.resid, res2.resid, rtol=1e-6, atol=1e-11)
 
         ex = res1.model.exog.mean(0)
         predicted1 = res1.predict(ex)
         predicted2 = res2.predict(ex[keep_index])
-        assert_allclose(predicted1, predicted2, rtol=1e-8, atol=1e-13)
+        assert_allclose(predicted1, predicted2, rtol=1e-8, atol=1e-11)
 
         ex = res1.model.exog[:5]
         predicted1 = res1.predict(ex)
         predicted2 = res2.predict(ex[:, keep_index])
-        assert_allclose(predicted1, predicted2, rtol=1e-8, atol=1e-13)
+        assert_allclose(predicted1, predicted2, rtol=1e-8, atol=1e-11)
 
 
 
@@ -364,11 +364,15 @@ class TestGenericNegativeBinomial(CheckGenericMixin):
         np.random.seed(987689)
         data = sm.datasets.randhie.load()
         exog = sm.add_constant(data.exog, prepend=False)
-        mod = sm.NegativeBinomial(data.endog, data.exog)
-        start_params = np.array([-0.0565406 , -0.21213599,  0.08783076,
+        #mod = sm.NegativeBinomial(data.endog, data.exog)
+        mod = sm.NegativeBinomial(data.endog, exog)
+        start_params = np.array([0.1, -0.0565406 , -0.21213599,  0.08783076,
                                  -0.02991835,  0.22901974,  0.0621026,
                                   0.06799283,  0.08406688,  0.18530969,
                                   1.36645452])
+        start_params = np.array([-0.05783623, -0.26655806,  0.04109148, -0.03815837,
+                                 0.2685168 ,   0.03811594, -0.04426238,  0.01614795,
+                                 0.17490962,  0.66461151,   1.2925957 ])
         self.results = mod.fit(start_params=start_params, disp=0)
 
 

--- a/statsmodels/base/tests/test_generic_methods.py
+++ b/statsmodels/base/tests/test_generic_methods.py
@@ -178,7 +178,7 @@ class CheckGenericMixin(object):
 
         if use_start_params:
             res1 = self.results.model._fit_zeros(keep_index,
-                                                 start_params=self.results.params[keep_index])
+                                                 start_params=self.results.params)#[keep_index])
         else:
             res1 = self.results.model._fit_zeros(keep_index)
 
@@ -217,6 +217,76 @@ class CheckGenericMixin(object):
         else:
             res = mod.fit()
         return res
+
+
+    def test_zero_collinear(self):
+        # not completely generic yet
+        if (isinstance(self.results.model, (sm.GEE))):#, sm.OLS, sm.WLS))):
+            raise SkipTest
+
+        use_start_params = not isinstance(self.results.model, (sm.RLM, sm.OLS, sm.WLS, sm.GLM))
+                                                               #sm.NegativeBinomial))
+        self.use_start_params = use_start_params  # attach for _get_constrained
+
+        keep_index = list(range(self.results.model.exog.shape[1]))
+        # index for params might include extra params
+        keep_index_p = list(range(self.results.params.shape[0]))
+        drop_index = []
+        for i in drop_index:
+            del keep_index[i]
+            del keep_index_p[i]
+
+        keep_index_p = list(range(self.results.params.shape[0]))
+
+        #create collinear model
+        mod2 = self.results.model
+        mod_cls = mod2.__class__
+        init_kwds = mod2._get_init_kwds()
+        ex = np.column_stack((mod2.exog, mod2.exog))
+        mod = mod_cls(mod2.endog, ex, **init_kwds)
+
+        keep_index = list(range(self.results.model.exog.shape[1]))
+        keep_index_p = list(range(self.results.model.exog.shape[1]))
+        k_vars = ex.shape[1]
+        k_extra = 0
+        if hasattr(mod, 'k_extra') and mod.k_extra > 0:
+            keep_index_p += list(range(k_vars, k_vars + mod.k_extra))
+            k_extra = mod.k_extra
+
+
+
+        if use_start_params:
+            start_params = np.zeros(k_vars + k_extra)
+            sp =  self.results.mle_settings['start_params'].copy()
+            start_params[keep_index_p] = sp #self.results.params
+            res1 = mod._fit_collinear(start_params=start_params)
+        else:
+            res1 = mod._fit_collinear()
+
+        #res2 = self._get_constrained(keep_index, keep_index_p)
+        res2 = self.results
+
+        # Poisson has reduced precision in params, difficult optimization?
+        assert_allclose(res1.params[keep_index_p], res2.params, rtol=1e-6) #rtol=1e-10)
+        assert_allclose(res1.params[drop_index], 0, rtol=1e-10)
+        assert_allclose(res1.bse[keep_index_p], res2.bse, rtol=1e-10)
+        assert_allclose(res1.bse[drop_index], 0, rtol=1e-10)
+        assert_allclose(res1.tvalues[keep_index_p], res2.tvalues, rtol=1e-10)
+        assert_allclose(res1.pvalues[keep_index_p], res2.pvalues, rtol=1e-10)
+
+        if hasattr(res1, 'resid'):
+            # discrete models, Logit don't have `resid` yet
+            assert_allclose(res1.resid, res2.resid, rtol=1e-10)
+
+        ex = res1.model.exog.mean(0)
+        predicted1 = res1.predict(ex)
+        predicted2 = res2.predict(ex[keep_index])
+        assert_allclose(predicted1, predicted2, rtol=1e-10)
+
+        ex = res1.model.exog[:5]
+        predicted1 = res1.predict(ex)
+        predicted2 = res2.predict(ex[:, keep_index])
+        assert_allclose(predicted1, predicted2, rtol=1e-10)
 
 
 #########  subclasses for individual models, unchanged from test_shrink_pickle

--- a/statsmodels/base/tests/test_generic_methods.py
+++ b/statsmodels/base/tests/test_generic_methods.py
@@ -272,8 +272,8 @@ class CheckGenericMixin(object):
         assert_allclose(res1.params[drop_index], 0, rtol=1e-10)
         assert_allclose(res1.bse[keep_index_p], res2.bse, rtol=1e-10)
         assert_allclose(res1.bse[drop_index], 0, rtol=1e-10)
-        assert_allclose(res1.tvalues[keep_index_p], res2.tvalues, rtol=1e-10)
-        assert_allclose(res1.pvalues[keep_index_p], res2.pvalues, rtol=1e-10)
+        assert_allclose(res1.tvalues[keep_index_p], res2.tvalues, rtol=1e-8)
+        assert_allclose(res1.pvalues[keep_index_p], res2.pvalues, rtol=1e-6, atol=1e-30)
 
         if hasattr(res1, 'resid'):
             # discrete models, Logit don't have `resid` yet

--- a/statsmodels/base/tests/test_generic_methods.py
+++ b/statsmodels/base/tests/test_generic_methods.py
@@ -253,51 +253,69 @@ class CheckGenericMixin(object):
             keep_index_p += list(range(k_vars, k_vars + mod.k_extra))
             k_extra = mod.k_extra
 
+        cov_types = ['nonrobust', 'HC0']
 
+        for cov_type in cov_types:
+            if cov_type != 'nonrobust' and (isinstance(self.results.model, (sm.RLM))):
+                raise SkipTest
 
-        if use_start_params:
-            start_params = np.zeros(k_vars + k_extra)
-            method =  self.results.mle_settings['optimizer']  #string not mutable
-            sp =  self.results.mle_settings['start_params'].copy()
-            start_params[keep_index_p] = sp #self.results.params
-            res1 = mod._fit_collinear(start_params=start_params, method=method, disp=0)
-        else:
-            res1 = mod._fit_collinear()
+            if use_start_params:
+                start_params = np.zeros(k_vars + k_extra)
+                method =  self.results.mle_settings['optimizer']  #string not mutable
+                sp =  self.results.mle_settings['start_params'].copy()
+                start_params[keep_index_p] = sp #self.results.params
+                res1 = mod._fit_collinear(cov_type=cov_type, start_params=start_params,
+                                          method=method, disp=0)
+                if cov_type != 'nonrobust':
+                    # reestimate original model to get robust cov
+                    res2 = self.results.model.fit(cov_type=cov_type,
+                                             start_params=sp,
+                                             method=method, disp=0)
+            else:
+                # more special casing RLM
+                if (isinstance(self.results.model, (sm.RLM))):
+                    res1 = mod._fit_collinear()
+                else:
+                    res1 = mod._fit_collinear(cov_type=cov_type)
+                if cov_type != 'nonrobust':
+                    # reestimate original model to get robust cov
+                    res2 = self.results.model.fit(cov_type=cov_type)
 
-        #res2 = self._get_constrained(keep_index, keep_index_p)
-        res2 = self.results
+            #res2 = self._get_constrained(keep_index, keep_index_p)
+            if cov_type == 'nonrobust':
+                res2 = self.results
 
-        # check fit optimizer arguments, if mle_settings is available
-        if hasattr(res2, 'mle_settings'):
-            assert_equal(res1.results_constrained.mle_settings['optimizer'],
-                         res2.mle_settings['optimizer'])
-            assert_allclose(res1.results_constrained.mle_settings['start_params'],
-                            res2.mle_settings['start_params'], rtol=1e-10, atol=1e-20)
-            assert_equal(res1.mle_settings['optimizer'], res2.mle_settings['optimizer'])
-            assert_allclose(res1.mle_settings['start_params'],
-                            res2.mle_settings['start_params'], rtol=1e-10, atol=1e-20)
+            # check fit optimizer arguments, if mle_settings is available
+            if hasattr(res2, 'mle_settings'):
+                assert_equal(res1.results_constrained.mle_settings['optimizer'],
+                             res2.mle_settings['optimizer'])
+                assert_allclose(res1.results_constrained.mle_settings['start_params'],
+                                res2.mle_settings['start_params'], rtol=1e-10, atol=1e-20)
+                assert_equal(res1.mle_settings['optimizer'], res2.mle_settings['optimizer'])
+                assert_allclose(res1.mle_settings['start_params'],
+                                res2.mle_settings['start_params'], rtol=1e-10, atol=1e-20)
 
-        # Poisson has reduced precision in params, difficult optimization?
-        assert_allclose(res1.params[keep_index_p], res2.params, rtol=1e-6) #rtol=1e-10)
-        assert_allclose(res1.params[drop_index], 0, rtol=1e-10)
-        assert_allclose(res1.bse[keep_index_p], res2.bse, rtol=1e-10)
-        assert_allclose(res1.bse[drop_index], 0, rtol=1e-10)
-        assert_allclose(res1.tvalues[keep_index_p], res2.tvalues, rtol=1e-8)
-        assert_allclose(res1.pvalues[keep_index_p], res2.pvalues, rtol=1e-6, atol=1e-30)
+            # Poisson has reduced precision in params, difficult optimization?
+            assert_allclose(res1.params[keep_index_p], res2.params, rtol=1e-6) #rtol=1e-10)
+            assert_allclose(res1.params[drop_index], 0, rtol=1e-10)
+            assert_allclose(res1.bse[keep_index_p], res2.bse, rtol=1e-10)
+            assert_allclose(res1.bse[drop_index], 0, rtol=1e-10)
+            assert_allclose(res1.tvalues[keep_index_p], res2.tvalues, rtol=1e-8)
+            assert_allclose(res1.pvalues[keep_index_p], res2.pvalues, rtol=1e-6, atol=1e-30)
 
-        if hasattr(res1, 'resid'):
-            # discrete models, Logit don't have `resid` yet
-            assert_allclose(res1.resid, res2.resid, rtol=1e-5, atol=1e-10)
+            if hasattr(res1, 'resid'):
+                # discrete models, Logit don't have `resid` yet
+                assert_allclose(res1.resid, res2.resid, rtol=1e-5, atol=1e-10)
 
-        ex = res1.model.exog.mean(0)
-        predicted1 = res1.predict(ex)
-        predicted2 = res2.predict(ex[keep_index])
-        assert_allclose(predicted1, predicted2, rtol=1e-8, atol=1e-11)
+            ex = res1.model.exog.mean(0)
+            predicted1 = res1.predict(ex)
+            predicted2 = res2.predict(ex[keep_index])
+            assert_allclose(predicted1, predicted2, rtol=1e-8, atol=1e-11)
 
-        ex = res1.model.exog[:5]
-        predicted1 = res1.predict(ex)
-        predicted2 = res2.predict(ex[:, keep_index])
-        assert_allclose(predicted1, predicted2, rtol=1e-8, atol=1e-11)
+            ex = res1.model.exog[:5]
+            predicted1 = res1.predict(ex)
+            predicted2 = res2.predict(ex[:, keep_index])
+            assert_allclose(predicted1, predicted2, rtol=1e-8, atol=1e-11)
 
 
 

--- a/statsmodels/base/tests/test_generic_methods.py
+++ b/statsmodels/base/tests/test_generic_methods.py
@@ -267,6 +267,16 @@ class CheckGenericMixin(object):
         #res2 = self._get_constrained(keep_index, keep_index_p)
         res2 = self.results
 
+        # check fit optimizer arguments, if mle_settings is available
+        if hasattr(res2, 'mle_settings'):
+            assert_equal(res1.results_constrained.mle_settings['optimizer'],
+                         res2.mle_settings['optimizer'])
+            assert_allclose(res1.results_constrained.mle_settings['start_params'],
+                            res2.mle_settings['start_params'], rtol=1e-10, atol=1e-20)
+            assert_equal(res1.mle_settings['optimizer'], res2.mle_settings['optimizer'])
+            assert_allclose(res1.mle_settings['start_params'],
+                            res2.mle_settings['start_params'], rtol=1e-10, atol=1e-20)
+
         # Poisson has reduced precision in params, difficult optimization?
         assert_allclose(res1.params[keep_index_p], res2.params, rtol=1e-6) #rtol=1e-10)
         assert_allclose(res1.params[drop_index], 0, rtol=1e-10)
@@ -289,15 +299,6 @@ class CheckGenericMixin(object):
         predicted2 = res2.predict(ex[:, keep_index])
         assert_allclose(predicted1, predicted2, rtol=1e-10)
 
-        # check fit optimizer arguments, if mle_settings is available
-        if hasattr(res2, 'mle_settings'):
-            assert_equal(res1.results_constrained.mle_settings['optimizer'],
-                         res2.mle_settings['optimizer'])
-            assert_allclose(res1.results_constrained.mle_settings['start_params'],
-                            res2.mle_settings['start_params'], rtol=1e-10, atol=1e-20)
-            assert_equal(res1.mle_settings['optimizer'], res2.mle_settings['optimizer'])
-            assert_allclose(res1.mle_settings['start_params'],
-                            res2.mle_settings['start_params'], rtol=1e-10, atol=1e-20)
 
 
 #########  subclasses for individual models, unchanged from test_shrink_pickle

--- a/statsmodels/base/tests/test_generic_methods.py
+++ b/statsmodels/base/tests/test_generic_methods.py
@@ -289,6 +289,16 @@ class CheckGenericMixin(object):
         predicted2 = res2.predict(ex[:, keep_index])
         assert_allclose(predicted1, predicted2, rtol=1e-10)
 
+        # check fit optimizer arguments, if mle_settings is available
+        if hasattr(res2, 'mle_settings'):
+            assert_equal(res1.results_constrained.mle_settings['optimizer'],
+                         res2.mle_settings['optimizer'])
+            assert_allclose(res1.results_constrained.mle_settings['start_params'],
+                            res2.mle_settings['start_params'], rtol=1e-10, atol=1e-20)
+            assert_equal(res1.mle_settings['optimizer'], res2.mle_settings['optimizer'])
+            assert_allclose(res1.mle_settings['start_params'],
+                            res2.mle_settings['start_params'], rtol=1e-10, atol=1e-20)
+
 
 #########  subclasses for individual models, unchanged from test_shrink_pickle
 # TODO: check if setup_class is faster than setup

--- a/statsmodels/base/tests/test_generic_methods.py
+++ b/statsmodels/base/tests/test_generic_methods.py
@@ -287,7 +287,7 @@ class CheckGenericMixin(object):
 
         if hasattr(res1, 'resid'):
             # discrete models, Logit don't have `resid` yet
-            assert_allclose(res1.resid, res2.resid, rtol=1e-6, atol=1e-11)
+            assert_allclose(res1.resid, res2.resid, rtol=1e-5, atol=1e-10)
 
         ex = res1.model.exog.mean(0)
         predicted1 = res1.predict(ex)

--- a/statsmodels/base/tests/test_penalized.py
+++ b/statsmodels/base/tests/test_penalized.py
@@ -131,6 +131,9 @@ class TestPenalizedPoissonOracleHC(CheckPenalizedPoisson):
         res2 = self.res2
 
         assert_equal(self.res1.cov_type, 'HC0')
+        cov_kwds = {'description': 'Standard Errors are heteroscedasticity robust (HC0)',
+                    'adjust_df': False, 'use_t': False, 'scaling_factor': None}
+        assert_equal(self.res1.cov_kwds, cov_kwds)
         # numbers are regression test using bfgs
         params = np.array([0.96817787574701109, 0.43674374940137434,
                            0.33096260487556745, 0.27415680046693747])
@@ -220,8 +223,13 @@ class TestPenalizedPoissonOraclePenalized2HC(CheckPenalizedPoisson):
         res1 = self.res1
         res2 = self.res2
 
-        #assert_equal(self.res1.cov_type, 'HC0')
+        assert_equal(self.res1.cov_type, 'HC0')
         assert_equal(self.res1.results_constrained.cov_type, 'HC0')
+        cov_kwds = {'description': 'Standard Errors are heteroscedasticity robust (HC0)',
+                    'adjust_df': False, 'use_t': False, 'scaling_factor': None}
+        assert_equal(self.res1.cov_kwds, cov_kwds)
+        assert_equal(self.res1.cov_kwds, self.res1.results_constrained.cov_kwds)
+
         # numbers are regression test using bfgs
         params = np.array([0.9681779773984035, 0.43674302990429331,
                            0.33096262545149246, 0.27415839700062317])

--- a/statsmodels/base/tests/test_penalized.py
+++ b/statsmodels/base/tests/test_penalized.py
@@ -1,0 +1,147 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Sun May 10 12:39:33 2015
+
+Author: Josef Perktold
+License: BSD-3
+"""
+
+import numpy as np
+from numpy.testing import assert_allclose, assert_equal
+from statsmodels.discrete.discrete_model import Poisson, Logit, Probit
+from statsmodels.base._penalized import PenalizedMixin
+import statsmodels.base._penalties as smpen
+
+class PoissonPenalized(PenalizedMixin, Poisson):
+    pass
+
+class LogitPenalized(PenalizedMixin, Logit):
+    pass
+
+class ProbitPenalized(PenalizedMixin, Probit):
+    pass
+
+
+class CheckPenalizedPoisson(object):
+
+
+    @classmethod
+    def setup_class(cls):
+        # simulate data
+        np.random.seed(987865)
+
+        nobs, k_vars = 500, 10
+        k_nonzero = 4
+        x = (np.random.rand(nobs, k_vars) + 0.5* (np.random.rand(nobs, 1)-0.5)) * 2 - 1
+        x *= 1.2
+        x[:, 0] = 1
+        beta = np.zeros(k_vars)
+        beta[:k_nonzero] = 1. / np.arange(1, k_nonzero + 1)
+        linpred = x.dot(beta)
+        mu = np.exp(linpred)
+        y = np.random.poisson(mu)
+
+        cls.k_nonzero = k_nonzero
+        cls.x = x
+        cls.y = y
+
+        # defaults to be overwritten by subclasses
+        cls.rtol = 1e-4
+        cls.atol = 1e-6
+        cls.exog_index = slice(None, None, None)
+        cls.k_params = k_vars
+        cls._initialize()
+
+
+    def test_params_table(self):
+        res1 = self.res1
+        res2 = self.res2
+        assert_equal((res1.params != 0).sum(), self.k_params)
+        assert_allclose(res1.params[self.exog_index], res2.params, rtol=self.rtol, atol=self.atol)
+        assert_allclose(res1.bse[self.exog_index], res2.bse, rtol=self.rtol, atol=self.atol)
+        assert_allclose(res1.pvalues[self.exog_index], res2.pvalues, rtol=self.rtol, atol=self.atol)
+        assert_allclose(res1.predict(), res2.predict(), rtol=0.05)
+
+    def test_smoke(self):
+        self.res1.summary()
+
+
+
+class TestPenalizedPoissonNoPenal(CheckPenalizedPoisson):
+    # TODO: check, adjust cov_type
+
+    @classmethod
+    def _initialize(cls):
+        y, x = cls.y, cls.x
+
+        modp = Poisson(y, x)
+        cls.res2 = modp.fit()
+
+        mod = PoissonPenalized(y, x)
+        mod.pen_weight = 0
+        cls.res1 = mod.fit(method='bfgs', maxiter=100)
+
+
+class TestPenalizedPoissonOracle(CheckPenalizedPoisson):
+    # TODO: check, adjust cov_type
+
+    @classmethod
+    def _initialize(cls):
+        y, x = cls.y, cls.x
+        modp = Poisson(y, x[:, :cls.k_nonzero])
+        cls.res2 = modp.fit()
+
+        mod = PoissonPenalized(y, x)
+        mod.pen_weight *= 1.5
+        mod.penal.tau = 0.05
+        cls.res1 = mod.fit(method='bfgs', maxiter=100)
+
+        cls.exog_index = slice(None, cls.k_nonzero, None)
+
+        cls.atol = 5e-3
+
+
+class TestPenalizedPoissonOraclePenalized(CheckPenalizedPoisson):
+    # TODO: check, adjust cov_type
+
+    @classmethod
+    def _initialize(cls):
+        y, x = cls.y, cls.x
+        modp = PoissonPenalized(y, x[:, :cls.k_nonzero])
+        cls.res2 = modp.fit()
+
+        mod = PoissonPenalized(y, x)
+        #mod.pen_weight *= 1.5
+        #mod.penal.tau = 0.05
+        cls.res1 = mod.fit(method='bfgs', maxiter=100, trim=False)
+
+        cls.exog_index = slice(None, cls.k_nonzero, None)
+
+        cls.atol = 1e-3
+
+
+class TestPenalizedPoissonOraclePenalized2(CheckPenalizedPoisson):
+    # TODO: check, adjust cov_type
+
+    @classmethod
+    def _initialize(cls):
+        y, x = cls.y, cls.x
+        modp = PoissonPenalized(y, x[:, :cls.k_nonzero])
+        cls.res2 = modp.fit()
+
+        mod = PoissonPenalized(y, x)
+        mod.pen_weight *= 1.5  # meed to penalize more to get oracle selection
+        #mod.penal.tau = 0.05
+        cls.res1 = mod.fit(method='bfgs', maxiter=100, trim=True)
+
+        cls.exog_index = slice(None, cls.k_nonzero, None)
+
+        cls.atol = 1e-8
+        cls.k_params = cls.k_nonzero
+
+    def test_zeros(self):
+
+        # first test for trimmed result
+        assert_equal(self.res1.params[self.k_nonzero:], 0)
+        # we also set bse to zero, TODO: check fit_regularized
+        assert_equal(self.res1.bse[self.k_nonzero:], 0)

--- a/statsmodels/discrete/discrete_model.py
+++ b/statsmodels/discrete/discrete_model.py
@@ -2274,7 +2274,7 @@ class NegativeBinomial(CountModel):
             if np.size(offset) == 1 and offset == 0:
                 offset = None
             mod_poi = Poisson(self.endog, self.exog, offset=offset)
-            start_params = mod_poi.fit(disp=0).params
+            start_params = mod_poi.fit(disp=0, skip_hessian=True, full_output=False).params
             if self.loglike_method.startswith('nb'):
                 start_params = np.append(start_params, 0.1)
         mlefit = super(NegativeBinomial, self).fit(start_params=start_params,

--- a/statsmodels/regression/linear_model.py
+++ b/statsmodels/regression/linear_model.py
@@ -214,6 +214,8 @@ class RegressionModel(base.LikelihoodModel):
             # used in ANOVA
             self.effects = effects = np.dot(Q.T, self.wendog)
             beta = np.linalg.solve(R, effects)
+        else:
+            raise ValueError('method has to be "pinv" or "qr"')
 
         if self._df_model is None:
             self._df_model = float(self.rank - self.k_constant)


### PR DESCRIPTION
first commit is adding `base._penalties.SCAD`
hessian/deriv2 not tested yet

now also with `PenalizedMixin` and `_fit_zeros`

open questions:
- Runtime Warnings: by design if bse are zero, silence them or not?
- use `skip_hessian` if we don't use it, or only use it to get an array to overwrite 
  Runtime Warning "inverting hessian failed" in singular exog case, but we work around

**review penalties**
- I added axis 0 to the sum in return of `func`, so it can be used in vectorized form
- naming conventions: I have problems remembering `grad` instead of deriv or score or whatever
  also `weights` should be spelled out
- sum in `func` surprised me initially, but I guess it makes sense. 
- I haven't converted my examples to unit tests yet.
- analytical and default numerical second derivatives are missing. (needed for Hessian)
- other penalization functions (MCD, XXXNet versions to combine with L2)

**PenalizedMixin**

My initial notebook is here to try out different things http://nbviewer.ipython.org/gist/josef-pkt/1847e9af6092da12b192
I only used Poisson to check the more complete class

open issues
- many TODOs in first draft
- argument handling, signatures
- main missing requirement: creating results instance, need new helper method used in seveal places. I reuse `fit_constrained` for Poisson which is not available for many other models and is computationally inefficient because it doesn't special case dropping variables.
- I used `cov_type='HC0'` in some examples in notebook but it's not yet implemented and default in the Mixin
- possible problem with fit defaults if they are incompatible, I partially handled IRLS for GLM, but haven't tried it out yet.
- extension to other optimizers, Kerby's coordinate descend

**_fit_zeros and recreating results instances**

Since we need it in several places this includes now also a new method to fit zero restrictions (dropping variables) which can be reused by other `fit_xxx` methods. The main purpose was to get a trial version for creating a results instance for the full model from a reduced or reparameterized auxiliary model.

As application of `_fit_zeros` it also contains a new **_fit_collinear**

**References**

So far all my scad code is based on several article by Fan Li 2001, additional articles of either with co-authors.

They mention some R packages, and I just saw http://cran.r-project.org/web/packages/mpath/index.html
which should be useful for unit tests and comparison. includes count models and sandwiches. 
