### PR TITLE
ENH: From classic to floor division for k_re2, removes NumPy DeprecationWarning

### DIFF
--- a/statsmodels/regression/mixed_linear_model.py
+++ b/statsmodels/regression/mixed_linear_model.py
@@ -153,7 +153,7 @@ class MixedLMParams(object):
 
         self.k_fe = k_fe
         self.k_re = k_re
-        self.k_re2 = k_re * (k_re + 1) / 2
+        self.k_re2 = k_re * (k_re + 1) // 2
         self.k_tot = self.k_fe + self.k_re2
         self.use_sqrt = use_sqrt
         self._ix = np.tril_indices(self.k_re)


### PR DESCRIPTION
There was a NumPy DeprecationWarning at line 160 (creation of a ``np.zeros`` array with length being a float instead of an integer).

```
/opt/Python-3.4.3_virtualenv/lib/python3.4/site-packages/statsmodels/regression/mixed_linear_model.py:160: DeprecationWarning: using a non-integer number instead of an integer will result in an error in the future
  self._params = np.zeros(self.k_tot)
```

According to source code, ``k_re2`` is the number of covariance parameters, hence should be an integer. Line 523 uses the floor division for creating ``k_re2``, while line 156 used the classic division (in Python 3). Changing from classic to floor division on line 156 removes the DeprecationWarning.