### PR TITLE
BUG: fix binary pred_table for zeros see #2968

### DIFF
--- a/statsmodels/discrete/discrete_model.py
+++ b/statsmodels/discrete/discrete_model.py
@@ -2748,7 +2748,9 @@ class BinaryResults(DiscreteResults):
         model = self.model
         actual = model.endog
         pred = np.array(self.predict() > threshold, dtype=float)
-        return np.histogram2d(actual, pred, bins=2)[0]
+        bins = np.array([0, 0.5, 1])
+        return np.histogram2d(actual, pred, bins=bins)[0]
+
 
     def summary(self, yname=None, xname=None, title=None, alpha=.05,
                 yname_list=None):
@@ -2956,11 +2958,12 @@ class MultinomialResults(DiscreteResults):
         pred_table[i,j] refers to the number of times "i" was observed and
         the model predicted "j". Correct predictions are along the diagonal.
         """
-        J = self.model.J
+        ju = self.model.J - 1  # highest index
         # these are the actual, predicted indices
-        idx = lzip(self.model.endog, self.predict().argmax(1))
+        #idx = lzip(self.model.endog, self.predict().argmax(1))
+        bins = np.concatenate(([0], np.linspace(0.5, ju - 0.5, ju), [ju]))
         return np.histogram2d(self.model.endog, self.predict().argmax(1),
-                              bins=J)[0]
+                              bins=bins)[0]
 
     @cache_readonly
     def bse(self):

--- a/statsmodels/discrete/tests/test_discrete.py
+++ b/statsmodels/discrete/tests/test_discrete.py
@@ -1407,6 +1407,22 @@ def test_formula_missing_exposure():
     assert_raises(ValueError, sm.Poisson, df.Foo, df[['constant', 'Bar']],
                   exposure=exposure)
 
+
+def test_binary_pred_table_zeros():
+    # see 2968
+    nobs = 10
+    y = np.zeros(nobs)
+    y[[1,3]] = 1
+
+    res = Logit(y, np.ones(nobs)).fit(disp=0)
+    expected = np.array([[ 8.,  0.], [ 2.,  0.]])
+    assert_equal(res.pred_table(), expected)
+
+    res = MNLogit(y, np.ones(nobs)).fit(disp=0)
+    expected = np.array([[ 8.,  0.], [ 2.,  0.]])
+    assert_equal(res.pred_table(), expected)
+
+
 if __name__ == "__main__":
     import nose
     nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb'],


### PR DESCRIPTION
should close #2968 
in discrete binary pred_table uses incorrect bins if a column is zero

I just saw that MNLogit has the same problem if a boundary column is zero
      not yet fixed or looked into, unit test commented out


Note: 
There is a backwards incompatible change in behavior if a probability is exactly at the threshold. 
Before, the ties are treated as 0 event, now as 1 event, which is the default

After thinking, I will change this again to be consistent with MNLogit, which inherits argmax behavior which chooses the first occurrence if there is not only one max.

**update**

switched back to ties go to lower index
fixed MNLogit.pred_table
