### PR TITLE
ENH: Data Interface to simplify numpy type conversion

### DIFF
--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -745,7 +745,7 @@ class Results(object):
         """
         from statsmodels.tools.data_interface import NumPyInterface
 
-        exog_interface = NumPyInterface(data=exog, model=self.model, use_formula=transform)
+        exog_interface = NumPyInterface(model=self.model, use_formula=transform)
         exog = exog_interface.to_statsmodels(exog)
 
         if exog is not None:

--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -748,6 +748,14 @@ class Results(object):
         exog_interface = NumPyInterface(data=exog, model=self.model, use_formula=transform)
         exog = exog_interface.to_statsmodels(exog)
 
+        if exog is not None:
+            exog = np.asarray(exog)
+
+            if exog.ndim == 1 and (self.model.exog.ndim == 1 or self.model.exog.shape[1] == 1):
+                exog = exog[:, None]
+
+            exog = np.atleast_2d(exog)  # needed in count model shape[1]
+
         predict_results = self.model.predict(self.params, exog, *args, **kwargs)
 
         return exog_interface.from_statsmodels(predict_results)

--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -754,14 +754,17 @@ class Results(object):
             if get_ndim(exog) == 1 and (self.model.exog.ndim == 1 or self.model.exog.shape[1] == 1):
                 require_col_vector = True
 
-        exog_interface = NumPyInterface(data=exog, model=self.model, use_formula=transform,
-                                        require_col_vector=require_col_vector, at_least_2d=at_least_2d)
+        exog_interface = NumPyInterface(model=self.model, use_formula=transform, require_col_vector=require_col_vector,
+                                        at_least_2d=at_least_2d)
 
         exog = exog_interface.to_statsmodels(exog)
 
         predict_results = self.model.predict(self.params, exog, *args, **kwargs)
 
-        return exog_interface.from_statsmodels(predict_results)
+        if hasattr(predict_results, 'predicted_values'):
+            return predict_results
+        else:
+            return exog_interface.from_statsmodels(predict_results)
 
 
     def summary(self):

--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -745,7 +745,18 @@ class Results(object):
         """
         from statsmodels.tools.data_interface import NumPyInterface
 
-        exog_interface = NumPyInterface(data=exog, model=self.model, use_formula=transform, require_1d=True)
+        at_least_2d = False
+        require_col_vector = False
+
+        if exog is not None:
+            at_least_2d = True
+
+            if exog.ndim == 1 and (self.model.exog.ndim == 1 or self.model.exog.shape[1] == 1):
+                require_col_vector = True
+
+        exog_interface = NumPyInterface(data=exog, model=self.model, use_formula=transform,
+                                        require_col_vector=require_col_vector, atleast_2d =at_least_2d)
+
         exog = exog_interface.to_statsmodels(exog)
 
         # if exog is not None:

--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -743,15 +743,15 @@ class Results(object):
             See self.model.predict
 
         """
-        from statsmodels.tools.data_interface import NumPyInterface
+        from statsmodels.tools.data_interface import NumPyInterface, get_ndim
 
         at_least_2d = False
         require_col_vector = False
 
         if exog is not None:
-            at_least_2d = True
+            at_least_2d = True # needed in count model shape[1]
 
-            if exog.ndim == 1 and (self.model.exog.ndim == 1 or self.model.exog.shape[1] == 1):
+            if get_ndim(exog) == 1 and (self.model.exog.ndim == 1 or self.model.exog.shape[1] == 1):
                 require_col_vector = True
 
         exog_interface = NumPyInterface(data=exog, model=self.model, use_formula=transform,

--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -755,7 +755,7 @@ class Results(object):
                 require_col_vector = True
 
         exog_interface = NumPyInterface(data=exog, model=self.model, use_formula=transform,
-                                        require_col_vector=require_col_vector, atleast_2d =at_least_2d)
+                                        require_col_vector=require_col_vector, at_least_2d=at_least_2d)
 
         exog = exog_interface.to_statsmodels(exog)
 

--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -745,15 +745,17 @@ class Results(object):
         """
         from statsmodels.tools.data_interface import NumPyInterface
 
-        exog_interface = NumPyInterface(model=self.model, use_formula=transform)
+        exog_interface = NumPyInterface(model=self.model, external_type=type(exog),
+                                        use_formula=transform, require_2d=True)
+
         exog = exog_interface.to_statsmodels(exog)
 
-        if exog is not None:
-
-            if exog.ndim == 1 and (self.model.exog.ndim == 1 or self.model.exog.shape[1] == 1):
-                exog = exog[:, None]
-
-            exog = np.atleast_2d(exog)  # needed in count model shape[1]
+        # if exog is not None:
+        #
+        #     if exog.ndim == 1 and (self.model.exog.ndim == 1 or self.model.exog.shape[1] == 1):
+        #         exog = exog[:, None]
+        #
+        #     exog = np.atleast_2d(exog)  # needed in count model shape[1]
 
         predict_results = self.model.predict(self.params, exog, *args, **kwargs)
 

--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -759,13 +759,6 @@ class Results(object):
 
         exog = exog_interface.to_statsmodels(exog)
 
-        # if exog is not None:
-        #
-        #     if exog.ndim == 1 and (self.model.exog.ndim == 1 or self.model.exog.shape[1] == 1):
-        #         exog = exog[:, None]
-        #
-        #     exog = np.atleast_2d(exog)  # needed in count model shape[1]
-
         predict_results = self.model.predict(self.params, exog, *args, **kwargs)
 
         return exog_interface.from_statsmodels(predict_results)

--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -745,7 +745,7 @@ class Results(object):
         """
         from statsmodels.tools.data_interface import NumPyInterface
 
-        exog_interface = NumPyInterface(data=exog, model=self.model, use_formula=transform, require_2d=True)
+        exog_interface = NumPyInterface(data=exog, model=self.model, use_formula=transform, require_1d=True)
         exog = exog_interface.to_statsmodels(exog)
 
         # if exog is not None:

--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -749,7 +749,6 @@ class Results(object):
         exog = exog_interface.to_statsmodels(exog)
 
         if exog is not None:
-            exog = np.asarray(exog)
 
             if exog.ndim == 1 and (self.model.exog.ndim == 1 or self.model.exog.shape[1] == 1):
                 exog = exog[:, None]

--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -745,9 +745,7 @@ class Results(object):
         """
         from statsmodels.tools.data_interface import NumPyInterface
 
-        exog_interface = NumPyInterface(model=self.model, external_type=type(exog),
-                                        use_formula=transform, require_2d=True)
-
+        exog_interface = NumPyInterface(data=exog, model=self.model, use_formula=transform, require_2d=True)
         exog = exog_interface.to_statsmodels(exog)
 
         # if exog is not None:

