### PR TITLE
MAINT: switch back to old TraviCI infrastructure - don't merge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@
 # required packages and is simpler to use to test up-to-date scientific Python
 # stack
 language: python
-sudo: false
+#sudo: false
 
 env:
   # Default values for common packages, override as needed


### PR DESCRIPTION
This is just to check the timing of old versus new, container based TravisCI infrastructure