### PR TITLE
BUG: TSA models if date index without known frequency

### DIFF
--- a/statsmodels/tsa/base/tests/test_base.py
+++ b/statsmodels/tsa/base/tests/test_base.py
@@ -1,7 +1,7 @@
 import numpy as np
 import numpy.testing as npt
 import pandas as pd
-
+from statsmodels.tsa.base.datetools import _freq_to_pandas
 from statsmodels.tsa.base.tsa_model import TimeSeriesModel
 from statsmodels.tools.testing import assert_equal
 
@@ -16,12 +16,21 @@ def test_pandas_nodates_index():
 
     # Test with a non-date index that doesn't raise an exception because it
     # can be coerced into a nanosecond DatetimeIndex
-    data = [988, 819, 964]
-    s = pd.Series(data)
-    mod = TimeSeriesModel(s)
-    start = mod._get_predict_start(0)
-    end, out_of_sample = mod._get_predict_end(4)
-    mod._make_predict_dates()
+    # (This test doesn't make sense for Numpy < 1.7 since they don't have
+    # nanosecond support)
+    try:
+        _freq_to_pandas['N']
+    except:
+        pass
+    else:
+        data = [988, 819, 964]
+        # index=pd.date_range('1970-01-01', periods=3, freq='QS')
+        s = pd.Series(data)
+        mod = TimeSeriesModel(s)
+        start = mod._get_predict_start(0)
+        end, out_of_sample = mod._get_predict_end(4)
+        mod._make_predict_dates()
+        assert_equal(len(mod.data.predict_dates), 5)
 
 def test_predict_freq():
     # test that predicted dates have same frequency

--- a/statsmodels/tsa/base/tests/test_base.py
+++ b/statsmodels/tsa/base/tests/test_base.py
@@ -3,7 +3,7 @@ import numpy.testing as npt
 import pandas as pd
 from statsmodels.tsa.base.datetools import _freq_to_pandas
 from statsmodels.tsa.base.tsa_model import TimeSeriesModel
-from statsmodels.tools.testing import assert_equal
+from statsmodels.tools.testing import assert_equal, assert_raises
 
 
 def test_pandas_nodates_index():
@@ -21,25 +21,29 @@ def test_pandas_nodates_index():
     # (This test also doesn't make sense for Pandas < 0.14 since we don't
     # support nanosecond index in Pandas < 0.14)
     try:
+        # Check for Numpy < 1.7
         _freq_to_pandas['N']
-        from pandas import version
-        if version.version < '0.14':
-            raise NotImplementedError
     except:
         pass
     else:
         data = [988, 819, 964]
         # index=pd.date_range('1970-01-01', periods=3, freq='QS')
         index = pd.to_datetime([100, 101, 102])
-        actual_str = (index[0].strftime('%Y-%m-%d %H:%M:%S.%f') +
-                      str(index[0].value))
-        assert_equal(actual_str, '1970-01-01 00:00:00.000000100')
         s = pd.Series(data, index=index)
-        mod = TimeSeriesModel(s)
-        start = mod._get_predict_start(0)
-        end, out_of_sample = mod._get_predict_end(4)
-        mod._make_predict_dates()
-        assert_equal(len(mod.data.predict_dates), 5)
+
+        # Alternate test for Pandas < 0.14
+        from pandas import version
+        if version.version < '0.14':
+            assert_raises(NotImplementedError, TimeSeriesModel, s)
+        else:
+            actual_str = (index[0].strftime('%Y-%m-%d %H:%M:%S.%f') +
+                          str(index[0].value))
+            assert_equal(actual_str, '1970-01-01 00:00:00.000000100')
+            mod = TimeSeriesModel(s)
+            start = mod._get_predict_start(0)
+            end, out_of_sample = mod._get_predict_end(4)
+            mod._make_predict_dates()
+            assert_equal(len(mod.data.predict_dates), 5)
 
 def test_predict_freq():
     # test that predicted dates have same frequency

--- a/statsmodels/tsa/base/tests/test_base.py
+++ b/statsmodels/tsa/base/tests/test_base.py
@@ -32,8 +32,9 @@ def test_pandas_nodates_index():
         s = pd.Series(data, index=index)
 
         # Alternate test for Pandas < 0.14
