### PR TITLE
Corrected version detection for new pandas

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@
 # required packages and is simpler to use to test up-to-date scientific Python
 # stack
 language: python
+sudo: false
 
 env:
   # Default values for common packages, override as needed

--- a/examples/python/discrete_choice_overview.py
+++ b/examples/python/discrete_choice_overview.py
@@ -81,7 +81,7 @@ print(mlogit_res.params)
 # Load the Rand data. Note that this example is similar to Cameron and Trivedi's `Microeconometrics` Table 20.5, but it is slightly different because of minor changes in the data. 
 
 rand_data = sm.datasets.randhie.load()
-rand_exog = rand_data.exog.view(float).reshape(len(rand_data.exog), -1)
+rand_exog = rand_data.exog.view(float, type=np.ndarray).reshape(len(rand_data.exog), -1)
 rand_exog = sm.add_constant(rand_exog, prepend=False)
 
 

--- a/examples/python/robust_models_1.py
+++ b/examples/python/robust_models_1.py
@@ -7,6 +7,7 @@ from scipy import stats
 import matplotlib.pyplot as plt
 
 import statsmodels.api as sm
+from statsmodels.compat.pandas import sort_values
 
 
 # * An M-estimator minimizes the function 
@@ -232,12 +233,12 @@ print(infl.summary_frame().ix['minister'])
 
 
 sidak = ols_model.outlier_test('sidak')
-sidak.sort('unadj_p', inplace=True)
+sort_values(sidak, 'unadj_p', inplace=True)
 print(sidak)
 
 
 fdr = ols_model.outlier_test('fdr_bh')
-fdr.sort('unadj_p', inplace=True)
+sort_values(fdr, 'unadj_p', inplace=True)
 print(fdr)
 
 
@@ -299,12 +300,12 @@ hat_diag.ix[hat_diag > h_bar]
 
 
 sidak2 = ols_model.outlier_test('sidak')
-sidak2.sort('unadj_p', inplace=True)
+sort_values(sidak2, 'unadj_p', inplace=True)
 print(sidak2)
 
 
 fdr2 = ols_model.outlier_test('fdr_bh')
-fdr2.sort('unadj_p', inplace=True)
+sort_values(fdr2, 'unadj_p', inplace=True)
 print(fdr2)
 
 

--- a/setup.py
+++ b/setup.py
@@ -134,10 +134,7 @@ def check_dependency_versions(min_versions):
                               (spversion, min_versions['scipy']))
 
     try:
-        import pandas
-        #FIXME: this will break for pandas 1.0.0.  Needs elaborate parsing now,
-        # due to pandas removing version.short_version
-        pversion = pandas.__version__[:6]
+        from pandas import __version__ as pversion
     except ImportError:
         install_requires.append('pandas')
     else:

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ from os.path import relpath, join as pjoin
 import sys
 import subprocess
 import re
-from distutils.version import StrictVersion
+from distutils.version import StrictVersion, LooseVersion
 
 
 # temporarily redirect config directory to prevent matplotlib importing
@@ -116,7 +116,7 @@ def check_dependency_versions(min_versions):
         setup_requires.append('numpy')
         install_requires.append('numpy')
     else:
-        if not (StrictVersion(strip_rc(npversion)) >= min_versions['numpy']):
+        if not (LooseVersion(npversion) >= min_versions['numpy']):
             raise ImportError("Numpy version is %s. Requires >= %s" %
                               (npversion, min_versions['numpy']))
 
@@ -129,7 +129,7 @@ def check_dependency_versions(min_versions):
             from scipy.version import short_version as spversion
         except ImportError:
             from scipy.version import version as spversion  # scipy 0.7.0
-        if not (StrictVersion(strip_rc(spversion)) >= min_versions['scipy']):
+        if not (LooseVersion(spversion) >= min_versions['scipy']):
             raise ImportError("Scipy version is %s. Requires >= %s" %
                               (spversion, min_versions['scipy']))
 
