### PR TITLE
MAINT: fix numpy deprecation warnings

### DIFF
--- a/statsmodels/__init__.py
+++ b/statsmodels/__init__.py
@@ -13,6 +13,17 @@ simplefilter("always", (ConvergenceWarning, CacheWriteWarning,
                         IterationLimitWarning, InvalidTestWarning))
 
 
+debug_warnings = True
+
+if debug_warnings:
+    import sys, warnings
+    warnings.simplefilter("default") #always") #
+    if (sys.version_info[0] >= 3):
+        # ResourceWarning doesn't exist in python 2
+        # we have currently many ResourceWarnings in the datasets on python 3.4
+        warnings.simplefilter("ignore", ResourceWarning)
+
+
 class NoseWrapper(Tester):
     '''
     This is simply a monkey patch for numpy.testing.Tester.

--- a/statsmodels/__init__.py
+++ b/statsmodels/__init__.py
@@ -13,11 +13,13 @@ simplefilter("always", (ConvergenceWarning, CacheWriteWarning,
                         IterationLimitWarning, InvalidTestWarning))
 
 
-debug_warnings = True
+debug_warnings = False
 
 if debug_warnings:
     import sys, warnings
-    warnings.simplefilter("default") #always") #
+    warnings.simplefilter("default")
+    # use the following to raise an exception for debugging specific warnings
+    #warnings.filterwarnings("error", message=".*integer.*")
     if (sys.version_info[0] >= 3):
         # ResourceWarning doesn't exist in python 2
         # we have currently many ResourceWarnings in the datasets on python 3.4

--- a/statsmodels/base/tests/test_data.py
+++ b/statsmodels/base/tests/test_data.py
@@ -747,9 +747,9 @@ class CheckHasConstant(object):
         x2 = np.column_stack((np.arange(20) < 10.5,
                               np.arange(20) > 10.5)).astype(float)
         result2 = (1, None)
-        x3 = np.column_stack((np.arange(20), np.zeros(20.)))
+        x3 = np.column_stack((np.arange(20), np.zeros(20)))
         result3 = (0, None)
-        x4 = np.column_stack((np.arange(20), np.zeros((20., 2))))
+        x4 = np.column_stack((np.arange(20), np.zeros((20, 2))))
         result4 = (0, None)
         x5 = np.column_stack((np.zeros(20), 0.5 * np.ones(20)))
         result5 = (1, 1)
@@ -760,11 +760,11 @@ class CheckHasConstant(object):
         # implicit and zero column
         x6 = np.column_stack((np.arange(20) < 10.5,
                               np.arange(20) > 10.5,
-                              np.zeros(20.))).astype(float)
+                              np.zeros(20))).astype(float)
         result6 = (1, None)
         x7 = np.column_stack((np.arange(20) < 10.5,
                               np.arange(20) > 10.5,
-                              np.zeros((20., 2)))).astype(float)
+                              np.zeros((20, 2)))).astype(float)
         result7 = (1, None)
 
         cls.exogs = (x1, x2, x3, x4, x5, x5b, x5c, x6, x7)

--- a/statsmodels/discrete/discrete_margins.py
+++ b/statsmodels/discrete/discrete_margins.py
@@ -217,7 +217,7 @@ def _margeff_cov_params_dummy(model, cov_margins, params, exog, dummy_ind,
         if dfdb.ndim >= 2: # for overall
             dfdb = dfdb.mean(0)
         if J > 1:
-            K = dfdb.shape[1] / (J-1)
+            K = dfdb.shape[1] // (J-1)
             cov_margins[i::K, :] = dfdb
         else:
             cov_margins[i, :] = dfdb # how each F changes with change in B

--- a/statsmodels/discrete/discrete_model.py
+++ b/statsmodels/discrete/discrete_model.py
@@ -15,6 +15,7 @@ G.S. Madalla. `Limited-Dependent and Qualitative Variables in Econometrics`.
 
 W. Greene. `Econometric Analysis`. Prentice Hall, 5th. edition. 2003.
 """
+from __future__ import division
 
 __all__ = ["Poisson", "Logit", "Probit", "MNLogit", "NegativeBinomial"]
 
@@ -536,8 +537,8 @@ class MultinomialModel(BinaryModel):
         super(MultinomialModel, self).initialize()
         # This is also a "whiten" method in other models (eg regression)
         self.endog = self.endog.argmax(1)  # turn it into an array of col idx
-        self.J = float(self.wendog.shape[1])
-        self.K = float(self.exog.shape[1])
+        self.J = self.wendog.shape[1]
+        self.K = self.exog.shape[1]
         self.df_model *= (self.J-1)  # for each J - 1 equation.
         self.df_resid = self.exog.shape[0] - self.df_model - (self.J-1)
 

--- a/statsmodels/duration/tests/test_phreg.py
+++ b/statsmodels/duration/tests/test_phreg.py
@@ -72,7 +72,7 @@ class TestPHReg(object):
         ties1 = ties[0:3]
 
         # Needs to match the kronecker statement in survival.R
-        strata = np.kron(range(5), np.ones(n/5))
+        strata = np.kron(range(5), np.ones(n // 5))
 
         # No stratification or entry times
         mod = PHReg(time, exog, status, ties=ties)

--- a/statsmodels/emplike/aft_el.py
+++ b/statsmodels/emplike/aft_el.py
@@ -27,6 +27,7 @@ Statistics. 14:3, 643-656.
 
 
 """
+from __future__ import division
 
 import numpy as np
 from statsmodels.regression.linear_model import OLS, WLS
@@ -234,7 +235,7 @@ class emplikeAFT(object):
     estimation and inference possible.
     """
     def __init__(self, endog, exog, censors):
-        self.nobs = float(np.shape(exog)[0])
+        self.nobs = np.shape(exog)[0]
         self.endog = endog.reshape(self.nobs, 1)
         self.exog = exog.reshape(self.nobs, -1)
         self.censors = censors.reshape(self.nobs, 1)
@@ -244,7 +245,7 @@ class emplikeAFT(object):
         self.exog = self.exog[idx]
         self.censors = self.censors[idx]
         self.censors[-1] = 1  # Sort in init, not in function
-        self.uncens_nobs = np.sum(self.censors)
+        self.uncens_nobs = int(np.sum(self.censors))
         mask = self.censors.ravel().astype(bool)
         self.uncens_endog = self.endog[mask, :].reshape(-1, 1)
         self.uncens_exog = self.exog[mask, :]

--- a/statsmodels/emplike/descriptive.py
+++ b/statsmodels/emplike/descriptive.py
@@ -15,6 +15,8 @@ General References:
 Owen, A. (2001). "Empirical Likelihood." Chapman and Hall
 
 """
+from __future__ import division
+
 import numpy as np
 from scipy import optimize
 from scipy.stats import chi2, skew, kurtosis
@@ -485,7 +487,7 @@ class DescStatUV(_OptFuncts):
 
     def __init__(self, endog):
         self.endog = np.squeeze(endog)
-        self.nobs = float(endog.shape[0])
+        self.nobs = endog.shape[0]
 
     def test_mean(self, mu0, return_weights=False):
         """
@@ -952,7 +954,7 @@ class DescStatMV(_OptFuncts):
 
     def __init__(self, endog):
         self.endog = endog
-        self.nobs = float(endog.shape[0])
+        self.nobs = endog.shape[0]
 
     def mv_test_mean(self, mu_array, return_weights=False):
         """
@@ -983,7 +985,7 @@ class DescStatMV(_OptFuncts):
         means = np.ones((endog.shape[0], endog.shape[1]))
         means = mu_array * means
         est_vect = endog - means
-        start_vals = 1 / nobs * np.ones(endog.shape[1])
+        start_vals = 1. / nobs * np.ones(endog.shape[1])
         eta_star = self._modif_newton(start_vals, est_vect,
                                       np.ones(nobs) * (1. / nobs))
         denom = 1 + np.dot(eta_star, est_vect.T)

--- a/statsmodels/emplike/elanova.py
+++ b/statsmodels/emplike/elanova.py
@@ -9,6 +9,7 @@ General References
 
 Owen, A. B. (2001). Empirical Likelihood. Chapman and Hall.
 """
+from __future__ import division
 
 from statsmodels.compat.python import range
 import numpy as np

--- a/statsmodels/emplike/elregress.py
+++ b/statsmodels/emplike/elregress.py
@@ -12,6 +12,8 @@ General References
 Owen, A.B.(2001). Empirical Likelihood. Chapman and Hall
 
 """
+from __future__ import division
+
 import numpy as np
 from statsmodels.emplike.descriptive import _OptFuncts
 
@@ -59,7 +61,7 @@ class _ELRegOpts(_OptFuncts):
         new_params = params.reshape(nvar, 1)
         self.new_params = new_params
         est_vect = exog * \
-          (endog - np.squeeze(np.dot(exog, new_params))).reshape(nobs, 1)
+          (endog - np.squeeze(np.dot(exog, new_params))).reshape(int(nobs), 1)
         if not stochastic_exog:
             exog_means = np.mean(exog, axis=0)[1:]
             exog_mom2 = (np.sum(exog * exog, axis=0))[1:]\

--- a/statsmodels/emplike/elregress.py
+++ b/statsmodels/emplike/elregress.py
@@ -73,7 +73,7 @@ class _ELRegOpts(_OptFuncts):
             est_vect = np.concatenate((est_vect, regressor_est_vect),
                                            axis=1)
 
-        wts = np.ones(nobs) * (1. / nobs)
+        wts = np.ones(int(nobs)) * (1. / nobs)
         x0 = np.zeros(est_vect.shape[1]).reshape(-1, 1)
         try:
             eta_star = self._modif_newton(x0, est_vect, wts)

--- a/statsmodels/emplike/originregress.py
+++ b/statsmodels/emplike/originregress.py
@@ -16,6 +16,7 @@ General References
 Owen, A.B. (2001). Empirical Likelihood.  Chapman and Hall. p. 82.
 
 """
+from __future__ import division
 
 import numpy as np
 from scipy.stats import chi2
@@ -56,7 +57,7 @@ class ELOriginRegress(object):
     def __init__(self, endog, exog):
         self.endog = endog
         self.exog = exog
-        self.nobs = float(self.exog.shape[0])
+        self.nobs = self.exog.shape[0]
         try:
             self.nvar = float(exog.shape[1])
         except IndexError:

--- a/statsmodels/emplike/tests/test_aft.py
+++ b/statsmodels/emplike/tests/test_aft.py
@@ -1,3 +1,5 @@
+from __future__ import division
+
 import numpy as np
 from numpy.testing import assert_almost_equal
 from statsmodels.datasets import heart

--- a/statsmodels/emplike/tests/test_anova.py
+++ b/statsmodels/emplike/tests/test_anova.py
@@ -1,3 +1,5 @@
+from __future__ import division
+
 from numpy.testing import assert_almost_equal
 from statsmodels.datasets import star98
 from statsmodels.emplike.elanova import ANOVA

--- a/statsmodels/emplike/tests/test_descriptive.py
+++ b/statsmodels/emplike/tests/test_descriptive.py
@@ -1,3 +1,5 @@
+from __future__ import division
+
 import numpy as np
 from numpy.testing import assert_almost_equal
 from statsmodels.datasets import star98

--- a/statsmodels/emplike/tests/test_origin.py
+++ b/statsmodels/emplike/tests/test_origin.py
@@ -1,3 +1,5 @@
+from __future__ import division
+
 from numpy.testing import assert_almost_equal
 from statsmodels.emplike.originregress import ELOriginRegress
 from statsmodels.datasets import cancer

--- a/statsmodels/emplike/tests/test_regression.py
+++ b/statsmodels/emplike/tests/test_regression.py
@@ -1,3 +1,5 @@
+from __future__ import division
+
 from numpy.testing import assert_almost_equal
 from numpy.testing.decorators import slow
 from statsmodels.regression.linear_model import OLS

--- a/statsmodels/genmod/generalized_estimating_equations.py
+++ b/statsmodels/genmod/generalized_estimating_equations.py
@@ -2197,7 +2197,7 @@ class NominalGEE(GEE):
 
         # Reshape so that each row contains all the indicators
         # corresponding to one multinomial observation.
-        expval_m = np.reshape(expval, (len(expval) / self.ncut,
+        expval_m = np.reshape(expval, (len(expval) // self.ncut,
                                        self.ncut))
 
         # The normalizing constant for the multinomial probabilities.
@@ -2248,7 +2248,7 @@ class NominalGEE(GEE):
         lpr = np.dot(exog, params)
         expval = np.exp(lpr)
 
-        expval_m = np.reshape(expval, (len(expval) / self.ncut,
+        expval_m = np.reshape(expval, (len(expval) // self.ncut,
                                        self.ncut))
 
         denom = 1 + expval_m.sum(1)
@@ -2261,9 +2261,9 @@ class NominalGEE(GEE):
         for j in range(self.ncut):
             ee = np.zeros(self.ncut, dtype=np.float64)
             ee[j] = 1
-            qmat.append(np.kron(ee, np.ones(len(params) / self.ncut)))
+            qmat.append(np.kron(ee, np.ones(len(params) // self.ncut)))
         qmat = np.array(qmat)
-        qmat = np.kron(np.ones((exog.shape[0]/self.ncut, 1)), qmat)
+        qmat = np.kron(np.ones((exog.shape[0] // self.ncut, 1)), qmat)
         bmat = bmat0 * qmat
 
         dmat = expval[:, None] * bmat / denom[:, None]

--- a/statsmodels/genmod/generalized_estimating_equations.py
+++ b/statsmodels/genmod/generalized_estimating_equations.py
@@ -2435,7 +2435,7 @@ class _MultinomialLogit(Link):
 
         expval = np.exp(lpr)
 
-        denom = 1 + np.reshape(expval, (len(expval) / self.ncut,
+        denom = 1 + np.reshape(expval, (len(expval) // self.ncut,
                                         self.ncut)).sum(1)
         denom = np.kron(denom, np.ones(self.ncut, dtype=np.float64))
 

--- a/statsmodels/nonparametric/bandwidths.py
+++ b/statsmodels/nonparametric/bandwidths.py
@@ -1,3 +1,5 @@
+from __future__ import division
+
 import numpy as np
 from scipy.stats import scoreatpercentile as sap
 from statsmodels.sandbox.nonparametric import kernels

--- a/statsmodels/nonparametric/kde.py
+++ b/statsmodels/nonparametric/kde.py
@@ -11,7 +11,7 @@ http://en.wikipedia.org/wiki/Kernel_%28statistics%29
 
 Silverman, B.W.  Density Estimation for Statistics and Data Analysis.
 """
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, division
 from statsmodels.compat.python import range
 # for 2to3 with extensions
 import warnings
@@ -324,7 +324,7 @@ def kdensity(X, kernel="gau", bw="normal_reference", weights=None, gridsize=None
     clip_x = np.logical_and(X>clip[0], X<clip[1])
     X = X[clip_x]
 
-    nobs = float(len(X)) # after trim
+    nobs = len(X) # after trim
 
     if gridsize == None:
         gridsize = max(nobs,50) # don't need to resize if no FFT
@@ -463,7 +463,7 @@ def kdensityfft(X, kernel="gau", bw="normal_reference", weights=None, gridsize=N
         bw = bandwidths.select_bandwidth(X, bw, kern) # will cross-val fit this pattern?
     bw *= adjust
 
-    nobs = float(len(X)) # after trim
+    nobs = len(X) # after trim
 
     # 1 Make grid and discretize the data
     if gridsize == None:

--- a/statsmodels/nonparametric/kdetools.py
+++ b/statsmodels/nonparametric/kdetools.py
@@ -1,4 +1,5 @@
 #### Convenience Functions to be moved to kerneltools ####
+from __future__ import division
 from statsmodels.compat.python import range
 import numpy as np
 

--- a/statsmodels/nonparametric/kdetools.py
+++ b/statsmodels/nonparametric/kdetools.py
@@ -17,7 +17,7 @@ def revrt(X,m=None):
     """
     if m is None:
         m = len(X)
-    y = X[:m/2+1] + np.r_[0,X[m/2+1:],0]*1j
+    y = X[:m // 2+1] + np.r_[0,X[m // 2 + 1:],0]*1j
     return np.fft.irfft(y)*m
 
 def silverman_transform(bw, M, RANGE):

--- a/statsmodels/nonparametric/kernel_density.py
+++ b/statsmodels/nonparametric/kernel_density.py
@@ -27,7 +27,7 @@ References
         Models", 2006, Econometric Reviews 25, 523-544
 
 """
-
+from __future__ import division
 # TODO: make default behavior efficient=True above a certain n_obs
 
 from statsmodels.compat.python import range, next

--- a/statsmodels/nonparametric/kernel_regression.py
+++ b/statsmodels/nonparametric/kernel_regression.py
@@ -28,6 +28,7 @@ References
 
 """
 
+from __future__ import division
 # TODO: make default behavior efficient=True above a certain n_obs
 
 from statsmodels.compat.python import range, string_types, next

--- a/statsmodels/nonparametric/kernels.py
+++ b/statsmodels/nonparametric/kernels.py
@@ -11,6 +11,7 @@ kernel density estimation much easier.
 NOTE: As it is, this module does not interact with the existing API
 """
 
+from __future__ import division
 
 import numpy as np
 from scipy.special import erf

--- a/statsmodels/regression/tests/test_regression.py
+++ b/statsmodels/regression/tests/test_regression.py
@@ -1013,8 +1013,8 @@ class TestRegularizedFit(object):
             lam = float(vec[3])
             params = vec[4:].astype(np.float64)
 
-            endog = data[0:n, 0]
-            exog = data[0:n, 1:(p+1)]
+            endog = data[0:int(n), 0]
+            exog = data[0:int(n), 1:(int(p)+1)]
 
             endog = endog - endog.mean()
             endog /= endog.std(ddof=1)

--- a/statsmodels/regression/tests/tests_predict.py
+++ b/statsmodels/regression/tests/tests_predict.py
@@ -26,7 +26,7 @@ def test_predict_se():
     beta = [0.5, -0.01, 5.]
     y_true2 = np.dot(x, beta)
     w = np.ones(nsample)
-    w[nsample * 6. / 10:] = 3
+    w[int(nsample * 6. / 10):] = 3
     sig = 0.5
     y2 = y_true2 + sig * w * np.random.normal(size=nsample)
     x2 = x[:,[0,2]]
@@ -121,7 +121,7 @@ class TestWLSPrediction(object):
         beta = [5., 0.5, -0.01]
         sig = 0.5
         w = np.ones(nsample)
-        w[nsample * 6/10:] = 3
+        w[int(nsample * 6. / 10):] = 3
         y_true = np.dot(X, beta)
         e = np.random.normal(size=nsample)
         y = y_true + sig * w * e

--- a/statsmodels/robust/tests/results/results_rlm.py
+++ b/statsmodels/robust/tests/results/results_rlm.py
@@ -8,7 +8,7 @@ def _shift_intercept(arr):
     compatible with statsmodels.rlm covariance
     """
     arr = np.asarray(arr)
-    side = np.sqrt(len(arr))
+    side = int(np.sqrt(len(arr)))
     return np.roll(np.roll(arr.reshape(side,side),-1, axis =1), -1, axis=0)
 
 class Huber(object):

--- a/statsmodels/sandbox/distributions/extras.py
+++ b/statsmodels/sandbox/distributions/extras.py
@@ -1036,7 +1036,7 @@ def mvstdnormcdf(lower, upper, corrcoef, **kwds):
     upper = np.array(upper)
     corrcoef = np.array(corrcoef)
 
-    correl = np.zeros(n*(n-1)/2.0)  #dtype necessary?
+    correl = np.zeros(int(n*(n-1)/2.0))  #dtype necessary?
 
     if (lower.ndim != 1) or (upper.ndim != 1):
         raise ValueError('can handle only 1D bounds')

--- a/statsmodels/sandbox/panel/panel_short.py
+++ b/statsmodels/sandbox/panel/panel_short.py
@@ -144,7 +144,7 @@ class ShortPanelGLS(GLS):
 
         #
         if sigma_i is None:
-            sigma_i = np.eye(nobs_i)
+            sigma_i = np.eye(int(nobs_i))
         self.cholsigmainv_i = np.linalg.cholesky(np.linalg.pinv(sigma_i)).T
 
         #super is taking care of endog, exog and sigma

--- a/statsmodels/stats/sandwich_covariance.py
+++ b/statsmodels/stats/sandwich_covariance.py
@@ -345,7 +345,7 @@ def weights_uniform(nlags):
     '''
 
     #with lag zero
