### PR TITLE
MAINT: fix some test issues due to numpy 1.10.0 and pandas 0.17.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -134,7 +134,10 @@ def check_dependency_versions(min_versions):
                               (spversion, min_versions['scipy']))
 
     try:
-        from pandas.version import short_version as pversion
+        import pandas
+        #FIXME: this will break for pandas 1.0.0.  Needs elaborate parsing now,
+        # due to pandas removing version.short_version
+        pversion = pandas.__version__[:6]
     except ImportError:
         install_requires.append('pandas')
     else:

--- a/statsmodels/graphics/tests/test_mosaicplot.py
+++ b/statsmodels/graphics/tests/test_mosaicplot.py
@@ -113,7 +113,7 @@ def test_mosaic():
     # sort by the marriage quality and give meaningful name
     # [rate_marriage, age, yrs_married, children,
     # religious, educ, occupation, occupation_husb]
-    datas = datas.sort(['rate_marriage', 'religious'])
+    datas = datas.sort_values(by=['rate_marriage', 'religious'])
     num_to_desc = {1: 'awful', 2: 'bad', 3: 'intermediate',
                       4: 'good', 5: 'wonderful'}
     datas['rate_marriage'] = datas['rate_marriage'].map(num_to_desc)

--- a/statsmodels/graphics/tests/test_mosaicplot.py
+++ b/statsmodels/graphics/tests/test_mosaicplot.py
@@ -113,7 +113,11 @@ def test_mosaic():
     # sort by the marriage quality and give meaningful name
     # [rate_marriage, age, yrs_married, children,
     # religious, educ, occupation, occupation_husb]
-    datas = datas.sort_values(by=['rate_marriage', 'religious'])
+    if pandas.__version__ < '0.17.0':
+        datas = datas.sort(['rate_marriage', 'religious'])
+    else:
+        datas = datas.sort_values(by=['rate_marriage', 'religious'])
+
     num_to_desc = {1: 'awful', 2: 'bad', 3: 'intermediate',
                       4: 'good', 5: 'wonderful'}
     datas['rate_marriage'] = datas['rate_marriage'].map(num_to_desc)

--- a/statsmodels/graphics/tests/test_tsaplots.py
+++ b/statsmodels/graphics/tests/test_tsaplots.py
@@ -1,4 +1,4 @@
-from statsmodels.compat.python import lmap, lzip, map
+from statsmodels.compat.python import lmap, map
 import numpy as np
 import pandas as pd
 from numpy.testing import dec
@@ -51,8 +51,8 @@ def test_plot_month():
     dta = sm.datasets.elnino.load_pandas().data
     dta['YEAR'] = dta.YEAR.astype(int).apply(str)
     dta = dta.set_index('YEAR').T.unstack()
-    dates = lmap(lambda x : pd.datetools.parse('1 '+' '.join(x)),
-                                            dta.index.values)
+    dates = lmap(lambda x : pd.datetools.parse_time_string('1 '+' '.join(x))[0],
+                                                           dta.index.values)
 
     # test dates argument
     fig = month_plot(dta.values, dates=dates, ylabel='el nino')

--- a/statsmodels/graphics/tsaplots.py
+++ b/statsmodels/graphics/tsaplots.py
@@ -2,6 +2,7 @@
 
 
 import numpy as np
+import pandas
 
 from statsmodels.graphics import utils
 from statsmodels.tsa.stattools import acf, pacf
@@ -200,7 +201,10 @@ def seasonal_plot(grouped_x, xticklabels, ylabel=None, ax=None):
     ticks = []
     for season, df in grouped_x:
         df = df.copy() # or sort balks for series. may be better way
-        df.sort_values(inplace=True)
+        if pandas.__version__ < '0.17.0':
+            df.sort()
+        else:
+            df.sort_values(inplace=True)
         nobs = len(df)
         x_plot = np.arange(start, start + nobs)
         ticks.append(x_plot.mean())

--- a/statsmodels/graphics/tsaplots.py
+++ b/statsmodels/graphics/tsaplots.py
@@ -200,7 +200,7 @@ def seasonal_plot(grouped_x, xticklabels, ylabel=None, ax=None):
     ticks = []
     for season, df in grouped_x:
         df = df.copy() # or sort balks for series. may be better way
-        df.sort()
+        df.sort_values(inplace=True)
         nobs = len(df)
         x_plot = np.arange(start, start + nobs)
         ticks.append(x_plot.mean())

--- a/statsmodels/tools/testing.py
+++ b/statsmodels/tools/testing.py
@@ -16,10 +16,8 @@ def strip_rc(version):
 
 
 def is_pandas_min_version(min_version):
-    '''check whether pandas is at least min_version
-    '''
-    from pandas.version import short_version as pversion
-    return StrictVersion(strip_rc(pversion)) >= min_version
+    '''check whether pandas is at least min_version '''
+    return StrictVersion((pandas.__version__[:6])) >= min_version
 
 
 # local copies, all unchanged

--- a/statsmodels/tsa/ar_model.py
+++ b/statsmodels/tsa/ar_model.py
@@ -261,10 +261,8 @@ class AR(tsbase.TimeSeriesModel):
 
         Vpinv = np.zeros((p, p), dtype=params.dtype)
         for i in range(1, p1):
-            Vpinv[i-1, i-1:] = np.correlate(params0, params0[:i],
-                                            old_behavior=False)[:-1]
-            Vpinv[i-1, i-1:] -= np.correlate(params0[-i:], params0,
-                                             old_behavior=False)[:-1]
+            Vpinv[i-1, i-1:] = np.correlate(params0, params0[:i],)[:-1]
+            Vpinv[i-1, i-1:] -= np.correlate(params0[-i:], params0,)[:-1]
 
         Vpinv = Vpinv + Vpinv.T - np.diag(Vpinv.diagonal())
         return Vpinv


### PR DESCRIPTION
- fix old_behavior kw for numpy.correlate (was removed in 1.10.0). Closes gh-2667.
- fix deprecation warnings from pandas 0.17.0
- fix backwards compat break in pandas 0.17.0 (removal of ``pandas.version``)

Numpy PR that removed ``old_behavior`` kw: https://github.com/numpy/numpy/pull/5991
