### PR TITLE
BUG: Statespace: Error with dynamic predict over a subsample when time-varying matrices are present.

### DIFF
--- a/statsmodels/tsa/statespace/kalman_filter.py
+++ b/statsmodels/tsa/statespace/kalman_filter.py
@@ -1179,7 +1179,7 @@ class FilterResults(FrozenRepresentation):
         # KalmanFilter(...) construction call, because the endog has length
         # nstatic + ndynamic + nforecast, whereas the time-varying matrices
         # from `representation` have length nobs.
-        if ndynamic > 0:
+        if ndynamic > 0 and end < self.nobs:
             for name, shape in self.shapes.items():
                 if not name == 'obs' and representation[name].shape[-1] > 1:
                     representation[name] = representation[name][..., :end]

--- a/statsmodels/tsa/statespace/kalman_filter.py
+++ b/statsmodels/tsa/statespace/kalman_filter.py
@@ -1172,6 +1172,18 @@ class FilterResults(FrozenRepresentation):
                             raise ValueError(exception % name)
                         representation[name] = np.c_[representation[name], mat]
 
+        # Update the matrices from kwargs for dynamic prediction in the case
+        # that `end` is less than `nobs` and `dynamic` is less than `end`. In
+        # this case, any time-varying matrices in the default `representation`
+        # will be too long, causing an error to be thrown below in the
+        # KalmanFilter(...) construction call, because the endog has length
+        # nstatic + ndynamic + nforecast, whereas the time-varying matrices
+        # from `representation` have length nobs.
+        if ndynamic > 0:
+            for name, shape in self.shapes.items():
+                if not name == 'obs' and representation[name].shape[-1] > 1:
+                    representation[name] = representation[name][..., :end]
+
         # Construct the predicted state and covariance matrix for each time
         # period depending on whether that time period corresponds to
         # one-step-ahead prediction, dynamic prediction, or out-of-sample

--- a/statsmodels/tsa/statespace/mlemodel.py
+++ b/statsmodels/tsa/statespace/mlemodel.py
@@ -1126,7 +1126,7 @@ class MLEResults(tsbase.TimeSeriesModelResults):
             parse or a datetime type. Default is the the zeroth observation.
         end : int, str, or datetime, optional
             Zero-indexed observation number at which to end forecasting, ie.,
-            the first forecast is start. Can also be a date string to
+            the last forecast is end. Can also be a date string to
             parse or a datetime type. However, if the dates index does not
             have a fixed frequency, end must be an integer index if you
             want out of sample prediction. Default is the last observation in

--- a/statsmodels/tsa/statespace/sarimax.py
+++ b/statsmodels/tsa/statespace/sarimax.py
@@ -1870,7 +1870,7 @@ class SARIMAXResults(MLEResults):
             Array of out of sample forecasts.
         """
         if start is None:
-                start = 0
+            start = 0
 
         # Handle end (e.g. date)
         _start = self.model._get_predict_start(start)


### PR DESCRIPTION
See #2554 for description of the problem. If there are time-varying matrices and a subsample with `end < nobs` is selected, the time-varying matrices are never cut down to match the size of that subsample. Thus the time-varying matrix used for prediction still has time-dimension length of `nobs` even though it should have time dimension length of `end`.