### PR TITLE
BUG: Statespace: get_prediction/get_forecast with exog

### DIFF
--- a/statsmodels/base/data.py
+++ b/statsmodels/base/data.py
@@ -537,6 +537,9 @@ class PandasData(ModelData):
         # assumes if len(row_labels) > len(result) it's bc it was truncated
         # at the front, for AR lags, for example
         squeezed = result.squeeze()
+        k_endog = np.array(self.ynames, ndmin=1).shape[0]
+        if k_endog > 1 and squeezed.shape == (k_endog,):
+            squeezed = squeezed[None, :]
         # May be zero-dim, for example in the case of forecast one step in tsa
         if squeezed.ndim < 2:
             return Series(squeezed, index=self.row_labels[-len(result):])
@@ -546,6 +549,9 @@ class PandasData(ModelData):
 
     def attach_dates(self, result):
         squeezed = result.squeeze()
+        k_endog = np.array(self.ynames, ndmin=1).shape[0]
+        if k_endog > 1 and squeezed.shape == (k_endog,):
+            squeezed = squeezed[None, :]
         # May be zero-dim, for example in the case of forecast one step in tsa
         if squeezed.ndim < 2:
             return Series(squeezed, index=self.predict_dates)

--- a/statsmodels/tsa/statespace/dynamic_factor.py
+++ b/statsmodels/tsa/statespace/dynamic_factor.py
@@ -526,7 +526,6 @@ class DynamicFactor(MLEModel):
             res_errors = mod_errors.fit(maxlags=self.error_order, ic=None,
                                         trend='nc')
 