@@ -138,7 +138,7 @@ def check_dependency_versions(min_versions):
     except ImportError:
         install_requires.append('pandas')
     else:
-        if not (StrictVersion(strip_rc(pversion)) >= min_versions['pandas']):
+        if not (LooseVersion(pversion) >= min_versions['pandas']):
             ImportError("Pandas version is %s. Requires >= %s" %
                         (pversion, min_versions['pandas']))
 
@@ -149,7 +149,7 @@ def check_dependency_versions(min_versions):
     else:
         # patsy dev looks like 0.1.0+dev
         pversion = re.match("\d*\.\d*\.\d*", patsy_version).group()
-        if not (StrictVersion(pversion) >= min_versions['patsy']):
+        if not (LooseVersion(pversion) >= min_versions['patsy']):
             raise ImportError("Patsy version is %s. Requires >= %s" %
                               (pversion, min_versions["patsy"]))
 

--- a/statsmodels/base/tests/test_data.py
+++ b/statsmodels/base/tests/test_data.py
@@ -161,8 +161,8 @@ class TestRecarrays(TestArrays):
         cls.ynames = 'y_1'
 
     def test_endogexog(self):
-        np.testing.assert_equal(self.data.endog, self.endog.view(float))
-        np.testing.assert_equal(self.data.exog, self.exog.view((float,3)))
+        np.testing.assert_equal(self.data.endog, self.endog.view(float, type=np.ndarray))
+        np.testing.assert_equal(self.data.exog, self.exog.view((float, 3), type=np.ndarray))
 
 
 class TestStructarrays(TestArrays):
@@ -180,8 +180,8 @@ class TestStructarrays(TestArrays):
         cls.ynames = 'y_1'
 
     def test_endogexog(self):
-        np.testing.assert_equal(self.data.endog, self.endog.view(float))
-        np.testing.assert_equal(self.data.exog, self.exog.view((float,3)))
+        np.testing.assert_equal(self.data.endog, self.endog.view(float, type=np.ndarray))
+        np.testing.assert_equal(self.data.exog, self.exog.view((float,3), type=np.ndarray))
 
 
 class TestListDataFrame(TestDataFrames):

--- a/statsmodels/compat/pandas.py
+++ b/statsmodels/compat/pandas.py
@@ -1,7 +1,9 @@
 import pandas
-from ..tools.testing import is_pandas_min_version
+from distutils.version import LooseVersion
 
-if is_pandas_min_version('0.17.0'):
+version = LooseVersion(pandas.__version__)
+
+if version >= '0.17.0':
     def sort_values(df, *args, **kwargs):
         return df.sort_values(*args, **kwargs)
 else:

--- a/statsmodels/compat/pandas.py
+++ b/statsmodels/compat/pandas.py
@@ -1,0 +1,9 @@
+import pandas
+from ..tools.testing import is_pandas_min_version
+
+if is_pandas_min_version('0.17.0'):
+    def sort_values(df, *args, **kwargs):
+        return df.sort_values(*args, **kwargs)
+else:
+    def sort_values(df, *args, **kwargs):
+        return df.sort(*args, **kwargs)

--- a/statsmodels/compat/pandas.py
+++ b/statsmodels/compat/pandas.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import pandas
 from distutils.version import LooseVersion
 

--- a/statsmodels/compat/pandas.py
+++ b/statsmodels/compat/pandas.py
@@ -7,6 +7,19 @@ version = LooseVersion(pandas.__version__)
 if version >= '0.17.0':
     def sort_values(df, *args, **kwargs):
         return df.sort_values(*args, **kwargs)
-else:
+elif version >= '0.14.0':
     def sort_values(df, *args, **kwargs):
+        kwargs.setdefault('inplace', False)  # always set inplace with 'False' as default
         return df.sort(*args, **kwargs)
