### PR TITLE
Fixed bug in approx_hess3 related to floats and tuples.

### DIFF
--- a/statsmodels/tools/numdiff.py
+++ b/statsmodels/tools/numdiff.py
@@ -349,7 +349,7 @@ def approx_hess3(x, f, epsilon=None, args=(), kwargs={}):
             hess[i, j] = (f(*((x + ee[i, :] + ee[j, :],) + args), **kwargs)
                           - f(*((x + ee[i, :] - ee[j, :],) + args), **kwargs)
                           - (f(*((x - ee[i, :] + ee[j, :],) + args), **kwargs)
-                          - f(*((x - ee[i, :] - ee[j, :],) + args), **kwargs),)
+                          - f(*((x - ee[i, :] - ee[j, :],) + args), **kwargs))
                           )/(4.*hess[i, j])
             hess[j, i] = hess[i, j]
     return hess


### PR DESCRIPTION
If the function being differentiated by `sm.tools.numdiff.approx_hess3()` returns a `numpy.float64`, the function works fine, but if it returns, e.g., a `float`, there is a `TypeError: unsupported operand type(s) for -: 'float' and 'tuple'`. This is because there is an extra comma in the lines calculating the entries of the Hessian, resulting in the unintended creation of a tuple. Because of operator overloading of some Numpy types, this is not a problem in many contexts, but if the function being differentiated returns a `float`, this bug rears its head.

I fixed the bug by deleting the comma.

Here is a code snippet to reproduce the bug.
```python
import numpy as np
import statsmodels as sm
import statsmodels.tools.numdiff

print('statsmodels version:', sm.version.full_version)

def f(x):
    return np.dot(x, x) / 2.0

def f_float(x):
    return float(np.dot(x, x) / 2.0)

# Test array for differentiating
x = np.array([1.0])

# This works (returns numpy.float64)
print(type(f(x)))
print(statsmodels.tools.numdiff.approx_hess3(x, f))

# Now try with float returned
print(type(f_float(x)))

# Raises TypeError: unsupported operand type(s) for -: 'float' and 'tuple'
statsmodels.tools.numdiff.approx_hess3(x, f_float)
```