### PR TITLE
Escape more special characters in "as_latex_tabular()" function

### DIFF
--- a/statsmodels/iolib/table.py
+++ b/statsmodels/iolib/table.py
@@ -878,7 +878,7 @@ default_latex_fmt = dict(
     stub=r'\textbf{%s}',
     empty='',
     missing='--',
-    replacements={"%" : "\%", ">" : "$>$", "|" : "$|$"}
+    replacements={"%" : "\%", ">" : "$>$", "|" : "$|$", "_" : "\_", "$" : "\$", "&" : "\&", "#" : "\#"}
 )
 
 default_fmts = dict(

--- a/statsmodels/iolib/table.py
+++ b/statsmodels/iolib/table.py
@@ -716,7 +716,7 @@ class Cell(object):
         elif datatype in fmt:
             if "replacements" in fmt:
                 if isinstance(data, str):
-                    for repl in fmt["replacements"]:
+                    for repl in sorted(fmt["replacements"]):
                         data = data.replace(repl, fmt["replacements"][repl])
 
             dfmt = fmt.get(datatype)
@@ -878,7 +878,8 @@ default_latex_fmt = dict(
     stub=r'\textbf{%s}',
     empty='',
     missing='--',
-    replacements={"%" : "\%", ">" : "$>$", "|" : "$|$", "_" : "\_", "$" : "\$", "&" : "\&", "#" : "\#"}
+    #replacements will be processed in lexicographical order
+    replacements={"#" : "\#", "$" : "\$", "%" : "\%", "&" : "\&", ">" : "$>$", "_" : "\_", "|" : "$|$"} 
 )
 
 default_fmts = dict(

--- a/statsmodels/iolib/tests/test_table.py
+++ b/statsmodels/iolib/tests/test_table.py
@@ -144,30 +144,6 @@ stub R2 C2  40.95038  40.65765
 """ % desired[1:-1]
             actual_centered = '\n%s\n' % tbl.as_latex_tabular()
             self.assertEqual(actual_centered, desired_centered)
-    def test_SimpleTable_special_chars(self):
-		# Simple table with characters: (%, >, |, _, $, &, #)
-		cell0c_data = 22
-		cell1c_data = 1053
-		row0c_data = [cell0c_data, cell1c_data]
-		row1c_data = [23, 6250.4]
-		table1c_data = [ row0c_data, row1c_data ]
-		test1c_stubs = ('> stub1 %', 'stub_2')
-		test1c_header = ('#header 1$', 'header&2 |')
-		tbl_c = SimpleTable(table1c_data, test1c_header, test1c_stubs, ltx_fmt=ltx_fmt1)
-        def test_ltx_special_chars(self):
-            # Test for special characters (latex) in headers and stubs
-            desired = r"""
-\begin{tabular}{lcc}
-\toprule
-               & \textbf{\#header 1\$} & \textbf{header\&2 $|$}  \\
-\midrule
-\textbf{$>$ stub1 \%} &       22        &        1053          \\
-\textbf{stub\_2} &        23         &      6250.4        \\
-\bottomrule
-\end{tabular}
-"""
-            actual = '\n%s\n' % tbl_c.as_latex_tabular(center=False)
-            self.assertEqual(actual, desired)
         def test_html_fmt1(self):
             # Limited test of custom html_fmt
             desired = """
@@ -188,6 +164,31 @@ stub R2 C2  40.95038  40.65765
         test_txt_fmt1(self)
         test_ltx_fmt1(self)
         test_html_fmt1(self)
+    def test_SimpleTable_special_chars(self):
+    # Simple table with characters: (%, >, |, _, $, &, #)
+        cell0c_data = 22
+        cell1c_data = 1053
+        row0c_data = [cell0c_data, cell1c_data]
+        row1c_data = [23, 6250.4]
+        table1c_data = [ row0c_data, row1c_data ]
+        test1c_stubs = ('> stub1 %', 'stub_2')
+        test1c_header = ('#header 1$', 'header&2 |')
+        tbl_c = SimpleTable(table1c_data, test1c_header, test1c_stubs, ltx_fmt=ltx_fmt1)
+        def test_ltx_special_chars(self):
+        # Test for special characters (latex) in headers and stubs
+            desired = r"""
+\begin{tabular}{lcc}
+\toprule
+               & \textbf{\#header 1\$} & \textbf{header\&2 $|$}  \\
+\midrule
+\textbf{$>$ stub1 \%} &       22        &        1053          \\
+\textbf{stub\_2} &        23         &      6250.4        \\
+\bottomrule
+\end{tabular}
+"""
+            actual = '\n%s\n' % tbl_c.as_latex_tabular(center=False)
+            self.assertEqual(actual, desired)
+        test_ltx_special_chars(self)
     def test_regression_with_tuples(self):
         i = pandas.Series( [1,2,3,4]*10 , name="i")
         y = pandas.Series( [1,2,3,4,5]*8, name="y")

--- a/statsmodels/iolib/tests/test_table.py
+++ b/statsmodels/iolib/tests/test_table.py
@@ -179,10 +179,10 @@ stub R2 C2  40.95038  40.65765
             desired = r"""
 \begin{tabular}{lcc}
 \toprule
-               & \textbf{\#header 1\$} & \textbf{header\&2 $|$}  \\
+                    & \textbf{\#header1\$} & \textbf{header\&$|$}  \\
 \midrule
-\textbf{$>$ stub1 \%} &       22        &        1053          \\
-\textbf{stub\_2} &        23         &      6250.4        \\
+\textbf{$>$stub1\%} &          22          &         1053          \\
+\textbf{stub\_2}    &          23          &        6250.4         \\
 \bottomrule
 \end{tabular}
 """

--- a/statsmodels/iolib/tests/test_table.py
+++ b/statsmodels/iolib/tests/test_table.py
@@ -144,6 +144,30 @@ stub R2 C2  40.95038  40.65765
 """ % desired[1:-1]
             actual_centered = '\n%s\n' % tbl.as_latex_tabular()
             self.assertEqual(actual_centered, desired_centered)
+    def test_SimpleTable_special_chars(self):
+		# Simple table with characters: (%, >, |, _, $, &, #)
+		cell0c_data = 22
+		cell1c_data = 1053
+		row0c_data = [cell0c_data, cell1c_data]
+		row1c_data = [23, 6250.4]
+		table1c_data = [ row0c_data, row1c_data ]
+		test1c_stubs = ('> stub1 %', 'stub_2')
+		test1c_header = ('#header 1$', 'header&2 |')
+		tbl_c = SimpleTable(table1c_data, test1c_header, test1c_stubs, ltx_fmt=ltx_fmt1)
+        def test_ltx_special_chars(self):
+            # Test for special characters (latex) in headers and stubs
+            desired = r"""
+\begin{tabular}{lcc}
+\toprule
+               & \textbf{\#header 1\$} & \textbf{header\&2 $|$}  \\
+\midrule
+\textbf{$>$ stub1 \%} &       22        &        1053          \\
+\textbf{stub\_2} &        23         &      6250.4        \\
+\bottomrule
+\end{tabular}
+"""
+            actual = '\n%s\n' % tbl_c.as_latex_tabular(center=False)
+            self.assertEqual(actual, desired)
         def test_html_fmt1(self):
             # Limited test of custom html_fmt
             desired = """

--- a/statsmodels/iolib/tests/test_table.py
+++ b/statsmodels/iolib/tests/test_table.py
@@ -171,8 +171,8 @@ stub R2 C2  40.95038  40.65765
         row0c_data = [cell0c_data, cell1c_data]
         row1c_data = [23, 6250.4]
         table1c_data = [ row0c_data, row1c_data ]
-        test1c_stubs = ('> stub1 %', 'stub_2')
-        test1c_header = ('#header 1$', 'header&2 |')
+        test1c_stubs = ('>stub1%', 'stub_2')
+        test1c_header = ('#header1$', 'header&|')
         tbl_c = SimpleTable(table1c_data, test1c_header, test1c_stubs, ltx_fmt=ltx_fmt1)
         def test_ltx_special_chars(self):
         # Test for special characters (latex) in headers and stubs


### PR DESCRIPTION
Solve issue #2862 . 
Update list "replacements" in table.py and a unit test in test_table.py.