-
             # Test for stationarity
             coefficient_matrices = (
                 np.array(res_errors.params.T).ravel().reshape(
@@ -1230,31 +1229,6 @@ class DynamicFactorResults(MLEResults):
         return super(DynamicFactorResults, self).get_prediction(
             start=start, end=end, dynamic=dynamic, exog=exog, **kwargs
         )
-
-    def get_forecast(self, steps=1, exog=None, **kwargs):
-        """
-        Out-of-sample forecasts
-
-        Parameters
-        ----------
-        steps : int, optional
-            The number of out of sample forecasts from the end of the
-            sample. Default is 1.
-        exog : array_like, optional
-            If the model includes exogenous regressors, you must provide
-            exactly enough out-of-sample values for the exogenous variables for
-            each step forecasted.
-        **kwargs
-            Additional arguments may required for forecasting beyond the end
-            of the sample. See `FilterResults.predict` for more details.
-
-        Returns
-        -------
-        forecast : array
-            Array of out of sample forecasts.
-        """
-        return super(DynamicFactorResults, self).get_forecast(steps, exog=exog,
-                                                              **kwargs)
 
     def summary(self, alpha=.05, start=None, separate_params=True):
         from statsmodels.iolib.summary import summary_params

--- a/statsmodels/tsa/statespace/dynamic_factor.py
+++ b/statsmodels/tsa/statespace/dynamic_factor.py
@@ -1132,8 +1132,8 @@ class DynamicFactorResults(MLEResults):
 
         return fig
 
-    def predict(self, start=None, end=None, exog=None, dynamic=False,
-                **kwargs):
+    def get_prediction(self, start=None, end=None, dynamic=False, exog=None,
+                       **kwargs):
         """
         In-sample prediction and out-of-sample forecasting
 
@@ -1227,11 +1227,11 @@ class DynamicFactorResults(MLEResults):
             warn('Exogenous array provided to predict, but additional data not'
                  ' required. `exog` argument ignored.', ValueWarning)
 
-        return super(DynamicFactorResults, self).predict(
-            start=start, end=end, exog=exog, dynamic=dynamic, **kwargs
+        return super(DynamicFactorResults, self).get_prediction(
+            start=start, end=end, dynamic=dynamic, exog=exog, **kwargs
         )
 
-    def forecast(self, steps=1, exog=None, **kwargs):
+    def get_forecast(self, steps=1, exog=None, **kwargs):
         """
         Out-of-sample forecasts
 
@@ -1253,8 +1253,8 @@ class DynamicFactorResults(MLEResults):
         forecast : array
             Array of out of sample forecasts.
         """
-        return super(DynamicFactorResults, self).forecast(steps, exog=exog,
-                                                          **kwargs)
+        return super(DynamicFactorResults, self).get_forecast(steps, exog=exog,
+                                                              **kwargs)
 
     def summary(self, alpha=.05, start=None, separate_params=True):
         from statsmodels.iolib.summary import summary_params

--- a/statsmodels/tsa/statespace/mlemodel.py
+++ b/statsmodels/tsa/statespace/mlemodel.py
@@ -12,14 +12,12 @@ import pandas as pd
 from scipy.stats import norm
 
 from .kalman_smoother import KalmanSmoother, SmootherResults
-from .kalman_filter import (
-    KalmanFilter, FilterResults, PredictionResults, INVERT_UNIVARIATE, SOLVE_LU
-)
+from .kalman_filter import (KalmanFilter, FilterResults, INVERT_UNIVARIATE,
+                            SOLVE_LU)
 import statsmodels.tsa.base.tsa_model as tsbase
 import statsmodels.base.wrapper as wrap
-from statsmodels.tools.numdiff import (
-    _get_epsilon, approx_hess_cs, approx_fprime_cs, approx_fprime
-)
+from statsmodels.tools.numdiff import (_get_epsilon, approx_hess_cs,
+                                       approx_fprime_cs, approx_fprime)
 from statsmodels.tools.decorators import cache_readonly, resettable_cache
 from statsmodels.tools.eval_measures import aic, bic, hqic
 from statsmodels.tools.tools import pinv_extended, Bunch

--- a/statsmodels/tsa/statespace/sarimax.py
+++ b/statsmodels/tsa/statespace/sarimax.py
@@ -419,9 +419,9 @@ class SARIMAX(MLEModel):
                 exog = np.asarray(exog)
 
             # Make sure we have 2-dimensional array
-            if exog.ndim == 1:
+            if exog.ndim < 2:
                 if not exog_is_using_pandas:
-                    exog = exog[:, None]
+                    exog = np.atleast_2d(exog).T
                 else:
                     exog = pd.DataFrame(exog)
 
@@ -1826,7 +1826,7 @@ class SARIMAXResults(MLEResults):
         """
         return self._params_ma
 
-    def predict(self, start=None, end=None, exog=None, dynamic=False,
+    def get_prediction(self, start=None, end=None, dynamic=False, exog=None,
                 **kwargs):
         """
         In-sample prediction and out-of-sample forecasting
@@ -1917,11 +1917,11 @@ class SARIMAXResults(MLEResults):
             warn('Exogenous array provided to predict, but additional data not'
                  ' required. `exog` argument ignored.', ValueWarning)
 
-        return super(SARIMAXResults, self).predict(
+        return super(SARIMAXResults, self).get_prediction(
             start=start, end=end, exog=exog, dynamic=dynamic, **kwargs
         )
 
-    def forecast(self, steps=1, exog=None, **kwargs):
+    def get_forecast(self, steps=1, exog=None, **kwargs):
         """
         Out-of-sample forecasts
 
@@ -1943,7 +1943,7 @@ class SARIMAXResults(MLEResults):
         forecast : array
             Array of out of sample forecasts.
         """
-        return super(SARIMAXResults, self).forecast(steps, exog=exog, **kwargs)
+        return super(SARIMAXResults, self).get_forecast(steps, exog=exog, **kwargs)
 
     def summary(self, alpha=.05, start=None):
         # Create the model name

--- a/statsmodels/tsa/statespace/sarimax.py
+++ b/statsmodels/tsa/statespace/sarimax.py
@@ -1918,7 +1918,7 @@ class SARIMAXResults(MLEResults):
                  ' required. `exog` argument ignored.', ValueWarning)
 
         return super(SARIMAXResults, self).get_prediction(
-            start=start, end=end, exog=exog, dynamic=dynamic, **kwargs
+            start=start, end=end, dynamic=dynamic, exog=exog, **kwargs
         )
 
     def get_forecast(self, steps=1, exog=None, **kwargs):
@@ -1943,7 +1943,8 @@ class SARIMAXResults(MLEResults):
         forecast : array
             Array of out of sample forecasts.
         """
-        return super(SARIMAXResults, self).get_forecast(steps, exog=exog, **kwargs)
+        return super(SARIMAXResults, self).get_forecast(steps, exog=exog,
+                                                        **kwargs)
 
     def summary(self, alpha=.05, start=None):
         # Create the model name

--- a/statsmodels/tsa/statespace/sarimax.py
+++ b/statsmodels/tsa/statespace/sarimax.py
@@ -1921,31 +1921,6 @@ class SARIMAXResults(MLEResults):
             start=start, end=end, dynamic=dynamic, exog=exog, **kwargs
         )
 
-    def get_forecast(self, steps=1, exog=None, **kwargs):
-        """
-        Out-of-sample forecasts
-
-        Parameters
-        ----------
-        steps : int, optional
-            The number of out of sample forecasts from the end of the
-            sample. Default is 1.
-        exog : array_like, optional
-            If the model includes exogenous regressors, you must provide
-            exactly enough out-of-sample values for the exogenous variables for
-            each step forecasted.
-        **kwargs
-            Additional arguments may required for forecasting beyond the end
-            of the sample. See `FilterResults.predict` for more details.
-
-        Returns
-        -------
-        forecast : array
-            Array of out of sample forecasts.
-        """
-        return super(SARIMAXResults, self).get_forecast(steps, exog=exog,
-                                                        **kwargs)
-
     def summary(self, alpha=.05, start=None):
         # Create the model name
 

--- a/statsmodels/tsa/statespace/sarimax.py
+++ b/statsmodels/tsa/statespace/sarimax.py
@@ -953,7 +953,7 @@ class SARIMAX(MLEModel):
         # Although the Kalman filter can deal with missing values in endog,
         # conditional sum of squares cannot
         if np.any(np.isnan(endog)):
-            mask = ~np.isnan(endog)
+            mask = ~np.isnan(endog).squeeze()
             endog = endog[mask]
             if exog is not None:
                 exog = exog[mask]

--- a/statsmodels/tsa/statespace/structural.py
+++ b/statsmodels/tsa/statespace/structural.py
@@ -1430,8 +1430,8 @@ class UnobservedComponentsResults(MLEResults):
 
         return fig
 
-    def predict(self, start=None, end=None, exog=None, dynamic=False,
-                **kwargs):
+    def get_prediction(self, start=None, end=None, dynamic=False, exog=None,
+                       **kwargs):
         """
         In-sample prediction and out-of-sample forecasting
 
@@ -1522,11 +1522,11 @@ class UnobservedComponentsResults(MLEResults):
             warn('Exogenous array provided to predict, but additional data not'
                  ' required. `exog` argument ignored.', ValueWarning)
 
-        return super(UnobservedComponentsResults, self).predict(
-            start=start, end=end, exog=exog, dynamic=dynamic, **kwargs
+        return super(UnobservedComponentsResults, self).get_prediction(
+            start=start, end=end, dynamic=dynamic, exog=exog, **kwargs
         )
 
-    def forecast(self, steps=1, exog=None, **kwargs):
+    def get_forecast(self, steps=1, exog=None, **kwargs):
         """
         Out-of-sample forecasts
 
@@ -1548,7 +1548,7 @@ class UnobservedComponentsResults(MLEResults):
         forecast : array
             Array of out of sample forecasts.
         """
-        return super(UnobservedComponentsResults, self).forecast(
+        return super(UnobservedComponentsResults, self).get_forecast(
             steps, exog=exog, **kwargs)
 
     def summary(self, alpha=.05, start=None):

--- a/statsmodels/tsa/statespace/structural.py
+++ b/statsmodels/tsa/statespace/structural.py
@@ -1527,31 +1527,6 @@ class UnobservedComponentsResults(MLEResults):
             start=start, end=end, dynamic=dynamic, exog=exog, **kwargs
         )
 
-    def get_forecast(self, steps=1, exog=None, **kwargs):
-        """
-        Out-of-sample forecasts
-
-        Parameters
-        ----------
-        steps : int, optional
-            The number of out of sample forecasts from the end of the
-            sample. Default is 1.
-        exog : array_like, optional
-            If the model includes exogenous regressors, you must provide
-            exactly enough out-of-sample values for the exogenous variables for
-            each step forecasted.
-        **kwargs
-            Additional arguments may required for forecasting beyond the end
-            of the sample. See `FilterResults.predict` for more details.
-
-        Returns
-        -------
-        forecast : array
-            Array of out of sample forecasts.
-        """
-        return super(UnobservedComponentsResults, self).get_forecast(
-            steps, exog=exog, **kwargs)
-
     def summary(self, alpha=.05, start=None):
         # Create the model name
 

--- a/statsmodels/tsa/statespace/structural.py
+++ b/statsmodels/tsa/statespace/structural.py
@@ -1360,7 +1360,7 @@ class UnobservedComponentsResults(MLEResults):
 
             # Get the predicted values and confidence intervals
             predict = self.filter_results.forecasts[0]
-            std_errors = np.sqrt(self.filter_results.forecasts_error_cov[0,0])
+            std_errors = np.sqrt(self.filter_results.forecasts_error_cov[0, 0])
             ci_lower = predict - critical_value * std_errors
             ci_upper = predict + critical_value * std_errors
 
@@ -1370,7 +1370,7 @@ class UnobservedComponentsResults(MLEResults):
             ci_poly = ax.fill_between(
                 dates[llb:], ci_lower[llb:], ci_upper[llb:], alpha=0.2
             )
-            ci_label = '$%.3g \\%%$ confidence interval' % ((1 - alpha)*100)
+            ci_label = '$%.3g \\%%$ confidence interval' % ((1 - alpha) * 100)
 
             # Proxy artist for fill_between legend entry
             # See e.g. http://matplotlib.org/1.3.1/users/legend_guide.html
@@ -1427,7 +1427,7 @@ class UnobservedComponentsResults(MLEResults):
         if llb > 0:
             text = ('Note: The first %d observations are not shown, due to'
                     ' approximate diffuse initialization.')
-            fig.text(0.1, 0.01, text % llb, fontsize='large');
+            fig.text(0.1, 0.01, text % llb, fontsize='large')
 
         return fig
 

--- a/statsmodels/tsa/statespace/tests/test_sarimax.py
+++ b/statsmodels/tsa/statespace/tests/test_sarimax.py
@@ -1935,3 +1935,57 @@ def test_results():
 
     assert_almost_equal(res.arparams, [0.5])
     assert_almost_equal(res.maparams, [-0.5])
+
+
+def test_misc_exog():
+    # Tests for missing data
+    nobs = 20
+    k_endog = 1
+    np.random.seed(1208)
+    endog = np.random.normal(size=(nobs, k_endog))
+    endog[:4, 0] = np.nan
+    exog1 = np.random.normal(size=(nobs, 1))
+    exog2 = np.random.normal(size=(nobs, 2))
+
+    index = pd.date_range('1970-01-01', freq='QS', periods=nobs)
+    endog_pd = pd.DataFrame(endog, index=index)
+    exog1_pd = pd.Series(exog1.squeeze(), index=index)
+    exog2_pd = pd.DataFrame(exog2, index=index)
+
+    models = [
+        sarimax.SARIMAX(endog, exog=exog1, order=(1, 1, 0)),
+        sarimax.SARIMAX(endog, exog=exog2, order=(1, 1, 0)),
+        sarimax.SARIMAX(endog, exog=exog2, order=(1, 1, 0),
+                        simple_differencing=False),
+        sarimax.SARIMAX(endog_pd, exog=exog1_pd, order=(1, 1, 0)),
+        sarimax.SARIMAX(endog_pd, exog=exog2_pd, order=(1, 1, 0)),
+        sarimax.SARIMAX(endog_pd, exog=exog2_pd, order=(1, 1, 0),
+                        simple_differencing=False),
+    ]
+
+    for mod in models:
+        # Smoke tests
+        mod.start_params
+        res = mod.fit(disp=False)
+        res.summary()
+        res.predict()
+        res.predict(dynamic=True)
+        res.get_prediction()
+
+        oos_exog = np.random.normal(size=(1, mod.k_exog))
+        res.forecast(steps=1, exog=oos_exog)
+        res.get_forecast(steps=1, exog=oos_exog)
+
+        # Smoke tests for invalid exog
+        oos_exog = np.random.normal(size=(1))
+        assert_raises(ValueError, res.forecast, steps=1, exog=oos_exog)
+
+        oos_exog = np.random.normal(size=(2, mod.k_exog))
+        assert_raises(ValueError, res.forecast, steps=1, exog=oos_exog)
+
+        oos_exog = np.random.normal(size=(1, mod.k_exog + 1))
+        assert_raises(ValueError, res.forecast, steps=1, exog=oos_exog)
+
+    # Test invalid model specifications
+    assert_raises(ValueError, sarimax.SARIMAX, endog, exog=np.zeros((10, 4)),
+                  order=(1, 1, 0))

--- a/statsmodels/tsa/statespace/tests/test_structural.py
+++ b/statsmodels/tsa/statespace/tests/test_structural.py
@@ -288,3 +288,55 @@ def test_forecast():
     actual = res.forecast(10, exog=np.arange(50,60)[:,np.newaxis])
     desired = np.arange(50,60) + 10
     assert_allclose(actual, desired)
+
+
+def test_misc_exog():
+    # Tests for missing data
+    nobs = 20
+    k_endog = 1
+    np.random.seed(1208)
+    endog = np.random.normal(size=(nobs, k_endog))
+    endog[:4, 0] = np.nan
+    exog1 = np.random.normal(size=(nobs, 1))
+    exog2 = np.random.normal(size=(nobs, 2))
+
+    index = pd.date_range('1970-01-01', freq='QS', periods=nobs)
+    endog_pd = pd.DataFrame(endog, index=index)
+    exog1_pd = pd.Series(exog1.squeeze(), index=index)
+    exog2_pd = pd.DataFrame(exog2, index=index)
+
+    models = [
+        UnobservedComponents(endog, 'llevel', exog=exog1),
+        UnobservedComponents(endog, 'llevel', exog=exog2),
+        UnobservedComponents(endog, 'llevel', exog=exog2),
+        UnobservedComponents(endog_pd, 'llevel', exog=exog1_pd),
+        UnobservedComponents(endog_pd, 'llevel', exog=exog2_pd),
+        UnobservedComponents(endog_pd, 'llevel', exog=exog2_pd),
+    ]
+
+    for mod in models:
+        # Smoke tests
+        mod.start_params
+        res = mod.fit(disp=False)
+        res.summary()
+        res.predict()
+        res.predict(dynamic=True)
+        res.get_prediction()
+
+        oos_exog = np.random.normal(size=(1, mod.k_exog))
+        res.forecast(steps=1, exog=oos_exog)
+        res.get_forecast(steps=1, exog=oos_exog)
+
+        # Smoke tests for invalid exog
+        oos_exog = np.random.normal(size=(1))
+        assert_raises(ValueError, res.forecast, steps=1, exog=oos_exog)
+
+        oos_exog = np.random.normal(size=(2, mod.k_exog))
+        assert_raises(ValueError, res.forecast, steps=1, exog=oos_exog)
+
+        oos_exog = np.random.normal(size=(1, mod.k_exog + 1))
+        assert_raises(ValueError, res.forecast, steps=1, exog=oos_exog)
+
+    # Test invalid model specifications
+    assert_raises(ValueError, UnobservedComponents, endog, 'llevel',
+                  exog=np.zeros((10, 4)))

--- a/statsmodels/tsa/statespace/varmax.py
+++ b/statsmodels/tsa/statespace/varmax.py
@@ -23,8 +23,8 @@ from statsmodels.tools.tools import Bunch
 from statsmodels.tools.data import _is_using_pandas
 from statsmodels.tsa.vector_ar import var_model
 import statsmodels.base.wrapper as wrap
-from statsmodels.tools.sm_exceptions import (EstimationWarning,
-    ValueWarning)
+from statsmodels.tools.sm_exceptions import (EstimationWarning, ValueWarning)
+
 
 class VARMAX(MLEModel):
     r"""

--- a/statsmodels/tsa/statespace/varmax.py
+++ b/statsmodels/tsa/statespace/varmax.py
@@ -822,31 +822,6 @@ class VARMAXResults(MLEResults):
             start=start, end=end, dynamic=dynamic, exog=exog, **kwargs
         )
 
-    def get_forecast(self, steps=1, exog=None, **kwargs):
-        """
-        Out-of-sample forecasts
-
-        Parameters
-        ----------
-        steps : int, optional
-            The number of out of sample forecasts from the end of the
-            sample. Default is 1.
-        exog : array_like, optional
-            If the model includes exogenous regressors, you must provide
-            exactly enough out-of-sample values for the exogenous variables for
-            each step forecasted.
-        **kwargs
-            Additional arguments may required for forecasting beyond the end
-            of the sample. See `FilterResults.predict` for more details.
-
-        Returns
-        -------
-        forecast : array
-            Array of out of sample forecasts.
-        """
-        return super(VARMAXResults, self).get_forecast(steps, exog=exog,
-                                                       **kwargs)
-
     def summary(self, alpha=.05, start=None, separate_params=True):
         from statsmodels.iolib.summary import summary_params
 

--- a/statsmodels/tsa/statespace/varmax.py
+++ b/statsmodels/tsa/statespace/varmax.py
@@ -723,8 +723,8 @@ class VARMAXResults(MLEResults):
                 ma_params.reshape(k_endog * k_ma, k_endog).T
             ).reshape(k_endog, k_endog, k_ma).T
 
