### PR TITLE
ENH: add function ROS implementation to imputation module

### DIFF
--- a/statsmodels/imputation/ros.py
+++ b/statsmodels/imputation/ros.py
@@ -461,10 +461,10 @@ def _do_ros(df, result, censorship, transform_in, transform_out):
     return modeled
 
 
-def ROS(result, censorship, df=None, min_uncensored=2,
-        max_fraction_censored=0.8, substitution_fraction=0.5,
-        transform_in=numpy.log, transform_out=numpy.exp,
-        as_array=True):
+def impute_ros(result, censorship, df=None, min_uncensored=2,
+           max_fraction_censored=0.8, substitution_fraction=0.5,
+           transform_in=numpy.log, transform_out=numpy.exp,
+           as_array=True):
     """
     Impute censored dataset using Regression on Order Statistics (ROS)
     or simple substitution if insufficient uncensored data exists.

--- a/statsmodels/imputation/ros.py
+++ b/statsmodels/imputation/ros.py
@@ -11,7 +11,7 @@ Company: Geosyntec Consultants (Portland, OR)
 2016-06-14
 
 """
-
+from __future__ import division
 import warnings
 
 import numpy

--- a/statsmodels/imputation/ros.py
+++ b/statsmodels/imputation/ros.py
@@ -1,0 +1,558 @@
+"""
+Implementation of Regression on Order Statistics for imputing left-
+censored (non-detect data)
+
+Method described in *Nondetects and Data Analysis* by Dennis R.
+Helsel (John Wiley, 2005) to estimate the left-censored (non-detect)
+values of a dataset.
+
+Author: Paul M. Hobson
+Company: Geosyntec Consultants (Portland, OR)
+2016-06-14
+
+"""
+
+import warnings
+
+import numpy
+from scipy import stats
+import pandas
+
+
+def _ros_sort(df, result, censorship, warn=False):
+    """
+    This function prepares a dataframe for ROS. It sorts ascending with
+    left-censored observations first. Censored results larger than the
+    maximum uncensored results are removed from the dataframe.
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+
+    result : str
+        Name of the column in the dataframe that contains observed
+        values. Censored values should be set to the detection (upper)
+        limit.
+
+    censorship : str
+        Name of the column in the dataframe that indicates that a
+        result is left-censored. (i.e., True -> censored,
+        False -> uncensored)
+
+    Returns
+    ------
+    sorted_df : pandas.DataFrame
+        The sorted dataframe with all columns dropped except the
+        result and censorship columns.
+
+    """
+
+    # separate uncensored data from censored data
+    censored = df[df[censorship]].sort_values(by=result)
+    uncensored = df[~df[censorship]].sort_values(by=result)
+
+    if censored[result].max() > uncensored[result].max():
+        censored = censored[censored[result] <= uncensored[result].max()]
+
+        if warn:
+            msg = ("Dropping censored results greater than "
+                   "the max uncensored result.")
+            warnings.warn(msg)
+
+    return censored.append(uncensored)[[result, censorship]].reset_index(drop=True)
+
+
+def cohn_numbers(df, result, censorship):
+    """
+    Computes the Cohn numbers for the detection limits in the dataset.
+
+    The Cohn Numbers are:
+
+        - :math:`A_j =` the number of uncensored obs above the jth
+          threshold.
+        - :math:`B_j =` the number of observations (cen & uncen) below
+          the jth threshold.
+        - :math:`C_j =` the number of censored observations at the jth
+          threshold.
+        - :math:`\mathrm{PE}_j =` the probability of exceeding the jth
+          threshold
+        - :math:`\mathrm{DL}_j =` the unique, sorted detection limits
+        - :math:`\mathrm{DL}_{j+1} = \mathrm{DL}_j` shifted down a
+          single index (row)
+
+    Parameters
+    ----------
+    dataframe : pandas.DataFrame
+
+    result : str
+        Name of the column in the dataframe that contains observed
+        values. Censored values should be set to the detection (upper)
+        limit.
+
+    censorship : str
+        Name of the column in the dataframe that indicates that a
+        result is left-censored. (i.e., True -> censored,
+        False -> uncensored)
+
+    Returns
+    -------
+    cohn : pandas.DataFrame
+
+    """
+
+    def nuncen_above(row):
+        """ A, the number of uncensored obs above the given threshold.
+        """
+
+        # index of results above the lower_dl DL
+        above = df[result] >= row['lower_dl']
+
+        # index of results below the upper_dl DL
+        below = df[result] < row['upper_dl']
+
+        # index of non-detect results
+        detect = df[censorship] == False
+
+        # return the number of results where all conditions are True
+        return df[above & below & detect].shape[0]
+
+    def nobs_below(row):
+        """ B, the number of observations (cen & uncen) below the given
+        threshold
+        """
+
+        # index of data less than the lower_dl DL
+        less_than = df[result] < row['lower_dl']
+
+        # index of data less than or equal to the lower_dl DL
+        less_thanequal = df[result] <= row['lower_dl']
+
+        # index of detects, non-detects
+        uncensored = df[censorship] == False
+        censored = df[censorship] == True
+
+        # number results less than or equal to lower_dl DL and non-detect
+        LTE_censored = df[less_thanequal & censored].shape[0]
+
+        # number of results less than lower_dl DL and detected
+        LT_uncensored = df[less_than & uncensored].shape[0]
+
+        # return the sum
+        return LTE_censored + LT_uncensored
+
+    def ncen_equal(row):
+        """ C, the number of censored observations at the given
+        threshold.
+        """
+
+        censored_index = df[censorship]
+        censored_data = df[result][censored_index]
+        censored_below = censored_data == row['lower_dl']
+        return censored_below.sum()
+
+    def set_upper_limit(cohn):
+        """ Sets the upper_dl DL for each row of the Cohn dataframe. """
+        if cohn.shape[0] > 1:
+            return cohn['lower_dl'].shift(-1).fillna(value=numpy.inf)
+        else:
+            return [numpy.inf]
+
+    def compute_PE(A, B):
+        """ Computes the probability of excedance for each row of the
+        Cohn dataframe. """
+        N = len(A)
+        PE = numpy.empty(N, dtype='float64')
+        PE[-1] = 0.0
+        for j in range(N-2, -1, -1):
+            PE[j] = PE[j+1] + (1 - PE[j+1]) * A[j] / (A[j] + B[j])
+
+        return PE
+
+    # unique, sorted detection limts
+    censored_data = df[censorship]
+    DLs = pandas.unique(df.loc[censored_data, result])
+    DLs.sort()
+
+    # if there is a results smaller than the minimum detection limit,
+    # add that value to the array
+    if DLs.shape[0] > 0:
+        if df[result].min() < DLs.min():
+            DLs = numpy.hstack([df[result].min(), DLs])
+
+        # create a dataframe
+        cohn = (
+            pandas.DataFrame(DLs, columns=['lower_dl'])
+                .assign(upper_dl=lambda df: set_upper_limit(df))
+                .assign(nuncen_above=lambda df: df.apply(nuncen_above, axis=1))
+                .assign(nobs_below=lambda df: df.apply(nobs_below, axis=1))
+                .assign(ncen_equal=lambda df: df.apply(ncen_equal, axis=1))
+                .reindex(range(DLs.shape[0] + 1))
+                .assign(prob_exceedance=lambda df: compute_PE(df['nuncen_above'], df['nobs_below']))
+        )
+
+    else:
+        dl_cols = ['lower_dl', 'upper_dl', 'nuncen_above',
+                   'nobs_below', 'ncen_equal', 'prob_exceedance']
+        cohn = pandas.DataFrame(numpy.empty((0, len(dl_cols))), columns=dl_cols)
+
+    return cohn
+
+
+def _detection_limit_index(res, cohn):
+    """ Helper function to create an array of indices for the detection
+    limits (cohn) corresponding to each data point.
+
+    Parameters
+    ----------
+    res : float
+        A single observed result from the larger dataset.
+
+    cohn : pandas.DataFrame
+        Dataframe of Cohn numbers.
+
+    Returns
+    -------
+    det_limit_index : int
+        The index of the corresponding detection limit in `cohn`
+
+    See also
+    --------
+    cohn_numbers
+
+    """
+
+    if cohn.shape[0] > 0:
+        index, = numpy.where(cohn['lower_dl'] <= res)
+        det_limit_index = index[-1]
+    else:
+        det_limit_index = 0
+
+    return det_limit_index
+
+
+def _ros_group_rank(df, dl_idx, censorship):
+    """
+    Ranks each result within the groups defined by the record's
+    detection limit index and censorship.
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+
+    dl_idx : str
+        Name of the column in the dataframe the index of the result's
+        corresponding detection limit in the `cohn` dataframe.
+
+    censorship : str
+        Name of the column in the dataframe that indicates that a
+        result is left-censored. (i.e., True -> censored,
+        False -> uncensored)
+
+    Returns
+    -------
+    ranks : numpy.array
+        Array of ranks for the dataset.
+
+    """
+
+    ranks = (
+        df.assign(rank=1)
+          .groupby(by=[dl_idx, censorship])['rank']
+          .transform(lambda g: g.cumsum())
+    )
+    return ranks
+
+
+def _ros_plot_pos(row, censorship, cohn):
+    """
+    Compute the ROS plotting position for a result based on its rank,
+    censorship, detection limit index.
+
+    Parameters
+    ----------
+    row : pandas.Series or dict-like
+        Full observation (row) from a censored dataset. Requires a
+        'rank', 'detection_limit', and `censorship` column.
+    censorship : str
+        Name of the column in the dataframe that indicates that a
+        result is left-censored. (i.e., True -> censored,
+        False -> uncensored)
+    cohn : pandas.DataFrame
+        Dataframe of Cohn numbers.
+
+    Returns
+    -------
+    plotting_position : float
+
+    See also
+    --------
+    cohn_numbers
+
+    """
+
+    DL_index = row['det_limit_index']
+    rank = row['rank']
+    censored = row[censorship]
+
+    dl_1 = cohn.iloc[DL_index]
+    dl_2 = cohn.iloc[DL_index + 1]
+    if censored:
+        return (1 - dl_1['prob_exceedance']) * rank / (dl_1['ncen_equal']+1)
+    else:
+        return (1 - dl_1['prob_exceedance']) + (dl_1['prob_exceedance'] - dl_2['prob_exceedance']) * \
+                rank / (dl_1['nuncen_above']+1)
+
+
+def _norm_plot_pos(results):
+    """
+    Computes standard normal (Gaussian) plotting positions using scipy.
+
+    Parameters
+    ----------
+    results : array-like
+        Sequence of observed quantities.
+
+    Returns
+    -------
+    plotting_position : array of floats
+
+    """
+    ppos, sorted_res = stats.probplot(results, fit=False)
+    return stats.norm.cdf(ppos)
+
+
+def plotting_positions(df, censorship, cohn):
+    """
+    Compute the ROS plotting positions for results based on their rank,
+    censorship, detection limit index.
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+
+    censorship : str
+        Name of the column in the dataframe that indicates that a
+        result is left-censored. (i.e., True -> censored,
+        False -> uncensored)
+
+    cohn : pandas.DataFrame
+        Dataframe of Cohn numbers.
+
+    Returns
+    -------
+    plotting_position : array of float
+
+    See also
+    --------
+    cohn_numbers
+
+    """
+
+    plot_pos = df.apply(lambda r: _ros_plot_pos(r, censorship, cohn), axis=1)
+
+    # correctly sort the plotting positions of the ND data:
+    ND_plotpos = plot_pos[df[censorship]]
+    ND_plotpos.values.sort()
+    plot_pos.loc[df[censorship]] = ND_plotpos
+
+    return plot_pos
+
+
+def _ros_estimate(df, result, censorship, transform_in, transform_out):
+    """ Computed the estimated censored from the best-fit line of a
+    probability plot of the uncensored values.
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+    result : str
+        Name of the column in the dataframe that contains observed
+        values. Censored values should be set to the detection (upper)
+        limit.
+    censorship : str
+        Name of the column in the dataframe that indicates that a
+        result is left-censored. (i.e., True -> censored,
+        False -> uncensored)
+    transform_in, transform_out : callable
+        Transformations to be applied to the data prior to fitting
+        the line and after estimated values from that line. Typically,
+        `numpy.log` and `numpy.exp` are used, respectively.
+
+    Returns
+    -------
+    estimated : pandas.DataFrame
+        A new dataframe with two new columns: "estimated" and "final".
+        The "estimated" column contains of the values inferred from the
+        best-fit line. The "final" column contains the estimated values
+        only where the original results were censored, and the original
+        results everwhere else.
+
+    """
+
+    # detect/non-detect selectors
+    uncensored_mask = df[censorship] == False
+    censored_mask = df[censorship] == True
+
+    # fit a line to the logs of the detected data
+    fit_params = stats.linregress(
+        df['Zprelim'][uncensored_mask],
+        transform_in(df[result][uncensored_mask])
+    )
+
+    # pull out the slope and intercept for use later
+    slope, intercept = fit_params[:2]
+
+    # model the data based on the best-fit curve
+    df = (
+        df.assign(estimated=transform_out(slope * df['Zprelim'][censored_mask] + intercept))
+          .assign(final=lambda df: numpy.where(df[censorship], df['estimated'], df[result]))
+    )
+
+    return df
+
+
+def _do_ros(df, result, censorship, transform_in, transform_out):
+    """
+    Prepares a dataframe for, and then esimates the values of a censored
+    dataset using Regression on Order Statistics
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+
+    result : str
+        Name of the column in the dataframe that contains observed
+        values. Censored values should be set to the detection (upper)
+        limit.
+
+    censorship : str
+        Name of the column in the dataframe that indicates that a
+        result is left-censored. (i.e., True -> censored,
+        False -> uncensored)
+
+    transform_in, transform_out : callable
+        Transformations to be applied to the data prior to fitting
+        the line and after estimated values from that line. Typically,
+        `numpy.log` and `numpy.exp` are used, respectively.
+
+    Returns
+    -------
+    estimated : pandas.DataFrame
+        A new dataframe with two new columns: "estimated" and "final".
+        The "estimated" column contains of the values inferred from the
+        best-fit line. The "final" column contains the estimated values
+        only where the original results were censored, and the original
+        results everwhere else.
+
+    """
+
+    # compute the Cohn numbers
+    cohn = cohn_numbers(df, result=result, censorship=censorship)
+
+    modeled = (
+        df.pipe(_ros_sort, result=result, censorship=censorship)
+          .assign(det_limit_index=lambda df: df[result].apply(_detection_limit_index, args=(cohn,)))
+          .assign(rank=lambda df: _ros_group_rank(df, 'det_limit_index', censorship))
+          .assign(plot_pos=lambda df: plotting_positions(df, censorship, cohn))
+          .assign(Zprelim=lambda df: stats.norm.ppf(df['plot_pos']))
+          .pipe(_ros_estimate, result, censorship, transform_in, transform_out)
+    )
+
+    return modeled
+
+
+def ROS(result, censorship, df=None, min_uncensored=2,
+        max_fraction_censored=0.8, substitution_fraction=0.5,
+        transform_in=numpy.log, transform_out=numpy.exp,
+        as_array=True):
+    """
+    Impute censored dataset using Regression on Order Statistics (ROS)
+    or simple substitution if insufficient uncensored data exists.
+
+    Method described in *Nondetects and Data Analysis* by Dennis R.
+    Helsel (John Wiley, 2005) to estimate the left-censored (non-detect)
+    values of a dataset.
+
+    Parameters
+    ----------
+    result : str or array-like
+        Label of the column or the float array of censored results
+
+    censorship : str
+        Label of the column or the bool array of the censorship
+        status of the results.
+
+          * True if censored,
+          * False if uncensored
+
+    df : pandas.DataFrame, optional
+        If `result` and `censorship` are labels, this is the DataFrame
+        that contains those columns.
+
+    min_uncensored : int (default is 2)
+        The minimum number of uncensored values required before ROS
+        can be used to impute the censored results. When this criterion
+        is not met, simple substituion is used instead.
+
+    max_fraction_censored : float (default is 0.8)
+        The maximum fraction of censored data below which ROS can be
+        used to impute the censored results. When this fraction is
+        exceeded, simple substituion is used instead.
+
+    substitution_fraction : float (default is 0.5)
+        The fraction of the detection limit to be used during simple
+        substitution of the censored values.
+
+    transform_in : callable (default is numpy.log)
+        Transformation to be applied to the values prior to fitting a
+        line to the plotting positions vs. uncensored values.
+
+    transform_out : callable (default is numpy.exp)
+        Transformation to be applied to the imputed censored values
+        estimated from the previously computed best-fit line.
+
+    as_array : bool (default is True)
+        When True, a numpy array of the imputed results is returned.
+        Otherwise, a modified copy of the original dataframe with all
+        of the intermediate calculations is returned.
+
+    Returns
+    -------
+    imputed : numpy.array (default) or pandas.DataFrame
+        The final results where the censored values have either been
+        imputed through ROS or substituted as a fraction of the
+        detection limit.
+
+    """
+
+    # process arrays into a dataframe, if necessary
+    if df is None:
+        df = pandas.DataFrame({'res': result, 'cen': censorship})
+        result = 'res'
+        censorship = 'cen'
+
+    # basic counts/metrics of the dataset
+    N_observations = df.shape[0]
+    N_censored = df[censorship].astype(int).sum()
+    N_uncensored = N_observations - N_censored
+    fraction_censored = N_censored / N_observations
+
+    # add plotting positions if there are no censored values
+    if N_censored == 0:
+        output = df[[result, censorship]].assign(final=df[result])
+
+    # substitute w/ fraction of the DLs if there's insufficient
+    # uncensored data
+    elif (N_uncensored < min_uncensored) or (fraction_censored > max_fraction_censored):
+        final = numpy.where(df[censorship], df[result] * substitution_fraction, df[result])
+        output = df.assign(final=final)[[result, censorship, 'final']]
+
+    # normal ROS stuff
+    else:
+        output = _do_ros(df, result, censorship, transform_in, transform_out)
+
+    # convert to an array if necessary
+    if as_array:
+        output = output['final'].values
+
+    return output

