### PR TITLE
Ensure files are not left open, mostly in the  data sets

### DIFF
--- a/statsmodels/datasets/anes96/data.py
+++ b/statsmodels/datasets/anes96/data.py
@@ -85,7 +85,7 @@ NOTE        = """::
             logpopul - log(popul + .1)
 """
 
-from numpy import recfromtxt, column_stack, array, log
+from numpy import recfromtxt, log
 import numpy.lib.recfunctions as nprf
 from statsmodels.datasets import utils as du
 from os.path import dirname, abspath
@@ -99,8 +99,9 @@ def load():
         See DATASET_PROPOSAL.txt for more information.
     """
     data = _get_data()
-    return du.process_recarray(data, endog_idx=5, exog_idx=[10,2,6,7,8],
-            dtype=float)
+    return du.process_recarray(data, endog_idx=5,
+                               exog_idx=[10, 2, 6, 7, 8],
+                               dtype=float)
 
 def load_pandas():
     """Load the anes96 data and returns a Dataset class.
@@ -111,14 +112,15 @@ def load_pandas():
         See DATASET_PROPOSAL.txt for more information.
     """
     data = _get_data()
-    return du.process_recarray_pandas(data, endog_idx=5, exog_idx=[10,2,6,7,8],
-            dtype=float)
+    return du.process_recarray_pandas(data, endog_idx=5,
+                                      exog_idx=[10, 2, 6, 7, 8],
+                                      dtype=float)
 
 def _get_data():
     filepath = dirname(abspath(__file__))
-    data = recfromtxt(open(filepath + '/anes96.csv',"rb"), delimiter="\t",
-            names = True, dtype=float)
-    logpopul = log(data['popul'] + .1)
-    data = nprf.append_fields(data, 'logpopul', logpopul, usemask=False,
-                                                          asrecarray=True)
-    return data
+    with open(filepath + '/anes96.csv', "rb") as f:
+        data = recfromtxt(f, delimiter="\t", names=True, dtype=float)
+        logpopul = log(data['popul'] + .1)
+        data = nprf.append_fields(data, 'logpopul', logpopul, usemask=False,
+                                  asrecarray=True)
+        return data

--- a/statsmodels/datasets/cancer/data.py
+++ b/statsmodels/datasets/cancer/data.py
@@ -54,6 +54,6 @@ def load_pandas():
 def _get_data():
     filepath = dirname(abspath(__file__))
     ##### EDIT THE FOLLOWING TO POINT TO DatasetName.csv #####
-    data = np.recfromtxt(open(filepath + '/cancer.csv', 'rb'),
-            delimiter=",", names = True, dtype=float)
-    return data
+    with open(filepath + '/cancer.csv', 'rb') as f:
+        data = np.recfromtxt(f, delimiter=",", names=True, dtype=float)
+        return data

--- a/statsmodels/datasets/ccard/data.py
+++ b/statsmodels/datasets/ccard/data.py
@@ -26,7 +26,7 @@ NOTE        = """::
                                 variables.
 """
 
-from numpy import recfromtxt, column_stack, array
+from numpy import recfromtxt
 from statsmodels.datasets import utils as du
 from os.path import dirname, abspath
 
@@ -54,6 +54,6 @@ def load_pandas():
 
 def _get_data():
     filepath = dirname(abspath(__file__))
-    data = recfromtxt(open(filepath + '/ccard.csv', 'rb'), delimiter=",",
-            names=True, dtype=float)
-    return data
+    with open(filepath + "/ccard.csv", 'rb') as f:
+        data = recfromtxt(f, delimiter=",", names=True, dtype=float)
+        return data

--- a/statsmodels/datasets/co2/data.py
+++ b/statsmodels/datasets/co2/data.py
@@ -75,6 +75,6 @@ def load_pandas():
 
 def _get_data():
     filepath = dirname(abspath(__file__))
-    data = np.recfromtxt(open(filepath + '/co2.csv', 'rb'),
-                         delimiter=",", names=True, dtype=['a8', float])
-    return data
+    with open(filepath + '/co2.csv', 'rb') as f:
+        data = np.recfromtxt(f, delimiter=",", names=True, dtype=['a8', float])
+        return data

--- a/statsmodels/datasets/committee/data.py
+++ b/statsmodels/datasets/committee/data.py
@@ -66,6 +66,7 @@ def load_pandas():
 
 def _get_data():
     filepath = dirname(abspath(__file__))
-    data = recfromtxt(open(filepath + '/committee.csv', 'rb'), delimiter=",",
-            names=True, dtype=float, usecols=(1,2,3,4,5,6))
-    return data
+    with open(filepath + '/committee.csv', 'rb') as f:
+        data = recfromtxt(f, delimiter=",",
+                          names=True, dtype=float, usecols=(1,2,3,4,5,6))
+        return data

--- a/statsmodels/datasets/copper/data.py
+++ b/statsmodels/datasets/copper/data.py
@@ -57,9 +57,10 @@ def load():
 
 def _get_data():
     filepath = dirname(abspath(__file__))
-    data = recfromtxt(open(filepath + '/copper.csv', 'rb'), delimiter=",",
-                      names=True, dtype=float, usecols=(1,2,3,4,5,6))
-    return data
+    with open(filepath + '/copper.csv', 'rb') as f:
+        data = recfromtxt(f, delimiter=",",
+                          names=True, dtype=float, usecols=(1,2,3,4,5,6))
+        return data
 
 def load_pandas():
     """

