### PR TITLE
BUG: All t-stat lag length selection when nothing significant

### DIFF
--- a/statsmodels/tsa/ar_model.py
+++ b/statsmodels/tsa/ar_model.py
@@ -448,6 +448,7 @@ class AR(tsbase.TimeSeriesModel):
                                         full_output=0, trend=trend,
                                         maxiter=35, disp=-1)
 
+                bestlag = 0
                 if np.abs(fit.tvalues[-1]) >= stop:
                     bestlag = lag
                     break

--- a/statsmodels/tsa/tests/test_ar.py
+++ b/statsmodels/tsa/tests/test_ar.py
@@ -303,6 +303,20 @@ def test_ar_select_order():
     res = ar.select_order(maxlag=12, ic='aic')
     assert_(res == 2)
 
+# GH 2658
+def test_ar_select_order_tstat():
+    rs = np.random.RandomState(123)
+    tau = 25
+    y = rs.randn(tau)
+    ts = Series(y, index=DatetimeIndex(start='1/1/1990', periods=tau,
+                                   freq='M'))
+
+    ar = AR(ts)
+    res = ar.select_order(maxlag=5, ic='t-stat')
+    assert_equal(res, 0)
+
+
+
 #TODO: likelihood for ARX model?
 #class TestAutolagARX(object):
 #    def setup(self):


### PR DESCRIPTION
Fix select_order to allow 0 lag length selection when all coefficients
are insignificant

closes #2658