### PR TITLE
expose nsides to the seasonal_decompose so users can choose their favorite filter method for the resulting trend and residual.

### DIFF
--- a/statsmodels/tsa/seasonal.py
+++ b/statsmodels/tsa/seasonal.py
@@ -18,7 +18,7 @@ def seasonal_mean(x, freq):
     return np.array([pd_nanmean(x[i::freq]) for i in range(freq)])
 
 
-def seasonal_decompose(x, model="additive", filt=None, freq=None):
+def seasonal_decompose(x, model="additive", filt=None, freq=None, nsides=2):
     """
     Parameters
     ----------
@@ -85,7 +85,7 @@ def seasonal_decompose(x, model="additive", filt=None, freq=None):
         else:
             filt = np.repeat(1./freq, freq)
 
-    trend = convolution_filter(x, filt)
+    trend = convolution_filter(x, filt, nsides)
 
     # nan pad for conformability - convolve doesn't do it
     if model.startswith('m'):

--- a/statsmodels/tsa/seasonal.py
+++ b/statsmodels/tsa/seasonal.py
@@ -18,7 +18,7 @@ def seasonal_mean(x, freq):
     return np.array([pd_nanmean(x[i::freq]) for i in range(freq)])
 
 
-def seasonal_decompose(x, model="additive", filt=None, freq=None, nsides=2):
+def seasonal_decompose(x, model="additive", filt=None, freq=None, two_sided=True):
     """
     Parameters
     ----------
@@ -28,10 +28,14 @@ def seasonal_decompose(x, model="additive", filt=None, freq=None, nsides=2):
         Type of seasonal component. Abbreviations are accepted.
     filt : array-like
         The filter coefficients for filtering out the seasonal component.
-        The default is a symmetric moving average.
+        The concrete moving average method used in filtering is determined by two_sided.
     freq : int, optional
         Frequency of the series. Must be used if x is not a pandas
         object with a timeseries index.
+    two_sided : bool
+        The moving average method used in filtering.
+        If True (default), a centered moving average is computed using the filt.
+        If False, the filter coefficients are for past values only.
 
     Returns
     -------
@@ -85,6 +89,7 @@ def seasonal_decompose(x, model="additive", filt=None, freq=None, nsides=2):
         else:
             filt = np.repeat(1./freq, freq)
 
+    nsides = int(two_sided) + 1
     trend = convolution_filter(x, filt, nsides)
 
     # nan pad for conformability - convolve doesn't do it

--- a/statsmodels/tsa/tests/test_seasonal.py
+++ b/statsmodels/tsa/tests/test_seasonal.py
@@ -151,6 +151,82 @@ class TestDecompose:
         assert_almost_equal(res_add.trend, trend, 2)
         assert_almost_equal(res_add.resid, random, 3)
 