+else:  # Before that, sort didn't have 'inplace' for non data-frame
+    def sort_values(df, *args, **kwargs):
+        if isinstance(df, pandas.DataFrame):
+            return df.sort(*args, **kwargs)
+        # Just make sure inplace is 'False' by default, but doesn't appear in the final arguments
+        # Here, setdefaults will ensure the del operation always succeeds
+        inplace = kwargs.setdefault('inplace', False)
+        del kwargs['inplace']
+        if not inplace:
+            df = df.copy()
+        df.sort(*args, **kwargs)
+        return df

--- a/statsmodels/discrete/discrete_model.py
+++ b/statsmodels/discrete/discrete_model.py
@@ -3145,7 +3145,7 @@ if __name__=="__main__":
     endog = data2['doctorco']
     exog = data2[['sex','age','agesq','income','levyplus','freepoor',
             'freerepa','illness','actdays','hscore','chcond1',
-            'chcond2']].view(float).reshape(len(data2),-1)
+            'chcond2']].view(float, np.ndarray).reshape(len(data2),-1)
     exog = sm.add_constant(exog, prepend=True)
     poisson_mod = Poisson(endog, exog)
     poisson_res = poisson_mod.fit()

--- a/statsmodels/graphics/tests/test_mosaicplot.py
+++ b/statsmodels/graphics/tests/test_mosaicplot.py
@@ -18,8 +18,8 @@ try:
 except:
     have_matplotlib = False
 
-import pandas
-pandas_old = int(pandas.__version__.split('.')[1]) < 9
+from statsmodels.compat.pandas import version as pandas_version
+pandas_old = pandas_version < '0.9'
 
 # the main drawing function
 from statsmodels.graphics.mosaicplot import mosaic

--- a/statsmodels/graphics/tests/test_mosaicplot.py
+++ b/statsmodels/graphics/tests/test_mosaicplot.py
@@ -6,6 +6,7 @@ from numpy.testing import run_module_suite
 
 # utilities for the tests
 
+from statsmodels.compat.pandas import sort_values
 from statsmodels.compat.collections import OrderedDict
 from statsmodels.api import datasets
 
@@ -113,10 +114,7 @@ def test_mosaic():
     # sort by the marriage quality and give meaningful name
     # [rate_marriage, age, yrs_married, children,
     # religious, educ, occupation, occupation_husb]
-    if pandas.__version__ < '0.17.0':
-        datas = datas.sort(['rate_marriage', 'religious'])
-    else:
-        datas = datas.sort_values(by=['rate_marriage', 'religious'])
+    datas = sort_values(datas, ['rate_marriage', 'religious'])
 
     num_to_desc = {1: 'awful', 2: 'bad', 3: 'intermediate',
                       4: 'good', 5: 'wonderful'}

--- a/statsmodels/graphics/tsaplots.py
+++ b/statsmodels/graphics/tsaplots.py
@@ -6,7 +6,6 @@ import pandas
 
 from statsmodels.graphics import utils
 from statsmodels.tsa.stattools import acf, pacf
-from statsmodels.tools.testing import is_pandas_min_version, StrictVersion
 
 def plot_acf(x, ax=None, lags=None, alpha=.05, use_vlines=True, unbiased=False,
             fft=False, **kwargs):

--- a/statsmodels/graphics/tsaplots.py
+++ b/statsmodels/graphics/tsaplots.py
@@ -2,8 +2,8 @@
 
 
 import numpy as np
-import pandas
 
+from statsmodels.compat.pandas import sort_values
 from statsmodels.graphics import utils
 from statsmodels.tsa.stattools import acf, pacf
 
@@ -201,7 +201,7 @@ def seasonal_plot(grouped_x, xticklabels, ylabel=None, ax=None):
     ticks = []
     for season, df in grouped_x:
         df = df.copy() # or sort balks for series. may be better way
-        df.sort(inplace=True)
+        sort_values(df, inplace=True)
         nobs = len(df)
         x_plot = np.arange(start, start + nobs)
         ticks.append(x_plot.mean())

