### PR TITLE
WIP ENH: exact test equality of two proportions

### DIFF
--- a/statsmodels/examples/ex_proportion_exact.py
+++ b/statsmodels/examples/ex_proportion_exact.py
@@ -1,0 +1,96 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Tue Sep  1 15:28:26 2015
+
+Author: Josef Perktold
+License: BSD-3
+
+"""
+
+from __future__ import division
+
+import numpy as np
+from scipy import stats
+
+from statsmodels.stats._proportion_exact import ExactTwoProportion
+
+ex = 2
+n1, n2 = 15, 15
+yo1 = 7
+yo2 = 12
+
+if ex == 2:
+    n1, n2 = 69, 88
+    yo1 = 67
+    yo2 = 76
+
+pt = ExactTwoProportion(yo1, n1, yo2, n2)
+
+print(pt.chisquare_proportion_indep(yo1, yo2))
+print(pt.chisquare_proportion_indep(yo1, yo2, alternative='todo'))
+print(pt.chisquare_proportion_indep(yo1, yo2, alternative='todo'))
+
+print(pt.chisquare_proportion_indep(np.arange(0, 16), np.arange(0, 16))[1])
+stats.binom.pmf(np.arange(n1 + 1), n1, 0.5)
+
+if ex == 2:
+    alternative='2-sided' #'todo'
+else:
+    alternative='todo'
+sto, pvo = pt.chisquare_proportion_indep(yo1, yo2, alternative=alternative)
+
+ys1 = np.arange(n1 + 1)
+ys2 = np.arange(n2 + 1)
+
+st, pv =  pt.chisquare_proportion_indep(ys1[None, :], ys2[:,None], alternative=alternative)
+
+prob1 = stats.binom.pmf(np.arange(n1 + 1), n1, pt.prob_pooled)
+prob2 = stats.binom.pmf(np.arange(n2 + 1), n1, pt.prob_pooled)
+
+prob = prob1[None, :] * prob2[:, None]
+pvemp = prob[pv < pvo].sum()
+print(pvemp)
+
+st, pv =  pt.chisquare_proportion_indep(ys1[None, :], ys2[:,None],
+                                     prob_var=pt.prob_pooled,
+                                     alternative=alternative)
+
+prob1 = stats.binom.pmf(np.arange(n1 + 1), n1, pt.prob_pooled)
+prob2 = stats.binom.pmf(np.arange(n2 + 1), n1, pt.prob_pooled)
+
+prob = prob1[None, :] * prob2[:, None]
+pvemp = prob[pv < pvo].sum()
+print(pvemp)
+
+res = []
+for prob0 in np.linspace(0.001, 0.999, 1001):
+    #print(prob,)
+    st, pv =  pt.chisquare_proportion_indep(ys1[None, :], ys2[:,None],
+                                     #prob_var=prob0,
+                                     alternative=alternative)
+
+    prob1 = stats.binom.pmf(np.arange(n1 + 1), n1, prob0)
+    prob2 = stats.binom.pmf(np.arange(n2 + 1), n2, prob0)
+
+    prob = prob1[None, :] * prob2[:, None]
+    pvemp = prob[pv <= pvo].sum()
+    #print(pvemp)
+    res.append([prob0, pvemp])
+
+res =np.array(res)
+pvm_ind = res[:,1].argmax(0)
+print(res[pvm_ind])
+
+print(pt.pvalue_exactdist_mle())
+import time
+t0 = time.time()
+pres = pt.pvalue_exact_sup()
+t1 = time.time()
+print(pres[:2])
+print('time', t1 - t0)
+
+t0 = time.time()
+presbb = pt.pvalue_exact_sup(grid=('bb', 0.0001, 101))
+t1 = time.time()
+print(pres[:2])
+print('time', t1 - t0)

--- a/statsmodels/stats/_proportion_exact.py
+++ b/statsmodels/stats/_proportion_exact.py
@@ -1,0 +1,187 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Tue Sep  1 15:28:26 2015
+
+Author: Josef Perktold
+License: BSD-3
+
+"""
+
+from __future__ import division
+
+import numpy as np
+from scipy import stats
+
+
+class ExactTwoProportion(object):
+    """Tests for equality of two independent proportions
+
+    This class provides methods for unconditional exact and for approximate or
+    asymptotic tests for the difference between two proportions from
+    independent samples.
+
+
+    Warning: this is designed for small to moderate sample sizes. It creates
+    arrays with size equal to the cardinality of the underlying sample space.
+
+
+    There is some ambiguity in how the test statistic is defined in corner
+    cases when all observations have the same outcome, i.e. points in the
+    sample space where proportions are either zero or one.
+    Currently the p-value when (p1, p2) is either (0, 0) or (1, 1) is one, i.e.
+    it is never in the rejection region. This implies that the pvalue is
+    always conservative if the both true probabilities approach zero or one.
+
+
+    TODO: API is undecided
+    - what goes in __init__, what in method arguments? e.g. `alternative`
+    - return Results class or test class holds results?
+
+    """
+
+    # use a class to store attributes that don't always change
+    # instead of nested functions or full arguments
+
+    def __init__(self, count1, nobs1, count2, nobs2, alternative='2-sided'):
+        # use yo1, yo2 as local alias for observed counts of successes
+        self.count1 = yo1 = count1
+        self.count2 = yo2 = count2
+        self.count = count1 + count2
+        self.nobs1 = n1 = nobs1
+        self.nobs2 = n2 = nobs2
+        self.nobs = nobs1 + nobs2
+        self.alternative = alternative
+        self.prob_pooled = (yo1 + yo2) / (n1 + n2)
+        self.prop1 = yo1 / n1
+        self.prop2 = yo2 / n2
+        self.statistic_base, self.pvalue_base = self.chisquare_proportion_indep(yo1, yo2,
+                                                 alternative=alternative)
+
+
+    def statistic(self, y1, y2, prob_var=None, alternative='2-sided'):
+        n1, n2 = self.nobs1, self.nobs2
+        # n1, n2 from outer scope
+        p1 = y1 / n1
+        p2 = y2 / n2
+        if prob_var is None:
+            #use pooled probability for variance, i.e. under H0 p1 = p2
+            prob_var = (y1 + y2) / (n1 + n2)
+
+
+        v = prob_var * (1 - prob_var) * (1. / n1 + 1. / n2)
+        v = np.atleast_1d(v)
+        v[v == 0] = 1  #TODO: check corner cases
+        # Todo what's the stat and pvalue if p1 = 0 and p2 = 1, or reversed?
+        # This is well defined since we use pooled variance
+        diff = p2 - p1
+        if alternative == '2-sided':
+            stat = diff**2 / v  # chisquare for two sided
+            return stat
+        else:
+            return diff / np.sqrt(v)
+
+
+    def chisquare_proportion_indep(self, y1, y2, prob_var=None, alternative='2-sided'):
+        stat = self.statistic(y1, y2, prob_var=prob_var, alternative=alternative)
+        if alternative == '2-sided':
+            pvalue = stats.chi2.sf(stat, 1)
+        else:
+            pvalue = stats.norm.sf(stat)
+        return stat, pvalue
+
+
+    def test_asymptotic(self):
+        return self.statistic_base, self.pvalue_base
+
+
+    def pvalue_exactdist_mle(self):
+        """pvalue based on exact distribution with MLE nuisance parameter
+
+        this is not an exact test.
+        The size of the test is close to the nominal value, but not guaranteed
+        to be below it, i.e. test can be liberal in some cases and over reject.
+        """
+        n1, n2 = self.nobs1, self.nobs2
+        alternative = self.alternative  # TODO check if it should be argument
+        pvo = self.pvalue_base  # TODO check, define attribute rejection set
+        # TODO: DRY separate out common code
+        ys1 = np.arange(n1 + 1)
+        ys2 = np.arange(n2 + 1)
+        st, pv =  self.chisquare_proportion_indep(ys1[None, :], ys2[:,None],
+                                     prob_var=self.prob_pooled,
+                                     alternative=alternative)
+
+        prob1 = stats.binom.pmf(np.arange(n1 + 1), n1, self.prob_pooled)
+        prob2 = stats.binom.pmf(np.arange(n2 + 1), n1, self.prob_pooled)
+
+        prob = prob1[None, :] * prob2[:, None]
+        pvemp = prob[pv < pvo].sum()
+
+        return pvemp
+
+
+    def pvalue_exact_sup(self, grid=None):
+        """pvalue based on max of pvalues over nuisance parameter
+
+        This is an exact pvalue and maintains and guarantees the size.
+
+        `grid` argument is currently not used.
+        `grid` can be None, array, int or tuple
+        If None, then the default method is used, currently a grid.
+        If int, then the integer specifies the number of grid points.
+        If grid is a tuple, then either the values are integers for linspace or
+        ('bb', alpha, n_points) for Berger, Boos limitats for the maximum.
+
+        TODO: replace pure grid search by coarse grid plus local optimize
+        check diagnostic plot to see whether there are spikes
+        """
+        n1, n2 = self.nobs1, self.nobs2  # local alias
+        alternative = self.alternative  # TODO check if it should be argument
+        use_bb = False
+        bb_correct = 0
+        res = []
+        if grid is None:
+            grid = np.linspace(0.001, 0.999, 1001)
+        elif isinstance(grid, tuple):
+            if grid[0] == 'bb':
+                use_bb = True
+                y = self.count1 + self.count2
+                nobs = self.nobs1 + self.nobs2
+                alpha = grid[1]
+                bb_correct = alpha
+                if len(grid) > 2:
+                    n_points = grid[2]
+                else:
+                    n_points = 1001
+                import statsmodels.stats.proportion as smprop
+                # use Clopper-Pearson interval
+                ci = smprop.proportion_confint(y, nobs, method = 'beta',
+                                               alpha=alpha)
+                grid = np.linspace(ci[0], ci[1], n_points)
+
+        grid = np.concatenate(([self.prob_pooled], grid))
+        #TODO: store rejection region and use for ys1, ys2
+        ys1 = np.arange(n1 + 1)
+        ys2 = np.arange(n2 + 1)
+        pvo = self.pvalue_base  # TODO check, define attribute rejection set
+
+        for prob0 in grid:
+            #print(prob,)
+            st, pv =  self.chisquare_proportion_indep(ys1[None, :], ys2[:,None],
+                                             #prob_var=prob0,  # trying out, doesn't work well
+                                             alternative=alternative)
+
+            prob1 = stats.binom.pmf(ys1, n1, prob0)
+            prob2 = stats.binom.pmf(ys2, n2, prob0)
+
+            prob = prob1[None, :] * prob2[:, None]
+            #TODO: store rejection region
+            reject_mask = pv <= pvo  # TODO move outside of loop
+            pvemp = prob[reject_mask].sum()
+            #print(pvemp)
+            res.append([prob0, pvemp])
+
+        res =np.array(res)
+        pvm_ind = res[:,1].argmax(0)
+
+        return res[pvm_ind, 1] + bb_correct, res[pvm_ind, 0], pvm_ind, res

