### PR TITLE
DOC: Fix typos in statsmodels.regression

### DIFF
--- a/statsmodels/regression/linear_model.py
+++ b/statsmodels/regression/linear_model.py
@@ -471,7 +471,7 @@ class WLS(RegressionModel):
     weights : array-like, optional
         1d array of weights.  If you supply 1/W then the variables are pre-
         multiplied by 1/sqrt(W).  If no weights are supplied the default value
-        is 1 and WLS reults are the same as OLS.
+        is 1 and WLS results are the same as OLS.
     %(extra_params)s
 
     Attributes
@@ -1105,11 +1105,11 @@ class RegressionResults(base.LikelihoodModelResults):
     **Attributes**
 
     aic
-        Aikake's information criteria. For a model with a constant
+        Akaike's information criteria. For a model with a constant
         :math:`-2llf + 2(df_model + 1)`. For a model without a constant
         :math:`-2llf + 2(df_model)`.
     bic
-        Bayes' information criteria For a model with a constant
+        Bayes' information criteria. For a model with a constant
         :math:`-2llf + \log(n)(df_model+1)`. For a model without a constant
         :math:`-2llf + \log(n)(df_model)`
     bse
@@ -1380,7 +1380,7 @@ class RegressionResults(base.LikelihoodModelResults):
             k_params = self.normalized_cov_params.shape[0]
             mat = np.eye(k_params)
             const_idx = self.model.data.const_idx
-            # TODO: What if model includes implcit constant, e.g. all dummies but no constant regressor?
+            # TODO: What if model includes implicit constant, e.g. all dummies but no constant regressor?
             # TODO: Restats as LM test by projecting orthogonalizing to constant?
             if self.model.data.k_constant == 1:
                 # if constant is implicit, return nan see #2444
@@ -1866,9 +1866,9 @@ class RegressionResults(base.LikelihoodModelResults):
             - `groups` array_like, integer (required) :
                   index of clusters or groups
             - `use_correction` bool (optional) :
-                  If True the sandwich covariance is calulated with a small
+                  If True the sandwich covariance is calculated with a small
                   sample correction.
-                  If False the the sandwich covariance is calulated without
+                  If False the sandwich covariance is calculated without
                   small sample correction.
             - `df_correction` bool (optional)
                   If True (default), then the degrees of freedom for the
@@ -1901,9 +1901,9 @@ class RegressionResults(base.LikelihoodModelResults):
             errors in panel data.
             The data needs to be sorted in this case, the time series for
             each panel unit or cluster need to be stacked. The membership to
-            a timeseries of an individual or group can be either specified by 
+            a timeseries of an individual or group can be either specified by
             group indicators or by increasing time periods.
-            
+
             keywords
 
             - either `groups` or `time` : array_like (required)
@@ -1912,7 +1912,7 @@ class RegressionResults(base.LikelihoodModelResults):
             - `maxlag` integer (required) : number of lags to use
             - `kernel` string (optional) : kernel, default is Bartlett
             - `use_correction` False or string in ['hac', 'cluster'] (optional) :
-                  If False the the sandwich covariance is calulated without
+                  If False the sandwich covariance is calculated without
                   small sample correction.
             - `df_correction` bool (optional)
                   adjustment to df_resid, see cov_type 'cluster' above

--- a/statsmodels/regression/mixed_linear_model.py
+++ b/statsmodels/regression/mixed_linear_model.py
@@ -4,7 +4,7 @@ They can be used to estimate regression relationships involving both
 means and variances.
 
 These models are also known as multilevel linear models, and
-hierachical linear models.
+hierarchical linear models.
 
 The MixedLM class fits linear mixed effects models to data, and
 provides support for some common post-estimation tasks.  This is a
@@ -53,7 +53,7 @@ structure is of interest, GEE is an alternative to using linear mixed
 models.
 
 Two types of random effects are supported.  Standard random effects
-are correlated with each other in arbitary ways.  Every group has the
+are correlated with each other in arbitrary ways.  Every group has the
 same number (`k_re`) of standard random effects, with the same joint
 distribution (but with independent realizations across the groups).
 
@@ -140,7 +140,7 @@ effects parameters (if any).  As a result of this profiling, it is
 difficult and unnecessary to calculate the Hessian of the profiled log
 likelihood function, so that calculation is not implemented here.
 Therefore, optimization methods requiring the Hessian matrix such as
-the Newton-Raphson algorihm cannot be used for model fitting.
+the Newton-Raphson algorithm cannot be used for model fitting.
 """
 
 import numpy as np
@@ -526,7 +526,7 @@ class MixedLM(base.LikelihoodModel):
         covariance structure (the "random effects" covariates).  If
         None, defaults to a random intercept for each group.
     exog_vc : dict-like
-        A dicationary containing specifications of the variance
+        A dictionary containing specifications of the variance
         component terms.  See below for details.
     use_sqrt : bool
         If True, optimization is carried out using the lower
@@ -1196,7 +1196,7 @@ class MixedLM(base.LikelihoodModel):
         -----
         If P are the standard form parameters and R are the
         transformed parameters (i.e. with the Cholesky square root
-        covariance and square root transformed variane components),
+        covariance and square root transformed variance components),
         then P[i] = lin[i] * R + R' * quad[i] * R
         """
 
@@ -1252,7 +1252,7 @@ class MixedLM(base.LikelihoodModel):
         group : string
             The group label
 
-        Returns an expaded version of vcomp, in which each variance
+        Returns an expanded version of vcomp, in which each variance
         parameter is copied as many times as there are independent
         realizations of the variance component in the given group.
         """
@@ -1899,7 +1899,7 @@ class MixedLM(base.LikelihoodModel):
         Parameters
         ----------
         start_params: array-like or MixedLMParams
-            Starting values for the profile log-likeihood.  If not a
+            Starting values for the profile log-likelihood.  If not a
             `MixedLMParams` instance, this should be an array
             containing the packed parameters for the profile
             log-likelihood, including the fixed effects
@@ -1918,7 +1918,7 @@ class MixedLM(base.LikelihoodModel):
             it is fixed at its starting value.  Setting the `cov_re`
             component to the identity matrix fits a model with
             independent random effects.  Note that some optimization
-            methods do not respect this contraint (bfgs and lbfgs both
+            methods do not respect this constraint (bfgs and lbfgs both
             work).
         full_output : bool
             If true, attach iteration history to results

--- a/statsmodels/regression/recursive_ls.py
+++ b/statsmodels/regression/recursive_ls.py
@@ -170,7 +170,7 @@ class RecursiveLS(MLEModel):
 
     @property
     def start_params(self):
-        # Only parameter is the measurment disturbance standard deviation
+        # Only parameter is the measurement disturbance standard deviation
         return np.zeros(0)
 
     def update(self, params, **kwargs):


### PR DESCRIPTION
This PR fixes a number of typos in docstrings and comments inside `statsmodels.regression`.
