### PR TITLE
MixedLM test enhancements

### DIFF
--- a/statsmodels/regression/tests/test_lme.py
+++ b/statsmodels/regression/tests/test_lme.py
@@ -210,11 +210,17 @@ class TestMixedLM(object):
                         dist_high=0.5, num_high=3)
 
     # Fails on old versions of scipy/numpy
-    def txest_vcomp_1(self):
+    def test_vcomp_1(self):
         """
         Fit the same model using constrained random effects and
         variance components.
         """
+
+        import scipy
+        v = scipy.__version__.split(".")[1]
+        v = int(v)
+        if v < 16:
+            return
 
         np.random.seed(4279)
         exog = np.random.normal(size=(400, 1))
@@ -312,6 +318,12 @@ class TestMixedLM(object):
                         0.12610, 0.03938, 0.03848], rtol=1e-3)
 
     def test_sparse(self):
+
+        import scipy
+        v = scipy.__version__.split(".")[1]
+        v = int(v)
+        if v < 16:
+            return
 
         cur_dir = os.path.dirname(os.path.abspath(__file__))
         rdir = os.path.join(cur_dir, 'results')

--- a/statsmodels/regression/tests/test_lme.py
+++ b/statsmodels/regression/tests/test_lme.py
@@ -12,6 +12,7 @@ import csv
 
 # TODO: add tests with unequal group sizes
 
+
 class R_Results(object):
     """
     A class for holding various results obtained from fitting one data
@@ -56,15 +57,14 @@ class R_Results(object):
         data = np.asarray(data)
 
         # Split into exog, endog, etc.
-        self.endog = data[:,header.index("endog")]
-        self.groups = data[:,header.index("groups")]
-        ii = [i for i,x in enumerate(header) if
+        self.endog = data[:, header.index("endog")]
+        self.groups = data[:, header.index("groups")]
+        ii = [i for i, x in enumerate(header) if
               x.startswith("exog_fe")]
-        self.exog_fe = data[:,ii]
-        ii = [i for i,x in enumerate(header) if
+        self.exog_fe = data[:, ii]
+        ii = [i for i, x in enumerate(header) if
               x.startswith("exog_re")]
-        self.exog_re = data[:,ii]
-
+        self.exog_re = data[:, ii]
 
 
 def loglike_function(model, profile_fe, has_fe):
@@ -73,20 +73,9 @@ def loglike_function(model, profile_fe, has_fe):
     the given model.
     """
     def f(x):
-        params = MixedLMParams.from_packed(x, model.k_fe, model.k_re, model.use_sqrt, has_fe=has_fe)
+        params = MixedLMParams.from_packed(
+            x, model.k_fe, model.k_re, model.use_sqrt, has_fe=has_fe)
         return -model.loglike(params, profile_fe=profile_fe)
-
-    return f
-
-
-def score_function(model, profile_fe, has_fe):
-    """
-    Returns a function that evaluates the negative score function for
-    the given model.
-    """
-    def f(x):
-        params = MixedLMParams.from_packed(x, model.k_fe, model.use_sqrt, has_fe=not profile_fe)
-        return -model.score(params, profile_fe=profile_fe)
 
     return f
 
@@ -102,24 +91,24 @@ class TestMixedLM(object):
         k_fe = 3
         k_re = 2
 
-        for use_sqrt in False,True:
-            for reml in False,True:
-                for profile_fe in False,True:
+        for use_sqrt in False, True:
+            for reml in False, True:
+                for profile_fe in False, True:
 
                     np.random.seed(3558)
-                    exog_fe = np.random.normal(size=(n_grp*grpsize, k_fe))
-                    exog_re = np.random.normal(size=(n_grp*grpsize, k_re))
+                    exog_fe = np.random.normal(size=(n_grp * grpsize, k_fe))
+                    exog_re = np.random.normal(size=(n_grp * grpsize, k_re))
                     exog_re[:, 0] = 1
-                    exog_vc = np.random.normal(size=(n_grp*grpsize, 3))
+                    exog_vc = np.random.normal(size=(n_grp * grpsize, 3))
                     slopes = np.random.normal(size=(n_grp, k_re))
                     slopes[:, -1] *= 2