--- a/statsmodels/graphics/tsaplots.py
+++ b/statsmodels/graphics/tsaplots.py
@@ -202,10 +202,7 @@ def seasonal_plot(grouped_x, xticklabels, ylabel=None, ax=None):
     ticks = []
     for season, df in grouped_x:
         df = df.copy() # or sort balks for series. may be better way
-        if is_pandas_min_version(StrictVersion('0.17.0')):
-            df.sort_values(inplace=True)
-        else:
-            df.sort()
+        df.sort(inplace=True)
         nobs = len(df)
         x_plot = np.arange(start, start + nobs)
         ticks.append(x_plot.mean())

--- a/statsmodels/graphics/tsaplots.py
+++ b/statsmodels/graphics/tsaplots.py
@@ -6,6 +6,7 @@ import pandas
 
 from statsmodels.graphics import utils
 from statsmodels.tsa.stattools import acf, pacf
+from statsmodels.tools.testing import is_pandas_min_version, StrictVersion
 
 def plot_acf(x, ax=None, lags=None, alpha=.05, use_vlines=True, unbiased=False,
             fft=False, **kwargs):
@@ -201,10 +202,10 @@ def seasonal_plot(grouped_x, xticklabels, ylabel=None, ax=None):
     ticks = []
     for season, df in grouped_x:
         df = df.copy() # or sort balks for series. may be better way
-        if pandas.__version__ < '0.17.0':
-            df.sort()
-        else:
+        if is_pandas_min_version(StrictVersion('0.17.0')):
             df.sort_values(inplace=True)
+        else:
+            df.sort()
         nobs = len(df)
         x_plot = np.arange(start, start + nobs)
         ticks.append(x_plot.mean())

