### PR TITLE
ENH: Allow predict to return a DataFrame

### DIFF
--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -755,8 +755,6 @@ class Results(object):
 
         if hasattr(exog, 'index'):
             row_labels = exog.index
-        elif hasattr(self.model.data.orig_exog, 'index'):
-            row_labels = self.model.data.orig_exog.index
         else:
             row_labels = None
 

--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -751,7 +751,23 @@ class Results(object):
                 exog = exog[:, None]
             exog = np.atleast_2d(exog)  # needed in count model shape[1]
 
-        return self.model.predict(self.params, exog, *args, **kwargs)
+        predict_results = self.model.predict(self.params, exog, *args, **kwargs)
+
+        if hasattr(exog, 'index'):
+            row_labels = exog.index
+        elif hasattr(self.model.data.orig_exog, 'index'):
+            row_labels = self.model.data.orig_exog.index
+
+        if row_labels is not None:
+            import pandas as pd
+
+            if predict_results.ndim == 1:
+                return pd.Series(predict_results, index=row_labels)
+            else:
+                return pd.DataFrame(predict_results, index=row_labels)
+
+        else:
+            return predict_results
 
 
 #TODO: public method?

--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -739,6 +739,11 @@ class Results(object):
             See self.model.predict
 
         """
+        from copy import copy
+        import pandas as pd
+
+        orig_exog = copy(exog)
+
         if transform and hasattr(self.model, 'formula') and exog is not None:
             from patsy import dmatrix
             exog = dmatrix(self.model.data.design_info.builder,
@@ -753,13 +758,12 @@ class Results(object):
 
         predict_results = self.model.predict(self.params, exog, *args, **kwargs)
 
-        if hasattr(exog, 'index'):
-            row_labels = exog.index
+        if isinstance(orig_exog, pd.Series) or isinstance(orig_exog, pd.DataFrame):
+            row_labels = orig_exog.index
         else:
             row_labels = None
 
         if row_labels is not None:
-            import pandas as pd
 
             if predict_results.ndim == 1:
                 return pd.Series(predict_results, index=row_labels)

--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -735,7 +735,7 @@ class Results(object):
 
         Returns
         -------
-        prediction : ndarray or pandas.Series
+        prediction : ndarray, pandas.Series or pandas.DataFrame
             See self.model.predict
 
         """

--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -757,6 +757,8 @@ class Results(object):
             row_labels = exog.index
         elif hasattr(self.model.data.orig_exog, 'index'):
             row_labels = self.model.data.orig_exog.index
+        else:
+            row_labels = None
 
         if row_labels is not None:
             import pandas as pd

--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -758,7 +758,9 @@ class Results(object):
 
         predict_results = self.model.predict(self.params, exog, *args, **kwargs)
 
-        if isinstance(orig_exog, pd.Series) or isinstance(orig_exog, pd.DataFrame):
+        if (isinstance(orig_exog, pd.Series) or isinstance(orig_exog, pd.DataFrame) and
+           not hasattr(predict_results, 'predicted_values')):
+
             row_labels = orig_exog.index
 
             if predict_results.ndim == 1:

--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -760,10 +760,6 @@ class Results(object):
 
         if isinstance(orig_exog, pd.Series) or isinstance(orig_exog, pd.DataFrame):
             row_labels = orig_exog.index
-        else:
-            row_labels = None
-
-        if row_labels is not None:
 
             if predict_results.ndim == 1:
                 return pd.Series(predict_results, index=row_labels)
@@ -771,6 +767,7 @@ class Results(object):
                 return pd.DataFrame(predict_results, index=row_labels)
 
         else:
+
             return predict_results
 
 

--- a/statsmodels/base/tests/test_generic_methods.py
+++ b/statsmodels/base/tests/test_generic_methods.py
@@ -144,7 +144,6 @@ class CheckGenericMixin(object):
         else:
 
             import pandas as pd
