### PR TITLE
ENH: add scipy's minimize to optimizer

### DIFF
--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -273,6 +273,7 @@ class LikelihoodModel(Model):
             - 'cg' for conjugate gradient
             - 'ncg' for Newton-conjugate gradient
             - 'basinhopping' for global basin-hopping solver
+            - 'minimize' for generic wrapper of scipy minimize (BFGS by default)
 
             The explicit arguments in `fit` are passed to the solver,
             with the exception of the basin-hopping solver. Each
@@ -408,6 +409,13 @@ class LikelihoodModel(Model):
                       - `args` <- `fargs`
                       - `jac` <- `score`
                       - `hess` <- `hess`
+            'minimize'
+                min_method : str, optional
+                    Name of minimization method to use.
+                    Any method specific arguments can be passed directly.
+                    For a list of methods and their arguments, see
+                    documentation of `scipy.optimize.minimize`.
+                    If no method is specified, then BFGS is used.
         """
         Hinv = None  # JP error if full_output=0, Hinv not defined
 

--- a/statsmodels/base/optimizer.py
+++ b/statsmodels/base/optimizer.py
@@ -16,7 +16,6 @@ def _check_method(method, methods):
 
 
 class Optimizer(object):
-
     def _fit(self, objective, gradient, start_params, fargs, kwargs,
              hessian=None, method='newton', maxiter=100, full_output=True,
              disp=True, callback=None, retall=False):
@@ -28,12 +27,14 @@ class Optimizer(object):
         start_params : array-like, optional
             Initial guess of the solution for the loglikelihood maximization.
             The default is an array of zeros.
-        method : str {'newton','nm','bfgs','powell','cg','ncg','basinhopping'}
+        method : str {'newton','nm','bfgs','powell','cg','ncg','basinhopping',
+            'minimize'}
             Method can be 'newton' for Newton-Raphson, 'nm' for Nelder-Mead,
             'bfgs' for Broyden-Fletcher-Goldfarb-Shanno, 'powell' for modified
             Powell's method, 'cg' for conjugate gradient, 'ncg' for Newton-
-            conjugate gradient or 'basinhopping' for global basin-hopping
-            solver, if available. `method` determines which solver from
+            conjugate gradient, 'basinhopping' for global basin-hopping
+            solver, if available or a generic 'minimize' which is a wrapper for
+            scipy.optimize.minimize. `method` determines which solver from
             scipy.optimize is used. The explicit arguments in `fit` are passed
             to the solver, with the exception of the basin-hopping solver. Each
             solver has several optional arguments that are not the same across
@@ -150,13 +151,20 @@ class Optimizer(object):
                     - `args` <- `fargs`
                     - `jac` <- `score`
                     - `hess` <- `hess`
+            'minimize'
+                min_method : str, optional
+                    Name of minimization method to use.
+                    Any method specific arguments can be passed directly.
+                    For a list of methods and their arguments, see
+                    documentation of `scipy.optimize.minimize`.
+                    If no method is specified, then BFGS is used.
         """
         #TODO: generalize the regularization stuff
         # Extract kwargs specific to fit_regularized calling fit
         extra_fit_funcs = kwargs.setdefault('extra_fit_funcs', dict())
 
         methods = ['newton', 'nm', 'bfgs', 'lbfgs', 'powell', 'cg', 'ncg',
-                'basinhopping']
+                'basinhopping', 'minimize']
         methods += extra_fit_funcs.keys()
         method = method.lower()
         _check_method(method, methods)
@@ -170,6 +178,7 @@ class Optimizer(object):
             'ncg': _fit_ncg,
             'powell': _fit_powell,
             'basinhopping': _fit_basinhopping,
+            'minimize': _fit_minimize # wrapper for scipy.optimize.minimize
         }
 
         #NOTE: fit_regularized checks the methods for these but it should be
@@ -216,6 +225,40 @@ class Optimizer(object):
 
 ########################################
 # Helper functions to fit
