### PR TITLE
ENH: Add freq_weights to Kaplan Meier estimation

### DIFF
--- a/statsmodels/duration/survfunc.py
+++ b/statsmodels/duration/survfunc.py
@@ -107,7 +107,6 @@ class SurvfuncRight(object):
         self.status = np.asarray(status)
         if freq_weights is not None:
             self.freq_weights = np.asarray(freq_weights)
-        m = len(status)
         x = _calc_survfunc_right(time, status, freq_weights)
         self.surv_prob = x[0]
         self.surv_prob_se = x[1]
@@ -115,7 +114,6 @@ class SurvfuncRight(object):
         self.n_risk = x[3]
         self.n_events = x[4]
         self.title = "" if not title else title
-
 
     def plot(self, ax=None):
         """
@@ -141,7 +139,6 @@ class SurvfuncRight(object):
 
         return plot_survfunc(self, ax)
 
-
     def quantile(self, p):
         """
         Estimated quantile of a survival distribution.
@@ -162,7 +159,6 @@ class SurvfuncRight(object):
             return np.nan
 
         return self.surv_times[ii[0]]
-
 
     def quantile_ci(self, p, alpha=0.05, method='cloglog'):
         """
@@ -203,20 +199,20 @@ class SurvfuncRight(object):
 
         method = method.lower()
         if method == "cloglog":
-            g = lambda x : np.log(-np.log(x))
-            gprime = lambda x : -1 / (x * np.log(x))
+            g = lambda x: np.log(-np.log(x))
+            gprime = lambda x: -1 / (x * np.log(x))
         elif method == "linear":
-            g = lambda x : x
-            gprime = lambda x : 1
+            g = lambda x: x
+            gprime = lambda x: 1
         elif method == "log":
-            g = lambda x : np.log(x)
-            gprime = lambda x : 1 / x
+            g = lambda x: np.log(x)
+            gprime = lambda x: 1 / x
         elif method == "logit":
-            g = lambda x : np.log(x / (1 - x))
-            gprime = lambda x : 1 / (x * (1 - x))
+            g = lambda x: np.log(x / (1 - x))
+            gprime = lambda x: 1 / (x * (1 - x))
         elif method == "asinsqrt":
-            g = lambda x : np.arcsin(np.sqrt(x))
-            gprime = lambda x : 1 / (2 * np.sqrt(x) * np.sqrt(1 - x))
+            g = lambda x: np.arcsin(np.sqrt(x))
+            gprime = lambda x: 1 / (2 * np.sqrt(x) * np.sqrt(1 - x))
         else:
             raise ValueError("unknown method")
 
@@ -236,7 +232,6 @@ class SurvfuncRight(object):
 
         return lb, ub
 
-
     def summary(self):
         """
         Return a summary of the estimated survival function.
@@ -253,7 +248,6 @@ class SurvfuncRight(object):
         df["num events"] = self.n_events
 
         return df
