### PR TITLE
Mosaic cornercase rebased

### DIFF
--- a/statsmodels/graphics/mosaicplot.py
+++ b/statsmodels/graphics/mosaicplot.py
@@ -41,7 +41,7 @@ def _normalize_split(proportion):
         raise ValueError("proportions should be positive,"
                           "given value: {}".format(proportion))
     if np.allclose(proportion, 0):
-        raise ValueError("at least one proportion should be"
+        raise ValueError("at least one proportion should be "
                           "greater than zero".format(proportion))
     # ok, data are meaningful, so go on
     if len(proportion) < 2:
@@ -376,6 +376,12 @@ def _statistical_coloring(data):
     return props
 
 
+def _get_position(x, w, h, W):
+    if W == 0:
+        return x
+    return (x + w / 2.0) * w * h / W
+
+
 def _create_labels(rects, horizontal, ax, rotation):
     """find the position of the label for each value of each category
 
@@ -444,8 +450,8 @@ def _create_labels(rects, horizontal, ax, rotation):
 
             vals = list(itervalues(subset))
             W = sum(w * h for (x, y, w, h) in vals)
-            x_lab = sum((x + w / 2.0) * w * h / W for (x, y, w, h) in vals)
-            y_lab = sum((y + h / 2.0) * w * h / W for (x, y, w, h) in vals)
+            x_lab = sum(_get_position(x, w, h, W) for (x, y, w, h) in vals)
+            y_lab = sum(_get_position(y, h, w, W) for (x, y, w, h) in vals)
             #now base on the ordering, select which position to keep
             #needs to be written in a more general form of 4 level are enough?
             #should give also the horizontal and vertical alignment

--- a/statsmodels/graphics/tests/test_mosaicplot.py
+++ b/statsmodels/graphics/tests/test_mosaicplot.py
@@ -196,6 +196,28 @@ def test_axes_labeling():
     fig.suptitle("correct alignment of the axes labels")
     #pylab.show()
 
+@dec.skipif(not have_matplotlib or pandas_old)
+def test_mosaic_empty_cells():
+    # SMOKE test  see #2286
+    import pandas as pd
+
+    mydata = pd.DataFrame({'id2': {64: 'Angelica',
+                                   65: 'DXW_UID', 66: 'casuid01',
+                                   67: 'casuid01', 68: 'EC93_uid',
+                                   69: 'EC93_uid', 70: 'EC93_uid',
+                                   60: 'DXW_UID',  61: 'AtmosFox',
+                                   62: 'DXW_UID', 63: 'DXW_UID'},
+                           'id1': {64: 'TGP',
+                                   65: 'Retention01', 66: 'default',
+                                   67: 'default', 68: 'Musa_EC_9_3',
+                                   69: 'Musa_EC_9_3', 70: 'Musa_EC_9_3',
+                                   60: 'default', 61: 'default',
+                                   62: 'default', 63: 'default'}})
+
+    ct = pd.crosstab(mydata.id1, mydata.id2)
+    fig, vals = mosaic(ct.T.unstack())
+    fig, vals = mosaic(mydata, ['id1','id2'])
+
 
 eq = lambda x, y: assert_(np.allclose(x, y))
 


### PR DESCRIPTION
rebased version of Kerby's PR #2286

adds a smoke test based on http://stackoverflow.com/questions/31031780/statsmodels-mosaic-plot-valueerror-cannot-convert-float-nan-to-integer

I also tried to remove the labels for empty cells, but didn't manage to remove all overlapping labels, and didn't add this change

in 
`@@ -454,11 +454,15 @@ def _create_labels(rects, horizontal, ax, rotation):`

```
-            level_ticks[value] = y_lab if side % 2 else x_lab
+            if W > 0:
+                level_ticks[value] = y_lab if side % 2 else x_lab
```