### PR TITLE
BUG: Statespace: Error in determinant calculation with certain patterns of missing data

### DIFF
--- a/statsmodels/tsa/statespace/_statespace.pyx.in
+++ b/statsmodels/tsa/statespace/_statespace.pyx.in
@@ -758,7 +758,7 @@ cdef {{cython_type}} {{prefix}}factorize_cholesky({{prefix}}KalmanFilter kfilter
         # diagonals, in the Cholesky decomposition case)
         determinant = 1.0
         for i in range(kfilter.k_endog):
-            determinant = determinant * kfilter.forecast_error_fac[i, i]
+            determinant = determinant * kfilter._forecast_error_fac[i + i*kfilter.k_endog]
         determinant = determinant**2
 
     return determinant
@@ -802,9 +802,9 @@ cdef {{cython_type}} {{prefix}}factorize_lu({{prefix}}KalmanFilter kfilter, {{cy
         determinant = 1
         for i in range(kfilter.k_endog):
             if not kfilter._forecast_error_ipiv[i] == i+1:
-                determinant *= -1*kfilter.forecast_error_fac[i, i]
+                determinant *= -1*kfilter._forecast_error_fac[i + i*kfilter.k_endog]
             else:
-                determinant *= kfilter.forecast_error_fac[i, i]
+                determinant *= kfilter._forecast_error_fac[i + i*kfilter.k_endog]
 
     return determinant
 

--- a/statsmodels/tsa/statespace/tests/test_representation.py
+++ b/statsmodels/tsa/statespace/tests/test_representation.py
@@ -1236,7 +1236,7 @@ def test_missing():
     endog_post_na = np.c_[
         endog, endog, endog.copy() * np.nan, endog.copy() * np.nan]
     endog_inject_na = np.c_[
-        endog, endog.copy() * np.nan, endog, endog.copy() * np.nan, endog]
+        endog, endog.copy() * np.nan, endog, endog.copy() * np.nan]
 
     # Base model
     mod = KalmanFilter(np.c_[endog, endog], k_states=1,
@@ -1271,3 +1271,15 @@ def test_missing():
     llf_post_na = mod.loglike()
 
     assert_allclose(llf_post_na, llf)
+
+    # Model with injected nans
+    mod = KalmanFilter(endog_inject_na, k_states=1,
+                       initialization='approximate_diffuse')
+    mod['design', :, :] = 1
+    mod['obs_cov', :, :] = np.eye(mod.k_endog)*0.5
+    mod['transition', :, :] = 0.5
+    mod['selection', :, :] = 1
+    mod['state_cov', :, :] = 0.5
+    llf_inject_na = mod.loglike()
+
+    assert_allclose(llf_inject_na, llf)

--- a/statsmodels/tsa/statespace/tests/test_representation.py
+++ b/statsmodels/tsa/statespace/tests/test_representation.py
@@ -1246,7 +1246,7 @@ def test_missing():
     mod['transition', :, :] = 0.5
     mod['selection', :, :] = 1
     mod['state_cov', :, :] = 0.5
-    llf = mod.loglike()
+    llf = mod.loglikeobs()
 
     # Model with prepended nans
     mod = KalmanFilter(endog_pre_na, k_states=1,
@@ -1256,7 +1256,7 @@ def test_missing():
     mod['transition', :, :] = 0.5
     mod['selection', :, :] = 1
     mod['state_cov', :, :] = 0.5
-    llf_pre_na = mod.loglike()
+    llf_pre_na = mod.loglikeobs()
 
     assert_allclose(llf_pre_na, llf)
 
@@ -1268,7 +1268,7 @@ def test_missing():
     mod['transition', :, :] = 0.5
     mod['selection', :, :] = 1
     mod['state_cov', :, :] = 0.5
-    llf_post_na = mod.loglike()
+    llf_post_na = mod.loglikeobs()
 
     assert_allclose(llf_post_na, llf)
 
@@ -1280,6 +1280,6 @@ def test_missing():
     mod['transition', :, :] = 0.5
     mod['selection', :, :] = 1
     mod['state_cov', :, :] = 0.5
-    llf_inject_na = mod.loglike()
+    llf_inject_na = mod.loglikeobs()
 
     assert_allclose(llf_inject_na, llf)

--- a/statsmodels/tsa/statespace/tests/test_representation.py
+++ b/statsmodels/tsa/statespace/tests/test_representation.py
@@ -1231,15 +1231,15 @@ def test_impulse_responses():
 def test_missing():
     # Datasets
     endog = np.arange(10).reshape(10,1)
-    endog_pre_na = np.c_[
-        endog.copy() * np.nan, endog.copy() * np.nan, endog, endog]
-    endog_post_na = np.c_[
-        endog, endog, endog.copy() * np.nan, endog.copy() * np.nan]
-    endog_inject_na = np.c_[
-        endog, endog.copy() * np.nan, endog, endog.copy() * np.nan]
+    endog_pre_na = np.ascontiguousarray(np.c_[
+        endog.copy() * np.nan, endog.copy() * np.nan, endog, endog])
+    endog_post_na = np.ascontiguousarray(np.c_[
+        endog, endog, endog.copy() * np.nan, endog.copy() * np.nan])
+    endog_inject_na = np.ascontiguousarray(np.c_[
+        endog, endog.copy() * np.nan, endog, endog.copy() * np.nan])
 
     # Base model
-    mod = KalmanFilter(np.c_[endog, endog], k_states=1,
+    mod = KalmanFilter(np.ascontiguousarray(np.c_[endog, endog]), k_states=1,
                        initialization='approximate_diffuse')
     mod['design', :, :] = 1
     mod['obs_cov', :, :] = np.eye(mod.k_endog)*0.5

--- a/statsmodels/tsa/statespace/tests/test_representation.py
+++ b/statsmodels/tsa/statespace/tests/test_representation.py
@@ -1227,3 +1227,47 @@ def test_impulse_responses():
     res = mod.filter([phi, 1.])
     actual = res.impulse_responses(steps=10)
     assert_allclose(actual, desired)
+
+def test_missing():
+    # Datasets
+    endog = np.arange(10).reshape(10,1)
+    endog_pre_na = np.c_[
+        endog.copy() * np.nan, endog.copy() * np.nan, endog, endog]
+    endog_post_na = np.c_[
+        endog, endog, endog.copy() * np.nan, endog.copy() * np.nan]
+    endog_inject_na = np.c_[
+        endog, endog.copy() * np.nan, endog, endog.copy() * np.nan, endog]
+
+    # Base model
+    mod = KalmanFilter(np.c_[endog, endog], k_states=1,
+                       initialization='approximate_diffuse')
+    mod['design', :, :] = 1
+    mod['obs_cov', :, :] = np.eye(mod.k_endog)*0.5
+    mod['transition', :, :] = 0.5
+    mod['selection', :, :] = 1
+    mod['state_cov', :, :] = 0.5
+    llf = mod.loglike()
+
+    # Model with prepended nans
+    mod = KalmanFilter(endog_pre_na, k_states=1,
+                       initialization='approximate_diffuse')
+    mod['design', :, :] = 1
+    mod['obs_cov', :, :] = np.eye(mod.k_endog)*0.5
+    mod['transition', :, :] = 0.5
+    mod['selection', :, :] = 1
+    mod['state_cov', :, :] = 0.5
+    llf_pre_na = mod.loglike()
+
+    assert_allclose(llf_pre_na, llf)
+
+    # Model with appended nans
+    mod = KalmanFilter(endog_post_na, k_states=1,
+                       initialization='approximate_diffuse')
+    mod['design', :, :] = 1
+    mod['obs_cov', :, :] = np.eye(mod.k_endog)*0.5
+    mod['transition', :, :] = 0.5
+    mod['selection', :, :] = 1
+    mod['state_cov', :, :] = 0.5
+    llf_post_na = mod.loglike()
+
+    assert_allclose(llf_post_na, llf)


### PR DESCRIPTION
Fixes #2732 by correctly indexing in the case of missing data (so the `kfilter.e_endog` variable will be different than the dimensions of the `kfilter.forecast_error_fac` array in memory).