### PR TITLE
Covtype hacpanel groups

### DIFF
--- a/statsmodels/base/covtype.py
+++ b/statsmodels/base/covtype.py
@@ -99,11 +99,15 @@ def get_robustcov_results(self, cov_type='HC1', use_t=None, **kwds):
     - 'hac-panel' heteroscedasticity and autocorrelation robust standard
         errors in panel data.
         The data needs to be sorted in this case, the time series for
-        each panel unit or cluster need to be stacked.
+        each panel unit or cluster need to be stacked. The membership to
+        a timeseries of an individual or group can be either specified by
+        group indicators or by increasing time periods.
+
         keywords
 
-        - `time` array_like (required) : index of time periods
-
+        - either `groups` or `time` : array_like (required)
+          `groups` : indicator for groups
+          `time` : index of time periods
         - `maxlag` integer (required) : number of lags to use
         - `kernel` string (optional) : kernel, default is Bartlett
         - `use_correction` False or string in ['hac', 'cluster'] (optional) :
@@ -231,7 +235,8 @@ def get_robustcov_results(self, cov_type='HC1', use_t=None, **kwds):
 
     elif cov_type == 'hac-panel':
         #cluster robust standard errors
-        res.cov_kwds['time'] = time = kwds['time']
+        res.cov_kwds['time'] = time = kwds.get('time', None)
+        res.cov_kwds['groups'] = groups = kwds.get('groups', None)
         #TODO: nlags is currently required
         #nlags = kwds.get('nlags', True)
         #res.cov_kwds['nlags'] = nlags
@@ -242,8 +247,16 @@ def get_robustcov_results(self, cov_type='HC1', use_t=None, **kwds):
         weights_func = kwds.get('weights_func', sw.weights_bartlett)
         res.cov_kwds['weights_func'] = weights_func
         # TODO: clumsy time index in cov_nw_panel
-        tt = (np.nonzero(np.diff(time) < 0)[0] + 1).tolist()
-        groupidx = lzip([0] + tt, tt + [len(time)])
+        if groups is not None:
+            tt = (np.nonzero(groups[:-1] != groups[1:])[0] + 1).tolist()
+            nobs_ = len(groups)
+        elif time is not None:
+            # TODO: clumsy time index in cov_nw_panel
+            tt = (np.nonzero(np.diff(time) < 0)[0] + 1).tolist()
+            nobs_ = len(time)
+        else:
+            raise ValueError('either time or groups needs to be given')
+        groupidx = lzip([0] + tt, tt + [nobs_])
         self.n_groups = n_groups = len(groupidx)
         res.cov_params_default = sw.cov_nw_panel(self, maxlags, groupidx,
                                             weights_func=weights_func,

--- a/statsmodels/base/covtype.py
+++ b/statsmodels/base/covtype.py
@@ -252,7 +252,7 @@ def get_robustcov_results(self, cov_type='HC1', use_t=None, **kwds):
             nobs_ = len(groups)
         elif time is not None:
             # TODO: clumsy time index in cov_nw_panel
-            tt = (np.nonzero(np.diff(time) < 0)[0] + 1).tolist()
+            tt = (np.nonzero(time[1:] < time[:-1])[0] + 1).tolist()
             nobs_ = len(time)
         else:
             raise ValueError('either time or groups needs to be given')
@@ -277,7 +277,7 @@ def get_robustcov_results(self, cov_type='HC1', use_t=None, **kwds):
         res.cov_kwds['weights_func'] = weights_func
         if adjust_df:
             # need to find number of groups
-            tt = (np.nonzero(np.diff(time) < 0)[0] + 1)
+            tt = (np.nonzero(time[1:] < time[:-1])[0] + 1)
             self.n_groups = n_groups = len(tt) + 1
         res.cov_params_default = sw.cov_nw_groupsum(self, maxlags, time,
                                         weights_func=weights_func,

--- a/statsmodels/base/covtype.py
+++ b/statsmodels/base/covtype.py
@@ -167,7 +167,7 @@ def get_robustcov_results(self, cov_type='HC1', use_t=None, **kwds):
     # TODO: this should be outsourced in a function so we can reuse it in
     #       other models
     # TODO: make it DRYer   repeated code for checking kwds
-    if cov_type in ('HC0', 'HC1', 'HC2', 'HC3'):
+    if cov_type.upper() in ('HC0', 'HC1', 'HC2', 'HC3'):
         if kwds:
             raise ValueError('heteroscedasticity robust covarians ' +
                              'does not use keywords')
@@ -179,7 +179,7 @@ def get_robustcov_results(self, cov_type='HC1', use_t=None, **kwds):
             # results classes that don't have cov_HCx attribute
             res.cov_params_default = sw.cov_white_simple(self,
                                                          use_correction=False)
-    elif cov_type == 'HAC':
+    elif cov_type.lower() == 'hac':
         maxlags = kwds['maxlags']   # required?, default in cov_hac_simple
         res.cov_kwds['maxlags'] = maxlags
         weights_func = kwds.get('weights_func', sw.weights_bartlett)
@@ -193,7 +193,7 @@ def get_robustcov_results(self, cov_type='HC1', use_t=None, **kwds):
         res.cov_params_default = sw.cov_hac_simple(self, nlags=maxlags,
                                              weights_func=weights_func,
                                              use_correction=use_correction)
-    elif cov_type == 'cluster':
+    elif cov_type.lower() == 'cluster':
         #cluster robust standard errors, one- or two-way
         groups = kwds['groups']
         if not hasattr(groups, 'shape'):
@@ -233,7 +233,7 @@ def get_robustcov_results(self, cov_type='HC1', use_t=None, **kwds):
         res.cov_kwds['description'] = ('Standard Errors are robust to' +
                             'cluster correlation ' + '(' + cov_type + ')')
 
-    elif cov_type == 'hac-panel':
+    elif cov_type.lower() == 'hac-panel':
         #cluster robust standard errors
         res.cov_kwds['time'] = time = kwds.get('time', None)
         res.cov_kwds['groups'] = groups = kwds.get('groups', None)
@@ -263,7 +263,7 @@ def get_robustcov_results(self, cov_type='HC1', use_t=None, **kwds):
                                             use_correction=use_correction)
         res.cov_kwds['description'] = ('Standard Errors are robust to' +
                             'cluster correlation ' + '(' + cov_type + ')')
-    elif cov_type == 'hac-groupsum':
+    elif cov_type.lower() == 'hac-groupsum':
         # Driscoll-Kraay standard errors
         res.cov_kwds['time'] = time = kwds['time']
         #TODO: nlags is currently required

--- a/statsmodels/discrete/tests/test_sandwich_cov.py
+++ b/statsmodels/discrete/tests/test_sandwich_cov.py
@@ -653,7 +653,6 @@ class TestGLMGaussHACPanelGroups(CheckDiscreteGLM):
                     use_correction='hac',
                     df_correction=False)
         cls.res1 = mod1.fit(cov_type='hac-panel', cov_kwds=kwds)
