### PR TITLE
BUG: Statespace: Summary fails if diagnostic tests fail

### DIFF
--- a/statsmodels/tsa/statespace/mlemodel.py
+++ b/statsmodels/tsa/statespace/mlemodel.py
@@ -2598,9 +2598,18 @@ class MLEResults(tsbase.TimeSeriesModelResults):
             model_name = model.__class__.__name__
 
         # Diagnostic tests results
-        het = self.test_heteroskedasticity(method='breakvar')
-        lb = self.test_serial_correlation(method='ljungbox')
-        jb = self.test_normality(method='jarquebera')
+        try:
+            het = self.test_heteroskedasticity(method='breakvar')
+        except:
+            het = np.array([[np.nan]*2])
+        try:
+            lb = self.test_serial_correlation(method='ljungbox')
+        except:
+            lb = np.array([[np.nan]*2]).reshape(1, 2, 1)
+        try:
+            jb = self.test_normality(method='jarquebera')
+        except:
+            jb = np.array([[np.nan]*4])
 
         # Create the tables
         if not isinstance(model_name, list):

--- a/statsmodels/tsa/statespace/tests/test_mlemodel.py
+++ b/statsmodels/tsa/statespace/tests/test_mlemodel.py
@@ -488,6 +488,10 @@ def test_summary():
     # Smoke test that summary still works when diagnostic tests fail
     res.filter_results._standardized_forecasts_error[:] = np.nan
     res.summary()
+    res.filter_results._standardized_forecasts_error = 1
+    res.summary()
+    res.filter_results._standardized_forecasts_error = 'a'
+    res.summary()
 
 
 def check_endog(endog, nobs=2, k_endog=1, **kwargs):

--- a/statsmodels/tsa/statespace/tests/test_mlemodel.py
+++ b/statsmodels/tsa/statespace/tests/test_mlemodel.py
@@ -485,6 +485,10 @@ def test_summary():
     # Test res.summary when `model_name` was not provided
     assert_equal(re.search('Model:\s+MLEModel', txt) is not None, True)
 
+    # Smoke test that summary still works when diagnostic tests fail
+    res.filter_results._standardized_forecasts_error[:] = np.nan
+    res.summary()
+
 
 def check_endog(endog, nobs=2, k_endog=1, **kwargs):
     # create the model


### PR DESCRIPTION
Currently if a diagnostic test fails during a `summary` call, the exception is passed through. This PR catches the exception and displays the summary, where the failing test statistics are replaced by `nan`.