-            from statsmodels.genmod.generalized_estimating_equations import GEEResultsWrapper
 
             fitted = res.fittedvalues[:2]
             assert_allclose(fitted, res.predict(p_exog), rtol=1e-12)

--- a/statsmodels/base/tests/test_generic_methods.py
+++ b/statsmodels/base/tests/test_generic_methods.py
@@ -120,6 +120,7 @@ class CheckGenericMixin(object):
         assert_allclose(fitted, res.predict(), rtol=1e-12)
 
     def test_predict_types(self):
+
         res = self.results
         # squeeze to make 1d for single regressor test case
         p_exog = np.squeeze(np.asarray(res.model.exog[:2]))
@@ -141,6 +142,10 @@ class CheckGenericMixin(object):
             res.predict(p_exog.tolist())
             res.predict(p_exog[0].tolist())
         else:
+
+            import pandas as pd
+            from statsmodels.genmod.generalized_estimating_equations import GEEResultsWrapper
+
             fitted = res.fittedvalues[:2]
             assert_allclose(fitted, res.predict(p_exog), rtol=1e-12)
             # this needs reshape to column-vector:
@@ -152,11 +157,32 @@ class CheckGenericMixin(object):
             assert_allclose(fitted[:1], res.predict(p_exog[0]),
                             rtol=1e-12)
 
-            # predict doesn't preserve DataFrame, e.g. dot converts to ndarray
-#             import pandas
-#             predicted = res.predict(pandas.DataFrame(p_exog))
-#             assert_(isinstance(predicted, pandas.DataFrame))
-#             assert_allclose(predicted, fitted, rtol=1e-12)
+            exog_index=range(len(p_exog))
+            predicted = res.predict(p_exog)
+
+            if p_exog.ndim == 1:
+                predicted_pandas = res.predict(pd.Series(p_exog, index=exog_index))
+
+            else:
+                predicted_pandas = res.predict(pd.DataFrame(p_exog, index=exog_index))
+
+            if predicted.ndim == 1:
+
+                try:
+                    assert_(isinstance(predicted_pandas, pd.Series))
+
+                except AssertionError:
+                    import pdb
+                    pdb.set_trace()
+
+                predicted_expected = pd.Series(predicted, index=exog_index)
+                assert_(predicted_expected.equals(predicted_pandas))
+
+            else:
+                assert_(isinstance(predicted_pandas, pd.DataFrame))
+
+                predicted_expected = pd.DataFrame(predicted, index=exog_index)
+                assert_(predicted_expected.equals(predicted_pandas))
 
 
 #########  subclasses for individual models, unchanged from test_shrink_pickle

--- a/statsmodels/base/tests/test_generic_methods.py
+++ b/statsmodels/base/tests/test_generic_methods.py
@@ -168,12 +168,7 @@ class CheckGenericMixin(object):
 
             if predicted.ndim == 1:
 
-                try:
-                    assert_(isinstance(predicted_pandas, pd.Series))
-
-                except AssertionError:
-                    import pdb
-                    pdb.set_trace()
+                assert_(isinstance(predicted_pandas, pd.Series))
 
                 predicted_expected = pd.Series(predicted, index=exog_index)
                 assert_(predicted_expected.equals(predicted_pandas))

--- a/statsmodels/base/tests/test_generic_methods.py
+++ b/statsmodels/base/tests/test_generic_methods.py
@@ -157,7 +157,7 @@ class CheckGenericMixin(object):
             assert_allclose(fitted[:1], res.predict(p_exog[0]),
                             rtol=1e-12)
 
-            exog_index=range(len(p_exog))
+            exog_index = range(len(p_exog))
             predicted = res.predict(p_exog)
 
             if p_exog.ndim == 1:

--- a/statsmodels/base/tests/test_generic_methods.py
+++ b/statsmodels/base/tests/test_generic_methods.py
@@ -144,6 +144,7 @@ class CheckGenericMixin(object):
         else:
 
             import pandas as pd
