### PR TITLE
prevent _make_arma_names from adding exog_names when already present

### DIFF
--- a/statsmodels/tsa/arima_model.py
+++ b/statsmodels/tsa/arima_model.py
@@ -409,6 +409,8 @@ def _make_arma_names(data, k_trend, order, exog_names):
     ma_lag_names = [''.join(('ma.', i)) for i in ma_lag_names]
     trend_name = util.make_lag_names('', 0, k_trend)
 
+    # ensure exog_names stays unchanged when the `fit` method
+    # is called multiple times.
     if exog_names[-k_ma:] == ma_lag_names and \
        exog_names[-(k_ar+k_ma):-k_ma] == ar_lag_names and \
        (not exog_names or not trend_name or trend_name[0] == exog_names[0]):

--- a/statsmodels/tsa/arima_model.py
+++ b/statsmodels/tsa/arima_model.py
@@ -408,6 +408,12 @@ def _make_arma_names(data, k_trend, order, exog_names):
     ma_lag_names = util.make_lag_names([data.ynames], k_ma, 0)
     ma_lag_names = [''.join(('ma.', i)) for i in ma_lag_names]
     trend_name = util.make_lag_names('', 0, k_trend)
+
+    if exog_names[-k_ma:] == ma_lag_names and \
+       exog_names[-(k_ar+k_ma):-k_ma] == ar_lag_names and \
+       (not exog_names or not trend_name or trend_name[0] == exog_names[0]):
+        return exog_names
+
     exog_names = trend_name + exog_names + ar_lag_names + ma_lag_names
     return exog_names
 

--- a/statsmodels/tsa/tests/test_arima.py
+++ b/statsmodels/tsa/tests/test_arima.py
@@ -2210,6 +2210,13 @@ def test_ARIMA_exog_predict():
     assert_allclose(dpredict_002, res_d002[-len(dpredict_002):], rtol=1e-4, atol=1e-6)
 
 
+def test_arima_fit_mutliple_calls():
+    y = [-1214.360173, -1848.209905, -2100.918158, -3647.483678, -4711.186773]
+    mod = ARIMA(y, (1, 0, 2))
+    # Make multiple calls to fit
+    mod.fit(disp=0, start_params=[np.mean(y), .1, .1, .1])
+    mod.fit(disp=0, start_params=[np.mean(y), .1, .1, .1])
+    assert_equal(mod.exog_names,  ['const', 'ar.L1.y', 'ma.L1.y', 'ma.L2.y']) 
 
 if __name__ == "__main__":
     import nose

--- a/statsmodels/tsa/tests/test_arima.py
+++ b/statsmodels/tsa/tests/test_arima.py
@@ -2215,6 +2215,7 @@ def test_arima_fit_mutliple_calls():
     mod = ARIMA(y, (1, 0, 2))
     # Make multiple calls to fit
     mod.fit(disp=0, start_params=[np.mean(y), .1, .1, .1])
+    assert_equal(mod.exog_names,  ['const', 'ar.L1.y', 'ma.L1.y', 'ma.L2.y']) 
     mod.fit(disp=0, start_params=[np.mean(y), .1, .1, .1])
     assert_equal(mod.exog_names,  ['const', 'ar.L1.y', 'ma.L1.y', 'ma.L2.y']) 
 


### PR DESCRIPTION
closes #1691

I have some doubts about my approach here. It looks like exog_names was added to address Issue #626 back in the day, but it almost seems to assume that `_make_arma_names` (and hence `fit`) is run at most once against the model.