### PR TITLE
BUG/ENH: Intercept handling for PHReg

### DIFF
--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -158,7 +158,7 @@ class Model(object):
             if len(cols) < len(exog.columns):
                 exog = exog[cols]
                 cols = list(design_info.term_names)
-                for col in cols:
+                for col in drop_cols:
                     try:
                         cols.remove(col)
                     except ValueError:

--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -153,16 +153,17 @@ class Model(object):
                                   missing=missing)
         ((endog, exog), missing_idx, design_info) = tmp
 
-        if drop_cols is not None:
+        if drop_cols is not None and len(drop_cols) > 0:
             cols = [x for x in exog.columns if x not in drop_cols]
-            exog = exog[cols]
-            cols = list(design_info.term_names)
-            for col in cols:
-                try:
-                    cols.remove(col)
-                except ValueError:
-                    pass # OK if not present
-            design_info = design_info.builder.subset(cols).design_info
+            if len(cols) < len(exog.cols):
+                exog = exog[cols]
+                cols = list(design_info.term_names)
+                for col in cols:
+                    try:
+                        cols.remove(col)
+                    except ValueError:
+                        pass # OK if not present
+                design_info = design_info.builder.subset(cols).design_info
 
         kwargs.update({'missing_idx': missing_idx,
                        'missing': missing,

--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -155,7 +155,7 @@ class Model(object):
 
         if drop_cols is not None and len(drop_cols) > 0:
             cols = [x for x in exog.columns if x not in drop_cols]
-            if len(cols) < len(exog.cols):
+            if len(cols) < len(exog.columns):
                 exog = exog[cols]
                 cols = list(design_info.term_names)
                 for col in cols:

--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -112,7 +112,8 @@ class Model(object):
             indicate the subset of df to use in the model. Assumes df is a
             `pandas.DataFrame`
         drop_cols : array-like
-            Columns to drop from the design matrix.
+            Columns to drop from the design matrix.  Cannot be used to
+            drop terms involving categoricals.
         args : extra arguments
             These are passed to the model
         kwargs : extra keyword arguments

--- a/statsmodels/duration/hazard_regression.py
+++ b/statsmodels/duration/hazard_regression.py
@@ -402,10 +402,19 @@ class PHReg(model.LikelihoodModel):
         if isinstance(offset, str):
             offset = data[offset]
 
+        import re
+        terms = re.split("[+\-~]", formula)
+        for term in terms:
+            term = term.strip()
+            if term in ("0", "1"):
+                import warnings
+                warnings.warn("PHReg formulas should not include any '0' or '1' terms")
+
         mod = super(PHReg, cls).from_formula(formula, data,
                     status=status, entry=entry, strata=strata,
                     offset=offset, subset=subset, ties=ties,
-                    missing=missing, *args, **kwargs)
+                    missing=missing, drop_cols=["Intercept"], *args,
+                    **kwargs)
 
         return mod
 

--- a/statsmodels/duration/tests/test_phreg.py
+++ b/statsmodels/duration/tests/test_phreg.py
@@ -156,7 +156,8 @@ class TestPHReg(object):
         mod1 = PHReg(time, exog, status, entry=entry)
         rslt1 = mod1.fit()
 
-        fml = "time ~ 0 + exog1 + exog2 + exog3 + exog4"
+        # works with "0 +" on RHS but issues warning
+        fml = "time ~ exog1 + exog2 + exog3 + exog4"
         mod2 = PHReg.from_formula(fml, df, status=status,
                                   entry=entry)
         rslt2 = mod2.fit()
@@ -170,6 +171,19 @@ class TestPHReg(object):
         assert_allclose(rslt1.bse, rslt2.bse)
         assert_allclose(rslt1.bse, rslt3.bse)
 
+    def test_formula_cat_interactions(self):
+
+        time = np.r_[1, 2, 3, 4, 5, 6, 7, 8, 9]
+        status = np.r_[1, 1, 0, 0, 1, 0, 1, 1, 1]
+        x1 = np.r_[1, 1, 1, 2, 2, 2, 3, 3, 3]
+        x2 = np.r_[1, 2, 3, 1, 2, 3, 1, 2, 3]
+        df = pd.DataFrame({"time": time, "status": status,
+                           "x1": x1, "x2": x2})
+
+        model1 = PHReg.from_formula("time ~ C(x1) + C(x2) + C(x1)*C(x2)", status="status",
+                                    data=df)
+        assert_equal(model1.exog.shape, [9, 8])
+
     def test_predict_formula(self):
 
         n = 100
@@ -181,7 +195,8 @@ class TestPHReg(object):
         df = pd.DataFrame({"time": time, "status": status,
                            "exog1": exog[:, 0], "exog2": exog[:, 1]})
 
-        fml = "time ~ 0 + exog1 + np.log(exog2) + exog1*exog2"
+        # Works with "0 +" on RHS but issues warning
+        fml = "time ~ exog1 + np.log(exog2) + exog1*exog2"
         model1 = PHReg.from_formula(fml, df, status=status)
         result1 = model1.fit()
 

--- a/statsmodels/genmod/generalized_estimating_equations.py
+++ b/statsmodels/genmod/generalized_estimating_equations.py
@@ -678,8 +678,8 @@ class GEE(base.Model):
         if type(exposure) == str:
             exposure = data[exposure]
 
-        model = super(GEE, cls).from_formula(formula, data, subset,
-                                             groups, time=time,
+        model = super(GEE, cls).from_formula(formula, data=data, subset=subset,
+                                             groups=groups, time=time,
                                              offset=offset,
                                              exposure=exposure,
                                              *args, **kwargs)


### PR DESCRIPTION
This PR is intended to solve a longstanding problem with Cox models, which must not have an intercept (either explicit, or hidden in the columnspan of the design matrix).

When the formula has no categoricals, it is sufficient to use "0 + " or "- 1" in the formula.  But with categoricals, having "0 +" just means that the intercept is hidden as a linear combination of columns.  

The solution we have found is to allow Patsy to put the intercept in, then remove it.  It works with everything we have tried including some fairly complex things (e.g. high order interactions of multi-level categoricals mixed with non-categoricals).

Unfortunately, there is no easy way to implement this purely inside the PHReg class  -- you need to get in between where the formula is processed and where the model is created.

Rather than implementing this as a one-off, I added an optional keyword argument to the base `from_formula` method called `drop_cols`.  We use it here to drop "Intercept", but it could have other uses.  It defaults to the empty list.

This should be backward compatible, as only a warning is given if "0 + " or "- 1" appears in a formula for PHReg. 

The same issue could arise in other models that must not have an intercept, like multinomial logit.