### PR TITLE
ENH: Statespace: Improve operability with wrappers.

### DIFF
--- a/examples/notebooks/statespace_arma_0.ipynb
+++ b/examples/notebooks/statespace_arma_0.ipynb
@@ -1,326 +1,357 @@
 {
- "metadata": {
-  "name": "",
-  "signature": "sha256:9136438335b909aad7f511cb3e18b8ad11b64630b98d8f96c556ee7ddabcf76b"
- },
- "nbformat": 3,
- "nbformat_minor": 0,
- "worksheets": [
+ "cells": [
   {
-   "cells": [
-    {
-     "cell_type": "heading",
-     "level": 1,
-     "metadata": {},
-     "source": [
-      "Autoregressive Moving Average (ARMA): Sunspots data"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "This notebook replicates the existing ARMA notebook using the `statsmodels.tsa.statespace.SARIMAX` class rather than the `statsmodels.tsa.ARMA` class."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "%matplotlib inline"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "from __future__ import print_function\n",
-      "import numpy as np\n",
-      "from scipy import stats\n",
-      "import pandas as pd\n",
-      "import matplotlib.pyplot as plt\n",
-      "\n",
-      "import statsmodels.api as sm"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "from statsmodels.graphics.api import qqplot"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "heading",
-     "level": 2,
-     "metadata": {},
-     "source": [
-      "Sunpots Data"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "print(sm.datasets.sunspots.NOTE)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "dta = sm.datasets.sunspots.load_pandas().data"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "dta.index = pd.Index(sm.tsa.datetools.dates_from_range('1700', '2008'))\n",
-      "del dta[\"YEAR\"]"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "dta.plot(figsize=(12,4));"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "fig = plt.figure(figsize=(12,8))\n",
-      "ax1 = fig.add_subplot(211)\n",
-      "fig = sm.graphics.tsa.plot_acf(dta.values.squeeze(), lags=40, ax=ax1)\n",
-      "ax2 = fig.add_subplot(212)\n",
-      "fig = sm.graphics.tsa.plot_pacf(dta, lags=40, ax=ax2)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "arma_mod20 = sm.tsa.statespace.SARIMAX(dta, order=(2,0,0), trend='c').fit()\n",
-      "print(arma_mod20.params)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "arma_mod30 = sm.tsa.statespace.SARIMAX(dta, order=(3,0,0), trend='c').fit()"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "print(arma_mod20.aic, arma_mod20.bic, arma_mod20.hqic)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "print(arma_mod30.params)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "print(arma_mod30.aic, arma_mod30.bic, arma_mod30.hqic)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "* Does our model obey the theory?"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "sm.stats.durbin_watson(arma_mod30.resid()[0])"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "fig = plt.figure(figsize=(12,4))\n",
-      "ax = fig.add_subplot(111)\n",
-      "ax = plt.plot(arma_mod30.resid()[0])"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "resid = arma_mod30.resid()[0]"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "stats.normaltest(resid)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "fig = plt.figure(figsize=(12,4))\n",
-      "ax = fig.add_subplot(111)\n",
-      "fig = qqplot(resid, line='q', ax=ax, fit=True)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "fig = plt.figure(figsize=(12,8))\n",
-      "ax1 = fig.add_subplot(211)\n",
-      "fig = sm.graphics.tsa.plot_acf(resid, lags=40, ax=ax1)\n",
-      "ax2 = fig.add_subplot(212)\n",
-      "fig = sm.graphics.tsa.plot_pacf(resid, lags=40, ax=ax2)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "r,q,p = sm.tsa.acf(resid, qstat=True)\n",
-      "data = np.c_[range(1,41), r[1:], q, p]\n",
-      "table = pd.DataFrame(data, columns=['lag', \"AC\", \"Q\", \"Prob(>Q)\"])\n",
-      "print(table.set_index('lag'))"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "* This indicates a lack of fit."
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "* In-sample dynamic prediction. How good does our model do?"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "predict_sunspots = arma_mod30.predict(start='1990', end='2012', dynamic=True)\n",
-      "index = pd.date_range('1990','2013',freq='A')"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "fig, ax = plt.subplots(figsize=(12, 8))\n",
-      "ax.plot(dta.ix['1950':].index._mpl_repr(), dta.ix['1950':])\n",
-      "ax.plot(index, predict_sunspots[0], 'r');"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "def mean_forecast_err(y, yhat):\n",
-      "    return y.sub(yhat).mean()"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "mean_forecast_err(dta.SUNACTIVITY, pd.Series(predict_sunspots[0], index=index))"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    }
-   ],
-   "metadata": {}
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Autoregressive Moving Average (ARMA): Sunspots data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This notebook replicates the existing ARMA notebook using the `statsmodels.tsa.statespace.SARIMAX` class rather than the `statsmodels.tsa.ARMA` class."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from __future__ import print_function\n",
+    "import numpy as np\n",
+    "from scipy import stats\n",
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "import statsmodels.api as sm"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from statsmodels.graphics.api import qqplot"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Sunpots Data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print(sm.datasets.sunspots.NOTE)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "dta = sm.datasets.sunspots.load_pandas().data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "dta.index = pd.Index(sm.tsa.datetools.dates_from_range('1700', '2008'))\n",
+    "del dta[\"YEAR\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "dta.plot(figsize=(12,4));"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "fig = plt.figure(figsize=(12,8))\n",
+    "ax1 = fig.add_subplot(211)\n",
+    "fig = sm.graphics.tsa.plot_acf(dta.values.squeeze(), lags=40, ax=ax1)\n",
+    "ax2 = fig.add_subplot(212)\n",
+    "fig = sm.graphics.tsa.plot_pacf(dta, lags=40, ax=ax2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "arma_mod20 = sm.tsa.statespace.SARIMAX(dta, order=(2,0,0), trend='c').fit()\n",
+    "print(arma_mod20.params)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "arma_mod30 = sm.tsa.statespace.SARIMAX(dta, order=(3,0,0), trend='c').fit()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print(arma_mod20.aic, arma_mod20.bic, arma_mod20.hqic)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print(arma_mod30.params)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print(arma_mod30.aic, arma_mod30.bic, arma_mod30.hqic)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "* Does our model obey the theory?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "sm.stats.durbin_watson(arma_mod30.resid)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "fig = plt.figure(figsize=(12,4))\n",
+    "ax = fig.add_subplot(111)\n",
+    "ax = plt.plot(arma_mod30.resid)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "resid = arma_mod30.resid"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "stats.normaltest(resid)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "fig = plt.figure(figsize=(12,4))\n",
+    "ax = fig.add_subplot(111)\n",
+    "fig = qqplot(resid, line='q', ax=ax, fit=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "fig = plt.figure(figsize=(12,8))\n",
+    "ax1 = fig.add_subplot(211)\n",
+    "fig = sm.graphics.tsa.plot_acf(resid, lags=40, ax=ax1)\n",
+    "ax2 = fig.add_subplot(212)\n",
+    "fig = sm.graphics.tsa.plot_pacf(resid, lags=40, ax=ax2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "r,q,p = sm.tsa.acf(resid, qstat=True)\n",
+    "data = np.c_[range(1,41), r[1:], q, p]\n",
+    "table = pd.DataFrame(data, columns=['lag', \"AC\", \"Q\", \"Prob(>Q)\"])\n",
+    "print(table.set_index('lag'))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "* This indicates a lack of fit."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "* In-sample dynamic prediction. How good does our model do?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "predict_sunspots = arma_mod30.predict(start='1990', end='2012', dynamic=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots(figsize=(12, 8))\n",
+    "dta.ix['1950':].plot(ax=ax)\n",
+    "predict_sunspots.plot(ax=ax, style='r');"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def mean_forecast_err(y, yhat):\n",
+    "    return y.sub(yhat).mean()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "mean_forecast_err(dta.SUNACTIVITY, pd.Series(predict_sunspots[0], index=index))"
+   ]
   }
- ]
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
 }

--- a/examples/notebooks/statespace_local_linear_trend.ipynb
+++ b/examples/notebooks/statespace_local_linear_trend.ipynb
@@ -208,19 +208,8 @@
    "outputs": [],
    "source": [
     "# Perform prediction and forecasting\n",
-    "predict_res =res.predict(end='2014', full_results=True)\n",
-    "\n",
-    "predict = predict_res.forecasts\n",
-    "cov = predict_res.forecasts_error_cov\n",
-    "idx = res.data.predict_dates\n",
-    "\n",
-    "# 95% confidence intervals\n",
-    "critical_value = norm.ppf(1 - 0.05 / 2.)\n",
-    "std_errors = np.sqrt(cov.diagonal().T)\n",
-    "ci = np.c_[\n",
-    "    (predict - critical_value*std_errors)[:, :, None],\n",
-    "    (predict + critical_value*std_errors)[:, :, None],\n",
-    "]"
+    "predict = res.predict()\n",
+    "forecast = res.forecast('2014')"
    ]
   },
   {
@@ -234,18 +223,13 @@
     "fig, ax = plt.subplots(figsize=(10,4))\n",
     "\n",
     "# Plot the results\n",
-    "dates = df.index._mpl_repr()\n",
-    "ax.plot(dates, df['lff'], 'k.', label='Observations');\n",
-    "ax.plot(idx[:-10], predict[0][:-10], label='One-step-ahead Prediction');\n",
-    "ax.plot(idx[:-10], ci[0, :-10], 'k--', alpha=0.5);\n",
-    "\n",
-    "ax.plot(idx[-10:], predict[0][-10:], 'r', label='Forecast');\n",
-    "ax.plot(idx[-10:], ci[0, -10:], 'k--', alpha=0.5);\n",
+    "df['lff'].plot(ax=ax, style='k.', label='Observations')\n",
+    "predict.plot(ax=ax, label='One-step-ahead Prediction')\n",
+    "forecast.plot(ax=ax, style='r', label='Forecast')\n",
     "\n",
     "# Cleanup the image\n",
     "ax.set_ylim((4, 8));\n",
-    "legend = ax.legend(loc='lower left');\n",
-    "legend.get_frame().set_facecolor('w')"
+    "legend = ax.legend(loc='lower left');"
    ]
   },
   {
@@ -269,18 +253,6 @@
    "display_name": "Python 2",
    "language": "python",
    "name": "python2"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 2
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.6"
   }
  },
  "nbformat": 4,

