### PR TITLE
BUG: Fix name-related error in random_effects

### DIFF
--- a/statsmodels/regression/mixed_linear_model.py
+++ b/statsmodels/regression/mixed_linear_model.py
@@ -221,7 +221,7 @@ def _get_exog_re_names(self, exog_re):
         return [exog_re.name]
     elif isinstance(exog_re, list):
         return exog_re
-    return ["Z{0}".format(k + 1) for k in range(exog_re.shape[1])]
+    return ["V{0}".format(k + 1) for k in range(exog_re.shape[1])]
 
 
 class MixedLMParams(object):

--- a/statsmodels/regression/mixed_linear_model.py
+++ b/statsmodels/regression/mixed_linear_model.py
@@ -637,7 +637,10 @@ class MixedLM(base.LikelihoodModel):
             self.k_re2 = 1
             self.exog_re = np.ones((len(endog), 1), dtype=np.float64)
             self.data.exog_re = self.exog_re
-            self.data.param_names = self.exog_names + ['Group RE']
+            names = ['Group RE']
+            self.data.param_names = self.exog_names + names
+            self.data.exog_re_names = names
+            self.data.exog_re_names_full = names
 
         elif exog_re is not None:
             # Process exog_re the same way that exog is handled

--- a/statsmodels/regression/mixed_linear_model.py
+++ b/statsmodels/regression/mixed_linear_model.py
@@ -1265,7 +1265,6 @@ class MixedLM(base.LikelihoodModel):
         if len(vc_var) > 0:
             return np.concatenate(vc_var)
         else:
-            1/0
             return np.empty(0)
 
 

--- a/statsmodels/regression/mixed_linear_model.py
+++ b/statsmodels/regression/mixed_linear_model.py
@@ -221,8 +221,10 @@ def _get_exog_re_names(self, exog_re):
         return [exog_re.name]
     elif isinstance(exog_re, list):
         return exog_re
-    return ["V{0}".format(k + 1) for k in range(exog_re.shape[1])]
 
+    # Default names
+    defnames = ["x_re{0:1d}".format(k + 1) for k in range(exog_re.shape[1])]
+    return defnames
 
 class MixedLMParams(object):
     """

--- a/statsmodels/regression/tests/test_lme.py
+++ b/statsmodels/regression/tests/test_lme.py
@@ -482,8 +482,8 @@ class TestMixedLM(object):
         mod1 = MixedLM(endog, exog, groups, exog_re)
         # test the names
         assert_(mod1.data.xnames == ["x1", "x2", "x3", "x4"])
-        assert_(mod1.data.exog_re_names == ["Z1"])
-        assert_(mod1.data.exog_re_names_full == ["Z1 RE"])
+        assert_(mod1.data.exog_re_names == ["V1"])
+        assert_(mod1.data.exog_re_names_full == ["V1 RE"])
 
         rslt1 = mod1.fit()
 
@@ -736,7 +736,6 @@ def test_random_effects():
     assert_(len(re) == ngrp)
     assert_(isinstance(re[0], pd.Series))
     assert_(len(re[0]) == 2)
-
 
 if __name__ == "__main__":
 

--- a/statsmodels/regression/tests/test_lme.py
+++ b/statsmodels/regression/tests/test_lme.py
@@ -693,6 +693,50 @@ def test_mixed_lm_wrapper():
     bse_re = result.bse_re
     assert_(bse_re.index.tolist() == re_names_full)
 
+def test_random_effects():
+
+    np.random.seed(23429)
+
+    # Default model (random effects only)
+    ngrp = 100
+    gsize = 10
+    rsd = 2
+    gsd = 3
+    mn = gsd*np.random.normal(size=ngrp)
+    gmn = np.kron(mn, np.ones(gsize))
+    y = gmn + rsd*np.random.normal(size=ngrp*gsize)
+    gr = np.kron(np.arange(ngrp), np.ones(gsize))
+    x = np.ones(ngrp * gsize)
+    model = MixedLM(y, x, groups=gr)
+    result = model.fit()
+    re = result.random_effects
+    assert_(isinstance(re, dict))
+    assert_(len(re) == ngrp)
+    assert_(isinstance(re[0], pd.Series))
+    assert_(len(re[0]) == 1)
+
+    # Random intercept only, set explicitly
+    model = MixedLM(y, x, exog_re=x, groups=gr)
+    result = model.fit()
+    re = result.random_effects
+    assert_(isinstance(re, dict))
+    assert_(len(re) == ngrp)
+    assert_(isinstance(re[0], pd.Series))
+    assert_(len(re[0]) == 1)
+
+    # Random intercept and slope
+    xr = np.random.normal(size=(ngrp*gsize, 2))
+    xr[:, 0] = 1
+    qp = np.linspace(-1, 1, gsize)
+    xr[:, 1] = np.kron(np.ones(ngrp), qp)
+    model = MixedLM(y, x, exog_re=xr, groups=gr)
+    result = model.fit()
+    re = result.random_effects
+    assert_(isinstance(re, dict))
+    assert_(len(re) == ngrp)
+    assert_(isinstance(re[0], pd.Series))
+    assert_(len(re[0]) == 2)
+
 
 if __name__ == "__main__":
 

--- a/statsmodels/regression/tests/test_lme.py
+++ b/statsmodels/regression/tests/test_lme.py
@@ -482,9 +482,8 @@ class TestMixedLM(object):
         mod1 = MixedLM(endog, exog, groups, exog_re)
         # test the names
         assert_(mod1.data.xnames == ["x1", "x2", "x3", "x4"])
-        assert_(mod1.data.exog_re_names == ["V1"])
-        assert_(mod1.data.exog_re_names_full == ["V1 RE"])
-
+        assert_(mod1.data.exog_re_names == ["x_re1"])
+        assert_(mod1.data.exog_re_names_full == ["x_re1 RE"])
         rslt1 = mod1.fit()
 
         # Fit with a formula, passing groups as the actual values.


### PR DESCRIPTION
This came up in discussion of #2961.

What I have here fixes the issue and adds a test, but I want to change the names to be more consistent (sometimes they are Z1, Z2, etc. which is not very meaningful). 