-                    slopes = np.kron(slopes, np.ones((grpsize,1)))
+                    slopes = np.kron(slopes, np.ones((grpsize, 1)))
                     slopes_vc = np.random.normal(size=(n_grp, 3))
-                    slopes_vc = np.kron(slopes_vc, np.ones((grpsize,1)))
+                    slopes_vc = np.kron(slopes_vc, np.ones((grpsize, 1)))
                     slopes_vc[:, -1] *= 2
                     re_values = (slopes * exog_re).sum(1)
                     vc_values = (slopes_vc * exog_vc).sum(1)
-                    err = np.random.normal(size=n_grp*grpsize)
+                    err = np.random.normal(size=n_grp * grpsize)
                     endog = exog_fe.sum(1) + re_values + vc_values + err
                     groups = np.kron(range(n_grp), np.ones(grpsize))
 
@@ -129,20 +118,23 @@ class TestMixedLM(object):
                         vc["a"][i] = exog_vc[ix, 0:2]
                         vc["b"][i] = exog_vc[ix, 2:3]
 
-                    model = MixedLM(endog, exog_fe, groups, exog_re, exog_vc=vc, use_sqrt=use_sqrt)
+                    model = MixedLM(endog, exog_fe, groups,
+                                    exog_re, exog_vc=vc, use_sqrt=use_sqrt)
                     rslt = model.fit(reml=reml)
 
-                    loglike = loglike_function(model, profile_fe=profile_fe, has_fe=not profile_fe)
-                    score = score_function(model, profile_fe=profile_fe, has_fe=not profile_fe)
+                    loglike = loglike_function(
+                        model, profile_fe=profile_fe, has_fe=not profile_fe)
 
                     # Test the score at several points.
                     for kr in range(5):
                         fe_params = np.random.normal(size=k_fe)
                         cov_re = np.random.normal(size=(k_re, k_re))
                         cov_re = np.dot(cov_re.T, cov_re)
-                        vcomp = np.random.normal(size=2)**2
-                        params = MixedLMParams.from_components(fe_params, cov_re=cov_re, vcomp=vcomp)
-                        params_vec = params.get_packed(has_fe=not profile_fe, use_sqrt=use_sqrt)
+                        vcomp = np.random.normal(size=2) ** 2
+                        params = MixedLMParams.from_components(
+                            fe_params, cov_re=cov_re, vcomp=vcomp)
+                        params_vec = params.get_packed(
+                            has_fe=not profile_fe, use_sqrt=use_sqrt)
 
                         # Check scores
                         gr = -model.score(params, profile_fe=profile_fe)
@@ -153,20 +145,21 @@ class TestMixedLM(object):
                     # the profile Hessian matrix and we don't care
                     # about the Hessian for the square root
                     # transformed parameter).
-                    if (profile_fe == False) and (use_sqrt == False):
+                    if (profile_fe is False) and (use_sqrt is False):
                         hess = -model.hessian(rslt.params_object)
-                        params_vec = rslt.params_object.get_packed(use_sqrt=False, has_fe=True)
-                        loglike_h = loglike_function(model, profile_fe=False, has_fe=True)
+                        params_vec = rslt.params_object.get_packed(
+                            use_sqrt=False, has_fe=True)
+                        loglike_h = loglike_function(
+                            model, profile_fe=False, has_fe=True)
                         nhess = nd.approx_hess(params_vec, loglike_h)
                         assert_allclose(hess, nhess, rtol=1e-3)
-
 
     def test_default_re(self):
 
         np.random.seed(3235)
-        exog = np.random.normal(size=(300,4))
-        groups = np.kron(np.arange(100), [1,1,1])
-        g_errors = np.kron(np.random.normal(size=100), [1,1,1])
+        exog = np.random.normal(size=(300, 4))
+        groups = np.kron(np.arange(100), [1, 1, 1])
+        g_errors = np.kron(np.random.normal(size=100), [1, 1, 1])
         endog = exog.sum(1) + g_errors + np.random.normal(size=300)
         mdf1 = MixedLM(endog, exog, groups).fit()
         mdf2 = MixedLM(endog, exog, groups, np.ones(300)).fit()
@@ -175,9 +168,9 @@ class TestMixedLM(object):
     def test_history(self):
 
         np.random.seed(3235)