+            from pandas.util.testing import assert_series_equal
 
             fitted = res.fittedvalues[:2]
             assert_allclose(fitted, res.predict(p_exog), rtol=1e-12)
@@ -170,7 +171,7 @@ class CheckGenericMixin(object):
                 assert_(isinstance(predicted_pandas, pd.Series))
 
                 predicted_expected = pd.Series(predicted, index=exog_index)
-                assert_(predicted_expected.equals(predicted_pandas))
+                assert_series_equal(predicted_expected, predicted_pandas)
 
             else:
                 assert_(isinstance(predicted_pandas, pd.DataFrame))

--- a/statsmodels/base/tests/test_shrink_pickle.py
+++ b/statsmodels/base/tests/test_shrink_pickle.py
@@ -51,6 +51,9 @@ class RemoveDataPickle(object):
         self.l_max = 20000
 
     def test_remove_data_pickle(self):
+
+        import pandas as pd
+
         if winoldnp:
             raise SkipTest
         results = self.results
@@ -72,7 +75,12 @@ class RemoveDataPickle(object):
         #remove data arrays, check predict still works
         results.remove_data()
         pred2 = results.predict(xf, **pred_kwds)
-        np.testing.assert_equal(pred2, pred1)
+
+        if ((isinstance(pred1, pd.Series) and isinstance(pred2, pd.Series)) or
+            (isinstance(pred1, pd.DataFrame) and isinstance(pred2, pd.DataFrame))):
+            assert_(pred1.equals(pred2))
+        else:
+            np.testing.assert_equal(pred2, pred1)
 
         #pickle, unpickle reduced array
         res, l = check_pickle(results._results)
@@ -86,7 +94,12 @@ class RemoveDataPickle(object):
 
 
         pred3 = results.predict(xf, **pred_kwds)
-        np.testing.assert_equal(pred3, pred1)
+
+        if ((isinstance(pred1, pd.Series) and isinstance(pred3, pd.Series)) or
+            (isinstance(pred1, pd.DataFrame) and isinstance(pred3, pd.DataFrame))):
+            assert_(pred1.equals(pred3))
+        else:
+            np.testing.assert_equal(pred3, pred1)
 
     def test_remove_data_docstring(self):
         assert_(self.results.remove_data.__doc__ is not None)

--- a/statsmodels/base/tests/test_shrink_pickle.py
+++ b/statsmodels/base/tests/test_shrink_pickle.py
@@ -53,6 +53,7 @@ class RemoveDataPickle(object):
     def test_remove_data_pickle(self):
 
         import pandas as pd
+        from pandas.util.testing import assert_series_equal
 
         if winoldnp:
             raise SkipTest
@@ -76,9 +77,12 @@ class RemoveDataPickle(object):
         results.remove_data()
         pred2 = results.predict(xf, **pred_kwds)
 
-        if ((isinstance(pred1, pd.Series) and isinstance(pred2, pd.Series)) or
-            (isinstance(pred1, pd.DataFrame) and isinstance(pred2, pd.DataFrame))):
+        if isinstance(pred1, pd.Series) and isinstance(pred2, pd.Series):
+            assert_series_equal(pred1, pred2)
+
+        elif isinstance(pred1, pd.DataFrame) and isinstance(pred2, pd.DataFrame):
             assert_(pred1.equals(pred2))
+
         else:
             np.testing.assert_equal(pred2, pred1)
 
@@ -95,9 +99,12 @@ class RemoveDataPickle(object):
 
         pred3 = results.predict(xf, **pred_kwds)
 
-        if ((isinstance(pred1, pd.Series) and isinstance(pred3, pd.Series)) or
-            (isinstance(pred1, pd.DataFrame) and isinstance(pred3, pd.DataFrame))):
+        if isinstance(pred1, pd.Series) and isinstance(pred3, pd.Series):
+            assert_series_equal(pred1, pred3)
+
+        elif isinstance(pred1, pd.DataFrame) and isinstance(pred3, pd.DataFrame):
             assert_(pred1.equals(pred3))