-
 
     def simultaneous_cb(self, alpha=0.05, method="hw", transform="log"):
         """
@@ -287,7 +281,8 @@ class SurvfuncRight(object):
 
         method = method.lower()
         if method != "hw":
-            raise ValueError("only the Hall-Wellner (hw) method is implemented")
+            msg = "only the Hall-Wellner (hw) method is implemented"
+            raise ValueError(msg)
 
         if alpha != 0.05:
             raise ValueError("alpha must be set to 0.05")
@@ -314,7 +309,6 @@ class SurvfuncRight(object):
             raise ValueError("Unknown transform")
 
         return lcb, ucb
-
 
 
 def survdiff(time, status, group, weight_type=None, strata=None, **kwargs):
@@ -442,7 +436,8 @@ def _survdiff(time, status, group, weight_type, gr, **kwargs):
             weights = np.sqrt(n)
         elif weight_type == "fh":
             if "fh_p" not in kwargs:
-                raise ValueError("weight_type type 'fh' requires specification of fh_p")
+                msg = "weight_type type 'fh' requires specification of fh_p"
+                raise ValueError(msg)
             fh_p = kwargs["fh_p"]
             # Calculate the survivor function directly to avoid the
             # overhead of creating a SurvfuncRight object
@@ -467,7 +462,6 @@ def _survdiff(time, status, group, weight_type, gr, **kwargs):
         var = np.dot(weights[ix]**2, var[ix])
 
     return obs, var
-
 
 
 def plot_survfunc(survfuncs, ax=None):
@@ -531,7 +525,8 @@ def plot_survfunc(survfuncs, ax=None):
 
         label = getattr(sf, "title", "Group %d" % (gx + 1))
 
-        li, = ax.step(surv_times, surv_prob, '-', label=label, lw=2, where='post')
+        li, = ax.step(surv_times, surv_prob, '-', label=label, lw=2,
+                      where='post')
 
         # Plot the censored points.
         ii = np.flatnonzero(np.logical_not(sf.status))

--- a/statsmodels/duration/tests/test_survfunc.py
+++ b/statsmodels/duration/tests/test_survfunc.py
@@ -238,3 +238,50 @@ def test_plot_km():
 
     if pdf_output:
         pdf.close()
+
+
+def test_weights1():
+    """
+    tm = c(1, 3, 5, 6, 7, 8, 8, 9, 3, 4, 1, 3, 2)
+    st = c(1, 1, 0, 1, 1, 0, 0, 1, 0, 0, 1, 1, 0)
+    wt = c(1, 2, 3, 2, 3, 1, 2, 1, 1, 2, 2, 3, 1)
+    library(survival)
+    sf = survfit(Surv(tm, st) ~ 1, weights=wt, err='tsiatis')
+    """
+
+    tm = np.r_[1, 3, 5, 6, 7, 8, 8, 9, 3, 4, 1, 3, 2]
+    st = np.r_[1, 1, 0, 1, 1, 0, 0, 1, 0, 0, 1, 1, 0]
+    wt = np.r_[1, 2, 3, 2, 3, 1, 2, 1, 1, 2, 2, 3, 1]
+
+    sf = SurvfuncRight(tm, st, "", freq_weights=wt)
+    assert_allclose(sf.surv_times, np.r_[1, 3, 6, 7, 9])
+    assert_allclose(sf.surv_prob,
+                    np.r_[0.875, 0.65625, 0.51041667, 0.29166667, 0.])
+    assert_allclose(sf.surv_prob_se,
+                    np.r_[0.07216878, 0.13307266, 0.20591185, 0.3219071, 1.05053519])
+
+def test_weights2():
+    """
+    tm = c(1, 3, 5, 6, 7, 2, 4, 6, 8, 10)
+    st = c(1, 1, 0, 1, 1, 1, 1, 0, 1, 1)
+    wt = c(1, 1, 1, 1, 1, 2, 2, 2, 2, 2)
+    library(survival)
+    sf = survfit(Surv(tm, st) ~ 1, weights=wt, err='tsiatis')
+    """
+
+    tm = np.r_[1, 3, 5, 6, 7, 2, 4, 6, 8, 10]
+    st = np.r_[1, 1, 0, 1, 1, 1, 1, 0, 1, 1]
+    wt = np.r_[1, 1, 1, 1, 1, 2, 2, 2, 2, 2]
+    tm0 = np.r_[1, 3, 5, 6, 7, 2, 4, 6, 8, 10, 2, 4, 6, 8, 10]
+    st0 = np.r_[1, 1, 0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0, 1, 1]
+
+    sf0 = SurvfuncRight(tm, st, "", freq_weights=wt)
+    sf1 = SurvfuncRight(tm0, st0, "")
+
+    assert_allclose(sf0.surv_times, sf1.surv_times)
+    assert_allclose(sf0.surv_prob, sf1.surv_prob)
+
+    assert_allclose(sf0.surv_prob_se,
+                    np.r_[0.06666667, 0.1210311, 0.14694547,
+                          0.19524829, 0.23183377,
+                          0.30618115, 0.46770386, 0.84778942])


### PR DESCRIPTION
This is a relatively simple extension to support frequency weights in Kaplan Meier estimation of survival curves.

Some relevant background:

http://www.inside-r.org/r-doc/survival/survfit.formula

http://www.ssc.ca/survey/documents/SSC2003_J_Lawless.pdf