-        exog = np.random.normal(size=(300,4))
-        groups = np.kron(np.arange(100), [1,1,1])
-        g_errors = np.kron(np.random.normal(size=100), [1,1,1])
+        exog = np.random.normal(size=(300, 4))
+        groups = np.kron(np.arange(100), [1, 1, 1])
+        g_errors = np.kron(np.random.normal(size=100), [1, 1, 1])
         endog = exog.sum(1) + g_errors + np.random.normal(size=300)
         mod = MixedLM(endog, exog, groups)
         rslt = mod.fit(full_output=True)
@@ -204,22 +197,23 @@ class TestMixedLM(object):
         errors += np.random.normal(size=n_grp * gsize)
 
         endog = exog.sum(1) + errors
-        vc = {"a" : {}, "b" : {}}
+        vc = {"a": {}, "b": {}}
         for k in range(n_grp):
             ii = np.flatnonzero(groups == k)
             vc["a"][k] = vca[ii][:, None]
             vc["b"][k] = vcb[ii][:, None]
-        rslt = MixedLM(endog, exog, groups=groups, exog_re=exog_re, exog_vc=vc).fit()
-        prof_re = rslt.profile_re(0, vtype='re', dist_low=1, num_low=3, dist_high=1,
-                                  num_high=3)
-        prof_vc = rslt.profile_re('b', vtype='vc', dist_low=0.5, num_low=3, dist_high=0.5,
-                                  num_high=3)
-
+        rslt = MixedLM(endog, exog, groups=groups,
+                       exog_re=exog_re, exog_vc=vc).fit()
+        rslt.profile_re(0, vtype='re', dist_low=1, num_low=3, dist_high=1,
+                        num_high=3)
+        rslt.profile_re('b', vtype='vc', dist_low=0.5, num_low=3,
+                        dist_high=0.5, num_high=3)
 
     # Fails on old versions of scipy/numpy
     def txest_vcomp_1(self):
         """
-        Fit the same model using constrained random effects and variance components.
+        Fit the same model using constrained random effects and
+        variance components.
         """
 
         np.random.seed(4279)
@@ -241,7 +235,7 @@ class TestMixedLM(object):
         result1 = model1.fit(free=free)
 
         exog_vc = {"a": {}, "b": {}}
-        for k,group in enumerate(model1.group_labels):
+        for k, group in enumerate(model1.group_labels):
             ix = model1.row_indices[group]
             exog_vc["a"][group] = exog_re[ix, 0:1]
             exog_vc["b"][group] = exog_re[ix, 1:2]
@@ -250,9 +244,10 @@ class TestMixedLM(object):
         result2.summary()
 
         assert_allclose(result1.fe_params, result2.fe_params, atol=1e-4)
