### PR TITLE
COMPAT/TST: Statespace: Standardized residuals: fix compatibility with Scipy 0.11, add tests

### DIFF
--- a/statsmodels/tsa/statespace/kalman_filter.py
+++ b/statsmodels/tsa/statespace/kalman_filter.py
@@ -982,11 +982,9 @@ class FilterResults(FrozenRepresentation):
                 self.forecasts_error.shape, dtype=self.dtype)
 
             for t in range(self.forecasts_error_cov.shape[2]):
-                upper, _ = linalg.cho_factor(self.forecasts_error_cov[:, :, t],
-                                             check_finite=False)
+                upper, _ = linalg.cho_factor(self.forecasts_error_cov[:, :, t])
                 self._standardized_forecasts_error[:, t] = (
-                    linalg.solve_triangular(upper, self.forecasts_error[:, t],
-                                            check_finite=False))
+                    linalg.solve_triangular(upper, self.forecasts_error[:, t]))
 
         return self._standardized_forecasts_error
 

--- a/statsmodels/tsa/statespace/tests/test_kalman.py
+++ b/statsmodels/tsa/statespace/tests/test_kalman.py
@@ -35,6 +35,7 @@ except ImportError:
         return (prefix, dtype, None)
 
 
+from statsmodels.tsa.statespace.sarimax import SARIMAX
 from statsmodels.tsa.statespace import _statespace as ss
 from .results import results_kalman_filter
 from numpy.testing import assert_almost_equal, assert_allclose
@@ -676,3 +677,33 @@ class TestClark1989ConserveAll(Clark1989):
             self.result['state'][5][-1],
             self.true_states.iloc[end-1, 3], 4
         )
+
+
+def test_standardized_forecasts_error():
+    """
+    Simple test that standardized forecasts errors are calculated correctly.
+
+    Just uses a different calculation method on a univariate series.
+    """
+
+    # Get the dataset
+    true = results_kalman_filter.uc_uni
+    data = pd.DataFrame(
+        true['data'],
+        index=pd.date_range('1947-01-01', '1995-07-01', freq='QS'),
+        columns=['GDP']
+    )
+    data['lgdp'] = np.log(data['GDP'])
+
+    # Fit an ARIMA(1,1,0) to log GDP
+    mod = SARIMAX(data['lgdp'], order=(1,1,0))
+    res = mod.fit()
+
+    standardized_forecasts_error = (
+        res.forecasts_error[0] / np.sqrt(res.forecasts_error_cov[0,0])
+    )
+
+    assert_allclose(
+        res.standardized_forecasts_error[0],
+        standardized_forecasts_error,
+    )


### PR DESCRIPTION
Scipy 0.11 didn't have the `check_finite` argument to `cho_factor`.