### PR TITLE
COV: Improve accuracy of coverage

### DIFF
--- a/.travis_coveragerc
+++ b/.travis_coveragerc
@@ -1,5 +1,31 @@
-
 [run]
 branch = True
 include =
     */statsmodels/*
+
+omit =
+    # print_version is untestable
+    */print_version.py
+    # skip compatability code
+    */compat/*
+    # Unused file
+    */results/gee_generate_tests.py
+
+[report]
+# Regexes for lines to exclude from consideration
+exclude_lines =
+    # Have to re-enable the standard pragma
+    pragma: no cover
+
+    # Don't complain about missing debug-only code:
+    def __repr__
+    if self\.debug
+
+    # Don't complain if tests don't hit defensive assertion code:
+    raise AssertionError
+    raise NotImplementedError
+
+    # Don't complain if non-runnable code isn't run:
+    if 0:
+    if __name__ == .__main__.:
+    if name == .__main__.:


### PR DESCRIPTION
Exclude compat code
Exclude print_version
Exclude code after __name__ == '__main__'
Exclude other unrunnable code from coverage