### PR TITLE
TST: Fixed failing tests

### DIFF
--- a/statsmodels/tools/grouputils.py
+++ b/statsmodels/tools/grouputils.py
@@ -403,6 +403,7 @@ class Grouping(object):
         """
         # TODO: refactor this
         groups = self.index.get_level_values(level).unique()
+        groups = np.array(groups)
         groups.sort()
         if isinstance(self.index, MultiIndex):
             self.slices = [self.index.get_loc_level(x, level=level)[0]


### PR DESCRIPTION
I fixed some failing tests. 

Seems to be 2 things...
1. I _think_ pandas `read_table` in 0.19 closes a `StringIO` automatically somehow in python 2.7. (Not exactly sure why...) So I just went around that. 
2. `sort` is deprecated on an index... its now `sort_values`

I can squash this all this if desired. I was trying to figure out the fails and kept making new unnecessary commits. 