--- a/examples/notebooks/statespace_sarimax_internet.ipynb
+++ b/examples/notebooks/statespace_sarimax_internet.ipynb
@@ -219,54 +219,19 @@
    },
    "outputs": [],
    "source": [
-    "# In-sample one-step-ahead predictions\n",
-    "predict_res = res.predict(full_results=True)\n",
-    "\n",
-    "predict = predict_res.forecasts\n",
-    "cov = predict_res.forecasts_error_cov\n",
-    "predict_idx = np.arange(len(predict[0]))\n",
-    "\n",
-    "# 95% confidence intervals\n",
-    "critical_value = norm.ppf(1 - 0.05 / 2.)\n",
-    "std_errors = np.sqrt(cov.diagonal().T)\n",
-    "ci = np.c_[\n",
-    "    (predict - critical_value*std_errors)[:, :, None],\n",
-    "    (predict + critical_value*std_errors)[:, :, None],\n",
-    "][0].T"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "# Out-of-sample forecasts and confidence intervals\n",
+    "# In-sample one-step-ahead predictions, and out-of-sample forecasts\n",
     "nforecast = 20\n",
-    "forecast = res.forecast(nforecast)\n",
-    "forcast_idx = len(dta_full) + np.arange(nforecast)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
+    "predict = res.predict(end=mod.nobs + nforecast)\n",
+    "idx = np.arange(mod.nobs + nforecast + 1)\n",
+    "\n",
     "# Graph\n",
     "fig, ax = plt.subplots(figsize=(12,6))\n",
     "ax.xaxis.grid()\n",
-    "ax.plot(predict_idx, dta_miss, 'k.')\n",
+    "ax.plot(dta_miss, 'k.')\n",
     "\n",
     "# Plot\n",
-    "ax.plot(predict_idx, predict[0], 'gray');\n",
-    "ax.fill_between(predict_idx, ci[0], ci[1], alpha=0.1)\n",
-    "\n",
-    "ax.plot(forcast_idx[-20:], forecast[0], 'k--', linestyle='--', linewidth=2)\n",
+    "ax.plot(idx[:-nforecast], predict[:-nforecast], 'gray');\n",
+    "ax.plot(idx[-nforecast:], predict[-nforecast:], 'k--', linestyle='--', linewidth=2)\n",
     "\n",
     "ax.set(title='Figure 8.9 - Internet series');"
    ]

