### PR TITLE
ENH: large categorical, OLSAbsorb with sparse projection

### DIFF
--- a/statsmodels/regression/special_linear_model.py
+++ b/statsmodels/regression/special_linear_model.py
@@ -1,0 +1,106 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Sat Jan 16 22:31:14 2016
+
+Author: Josef Perktold
+License: BSD-3
+"""
+
+import numpy as np
+from scipy import sparse
+#import scipy.sparse.linalg as sparsela
+import pandas as pd
+
+
+from statsmodels.regression.linear_model import OLS
+from statsmodels.tools._sparse import PartialingSparse
+
+def cat2dummy_sparse(xcat):
+    """categorical to sparse dummy, use pandas for quick implementation
+
+    xcat needs to be ndarray for now
+    """
+    # prepare np array for column iteration
+    if xcat.ndim == 1:
+        xcat_t = [xcat]
+    else:
+        xcat_t = xcat.T
+
+    dfs = [pd.get_dummies(xc) for xc in xcat_t]
+    x = np.column_stack(dfs)[:, 1:]   # full rank
+    xsp = sparse.csc_matrix(x)  #.astype(int))  # int breaks in LU-solve
+    return xsp
+
+
+class OLSAbsorb(OLS):
+    """OLS model that absorbs categorical explanatory variables
+
+    see docstring for OLS, the following only has the extra parameters for now
+
+    Parameters
+    ----------
+    exog_absorb : ndarray, 1D or 2D
+        categorical, factor variables that will be absorbed
+    absorb_method : string, 'lu' or 'lmgres'
+        method used in projection for absorbing the factor variables.
+        Currently the options use either sparse LU decomposition or sparse
+        `lmgres`
+
+    Notes
+    -----
+    constant: the current parameterization produces a constant when the mean
+    categorical effect is set to zero
+
+    Warning: currently not all inherited methods for OLS are correct.
+    Parameters and inference are correct and correspond to the full model for
+    OLS that includes all factor variables as dummies with zero mean factor
+    effects.
+    """
+
+    def __init__(self, endog, exog, exog_absorb, absorb_method='lu', **kwds):
+        # TODO: does exog_absorb need to be a keyword for from_formula ?
+        # TODO: missing handling and shape, type check for exog_absorb in super
+        absorb = cat2dummy_sparse(exog_absorb)
+        self.projector = PartialingSparse(absorb, method=absorb_method)
+        super(OLSAbsorb, self).__init__(endog, exog, **kwds)
+        # projection is moved to whiten
+        #self.wendog = projector.partial_sparse(self.endog)[1]
+        #self.wexog = projector.partial_sparse(self.exog)[1]
+        self.k_absorb = absorb.shape[1]
+        #self.df_resid -= self.k_absorb
+        # inline doesn't work, df_resid is property
+        self.df_resid = self.df_resid - self.k_absorb + 1
+        #check this, why + 1
+
+
+        self.absorb = absorb   # mainly for checking
+
+    def whiten(self, y):
+        # add the mean back in to get a constant
+        # this does not reproduce the constant if fixed effect use reference encoding
+        # It produces the constant if the mean fixed effect is zero
+        y_mean = y.mean(0)
+        return self.projector.partial_sparse(y)[1] + y_mean
+
+
+    def _get_fixed_effects(self, resid):
+        """temporary: recover fixed effects from regression using residuals
+
+        Warning: This uses dense fixed effects dummies at the moment
+
+        We add a constant to correct for constant in absorbed regression.
+        This will depend on the encoding of the absorb fixed effects.
+
+        Parameter
+        ---------
+        resid : ndarray
+            residuals of absorbed OLS regression
+
+        """
+
+        exog_dummies = np.column_stack((np.ones(len(self.endog)),
+                                        self.absorb.toarray()[:, :-1]))
+
+        # [:, :-1] is just because I used it in the example, drop again
+
+        return OLS(resid, exog_dummies).fit()

--- a/statsmodels/regression/tests/test_special_linear.py
+++ b/statsmodels/regression/tests/test_special_linear.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Mon Jan 18 23:39:45 2016
+
+Author: Josef Perktold
+License: BSD-3
+"""
+
+import numpy as np
+from scipy import sparse
+import pandas as pd
+
+from statsmodels.regression.special_linear_model import OLS
+from statsmodels.regression.special_linear_model import OLSAbsorb
+
+from numpy.testing import assert_allclose
+
+
+class CompareModels(object):
+    pass
+
+class TestSparseAbsorb(CompareModels):
+
+    def test_temp(self):
+        #def generate_sample2():
+        xcat1 = np.repeat(np.arange(5), 10)
+        xcat2 = np.tile(np.arange(5), 10)
+        exog_absorb = np.column_stack((xcat1, xcat2))
+
+        df1 = pd.get_dummies(xcat1)  #sparse=True) #sparse requires v 0.16
+        df2 = pd.get_dummies(xcat2)
+        x = np.column_stack((np.asarray(df1)[:, 1:], np.asarray(df2)))
+        exog = sparse.csc_matrix(x) #.astype(np.int8))
+        beta = 1. / np.r_[np.arange(1, df1.shape[1]), np.arange(1, df2.shape[1] + 1)]
+
+        np.random.seed(999)
+        betad = np.ones(3)
+        exogd = np.column_stack((np.ones(exog.shape[0]), np.random.randn(exog.shape[0], len(betad) - 1)))
+        y = exogd.dot(betad) + exog.dot(beta) + 0.01 * np.random.randn(exog.shape[0])
+
+        exog_full = np.column_stack((exogd, exog.toarray()))
+
+        #return y, exog
+
+
+
+        res_ols = OLS(y, exog_full[:, :-1]).fit()
+        #print(res_ols.params)
+        #print(res_ols.bse)
+
+        mod_absorb = OLSAbsorb(y, exogd, exog_absorb)
+        res_absorb = mod_absorb.fit()
+        #print(res_absorb.params)
+        #print(res_absorb.bse)
+
+        # recover and check fixed effects parameters
+        res_fe = mod_absorb._get_fixed_effects(res_absorb.resid)
+        #print(res_fe.params[1:] - res_ols.params[3:])
+
+        # check constant, corresponds to mean prediction of absorbed factors and constant
+        #print(res_ols.predict(np.concatenate(([1, 0, 0], exog.toarray()[:,:-1].mean(0))))
+        #      - res_absorb.params[0])
+        # same as res_absorb.predict([1, 0, 0])
+
+        slice_res1 = slice(1, 3, None)
+        slice_res2 = slice(1, 3, None)
+
+        res1 = res_absorb
+        res2 = res_ols
+        assert_allclose(res1.params[slice_res1], res2.params[slice_res2], rtol=1e-13)
+        assert_allclose(res1.bse[slice_res1], res2.bse[slice_res2], rtol=1e-13)
+        assert_allclose(res1.pvalues[slice_res1], res2.pvalues[slice_res2], rtol=1e-10)
+        assert_allclose(res_fe.params[1:], res_ols.params[3:], rtol=1e-13)

