### PR TITLE
ENH: Add initialization via keyword args to init.

### DIFF
--- a/statsmodels/tsa/statespace/representation.py
+++ b/statsmodels/tsa/statespace/representation.py
@@ -107,9 +107,6 @@ class Representation(object):
         specified. Default is 1e6.
     initialization : {'approximate_diffuse','stationary','known'}, optional
         Initialization method for the initial state.
-    initial_variance : float, optional
-        If approximate diffuse initialization is used, the initial variance of
-        states.
     initial_state : array_like, optional
         If known initialization is used, the mean of the initial state's
         distribution.

--- a/statsmodels/tsa/statespace/sarimax.py
+++ b/statsmodels/tsa/statespace/sarimax.py
@@ -541,9 +541,6 @@ class SARIMAX(MLEModel):
         kwds = super(SARIMAX, self)._get_init_kwds()
         kwds['endog'] = self.orig_endog
         kwds['exog'] = self.orig_exog
-        # if self.initialization == 'approximate_diffuse':
-        #     import warnings
-        #     warnings.warn('not all init keys or initialization is available yet')
         return kwds
 
 

--- a/statsmodels/tsa/statespace/sarimax.py
+++ b/statsmodels/tsa/statespace/sarimax.py
@@ -522,8 +522,8 @@ class SARIMAX(MLEModel):
         self.selection = self.initial_selection
 
         # If we are estimating a simple ARMA model, then we can use a faster
-        # initialization method.
-        if k_diffuse_states == 0:
+        # initialization method (unless initialization was already specified).
+        if k_diffuse_states == 0 and self.initialization is None:
             self.initialize_stationary()
 
         # update _init_keys attached by super
@@ -541,9 +541,9 @@ class SARIMAX(MLEModel):
         kwds = super(SARIMAX, self)._get_init_kwds()
         kwds['endog'] = self.orig_endog
         kwds['exog'] = self.orig_exog
-        if self.initialization == 'approximate_diffuse':
-            import warnings
-            warnings.warn('not all init keys or initialization is available yet')
+        # if self.initialization == 'approximate_diffuse':
+        #     import warnings
+        #     warnings.warn('not all init keys or initialization is available yet')
         return kwds
 
 

--- a/statsmodels/tsa/statespace/tests/test_sarimax.py
+++ b/statsmodels/tsa/statespace/tests/test_sarimax.py
@@ -158,9 +158,13 @@ class TestARIMAStationary(ARIMA):
 
 
 class TestARIMADiffuse(ARIMA):
-    def __init__(self):
-        super(TestARIMADiffuse, self).__init__(results_sarimax.wpi1_diffuse)
-        self.model.initialize_approximate_diffuse(self.true['initial_variance'])
+    def __init__(self, **kwargs):
+        kwargs['initialization'] = 'approximate_diffuse'
+        kwargs['initial_variance'] = (
+            results_sarimax.wpi1_diffuse['initial_variance']
+        )
+        super(TestARIMADiffuse, self).__init__(results_sarimax.wpi1_diffuse,
+                                               **kwargs)
         self.result = self.model.filter()
 
     def test_bse(self):
@@ -633,8 +637,8 @@ class SARIMAXCoverageTest(object):
         mod1 = self.model
         mod1.update(self.true_params)  # test with side effect ?
 
-        if mod1.initialization == 'approximate_diffuse':
-            raise SkipTest('known failure: init_keys incomplete')
+        # if mod1.initialization == 'approximate_diffuse':
+        #     raise SkipTest('known failure: init_keys incomplete')
         kwargs = self.model._get_init_kwds()
         # TODO: current limitations #2259 comments
         #endog = mod1.endog.squeeze() # test failures, endog may be transformed
@@ -727,8 +731,9 @@ class Test_ar_diffuse(SARIMAXCoverageTest):
     # save_results 7
     def __init__(self, *args, **kwargs):
         kwargs['order'] = (3,0,0)
+        kwargs['initialization'] = 'approximate_diffuse'
+        kwargs['initial_variance'] = 1e9
         super(Test_ar_diffuse, self).__init__(6, *args, **kwargs)
-        self.model.initialize_approximate_diffuse(1e9)
 
 class Test_ar_no_enforce(SARIMAXCoverageTest):
     # // AR: (p,0,0) x (0,0,0,0)
@@ -739,6 +744,7 @@ class Test_ar_no_enforce(SARIMAXCoverageTest):
         kwargs['enforce_stationarity'] = False
         kwargs['enforce_invertibility'] = False
         kwargs['initial_variance'] = 1e9
