### PR TITLE
WIP: ENH Robust nonlinear estimators

### DIFF
--- a/statsmodels/examples/ex_robust_genericmle.py
+++ b/statsmodels/examples/ex_robust_genericmle.py
@@ -1,0 +1,319 @@
+# -*- coding: utf-8 -*-
+"""
+
+Created on Thu Feb 27 13:32:36 2014
+
+Author: Josef Perktold
+"""
+
+import numpy as np
+
+from statsmodels.miscmodels.robust_genericmle import *
+
+
+#import statsmodels.api as sm
+
+if 0:
+    data = sm.datasets.stackloss.load()
+    data.exog = sm.add_constant(data.exog)
+    endog, exog = data.endog, data.exog
+
+    seed = 976537
+    np.random.seed(seed)
+    nobs, k_vars = 100, 5
+    n_outliers = 10
+    sig_e = 0.5
+    beta = np.ones(k_vars)
+    beta[-2:] *= 0.25
+    exog = sm.add_constant(np.random.uniform(0, 1, size=(nobs, k_vars - 1)))
+    y_true = np.dot(exog, beta)
+    endog = y_true + sig_e * np.random.randn(nobs)
+    endog[-n_outliers:] += 100
+
+    print_summary = False
+    # Huber's T norm with the (default) median absolute deviation scaling
+
+    huber_t = sm.RLM(endog, exog, M=sm.robust.norms.HuberT())
+    hub_results = huber_t.fit(scale_est=rscale.HuberScale())
+    print(hub_results.params)
+    print(hub_results.bse)
+    if print_summary:
+        print(hub_results.summary(yname='y',
+                xname=['var_%d' % i for i in range(len(hub_results.params))]))
+
+    res_ols = sm.OLS(endog, exog).fit()
+    start_ols = np.concatenate((res_ols.params, [np.sqrt(res_ols.scale)]))
+    start_ols = np.concatenate((res_ols.params, [rscale.mad(res_ols.resid, center=0)]))
+
+    start_hub = np.concatenate((hub_results.params, [hub_results.scale]))
+    start_params = start_hub
+
+    mod = MEstimator(endog, exog)
+    print('loss RLM', mod.loglike(start_hub), 'scale RLM', hub_results.scale)
+    print(start_params + 0.5, (start_params * 0.5).shape)
+    start_params = np.ones(mod.exog.shape[1] + 1)
+    start_params = start_ols
+    res = mod.fit(start_params=start_params, method='bfgs') # nm')#
+    print('\n M-E joint with scale')
+    print(res.params)
+    if print_summary:
+        print(res.summary())  # no normalized_params
+
+    mod2 = MEstimator(endog, exog)
+    mod2.scale_fixed = hub_results.scale / 0.491
+    res2 = mod2.fit(start_params=start_params[:-1]*0.5, method='bfgs')
+
+    print('\n M-E fixed scale')
+    print(res2.params)
+    if print_summary:
+        print(res2.summary())  # no normalized_params
+
+
+    # chekc gradient, jac, score
+    print(mod.jac(start_ols).sum(0))
+    print(mod.score(start_ols))
+    import statsmodels.tools.numdiff as nd
+    print(nd.approx_fprime(start_ols, mod.loglike))
+
+
+
+    mod4 = MEstimatorHD(endog, exog)
+    #mod4.scale_fixed = hub_results.scale / 0.491
+    res4 = mod4.fit(start_params=start_params, method='bfgs')
+
+    print('\n M-E HD jointly estimated scale')
+    print(res4.params)
+    print(res4.summary())  # no normalized_params
+
+
+    # chekc gradient, jac, score
+    print(mod4.jac(start_ols).sum(0))
+    print(mod4.score(start_ols))
+    import statsmodels.tools.numdiff as nd
+    print(nd.approx_fprime(start_ols, mod4.loglike))
+
+    print('\ncompare params')
+    print(res_ols.params)
+    print(hub_results.params)
+    print(res2.params)
+    print(res.params)
+    print(res4.params)
+
+    mod_mit = RLMIterative(endog, exog, M=rnorms.HuberT(), meef_scale=lambda x:rnorms.TukeyBiweight().rho(x)-0)
+    res_mit = mod_mit.fit()
+
+    mod_mit2 = RLMIterative(endog, exog, M=rnorms.HuberT(),
+                           meef_scale=lambda x:rnorms.TukeyBiweight().rho(x)-0,
+                           update_scale=False)
+    res_mit2 = mod_mit2.fit(start_params=res2.params, start_scale=0.79598, update_scale=False)
+
+    mod_mit3 = RLMIterative(endog, exog, M=rnorms.HuberT(), meef_scale=lambda x:rnorms.HuberT(2.5).psi(np.abs(x)**2)-0)
+    mod_mit3.scale_bias=0.97755998345280681
+    res_mit3a = mod_mit3.fit()
+    print(res_mit3a[0].params)
+
+
+chem = np.array([2.20, 2.20, 2.4, 2.4, 2.5, 2.7, 2.8, 2.9, 3.03,
+            3.03, 3.10, 3.37, 3.4, 3.4, 3.4, 3.5, 3.6, 3.7, 3.7, 3.7, 3.7,
+            3.77, 5.28, 28.95])
+
+example = ['menton', 'exp', 'sigmoid'][:]
+
+if 'menton' in example:
+    def func_m(params, x):
+        a, b = params
+        return a * x / (np.exp(b) + x)
+
+    nobs2 = 30
+    sig_e = 0.75
+    np.random.seed(456753)
+    x = np.random.uniform(0, 10, size=nobs2)
+    x.sort()
+    beta_m = [10, 1]
+    y_true = func_m(beta_m, x)
+    y = y_true + np.random.randn(nobs2)
+    y[-8::2] += 5
+
+
+
+
+
+    modm = MentenNL(y, x)
+    resm0 = modm.fit([0.5, 0.5, 0.5], method='nm')
+    resm = modm.fit(resm0.params, method='bfgs')
+    print(resm.summary())
+    fittedvalues = resm.predict()
+    resid = y - fittedvalues
+
+    from scipy.optimize import leastsq
+    res_cf = leastsq(lambda p: y - func_m(p,x), x0=[0.5,0.5])
+    fitted_ls = func_m(res_cf[0], x)
+
+
+
+    modm2 = MentenNL(y, x, norm=rnorms.TukeyBiweight())
+    modm2.scale_fixed = rscale.mad(resid, center=0)
+    resm2 = modm2.fit(resm.params[:-1], method='bfgs')
+    store = []
+    for i in range(10):
+        fittedvalues2 = resm2.predict()
+        modm2.scale_fixed = rscale.mad(y - fittedvalues2, center=0)
+        resm2 = modm2.fit(resm.params[:-1], method='bfgs')
+        store.append(resm2.params)
+
+
+
+####################### mostly copy and paste
+
+if 'exp' in example:
+    func_m = lambda beta, x: np.exp(beta[0] + np.dot(x, beta[1:]))
+    func_m = lambda beta, x: np.exp(np.dot(x, beta))
+
+    nobs2 = 30
+    sig_e = 10
+    np.random.seed(456753)
+    x = np.random.uniform(0, 10, size=nobs2)
+    x.sort()
+    exog = np.column_stack((np.ones(x.shape[0]), x))
+    beta_m = [-5, 0.75]
+    y_true = func_m(beta_m, exog)
+    y = y_true + np.random.randn(nobs2)
+    y[-8::2] += 15
+
+    from scipy.optimize import leastsq
+    res_cf = leastsq(lambda p: y - func_m(p,exog), x0=[0.5,0.5])
+    fitted_ls = func_m(res_cf[0], exog)
+
+    modm = ExpNL(y, exog)
+    resm0 = modm.fit([0.5, 0.5, 0.5], method='nm')
+    resm = modm.fit(resm0.params, method='bfgs')
+    print(resm.summary())
+    fittedvalues = resm.predict()
+    resid = y - fittedvalues
+
+
+
+    modm2 = ExpNL(y, exog, norm=rnorms.TukeyBiweight())
+    modm2.scale_fixed = rscale.mad(resid, center=0)
+    resm2 = modm2.fit(resm.params[:-1], method='nm')
+    store = []
+    for i in range(10):
+        fittedvalues2 = resm2.predict()
+        modm2.scale_fixed = rscale.mad(y - fittedvalues2, center=0)
+        resm2 = modm2.fit(resm2.params, method='bfgs')
+        store.append(np.concatenate((resm2.params, [modm2.scale_fixed])))
+    fittedvalues2 = resm2.predict()
+
+##########################
+
+if 'sigmoid' in example:
+
+    func_m = sigmoid
+
+    nobs2 = 50
+    sig_e = 2
+    seed = 456753
+    seed = 139146
+    seed = 581472
+    seed = np.random.RandomState().randint(999999)
+    print('seed', seed)
+    np.random.seed(seed)
+    x = np.random.uniform(0, 10, size=nobs2)
+    x.sort()
+    exog = np.column_stack((np.ones(x.shape[0]), x))
+    x0, y0, c, k = 5, 8, 10, 1.
+    beta_m = [x0, y0, c, k]
+    y_true = func_m(beta_m, x)
+    y = y_true + np.random.randn(nobs2)
+    y[-10::2] += 10
+
+    start = sig_start(y, x)
+
+    from scipy.optimize import leastsq
+    res_cf = leastsq(lambda p: y - func_m(p, x), x0=start)
+    fitted_ls = func_m(res_cf[0], x)
+
+    start1 = res_cf[0]
+    modm = SigmoidNL(y, x)
+    resm0 = modm.fit(np.concatenate((start1,[0.5])), method='nm')
+    resm = modm.fit(resm0.params, method='bfgs')
+    print(resm.summary())
+    fittedvalues = resm.predict()
+    resid = y - fittedvalues
+
+
+
+
+
+    modm2 = SigmoidNL(y, x, norm=rnorms.TukeyBiweight())
+    modm2.scale_fixed = rscale.mad(resid, center=0)
+    resm2 = modm2.fit(resm.params[:-1], method='nm')
+    store = []
+    for i in range(10):
+        fittedvalues2 = resm2.predict()
+        modm2.scale_fixed = rscale.mad(y - fittedvalues2, center=0)
+        resm2 = modm2.fit(resm2.params, method='bfgs')
+        store.append(np.concatenate((resm2.params, [modm2.scale_fixed])))
+    fittedvalues2 = resm2.predict()
+##########################
+
+print(np.array(store))
+
+
+import matplotlib.pyplot as plt
+#fig = plt.figure()
+#ax = fig.add_subplot()
+plt.plot(x, y, 'o')
+plt.plot(x, y_true, '-', color='b', lw=2, alpha = 0.75, label='true')
+plt.plot(x, fittedvalues, '-', lw=2, alpha = 0.75, label='fit_robust')
+plt.plot(x, fittedvalues2, '-', lw=2, alpha = 0.75, label='fit_robust_bs')
+plt.plot(x, fitted_ls, '-', lw=2, alpha = 0.75, label='fit_leastsq')
+plt.legend(loc='upper left')
+plt.title('Robust Nonlinear M-Estimation - outliers')
+#plt.title('Robust Nonlinear M-Estimation - no outliers')
+plt.show()
+
+
+'''Initially we planned this year to focus on maintenance and skip GSOC, even though it's the tenth. However, currently we have a student interested in the high priority "maintenance" project (preparing a backlog of pull requests for merge and increase test coverage). Additionally, we have a statistics professor that started to contribute last year, who is interested in mentoring a statistics enhancement.
+'''
+
+def predict_jac(model, params_loc, exog=None):
+    if exog is None:
+        exog = model.exog
+    from statsmodels.tools.numdiff import approx_fprime
+    return approx_fprime(params_loc, model.predict)
+
+
+print(resm2.model.score(resm2.params))
+print(resm2.model.predict_jac(resm2.params).sum(0))
+print(resm2.model._predict_jac(resm2.params).sum(0))
+print(predict_jac(modm2, resm2.params, exog=None).sum(0))
+
+
+resm_it = modm2.fit_iterative(resm.params[:-1], method='nm')
+print(resm_it.params)
+print(resm2.params)
+
+modm_biw = SigmoidNL(y, x, norm=rnorms.TukeyBiweight())
+resm_biw = modm_biw.fit(start_params=resm_it.history[-1]) #history includes scale
+print(resm_biw.params)
+
+s_params = resm_it.history[-1]
+print(resm_biw.model.score(s_params))
+print(resm_biw.model.predict_jac(s_params).sum(0))
+print(resm_biw.model._predict_jac(s_params).sum(0))
+print(predict_jac(modm_biw, s_params, exog=None).sum(0))
+
+'''
+>>> from scipy import stats
+>>> norm=rnorms.TukeyBiweight()
+>>> stats.norm.expect(lambda t: t*norm.psi(t) - norm.rho(t))
+3.9791304551565183
+'''
+
+''' with corrected norm, branch fix_robust_scale
+>>> norm=rnorms.TukeyBiweight()
+>>> from scipy import stats
+>>> stats.norm.expect(lambda t: t*norm.psi(t) - norm.rho(t))
+0.3209262884898523
+'''

