### PR TITLE
ENH: simultaneous confidence intervals for multinomial proportions (rebased)

### DIFF
--- a/docs/source/stats.rst
+++ b/docs/source/stats.rst
@@ -335,6 +335,7 @@ proportions that can be used with NormalIndPower.
    binom_tost
    binom_tost_reject_interval
 
+   multinomial_proportions_confint
 
    proportions_ztest
    proportions_ztost

--- a/statsmodels/stats/proportion.py
+++ b/statsmodels/stats/proportion.py
@@ -120,6 +120,190 @@ def proportion_confint(count, nobs, alpha=0.05, method='normal'):
         raise NotImplementedError('method "%s" is not available' % method)
     return ci_low, ci_upp
 
+def multinomial_proportions_confint(counts, alpha=0.05, method='goodman'):
+    '''Confidence intervals for multinomial proportions.
+
+    Parameters
+    ----------
+    counts : array_like of int, 1-D
+        Number of observations in each category.
+    alpha : float in (0, 1), optional
+        Significance level, defaults to 0.05.
+    method : {'goodman', 'sison-glaz'}, optional
+        Method to use to compute the confidence intervals; available methods
+        are:
+
+         - `goodman`: based on a chi-squared approximation, valid if all
+           values in `counts` are greater or equal to 5 [2]_
+         - `sison-glaz`: less conservative than `goodman`, but only valid if
+           `counts` has 7 or more categories (``len(counts) >= 7``) [3]_
+
+    Returns
+    -------
+    confint : ndarray, 2-D
+        Array of [lower, upper] confidence levels for each category, such that
+        overall coverage is (approximately) `1-alpha`.
+
+    Raises
+    ------
+    ValueError
+        If `alpha` is not in `(0, 1)` (bounds excluded), or if the values in
+        `counts` are not all positive or null.
+    NotImplementedError
+        If `method` is not kown.
+    Exception
+        When ``method == 'sison-glaz'``, if for some reason `c` cannot be
+        computed; this signals a bug and should be reported.
+
+    Notes
+    -----
+    The `goodman` method [2]_ is based on approximating a statistic based on
+    the multinomial as a chi-squared random variable. The usual recommendation
+    is that this is valid if all the values in `counts` are greater than or
+    equal to 5. There is no condition on the number of categories for this
+    method.
+
+    The `sison-glaz` method [3]_ approximates the multinomial probabilities,
+    and evaluates that with a maximum-likelihood estimator. The first
+    approximation is an Edgeworth expansion that converges when the number of
+    categories goes to infinity, and the maximum-likelihood estimator converges
+    when the number of observations (``sum(counts)``) goes to infinity. In
+    their paper, Sison & Glaz demo their method with at least 7 categories, so
+    ``len(counts) >= 7`` with all values in `counts` at or above 5 can be used
+    as a rule of thumb for the validity of this method. This method is less
+    conservative than the `goodman` method (i.e. it will yield confidence
+    intervals closer to the desired significance level), but produces
+    confidence intervals of uniform width over all categories (except when the
+    intervals reach 0 or 1, in which case they are truncated), which makes it
+    most useful when proportions are of similar magnitude.
+
+    Aside from the original sources ([1]_, [2]_, and [3]_), the implementation
+    uses the formulas (though not the code) presented in [4]_ and [5]_.
+
+    References
+    ----------
+    .. [1] Levin, Bruce, "A representation for multinomial cumulative
+           distribution functions," The Annals of Statistics, Vol. 9, No. 5,
+           1981, pp. 1123-1126.
+
+    .. [2] Goodman, L.A., "On simultaneous confidence intervals for multinomial
+           proportions," Technometrics, Vol. 7, No. 2, 1965, pp. 247-254.
+
+    .. [3] Sison, Cristina P., and Joseph Glaz, "Simultaneous Confidence
+           Intervals and Sample Size Determination for Multinomial
+           Proportions," Journal of the American Statistical Association,
+           Vol. 90, No. 429, 1995, pp. 366-369.
+
+    .. [4] May, Warren L., and William D. Johnson, "A SAS® macro for
+           constructing simultaneous confidence intervals  for multinomial
+           proportions," Computer methods and programs in Biomedicine, Vol. 53,
+           No. 3, 1997, pp. 153-162.
+
+    .. [5] May, Warren L., and William D. Johnson, "Constructing two-sided
+           simultaneous confidence intervals for multinomial proportions for
+           small counts in a large number of cells," Journal of Statistical
+           Software, Vol. 5, No. 6, 2000, pp. 1-24.
+    '''
+    if alpha <= 0 or alpha >= 1:
+        raise ValueError('alpha must be in (0, 1), bounds excluded')
+    counts = np.array(counts, dtype=np.float)
+    if (counts < 0).any():
+        raise ValueError('counts must be > 0')
+    elif (counts == 0).any():
+        # This case is separated from (counts < 0).any() so we can give clearer
+        # advice.
+        raise ValueError('The behavior is not undefined for 0-valued counts; '
+                         'try adding 0.5 to your 0-valued counts to run this')
+    n = counts.sum()
+    k = len(counts)
+    proportions = counts / n
+    if method == 'goodman':
+        chi2 = stats.chi2.ppf(1 - alpha / k, 1)
+        delta = chi2 ** 2 + (4 * n * proportions * chi2 * (1 - proportions))
+        region = ((2 * n * proportions + chi2 +
+                   np.array([- np.sqrt(delta), np.sqrt(delta)])) /
+                  (2 * (chi2 + n))).T
+    elif method[:5] == 'sison':  # We accept any name starting with 'sison'
+        # Define a few functions we'll use a lot.
+        def poisson_interval(interval, p):
+            """Compute P(b <= Z <= a) where Z ~ Poisson(p) and
+            `interval = (b, a)`."""
+            b, a = interval
+            return stats.poisson.cdf(a, p) - stats.poisson.cdf(b - 1, p)
+
+        def truncated_poisson_factorial_moment(interval, r, p):
+            """Compute mu_r, the r-th factorial moment of a poisson random
+            variable of parameter `p` truncated to `interval = (b, a)`."""
+            b, a = interval
+            return p ** r * (1 - ((poisson_interval((a - r + 1, a), p) -
+                                   poisson_interval((b - r, b - 1), p)) /
+                                  poisson_interval((b, a), p)))
+
+        def edgeworth(intervals):
+            """Compute the Edgeworth expansion term of Sison & Glaz's formula
+            (1) (approximated probability for multinomial proportions in a
+            given box)."""
+            # Compute means and central moments of the truncated poisson
+            # variables.
+            mu_r1, mu_r2, mu_r3, mu_r4 = [
+                np.array([truncated_poisson_factorial_moment(interval, r, p)
+                          for (interval, p) in zip(intervals, counts)])
+                for r in range(1, 5)
+            ]
+            mu = mu_r1
+            mu2 = mu_r2 + mu - mu ** 2
+            mu3 = mu_r3 + mu_r2 * (3 - 3 * mu) + mu - 3 * mu ** 2 + 2 * mu ** 3
+            mu4 = (mu_r4 + mu_r3 * (6 - 4 * mu) +
+                   mu_r2 * (7 - 12 * mu + 6 * mu ** 2) +
+                   mu - 4 * mu ** 2 + 6 * mu ** 3 - 3 * mu ** 4)
+
+            # Compute expansion factors, gamma_1 and gamma_2.
+            g1 = mu3.sum() / mu2.sum() ** 1.5
+            g2 = (mu4.sum() - 3 * (mu2 ** 2).sum()) / mu2.sum() ** 2
+
+            # Compute the expansion itself.
+            x = (n - mu.sum()) / np.sqrt(mu2.sum())
+            phi = np.exp(- x ** 2 / 2) / np.sqrt(2 * np.pi)
+            H3 = x ** 3 - 3 * x
+            H4 = x ** 4 - 6 * x ** 2 + 3
+            H6 = x ** 6 - 15 * x ** 4 + 45 * x ** 2 - 15
+            f = phi * (1 + g1 * H3 / 6 + g2 * H4 / 24 + g1 ** 2 * H6 / 72)
+            return f / np.sqrt(mu2.sum())
+
+        def approximated_multinomial_interval(intervals):
+            """Compute approximated probability for Multinomial(n, proportions)
+            to be in `intervals` (Sison & Glaz's formula (1))."""
+            return np.exp(
+                np.sum(np.log([poisson_interval(interval, p)
+                               for (interval, p) in zip(intervals, counts)])) +
+                np.log(edgeworth(intervals)) -
+                np.log(stats.poisson.pmf(n, n))
+            )
+
+        def nu(c):
+            """Compute interval coverage for a given `c` (Sison & Glaz's
+            formula (7))."""
+            return approximated_multinomial_interval(
+                [(count - c, count + c) for count in counts])
+
+        # Find the value of `c` that will give us the confidence intervals
+        # (solving nu(c) <= 1 - alpha < nu(c + 1).
+        c = 1.0
+        while not (nu(c) <= (1 - alpha) < nu(c + 1)):
+            if c > n:
+                raise Exception("Couldn't find a value for `c` that "
+                                "solves nu(c) <= 1 - alpha < nu(c + 1)")
+            c += 1
+
+        # Compute gamma and the corresponding confidence intervals.
+        g = (1 - alpha - nu(c)) / (nu(c + 1) - nu(c))
+        ci_lower = np.maximum(proportions - c / n, 0)
+        ci_upper = np.minimum(proportions + (c + 2 * g) / n, 1)
+        region = np.array([ci_lower, ci_upper]).T
+    else:
+        raise NotImplementedError('method "%s" is not available' % method)
+    return region
+
 def samplesize_confint_proportion(proportion, half_length, alpha=0.05,
                                   method='normal'):
     '''find sample size to get desired confidence interval length

--- a/statsmodels/stats/tests/results/results_multinomial_proportions.py
+++ b/statsmodels/stats/tests/results/results_multinomial_proportions.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+"""Test values for multinomial_proportion_confint.
+
+Author: Sébastien Lerique
+"""
+
+
+import collections
+import numpy as np
+
+
+class Holder(object):
+    pass
+
+
+res_multinomial = collections.defaultdict(Holder)
+
+# The following examples come from the Sison & Glaz paper, and the values were
+# computed using the R MultinomialCI package.
+
+# Floating-point arithmetic errors get blown up in the Edgeworth expansion
+# (starting in g1 and g2, but mostly when computing f, because of the
+# polynomials), which explains why we only obtain a precision of 4 decimals
+# when comparing to values computed in R.
+
+# We test with any method name that starts with 'sison', as that is the
+# criterion.
+res_multinomial[('sison', 'Sison-Glaz example 1')]\
+    .proportions = [56, 72, 73, 59, 62, 87, 58]
+res_multinomial[('sison', 'Sison-Glaz example 1')]\
+    .cis = np.array([[.07922912, .1643361], [.11349036, .1985973],
+                     [.11563169, .2007386], [.08565310, .1707601],
+                     [.09207709, .1771840], [.14561028, .2307172],
+                     [.08351178, .1686187]])
+res_multinomial[('sison', 'Sison-Glaz example 1')].precision = 4
+
+res_multinomial[('sisonandglaz', 'Sison-Glaz example 2')].proportions = [5] * 50
+res_multinomial[('sisonandglaz', 'Sison-Glaz example 2')]\
+    .cis = [0, .05304026] * np.ones((50, 2))
+res_multinomial[('sisonandglaz', 'Sison-Glaz example 2')].precision = 4
+
+res_multinomial[('sison-whatever', 'Sison-Glaz example 3')]\
+    .proportions = [1] * 10 + [12] * 10 + [5] * 10 + [3] * 10 + [4] * 10
+res_multinomial[('sison-whatever', 'Sison-Glaz example 3')].cis = np.concatenate([
+    [0, .04120118] * np.ones((10, 2)), [.012, .08520118] * np.ones((10, 2)),
+    [0, .05720118] * np.ones((10, 2)), [0, .04920118] * np.ones((10, 2)),
+    [0, .05320118] * np.ones((10, 2))
+])
+res_multinomial[('sison-whatever', 'Sison-Glaz example 3')].precision = 4
+
+# The examples from the Sison & Glaz paper only include 3 decimals.
+res_multinomial[('goodman', 'Sison-Glaz example 1')]\
+    .proportions = [56, 72, 73, 59, 62, 87, 58]
+res_multinomial[('goodman', 'Sison-Glaz example 1')]\
+    .cis = np.array([[.085, .166], [.115, .204], [.116, .207], [.091, .173],
+                     [.096, .181], [.143, .239], [.089, .171]])
+res_multinomial[('goodman', 'Sison-Glaz example 1')].precision = 3
+
+res_multinomial[('goodman', 'Sison-Glaz example 2')].proportions = [5] * 50
+res_multinomial[('goodman', 'Sison-Glaz example 2')]\
+    .cis = [.005, .075] * np.ones((50, 2))
+res_multinomial[('goodman', 'Sison-Glaz example 2')].precision = 3
+
+res_multinomial[('goodman', 'Sison-Glaz example 3')]\
+    .proportions = [1] * 10 + [12] * 10 + [5] * 10 + [3] * 10 + [4] * 10
+res_multinomial[('goodman', 'Sison-Glaz example 3')].cis = np.concatenate([
+    [0, .049] * np.ones((10, 2)), [.019, .114] * np.ones((10, 2)),
+    [.005, .075] * np.ones((10, 2)), [.002, .062] * np.ones((10, 2)),
+    [.004, .069] * np.ones((10, 2))
+])
+res_multinomial[('goodman', 'Sison-Glaz example 3')].precision = 3


### PR DESCRIPTION
This should (at least partially) close #2895 (thanks for the help in that discussion!), implementing the "Goodman" and "Sison & Glaz" methods. No existing code was used for the implementation (aside from the MultinomialCI R package for generating test values and finding bugs by comparing intermediate values).

A few notes:

* I just found out about the [informal commit format standard](http://statsmodels.sourceforge.net/devel/dev/maintainer_notes.html#commit-comments), so commit messages don't all follow it; sorry about that (although rebasing+squashing could solve this I believe). I also tried to follow the general code style, but there might be fixes to do (e.g. I define several local functions for `sison_glaz`).
* I didn't include this addition in `docs/source/release/versionX.X.rst`, I'm not sure if it qualifies for it.
* I'm having a few problems building the docs: see #2952 for this
* Another method that might be interesting to implement is [Hou, Chiang, & Tai (2003)](https://www.researchgate.net/profile/Jeng_Tung_Chiang/publication/4897839_A_family_of_simultaneous_confidence_intervals_for_multinomial_proportions/links/55fa704108aeafc8ac39f24c.pdf), using monte-carlo simulations to find more accurate CIs. But it's too much work for me right now.
* Another nice feature I did not implement would be some advice (in the form of warnings) on which method to use depending on what `counts` looks like (e.g., very high number of categories ➔ use `sison_glaz`). But I'd need some help in determining the exact advice to give.
* Performance can be easily improved if necessary (e.g. with a cache on `nu(c)`).