### PR TITLE
DOC: add 0.7 and 0.8 to release notes/what's new index

### DIFF
--- a/docs/source/release/index.rst
+++ b/docs/source/release/index.rst
@@ -16,6 +16,8 @@ What's new in Statsmodels
 .. toctree::
    :maxdepth: 1
 
+   version0.8
+   version0.7
    version0.6
    github-stats-0.6
    version0.5


### PR DESCRIPTION
this add the release notes to the index

but is missing the github-stats that I don't have