--- a/statsmodels/miscmodels/robust_genericmle.py
+++ b/statsmodels/miscmodels/robust_genericmle.py
@@ -1,0 +1,358 @@
+# -*- coding: utf-8 -*-
+"""
+
+Created on Thu Feb 27 13:32:36 2014
+
+Author: Josef Perktold
+"""
+
+import numpy as np
+from statsmodels.base.model import GenericLikelihoodModel
+
+import statsmodels.robust.norms as rnorms
+import statsmodels.robust.scale as rscale
+import statsmodels.robust.robust_linear_model as rlm
+
+
+class MEstimator(GenericLikelihoodModel):
+
+    def __init__(self, *args, **kwds):
+        self.norm = rnorms.HuberT()
+        super(MEstimator, self).__init__(*args, **kwds)
+        self.scale_fixed = None
+
+    def transform_params(self, params):
+
+        if self.scale_fixed is None:
+            params_loc, scale = params[:-1], params[-1]
+            scale = np.abs(scale)
+        else:
+            params_loc = params
+            scale = self.scale_fixed
+
+        return params_loc, scale
+
+
+    def nloglikeobs(self, params):
+        # Note: norms is a loss function, so this is nloglikeobs
+
+        params_loc, scale = self.transform_params(params)
+
+        #nobs = len(self.endog)
+        resid_scaled = (self.endog - np.dot(self.exog, params_loc)) / scale
+        scale_fac = 0.491
+        rho_fac = scale * scale_fac
+        objective = (rho_fac * self.norm(resid_scaled / scale_fac) +
+                      rho_fac * np.log(scale * scale_fac))
+        return objective
+
+    def score(self, params):
+        return self.jac(params).sum(0)
+
+    def jac(self, params): #, **kwds):
+        # Todo   verify signs,  derivative of loglike or nloglike ?
+        params_loc, scale = self.transform_params(params)
+
+        resid_scaled = (self.endog - np.dot(self.exog, params_loc)) / scale / 0.491
+        score_obs = -self.norm.psi(resid_scaled)[:,None] * self.exog #/ scale
+        # note: extra scale cancels between nominator and denominator
+
+        if self.scale_fixed is None:
+            def func(s):
+                s = np.atleast_1d(s)
+                #for derivative wrt. scale
+                p = np.concatenate((params_loc, s))
+                return self.loglikeobs(p)
+
+            import statsmodels.tools.numdiff as nd
+            grad_scale = nd.approx_fprime([scale], func)
+            return -np.column_stack((score_obs, -grad_scale))
+
+        else:
+            return -score_obs
+
+    def predict(self, params, exog=None):
+        if exog is None:
+            exog = self.exog
+        return np.dot(exog, params[:self.exog.shape[1]])
+
+
+class MEstimatorHD(GenericLikelihoodModel):
+
+    def __init__(self, *args, **kwds):
+        self.norm = kwds.get('norm', rnorms.HuberT())
+        super(MEstimatorHD, self).__init__(*args, **kwds)
+        self.scale_fixed = None
+        # TODO verify scale_fac
+        # stats.norm.expect(lambda t: t*norm.psi(t) - norm.rho(t))
+        self.scale_fac = 0.35508
+        if isinstance(self.norm, rnorms.TukeyBiweight):
+            # hardcoded for default shape/tuning parameter
+            self.scale_fac = 3.97913
+
+    def transform_params(self, params):
+
+        if self.scale_fixed is None:
+            params_loc, scale = params[:-1], params[-1]
+            scale = np.abs(scale)
+        else:
+            params_loc = params
+            scale = self.scale_fixed
+
+        return params_loc, scale
+
+
+    def nloglikeobs(self, params):
+        # Note: norms is a loss function, so this is nloglikeobs
+
+        params_loc, scale = self.transform_params(params)
+
+        #nobs = len(self.endog)
+        resid_scaled = (self.endog - self.predict(params_loc)) / scale
+        scale_fac = self.scale_fac
+        objective = (scale * self.norm(resid_scaled) + scale_fac * scale)
+        return objective
+
+    def score(self, params):
+        return self.jac(params).sum(0)
+
+    def jac(self, params): #, **kwds):
+        # Todo   verify signs,  derivative of loglike or nloglike ?
+        params_loc, scale = self.transform_params(params)
+
+        resid_scaled = (self.endog - self.predict(params_loc)) / scale
+        score_obs = -self.norm.psi(resid_scaled)[:,None] * self.predict_jac(params_loc) #/ scale
+        # note: extra scale cancels between nominator and denominator
+
+        if self.scale_fixed is None:
+            def func(s):
+                s = np.atleast_1d(s)
+                #for derivative wrt. scale
+                p = np.concatenate((params_loc, s))
+                return self.loglikeobs(p)
+
+            import statsmodels.tools.numdiff as nd
+            grad_scale = nd.approx_fprime(np.atleast_1d(scale), func)
+            return -np.column_stack((score_obs, -grad_scale))
+
+        else:
+            return -score_obs
+
+    def predict(self, params, exog=None):
+        if exog is None:
+            exog = self.exog
+        return np.dot(exog, params[:self.exog.shape[1]])
+
+    def predict_jac(self, params, exog=None):
+        if exog is None:
+            exog = self.exog
+        return exog
+
+    def fit_iterative(self, start_params=None, **kwds):
+        """
+        iterative fit with MAD scale updating
+
+        """
+        # TODO add fit keywords, method is hardcoded
+
+        # TODO: this should only be needed in `fit`
+        if start_params is None:
+            if hasattr(self, 'start_params'):
+                start_params = self.start_params(self.endog, self.exog)
+            else:
+                start_params = 0.1 * np.ones(self.exog.shape[1])
+
+        res_it = self.fit(start_params, method='nm')
+        history = []
+        #self.scale_fixed = rscale.mad(res_it.resid, center=0)
+        for i in range(10):
+            fittedvalues = res_it.predict()
+            self.scale_fixed = rscale.mad(self.endog - fittedvalues, center=0)
+            res_it = self.fit(res_it.params, method='bfgs')
+            history.append(np.concatenate((res_it.params, [self.scale_fixed])))
+            if (i > 0) and np.allclose(history[-1], history[-2], atol=1e-6, rtol=1e-6):
+                # Note: we check when we have at least two fit iterations
+                converged = True
+                break
+        else:
+            converged = False
+
+        #TODO: update res_it with iteration results
+        res_it.converged = converged
+        res_it.history = history
+
+        return res_it
+
+
+
+class RLMIterative(rlm.RLM):
+
+    def __init__(self, *args, **kwds):
+        self.weights_prior = kwds.pop('weights', None)
+        self.scale_bias = kwds.pop('weights', 1)   # TODO
+        self.meef_scale = kwds.pop('meef_scale', None)
+        self.update_scale = kwds.pop('update_scale', True)
+
+        super(RLMIterative, self).__init__(*args, **kwds)
+        # linear to get started
+        from statsmodels.regression.linear_model import WLS
+        self.fit_loc = WLS
+        self.norm_loc = self.M
+
+
+
+    def update_location(self, weight, *args):
+        pass
+
+    def fit(self, start_params=None, start_scale=None, update_scale=True,
+            optim_options=None):
+        # note scale is not squared
+        #nobs = self.endog.shape[0]
+
+        if optim_options is None:
+            optim_options = {}
+        maxiter = optim_options.get('maxiter', 10)
+        res_loc = self.fit_loc(self.endog, self.exog).fit()#, weights=None)
+        if start_params is None:
+            resid = res_loc.resid
+            params = res_loc.params
+        else:
+            params = start_params
+            resid = self.endog - res_loc.model.predict(params)
+        if start_scale is None:
+            # use MAD for now, TODO: use same as in iteration
+            scale = rscale.mad(resid, center=0)
+        else:
+            scale = start_scale
+
+        for i in range(maxiter):
+            # update location
+            weights = self.norm_loc.weights(resid / scale)
+            if self.weights_prior is not None:
+                weights *= self.weights_prior
+            res_loc = self.fit_loc(self.endog, self.exog, weights=weights).fit()
+            params_old = params
+            params = res_loc.params
+            resid = res_loc.resid
+            resid_scaled = resid / scale
+
+            if update_scale:
+                # update scale
+                # Note: use old residuals or new ?
+                weights_scale = self.meef_scale(resid_scaled) / resid_scaled**2
+                #scale_old = scale
+                scale2 = (weights_scale * resid**2).mean()
+                #scale *= scale_old**2
+                scale2 /= self.scale_bias
+                scale = np.sqrt(scale2)
+
+            #check convergence
+            if np.allclose(params, params_old, rtol=1e-6, atol=1e-10):
+                converged = True
+                break
+        else:
+            converged = False
+
+        # Force estimated scale for WLS results
+        res_loc._cache['scale'] = scale**2
+
+        # TODO return Results
+        return res_loc, scale, converged
+
+
+# examples: special cases of non-linear functions
+
+def func_menten(params, x):
+    a, b = params
+    return a * x / (np.exp(b) + x)
+
+class MentenNL(MEstimatorHD):
+
+    def predict(self, params, exog=None):
+        if exog is None:
+            exog = self.exog
+        return np.squeeze(func_menten(params[:2], exog))
+
+    def predict_jac(self, params, exog=None):
+        if exog is None:
+            exog = self.exog
+        from statsmodels.tools.numdiff import approx_fprime
+        return approx_fprime(params[:2], self.predict)
+
+
+class ExpNL(MEstimatorHD):
+
+    def predict(self, params, exog=None, linear=False):
+        if exog is None:
+            exog = self.exog
+        xb = np.dot(exog, params[:self.exog.shape[1]])
+        if linear:
+            return xb
+        else:
+            return np.exp(xb)
+
+    def _predict_jac(self, params, exog=None):
+        if exog is None:
+            exog = self.exog
+        from statsmodels.tools.numdiff import approx_fprime
+        return approx_fprime(params[:2], self.predict)
+
+    def predict_jac(self, params, exog=None, linear=False):
+        if exog is None:
+            exog = self.exog
+        if linear:
+            return exog
+        else:
+            xb = np.dot(exog, params[:self.exog.shape[1]])
+            return np.exp(xb)[:, None] * exog
+
+
+def sigmoid(params, x):
+    x0, y0, c, k = params
+    y = c / (1. + np.exp(-k * (x - x0))) + y0
+    return y
+
+
+def sigmoid_deriv(params, x):
+    x0, y0, c, k = params
+    term = np.exp(-k * (x - x0))
+    denom = 1. / (1 + term)
+    denom2 = denom**2
+    dx0 =  - c * denom2 * term * k
+    dy0 = np.ones(x.shape[0])
+    dc = denom
+    dk =  c * denom2 * term * (x - x0)
+
+    return np.column_stack([dx0, dy0, dc, dk])
+
+def sig_start(y, x):
+    #return x.min(), y.min(), y.max(), np.corrcoef(x, y)[0, 1]
+    return np.median(x), np.median(y), y.max(), np.corrcoef(x, y)[0, 1]
+
+
+class SigmoidNL(MEstimatorHD):
+
+    def predict(self, params, exog=None, linear=False):
+        if exog is None:
+            exog = self.exog
+        xb = np.dot(exog, params[:self.exog.shape[1]])
+        if linear:
+            return xb
+        else:
+            return np.squeeze(sigmoid(params[:4], exog))
+
+    def _predict_jac(self, params, exog=None):
+        if exog is None:
+            exog = self.exog
+        from statsmodels.tools.numdiff import approx_fprime
+        return approx_fprime(params[:4], self.predict)
+
+    def predict_jac(self, params, exog=None, linear=False):
+        if exog is None:
+            exog = self.exog
+        if linear:
+            # doesn't make sense in this case
+            return exog
+        else:
+            #xb = np.dot(exog, params[:self.exog.shape[1]])
+            return sigmoid_deriv(params[:4], exog)


