### PR TITLE
Update quantile_regression.py

### DIFF
--- a/statsmodels/regression/quantile_regression.py
+++ b/statsmodels/regression/quantile_regression.py
@@ -189,8 +189,8 @@ class QuantReg(RegressionModel):
                 warnings.warn("Convergence cycle detected", ConvergenceWarning)
 
         if n_iter == max_iter:
-            warnings.warn("Maximum number of iterations (1000) reached.",
-                          IterationLimitWarning)
+            warnings.warn("Maximum number of iterations (" + str(max_iter) + 
+                          ") reached.", IterationLimitWarning)
 
         e = endog - np.dot(exog, beta)
         # Greene (2008, p.407) writes that Stata 6 uses this bandwidth:


### PR DESCRIPTION
STY: Use of str(max_iter) instead of "(1000)" by default in the warning message. Line 192