### PR TITLE
Key defined twice

### DIFF
--- a/statsmodels/tsa/statespace/sarimax.py
+++ b/statsmodels/tsa/statespace/sarimax.py
@@ -1713,7 +1713,6 @@ class SARIMAXResults(MLEResults):
             'k_seasons': self.model.k_seasons,
             'measurement_error': self.model.measurement_error,
             'time_varying_regression': self.model.time_varying_regression,
-            'mle_regression': self.model.mle_regression,
             'simple_differencing': self.model.simple_differencing,
             'enforce_stationarity': self.model.enforce_stationarity,
             'enforce_invertibility': self.model.enforce_invertibility,


### PR DESCRIPTION
Nothing big, this exact key is defined about ten lines down in the same dict.

Noticed this while browsing for a good place to insert the BoxCox mixin.