--- a/examples/notebooks/statespace_sarimax_stata.ipynb
+++ b/examples/notebooks/statespace_sarimax_stata.ipynb
@@ -471,7 +471,7 @@
    "outputs": [],
    "source": [
     "mod = sm.tsa.statespace.SARIMAX(endog, exog=exog, order=(1,0,1))\n",
-    "res = mod.filter(np.array(fit_res.params))"
+    "res = mod.filter(fit_res.params)"
    ]
   },
   {
@@ -492,19 +492,7 @@
    "outputs": [],
    "source": [
     "# In-sample one-step-ahead predictions\n",
-    "predict_res = res.predict(full_results=True)\n",
-    "\n",
-    "predict = predict_res.forecasts\n",
-    "cov = predict_res.forecasts_error_cov\n",
-    "idx = res.data.predict_dates._mpl_repr()\n",
-    "\n",
-    "# 95% confidence intervals\n",
-    "critical_value = norm.ppf(1 - 0.05 / 2.)\n",
-    "std_errors = np.sqrt(cov.diagonal().T)\n",
-    "ci = np.c_[\n",
-    "    (predict - critical_value*std_errors)[:, :, None],\n",
-    "    (predict + critical_value*std_errors)[:, :, None],\n",
-    "]"
+    "predict = res.predict()"
    ]
   },
   {
@@ -527,20 +515,7 @@
    "outputs": [],
    "source": [
     "# Dynamic predictions\n",
-    "npredict = data.ix['1978-01-01':].shape[0]\n",
-    "\n",
-    "predict_dy_res = res.predict(dynamic=nobs-npredict-1, full_results=True)\n",
-    "\n",
-    "predict_dy = predict_dy_res.forecasts\n",
-    "cov_dy = predict_dy_res.forecasts_error_cov\n",
-    "\n",
-    "# 95% confidence intervals\n",
-    "critical_value = norm.ppf(1 - 0.05 / 2.)\n",
-    "std_errors_dy = np.sqrt(cov_dy.diagonal().T)\n",
-    "ci_dy = np.c_[\n",
-    "    (predict_dy - critical_value*std_errors_dy)[:, :, None],\n",
-    "    (predict_dy + critical_value*std_errors_dy)[:, :, None],\n",
-    "]"
+    "predict_dy = res.predict(dynamic='1977-10-01')"
    ]
   },
   {
@@ -562,18 +537,15 @@
     "fig, ax = plt.subplots(figsize=(9,4))\n",
     "npre = 4\n",
     "ax.set(title='Personal consumption', xlabel='Date', ylabel='Billions of dollars')\n",
-    "dates = data.index[-npredict-npre+1:]._mpl_repr()\n",
-    "ax.plot(dates, data.ix[-npredict-npre+1:, 'consump'], 'o', label='Observed')\n",
+    "\n",
+    "# Plot data points\n",
+    "data.ix['1977-07-01':, 'consump'].plot(ax=ax, style='o', label='Observed')\n",
     "\n",
     "# Plot predictions\n",
-    "ax.plot(idx[-npredict-npre:], predict[0, -npredict-npre:], 'r--', label='One-step-ahead forecast');\n",
-    "ax.plot(idx[-npredict-npre:], ci[0, -npredict-npre:], 'r--', alpha=0.3);\n",
+    "predict.ix['1977-07-01':].plot(ax=ax, style='r--', label='One-step-ahead forecast')\n",
+    "predict_dy.ix['1977-07-01':].plot(ax=ax, style='g', label='Dynamic forecast (1978)')\n",
     "\n",
-    "ax.plot(idx[-npredict-npre:], predict_dy[0, -npredict-npre:], 'g', label='Dynamic forecast (1978)');\n",
-    "ax.plot(idx[-npredict-npre:], ci_dy[0, -npredict-npre:], 'g:', alpha=0.3);\n",
-    "\n",
-    "legend = ax.legend(loc='lower right')\n",
-    "legend.get_frame().set_facecolor('w')"
+    "legend = ax.legend(loc='lower right')"
    ]
   },
   {
@@ -599,16 +571,12 @@
     "ax.set(title='Forecast error', xlabel='Date', ylabel='Forecast - Actual')\n",
     "\n",
     "# In-sample one-step-ahead predictions and 95% confidence intervals\n",
-    "predict_error = predict[0, -npredict-1:] - endog.iloc[-npredict-1:]\n",
-    "predict_ci = ci[0, -npredict-1:] - endog.iloc[-npredict-1:][:, None]\n",
-    "ax.plot(idx[-npredict-1:], predict_error, label='One-step-ahead forecast');\n",
-    "ax.plot(idx[-npredict-1:], predict_ci, 'b--', alpha=0.4)\n",
+    "predict_error = predict - endog\n",
+    "predict_error.ix['1977-10-01':].plot(ax=ax, label='One-step-ahead forecast')\n",
     "\n",
     "# Dynamic predictions and 95% confidence intervals\n",
-    "predict_dy_error = predict_dy[0, -npredict-1:] - endog.iloc[-npredict-1:]\n",
-    "predict_dy_ci = ci_dy[0, -npredict-1:] - endog.iloc[-npredict-1:][:, None]\n",
-    "ax.plot(idx[-npredict-1:], predict_dy_error, 'r', label='Dynamic forecast (1978)');\n",
-    "ax.plot(idx[-npredict-1:], predict_dy_ci, 'r--', alpha=0.4)\n",
+    "predict_dy_error = predict_dy - endog\n",
+    "predict_dy_error.ix['1977-10-01':].plot(ax=ax, style='r', label='Dynamic forecast (1978)')\n",
     "\n",
     "legend = ax.legend(loc='lower left');\n",
     "legend.get_frame().set_facecolor('w')"

--- a/statsmodels/base/data.py
+++ b/statsmodels/base/data.py
@@ -531,8 +531,10 @@ class PandasData(ModelData):
     def attach_rows(self, result):
         # assumes if len(row_labels) > len(result) it's bc it was truncated
         # at the front, for AR lags, for example
-        if result.squeeze().ndim == 1:
-            return Series(result, index=self.row_labels[-len(result):])
+        squeezed = result.squeeze()
+        # May be zero-dim, for example in the case of forecast one step in tsa
+        if squeezed.ndim < 2:
+            return Series(squeezed, index=self.row_labels[-len(result):])
         else:  # this is for VAR results, may not be general enough
             return DataFrame(result, index=self.row_labels[-len(result):],
                              columns=self.ynames)

--- a/statsmodels/base/data.py
+++ b/statsmodels/base/data.py
@@ -538,8 +538,13 @@ class PandasData(ModelData):
                              columns=self.ynames)
 
     def attach_dates(self, result):