--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -743,34 +743,14 @@ class Results(object):
             See self.model.predict
 
         """
-        import pandas as pd
+        from statsmodels.tools.data_interface import NumPyInterface
 
-        exog_index = exog.index if _is_using_pandas(exog, None) else None
-
-        if transform and hasattr(self.model, 'formula') and exog is not None:
-            from patsy import dmatrix
-            exog = dmatrix(self.model.data.design_info.builder,
-                           exog)
-
-        if exog is not None:
-            exog = np.asarray(exog)
-            if exog.ndim == 1 and (self.model.exog.ndim == 1 or
-                                   self.model.exog.shape[1] == 1):
-                exog = exog[:, None]
-            exog = np.atleast_2d(exog)  # needed in count model shape[1]
+        exog_interface = NumPyInterface(data=exog, model=self.model, use_formula=transform)
+        exog = exog_interface.to_statsmodels(exog)
 
         predict_results = self.model.predict(self.params, exog, *args, **kwargs)
 
-        if exog_index is not None and not hasattr(predict_results, 'predicted_values'):
-
-            if predict_results.ndim == 1:
-                return pd.Series(predict_results, index=exog_index)
-            else:
-                return pd.DataFrame(predict_results, index=exog_index)
-
-        else:
-
-            return predict_results
+        return exog_interface.from_statsmodels(predict_results)
 
 
     def summary(self):

--- a/statsmodels/base/tests/test_generic_methods.py
+++ b/statsmodels/base/tests/test_generic_methods.py
@@ -147,15 +147,13 @@ class CheckGenericMixin(object):
             from pandas.util.testing import assert_series_equal
 
             fitted = res.fittedvalues[:2]
+
             assert_allclose(fitted, res.predict(p_exog), rtol=1e-12)
             # this needs reshape to column-vector:
-            assert_allclose(fitted, res.predict(np.squeeze(p_exog).tolist()),
-                            rtol=1e-12)
+            assert_allclose(fitted, res.predict(np.squeeze(p_exog).tolist()), rtol=1e-12)
             # only one prediction:
-            assert_allclose(fitted[:1], res.predict(p_exog[0].tolist()),
-                            rtol=1e-12)
-            assert_allclose(fitted[:1], res.predict(p_exog[0]),
-                            rtol=1e-12)
+            assert_allclose(fitted[:1], res.predict(p_exog[0].tolist()), rtol=1e-12)
+            assert_allclose(fitted[:1], res.predict(p_exog[0]), rtol=1e-12)
 
             exog_index = range(len(p_exog))
             predicted = res.predict(p_exog)

--- a/statsmodels/discrete/tests/test_discrete.py
+++ b/statsmodels/discrete/tests/test_discrete.py
@@ -1343,7 +1343,7 @@ def test_issue_341():
     res1 = sm.MNLogit(data.endog, exog).fit(method="newton", disp=0)
     x = exog[0]
     np.testing.assert_equal(res1.predict(x).shape, (7,))
-    np.testing.assert_equal(res1.predict(x[None]).shape, (1,7))
+    np.testing.assert_equal(res1.predict(x[None]).shape, (7,))
 
 def test_iscount():
     X = np.random.random((50, 10))

--- a/statsmodels/discrete/tests/test_discrete.py
+++ b/statsmodels/discrete/tests/test_discrete.py
@@ -1343,7 +1343,7 @@ def test_issue_341():
     res1 = sm.MNLogit(data.endog, exog).fit(method="newton", disp=0)
     x = exog[0]
     np.testing.assert_equal(res1.predict(x).shape, (7,))
-    np.testing.assert_equal(res1.predict(x[None]).shape, (7,))
+    np.testing.assert_equal(res1.predict(x[None]).shape, (1, 7))
 
 def test_iscount():
     X = np.random.random((50, 10))

--- a/statsmodels/discrete/tests/test_discrete.py
+++ b/statsmodels/discrete/tests/test_discrete.py
@@ -1342,7 +1342,7 @@ def test_issue_341():
     exog = sm.add_constant(exog, prepend=True)
     res1 = sm.MNLogit(data.endog, exog).fit(method="newton", disp=0)
     x = exog[0]
-    np.testing.assert_equal(res1.predict(x).shape, (1,7))
+    np.testing.assert_equal(res1.predict(x).shape, (7,))
     np.testing.assert_equal(res1.predict(x[None]).shape, (1,7))
 
 def test_iscount():

--- a/statsmodels/tools/data_interface.py
+++ b/statsmodels/tools/data_interface.py
@@ -146,10 +146,10 @@ class DataInterface(object):
             np_data = self.to_numpy_array(data)
 
             if np_data.ndim == 1:
-                return pd.Series(np_data, name=self.name, dtype=self.dtype)
+                return pd.Series(np_data, name=self.name)
 
             else:
-                return pd.DataFrame(np_data, columns=self.columns, dtype=self.dtype)
+                return pd.DataFrame(np_data, columns=self.columns)
 
     def from_numpy_array(self, data):
 
@@ -166,20 +166,20 @@ class DataInterface(object):
 
         elif self.external_type == pd.Series:
             index = getattr(data, 'index', None)
-            return pd.Series(data=data, index=index, dtype=self.dtype)
+            return pd.Series(data=data, index=index)
 
         elif self.external_type == pd.DataFrame:
             ndim = getattr(data, 'ndim', None)
 
             if ndim in [1, None]:
-                return pd.Series(data=data, index=self.index, dtype=self.dtype)
+                return pd.Series(data=data, index=self.index)
 
             elif self.ndim == ndim:
                 df = pd.DataFrame(data=data, columns=self.columns, index=self.index)
                 return apply_dtype_to_df(df, self.dtype)
 
             else:
-                df = pd.DataFrame(data=data, dtype=self.dtype, index=self.index)
+                df = pd.DataFrame(data=data, index=self.index)
                 return apply_dtype_to_df(df, self.dtype)
 
         else:
@@ -200,7 +200,7 @@ class DataInterface(object):
 
         elif from_type == pd.DataFrame and self.external_type == pd.Series:
             if data.ndim == 1:
-                return pd.Series(data.values, index=data.index, name=data.columns[0], dtype=self.dtype)
+                return pd.Series(data.values, index=data.index, name=data.columns[0])
             else:
                 raise TypeError('Cannot convert multi dimensional DataFrame to a Series')
 

--- a/statsmodels/tools/data_interface.py
+++ b/statsmodels/tools/data_interface.py
@@ -2,6 +2,7 @@ import pandas as pd
 import numpy as np
 from functools import partial
 from patsy import dmatrix
+from patsy.design_info import DesignMatrix
 
 NUMPY_TYPES = [np.ndarray, np.float64]
 PANDAS_TYPES = [pd.Series, pd.DataFrame]
@@ -51,7 +52,17 @@ class DataInterface(object):
 
         from_type = type(data)
 
-        if from_type in NUMPY_TYPES:
+        if from_type == DesignMatrix:
+            if self.model is None:
+                raise ValueError('When a DesignMatrix is returned, a model must be specified.')
+            else:
+                data = dmatrix(self.model.data.design_info.builder, data)
+                from_type = type(data)
+
+        if data is None:
+            return None
+
+        elif from_type in NUMPY_TYPES:
             return self.from_numpy_array(data)
 
         elif from_type in PANDAS_TYPES:

--- a/statsmodels/tools/data_interface.py
+++ b/statsmodels/tools/data_interface.py
@@ -11,13 +11,14 @@ PANDAS_TYPES = [pd.Series, pd.DataFrame]
 class DataInterface(object):
 
     def __init__(self, permitted_types, internal_type=None, data=None, external_type=None, model=None,
-                 use_formula=False, require_1d=False):
+                 use_formula=False, require_col_vector=False, at_least_2d=False):
 
         self.permitted_types = permitted_types
         self.internal_type = np.ndarray if internal_type is None else internal_type
         self.model = model
         self.use_formula = use_formula
-        self.require_1d = require_1d
+        self.require_col_vector = require_col_vector
+        self.at_least_2d = at_least_2d
 
         if external_type is not None:
             self.external_type = external_type
@@ -83,17 +84,25 @@ class DataInterface(object):
         else:
             raise TypeError('Type conversion to {} from {} is not possible.'.format(self.internal_type, type(data)))
 
-        if self.require_1d and self.ndim == 1:
-            if is_col_vector(to_return):
-                to_return = transpose(to_return)
+        if self.require_col_vector and self.ndim == 1 and not is_col_vector(to_return):
+            to_return = transpose(to_return)
 
-            if is_nested_row_vector(to_return):
-                to_return = to_return[0]
+        if self.at_least_2d:
+            to_return = np.atleast_2d(to_return)
 
-            return to_return
+        # if self.require_1d and self.ndim == 1:
+        #     if is_col_vector(to_return):
+        #         to_return = transpose(to_return)
+        #
+        #     if is_nested_row_vector(to_return):
+        #         to_return = to_return[0]
+        #
+        #     return to_return
 
-        else:
-            return to_return
+        # else:
+        #     return to_return
+
+        return to_return
 
     def from_statsmodels(self, data):
 

--- a/statsmodels/tools/data_interface.py
+++ b/statsmodels/tools/data_interface.py
@@ -87,11 +87,6 @@ class DataInterface(object):
                 TypeError('Type conversion to numpy from {} is not possible.'.format(from_type))
 
 
-        if self.model is not None:
-            return clean_ndim(to_return, self.model)
-        else:
-            return to_return
-
     def to_pandas(self, data):
 
         from_type = type(data)
@@ -164,15 +159,6 @@ class DataInterface(object):
 
 NumPyInterface = partial(DataInterface, [np.ndarray])
 PandasInterface = partial(DataInterface, [np.ndarray, pd.Series, pd.DataFrame])
-
-def clean_ndim(data, model):
-
-    if data.ndim == 1 and (model.exog.ndim == 1 or model.exog.shape[1] == 1):
-        data = data[:, None]
-
-    data = np.atleast_2d(data)  # needed in count model shape[1]
-
-    return data
 
 def get_dtype(data):
 

--- a/statsmodels/tools/data_interface.py
+++ b/statsmodels/tools/data_interface.py
@@ -92,7 +92,8 @@ class DataInterface(object):
             data_to_return = self.from_numpy_array(data)
 
             if self.to_transpose(data_to_return):
-                return data_to_return.squeeze()
+                return transpose(data)
+
             else:
                 return data_to_return
 
@@ -100,7 +101,8 @@ class DataInterface(object):
             data_to_return = self.from_pandas(data)
 
             if self.to_transpose(data_to_return):
-                return
+                return transpose(data)
+
             else:
                 return data_to_return
 

--- a/statsmodels/tools/data_interface.py
+++ b/statsmodels/tools/data_interface.py
@@ -10,15 +10,23 @@ PANDAS_TYPES = [pd.Series, pd.DataFrame]
 
 class DataInterface(object):
 
-    def __init__(self, permitted_types, internal_type=None, external_type=None, model=None, use_formula=False,
+    def __init__(self, permitted_types, internal_type=None, data=None, external_type=None, model=None, use_formula=False,
                  require_2d=False):
 
         self.permitted_types = permitted_types
         self.internal_type = np.ndarray if internal_type is None else internal_type
         self.model = model
         self.use_formula = use_formula
-        self.external_type = external_type
         self.require_2d = require_2d
+
+        if external_type is not None:
+            self.external_type = external_type
+
+        elif data is not None:
+            self.external_type = type(data)
+
+        else:
+            self.external_type = np.ndarray
 
         self.columns = None
         self.name = None
@@ -35,9 +43,6 @@ class DataInterface(object):
         self.ndim = get_ndim(data)
         self.is_nested_row_vector = is_nested_row_vector(data)
         self.is_col_vector = is_col_vector(data)
-
-        if self.external_type is None:
-            self.external_type = type(data)
 
     def to_transpose(self, data):
 
@@ -56,6 +61,7 @@ class DataInterface(object):
 
         if data is None:
             return None
+
         else:
             self.init_data_interface(data)
 
@@ -86,16 +92,17 @@ class DataInterface(object):
 
     def from_statsmodels(self, data):
 
-        from_type = type(data)
-        self.index = getattr(data, 'index', None)
-
         if data is None:
             return None
 
-        elif from_type == DesignMatrix:
+        from_type = type(data)
+
+        if from_type == DesignMatrix:
             return data
 
-        elif from_type in NUMPY_TYPES:
+        self.index = getattr(data, 'index', None)
+
+        if from_type in NUMPY_TYPES:
             data_to_return = self.from_numpy_array(data)
 
         elif from_type in PANDAS_TYPES:

--- a/statsmodels/tools/data_interface.py
+++ b/statsmodels/tools/data_interface.py
@@ -23,7 +23,7 @@ class DataInterface(object):
         if external_type is not None:
             self.external_type = external_type
 
-        elif data is not None:
+        elif data is not None and not np.isscalar(data):
             self.external_type = type(data)
 
         else:

--- a/statsmodels/tools/data_interface.py
+++ b/statsmodels/tools/data_interface.py
@@ -6,6 +6,7 @@ from patsy.design_info import DesignMatrix
 
 NUMPY_TYPES = [np.ndarray, np.float64]
 PANDAS_TYPES = [pd.Series, pd.DataFrame]
+DEFAULT_EXTERNAL_TYPE = np.ndarray
 
 
 class DataInterface(object):
@@ -19,7 +20,7 @@ class DataInterface(object):
         self.use_formula = use_formula
         self.require_col_vector = require_col_vector
         self.at_least_2d = at_least_2d
-        self.external_type = external_type
+        self.external_type = external_type if external_type is not None else DEFAULT_EXTERNAL_TYPE
 
         self.columns = None
         self.name = None
@@ -37,12 +38,9 @@ class DataInterface(object):
         self.is_nested_row_vector = is_nested_row_vector(data)
         self.is_col_vector = is_col_vector(data)
 
-        if self.external_type is None:
-            if data is not None and not np.isscalar(data):
+        if self.external_type == DEFAULT_EXTERNAL_TYPE and data is not None:
+            if not np.isscalar(data):
                 self.external_type = type(data)
-
-            else:
-                self.external_type = np.ndarray
 
     def to_transpose(self, data):
 

--- a/statsmodels/tools/data_interface.py
+++ b/statsmodels/tools/data_interface.py
@@ -11,7 +11,7 @@ DEFAULT_EXTERNAL_TYPE = np.ndarray
 
 class DataInterface(object):
 
-    def __init__(self, permitted_types, internal_type=None, data=None, external_type=None, model=None,
+    def __init__(self, permitted_types, internal_type=None, external_type=None, model=None,
                  use_formula=False, require_col_vector=False, at_least_2d=False):
 
         self.permitted_types = permitted_types

--- a/statsmodels/tools/data_interface.py
+++ b/statsmodels/tools/data_interface.py
@@ -84,18 +84,16 @@ class DataInterface(object):
         else:
             raise TypeError('Type conversion to {} from {} is not possible.'.format(self.internal_type, type(data)))
 
-        if self.require_col_vector and self.ndim == 1 and not is_col_vector(to_return):
+        if self.require_col_vector and get_ndim(to_return) == 1 and not is_col_vector(to_return):
             to_return = transpose(to_return)
 
         if self.at_least_2d:
-            to_return = np.atleast_2d(to_return)
+            if get_ndim(to_return) == 1 and not is_col_vector(to_return):
+                to_return = to_nested_row_vector(to_return)
 
         return to_return
 
     def from_statsmodels(self, data):
-
-        # from pdb import set_trace
-        # set_trace()
 
         if data is None:
             return None

--- a/statsmodels/tools/data_interface.py
+++ b/statsmodels/tools/data_interface.py
@@ -23,8 +23,8 @@ class DataInterface(object):
         if external_type is not None:
             self.external_type = external_type
 
-        elif data is not None and not np.isscalar(data):
-            self.external_type = type(data)
+        # elif data is not None and not np.isscalar(data):
+        #     self.external_type = type(data)
 
         else:
             self.external_type = np.ndarray
@@ -90,21 +90,12 @@ class DataInterface(object):
         if self.at_least_2d:
             to_return = np.atleast_2d(to_return)
 
-        # if self.require_1d and self.ndim == 1:
-        #     if is_col_vector(to_return):
-        #         to_return = transpose(to_return)
-        #
-        #     if is_nested_row_vector(to_return):
-        #         to_return = to_return[0]
-        #
-        #     return to_return
-
-        # else:
-        #     return to_return
-
         return to_return
 
     def from_statsmodels(self, data):
+
+        # from pdb import set_trace
+        # set_trace()
 
         if data is None:
             return None

--- a/statsmodels/tools/data_interface.py
+++ b/statsmodels/tools/data_interface.py
@@ -175,12 +175,10 @@ class DataInterface(object):
                 return pd.Series(data=data, index=self.index)
 
             elif self.ndim == ndim:
-                df = pd.DataFrame(data=data, columns=self.columns, index=self.index)
-                return apply_dtype_to_df(df, self.dtype)
+                return pd.DataFrame(data=data, columns=self.columns, index=self.index)
 
             else:
-                df = pd.DataFrame(data=data, index=self.index)
-                return apply_dtype_to_df(df, self.dtype)
+                return pd.DataFrame(data=data, index=self.index)
 
         else:
             return data

--- a/statsmodels/tools/data_interface.py
+++ b/statsmodels/tools/data_interface.py
@@ -7,6 +7,7 @@ from patsy.design_info import DesignMatrix
 NUMPY_TYPES = [np.ndarray, np.float64]
 PANDAS_TYPES = [pd.Series, pd.DataFrame]
 
+
 class DataInterface(object):
 
     def __init__(self, permitted_types, internal_type=np.ndarray, data=None, external_type=None, model=None,
@@ -14,11 +15,15 @@ class DataInterface(object):
 
         self.permitted_types = permitted_types
         self.internal_type = internal_type
-        self.columns = getattr(data, 'columns', None)
-        self.name = getattr(data, 'name', None)
-        self.ndim = getattr(data, 'ndim', None)
         self.model = model
         self.use_formula = use_formula
+
+        self.columns = None
+        self.name = None
+        self.dtype = None
+        self.index = None
+        self.ndim = None
+        self.is_col_vector = None
 
         if external_type is not None:
             self.external_type = external_type
@@ -29,21 +34,45 @@ class DataInterface(object):
         else:
             self.external_type = np.ndarray
 
-        self.dtype = get_dtype(data)
+    def init_data_interface(self, data):
+
+        self.columns = getattr(data, 'columns', None)
+        self.name = getattr(data, 'name', None)
+        self.dtype = get_dtypes(data)
+        self.ndim = get_ndim(data)
+        self.is_col_vector = is_col_vector(data)
+
+    def to_transpose(self, data):
+
+        data_ndim = get_ndim(data)
+        data_col_vector = is_col_vector(data)
+
+        if self.ndim == 1 and data_ndim == 1:
+            if self.is_col_vector == data_col_vector:
+                return False
+            else:
+                return True
+        else:
+            return False
 
     def to_statsmodels(self, data):
 
         if data is None:
             return None
+        else:
+            self.init_data_interface(data)
 
-        elif self.use_formula and self.model is not None and hasattr(self.model, 'formula'):
+        if self.use_formula and self.model is not None and hasattr(self.model, 'formula'):
             return dmatrix(self.model.data.design_info.builder, data)
 
         elif type(data) in self.permitted_types:
             return data
 
         elif self.internal_type == np.ndarray:
-             return self.to_numpy_array(data)
+            return self.to_numpy_array(data)
+
+        elif self.internal_type in PANDAS_TYPES:
+            self.to_pandas(data)
 
         else:
             raise TypeError('Type conversion to {} from {} is not possible.'.format(self.internal_type, type(data)))
@@ -51,6 +80,7 @@ class DataInterface(object):
     def from_statsmodels(self, data):
 
         from_type = type(data)
+        self.index = getattr(data, 'index', None)
 
         if data is None:
             return None
@@ -59,10 +89,20 @@ class DataInterface(object):
             return data
 
         elif from_type in NUMPY_TYPES:
-            return self.from_numpy_array(data)
+            data_to_return = self.from_numpy_array(data)
+
+            if self.to_transpose(data_to_return):
+                return data_to_return.squeeze()
+            else:
+                return data_to_return
 
         elif from_type in PANDAS_TYPES:
-            return self.from_pandas(data)
+            data_to_return = self.from_pandas(data)
+
+            if self.to_transpose(data_to_return):
+                return
+            else:
+                return data_to_return
 
         else:
             raise TypeError('Type conversion from {} to {} is not possible.'.format(from_type, self.external_type))
@@ -90,9 +130,8 @@ class DataInterface(object):
         else:
             try:
                 return np.asarray(data)
-            except:
+            except TypeError:
                 TypeError('Type conversion to numpy from {} is not possible.'.format(from_type))
-
 
     def to_pandas(self, data):
 
@@ -105,9 +144,10 @@ class DataInterface(object):
             np_data = self.to_numpy_array(data)
 
             if np_data.ndim == 1:
-                return pd.Series(np_data, name=self.name)
+                return pd.Series(np_data, name=self.name, dtype=self.dtype)
+
             else:
-                return pd.DataFrame(np_data, columns=self.columns)
+                return pd.DataFrame(np_data, columns=self.columns, dtype=self.dtype)
 
     def from_numpy_array(self, data):
 
@@ -130,13 +170,15 @@ class DataInterface(object):
             ndim = getattr(data, 'ndim', None)
 
             if ndim in [1, None]:
-                index = getattr(data, 'index', None)
+                return pd.Series(data=data, index=self.index, dtype=self.dtype)
 
-                return pd.Series(data=data, index=index)
             elif self.ndim == ndim:
-                return pd.DataFrame(data=data, columns=self.columns, dtype=self.dtype)
+                df = pd.DataFrame(data=data, columns=self.columns, index=self.index)
+                return apply_dtype_to_df(df, self.dtype)
+
             else:
-                return pd.DataFrame(data=data, dtype=self.dtype)
+                df = pd.DataFrame(data=data, dtype=self.dtype, index=self.index)
+                return apply_dtype_to_df(df, self.dtype)
 
         else:
             return data
@@ -149,49 +191,133 @@ class DataInterface(object):
             return data
 
         elif self.external_type == np.ndarray:
-            return  data.values
+            return data.values
 
         elif from_type == pd.Series and self.external_type == pd.DataFrame:
             return data.to_frame()
 
         elif from_type == pd.DataFrame and self.external_type == pd.Series:
             if data.ndim == 1:
-                return pd.Series(data.values, index=data.index, name=data.columns[0])
+                return pd.Series(data.values, index=data.index, name=data.columns[0], dtype=self.dtype)
             else:
-                raise TypeError('Cannot convert multi dimentional DataFrame to a Series')
+                raise TypeError('Cannot convert multi dimensional DataFrame to a Series')
 
         elif self.external_type == list:
             return data.values.tolist()
+
+        else:
+            return data
 
 
 NumPyInterface = partial(DataInterface, [np.ndarray])
 PandasInterface = partial(DataInterface, [np.ndarray, pd.Series, pd.DataFrame])
 
-def get_dtype(data):
+
+def get_ndim(data):
+    if type(data) == pd.Series:
+        return 1
+
+    if type(data) == pd.DataFrame:
+        if safe_get(data.shape, 1, None) == 1 and safe_get(data.shape, 0, None) > 1:
+            return 1
+
+        elif safe_get(data.shape, 1, None) > 1 and safe_get(data.shape, 0, None) == 1:
+            return 1
+
+        else:
+            return data.ndim
+
+    try:
+        data = np.asarray(data)
+        data_ndim = data.ndim
+        data_squeeze_ndim = data.squeeze().ndim
+
+        if data_ndim > 1 and data_squeeze_ndim == 1:
+            return 1
+        else:
+            return data_ndim
+
+    except:
+        return None
+
+
+def is_col_vector(data):
+    if type(data) == pd.Series:
+        return False
+
+    if type(data) == pd.DataFrame:
+        if safe_get(data.shape, 1, None) == 1:
+            return True
+        else:
+            return False
+
+    try:
+        data = np.asarray(data)
+        data_ndim = data.ndim
+        data_squeeze_ndim = data.squeeze().ndim
+
+        if data_ndim > 1 and data_squeeze_ndim == 1:
+            return True
+        else:
+            return False
+    except:
+        raise ValueError('Cannot determine if the vector is a column')
+
+
+def transpose(data):
+
+    transpose_type = type(data)
+
+    if is_col_vector(data):
+
+        if transpose_type == np.ndarray:
+            return data.squeeze()
+
+        elif transpose_type == pd.DataFrame:
+            return data.T.squeeze()
+
+        else:
+            raise TypeError('Cannot transpose {} into a row vector'.format(transpose_type))
+
+    else:
+
+        if transpose_type == np.ndarray:
+            return data[np.newaxis].T
+
+        elif transpose_type == pd.Series:
+            data_col = data.values[np.newaxis].T
+            return pd.DataFrame(data_col, index=data.index)
+
+        elif transpose_type == pd.DataFrame:
+            return data.T
+
+        else:
+            raise TypeError('Cannot transpose {} into a column vector'.format(transpose_type))
+
+
+def safe_get(data, index, default):
+    try:
+        return data[index]
+
+    except IndexError:
+        return default
+
+
+def get_dtypes(data):
 
     if hasattr(data, 'dtype'):
         return data.dtype
+
     elif hasattr(data, 'dtypes'):
         return data.dtypes
+
     else:
         return None
 
-def is_1d(data):
 
-    try:
-        if np.asarray(data).ndim > 1 and np.asarray(data).squeeze().ndim == 1:
-            return False
-        elif np.asarray(data).ndim == 1:
-            return True
-    except:
-        pass
+def apply_dtype_to_df(df, dtypes):
 
-    try:
-        if data.ndim > 1:
-            return False
-        elif data.ndim == 1:
-            return True
-    except:
-        pass
+    for col, dtype in zip(df.columns, dtypes.values):
+        df[col] = df[col].astype(dtype)
 
-    raise ValueError('Cannot determine number of dimensions')
+    return df

--- a/statsmodels/tools/data_interface.py
+++ b/statsmodels/tools/data_interface.py
@@ -52,15 +52,11 @@ class DataInterface(object):
 
         from_type = type(data)
 
-        if from_type == DesignMatrix:
-            if self.model is None:
-                raise ValueError('When a DesignMatrix is returned, a model must be specified.')
-            else:
-                data = dmatrix(self.model.data.design_info.builder, data)
-                from_type = type(data)
-
         if data is None:
             return None
+
+        elif from_type == DesignMatrix:
+            return data
 
         elif from_type in NUMPY_TYPES:
             return self.from_numpy_array(data)
@@ -76,24 +72,24 @@ class DataInterface(object):
         from_type = type(data)
 
         if from_type in NUMPY_TYPES:
-            to_return = data
+            return data
 
         elif from_type == list:
-            to_return = np.array(data)
+            return np.array(data)
 
         elif from_type == np.recarray:
-            to_return = data.view(np.ndarray)
+            return data.view(np.ndarray)
 
         elif from_type == pd.Series:
 
-            to_return = data.values
+            return data.values
 
         elif from_type == pd.DataFrame:
-            to_return = data.values
+            return data.values
 
         else:
             try:
-                to_return = np.asarray(data)
+                return np.asarray(data)
             except:
                 TypeError('Type conversion to numpy from {} is not possible.'.format(from_type))
 

--- a/statsmodels/tools/data_interface.py
+++ b/statsmodels/tools/data_interface.py
@@ -35,7 +35,9 @@ class DataInterface(object):
         self.ndim = get_ndim(data)
         self.is_nested_row_vector = is_nested_row_vector(data)
         self.is_col_vector = is_col_vector(data)
-        self.external_type = type(data) if self.external_type is None else self.external_type
+
+        if self.external_type is None:
+            self.external_type = type(data)
 
     def to_transpose(self, data):
 
@@ -76,6 +78,7 @@ class DataInterface(object):
             raise TypeError('Type conversion to {} from {} is not possible.'.format(self.internal_type, type(data)))
 
         if self.require_2d and self.ndim == 1 and not is_col_vector(to_return):
+            self.is_col_vector = True
             return transpose(to_return)
 
         else:

--- a/statsmodels/tools/data_interface.py
+++ b/statsmodels/tools/data_interface.py
@@ -320,7 +320,7 @@ def to_nested_row_vector(data):
         return pd.DataFrame([data.values])
 
     elif data_type == np.ndarray:
-        return data[np.newaxis]
+        return np.atleast_2d(data)
 
     elif data_type == list:
         return [data]

--- a/statsmodels/tools/data_interface.py
+++ b/statsmodels/tools/data_interface.py
@@ -19,15 +19,7 @@ class DataInterface(object):
         self.use_formula = use_formula
         self.require_col_vector = require_col_vector
         self.at_least_2d = at_least_2d
-
-        if external_type is not None:
-            self.external_type = external_type
-
-        elif data is not None and not np.isscalar(data):
-            self.external_type = type(data)
-
-        else:
-            self.external_type = np.ndarray
+        self.external_type = external_type
 
         self.columns = None
         self.name = None
@@ -44,6 +36,13 @@ class DataInterface(object):
         self.ndim = get_ndim(data)
         self.is_nested_row_vector = is_nested_row_vector(data)
         self.is_col_vector = is_col_vector(data)
+
+        if self.external_type is None:
+            if data is not None and not np.isscalar(data):
+                self.external_type = type(data)
+
+            else:
+                self.external_type = np.ndarray
 
     def to_transpose(self, data):
 

--- a/statsmodels/tools/data_interface.py
+++ b/statsmodels/tools/data_interface.py
@@ -224,10 +224,10 @@ def get_ndim(data):
         except TypeError:
             raise TypeError('Cannot find dimension of {}'.format(type(data)))
 
-    if safe_get(data.shape, 0, None) > 1 and safe_get(data.shape, 1, None) == 1:
+    if get_shape_dim(data.shape, 0) > 1 and get_shape_dim(data.shape, 1) == 1:
         return 1
 
-    elif safe_get(data.shape, 0, None) == 1 and safe_get(data.shape, 1, None) > 1:
+    elif get_shape_dim(data.shape, 0) == 1 and get_shape_dim(data.shape, 1) > 1:
         return 1
 
     else:
@@ -249,7 +249,7 @@ def is_nested_row_vector(data):
         except TypeError:
             raise TypeError('Cannot find dimension of {}'.format(type(data)))
 
-    if safe_get(data.shape, 0, None) == 1 and safe_get(data.shape, 1, None) > 1:
+    if get_shape_dim(data.shape, 0) == 1 and get_shape_dim(data.shape, 1) > 1:
         return True
 
     else:
@@ -269,7 +269,7 @@ def is_col_vector(data):
         except TypeError:
             raise TypeError('Cannot convert {} to array'.format(type(data)))
 
-    if safe_get(data.shape, 0, None) > 1 and safe_get(data.shape, 1, None) == 1:
+    if get_shape_dim(data.shape, 0) > 1 and get_shape_dim(data.shape, 1) == 1:
         return True
 
     else:
@@ -299,7 +299,7 @@ def transpose(data):
 
         elif transpose_type == np.ndarray:
 
-            if safe_get(data.shape, 0, None) == 1 and safe_get(data.shape, 1, None) > 1:
+            if get_shape_dim(data.shape, 0) == 1 and get_shape_dim(data.shape, 1) > 1:
                 data = data[0]
 
             return data[np.newaxis].T
@@ -311,9 +311,9 @@ def transpose(data):
             raise TypeError('Cannot transpose {} into a column vector'.format(transpose_type))
 
 
-def safe_get(data, index, default):
+def get_shape_dim(data, index):
     try:
-        return data[index]
+        return np.int32(data[index])
 
     except IndexError:
-        return default
+        return None

--- a/statsmodels/tools/data_interface.py
+++ b/statsmodels/tools/data_interface.py
@@ -87,9 +87,8 @@ class DataInterface(object):
         if self.require_col_vector and get_ndim(to_return) == 1 and not is_col_vector(to_return):
             to_return = transpose(to_return)
 
-        if self.at_least_2d:
-            if get_ndim(to_return) == 1 and not is_col_vector(to_return):
-                to_return = to_nested_row_vector(to_return)
+        if self.at_least_2d and get_ndim(to_return) == 1 and not is_col_vector(to_return):
+            to_return = to_nested_row_vector(to_return)
 
         return to_return
 

--- a/statsmodels/tools/data_interface.py
+++ b/statsmodels/tools/data_interface.py
@@ -23,8 +23,8 @@ class DataInterface(object):
         if external_type is not None:
             self.external_type = external_type
 
-        # elif data is not None and not np.isscalar(data):
-        #     self.external_type = type(data)
+        elif data is not None and not np.isscalar(data):
+            self.external_type = type(data)
 
         else:
             self.external_type = np.ndarray
@@ -227,7 +227,7 @@ class DataInterface(object):
             return data.values
 
         elif from_type == pd.Series and self.external_type == pd.DataFrame:
-            return data.to_frame()
+            return data
 
         elif from_type == pd.DataFrame and self.external_type == pd.Series:
             if data.ndim == 1:

--- a/statsmodels/tools/data_interface.py
+++ b/statsmodels/tools/data_interface.py
@@ -11,13 +11,13 @@ PANDAS_TYPES = [pd.Series, pd.DataFrame]
 class DataInterface(object):
 
     def __init__(self, permitted_types, internal_type=None, data=None, external_type=None, model=None,
-                 use_formula=False, require_2d=False):
+                 use_formula=False, require_1d=False):
 
         self.permitted_types = permitted_types
         self.internal_type = np.ndarray if internal_type is None else internal_type
         self.model = model
         self.use_formula = use_formula
-        self.require_2d = require_2d
+        self.require_1d = require_1d
 
         if external_type is not None:
             self.external_type = external_type
@@ -83,8 +83,14 @@ class DataInterface(object):
         else:
             raise TypeError('Type conversion to {} from {} is not possible.'.format(self.internal_type, type(data)))
 
-        if self.require_2d and self.ndim == 1 and not is_col_vector(to_return):
-            return transpose(to_return)
+        if self.require_1d and self.ndim == 1:
+            if is_col_vector(to_return):
+                to_return = transpose(to_return)
+
+            if is_nested_row_vector(to_return):
+                to_return = to_return[0]
+
+            return to_return
 
         else:
             return to_return
@@ -112,9 +118,6 @@ class DataInterface(object):
 
         else:
             raise TypeError('Type conversion from {} to {} is not possible.'.format(from_type, self.external_type))
-
-        # from pdb import set_trace
-        # set_trace()
 
         if self.to_transpose(data_to_return):
             data_to_return = transpose(data)

--- a/statsmodels/tools/data_interface.py
+++ b/statsmodels/tools/data_interface.py
@@ -10,8 +10,8 @@ PANDAS_TYPES = [pd.Series, pd.DataFrame]
 
 class DataInterface(object):
 
-    def __init__(self, permitted_types, internal_type=None, data=None, external_type=None, model=None, use_formula=False,
-                 require_2d=False):
+    def __init__(self, permitted_types, internal_type=None, data=None, external_type=None, model=None,
+                 use_formula=False, require_2d=False):
 
         self.permitted_types = permitted_types
         self.internal_type = np.ndarray if internal_type is None else internal_type
@@ -84,7 +84,6 @@ class DataInterface(object):
             raise TypeError('Type conversion to {} from {} is not possible.'.format(self.internal_type, type(data)))
 
         if self.require_2d and self.ndim == 1 and not is_col_vector(to_return):
-            self.is_col_vector = True
             return transpose(to_return)
 
         else:

--- a/statsmodels/tools/data_interface.py
+++ b/statsmodels/tools/data_interface.py
@@ -1,0 +1,136 @@
+import pandas as pd
+import numpy as np
+from functools import partial
+from patsy import dmatrix
+
+NUMPY_TYPES = [np.ndarray, np.float64]
+
+class DataInterface(object):
+
+    def __init__(self, permitted_types, internal_type, data=None, external_type=None, model=None, use_formula=False):
+
+        self.permitted_types = permitted_types
+        self.internal_type = internal_type
+        self.columns = getattr(data, 'columns', None)
+        self.name = getattr(data, 'name', None)
+        self.index = getattr(data, 'index', None)
+        self.ndim = getattr(data, 'ndim', None)
+        self.model = model
+        self.use_formula = use_formula
+
+        if external_type is not None:
+            self.external_type = external_type
+        elif data is not None:
+            self.external_type = type(data)
+        else:
+            self.external_type = np.ndarray
+
+        self.dtype = get_dtype(data)
+
+    def to_statsmodels(self, data):
+
+        if data is None:
+            return None
+
+        elif self.use_formula and self.model is not None and hasattr(self.model, 'formula'):
+                return dmatrix(self.model.data.design_info.builder, data)
+
+        elif type(data) in self.permitted_types:
+            return data
+
+        elif self.internal_type == np.ndarray:
+             return self.to_numpy(data)
+
+        else:
+            raise TypeError('Type conversion to {} from {} is not possible.'.format(self.internal_type, type(data)))
+
+    def from_statsmodels(self, data):
+
+        internal_type = type(data)
+
+        if internal_type in NUMPY_TYPES:
+            return self.from_numpy(data)
+
+        else:
+            raise TypeError('Type conversion from {} to {} is not possible.'.format(internal_type, self.external_type))
+
+    def to_numpy(self, data):
+
+        from_type = type(data)
+
+        if from_type in NUMPY_TYPES:
+            to_return = data
+
+        elif from_type == list:
+            to_return = np.array(data)
+
+        elif from_type == np.recarray:
+            to_return = data.view(np.ndarray)
+
+        elif from_type == pd.Series:
+
+            to_return = data.values
+
+        elif from_type == pd.DataFrame:
+            to_return = data.values
+
+        else:
+            try:
+                to_return = np.asarray(data)
+            except:
+                TypeError('Type conversion to numpy from {} is not possible.'.format(from_type))
+
+
+        if self.model is not None:
+            return clean_ndim(to_return, self.model)
+        else:
+            return to_return
+
+    def from_numpy(self, data):
+
+        if type(data) == self.external_type:
+            return data
+
+        elif self.external_type == list:
+            return data.tolist()
+
+        elif self.external_type == np.recarray:
+            return data.view(np.recarray)
+
+        elif self.external_type == pd.Series:
+            return pd.Series(data=data, index=self.index, dtype=self.dtype)
+
+        elif self.external_type == pd.DataFrame:
+            ndim = getattr(data, 'ndim', None)
+
+            if ndim in [1, None]:
+                return pd.Series(data=data, index=self.index)
+            elif self.ndim == ndim:
+                return pd.DataFrame(data=data, columns=self.columns, dtype=self.dtype)
+            else:
+                return pd.DataFrame(data=data, dtype=self.dtype)
+
+        else:
+            return data
+
+
+NumPyInterface = partial(DataInterface, [np.ndarray], np.ndarray)
+PandasInterface = partial(DataInterface, [np.ndarray, pd.Series, pd.DataFrame], np.ndarray)
+
+def clean_ndim(data, model):
+
+    if data.ndim == 1 and (model.exog.ndim == 1 or model.exog.shape[1] == 1):
+        data = data[:, None]
+
+    data = np.atleast_2d(data)  # needed in count model shape[1]
+
+    return data
+
+def get_dtype(data):
+
+    if hasattr(data, 'dtype'):
+        return data.dtype
+    elif hasattr(data, 'dtypes'):
+        return data.dtypes
+    else:
+        return None

--- a/statsmodels/tools/tests/test_data_interface.py
+++ b/statsmodels/tools/tests/test_data_interface.py
@@ -37,24 +37,27 @@ def test_data_frame_numpy():
 def test_ndim():
 
     list_row_vector = [1, 2, 3]
+    list_row_vector2 = [[1, 2, 3]]
     list_col_vector = [[1], [2], [3]]
     list_matrix = [[1, 2, 3], [4, 5, 6]]
 
     np_row_vector = np.array(list_row_vector)
+    np_row_vector2 = np.array(list_row_vector2)
     np_col_vector = np.array(list_col_vector)
     np_matrix = np.array(list_matrix)
 
     pd_row_vector = pd.Series(np_row_vector)
-    pd_row_vector2 = pd.DataFrame([np_row_vector])
+    pd_row_vector2 = pd.DataFrame(np_row_vector2)
     pd_col_vector = pd.DataFrame(np_col_vector)
     pd_matrix = pd.DataFrame(np_matrix)
 
-
     assert get_ndim(list_row_vector) == 1
+    assert get_ndim(list_row_vector2) == 1
     assert get_ndim(list_col_vector) == 1
     assert get_ndim(list_matrix) == 2
 
     assert get_ndim(np_row_vector) == 1
+    assert get_ndim(np_row_vector2) == 1
     assert get_ndim(np_col_vector) == 1
     assert get_ndim(np_matrix) == 2
 
@@ -64,10 +67,12 @@ def test_ndim():
     assert get_ndim(pd_matrix) == 2
 
     assert is_col_vector(list_row_vector) == False
+    assert is_col_vector(list_row_vector2) == False
     assert is_col_vector(list_col_vector) == True
     assert is_col_vector(list_matrix) == False
 
     assert is_col_vector(np_row_vector) == False
+    assert is_col_vector(np_row_vector2) == False
     assert is_col_vector(np_col_vector) == True
     assert is_col_vector(np_matrix) == False
 
@@ -79,19 +84,21 @@ def test_ndim():
 def test_transpose():
 
     list_row_vector = [1, 2, 3]
+    list_row_vector2 = [[1, 2, 3]]
     list_col_vector = [[1], [2], [3]]
 
-    np_row_vector = np.array(list_row_vector, dtype=np.int64)
-    np_col_vector = np.array(list_col_vector, dtype=np.int64)
+    np_row_vector = np.array(list_row_vector)
+    np_row_vector2 = np.array(list_row_vector2)
+    np_col_vector = np.array(list_col_vector)
 
     pd_row_vector = pd.Series(np_row_vector)
-    pd_row_vector2 = pd.DataFrame([np_row_vector])
+    pd_row_vector2 = pd.DataFrame(np_row_vector2)
     pd_col_vector = pd.DataFrame(np_col_vector)
 
-    np.testing.assert_equal(transpose(np_row_vector), np_col_vector)
-    np.testing.assert_equal(transpose(np_col_vector), np_row_vector)
+    np.testing.assert_equal(np_col_vector, transpose(np_row_vector))
+    np.testing.assert_equal(np_col_vector, transpose(np_row_vector2))
+    np.testing.assert_equal(np_row_vector, transpose(np_col_vector))
 
     assert pd_row_vector.equals(transpose(pd_col_vector))
-    assert pd_col_vector.equals(transpose(pd_row_vector))
-
+    assert_frame_equal(pd_col_vector, transpose(pd_row_vector))
     assert_frame_equal(pd_col_vector, transpose(pd_row_vector2))

--- a/statsmodels/tools/tests/test_data_interface.py
+++ b/statsmodels/tools/tests/test_data_interface.py
@@ -1,13 +1,16 @@
-
 from statsmodels.tools.data_interface import (NumPyInterface, ListInterface, SeriesInterface, DataFrameInterface,
-                                              get_ndim, is_col_vector, transpose)
+                                              get_ndim, is_col_vector, transpose, to_categorical)
 
 from pandas.util.testing import assert_frame_equal, assert_series_equal
+from numpy.testing import assert_equal, assert_array_equal
+
 import pandas as pd
 import numpy as np
 
-def test_list_numpy():
+from pdb import set_trace
 
+
+def test_list_numpy():
     data_list = [1, 2, 3]
 
     list_interface = NumPyInterface(external_type=list)
@@ -18,7 +21,6 @@ def test_list_numpy():
 
 
 def test_numpy_list():
-
     data = np.array([1, 2, 3])
 
     list_interface = ListInterface(external_type=np.ndarray)
@@ -29,7 +31,6 @@ def test_numpy_list():
 
 
 def test_series_numpy():
-
     data_list = [1, 2, 3]
 
     data_series = pd.Series(data_list)
@@ -41,7 +42,6 @@ def test_series_numpy():
 
 
 def test_numpy_series():
-
     data = np.array([1, 2, 3])
 
     series_interface = SeriesInterface(external_type=np.ndarray)
@@ -52,7 +52,6 @@ def test_numpy_series():
 
 
 def test_data_frame_numpy():
-
     data_nested_list = [[1, 2, 3], [4, 5, 6]]
 
     data_frame = pd.DataFrame(data_nested_list)
@@ -64,7 +63,6 @@ def test_data_frame_numpy():
 
 
 def test_numpy_data_frame():
-
     data = np.array([[1, 2, 3], [4, 5, 6]])
 
     data_frame_interface = DataFrameInterface(external_type=np.ndarray)
@@ -75,7 +73,6 @@ def test_numpy_data_frame():
 
 
 def test_numpy_numpy():
-
     data_list = [1.368312, 2.667389, 2.387636, 1.797382, 1.935495, 3.482808, 2.520573, 2.804281, 1.264108, 1.305208]
     data_list_nested = [data_list]
 
@@ -121,7 +118,6 @@ def test_numpy_numpy():
 
 
 def test_list_list():
-
     data = [1.368312, 2.667389, 2.387636, 1.797382, 1.935495, 3.482808, 2.520573, 2.804281, 1.264108, 1.305208]
     data_nested = [data]
     data_transpose = transpose(data)
@@ -164,7 +160,6 @@ def test_list_list():
 
 
 def test_ndim():
-
     list_row_vector = [1, 2, 3]
     list_row_vector2 = [[1, 2, 3]]
     list_col_vector = [[1], [2], [3]]
@@ -195,24 +190,23 @@ def test_ndim():
     assert get_ndim(pd_col_vector) == 1
     assert get_ndim(pd_matrix) == 2
 
-    assert is_col_vector(list_row_vector) == False
-    assert is_col_vector(list_row_vector2) == False
-    assert is_col_vector(list_col_vector) == True
-    assert is_col_vector(list_matrix) == False
+    assert is_col_vector(list_row_vector) is False
+    assert is_col_vector(list_row_vector2) is False
+    assert is_col_vector(list_col_vector) is True
+    assert is_col_vector(list_matrix) is False
 
-    assert is_col_vector(np_row_vector) == False
-    assert is_col_vector(np_row_vector2) == False
-    assert is_col_vector(np_col_vector) == True
-    assert is_col_vector(np_matrix) == False
+    assert is_col_vector(np_row_vector) is False
+    assert is_col_vector(np_row_vector2) is False
+    assert is_col_vector(np_col_vector) is True
+    assert is_col_vector(np_matrix) is False
 
-    assert is_col_vector(pd_row_vector) == False
-    assert is_col_vector(pd_row_vector2) == False
-    assert is_col_vector(pd_col_vector) == True
-    assert is_col_vector(pd_matrix) == False
+    assert is_col_vector(pd_row_vector) is False
+    assert is_col_vector(pd_row_vector2) is False
+    assert is_col_vector(pd_col_vector) is True
+    assert is_col_vector(pd_matrix) is False
 
 
 def test_transpose():
-
     list_row_vector = [1, 2, 3]
     list_row_vector2 = [[1, 2, 3]]
     list_col_vector = [[1], [2], [3]]
@@ -235,9 +229,264 @@ def test_transpose():
 
     pd_col_vector_transpose = transpose(pd_col_vector)
 
-    # Fix the changing Series name from None to 0
+    # Fix default behavior of changing Series name from None to 0
     pd_col_vector_transpose.name = None
 
     assert_series_equal(pd_row_vector, pd_col_vector_transpose)
     assert_frame_equal(pd_col_vector, transpose(pd_row_vector))
     assert_frame_equal(pd_col_vector, transpose(pd_row_vector2))
+
+
+class TestCategorical(object):
+
+    def __init__(self):
+
+        stringabc = 'abcdefghijklmnopqrstuvwxy'
+
+        self.des = np.random.randn(25, 2)
+        self.instr = np.floor(np.arange(10, 60, step=2) / 10)
+
+        x = np.zeros((25, 5))
+        x[:5, 0] = 1
+        x[5:10, 1] = 1
+        x[10:15, 2] = 1
+        x[15:20, 3] = 1
+        x[20:25, 4] = 1
+        self.dummy = x
+
+        structdes = np.zeros((25, 1), dtype=[('var1', 'f4'), ('var2', 'f4'), ('instrument', 'f4'),
+                                             ('str_instr', 'a10')])
+
+        structdes['var1'] = self.des[:, 0][:, None]
+        structdes['var2'] = self.des[:, 1][:, None]
+        structdes['instrument'] = self.instr[:, None]
+
+        string_var = [stringabc[0:5], stringabc[5:10], stringabc[10:15], stringabc[15:20], stringabc[20:25]]
+        string_var *= 5
+        self.string_var = np.array(sorted(string_var))
+
+        structdes['str_instr'] = self.string_var[:, None]
+        self.structdes = structdes
+        self.recdes = structdes.view(np.recarray)
+
+
+class TestCategoricalNumerical(TestCategorical):
+    # TODO: use assert_raises to check that bad inputs are taken care of
+
+    def test_array2d(self):
+        set_trace()
+
+        des = np.column_stack((self.des, self.instr, self.des))
+        des = to_categorical(des, col=2)
+        assert_array_equal(des[:, -5:], self.dummy)
+        assert_equal(des.shape[1], 10)
+
+    def test_array1d(self):
+        set_trace()
+
+        des = to_categorical(self.instr)
+        assert_array_equal(des[:, -5:], self.dummy)
+        assert_equal(des.shape[1], 6)
+
+    def test_array2d_drop(self):
+        des = np.column_stack((self.des, self.instr, self.des))
+        des = to_categorical(des, col=2, drop=True)
+        assert_array_equal(des[:, -5:], self.dummy)
+        assert_equal(des.shape[1], 9)
+
+    def test_array1d_drop(self):
+        des = to_categorical(self.instr, drop=True)
+        assert_array_equal(des, self.dummy)
+        assert_equal(des.shape[1], 5)
+
+    def test_recarray2d(self):
+        des = to_categorical(self.recdes, col='instrument')
+        # better way to do this?
+        test_des = np.column_stack(([des[_] for _ in des.dtype.names[-5:]]))
+        assert_array_equal(test_des, self.dummy)
+        assert_equal(len(des.dtype.names), 9)
+
+    def test_recarray2dint(self):
+        des = to_categorical(self.recdes, col=2)
+        test_des = np.column_stack(([des[_] for _ in des.dtype.names[-5:]]))
+        assert_array_equal(test_des, self.dummy)
+        assert_equal(len(des.dtype.names), 9)
+
+    def test_recarray1d(self):
+        instr = self.structdes['instrument'].view(np.recarray)
+        dum = to_categorical(instr)
+        test_dum = np.column_stack(([dum[_] for _ in dum.dtype.names[-5:]]))
+        assert_array_equal(test_dum, self.dummy)
+        assert_equal(len(dum.dtype.names), 6)
+
+    def test_recarray1d_drop(self):
+        instr = self.structdes['instrument'].view(np.recarray)
+        dum = to_categorical(instr, drop=True)
+        test_dum = np.column_stack(([dum[_] for _ in dum.dtype.names]))
+        assert_array_equal(test_dum, self.dummy)
+        assert_equal(len(dum.dtype.names), 5)
+
+    def test_recarray2d_drop(self):
+        des = to_categorical(self.recdes, col='instrument', drop=True)
+        test_des = np.column_stack(([des[_] for _ in des.dtype.names[-5:]]))
+        assert_array_equal(test_des, self.dummy)
+        assert_equal(len(des.dtype.names), 8)
+
+    def test_structarray2d(self):
+        des = to_categorical(self.structdes, col='instrument')
+        test_des = np.column_stack(([des[_] for _ in des.dtype.names[-5:]]))
+        assert_array_equal(test_des, self.dummy)
+        assert_equal(len(des.dtype.names), 9)
+
+    def test_structarray2dint(self):
+        des = to_categorical(self.structdes, col=2)
+        test_des = np.column_stack(([des[_] for _ in des.dtype.names[-5:]]))
+        assert_array_equal(test_des, self.dummy)
+        assert_equal(len(des.dtype.names), 9)
+
+    def test_structarray1d(self):
+        instr = self.structdes['instrument'].view(dtype=[('var1', 'f4')])
+        dum = to_categorical(instr)
+        test_dum = np.column_stack(([dum[_] for _ in dum.dtype.names[-5:]]))
+        assert_array_equal(test_dum, self.dummy)
+        assert_equal(len(dum.dtype.names), 6)
+
+    def test_structarray2d_drop(self):
+        des = to_categorical(self.structdes, col='instrument', drop=True)
+        test_des = np.column_stack(([des[_] for _ in des.dtype.names[-5:]]))
+        assert_array_equal(test_des, self.dummy)
+        assert_equal(len(des.dtype.names), 8)
+
+    def test_structarray1d_drop(self):
+        instr = self.structdes['instrument'].view(dtype=[('var1', 'f4')])
+        dum = to_categorical(instr, drop=True)
+        test_dum = np.column_stack(([dum[_] for _ in dum.dtype.names]))
+        assert_array_equal(test_dum, self.dummy)
+        assert_equal(len(dum.dtype.names), 5)
+
+# def test_arraylike2d(self):
+#        des = to_categorical(self.structdes.tolist(), col=2)
+#        test_des = des[:,-5:]
+#        assert_array_equal(test_des, self.dummy)
+#        assert_equal(des.shape[1], 9)
+
+#    def test_arraylike1d(self):
+#        instr = self.structdes['instrument'].tolist()
+#        dum = to_categorical(instr)
+#        test_dum = dum[:,-5:]
+#        assert_array_equal(test_dum, self.dummy)
+#        assert_equal(dum.shape[1], 6)
+
+#    def test_arraylike2d_drop(self):
+#        des = to_categorical(self.structdes.tolist(), col=2, drop=True)
+#        test_des = des[:,-5:]
+#        assert_array_equal(test__des, self.dummy)
+#        assert_equal(des.shape[1], 8)
+
+#    def test_arraylike1d_drop(self):
+#        instr = self.structdes['instrument'].tolist()
+#        dum = to_categorical(instr, drop=True)
+#        assert_array_equal(dum, self.dummy)
+#        assert_equal(dum.shape[1], 5)
+
+
+class TestCategoricalString(TestCategorical):
+    # comment out until we have type coercion
+    #    def test_array2d(self):
+    #        des = np.column_stack((self.des, self.instr, self.des))
+    #        des = to_categorical(des, col=2)
+    #        assert_array_equal(des[:,-5:], self.dummy)
+    #        assert_equal(des.shape[1],10)
+
+    #    def test_array1d(self):
+    #        des = to_categorical(self.instr)
+    #        assert_array_equal(des[:,-5:], self.dummy)
+    #        assert_equal(des.shape[1],6)
+
+    #    def test_array2d_drop(self):
+    #        des = np.column_stack((self.des, self.instr, self.des))
+    #        des = to_categorical(des, col=2, drop=True)
+    #        assert_array_equal(des[:,-5:], self.dummy)
+    #        assert_equal(des.shape[1],9)
+
+    def test_array1d_drop(self):
+        des = to_categorical(self.string_var, drop=True)
+        assert_array_equal(des, self.dummy)
+        assert_equal(des.shape[1], 5)
+
+    def test_recarray2d(self):
+        des = to_categorical(self.recdes, col='str_instr')
+        # better way to do this?
+        test_des = np.column_stack(([des[_] for _ in des.dtype.names[-5:]]))
+        assert_array_equal(test_des, self.dummy)
+        assert_equal(len(des.dtype.names), 9)
+
+    def test_recarray2dint(self):
+        des = to_categorical(self.recdes, col=3)
+        test_des = np.column_stack(([des[_] for _ in des.dtype.names[-5:]]))
+        assert_array_equal(test_des, self.dummy)
+        assert_equal(len(des.dtype.names), 9)
+
+    def test_recarray1d(self):
+        instr = self.structdes['str_instr'].view(np.recarray)
+        dum = to_categorical(instr)
+        test_dum = np.column_stack(([dum[_] for _ in dum.dtype.names[-5:]]))
+        assert_array_equal(test_dum, self.dummy)
+        assert_equal(len(dum.dtype.names), 6)
+
+    def test_recarray1d_drop(self):
+        instr = self.structdes['str_instr'].view(np.recarray)
+        dum = to_categorical(instr, drop=True)
+        test_dum = np.column_stack(([dum[_] for _ in dum.dtype.names]))
+        assert_array_equal(test_dum, self.dummy)
+        assert_equal(len(dum.dtype.names), 5)
+
+    def test_recarray2d_drop(self):
+        des = to_categorical(self.recdes, col='str_instr', drop=True)
+        test_des = np.column_stack(([des[_] for _ in des.dtype.names[-5:]]))
+        assert_array_equal(test_des, self.dummy)
+        assert_equal(len(des.dtype.names), 8)
+
+    def test_structarray2d(self):
+        des = to_categorical(self.structdes, col='str_instr')
+        test_des = np.column_stack(([des[_] for _ in des.dtype.names[-5:]]))
+        assert_array_equal(test_des, self.dummy)
+        assert_equal(len(des.dtype.names), 9)
+
+    def test_structarray2dint(self):
+        des = to_categorical(self.structdes, col=3)
+        test_des = np.column_stack(([des[_] for _ in des.dtype.names[-5:]]))
+        assert_array_equal(test_des, self.dummy)
+        assert_equal(len(des.dtype.names), 9)
+
+    def test_structarray1d(self):
+        instr = self.structdes['str_instr'].view(dtype=[('var1', 'a10')])
+        dum = to_categorical(instr)
+        test_dum = np.column_stack(([dum[_] for _ in dum.dtype.names[-5:]]))
+        assert_array_equal(test_dum, self.dummy)
+        assert_equal(len(dum.dtype.names), 6)
+
+    def test_structarray2d_drop(self):
+        des = to_categorical(self.structdes, col='str_instr', drop=True)
+        test_des = np.column_stack(([des[_] for _ in des.dtype.names[-5:]]))
+        assert_array_equal(test_des, self.dummy)
+        assert_equal(len(des.dtype.names), 8)
+
+    def test_structarray1d_drop(self):
+        instr = self.structdes['str_instr'].view(dtype=[('var1', 'a10')])
+        dum = to_categorical(instr, drop=True)
+        test_dum = np.column_stack(([dum[_] for _ in dum.dtype.names]))
+        assert_array_equal(test_dum, self.dummy)
+        assert_equal(len(dum.dtype.names), 5)
+
+    def test_arraylike2d(self):
+        pass
+
+    def test_arraylike1d(self):
+        pass
+
+    def test_arraylike2d_drop(self):
+        pass
+
+    def test_arraylike1d_drop(self):
+        pass

--- a/statsmodels/tools/tests/test_data_interface.py
+++ b/statsmodels/tools/tests/test_data_interface.py
@@ -1,5 +1,8 @@
-from statsmodels.tools.data_interface import NumPyInterface
+
+from statsmodels.tools.data_interface import NumPyInterface, get_ndim, is_col_vector, transpose
+from pandas.util.testing import assert_frame_equal
 import pandas as pd
+import numpy as np
 
 
 def test_list_numpy():
@@ -30,3 +33,65 @@ def test_data_frame_numpy():
     numpy_to_data_frame = data_frame_interface.from_statsmodels(data_frame_to_numpy)
 
     assert data_frame.equals(numpy_to_data_frame)
+
+def test_ndim():
+
+    list_row_vector = [1, 2, 3]
+    list_col_vector = [[1], [2], [3]]
+    list_matrix = [[1, 2, 3], [4, 5, 6]]
+
+    np_row_vector = np.array(list_row_vector)
+    np_col_vector = np.array(list_col_vector)
+    np_matrix = np.array(list_matrix)
+
+    pd_row_vector = pd.Series(np_row_vector)
+    pd_row_vector2 = pd.DataFrame([np_row_vector])
+    pd_col_vector = pd.DataFrame(np_col_vector)
+    pd_matrix = pd.DataFrame(np_matrix)
+
+
+    assert get_ndim(list_row_vector) == 1
+    assert get_ndim(list_col_vector) == 1
+    assert get_ndim(list_matrix) == 2
+
+    assert get_ndim(np_row_vector) == 1
+    assert get_ndim(np_col_vector) == 1
+    assert get_ndim(np_matrix) == 2
+
+    assert get_ndim(pd_row_vector) == 1
+    assert get_ndim(pd_row_vector2) == 1
+    assert get_ndim(pd_col_vector) == 1
+    assert get_ndim(pd_matrix) == 2
+
+    assert is_col_vector(list_row_vector) == False
+    assert is_col_vector(list_col_vector) == True
+    assert is_col_vector(list_matrix) == False
+
+    assert is_col_vector(np_row_vector) == False
+    assert is_col_vector(np_col_vector) == True
+    assert is_col_vector(np_matrix) == False
+
+    assert is_col_vector(pd_row_vector) == False
+    assert is_col_vector(pd_row_vector2) == False
+    assert is_col_vector(pd_col_vector) == True
+    assert is_col_vector(pd_matrix) == False
+
+def test_transpose():
+
+    list_row_vector = [1, 2, 3]
+    list_col_vector = [[1], [2], [3]]
+
+    np_row_vector = np.array(list_row_vector, dtype=np.int64)
+    np_col_vector = np.array(list_col_vector, dtype=np.int64)
+
+    pd_row_vector = pd.Series(np_row_vector)
+    pd_row_vector2 = pd.DataFrame([np_row_vector])
+    pd_col_vector = pd.DataFrame(np_col_vector)
+
+    np.testing.assert_equal(transpose(np_row_vector), np_col_vector)
+    np.testing.assert_equal(transpose(np_col_vector), np_row_vector)
+
+    assert pd_row_vector.equals(transpose(pd_col_vector))
+    assert pd_col_vector.equals(transpose(pd_row_vector))
+
+    assert_frame_equal(pd_col_vector, transpose(pd_row_vector2))

--- a/statsmodels/tools/tests/test_data_interface.py
+++ b/statsmodels/tools/tests/test_data_interface.py
@@ -5,8 +5,7 @@ from statsmodels.tools.data_interface import (NumPyInterface, ListInterface, Ser
 from pandas.util.testing import assert_frame_equal
 import pandas as pd
 import numpy as np
-from pdb import set_trace
-from numpy.testing import assert_allclose
+
 
 def test_list_numpy():
 
@@ -18,6 +17,7 @@ def test_list_numpy():
 
     assert data_list == numpy_to_list
 
+
 def test_numpy_list():
 
     data = np.array([1, 2, 3])
@@ -27,6 +27,7 @@ def test_numpy_list():
     list_to_numpy = list_interface.from_statsmodels(numpy_to_list)
 
     assert np.array_equal(data, list_to_numpy)
+
 
 def test_series_numpy():
 
@@ -39,6 +40,7 @@ def test_series_numpy():
 
     assert data_series.equals(numpy_to_series)
 
+
 def test_numpy_series():
 
     data = np.array([1, 2, 3])
@@ -48,6 +50,7 @@ def test_numpy_series():
     series_to_numpy = series_interface.from_statsmodels(numpy_to_series)
 
     assert np.array_equal(data, series_to_numpy)
+
 
 def test_data_frame_numpy():
 
@@ -60,6 +63,7 @@ def test_data_frame_numpy():
 
     assert data_frame.equals(numpy_to_data_frame)
 
+
 def test_numpy_data_frame():
 
     data = np.array([[1, 2, 3], [4, 5, 6]])
@@ -69,6 +73,7 @@ def test_numpy_data_frame():
     data_frame_to_numpy = data_frame_interface.from_statsmodels(numpy_to_data_frame)
 
     assert np.array_equal(data, data_frame_to_numpy)
+
 
 def test_numpy_numpy():
 
@@ -115,6 +120,7 @@ def test_numpy_numpy():
 
     assert np.array_equal(data_nested, numpy_result)
 
+
 def test_list_list():
 
     data = [1.368312, 2.667389, 2.387636, 1.797382, 1.935495, 3.482808, 2.520573, 2.804281, 1.264108, 1.305208]
@@ -156,6 +162,7 @@ def test_list_list():
     list_result = list_interface.from_statsmodels(data)
 
     assert data_nested == list_result
+
 
 def test_ndim():
 
@@ -204,6 +211,7 @@ def test_ndim():
     assert is_col_vector(pd_col_vector) == True
     assert is_col_vector(pd_matrix) == False
 
+
 def test_transpose():
 
     list_row_vector = [1, 2, 3]
@@ -229,50 +237,3 @@ def test_transpose():
     assert pd_row_vector.equals(transpose(pd_col_vector))
     assert_frame_equal(pd_col_vector, transpose(pd_row_vector))
     assert_frame_equal(pd_col_vector, transpose(pd_row_vector2))
-
-def test_gee():
-
-    from statsmodels.genmod.generalized_estimating_equations import GEE
-    from statsmodels.genmod.families import Poisson
-
-    n = 50
-    X1 = np.random.normal(size=n)
-    X2 = np.random.normal(size=n)
-    groups = np.kron(np.arange(25), np.r_[1, 1])
-    offset = np.random.uniform(1, 2, size=n)
-    exposure = np.random.uniform(1, 2, size=n)
-    Y = np.random.poisson(0.1 * (X1 + X2) + offset +
-                          np.log(exposure), size=n)
-    data = pd.DataFrame({"Y": Y, "X1": X1, "X2": X2, "groups": groups,
-                         "offset": offset, "exposure": exposure})
-
-
-    fml = "Y ~ X1 + X2"
-    model = GEE.from_formula(fml, groups, data, family=Poisson(),
-                             offset="offset", exposure="exposure")
-    result = model.fit()
-
-    pred1 = result.predict()
-    pred3 = result.predict(exposure=data["exposure"])
-
-    pred5 = result.predict(exog=data[-10:],
-                           offset=data["offset"][-10:],
-                           exposure=data["exposure"][-10:])
-
-    assert type(pred5) == pd.Series
-    assert_allclose(pred1, pred3)
-    assert_allclose(pred1[-10:], pred5)
-
-def test_discrete():
-
-    import statsmodels.api as sm
-
-    data = sm.datasets.anes96.load()
-    exog = data.exog
-    # leave out last exog column
-    exog = exog[:, :-1]
-    exog = sm.add_constant(exog, prepend=True)
-    res1 = sm.MNLogit(data.endog, exog).fit(method="newton", disp=0)
-    x = exog[0]
-
-    np.testing.assert_equal(res1.predict(x).shape, (7,))

--- a/statsmodels/tools/tests/test_data_interface.py
+++ b/statsmodels/tools/tests/test_data_interface.py
@@ -24,6 +24,16 @@ def test_series_numpy():
 
     assert data_series.equals(numpy_to_series)
 
+def test_series_numpy2():
+    data_list = [[1, 2, 3]]
+
+    data_series = pd.Series(data_list)
+    series_interface = NumPyInterface(external_type=pd.Series)
+    series_to_numpy = series_interface.to_statsmodels(data_series)
+    numpy_to_series = series_interface.from_statsmodels(series_to_numpy)
+
+    assert data_series.equals(numpy_to_series)
+
 def test_data_frame_numpy():
     data_nested_list = [[1, 2, 3], [4, 5, 6]]
 

--- a/statsmodels/tools/tests/test_data_interface.py
+++ b/statsmodels/tools/tests/test_data_interface.py
@@ -2,10 +2,9 @@
 from statsmodels.tools.data_interface import (NumPyInterface, ListInterface, SeriesInterface, DataFrameInterface,
                                               get_ndim, is_col_vector, transpose)
 
-from pandas.util.testing import assert_frame_equal
+from pandas.util.testing import assert_frame_equal, assert_series_equal
 import pandas as pd
 import numpy as np
-
 
 def test_list_numpy():
 
@@ -38,7 +37,7 @@ def test_series_numpy():
     series_to_numpy = series_interface.to_statsmodels(data_series)
     numpy_to_series = series_interface.from_statsmodels(series_to_numpy)
 
-    assert data_series.equals(numpy_to_series)
+    assert_series_equal(data_series, numpy_to_series)
 
 
 def test_numpy_series():
@@ -61,7 +60,7 @@ def test_data_frame_numpy():
     data_frame_to_numpy = data_frame_interface.to_statsmodels(data_frame)
     numpy_to_data_frame = data_frame_interface.from_statsmodels(data_frame_to_numpy)
 
-    assert data_frame.equals(numpy_to_data_frame)
+    assert_frame_equal(data_frame, numpy_to_data_frame)
 
 
 def test_numpy_data_frame():
@@ -234,6 +233,11 @@ def test_transpose():
     np.testing.assert_equal(np_col_vector, transpose(np_row_vector2))
     np.testing.assert_equal(np_row_vector, transpose(np_col_vector))
 
-    assert pd_row_vector.equals(transpose(pd_col_vector))
+    pd_col_vector_transpose = transpose(pd_col_vector)
+
+    # Fix the changing Series name from None to 0
+    pd_col_vector_transpose.name = None
+
+    assert_series_equal(pd_row_vector, pd_col_vector_transpose)
     assert_frame_equal(pd_col_vector, transpose(pd_row_vector))
     assert_frame_equal(pd_col_vector, transpose(pd_row_vector2))

--- a/statsmodels/tools/tests/test_data_interface.py
+++ b/statsmodels/tools/tests/test_data_interface.py
@@ -255,14 +255,24 @@ def test_gee():
     pred1 = result.predict()
     pred3 = result.predict(exposure=data["exposure"])
 
-    # set_trace()
-
     pred5 = result.predict(exog=data[-10:],
                            offset=data["offset"][-10:],
                            exposure=data["exposure"][-10:])
 
+    assert type(pred5) == pd.Series
     assert_allclose(pred1, pred3)
-
-    # set_trace()
-
     assert_allclose(pred1[-10:], pred5)
+
+def test_discrete():
+
+    import statsmodels.api as sm
+
+    data = sm.datasets.anes96.load()
+    exog = data.exog
+    # leave out last exog column
+    exog = exog[:, :-1]
+    exog = sm.add_constant(exog, prepend=True)
+    res1 = sm.MNLogit(data.endog, exog).fit(method="newton", disp=0)
+    x = exog[0]
+
+    np.testing.assert_equal(res1.predict(x).shape, (7,))

--- a/statsmodels/tools/tests/test_data_interface.py
+++ b/statsmodels/tools/tests/test_data_interface.py
@@ -3,6 +3,7 @@ from statsmodels.tools.data_interface import NumPyInterface, get_ndim, is_col_ve
 from pandas.util.testing import assert_frame_equal
 import pandas as pd
 import numpy as np
+from pdb import set_trace
 
 
 def test_list_numpy():
@@ -24,15 +25,29 @@ def test_series_numpy():
 
     assert data_series.equals(numpy_to_series)
 
-def test_series_numpy2():
+def test_numpy_numpy():
     data_list = [[1, 2, 3]]
 
-    data_series = pd.Series(data_list)
-    series_interface = NumPyInterface(external_type=pd.Series)
-    series_to_numpy = series_interface.to_statsmodels(data_series)
-    numpy_to_series = series_interface.from_statsmodels(series_to_numpy)
+    data = np.array(data_list)
+    numpy_interface = NumPyInterface()
+    numpy_internal = numpy_interface.to_statsmodels(data)
+    numpy_result = numpy_interface.from_statsmodels(numpy_internal)
 
-    assert data_series.equals(numpy_to_series)
+    assert np.array_equal(data, numpy_result)
+
+def test_numpy_numpy2():
+    data_list = [1, 2, 3]
+    data_list_nested = [[1, 2, 3]]
+
+    data = np.array(data_list)
+    data_nested = np.array(data_list_nested)
+
+    numpy_interface = NumPyInterface()
+
+    numpy_interface.to_statsmodels(data)
+    numpy_result = numpy_interface.from_statsmodels(data_nested)
+
+    assert np.array_equal(data, numpy_result)
 
 def test_data_frame_numpy():
     data_nested_list = [[1, 2, 3], [4, 5, 6]]

--- a/statsmodels/tools/tests/test_data_interface.py
+++ b/statsmodels/tools/tests/test_data_interface.py
@@ -1,0 +1,32 @@
+from statsmodels.tools.data_interface import NumPyInterface
+import pandas as pd
+
+
+def test_list_numpy():
+    data_list = [1, 2, 3]
+
+    list_interface = NumPyInterface(external_type=list)
+    list_to_numpy = list_interface.to_statsmodels(data_list)
+    numpy_to_list = list_interface.from_statsmodels(list_to_numpy)
+
+    assert data_list == numpy_to_list
+
+def test_series_numpy():
+    data_list = [1, 2, 3]
+
+    data_series = pd.Series(data_list)
+    series_interface = NumPyInterface(external_type=pd.Series)
+    series_to_numpy = series_interface.to_statsmodels(data_series)
+    numpy_to_series = series_interface.from_statsmodels(series_to_numpy)
+
+    assert data_series.equals(numpy_to_series)
+
+def test_data_frame_numpy():
+    data_nested_list = [[1, 2, 3], [4, 5, 6]]
+
+    data_frame = pd.DataFrame(data_nested_list)
+    data_frame_interface = NumPyInterface(external_type=pd.DataFrame)
+    data_frame_to_numpy = data_frame_interface.to_statsmodels(data_frame)
+    numpy_to_data_frame = data_frame_interface.from_statsmodels(data_frame_to_numpy)
+
+    assert data_frame.equals(numpy_to_data_frame)

--- a/statsmodels/tools/tests/test_data_interface.py
+++ b/statsmodels/tools/tests/test_data_interface.py
@@ -274,16 +274,12 @@ class TestCategoricalNumerical(TestCategorical):
     # TODO: use assert_raises to check that bad inputs are taken care of
 
     def test_array2d(self):
-        set_trace()
-
         des = np.column_stack((self.des, self.instr, self.des))
         des = to_categorical(des, col=2)
         assert_array_equal(des[:, -5:], self.dummy)
         assert_equal(des.shape[1], 10)
 
     def test_array1d(self):
-        set_trace()
-
         des = to_categorical(self.instr)
         assert_array_equal(des[:, -5:], self.dummy)
         assert_equal(des.shape[1], 6)
@@ -295,6 +291,8 @@ class TestCategoricalNumerical(TestCategorical):
         assert_equal(des.shape[1], 9)
 
     def test_array1d_drop(self):
+        set_trace()
+
         des = to_categorical(self.instr, drop=True)
         assert_array_equal(des, self.dummy)
         assert_equal(des.shape[1], 5)

--- a/statsmodels/tools/tests/test_data_interface.py
+++ b/statsmodels/tools/tests/test_data_interface.py
@@ -1,5 +1,7 @@
 
-from statsmodels.tools.data_interface import NumPyInterface, get_ndim, is_col_vector, transpose
+from statsmodels.tools.data_interface import (NumPyInterface, ListInterface, SeriesInterface, DataFrameInterface,
+                                              get_ndim, is_col_vector, transpose)
+
 from pandas.util.testing import assert_frame_equal
 import pandas as pd
 import numpy as np
@@ -7,6 +9,7 @@ from pdb import set_trace
 
 
 def test_list_numpy():
+
     data_list = [1, 2, 3]
 
     list_interface = NumPyInterface(external_type=list)
@@ -15,7 +18,18 @@ def test_list_numpy():
 
     assert data_list == numpy_to_list
 
+def test_numpy_list():
+
+    data = np.array([1, 2, 3])
+
+    list_interface = ListInterface(external_type=np.ndarray)
+    numpy_to_list = list_interface.to_statsmodels(data)
+    list_to_numpy = list_interface.from_statsmodels(numpy_to_list)
+
+    assert np.array_equal(data, list_to_numpy)
+
 def test_series_numpy():
+
     data_list = [1, 2, 3]
 
     data_series = pd.Series(data_list)
@@ -25,31 +39,18 @@ def test_series_numpy():
 
     assert data_series.equals(numpy_to_series)
 
-def test_numpy_numpy():
-    data_list = [[1, 2, 3]]
+def test_numpy_series():
 
-    data = np.array(data_list)
-    numpy_interface = NumPyInterface()
-    numpy_internal = numpy_interface.to_statsmodels(data)
-    numpy_result = numpy_interface.from_statsmodels(numpy_internal)
+    data = np.array([1, 2, 3])
 
-    assert np.array_equal(data, numpy_result)
+    series_interface = SeriesInterface(external_type=np.ndarray)
+    numpy_to_series = series_interface.to_statsmodels(data)
+    series_to_numpy = series_interface.from_statsmodels(numpy_to_series)
 
-def test_numpy_numpy2():
-    data_list = [1, 2, 3]
-    data_list_nested = [[1, 2, 3]]
-
-    data = np.array(data_list)
-    data_nested = np.array(data_list_nested)
-
-    numpy_interface = NumPyInterface()
-
-    numpy_interface.to_statsmodels(data)
-    numpy_result = numpy_interface.from_statsmodels(data_nested)
-
-    assert np.array_equal(data, numpy_result)
+    assert np.array_equal(data, series_to_numpy)
 
 def test_data_frame_numpy():
+
     data_nested_list = [[1, 2, 3], [4, 5, 6]]
 
     data_frame = pd.DataFrame(data_nested_list)
@@ -58,6 +59,103 @@ def test_data_frame_numpy():
     numpy_to_data_frame = data_frame_interface.from_statsmodels(data_frame_to_numpy)
 
     assert data_frame.equals(numpy_to_data_frame)
+
+def test_numpy_data_frame():
+
+    data = np.array([[1, 2, 3], [4, 5, 6]])
+
+    data_frame_interface = DataFrameInterface(external_type=np.ndarray)
+    numpy_to_data_frame = data_frame_interface.to_statsmodels(data)
+    data_frame_to_numpy = data_frame_interface.from_statsmodels(numpy_to_data_frame)
+
+    assert np.array_equal(data, data_frame_to_numpy)
+
+def test_numpy_numpy():
+
+    data_list = [1.368312, 2.667389, 2.387636, 1.797382, 1.935495, 3.482808, 2.520573, 2.804281, 1.264108, 1.305208]
+    data_list_nested = [data_list]
+
+    data = np.array(data_list)
+    data_nested = np.array(data_list_nested)
+    data_transpose = transpose(data)
+
+    numpy_interface = NumPyInterface()
+    numpy_internal = numpy_interface.to_statsmodels(data)
+    numpy_result = numpy_interface.from_statsmodels(numpy_internal)
+
+    assert np.array_equal(data, numpy_result)
+
+    numpy_interface = NumPyInterface()
+    numpy_internal = numpy_interface.to_statsmodels(data_nested)
+    numpy_result = numpy_interface.from_statsmodels(numpy_internal)
+
+    assert np.array_equal(data_nested, numpy_result)
+
+    numpy_interface = NumPyInterface()
+    numpy_interface.to_statsmodels(data)
+    numpy_result = numpy_interface.from_statsmodels(data_transpose)
+
+    assert np.array_equal(data, numpy_result)
+
+    numpy_interface = NumPyInterface()
+    numpy_interface.to_statsmodels(data_transpose)
+    numpy_result = numpy_interface.from_statsmodels(data)
+
+    assert np.array_equal(data_transpose, numpy_result)
+
+    numpy_interface = NumPyInterface()
+    numpy_interface.to_statsmodels(data)
+    numpy_result = numpy_interface.from_statsmodels(data_nested)
+
+    assert np.array_equal(data, numpy_result)
+
+    numpy_interface = NumPyInterface()
+    numpy_interface.to_statsmodels(data_nested)
+    numpy_result = numpy_interface.from_statsmodels(data)
+
+    assert np.array_equal(data_nested, numpy_result)
+
+def test_list_list():
+
+    data = [1.368312, 2.667389, 2.387636, 1.797382, 1.935495, 3.482808, 2.520573, 2.804281, 1.264108, 1.305208]
+    data_nested = [data]
+    data_transpose = transpose(data)
+
+    list_interface = ListInterface()
+    list_internal = list_interface.to_statsmodels(data)
+    list_result = list_interface.from_statsmodels(list_internal)
+
+    assert data == list_result
+
+    list_interface = ListInterface()
+    list_internal = list_interface.to_statsmodels(data_nested)
+    list_result = list_interface.from_statsmodels(list_internal)
+
+    assert data_nested == list_result
+
+    list_interface = ListInterface()
+    list_interface.to_statsmodels(data)
+    list_result = list_interface.from_statsmodels(data_transpose)
+
+    assert data == list_result
+
+    list_interface = ListInterface()
+    list_interface.to_statsmodels(data_transpose)
+    list_result = list_interface.from_statsmodels(data)
+
+    assert data_transpose == list_result
+
+    list_interface = ListInterface()
+    list_interface.to_statsmodels(data)
+    list_result = list_interface.from_statsmodels(data_nested)
+
+    assert data == list_result
+
+    list_interface = ListInterface()
+    list_interface.to_statsmodels(data_nested)
+    list_result = list_interface.from_statsmodels(data)
+
+    assert data_nested == list_result
 
 def test_ndim():
 
@@ -119,6 +217,10 @@ def test_transpose():
     pd_row_vector = pd.Series(np_row_vector)
     pd_row_vector2 = pd.DataFrame(np_row_vector2)
     pd_col_vector = pd.DataFrame(np_col_vector)
+
+    assert list_col_vector == transpose(list_row_vector)
+    assert list_col_vector == transpose(list_row_vector2)
+    assert list_row_vector == transpose(list_col_vector)
 
     np.testing.assert_equal(np_col_vector, transpose(np_row_vector))
     np.testing.assert_equal(np_col_vector, transpose(np_row_vector2))

--- a/statsmodels/tools/tests/test_data_interface.py
+++ b/statsmodels/tools/tests/test_data_interface.py
@@ -121,37 +121,37 @@ def test_list_list():
     data_nested = [data]
     data_transpose = transpose(data)
 
-    list_interface = ListInterface()
+    list_interface = ListInterface(external_type=list)
     list_internal = list_interface.to_statsmodels(data)
     list_result = list_interface.from_statsmodels(list_internal)
 
     assert data == list_result
 
-    list_interface = ListInterface()
+    list_interface = ListInterface(external_type=list)
     list_internal = list_interface.to_statsmodels(data_nested)
     list_result = list_interface.from_statsmodels(list_internal)
 
     assert data_nested == list_result
 
-    list_interface = ListInterface()
+    list_interface = ListInterface(external_type=list)
     list_interface.to_statsmodels(data)
     list_result = list_interface.from_statsmodels(data_transpose)
 
     assert data == list_result
 
-    list_interface = ListInterface()
+    list_interface = ListInterface(external_type=list)
     list_interface.to_statsmodels(data_transpose)
     list_result = list_interface.from_statsmodels(data)
 
     assert data_transpose == list_result
 
-    list_interface = ListInterface()
+    list_interface = ListInterface(external_type=list)
     list_interface.to_statsmodels(data)
     list_result = list_interface.from_statsmodels(data_nested)
 
     assert data == list_result
 
-    list_interface = ListInterface()
+    list_interface = ListInterface(external_type=list)
     list_interface.to_statsmodels(data_nested)
     list_result = list_interface.from_statsmodels(data)
 

--- a/statsmodels/tools/tests/test_tools.py
+++ b/statsmodels/tools/tests/test_tools.py
@@ -212,8 +212,8 @@ class TestCategoricalNumerical(object):
         self.recdes = structdes.view(np.recarray)
 
     def test_array2d(self):
-        des = np.column_stack((self.des, self.instr, self.des))
-        des = tools.categorical(des, col=2)
+        des1 = np.column_stack((self.des, self.instr, self.des))
+        des = tools.categorical(des1, col=2)
         assert_array_equal(des[:,-5:], self.dummy)
         assert_equal(des.shape[1],10)
 


### PR DESCRIPTION
As a follow-up to the discussion in #3027, many functions have code that converts user provided data objects into the internal data representation used by that part of the library.  This is an initial implementation of a DataInterface class to give developers control over that process.

Closes #3027 

@josef-pkt I know you are on vacation, but I would appreciate any comments when you have time.