### PR TITLE
DOC: change doc link and remove easy_install

### DIFF
--- a/docs/source/_static/examples.css
+++ b/docs/source/_static/examples.css
@@ -8,7 +8,7 @@
     padding-left: 30px;
 }
 
-.examples-page h1, h2, h3 {
+.examples-page h1, .examples-page h2, .examples-page h3 {
     padding-left: 30px; /* to make up for margin above */
 }
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -8,7 +8,7 @@ of many different statistical models, as well as for conducting statistical test
 data exploration. An extensive list of result statistics are available for each estimator.
 The results are tested against existing statistical packages to ensure that they are correct. The
 package is released under the open source Modified BSD (3-clause) license.
-The online documentation is hosted at `sourceforge <http://statsmodels.sourceforge.net/>`__.
+The online documentation is hosted at `statsmodels.org <http://www.statsmodels.org/>`__.
 
 
 Minimal Examples

--- a/docs/themes/statsmodels/indexsidebar.html
+++ b/docs/themes/statsmodels/indexsidebar.html
@@ -7,9 +7,13 @@ released yet. Grab the source code from <a href="https://github.com/statsmodels/
 
 {% else %}
 
-<p>This documentation is for the <b>{{ release }}</b> release. You can install it with:</p>
-<pre style="margin:0px 1px">easy_install -U statsmodels</pre>
-<p>Or get it from the <a href="http://pypi.python.org/pypi/statsmodels">Python Package Index</a>.
+<p>This documentation is for the <b>{{ release }}</b> release. You can install it with pip:
+
+  <pre style="margin:0px 1px">pip install --upgrade --no-deps statsmodels</pre>
+
+  or conda:
+
+  <pre style="margin:0px 1px">conda install statsmodels</pre>
 Documentation for the current development version is <a href="http://statsmodels.sourceforge.net/devel/">here</a>.</p>
 
 {% endif %}


### PR DESCRIPTION
cc @josef-pkt 

Also removed the suggestion to use the `--upgrade` flag, since that can cause all sorts of trouble by updating not just statsmodels.

looks like
<img width="266" alt="screen shot 2016-06-21 at 11 05 47 am" src="https://cloud.githubusercontent.com/assets/1312546/16237085/626d10a6-37a0-11e6-9af8-1dcac07811b9.png">