-        return TimeSeries(result, index=self.predict_dates)
-
+        squeezed = result.squeeze()
+        # May be zero-dim, for example in the case of forecast one step in tsa
+        if squeezed.ndim < 2:
+            return TimeSeries(squeezed, index=self.predict_dates)
+        else:
+            return DataFrame(result, index=self.predict_dates,
+                             columns=self.ynames)
 
 def _make_endog_names(endog):
     if endog.ndim == 1 or endog.shape[1] == 1:

--- a/statsmodels/tsa/statespace/mlemodel.py
+++ b/statsmodels/tsa/statespace/mlemodel.py
@@ -1139,11 +1139,11 @@ class MLEResults(tsbase.TimeSeriesModelResults):
         Parameters
         ----------
         start : int, str, or datetime, optional
-            Zero-indexed observation number at which to start forecasting, ie.,
-            the first forecast is start. Can also be a date string to
+            Zero-indexed observation number at which to start forecasting,
+            i.e., the first forecast is start. Can also be a date string to
             parse or a datetime type. Default is the the zeroth observation.
         end : int, str, or datetime, optional
-            Zero-indexed observation number at which to end forecasting, ie.,
+            Zero-indexed observation number at which to end forecasting, i.e.,
             the last forecast is end. Can also be a date string to
             parse or a datetime type. However, if the dates index does not
             have a fixed frequency, end must be an integer index if you