-        assert_allclose(np.diag(result1.cov_re), result2.vcomp, atol=1e-2, rtol=1e-4)
-        assert_allclose(result1.bse[[0, 1, 3]], result2.bse, atol=1e-2, rtol=1e-2)
-
+        assert_allclose(np.diag(result1.cov_re),
+                        result2.vcomp, atol=1e-2, rtol=1e-4)
+        assert_allclose(result1.bse[[0, 1, 3]],
+                        result2.bse, atol=1e-2, rtol=1e-2)
 
     def test_vcomp_2(self):
         """
@@ -262,7 +257,6 @@ class TestMixedLM(object):
         np.random.seed(6241)
         n = 1600
         exog = np.random.normal(size=(n, 2))
-        ex_vc = []
         groups = np.kron(np.arange(n / 16), np.ones(16))
 
         # Build up the random error vector
@@ -276,11 +270,11 @@ class TestMixedLM(object):
 
         # First variance component
         subgroups1 = np.kron(np.arange(n / 4), np.ones(4))
-        errors += np.kron(2*np.random.normal(size=n/4), np.ones(4))
+        errors += np.kron(2 * np.random.normal(size=n / 4), np.ones(4))
 
         # Second variance component
         subgroups2 = np.kron(np.arange(n / 2), np.ones(2))
-        errors += np.kron(2*np.random.normal(size=n/2), np.ones(2))
+        errors += np.kron(2 * np.random.normal(size=n / 2), np.ones(2))
 
         # iid errors
         errors += np.random.normal(size=n)
@@ -299,19 +293,23 @@ class TestMixedLM(object):
 
         # Equivalent model in R:
         # df.to_csv("tst.csv")
-        # model = lmer(y ~ x1 + x2 + (0 + z1 + z2 | groups) + (1 | v1) + (1 | v2), df)
+        # model = lmer(y ~ x1 + x2 + (0 + z1 + z2 | groups) + (1 | v1) + (1 |
+        # v2), df)
 
         vcf = {"a": "0 + C(v1)", "b": "0 + C(v2)"}
-        model1 = MixedLM.from_formula("y ~ x1 + x2", groups=groups, re_formula="0+z1+z2",
+        model1 = MixedLM.from_formula("y ~ x1 + x2", groups=groups,
+                                      re_formula="0+z1+z2",
                                       vc_formula=vcf, data=df)
         result1 = model1.fit()
 
         # Compare to R
-        assert_allclose(result1.fe_params, [0.16527, 0.99911, 0.96217], rtol=1e-4)
-        assert_allclose(result1.cov_re, [[1.244,  0.146], [0.146  , 1.371]], rtol=1e-3)
+        assert_allclose(result1.fe_params, [
+                        0.16527, 0.99911, 0.96217], rtol=1e-4)
+        assert_allclose(result1.cov_re, [
+                        [1.244,  0.146], [0.146, 1.371]], rtol=1e-3)
         assert_allclose(result1.vcomp, [4.024, 3.997], rtol=1e-3)
-        assert_allclose(result1.bse.iloc[0:3], [0.12610, 0.03938, 0.03848], rtol=1e-3)
-
+        assert_allclose(result1.bse.iloc[0:3], [
+                        0.12610, 0.03938, 0.03848], rtol=1e-3)
 
     def test_sparse(self):
 
@@ -321,22 +319,20 @@ class TestMixedLM(object):
 
         # Dense
         data = pd.read_csv(fname)
-        vcf = {"cask" : "0 + cask"}
+        vcf = {"cask": "0 + cask"}
         model = MixedLM.from_formula("strength ~ 1", groups="batch",
                                      re_formula="1", vc_formula=vcf,
                                      data=data)
         result = model.fit()
 
         # Sparse
-        from scipy import sparse
         model2 = MixedLM.from_formula("strength ~ 1", groups="batch",
                                       re_formula="1", vc_formula=vcf,
                                       use_sparse=True, data=data)
-        result2 = model.fit()
+        result2 = model2.fit()
 
         assert_allclose(result.params, result2.params)
         assert_allclose(result.bse, result2.bse)
-
 
     def test_pastes_vcomp(self):
         """
@@ -353,7 +349,7 @@ class TestMixedLM(object):
 
         # REML
         data = pd.read_csv(fname)
-        vcf = {"cask" : "0 + cask"}
+        vcf = {"cask": "0 + cask"}
         model = MixedLM.from_formula("strength ~ 1", groups="batch",
                                      re_formula="1", vc_formula=vcf,
                                      data=data)
@@ -364,10 +360,11 @@ class TestMixedLM(object):
         assert_allclose(result.cov_re.iloc[0, 0], 1.657, rtol=1e-3)
         assert_allclose(result.scale, 0.678, rtol=1e-3)
         assert_allclose(result.llf, -123.49, rtol=1e-1)
-        assert_equal(result.aic, np.nan) # don't provide aic/bic with REML
+        assert_equal(result.aic, np.nan)  # don't provide aic/bic with REML
         assert_equal(result.bic, np.nan)
 
-        resid = np.r_[0.17133538, -0.02866462, -1.08662875, 1.11337125, -0.12093607]
+        resid = np.r_[0.17133538, -0.02866462, -
+                      1.08662875, 1.11337125, -0.12093607]
         assert_allclose(result.resid[0:5], resid, rtol=1e-3)
 
         fit = np.r_[62.62866, 62.62866, 61.18663, 61.18663, 62.82094]
@@ -375,7 +372,7 @@ class TestMixedLM(object):
 
         # ML
         data = pd.read_csv(fname)
-        vcf = {"cask" : "0 + cask"}
+        vcf = {"cask": "0 + cask"}
         model = MixedLM.from_formula("strength ~ 1", groups="batch",
                                      re_formula="1", vc_formula=vcf,
                                      data=data)
