### PR TITLE
BUG: Statespace: Test failures on certain Travis builds.

### DIFF
--- a/statsmodels/tsa/statespace/mlemodel.py
+++ b/statsmodels/tsa/statespace/mlemodel.py
@@ -962,7 +962,7 @@ class MLEResults(tsbase.TimeSeriesModelResults):
         )
         self.model.update(self.params)
 
-        return -np.linalg.inv(nobs * evaluated_hessian)
+        return -np.linalg.pinv(nobs * evaluated_hessian)
 
     @cache_readonly
     def cov_params_delta(self):
@@ -975,7 +975,7 @@ class MLEResults(tsbase.TimeSeriesModelResults):
 
         unconstrained = self.model.untransform_params(self.params)
         jacobian = self.model.transform_jacobian(unconstrained)
-        cov_cs = -np.linalg.inv(
+        cov_cs = -np.linalg.pinv(
             nobs * self.model._hessian_cs(unconstrained, transformed=False)
         )
 
@@ -988,7 +988,7 @@ class MLEResults(tsbase.TimeSeriesModelResults):
         from Harvey (1989).
         """
         nobs = (self.model.nobs - self.filter_results.loglikelihood_burn)
-        return np.linalg.inv(
+        return np.linalg.pinv(
             nobs * self.model.observed_information_matrix(self.params)
         )
 
@@ -1003,7 +1003,7 @@ class MLEResults(tsbase.TimeSeriesModelResults):
         # because variance parameters will then have a complex component which
         # which implies non-positive-definiteness.
         inversion_method = INVERT_UNIVARIATE | SOLVE_LU
-        return np.linalg.inv(
+        return np.linalg.pinv(
             nobs *
             self.model.opg_information_matrix(
                 self.params, inversion_method=inversion_method
@@ -1029,7 +1029,7 @@ class MLEResults(tsbase.TimeSeriesModelResults):
         evaluated_hessian = (
             nobs * self.model.observed_information_matrix(self.params)
         )
-        return np.linalg.inv(
+        return np.linalg.pinv(
             np.dot(np.dot(evaluated_hessian, cov_opg), evaluated_hessian)
         )
 
@@ -1051,7 +1051,7 @@ class MLEResults(tsbase.TimeSeriesModelResults):
             self.model._hessian_cs(self.params, transformed=True,
                                    inversion_method=inversion_method)
         )
-        return np.linalg.inv(
+        return np.linalg.pinv(
             np.dot(np.dot(evaluated_hessian, cov_opg), evaluated_hessian)
         )
 

--- a/statsmodels/tsa/statespace/mlemodel.py
+++ b/statsmodels/tsa/statespace/mlemodel.py
@@ -891,6 +891,7 @@ class MLEResults(tsbase.TimeSeriesModelResults):
         # Calculate the new covariance matrix
         if len(self.params) == 0:
             res.cov_params_default = np.zeros((0,0))
+            res._rank = 0
             res.cov_kwds['cov_type'] = (
                 'No parameters estimated.')
         elif self.cov_type == 'cs':

--- a/statsmodels/tsa/statespace/tests/test_representation.py
+++ b/statsmodels/tsa/statespace/tests/test_representation.py
@@ -369,7 +369,7 @@ class TestClark1989(Clark1989):
 
     def test_kalman_gain(self):
         assert_allclose(self.results.kalman_gain.sum(axis=1).sum(axis=0),
-                        clark1989_results['V1'], atol=1e-5)
+                        clark1989_results['V1'], atol=1e-4)
 
 
 class TestClark1989Conserve(Clark1989):


### PR DESCRIPTION
Fixes #2611, by reducing the precision of `test_kalman_gain` and using pseudo-inverse instead of true inverse in covariance matrix calculations.