+    def test_one_sided_moving_average_in_stl_decompose(self):
+        res_add = seasonal_decompose(self.data.values, freq=4, two_sided=False)
+
+        seasonal = np.array([76.76, 90.03, -114.4, -52.4, 76.76, 90.03, -114.4,
+                             -52.4, 76.76, 90.03, -114.4, -52.4, 76.76, 90.03,
+                             -114.4, -52.4, 76.76, 90.03, -114.4, -52.4, 76.76,
+                             90.03, -114.4, -52.4, 76.76, 90.03, -114.4, -52.4,
+                             76.76, 90.03, -114.4, -52.4])
+
+        trend = np.array([np.nan, np.nan, np.nan, np.nan, 159.12, 204., 221.25,
+                          245.12, 319.75, 451.5, 561.12, 619.25, 615.62, 548.,
+                          462.12, 381.12, 316.62, 264., 228.38, 210.75, 188.38,
+                          199., 207.12, 191., 166.88, 72., -9.25, -33.12,
+                          -36.75, 36.25, 103., 131.62])
+
+        resid = np.array([np.nan, np.nan, np.nan, np.nan, 11.112, -57.031,
+                          118.147, 136.272, 332.487, 267.469, 83.272, -77.853,
+                          -152.388, -181.031, -152.728, -152.728, -56.388, -115.031,
+                          14.022, -56.353, -33.138, 139.969, -89.728, -40.603,
+                          -200.638, -303.031, 46.647, 72.522, 84.987, 234.719,
+                          -33.603, 104.772])
+
+        assert_almost_equal(res_add.seasonal, seasonal, 2)
+        assert_almost_equal(res_add.trend, trend, 2)
+        assert_almost_equal(res_add.resid, resid, 3)
+
+        res_mult = seasonal_decompose(np.abs(self.data.values), 'm', freq=4, two_sided=False)
+
+        seasonal = np.array([1.1985, 1.5449, 0.5811, 0.6755, 1.1985, 1.5449, 0.5811,
+                             0.6755, 1.1985, 1.5449, 0.5811, 0.6755, 1.1985, 1.5449,
+                             0.5811, 0.6755, 1.1985, 1.5449, 0.5811, 0.6755, 1.1985,
+                             1.5449, 0.5811, 0.6755, 1.1985, 1.5449, 0.5811, 0.6755,
+                             1.1985, 1.5449, 0.5811, 0.6755])
+
+        trend = np.array([np.nan, np.nan, np.nan, np.nan, 171.625, 204.,
+                          221.25, 245.125, 319.75, 451.5, 561.125, 619.25,
+                          615.625, 548., 462.125, 381.125, 316.625, 264.,
+                          228.375, 210.75, 188.375, 199., 207.125, 191.,
+                          166.875, 107.25, 80.5, 79.125, 78.75, 116.5,
+                          140., 157.375])
+
+        resid = np.array([np.nan, np.nan, np.nan, np.nan, 1.2008, 0.752, 1.75,
+                          1.987, 1.9023, 1.1598, 1.6253, 1.169, 0.7319, 0.5398,
+                          0.7261, 0.6837, 0.888, 0.586, 0.9645, 0.7165, 1.0276,
+                          1.3954, 0.0249, 0.7596, 0.215, 0.851, 1.646, 0.2432,
+                          1.3244, 2.0058, 0.5531, 1.7309])
+
+        assert_almost_equal(res_mult.seasonal, seasonal, 4)
+        assert_almost_equal(res_mult.trend, trend, 2)
+        assert_almost_equal(res_mult.resid, resid, 4)
+
+        # test odd
+        res_add = seasonal_decompose(self.data.values[:-1], freq=4, two_sided=False)
+        seasonal = np.array([81.21, 94.48, -109.95, -65.74, 81.21, 94.48, -109.95,
+                             -65.74, 81.21, 94.48, -109.95, -65.74, 81.21, 94.48,
+                             -109.95, -65.74, 81.21, 94.48, -109.95, -65.74, 81.21,
+                             94.48, -109.95, -65.74, 81.21, 94.48, -109.95, -65.74,
+                             81.21, 94.48, -109.95])
+
+        trend = [np.nan, np.nan, np.nan, np.nan, 159.12, 204., 221.25,
+                 245.12, 319.75, 451.5, 561.12, 619.25, 615.62, 548.,
+                 462.12, 381.12, 316.62, 264., 228.38, 210.75, 188.38,
+                 199., 207.12, 191., 166.88, 72., -9.25, -33.12,
+                 -36.75, 36.25, 103.]
+
+        random = [np.nan, np.nan, np.nan, np.nan, 6.663, -61.48,
+                  113.699, 149.618, 328.038, 263.02, 78.824, -64.507,
+                  -156.837, -185.48, -157.176, -139.382, -60.837, -119.48,
+                  9.574, -43.007, -37.587, 135.52, -94.176, -27.257,
+                  -205.087, -307.48, 42.199, 85.868, 80.538, 230.27, -38.051]
+
+        assert_almost_equal(res_add.seasonal, seasonal, 2)
+        assert_almost_equal(res_add.trend, trend, 2)
+        assert_almost_equal(res_add.resid, random, 3)
+
+
     def test_raises(self):
         assert_raises(ValueError, seasonal_decompose, self.data.values)
         assert_raises(ValueError, seasonal_decompose, self.data, 'm',


### PR DESCRIPTION
Added nside=2 to the arg list of seasonal_decompose in tsa/seasonal.py, so users can choose the way to do filter on the trend in STL decomposition. 