@@ -388,7 +385,6 @@ class TestMixedLM(object):
         assert_allclose(result.aic, 255.9944, rtol=1e-3)
         assert_allclose(result.bic, 264.3718, rtol=1e-3)
 
-
     def test_vcomp_formula(self):
 
         np.random.seed(6241)
@@ -396,14 +392,14 @@ class TestMixedLM(object):
         exog = np.random.normal(size=(n, 2))
         exog[:, 0] = 1
         ex_vc = []
-        groups = np.kron(np.arange(n/4), np.ones(4))
+        groups = np.kron(np.arange(n / 4), np.ones(4))
         errors = 0
         exog_re = np.random.normal(size=(n, 2))
-        slopes = np.random.normal(size=(n/4, 2))
+        slopes = np.random.normal(size=(n / 4, 2))
         slopes = np.kron(slopes, np.ones((4, 1))) * exog_re
         errors += slopes.sum(1)
         ex_vc = np.random.normal(size=(n, 4))
-        slopes = np.random.normal(size=(n/4, 4))
+        slopes = np.random.normal(size=(n / 4, 4))
         slopes[:, 2:] *= 2
         slopes = np.kron(slopes, np.ones((4, 1))) * ex_vc
         errors += slopes.sum(1)
@@ -411,14 +407,14 @@ class TestMixedLM(object):
         endog = exog.sum(1) + errors
 
         exog_vc = {"a": {}, "b": {}}
-        for k,group in enumerate(range(int(n/4))):
+        for k, group in enumerate(range(int(n / 4))):
             ix = np.flatnonzero(groups == group)
             exog_vc["a"][group] = ex_vc[ix, 0:2]
             exog_vc["b"][group] = ex_vc[ix, 2:]
         model1 = MixedLM(endog, exog, groups, exog_re=exog_re, exog_vc=exog_vc)
         result1 = model1.fit()
 
-        df = pd.DataFrame(exog[:, 1:], columns=["x1",])
+        df = pd.DataFrame(exog[:, 1:], columns=["x1", ])
         df["y"] = endog
         df["re1"] = exog_re[:, 0]
         df["re2"] = exog_re[:, 1]
@@ -427,7 +423,8 @@ class TestMixedLM(object):
         df["vc3"] = ex_vc[:, 2]
         df["vc4"] = ex_vc[:, 3]
         vc_formula = {"a": "0 + vc1 + vc2", "b": "0 + vc3 + vc4"}
-        model2 = MixedLM.from_formula("y ~ x1", groups=groups, re_formula="0 + re1 + re2",
+        model2 = MixedLM.from_formula("y ~ x1", groups=groups,
+                                      re_formula="0 + re1 + re2",
                                       vc_formula=vc_formula, data=df)
         result2 = model2.fit()
 
@@ -437,14 +434,13 @@ class TestMixedLM(object):
         assert_allclose(result1.params, result2.params, rtol=1e-8)
         assert_allclose(result1.bse, result2.bse, rtol=1e-8)
 
-
     def test_formulas(self):
         np.random.seed(2410)
-        exog = np.random.normal(size=(300,4))
+        exog = np.random.normal(size=(300, 4))
         exog_re = np.random.normal(size=300)
-        groups = np.kron(np.arange(100), [1,1,1])
+        groups = np.kron(np.arange(100), [1, 1, 1])
         g_errors = exog_re * np.kron(np.random.normal(size=100),
-                                     [1,1,1])
+                                     [1, 1, 1])
         endog = exog.sum(1) + g_errors + np.random.normal(size=300)
 
         mod1 = MixedLM(endog, exog, groups, exog_re)
@@ -458,7 +454,7 @@ class TestMixedLM(object):
         # Fit with a formula, passing groups as the actual values.
         df = pd.DataFrame({"endog": endog})
         for k in range(exog.shape[1]):
-            df["exog%d" % k] = exog[:,k]
+            df["exog%d" % k] = exog[:, k]
         df["exog_re"] = exog_re
         fml = "endog ~ 0 + exog0 + exog1 + exog2 + exog3"
         re_fml = "0 + exog_re"