### PR DESCRIPTION
(another PR to consolidate my robust regression code)

I added it for now to miscmodels because the models subclass GenericLikelihoodModel.

this includes a Huber-Dutter model class, see related #3258 (i.e. could be used for linear model with AR(1) errors and innovation outliers)

Also includes a few examples, classes for nonlinear functions like sigmoid and menten. Related, lmfit includes no more predefined nonlinear functions. We had related discussion around the time I wrote this in 2014. https://mail.scipy.org/pipermail/scipy-user/2014-March/035552.html
scipy.optimize leastsq also includes now some robust objective functions like Huber, since GSOC 2015

inference: AFAIR, I didn't check much, however we have now cov_type="HC0" which is the basic M-estimator sandwich also in GenericLikelihoodModel, and that should be the default for these type of functions. (RLM has an additional small sample correction based on Huber 197?)

analytical derivatives: I guess they can be build up from the different components
Hu, Hongchang. 2013. “Asymptotic Normality of Huber–Dutter Estimators in a Linear Model with AR(1) Processes.” Journal of Statistical Planning and Inference 143 (3): 548–62. doi:10.1016/j.jspi.2012.08.012.
has expressions for score and hessian (?) for Huber-Dutter that could be useful. (He uses a "nonstandard" robust norm function based on normal cdf, instead of Huber or bisquare.)

not clear (I never read about this): What do we use for global optimization, possibly many local optima with redescending weight functions? This might be more of a problem for generic nonlinear cases than for linear models. (Use basinhopping instead of the usual random starting values as in LTS?)

maybe still to come: simple and short class as prototype for RobustGMM, i.e. start with robust estimating equations which is useful if the estimating equations for mean and scale don't come from a consistent objective function.
