### PR TITLE
FIX: Conda needs some more dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ matrix:
     - PYTHON=2.7
     - NUMPY=1.7
     - SCIPY=0.12
-    - OPTIONAL=cvxopt
+    - OPTIONAL="cvxopt mkl libgfortran"
     - COVERAGE=true
   - python: 2.7
     env:
@@ -48,6 +48,7 @@ matrix:
     - SCIPY=0.14
     - PANDAS=0.14
     - MATPLOTLIB=1.4
+    - OPTIONAL=libgfortran
   - python: 2.7
     env:
     - PYTHON=2.7


### PR DESCRIPTION
Ok, I was curious about why 2 of the builds weren't working. I figured out how to make one of them work, but the other is kind of a pickle still. 

- It seems that I need to force conda to install the `libgfortran` package. I think this package probably used to be installed via a dependency in the past, but that is over. This prevents builds .2 and .4 from running. 
- On build .2, I think we are trying to use mkl to do the test. I need to force conda to install mkl as well. 

Once I did those 2 things, this all ran. One weird thing... it appears that build .2 fails now only using the mkl drivers. Its a close fail--it may be related to some of the other changes we've made. But it only happening on build .2 is strange. I'm especially confused by the test `statsmodels.tsa.statespace.tests.test_sarimax.TestFriedmanStateRegression.test_mle`. The tolerance levels are set to be very high (atol=0.1 and rtol=0.1), and based on that it appears to pass, but the code says it fails. 

In any event, I don't think you'll want to merge this PR. In fact, you might want to tell conda about this. But I'm admittedly not familiar with conda--or if they'll fix this--so this code at least should point us in the right direction. 