@@ -1210,9 +1210,11 @@ class MLEResults(tsbase.TimeSeriesModelResults):
 
         Parameters
         ----------
-        steps : int, optional
-            The number of out of sample forecasts from the end of the
-            sample. Default is 1.
+        steps : int, str, or datetime, optional
+            If an integer, the number of steps to forecast from the end of the
+            sample. Can also be a date string to parse or a datetime type.
+            However, if the dates index does not have a fixed frequency, steps
+            must be an integer. Default
         **kwargs
             Additional arguments may required for forecasting beyond the end
             of the sample. See `FilterResults.predict` for more details.
@@ -1222,8 +1224,11 @@ class MLEResults(tsbase.TimeSeriesModelResults):
         forecast : array
             Array of out of sample forecasts. A (steps x k_endog) array.
         """
-        forecasts = self.predict(start=self.nobs, end=self.nobs+steps-1, **kwargs)
-        print(forecasts.shape)
+        if isinstance(steps, int):
+            end = self.nobs+steps-1
+        else:
+            end = steps
+        forecasts = self.predict(start=self.nobs, end=end, **kwargs)
         return forecasts
 
     def summary(self, alpha=.05, start=None, model_name=None):

--- a/statsmodels/tsa/statespace/mlemodel.py
+++ b/statsmodels/tsa/statespace/mlemodel.py
@@ -1055,11 +1055,20 @@ class MLEResults(tsbase.TimeSeriesModelResults):
             np.dot(np.dot(evaluated_hessian, cov_opg), evaluated_hessian)
         )
 
+    @cache_readonly
     def fittedvalues(self):
         """
