### PR TITLE
Bug quantreg zero residuals

### DIFF
--- a/statsmodels/regression/quantile_regression.py
+++ b/statsmodels/regression/quantile_regression.py
@@ -172,7 +172,7 @@ class QuantReg(RegressionModel):
             resid = endog - np.dot(exog, beta)
 
             mask = np.abs(resid) < .000001
-            resid[mask] = np.sign(resid[mask]) * .000001
+            resid[mask] = ((resid[mask] >= 0) * 2 - 1) * .000001
             resid = np.where(resid < 0, q * resid, (1-q) * resid)
             resid = np.abs(resid)
             xstar = exog / resid[:, np.newaxis]

--- a/statsmodels/regression/quantile_regression.py
+++ b/statsmodels/regression/quantile_regression.py
@@ -366,18 +366,18 @@ class QuantRegResults(RegressionResults):
 
         """
 
-        #TODO: import where we need it (for now), add as cached attributes
-        from statsmodels.stats.stattools import (jarque_bera,
-                omni_normtest, durbin_watson)
-        jb, jbpv, skew, kurtosis = jarque_bera(self.wresid)
-        omni, omnipv = omni_normtest(self.wresid)
-
+        # #TODO: import where we need it (for now), add as cached attributes
+        # from statsmodels.stats.stattools import (jarque_bera,
+        #         omni_normtest, durbin_watson)
+        # jb, jbpv, skew, kurtosis = jarque_bera(self.wresid)
+        # omni, omnipv = omni_normtest(self.wresid)
+        #
         eigvals = self.eigenvals
         condno = self.condition_number
-
-        self.diagn = dict(jb=jb, jbpv=jbpv, skew=skew, kurtosis=kurtosis,
-                          omni=omni, omnipv=omnipv, condno=condno,
-                          mineigval=eigvals[0])
+        #
+        # self.diagn = dict(jb=jb, jbpv=jbpv, skew=skew, kurtosis=kurtosis,
+        #                   omni=omni, omnipv=omnipv, condno=condno,
+        #                   mineigval=eigvals[0])
 
         top_left = [('Dep. Variable:', None),
                     ('Model:', None),
@@ -394,17 +394,17 @@ class QuantRegResults(RegressionResults):
                      ('Df Model:', None) #[self.df_model])
                     ]
 
-        diagn_left = [('Omnibus:', ["%#6.3f" % omni]),
-                      ('Prob(Omnibus):', ["%#6.3f" % omnipv]),
-                      ('Skew:', ["%#6.3f" % skew]),
-                      ('Kurtosis:', ["%#6.3f" % kurtosis])
-                      ]
-
-        diagn_right = [('Durbin-Watson:', ["%#8.3f" % durbin_watson(self.wresid)]),
-                       ('Jarque-Bera (JB):', ["%#8.3f" % jb]),
-                       ('Prob(JB):', ["%#8.3g" % jbpv]),
-                       ('Cond. No.', ["%#8.3g" % condno])
-                       ]
+        # diagn_left = [('Omnibus:', ["%#6.3f" % omni]),
+        #               ('Prob(Omnibus):', ["%#6.3f" % omnipv]),
+        #               ('Skew:', ["%#6.3f" % skew]),
+        #               ('Kurtosis:', ["%#6.3f" % kurtosis])
+        #               ]
+        #
+        # diagn_right = [('Durbin-Watson:', ["%#8.3f" % durbin_watson(self.wresid)]),
+        #                ('Jarque-Bera (JB):', ["%#8.3f" % jb]),
+        #                ('Prob(JB):', ["%#8.3g" % jbpv]),
+        #                ('Cond. No.', ["%#8.3g" % condno])
+        #                ]
 
 
         if title is None:

--- a/statsmodels/regression/tests/test_quantile_regression.py
+++ b/statsmodels/regression/tests/test_quantile_regression.py
@@ -208,3 +208,30 @@ class TestParzeneHsheather(CheckModelResultsMixin):
     #@classmethod
     #def setUp(cls):
         #cls.res1, cls.res2 = setup_fun('tri', 'hsheather')
+
+def test_zero_resid():
+    # smoke and regression tests
+
+    X = np.array([[1, 0], [0, 1], [0, 2.1], [0, 3.1]], dtype=np.float64)
+    y = np.array([0, 1, 2, 3], dtype=np.float64)
+
+    res = QuantReg(y, X).fit(0.5, bandwidth='chamberlain') #'bofinger')
+    res.summary()
+
+    assert_allclose(res.params, np.array([0.0,  0.96774163]), rtol=1e-4, atol=1e-20)
+    assert_allclose(res.bse, np.array([0.0447576, 0.01154867]), rtol=1e-4, atol=1e-20)
+    assert_allclose(res.resid, np.array([0.0,  3.22583680e-02,  -3.22574272e-02,
+         9.40732912e-07]), rtol=1e-4, atol=1e-20)
+
+
+    X = np.array([[1, 0], [0.1, 1], [0, 2.1], [0, 3.1]], dtype=np.float64)
+    y = np.array([0, 1, 2, 3], dtype=np.float64)
+
+    res = QuantReg(y, X).fit(0.5, bandwidth='chamberlain')
+    res.summary()
+
+    assert_allclose(res.params, np.array([9.99982796e-08, 9.67741630e-01]),
+                    rtol=1e-4, atol=1e-20)
+    assert_allclose(res.bse, np.array([0.04455029, 0.01155251]), rtol=1e-4, atol=1e-20)
+    assert_allclose(res.resid, np.array([-9.99982796e-08, 3.22583598e-02,
+                            -3.22574234e-02, 9.46361860e-07]), rtol=1e-4, atol=1e-20)


### PR DESCRIPTION
fixes #2377 (exception with zero residuals) by replacing sign with inequality, assigns zero residual to positive

see also #2485

this includes smoke and regression unit tests
comment on second test case: If I did it correctly during debugging, then the second example raised the exception in the 6th iteration on my computer. The final result doesn't contain zero residuals.
