### PR TITLE
TST: Switch appveyor 64bit

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ os: Visual Studio 2015
 environment:
   matrix:
     - PY_MAJOR_VER: 2
-      PYTHON_ARCH: "x86"
+      PYTHON_ARCH: "x86_64"
     - PY_MAJOR_VER: 3
       PYTHON_ARCH: "x86_64"
 

--- a/statsmodels/datasets/utils.py
+++ b/statsmodels/datasets/utils.py
@@ -1,6 +1,6 @@
 from statsmodels.compat.python import (range, StringIO, urlopen,
                                        HTTPError, URLError, lrange,
-                                       cPickle, urljoin, BytesIO)
+                                       cPickle, urljoin, BytesIO, long)
 import sys
 import shutil
 from os import environ
@@ -77,7 +77,7 @@ class Dataset(dict):
 def process_recarray(data, endog_idx=0, exog_idx=None, stack=True, dtype=None):
     names = list(data.dtype.names)
 
-    if isinstance(endog_idx, int):
+    if isinstance(endog_idx, (int, long)):
         endog = array(data[names[endog_idx]], dtype=dtype)
         endog_name = names[endog_idx]
         endog_idx = [endog_idx]
@@ -116,7 +116,7 @@ def process_recarray_pandas(data, endog_idx=0, exog_idx=None, dtype=None,
     data = DataFrame(data, dtype=dtype)
     names = data.columns
 
-    if isinstance(endog_idx, int):
+    if isinstance(endog_idx, (int, long)):
         endog_name = names[endog_idx]
         endog = data[endog_name]
         if exog_idx is None:
@@ -128,7 +128,7 @@ def process_recarray_pandas(data, endog_idx=0, exog_idx=None, dtype=None,
         endog_name = list(endog.columns)
         if exog_idx is None:
             exog = data.drop(endog_name, axis=1)
-        elif isinstance(exog_idx, int):
+        elif isinstance(exog_idx, (int, long)):
             exog = data.filter([names[exog_idx]])
         else:
             exog = data.filter(names[exog_idx])

--- a/statsmodels/graphics/utils.py
+++ b/statsmodels/graphics/utils.py
@@ -1,5 +1,5 @@
 """Helper functions for graphics with Matplotlib."""
-from statsmodels.compat.python import lrange, range
+from statsmodels.compat.python import lrange, range, long
 
 __all__ = ['create_mpl_ax', 'create_mpl_fig']
 
@@ -98,7 +98,7 @@ def maybe_name_or_idx(idx, model):
     """
     if idx is None:
         idx = lrange(model.exog.shape[1])
-    if isinstance(idx, int):
+    if isinstance(idx, (int, long)):
         exog_name = model.exog_names[idx]
         exog_idx = idx
     # anticipate index as list and recurse

--- a/statsmodels/iolib/table.py
+++ b/statsmodels/iolib/table.py
@@ -85,7 +85,7 @@ Potential problems for Python 3
 
 from __future__ import division
 from statsmodels.compat.python import (lmap, lrange, zip, next, iteritems,
-                                       zip_longest, range)
+                                       zip_longest, range, long)
 
 from itertools import cycle
 import csv
@@ -316,7 +316,7 @@ class SimpleTable(list):
             return [0] * ncols
         elif request is None:  # assume no extra space desired (e.g, CSV)
             request = [0] * ncols
-        elif isinstance(request, int):
+        elif isinstance(request, (int, long)):
             request = [request] * ncols
         elif len(request) < ncols:
             request = [request[i % len(request)] for i in range(ncols)]
@@ -677,7 +677,7 @@ class Cell(object):
         fmt = self._get_fmt(output_format, **fmt_dict)
         datatype = self.datatype
         data_aligns = fmt.get('data_aligns', 'c')
-        if isinstance(datatype, int):
+        if isinstance(datatype, (int, long)):
             align = data_aligns[datatype % len(data_aligns)]
         elif datatype == 'stub':
             # still support deprecated `stubs_align`
@@ -710,7 +710,7 @@ class Cell(object):
             if data_fmt is None:
                 data_fmt = '%s'
             data_fmts = [data_fmt]
-        if isinstance(datatype, int):
+        if isinstance(datatype, (int, long)):
             datatype = datatype % len(data_fmts)  # constrain to indexes
             content = data_fmts[datatype] % (data,)
         elif datatype in fmt:

--- a/statsmodels/sandbox/nonparametric/smoothers.py
+++ b/statsmodels/sandbox/nonparametric/smoothers.py
@@ -8,6 +8,8 @@ who generate a smooth fit of a set of (x,y) pairs.
 # pylint: disable-msg=E0611
 # pylint: disable-msg=E1101
 from __future__ import print_function
+from statsmodels.compat.python import long
+
 import numpy as np
 from . import kernels
 #import numbers
@@ -70,7 +72,7 @@ class KernelSmoother(object):
         xth sample point - so they are closer together where the data
         is denser.
         """
-        if isinstance(x, int):
+        if isinstance(x, (int, long)):
             sorted_x = np.array(self.x)
             sorted_x.sort()
             confx = sorted_x[::x]

--- a/statsmodels/sandbox/regression/try_treewalker.py
+++ b/statsmodels/sandbox/regression/try_treewalker.py
@@ -6,7 +6,7 @@ should collect and aggregate likelihood contributions bottom up
 
 '''
 from __future__ import print_function
-from statsmodels.compat.python import iteritems, itervalues, lrange, zip
+from statsmodels.compat.python import iteritems, itervalues, lrange, zip, long
 import numpy as np
 
 tree = [[0,1],[[2,3],[4,5,6]],[7]]
@@ -19,7 +19,7 @@ def branch(tree):
     '''walking a tree bottom-up
     '''
 
-    if not isinstance(tree[0], int):   #assumes leaves are int for choice index
+    if not isinstance(tree[0], (int, long)):   #assumes leaves are int for choice index
         branchsum = 0
         for b in tree:
             branchsum += branch(b)

--- a/statsmodels/sandbox/stats/diagnostic.py
+++ b/statsmodels/sandbox/stats/diagnostic.py
@@ -30,7 +30,7 @@ missing:
 
 """
 from __future__ import print_function
-from statsmodels.compat.python import iteritems, lrange, map
+from statsmodels.compat.python import iteritems, lrange, map, long
 import numpy as np
 from scipy import stats
 from statsmodels.regression.linear_model import OLS
@@ -284,7 +284,7 @@ def acorr_ljungbox(x, lags=None, boxpierce=False):
     nobs = x.shape[0]
     if lags is None:
         lags = lrange(1,41)  #TODO: check default; SS: changed to 40
-    elif isinstance(lags, int):
+    elif isinstance(lags, (int, long)):
         lags = lrange(1,lags+1)
     maxlag = max(lags)
     lags = np.asarray(lags)

--- a/statsmodels/tools/tools.py
+++ b/statsmodels/tools/tools.py
@@ -1,7 +1,7 @@
 '''
 Utility functions models code
 '''
-from statsmodels.compat.python import reduce, lzip, lmap, asstr2, range
+from statsmodels.compat.python import reduce, lzip, lmap, asstr2, range, long
 import numpy as np
 import numpy.lib.recfunctions as nprf
 import numpy.linalg as L
@@ -146,7 +146,7 @@ def categorical(data, col=None, dictnames=False, drop=False, ):
     if data.dtype.names or data.__class__ is np.recarray:
         if not col and np.squeeze(data).ndim > 1:
             raise IndexError("col is None and the input array is not 1d")
-        if isinstance(col, int):
+        if isinstance(col, (int, long)):
             col = data.dtype.names[col]
         if col is None and data.dtype.names and len(data.dtype.names) == 1:
             col = data.dtype.names[0]
@@ -200,7 +200,7 @@ def categorical(data, col=None, dictnames=False, drop=False, ):
         if not isinstance(data, np.ndarray):
             raise NotImplementedError("Array-like objects are not supported")
 
-        if isinstance(col, int):
+        if isinstance(col, (int, long)):
             offset = data.shape[1]          # need error catching here?
             tmp_arr = np.unique(data[:, col])
             tmp_dummy = (tmp_arr[:, np.newaxis] == data[:, col]).astype(float)

--- a/statsmodels/tsa/ar_model.py
+++ b/statsmodels/tsa/ar_model.py
@@ -1,5 +1,5 @@
 from __future__ import division
-from statsmodels.compat.python import iteritems, range, string_types, lmap
+from statsmodels.compat.python import iteritems, range, string_types, lmap, long
 
 import numpy as np
 from numpy import dot, identity
@@ -153,7 +153,7 @@ class AR(tsbase.TimeSeriesModel):
                 start = 0
             else:  # can't do presample fit for cmle or dynamic
                 start = k_ar
-        elif isinstance(start, int):
+        elif isinstance(start, (int, long)):
             start = super(AR, self)._get_predict_start(start)
         else:  # should be a date
             start = _validate(start, k_ar, self.data.dates, method)

--- a/statsmodels/tsa/arima_model.py
+++ b/statsmodels/tsa/arima_model.py
@@ -5,7 +5,7 @@
 #       packages such as gretl and X12-ARIMA
 
 from __future__ import absolute_import
-from statsmodels.compat.python import string_types, range
+from statsmodels.compat.python import string_types, range, long
 # for 2to3 with extensions
 
 from datetime import datetime
@@ -646,7 +646,7 @@ class ARMA(tsbase.TimeSeriesModel):
             else:
                 start = k_ar
             self._set_predict_start_date(start)  # else it's done in super
-        elif isinstance(start, int):
+        elif isinstance(start, (int, long)):
             start = super(ARMA, self)._get_predict_start(start)
         else:  # should be on a date
             #elif 'mle' not in method or dynamic: # should be on a date
@@ -1014,7 +1014,7 @@ class ARIMA(ARMA):
                 start = 0
             else:
                 start = k_ar
-        elif isinstance(start, int):
+        elif isinstance(start, (int, long)):
                 start -= k_diff
                 try:  # catch when given an integer outside of dates index
                     start = super(ARIMA, self)._get_predict_start(start,

--- a/statsmodels/tsa/base/tsa_model.py
+++ b/statsmodels/tsa/base/tsa_model.py
@@ -1,4 +1,4 @@
-from statsmodels.compat.python import lrange
+from statsmodels.compat.python import lrange, long
 import statsmodels.base.model as base
 from statsmodels.base import data
 import statsmodels.base.wrapper as wrap
@@ -178,7 +178,7 @@ class TimeSeriesModel(base.LikelihoodModel):
                         raise err # should never get here
             self._make_predict_dates() # attaches self.data.predict_dates
 
-        elif isinstance(end, int) and dates is not None:
+        elif isinstance(end, (int, long)) and dates is not None:
             try:
                 self.data.predict_end = dates[end]
             except IndexError as err:
@@ -203,7 +203,7 @@ class TimeSeriesModel(base.LikelihoodModel):
 
             self._make_predict_dates()
 
-        elif isinstance(end, int):
+        elif isinstance(end, (int, long)):
             nobs = len(self.data.endog) - 1 # is an index
             if end > nobs:
                 out_of_sample = end - nobs
@@ -242,8 +242,8 @@ class TimeSeriesModel(base.LikelihoodModel):
                 from pandas import DateRange
                 dates = DateRange(dtstart, dtend, offset = pandas_freq).values
         # handle
-        elif freq is None and (isinstance(dtstart, int) and
-                               isinstance(dtend, int)):
+        elif freq is None and (isinstance(dtstart, (int, long)) and
+                               isinstance(dtend, (int, long))):
             from pandas import Index
             dates = Index(lrange(dtstart, dtend+1))
         # if freq is None and dtstart and dtend aren't integers, we're

--- a/statsmodels/tsa/base/tsa_model.py
+++ b/statsmodels/tsa/base/tsa_model.py
@@ -210,10 +210,18 @@ class TimeSeriesModel(base.LikelihoodModel):
                 end = nobs
 
         elif freq is None: # should have a date with freq = None
+            print('#'*80)
+            print(freq)
+            print(type(freq))
+            print('#'*80)
             raise ValueError("When freq is None, you must give an integer "
                              "index for end.")
 
         else:
+            print('#'*80)
+            print(freq)
+            print(type(freq))
+            print('#'*80)
             raise ValueError("no rule for interpreting end")
 
         return end, out_of_sample

--- a/statsmodels/tsa/statespace/mlemodel.py
+++ b/statsmodels/tsa/statespace/mlemodel.py
@@ -5,6 +5,7 @@ Author: Chad Fulton
 License: Simplified-BSD
 """
 from __future__ import division, absolute_import, print_function
+from statsmodels.compat.python import long
 
 import numpy as np
 import pandas as pd
@@ -2308,7 +2309,7 @@ class MLEResults(tsbase.TimeSeriesModelResults):
         forecast : array
             Array of out of sample forecasts. A (steps x k_endog) array.
         """
-        if isinstance(steps, int):
+        if isinstance(steps, (int, long)):
             end = self.nobs+steps-1
         else:
             end = steps
@@ -2373,7 +2374,7 @@ class MLEResults(tsbase.TimeSeriesModelResults):
         forecast : array
             Array of out of sample forecasts. A (steps x k_endog) array.
         """
-        if isinstance(steps, int):
+        if isinstance(steps, (int, long)):
             end = self.nobs+steps-1
         else:
             end = steps

--- a/statsmodels/tsa/statespace/sarimax.py
+++ b/statsmodels/tsa/statespace/sarimax.py
@@ -5,6 +5,7 @@ Author: Chad Fulton
 License: Simplified-BSD
 """
 from __future__ import division, absolute_import, print_function
+from statsmodels.compat.python import long
 
 from warnings import warn
 
@@ -309,18 +310,18 @@ class SARIMAX(MLEModel):
         # Assume that they are given from lowest degree to highest, that all
         # degrees except for the constant are included, and that they are
         # boolean vectors (0 for not included, 1 for included).
-        if isinstance(order[0], int):
+        if isinstance(order[0], (int, long)):
             self.polynomial_ar = np.r_[1., np.ones(order[0])]
         else:
             self.polynomial_ar = np.r_[1., order[0]]
-        if isinstance(order[2], int):
+        if isinstance(order[2], (int, long)):
             self.polynomial_ma = np.r_[1., np.ones(order[2])]
         else:
             self.polynomial_ma = np.r_[1., order[2]]
         # Assume that they are given from lowest degree to highest, that the
         # degrees correspond to (1*s, 2*s, ..., P*s), and that they are
         # boolean vectors (0 for not included, 1 for included).
-        if isinstance(seasonal_order[0], int):
+        if isinstance(seasonal_order[0], (int, long)):
             self.polynomial_seasonal_ar = np.r_[
                 1.,  # constant
                 ([0] * (self.k_seasons - 1) + [1]) * seasonal_order[0]
@@ -333,7 +334,7 @@ class SARIMAX(MLEModel):
                 self.polynomial_seasonal_ar[(i + 1) * self.k_seasons] = (
                     seasonal_order[0][i]
                 )
-        if isinstance(seasonal_order[2], int):
+        if isinstance(seasonal_order[2], (int, long)):
             self.polynomial_seasonal_ma = np.r_[
                 1.,  # constant
                 ([0] * (self.k_seasons - 1) + [1]) * seasonal_order[2]

--- a/statsmodels/tsa/statespace/tests/test_mlemodel.py
+++ b/statsmodels/tsa/statespace/tests/test_mlemodel.py
@@ -17,7 +17,7 @@ from statsmodels.tsa.statespace.mlemodel import MLEModel, MLEResultsWrapper
 from statsmodels.datasets import nile
 from numpy.testing import assert_almost_equal, assert_equal, assert_allclose, assert_raises
 from nose.exc import SkipTest
-from .results import results_sarimax
+from statsmodels.tsa.statespace.tests.results import results_sarimax
 
 current_path = os.path.dirname(os.path.abspath(__file__))
 

--- a/statsmodels/tsa/statespace/tests/test_structural.py
+++ b/statsmodels/tsa/statespace/tests/test_structural.py
@@ -14,7 +14,7 @@ import warnings
 from statsmodels.datasets import macrodata
 from statsmodels.tsa.statespace import structural
 from statsmodels.tsa.statespace.structural import UnobservedComponents
-from .results import results_structural
+from statsmodels.tsa.statespace.tests.results import results_structural
 from statsmodels.tools import add_constant
 from numpy.testing import assert_equal, assert_almost_equal, assert_raises, assert_allclose
 from nose.exc import SkipTest

--- a/statsmodels/tsa/stattools.py
+++ b/statsmodels/tsa/stattools.py
@@ -2,7 +2,7 @@
 Statistical tools for time series analysis
 """
 from statsmodels.compat.python import (iteritems, range, lrange, string_types,
-                                       lzip, zip)
+                                       lzip, zip, long)
 from statsmodels.compat.scipy import _next_regular
 
 import numpy as np
@@ -200,7 +200,7 @@ def adfuller(x, maxlag=None, regression="c", autolag='AIC',
         store = True
 
     trenddict = {None: 'nc', 0: 'c', 1: 'ct', 2: 'ctt'}
-    if regression is None or isinstance(regression, int):
+    if regression is None or isinstance(regression, (int, long)):
         regression = trenddict[regression]
     regression = regression.lower()
     if regression not in ['c', 'nc', 'ct', 'ctt']:

--- a/statsmodels/tsa/tsatools.py
+++ b/statsmodels/tsa/tsatools.py
@@ -1,4 +1,4 @@
-from statsmodels.compat.python import range, lrange, lzip
+from statsmodels.compat.python import range, lrange, lzip, long
 
 import numpy as np
 import numpy.lib.recfunctions as nprf
@@ -169,7 +169,7 @@ def add_lag(x, col=None, lags=1, drop=False, insert=True):
             raise IndexError("col is None and the input array is not 1d")
         elif len(names) == 1:
             col = names[0]
-        if isinstance(col, int):
+        if isinstance(col, (int, long)):
             col = x.dtype.names[col]
         contemp = x[col]
 

--- a/statsmodels/tsa/vector_ar/util.py
+++ b/statsmodels/tsa/vector_ar/util.py
@@ -1,14 +1,12 @@
 """
 Miscellaneous utility code for VAR estimation
 """
-from statsmodels.compat.python import range, string_types, asbytes
+from statsmodels.compat.python import range, string_types, asbytes, long
 import numpy as np
 import scipy.stats as stats
-import scipy.linalg as L
 import scipy.linalg.decomp as decomp
 
 import statsmodels.tsa.tsatools as tsa
-from scipy.linalg import cholesky
 
 #-------------------------------------------------------------------------------
 # Auxiliary functions for estimation
@@ -208,7 +206,7 @@ def get_index(lst, name):
     try:
         result = lst.index(name)
     except Exception:
-        if not isinstance(name, int):
+        if not isinstance(name, (int, long)):
             raise
         result = name
     return result


### PR DESCRIPTION
Switched Python 2.7 to 64 bit which mostly elimiates noise which seems to be driven by small integer types.  

@ChadFulton Also found an incorrect practice of using `isinstance(*, int)` which should usually be `isinstance(*, (int, long))` for older Python.  Fixed all instances where I though it could be hit, even it accidentally.