--- a/statsmodels/datasets/cpunish/data.py
+++ b/statsmodels/datasets/cpunish/data.py
@@ -72,6 +72,7 @@ def load_pandas():
 
 def _get_data():
     filepath = dirname(abspath(__file__))
-    data = recfromtxt(open(filepath + '/cpunish.csv', 'rb'), delimiter=",",
-            names=True, dtype=float, usecols=(1,2,3,4,5,6,7))
-    return data
+    with open(filepath + '/cpunish.csv', 'rb') as f:
+        data = recfromtxt(f, delimiter=",",
+                          names=True, dtype=float, usecols=(1,2,3,4,5,6,7))
+        return data

--- a/statsmodels/datasets/elnino/data.py
+++ b/statsmodels/datasets/elnino/data.py
@@ -68,6 +68,7 @@ def load_pandas():
 
 def _get_data():
     filepath = dirname(abspath(__file__))
-    data = recfromtxt(open(filepath + '/elnino.csv', 'rb'), delimiter=",",
-                      names=True, dtype=float)
-    return data
+    with open(filepath + '/elnino.csv', 'rb') as f:
+        data = recfromtxt(f, delimiter=",",
+                          names=True, dtype=float)
+        return data

--- a/statsmodels/datasets/engel/data.py
+++ b/statsmodels/datasets/engel/data.py
@@ -59,6 +59,7 @@ def load_pandas():
 def _get_data():
     filepath = dirname(abspath(__file__))
     ##### EDIT THE FOLLOWING TO POINT TO DatasetName.csv #####
-    data = np.recfromtxt(open(filepath + '/engel.csv', 'rb'),
-            delimiter=",", names = True, dtype=float)
-    return data
+    with open(filepath + '/engel.csv', 'rb') as f:
+        data = np.recfromtxt(f,
+                             delimiter=",", names = True, dtype=float)
+        return data

--- a/statsmodels/datasets/fair/data.py
+++ b/statsmodels/datasets/fair/data.py
@@ -78,6 +78,6 @@ def load_pandas():
 def _get_data():
     filepath = dirname(abspath(__file__))
     ##### EDIT THE FOLLOWING TO POINT TO DatasetName.csv #####
-    data = np.recfromtxt(open(filepath + '/fair.csv', 'rb'),
-            delimiter=",", names = True, dtype=float)
-    return data
+    with open(filepath + '/fair.csv', 'rb') as f:
+        data = np.recfromtxt(f, delimiter=",", names=True, dtype=float)
+        return data

--- a/statsmodels/datasets/grunfeld/data.py
+++ b/statsmodels/datasets/grunfeld/data.py
@@ -88,6 +88,7 @@ def load_pandas():
 
 def _get_data():
     filepath = dirname(abspath(__file__))
-    data = recfromtxt(open(filepath + '/grunfeld.csv','rb'), delimiter=",",
-            names=True, dtype="f8,f8,f8,a17,f8")
-    return data
+    with open(filepath + '/grunfeld.csv','rb') as f:
+        data = recfromtxt(f, delimiter=",",
+                          names=True, dtype="f8,f8,f8,a17,f8")
+        return data