--- a/statsmodels/iolib/tests/test_foreign.py
+++ b/statsmodels/iolib/tests/test_foreign.py
@@ -17,9 +17,8 @@ from statsmodels.iolib.foreign import (StataWriter, genfromdta,
 from statsmodels.datasets import macrodata
 
 
-import pandas
-pandas_old = int(pandas.__version__.split('.')[1]) < 9
-
+from statsmodels.compat.pandas import version as pandas_version
+pandas_old = pandas_version < '0.9'
 
 # Test precisions
 DECIMAL_4 = 4

--- a/statsmodels/sandbox/multilinear.py
+++ b/statsmodels/sandbox/multilinear.py
@@ -11,6 +11,7 @@ multigroup:
     more significant than outside the group.
 """
 
+from statsmodels.compat.pandas import sort_values
 from statsmodels.compat.python import iteritems, string_types
 from patsy import dmatrix
 import pandas as pd
@@ -171,7 +172,7 @@ def multiOLS(model, dataframe, column_list=None, method='fdr_bh',
     # mangle them togheter and sort by complexive p-value
     summary = pd.DataFrame(col_results)
     # order by the p-value: the most useful model first!
-    summary = summary.T.sort([('pvals', '_f_test')])
+    summary = sort_values(summary.T, [('pvals', '_f_test')])
     summary.index.name = 'endogenous vars'
     # implementing the pvalue correction method
     smt = stats.multipletests
@@ -316,7 +317,7 @@ def multigroup(pvals, groups, exact=True, keep_all=True, alpha=0.05):
         results['_in_non'][group_name] = res[2][1]
         results['_out_sign'][group_name] = res[2][2]
         results['_out_non'][group_name] = res[2][3]
-    result_df = pd.DataFrame(results).sort('pvals')
+    result_df = sort_values(pd.DataFrame(results), 'pvals')
     if not keep_all:
         result_df = result_df[result_df.increase]
     smt = stats.multipletests

--- a/statsmodels/tools/data.py
+++ b/statsmodels/tools/data.py
@@ -81,7 +81,7 @@ def interpret_data(data, colnames=None, rownames=None):
 
 
 def struct_to_ndarray(arr):
-    return arr.view((float, len(arr.dtype.names)))
+    return arr.view((float, len(arr.dtype.names)), type=np.ndarray)
 
 
 def _is_using_ndarray_type(endog, exog):

--- a/statsmodels/tools/print_version.py
+++ b/statsmodels/tools/print_version.py
@@ -62,7 +62,7 @@ def _show_versions_only():
 
     try:
         import pandas
-        print("pandas: %s" % safe_version(pandas, ['version', 'version'], '__version__'))
+        print("pandas: %s" % safe_version(pandas))
     except ImportError:
         print("pandas: Not installed")
 

--- a/statsmodels/tools/print_version.py
+++ b/statsmodels/tools/print_version.py
@@ -5,12 +5,14 @@ import sys
 from os.path import dirname
 
 
-def safe_version(module, attr='__version__'):
+def safe_version(module, attr='__version__', *others):
     if not isinstance(attr, list):
         attr = [attr]
     try:
         return reduce(getattr, [module] + attr)
     except AttributeError:
+        if others:
+            return safe_version(module, others[0], *others[1:])
         return "Cannot detect version"
 
 
@@ -60,7 +62,7 @@ def _show_versions_only():
 
     try:
         import pandas
-        print("pandas: %s" % safe_version(pandas, ['version', 'version']))
+        print("pandas: %s" % safe_version(pandas, ['version', 'version'], '__version__'))
     except ImportError:
         print("pandas: Not installed")
 
@@ -184,8 +186,8 @@ def show_versions(show_dirs=True):
 
     try:
         import pandas
-        print("pandas: %s (%s)" % (safe_version(pandas, ['version',
-                                                         'version']),
+        print("pandas: %s (%s)" % (safe_version(pandas, ['version', 'version'],
+                                                '__version__'),
                                    dirname(pandas.__file__)))
     except ImportError:
         print("pandas: Not installed")

--- a/statsmodels/tools/testing.py
+++ b/statsmodels/tools/testing.py
@@ -3,7 +3,7 @@
 """
 
 import re
-from distutils.version import StrictVersion
+from distutils.version import StrictVersion, LooseVersion
 
 import numpy as np
 import numpy.testing as npt
@@ -19,7 +19,7 @@ def is_pandas_min_version(min_version):
     '''check whether pandas is at least min_version
     '''
     from pandas import __version__ as pversion
-    return StrictVersion(strip_rc(pversion)) >= min_version
+    return LooseVersion(pversion) >= min_version
 
 
 # local copies, all unchanged
@@ -31,11 +31,11 @@ from numpy.testing import (assert_allclose, assert_almost_equal,
 
 # adjusted functions
 
-def assert_equal(actual, desired, err_msg='', verbose=True, **kwds):
-
-    if not is_pandas_min_version('0.14.1'):
+if not is_pandas_min_version('0.14.1'):
+    def assert_equal(actual, desired, err_msg='', verbose=True, **kwds):
         npt.assert_equal(actual, desired, err_msg='', verbose=True)
-    else:
+else:
+    def assert_equal(actual, desired, err_msg='', verbose=True, **kwds):
         if isinstance(desired, pandas.Index):
             pdt.assert_index_equal(actual, desired)
         elif isinstance(desired, pandas.Series):

--- a/statsmodels/tools/testing.py
+++ b/statsmodels/tools/testing.py
@@ -16,8 +16,10 @@ def strip_rc(version):
 
 
 def is_pandas_min_version(min_version):
-    '''check whether pandas is at least min_version '''
-    return StrictVersion((pandas.__version__[:6])) >= min_version
+    '''check whether pandas is at least min_version
+    '''
+    from pandas import __version__ as pversion
+    return StrictVersion(strip_rc(pversion)) >= min_version
 
 
 # local copies, all unchanged

--- a/statsmodels/tsa/statespace/dynamic_factor.py
+++ b/statsmodels/tsa/statespace/dynamic_factor.py
@@ -181,7 +181,7 @@ class DynamicFactor(MLEModel):
 
         # We need to have an array or pandas at this point
         if not _is_using_pandas(endog, None):
-            endog = np.asanyarray(endog)
+            endog = np.asanyarray(endog, order='C')
 
         # Save some useful model orders, internally used
         k_endog = endog.shape[1] if endog.ndim > 1 else 1

--- a/statsmodels/tsa/statespace/mlemodel.py
+++ b/statsmodels/tsa/statespace/mlemodel.py
@@ -82,8 +82,8 @@ class MLEModel(tsbase.TimeSeriesModel):
                  **kwargs):
         # Initialize the model base
         super(MLEModel, self).__init__(endog=endog, exog=exog,
-                                              dates=dates, freq=freq,
-                                              missing='none')
+                                       dates=dates, freq=freq,
+                                       missing='none')
 
         # Store kwargs to recreate model
         self._init_kwargs = kwargs
