### PR TITLE
Cast array indices to integers in kdetools

### DIFF
--- a/statsmodels/nonparametric/kdetools.py
+++ b/statsmodels/nonparametric/kdetools.py
@@ -18,7 +18,8 @@ def revrt(X,m=None):
     """
     if m is None:
         m = len(X)
-    y = X[:m // 2+1] + np.r_[0,X[m // 2 + 1:],0]*1j
+    i = int(m // 2+1)
+    y = X[:i] + np.r_[0,X[i:],0]*1j
     return np.fft.irfft(y)*m
 
 def silverman_transform(bw, M, RANGE):


### PR DESCRIPTION
Numpy in master now raises exceptions for array indices that are not integers.