### PR TITLE
ENH: Relative tolerance for GLM convergence

### DIFF
--- a/statsmodels/discrete/tests/test_constrained.py
+++ b/statsmodels/discrete/tests/test_constrained.py
@@ -357,14 +357,16 @@ class TestGLMPoissonConstrained1b(CheckPoissonConstrainedMixin):
         # example with offset
         formula = 'deaths ~ smokes + C(agecat)'
         mod = GLM.from_formula(formula, data=data,
-                                    family=families.Poisson(),
-                                    offset=np.log(data['pyears'].values))
+                               family=families.Poisson(),
+                               offset=np.log(data['pyears'].values))
 
         constr = 'C(agecat)[T.4] = C(agecat)[T.5]'
         lc = patsy.DesignInfo(mod.exog_names).linear_constraint(constr)
-        cls.res1 = fit_constrained(mod, lc.coefs, lc.constants)
+
+        cls.res1 = fit_constrained(mod, lc.coefs, lc.constants,
+                                   fit_kwds={'atol': 1e-10})
         cls.constraints = lc
-        cls.res1m = mod.fit_constrained(constr)._results
+        cls.res1m = mod.fit_constrained(constr, atol=1e-10)._results
 
     def test_compare_glm_poisson(self):
         res1 = self.res1m
@@ -450,10 +452,10 @@ class TestGLMLogitConstrained2(CheckGLMConstrainedMixin):
                    family=families.Binomial())
 
         constr = 'x1 - x3 = 0'
-        cls.res1m = mod1.fit_constrained(constr)
+        cls.res1m = mod1.fit_constrained(constr, atol=1e-10)
 
         R, q = cls.res1m.constraints.coefs, cls.res1m.constraints.constants
-        cls.res1 = fit_constrained(mod1, R, q)
+        cls.res1 = fit_constrained(mod1, R, q, fit_kwds={'atol': 1e-10})
         cls.constraints_rq = (R, q)
 
 

--- a/statsmodels/stats/tests/test_mediation.py
+++ b/statsmodels/stats/tests/test_mediation.py
@@ -71,7 +71,8 @@ def test_framing_example():
               mediator_exog.columns.tolist().index("treat")]
     med_pos = outcome_exog.columns.tolist().index("emo")
 
-    med = Mediation(outcome_model, mediator_model, tx_pos, med_pos)
+    med = Mediation(outcome_model, mediator_model, tx_pos, med_pos,
+                    outcome_fit_kwargs={'atol':1e-11})
 
     np.random.seed(4231)
     para_rslt = med.fit(method='parametric', n_rep=100)
@@ -128,7 +129,8 @@ def test_framing_example_formula():
 
     mediator_model = sm.OLS.from_formula("emo ~ treat + age + educ + gender + income", data)
 
-    med = Mediation(outcome_model, mediator_model, "treat", "emo")
+    med = Mediation(outcome_model, mediator_model, "treat", "emo",
+                    outcome_fit_kwargs={'atol': 1e-11})
 
     np.random.seed(4231)
     med_rslt = med.fit(method='boot', n_rep=100)


### PR DESCRIPTION
Hello, 

I'd like to propose changing how you do convergence checking for GLM IRLS fits. 

A few notes:

1. Currently, I think the iteration check for IRLS has an off-by-1 error. The 1st run check's the 0th iteration vs. the -1st iteration. The 2nd  iteration will check the 1st and 0th. The 3rd with check the 1st and the 2nd, and so on. 
2.  I've been playing with statsmodels on some insurance datasets. I typically get really large datasets (hundreds of thousands of observations). I'm having difficulty getting convergence in reasonable times because the convergence tolerance is an absolute `1e-8`. I think this makes more sense because deviance increases as you add more observations. On a large dataset, waiting for deviance changes as small as 1e-8 requires many (essentially useless) iterations. 
3.  As a result of 2., a few of the tests break. I think my tolerance is a little more lenient so you lose a few significant digits. I'll work through that, but I want to know if this is a PR that you'd consider before I invest the time in fixing that. 

Thanks for your consideration. 