-        (array) The predicted values of the model.
+        (array) The predicted values of the model. An (nobs x k_endog) array.
         """
-        return self.filter_results.forecasts
+        # This is a (k_endog x nobs array; don't want to squeeze in case of
+        # the corner case where nobs = 1 (mostly a concern in the predict or
+        # forecast functions, but here also to maintain consistency)
+        fittedvalues = self.filter_results.forecasts
+        if fittedvalues.shape[0] == 1:
+            fittedvalues = fittedvalues[0,:]
+        else:
+            fittedvalues = fittedvalues.T
+        return fittedvalues
 
     @cache_readonly
     def hqic(self):
@@ -1100,11 +1109,20 @@ class MLEResults(tsbase.TimeSeriesModelResults):
         """
         return norm.sf(np.abs(self.zvalues)) * 2
 
+    @cache_readonly
     def resid(self):
         """
-        (array) The model residuals.
+        (array) The model residuals. An (nobs x k_endog) array.
         """
-        return self.filter_results.forecasts_error
+        # This is a (k_endog x nobs array; don't want to squeeze in case of
+        # the corner case where nobs = 1 (mostly a concern in the predict or
+        # forecast functions, but here also to maintain consistency)
+        resid = self.filter_results.forecasts_error
+        if resid.shape[0] == 1:
+            resid = resid[0,:]
+        else:
+            resid = resid.T
+        return resid
 
     @cache_readonly
     def zvalues(self):
@@ -1150,7 +1168,8 @@ class MLEResults(tsbase.TimeSeriesModelResults):
         Returns
         -------
         forecast : array