--- a/statsmodels/datasets/heart/data.py
+++ b/statsmodels/datasets/heart/data.py
@@ -58,6 +58,6 @@ def load_pandas():
 def _get_data():
     filepath = dirname(abspath(__file__))
     ##### EDIT THE FOLLOWING TO POINT TO DatasetName.csv #####
-    data = np.recfromtxt(open(filepath + '/heart.csv', 'rb'),
-            delimiter=",", names = True, dtype=float)
-    return data
+    with open(filepath + '/heart.csv', 'rb') as f:
+        data = np.recfromtxt(f, delimiter=",", names = True, dtype=float)
+        return data

--- a/statsmodels/datasets/longley/data.py
+++ b/statsmodels/datasets/longley/data.py
@@ -69,6 +69,7 @@ def load_pandas():
 
 def _get_data():
     filepath = dirname(abspath(__file__))
-    data = recfromtxt(open(filepath+'/longley.csv',"rb"), delimiter=",",
-                      names=True, dtype=float, usecols=(1,2,3,4,5,6,7))
-    return data
+    with open(filepath+'/longley.csv',"rb") as f:
+        data = recfromtxt(f, delimiter=",",
+                          names=True, dtype=float, usecols=(1,2,3,4,5,6,7))
+        return data

--- a/statsmodels/datasets/macrodata/data.py
+++ b/statsmodels/datasets/macrodata/data.py
@@ -84,6 +84,7 @@ def load_pandas():
 
 def _get_data():
     filepath = dirname(abspath(__file__))
-    data = recfromtxt(open(filepath + '/macrodata.csv', 'rb'), delimiter=",",
-                      names=True, dtype=float)
-    return data
+    with open(filepath + '/macrodata.csv', 'rb') as f:
+        data = recfromtxt(f, delimiter=",",
+                          names=True, dtype=float)
+        return data

--- a/statsmodels/datasets/modechoice/data.py
+++ b/statsmodels/datasets/modechoice/data.py
@@ -85,6 +85,6 @@ def load_pandas():
 
 def _get_data():
     filepath = dirname(abspath(__file__))
-    data = np.recfromtxt(open(filepath + '/modechoice.csv', 'rb'),
-            delimiter=";", names = True, dtype=float)
-    return data
+    with open(filepath + '/modechoice.csv', 'rb') as f:
+        data = np.recfromtxt(f, delimiter=";", names=True, dtype=float)
+        return data

--- a/statsmodels/datasets/nile/data.py
+++ b/statsmodels/datasets/nile/data.py
@@ -60,6 +60,7 @@ def load_pandas():
 
 def _get_data():
     filepath = dirname(abspath(__file__))
-    data = recfromtxt(open(filepath + '/nile.csv', 'rb'), delimiter=",",
-            names=True, dtype=float)
-    return data
+    with open(filepath + '/nile.csv', 'rb') as f:
+        data = recfromtxt(f, delimiter=",",
+                          names=True, dtype=float)
+        return data

--- a/statsmodels/datasets/randhie/data.py
+++ b/statsmodels/datasets/randhie/data.py
@@ -83,6 +83,6 @@ def load_pandas():
     return du.process_recarray_pandas(data, endog_idx=0)
 
 def _get_data():
-    filepath = dirname(abspath(__file__))
-    data = recfromtxt(open(PATH, "rb"), delimiter=",", names=True, dtype=float)
-    return data
+    with open(PATH, "rb") as f:
+        data = recfromtxt(f, delimiter=",", names=True, dtype=float)
+        return data

--- a/statsmodels/datasets/scotland/data.py
+++ b/statsmodels/datasets/scotland/data.py
@@ -81,6 +81,7 @@ def load_pandas():
 
 def _get_data():
     filepath = dirname(abspath(__file__))
-    data = np.recfromtxt(open(filepath + '/scotvote.csv',"rb"), delimiter=",",
-                         names=True, dtype=float, usecols=(1,2,3,4,5,6,7,8))
-    return data
+    with open(filepath + '/scotvote.csv',"rb") as f:
+        data = np.recfromtxt(f, delimiter=",",
+                             names=True, dtype=float, usecols=(1,2,3,4,5,6,7,8))
+        return data

--- a/statsmodels/datasets/spector/data.py
+++ b/statsmodels/datasets/spector/data.py
@@ -62,7 +62,8 @@ def load_pandas():
 
 def _get_data():
     filepath = dirname(abspath(__file__))
