### PR TITLE
DOC: Fix small documentation errors

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -22,7 +22,6 @@ sys.path.insert(0, os.path.abspath('../sphinxext'))
 # -- General configuration -----------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
-#needs_sphinx = '1.0'
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
@@ -39,11 +38,7 @@ extensions = ['sphinx.ext.autodoc', 'sphinx.ext.doctest',
               'numpydoc',
               ]
 
-import sphinx
-if sphinx.__version__ == '1.1.3':
-    print ("WARNING: Not building inheritance diagrams on sphinx 1.1.3. "
-           "See https://github.com/statsmodels/statsmodels/issues/1002")
-    extensions.remove('sphinx.ext.inheritance_diagram')
+ipython_savefig_dir = '../build/html/_static'
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -271,7 +266,7 @@ man_pages = [
 epub_title = u'statsmodels'
 epub_author = u'Josef Perktold, Skipper Seabold'
 epub_publisher = u'Josef Perktold, Skipper Seabold'
-epub_copyright = u'2009-2013, Josef Perktold, Skipper Seabold, Jonathan Taylor, statsmodels-developers'
+epub_copyright = u'2009-2016, Josef Perktold, Skipper Seabold, Jonathan Taylor, statsmodels-developers'
 
 # The language of the text. It defaults to the language option
 # or en if the language is not set.

--- a/docs/source/imputation.rst
+++ b/docs/source/imputation.rst
@@ -32,7 +32,7 @@ for each variable.
 Classes
 -------
 
-.. currentmodule:: statsmodels.distributions.empirical_distribution
+.. currentmodule:: statsmodels.imputation.mice
 
 .. autosummary::
    :toctree: generated/
@@ -44,4 +44,6 @@ Classes
 Implementation Details
 ----------------------
 
-Internally, this function uses `pandas.isnull <pandas:http://pandas.pydata.org/pandas-docs/stable/missing_data.html#working-with-missing-data>`_. Anything that returns True from this function will be treated as missing data.
+Internally, this function uses
+`pandas.isnull <pandas:http://pandas.pydata.org/pandas-docs/stable/missing_data.html#working-with-missing-data>`_.
+Anything that returns True from this function will be treated as missing data.

--- a/statsmodels/base/elastic_net.py
+++ b/statsmodels/base/elastic_net.py
@@ -274,8 +274,8 @@ def _opt_1d(func, grad, hess, model, start, L1_wt, tol):
     global minimum is returned in one step.  Otherwise numerical
     bisection is used.
 
-    Returns:
-    --------
+    Returns
+    -------
     The argmin of the objective function.
     """
 

--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -164,10 +164,12 @@ class Model(object):
 
     @property
     def endog_names(self):
+        """Names of endogenous variables"""
         return self.data.ynames
 
     @property
     def exog_names(self):
+        """Names of exogenous variables"""
         return self.data.xnames
 
     def fit(self):

--- a/statsmodels/duration/survfunc.py
+++ b/statsmodels/duration/survfunc.py
@@ -253,8 +253,8 @@ class SurvfuncRight(object):
         """
         Returns a simultaneous confidence band for the survival function.
 
-        Arguments
-        ---------
+        Parameters
+        ----------
         alpha : float
             `1 - alpha` is the desired simultaneous coverage
             probability for the confidence region.  Currently alpha
@@ -339,7 +339,7 @@ def survdiff(time, status, group, weight_type=None, strata=None, **kwargs):
     strata : array-like
         Optional stratum indicators for a stratified test
 
-    Returns:
+    Returns
     --------
     chisq : The chi-square (1 degree of freedom) distributed test
             statistic value
@@ -468,8 +468,8 @@ def plot_survfunc(survfuncs, ax=None):
     """
     Plot one or more survivor functions.
 
-    Arguments
-    ---------
+    Parameters
+    ----------
     survfuncs : object or array-like
         A single SurvfuncRight object, or a list or SurvfuncRight
         objects that are plotted together.

--- a/statsmodels/emplike/originregress.py
+++ b/statsmodels/emplike/originregress.py
@@ -69,7 +69,7 @@ class ELOriginRegress(object):
 
         Returns
         -------
-        Results: class
+        Results : class
             Empirical likelihood regression class
 
         """

--- a/statsmodels/imputation/mice.py
+++ b/statsmodels/imputation/mice.py
@@ -641,8 +641,8 @@ class MICEData(object):
         points are colored according to whether the values are
         observed or imputed.
 
-        Parameters:
-        -----------
+        Parameters
+        ----------
         col1_name : string
             The variable to be plotted on the horizontal axis.
         col2_name : string
@@ -662,8 +662,8 @@ class MICEData(object):
         ax : matplotlib axes object
             Axes on which to plot, created if not provided.
 
-        Returns:
-        --------
+        Returns
+        -------
         The matplotlib figure on which the plot id drawn.
         """
 
@@ -749,8 +749,8 @@ class MICEData(object):
         """
         Plot fitted versus imputed or observed values as a scatterplot.
 
-        Parameters:
-        -----------
+        Parameters
+        ----------
         col_name : string
             The variable to be plotted on the horizontal axis.
         lowess_args : dict-like
@@ -768,8 +768,8 @@ class MICEData(object):
         ax : matplotlib axes object
             Axes on which to plot, created if not provided.
 
-        Returns:
-        --------
+        Returns
+        -------
         The matplotlib figure on which the plot is drawn.
         """
 
@@ -846,8 +846,8 @@ class MICEData(object):
         """
         Display imputed values for one variable as a histogram.
 
-        Parameters:
-        -----------
+        Parameters
+        ----------
         col_name : string
             The name of the variable to be plotted.
         ax : matplotlib axes
@@ -863,8 +863,8 @@ class MICEData(object):
             Keyword arguments to be passed to pyplot.hist when
             creating the histogram for all values.
 
-        Returns:
-        --------
+        Returns
+        -------
         The matplotlib figure on which the histograms were drawn
         """
 

--- a/statsmodels/sandbox/formula.py
+++ b/statsmodels/sandbox/formula.py
@@ -300,11 +300,14 @@ class Factor(Term):
         """
         Retrieve the column corresponding to key in a Formula.
 
-        :Parameters:
-            key : one of the Factor's keys
+        Parameters
+        ----------
+        key : Factor key
+            one of the Factor's keys
 
-        :Returns: ndarray corresponding to key, when evaluated in
-                  current namespace
+        Returns
+        -------
+        ndarray corresponding to key, when evaluated in current namespace
         """
         if not self.ordinal:
             i = self.names().index('(%s==%s)' % (self.termname, str(key)))

--- a/statsmodels/stats/contingency_tables.py
+++ b/statsmodels/stats/contingency_tables.py
@@ -705,8 +705,8 @@ class Table2x2(SquareTable):
         """
         P-value for a hypothesis test about the odds ratio.
 
-        Arguments
-        ---------
+        Parameters
+        ----------
         null : float
             The null value of the odds ratio.
         """
@@ -718,8 +718,8 @@ class Table2x2(SquareTable):
         """
         P-value for a hypothesis test about the log odds ratio.
 
-        Arguments
-        ---------
+        Parameters
+        ----------
         null : float
             The null value of the log odds ratio.
         """
@@ -797,8 +797,8 @@ class Table2x2(SquareTable):
         """
         p-value for a hypothesis test about the risk ratio.
 
-        Arguments
-        ---------
+        Parameters
+        ----------
         null : float
             The null value of the risk ratio.
         """
@@ -810,8 +810,8 @@ class Table2x2(SquareTable):
         """
         p-value for a hypothesis test about the log risk ratio.
 
-        Arguments
-        ---------
+        Parameters
+        ----------
         null : float
             The null value of the log risk ratio.
         """

--- a/statsmodels/stats/mediation.py
+++ b/statsmodels/stats/mediation.py
@@ -259,8 +259,8 @@ class Mediation(object):
         """
         Fit a regression model to assess mediation.
 
-        Arguments
-        ---------
+        Parameters
+        ----------
         method : string
             Either 'parametric' or 'bootstrap'.
         n_rep : integer

--- a/statsmodels/stats/multitest.py
+++ b/statsmodels/stats/multitest.py
@@ -451,8 +451,8 @@ def local_fdr(zscores, null_proportion=1.0, null_pdf=None, deg=7,
     """
     Calculate local FDR values for a list of Z-scores.
 
-    Arguments
-    ---------
+    Parameters
+    ----------
     zscores : array-like
         A vector of Z-scores
     null_proportion : float

--- a/statsmodels/tsa/vector_ar/var_model.py
+++ b/statsmodels/tsa/vector_ar/var_model.py
@@ -863,7 +863,7 @@ class VARResults(VARProcess):
 
     @property
     def df_resid(self):
-        "Number of observations minus number of estimated parameters"
+        """Number of observations minus number of estimated parameters"""
         return self.nobs - self.df_model
 
     @cache_readonly
@@ -1486,7 +1486,7 @@ class VARResults(VARProcess):
 
     @property
     def aic(self):
-        "Akaike information criterion"
+        """Akaike information criterion"""
         return self.info_criteria['aic']
 
     @property
@@ -1499,12 +1499,12 @@ class VARResults(VARProcess):
 
     @property
     def hqic(self):
-        "Hannan-Quinn criterion"
+        """Hannan-Quinn criterion"""
         return self.info_criteria['hqic']
 
     @property
     def bic(self):
-        "Bayesian a.k.a. Schwarz info criterion"
+        """Bayesian a.k.a. Schwarz info criterion"""
         return self.info_criteria['bic']
 
     @cache_readonly


### PR DESCRIPTION
Fixes a number of small documentation errors such as
wrong descriptions (Arguments vs Parameters) and typos.
Also fixes wrong module locations for moved modiel