@@ -102,7 +102,7 @@ class MLEModel(tsbase.TimeSeriesModel):
         """
         Prepare data for use in the state space representation
         """
-        endog = np.array(self.data.orig_endog)
+        endog = np.array(self.data.orig_endog, order='C')
         exog = self.data.orig_exog
         if exog is not None:
             exog = np.array(exog)
@@ -110,16 +110,6 @@ class MLEModel(tsbase.TimeSeriesModel):
         # Base class may allow 1-dim data, whereas we need 2-dim
         if endog.ndim == 1:
             endog.shape = (endog.shape[0], 1)  # this will be C-contiguous
-
-        # Base classes data may be either C-ordered or F-ordered - we want it
-        # to be C-ordered since it will also be in shape (nobs, k_endog), and
-        # then we can just transpose it.
-        if not endog.flags['C_CONTIGUOUS']:
-            # TODO this breaks the reference link between the model endog
-            # variable and the original object - do we need a warn('')?
-            # This will happen often with Pandas DataFrames, which are often
-            # Fortran-ordered and in the long format
-            endog = np.ascontiguousarray(endog)
 
         return endog, exog
 

--- a/statsmodels/tsa/statespace/representation.py
+++ b/statsmodels/tsa/statespace/representation.py
@@ -262,7 +262,7 @@ class Representation(object):
             endog = k_endog
             # If so, assume that it is either column-ordered and in wide format
             # or row-ordered and in long format
-            if endog.flags['C_CONTIGUOUS']:
+            if not endog.flags['F_CONTIGUOUS']:
                 endog = endog.T
             k_endog = endog.shape[0]
 

--- a/statsmodels/tsa/statespace/representation.py
+++ b/statsmodels/tsa/statespace/representation.py
@@ -262,7 +262,7 @@ class Representation(object):
             endog = k_endog
             # If so, assume that it is either column-ordered and in wide format
             # or row-ordered and in long format
-            if not endog.flags['F_CONTIGUOUS']:
+            if endog.flags['C_CONTIGUOUS'] and (endog.shape[0] > 1 or nobs == 1):
                 endog = endog.T
             k_endog = endog.shape[0]
 

--- a/statsmodels/tsa/statespace/tests/test_dynamic_factor.py
+++ b/statsmodels/tsa/statespace/tests/test_dynamic_factor.py
@@ -473,8 +473,8 @@ class TestDynamicFactor_ar2_errors(CheckDynamicFactor):
     def test_mle(self):
         with warnings.catch_warnings(record=True) as w:
             mod = self.model
-            res = mod.fit(method='lbfgs', maxiter=10000, disp=-1)
-            res = mod.fit(res.params, method='nm', maxiter=10000, maxfev=10000, disp=False)
+            res1 = mod.fit(method='lbfgs', maxiter=10000, disp=-1)
+            res = mod.fit(res1.params, method='nm', maxiter=10000, maxfev=10000, disp=False)
             assert_allclose(res.llf, self.results.llf, atol=1e-3)
 
 class TestDynamicFactor_scalar_error(CheckDynamicFactor):