-    return np.ones(nlags+1.)
+    return np.ones(nlags+1)
 
 def S_hac_simple(x, nlags=None, weights_func=weights_bartlett):
     '''inner covariance matrix for HAC (Newey, West) sandwich

--- a/statsmodels/tools/tests/test_numdiff.py
+++ b/statsmodels/tools/tests/test_numdiff.py
@@ -61,7 +61,7 @@ class CheckGradLoglikeMixin(object):
             assert_almost_equal(he, hefd, decimal=7)
             hefd = numdiff.approx_fprime(test_params, self.mod.score,
                                          centered=True)
-            assert_allclose(he, hefd, rtol=5e-10)
+            assert_allclose(he, hefd, rtol=1e-9)
             hefd = numdiff.approx_fprime(test_params, self.mod.score,
                                          centered=False)
             assert_almost_equal(he, hefd, decimal=4)

--- a/statsmodels/tsa/filters/filtertools.py
+++ b/statsmodels/tsa/filters/filtertools.py
@@ -272,8 +272,8 @@ def convolution_filter(x, filt, nsides=2):
         trim_head = len(filt) - 1
         trim_tail = None
     elif nsides == 2:
-        trim_head = np.ceil(len(filt)/2.) - 1 or None
-        trim_tail = (np.ceil(len(filt)/2.) - len(filt) % 2) or None
+        trim_head = int(np.ceil(len(filt)/2.) - 1) or None
+        trim_tail = int(np.ceil(len(filt)/2.) - len(filt) % 2) or None
     else:  # pragma : no cover
         raise ValueError("nsides must be 1 or 2")
 

--- a/statsmodels/tsa/tests/test_ar.py
+++ b/statsmodels/tsa/tests/test_ar.py
@@ -281,7 +281,7 @@ def test_ar_start_params():
     # fix 236
     # smoke test
     data = sm.datasets.sunspots.load()
-    res = AR(data.endog).fit(maxlag=9, start_params=0.1*np.ones(10.),
+    res = AR(data.endog).fit(maxlag=9, start_params=0.1*np.ones(10),
                              method="mle", disp=-1, maxiter=100)
 
 def test_ar_series():

--- a/statsmodels/tsa/tests/test_tsa_tools.py
+++ b/statsmodels/tsa/tests/test_tsa_tools.py
@@ -60,7 +60,7 @@ def test_yule_walker_inter():
 
 def test_duplication_matrix():
     for k in range(2, 10):
-        m = tools.unvech(np.random.randn(k * (k + 1) / 2))
+        m = tools.unvech(np.random.randn(k * (k + 1) // 2))
         Dk = tools.duplication_matrix(k)
         assert(np.array_equal(vec(m), np.dot(Dk, vech(m))))
 

--- a/statsmodels/tsa/tsatools.py
+++ b/statsmodels/tsa/tsatools.py
@@ -441,7 +441,7 @@ def duplication_matrix(n):
     -------
     D_n : ndarray
     """
-    tmp = np.eye(n * (n + 1) / 2)
+    tmp = np.eye(n * (n + 1) // 2)
     return np.array([unvech(x).ravel() for x in tmp]).T
 
 def elimination_matrix(n):

--- a/statsmodels/tsa/vector_ar/svar_model.py
+++ b/statsmodels/tsa/vector_ar/svar_model.py
@@ -391,12 +391,12 @@ class SVAR(tsbase.TimeSeriesModel):
 
         #first generate duplication matrix, see MN (1980) for notation
 
-        D_nT=np.zeros([(1.0/2)*(neqs)*(neqs+1),neqs**2])
+        D_nT = np.zeros([int((1.0 / 2) * (neqs) * (neqs + 1)), neqs**2])
 
         for j in range(neqs):
             i=j
             while j <= i < neqs:
-                u=np.zeros([(1.0/2)*neqs*(neqs+1),1])
+                u=np.zeros([int((1.0/2)*neqs*(neqs+1)), 1])
                 u[(j)*neqs+(i+1)-(1.0/2)*(j+1)*j-1]=1
                 Tij=np.zeros([neqs,neqs])
                 Tij[i,j]=1

--- a/statsmodels/tsa/vector_ar/svar_model.py
+++ b/statsmodels/tsa/vector_ar/svar_model.py
@@ -397,7 +397,7 @@ class SVAR(tsbase.TimeSeriesModel):
             i=j
             while j <= i < neqs:
                 u=np.zeros([int((1.0/2)*neqs*(neqs+1)), 1])
-                u[(j)*neqs+(i+1)-(1.0/2)*(j+1)*j-1]=1
+                u[int(j * neqs + (i + 1) - (1.0 / 2) * (j + 1) * j - 1)] = 1
                 Tij=np.zeros([neqs,neqs])
                 Tij[i,j]=1
                 Tij[j,i]=1


### PR DESCRIPTION
see #2480 enabling deprecation warnings creates many of them from numpy, mostly non-integers

I'm using Python 3.4, and need TravisCI to check the changes.
I didn't manage to find the sources of all deprecation warnings yet

Note: This are **not** all innocent changes, 
There are possible problems related to integer division and rounding (int conversion), but the test suite never had failures.

- I replaced division `/` by `//` in some cases which was inconsistent across python 2 versus python 3
- I converted some attributes like `nobs` from float to int, and added `from __future__ import division` to several but not all modules.

