### PR TITLE
Missing attributes and improved summary for Cox models

### DIFF
--- a/statsmodels/duration/hazard_regression.py
+++ b/statsmodels/duration/hazard_regression.py
@@ -1698,7 +1698,7 @@ class PHRegResults(base.LikelihoodModelResults):
 
         dstrat = self.model.surv.nstrat_orig - self.model.surv.nstrat
         if dstrat > 0:
-            if dstrata == 1:
+            if dstrat == 1:
                 smry.add_text("1 stratum dropped for having no events")
             else:
                 smry.add_text("%d strata dropped for having no events" % dstrat)

--- a/statsmodels/duration/hazard_regression.py
+++ b/statsmodels/duration/hazard_regression.py
@@ -1465,6 +1465,8 @@ class PHRegResults(base.LikelihoodModelResults):
     def __init__(self, model, params, cov_params, covariance_type="naive"):
 
         self.covariance_type = covariance_type
+        self.df_resid = model.df_resid
+        self.df_model = model.df_model
 
         super(PHRegResults, self).__init__(model, params,
            normalized_cov_params=cov_params)

--- a/statsmodels/duration/hazard_regression.py
+++ b/statsmodels/duration/hazard_regression.py
@@ -334,7 +334,7 @@ class PHReg(model.LikelihoodModel):
 
         self.df_resid = (np.float(self.exog.shape[0] -
                                   np_matrix_rank(self.exog)))
-        self.df_model = np.float(np_matrix_rank(self.exog) - 1)
+        self.df_model = np.float(np_matrix_rank(self.exog))
 
         ties = ties.lower()
         if ties not in ("efron", "breslow"):

--- a/statsmodels/duration/tests/test_phreg.py
+++ b/statsmodels/duration/tests/test_phreg.py
@@ -102,7 +102,7 @@ class TestPHReg(object):
         coef, se, time_r, hazard_r = get_results(n, p, "et_st", ties1)
         assert_allclose(phrb.params, coef, rtol=1e-3)
         assert_allclose(phrb.bse, se, rtol=1e-4)
-        
+
         #smoke test
         time_h, cumhaz, surv = phrb.baseline_cumulative_hazard[0]
 

--- a/statsmodels/duration/tests/test_phreg.py
+++ b/statsmodels/duration/tests/test_phreg.py
@@ -272,6 +272,20 @@ class TestPHReg(object):
         rslt = mod.fit()
         rslt.summary()
 
+        strata = np.kron(np.arange(50), np.ones(4))
+        mod = PHReg(time, exog, status, strata=strata)
+        rslt = mod.fit()
+        smry = rslt.summary()
+        msg = "3 strata dropped for having no events"
+        assert(msg in str(smry))
+
+        entry = np.random.uniform(0.1, 0.8, 200) * time
+        mod = PHReg(time, exog, status, entry=entry)
+        rslt = mod.fit()
+        smry = rslt.summary()
+        msg = "200 observations have positive entry times"
+        assert(msg in str(smry))
+
     def test_predict(self):
         # All smoke tests. We should be able to convert the lhr and hr
         # tests into real tests against R.  There are many options to

--- a/statsmodels/duration/tests/test_phreg.py
+++ b/statsmodels/duration/tests/test_phreg.py
@@ -2,7 +2,7 @@ import os
 import numpy as np
 from statsmodels.duration.hazard_regression import PHReg
 from numpy.testing import (assert_allclose,
-                           assert_equal)
+                           assert_equal, assert_)
 import pandas as pd
 
 # TODO: Include some corner cases: data sets with empty strata, strata
@@ -277,14 +277,14 @@ class TestPHReg(object):
         rslt = mod.fit()
         smry = rslt.summary()
         msg = "3 strata dropped for having no events"
-        assert(msg in str(smry))
+        assert_(msg in str(smry))
 
         entry = np.random.uniform(0.1, 0.8, 200) * time
         mod = PHReg(time, exog, status, entry=entry)
         rslt = mod.fit()
         smry = rslt.summary()
         msg = "200 observations have positive entry times"
-        assert(msg in str(smry))
+        assert_(msg in str(smry))
 
     def test_predict(self):
         # All smoke tests. We should be able to convert the lhr and hr

--- a/statsmodels/duration/tests/test_phreg.py
+++ b/statsmodels/duration/tests/test_phreg.py
@@ -270,7 +270,7 @@ class TestPHReg(object):
 
         mod = PHReg(time, exog, status)
         rslt = mod.fit()
-        rslt.summary()
+        smry = rslt.summary()
 
         strata = np.kron(np.arange(50), np.ones(4))
         mod = PHReg(time, exog, status, strata=strata)
@@ -278,6 +278,11 @@ class TestPHReg(object):
         smry = rslt.summary()
         msg = "3 strata dropped for having no events"
         assert_(msg in str(smry))
+
+        groups = np.kron(np.arange(25), np.ones(8))
+        mod = PHReg(time, exog, status)
+        rslt = mod.fit(groups=groups)
+        smry = rslt.summary()
 
         entry = np.random.uniform(0.1, 0.8, 200) * time
         mod = PHReg(time, exog, status, entry=entry)


### PR DESCRIPTION
Miscellaneous minor improvements to PHReg:

* attach `df_resid` and `df_model` attributes (otherwise can't be used with `predict_functional` and perhaps other places)

* better handling of variable names passed as auxiliary variables (e.g. `entry`)

* provide additional information about dropped strata and entry times in summary output