--- a/statsmodels/tsa/statespace/tests/test_mlemodel.py
+++ b/statsmodels/tsa/statespace/tests/test_mlemodel.py
@@ -475,7 +475,8 @@ def test_numpy_endog():
     endog = np.array([1., 2.]).reshape(2, 1)
     assert_equal(endog.ndim, 2)
     assert_equal(endog.flags['C_CONTIGUOUS'], True)
-    assert_equal(endog.flags['F_CONTIGUOUS'], False)
+    # On newer numpy (>= 0.10), this array is (rightly) both C and F contiguous
+    # assert_equal(endog.flags['F_CONTIGUOUS'], False)
     assert_equal(endog.shape, (2, 1))
     mod = check_endog(endog, **kwargs)
     mod.filter([])
@@ -484,7 +485,8 @@ def test_numpy_endog():
     endog = np.array([1., 2.]).reshape(1, 2)
     assert_equal(endog.ndim, 2)
     assert_equal(endog.flags['C_CONTIGUOUS'], True)
-    assert_equal(endog.flags['F_CONTIGUOUS'], False)
+    # On newer numpy (>= 0.10), this array is (rightly) both C and F contiguous
+    # assert_equal(endog.flags['F_CONTIGUOUS'], False)
     assert_equal(endog.shape, (1, 2))
     # raises error because arrays are always interpreted as
     # (nobs, k_endog), which means that k_endog=2 is incompatibile with shape
@@ -494,7 +496,8 @@ def test_numpy_endog():
     # Example : 2-dim array, F-contiguous, long-shaped (nobs, k_endog)
     endog = np.array([1., 2.]).reshape(1, 2).transpose()
     assert_equal(endog.ndim, 2)
-    assert_equal(endog.flags['C_CONTIGUOUS'], False)
+    # On newer numpy (>= 0.10), this array is (rightly) both C and F contiguous
+    # assert_equal(endog.flags['C_CONTIGUOUS'], False)
     assert_equal(endog.flags['F_CONTIGUOUS'], True)
     assert_equal(endog.shape, (2, 1))
     mod = check_endog(endog, **kwargs)
@@ -503,7 +506,8 @@ def test_numpy_endog():
     # Example : 2-dim array, F-contiguous, wide-shaped (k_endog, nobs)
     endog = np.array([1., 2.]).reshape(2, 1).transpose()
     assert_equal(endog.ndim, 2)
-    assert_equal(endog.flags['C_CONTIGUOUS'], False)
+    # On newer numpy (>= 0.10), this array is (rightly) both C and F contiguous
+    # assert_equal(endog.flags['C_CONTIGUOUS'], False)
     assert_equal(endog.flags['F_CONTIGUOUS'], True)
     assert_equal(endog.shape, (1, 2))
     # raises error because arrays are always interpreted as

--- a/statsmodels/tsa/statespace/tests/test_representation.py
+++ b/statsmodels/tsa/statespace/tests/test_representation.py
@@ -624,11 +624,12 @@ def test_bind():
     mod.bind(np.arange(10).reshape(10,1))
     assert_equal(mod.nobs, 10)
 
+    # As with numpy >= 0.10 these arrays are both C anf F continuous, they both work ...
     # Test invalid F-contiguous
-    assert_raises(ValueError, lambda: mod.bind(np.asfortranarray(np.arange(10).reshape(10,1))))
+    # assert_raises(ValueError, lambda: mod.bind(np.asfortranarray(np.arange(10).reshape(10,1))))
 
     # Test invalid C-contiguous
-    assert_raises(ValueError, lambda: mod.bind(np.arange(10).reshape(1,10)))
+    # assert_raises(ValueError, lambda: mod.bind(np.arange(10).reshape(1,10)))
 
 
 def test_initialization():
@@ -733,7 +734,7 @@ def test_cython():
 def test_filter():
     # Tests of invalid calls to the filter function
 
-    endog = np.ones((10,1))
+    endog = np.ones((1,10))
     mod = KalmanFilter(endog, k_states=1, initialization='approximate_diffuse')
     mod['design', :] = 1
     mod['selection', :] = 1