--- a/statsmodels/imputation/ros.py
+++ b/statsmodels/imputation/ros.py
@@ -8,9 +8,10 @@ values of a dataset.
 
 Author: Paul M. Hobson
 Company: Geosyntec Consultants (Portland, OR)
-2016-06-14
+Date: 2016-06-14
 
 """
+
 from __future__ import division
 import warnings
 
@@ -21,7 +22,9 @@ import pandas
 
 def _ros_sort(df, result, censorship, warn=False):
     """
-    This function prepares a dataframe for ROS. It sorts ascending with
+    This function prepares a dataframe for ROS.
+
+    It sorts ascending with
     left-censored observations first. Censored results larger than the
     maximum uncensored results are removed from the dataframe.
 
@@ -199,8 +202,11 @@ def cohn_numbers(df, result, censorship):
 
 
 def _detection_limit_index(res, cohn):
-    """ Helper function to create an array of indices for the detection
-    limits (cohn) corresponding to each data point.
+    """
+    Locates the corresponding detection limit for each observation.
+
+    Basically, creates an array of indices for the detection limits
+    (Cohn numbers) corresponding to each data point.
 
     Parameters
     ----------
@@ -232,8 +238,10 @@ def _detection_limit_index(res, cohn):
 
 def _ros_group_rank(df, dl_idx, censorship):
     """
-    Ranks each result within the groups defined by the record's
-    detection limit index and censorship.
+    Ranks each result within the data groups.
+
+    In this case, the groups are defined by the record's detection
+    limit index and censorship status.
 
     Parameters
     ----------
@@ -265,18 +273,22 @@ def _ros_group_rank(df, dl_idx, censorship):
 
 def _ros_plot_pos(row, censorship, cohn):
     """