+
         else:
             np.testing.assert_equal(pred3, pred1)
 

--- a/statsmodels/duration/tests/test_phreg.py
+++ b/statsmodels/duration/tests/test_phreg.py
@@ -189,6 +189,10 @@ class TestPHReg(object):
         dfp = dmatrix(model1.data.design_info.builder, df)
 
         pr1 = result1.predict()
+
+        import pdb
+        pdb.set_trace()
+
         pr2 = result1.predict(exog=df)
         pr3 = model1.predict(result1.params, exog=dfp) # No standard errors
         pr4 = model1.predict(result1.params, cov_params=result1.cov_params(), exog=dfp)

--- a/statsmodels/duration/tests/test_phreg.py
+++ b/statsmodels/duration/tests/test_phreg.py
@@ -189,10 +189,6 @@ class TestPHReg(object):
         dfp = dmatrix(model1.data.design_info.builder, df)
 
         pr1 = result1.predict()
-
-        import pdb
-        pdb.set_trace()
-
         pr2 = result1.predict(exog=df)
         pr3 = model1.predict(result1.params, exog=dfp) # No standard errors
         pr4 = model1.predict(result1.params, cov_params=result1.cov_params(), exog=dfp)

--- a/statsmodels/regression/linear_model.py
+++ b/statsmodels/regression/linear_model.py
@@ -33,7 +33,6 @@ W. Green.  "Econometric Analysis," 5th ed., Pearson, 2003.
 
 from __future__ import print_function
 
-from statsmodels.base.data import PandasData
 from statsmodels.compat.python import lrange, lzip, range
 __docformat__ = 'restructuredtext en'
 
@@ -364,8 +363,7 @@ class RegressionModel(base.LikelihoodModel):
 
         Returns
         -------
-        A pandas Series if model data was a pandas DataFrame
-        otherwise, it returns an ndarray.
+        An array of fitted values
 
         Notes
         -----
@@ -375,17 +373,9 @@ class RegressionModel(base.LikelihoodModel):
         #SS: it needs its own predict method
 
         if exog is None:
-            exog_to_fit = self.exog
-        else:
-            exog_to_fit = exog
+            exog = self.exog
 
-        fitted_values = np.dot(exog_to_fit, params)
-
-        if isinstance(self.data, PandasData):
-            return pd.Series(data=fitted_values, index=self.data.orig_exog.index)
-
-        else:
-            return fitted_values
+        return np.dot(exog, params)
 
     def get_distribution(self, params, scale, exog=None, dist_class=None):
         """

--- a/statsmodels/regression/linear_model.py
+++ b/statsmodels/regression/linear_model.py
@@ -364,7 +364,7 @@ class RegressionModel(base.LikelihoodModel):
 
         Returns
         -------
-        A pandas DataFrame if model data was a pandas DataFrame
+        A pandas Series if model data was a pandas DataFrame
         otherwise, it returns an ndarray.
 
         Notes
@@ -381,8 +381,8 @@ class RegressionModel(base.LikelihoodModel):
 
         fitted_values = np.dot(exog_to_fit, params)
 
-        if isinstance(self.data, PandasData) and exog is not None:
-            return pd.DataFrame(data=fitted_values, index=self.data.orig_exog.index)
+        if isinstance(self.data, PandasData):
+            return pd.Series(data=fitted_values, index=self.data.orig_exog.index)
 
         else:
             return fitted_values

--- a/statsmodels/regression/linear_model.py
+++ b/statsmodels/regression/linear_model.py
@@ -32,6 +32,8 @@ W. Green.  "Econometric Analysis," 5th ed., Pearson, 2003.
 """
 
 from __future__ import print_function
+
+from statsmodels.base.data import PandasData
 from statsmodels.compat.python import lrange, lzip, range
 __docformat__ = 'restructuredtext en'
 
