### PR TITLE
BUG: Try to coerce index into datetime before failing

### DIFF
--- a/statsmodels/tsa/base/tests/test_base.py
+++ b/statsmodels/tsa/base/tests/test_base.py
@@ -1,14 +1,16 @@
 import numpy as np
-from pandas import Series
-from pandas import date_range
+import pandas as pd
 from statsmodels.tsa.base.tsa_model import TimeSeriesModel
 import numpy.testing as npt
 from statsmodels.tools.testing import assert_equal
 
 def test_pandas_nodates_index():
-    from statsmodels.datasets import sunspots
-    y = sunspots.load_pandas().data.SUNACTIVITY
-    npt.assert_raises(ValueError, TimeSeriesModel, y)
+
+    data = [988, 819, 964]
+    dates = ['a', 'b', 'c']
+    s = pd.Series(data, index=dates)
+
+    npt.assert_raises(ValueError, TimeSeriesModel, s)
 
 def test_predict_freq():
     # test that predicted dates have same frequency
@@ -16,8 +18,8 @@ def test_predict_freq():
 
     # there's a bug in pandas up to 0.10.2 for YearBegin
     #dates = date_range("1972-4-1", "2007-4-1", freq="AS-APR")
-    dates = date_range("1972-4-30", "2006-4-30", freq="A-APR")
-    series = Series(x, index=dates)
+    dates = pd.date_range("1972-4-30", "2006-4-30", freq="A-APR")
+    series = pd.Series(x, index=dates)
     model = TimeSeriesModel(series)
     #npt.assert_(model.data.freq == "AS-APR")
     npt.assert_(model.data.freq == "A-APR")
@@ -30,7 +32,7 @@ def test_predict_freq():
 
     #expected_dates = date_range("2006-12-31", "2016-12-31",
     #                            freq="AS-APR")
-    expected_dates = date_range("2006-4-30", "2016-4-30", freq="A-APR")
+    expected_dates = pd.date_range("2006-4-30", "2016-4-30", freq="A-APR")
     assert_equal(predict_dates, expected_dates)
     #ptesting.assert_series_equal(predict_dates, expected_dates)
 
@@ -38,23 +40,35 @@ def test_predict_freq():
 def test_keyerror_start_date():
     x = np.arange(1,36.)
 
-    from pandas import date_range
-
     # there's a bug in pandas up to 0.10.2 for YearBegin
     #dates = date_range("1972-4-1", "2007-4-1", freq="AS-APR")
-    dates = date_range("1972-4-30", "2006-4-30", freq="A-APR")
-    series = Series(x, index=dates)
+    dates = pd.date_range("1972-4-30", "2006-4-30", freq="A-APR")
+    series = pd.Series(x, index=dates)
     model = TimeSeriesModel(series)
 
     npt.assert_raises(ValueError, model._get_predict_start, "1970-4-30")
 
 def test_period_index():
     # test 1285
-    from pandas import PeriodIndex
-    dates = PeriodIndex(start="1/1/1990", periods=20, freq="M")
+
+    dates = pd.PeriodIndex(start="1/1/1990", periods=20, freq="M")
     x = np.arange(1, 21.)
 
-    model = TimeSeriesModel(Series(x, index=dates))
+    model = TimeSeriesModel(pd.Series(x, index=dates))
     npt.assert_(model.data.freq == "M")
-    model = TimeSeriesModel(Series(x, index=dates))
+    model = TimeSeriesModel(pd.Series(x, index=dates))
     npt.assert_(model.data.freq == "M")
+
+def test_pandas_dates():
+
+    data = [988, 819, 964]
+    dates = ['2016-01-01 12:00:00', '2016-02-01 12:00:00', '2016-03-01 12:00:00']
+
+    datetime_dates = pd.to_datetime(dates)
+
+    result = pd.Series(data=data, index=datetime_dates, name='price')
+    df = pd.DataFrame(data={'price': data}, index=dates)
+
+    model = TimeSeriesModel(df['price'])
+
+    assert_equal(model.data.dates, result.index)

--- a/statsmodels/tsa/base/tsa_model.py
+++ b/statsmodels/tsa/base/tsa_model.py
@@ -4,7 +4,7 @@ from statsmodels.base import data
 import statsmodels.base.wrapper as wrap
 from statsmodels.tsa.base import datetools
 from numpy import arange, asarray
-from pandas import Index
+from pandas import Index, to_datetime
 from pandas import datetools as pandas_datetools
 import datetime
 
@@ -48,8 +48,11 @@ class TimeSeriesModel(base.LikelihoodModel):
         if dates is not None:
             if (not datetools._is_datetime_index(dates) and
                     isinstance(self.data, data.PandasData)):
-                raise ValueError("Given a pandas object and the index does "
-                                 "not contain dates")
+                try:
+                    dates = to_datetime(dates)
+                except ValueError:
+                    raise ValueError("Given a pandas object and the index does "
+                                     "not contain dates")
             if not freq:
                 try:
                     freq = datetools._infer_freq(dates)


### PR DESCRIPTION
Fixes #1180

TimeSeriesModel tries to coerce pandas index to datetime before throwing an error.