--- a/statsmodels/stats/tests/test_proportion_exact.py
+++ b/statsmodels/stats/tests/test_proportion_exact.py
@@ -1,0 +1,108 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Thu Sep  3 12:36:51 2015
+
+Author: Josef Perktold
+License: BSD-3
+"""
+
+import numpy as np
+from scipy import stats
+
+from numpy.testing import assert_allclose
+
+from statsmodels.stats._proportion_exact import ExactTwoProportion
+
+
+def test_prop_exact1():
+    # example 1 from Lin and Yang 2009
+
+
+    n1, n2 = 15, 15
+    yo1 = 7
+    yo2 = 12
+
+    # one sided
+    # reference numbers for 1-sided alternative
+    pval_lj_asymp = 0.02909
+    pval_lj_exact = 0.03411
+    pval_lj_bb = 0.03511
+
+    pt = ExactTwoProportion(yo1, n1, yo2, n2, alternative='todo')
+    pval_asymp = pt.pvalue_base
+    assert_allclose(pval_asymp, pval_lj_asymp, rtol=0, atol=5e-5)
+
+    # TODO use regression test if no reference value here
+    pval_mle = pt.pvalue_exactdist_mle()
+    #assert_allclose(pval_mle, pval_lj_mle, rtol=0, atol=5e-5)
+
+    pres = pt.pvalue_exact_sup()
+    pval_exact = pres[0]
+    assert_allclose(pval_exact, pval_lj_exact, rtol=0, atol=5e-5)
+
+    presbb = pt.pvalue_exact_sup(grid=('bb', 0.001, 1001))
+    pval_bb = presbb[0]
+    assert_allclose(pval_bb, pval_lj_bb, rtol=0, atol=5e-5)
+
+    # reference numbers from bergers website for bb
+    bb_confint = (0.3243, 0.8786)
+    bb_pvalue = 0.0351
+    p_argmax = 0.3333
+    bb_statistic = - (-1.8943)  # Note: I have different sign
+    # note currently we prepend p_cmle, low is in row 1 (2nd row)
+    p_confint = (presbb[-1][1, 0], presbb[-1][-1, 0])
+    assert_allclose(p_confint, bb_confint, rtol=0, atol=5e-4)
+    assert_allclose(pt.statistic_base, bb_statistic, rtol=0, atol=5e-4)
+    assert_allclose(pval_bb, bb_pvalue, rtol=0, atol=5e-4)
+    #assert_allclose(presbb[1], p_argmax, rtol=0, atol=5e-4)
+    # skip in this case, not unique
+    #x: array(0.6646393071907146)  y: array(0.3333)
+
+
+    # two sided compared with Berger website
+    pt = ExactTwoProportion(yo1, n1, yo2, n2, alternative='2-sided')
+    presbb = pt.pvalue_exact_sup(grid=('bb', 0.00001, 1001))
+    pval_bb = presbb[0]
+
+    # reference numbers from bergers website for bb
+    bb_confint = (0.2389, 0.9264)
+    bb_pvalue = 0.0682
+    p_argmax = 0.3333
+    bb_statistic = (-1.8943)**2
+
+    # note currently we prepend p_cmle
+    p_confint = (presbb[-1][1, 0], presbb[-1][-1, 0])
+    assert_allclose(p_confint, bb_confint, rtol=0, atol=5e-4)
+    assert_allclose(pt.statistic_base, bb_statistic, rtol=0, atol=5e-4)
+    assert_allclose(pval_bb, bb_pvalue, rtol=0, atol=5e-4)
+    #assert_allclose(presbb[1], p_argmax, rtol=0, atol=5e-4)
+    # skip in this case, not unique ? or symmetric
+    #x: array(0.6646393071907146)  y: array(0.3333)
+
+
+
+def test_prop_exact2():
+    # example 1 from Lin and Yang 2009
+    n1, n2 = 69, 88
+    yo1 = 67
+    yo2 = 76
+
+    # two sided
+    # reference numbers for 2-sided alternative of Ling Yang
+    pval_lj_asymp = 0.01912
+    pval_lj_exact = 0.02099
+    pval_lj_bb = 0.02151
+
+    pt = ExactTwoProportion(yo1, n1, yo2, n2, alternative='2-sided')
+    pval_asymp = pt.pvalue_base
+    assert_allclose(pval_asymp, pval_lj_asymp, rtol=0, atol=5e-5)
+    pval_mle = pt.pvalue_exactdist_mle()
+    #assert_allclose(pval_mle, pval_lj_mle, rtol=0, atol=5e-5)
+
+    pres = pt.pvalue_exact_sup()
+    pval_exact = pres[0]
+    assert_allclose(pval_exact, pval_lj_exact, rtol=0, atol=5e-5)
+
+    presbb = pt.pvalue_exact_sup(grid=('bb', 0.001, 101))
+    pval_bb = presbb[0]
+    assert_allclose(pval_bb, pval_lj_bb, rtol=0, atol=5e-5)


### PR DESCRIPTION
see #2607 

This PR implements an unconditional exact test for the equality of two independent proportions, either based on full max or on Berger/Boos confidence interval test.

verified and unit tested with published example and website with online calculation at print precision.

work in progress, PR so I don't forget this and can go back to other things.

main Todos

- API
- optimize code, currently unit test are a bit slow
  - streamline code: currently expensive repeated or unnecessary calculations
  - use special properties of test like monotonicity to shortcut calculations
  - better optimization than pure grid search, looks smooth in example but many local maxima
    I didn't see any spikes yet that are described in several references. 

extend:

- basic extension is to allow for non-zero difference in the null
