### PR TITLE
BUG: base.Results.predict, handle nan index with formula

### DIFF
--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -764,7 +764,14 @@ class Results(object):
         if transform and hasattr(self.model, 'formula') and exog is not None:
             from patsy import dmatrix
             exog = dmatrix(self.model.data.design_info.builder,
-                           exog)
+                           exog, return_type="dataframe")
+            if len(exog) < len(exog_index):
+                # missing values, rows have been dropped
+                if exog_index is not None:
+                    exog = exog.reindex(exog_index)
+                else:
+                    import warnings
+                    warnings.warn("nan rows have been dropped", ValueWarning)
 
         if exog is not None:
             exog = np.asarray(exog)

--- a/statsmodels/base/tests/test_generic_methods.py
+++ b/statsmodels/base/tests/test_generic_methods.py
@@ -445,7 +445,13 @@ class TestWaldAnovaOLSF(CheckAnovaMixin):
         ex.iloc[0, 1] = np.nan
         predicted1 = self.res.predict(ex)
         predicted2 = self.res.predict(ex[1:])
-        from pandas.util.testing import assert_series_equal, assert_index_equal
+        from pandas.util.testing import assert_series_equal
+        try:
+            from pandas.util.testing import assert_index_equal
+        except ImportError:
+            # for old pandas
+            from numpy.testing import assert_array_equal as assert_index_equal
+
         assert_index_equal(predicted1.index, ex.index)
         assert_series_equal(predicted1[1:], predicted2)
         assert_equal(predicted1.values[0], np.nan)

--- a/statsmodels/base/tests/test_generic_methods.py
+++ b/statsmodels/base/tests/test_generic_methods.py
@@ -440,6 +440,17 @@ class TestWaldAnovaOLSF(CheckAnovaMixin):
         cls.res = mod.fit()  # default use_t=True
 
 
+    def test_predict_missing(self):
+        ex = self.data[:5].copy()
+        ex.iloc[0, 1] = np.nan
+        predicted1 = self.res.predict(ex)
+        predicted2 = self.res.predict(ex[1:])
+        from pandas.util.testing import assert_series_equal, assert_index_equal
+        assert_index_equal(predicted1.index, ex.index)
+        assert_series_equal(predicted1[1:], predicted2)
+        assert_equal(predicted1.values[0], np.nan)
+
+
 class TestWaldAnovaGLM(CheckAnovaMixin):
 
     @classmethod


### PR DESCRIPTION
closes #3087

solution: reindex to original exog after patsy has removed rows with missing
Considered as a bugfix, with backwards incompatibility in the formula-missing case.

needs update of release notes.