-        cls.res1b = mod1.fit(cov_type='nw-panel', cov_kwds=kwds)
 
         mod2 = OLS(endog, exog)
         cls.res2 = mod2.fit(cov_type='hac-panel', cov_kwds=kwds)

--- a/statsmodels/discrete/tests/test_sandwich_cov.py
+++ b/statsmodels/discrete/tests/test_sandwich_cov.py
@@ -619,7 +619,6 @@ class TestGLMGaussHACPanel(CheckDiscreteGLM):
 
     @classmethod
     def setup_class(cls):
-        import statsmodels.stats.sandwich_covariance as sw
         cls.cov_type = 'hac-panel'
         # time index is just made up to have a test case
         time = np.tile(np.arange(7), 5)[:-1]
@@ -638,6 +637,26 @@ class TestGLMGaussHACPanel(CheckDiscreteGLM):
     def test_kwd(self):
         # test corrected keyword name
         assert_allclose(self.res1b.bse, self.res1.bse, rtol=1e-12)
+
+
+class TestGLMGaussHACPanelGroups(CheckDiscreteGLM):
+
+    @classmethod
+    def setup_class(cls):
+        cls.cov_type = 'hac-panel'
+        # time index is just made up to have a test case
+        groups = np.repeat(np.arange(5), 7)[:-1]
+        mod1 = GLM(endog.copy(), exog.copy(), family=families.Gaussian())
+        kwds = dict(groups=groups,
+                    maxlags=2,
+                    kernel=sw.weights_uniform,
+                    use_correction='hac',
+                    df_correction=False)
+        cls.res1 = mod1.fit(cov_type='hac-panel', cov_kwds=kwds)
+        cls.res1b = mod1.fit(cov_type='nw-panel', cov_kwds=kwds)
+
+        mod2 = OLS(endog, exog)
+        cls.res2 = mod2.fit(cov_type='hac-panel', cov_kwds=kwds)
 
 
 class TestGLMGaussHACGroupsum(CheckDiscreteGLM):

--- a/statsmodels/regression/linear_model.py
+++ b/statsmodels/regression/linear_model.py
@@ -1973,7 +1973,7 @@ class RegressionResults(base.LikelihoodModelResults):
 
             res.cov_kwds['scale'] = scale = kwds.get('scale', 1.)
             res.cov_params_default = scale * res.normalized_cov_params
-        elif cov_type in ('HC0', 'HC1', 'HC2', 'HC3'):
+        elif cov_type.upper() in ('HC0', 'HC1', 'HC2', 'HC3'):
             if kwds:
                 raise ValueError('heteroscedasticity robust covarians ' +
                                  'does not use keywords')
@@ -1982,7 +1982,7 @@ class RegressionResults(base.LikelihoodModelResults):
             # TODO cannot access cov without calling se first
             getattr(self, cov_type.upper() + '_se')
             res.cov_params_default = getattr(self, 'cov_' + cov_type.upper())