-            Array of out of sample forecasts.
+            Array of out of in-sample predictions and / or out-of-sample
+            forecasts. An (npredict x k_endog) array.
         """
         if start is None:
             start = 0
@@ -1174,20 +1193,16 @@ class MLEResults(tsbase.TimeSeriesModelResults):
                                  (str(dynamic), str(dtdynamic)))
 
         # Perform the prediction
-        results = self.filter_results.predict(
-            start, end+out_of_sample+1, dynamic, full_results, **kwargs
+        # This is a (k_endog x npredictions) array; don't want to squeeze in
+        # case of npredictions = 1
+        predictions = self.filter_results.predict(
+            start, end+out_of_sample+1, dynamic, **kwargs
         )
-
-        # Note: to be consistent with Statsmodels, return only the forecasts
-        # unless full_results is specified. Confidence intervals and the date
-        # indices are left out for now, but will likely be moved to a separate
-        # function in the future.
-        if full_results:
-            return results
+        if predictions.shape[0] == 1:
+            predictions = predictions[0,:]
         else:
-            forecasts = results
-
-        return forecasts
+            predictions = predictions.T
+        return predictions
 
     def forecast(self, steps=1, **kwargs):
         """
@@ -1205,9 +1220,11 @@ class MLEResults(tsbase.TimeSeriesModelResults):
         Returns
         -------
         forecast : array
-            Array of out of sample forecasts.
+            Array of out of sample forecasts. A (steps x k_endog) array.
         """
-        return self.predict(start=self.nobs, end=self.nobs+steps-1, **kwargs)
+        forecasts = self.predict(start=self.nobs, end=self.nobs+steps-1, **kwargs)
+        print(forecasts.shape)
+        return forecasts
 
     def summary(self, alpha=.05, start=None, model_name=None):
         """
@@ -1292,17 +1309,21 @@ class MLEResults(tsbase.TimeSeriesModelResults):
 
 
 class MLEResultsWrapper(wrap.ResultsWrapper):
-    _attrs = {}
+    _attrs = {
+        'zvalues': 'columns',
+        'cov_params_cs': 'cov',
+        'cov_params_default': 'cov',
+        'cov_params_delta': 'cov',
+        'cov_params_oim': 'cov',
+        'cov_params_opg': 'cov',
+        'cov_params_robust': 'cov',
+        'cov_params_robust_cs': 'cov',
+        'cov_params_robust_oim': 'cov',
+    }
     _wrap_attrs = wrap.union_dicts(tsbase.TimeSeriesResultsWrapper._wrap_attrs,
                                    _attrs)
-    # TODO right now, predict with full_results=True can return something other
-    # than a time series, so the `attach_dates` call will fail if we have
-    # 'predict': 'dates' here. In the future, remove `full_results` and replace
-    # it with new methods, e.g. get_prediction, get_forecast, and likely will
-    # want those to be a subclass of FilterResults with e.g. confidence
-    # intervals calculated and dates attached.
-    # Also, need to modify `attach_dates` to account for DataFrames.
-    _methods = {'predict': None}
-    _wrap_methods = wrap.union_dicts(tsbase.TimeSeriesResultsWrapper._wrap_methods,
-                                     _methods)
+
+    _methods = {'forecast': 'dates'}
+    _wrap_methods = wrap.union_dicts(
+        tsbase.TimeSeriesResultsWrapper._wrap_methods, _methods)
 wrap.populate_wrapper(MLEResultsWrapper, MLEResults)

--- a/statsmodels/tsa/statespace/tests/test_mlemodel.py
+++ b/statsmodels/tsa/statespace/tests/test_mlemodel.py
@@ -230,6 +230,7 @@ def test_forecast():
     mod = MLEModel(pd.Series([1,2], index=index), **kwargs)
     res = mod.filter([])
     assert_allclose(res.forecast(steps=10), np.ones((10,)) * 2)
+    assert_allclose(res.forecast(steps='1960-12-01'), np.ones((10,)) * 2)
 
 
 def test_summary():

