### PR TITLE
ENH: Add significance test for elastic_net

### DIFF
--- a/statsmodels/base/elastic_net.py
+++ b/statsmodels/base/elastic_net.py
@@ -1,4 +1,4 @@
-from scipy.stats import f
+from scipy.stats import f, exp
 import numpy as np
 from statsmodels.stats.contrast import CovTestResults
 from statsmodels.base.model import Results

--- a/statsmodels/stats/contrast.py
+++ b/statsmodels/stats/contrast.py
@@ -409,3 +409,18 @@ class WaldTestResults(object):
 
     def __repr__(self):
         return str(self.__class__) + '\n' + self.__str__()
+
+
+class CovTestResults(object):
+    """a minimal class to hold the results from the cov test
+    for elastic net"""
+
+    def __init__(self, statistic, table=None, pvalues=None):
+
+        self.table = table
+        self.statistic = statistic
+        self.pvalues = self.pvalues
+
+        if table is not None:
+            self.statistic = table["statistic"].values
+            self.pvalues = table["pvalues"].values


### PR DESCRIPTION
This add the basics for handling the cov test described in 

http://statweb.stanford.edu/~tibs/ftp/covtest.pdf

for the elastic_net code.  I'm working on the tests now but I wanted to post this so that people can get a sense of the structure of things.  See the covTest R package for a reference on previous implementations.  @kshedden let me know if you have any thoughts.

One thing to note, this implements a separate CovTestResults class similar to WaldTestResults, at some point it might make sense to do some restructuring with constrast.py in general but that's probably beyond the scope of this PR. 