-    Compute the ROS plotting position for a result based on its rank,
-    censorship, detection limit index.
+    ROS-specific plotting positions.
+
+    Computes the plotting position for an observation based on its rank,
+    censorship status, and detection limit index.
 
     Parameters
     ----------
     row : pandas.Series or dict-like
         Full observation (row) from a censored dataset. Requires a
         'rank', 'detection_limit', and `censorship` column.
+
     censorship : str
         Name of the column in the dataframe that indicates that a
         result is left-censored. (i.e., True -> censored,
         False -> uncensored)
+
     cohn : pandas.DataFrame
         Dataframe of Cohn numbers.
 
@@ -323,8 +335,10 @@ def _norm_plot_pos(results):
 
 def plotting_positions(df, censorship, cohn):
     """
-    Compute the ROS plotting positions for results based on their rank,
-    censorship, detection limit index.
+    Compute the plotting positions for the observations.
+
+    The ROS-specific plotting postions are based on the observations'
+    rank, censorship status, and corresponding detection limit.
 
     Parameters
     ----------
@@ -358,8 +372,11 @@ def plotting_positions(df, censorship, cohn):
     return plot_pos
 
 
-def _ros_estimate(df, result, censorship, transform_in, transform_out):
-    """ Computed the estimated censored from the best-fit line of a
+def _impute(df, result, censorship, transform_in, transform_out):
+    """
+    Executes the basic regression on order stat (ROS) proceedure.
+
+    Uses ROS to impute censored from the best-fit line of a
     probability plot of the uncensored values.
 
     Parameters
@@ -413,6 +430,8 @@ def _ros_estimate(df, result, censorship, transform_in, transform_out):
 
 def _do_ros(df, result, censorship, transform_in, transform_out):
     """
+    Dataframe-centric function to impute censored valies with ROS.
+
     Prepares a dataframe for, and then esimates the values of a censored
     dataset using Regression on Order Statistics
 
@@ -455,7 +474,7 @@ def _do_ros(df, result, censorship, transform_in, transform_out):
           .assign(rank=lambda df: _ros_group_rank(df, 'det_limit_index', censorship))
           .assign(plot_pos=lambda df: plotting_positions(df, censorship, cohn))
           .assign(Zprelim=lambda df: stats.norm.ppf(df['plot_pos']))
-          .pipe(_ros_estimate, result, censorship, transform_in, transform_out)
+          .pipe(_impute, result, censorship, transform_in, transform_out)
     )
 
     return modeled
