### PR TITLE
BUG: SARIMAX start_params when endog is integer

### DIFF
--- a/statsmodels/tsa/statespace/sarimax.py
+++ b/statsmodels/tsa/statespace/sarimax.py
@@ -964,7 +964,7 @@ class SARIMAX(MLEModel):
         params_exog = []
         if self.k_exog > 0:
             params_exog = np.linalg.pinv(exog).dot(endog)
-            endog -= np.dot(exog, params_exog)
+            endog = endog - np.dot(exog, params_exog)
         if self.state_regression:
             params_exog = []
 

--- a/statsmodels/tsa/statespace/tests/test_sarimax.py
+++ b/statsmodels/tsa/statespace/tests/test_sarimax.py
@@ -1995,3 +1995,13 @@ def test_misc_exog():
     # Test invalid model specifications
     assert_raises(ValueError, sarimax.SARIMAX, endog, exog=np.zeros((10, 4)),
                   order=(1, 1, 0))
+
+
+def test_datasets():
+    # Test that some unusual types of datasets work
+
+    np.random.seed(232849)
+    endog = np.random.binomial(1, 0.5, size=100)
+    exog = np.random.binomial(1, 0.5, size=100)
+    mod = sarimax.SARIMAX(endog, exog=exog, order=(1, 0, 0))
+    res = mod.fit()


### PR DESCRIPTION
Fails due to attempted in-place subtraction of float array from integer array.