### PR TITLE
COMPAT: Remove dependence on getargspec in Python 3

### DIFF
--- a/statsmodels/base/wrapper.py
+++ b/statsmodels/base/wrapper.py
@@ -2,7 +2,7 @@ import inspect
 import functools
 
 import numpy as np
-from statsmodels.compat.python import get_function_name, iteritems
+from statsmodels.compat.python import get_function_name, iteritems, getargspec
 
 class ResultsWrapper(object):
     """
@@ -95,7 +95,7 @@ def make_wrapper(func, how):
             obj = data.wrap_output(func(results, *args, **kwargs), how)
         return obj
 
-    argspec = inspect.getargspec(func)
+    argspec = getargspec(func)
     formatted = inspect.formatargspec(argspec[0], varargs=argspec[1],
                                       defaults=argspec[3])
 


### PR DESCRIPTION
Python 3 has deprecated getargspec in favor of signature.
getargspec has been removed in Python 3.6.