### PR TITLE
WIP  ENH: add blaker proportion confint

### DIFF
--- a/statsmodels/examples/ex_binom_blaker.py
+++ b/statsmodels/examples/ex_binom_blaker.py
@@ -1,0 +1,53 @@
+
+
+
+import numpy as np
+from scipy import stats, optimize
+import statsmodels.stats.proportion as prop
+from statsmodels.stats.proportion import (proportion_confint_baker,
+                                          accept_binom, _delta_blaker)
+
+
+
+alpha = 0.05
+
+ex = 1
+if ex == 1:
+    n = 10
+    x = int(n * 0.4)
+
+    ci_005 = prop.proportion_confint(x, n, method='beta')
+    ci_01 = prop.proportion_confint(x, n, alpha=0.1, method='beta')
+    print(ci_005)
+    print(ci_01)
+
+    low, upp = ci_005
+    print(stats.binom.sf(x - 1, n, upp))
+    print(stats.binom.cdf(x, n, upp))
+    low_exact, upp_exact = prop.proportion_confint(x, n, alpha=0.05, method='beta')
+    low_exact2, upp_exact2 = prop.proportion_confint(x, n, alpha=2 * 0.05,
+                                                     method='beta')
+
+    pp = np.linspace(low_exact, low_exact2, 11)
+    #print(np.column_stack((pp, np.column_stack(accept_binom(x, n, pp)))))
+
+    pp = np.linspace(upp_exact2, upp_exact, 11)
+    #print(np.column_stack((pp, np.column_stack(accept_binom(x, n, pp)))))
+
+    low_b, upp_b = 0.150, 0.717
+    print(accept_binom(x, n, low_b))
+    print(accept_binom(x, n, upp_b))
+
+    optimize.brentq(lambda p_: accept_binom(x, n, p_)[0] - 0.05, upp_exact2, upp_exact)
+
+    print(proportion_confint_baker(4, 10, alpha=0.05)[0])
+
+    print(proportion_confint_baker(2, 10, alpha=0.05)[:2])
+    print(proportion_confint_baker(2, 123, alpha=0.05)[:2])
+
+
+x=5;n=20
+print(proportion_confint_baker(5, 20, alpha=0.05)[:2])
+pl, pu = prop.proportion_confint(5, 20, alpha=0.05, method='beta')
+pl2, pu2 = prop.proportion_confint(5, 20, alpha=2*0.05, method='beta')
+print(_delta_blaker(x, n, pu))

--- a/statsmodels/stats/proportion.py
+++ b/statsmodels/stats/proportion.py
@@ -123,6 +123,140 @@ def proportion_confint(count, nobs, alpha=0.05, method='normal'):
         raise NotImplementedError('method "%s" is not available' % method)
     return ci_low, ci_upp
 
