### PR TITLE
PERF: Use einsum instead of broadcasting in PHReg hessian calculations

### DIFF
--- a/statsmodels/duration/hazard_regression.py
+++ b/statsmodels/duration/hazard_regression.py
@@ -799,9 +799,10 @@ class PHReg(model.LikelihoodModel):
                     xp0 += e_linpred[ix].sum()
                     v = exog_s[ix,:]
                     xp1 += (e_linpred[ix][:,None] * v).sum(0)
-                    mat = v[None,:,:]
+                    #mat = v[None,:,:]
                     elx = e_linpred[ix]
-                    xp2 += (mat.T * mat * elx[None,:,None]).sum(1)
+                    #xp2 += (mat.T * mat * elx[None,:,None]).sum(1)
+                    xp2 += np.einsum("ij,ik,i->jk", v, v, elx)
 
                 # Account for all cases that fail at this point.
                 m = len(uft_ix[i])
@@ -813,10 +814,10 @@ class PHReg(model.LikelihoodModel):
                     xp0 -= e_linpred[ix].sum()
                     v = exog_s[ix,:]
                     xp1 -= (e_linpred[ix][:,None] * v).sum(0)
-                    mat = v[None,:,:]
+                    #mat = v[None,:,:]
                     elx = e_linpred[ix]
-                    xp2 -= (mat.T * mat * elx[None,:,None]).sum(1)
-
+                    #xp2 -= (mat.T * mat * elx[None,:,None]).sum(1)
+                    xp2 -= np.einsum("ij,ik,i->jk", v, v, elx)
         return -hess
 
     def efron_hessian(self, params):

--- a/statsmodels/duration/hazard_regression.py
+++ b/statsmodels/duration/hazard_regression.py
@@ -799,9 +799,7 @@ class PHReg(model.LikelihoodModel):
                     xp0 += e_linpred[ix].sum()
                     v = exog_s[ix,:]
                     xp1 += (e_linpred[ix][:,None] * v).sum(0)
-                    #mat = v[None,:,:]
                     elx = e_linpred[ix]
-                    #xp2 += (mat.T * mat * elx[None,:,None]).sum(1)
                     xp2 += np.einsum("ij,ik,i->jk", v, v, elx)
 
                 # Account for all cases that fail at this point.
@@ -814,9 +812,7 @@ class PHReg(model.LikelihoodModel):
                     xp0 -= e_linpred[ix].sum()
                     v = exog_s[ix,:]
                     xp1 -= (e_linpred[ix][:,None] * v).sum(0)
-                    #mat = v[None,:,:]
                     elx = e_linpred[ix]
-                    #xp2 -= (mat.T * mat * elx[None,:,None]).sum(1)
                     xp2 -= np.einsum("ij,ik,i->jk", v, v, elx)
         return -hess
 
@@ -855,28 +851,25 @@ class PHReg(model.LikelihoodModel):
                     xp0 += e_linpred[ix].sum()
                     v = exog_s[ix,:]
                     xp1 += (e_linpred[ix][:,None] * v).sum(0)
-                    mat = v[None,:,:]
                     elx = e_linpred[ix]
-                    xp2 += (mat.T * mat * elx[None,:,None]).sum(1)
+                    xp2 += np.einsum("ij,ik,i->jk", v, v, elx)
 
                 ixf = uft_ix[i]
                 if len(ixf) > 0:
                     v = exog_s[ixf,:]
                     xp0f = e_linpred[ixf].sum()
                     xp1f = (e_linpred[ixf][:,None] * v).sum(0)
-                    mat = v[None,:,:]
                     elx = e_linpred[ixf]
-                    xp2f = (mat.T * mat * elx[None,:,None]).sum(1)
+                    xp2f = np.einsum("ij,ik,i->jk", v, v, elx)
 
                 # Account for all cases that fail at this point.
                 m = len(uft_ix[i])
                 J = np.arange(m, dtype=np.float64) / m
                 c0 = xp0 - J*xp0f
-                mat = (xp2[None,:,:] - J[:,None,None]*xp2f) / c0[:,None,None]
-                hess += mat.sum(0)
+                hess += xp2 * np.sum(1 / c0)
+                hess -= xp2f * np.sum(J / c0)
                 mat = (xp1[None, :] - np.outer(J, xp1f)) / c0[:, None]
-                mat = mat[:, :, None] * mat[:, None, :]
-                hess -= mat.sum(0)
+                hess -= np.einsum("ij,ik->jk", mat, mat)
 
                 # Update for new cases entering the risk set.
                 ix = surv.risk_exit[stx][i]
@@ -884,9 +877,8 @@ class PHReg(model.LikelihoodModel):
                     xp0 -= e_linpred[ix].sum()
                     v = exog_s[ix,:]
                     xp1 -= (e_linpred[ix][:,None] * v).sum(0)
-                    mat = v[None,:,:]
                     elx = e_linpred[ix]
-                    xp2 -= (mat.T * mat * elx[None,:,None]).sum(1)
+                    xp2 -= np.einsum("ij,ik,i->jk", v, v, elx)
 
         return -hess
 

--- a/statsmodels/duration/tests/test_phreg.py
+++ b/statsmodels/duration/tests/test_phreg.py
@@ -225,15 +225,16 @@ class TestPHReg(object):
         status = np.random.randint(0, 2, 200).astype(np.float64)
         exog = np.random.normal(size=(200,4))
 
-        mod1 = PHReg(time, exog, status)
-        rslt1 = mod1.fit()
-        offset = exog[:,0] * rslt1.params[0]
-        exog = exog[:, 1:]
+        for ties in "breslow", "efron":
+            mod1 = PHReg(time, exog, status)
+            rslt1 = mod1.fit()
+            offset = exog[:,0] * rslt1.params[0]
+            exog = exog[:, 1:]
 
-        mod2 = PHReg(time, exog, status, offset=offset)
-        rslt2 = mod2.fit()
+            mod2 = PHReg(time, exog, status, offset=offset)
+            rslt2 = mod2.fit()
 
-        assert_allclose(rslt2.params, rslt1.params[1:])
+            assert_allclose(rslt2.params, rslt1.params[1:])
 
     def test_post_estimation(self):
         # All regression tests


### PR DESCRIPTION
The broadcasting approach creates all the outer products first then reduces them by summation.  For large datasets we encountered memory errors when there wasn't enough room to store the broadcasted matrix.

The einsum approach resolves the memory problem, but I expected it to be slower for small data sets.  But actually it seems to be about 2x faster, so win-win, at least in the checking I have done.

There is possible further improvement using the `out` parameter of einsum, but I will not get to that now.

(edited for clarity)