### PR TITLE
TST: Update travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,14 +51,14 @@ matrix:
     - OPTIONAL="libgfortran=1.0"
   - python: 2.7
     env:
-    - PYTHON=2.7
+    - PYTHON=3.5
     - NUMPY=1.10
     - SCIPY=0.16
     - PANDAS=0.17
     - USEMPL=false
   - python: 2.7
     env:
-    - PYTHON=3.5
+    - PYTHON=3.6
     - MATPLOTLIB=1.5
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,52 +23,43 @@ matrix:
   include:
   - python: 2.7
     env:
-    - PYTHON=2.6
-    - dateutil=
-    - NUMPY="1.6.2=py26_4"
-    - SCIPY="0.11.0=np16py26_3"
-    - MATPLOTLIB=1.2
+    - PYTHON=2.7
+    - NUMPY=
+    - SCIPY=
+    - COVERAGE=true
+    - MATPLOTLIB=1.5
   - python: 2.7
     env:
     - PYTHON=2.7
-    - dateutil=
-    - NUMPY=1.7
-    - SCIPY=0.12
-    - OPTIONAL="mkl mkl-rt libgfortran=1.0"
-    - COVERAGE=true
+    - NUMPY=1.10
+    - SCIPY=0.16
+    - MATPLOTLIB=1.4
   - python: 2.7
     env:
     - PYTHON=3.3
-    - dateutil=
     - NUMPY=1.8
-    - SCIPY=0.13
+    - SCIPY=0.14
     - MATPLOTLIB=1.3
-    - PANDAS=0.13
+    - PANDAS=0.14
   - python: 2.7
     env:
     - PYTHON=3.4
-    - dateutil=
     - NUMPY=1.9
-    - SCIPY=0.14
-    - PANDAS=0.14
+    - SCIPY=0.15
+    - PANDAS=0.15
     - MATPLOTLIB=1.4
-    - OPTIONAL=libgfortran=1.0
+    - OPTIONAL="libgfortran=1.0"
   - python: 2.7
     env:
     - PYTHON=2.7
-    - dateutil=
-    - NUMPY=
-    - SCIPY=
+    - NUMPY=1.10
+    - SCIPY=0.16
+    - PANDAS=0.17
     - USEMPL=false
-    - PANDAS=
   - python: 2.7
     env:
     - PYTHON=3.5
-    - python-dateutil=
-    - NUMPY=
-    - SCIPY=
-    - PANDAS=
-    - MATPLOTLIB=1.4
+    - MATPLOTLIB=1.5
 
 notifications:
   email:
@@ -89,10 +80,15 @@ before_install:
   - mkdir $HOME/.config
   - mkdir $HOME/.config/matplotlib
   - SRCDIR=$PWD
-  - cp $SRCDIR/tools/matplotlibrc $HOME/.config/matplotlib/matplotlibrc
-  # Location for older version of matplotlib
-  - if [ ${MATPLOTLIB} = "1.2" ]; then mkdir $HOME/.matplotlib; fi
-  - if [ ${MATPLOTLIB} = "1.2" ]; then cp ${SRCDIR}/tools/matplotlibrc $HOME/.matplotlib/matplotlibrc; fi
+  - |
+    if [ ${USEMPL} = true ]; then
+      if [[ ${MATPLOTLIB} < "1.5" ]]; then
+        export MATPLOTLIBRC=matplotlibrc.qt4
+      else
+        export MATPLOTLIBRC=matplotlibrc.qt5
+      fi
+      cp $SRCDIR/tools/${MATPLOTLIBRC} $HOME/.config/matplotlib/matplotlibrc
+    fi
   # Build package list to avoid empty package=versions; only needed for versioned pacakges
   - PKGS="python=${PYTHON}"
   - PKGS="${PKGS} numpy"; if [ ${NUMPY} ]; then PKGS="${PKGS}=${NUMPY}"; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,14 +25,17 @@ matrix:
   - python: 2.7
     env:
     - PYTHON=2.7
-    - COVERAGE=true
+    - NUMPY=1.11
     - MATPLOTLIB=1.5
+    - COVERAGE=true
   - python: 2.7
     env:
     - PYTHON=2.7
-    - NUMPY=1.10
-    - SCIPY=0.16
+    - NUMPY=1.9
+    - SCIPY=0.15
+    - PANDAS=0.15
     - USEMPL=false
+    - OPTIONAL="libgfortran=1.0"
   - python: 2.7
     env:
     - PYTHON=3.3
@@ -43,8 +46,8 @@ matrix:
   - python: 2.7
     env:
     - PYTHON=3.4
-    - NUMPY=1.9
-    - SCIPY=0.15
+    - NUMPY=1.10
+    - SCIPY=0.16
     - PANDAS=0.16
     - MATPLOTLIB=1.4
     - OPTIONAL="libgfortran=1.0"