-##### EDIT THE FOLLOWING TO POINT TO DatasetName.csv #####
-    data = np.recfromtxt(open(filepath + '/spector.csv',"rb"), delimiter=" ",
-                         names=True, dtype=float, usecols=(1,2,3,4))
-    return data
+    ##### EDIT THE FOLLOWING TO POINT TO DatasetName.csv #####
+    with open(filepath + '/spector.csv',"rb") as f:
+        data = np.recfromtxt(f, delimiter=" ",
+                             names=True, dtype=float, usecols=(1,2,3,4))
+        return data

--- a/statsmodels/datasets/stackloss/data.py
+++ b/statsmodels/datasets/stackloss/data.py
@@ -60,6 +60,7 @@ def load_pandas():
 
 def _get_data():
     filepath = dirname(abspath(__file__))
-    data = recfromtxt(open(filepath + '/stackloss.csv',"rb"), delimiter=",",
-            names=True, dtype=float)
-    return data
+    with open(filepath + '/stackloss.csv',"rb") as f:
+        data = recfromtxt(f, delimiter=",",
+                          names=True, dtype=float)
+        return data

--- a/statsmodels/datasets/star98/data.py
+++ b/statsmodels/datasets/star98/data.py
@@ -93,14 +93,15 @@ def _get_data():
             "PCTCHRT","PCTYRRND","PERMINTE_AVYRSEXP","PERMINTE_AVSAL",
             "AVYRSEXP_AVSAL","PERSPEN_PTRATIO","PERSPEN_PCTAF","PTRATIO_PCTAF",
             "PERMINTE_AVYRSEXP_AVSAL","PERSPEN_PTRATIO_PCTAF"]
-    data = recfromtxt(open(filepath + '/star98.csv',"rb"), delimiter=",",
-            names=names, skip_header=1, dtype=float)
+    with open(filepath + '/star98.csv',"rb") as f:
+        data = recfromtxt(f, delimiter=",",
+                          names=names, skip_header=1, dtype=float)
 
-    # careful now
-    nabove = data['NABOVE'].copy()
-    nbelow = data['NBELOW'].copy()
+        # careful now
+        nabove = data['NABOVE'].copy()
+        nbelow = data['NBELOW'].copy()
 
-    data['NABOVE'] = nbelow # successes
-    data['NBELOW'] = nabove - nbelow # now failures
+        data['NABOVE'] = nbelow # successes
+        data['NBELOW'] = nabove - nbelow # now failures
 
-    return data
+        return data

--- a/statsmodels/datasets/statecrime/data.py
+++ b/statsmodels/datasets/statecrime/data.py
@@ -82,6 +82,6 @@ def load_pandas():
 def _get_data():
     filepath = dirname(abspath(__file__))
     ##### EDIT THE FOLLOWING TO POINT TO DatasetName.csv #####
-    data = np.recfromtxt(open(filepath + '/statecrime.csv', 'rb'),
-            delimiter=",", names=True, dtype=None)
-    return data
+    with open(filepath + '/statecrime.csv', 'rb') as f:
+        data = np.recfromtxt(f, delimiter=",", names=True, dtype=None)
+        return data

--- a/statsmodels/datasets/strikes/data.py
+++ b/statsmodels/datasets/strikes/data.py
@@ -66,6 +66,6 @@ def load_pandas():
 
 def _get_data():
     filepath = dirname(abspath(__file__))
-    data = recfromtxt(open(filepath + '/strikes.csv', 'rb'), delimiter=",",
-            names=True, dtype=float)
-    return data
+    with open(filepath + '/strikes.csv', 'rb') as f:
+        data = recfromtxt(f, delimiter=",", names=True, dtype=float)
+        return data

--- a/statsmodels/datasets/sunspots/data.py
+++ b/statsmodels/datasets/sunspots/data.py
@@ -27,7 +27,7 @@ NOTE        = """::
     The data file contains a 'YEAR' variable that is not returned by load.
 """
 
-from numpy import recfromtxt, column_stack, array
+from numpy import recfromtxt, array
 from pandas import Series, DataFrame
 
 from statsmodels.datasets.utils import Dataset
@@ -65,6 +65,7 @@ def load_pandas():
 
 def _get_data():
     filepath = dirname(abspath(__file__))
