### PR TITLE
BUG: ARMA predict better input handling

### DIFF
--- a/statsmodels/base/optimizer.py
+++ b/statsmodels/base/optimizer.py
@@ -323,6 +323,7 @@ def _fit_lbfgs(f, score, start_params, fargs, kwargs, disp=True,
 
     # Use unconstrained optimization by default.
     bounds = kwargs.setdefault('bounds', [(None, None)] * len(start_params))
+    kwargs.setdefault('iprint', 0)
 
     # Pass the following keyword argument names through to fmin_l_bfgs_b
     # if they are present in kwargs, otherwise use the fmin_l_bfgs_b

--- a/statsmodels/tsa/arima_model.py
+++ b/statsmodels/tsa/arima_model.py
@@ -725,11 +725,14 @@ class ARMA(tsbase.TimeSeriesModel):
         resid = self.geterrors(params)
         k_ar = self.k_ar
 
-        if out_of_sample != 0 and self.k_exog > 0:
+        if exog is not None:
+            # Note: we ignore currently the index of exog if it is available
             exog = np.asarray(exog)
             if self.k_exog == 1 and exog.ndim == 1:
                 exog = exog[:, None]
-                # we need the last k_ar exog for the lag-polynomial
+
+        if out_of_sample != 0 and self.k_exog > 0:
+            # we need the last k_ar exog for the lag-polynomial
             if self.k_exog > 0 and k_ar > 0 and not dynamic:
                 # need the last k_ar exog for the lag-polynomial
                 exog = np.vstack((self.exog[-k_ar:, self.k_trend:], exog))

--- a/statsmodels/tsa/base/tsa_model.py
+++ b/statsmodels/tsa/base/tsa_model.py
@@ -145,12 +145,18 @@ class TimeSeriesModel(base.LikelihoodModel):
         dates = self.data.dates
         freq = self.data.freq
 
-        if isinstance(end, str):
+        if isinstance(end, str) or (dates is not None
+                                    and isinstance(end, type(dates[0]))):
             if dates is None:
-                raise ValueError("Got a string for end and dates is None")
-            try:
+                raise ValueError("Got a string or date for `end` and `dates` is None")
+
+            if isinstance(end, str):
                 dtend = self._str_to_date(end)
-                self.data.predict_end = dtend
+            else:
+                dtend = end  # end could be a pandas TimeStamp not a datetime
+
+            self.data.predict_end = dtend
+            try:
                 end = self._get_dates_loc(dates, dtend)
             except KeyError as err: # end is greater than dates[-1]...probably
                 if dtend > self.data.dates[-1]:
@@ -203,6 +209,9 @@ class TimeSeriesModel(base.LikelihoodModel):
         elif freq is None: # should have a date with freq = None
             raise ValueError("When freq is None, you must give an integer "
                              "index for end.")
+
+        else:
+            raise ValueError("no rule for interpreting end")
 
         return end, out_of_sample
 


### PR DESCRIPTION
ARMA predict  (usability bugs, not incorrect numbers)

fixes #2587 pandas date handling in `end`
fixes #2589 1d exog

This also includes changing the default iprint to zero in lbfgsb optimizer.
This should solve several reported crashes when the lbfgsb fortran code tries to write to a file but is not able to.
(It looked like it didn't close the file handle when optimization finished. Two processes blocked each other for file write access and crashed/segfaulted.)