+
+class Holder(object):
+    def __init__(self, **kwds):
+        self.__dict__.update(kwds)
+
+
+def _delta_blaker(count, n, prob, q2d=None):
+    """
+    delta function of Lecoutre and Poitevineau 2016 for upper confidence limit
+
+    """
+    x, n, p = count, n, prob
+    p2 = stats.binom.cdf(x, n, p)
+    q2 = stats.binom.isf(p2, n, p)
+
+    if q2d is None:
+        q2d = q2
+
+    pd2 = np.asarray(p2).copy()
+    delta2a = pd2 - stats.binom.sf(q2d, n, p)
+    delta2b = pd2 - stats.binom.sf(q2d - 1, n, p)
+
+    p2 += stats.binom.sf(q2, n, p)
+
+    return q2, delta2a, delta2b
+
+
+def accept_binom(count, n, prob):
+    """acceptance function of Blaker for a binomial proportion
+
+    """
+
+    x, n, p = count, n, prob
+
+    p1 = stats.binom.sf(x - 1, n, p)
+    q1 = stats.binom.ppf(p1, n, p)
+    pd1 = np.asarray(p1).copy()
+    p1 +- stats.binom.cdf(q1, n, p)
+    delta1 = pd1 - stats.binom.cdf(q1, n, p)
+
+    p2 = stats.binom.cdf(x, n, p)
+    q2 = stats.binom.isf(p2, n, p)
+    pd2 = np.asarray(p2).copy()
+    p2 += stats.binom.sf(q2, n, p)
+    delta2 = pd2 - stats.binom.sf(q2, n, p)
+
+    return np.minimum(p1, p2), p1, p2, delta1, delta2
+
+
+def proportion_confint_baker(count, n, alpha=0.05, check=False):
+    """Find confidence interval for binomial proportion using Blaker's exact
+
+    The exact confidence interval of Blaker is a subset of the exact central
+    confidence interval of Clopper-Pearson
+
+    This is only for two sided alternative, one-sided is Clopper-Pearson
+
+    Parameters
+    ----------
+    count : int or array
+        number of successes
+    nobs : int
+        total number of trials
+    alpha : float in (0, 1)
+        significance level, default 0.05
+    check : bool
+        temporary option, checks the
+
+    Returns
+    -------
+    ci_low, ci_upp : float
+        lower and upper confidence level with coverage at least 1-alpha.
+    res : results instance
+        this holds additional results as attributes
+
+    Notes
+    -----
+
+    Currently there are some duplicate calculations in here to compare two
+    numerical procedures to find the confidence interval. The rootfinding
+    method for Blaker's method might not find the wider confidence interval if
+    the acceptance function has multiple crossings with alpha in the relevant
+    range.
+    The second method is an adaptation of Lecoutre and Poitevineau 2016
+    which should have a unique zero of the criterion function, but is currently
+    only implemented for the upper limit of the confidence interval, and might
+    not have the correct corner solutions yet.
+    This duplication will be removed after the function is verified for more
+    cases.
+
+    """
+    low_exact, upp_exact = proportion_confint(count, n, alpha=alpha, method='beta')
+    low_exact2, upp_exact2 = proportion_confint(count, n, alpha=2 * alpha,
+                                                method='beta')
+
+    # find zero for Blake's acceptance function, may not be most extreme zero
+    func = lambda p_: accept_binom(count, n, p_)[0] - alpha
+    eps = 1e-10
+    low, upp = 0, 1
+    if count > 0:
+        low = optimize.brentq(func, low_exact - eps, low_exact2 + eps)
+    if count < n:
+        upp = optimize.brentq(func, upp_exact2 - eps, upp_exact + eps)
+
+    #Todo: add check that solution satisfies func >= 0, and smaller outside
+
+    # check upper with Lecoutre, Poitevineau 2016
+    delta = accept_binom(count, n, upp)[-1]
+
+    q2d = _delta_blaker(count, n, upp_exact, q2d=None)[0]
+
+
+    # find the zero of the delta function, using blaker as lower bound
+    uppd = np.nan
+    if count < n and check:
+        func_d = lambda p_: _delta_blaker(count, n, p_, q2d=q2d)[-1]
+        uppd = optimize.brentq(func_d, upp - eps, upp_exact + eps)
+
+    # find the zero of the delta function, using exact as bounds
+    upp_delta = np.nan
+    if count < n:
+        func_d = lambda p_: _delta_blaker(count, n, p_, q2d=q2d)[-1]
+        upp_delta = optimize.brentq(func_d, upp_exact2 - eps, upp_exact + eps)
+
+
+    res = Holder(confint = (low, upp),
+                 confint_exact_centered = (low_exact, upp_exact),
+                 confint_exact_centered2 = (low_exact2, upp_exact2),
+                 delta=delta, upp_delta=upp_delta, uppd=uppd)
+
+    return low, upp, res
+
+
+
 def samplesize_confint_proportion(proportion, half_length, alpha=0.05,
                                   method='normal'):
     '''find sample size to get desired confidence interval length

--- a/statsmodels/stats/tests/test_proportion.py
+++ b/statsmodels/stats/tests/test_proportion.py
@@ -7,7 +7,8 @@ Author: Josef Perktold
 """
 
 import numpy as np
-from numpy.testing import assert_almost_equal, assert_equal, assert_array_less
+from numpy.testing import (assert_almost_equal, assert_equal, assert_array_less,
+                           assert_allclose)
 
 from statsmodels.stats.proportion import proportion_confint
 import statsmodels.stats.proportion as smprop
@@ -37,6 +38,26 @@ def test_confint_proportion():
 
             assert_almost_equal(ci, [res_low, res_upp], decimal=6,
                                 err_msg=repr(case) + method)
+
+
+def test_confint_proportion_blaker():
+
+    # x, n, ci from article Somerville and Brown 2013 Pharmaceutical Statistics
+    cases = [( 0, 10, (0., 0.283)),
+             ( 1, 10, (0.005, 0.444)),
+             ( 4, 10, (0.150, 0.717)),
+             ( 0, 50, (0., 0.064)),
+             ( 5, 50, (0.040, 0.215)),
+             #( 20, 50, (0.266, 0.541)),  # fail at low
+             ( 0, 200, (0., 0.018)),
+             ( 20, 200, (0.063, 0.148)),
+             #( 80, 200, (0.332, 0.470))  # fail at low
+             ]
+
+    for x, n, ci2 in cases:
+        ci1 = smprop.proportion_confint_baker(x, n, alpha=0.05)[:2]
+        assert_allclose(ci1, ci2, rtol=0, atol=5e-3)
+
 
 def test_samplesize_confidenceinterval_prop():
     #consistency test for samplesize to achieve confidence_interval


### PR DESCRIPTION
initial version, still failures in root finding

This adds exact Blaker confidence intervals for a one sample Binomial proportion. It should be added as option to the existing function before merge.
Blaker confidence interval has smaller length than Clopper-Pearson and is contained in it. It doesn't have minimal length in contrast to other refinements of exact confidence intervals, but it produces nested confidence intervals (the confidence interval with a larger significance level is contained in the one with the smaller significance level), which is not the case for the other exact refinements.

The same approach also works for Poisson and other confidence intervals.

There are some R packages that implement it, probci and exactci. The second also for Poisson.

**Implementation notes**

Blaker does an inward grid search for the confidence limits. This can be slow because it needs a fine grid to avoid missing small non-monotonicities.
I'm using scipy.optimize.brentq which should be faster, but doesn't find the outermost limit (zero of the function).
There are two commented out test cases that fail and I didn't investigate yet. I thought we get the non-monotonicities only in exceptional cases.

Lecoutre and Poitevineau 2016 show that a different function is monotonic and has only one zero in the relevant range. I partially implemented the function for the upper confidence interval but not their approach, again using brentq instead of their several steps of finding the zero.