--- a/statsmodels/tools/_sparse.py
+++ b/statsmodels/tools/_sparse.py
@@ -1,0 +1,144 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Fri Jan 15 00:15:11 2016
+
+Author: Josef Perktold
+License: BSD-3
+
+"""
+
+import numpy as np
+from scipy import sparse
+import scipy.sparse.linalg as sparsela
+import pandas as pd
+
+
+def generate_sample1():
+    xcat = np.repeat(np.arange(5), 10)
+
+    df = pd.get_dummies(xcat)  #sparse=True) #sparse requires v 0.16
+
+    exog = sparse.csc_matrix(df.values)
+    beta = 1. / np.arange(1, 6)
+
+    np.random.seed(999)
+    y = exog.dot(beta) + 0.01 * np.random.randn(exog.shape[0])
+
+    return y, exog
+
+
+def generate_sample2():
+    xcat1 = np.repeat(np.arange(5), 10)
+    xcat2 = np.tile(np.arange(5), 10)
+
+    df1 = pd.get_dummies(xcat1)  #sparse=True) #sparse requires v 0.16
+    df2 = pd.get_dummies(xcat2)
+    x = np.column_stack((np.asarray(df1)[:, 1:], np.asarray(df2)))
+    exog = sparse.csc_matrix(x)   #.astype(np.int8))  int breaks in sparse
+    beta = 1. / np.r_[np.arange(1, df1.shape[1]), np.arange(1, df2.shape[1] + 1)]
+
+    np.random.seed(999)
+    y = exog.dot(beta) + 0.01 * np.random.randn(exog.shape[0])
+
+    return y, exog
+
+
+class PartialingSparse(object):
+    """class to condition an partial out a sparse matrix
+
+    Parameters
+    ----------
+    x_conditioning : sparse matrix
+        stored as attribute `xcond`
+        TODO: check this version needs full rank matrix
+        `lsqr` could gain a Ridge penalization implemented in scipy.
+        `lu` could gain Ridge penalization implemented here.
+        Using tiny Ridge penalization is close to using pinv.
+    method : 'lu' or 'lsqr'
+        sparse method to solf least squares problem. 'lu' stores
+        the LU factorization and should be faster in repeated calls.
+        'lsqr' does not store intermediate results.
+
+    Notes
+    -----
+    This solves a least squares problem and has methods for the parameters or
+    the projection. Those values are the same as params, fittedvalues and
+    resid in OLS results.
+
+
+    """
+
+    def __init__(self, x_conditioning, method='lu'):
+        self.xcond = x = x_conditioning
+        self.method = method.lower()
+        if self.method == 'lu':
+            self.xtx_solve = sparsela.factorized(x.T.dot(x))
+        else:
+            if self.method not in ['lsqr']:
+                raise ValueError('method can only be lu or lsqr')
+
+
+    def partial_params(self, x):
+        """find least squares parameters
+
+        This uses the method given in initialization.
+
+        Parameters
+        ----------
+        x : ndarray, 1D or 2D
+
+        Returns
+        -------
+        params : ndarray
+            least squares parameters
+
+
+        """
+        if self.method == 'lu':
+            return self.xtx_solve( self.xcond.T.dot(x))
+        else:
+            return sparsela.lsqr(self.xcond, x)
+
+
+    def partial_sparse(self, x):
+        '''calculate projection of x on x_conditioning
+
+        Note: x needs to be dense
+
+        Parameters
+        ----------
+        x : ndarray, 1D or 2D
+
+        Returns
+        -------
+        xhat : ndarray
+            projection of x on xcond
+        resid : ndarray
+            orthogonal projection on null space
+
+
+
+        TODO: this needs a pandas wrapper so we can create new DataFrames
+
+        '''
+        xhat = self.xcond.dot(self.partial_params(x))
+        resid = x - xhat
+        return xhat, resid
+
+
+if __name__ == '__main__':
+    y, x = generate_sample2()
+    #print(x.todense())
+
+    #x = x.todense()
+    yhat_dense = np.squeeze(x.dot(np.linalg.pinv(x.todense()).dot(y).T))
+    resid_dense = y - yhat_dense
+
+    yh, resid = PartialingSparse(x).partial_sparse(y)
+
+    print(yh - yhat_dense)
+    print(resid - resid_dense)
+
+
+
+


### PR DESCRIPTION
see #2568 for some design discussion, and references to different algorithms

We are partialing out fixed effects in panel data, or any categorical factor variable with many levels.

This includes currently only a sparse version for general multi-way factors. 

Warning: some results in returned OLS are still wrong (fvalue, llf, ...)
see docstrings and comments for other current definitions and limitations.

currently missing: function that creates sparse dummy representation uses currently a dense intermediate array


see also #2711 for OLSSparse, is currently SparseOLS

