### PR TITLE
DOC enhance misleading error message

### DIFF
--- a/statsmodels/tsa/seasonal.py
+++ b/statsmodels/tsa/seasonal.py
@@ -82,7 +82,8 @@ def seasonal_decompose(x, model="additive", filt=None, freq=None, two_sided=True
             freq = pfreq
         else:
             raise ValueError("You must specify a freq or x must be a "
-                             "pandas object with a timeseries index")
+                             "pandas object with a timeseries index with"
+                             "a freq not set to None")
 
     if filt is None:
         if freq % 2 == 0:  # split weights at ends


### PR DESCRIPTION
The old error message claims the timeseries index is not valid, even tough it could happen that this message is produced by a valid timeseries index with a timeseries frequency set to None.