### PR TITLE
COMPAT: for pandas deprecations

### DIFF
--- a/statsmodels/discrete/discrete_model.py
+++ b/statsmodels/discrete/discrete_model.py
@@ -128,7 +128,7 @@ def _pandas_to_dummies(endog):
     if endog.ndim == 2:
         if endog.shape[1] == 1:
             yname = endog.columns[0]
-            endog_dummies = get_dummies(endog.icol(0))
+            endog_dummies = get_dummies(endog.iloc[:, 0])
         else:  # series
             yname = 'y'
             endog_dummies = endog

--- a/statsmodels/iolib/tests/test_foreign.py
+++ b/statsmodels/iolib/tests/test_foreign.py
@@ -134,8 +134,8 @@ def test_genfromdta_datetime():
         dta = genfromdta(os.path.join(curdir, "results/time_series_examples.dta"),
                          pandas=True)
 
-    assert_array_equal(dta.irow(0).tolist(), results[0])
-    assert_array_equal(dta.irow(1).tolist(), results[1])
+    assert_array_equal(dta.iloc[0].tolist(), results[0])
+    assert_array_equal(dta.iloc[1].tolist(), results[1])
 
 def test_date_converters():
     ms = [-1479597200000, -1e6, -1e5, -100, 1e5, 1e6, 1479597200000]

--- a/statsmodels/stats/mediation.py
+++ b/statsmodels/stats/mediation.py
@@ -19,6 +19,7 @@ Barron-Kenny approach.
 import numpy as np
 import pandas as pd
 from statsmodels.graphics.utils import maybe_name_or_idx
+import statsmodels.compat.pandas as pdc  # pragma: no cover
 
 
 class Mediation(object):
@@ -390,6 +391,9 @@ class MediationResults(object):
             smry.iloc[i, 2] = np.percentile(vec, 100 * (1 - alpha / 2))
             smry.iloc[i, 3] = _pvalue(vec)
 
-        smry = smry.convert_objects(convert_numeric=True)
+        if pdc.version < '0.17.0':  # pragma: no cover
+            smry = smry.convert_objects(convert_numeric=True)
+        else:  # pragma: no cover
+            smry = smry.apply(pd.to_numeric, errors='coerce')
 
         return smry


### PR DESCRIPTION
Pandas 0.17.0 [deprecated](https://github.com/pydata/pandas/pull/11173) `DataFrame.convert_objects` in favor of type specific converters. This was the only usage of `convert_objects` that I found.

Also found a couple uses of `irow` and `icol`, which I've fixed up.