### PR TITLE
added **kwds to signature of ARMA predict methods

### DIFF
--- a/statsmodels/tsa/arima_model.py
+++ b/statsmodels/tsa/arima_model.py
@@ -711,7 +711,7 @@ class ARMA(tsbase.TimeSeriesModel):
             errors = e[0][k_ar:]
         return errors.squeeze()
 
-    def predict(self, params, start=None, end=None, exog=None, dynamic=False):
+    def predict(self, params, start=None, end=None, exog=None, dynamic=False, **kwds):
         method = getattr(self, 'method', 'mle')  # don't assume fit
         #params = np.asarray(params)
 
@@ -1455,7 +1455,7 @@ class ARMAResults(tsbase.TimeSeriesModelResults):
         df_resid = self.df_resid
         return t.sf(np.abs(self.tvalues), df_resid) * 2
 
-    def predict(self, start=None, end=None, exog=None, dynamic=False):
+    def predict(self, start=None, end=None, exog=None, dynamic=False, **kwds):
         return self.model.predict(self.params, start, end, exog, dynamic)
     predict.__doc__ = _arma_results_predict
 

--- a/statsmodels/tsa/arima_model.py
+++ b/statsmodels/tsa/arima_model.py
@@ -1456,7 +1456,10 @@ class ARMAResults(tsbase.TimeSeriesModelResults):
         return t.sf(np.abs(self.tvalues), df_resid) * 2
 
     def predict(self, start=None, end=None, exog=None, dynamic=False, **kwds):
-        return self.model.predict(self.params, start, end, exog, dynamic)
+        if 'typ' in kwds or not kwds:
+             return self.model.predict(self.params, start, end, exog, dynamic)
+        else:
+            raise ValueError("Invalid extra arguments found in call to predict")
     predict.__doc__ = _arma_results_predict
 
     def _forecast_error(self, steps):

--- a/statsmodels/tsa/arima_model.py
+++ b/statsmodels/tsa/arima_model.py
@@ -711,7 +711,7 @@ class ARMA(tsbase.TimeSeriesModel):
             errors = e[0][k_ar:]
         return errors.squeeze()
 
-    def predict(self, params, start=None, end=None, exog=None, dynamic=False, **kwds):
+    def predict(self, params, start=None, end=None, exog=None, dynamic=False):
         method = getattr(self, 'method', 'mle')  # don't assume fit
         #params = np.asarray(params)
 


### PR DESCRIPTION
Fix #2741 
The ARIMA predict methods has extra argument `typ`
But, when d is 0 in ARIMA model then, call to `fit` method of ARIMA class returns an object of ARMAResultsWrapper. Now if `predict` method is called on this ARMAResultsWrapper object then the constraint was that the call cannot have a `typ` keyword argument. This commit aims to do away with this constraint.