--- a/statsmodels/tsa/statespace/tests/test_sarimax.py
+++ b/statsmodels/tsa/statespace/tests/test_sarimax.py
@@ -728,14 +728,14 @@ class TestFriedmanPredict(Friedman):
 
     def test_predict(self):
         assert_almost_equal(
-            self.result.predict()[0],
+            self.result.predict(),
             self.true['predict'], 3
         )
 
     def test_dynamic_predict(self):
         dynamic = len(self.true['data']['consump'])-15-1
         assert_almost_equal(
-            self.result.predict(dynamic=dynamic)[0],
+            self.result.predict(dynamic=dynamic),
             self.true['dynamic_predict'], 3
         )
 
@@ -790,7 +790,7 @@ class TestFriedmanForecast(Friedman):
         end = len(self.true['data']['consump'])+15-1
         exog = add_constant(self.true['forecast_data']['m2'])
         assert_almost_equal(
-            self.result.predict(end=end, exog=exog)[0],
+            self.result.predict(end=end, exog=exog),
             self.true['forecast'], 3
         )
 
@@ -799,7 +799,7 @@ class TestFriedmanForecast(Friedman):
         dynamic = len(self.true['data']['consump'])-1
         exog = add_constant(self.true['forecast_data']['m2'])
         assert_almost_equal(
-            self.result.predict(end=end, dynamic=dynamic, exog=exog)[0],
+            self.result.predict(end=end, dynamic=dynamic, exog=exog),
             self.true['dynamic_forecast'], 3
         )
 
@@ -897,35 +897,35 @@ class SARIMAXCoverageTest(object):
         # Test predict does not throw exceptions, and produces the right shaped
         # output
         predict = result.predict()
-        assert_equal(predict.shape, (1, self.model.nobs))
+        assert_equal(predict.shape, (self.model.nobs,))
 
         predict = result.predict(start=10, end=20)
-        assert_equal(predict.shape, (1, 11))
+        assert_equal(predict.shape, (11,))
 
         predict = result.predict(start=10, end=20, dynamic=10)
-        assert_equal(predict.shape, (1, 11))
+        assert_equal(predict.shape, (11,))
 
         # Test forecasts
         if self.model.k_exog == 0:
             predict = result.predict(start=self.model.nobs,
                                  end=self.model.nobs+10, dynamic=-10)
-            assert_equal(predict.shape, (1, 11))
+            assert_equal(predict.shape, (11,))
 
             predict = result.predict(start=self.model.nobs,
                                      end=self.model.nobs+10, dynamic=-10)
 
             forecast = result.forecast()
-            assert_equal(forecast.shape, (1, 1))
+            assert_equal(forecast.shape, (1,))
 
             forecast = result.forecast(10)
-            assert_equal(forecast.shape, (1, 10))
+            assert_equal(forecast.shape, (10,))
         else:
             exog = np.r_[[0]*self.model.k_exog*11].reshape(11, self.model.k_exog)
 
             predict = result.predict(start=self.model.nobs,
                                      end=self.model.nobs+10, dynamic=-10,
                                      exog=exog)
-            assert_equal(predict.shape, (1, 11))
+            assert_equal(predict.shape, (11,))
 
             predict = result.predict(start=self.model.nobs,
                                      end=self.model.nobs+10, dynamic=-10,
@@ -933,7 +933,7 @@ class SARIMAXCoverageTest(object):
 
             exog = np.r_[[0]*self.model.k_exog].reshape(1, self.model.k_exog)
             forecast = result.forecast(exog=exog)
-            assert_equal(forecast.shape, (1, 1))
+            assert_equal(forecast.shape, (1,))
 
     def test_init_keys_replicate(self):
         mod1 = self.model


### PR DESCRIPTION
Does the following

- Fixes #2584 by improving the `attach_rows` and `attach_dates` functions to correctly support 0-dim, 1-dim, and >1-dim input.
- Adds `cov` wrapping to `predict`, `forecast`, and `cov_params_*` results.
- **Removes the `full_results` argument from `MLEModel.predict`**. This is required to properly support wrapping `predict` and `forecast`. This may break people's code who have been using SARIMAX etc. up to now and following the example notebooks. It also temporarily means that there is no obvious way to get prediction / forecast errors for confidence intervals.
- Allows `forecast` to be specified with an end date (previously only allowed the number of steps).