### PR TITLE
BF: relax test precision for 32-bit failures

### DIFF
--- a/statsmodels/tsa/statespace/tests/test_mlemodel.py
+++ b/statsmodels/tsa/statespace/tests/test_mlemodel.py
@@ -193,7 +193,8 @@ def test_fit_misc():
         warnings.simplefilter("ignore")
         res_params = mod.fit(disp=-1, return_params=True)
 
-    assert_almost_equal(res_params, [0,0], 6)
+    # 5 digits necessary to accommodate 32-bit numpy / scipy with OpenBLAS 0.2.18
+    assert_almost_equal(res_params, [0, 0], 5)
 
 
 def test_score_misc():

--- a/statsmodels/tsa/statespace/tests/test_sarimax.py
+++ b/statsmodels/tsa/statespace/tests/test_sarimax.py
@@ -1831,7 +1831,8 @@ def test_simple_time_varying():
         res = mod.fit(disp=-1)
 
     # Test that the estimated variances of the errors are essentially zero
-    assert_almost_equal(res.params, [0,0], 6)
+    # 5 digits necessary to accommodate 32-bit numpy / scipy with OpenBLAS 0.2.18
+    assert_almost_equal(res.params, [0, 0], 5)
 
     # Test that the time-varying coefficients are all 0.5 (except the first
     # one)


### PR DESCRIPTION
Backport of fix for precision errors with 32-bit manylinux wheels (#3069).

See: https://github.com/statsmodels/statsmodels/issues/3067