### PR TITLE
TST: disable imputation ros tests, incompatible with older pandas

### DIFF
--- a/statsmodels/imputation/tests/test_ros.py
+++ b/statsmodels/imputation/tests/test_ros.py
@@ -1,5 +1,7 @@
 from __future__ import division
 
+__test__ = False
+
 import sys
 from textwrap import dedent
 


### PR DESCRIPTION
try to temporarily disable test for imputation.ros