### PR TITLE
WIP ENH: robust add MQuantileNorm

### DIFF
--- a/statsmodels/robust/tests/test_mquantiles.py
+++ b/statsmodels/robust/tests/test_mquantiles.py
@@ -1,0 +1,94 @@
+'''
+Created on Nov. 29, 2022
+
+Author: Josef Perktold
+License: BSD-3
+'''
+
+import numpy as np
+from numpy.testing import assert_allclose
+import pandas as pd
+
+from statsmodels.regression.linear_model import OLS
+from statsmodels.regression.quantile_regression import QuantReg
+
+from statsmodels.robust import norms
+from statsmodels.robust.robust_linear_model import RLM
+
+ols = OLS.from_formula
+quantreg = QuantReg.from_formula
+
+
+def mean_func(x):
+    """mean function for example"""
+    return x + 0.25 * x**2
+
+
+def std_func(x):
+    """standard deviation function for example"""
+    return 0.1 * np.exp(2.5 + 0.75 * np.abs(x))
+
+
+class TestMQuantiles():
+
+    @classmethod
+    def setup_class(cls):
+
+        np.random.seed(654123)
+
+        # generate an interesting dataset with heteroscedasticity
+        nobs = 200
+        x = np.random.uniform(-4, 4, nobs)
+        y = mean_func(x) + std_func(x) * np.random.randn(nobs)
+
+        cls.df = pd.DataFrame({'temp': x, 'dens': y})
+
+    def test_ols(self):
+        # test expectile at q=0.5 versus OLS
+
+        res_ols = ols('dens ~ temp + I(temp ** 2.0)', self.df).fit(use_t=False)
+
+        y = res_ols.model.endog
+        xx = res_ols.model.exog
+
+        mq_norm = norms.MQuantileNorm(0.5, norms.LeastSquares())
+        mod_rlm = RLM(y, xx, M=mq_norm)
+        res_rlm = mod_rlm.fit()
+
+        assert_allclose(res_rlm.params, res_ols.params, rtol=1e-10)
+        assert_allclose(res_rlm.bse, res_ols.bse, rtol=1e-10)
+        assert_allclose(res_rlm.pvalues, res_ols.pvalues, rtol=1e-10)
+
+    def test_quantreg(self):
+        # test HuberT mquantile versus QuantReg
+        # cov_params inference will not agree
+        t_eps = 1e-6
+
+        mod1 = quantreg('dens ~ temp + I(temp ** 2.0)', self.df)
+        y = mod1.endog
+        xx = mod1.exog
+
+        for q in [0.25, 0.75]:
+            # Note HuberT does not agree very closely with quantreg for g=0.5
+
+            res1 = mod1.fit(q=q)
+
+            mq_norm = norms.MQuantileNorm(q, norms.HuberT(t=t_eps))
+            mod_rlm = RLM(y, xx, M=mq_norm)
+            res_rlm = mod_rlm.fit()
+
+            assert_allclose(res_rlm.params, res1.params, rtol=5e-4)
+            assert_allclose(res_rlm.fittedvalues, res1.fittedvalues, rtol=1e-3)
+
+        # for q=0.5, we compare with plain HuberT norm
+        q = 0.5
+        t_eps = 1e-2  # RuntimeWarning an bse are nan 0/0 if t_eps too small
+        mod1 = RLM(y, xx, M=norms.HuberT(t=t_eps))
+        res1 = mod1.fit()
+
+        mq_norm = norms.MQuantileNorm(q, norms.HuberT(t=t_eps))
+        mod_rlm = RLM(y, xx, M=mq_norm)
+        res_rlm = mod_rlm.fit()
+
+        assert_allclose(res_rlm.params, res1.params, rtol=1e-10)
+        assert_allclose(res_rlm.fittedvalues, res1.fittedvalues, rtol=1e-10)


### PR DESCRIPTION
work in progress, I opened the PR so I don't loose track of this

This is currently just a RobustNorm class.
no unit tests yet, and might not have correct standard errors when used in RLM.

currently I only checked that the prediction is close to quantile regression with HuberT(t=small) e.g. small=1e-6.  It "works" for expectiles when t is set very large, i.e. all observations are in the quadratic least squares range.

The prediction when using splines seems to become wigly very soon as the number of knots increases (unpenalized, just plain patsy), even more so in quantile regression and its M-quantile approximation than in least-squares expectiles.

There are several R packages mentioned in some of the articles but I have not yet looked at any of them.
## background and status:

This should work as smooth alternative for the optimization in quantile regression. I wanted to add this for some time because it avoids the problem with residuals that are zero or around zero in quantile regression. e.g. #2377 and #2485 

Just adding the norm is ok, it works for prediction. Full support for MQuantileRegression or asymmetric least squares requires more work, especially checking the cov_params and scale estimates.

For usability, we also need additional post-estimation features, like recovering quantiles and expected shortfall for risk analysis from the expectiles or M-quantiles.

spline application in general: we need to merge penalized splines, GAM and extend to RLM following a similar pattern as for GLM.

other extensions: quantile sheets and non-crossing M-quantiles. e.g. simple example had crossing 0.25 and 0.75 M-quantile with misspecified, quadratic M-quantile function. (splines don't seem to cross, at least not in the example)
## References

(some of them)
Nychka et al. have epsilon approximation to quantile regression in appendix
(they use penalization splines with a knot at each observation point and parameterize in terms of the value of the spline at the observation point, i.e. not in terms of basis functions)

Bianchi, Annamaria, and Nicola Salvati. 2015. “Asymptotic Properties and Variance Estimators of the M-Quantile Regression Coefficients Estimators.” Communications in Statistics - Theory and Methods 44 (11): 2416–29. doi:10.1080/03610926.2013.791375.

Breckling, Jens, and Ray Chambers. 1988. “M-Quantiles.” Biometrika 75 (4): 761–71. doi:10.2307/2336317.

Jones, M. C. 1994. “Expectiles and M-Quantiles Are Quantiles.” Statistics & Probability Letters 20 (2): 149–53. doi:10.1016/0167-7152(94)90031-0.

Newey, Whitney K., and James L. Powell. 1987. “Asymmetric Least Squares Estimation and Testing.” Econometrica 55 (4): 819–47. doi:10.2307/1911031.

Nychka, Doug, Gerry Gray, Perry Haaland, David Martin, and Michael O’Connell. 1995. “A Nonparametric Regression Approach to Syringe Grading for Quality Improvement.” Journal of the American Statistical Association 90 (432): 1171–78. doi:10.2307/2291509.

Reiss, Philip T., and Lei Huang. 2012. “Smoothness Selection for Penalized Quantile Regression Splines.” The International Journal of Biostatistics 8 (1). doi:10.1515/1557-4679.1381.