-    data = recfromtxt(open(filepath + '/sunspots.csv', 'rb'), delimiter=",",
-            names=True, dtype=float)
-    return data
+    with open(filepath + '/sunspots.csv', 'rb') as f:
+        data = recfromtxt(f, delimiter=",",
+                          names=True, dtype=float)
+        return data

--- a/statsmodels/iolib/foreign.py
+++ b/statsmodels/iolib/foreign.py
@@ -10,7 +10,7 @@ See also
 numpy.lib.io
 """
 from statsmodels.compat.python import (zip, lzip, lmap, lrange, string_types, long, lfilter,
-                                asbytes, asstr, range)
+                                       asbytes, asstr, range)
 from struct import unpack, calcsize, pack
 from struct import error as struct_error
 import datetime
@@ -1160,7 +1160,7 @@ def savetxt(fname, X, names=None, fmt='%.18e', delimiter=' '):
             import gzip
             fh = gzip.open(fname, 'wb')
         else:
-            fh = file(fname, 'w')
+            fh = open(fname, 'w')
     elif hasattr(fname, 'seek'):
         fh = fname
     else:

--- a/statsmodels/iolib/openfile.py
+++ b/statsmodels/iolib/openfile.py
@@ -1,0 +1,71 @@
+"""
+Handle file opening for read/write
+"""
+from numpy.lib._iotools import _is_string_like
+from statsmodels.compat.python import PY3
+
+class EmptyContextManager(object):
+    """
+    This class is needed to allow file-like object to be used as
+    context manager, but without getting closed.
+    """
+    def __init__(self, obj):
+        self._obj = obj
+
+    def __enter__(self):
+        '''When entering, return the embedded object'''
+        return self._obj
+
+    def __exit__(self, *args):
+        '''Don't hide anything'''
+        return False
+
+    def __getattr__(self, name):
+        return getattr(self._obj, name)
+
+if PY3:
+    def _open(fname, mode, encoding):
+        if fname.endswith('.gz'):
+            import gzip
+            return gzip.open(fname, mode, encoding=encoding)
+        else:
+            return open(fname, mode, encoding=encoding)
+else:
+    def _open(fname, mode, encoding):
+        if fname.endswith('.gz'):
+            import gzip
+            return gzip.open(fname, mode)
+        else:
+            return open(fname, mode)
+
+def get_file_obj(fname, mode='r', encoding=None):
+    """
+    Light wrapper to handle strings and let files (anything else) pass through.
+
+    It also handle '.gz' files.
+
+    Parameters
+    ==========
+    fname: string or file-like object
+        File to open / forward
+    mode: string
+        Argument passed to the 'open' or 'gzip.open' function
+    encoding: string
+        For Python 3 only, specify the encoding of the file
+
+    Returns
+    =======
+    A file-like object that is always a context-manager. If the `fname` was already a file-like object,
+    the returned context manager *will not close the file*.
+    """
+    if _is_string_like(fname):
+        return _open(fname, mode, encoding)
+    try:
+        # Make sure the object has the write methods
+        if 'r' in mode:
+            fname.read
+        if 'w' in mode or 'a' in mode:
+            fname.write
+    except AttributeError:
+        raise ValueError('fname must be a string or a file-like object')
+    return EmptyContextManager(fname)

--- a/statsmodels/iolib/smpickle.py
+++ b/statsmodels/iolib/smpickle.py
@@ -1,29 +1,6 @@
 '''Helper files for pickling'''
 from statsmodels.compat.python import cPickle
-
-class EmptyContextManager(object):
-    """
-    This class is needed to allow file-like object to be used as
-    context manager, but without getting closed.
-    """
-    def __init__(self, obj):
-        self._obj = obj
-
-    def __enter__(self):
-        return self._obj
-
-    def __exit__(self, *args):
-        return False
-
-def _get_file_obj(fname, mode):
-    """
-    Light wrapper to handle strings and let files (anything else) pass through
-    """
-    try:
-        fh = open(fname, mode)
-    except (IOError, TypeError):
-        fh = EmptyContextManager(fname)
-    return fh
+from statsmodels.iolib.openfile import get_file_obj
 
 def save_pickle(obj, fname):
     """
@@ -34,7 +11,7 @@ def save_pickle(obj, fname):
     fname : str
         Filename to pickle to
     """
-    with _get_file_obj(fname, 'wb') as fout:
+    with get_file_obj(fname, 'wb') as fout:
         cPickle.dump(obj, fout, protocol=-1)
 
 
@@ -51,6 +28,6 @@ def load_pickle(fname):
     -----
     This method can be used to load *both* models and results.
     """