+        from distutils.version import LooseVersion
         from pandas import __version__ as pd_version
-        if pd_version < '0.14':
+        if LooseVersion(pd_version) < '0.14':
             assert_raises(NotImplementedError, TimeSeriesModel, s)
         else:
             actual_str = (index[0].strftime('%Y-%m-%d %H:%M:%S.%f') +

--- a/statsmodels/tsa/base/tests/test_base.py
+++ b/statsmodels/tsa/base/tests/test_base.py
@@ -14,6 +14,15 @@ def test_pandas_nodates_index():
 
     npt.assert_raises(ValueError, TimeSeriesModel, s)
 
+    # Test with a non-date index that doesn't raise an exception because it
+    # can be coerced into a nanosecond DatetimeIndex
+    data = [988, 819, 964]
+    s = pd.Series(data)
+    mod = TimeSeriesModel(s)
+    start = mod._get_predict_start(0)
+    end, out_of_sample = mod._get_predict_end(4)
+    mod._make_predict_dates()
+
 def test_predict_freq():
     # test that predicted dates have same frequency
     x = np.arange(1,36.)

--- a/statsmodels/tsa/base/tests/test_base.py
+++ b/statsmodels/tsa/base/tests/test_base.py
@@ -18,15 +18,22 @@ def test_pandas_nodates_index():
     # can be coerced into a nanosecond DatetimeIndex
     # (This test doesn't make sense for Numpy < 1.7 since they don't have
     # nanosecond support)
+    # (This test also doesn't make sense for Pandas < 0.14 since we don't
+    # support nanosecond index in Pandas < 0.14)
     try:
         _freq_to_pandas['N']
+        from pandas import version
+        if version.version < '0.14':
+            raise NotImplementedError
     except:
         pass
     else:
         data = [988, 819, 964]
         # index=pd.date_range('1970-01-01', periods=3, freq='QS')
         index = pd.to_datetime([100, 101, 102])
-        assert_equal(str(index[0]), '1970-01-01 00:00:00.000000100')
+        actual_str = (index[0].strftime('%Y-%m-%d %H:%M:%S.%f') +
+                      str(index[0].value))
+        assert_equal(actual_str, '1970-01-01 00:00:00.000000100')
         s = pd.Series(data, index=index)
         mod = TimeSeriesModel(s)
         start = mod._get_predict_start(0)

--- a/statsmodels/tsa/base/tests/test_base.py
+++ b/statsmodels/tsa/base/tests/test_base.py
@@ -25,7 +25,9 @@ def test_pandas_nodates_index():
     else:
         data = [988, 819, 964]
         # index=pd.date_range('1970-01-01', periods=3, freq='QS')
-        s = pd.Series(data)
+        index = pd.to_datetime([100, 101, 102])
+        assert_equal(str(index[0]), '1970-01-01 00:00:00.000000100')
+        s = pd.Series(data, index=index)
         mod = TimeSeriesModel(s)
         start = mod._get_predict_start(0)
         end, out_of_sample = mod._get_predict_end(4)

--- a/statsmodels/tsa/base/tests/test_base.py
+++ b/statsmodels/tsa/base/tests/test_base.py
@@ -32,8 +32,8 @@ def test_pandas_nodates_index():
         s = pd.Series(data, index=index)
 
         # Alternate test for Pandas < 0.14
-        from pandas import version
-        if version.version < '0.14':
+        from pandas import __version__ as pd_version
+        if pd_version < '0.14':
             assert_raises(NotImplementedError, TimeSeriesModel, s)
         else:
             actual_str = (index[0].strftime('%Y-%m-%d %H:%M:%S.%f') +

--- a/statsmodels/tsa/base/tsa_model.py
+++ b/statsmodels/tsa/base/tsa_model.py
@@ -73,8 +73,9 @@ class TimeSeriesModel(base.LikelihoodModel):
 
         # Test for nanoseconds in early pandas versions
         if freq is not None and _freq_to_pandas[freq].freqstr == 'N':
+            from distutils.version import LooseVersion
             from pandas import __version__ as pd_version
-            if pd_version < '0.14':
+            if LooseVersion(pd_version) < '0.14':
                 raise NotImplementedError('Nanosecond index not available in'
                                           ' Pandas < 0.14')
 

--- a/statsmodels/tsa/base/tsa_model.py
+++ b/statsmodels/tsa/base/tsa_model.py
@@ -71,6 +71,14 @@ class TimeSeriesModel(base.LikelihoodModel):
         self.data.dates = dates
         self.data.freq = freq
 
+        # Test for nanoseconds in early pandas versions
+        if freq is not None and _freq_to_pandas[freq].freqstr == 'N':
+            from pandas import version
+            if version.version < '0.14':
+                raise NotImplementedError('Nanosecond index not available in'
+                                          ' Pandas < 0.14')
+
+
     def _get_exog_names(self):
         return self.data.xnames
 

--- a/statsmodels/tsa/base/tsa_model.py
+++ b/statsmodels/tsa/base/tsa_model.py
@@ -3,7 +3,7 @@ from statsmodels.compat.pandas import is_numeric_dtype
 
 import datetime
 
-from pandas import to_datetime, DatetimeIndex, Period, PeriodIndex
+from pandas import to_datetime, DatetimeIndex, Period, PeriodIndex, Timestamp
 
 from statsmodels.base import data
 import statsmodels.base.model as base
@@ -235,6 +235,13 @@ class TimeSeriesModel(base.LikelihoodModel):
             dates = self.data.dates.__class__(start=dtstart,
                                               end=dtend,
                                               freq=pandas_freq)
+            if not dates[-1] == dtend and pandas_freq == 'N':
+                # TODO: this is a hack because a DatetimeIndex with
+                # nanosecond frequency does not include "end"
+                dtend = Timestamp(dtend.value + 1)
+                dates = self.data.dates.__class__(start=dtstart,
+                                                  end=dtend,
+                                                  freq=pandas_freq)
         # handle
         elif freq is None and (isinstance(dtstart, (int, long)) and
                                isinstance(dtend, (int, long))):

--- a/statsmodels/tsa/base/tsa_model.py
+++ b/statsmodels/tsa/base/tsa_model.py
@@ -73,8 +73,8 @@ class TimeSeriesModel(base.LikelihoodModel):
 
         # Test for nanoseconds in early pandas versions
         if freq is not None and _freq_to_pandas[freq].freqstr == 'N':
-            from pandas import version
-            if version.version < '0.14':
+            from pandas import __version__ as pd_version
+            if pd_version < '0.14':
                 raise NotImplementedError('Nanosecond index not available in'
                                           ' Pandas < 0.14')
 

--- a/statsmodels/tsa/base/tsa_model.py
+++ b/statsmodels/tsa/base/tsa_model.py
@@ -235,13 +235,18 @@ class TimeSeriesModel(base.LikelihoodModel):
             dates = self.data.dates.__class__(start=dtstart,
                                               end=dtend,
                                               freq=pandas_freq)
-            if not dates[-1] == dtend and pandas_freq == 'N':
-                # TODO: this is a hack because a DatetimeIndex with
-                # nanosecond frequency does not include "end"
-                dtend = Timestamp(dtend.value + 1)
-                dates = self.data.dates.__class__(start=dtstart,
-                                                  end=dtend,
-                                                  freq=pandas_freq)
+
+            if pandas_freq.freqstr == 'N':
+                _dtend = dtend
+                if isinstance(dates[-1], Period):
+                    _dtend = pd.to_datetime(_dtend).to_period(dates.freq)
+                if not dates[-1] == _dtend:
+                    # TODO: this is a hack because a DatetimeIndex with
+                    # nanosecond frequency does not include "end"
+                    dtend = Timestamp(dtend.value + 1)
+                    dates = self.data.dates.__class__(start=dtstart,
+                                                      end=dtend,
+                                                      freq=pandas_freq)
         # handle
         elif freq is None and (isinstance(dtstart, (int, long)) and
                                isinstance(dtend, (int, long))):


### PR DESCRIPTION
Closes #3068.

Puts a shim in to allow correctly creating the `DatetimeIndex` in the nanosecond case.