@@ -466,12 +485,12 @@ def impute_ros(result, censorship, df=None, min_uncensored=2,
            transform_in=numpy.log, transform_out=numpy.exp,
            as_array=True):
     """
-    Impute censored dataset using Regression on Order Statistics (ROS)
-    or simple substitution if insufficient uncensored data exists.
+    Impute censored dataset using Regression on Order Statistics (ROS).
 
     Method described in *Nondetects and Data Analysis* by Dennis R.
     Helsel (John Wiley, 2005) to estimate the left-censored (non-detect)
-    values of a dataset.
+    values of a dataset. When there is insufficient non-censorded data,
+    simple substitution is used.
 
     Parameters
     ----------

--- a/statsmodels/imputation/tests/test_ros.py
+++ b/statsmodels/imputation/tests/test_ros.py
@@ -323,7 +323,7 @@ def test_plotting_positions():
     npt.assert_array_almost_equal(results, expected)
 
 
-def test__ros_estimate():
+def test__impute():
     expected = numpy.array([
          3.11279729,   3.60634338,   4.04602788,   4.04602788,
          4.71008116,   6.14010906,   6.97841457,   2.        ,
@@ -335,7 +335,7 @@ def test__ros_estimate():
         16.77      ,  17.81      ,  19.16      ,  19.19      ,
         19.64      ,  20.18      ,  22.97
     ])
-    df = load_advanced_data().pipe(ros._ros_estimate, 'conc', 'censored',
+    df = load_advanced_data().pipe(ros._impute, 'conc', 'censored',
                                    numpy.log, numpy.exp)
     result = df['final'].values
     npt.assert_array_almost_equal(result, expected)

--- a/statsmodels/imputation/tests/test_ros.py
+++ b/statsmodels/imputation/tests/test_ros.py
@@ -1,3 +1,5 @@
+from __future__ import division
+
 import sys
 from textwrap import dedent
 

--- a/statsmodels/imputation/tests/test_ros.py
+++ b/statsmodels/imputation/tests/test_ros.py
@@ -1,0 +1,656 @@
+import sys
+from textwrap import dedent
+
+import nose.tools as ntools
+import numpy.testing as npt
+import pandas.util.testing as pdtest
+
+import numpy
+import pandas
+
+from statsmodels.imputation import ros
+from statsmodels.compat.python import StringIO
+
+
+@ntools.nottest
+def load_basic_data():
+    raw_csv = StringIO(
+        "res,qual\n2.00,=\n4.20,=\n4.62,=\n5.00,ND\n5.00,ND\n5.50,ND\n"
+        "5.57,=\n5.66,=\n5.75,ND\n5.86,=\n6.65,=\n6.78,=\n6.79,=\n7.50,=\n"
+        "7.50,=\n7.50,=\n8.63,=\n8.71,=\n8.99,=\n9.50,ND\n9.50,ND\n9.85,=\n"
+        "10.82,=\n11.00,ND\n11.25,=\n11.25,=\n12.20,=\n14.92,=\n16.77,=\n"
+        "17.81,=\n19.16,=\n19.19,=\n19.64,=\n20.18,=\n22.97,=\n"
+    )
+    df = (
+        pandas.read_csv(raw_csv)
+            .assign(conc=lambda df: df['res'])
+            .assign(censored=lambda df: df['qual'] == 'ND')
+    )
+    return df
+
+
+@ntools.nottest
+def load_intermediate_data():
+    df = pandas.DataFrame([
+        {'censored': True, 'conc': 5.0, 'det_limit_index': 1, 'rank': 1},
+        {'censored': True, 'conc': 5.0, 'det_limit_index': 1, 'rank': 2},
+        {'censored': True, 'conc': 5.5, 'det_limit_index': 2, 'rank': 1},
+        {'censored': True, 'conc': 5.75, 'det_limit_index': 3, 'rank': 1},
+        {'censored': True, 'conc': 9.5, 'det_limit_index': 4, 'rank': 1},
+        {'censored': True, 'conc': 9.5, 'det_limit_index': 4, 'rank': 2},
+        {'censored': True, 'conc': 11.0, 'det_limit_index': 5, 'rank': 1},
+        {'censored': False, 'conc': 2.0, 'det_limit_index': 0, 'rank': 1},
+        {'censored': False, 'conc': 4.2, 'det_limit_index': 0, 'rank': 2},
+        {'censored': False, 'conc': 4.62, 'det_limit_index': 0, 'rank': 3},
+        {'censored': False, 'conc': 5.57, 'det_limit_index': 2, 'rank': 1},
+        {'censored': False, 'conc': 5.66, 'det_limit_index': 2, 'rank': 2},
+        {'censored': False, 'conc': 5.86, 'det_limit_index': 3, 'rank': 1},
+        {'censored': False, 'conc': 6.65, 'det_limit_index': 3, 'rank': 2},
+        {'censored': False, 'conc': 6.78, 'det_limit_index': 3, 'rank': 3},
+        {'censored': False, 'conc': 6.79, 'det_limit_index': 3, 'rank': 4},
+        {'censored': False, 'conc': 7.5, 'det_limit_index': 3, 'rank': 5},
+        {'censored': False, 'conc': 7.5, 'det_limit_index': 3, 'rank': 6},
+        {'censored': False, 'conc': 7.5, 'det_limit_index': 3, 'rank': 7},
+        {'censored': False, 'conc': 8.63, 'det_limit_index': 3, 'rank': 8},
+        {'censored': False, 'conc': 8.71, 'det_limit_index': 3, 'rank': 9},
+        {'censored': False, 'conc': 8.99, 'det_limit_index': 3, 'rank': 10},
+        {'censored': False, 'conc': 9.85, 'det_limit_index': 4, 'rank': 1},
+        {'censored': False, 'conc': 10.82, 'det_limit_index': 4, 'rank': 2},
+        {'censored': False, 'conc': 11.25, 'det_limit_index': 5, 'rank': 1},
+        {'censored': False, 'conc': 11.25, 'det_limit_index': 5, 'rank': 2},
+        {'censored': False, 'conc': 12.2, 'det_limit_index': 5, 'rank': 3},
+        {'censored': False, 'conc': 14.92, 'det_limit_index': 5, 'rank': 4},
+        {'censored': False, 'conc': 16.77, 'det_limit_index': 5, 'rank': 5},
+        {'censored': False, 'conc': 17.81, 'det_limit_index': 5, 'rank': 6},
+        {'censored': False, 'conc': 19.16, 'det_limit_index': 5, 'rank': 7},
+        {'censored': False, 'conc': 19.19, 'det_limit_index': 5, 'rank': 8},
+        {'censored': False, 'conc': 19.64, 'det_limit_index': 5, 'rank': 9},
+        {'censored': False, 'conc': 20.18, 'det_limit_index': 5, 'rank': 10},
+        {'censored': False, 'conc': 22.97, 'det_limit_index': 5, 'rank': 11}
+    ])
+
+    return df
+
+
+@ntools.nottest
+def load_advanced_data():
+    df = pandas.DataFrame([
+        {'Zprelim': -1.4456202174142005, 'censored': True, 'conc': 5.0,
+        'det_limit_index': 1, 'plot_pos': 0.07414187643020594, 'rank': 1},
+        {'Zprelim': -1.2201035333697587, 'censored': True, 'conc': 5.0,
+        'det_limit_index': 1, 'plot_pos': 0.11121281464530891, 'rank': 2},
+        {'Zprelim': -1.043822530159519, 'censored': True, 'conc': 5.5,
+        'det_limit_index': 2, 'plot_pos': 0.14828375286041187, 'rank': 1},
+        {'Zprelim': -1.0438225301595188, 'censored': True, 'conc': 5.75,
+        'det_limit_index': 3, 'plot_pos': 0.1482837528604119, 'rank': 1},
+        {'Zprelim': -0.8109553641377003, 'censored': True, 'conc': 9.5,
+        'det_limit_index': 4, 'plot_pos': 0.20869565217391303, 'rank': 1},
+        {'Zprelim': -0.4046779045300476, 'censored': True, 'conc': 9.5,
+        'det_limit_index': 4, 'plot_pos': 0.34285714285714286, 'rank': 2},
+        {'Zprelim': -0.20857169501420522, 'censored': True, 'conc': 11.0,
+        'det_limit_index': 5, 'plot_pos': 0.41739130434782606, 'rank': 1},
+        {'Zprelim': -1.5927654676048002, 'censored': False, 'conc': 2.0,
+        'det_limit_index': 0, 'plot_pos': 0.055606407322654455, 'rank': 1},
+        {'Zprelim': -1.2201035333697587, 'censored': False, 'conc': 4.2,
+        'det_limit_index': 0, 'plot_pos': 0.11121281464530891, 'rank': 2},
+        {'Zprelim': -0.9668111610681008, 'censored': False, 'conc': 4.62,
+        'det_limit_index': 0, 'plot_pos': 0.16681922196796337, 'rank': 3},
+        {'Zprelim': -0.6835186393930371, 'censored': False, 'conc': 5.57,
+        'det_limit_index': 2, 'plot_pos': 0.24713958810068648, 'rank': 1},
+        {'Zprelim': -0.6072167256926887, 'censored': False, 'conc': 5.66,
+        'det_limit_index': 2, 'plot_pos': 0.27185354691075514, 'rank': 2},
+        {'Zprelim': -0.44953240276543616, 'censored': False, 'conc': 5.86,
+        'det_limit_index': 3, 'plot_pos': 0.3265238194299979, 'rank': 1},
+        {'Zprelim': -0.36788328223414807, 'censored': False, 'conc': 6.65,
+        'det_limit_index': 3, 'plot_pos': 0.35648013313917204, 'rank': 2},
+        {'Zprelim': -0.28861907892223937, 'censored': False, 'conc': 6.78,
+        'det_limit_index': 3, 'plot_pos': 0.38643644684834616, 'rank': 3},
+        {'Zprelim': -0.21113039741112186, 'censored': False, 'conc': 6.79,
+        'det_limit_index': 3, 'plot_pos': 0.4163927605575203, 'rank': 4},
+        {'Zprelim': -0.1348908823006299, 'censored': False, 'conc': 7.5,
+        'det_limit_index': 3, 'plot_pos': 0.4463490742666944, 'rank': 5},
+        {'Zprelim': -0.05942854708257491, 'censored': False, 'conc': 7.5,
+        'det_limit_index': 3, 'plot_pos': 0.4763053879758685, 'rank': 6},
+        {'Zprelim': 0.015696403006170083, 'censored': False, 'conc': 7.5,
+        'det_limit_index': 3, 'plot_pos': 0.5062617016850427, 'rank': 7},
+        {'Zprelim': 0.09091016994359362, 'censored': False, 'conc': 8.63,
+        'det_limit_index': 3, 'plot_pos': 0.5362180153942168, 'rank': 8},
+        {'Zprelim': 0.16664251178856201, 'censored': False, 'conc': 8.71,
+        'det_limit_index': 3, 'plot_pos': 0.5661743291033909, 'rank': 9},
+        {'Zprelim': 0.24334426739770573, 'censored': False, 'conc': 8.99,
+        'det_limit_index': 3, 'plot_pos': 0.596130642812565, 'rank': 10},
+        {'Zprelim': 0.3744432988606558, 'censored': False, 'conc': 9.85,
+        'det_limit_index': 4, 'plot_pos': 0.6459627329192545, 'rank': 1},
+        {'Zprelim': 0.4284507519609981, 'censored': False, 'conc': 10.82,
+        'det_limit_index': 4, 'plot_pos': 0.6658385093167701, 'rank': 2},
+        {'Zprelim': 0.5589578655042562, 'censored': False, 'conc': 11.25,
+        'det_limit_index': 5, 'plot_pos': 0.7119047619047619, 'rank': 1},
+        {'Zprelim': 0.6374841609623771, 'censored': False, 'conc': 11.25,
+        'det_limit_index': 5, 'plot_pos': 0.7380952380952381, 'rank': 2},
+        {'Zprelim': 0.7201566171385521, 'censored': False, 'conc': 12.2,
+        'det_limit_index': 5, 'plot_pos': 0.7642857142857142, 'rank': 3},
+        {'Zprelim': 0.8080746339118065, 'censored': False, 'conc': 14.92,
+        'det_limit_index': 5, 'plot_pos': 0.7904761904761904, 'rank': 4},
+        {'Zprelim': 0.9027347916438648, 'censored': False, 'conc': 16.77,
+        'det_limit_index': 5, 'plot_pos': 0.8166666666666667, 'rank': 5},
+        {'Zprelim': 1.0062699858608395, 'censored': False, 'conc': 17.81,
+        'det_limit_index': 5, 'plot_pos': 0.8428571428571429, 'rank': 6},
+        {'Zprelim': 1.1219004674623523, 'censored': False, 'conc': 19.16,
+        'det_limit_index': 5, 'plot_pos': 0.8690476190476191, 'rank': 7},
+        {'Zprelim': 1.2548759122271174, 'censored': False, 'conc': 19.19,
+        'det_limit_index': 5, 'plot_pos': 0.8952380952380953, 'rank': 8},
+        {'Zprelim': 1.414746425534976, 'censored': False, 'conc': 19.64,
+        'det_limit_index': 5, 'plot_pos': 0.9214285714285714, 'rank': 9},
+        {'Zprelim': 1.622193585315426, 'censored': False, 'conc': 20.18,
+        'det_limit_index': 5, 'plot_pos': 0.9476190476190476, 'rank': 10},
+        {'Zprelim': 1.9399896117517081, 'censored': False, 'conc': 22.97,
+        'det_limit_index': 5, 'plot_pos': 0.9738095238095239, 'rank': 11}
+    ])
+
+    return df
+
+
+@ntools.nottest
+def load_basic_cohn():
+    cohn = pandas.DataFrame([
+        {'lower_dl': 2.0, 'ncen_equal': 0.0, 'nobs_below': 0.0,
+         'nuncen_above': 3.0, 'prob_exceedance': 1.0, 'upper_dl': 5.0},
+        {'lower_dl': 5.0, 'ncen_equal': 2.0, 'nobs_below': 5.0,
+         'nuncen_above': 0.0, 'prob_exceedance': 0.77757437070938218, 'upper_dl': 5.5},
+        {'lower_dl': 5.5, 'ncen_equal': 1.0, 'nobs_below': 6.0,
+         'nuncen_above': 2.0, 'prob_exceedance': 0.77757437070938218, 'upper_dl': 5.75},
+        {'lower_dl': 5.75, 'ncen_equal': 1.0, 'nobs_below': 9.0,
+         'nuncen_above': 10.0, 'prob_exceedance': 0.7034324942791762, 'upper_dl': 9.5},
+        {'lower_dl': 9.5, 'ncen_equal': 2.0, 'nobs_below': 21.0,
+         'nuncen_above': 2.0, 'prob_exceedance': 0.37391304347826088, 'upper_dl': 11.0},
+        {'lower_dl': 11.0, 'ncen_equal': 1.0, 'nobs_below': 24.0,
+         'nuncen_above': 11.0, 'prob_exceedance': 0.31428571428571428, 'upper_dl': numpy.inf},
+        {'lower_dl': numpy.nan, 'ncen_equal': numpy.nan, 'nobs_below': numpy.nan,
+         'nuncen_above': numpy.nan, 'prob_exceedance': 0.0, 'upper_dl': numpy.nan}
+    ])
+    return cohn
+
+
+class Test__ros_sort(object):
+    def setup(self):
+        self.df = load_basic_data()
+
+        self.expected_baseline = pandas.DataFrame([
+            {'censored': True,  'conc': 5.0},   {'censored': True,  'conc': 5.0},
+            {'censored': True,  'conc': 5.5},   {'censored': True,  'conc': 5.75},
+            {'censored': True,  'conc': 9.5},   {'censored': True,  'conc': 9.5},
+            {'censored': True,  'conc': 11.0},  {'censored': False, 'conc': 2.0},
+            {'censored': False, 'conc': 4.2},   {'censored': False, 'conc': 4.62},
+            {'censored': False, 'conc': 5.57},  {'censored': False, 'conc': 5.66},
+            {'censored': False, 'conc': 5.86},  {'censored': False, 'conc': 6.65},
+            {'censored': False, 'conc': 6.78},  {'censored': False, 'conc': 6.79},
+            {'censored': False, 'conc': 7.5},   {'censored': False, 'conc': 7.5},
+            {'censored': False, 'conc': 7.5},   {'censored': False, 'conc': 8.63},
+            {'censored': False, 'conc': 8.71},  {'censored': False, 'conc': 8.99},
+            {'censored': False, 'conc': 9.85},  {'censored': False, 'conc': 10.82},
+            {'censored': False, 'conc': 11.25}, {'censored': False, 'conc': 11.25},
+            {'censored': False, 'conc': 12.2},  {'censored': False, 'conc': 14.92},
+            {'censored': False, 'conc': 16.77}, {'censored': False, 'conc': 17.81},
+            {'censored': False, 'conc': 19.16}, {'censored': False, 'conc': 19.19},
+            {'censored': False, 'conc': 19.64}, {'censored': False, 'conc': 20.18},
+            {'censored': False, 'conc': 22.97},
+        ])[['conc', 'censored']]
+
+        self.expected_with_warning = self.expected_baseline.iloc[:-1]
+
+    def test_baseline(self):
+        result = ros._ros_sort(self.df, 'conc', 'censored')
+        pdtest.assert_frame_equal(result, self.expected_baseline)
+
+    def test_censored_greater_than_max(self):
+        df = self.df.copy()
+        max_row = df['conc'].argmax()
+        df.loc[max_row, 'censored'] = True
+        result = ros._ros_sort(df, 'conc', 'censored')
+        pdtest.assert_frame_equal(result, self.expected_with_warning)
+
+
+class Test_cohn_numbers(object):
+    def setup(self):
+        self.df = load_basic_data()
+        self.final_cols = ['lower_dl', 'upper_dl', 'nuncen_above', 'nobs_below',
+                           'ncen_equal', 'prob_exceedance']
+
+        self.expected_baseline = pandas.DataFrame([
+            {'lower_dl': 2.0, 'ncen_equal': 0.0, 'nobs_below': 0.0,
+             'nuncen_above': 3.0, 'prob_exceedance': 1.0, 'upper_dl': 5.0},
+            {'lower_dl': 5.0, 'ncen_equal': 2.0, 'nobs_below': 5.0,
+             'nuncen_above': 0.0, 'prob_exceedance': 0.77757437070938218, 'upper_dl': 5.5},
+            {'lower_dl': 5.5, 'ncen_equal': 1.0, 'nobs_below': 6.0,
+             'nuncen_above': 2.0, 'prob_exceedance': 0.77757437070938218, 'upper_dl': 5.75},
+            {'lower_dl': 5.75, 'ncen_equal': 1.0, 'nobs_below': 9.0,
+             'nuncen_above': 10.0, 'prob_exceedance': 0.7034324942791762, 'upper_dl': 9.5},
+            {'lower_dl': 9.5, 'ncen_equal': 2.0, 'nobs_below': 21.0,
+             'nuncen_above': 2.0, 'prob_exceedance': 0.37391304347826088, 'upper_dl': 11.0},
+            {'lower_dl': 11.0, 'ncen_equal': 1.0, 'nobs_below': 24.0,
+             'nuncen_above': 11.0, 'prob_exceedance': 0.31428571428571428, 'upper_dl': numpy.inf},
+            {'lower_dl': numpy.nan, 'ncen_equal': numpy.nan, 'nobs_below': numpy.nan,
+             'nuncen_above': numpy.nan, 'prob_exceedance': 0.0, 'upper_dl': numpy.nan}
+        ])[self.final_cols]
+
+
+    def test_baseline(self):
+        result = ros.cohn_numbers(self.df, result='conc', censorship='censored')
+        pdtest.assert_frame_equal(result, self.expected_baseline)
+
+    def test_no_NDs(self):
+        result = ros.cohn_numbers(self.df.assign(qual=False), result='conc', censorship='qual')
+        ntools.assert_tuple_equal(result.shape, (0, 6))
+
+
+class Test__detection_limit_index(object):
+    def setup(self):
+        self.cohn = load_basic_cohn()
+        self.empty_cohn = pandas.DataFrame(numpy.empty((0, 7)))
+
+    def test_empty(self):
+        ntools.assert_equal(ros._detection_limit_index(None, self.empty_cohn), 0)
+
+    def test_populated(self):
+         ntools.assert_equal(ros._detection_limit_index(3.5, self.cohn), 0)
+         ntools.assert_equal(ros._detection_limit_index(6.0, self.cohn), 3)
+         ntools.assert_equal(ros._detection_limit_index(12.0, self.cohn), 5)
+
+    @ntools.raises(IndexError)
+    def test_out_of_bounds(self):
+        ros._detection_limit_index(0, self.cohn)
+
+
+def test__ros_group_rank():
+    df = pandas.DataFrame({
+        'dl_idx': [1] * 12,
+        'params': list('AABCCCDE') + list('DCBA'),
+        'values': list(range(12))
+    })
+
+    result = ros._ros_group_rank(df, 'dl_idx', 'params')
+    expected = pandas.Series([1, 2, 1, 1, 2, 3, 1, 1, 2, 4, 2, 3], name='rank')
+    pdtest.assert_series_equal(result, expected)
+
+
+class Test__ros_plot_pos(object):
+    def setup(self):
+        self.cohn = load_basic_cohn()
+
+    def test_uncensored_1(self):
+        row = {'censored': False, 'det_limit_index': 2, 'rank': 1}
+        result = ros._ros_plot_pos(row, 'censored', self.cohn)
+        ntools.assert_equal(result, 0.24713958810068648)
+
+    def test_uncensored_2(self):
+        row = {'censored': False, 'det_limit_index': 2, 'rank': 12}
+        result = ros._ros_plot_pos(row, 'censored', self.cohn)
+        ntools.assert_equal(result, 0.51899313501144173)
+
+    def test_censored_1(self):
+        row = {'censored': True, 'det_limit_index': 5, 'rank': 4}
+        result = ros._ros_plot_pos(row, 'censored', self.cohn)
+        ntools.assert_equal(result, 1.3714285714285714)
+
+    def test_censored_2(self):
+        row = {'censored': True, 'det_limit_index': 4, 'rank': 2}
+        result = ros._ros_plot_pos(row, 'censored', self.cohn)
+        ntools.assert_equal(result, 0.41739130434782606)
+
+
+def test__norm_plot_pos():
+    result = ros._norm_plot_pos([1, 2, 3, 4])
+    expected = numpy.array([ 0.159104,  0.385452,  0.614548,  0.840896])
+    npt.assert_array_almost_equal(result, expected)
+
+
+def test_plotting_positions():
+    df = load_intermediate_data()
+    cohn = load_basic_cohn()
+
+    results = ros.plotting_positions(df, 'censored', cohn)
+    expected = numpy.array([
+        0.07414188,  0.11121281,  0.14828375,  0.14828375,  0.20869565,
+        0.34285714,  0.4173913 ,  0.05560641,  0.11121281,  0.16681922,
+        0.24713959,  0.27185355,  0.32652382,  0.35648013,  0.38643645,
+        0.41639276,  0.44634907,  0.47630539,  0.5062617 ,  0.53621802,
+        0.56617433,  0.59613064,  0.64596273,  0.66583851,  0.71190476,
+        0.73809524,  0.76428571,  0.79047619,  0.81666667,  0.84285714,
+        0.86904762,  0.8952381 ,  0.92142857,  0.94761905,  0.97380952
+    ])
+    npt.assert_array_almost_equal(results, expected)
+
+
+def test__ros_estimate():
+    expected = numpy.array([
+         3.11279729,   3.60634338,   4.04602788,   4.04602788,
+         4.71008116,   6.14010906,   6.97841457,   2.        ,
+         4.2       ,   4.62      ,   5.57      ,   5.66      ,
+         5.86      ,   6.65      ,   6.78      ,   6.79      ,
+         7.5       ,   7.5       ,   7.5       ,   8.63      ,
+         8.71      ,   8.99      ,   9.85      ,  10.82      ,
+        11.25      ,  11.25      ,  12.2       ,  14.92      ,
+        16.77      ,  17.81      ,  19.16      ,  19.19      ,
+        19.64      ,  20.18      ,  22.97
+    ])
+    df = load_advanced_data().pipe(ros._ros_estimate, 'conc', 'censored',
+                                   numpy.log, numpy.exp)
+    result = df['final'].values
+    npt.assert_array_almost_equal(result, expected)
+
+
+def test__do_ros():
+    expected = numpy.array([
+         3.11279729,   3.60634338,   4.04602788,   4.04602788,
+         4.71008116,   6.14010906,   6.97841457,   2.        ,
+         4.2       ,   4.62      ,   5.57      ,   5.66      ,
+         5.86      ,   6.65      ,   6.78      ,   6.79      ,
+         7.5       ,   7.5       ,   7.5       ,   8.63      ,
+         8.71      ,   8.99      ,   9.85      ,  10.82      ,
+        11.25      ,  11.25      ,  12.2       ,  14.92      ,
+        16.77      ,  17.81      ,  19.16      ,  19.19      ,
+        19.64      ,  20.18      ,  22.97
+    ])
+
+    df = load_basic_data().pipe(ros._do_ros, 'conc', 'censored',
+                                numpy.log, numpy.exp)
+    result = df['final'].values
+    npt.assert_array_almost_equal(result, expected)
+
+
+class CheckROSMixin(object):
+    def test_ros_df(self):
+        result = ros.ROS(self.rescol, self.cencol, df=self.df)
+        npt.assert_array_almost_equal(
+            sorted(result),
+            sorted(self.expected_final),
+            decimal=self.decimal
+        )
+
+    def test_ros_arrays(self):
+        result = ros.ROS(self.df[self.rescol], self.df[self.cencol], df=None)
+        npt.assert_array_almost_equal(
+            sorted(result),
+            sorted(self.expected_final),
+            decimal=self.decimal
+        )
+
+    def test_cohn(self):
+        cols = [
+            'nuncen_above', 'nobs_below',
+            'ncen_equal', 'prob_exceedance'
+        ]
+        cohn = ros.cohn_numbers(self.df, self.rescol, self.cencol)
+        pdtest.assert_frame_equal(
+            cohn[cols],
+            self.expected_cohn[cols],
+            check_less_precise=True,
+        )
+
+
+class Test_ROS_HelselAppendixB(CheckROSMixin):
+    """
+    Appendix B dataset from "Estimation of Descriptive Statists for
+    Multiply Censored Water Quality Data", Water Resources Research,
+    Vol 24, No 12, pp 1997 - 2004. December 1988.
+    """
+    decimal = 2
+    res = numpy.array([
+        1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 10., 10., 10.,
+        3.0, 7.0, 9.0, 12., 15., 20., 27., 33., 50.
+    ])
+    cen = numpy.array([
+        True, True, True, True, True, True, True, True, True,
+        False, False, False, False, False, False, False,
+        False, False
+    ])
+    rescol = 'obs'
+    cencol = 'cen'
+    df = pandas.DataFrame({rescol: res, cencol: cen})
+    expected_final = numpy.array([
+        0.47,  0.85, 1.11, 1.27, 1.76, 2.34, 2.50, 3.00, 3.03,
+        4.80, 7.00, 9.00, 12.0, 15.0, 20.0, 27.0, 33.0, 50.0
+    ])
+
+    expected_cohn = pandas.DataFrame({
+        'nuncen_above': numpy.array([3.0, 6.0, numpy.nan]),
+        'nobs_below': numpy.array([6.0, 12.0, numpy.nan]),
+        'ncen_equal': numpy.array([6.0, 3.0, numpy.nan]),
+        'prob_exceedance': numpy.array([0.5555, 0.3333, 0.0]),
+    })
+
+
+class Test_ROS_HelselArsenic(CheckROSMixin):
+    """
+    Oahu arsenic data from Nondetects and Data Analysis by
+    Dennis R. Helsel (John Wiley, 2005)
+
+    Plotting positions are fudged since relative to source data since
+    modeled data is what matters and (source data plot positions are
+    not uniformly spaced, which seems weird)
+    """
+    decimal = 2
+    res = numpy.array([
+        3.2, 2.8, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
+        2.0, 2.0, 1.7, 1.5, 1.0, 1.0, 1.0, 1.0,
+        0.9, 0.9, 0.7, 0.7, 0.6, 0.5, 0.5, 0.5
+    ])
+
+    cen = numpy.array([
+        False, False, True, True, True, True, True,
+        True, True, True, False, False, True, True,
+        True, True, False, True, False, False, False,
+        False, False, False
+    ])
+    rescol = 'obs'
+    cencol = 'cen'
+    df = pandas.DataFrame({rescol: res, cencol: cen})
+    expected_final = numpy.array([
+        3.20, 2.80, 1.42, 1.14, 0.95, 0.81, 0.68, 0.57,
+        0.46, 0.35, 1.70, 1.50, 0.98, 0.76, 0.58, 0.41,
+        0.90, 0.61, 0.70, 0.70, 0.60, 0.50, 0.50, 0.50
+    ])
+
+    expected_cohn = pandas.DataFrame({
+        'nuncen_above': numpy.array([6.0, 1.0, 2.0, 2.0, numpy.nan]),
+        'nobs_below': numpy.array([0.0, 7.0, 12.0, 22.0, numpy.nan]),
+        'ncen_equal': numpy.array([0.0, 1.0, 4.0, 8.0, numpy.nan]),
+        'prob_exceedance': numpy.array([1.0, 0.3125, 0.2143, 0.0833, 0.0]),
+    })
+
+
+class Test_ROS_RNADAdata(CheckROSMixin):
+    decimal = 3
+    datastring = StringIO(dedent("""\
+        res cen
+        0.090  True
+        0.090  True
+        0.090  True
+        0.101 False
+        0.136 False
+        0.340 False
+        0.457 False
+        0.514 False
+        0.629 False
+        0.638 False
+        0.774 False
+        0.788 False
+        0.900  True
+        0.900  True
+        0.900  True
+        1.000  True
+        1.000  True
+        1.000  True
+        1.000  True
+        1.000  True
+        1.000 False
+        1.000  True
+        1.000  True
+        1.000  True
+        1.000  True
+        1.000  True
+        1.000  True
+        1.000  True
+        1.000  True
+        1.000  True
+        1.000  True
+        1.000  True
+        1.000  True
+        1.100 False
+        2.000 False
+        2.000 False
+        2.404 False
+        2.860 False
+        3.000 False
+        3.000 False
+        3.705 False
+        4.000 False
+        5.000 False
+        5.960 False
+        6.000 False
+        7.214 False
+       16.000 False
+       17.716 False
+       25.000 False
+       51.000 False"""
+    ))
+    rescol = 'res'
+    cencol = 'cen'
+    df = pandas.read_csv(datastring, sep='\s+')
+    expected_final = numpy.array([
+        0.01907990,  0.03826254,  0.06080717,  0.10100000,  0.13600000,
+        0.34000000,  0.45700000,  0.51400000,  0.62900000,  0.63800000,
+        0.77400000,  0.78800000,  0.08745914,  0.25257575,  0.58544205,
+        0.01711153,  0.03373885,  0.05287083,  0.07506079,  0.10081573,
+        1.00000000,  0.13070334,  0.16539309,  0.20569039,  0.25257575,
+        0.30725491,  0.37122555,  0.44636843,  0.53507405,  0.64042242,
+        0.76644378,  0.91850581,  1.10390531,  1.10000000,  2.00000000,
+        2.00000000,  2.40400000,  2.86000000,  3.00000000,  3.00000000,
+        3.70500000,  4.00000000,  5.00000000,  5.96000000,  6.00000000,
+        7.21400000, 16.00000000, 17.71600000, 25.00000000, 51.00000000
+    ])
+
+    expected_cohn = pandas.DataFrame({
+        'nuncen_above': numpy.array([9., 0.0, 18., numpy.nan]),
+        'nobs_below': numpy.array([3., 15., 32., numpy.nan]),
+        'ncen_equal': numpy.array([3., 3., 17., numpy.nan]),
+        'prob_exceedance': numpy.array([0.84, 0.36, 0.36, 0]),
+    })
+
+
+class Test_NoOp_ZeroND(CheckROSMixin):
+    decimal = 2
+    numpy.random.seed(0)
+    N = 20
+    res = numpy.random.lognormal(size=N)
+    cen = [False] * N
+    rescol = 'obs'
+    cencol = 'cen'
+    df = pandas.DataFrame({rescol: res, cencol: cen})
+    expected_final = numpy.array([
+        0.38, 0.43, 0.81, 0.86, 0.90, 1.13, 1.15, 1.37, 1.40,
+        1.49, 1.51, 1.56, 2.14, 2.59, 2.66, 4.28, 4.46, 5.84,
+        6.47, 9.4
+    ])
+
+    expected_cohn = pandas.DataFrame({
+        'nuncen_above': numpy.array([]),
+        'nobs_below': numpy.array([]),
+        'ncen_equal': numpy.array([]),
+        'prob_exceedance': numpy.array([]),
+    })
+
+
+class Test_ROS_OneND(CheckROSMixin):
+    decimal = 3
+    res = numpy.array([
+        1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 10., 10., 10.,
+        3.0, 7.0, 9.0, 12., 15., 20., 27., 33., 50.
+    ])
+    cen = numpy.array([
+        True, False, False, False, False, False, False, False, False,
+        False, False, False, False, False, False, False,
+        False, False
+    ])
+    rescol = 'conc'
+    cencol = 'cen'
+    df = pandas.DataFrame({rescol: res, cencol: cen})
+    expected_final = numpy.array([
+        0.24, 1.0, 1.0, 1.0, 1.0, 1.0, 10., 10., 10.,
+        3.0 , 7.0, 9.0, 12., 15., 20., 27., 33., 50.
+    ])
+
+    expected_cohn = pandas.DataFrame({
+        'nuncen_above': numpy.array([17.0, numpy.nan]),
+        'nobs_below': numpy.array([1.0, numpy.nan]),
+        'ncen_equal': numpy.array([1.0, numpy.nan]),
+        'prob_exceedance': numpy.array([0.9444, 0.0]),
+    })
+
+
+class Test_HalfDLs_80pctNDs(CheckROSMixin):
+    decimal = 3
+    res = numpy.array([
+        1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 10., 10., 10.,
+        3.0, 7.0, 9.0, 12., 15., 20., 27., 33., 50.
+    ])
+    cen = numpy.array([
+        True, True, True, True, True, True, True, True,
+        True, True, True, True, True, True, True, False,
+        False, False
+    ])
+    rescol = 'value'
+    cencol = 'qual'
+    df = pandas.DataFrame({rescol: res, cencol: cen})
+    expected_final = numpy.array([
+        0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 5.0, 5.0, 5.0,
+        1.5, 3.5, 4.5, 6.0, 7.5, 10., 27., 33., 50.
+    ])
+
+    expected_cohn = pandas.DataFrame({
+        'nuncen_above': numpy.array([0., 0., 0., 0., 0., 0., 0., 3., numpy.nan]),
+        'nobs_below': numpy.array([6., 7., 8., 9., 12., 13., 14., 15., numpy.nan]),
+        'ncen_equal': numpy.array([6., 1., 1., 1., 3., 1., 1., 1., numpy.nan]),
+        'prob_exceedance': numpy.array([0.1667] * 8 + [0.]),
+    })
+
+
+class Test_HaflDLs_OneUncensored(CheckROSMixin):
+    decimal = 3
+    res = numpy.array([1.0, 1.0, 12., 15., ])
+    cen = numpy.array([True, True, True, False ])
+    rescol = 'value'
+    cencol = 'qual'
+    df = pandas.DataFrame({rescol: res, cencol: cen})
+    expected_final = numpy.array([0.5,   0.5,   6. ,  15.])
+
+    expected_cohn = pandas.DataFrame({
+        'nuncen_above': numpy.array([0., 1., numpy.nan]),
+        'nobs_below': numpy.array([2., 3., numpy.nan]),
+        'ncen_equal': numpy.array([2., 1., numpy.nan]),
+        'prob_exceedance': numpy.array([0.25, 0.25, 0.]),
+    })
+
+
+class Test_ROS_MaxCen_GT_MaxUncen(Test_ROS_HelselAppendixB):
+    res = numpy.array([
+        1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 10., 10., 10.,
+        3.0, 7.0, 9.0, 12., 15., 20., 27., 33., 50.,
+        60, 70
+    ])
+    cen = numpy.array([
+        True, True, True, True, True, True, True, True, True,
+        False, False, False, False, False, False, False,
+        False, False, True, True
+    ])
+
+
+class Test_ROS_OnlyDL_GT_MaxUncen(Test_NoOp_ZeroND):
+    numpy.random.seed(0)
+    N = 20
+    res =  [
+        0.38, 0.43, 0.81, 0.86, 0.90, 1.13, 1.15, 1.37, 1.40,
+        1.49, 1.51, 1.56, 2.14, 2.59, 2.66, 4.28, 4.46, 5.84,
+        6.47, 9.40, 10.0, 10.0
+    ]
+    cen = ([False] * N) + [True, True]

--- a/statsmodels/imputation/tests/test_ros.py
+++ b/statsmodels/imputation/tests/test_ros.py
@@ -362,7 +362,7 @@ def test__do_ros():
 
 class CheckROSMixin(object):
     def test_ros_df(self):
-        result = ros.ROS(self.rescol, self.cencol, df=self.df)
+        result = ros.impute_ros(self.rescol, self.cencol, df=self.df)
         npt.assert_array_almost_equal(
             sorted(result),
             sorted(self.expected_final),
@@ -370,7 +370,7 @@ class CheckROSMixin(object):
         )
 
     def test_ros_arrays(self):
-        result = ros.ROS(self.df[self.rescol], self.df[self.cencol], df=None)
+        result = ros.impute_ros(self.df[self.rescol], self.df[self.cencol], df=None)
         npt.assert_array_almost_equal(
             sorted(result),
             sorted(self.expected_final),


### PR DESCRIPTION
Supercedes #2021 

## Overview
In the environment, we can nearly never say that a certain parameter doesn't exist. Instead, we say that it was not detected, and as a result report a detection limit that corresponds to the lowest possible quantifiable value of the instrument and/or measurement method. You can think about this as measuring the diameter of hair with a ruler. You know the hairs have diameters, and you know they're <1 mm, but that's about all you can say.

So trying to compute basic stats about these data sets can be tricky. Luckily Dr. Helsel wrote a couple of text books about how to deal with this. [Here is the one I used to write this code](http://www.amazon.com/Nondetects-Data-Analysis-Statistics-Environmental/dp/0471671738).

Also [here's a overview paper](http://training.fws.gov/resources/course-resources/pesticides/Monitoring/USGS%20Nondetects%20water%20sampling%20bias.pdf) and an [R-package](http://cran.r-project.org/web/packages/NADA/index.html) written by I believe a colleague of Helsel.

## Tests
I got a lot of them. Coverage was 100% on my local machine. A lot of them are redundant, but check things like what should happen when >80% of values are censored, or if all but 1 values are censored, etc.

Most of the tests use known values that come from either text book or papers written by Helsel, or datasets and results that come from the R package.

## Future work
There's a lot more in the R-package that could easily be implemented in python. This is just the start.