@@ -52,9 +55,9 @@ matrix:
     env:
     - PYTHON=3.5
     - NUMPY=1.10
-    - SCIPY=0.16
-    - PANDAS=0.17
-    - MATPLOTLIB=1.4
+    - SCIPY=0.17
+    - PANDAS=0.18
+    - MATPLOTLIB=1.5
   - python: 2.7
     env:
     - PYTHON=3.6
@@ -80,15 +83,6 @@ before_install:
   - mkdir $HOME/.config
   - mkdir $HOME/.config/matplotlib
   - SRCDIR=$PWD
-  - |
-    if [ ${USEMPL} = true ]; then
-      if [[ ${MATPLOTLIB} > "1.4" ]]; then
-        export MATPLOTLIBRC=matplotlibrc.qt5
-      else
-        export MATPLOTLIBRC=matplotlibrc.qt4
-      fi
-      cp $SRCDIR/tools/${MATPLOTLIBRC} $HOME/.config/matplotlib/matplotlibrc
-    fi
   # Build package list to avoid empty package=versions; only needed for versioned pacakges
   - PKGS="python=${PYTHON}"
   - PKGS="${PKGS} numpy"; if [ ${NUMPY} ]; then PKGS="${PKGS}=${NUMPY}"; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ env:
     - OPTIONAL=
     - COVERAGE=false
     - USEMPL=true
+    - MATPLOTLIB=
 
 matrix:
   fast_finish: true
@@ -24,8 +25,6 @@ matrix:
   - python: 2.7
     env:
     - PYTHON=2.7
-    - NUMPY=
-    - SCIPY=
     - COVERAGE=true
     - MATPLOTLIB=1.5
   - python: 2.7
@@ -33,20 +32,20 @@ matrix:
     - PYTHON=2.7
     - NUMPY=1.10
     - SCIPY=0.16
-    - MATPLOTLIB=1.4
+    - USEMPL=false
   - python: 2.7
     env:
     - PYTHON=3.3
-    - NUMPY=1.8
+    - NUMPY=1.9
     - SCIPY=0.14
-    - MATPLOTLIB=1.3
+    - MATPLOTLIB=1.4
     - PANDAS=0.14
   - python: 2.7
     env:
     - PYTHON=3.4
     - NUMPY=1.9
     - SCIPY=0.15
-    - PANDAS=0.15
+    - PANDAS=0.16
     - MATPLOTLIB=1.4
     - OPTIONAL="libgfortran=1.0"
   - python: 2.7
@@ -55,11 +54,12 @@ matrix:
     - NUMPY=1.10
     - SCIPY=0.16
     - PANDAS=0.17
-    - USEMPL=false
+    - MATPLOTLIB=1.4
   - python: 2.7
     env:
     - PYTHON=3.6
-    - MATPLOTLIB=1.5
+    - COVERAGE=true
+
 
 notifications:
   email:
@@ -82,10 +82,10 @@ before_install:
   - SRCDIR=$PWD
   - |
     if [ ${USEMPL} = true ]; then
-      if [[ ${MATPLOTLIB} < "1.5" ]]; then
-        export MATPLOTLIBRC=matplotlibrc.qt4
-      else
+      if [[ ${MATPLOTLIB} > "1.4" ]]; then
         export MATPLOTLIBRC=matplotlibrc.qt5
+      else
+        export MATPLOTLIBRC=matplotlibrc.qt4
       fi
       cp $SRCDIR/tools/${MATPLOTLIBRC} $HOME/.config/matplotlib/matplotlibrc
     fi

--- a/statsmodels/tools/print_version.py
+++ b/statsmodels/tools/print_version.py
@@ -212,6 +212,7 @@ def show_versions(show_dirs=True):
         import matplotlib as mpl
         print("matplotlib: %s (%s)" % (safe_version(mpl),
                                        dirname(mpl.__file__)))
+        print("    backend: %s " % mpl.rcParams['backend'])
     except ImportError:
         print("matplotlib: Not installed")
 

--- a/statsmodels/tsa/statespace/tests/test_save.py
+++ b/statsmodels/tsa/statespace/tests/test_save.py
@@ -4,6 +4,7 @@ Tests of save / load / remove_data state space functionality.
 
 from __future__ import division, absolute_import, print_function
 
+from unittest import SkipTest
 import numpy as np
 import pandas as pd
 import os
