### PR TITLE
BUG: OLS set fvalue to nan if implicit constant and robust cov 

### DIFF
--- a/statsmodels/regression/linear_model.py
+++ b/statsmodels/regression/linear_model.py
@@ -1224,7 +1224,10 @@ class RegressionResults(base.LikelihoodModelResults):
             # TODO: What if model includes implcit constant, e.g. all dummies but no constant regressor?
             # TODO: Restats as LM test by projecting orthogonalizing to constant?
             if self.model.data.k_constant == 1:
-                # assume const_idx exists
+                # if constant is implicit, return nan see #2444
+                if const_idx is None:
+                    return np.nan
+
                 idx = lrange(k_params)
                 idx.pop(const_idx)
                 mat = mat[idx]  # remove constant

--- a/statsmodels/regression/tests/test_regression.py
+++ b/statsmodels/regression/tests/test_regression.py
@@ -6,7 +6,7 @@ from statsmodels.compat.python import long, lrange
 import warnings
 import pandas
 import numpy as np
-from numpy.testing import (assert_almost_equal, assert_approx_equal,
+from numpy.testing import (assert_almost_equal, assert_approx_equal, assert_,
                             assert_raises, assert_equal, assert_allclose)
 from scipy.linalg import toeplitz
 from statsmodels.tools.tools import add_constant, categorical
@@ -1066,6 +1066,29 @@ def test_missing_formula_predict():
     model = OLS.from_formula('y ~ x', data=data)
     fit = model.fit()
     pred = fit.predict(exog=data[:-1])
+
+
+def test_fvalue_implicit_constant():
+    nobs = 100
+    np.random.seed(2)
+    x = np.random.randn(nobs, 1)
+    x = ((x > 0) == [True, False]).astype(int)
+    y = x.sum(1) + np.random.randn(nobs)
+    w = 1 + 0.25 * np.random.rand(nobs)
+
+    from statsmodels.regression.linear_model import OLS, WLS
+
+    res = OLS(y, x).fit(cov_type='HC1')
+    assert_(np.isnan(res.fvalue))
+    assert_(np.isnan(res.f_pvalue))
+    res.summary()
+
+    res = WLS(y, x).fit(cov_type='HC1')
+    assert_(np.isnan(res.fvalue))
+    assert_(np.isnan(res.f_pvalue))
+    res.summary()
+
+
 
 if __name__=="__main__":
 


### PR DESCRIPTION
see #2444

I'm not closing 2444 in case I come up with the full solution, or sombody does.