### PR TITLE
ENH: approx_fprime with complex parameters.

### DIFF
--- a/statsmodels/tools/numdiff.py
+++ b/statsmodels/tools/numdiff.py
@@ -143,7 +143,7 @@ def approx_fprime(x, f, epsilon=None, args=(), kwargs={}, centered=False):
     # TODO:  add scaled stepsize
     f0 = f(*((x,)+args), **kwargs)
     dim = np.atleast_1d(f0).shape  # it could be a scalar
-    grad = np.zeros((n,) + dim, float)
+    grad = np.zeros((n,) + dim, np.promote_types(float, x.dtype))
     ei = np.zeros((n,), float)
     if not centered:
         epsilon = _get_epsilon(x, 2, epsilon, n)

--- a/statsmodels/tools/tests/test_numdiff.py
+++ b/statsmodels/tools/tests/test_numdiff.py
@@ -285,6 +285,17 @@ class TestDerivativeFun1(CheckDerivativeMixin):
         return (-x*2*(y-np.dot(x, params))[:,None])  #TODO: check shape
 
 
+def test_dtypes():
+    def f(x):
+        return 2*x
+
+    desired = np.array([[2, 0],
+                        [0, 2]])
+    assert_allclose(approx_fprime(np.array([1, 2]), f), desired)
+    assert_allclose(approx_fprime(np.array([1., 2.]), f), desired)
+    assert_allclose(approx_fprime(np.array([1.+0j, 2.+0j]), f), desired)
+
+
 if __name__ == '__main__':
 
     epsilon = 1e-6


### PR DESCRIPTION
`approx_fprime` does not allow complex dtype input parameters because the gradient vector is hardcoded to float. This just changes the type of the gradient vector to that of the input parameter vector.