### PR TITLE
DOC: add content to VAR docs.

### DIFF
--- a/docs/source/vector_ar.rst
+++ b/docs/source/vector_ar.rst
@@ -17,7 +17,7 @@ and their lagged values is the *vector autoregression process*:
 
 .. math::
 
-   Y_t = A_1 Y_{t-1} + \ldots + A_p Y_{t-p} + u_t
+   Y_t = \nu + A_1 Y_{t-1} + \ldots + A_p Y_{t-p} + u_t
 
    u_t \sim {\sf Normal}(0, \Sigma_u)
 
@@ -257,8 +257,16 @@ F-test.
 Normality
 ~~~~~~~~~
 
+As pointed out in the beginning of this document, the white noise component :math:`u_t` is assumed to be normally distributed. To test whether this assumption is acceptable or has to be rejected, :class:`VARResults` offers the `test_normality` method.
+
+.. ipython:: python
+
+    results.test_normality()
+
 Whiteness of residuals
 ~~~~~~~~~~~~~~~~~~~~~~
+
+To test the whiteness of the estimation residuals (this means absence of significant residual autocorrelations) one can use the `test_whiteness` method of :class:`VARResults`.
 
 Dynamic Vector Autoregressions
 ------------------------------


### PR DESCRIPTION
I have noticed that there are two sections in the VAR documentation consisting only of a heading. I have added some explanatory content to these sections.
Also, I have added \nu to the definition of a VAR(p) process (as can be found in [Lütkepohl 2005](http://www.springer.com/de/book/9783540401728) (page 13)).

Furthermore, I have played with the code and the [data provided by Lütkepohl](http://www.jmulti.de/download/datasets/e1.dat). It seems that the test statistic for the normality test shown in Lütkepohl 2005 (page 181) doesn't equal the value calculated by statsmodels. Here is an IPython notebook showing this example:
[test___VARResults___test_normality.zip](https://github.com/statsmodels/statsmodels/files/189787/test___VARResults___test_normality.zip)