+
+
+def _fit_minimize(f, score, start_params, fargs, kwargs, disp=True,
+                        maxiter=100, callback=None, retall=False,
+                        full_output=True, hess=None):
+    kwargs.setdefault('min_method', 'BFGS')
+
+    # prepare options dict for minimize
+    filter_opts = ['extra_fit_funcs', 'niter', 'min_method', 'tol']
+    options = dict((k,v) for k,v in kwargs.items() if k not in filter_opts)
+    options['disp']    = disp
+    options['maxiter'] = maxiter
+
+    # Use Hessian/Jacobian only if they're required by the method
+    no_hess = ['Nelder-Mead', 'Powell', 'CG', 'BFGS', 'COBYLA', 'SLSQP']
+    no_jac  = ['Nelder-Mead', 'Powell', 'COBYLA']
+    if kwargs['min_method'] in no_hess: hess = None
+    if kwargs['min_method'] in no_jac: score = None
+
+    res = optimize.minimize(f, start_params, args=fargs, method=kwargs['min_method'],
+                            jac=score, hess=hess, callback=callback, options=options)
+
+    xopt    = res.x
+    retvals = None
+    if full_output:
+        nit = getattr(res, 'nit', np.nan) # scipy 0.14 compat
+        retvals = {'fopt': res.fun, 'iterations': nit,
+                   'fcalls': res.nfev, 'warnflag': res.status,
+                   'converged': res.success}
+        if retall:
+            retvals.update({'allvecs': res.values()})
+
+    return xopt, retvals
+
 
 def _fit_newton(f, score, start_params, fargs, kwargs, disp=True,
                     maxiter=100, callback=None, retall=False,

--- a/statsmodels/discrete/tests/test_discrete.py
+++ b/statsmodels/discrete/tests/test_discrete.py
@@ -36,6 +36,12 @@ try:
 except ImportError:
     has_basinhopping = False
 
+try:
+    from scipy.optimize._trustregion_dogleg import  _minimize_dogleg
+    has_dogleg = True
+except ImportError:
+    has_dogleg = False
+
 DECIMAL_14 = 14
 DECIMAL_10 = 10
 DECIMAL_9 = 9
@@ -417,6 +423,44 @@ class TestProbitBasinhopping(CheckBinaryResults):
         fit = Probit(data.endog, data.exog).fit
         cls.res1 = fit(method="basinhopping", disp=0, niter=5,
                         minimizer={'method' : 'L-BFGS-B', 'tol' : 1e-8})
+
+class TestProbitMinimizeDefault(CheckBinaryResults):
+    @classmethod
+    def setupClass(cls):
+        data = sm.datasets.spector.load()
+        data.exog = sm.add_constant(data.exog, prepend=False)
+        res2 = Spector()
+        res2.probit()
+        cls.res2 = res2
+        fit = Probit(data.endog, data.exog).fit
+        cls.res1 = fit(method="minimize", disp=0, niter=5, tol = 1e-8)
+
+class TestProbitMinimizeDogleg(CheckBinaryResults):
+    @classmethod
+    def setupClass(cls):
+        if not has_dogleg:
+            raise SkipTest("Skipped TestProbitMinimizeDogleg since "
+                           "dogleg method is not available")
+
+        data = sm.datasets.spector.load()
+        data.exog = sm.add_constant(data.exog, prepend=False)
+        res2 = Spector()
+        res2.probit()
+        cls.res2 = res2
+        fit = Probit(data.endog, data.exog).fit
+        cls.res1 = fit(method="minimize", disp=0, niter=5, tol = 1e-8, min_method = 'dogleg')
+
+class TestProbitMinimizeAdditionalOptions(CheckBinaryResults):
+    @classmethod
+    def setupClass(cls):
+        data = sm.datasets.spector.load()
+        data.exog = sm.add_constant(data.exog, prepend=False)
+        res2 = Spector()
+        res2.probit()
+        cls.res2 = res2
+        cls.res1 = Probit(data.endog, data.exog).fit(method="minimize", disp=0,
+                                                     maxiter=500, min_method='Nelder-Mead',
+                                                     xtol=1e-4, ftol=1e-4)
 
 class CheckLikelihoodModelL1(object):
     """


### PR DESCRIPTION
Initial implementation for #2629.

Right now I've used it to add a proof-of-concept access to `dogleg` optimization method. 

As a next step I see a lot of room for refactoring of existing internal `_fit_*` methods to make use of the added `_fit_minimize`, rather than accessing `scipy`'s methods directly. @josef-pkt would that fit in with what you've envisioned for #2629?