+        # kwargs['loglikelihood_burn'] = 0
         super(Test_ar_no_enforce, self).__init__(6, *args, **kwargs)
         # Reset loglikelihood burn, which gets automatically set to the number
         # of states if enforce_stationarity = False
@@ -870,8 +876,9 @@ class Test_ma_diffuse(SARIMAXCoverageTest):
     # save_results 15
     def __init__(self, *args, **kwargs):
         kwargs['order'] = (0,0,3)
+        kwargs['initialization'] = 'approximate_diffuse'
+        kwargs['initial_variance'] = 1e9
         super(Test_ma_diffuse, self).__init__(14, *args, **kwargs)
-        self.model.initialize_approximate_diffuse(1e9)
 
 class Test_ma_exogenous(SARIMAXCoverageTest):
     # // MAX
@@ -956,10 +963,9 @@ class Test_arma_diffuse(SARIMAXCoverageTest):
     # save_results 24
     def __init__(self, *args, **kwargs):
         kwargs['order'] = (3,0,2)
-        # TODO: diffuse initialization not supported through keywords #2259
+        kwargs['initialization'] = 'approximate_diffuse'
         kwargs['initial_variance'] = 1e9
         super(Test_arma_diffuse, self).__init__(23, *args, **kwargs)
-        self.model.initialize_approximate_diffuse(1e9)
 
 class Test_arma_exogenous(SARIMAXCoverageTest):
     # // ARMAX
@@ -1050,8 +1056,9 @@ class Test_seasonal_ar_diffuse(SARIMAXCoverageTest):
     def __init__(self, *args, **kwargs):
         kwargs['order'] = (0,0,0)
         kwargs['seasonal_order'] = (3,0,0,4)
+        kwargs['initialization'] = 'approximate_diffuse'
+        kwargs['initial_variance'] = 1e9
         super(Test_seasonal_ar_diffuse, self).__init__(31, *args, **kwargs)
-        self.model.initialize_approximate_diffuse(1e9)
 
 class Test_seasonal_ar_exogenous(SARIMAXCoverageTest):
     # // SARX
@@ -1139,8 +1146,9 @@ class Test_seasonal_ma_diffuse(SARIMAXCoverageTest):
     def __init__(self, *args, **kwargs):
         kwargs['order'] = (0,0,0)
         kwargs['seasonal_order'] = (0,0,3,4)
+        kwargs['initialization'] = 'approximate_diffuse'
+        kwargs['initial_variance'] = 1e9
         super(Test_seasonal_ma_diffuse, self).__init__(39, *args, **kwargs)
-        self.model.initialize_approximate_diffuse(1e9)
 
 class Test_seasonal_ma_exogenous(SARIMAXCoverageTest):
     # // SMAX
@@ -1234,8 +1242,9 @@ class Test_seasonal_arma_diffuse(SARIMAXCoverageTest):
         kwargs['order'] = (0,0,0)
         kwargs['seasonal_order'] = (3,0,2,4)
         kwargs['decimal'] = 3
+        kwargs['initialization'] = 'approximate_diffuse'
+        kwargs['initial_variance'] = 1e9
         super(Test_seasonal_arma_diffuse, self).__init__(48, *args, **kwargs)
-        self.model.initialize_approximate_diffuse(1e9)
 
 class Test_seasonal_arma_exogenous(SARIMAXCoverageTest):
     # // SARMAX
@@ -1282,8 +1291,9 @@ class Test_sarimax_exogenous_diffuse(SARIMAXCoverageTest):
         endog = results_sarimax.wpi1_data
         kwargs['exog'] = (endog - np.floor(endog))**2
         kwargs['decimal'] = 2
+        kwargs['initialization'] = 'approximate_diffuse'
+        kwargs['initial_variance'] = 1e9
         super(Test_sarimax_exogenous_diffuse, self).__init__(51, *args, **kwargs)
-        self.model.initialize_approximate_diffuse(1e9)
 
 class Test_arma_exog_trend_polynomial_missing(SARIMAXCoverageTest):
     # // ARMA and exogenous and trend polynomial and missing


### PR DESCRIPTION
Fixes #2264. Quoting from there:

Currently, the Kalman filter initialization must be performed after construction. Need to add the ability to specify it during construction via keyword argument. Four new keywords (and then class attributes) would be specified:

    Parameters
    ----------

    initialization : {'approximate_diffuse','stationary','known'}, optional
        Method
    initial_variance : float, optional
        If approximate diffuse initialization is used, the initial variance of states.
    initial_state : array_like, optional
        If known initialization is used, the mean of the initial state's distribution.
    initial_state_cov : array_like, optional
        If known initialization is used, the covariance matrix of the initial state's distribution.