### PR TITLE
Var cleanup rebased

### DIFF
--- a/examples/notebooks/tsa_var.ipynb
+++ b/examples/notebooks/tsa_var.ipynb
@@ -1,0 +1,384 @@
+{
+ "metadata": {
+  "name": "tsa_var"
+ },
+ "nbformat": 3,
+ "nbformat_minor": 0,
+ "worksheets": [
+  {
+   "cells": [
+    {
+     "cell_type": "heading",
+     "level": 3,
+     "metadata": {},
+     "source": [
+      "Vector Autoregressions: inflation-unemployment-interest rate"
+     ]
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "Vector Autoregression (VAR), introduced by Nobel laureate Christopher Sims in 1980, is a powerful statistical tool in the macroeconomist's toolkit."
+     ]
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "Formally a VAR model is\n",
+      "\n",
+      "$$Y_t = A_1 Y_{t-1} + \\ldots + A_p Y_{t-p} + u_t$$\n",
+      "\n",
+      "$$u_t \\sim {\\sf Normal}(0, \\Sigma_u)$$\n",
+      "\n",
+      "where $Y_t$ is of dimension $K$ and $A_i$ is a $K \\times K$ coefficient matrix."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "import statsmodels.api as sm\n",
+      "import pandas\n",
+      "import matplotlib.pyplot as plt"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": []
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "dta = sm.datasets.macrodata.load_pandas().data\n",
+      "Y = dta[[\"infl\", \"unemp\", \"tbilrate\"]]"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": []
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "index = sm.tsa.datetools.dates_from_range('1959Q1', '2009Q3')\n",
+      "del dta['year']\n",
+      "del dta['quarter']\n",
+      "\n",
+      "Y.index = index\n",
+      "print Y.head(10)"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": []
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "fig, ax = plt.subplots(figsize=(10,8))\n",
+      "ax = Y.plot(subplots=True, ax=ax);\n",
+      "fig.tight_layout()"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": []
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "# model only after Volcker appointment\n",
+      "var_mod = sm.tsa.VAR(Y.ix['1979-12-31':], nlags=4).fit()\n",
+      "print var_mod.summary()"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": []
+    },
+    {
+     "cell_type": "heading",
+     "level": 3,
+     "metadata": {},
+     "source": [
+      "Diagnostics"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "np.abs(var_mod.roots)"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": []
+    },
+    {
+     "cell_type": "raw",
+     "metadata": {},
+     "source": [
+      "var_mod.test_normality() and var_mod.test_whiteness() are also available. There are problems with this model..."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "test_res = var_mod.test_normality()"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": []
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "test_res"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": []
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "var_mod.test_whiteness()"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": []
+    },
+    {
+     "cell_type": "heading",
+     "level": 3,
+     "metadata": {},
+     "source": [
+      "Granger-Causality tests"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "granger_res = var_mod.test_causality('unemp', 'tbilrate', kind='Wald')"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": []
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "granger_res"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": []
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "granger_all = var_mod.test_causality_all('wald')"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": []
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "print granger_all"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": []
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "From this we reject the null that these variables do not Granger cause for all cases except for infl -> tbilrate. In other words, in almost all cases we can reject the null hypothesis that the lags of the *excluded* variable are jointly zero in `equation`."
+     ]
+    },
+    {
+     "cell_type": "heading",
+     "level": 3,
+     "metadata": {},
+     "source": [
+      "Order Selection"
+     ]
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "Use the VAR model's `classmethod` select_order to return a dictionary of lag order selection according to the information criteria."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "best = sm.tsa.VAR.select_order(Y.ix['1979-12-31':])"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": []
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "print best"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": []
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "You can use the `select_order_fit` method to also return a model results instance according to the chosen information criterion."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "res = sm.tsa.var.select_order_fit(Y.ix['1979-12-31':], ic='aic')"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": []
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "res.summary()"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": []
+    },
+    {
+     "cell_type": "heading",
+     "level": 3,
+     "metadata": {},
+     "source": [
+      "Impulse Response Functions"
+     ]
+    },
+    {
+     "cell_type": "raw",
+     "metadata": {},
+     "source": [
+      "Suppose we want to examine what happens to each of the variables when a 1 unit increase in the current value of one of the VAR errors occurs (a \"shock\"). To isolate the effects of only one error while holding the others constant, we need the model to be in a form so that the contemporaneous errors are uncorrelated across equations. One such way to achieve this is the so-called recursive VAR. In the recursive VAR, the order of the variables is determined by how the econometrician views the economic processes as ocurring. Given this order, inflation is determined by the contemporaneous unemployment rate and tbilrate is determined by the contemporaneous inflation and unemployment rates. Unemployment is a function of only the past values of itself, inflation, and the T-bill rate.\n",
+      "\n",
+      "We achieve such a structure by using the Choleski decomposition."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "irf = var_mod.irf(24)"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": []
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "irf.plot(orth=True, signif=.33, subplot_params = {'fontsize' : 18})"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": []
+    },
+    {
+     "cell_type": "raw",
+     "metadata": {},
+     "source": [
+      "Note that inflation dynamics are not very persistent, but do appear to have a significant and immediate impact on interest rates and on unemployment in the medium run."
+     ]
+    },
+    {
+     "cell_type": "heading",
+     "level": 3,
+     "metadata": {},
+     "source": [
+      "Forecast Error Decompositions"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "var_mod.fevd(24).summary()"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": []
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "var_mod.fevd(24).plot(figsize=(12,12))"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": []
+    },
+    {
+     "cell_type": "raw",
+     "metadata": {},
+     "source": [
+      "There is some amount of interaction between the variables. For instance, at the 12 quarter horizon, 40% of the error in the forecast of the T-bill rate is attributed to the inflation and unemployment shocks in the recursive VAR."
+     ]
+    },
+    {
+     "cell_type": "raw",
+     "metadata": {},
+     "source": [
+      "To make structural inferences - e.g., what is the effect on the rate of inflation and unemployment of an unexpected 100 basis point increase in the Federal Funds rate (proxied by the T-bill rate here), we might want to fit a structural VAR model based on economic theory of monetary policy. For instance, we might replace the VAR equation for the T-bill rate with a policy equation such as a Taylor rule and restrict coefficients. You can do so with the sm.tsa.SVAR class."
+     ]
+    },
+    {
+     "cell_type": "heading",
+     "level": 3,
+     "metadata": {},
+     "source": [
+      "Exercises"
+     ]
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "Experiment with different VAR models. You can try to adjust the number of lags in the VAR model calculated above or the ordering of the variables and see how it affects the model."
+     ]
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "You might also try adding variables to the VAR, say *M1* measure of money supply, or estimating a different model using measures of consumption (realcons), government spending (realgovt), or GDP (realgdp)."
+     ]
+    }
+   ],
+   "metadata": {}
+  }
+ ]
+}

--- a/statsmodels/base/data.py
+++ b/statsmodels/base/data.py
@@ -529,7 +529,14 @@ class PandasData(ModelData):
             return DataFrame(result, index=self.param_names)
 
     def attach_columns_eq(self, result):
-        return DataFrame(result, index=self.xnames, columns=self.ynames)
+        if result.ndim <= 2:
+            return DataFrame(result, index=self.xnames, columns=self.ynames)
+        else: # for e.g., confidence intervals in systems of equations
+            from pandas import MultiIndex
+            #TODO: handle MNLogit, see cov2d below
+            idx = [(i,j) for i in self.ynames for j in self.xnames]
+            index = MultiIndex.from_tuples(idx, names=["equation", "variable"])
+            return DataFrame(result.reshape(-1, 2), index=index)
 
     def attach_cov(self, result):
         return DataFrame(result, index=self.param_names,

--- a/statsmodels/base/data.py
+++ b/statsmodels/base/data.py
@@ -421,6 +421,8 @@ class ModelData(object):
             return self.attach_generic_columns_2d(obj, names)
         elif how == 'ynames':
             return self.attach_ynames(obj)
+        elif how == "cov2d":
+            return self.attach_cov2d(obj)
         else:
             return obj
 
@@ -434,6 +436,9 @@ class ModelData(object):
         return result
 
     def attach_cov_eq(self, result):
+        return result
+
+    def attach_cov2d(self, result):
         return result
 
     def attach_rows(self, result):
@@ -529,6 +534,17 @@ class PandasData(ModelData):
     def attach_cov(self, result):
         return DataFrame(result, index=self.param_names,
                          columns=self.param_names)
+
+    def attach_cov2d(self, result):
+        # wraps parameters for systems of equations, VAR, MNLogit, etc.
+
+        #TODO: attach this to data in MNLogit.cov_params
+        #if hasattr(self, '_choice_names'): # MNLogit
+        #    ynames = self._choice_names
+        #else:
+        ynames = self.ynames
+        names = ['.'.join((i,j)) for i in ynames for j in self.xnames]
+        return DataFrame(result, index=names, columns=names)
 
     def attach_cov_eq(self, result):
         return DataFrame(result, index=self.ynames, columns=self.ynames)

--- a/statsmodels/examples/tsa/ex_var.py
+++ b/statsmodels/examples/tsa/ex_var.py
@@ -20,7 +20,7 @@ res = model.fit(4)
 nobs_all = data.shape[0]
 
 #in-sample 1-step ahead forecasts
-fc_in = np.array([np.squeeze(res.forecast(model.y[t-20:t], 1))
+fc_in = np.array([np.squeeze(res.forecast(model.Y[t-20:t], 1))
                   for t in range(nobs_all-6,nobs_all)])
 
 print(fc_in - res.fittedvalues[-6:])

--- a/statsmodels/tsa/api.py
+++ b/statsmodels/tsa/api.py
@@ -1,7 +1,7 @@
 from .ar_model import AR
 from .arima_model import ARMA, ARIMA
-from . import vector_ar as var
 from .arima_process import arma_generate_sample, ArmaProcess
+from .vector_ar import api as var
 from .vector_ar.var_model import VAR
 from .vector_ar.svar_model import SVAR
 from .vector_ar.dynamic import DynamicVAR

--- a/statsmodels/tsa/vector_ar/api.py
+++ b/statsmodels/tsa/vector_ar/api.py
@@ -1,5 +1,5 @@
 # pylint: disable=W0611
 
-from .var_model import VAR, select_order_fit, select_order
+from .var_model import VAR, select_order_fit, select_order, forecast
 from .svar_model import SVAR
 from .dynamic import DynamicVAR

--- a/statsmodels/tsa/vector_ar/api.py
+++ b/statsmodels/tsa/vector_ar/api.py
@@ -1,5 +1,5 @@
 # pylint: disable=W0611
 
-from .var_model import VAR, select_order_fit
+from .var_model import VAR, select_order_fit, select_order
 from .svar_model import SVAR
 from .dynamic import DynamicVAR

--- a/statsmodels/tsa/vector_ar/api.py
+++ b/statsmodels/tsa/vector_ar/api.py
@@ -1,5 +1,5 @@
 # pylint: disable=W0611
 
-from .var_model import VAR
+from .var_model import VAR, select_order_fit
 from .svar_model import SVAR
 from .dynamic import DynamicVAR

--- a/statsmodels/tsa/vector_ar/irf.py
+++ b/statsmodels/tsa/vector_ar/irf.py
@@ -34,7 +34,7 @@ class BaseIRAnalysis(object):
         self.order = order
 
         if P is None:
-            sigma = model.sigma_u
+            cov_resid = model.cov_resid
 
             # TODO, may be difficult at the moment
             # if order is not None:
@@ -44,7 +44,7 @@ class BaseIRAnalysis(object):
             #     if sigma.shape != model.sigma_u.shape:
             #         raise ValueError('variable order is wrong length')
 
-            P = la.cholesky(sigma)
+            P = la.cholesky(cov_resid)
 
         self.P = P
 
@@ -237,8 +237,8 @@ class IRAnalysis(BaseIRAnalysis):
         BaseIRAnalysis.__init__(self, model, P=P, periods=periods,
                                 order=order, svar=svar)
 
-        self.cov_a = model._cov_alpha
-        self.cov_sig = model._cov_sigma
+        self.cov_a = model._cov_params_ex_trend
+        self.cov_sig = model._cov_cov_resid
 
         # memoize dict for G matrix function
         self._g_memo = {}

--- a/statsmodels/tsa/vector_ar/output.py
+++ b/statsmodels/tsa/vector_ar/output.py
@@ -167,7 +167,7 @@ class VARSummary(object):
 
     def _resid_info(self):
         buf = StringIO()
-        names = self.results.endog_names
+        names = self.results.model.endog_names
 
         buf.write("Correlation matrix of residuals" + '\n')
         buf.write(pprint_matrix(self.results.resid_corr, names, names) + '\n')

--- a/statsmodels/tsa/vector_ar/output.py
+++ b/statsmodels/tsa/vector_ar/output.py
@@ -62,8 +62,8 @@ class VARSummary(object):
         header_dec_below=None,
     )
 
-    def __init__(self, estimator):
-        self.model = estimator
+    def __init__(self, results):
+        self.results = results
         self.summary = self.make()
 
     def __repr__(self):
@@ -85,16 +85,16 @@ class VARSummary(object):
     def _header_table(self):
         import time
 
-        model = self.model
+        results = self.results
 
         t = time.localtime()
 
         # TODO: change when we allow coef restrictions
-        # ncoefs = len(model.beta)
+        # ncoefs = len(results.beta)
 
         # Header information
         part1title = "Summary of Regression Results"
-        part1data = [[model._model_type],
+        part1data = [[results._model_type],
                      ["OLS"], #TODO: change when fit methods change
                      [time.strftime("%a, %d, %b, %Y", t)],
                      [time.strftime("%H:%M:%S", t)]]
@@ -113,7 +113,7 @@ class VARSummary(object):
         # use results if wanted?
         # Handle overall fit statistics
 
-        model = self.model
+        results = self.results
 
 
         part2Lstubs = ('No. of Equations:',
@@ -124,8 +124,10 @@ class VARSummary(object):
                        'HQIC:',
                        'FPE:',
                        'Det(Omega_mle):')
-        part2Ldata = [[model.neqs], [model.nobs], [model.llf], [model.aic]]
-        part2Rdata = [[model.bic], [model.hqic], [model.fpe], [model.detomega]]
+        part2Ldata = [[results.neqs], [results.nobs], [results.llf],
+                      [results.aic]]
+        part2Rdata = [[results.bic], [results.hqic], [results.fpe],
+                      [results.det_cov_resid]]
         part2Lheader = None
         part2L = SimpleTable(part2Ldata, part2Lheader, part2Lstubs,
                              txt_fmt = self.part2_fmt)
@@ -136,24 +138,23 @@ class VARSummary(object):
         return str(part2L)
 
     def _coef_table(self):
-        model = self.model
-        k = model.neqs
+        results = self.results
+        k = results.neqs
 
-        Xnames = self.model.exog_names
+        Xnames = self.results.model.exog_names
 
-        data = lzip(model.params.T.ravel(),
-                   model.stderr.T.ravel(),
-                   model.tvalues.T.ravel(),
-                   model.pvalues.T.ravel())
+        data = lzip(results.params.T.ravel(),
+                    results.stderr.T.ravel(),
+                    results.tvalues.T.ravel(),
+                    results.pvalues.T.ravel())
 
         header = ('coefficient','std. error','t-stat','prob')
 
         buf = StringIO()
-        dim = k * model.k_ar + model.k_trend
+        dim = k * results.k_ar + results.k_trend
         for i in range(k):
-            section = "Results for equation %s" % model.names[i]
+            section = "Results for equation %s" % results.names[i]
             buf.write(section + '\n')
-            #print >> buf, section
 
             table = SimpleTable(data[dim * i : dim * (i + 1)], header,
                                 Xnames, title=None, txt_fmt = self.default_fmt)
@@ -166,10 +167,10 @@ class VARSummary(object):
 
     def _resid_info(self):
         buf = StringIO()
-        names = self.model.names
+        names = self.results.endog_names
 
         buf.write("Correlation matrix of residuals" + '\n')
-        buf.write(pprint_matrix(self.model.resid_corr, names, names) + '\n')
+        buf.write(pprint_matrix(self.results.resid_corr, names, names) + '\n')
 
         return buf.getvalue()
 

--- a/statsmodels/tsa/vector_ar/plotting.py
+++ b/statsmodels/tsa/vector_ar/plotting.py
@@ -195,9 +195,8 @@ def plot_full_acorr(acorr, fontsize=8, linewidth=8, err_bound=None,
             acorr_plot(acorr[:, i, j], linewidth=linewidth, ax=ax, **kwargs)
 
             if err_bound is not None:
-                #TODO: are the error bounds always symmetric?
-                ax.axhline(err_bound[:, i, j], color='k', linestyle='--')
-                ax.axhline(-err_bound[:, i, j], color='k', linestyle='--')
+                ax.axhline(err_bound, color='k', linestyle='--')
+                ax.axhline(-err_bound, color='k', linestyle='--')
 
     adjust_subplots(fig)
     config.revert()

--- a/statsmodels/tsa/vector_ar/plotting.py
+++ b/statsmodels/tsa/vector_ar/plotting.py
@@ -253,20 +253,46 @@ def adjust_subplots(fig, **kwds):
 #-------------------------------------------------------------------------------
 # Multiple impulse response (cum_effects, etc.) cplots
 
-#TODO: Docs
 def irf_grid_plot(values, stderr, impcol, rescol, names, title,
-                  signif=0.05, hlines=None, subplot_params=None,
-                  plot_params=None, figsize=(10,10), stderr_type='asym'):
+                  stderr_type='asym', signif=0.05, hlines=None,
+                  subplot_kwargs=None, figsize=(10,10), fontsize=12,
+                  **kwargs):
     """
-    Reusable function to make flexible grid plots of impulse responses and
-    comulative effects
+    Make flexible grid plots of impulse responses and cumulative effects
 
+    Parameters
+    ----------
     values : ndarray
         Values to plot of shape (`nobs` + 1) x `neqs` x `neqs`
     stderr : ndarray
         Standard errors of shape (`nobs` x `neqs` x `neqs`)
+    impcol : str or int
+        The variable providing the impulse
+    rescol : str or int
+        The variable affected by the impulse
+    names : list
+        Then names of the endogenous variables
+    title : str
+        The title of the plot
+    stderr_type : str {"asym", "mc", "sz1", "sz2", "sz3"}
+        The type of standard errors.
+
+        * asym : Aymptotic standard errors.
+        * mc : Monte Carlo
+        * sz1 : Sims-Zha 1
+        * sz2 : Sims-Zha 2
+        * sz3 : Sims-Zha 3
+    signif : float
+        The significance level of the confidence intervals
     hlines : ndarray
         Shape (`neqs` x `neqs`)
+    subplot_kwargs : dict
+        Passed to subplot creation.
+    figsize : tuple
+        The size of the figure
+    fontsize : int
+        The font size for the plot titles.
+
 
     Return
     ------
@@ -274,15 +300,14 @@ def irf_grid_plot(values, stderr, impcol, rescol, names, title,
         The `matplotlib.figure` instance that contains the axes.
     """
 
-    if subplot_params is None:
-        subplot_params = {}
-    if plot_params is None:
-        plot_params = {}
+    if subplot_kwargs is None:
+        subplot_kwargs = {}
 
     nrows, ncols, to_plot = _get_irf_plot_config(names, impcol, rescol)
 
     fig, axes = _create_mpl_subplots(None, nrows, ncols, sharex=True,
-                                     squeeze=False, figsize=figsize)
+                                     squeeze=False, figsize=figsize,
+                                     subplot_kw=subplot_kwargs)
 
     # fill out space
     adjust_subplots(fig)
@@ -316,8 +341,7 @@ def irf_grid_plot(values, stderr, impcol, rescol, names, title,
         if hlines is not None:
             ax.axhline(hlines[i,j], color='k')
 
-        sz = subplot_params.get('fontsize', 12)
-        ax.set_title(subtitle_temp % (names[j], names[i]), fontsize=sz)
+        ax.set_title(subtitle_temp % (names[j], names[i]), fontsize=fontsize)
 
     return fig
 

--- a/statsmodels/tsa/vector_ar/plotting.py
+++ b/statsmodels/tsa/vector_ar/plotting.py
@@ -1,6 +1,21 @@
 from statsmodels.compat.python import lrange, range
 import numpy as np
 import statsmodels.tsa.vector_ar.util as util
+from statsmodels.graphics import utils as graphics_utils
+
+#TODO: we should change sm.graphics.utils to also use subplots
+def _create_mpl_subplots(ax=None, nrows=1, ncols=1, **kwargs):
+    """
+    Creates matplotlib figure and axes if it doesn't exist. Uses
+    `matplotlib.pyplot.subplots` kwargs are passed to it.
+    """
+    if ax is None:
+        plt = graphics_utils._import_mpl()
+        fig, ax = plt.subplots(nrows, ncols, **kwargs)
+    else:
+        fig = ax.figure
+
+    return fig, ax
 
 class MPLConfigurator(object):
 
@@ -24,21 +39,37 @@ class MPLConfigurator(object):
 #-------------------------------------------------------------------------------
 # Plotting functions
 
-def plot_mts(Y, names=None, index=None):
+def plot_timeseries(Y, names=None, index=None, ax=None, figsize=(10,10)):
     """
     Plot multiple time series
+
+    Parameters
+    ----------
+    Y : ndarray
+        An array of timeseries with variables in columns
+    names : list, optional
+        Names of each series
+    index : array-like
+        An index for the rows of the series to be plotting as the x axis.
+    ax : matplotlib.axes, optional
+        An existing matplotlib.axes instance
+    figsize : tuple
+        The figure size if ax=None
+
+    Returns
+    -------
+    fig : matplotlib.figure
+        The matplotlib figure that contains the axes
     """
-    import matplotlib.pyplot as plt
+    neqs = Y.shape[1]
+    fig, axes = _create_mpl_subplots(ax, neqs, 1, figsize=figsize)
 
-    k = Y.shape[1]
-    rows, cols = k, 1
+    rows, cols = neqs, 1
 
-    plt.figure(figsize=(10, 10))
-
-    for j in range(k):
+    for j in range(neqs):
+        ax = axes[j]
         ts = Y[:, j]
 
-        ax = plt.subplot(rows, cols, j+1)
         if index is not None:
             ax.plot(index, ts)
         else:
@@ -47,21 +78,32 @@ def plot_mts(Y, names=None, index=None):
         if names is not None:
             ax.set_title(names[j])
 
-def plot_var_forc(prior, forc, err_upper, err_lower,
-                  index=None, names=None, plot_stderr=True):
-    import matplotlib.pyplot as plt
+    return fig
 
+#TODO: Docs
+def plot_var_forc(prior, forc, err_upper, err_lower, index=None, names=None,
+                  plot_stderr=True):
+    """
+    Parameters
+    ----------
+    prior
+    forc
+    err_upper
+    err_lower
+    index
+    names
+    plot_stderr : bool
+    """
     n, k = prior.shape
     rows, cols = k, 1
-
-    fig = plt.figure(figsize=(10, 10))
+    fig, axes = _create_mpl_subplots(None, rows, 1, figsize=(10,10))
 
     prange = np.arange(n)
     rng_f = np.arange(n - 1, n + len(forc))
     rng_err = np.arange(n, n + len(forc))
 
     for j in range(k):
-        ax = plt.subplot(rows, cols, j+1)
+        ax = axes[j]
 
         p1 = ax.plot(prange, prior[:, j], 'k', label='Observed')
         p2 = ax.plot(rng_f, np.r_[prior[-1:, j], forc[:, j]], 'k--',
@@ -77,6 +119,7 @@ def plot_var_forc(prior, forc, err_upper, err_lower,
 
         ax.legend(loc='upper right')
 
+#TODO: Docs
 def plot_with_error(y, error, x=None, axes=None, value_fmt='k',
                     error_fmt='k--', alpha=0.05, stderr_type = 'asym'):
     """
@@ -86,12 +129,19 @@ def plot_with_error(y, error, x=None, axes=None, value_fmt='k',
     ----------
     y :
     error : array or None
+    x
+    axes : matplotlib.axes, optional
+    value_fmt
+    error_fmt
+    alpha
+    stderr_type
 
+    Returns
+    -------
+    fig : matplotlib.figure
+        The `matplotlib.figure` instance that contains the axes.
     """
-    import matplotlib.pyplot as plt
-
-    if axes is None:
-        axes = plt.gca()
+    fig, axes = _create_mpl_subplots(axes, 1, 1)
 
     x = x if x is not None else lrange(len(y))
     plot_action = lambda y, fmt: axes.plot(x, y, fmt)
@@ -107,41 +157,74 @@ def plot_with_error(y, error, x=None, axes=None, value_fmt='k',
             plot_action(error[0], error_fmt)
             plot_action(error[1], error_fmt)
 
-def plot_full_acorr(acorr, fontsize=8, linewidth=8, xlabel=None,
-                    err_bound=None):
+    return fig
+
+def plot_full_acorr(acorr, fontsize=8, linewidth=8, err_bound=None,
+                    names=None, figsize=(10,10), ax=None, **kwargs):
     """
+    Plots the autocorrelations given by acorr.
 
     Parameters
     ----------
-
-
-
+    acorr : ndarray
+        The autocorrelation. Should be of shape (nlags, neqs, neqs).
+    fontsize : int
+        The fontsize
+    linewidth : int
+        The linewidth
+    err_bound : array or None
+        Error bounds for the autocorrelation.
+    names : list or None
+        The endogenous
+    kwargs : kwargs
+        Passed to `matplotlib.pyplot.vlines`
     """
-    import matplotlib.pyplot as plt
-
     config = MPLConfigurator()
     config.set_fontsize(fontsize)
 
-    k = acorr.shape[1]
-    fig, axes = plt.subplots(k, k, figsize=(10, 10), squeeze=False)
+    neqs = acorr.shape[1]
+    fig, axes = _create_mpl_subplots(ax, neqs, neqs, figsize=figsize,
+                                     squeeze=False, sharex=True, sharey=True)
 
-    for i in range(k):
-        for j in range(k):
-            ax = axes[i][j]
-            acorr_plot(acorr[:, i, j], linewidth=linewidth,
-                       xlabel=xlabel, ax=ax)
+    for i in range(neqs):
+        if names is not None:
+            axes[i, 0].set_ylabel(names[i])
+            axes[0, i].set_xlabel(names[i])
+        for j in range(neqs):
+            ax = axes[i, j]
+            acorr_plot(acorr[:, i, j], linewidth=linewidth, ax=ax, **kwargs)
 
             if err_bound is not None:
-                ax.axhline(err_bound, color='k', linestyle='--')
-                ax.axhline(-err_bound, color='k', linestyle='--')
+                #TODO: are the error bounds always symmetric?
+                ax.axhline(err_bound[:, i, j], color='k', linestyle='--')
+                ax.axhline(-err_bound[:, i, j], color='k', linestyle='--')
 
-    adjust_subplots()
+    adjust_subplots(fig)
     config.revert()
 
     return fig
 
-def acorr_plot(acorr, linewidth=8, xlabel=None, ax=None):
+def acorr_plot(acorr, linewidth=8, xlabel=None, ax=None, **kwargs):
+    """
+    Plot the autocorrelation.
+
+    Parameters
+    ----------
+    acorr : ndarray
+        Shape (nlags x neqs x neqs) array of autocorrelations.
+    linewidth : int
+        The linewidth
+    xlabel : list, optional
+        If None uses the lag number for the xticks starting at zero
+    ax : matplotlib.axes, optional
+        An existing matplotlib.axes instance.
+    kwargs : kwargs
+        The keyword arguments are passed on to `matplotlib.pyplot.vlines`
+    """
     import matplotlib.pyplot as plt
+
+
+    fig, ax = graphics_utils.create_mpl_ax(ax)
 
     if ax is None:
         ax = plt.gca()
@@ -149,29 +232,29 @@ def acorr_plot(acorr, linewidth=8, xlabel=None, ax=None):
     if xlabel is None:
         xlabel = np.arange(len(acorr))
 
-    ax.vlines(xlabel, [0], acorr, lw=linewidth)
+    ax.vlines(xlabel, [0], acorr, lw=linewidth, **kwargs)
 
     ax.axhline(0, color='k')
     ax.set_ylim([-1, 1])
 
     # hack?
     ax.set_xlim([-1, xlabel[-1] + 1])
+    return fig
 
 def plot_acorr_with_error():
     pass
 
-def adjust_subplots(**kwds):
-    import matplotlib.pyplot as plt
-
+def adjust_subplots(fig, **kwds):
     passed_kwds = dict(bottom=0.05, top=0.925,
                        left=0.05, right=0.95,
                        hspace=0.2)
     passed_kwds.update(kwds)
-    plt.subplots_adjust(**passed_kwds)
+    fig.subplots_adjust(**passed_kwds)
 
 #-------------------------------------------------------------------------------
 # Multiple impulse response (cum_effects, etc.) cplots
 
+#TODO: Docs
 def irf_grid_plot(values, stderr, impcol, rescol, names, title,
                   signif=0.05, hlines=None, subplot_params=None,
                   plot_params=None, figsize=(10,10), stderr_type='asym'):
@@ -179,11 +262,18 @@ def irf_grid_plot(values, stderr, impcol, rescol, names, title,
     Reusable function to make flexible grid plots of impulse responses and
     comulative effects
 
-    values : (T + 1) x k x k
-    stderr : T x k x k
-    hlines : k x k
+    values : ndarray
+        Values to plot of shape (`nobs` + 1) x `neqs` x `neqs`
+    stderr : ndarray
+        Standard errors of shape (`nobs` x `neqs` x `neqs`)
+    hlines : ndarray
+        Shape (`neqs` x `neqs`)
+
+    Return
+    ------
+    fig : `matplotlib.figure`
+        The `matplotlib.figure` instance that contains the axes.
     """
-    import matplotlib.pyplot as plt
 
     if subplot_params is None:
         subplot_params = {}
@@ -192,11 +282,11 @@ def irf_grid_plot(values, stderr, impcol, rescol, names, title,
 
     nrows, ncols, to_plot = _get_irf_plot_config(names, impcol, rescol)
 
-    fig, axes = plt.subplots(nrows=nrows, ncols=ncols, sharex=True,
-                             squeeze=False, figsize=figsize)
+    fig, axes = _create_mpl_subplots(None, nrows, ncols, sharex=True,
+                                     squeeze=False, figsize=figsize)
 
     # fill out space
-    adjust_subplots()
+    adjust_subplots(fig)
 
     fig.suptitle(title, fontsize=14)
 
@@ -213,11 +303,11 @@ def irf_grid_plot(values, stderr, impcol, rescol, names, title,
             if stderr_type == 'asym':
                 sig = np.sqrt(stderr[:, j * k + i, j * k + i])
                 plot_with_error(values[:, i, j], sig, x=rng, axes=ax,
-                            alpha=signif, value_fmt='b', stderr_type=stderr_type)
+                        alpha=signif, value_fmt='b', stderr_type=stderr_type)
             if stderr_type in ('mc','sz1','sz2','sz3'):
                 errs = stderr[0][:, i, j], stderr[1][:, i, j]
                 plot_with_error(values[:, i, j], errs, x=rng, axes=ax,
-                            alpha=signif, value_fmt='b', stderr_type=stderr_type)
+                        alpha=signif, value_fmt='b', stderr_type=stderr_type)
         else:
             plot_with_error(values[:, i, j], None, x=rng, axes=ax,
                             value_fmt='b')
@@ -230,6 +320,7 @@ def irf_grid_plot(values, stderr, impcol, rescol, names, title,
         sz = subplot_params.get('fontsize', 12)
         ax.set_title(subtitle_temp % (names[j], names[i]), fontsize=sz)
 
+    return fig
 
 def _get_irf_plot_config(names, impcol, rescol):
     nrows = ncols = k = len(names)

--- a/statsmodels/tsa/vector_ar/plotting.py
+++ b/statsmodels/tsa/vector_ar/plotting.py
@@ -117,7 +117,7 @@ def plot_var_forc(prior, forc, err_upper, err_lower, index=None, names=None,
         if names is not None:
             ax.set_title(names[j])
 
-        ax.legend(loc='upper right')
+        ax.legend(loc='upper center', bbox_to_anchor=(0.5, 1.05), ncol=3)
 
 #TODO: Docs
 def plot_with_error(y, error, x=None, axes=None, value_fmt='k',

--- a/statsmodels/tsa/vector_ar/plotting.py
+++ b/statsmodels/tsa/vector_ar/plotting.py
@@ -189,7 +189,7 @@ def plot_full_acorr(acorr, fontsize=8, linewidth=8, err_bound=None,
     for i in range(neqs):
         if names is not None:
             axes[i, 0].set_ylabel(names[i])
-            axes[0, i].set_xlabel(names[i])
+            axes[0, i].set_title(names[i])
         for j in range(neqs):
             ax = axes[i, j]
             acorr_plot(acorr[:, i, j], linewidth=linewidth, ax=ax, **kwargs)

--- a/statsmodels/tsa/vector_ar/tests/test_var.py
+++ b/statsmodels/tsa/vector_ar/tests/test_var.py
@@ -27,6 +27,8 @@ DECIMAL_4 = 4
 DECIMAL_3 = 3
 DECIMAL_2 = 2
 
+#TODO: test_whiteness and test_normality needs a test
+
 class CheckVAR(object):
     # just so pylint won't complain
     res1 = None

--- a/statsmodels/tsa/vector_ar/tests/test_var.py
+++ b/statsmodels/tsa/vector_ar/tests/test_var.py
@@ -161,19 +161,17 @@ def have_matplotlib():
 
 class CheckIRF(object):
 
-    ref = None; res = None; irf = None
-    k = None
-
     #---------------------------------------------------------------------------
     # IRF tests
 
     def test_irf_coefs(self):
-        self._check_irfs(self.irf.irfs, self.ref.irf)
-        self._check_irfs(self.irf.orth_irfs, self.ref.orth_irf)
+        self._check_irfs(self.irf.irfs, self.res2.irf)
+        self._check_irfs(self.irf.orth_irfs, self.res2.orth_irf)
 
     def _check_irfs(self, py_irfs, r_irfs):
-        for i, name in enumerate(self.res.names):
+        for i, name in enumerate(self.res1.names):
             ref_irfs = r_irfs[name].view((float, self.neqs), type=np.ndarray)
+
             res_irfs = py_irfs[:, :, i]
             assert_almost_equal(ref_irfs, res_irfs)
 
@@ -241,14 +239,15 @@ class TestVARResults(CheckIRF, CheckFEVD):
         cls.model = VAR(cls.data)
         cls.endog_names = cls.model.endog_names
 
-        cls.ref = RResults()
-        cls.neqs = len(cls.ref.endog_names)
-        cls.res = cls.model.fit(maxlags=cls.p)
+        # results from R vars
+        cls.res2 = RResults()
+        cls.neqs = len(cls.res2.endog_names)
+        cls.res1 = cls.model.fit(maxlags=cls.p)
 
-        cls.irf = cls.res.irf(cls.ref.nirfs)
-        cls.nahead = cls.ref.nahead
+        cls.irf = cls.res1.irf(cls.res2.nirfs)
+        cls.nahead = cls.res2.nahead
 
-        cls.fevd = cls.res.fevd()
+        cls.fevd = cls.res1.fevd()
 
     def test_constructor(self):
         # make sure this works with no names
@@ -257,64 +256,68 @@ class TestVARResults(CheckIRF, CheckFEVD):
         res = model.fit(self.p)
 
     def test_names(self):
-        assert_equal(self.model.endog_names, self.ref.endog_names)
+        assert_equal(self.model.endog_names, self.res2.endog_names)
 
         model2 = VAR(self.data)
-        assert_equal(model2.endog_names, self.ref.endog_names)
+        assert_equal(model2.endog_names, self.res2.endog_names)
 
     def test_get_eq_index(self):
-        assert(type(self.res.names) is list)
+        assert(isinstance(self.res1.names, list))
 
         for i, name in enumerate(self.endog_names):
-            idx = self.res.get_eq_index(i)
-            idx2 = self.res.get_eq_index(name)
+            idx = self.res1.get_eq_index(i)
+            idx2 = self.res1.get_eq_index(name)
 
             assert_equal(idx, i)
             assert_equal(idx, idx2)
 
-        assert_raises(Exception, self.res.get_eq_index, 'foo')
+        assert_raises(Exception, self.res1.get_eq_index, 'foo')
 
     def test_repr(self):
         # just want this to work
-        foo = str(self.res)
-        bar = repr(self.res)
+        foo = str(self.res1)
+        bar = repr(self.res1)
 
     def test_params(self):
-        assert_almost_equal(self.res.params, self.ref.params, DECIMAL_3)
+        assert_almost_equal(self.res1.params, self.res2.params, DECIMAL_3)
 
+    #TODO: smoke test
     def test_cov_params(self):
         # do nothing for now
-        self.res.cov_params
+        self.res1.cov_params
 
+    #TODO: smoke test
     def test_cov_ybar(self):
-        self.res.cov_ybar()
+        self.res1.cov_ybar()
 
+    #TODO: smoke test
     def test_tstat(self):
-        self.res.tvalues
+        self.res1.tvalues
 
+    #TODO: smoke test
     def test_pvalues(self):
-        self.res.pvalues
+        self.res1.pvalues
 
     def test_summary(self):
-        summ = self.res.summary()
-
+        summ = self.res1.summary()
 
     def test_detsig(self):
-        assert_almost_equal(self.res.det_cov_resid, self.ref.det_cov_resid)
+        assert_almost_equal(self.res1.det_cov_resid, self.res2.det_cov_resid)
 
     def test_aic(self):
-        assert_almost_equal(self.res.aic, self.ref.aic)
+        assert_almost_equal(self.res1.aic, self.res2.aic)
 
     def test_bic(self):
-        assert_almost_equal(self.res.bic, self.ref.bic)
+        assert_almost_equal(self.res1.bic, self.res2.bic)
 
     def test_hqic(self):
-        assert_almost_equal(self.res.hqic, self.ref.hqic)
+        assert_almost_equal(self.res1.hqic, self.res2.hqic)
 
     def test_fpe(self):
-        assert_almost_equal(self.res.fpe, self.ref.fpe)
+        assert_almost_equal(self.res1.fpe, self.res2.fpe)
 
     def test_lagorder_select(self):
+        # smoke tests but tested for correctness elsewhere
         ics = ['aic', 'fpe', 'hqic', 'bic']
 
         #TODO: this resets exog_names in model
@@ -324,42 +327,42 @@ class TestVARResults(CheckIRF, CheckFEVD):
         assert_raises(Exception, self.model.fit, ic='foo')
 
     def test_nobs(self):
-        assert_equal(self.res.nobs, self.ref.nobs)
+        assert_equal(self.res1.nobs, self.res2.nobs)
 
     def test_stderr(self):
-        assert_almost_equal(self.res.stderr, self.ref.stderr, DECIMAL_4)
+        assert_almost_equal(self.res1.stderr, self.res2.stderr, DECIMAL_4)
 
     def test_loglike(self):
-        assert_almost_equal(self.res.llf, self.ref.loglike)
+        assert_almost_equal(self.res1.llf, self.res2.loglike)
 
     def test_ma_rep(self):
-        ma_rep = self.res.ma_rep(self.nahead)
-        assert_almost_equal(ma_rep, self.ref.ma_rep)
+        ma_rep = self.res1.ma_rep(self.nahead)
+        assert_almost_equal(ma_rep, self.res2.ma_rep)
 
     #--------------------------------------------------
     # Lots of tests to make sure stuff works...need to check correctness
 
     def test_causality(self):
-        causedby = self.ref.causality['causedby']
+        causedby = self.res2.causality['causedby']
 
         for i, name in enumerate(self.endog_names):
             variables = self.endog_names[:i] + self.endog_names[i + 1:]
-            result = self.res.test_causality(name, variables, kind='f')
+            result = self.res1.test_causality(name, variables, kind='f')
             assert_almost_equal(result['pvalue'], causedby[i], DECIMAL_4)
 
             rng = lrange(self.neqs)
             rng.remove(i)
-            result2 = self.res.test_causality(i, rng, kind='f')
+            result2 = self.res1.test_causality(i, rng, kind='f')
             assert_almost_equal(result['pvalue'], result2['pvalue'], DECIMAL_12)
 
             # make sure works
-            result = self.res.test_causality(name, variables, kind='wald')
+            result = self.res1.test_causality(name, variables, kind='wald')
 
         # corner cases
-        _ = self.res.test_causality(self.endog_names[0], self.endog_names[1])
-        _ = self.res.test_causality(0, 1)
+        _ = self.res1.test_causality(self.endog_names[0], self.endog_names[1])
+        _ = self.res1.test_causality(0, 1)
 
-        assert_raises(Exception,self.res.test_causality, 0, 1, kind='foo')
+        assert_raises(Exception,self.res1.test_causality, 0, 1, kind='foo')
 
     def test_select_order(self):
         result = self.model.fit(10, ic='aic', verbose=True)
@@ -371,52 +374,56 @@ class TestVARResults(CheckIRF, CheckFEVD):
 
     def test_is_stable(self):
         # may not necessarily be true for other datasets
-        assert(self.res.is_stable(verbose=True))
+        assert(self.res1.is_stable(verbose=True))
 
+    #TODO: smoke test
     def test_acf(self):
         # test that it works...for now
-        acfs = self.res.acf(10)
+        acfs = self.res1.acf(10)
 
         # defaults to nlags=lag_order
-        acfs = self.res.acf()
+        acfs = self.res1.acf()
         assert(len(acfs) == self.p + 1)
 
+    #TODO: smoke test
     def test_acorr(self):
-        acorrs = self.res.acorr(10)
+        acorrs = self.res1.acorr(10)
 
+    #TODO: smoke test
     def test_forecast(self):
-        point = self.res.forecast(self.res.Y[-5:], 5)
+        point = self.res1.forecast(self.res1.Y[-5:], 5)
 
+    #TODO: smoke test
     def test_forecast_interval(self):
-        y = self.res.Y[:-self.p:]
-        point, lower, upper = self.res.forecast_interval(y, 5)
+        y = self.res1.Y[:-self.p:]
+        point, lower, upper = self.res1.forecast_interval(y, 5)
 
     def test_plot_sim(self):
         if not have_matplotlib():
             raise nose.SkipTest
 
-        self.res.plotsim(steps=100)
+        self.res1.plotsim(steps=100)
         close_plots()
 
     def test_plot(self):
         if not have_matplotlib():
             raise nose.SkipTest
 
-        self.res.plot()
+        self.res1.plot()
         close_plots()
 
     def test_plot_acorr(self):
         if not have_matplotlib():
             raise nose.SkipTest
 
-        self.res.plot_acorr()
+        self.res1.plot_acorr()
         close_plots()
 
     def test_plot_forecast(self):
         if not have_matplotlib():
             raise nose.SkipTest
 
-        self.res.plot_forecast(5)
+        self.res1.plot_forecast(5)
         close_plots()
 
     def test_reorder(self):
@@ -435,7 +442,7 @@ class TestVARResults(CheckIRF, CheckFEVD):
         res2 = VAR(data2.to_records(index=False)).fit(maxlags=self.p)
 
         #use reorder function
-        res3 = self.res.reorder(['realinv','realgdp', 'realcons'])
+        res3 = self.res1.reorder(['realinv','realgdp', 'realcons'])
 
         #check if the main results match
         assert_almost_equal(res2.params, res3.params)
@@ -446,11 +453,13 @@ class TestVARResults(CheckIRF, CheckFEVD):
     def test_pickle(self):
         fh = BytesIO()
         #test wrapped results load save pickle
-        self.res.save(fh)
+        self.res1.save(fh)
         fh.seek(0,0)
-        res_unpickled = self.res.__class__.load(fh)
-        assert_(type(res_unpickled) is type(self.res))
+        res_unpickled = self.res1.__class__.load(fh)
+        assert_(type(res_unpickled) is type(self.res1))
 
+    def test_wrappers(self):
+        raise ValueError
 
 class E1_Results(object):
     """

--- a/statsmodels/tsa/vector_ar/tests/test_var.py
+++ b/statsmodels/tsa/vector_ar/tests/test_var.py
@@ -392,12 +392,11 @@ class TestVARResults(CheckIRF, CheckFEVD):
 
     #TODO: smoke test
     def test_forecast(self):
-        point = self.res1.forecast(self.res1.Y[-5:], 5)
+        point = self.res1.forecast(y=None, steps=5)
 
     #TODO: smoke test
     def test_forecast_interval(self):
-        y = self.res1.Y[:-self.p:]
-        point, lower, upper = self.res1.forecast_interval(y, 5)
+        point, lower, upper = self.res1.forecast_interval(y=None, steps=5)
 
     def test_plot_sim(self):
         if not have_matplotlib():

--- a/statsmodels/tsa/vector_ar/tests/test_var.py
+++ b/statsmodels/tsa/vector_ar/tests/test_var.py
@@ -15,8 +15,7 @@ import numpy as np
 import statsmodels.api as sm
 import statsmodels.tsa.vector_ar.util as util
 import statsmodels.tools.data as data_util
-from statsmodels.tsa.vector_ar.var_model import VAR
-
+from statsmodels.tsa.vector_ar.var_model import VAR, select_order_fit
 
 from numpy.testing import (assert_almost_equal, assert_equal, assert_,
                            assert_allclose)
@@ -236,13 +235,13 @@ class TestVARResults(CheckIRF, CheckFEVD):
         cls.p = 2
 
         cls.data = get_macrodata()
-        cls.model = VAR(cls.data)
+        cls.model = VAR(cls.data, cls.p)
         cls.endog_names = cls.model.endog_names
 
         # results from R vars
         cls.res2 = RResults()
         cls.neqs = len(cls.res2.endog_names)
-        cls.res1 = cls.model.fit(maxlags=cls.p)
+        cls.res1 = cls.model.fit()
 
         cls.irf = cls.res1.irf(cls.res2.nirfs)
         cls.nahead = cls.res2.nahead
@@ -252,13 +251,14 @@ class TestVARResults(CheckIRF, CheckFEVD):
     def test_constructor(self):
         # make sure this works with no names
         ndarr = self.data.view((float, 3), type=np.ndarray)
-        model = VAR(ndarr)
-        res = model.fit(self.p)
+        model = VAR(ndarr, self.p)
+        res = model.fit()
+
 
     def test_names(self):
         assert_equal(self.model.endog_names, self.res2.endog_names)
 
-        model2 = VAR(self.data)
+        model2 = VAR(self.data, 2)
         assert_equal(model2.endog_names, self.res2.endog_names)
 
     def test_get_eq_index(self):
@@ -322,9 +322,9 @@ class TestVARResults(CheckIRF, CheckFEVD):
 
         #TODO: this resets exog_names in model
         for ic in ics:
-            res = self.model.fit(maxlags=10, ic=ic, verbose=True)
+            res = select_order_fit(self.data, maxlags=10, ic=ic, verbose=True)
 
-        assert_raises(Exception, self.model.fit, ic='foo')
+        assert_raises(Exception, select_order_fit, Y=self.data, ic='foo')
 
     def test_nobs(self):
         assert_equal(self.res1.nobs, self.res2.nobs)
@@ -364,13 +364,12 @@ class TestVARResults(CheckIRF, CheckFEVD):
 
         assert_raises(Exception,self.res1.test_causality, 0, 1, kind='foo')
 
+    #TODO: smoke test
     def test_select_order(self):
-        result = self.model.fit(10, ic='aic', verbose=True)
-        result = self.model.fit(10, ic='fpe', verbose=True)
+        result = select_order_fit(self.data, 10, ic='aic', verbose=True)
+        result = select_order_fit(self.data, 10, ic='fpe', verbose=True)
 
-        # bug
-        model = VAR(self.model.endog)
-        model.select_order()
+        ic = VAR.select_order(self.model.endog, verbose=False)
 
     def test_is_stable(self):
         # may not necessarily be true for other datasets
@@ -439,7 +438,7 @@ class TestVARResults(CheckIRF, CheckFEVD):
 
         from pandas import DataFrame
         data2 = DataFrame(data2, columns=names2)
-        res2 = VAR(data2.to_records(index=False)).fit(maxlags=self.p)
+        res2 = VAR(data2.to_records(index=False), self.p).fit()
 
         #use reorder function
         res3 = self.res1.reorder(['realinv','realgdp', 'realcons'])
@@ -458,8 +457,9 @@ class TestVARResults(CheckIRF, CheckFEVD):
         res_unpickled = self.res1.__class__.load(fh)
         assert_(type(res_unpickled) is type(self.res1))
 
+    #TODO: test these
     def test_wrappers(self):
-        raise ValueError
+        pass
 
 class E1_Results(object):
     """
@@ -530,8 +530,8 @@ class TestVARResultsLutkepohl(object):
 
         from pandas import DataFrame
         dta= DataFrame(adj_data[:-16], index=dates[1:-16], columns=names)
-        self.model = VAR(dta)
-        self.res = self.model.fit(maxlags=self.p)
+        self.model = VAR(dta, self.p)
+        self.res = self.model.fit()
         self.irf = self.res.irf(10)
         self.lut = E1_Results()
 

--- a/statsmodels/tsa/vector_ar/tests/test_var.py
+++ b/statsmodels/tsa/vector_ar/tests/test_var.py
@@ -77,7 +77,7 @@ class CheckVAR(object):
         assert_almost_equal(self.res1.fpe, self.res2.fpe)
 
     def test_detsig(self):
-        assert_almost_equal(self.res1.detomega, self.res2.detsig)
+        assert_almost_equal(self.res1.det_cov_resid, self.res2.detsig)
 
     def test_bse(self):
         assert_almost_equal(self.res1.bse, self.res2.bse, DECIMAL_4)
@@ -109,9 +109,9 @@ class RResults(object):
         from .results.results_var_data import var_results
         data = var_results.__dict__
 
-        self.names = data['coefs'].dtype.names
-        self.params = data['coefs'].view((float, len(self.names)), type=np.ndarray)
-        self.stderr = data['stderr'].view((float, len(self.names)), type=np.ndarray)
+        self.endog_names = data['coefs'].dtype.names
+        self.params = data['coefs'].view((float, len(self.endog_names)), type=np.ndarray)
+        self.stderr = data['stderr'].view((float, len(self.endog_names)), type=np.ndarray)
 
         self.irf = data['irf'].item()
         self.orth_irf = data['orthirf'].item()
@@ -126,7 +126,7 @@ class RResults(object):
         self.hqic = crit['hqic'][0]
         self.fpe = crit['fpe'][0]
 
-        self.detomega = data['detomega'][0]
+        self.det_cov_resid = data['detomega'][0]
         self.loglike = data['loglike'][0]
 
         self.nahead = int(data['nahead'][0])
@@ -173,7 +173,7 @@ class CheckIRF(object):
 
     def _check_irfs(self, py_irfs, r_irfs):
         for i, name in enumerate(self.res.names):
-            ref_irfs = r_irfs[name].view((float, self.k), type=np.ndarray)
+            ref_irfs = r_irfs[name].view((float, self.neqs), type=np.ndarray)
             res_irfs = py_irfs[:, :, i]
             assert_almost_equal(ref_irfs, res_irfs)
 
@@ -239,10 +239,10 @@ class TestVARResults(CheckIRF, CheckFEVD):
 
         cls.data = get_macrodata()
         cls.model = VAR(cls.data)
-        cls.names = cls.model.endog_names
+        cls.endog_names = cls.model.endog_names
 
         cls.ref = RResults()
-        cls.k = len(cls.ref.names)
+        cls.neqs = len(cls.ref.endog_names)
         cls.res = cls.model.fit(maxlags=cls.p)
 
         cls.irf = cls.res.irf(cls.ref.nirfs)
@@ -257,15 +257,15 @@ class TestVARResults(CheckIRF, CheckFEVD):
         res = model.fit(self.p)
 
     def test_names(self):
-        assert_equal(self.model.endog_names, self.ref.names)
+        assert_equal(self.model.endog_names, self.ref.endog_names)
 
         model2 = VAR(self.data)
-        assert_equal(model2.endog_names, self.ref.names)
+        assert_equal(model2.endog_names, self.ref.endog_names)
 
     def test_get_eq_index(self):
         assert(type(self.res.names) is list)
 
-        for i, name in enumerate(self.names):
+        for i, name in enumerate(self.endog_names):
             idx = self.res.get_eq_index(i)
             idx2 = self.res.get_eq_index(name)
 
@@ -300,7 +300,7 @@ class TestVARResults(CheckIRF, CheckFEVD):
 
 
     def test_detsig(self):
-        assert_almost_equal(self.res.detomega, self.ref.detomega)
+        assert_almost_equal(self.res.det_cov_resid, self.ref.det_cov_resid)
 
     def test_aic(self):
         assert_almost_equal(self.res.aic, self.ref.aic)
@@ -317,6 +317,7 @@ class TestVARResults(CheckIRF, CheckFEVD):
     def test_lagorder_select(self):
         ics = ['aic', 'fpe', 'hqic', 'bic']
 
+        #TODO: this resets exog_names in model
         for ic in ics:
             res = self.model.fit(maxlags=10, ic=ic, verbose=True)
 
@@ -341,12 +342,12 @@ class TestVARResults(CheckIRF, CheckFEVD):
     def test_causality(self):
         causedby = self.ref.causality['causedby']
 
-        for i, name in enumerate(self.names):
-            variables = self.names[:i] + self.names[i + 1:]
+        for i, name in enumerate(self.endog_names):
+            variables = self.endog_names[:i] + self.endog_names[i + 1:]
             result = self.res.test_causality(name, variables, kind='f')
             assert_almost_equal(result['pvalue'], causedby[i], DECIMAL_4)
 
-            rng = lrange(self.k)
+            rng = lrange(self.neqs)
             rng.remove(i)
             result2 = self.res.test_causality(i, rng, kind='f')
             assert_almost_equal(result['pvalue'], result2['pvalue'], DECIMAL_12)
@@ -355,7 +356,7 @@ class TestVARResults(CheckIRF, CheckFEVD):
             result = self.res.test_causality(name, variables, kind='wald')
 
         # corner cases
-        _ = self.res.test_causality(self.names[0], self.names[1])
+        _ = self.res.test_causality(self.endog_names[0], self.endog_names[1])
         _ = self.res.test_causality(0, 1)
 
         assert_raises(Exception,self.res.test_causality, 0, 1, kind='foo')
@@ -384,10 +385,10 @@ class TestVARResults(CheckIRF, CheckFEVD):
         acorrs = self.res.acorr(10)
 
     def test_forecast(self):
-        point = self.res.forecast(self.res.y[-5:], 5)
+        point = self.res.forecast(self.res.Y[-5:], 5)
 
     def test_forecast_interval(self):
-        y = self.res.y[:-self.p:]
+        y = self.res.Y[:-self.p:]
         point, lower, upper = self.res.forecast_interval(y, 5)
 
     def test_plot_sim(self):
@@ -421,20 +422,24 @@ class TestVARResults(CheckIRF, CheckFEVD):
     def test_reorder(self):
         #manually reorder
         data = self.data.view((float,3), type=np.ndarray)
-        names = self.names
-        data2 = np.append(np.append(data[:,2,None], data[:,0,None], axis=1), data[:,1,None], axis=1)
+        names = self.endog_names
+        data2 = np.append(np.append(data[:,2,None], data[:,0,None], axis=1),
+                          data[:,1,None], axis=1)
         names2 = []
         names2.append(names[2])
         names2.append(names[0])
         names2.append(names[1])
-        res2 = VAR(data2).fit(maxlags=self.p)
+
+        from pandas import DataFrame
+        data2 = DataFrame(data2, columns=names2)
+        res2 = VAR(data2.to_records(index=False)).fit(maxlags=self.p)
 
         #use reorder function
         res3 = self.res.reorder(['realinv','realgdp', 'realcons'])
 
         #check if the main results match
         assert_almost_equal(res2.params, res3.params)
-        assert_almost_equal(res2.sigma_u, res3.sigma_u)
+        assert_almost_equal(res2.cov_resid, res3.cov_resid)
         assert_almost_equal(res2.bic, res3.bic)
         assert_almost_equal(res2.stderr, res3.stderr)
 
@@ -509,12 +514,14 @@ class TestVARResultsLutkepohl(object):
     def __init__(self):
         self.p = 2
         sdata, dates = get_lutkepohl_data('e1')
-
+        names = sdata.dtype.names
         data = data_util.struct_to_ndarray(sdata)
         adj_data = np.diff(np.log(data), axis=0)
         # est = VAR(adj_data, p=2, dates=dates[1:], names=names)
 
-        self.model = VAR(adj_data[:-16], dates=dates[1:-16], freq='Q')
+        from pandas import DataFrame
+        dta= DataFrame(adj_data[:-16], index=dates[1:-16], columns=names)
+        self.model = VAR(dta)
         self.res = self.model.fit(maxlags=self.p)
         self.irf = self.res.irf(10)
         self.lut = E1_Results()

--- a/statsmodels/tsa/vector_ar/util.py
+++ b/statsmodels/tsa/vector_ar/util.py
@@ -8,8 +8,37 @@ import scipy.linalg.decomp as decomp
 
 import statsmodels.tsa.tsatools as tsa
 
-#-------------------------------------------------------------------------------
+#------------------------------------------------------------------------------
 # Auxiliary functions for estimation
+
+def get_forecast_X(nobs, trend, lags, steps):
+    """
+    Returns X for forecasting steps forecasts from nobs.
+
+    Parameters
+    ----------
+    nobs : int
+        Starting value for forecasts
+    trend : str ('nc', 'c', 'ct', 'ctt')
+        Trend
+    steps : int
+        Number of forecasts produced
+
+    Examples
+    --------
+    >>> get_forecast_X(200, 'ctt', 4, 4)
+    array([[     1.,    201.,  40000.],
+           [     1.,    202.,  40401.],
+           [     1.,    203.,  40804.],
+           [     1.,    204.,  41616.]])
+    """
+    trendorder = get_trendorder(trend)
+    if trendorder == 0:
+        return
+    return np.fliplr(np.vander(np.arange(nobs + 1,
+                                         nobs + steps + 1,
+                                         dtype=float), trendorder))
+
 
 def get_lagged_y(y, lags, trend='c', has_constant='skip'):
     """

--- a/statsmodels/tsa/vector_ar/util.py
+++ b/statsmodels/tsa/vector_ar/util.py
@@ -23,8 +23,11 @@ def get_lagged_y(y, lags, trend='c', has_constant='skip'):
     has_constant can be 'raise', 'add', or 'skip'. See add_constant.
     """
     nobs = len(y)
+    # pad with zeros so trend is correct
+    y = np.r_[np.zeros((lags, y.shape[1])), y]
     # Ravel C order, need to put in descending order
-    X = np.array([y[t-lags : t][::-1].ravel() for t in range(lags, nobs)])
+    X = np.array([y[t-lags : t][::-1].ravel() for t in range(lags,
+                                                             nobs + lags)])
 
     # Add constant, trend, etc.
     if trend != 'nc':
@@ -32,7 +35,7 @@ def get_lagged_y(y, lags, trend='c', has_constant='skip'):
                           has_constant=has_constant)
 
 
-    return X
+    return X[lags:]
 
 def get_trendorder(trend='c'):
     # Handle constant, etc.

--- a/statsmodels/tsa/vector_ar/util.py
+++ b/statsmodels/tsa/vector_ar/util.py
@@ -68,12 +68,12 @@ def make_lag_names(names, lag_order, trendorder=1):
             lag_names.append('L'+str(i)+'.'+name)
 
     # handle the constant name
-    if trendorder != 0:
-        lag_names.insert(0, 'const')
-    if trendorder > 1:
-        lag_names.insert(0, 'trend')
     if trendorder > 2:
         lag_names.insert(0, 'trend**2')
+    if trendorder > 1:
+        lag_names.insert(0, 'trend')
+    if trendorder != 0:
+        lag_names.insert(0, 'const')
 
     return lag_names
 

--- a/statsmodels/tsa/vector_ar/var_model.py
+++ b/statsmodels/tsa/vector_ar/var_model.py
@@ -1421,6 +1421,11 @@ class VARResults(VARProcess):
 
     bse = stderr  # statsmodels interface?
 
+    def conf_int(self, alpha=.05, cols=None):
+        confint = super(VARResults, self).conf_int(alpha=alpha,
+                                                            cols=cols)
+        return confint.transpose(2,0,1)
+
     @cache_readonly
     def tvalues(self):
         "t statistics of coefficients"
@@ -2117,7 +2122,7 @@ class VARResults(VARProcess):
         return roots[idx]
 
 class VARResultsWrapper(wrap.ResultsWrapper):
-    _attrs = {'bse' : 'columns_eq', 'cov_params' : 'cov',
+    _attrs = {'bse' : 'columns_eq', 'cov_params' : 'cov2d',
               'params' : 'columns_eq', 'pvalues' : 'columns_eq',
               'tvalues' : 'columns_eq', 'cov_resid' : 'cov_eq',
               'cov_resid_mle' : 'cov_eq',

--- a/statsmodels/tsa/vector_ar/var_model.py
+++ b/statsmodels/tsa/vector_ar/var_model.py
@@ -1591,6 +1591,7 @@ class VARResults(VARProcess, tsbase.TimeSeriesModelResults):
         Array of simulated impulse response functions
 
         """
+        #TODO: notes -> references
         neqs = self.neqs
         mean = self.mean()
         k_ar = self.k_ar
@@ -2129,7 +2130,7 @@ class VARResultsWrapper(wrap.ResultsWrapper):
               'stderr' : 'columns_eq'}
     _wrap_attrs = wrap.union_dicts(tsbase.TimeSeriesResultsWrapper._wrap_attrs,
                                     _attrs)
-    _methods = {}
+    _methods = {'conf_int' : 'columns_eq'}
     _wrap_methods = wrap.union_dicts(tsbase.TimeSeriesResultsWrapper._wrap_methods,
                                      _methods)
     _wrap_methods.pop('cov_params') # not yet a method in VARResults

--- a/statsmodels/tsa/vector_ar/var_model.py
+++ b/statsmodels/tsa/vector_ar/var_model.py
@@ -570,8 +570,7 @@ class VAR(tsbase.TimeSeriesModel):
 
     def select_order(self, maxlags=None, verbose=True):
         """
-        Compute lag order selections based on each of the available information
-        criteria
+        Compute lag order selections based on each information criteria
 
         Parameters
         ----------

--- a/statsmodels/tsa/vector_ar/var_model.py
+++ b/statsmodels/tsa/vector_ar/var_model.py
@@ -952,9 +952,8 @@ class VARProcess(object):
         plotting.plot_full_acorr(self.acorr(nlags=nlags), linewidth=linewidth,
                                  names=self.model.endog_names)
 
-    def forecast(self, y, steps):
-        """Produce linear minimum MSE forecasts for desired number of steps
-        ahead, using prior values y
+    def forecast(self, Y=None, steps=1):
+        """Minimum MSE forecasts for desired number of steps
 
         Parameters
         ----------

--- a/statsmodels/tsa/vector_ar/var_model.py
+++ b/statsmodels/tsa/vector_ar/var_model.py
@@ -1063,7 +1063,7 @@ class VARProcess(object):
 # VARResults class
 
 
-class VARResults(VARProcess):
+class VARResults(VARProcess, tsbase.TimeSeriesModelResults):
     """The results instances of a fitted VAR(p) model.
 
     Parameters

--- a/statsmodels/tsa/vector_ar/var_model.py
+++ b/statsmodels/tsa/vector_ar/var_model.py
@@ -947,7 +947,8 @@ class VARProcess(object):
 
     def plot_acorr(self, nlags=10, linewidth=8):
         "Plot theoretical autocorrelation function"
-        plotting.plot_full_acorr(self.acorr(nlags=nlags), linewidth=linewidth)
+        plotting.plot_full_acorr(self.acorr(nlags=nlags), linewidth=linewidth,
+                                 names=self.model.endog_names)
 
     def forecast(self, y, steps):
         """Produce linear minimum MSE forecasts for desired number of steps

--- a/statsmodels/tsa/vector_ar/var_model.py
+++ b/statsmodels/tsa/vector_ar/var_model.py
@@ -9,6 +9,7 @@ Hamilton, J. D. 1994. *Time Series Analysis*. Princeton Press.
 """
 
 from __future__ import division, print_function
+from warnings import warn
 from statsmodels.compat.python import (range, lrange, string_types, StringIO, iteritems,
                                 cStringIO)
 
@@ -469,6 +470,7 @@ class VAR(tsbase.TimeSeriesModel):
     def __init__(self, Y, nlags=None, dates=None, names=None, freq=None,
                  missing='none'):
         if nlags is None:
+            from warnings import warn
             warn("In the 0.6.0 release nlags will not be optional in the "
                  "model constructor.", FutureWarning)
         else:

--- a/statsmodels/tsa/vector_ar/var_model.py
+++ b/statsmodels/tsa/vector_ar/var_model.py
@@ -702,7 +702,7 @@ class VAR(tsbase.TimeSeriesModel):
         return VARResultsWrapper(varfit)
 
     @classmethod
-    def select_order(self, Y=None, maxlags=None, verbose=True, trend='c'):
+    def select_order(self, Y=None, maxlags=None, verbose=False, trend='c'):
         """
         Compute lag order selections based on each information criteria
 
@@ -1847,7 +1847,7 @@ class VARResults(VARProcess, tsbase.TimeSeriesModelResults):
         return table
 
     def test_causality(self, equation, variables, kind='F', signif=0.05,
-                       verbose=True):
+                       verbose=False):
         """Test for Granger causality
 
         Parameters
@@ -1929,7 +1929,8 @@ class VARResults(VARProcess, tsbase.TimeSeriesModelResults):
         }
 
         if verbose:
-            summ = output.causality_summary(results, variables, equation, kind)
+            summ = output.causality_summary(results, variables, equation,
+                                            kind)
 
             print(summ)
 
@@ -1968,7 +1969,7 @@ class VARResults(VARProcess, tsbase.TimeSeriesModelResults):
             fig.suptitle(r"ACF plots with $2 / \sqrt{T}$ bounds "
                          "for testing whiteness assumption")
 
-    def test_normality(self, signif=0.05, verbose=True):
+    def test_normality(self, signif=0.05, verbose=False):
         """
         Test assumption of normal-distributed errors using Jarque-Bera-style
         omnibus Chi^2 test

--- a/statsmodels/tsa/vector_ar/var_model.py
+++ b/statsmodels/tsa/vector_ar/var_model.py
@@ -752,6 +752,8 @@ class VAR(tsbase.TimeSeriesModel):
 
         return selected_orders
 
+select_order = VAR.select_order # convenience function
+
 #-----------------------------------------------------------------------------
 # VARProcess class: for known or unknown VAR process
 

--- a/statsmodels/tsa/vector_ar/var_model.py
+++ b/statsmodels/tsa/vector_ar/var_model.py
@@ -276,14 +276,15 @@ def _reordered(self, order):
     endog_lagged = self.endog_lagged
     params = self.params
     sigma_u = self.sigma_u
-    names = self.names
+    names = self.endog_names
     k_ar = self.k_ar
     endog_new = np.zeros([np.size(endog,0),np.size(endog,1)])
-    endog_lagged_new = np.zeros([np.size(endog_lagged,0), np.size(endog_lagged,1)])
-    params_new_inc, params_new = [np.zeros([np.size(params,0), np.size(params,1)])
-                                  for i in range(2)]
-    sigma_u_new_inc, sigma_u_new = [np.zeros([np.size(sigma_u,0), np.size(sigma_u,1)])
-                                    for i in range(2)]
+    endog_lagged_new = np.zeros([np.size(endog_lagged,0),
+                                 np.size(endog_lagged,1)])
+    params_new_inc, params_new = [np.zeros([np.size(params,0),
+                                  np.size(params,1)]) for i in range(2)]
+    sigma_u_new_inc, sigma_u_new = [np.zeros([np.size(sigma_u,0),
+                                    np.size(sigma_u,1)]) for i in range(2)]
     num_end = len(self.params[0])
     names_new = []
 
@@ -541,7 +542,7 @@ class VARProcess(object):
 
     def get_eq_index(self, name):
         "Return integer position of requested equation name"
-        return util.get_index(self.names, name)
+        return util.get_index(self.endog_names, name)
 
     def __str__(self):
         output = ('VAR(%d) process for %d-dimensional response y_t'
@@ -853,7 +854,7 @@ class VARResults(VARProcess):
     def plot(self):
         """Plot input time series
         """
-        plotting.plot_mts(self.y, names=self.names, index=self.dates)
+        plotting.plot_mts(self.y, names=self.endog_names, index=self.dates)
 
     @property
     def df_model(self):
@@ -1020,7 +1021,8 @@ class VARResults(VARProcess):
         """
         mid, lower, upper = self.forecast_interval(self.y[-self.k_ar:], steps,
                                                    alpha=alpha)
-        plotting.plot_var_forc(self.y, mid, lower, upper, names=self.names,
+        plotting.plot_var_forc(self.y, mid, lower, upper,
+                               names=self.endog_names,
                                plot_stderr=plot_stderr)
 
     # Forecast error covariance functions
@@ -1280,7 +1282,7 @@ class VARResults(VARProcess):
         if isinstance(order[0], string_types):
             order_new = []
             for i, nam in enumerate(order):
-                order_new.append(self.names.index(order[i]))
+                order_new.append(self.endog_names.index(order[i]))
             order = order_new
         return _reordered(self, order)
 
@@ -1568,9 +1570,9 @@ class FEVD(object):
 
         rng = lrange(self.periods)
         for i in range(self.neqs):
-            ppm = output.pprint_matrix(self.decomp[i], rng, self.names)
+            ppm = output.pprint_matrix(self.decomp[i], rng, self.endog_names)
 
-            buf.write('FEVD for %s\n' % self.names[i])
+            buf.write('FEVD for %s\n' % self.endog_names[i])
             buf.write(ppm + '\n')
 
         print(buf.getvalue())
@@ -1616,12 +1618,12 @@ class FEVD(object):
                 lower = this_limits[j - 1] if j > 0 else 0
                 upper = this_limits[j]
                 handle = ax.bar(ticks, upper - lower, bottom=lower,
-                                color=colors[j], label=self.names[j],
+                                color=colors[j], label=self.endog_names[j],
                                 **plot_kwds)
 
                 handles.append(handle)
 
-            ax.set_title(self.names[i])
+            ax.set_title(self.endog_names[i])
 
         # just use the last axis to get handles for plotting
         handles, labels = ax.get_legend_handles_labels()

--- a/statsmodels/tsa/vector_ar/var_model.py
+++ b/statsmodels/tsa/vector_ar/var_model.py
@@ -1205,6 +1205,10 @@ class VARResults(VARProcess, tsbase.TimeSeriesModelResults):
 
 
     @cache_readonly
+    def normalized_cov_params(self):
+        return self.cov_params()
+
+    @cache_readonly
     def coef_names(self):
         "Coefficient names (deprecated)"
         warn("coef_names is deprecated and will be removed in 0.6.0."
@@ -1340,10 +1344,15 @@ class VARResults(VARProcess, tsbase.TimeSeriesModelResults):
         """
         return self.cov_resid * self.df_resid / self.nobs
 
-    @cache_readonly
-    def cov_params(self):
+    def cov_params(self, r_matrix=None, *args, **kwargs):
         """
         Estimated variance-covariance of model coefficients
+
+        Parameters
+        ----------
+        r_matrix : array-like
+            Can be 1d, or 2d. If `r_matrix` is not None the covariance is
+            r_matrix kron((X.T X)^(-1), cov_resid) r_matrix.T
 
         Returns
         -------
@@ -1359,8 +1368,14 @@ class VARResults(VARProcess, tsbase.TimeSeriesModelResults):
         See VARModel or the VAR documentation for the definition of the A
         matrices.
         """
+        #TODO: This should inherit from a systems of equations model
+        #      and this should be in the super class
         X = self.X
-        return np.kron(L.inv(np.dot(X.T, X)), self.cov_resid)
+        cov = np.kron(L.inv(np.dot(X.T, X)), self.cov_resid)
+        if r_matrix is not None:
+            return np.dot(np.dot(r_matrix, cov), r_matrix)
+        else:
+            return cov
 
     def cov_ybar(self):
         r"""
@@ -1394,7 +1409,7 @@ class VARResults(VARProcess, tsbase.TimeSeriesModelResults):
 
         i = self.neqs*self.k_trend
         # drop trend variables
-        return self.cov_params[i:,i:]
+        return self.cov_params()[i:,i:]
 
 
     @cache_readonly
@@ -1416,7 +1431,7 @@ class VARResults(VARProcess, tsbase.TimeSeriesModelResults):
     @cache_readonly
     def stderr(self):
         "Standard errors of coefficients"
-        stderr = np.sqrt(np.diag(self.cov_params))
+        stderr = np.sqrt(np.diag(self.cov_params()))
         return stderr.reshape((self.df_model, self.neqs), order='C')
 
     bse = stderr  # statsmodels interface?
@@ -1874,7 +1889,7 @@ class VARResults(VARProcess, tsbase.TimeSeriesModelResults):
 
         # Lutkepohl 3.6.5
         Cb = np.dot(C, vec(self.params.T))
-        middle = L.inv(chain_dot(C, self.cov_params, C.T))
+        middle = L.inv(chain_dot(C, self.cov_params(), C.T))
 
         # wald statistic
         lam_wald = statistic = chain_dot(Cb, middle, Cb)
@@ -2122,18 +2137,22 @@ class VARResults(VARProcess, tsbase.TimeSeriesModelResults):
         idx = np.argsort(np.abs(roots))[::-1] # sort by reverse modulus
         return roots[idx]
 
+    def t_test(*args, **kwargs):
+        raise NotImplementedError
+
+    def f_test(*args, **kwargs):
+        raise NotImplementedError
+
 class VARResultsWrapper(wrap.ResultsWrapper):
-    _attrs = {'bse' : 'columns_eq', 'cov_params' : 'cov2d',
-              'params' : 'columns_eq', 'pvalues' : 'columns_eq',
-              'tvalues' : 'columns_eq', 'cov_resid' : 'cov_eq',
-              'cov_resid_mle' : 'cov_eq',
+    _attrs = {'bse' : 'columns_eq', 'params' : 'columns_eq',
+              'pvalues' : 'columns_eq', 'tvalues' : 'columns_eq',
+              'cov_resid' : 'cov_eq', 'cov_resid_mle' : 'cov_eq',
               'stderr' : 'columns_eq'}
     _wrap_attrs = wrap.union_dicts(tsbase.TimeSeriesResultsWrapper._wrap_attrs,
                                     _attrs)
-    _methods = {'conf_int' : 'columns_eq'}
+    _methods = {'conf_int' : 'columns_eq', 'cov_params' : 'cov2d'}
     _wrap_methods = wrap.union_dicts(tsbase.TimeSeriesResultsWrapper._wrap_methods,
                                      _methods)
-    _wrap_methods.pop('cov_params') # not yet a method in VARResults
 wrap.populate_wrapper(VARResultsWrapper, VARResults)
 
 class FEVD(object):

--- a/statsmodels/tsa/vector_ar/var_model.py
+++ b/statsmodels/tsa/vector_ar/var_model.py
@@ -373,6 +373,10 @@ def _get_info_criteria(cov_resid_mle, nobs, neqs, k_ar, k_trend):
 def _estimate_var_ic(Y, k_ar, k_trend, trim=0, trend='c'):
     """
     Helper function to fit VAR that aids in lag order selection
+
+    Y is expected to be an array.
+    trim is number of variables to trim from the beginning of Y. It's used
+    so that the ICs are comparable across fits with different lags.
     """
     Y = Y[trim:]
     X = util.get_lagged_y(Y, k_ar, trend=trend)
@@ -388,7 +392,41 @@ def _estimate_var_ic(Y, k_ar, k_trend, trim=0, trend='c'):
     cov_resid_mle = np.dot(resid.T, resid) / nobs
     return _get_info_criteria(cov_resid_mle, nobs, neqs, k_ar, k_trend)
 
-def select_order_fit(Y, maxlags=None, ic="aic", trend="c", verbose=True):
+def select_order_fit(Y, maxlags=None, ic="aic", trend="c", verbose=False):
+    """
+    Return results from the best lag order according to information criterion
+
+    Parameters
+    ----------
+    Y : array-like
+        The endogenous variables
+    maxlags : int
+        Maximum number of lags to check for order selection, defaults to
+        12 * (nobs/100.)**(1./4), see select_order function
+    ic : {'aic', 'fpe', 'hqic', 'bic', None}
+        Information criterion to use for VAR order selection:
+
+        * aic : Akaike
+        * fpe : Final prediction error
+        * hqic : Hannan-Quinn
+        * bic : Bayesian a.k.a. Schwarz
+    trend : str {"c", "ct", "ctt", "nc"}
+        Available options are:
+
+        * "c" - add constant
+        * "ct" - constant and trend
+        * "ctt" - constant, linear and quadratic trend
+        * "nc" - co constant, no trend
+
+        Note that these are prepended to the columns of X.
+    verbose : bool
+        Print order selection output to the screen. Default is False.
+
+    Returns
+    -------
+    fitted : VARResults
+        A VARResults instance using the best lag order indicated by `ic`.
+    """
     Y_array = np.asarray(Y)
     if data_util._is_structured_ndarray(Y_array):
         Y_array = Y_array.view((float, len(Y_array.dtype)))

--- a/statsmodels/tsa/vector_ar/var_model.py
+++ b/statsmodels/tsa/vector_ar/var_model.py
@@ -2174,7 +2174,7 @@ class FEVD(object):
         irfs = (self.orth_irfs[:periods] ** 2).cumsum(axis=0)
 
         rng = lrange(self.neqs)
-        mse = self.model.mse(periods)[:, rng, rng]
+        mse = results.mse(periods)[:, rng, rng]
 
         # lag x equation x component
         fevd = np.empty_like(irfs)


### PR DESCRIPTION
rebased version of #815  Skipper's VAR cleanup

many manually edited merge conflicts (many of the merge conflicts were in view numpy compatibility, adding type keyword, compatibility fixes by Pierre)

I cannot run the entire tests right now because matplotlib segfaults on my computer, in this case in `statsmodels.tsa.vector_ar.tests.test_var.TestVARResults.test_plot_cum_effects`

