### PR TITLE
BUG: Scipy seems to have broken things

### DIFF
--- a/statsmodels/stats/stattools.py
+++ b/statsmodels/stats/stattools.py
@@ -100,8 +100,8 @@ def jarque_bera(resids, axis=0):
     """
     resids = np.asarray(resids)
     # Calculate residual skewness and kurtosis
-    skew = stats.skew(resids, axis=axis)
-    kurtosis = 3 + stats.kurtosis(resids, axis=axis)
+    skew = np.array(stats.skew(resids, axis=axis), ndmin=axis)
+    kurtosis = np.array(3 + stats.kurtosis(resids, axis=axis), ndmin=axis)
 
     # Calculate the Jarque-Bera test for normality
     n = resids.shape[axis]


### PR DESCRIPTION
Hello, 

I noticed that statsmodels appears to not be building on the new version of scipy 0.17. There seems to be a change in behavior when you have `np.nan` fed into a scipy.stat.skew and scipy.stat.kurtosis

This fixes that. 

There is still some kind of an MKL bug, which I have no clue how to fix. I'm happy to investigate if someone points me in the right direction. 

The build is here:

https://travis-ci.org/thequackdaddy/statsmodels/builds/107512963

Thanks!