### PR TITLE
Relaxed version number constraints in setup.py to allow numpy version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,7 @@ def generate_cython():
 
 
 def strip_rc(version):
-    return re.sub(r"rc\d+$", "", version)
+    return re.sub(r"\.?\w+\d+$", "", version)
 
 
 def check_dependency_versions(min_versions):


### PR DESCRIPTION
The current version I have of numpy, 1.10.0.post2 fails `check_dependency_versions` in `setup.py` since `strip_rc()` is expecting 'rc\d' at the end.

I made the minimal change to the regex in this pull request to work around that for your consideration.

Happy to make additional changes eg change the name of `strip_rc` to reflect the changes.  Also it would be good to have other eyes on my regex to sanity check it.
