### PR TITLE
surv object being overwritten bug

### DIFF
--- a/statsmodels/duration/hazard_regression.py
+++ b/statsmodels/duration/hazard_regression.py
@@ -1222,8 +1222,8 @@ class PHReg(model.LikelihoodModel):
                 xp0 -= e_linpred[ix].sum()
 
             cumhaz = np.cumsum(h0) - h0
-            surv = np.exp(-cumhaz)
-            rslt.append([uft, cumhaz, surv])
+            current_strata_surv = np.exp(-cumhaz)
+            rslt.append([uft, cumhaz, current_strata_surv])
 
         return rslt
 

--- a/statsmodels/duration/tests/test_phreg.py
+++ b/statsmodels/duration/tests/test_phreg.py
@@ -102,6 +102,9 @@ class TestPHReg(object):
         coef, se, time_r, hazard_r = get_results(n, p, "et_st", ties1)
         assert_allclose(phrb.params, coef, rtol=1e-3)
         assert_allclose(phrb.bse, se, rtol=1e-4)
+        
+        #smoke test
+        time_h, cumhaz, surv = phrb.baseline_cumulative_hazard[0]
 
 
     # Run all the tests

--- a/statsmodels/duration/tests/test_phreg.py
+++ b/statsmodels/duration/tests/test_phreg.py
@@ -80,7 +80,7 @@ class TestPHReg(object):
         coef_r, se_r, time_r, hazard_r = get_results(n, p, None, ties1)
         assert_allclose(phrb.params, coef_r, rtol=1e-3)
         assert_allclose(phrb.bse, se_r, rtol=1e-4)
-        #time_h, cumhaz, surv = phrb.baseline_hazard[0]
+        time_h, cumhaz, surv = phrb.baseline_cumulative_hazard[0]
 
         # Entry times but no stratification
         phrb = PHReg(time, exog, status, entry=entry,


### PR DESCRIPTION
the PHSurvivalTime.surv object was getting overwritten when the number of strata is greater than 1. This commit fixes the bug. I did not include a test. I'm not that comfortable writing them yet.