-    with _get_file_obj(fname, 'rb') as fin:
+    with get_file_obj(fname, 'rb') as fin:
         return cPickle.load(fin)
 

--- a/statsmodels/iolib/smpickle.py
+++ b/statsmodels/iolib/smpickle.py
@@ -20,8 +20,8 @@ def save_pickle(obj, fname):
     fname : str
         Filename to pickle to
     """
-    fout = _get_file_obj(fname, 'wb')
-    cPickle.dump(obj, fout, protocol=-1)
+    with _get_file_obj(fname, 'wb') as fout:
+        cPickle.dump(obj, fout, protocol=-1)
 
 
 def load_pickle(fname):
@@ -37,6 +37,6 @@ def load_pickle(fname):
     -----
     This method can be used to load *both* models and results.
     """
-    fin = _get_file_obj(fname, 'rb')
-    return cPickle.load(fin)
+    with _get_file_obj(fname, 'rb') as fin:
+        return cPickle.load(fin)
 

--- a/statsmodels/iolib/smpickle.py
+++ b/statsmodels/iolib/smpickle.py
@@ -1,6 +1,20 @@
 '''Helper files for pickling'''
 from statsmodels.compat.python import cPickle
 
+class EmptyContextManager(object):
+    """
+    This class is needed to allow file-like object to be used as
+    context manager, but without getting closed.
+    """
+    def __init__(self, obj):
+        self._obj = obj
+
+    def __enter__(self):
+        return self._obj
+
+    def __exit__(self, *args):
+        return False
+
 def _get_file_obj(fname, mode):
     """
     Light wrapper to handle strings and let files (anything else) pass through
@@ -8,7 +22,7 @@ def _get_file_obj(fname, mode):
     try:
         fh = open(fname, mode)
     except (IOError, TypeError):
-        fh = fname
+        fh = EmptyContextManager(fname)
     return fh
 
 def save_pickle(obj, fname):

--- a/statsmodels/tsa/kalmanf/kalmanfilter.py
+++ b/statsmodels/tsa/kalmanf/kalmanfilter.py
@@ -828,7 +828,8 @@ if __name__ == "__main__":
         dk = zipfile.ZipFile('/home/skipper/statsmodels/statsmodels-skipper/scikits/statsmodels/sandbox/tsa/DK-data.zip')
     except:
         raise IOError("Install DK-data.zip from http://www.ssfpack.com/DKbook.html or specify its correct local path.")
-    nile = dk.open('Nile.dat').readlines()
+    with dk.open('Nile.dat') as f:
+        nile = f.readlines()
     nile = [float(_.strip()) for _ in nile[1:]]
     nile = np.asarray(nile)
 #    v = np.zeros_like(nile)
@@ -852,7 +853,8 @@ if __name__ == "__main__":
 #                Q=Q, R=R, penalty=False, ntrain=0)
 
 # p. 162 univariate structural time series example
-    seatbelt = dk.open('Seatbelt.dat').readlines()
+    with dk.open('Seatbelt.dat') as f:
+        seatbelt = f.readlines()
     seatbelt = [lmap(float,_.split()) for _ in seatbelt[2:]]
     sb_ssm = StateSpaceModel(seatbelt)
     s = 12 # monthly data

--- a/statsmodels/tsa/vector_ar/util.py
+++ b/statsmodels/tsa/vector_ar/util.py
@@ -118,7 +118,8 @@ def parse_lutkepohl_data(path): # pragma: no cover
     import re
 
     regex = re.compile(asbytes('<(.*) (\w)([\d]+)>.*'))
-    lines = deque(open(path, 'rb'))
+    with open(path, 'rb') as f:
+        lines = deque(f)
 
     to_skip = 0
     while asbytes('*/') not in lines.popleft():


### PR DESCRIPTION
I started this when I got a warning about a lot of files being open during the tests. Checking the code, all the data loading had a dangling call to  'open'. Although this should be collected at some point, this may be delayed and it happened to me a few times.

This PR is to solve this by replacing all the call to the `open` function by a `with`-statement, to ensure the file is close when returning the data.

I also use this opportunity to remove some needlessly imported symbols in the data modules.
