### PR TITLE
Glar history add

### DIFF
--- a/examples/incomplete/glsar.py
+++ b/examples/incomplete/glsar.py
@@ -21,7 +21,7 @@ examples = examples_all  # [5]
 if 0 in examples:
     print('\n Example 0')
     X = np.arange(1, 8)
-    X = sm.add_constant(X)
+    X = sm.add_constant(X, prepend=False)
     Y = np.array((1, 3, 4, 5, 8, 10, 9))
     rho = 2
     model = GLSAR(Y, X, 2)

--- a/examples/incomplete/glsar.py
+++ b/examples/incomplete/glsar.py
@@ -150,3 +150,7 @@ if 5 in examples:
     model3b = GLSAR(Y, rho=0.1)
     for i in range(6):
         print(i, model3b.iterative_fit(2).params, model3b.rho)
+
+
+print(np.array(res.history['params']))
+print(np.array(res.history['rho']))

--- a/statsmodels/regression/linear_model.py
+++ b/statsmodels/regression/linear_model.py
@@ -847,14 +847,18 @@ class GLSAR(GLS):
         if hasattr(self, 'pinv_wexog'):
             del self.pinv_wexog
         self.initialize()
-        if _is_using_pandas(history['params'][0], None):
-            history['params'] = pd.concat(history['params'], 1)
-            history['params'].columns = ['iter_' + int(i) for i in range(history['params'].shape[1])]
-        else:
-            history['params'] = np.column_stack(history['params'])
+        if history['params']:
+            if _is_using_pandas(history['params'][0], None):
+                history['params'] = pd.concat(history['params'], 1)
+                history['params'].columns = ['iter_' + int(i) for i in range(history['params'].shape[1])]
+            else:
+                history['params'] = np.array(history['params'])
         # Use kwarg to insert history
 
         results = self.fit(history=history)
+#         # add last fit to history
+#         results.history['params'] = np.vstack((results.history['params'],
+#                                                results.params))
 
         return results
 

--- a/statsmodels/regression/tests/test_glsar_stata.py
+++ b/statsmodels/regression/tests/test_glsar_stata.py
@@ -69,9 +69,12 @@ class TestGLSARCorc(CheckStataResultsPMixin):
         assert_allclose(res.bse, res_arma.bse[[1,2,0]], atol=0.015, rtol=1e-3)
 
         assert_equal(len(res.history['params']), 5)
-        #assert_equal(res.history['params'][-1], res.params)
-        assert_allclose(res.history['params'][-1], res.params, rtol=1e-10)
+        # this should be identical, history has last fit
+        assert_equal(res.history['params'][-1], res.params)
 
+        res2 = mod1.iterative_fit(4, rtol=0)
+        assert_equal(len(res2.history['params']), 4)
+        assert_equal(len(res2.history['rho']), 4)
 
 
     def test_glsar_iter0(self):

--- a/statsmodels/regression/tests/test_glsar_stata.py
+++ b/statsmodels/regression/tests/test_glsar_stata.py
@@ -7,7 +7,7 @@ Author: Josef Perktold
 """
 
 import numpy as np
-from numpy.testing import assert_almost_equal, assert_allclose
+from numpy.testing import assert_almost_equal, assert_allclose, assert_equal
 
 from statsmodels.regression.linear_model import GLSAR
 from statsmodels.tools.tools import add_constant
@@ -53,6 +53,41 @@ class TestGLSARCorc(CheckStataResultsPMixin):
         assert_almost_equal(self.res.model.rho, self.results.rho, 3)  # pylint: disable-msg=E1101
 
         assert_almost_equal(self.res.llf, self.results.ll, 4)
+
+
+    def test_glsar_arima(self):
+        from statsmodels.tsa.arima_model import ARMA
+
+        endog = self.res.model.endog
+        exog = self.res.model.exog
+        mod1 = GLSAR(endog, exog, 3)
+        res = mod1.iterative_fit(10)
+        mod_arma = ARMA(endog, order=(3,0), exog=exog[:, :-1])
+        res_arma = mod_arma.fit(method='css', iprint=0, disp=0)
+        assert_allclose(res.params, res_arma.params[[1,2,0]], atol=0.01, rtol=1e-3)
+        assert_allclose(res.model.rho, res_arma.params[3:], atol=0.05, rtol=1e-3)
+        assert_allclose(res.bse, res_arma.bse[[1,2,0]], atol=0.015, rtol=1e-3)
+
+        assert_equal(len(res.history['params']), 5)
+        #assert_equal(res.history['params'][-1], res.params)
+        assert_allclose(res.history['params'][-1], res.params, rtol=1e-10)
+
+
+
+    def test_glsar_iter0(self):
+        endog = self.res.model.endog
+        exog = self.res.model.exog
+
+        rho = np.array([ 0.207,  0.275,  1.033])
+        mod1 = GLSAR(endog, exog, rho)
+        res1 = mod1.fit()
+        res0 = mod1.iterative_fit(0)
+        res0b = mod1.iterative_fit(1)
+        # check iterative_fit(0) or iterative_fit(1) doesn't update rho
+        assert_allclose(res0.params, res1.params, rtol=1e-11)
+        assert_allclose(res0b.params, res1.params, rtol=1e-11)
+        assert_allclose(res0.model.rho, rho, rtol=1e-11)
+        assert_allclose(res0b.model.rho, rho, rtol=1e-11)
 
 
 if __name__=="__main__":


### PR DESCRIPTION
This is a version of #2269  with additional commits: fix empty history, additional unit tests, update example file

The last commit adds some refactoring, and adds whitening for the last fit. The last fit after convergence is still a duplicate that doesn't update the whitened endog and exog.

changed that history parameters numpy array has params in rows 