### PR TITLE
ENH: Statespace: Diagnostic tests in missing data case.

### DIFF
--- a/statsmodels/tsa/statespace/mlemodel.py
+++ b/statsmodels/tsa/statespace/mlemodel.py
@@ -1745,6 +1745,8 @@ class MLEResults(tsbase.TimeSeriesModelResults):
         specified model, `loglikelihood_burn=d`), then this test is calculated
         ignoring the first `d` residuals.
 
+        Output is nan for any endogenous variable which has missing values.
+
         See Also
         --------
         statsmodels.stats.diagnostic.acorr_ljungbox


### PR DESCRIPTION
Fixes the issue in #2798 and #2800 by making sure `jarquebera` is not called with nan elements. Allows test results from `test_normality` and `test_heteroskedasticity` in the case of missing data. Puts a note in `test_serial_correlation` documentation about output (which is `nan`) in the case of missing data.