### PR TITLE
Fix plot_components issue if endog without dates

### DIFF
--- a/statsmodels/tsa/statespace/structural.py
+++ b/statsmodels/tsa/statespace/structural.py
@@ -1339,7 +1339,7 @@ class UnobservedComponentsResults(MLEResults):
         if hasattr(self.data, 'dates') and self.data.dates is not None:
             dates = self.data.dates._mpl_repr()
         else:
-            dates = np.arange(len(resid))
+            dates = np.arange(len(self.data.endog))
 
         # Get the critical value for confidence intervals
         critical_value = norm.ppf(1 - alpha / 2.)


### PR DESCRIPTION
There's no 'resid' in plot_components function, I think it will be the endog length.