@@ -362,7 +364,8 @@ class RegressionModel(base.LikelihoodModel):
 
         Returns
         -------
-        An array of fitted values
+        A pandas Series if model data was a pandas DataFrame
+        otherwise, it returns an ndarray.
 
         Notes
         -----
@@ -370,10 +373,19 @@ class RegressionModel(base.LikelihoodModel):
         """
         #JP: this doesn't look correct for GLMAR
         #SS: it needs its own predict method
-        if exog is None:
-            exog = self.exog
-        return np.dot(exog, params)
 
+        if exog is None:
+            exog_to_fit = self.exog
+        else:
+            exog_to_fit = exog
+
+        fitted_values = np.dot(exog_to_fit, params)
+
+        if isinstance(self.data, PandasData):
+            return pd.Series(data=fitted_values, index=self.data.orig_exog.index)
+
+        else:
+            return fitted_values
 
     def get_distribution(self, params, scale, exog=None, dist_class=None):
         """

--- a/statsmodels/regression/tests/test_regression.py
+++ b/statsmodels/regression/tests/test_regression.py
@@ -1105,7 +1105,7 @@ def test_pandas_fit():
 
     result = fit.predict(data)
 
-    answer = pd.DataFrame(result.values, index=data.index.values[1:])
+    answer = pd.Series(result.values, index=data.index.values[1:])
 
     assert_(answer.equals(result))
 

--- a/statsmodels/regression/tests/test_regression.py
+++ b/statsmodels/regression/tests/test_regression.py
@@ -1089,27 +1089,6 @@ def test_fvalue_implicit_constant():
     res.summary()
 
 
-def test_pandas_fit():
-
-    import pandas as pd
-    from statsmodels.formula.api import ols
-
-    data = pd.Series(range(10), index=pd.date_range("2013-1-1", periods=10))
-
-    def shifter(x):
-        return x.shift()
-
-    model = "data ~ shifter(data)"
-
-    fit = ols(model, data=data).fit()
-
-    result = fit.predict(data)
-
-    answer = pd.Series(result.values, index=data.index.values[1:])
-
-    assert_(answer.equals(result))
-
-
 if __name__=="__main__":
 
     import nose

--- a/statsmodels/regression/tests/test_regression.py
+++ b/statsmodels/regression/tests/test_regression.py
@@ -1089,6 +1089,26 @@ def test_fvalue_implicit_constant():
     res.summary()
 
 
+def test_pandas_fit():
+
+    import pandas as pd
+    from statsmodels.formula.api import ols
+
+    data = pd.Series(range(10), index=pd.date_range("2013-1-1", periods=10))
+
+    def shifter(x):
+        return x.shift()
+
+    model = "data ~ shifter(data)"
+
+    fit = ols(model, data=data).fit()
+
+    result = fit.predict()
+
+    answer = pd.Series(result.values, index=data.index.values[1:])
+
+    assert_(answer.equals(result))
+
 
 if __name__=="__main__":
 

--- a/statsmodels/sandbox/mice/mice.py
+++ b/statsmodels/sandbox/mice/mice.py
@@ -775,6 +775,7 @@ class MICEData(object):
 
         from statsmodels.graphics import utils as gutils
         from statsmodels.nonparametric.smoothers_lowess import lowess
+        import pandas as pd
 
         if lowess_args is None:
             lowess_args = {}
@@ -1006,10 +1007,12 @@ class MICEData(object):
 
         if isinstance(obj, np.ndarray):
             return obj
+        elif isinstance(obj, pd.Series):
+            return obj.values
         elif hasattr(obj, 'predicted_values'):
             return obj.predicted_values
         else:
-            raise "cannot obtain predicted values from %s" % obj.__class__
+            raise ValueError("cannot obtain predicted values from %s" % obj.__class__)
 
 
     def impute_pmm(self, vname):


### PR DESCRIPTION
Modified the RegressionModel predict method to return a pandas DataFrame if the original model data was in the form of a DataFrame.

Fixes #1352 
