### PR TITLE
BF: leftover pd.datetools.parse -> parse_time_string for compat with recent pandas

### DIFF
--- a/docs/source/plots/graphics_month_plot.py
+++ b/docs/source/plots/graphics_month_plot.py
@@ -4,7 +4,7 @@ import pandas as pd
 dta = sm.datasets.elnino.load_pandas().data
 dta['YEAR'] = dta.YEAR.astype(int).astype(str)
 dta = dta.set_index('YEAR').T.unstack()
-dates = map(lambda x : pd.datetools.parse('1 '+' '.join(x)),
+dates = map(lambda x : pd.datetools.parse_time_string('1 '+' '.join(x)),
                                        dta.index.values)
 
 dta.index = pd.DatetimeIndex(dates, freq='M')

--- a/statsmodels/graphics/tsaplots.py
+++ b/statsmodels/graphics/tsaplots.py
@@ -245,7 +245,7 @@ def month_plot(x, dates=None, ylabel=None, ax=None):
     >>> dta = sm.datasets.elnino.load_pandas().data
     >>> dta['YEAR'] = dta.YEAR.astype(int).astype(str)
     >>> dta = dta.set_index('YEAR').T.unstack()
-    >>> dates = map(lambda x : pd.datetools.parse('1 '+' '.join(x)),
+    >>> dates = map(lambda x : pd.datetools.parse_time_string('1 '+' '.join(x)),
     ...                                        dta.index.values)
 
     >>> dta.index = pd.DatetimeIndex(dates, freq='M')


### PR DESCRIPTION
isn't tested, plain substitution to reflect changes for which e.g. f1dc89 was the fix