-    def predict(self, start=None, end=None, exog=None, dynamic=False,
-                **kwargs):
+    def get_prediction(self, start=None, end=None, dynamic=False, exog=None,
+                       **kwargs):
         """
         In-sample prediction and out-of-sample forecasting
 
@@ -818,11 +818,11 @@ class VARMAXResults(MLEResults):
             warn('Exogenous array provided to predict, but additional data not'
                  ' required. `exog` argument ignored.', ValueWarning)
 
-        return super(VARMAXResults, self).predict(
-            start=start, end=end, exog=exog, dynamic=dynamic, **kwargs
+        return super(VARMAXResults, self).get_prediction(
+            start=start, end=end, dynamic=dynamic, exog=exog, **kwargs
         )
 
-    def forecast(self, steps=1, exog=None, **kwargs):
+    def get_forecast(self, steps=1, exog=None, **kwargs):
         """
         Out-of-sample forecasts
 
@@ -844,7 +844,8 @@ class VARMAXResults(MLEResults):
         forecast : array
             Array of out of sample forecasts.
         """
-        return super(VARMAXResults, self).forecast(steps, exog=exog, **kwargs)
+        return super(VARMAXResults, self).get_forecast(steps, exog=exog,
+                                                       **kwargs)
 
     def summary(self, alpha=.05, start=None, separate_params=True):
         from statsmodels.iolib.summary import summary_params

--- a/statsmodels/tsa/statespace/varmax.py
+++ b/statsmodels/tsa/statespace/varmax.py
@@ -303,9 +303,10 @@ class VARMAX(MLEModel):
         # Although the Kalman filter can deal with missing values in endog,
         # conditional sum of squares cannot
         if np.any(np.isnan(endog)):
-            endog = endog[~np.isnan(endog)]
+            mask = ~np.any(np.isnan(endog), axis=1)
+            endog = endog[mask]
             if exog is not None:
-                exog = exog[~np.isnan(endog)]
+                exog = exog[mask]
 
         # Regression effects via OLS
         exog_params = np.zeros(0)


### PR DESCRIPTION
Closes #3108.

@josef-pkt I change the order of keyword arguments in this PR to make the SARIMAX methods match with the generic mlemodel method order. Is that considered a backwards incompatible change that I should avoid?