### PR TITLE
Fixing a typo

### DIFF
--- a/examples/notebooks/tsa_arma_1.ipynb
+++ b/examples/notebooks/tsa_arma_1.ipynb
@@ -60,7 +60,7 @@
    "outputs": [],
    "source": [
     "arparams = np.r_[1, -arparams]\n",
-    "maparam = np.r_[1, maparams]\n",
+    "maparams = np.r_[1, maparams]\n",
     "nobs = 250\n",
     "y = arma_generate_sample(arparams, maparams, nobs)"
    ]


### PR DESCRIPTION
`maparams` was missing `s`. This creates ARMA(2,1) process instead of ARMA(2,2) as originally intended.