### PR TITLE
BUG: predict_functional rows of zeros

### DIFF
--- a/statsmodels/sandbox/predict_functional.py
+++ b/statsmodels/sandbox/predict_functional.py
@@ -253,8 +253,9 @@ def _make_exog_from_arrays(result, focus_var, summaries, values, num_points):
 
     # 0 rows cause problems for t-test
     ii = np.abs(exog).sum(1) > 1e-10
+    ii = np.flatnonzero(ii)
     exog = exog[ii, :]
-    fvals = fvals[np.asarray(ii)]
+    fvals = fvals[ii]
 
     return exog, fvals
 

--- a/statsmodels/sandbox/predict_functional.py
+++ b/statsmodels/sandbox/predict_functional.py
@@ -191,6 +191,13 @@ def _make_exog_from_formula(result, focus_var, summaries, values, num_points):
         fexog.loc[:, ky] = values[ky]
 
     dexog = patsy.dmatrix(model.data.design_info.builder, fexog, return_type='dataframe')
+
+    # 0 rows cause problems for t-test
+    ii = np.abs(dexog).sum(1) > 1e-10
+    dexog = dexog.loc[ii, :]
+    fexog = fexog.loc[ii, :]
+    fvals = fvals[np.asarray(ii)]
+
     return dexog, fexog, fvals
 
 
@@ -243,6 +250,11 @@ def _make_exog_from_arrays(result, focus_var, summaries, values, num_points):
     for ky in values.keys():
         ix = exog_names.index(ky)
         exog[:, ix] = values[ky]
+
+    # 0 rows cause problems for t-test
+    ii = np.abs(exog).sum(1) > 1e-10
+    exog = exog[ii, :]
+    fvals = fvals[np.asarray(ii)]
 
     return exog, fvals
 


### PR DESCRIPTION
Since we use t_test in `predict_functional` to get standard errors, an exception results if a row of the contrast matrix is entirely zero.  But this can be perfectly OK to use in `predict_functional`.

Usually, a model will have an intercept so there will be a "1" somewhere in the contrast matrix and this issue cannot arise. But for Cox models, we may want to predict at a set of points that includes the reference level, which by construction has log hazard ratio = 0 with zero standard error. That is the use-case that prompted this PR.
