### PR TITLE
BUG: fix GLM resid_working

### DIFF
--- a/statsmodels/genmod/generalized_linear_model.py
+++ b/statsmodels/genmod/generalized_linear_model.py
@@ -1309,7 +1309,7 @@ class GLMResults(base.LikelihoodModelResults):
     @cache_readonly
     def resid_working(self):
         # Isn't self.resid_response is already adjusted by _n_trials?
-        val = (self.resid_response / self.family.link.deriv(self.mu))
+        val = (self.resid_response * self.family.link.deriv(self.mu))
         val *= self._n_trials
         return val
 

--- a/statsmodels/genmod/tests/test_glm_weights.py
+++ b/statsmodels/genmod/tests/test_glm_weights.py
@@ -50,6 +50,7 @@ class CheckWeight(object):
         assert_allclose(res1.resid_pearson, resid_all['resid_pearson'], atol= 1e-6, rtol=2e-6)
         assert_allclose(res1.resid_deviance, resid_all['resid_deviance'], atol= 1e-6, rtol=2e-6)
         assert_allclose(res1.resid_anscombe, resid_all['resid_anscombe'], atol= 1e-6, rtol=2e-6)
+        assert_allclose(res1.resid_working, resid_all['resid_working'], atol= 1e-6, rtol=2e-6)
 
 
 class TestGlmPoissonPlain(CheckWeight):


### PR DESCRIPTION
closes #2891

GLM resid_working is calculated incorrectly

I didn't try to run the test examples in Stata. (that's a lot of work without ready made `do` files)
I corrected the reference numbers, and activated the tests that has correct Stata numbers in test_glm_weights.

(One-character bug fix with several hours of figuring out the unit tests.)