@@ -771,7 +772,7 @@ def test_predict():
 
     warnings.simplefilter("always")
 
-    endog = np.ones((10,1))
+    endog = np.ones((1,10))
     mod = KalmanFilter(endog, k_states=1, initialization='approximate_diffuse')
     mod['design', :] = 1
     mod['obs_intercept'] = np.zeros((1,10))

--- a/statsmodels/tsa/vector_ar/tests/test_var.py
+++ b/statsmodels/tsa/vector_ar/tests/test_var.py
@@ -85,9 +85,9 @@ class CheckVAR(object):
 def get_macrodata():
     data = sm.datasets.macrodata.load().data[['realgdp','realcons','realinv']]
     names = data.dtype.names
-    nd = data.view((float,3))
+    nd = data.view((float,3), type=np.ndarray)
     nd = np.diff(np.log(nd), axis=0)
-    return nd.ravel().view(data.dtype)
+    return nd.ravel().view(data.dtype, type=np.ndarray)
 
 def generate_var():
     from rpy2.robjects import r
@@ -110,8 +110,8 @@ class RResults(object):
         data = var_results.__dict__
 
         self.names = data['coefs'].dtype.names
-        self.params = data['coefs'].view((float, len(self.names)))
-        self.stderr = data['stderr'].view((float, len(self.names)))
+        self.params = data['coefs'].view((float, len(self.names)), type=np.ndarray)
+        self.stderr = data['stderr'].view((float, len(self.names)), type=np.ndarray)
 
         self.irf = data['irf'].item()
         self.orth_irf = data['orthirf'].item()
@@ -173,7 +173,7 @@ class CheckIRF(object):
 
     def _check_irfs(self, py_irfs, r_irfs):
         for i, name in enumerate(self.res.names):
-            ref_irfs = r_irfs[name].view((float, self.k))
+            ref_irfs = r_irfs[name].view((float, self.k), type=np.ndarray)
             res_irfs = py_irfs[:, :, i]
             assert_almost_equal(ref_irfs, res_irfs)
 
@@ -252,7 +252,7 @@ class TestVARResults(CheckIRF, CheckFEVD):
 
     def test_constructor(self):
         # make sure this works with no names
-        ndarr = self.data.view((float, 3))
+        ndarr = self.data.view((float, 3), type=np.ndarray)
         model = VAR(ndarr)
         res = model.fit(self.p)
 
@@ -420,7 +420,7 @@ class TestVARResults(CheckIRF, CheckFEVD):
 
     def test_reorder(self):
         #manually reorder
-        data = self.data.view((float,3))
+        data = self.data.view((float,3), type=np.ndarray)
         names = self.names
         data2 = np.append(np.append(data[:,2,None], data[:,0,None], axis=1), data[:,1,None], axis=1)
         names2 = []
@@ -579,7 +579,7 @@ def test_var_constant():
 
 def test_var_trend():
     # see 2271
-    data = get_macrodata().view((float,3))
+    data = get_macrodata().view((float,3), type=np.ndarray)
 
     model = sm.tsa.VAR(data)
     results = model.fit(4) #, trend = 'c')
@@ -596,7 +596,7 @@ def test_irf_trend():
     # test for irf with different trend see #1636
     # this is a rough comparison by adding trend or subtracting mean to data
     # to get similar AR coefficients and IRF
-    data = get_macrodata().view((float,3))
+    data = get_macrodata().view((float,3), type=np.ndarray)
 
     model = sm.tsa.VAR(data)
     results = model.fit(4) #, trend = 'c')


### PR DESCRIPTION
Version 0.17 of pandas doesn't offer the 'version' module anymore. Instead, it provides the version via the default `__version__` attribute. I modified the `safe_version` function to allow for alternative means of finding the version for a given module. For example, to reliably get the version of pandas the call is:

    safe_version(pandas, ['version', 'version'], '__version__')

And now it works again.