-        elif cov_type == 'HAC':
+        elif cov_type.lower() == 'hac':
             maxlags = kwds['maxlags']   # required?, default in cov_hac_simple
             res.cov_kwds['maxlags'] = maxlags
             weights_func = kwds.get('weights_func', sw.weights_bartlett)
@@ -1996,7 +1996,7 @@ class RegressionResults(base.LikelihoodModelResults):
             res.cov_params_default = sw.cov_hac_simple(self, nlags=maxlags,
                                                  weights_func=weights_func,
                                                  use_correction=use_correction)
-        elif cov_type == 'cluster':
+        elif cov_type.lower() == 'cluster':
             #cluster robust standard errors, one- or two-way
             groups = kwds['groups']
             if not hasattr(groups, 'shape'):
@@ -2036,7 +2036,7 @@ class RegressionResults(base.LikelihoodModelResults):
             res.cov_kwds['description'] = ('Standard Errors are robust to' +
                                 'cluster correlation ' + '(' + cov_type + ')')
 
-        elif cov_type == 'hac-panel':
+        elif cov_type.lower() == 'hac-panel':
             #cluster robust standard errors
             res.cov_kwds['time'] = time = kwds.get('time', None)
             res.cov_kwds['groups'] = groups = kwds.get('groups', None)
@@ -2065,7 +2065,7 @@ class RegressionResults(base.LikelihoodModelResults):
                                                 use_correction=use_correction)
             res.cov_kwds['description'] = ('Standard Errors are robust to' +
                                 'cluster correlation ' + '(' + cov_type + ')')
-        elif cov_type == 'hac-groupsum':
+        elif cov_type.lower() == 'hac-groupsum':
             # Driscoll-Kraay standard errors
             res.cov_kwds['time'] = time = kwds['time']
             #TODO: nlags is currently required

--- a/statsmodels/regression/linear_model.py
+++ b/statsmodels/regression/linear_model.py
@@ -2054,7 +2054,7 @@ class RegressionResults(base.LikelihoodModelResults):
                 nobs_ = len(groups)
             elif time is not None:
                 # TODO: clumsy time index in cov_nw_panel
-                tt = (np.nonzero(np.diff(time) < 0)[0] + 1).tolist()
+                tt = (np.nonzero(time[1:] < time[:-1])[0] + 1).tolist()
                 nobs_ = len(time)
             else:
                 raise ValueError('either time or groups needs to be given')
@@ -2079,7 +2079,7 @@ class RegressionResults(base.LikelihoodModelResults):
             res.cov_kwds['weights_func'] = weights_func
             if adjust_df:
                 # need to find number of groups
-                tt = (np.nonzero(np.diff(time) < 0)[0] + 1)
+                tt = (np.nonzero(time[1:] < time[:-1])[0] + 1)
                 self.n_groups = n_groups = len(tt) + 1
             res.cov_params_default = sw.cov_nw_groupsum(self, maxlags, time,
                                             weights_func=weights_func,

--- a/statsmodels/regression/tests/test_robustcov.py
+++ b/statsmodels/regression/tests/test_robustcov.py
@@ -605,6 +605,32 @@ class TestOLSRobustClusterNWP(CheckOLSRobustCluster, CheckOLSRobustNewMixin):
         assert_allclose(res_ols.bse, self.res1.bse, rtol=1e-12)
 
 
+class TestOLSRobustClusterNWPGroupsFit(CheckOLSRobustCluster, CheckOLSRobustNewMixin):
+    # compare with `reg cluster`
+
+    def setup(self):
+        res_ols = self.res1.model.fit(cov_type='nw-panel',
+                                      cov_kwds = dict(groups=self.groups,
+                                                      maxlags=4,
+                                                      use_correction='hac',
+                                                      use_t=True,
+                                                      df_correction=False))
+        self.res3 = self.res1
+        self.res1 = res_ols
+        self.bse_robust = res_ols.bse
+        self.cov_robust = res_ols.cov_params()
+        cov1 = sw.cov_nw_panel(self.res1, 4, self.tidx)
+        se1 =  sw.se_cov(cov1)
+        self.bse_robust2 = se1
+        self.cov_robust2 = cov1
+        self.small = True
+        self.res2 = res2.results_nw_panel4
+
+        self.skip_f = True
+        self.rtol = 1e-6
+        self.rtolh = 1e-10
+
+
 # TODO: low precision/agreement
 class TestOLSRobustCluster2G(CheckOLSRobustCluster, CheckOLSRobustNewMixin):
     # compare with `reg cluster`


### PR DESCRIPTION
closes #3155

`cov_type='hac_panel'` allow groups instead of time to specify panel units

adds also case insensitivity to cov_type keyword

I didn't check if `hac-groupsum' can be similarly changed. Without checking the details again, I think it's not possible because we need the time index to aggregate for contemporaneous correlation.