@@ -14,6 +15,9 @@ from statsmodels.tsa.statespace import (sarimax, structural, varmax,
 from numpy.testing import assert_allclose
 macrodata = datasets.macrodata.load_pandas().data
 
+import sys
+if sys.version_info >= (3,6):
+    raise SkipTest('pickling statespace models does not work on Python >= 3.6')
 
 def test_sarimax():
     mod = sarimax.SARIMAX(macrodata['realgdp'].values, order=(4, 1, 0))

--- a/statsmodels/tsa/tests/test_ar.py
+++ b/statsmodels/tsa/tests/test_ar.py
@@ -264,7 +264,7 @@ def test_ar_dates():
     endog = Series(data.endog, index=dates)
     ar_model = sm.tsa.AR(endog, freq='A').fit(maxlag=9, method='mle', disp=-1)
     pred = ar_model.predict(start='2005', end='2015')
-    predict_dates = DatetimeIndex(start='2005', end='2016', freq='A')
+    predict_dates = DatetimeIndex(start='2005', end='2016', freq='A')[:11]
 
     assert_equal(ar_model.data.predict_dates, predict_dates)
     assert_equal(pred.index, predict_dates)

--- a/statsmodels/tsa/tests/test_arima.py
+++ b/statsmodels/tsa/tests/test_arima.py
@@ -1588,7 +1588,7 @@ def test_arima_predict_bug():
     #predict_start_date wasn't getting set on start = None
     from statsmodels.datasets import sunspots
     dta = sunspots.load_pandas().data.SUNACTIVITY
-    dta.index = pd.DatetimeIndex(start='1700', end='2009', freq='A')
+    dta.index = pd.DatetimeIndex(start='1700', end='2009', freq='A')[:309]
     print(dta.index)
     arma_mod20 = ARMA(dta, (2,0)).fit(disp=-1)
     arma_mod20.predict(None, None)
@@ -2007,7 +2007,7 @@ def test_plot_predict():
     from statsmodels.datasets.sunspots import load_pandas
 
     dta = load_pandas().data[['SUNACTIVITY']]
-    dta.index = DatetimeIndex(start='1700', end='2009', freq='A')
+    dta.index = DatetimeIndex(start='1700', end='2009', freq='A')[:309]
     res = ARMA(dta, (3, 0)).fit(disp=-1)
     fig = res.plot_predict('1990', '2012', dynamic=True, plot_insample=False)
     plt.close(fig)

--- a/statsmodels/tsa/tests/test_stattools.py
+++ b/statsmodels/tsa/tests/test_stattools.py
@@ -465,7 +465,7 @@ def test_pandasacovf():
 
 def test_acovf2d():
     dta = sunspots.load_pandas().data
-    dta.index = DatetimeIndex(start='1700', end='2009', freq='A')
+    dta.index = DatetimeIndex(start='1700', end='2009', freq='A')[:309]
     del dta["YEAR"]
     res = acovf(dta)
     assert_equal(res, acovf(dta.values))

--- a/tools/matplotlibrc.qt4
+++ b/tools/matplotlibrc.qt4
@@ -28,7 +28,7 @@
 # You can also deploy your own backend outside of matplotlib by
 # referring to the module name (which must be in the PYTHONPATH) as
 # 'module://my_backend'
-backend      : Agg
+backend      : Qt4Agg
 
 # if you are runing pyplot inside a GUI and your backend choice
 # conflicts, we will automatically try and find a compatible one for

--- a/tools/matplotlibrc.qt5
+++ b/tools/matplotlibrc.qt5
@@ -1,0 +1,510 @@
+### MATPLOTLIBRC FORMAT
+
+# This is a sample matplotlib configuration file - you can find a copy
+# of it on your system in
+# site-packages/matplotlib/mpl-data/matplotlibrc.  If you edit it
+# there, please note that it will be overwritten in your next install.
+# If you want to keep a permanent local copy that will not be
+# overwritten, place it in the following location:
+# unix/linux:
+#     $HOME/.config/matplotlib/matplotlibrc or
+#     $XDG_CONFIG_HOME/matplotlib/matplotlibrc (if $XDG_CONFIG_HOME is set)
+# other platforms:
+#     $HOME/.matplotlib/matplotlibrc
+#
+# See http://matplotlib.org/users/customizing.html#the-matplotlibrc-file for
+# more details on the paths which are checked for the configuration file.
+#
+# This file is best viewed in a editor which supports python mode
+# syntax highlighting. Blank lines, or lines starting with a comment
+# symbol, are ignored, as are trailing comments.  Other lines must
+# have the format
+#    key : val # optional comment
+#
+# Colors: for the color values below, you can either use - a
+# matplotlib color string, such as r, k, or b - an rgb tuple, such as
+# (1.0, 0.5, 0.0) - a hex string, such as ff00ff or #ff00ff - a scalar
+# grayscale intensity such as 0.75 - a legal html color name, e.g., red,
+# blue, darkslategray
+
+#### CONFIGURATION BEGINS HERE
+
+# The default backend; one of GTK GTKAgg GTKCairo GTK3Agg GTK3Cairo
+# CocoaAgg MacOSX Qt4Agg Qt5Agg TkAgg WX WXAgg Agg Cairo GDK PS PDF SVG
+# Template.
+# You can also deploy your own backend outside of matplotlib by
+# referring to the module name (which must be in the PYTHONPATH) as
+# 'module://my_backend'.
+backend      : Qt5Agg
+
+# If you are using the Qt4Agg backend, you can choose here
+# to use the PyQt4 bindings or the newer PySide bindings to
+# the underlying Qt4 toolkit.
+backend.qt5 : PyQt5
+
+# Note that this can be overridden by the environment variable
+# QT_API used by Enthought Tool Suite (ETS); valid values are
+# "pyqt" and "pyside".  The "pyqt" setting has the side effect of
+# forcing the use of Version 2 API for QString and QVariant.
+
+# The port to use for the web server in the WebAgg backend.
+# webagg.port : 8888
+
+# If webagg.port is unavailable, a number of other random ports will
+# be tried until one that is available is found.
+# webagg.port_retries : 50
+
+# When True, open the webbrowser to the plot that is shown
+# webagg.open_in_browser : True
+
+# When True, the figures rendered in the nbagg backend are created with
+# a transparent background.
+# nbagg.transparent : True
+
+# if you are running pyplot inside a GUI and your backend choice
+# conflicts, we will automatically try to find a compatible one for
+# you if backend_fallback is True
+#backend_fallback: True
+
+#interactive  : False
+#toolbar      : toolbar2   # None | toolbar2  ("classic" is deprecated)
+#timezone     : UTC        # a pytz timezone string, e.g., US/Central or Europe/Paris
+
+# Where your matplotlib data lives if you installed to a non-default
+# location.  This is where the matplotlib fonts, bitmaps, etc reside
+#datapath : /home/jdhunter/mpldata
+
+
+### LINES
+# See http://matplotlib.org/api/artist_api.html#module-matplotlib.lines for more
+# information on line properties.
+#lines.linewidth   : 1.0     # line width in points
+#lines.linestyle   : -       # solid line
+#lines.color       : blue    # has no affect on plot(); see axes.prop_cycle
+#lines.marker      : None    # the default marker
+#lines.markeredgewidth  : 0.5     # the line width around the marker symbol
+#lines.markersize  : 6            # markersize, in points
+#lines.dash_joinstyle : miter        # miter|round|bevel
+#lines.dash_capstyle : butt          # butt|round|projecting
+#lines.solid_joinstyle : miter       # miter|round|bevel
+#lines.solid_capstyle : projecting   # butt|round|projecting
+#lines.antialiased : True         # render lines in antialiased (no jaggies)
+
+#markers.fillstyle: full # full|left|right|bottom|top|none
+
+### PATCHES
+# Patches are graphical objects that fill 2D space, like polygons or
+# circles.  See
+# http://matplotlib.org/api/artist_api.html#module-matplotlib.patches
+# information on patch properties
+#patch.linewidth        : 1.0     # edge width in points
+#patch.facecolor        : blue
+#patch.edgecolor        : black
+#patch.antialiased      : True    # render patches in antialiased (no jaggies)
+
+### FONT
+#
+# font properties used by text.Text.  See
+# http://matplotlib.org/api/font_manager_api.html for more
+# information on font properties.  The 6 font properties used for font
+# matching are given below with their default values.
+#
+# The font.family property has five values: 'serif' (e.g., Times),
+# 'sans-serif' (e.g., Helvetica), 'cursive' (e.g., Zapf-Chancery),
+# 'fantasy' (e.g., Western), and 'monospace' (e.g., Courier).  Each of
+# these font families has a default list of font names in decreasing
+# order of priority associated with them.  When text.usetex is False,
+# font.family may also be one or more concrete font names.
+#
+# The font.style property has three values: normal (or roman), italic
+# or oblique.  The oblique style will be used for italic, if it is not
+# present.
+#
+# The font.variant property has two values: normal or small-caps.  For
+# TrueType fonts, which are scalable fonts, small-caps is equivalent
+# to using a font size of 'smaller', or about 83% of the current font
+# size.
+#
+# The font.weight property has effectively 13 values: normal, bold,
+# bolder, lighter, 100, 200, 300, ..., 900.  Normal is the same as
+# 400, and bold is 700.  bolder and lighter are relative values with
+# respect to the current weight.
+#
+# The font.stretch property has 11 values: ultra-condensed,
+# extra-condensed, condensed, semi-condensed, normal, semi-expanded,
+# expanded, extra-expanded, ultra-expanded, wider, and narrower.  This
+# property is not currently implemented.
+#
+# The font.size property is the default font size for text, given in pts.
+# 12pt is the standard value.
+#
+#font.family         : sans-serif
+#font.style          : normal
+#font.variant        : normal
+#font.weight         : medium
+#font.stretch        : normal
+# note that font.size controls default text sizes.  To configure
+# special text sizes tick labels, axes, labels, title, etc, see the rc
+# settings for axes and ticks. Special text sizes can be defined
+# relative to font.size, using the following values: xx-small, x-small,
+# small, medium, large, x-large, xx-large, larger, or smaller
+#font.size           : 12.0
+#font.serif          : Bitstream Vera Serif, New Century Schoolbook, Century Schoolbook L, Utopia, ITC Bookman, Bookman, Nimbus Roman No9 L, Times New Roman, Times, Palatino, Charter, serif
+#font.sans-serif     : Bitstream Vera Sans, Lucida Grande, Verdana, Geneva, Lucid, Arial, Helvetica, Avant Garde, sans-serif
+#font.cursive        : Apple Chancery, Textile, Zapf Chancery, Sand, Script MT, Felipa, cursive
+#font.fantasy        : Comic Sans MS, Chicago, Charcoal, Impact, Western, Humor Sans, fantasy
+#font.monospace      : Bitstream Vera Sans Mono, Andale Mono, Nimbus Mono L, Courier New, Courier, Fixed, Terminal, monospace
+
+### TEXT
+# text properties used by text.Text.  See
+# http://matplotlib.org/api/artist_api.html#module-matplotlib.text for more
+# information on text properties
+
+#text.color          : black
+
+### LaTeX customizations. See http://wiki.scipy.org/Cookbook/Matplotlib/UsingTex
+#text.usetex         : False  # use latex for all text handling. The following fonts
+                              # are supported through the usual rc parameter settings:
+                              # new century schoolbook, bookman, times, palatino,
+                              # zapf chancery, charter, serif, sans-serif, helvetica,
+                              # avant garde, courier, monospace, computer modern roman,
+                              # computer modern sans serif, computer modern typewriter
+                              # If another font is desired which can loaded using the
+                              # LaTeX \usepackage command, please inquire at the
+                              # matplotlib mailing list
+#text.latex.unicode : False # use "ucs" and "inputenc" LaTeX packages for handling
+                            # unicode strings.
+#text.latex.preamble :  # IMPROPER USE OF THIS FEATURE WILL LEAD TO LATEX FAILURES
+                            # AND IS THEREFORE UNSUPPORTED. PLEASE DO NOT ASK FOR HELP
+                            # IF THIS FEATURE DOES NOT DO WHAT YOU EXPECT IT TO.
+                            # preamble is a comma separated list of LaTeX statements
+                            # that are included in the LaTeX document preamble.
+                            # An example:
+                            # text.latex.preamble : \usepackage{bm},\usepackage{euler}
+                            # The following packages are always loaded with usetex, so
+                            # beware of package collisions: color, geometry, graphicx,
+                            # type1cm, textcomp. Adobe Postscript (PSSNFS) font packages
+                            # may also be loaded, depending on your font settings
+
+#text.dvipnghack : None      # some versions of dvipng don't handle alpha
+                             # channel properly.  Use True to correct
+                             # and flush ~/.matplotlib/tex.cache
+                             # before testing and False to force
+                             # correction off.  None will try and
+                             # guess based on your dvipng version
+
+#text.hinting : auto   # May be one of the following:
+                       #   'none': Perform no hinting
+                       #   'auto': Use freetype's autohinter
+                       #   'native': Use the hinting information in the
+                       #             font file, if available, and if your
+                       #             freetype library supports it
+                       #   'either': Use the native hinting information,
+                       #             or the autohinter if none is available.
+                       # For backward compatibility, this value may also be
+                       # True === 'auto' or False === 'none'.
+#text.hinting_factor : 8 # Specifies the amount of softness for hinting in the
+                         # horizontal direction.  A value of 1 will hint to full
+                         # pixels.  A value of 2 will hint to half pixels etc.
+
+#text.antialiased : True # If True (default), the text will be antialiased.
+                         # This only affects the Agg backend.
+
+# The following settings allow you to select the fonts in math mode.
+# They map from a TeX font name to a fontconfig font pattern.
+# These settings are only used if mathtext.fontset is 'custom'.
+# Note that this "custom" mode is unsupported and may go away in the
+# future.
+#mathtext.cal : cursive
+#mathtext.rm  : serif
+#mathtext.tt  : monospace
+#mathtext.it  : serif:italic
+#mathtext.bf  : serif:bold
+#mathtext.sf  : sans
+#mathtext.fontset : cm # Should be 'cm' (Computer Modern), 'stix',
+                       # 'stixsans' or 'custom'
+#mathtext.fallback_to_cm : True  # When True, use symbols from the Computer Modern
+                                 # fonts when a symbol can not be found in one of
+                                 # the custom math fonts.
+
+#mathtext.default : it # The default font to use for math.
+                       # Can be any of the LaTeX font names, including
+                       # the special name "regular" for the same font
+                       # used in regular text.
+
+### AXES
+# default face and edge color, default tick sizes,
+# default fontsizes for ticklabels, and so on.  See
+# http://matplotlib.org/api/axes_api.html#module-matplotlib.axes
+#axes.hold           : True    # whether to clear the axes by default on
+#axes.facecolor      : white   # axes background color
+#axes.edgecolor      : black   # axes edge color
+#axes.linewidth      : 1.0     # edge linewidth
+#axes.grid           : False   # display grid or not
+#axes.titlesize      : large   # fontsize of the axes title
+#axes.labelsize      : medium  # fontsize of the x any y labels
+#axes.labelpad       : 5.0     # space between label and axis
+#axes.labelweight    : normal  # weight of the x and y labels
+#axes.labelcolor     : black
+#axes.axisbelow      : False   # whether axis gridlines and ticks are below
+                               # the axes elements (lines, text, etc)
+
+#axes.formatter.limits : -7, 7 # use scientific notation if log10
+                               # of the axis range is smaller than the
+                               # first or larger than the second
+#axes.formatter.use_locale : False # When True, format tick labels
+                                   # according to the user's locale.
+                                   # For example, use ',' as a decimal
+                                   # separator in the fr_FR locale.
+#axes.formatter.use_mathtext : False # When True, use mathtext for scientific
+                                     # notation.
+#axes.formatter.useoffset      : True    # If True, the tick label formatter
+                                         # will default to labeling ticks relative
+                                         # to an offset when the data range is very
+                                         # small compared to the minimum absolute
+                                         # value of the data.
+
+#axes.unicode_minus  : True    # use unicode for the minus symbol
+                               # rather than hyphen.  See
+                               # http://en.wikipedia.org/wiki/Plus_and_minus_signs#Character_codes
+#axes.prop_cycle    : cycler('color', 'bgrcmyk')
+                                            # color cycle for plot lines
+                                            # as list of string colorspecs:
+                                            # single letter, long name, or
+                                            # web-style hex
+#axes.xmargin        : 0  # x margin.  See `axes.Axes.margins`
+#axes.ymargin        : 0  # y margin See `axes.Axes.margins`
+
+#polaraxes.grid      : True    # display grid on polar axes
+#axes3d.grid         : True    # display grid on 3d axes
+
+### TICKS
+# see http://matplotlib.org/api/axis_api.html#matplotlib.axis.Tick
+#xtick.major.size     : 4      # major tick size in points
+#xtick.minor.size     : 2      # minor tick size in points
+#xtick.major.width    : 0.5    # major tick width in points
+#xtick.minor.width    : 0.5    # minor tick width in points
+#xtick.major.pad      : 4      # distance to major tick label in points
+#xtick.minor.pad      : 4      # distance to the minor tick label in points
+#xtick.color          : k      # color of the tick labels
+#xtick.labelsize      : medium # fontsize of the tick labels
+#xtick.direction      : in     # direction: in, out, or inout
+
+#ytick.major.size     : 4      # major tick size in points
+#ytick.minor.size     : 2      # minor tick size in points
+#ytick.major.width    : 0.5    # major tick width in points
+#ytick.minor.width    : 0.5    # minor tick width in points
+#ytick.major.pad      : 4      # distance to major tick label in points
+#ytick.minor.pad      : 4      # distance to the minor tick label in points
+#ytick.color          : k      # color of the tick labels
+#ytick.labelsize      : medium # fontsize of the tick labels
+#ytick.direction      : in     # direction: in, out, or inout
+
+
+### GRIDS
+#grid.color       :   black   # grid color
+#grid.linestyle   :   :       # dotted
+#grid.linewidth   :   0.5     # in points
+#grid.alpha       :   1.0     # transparency, between 0.0 and 1.0
+
+### Legend
+#legend.fancybox      : False  # if True, use a rounded box for the
+                               # legend, else a rectangle
+#legend.isaxes        : True
+#legend.numpoints     : 2      # the number of points in the legend line
+#legend.fontsize      : large
+#legend.borderpad     : 0.5    # border whitespace in fontsize units
+#legend.markerscale   : 1.0    # the relative size of legend markers vs. original
+# the following dimensions are in axes coords
+#legend.labelspacing  : 0.5    # the vertical space between the legend entries in fraction of fontsize
+#legend.handlelength  : 2.     # the length of the legend lines in fraction of fontsize
+#legend.handleheight  : 0.7     # the height of the legend handle in fraction of fontsize
+#legend.handletextpad : 0.8    # the space between the legend line and legend text in fraction of fontsize
+#legend.borderaxespad : 0.5   # the border between the axes and legend edge in fraction of fontsize
+#legend.columnspacing : 2.    # the border between the axes and legend edge in fraction of fontsize
+#legend.shadow        : False
+#legend.frameon       : True   # whether or not to draw a frame around legend
+#legend.framealpha    : None    # opacity of of legend frame
+#legend.scatterpoints : 3 # number of scatter points
+
+### FIGURE
+# See http://matplotlib.org/api/figure_api.html#matplotlib.figure.Figure
+#figure.titlesize : medium     # size of the figure title
+#figure.titleweight : normal   # weight of the figure title
+#figure.figsize   : 8, 6    # figure size in inches
+#figure.dpi       : 80      # figure dots per inch
+#figure.facecolor : 0.75    # figure facecolor; 0.75 is scalar gray
+#figure.edgecolor : white   # figure edgecolor
+#figure.autolayout : False  # When True, automatically adjust subplot
+                            # parameters to make the plot fit the figure
+#figure.max_open_warning : 20  # The maximum number of figures to open through
+                               # the pyplot interface before emitting a warning.
+                               # If less than one this feature is disabled.
+
+# The figure subplot parameters.  All dimensions are a fraction of the
+# figure width or height
+#figure.subplot.left    : 0.125  # the left side of the subplots of the figure
+#figure.subplot.right   : 0.9    # the right side of the subplots of the figure
+#figure.subplot.bottom  : 0.1    # the bottom of the subplots of the figure
+#figure.subplot.top     : 0.9    # the top of the subplots of the figure
+#figure.subplot.wspace  : 0.2    # the amount of width reserved for blank space between subplots
+#figure.subplot.hspace  : 0.2    # the amount of height reserved for white space between subplots
+
+### IMAGES
+#image.aspect : equal             # equal | auto | a number
+#image.interpolation  : bilinear  # see help(imshow) for options
+#image.cmap   : jet               # gray | jet etc...
+#image.lut    : 256               # the size of the colormap lookup table
+#image.origin : upper             # lower | upper
+#image.resample  : False
+#image.composite_image : True     # When True, all the images on a set of axes are
+                                  # combined into a single composite image before
+                                  # saving a figure as a vector graphics file,
+                                  # such as a PDF.
+
+### CONTOUR PLOTS
+#contour.negative_linestyle : dashed # dashed | solid
+#contour.corner_mask        : True   # True | False | legacy
+
+### ERRORBAR PLOTS
+#errorbar.capsize : 3             # length of end cap on error bars in pixels
+
+### Agg rendering
+### Warning: experimental, 2008/10/10
+#agg.path.chunksize : 0           # 0 to disable; values in the range
+                                  # 10000 to 100000 can improve speed slightly
+                                  # and prevent an Agg rendering failure
+                                  # when plotting very large data sets,
+                                  # especially if they are very gappy.
+                                  # It may cause minor artifacts, though.
+                                  # A value of 20000 is probably a good
+                                  # starting point.
+### SAVING FIGURES
+#path.simplify : True   # When True, simplify paths by removing "invisible"
+                        # points to reduce file size and increase rendering
+                        # speed
+#path.simplify_threshold : 0.1  # The threshold of similarity below which
+                                # vertices will be removed in the simplification
+                                # process
+#path.snap : True # When True, rectilinear axis-aligned paths will be snapped to
+                  # the nearest pixel when certain criteria are met.  When False,
+                  # paths will never be snapped.
+#path.sketch : None # May be none, or a 3-tuple of the form (scale, length,
+                    # randomness).
+                    # *scale* is the amplitude of the wiggle
+                    # perpendicular to the line (in pixels).  *length*
+                    # is the length of the wiggle along the line (in
+                    # pixels).  *randomness* is the factor by which
+                    # the length is randomly scaled.
+
+# the default savefig params can be different from the display params
+# e.g., you may want a higher resolution, or to make the figure
+# background white
+#savefig.dpi         : 100      # figure dots per inch
+#savefig.facecolor   : white    # figure facecolor when saving
+#savefig.edgecolor   : white    # figure edgecolor when saving
+#savefig.format      : png      # png, ps, pdf, svg
+#savefig.bbox        : standard # 'tight' or 'standard'.
+                                # 'tight' is incompatible with pipe-based animation
+                                # backends but will workd with temporary file based ones:
+                                # e.g. setting animation.writer to ffmpeg will not work,
+                                # use ffmpeg_file instead
+#savefig.pad_inches  : 0.1      # Padding to be used when bbox is set to 'tight'
+#savefig.jpeg_quality: 95       # when a jpeg is saved, the default quality parameter.
+#savefig.directory   : ~        # default directory in savefig dialog box,
+                                # leave empty to always use current working directory
+#savefig.transparent : False    # setting that controls whether figures are saved with a
+                                # transparent background by default
+
+# tk backend params
+#tk.window_focus   : False    # Maintain shell focus for TkAgg
+
+# ps backend params
+#ps.papersize      : letter   # auto, letter, legal, ledger, A0-A10, B0-B10
+#ps.useafm         : False    # use of afm fonts, results in small files
+#ps.usedistiller   : False    # can be: None, ghostscript or xpdf
+                                          # Experimental: may produce smaller files.
+                                          # xpdf intended for production of publication quality files,
+                                          # but requires ghostscript, xpdf and ps2eps
+#ps.distiller.res  : 6000      # dpi
+#ps.fonttype       : 3         # Output Type 3 (Type3) or Type 42 (TrueType)
+
+# pdf backend params
+#pdf.compression   : 6 # integer from 0 to 9
+                       # 0 disables compression (good for debugging)
+#pdf.fonttype       : 3         # Output Type 3 (Type3) or Type 42 (TrueType)
+
+# svg backend params
+#svg.image_inline : True       # write raster image data directly into the svg file
+#svg.image_noscale : False     # suppress scaling of raster data embedded in SVG
+#svg.fonttype : 'path'         # How to handle SVG fonts:
+#    'none': Assume fonts are installed on the machine where the SVG will be viewed.
+#    'path': Embed characters as paths -- supported by most SVG renderers
+#    'svgfont': Embed characters as SVG fonts -- supported only by Chrome,
+#               Opera and Safari
+
+# docstring params
+#docstring.hardcopy = False  # set this when you want to generate hardcopy docstring
+
+# Set the verbose flags.  This controls how much information
+# matplotlib gives you at runtime and where it goes.  The verbosity
+# levels are: silent, helpful, debug, debug-annoying.  Any level is
+# inclusive of all the levels below it.  If your setting is "debug",
+# you'll get all the debug and helpful messages.  When submitting
+# problems to the mailing-list, please set verbose to "helpful" or "debug"
+# and paste the output into your report.
+#
+# The "fileo" gives the destination for any calls to verbose.report.
+# These objects can a filename, or a filehandle like sys.stdout.
+#
+# You can override the rc default verbosity from the command line by
+# giving the flags --verbose-LEVEL where LEVEL is one of the legal
+# levels, e.g., --verbose-helpful.
+#
+# You can access the verbose instance in your code
+#   from matplotlib import verbose.
+#verbose.level  : silent      # one of silent, helpful, debug, debug-annoying
+#verbose.fileo  : sys.stdout  # a log filename, sys.stdout or sys.stderr
+
+# Event keys to interact with figures/plots via keyboard.
+# Customize these settings according to your needs.
+# Leave the field(s) empty if you don't need a key-map. (i.e., fullscreen : '')
+
+#keymap.fullscreen : f               # toggling
+#keymap.home : h, r, home            # home or reset mnemonic
+#keymap.back : left, c, backspace    # forward / backward keys to enable
+#keymap.forward : right, v           #   left handed quick navigation
+#keymap.pan : p                      # pan mnemonic
+#keymap.zoom : o                     # zoom mnemonic
+#keymap.save : s                     # saving current figure
+#keymap.quit : ctrl+w, cmd+w         # close the current figure
+#keymap.grid : g                     # switching on/off a grid in current axes
+#keymap.yscale : l                   # toggle scaling of y-axes ('log'/'linear')
+#keymap.xscale : L, k                # toggle scaling of x-axes ('log'/'linear')
+#keymap.all_axes : a                 # enable all axes
+
+# Control location of examples data files
+#examples.directory : ''   # directory to look in for custom installation
+
+###ANIMATION settings
+#animation.html : 'none'           # How to display the animation as HTML in
+                                   # the IPython notebook. 'html5' uses
+                                   # HTML5 video tag.
+#animation.writer : ffmpeg         # MovieWriter 'backend' to use
+#animation.codec : mpeg4           # Codec to use for writing movie
+#animation.bitrate: -1             # Controls size/quality tradeoff for movie.
+                                   # -1 implies let utility auto-determine
+#animation.frame_format: 'png'     # Controls frame format used by temp files
+#animation.ffmpeg_path: 'ffmpeg'   # Path to ffmpeg binary. Without full path
+                                   # $PATH is searched
+#animation.ffmpeg_args: ''         # Additional arguments to pass to ffmpeg
+#animation.avconv_path: 'avconv'   # Path to avconv binary. Without full path
+                                   # $PATH is searched
+#animation.avconv_args: ''         # Additional arguments to pass to avconv
+#animation.mencoder_path: 'mencoder'
+                                   # Path to mencoder binary. Without full path
+                                   # $PATH is searched
+#animation.mencoder_args: ''       # Additional arguments to pass to mencoder
+#animation.convert_path: 'convert' # Path to ImageMagick's convert binary.
+                                   # On Windows use the full path since convert
+                                   # is also the name of a system tool.


### PR DESCRIPTION
Suggested new testing defaults for Travis using a rule to test things back at least 2 years. Dates below.

Update travis config to test releases at least 2 years old:

NumPy 1.8+ (Oct 2013)
SciPy: 0.15+ (May 3, 2014)
Pandas: 0.14+ (May 30, 2014)
Matplotlib: 1.3+ (July 31, 2013)
