### PR TITLE
CLN/TST reduce test noise

### DIFF
--- a/statsmodels/__init__.py
+++ b/statsmodels/__init__.py
@@ -18,8 +18,10 @@ debug_warnings = False
 if debug_warnings:
     import sys, warnings
     warnings.simplefilter("default")
+
     # use the following to raise an exception for debugging specific warnings
     #warnings.filterwarnings("error", message=".*integer.*")
+    #warnings.simplefilter("error", UserWarning)
     if (sys.version_info[0] >= 3):
         # ResourceWarning doesn't exist in python 2
         # we have currently many ResourceWarnings in the datasets on python 3.4

--- a/statsmodels/stats/tests/test_pairwise.py
+++ b/statsmodels/stats/tests/test_pairwise.py
@@ -257,7 +257,10 @@ class TestTuckeyHSD2Pandas(TestTuckeyHSD2):
         # we do tukey_hsd with reduced set of observations
         data = np.arange(15)
         groups = np.repeat([1, 2, 3], 5)
-        mod1 = MultiComparison(np.array(data), groups, group_order=[1, 2])
+        # group_order doesn't select all observations, one group is excluded
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            mod1 = MultiComparison(np.array(data), groups, group_order=[1, 2])
         res1 = mod1.tukeyhsd(alpha=0.01)
         mod2 = MultiComparison(np.array(data[:10]), groups[:10])
         res2 = mod2.tukeyhsd(alpha=0.01)


### PR DESCRIPTION
test_pairwise catch warning closes #2492


There are several warnings created during a unit test run. They will need individual checking to see whether there are version specific problems or whether they are just expected problems and we should remove/catch the noise.