@@ -503,12 +499,12 @@ class TestMixedLM(object):
     def test_regularized(self):
 
         np.random.seed(3453)
-        exog = np.random.normal(size=(400,5))
+        exog = np.random.normal(size=(400, 5))
         groups = np.kron(np.arange(100), np.ones(4))
-        expected_endog = exog[:,0] - exog[:,2]
+        expected_endog = exog[:, 0] - exog[:, 2]
         endog = expected_endog +\
-                np.kron(np.random.normal(size=100), np.ones(4)) +\
-                np.random.normal(size=400)
+            np.kron(np.random.normal(size=100), np.ones(4)) +\
+            np.random.normal(size=400)
 
         # L1 regularization
         md = MixedLM(endog, exog, groups)
@@ -517,7 +513,7 @@ class TestMixedLM(object):
 
         # L1 regularization
         md = MixedLM(endog, exog, groups)
-        mdf2 = md.fit_regularized(alpha=10*np.ones(5))
+        mdf2 = md.fit_regularized(alpha=10 * np.ones(5))
         mdf2.summary()
 
         # L2 regularization
@@ -537,7 +533,6 @@ class TestMixedLM(object):
         mdf5 = md.fit_regularized(method=pen, alpha=1.)
         mdf5.summary()
 
-
     def do1(self, reml, irf, ds_ix):
 
         # No need to check independent random effects when there is
@@ -553,14 +548,14 @@ class TestMixedLM(object):
         # Fit the model
         md = MixedLM(rslt.endog, rslt.exog_fe, rslt.groups,
                      rslt.exog_re)
-        if not irf: # Free random effects covariance
+        if not irf:  # Free random effects covariance
             if np.any(np.diag(rslt.cov_re_r) < 1e-5):
                 with warnings.catch_warnings():
                     warnings.simplefilter("ignore")
                     mdf = md.fit(gtol=1e-7, reml=reml)
             else:
                 mdf = md.fit(gtol=1e-7, reml=reml)
-        else: # Independent random effects
+        else:  # Independent random effects
             k_fe = rslt.exog_fe.shape[1]
             k_re = rslt.exog_re.shape[1]
             free = MixedLMParams(k_fe, k_re, 0)
@@ -579,7 +574,7 @@ class TestMixedLM(object):
         assert_almost_equal(mdf.scale, rslt.scale_r, decimal=4)
 
         k_fe = md.k_fe
-        assert_almost_equal(rslt.vcov_r, mdf.cov_params()[0:k_fe,0:k_fe],
+        assert_almost_equal(rslt.vcov_r, mdf.cov_params()[0:k_fe, 0:k_fe],
                             decimal=3)
 
         assert_almost_equal(mdf.llf, rslt.loglike[0], decimal=2)
@@ -602,8 +597,8 @@ class TestMixedLM(object):
                   and x.endswith(".csv")]
 
         for fname in fnames:
-            for reml in False,True:
-                for irf in False,True:
+            for reml in False, True:
+                for irf in False, True:
                     ds_ix = int(fname[3:5])
 
                     yield self.do1, reml, irf, ds_ix
@@ -629,7 +624,7 @@ def test_mixed_lm_wrapper():
     mod2 = MixedLM.from_formula(fml, df, re_formula=re_fml,
                                 groups=groups)
     result = mod2.fit()
-    smoke = result.summary()
+    result.summary()
 
     xnames = ["exog0", "exog1", "exog2", "exog3"]
     re_names = ["Intercept", "exog_re"]
@@ -663,11 +658,9 @@ def test_mixed_lm_wrapper():
     assert_(bse_re.index.tolist() == re_names_full)
 
 
-
-
-if  __name__=="__main__":
+if __name__ == "__main__":
 
     import nose
 
-    nose.runmodule(argv=[__file__,'-vvs','-x','--pdb', '--pdb-failure'],
+    nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],
                    exit=False)


### PR DESCRIPTION
@josef-pkt noticed some warnings in MixedLM tests.

A few of these were due to incorrectly using stale starting values.  That is fixed.

Several others were due to fitting models where the MLE is on the boundary of the parameters space.  I have silenced these.

I also caught and fixed an error in `test_sparse`.

Everything should now run clean.

Finally, a bunch of pep8 fixes.