### PR TITLE
BUG: SARIMAX dates if simple_differencing=True

### DIFF
--- a/statsmodels/tsa/statespace/sarimax.py
+++ b/statsmodels/tsa/statespace/sarimax.py
@@ -546,6 +546,8 @@ class SARIMAX(MLEModel):
         # Perform simple differencing if requested
         if (self.simple_differencing and
            (self.orig_k_diff > 0 or self.orig_k_seasonal_diff > 0)):
+            # Save the original length
+            orig_length = endog.shape[0]
             # Perform simple differencing
             endog = diff(endog.copy(), self.orig_k_diff,
                          self.orig_k_seasonal_diff, self.k_seasons)
@@ -556,6 +558,11 @@ class SARIMAX(MLEModel):
             # Reset the ModelData datasets
             self.data.endog, self.data.exog = (
                 self.data._convert_endog_exog(endog, exog))
+
+            # Reset dates, if provided
+            if self.data.dates is not None:
+                new_length = self.data.endog.shape[0]
+                self.data.dates = self.data.dates[orig_length - new_length:]
 
         # Reset the nobs
         self.nobs = endog.shape[0]

--- a/statsmodels/tsa/statespace/tests/test_prediction.py
+++ b/statsmodels/tsa/statespace/tests/test_prediction.py
@@ -45,3 +45,17 @@ def test_predict_dates():
     # Out-of-sample forecasting should still extend the index appropriately
     fcast = res.forecast()
     assert_equal(fcast.index[0], index[-1])
+
+    # Simple differencing again, this time with a more complex differencing
+    # structure
+    mod = sarimax.SARIMAX(endog, order=(1, 2, 0), seasonal_order=(0, 1, 0, 4),
+                          simple_differencing=True)
+    res = mod.filter(mod.start_params)
+    pred = res.predict()
+    # In-sample prediction should lose the first 6 index values
+    assert_equal(mod.nobs, endog.shape[0] - (4 + 2))
+    assert_equal(len(pred), mod.nobs)
+    assert_equal(pred.index.values, index[4 + 2:-1].values)
+    # Out-of-sample forecasting should still extend the index appropriately
+    fcast = res.forecast()
+    assert_equal(fcast.index[0], index[-1])

--- a/statsmodels/tsa/statespace/tests/test_prediction.py
+++ b/statsmodels/tsa/statespace/tests/test_prediction.py
@@ -1,0 +1,47 @@
+"""
+Tests for prediction of state space models
+
+Author: Chad Fulton
+License: Simplified-BSD
+"""
+
+from __future__ import division, absolute_import #, print_function
+
+import numpy as np
+import pandas as pd
+
+import warnings
+from statsmodels.tsa.statespace import sarimax
+from numpy.testing import assert_equal, assert_allclose, assert_raises
+from nose.exc import SkipTest
+
+
+def test_predict_dates():
+    index = pd.date_range(start='1950-01-01', periods=11, freq='D')
+    np.random.seed(324328)
+    endog = pd.Series(np.random.normal(size=10), index=index[:-1])
+
+    # Basic test
+    mod = sarimax.SARIMAX(endog, order=(1, 0, 0))
+    res = mod.filter(mod.start_params)
+
+    # In-sample prediction should have the same index
+    pred = res.predict()
+    assert_equal(len(pred), mod.nobs)
+    assert_equal(pred.index.values, index[:-1].values)
+    # Out-of-sample forecasting should extend the index appropriately
+    fcast = res.forecast()
+    assert_equal(fcast.index[0], index[-1])
+
+    # Simple differencing in the SARIMAX model should eliminate dates of
+    # series eliminated due to differencing
+    mod = sarimax.SARIMAX(endog, order=(1, 1, 0), simple_differencing=True)
+    res = mod.filter(mod.start_params)
+    pred = res.predict()
+    # In-sample prediction should lose the first index value
+    assert_equal(mod.nobs, endog.shape[0] - 1)
+    assert_equal(len(pred), mod.nobs)
+    assert_equal(pred.index.values, index[1:-1].values)
+    # Out-of-sample forecasting should still extend the index appropriately
+    fcast = res.forecast()
+    assert_equal(fcast.index[0], index[-1])


### PR DESCRIPTION
Fixes the problem with incorrect prediction index - and more generally with incorrect values in `self.data.dates` - when `simple_differencing=True`.

See #2939 for the bug report.