### PR TITLE
Allows start_params input in ARMA.fit() to be a function which takes …

### DIFF
--- a/statsmodels/tsa/arima_model.py
+++ b/statsmodels/tsa/arima_model.py
@@ -821,7 +821,9 @@ class ARMA(tsbase.TimeSeriesModel):
         Parameters
         ----------
         start_params : array-like, optional
-            Starting parameters for ARMA(p,q). If None, the default is given
+            Starting parameters for ARMA(p,q). May be a function with an ARMA
+            object as input and an numpy array with shape=(p+q+k,) as output.
+            If None, the default is given
             by ARMA._fit_start_params.  See there for more information.
         transparams : bool, optional
             Whehter or not to transform the parameters to ensure stationarity.
@@ -925,7 +927,10 @@ class ARMA(tsbase.TimeSeriesModel):
             self.nobs = len(self.endog) - k_ar
 
         if start_params is not None:
-            start_params = np.asarray(start_params)
+            if hasattr(start_params, '__call__'):
+                start_params = start_params(self)
+            else:
+                start_params = np.asarray(start_params)
 
         else:  # estimate starting parameters
             start_params = self._fit_start_params((k_ar, k_ma, k), method)

--- a/statsmodels/tsa/arima_model.py
+++ b/statsmodels/tsa/arima_model.py
@@ -820,7 +820,7 @@ class ARMA(tsbase.TimeSeriesModel):
 
         Parameters
         ----------
-        start_params : array-like, optional
+        start_params : array-like, callable, optional
             Starting parameters for ARMA(p,q). May be a function with an ARMA
             object as input and an numpy array with shape=(p+q+k,) as output.
             If None, the default is given
@@ -927,7 +927,7 @@ class ARMA(tsbase.TimeSeriesModel):
             self.nobs = len(self.endog) - k_ar
 
         if start_params is not None:
-            if hasattr(start_params, '__call__'):
+            if callable(start_params):
                 start_params = start_params(self)
             else:
                 start_params = np.asarray(start_params)

--- a/statsmodels/tsa/tests/test_arima.py
+++ b/statsmodels/tsa/tests/test_arima.py
@@ -1802,6 +1802,23 @@ def test_bad_start_params():
     inv = load_macrodata().data['realinv']
     arima_mod = ARIMA(np.log(inv), (1,1,2))
     assert_raises(ValueError, mod.fit)
+    
+    # Test start_params as a function
+    def start_params_func(model):
+        p = model.k_ar
+        q = model.k_ma
+        k = model.k_trend + model.k_exog
+        start_params = np.array([1.] * k + [1./(p+1)] * p + [1./(q+1)] * q)
+        return start_params
+    
+    np.random.seed(12345)
+    arparams = np.array([.75, -.25])
+    maparams = np.array([.65, .35])
+
+    nobs = 30
+
+    y = arma_generate_sample(arparams, maparams, nobs)
+    sres = ARMA(y, order=(2, 2)).fit(start_params=start_params_func)
 
 
 def test_arima_small_data_bug():


### PR DESCRIPTION
…an ARMA model and returns start_params. In response to #2521
