### PR TITLE
ENH: Allow MixedLM to work with Mediation

### DIFF
--- a/statsmodels/base/data.py
+++ b/statsmodels/base/data.py
@@ -213,6 +213,9 @@ class ModelData(object):
         combined_2d_names = []
         if len(kwargs):
             for key, value_array in iteritems(kwargs):
+                if not hasattr(value_array, 'ndim'):
+                    none_array_names += [key]
+                    continue
                 if value_array is None or value_array.ndim == 0:
                     none_array_names += [key]
                     continue

--- a/statsmodels/base/data.py
+++ b/statsmodels/base/data.py
@@ -213,9 +213,6 @@ class ModelData(object):
         combined_2d_names = []
         if len(kwargs):
             for key, value_array in iteritems(kwargs):
-                if not hasattr(value_array, 'ndim'):
-                    none_array_names += [key]
-                    continue
                 if value_array is None or value_array.ndim == 0:
                     none_array_names += [key]
                     continue

--- a/statsmodels/regression/mixed_linear_model.py
+++ b/statsmodels/regression/mixed_linear_model.py
@@ -628,9 +628,10 @@ class MixedLM(base.LikelihoodModel):
 
         # Calling super creates self.endog, etc. as ndarrays and the
         # original exog, endog, etc. are self.data.endog, etc.
-        kwargs.update({"groups": groups, "exog_re": exog_re, "exog_vc": exog_vc,
+        kwargs.update({"groups": groups, "exog_re": exog_re,
                        'missing': missing})
         super(MixedLM, self).__init__(endog, exog, **kwargs)
+        kwargs["exog_vc"] = exog_vc
 
         self._init_keys.extend(["use_sqrt", "exog_vc"])
 

--- a/statsmodels/regression/mixed_linear_model.py
+++ b/statsmodels/regression/mixed_linear_model.py
@@ -1010,9 +1010,10 @@ class MixedLM(base.LikelihoodModel):
 
                 if model.k_re > 0:
                     z0 = np.zeros(params.cov_re.shape[0])
-                    rv += np.random.multivariate_normal(
+                    mv = np.random.multivariate_normal(
                         mean=z0, cov=params.cov_re,
-                        size=model.nobs).sum(1)
+                        size=model.nobs)
+                    rv += mv.sum(1)
 
                 if model.k_vc > 0:
                     ix = model.row_indices
@@ -1023,6 +1024,8 @@ class MixedLM(base.LikelihoodModel):
                             mat = model.exog_vc[a][la]
                             r = np.sqrt(params.vcomp[j]) * np.random.normal(mat.shape[1])
                             rv[i] += (mat * r).sum(1)
+
+                rv += np.sqrt(scale) * np.random.normal(size=len(rv))
 
                 return rv
 

--- a/statsmodels/regression/tests/test_lme.py
+++ b/statsmodels/regression/tests/test_lme.py
@@ -770,7 +770,6 @@ def test_get_distribution():
                 kwargs["exog_vc"] = exog_vc
             model = MixedLM(y, exog, groups=groups, **kwargs)
             result = model.fit()
-            print(result.summary())
             gen = model.get_distribution(params=result.params, scale=result.scale)
             gen.rvs(1) # smoke test
 


### PR DESCRIPTION
This PR permits at least a subset of `MixedLM` models to be used with `Mediation`.  The main addition is `get_distribution` for `MixedLM`.  I also needed to change some kwarg handling in `MixedLM`.  ~~Finally, I needed to add a check in the missing data handling routines to pass over non-arrays (`exog_vc` slips through to the `ModelData` handler but cannot be processed as an ndarray).~~

To use mediation with MixedLM at this point, variance components should not be used, and the `bootstrap` (not the default `parametric`) method for mediation should be used.  We can probably find a way to make `vcomp` work with bootstrap and make `parametric` work but I don't want to go there right now.

Edit: don't need to modify missing data routines after all.
