### PR TITLE
BUG/ENH/TST: State space: Simulate / Impulse Responses

### DIFF
--- a/statsmodels/tsa/statespace/dynamic_factor.py
+++ b/statsmodels/tsa/statespace/dynamic_factor.py
@@ -223,6 +223,10 @@ class DynamicFactor(MLEModel):
             endog, exog=exog, k_states=k_states, k_posdef=k_posdef, **kwargs
         )
 
+        # Set as time-varying model if we have exog
+        if self.k_exog > 0:
+            self.ssm._time_invariant = False
+
         # Initialize the components
         self.parameters = OrderedDict()
         self._initialize_loadings()

--- a/statsmodels/tsa/statespace/kalman_filter.py
+++ b/statsmodels/tsa/statespace/kalman_filter.py
@@ -1157,12 +1157,16 @@ class KalmanFilter(Representation):
 
             # Get the impulse response function via simulation of the state
             # space model, but with other shocks set to zero
+            # Since simulate returns the zero-th period, we need to simulate
+            # steps + 1 periods and exclude the zero-th observation.
+            steps += 1
             measurement_shocks = np.zeros((steps, self.k_endog))
             state_shocks = np.zeros((steps, self.k_posdef))
             state_shocks[0] = impulse
             irf, _ = model.simulate(
                 steps, measurement_shocks=measurement_shocks,
                 state_shocks=state_shocks)
+            irf = irf[1:]
 
         # Get the cumulative response if requested
         if cumulative:

--- a/statsmodels/tsa/statespace/representation.py
+++ b/statsmodels/tsa/statespace/representation.py
@@ -350,6 +350,9 @@ class Representation(object):
         # Setup the underlying statespace object storage
         self._statespaces = {}
 
+        # Caches
+        self._time_invariant = None
+
     def __getitem__(self, key):
         _type = type(key)
         # If only a string is given then we must be getting an entire matrix
@@ -456,12 +459,15 @@ class Representation(object):
         (bool) Whether or not currently active representation matrices are
         time-invariant
         """
-        return (
-            self._design.shape[2] == self._obs_intercept.shape[1] ==
-            self._obs_cov.shape[2] == self._transition.shape[2] ==
-            self._state_intercept.shape[1] == self._selection.shape[2] ==
-            self._state_cov.shape[2]
-        )
+        if self._time_invariant is None:
+            return (
+                self._design.shape[2] == self._obs_intercept.shape[1] ==
+                self._obs_cov.shape[2] == self._transition.shape[2] ==
+                self._state_intercept.shape[1] == self._selection.shape[2] ==
+                self._state_cov.shape[2]
+            )
+        else:
+            return self._time_invariant
 
     @property
     def _statespace(self):

--- a/statsmodels/tsa/statespace/sarimax.py
+++ b/statsmodels/tsa/statespace/sarimax.py
@@ -510,6 +510,10 @@ class SARIMAX(MLEModel):
             endog, exog=exog, k_states=k_states, k_posdef=k_posdef, **kwargs
         )
 
+        # Set as time-varying model if we have time-trend or exog
+        if self.k_exog > 0 or len(self.polynomial_trend) > 1:
+            self.ssm._time_invariant = False
+
         # Handle kwargs specified initialization
         if self.ssm.initialization is not None:
             self._manual_initialization = True

--- a/statsmodels/tsa/statespace/simulation_smoother.py
+++ b/statsmodels/tsa/statespace/simulation_smoother.py
@@ -172,16 +172,16 @@ class SimulationSmoother(KalmanSmoother):
         simulator = self._simulators[prefix]
 
         # Set the disturbance variates
-        disturbance_variates = np.array(
+        disturbance_variates = np.atleast_1d(np.array(
             np.r_[measurement_shocks.ravel(), state_shocks.ravel()],
             dtype=self.dtype
-        ).squeeze()
+        ).squeeze())
         simulator.set_disturbance_variates(disturbance_variates)
 
         # Set the intial state vector
-        initial_state_variates = np.array(
+        initial_state_variates = np.atleast_1d(np.array(
             initial_state, dtype=self.dtype
-        ).squeeze()
+        ).squeeze())
         simulator.set_initial_state_variates(initial_state_variates)
 
         # Perform simulation smoothing

--- a/statsmodels/tsa/statespace/simulation_smoother.py
+++ b/statsmodels/tsa/statespace/simulation_smoother.py
@@ -140,7 +140,7 @@ class SimulationSmoother(KalmanSmoother):
 
         # Create the simulator if necessary
         if (prefix not in self._simulators or
-                nsimulations > self._simulators[prefix].nobs):
+                not nsimulations == self._simulators[prefix].nobs):
 
             # Make sure we have the required Statespace representation
             prefix, dtype, create_statespace = (

--- a/statsmodels/tsa/statespace/structural.py
+++ b/statsmodels/tsa/statespace/structural.py
@@ -490,6 +490,10 @@ class UnobservedComponents(MLEModel):
         )
         self.setup()
 
+        # Set as time-varying model if we have exog
+        if self.k_exog > 0:
+            self.ssm._time_invariant = False
+
         # Initialize the model
         self.ssm.loglikelihood_burn = loglikelihood_burn
 

--- a/statsmodels/tsa/statespace/tests/test_impulse_responses.py
+++ b/statsmodels/tsa/statespace/tests/test_impulse_responses.py
@@ -1,0 +1,310 @@
+"""
+Tests for impulse responses of time series
+
+Author: Chad Fulton
+License: Simplified-BSD
+"""
+
+from __future__ import division, absolute_import, print_function
+
+import warnings
+import numpy as np
+import pandas as pd
+import os
+from scipy.signal import lfilter
+
+from statsmodels.tsa.statespace import (sarimax, structural, varmax,
+                                        dynamic_factor)
+from numpy.testing import (assert_allclose, assert_almost_equal, assert_equal,
+                           assert_raises)
+from nose.exc import SkipTest
+
+
+def test_sarimax():
+    # AR(1)
+    mod = sarimax.SARIMAX([0], order=(1, 0, 0))
+    phi = 0.5
+    actual = mod.impulse_responses([phi, 1], steps=10)
+    desired = np.r_[[phi**i for i in range(11)]]
+    assert_allclose(actual[:, 0], desired)
+
+    # MA(1)
+    mod = sarimax.SARIMAX([0], order=(0, 0, 1))
+    theta = 0.5
+    actual = mod.impulse_responses([theta, 1], steps=10)
+    desired = np.r_[1, theta, [0]*9]
+    assert_allclose(actual[:, 0], desired)
+
+    # ARMA(2, 2) + constant
+    # Stata:
+    # webuse lutkepohl2
+    # arima dln_inc, arima(2, 0, 2)
+    # irf create irf1, set(irf1) step(10)
+    # irf table irf
+    params = [.01928228, -.03656216, .7588994,
+              .27070341, -.72928328, .01122177**0.5]
+    mod = sarimax.SARIMAX([0], order=(2, 0, 2), trend='c')
+    actual = mod.impulse_responses(params, steps=10)
+    desired = [1, .234141, .021055, .17692, .00951, .133917, .002321, .101544,
+               -.001951, .077133, -.004301]
+    assert_allclose(actual[:, 0], desired, atol=1e-6)
+
+    # SARIMAX(1,1,1)x(1,0,1,4) + constant + exog
+    # Stata:
+    # webuse lutkepohl2
+    # gen exog = _n^2
+    # arima inc exog, arima(1,1,1) sarima(1,0,1,4)
+    # irf create irf2, set(irf2) step(10)
+    # irf table irf
+    params = [.12853289, 12.207156, .86384742, -.71463236,
+              .81878967, -.9533955, 14.043884**0.5]
+    exog = np.arange(1, 92)**2
+    mod = sarimax.SARIMAX(np.zeros(91), order=(1, 1, 1),
+                          seasonal_order=(1, 0, 1, 4), trend='c', exog=exog,
+                          simple_differencing=True)
+    actual = mod.impulse_responses(params, steps=10)
+    desired = [1, .149215, .128899, .111349, -.038417, .063007, .054429,
+               .047018, -.069598, .018641, .016103]
+    assert_allclose(actual[:, 0], desired, atol=1e-6)
+
+
+def test_structural():
+    steps = 10
+
+    # AR(1)
+    mod = structural.UnobservedComponents([0], autoregressive=1)
+    phi = 0.5
+    actual = mod.impulse_responses([1, phi], steps)
+    desired = np.r_[[phi**i for i in range(steps + 1)]]
+    assert_allclose(actual[:, 0], desired)
+
+    # ARX(1)
+    # This is adequately tested in test_simulate.py, since in the time-varying
+    # case `impulse_responses` just calls `simulate`
+
+    # Irregular
+    mod = structural.UnobservedComponents([0], 'irregular')
+    actual = mod.impulse_responses([1.], steps)
+    assert_allclose(actual, 0)
+
+    # Fixed intercept
+    # (in practice this is a deterministic constant, because an irregular
+    #  component must be added)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        mod = structural.UnobservedComponents([0], 'fixed intercept')
+    actual = mod.impulse_responses([1.], steps)
+    assert_allclose(actual, 0)
+
+    # Deterministic constant
+    mod = structural.UnobservedComponents([0], 'deterministic constant')
+    actual = mod.impulse_responses([1.], steps)
+    assert_allclose(actual, 0)
+
+    # Local level
+    mod = structural.UnobservedComponents([0], 'local level')
+    actual = mod.impulse_responses([1., 1.], steps)
+    assert_allclose(actual, 1)
+
+    # Random walk
+    mod = structural.UnobservedComponents([0], 'random walk')
+    actual = mod.impulse_responses([1.], steps)
+    assert_allclose(actual, 1)
+
+    # Fixed slope
+    # (in practice this is a deterministic trend, because an irregular
+    #  component must be added)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        mod = structural.UnobservedComponents([0], 'fixed slope')
+    actual = mod.impulse_responses([1.], steps)
+    assert_allclose(actual, 0)
+
+    # Deterministic trend
+    mod = structural.UnobservedComponents([0], 'deterministic trend')
+    actual = mod.impulse_responses([1.], steps)
+    assert_allclose(actual, 0)
+
+    # Local linear deterministic trend
+    mod = structural.UnobservedComponents(
+        [0], 'local linear deterministic trend')
+    actual = mod.impulse_responses([1., 1.], steps)
+    assert_allclose(actual, 1)
+
+    # Random walk with drift
+    mod = structural.UnobservedComponents([0], 'random walk with drift')
+    actual = mod.impulse_responses([1.], steps)
+    assert_allclose(actual, 1)
+
+    # Local linear trend
+    mod = structural.UnobservedComponents([0], 'local linear trend')
+    # - shock the level
+    actual = mod.impulse_responses([1., 1., 1.], steps)
+    assert_allclose(actual, 1)
+    # - shock the trend
+    actual = mod.impulse_responses([1., 1., 1.], steps, impulse=1)
+    assert_allclose(actual[:, 0], np.arange(steps + 1))
+
+    # Smooth trend
+    mod = structural.UnobservedComponents([0], 'smooth trend')
+    actual = mod.impulse_responses([1., 1.], steps)
+    assert_allclose(actual[:, 0], np.arange(steps + 1))
+
+    # Random trend
+    mod = structural.UnobservedComponents([0], 'random trend')
+    actual = mod.impulse_responses([1., 1.], steps)
+    assert_allclose(actual[:, 0], np.arange(steps + 1))
+
+    # Seasonal (deterministic)
+    mod = structural.UnobservedComponents([0], 'irregular', seasonal=2,
+                                          stochastic_seasonal=False)
+    actual = mod.impulse_responses([1.], steps)
+    assert_allclose(actual, 0)
+
+    # Seasonal (stochastic)
+    mod = structural.UnobservedComponents([0], 'irregular', seasonal=2)
+    actual = mod.impulse_responses([1., 1.], steps)
+    desired = np.r_[1, np.tile([-1, 1], steps // 2)]
+    assert_allclose(actual[:, 0], desired)
+
+    # Cycle (deterministic)
+    mod = structural.UnobservedComponents([0], 'irregular', cycle=True)
+    actual = mod.impulse_responses([1., 1.2], steps)
+    assert_allclose(actual, 0)
+
+    # Cycle (stochastic)
+    mod = structural.UnobservedComponents([0], 'irregular', cycle=True,
+                                          stochastic_cycle=True)
+    actual = mod.impulse_responses([1., 1., 1.2], steps=10)
+    x1 = [np.cos(1.2), np.sin(1.2)]
+    x2 = [-np.sin(1.2), np.cos(1.2)]
+    T = np.array([x1, x2])
+    desired = np.zeros(steps + 1)
+    states = [1, 0]
+    for i in range(steps + 1):
+        desired[i] += states[0]
+        states = np.dot(T, states)
+    assert_allclose(actual[:, 0], desired)
+
+
+def test_varmax():
+    steps = 10
+
+    # Clear warnings
+    varmax.__warningregistry__ = {}
+
+    # VAR(2) - single series
+    mod1 = varmax.VARMAX([[0]], order=(2, 0), trend='nc')
+    mod2 = sarimax.SARIMAX([0], order=(2, 0, 0))
+    actual = mod1.impulse_responses([0.5, 0.2, 1], steps)
+    desired = mod2.impulse_responses([0.5, 0.2, 1], steps)
+    assert_allclose(actual, desired)
+
+    # VMA(2) - single series
+    mod1 = varmax.VARMAX([[0]], order=(0, 2), trend='nc')
+    mod2 = sarimax.SARIMAX([0], order=(0, 0, 2))
+    actual = mod1.impulse_responses([0.5, 0.2, 1], steps)
+    desired = mod2.impulse_responses([0.5, 0.2, 1], steps)
+    assert_allclose(actual, desired)
+
+    # VARMA(2, 2) - single series
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        mod1 = varmax.VARMAX([[0]], order=(2, 2), trend='nc')
+    mod2 = sarimax.SARIMAX([0], order=(2, 0, 2))
+    actual = mod1.impulse_responses([0.5, 0.2, 0.1, -0.2, 1], steps)
+    desired = mod2.impulse_responses([0.5, 0.2, 0.1, -0.2, 1], steps)
+    assert_allclose(actual, desired)
+
+    # VARMA(2, 2) + trend - single series
+    mod1 = varmax.VARMAX([[0]], order=(2, 2), trend='c')
+    mod2 = sarimax.SARIMAX([0], order=(2, 0, 2), trend='c')
+    actual = mod1.impulse_responses([10, 0.5, 0.2, 0.1, -0.2, 1], steps)
+    desired = mod2.impulse_responses([10, 0.5, 0.2, 0.1, -0.2, 1], steps)
+    assert_allclose(actual, desired)
+
+    # VAR(2) + constant
+    # Stata:
+    # webuse lutkepohl2
+    # var dln_inv dln_inc, lags(1/2)
+    # irf create irf3, set(irf3) step(10)
+    # irf table irf
+    # irf table oirf
+    params = [-.00122728, .01503679,
+              -.22741923, .71030531, -.11596357, .51494891,
+              .05974659, .02094608, .05635125, .08332519,
+              .04297918, .00159473, .01096298]
+    irf_00 = [1, -.227419, -.021806, .093362, -.001875, -.00906, .009605,
+              .001323, -.001041, .000769, .00032]
+    irf_01 = [0, .059747, .044015, -.008218, .007845, .004629, .000104,
+              .000451, .000638, .000063, .000042]
+    irf_10 = [0, .710305, .36829, -.065697, .084398, .043038, .000533,
+              .005755, .006051, .000548, .000526]
+    irf_11 = [1, .020946, .126202, .066419, .028735, .007477, .009878,
+              .003287, .001266, .000986, .0005]
+    oirf_00 = [0.042979, -0.008642, -0.00035, 0.003908, 0.000054, -0.000321,
+               0.000414, 0.000066, -0.000035, 0.000034, 0.000015]
+    oirf_01 = [0.001595, 0.002601, 0.002093, -0.000247, 0.000383, 0.000211,
+               0.00002, 0.000025, 0.000029, 4.30E-06, 2.60E-06]
+    oirf_10 = [0, 0.007787, 0.004037, -0.00072, 0.000925, 0.000472, 5.80E-06,
+               0.000063, 0.000066, 6.00E-06, 5.80E-06]
+    oirf_11 = [0.010963, 0.00023, 0.001384, 0.000728, 0.000315, 0.000082,
+               0.000108, 0.000036, 0.000014, 0.000011, 5.50E-06]
+
+    mod = varmax.VARMAX([[0, 0]], order=(2, 0), trend='c')
+
+    # IRFs
+    actual = mod.impulse_responses(params, steps, impulse=0)
+    assert_allclose(actual, np.c_[irf_00, irf_01], atol=1e-6)
+
+    actual = mod.impulse_responses(params, steps, impulse=1)
+    assert_allclose(actual, np.c_[irf_10, irf_11], atol=1e-6)
+
+    # Orthogonalized IRFs
+    actual = mod.impulse_responses(params, steps, impulse=0,
+                                   orthogonalized=True)
+    assert_allclose(actual, np.c_[oirf_00, oirf_01], atol=1e-6)
+
+    actual = mod.impulse_responses(params, steps, impulse=1,
+                                   orthogonalized=True)
+    assert_allclose(actual, np.c_[oirf_10, oirf_11], atol=1e-6)
+
+    # VARMA(2, 2) + trend + exog
+    # TODO: This is just a smoke test
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        mod = varmax.VARMAX(
+            np.random.normal(size=(steps, 2)), order=(2, 2), trend='c',
+            exog=np.ones(steps), enforce_stationarity=False)
+    mod.impulse_responses(mod.start_params, steps)
+
+
+def test_dynamic_factor():
+    steps = 10
+    exog = np.random.normal(size=steps)
+
+    # DFM: 2 series, AR(2) factor
+    mod1 = dynamic_factor.DynamicFactor([[0, 0]], k_factors=1, factor_order=2)
+    mod2 = sarimax.SARIMAX([0], order=(2, 0, 0))
+    actual = mod1.impulse_responses([-0.9, 0.8, 1., 1., 0.5, 0.2], steps)
+    desired = mod2.impulse_responses([0.5, 0.2, 1], steps)
+    assert_allclose(actual[:, 0], -0.9 * desired[:, 0])
+    assert_allclose(actual[:, 1], 0.8 * desired[:, 0])
+
+    # DFM: 2 series, AR(2) factor, exog
+    mod1 = dynamic_factor.DynamicFactor(np.zeros((steps, 2)), k_factors=1,
+                                        factor_order=2, exog=exog)
+    mod2 = sarimax.SARIMAX([0], order=(2, 0, 0))
+    actual = mod1.impulse_responses(
+        [-0.9, 0.8, 5, -2, 1., 1., 0.5, 0.2], steps)
+    desired = mod2.impulse_responses([0.5, 0.2, 1], steps)
+    assert_allclose(actual[:, 0], -0.9 * desired[:, 0])
+    assert_allclose(actual[:, 1], 0.8 * desired[:, 0])
+
+    # DFM, 3 series, VAR(2) factor, exog, error VAR
+    # TODO: This is just a smoke test
+    mod = dynamic_factor.DynamicFactor(np.random.normal(size=(steps, 3)),
+                                       k_factors=2, factor_order=2, exog=exog,
+                                       error_order=2, error_var=True,
+                                       enforce_stationarity=False)
+    mod.impulse_responses(mod.start_params, steps)

--- a/statsmodels/tsa/statespace/tests/test_impulse_responses.py
+++ b/statsmodels/tsa/statespace/tests/test_impulse_responses.py
@@ -26,14 +26,14 @@ def test_sarimax():
     phi = 0.5
     actual = mod.impulse_responses([phi, 1], steps=10)
     desired = np.r_[[phi**i for i in range(11)]]
-    assert_allclose(actual[:, 0], desired)
+    assert_allclose(actual, desired)
 
     # MA(1)
     mod = sarimax.SARIMAX([0], order=(0, 0, 1))
     theta = 0.5
     actual = mod.impulse_responses([theta, 1], steps=10)
     desired = np.r_[1, theta, [0]*9]
-    assert_allclose(actual[:, 0], desired)
+    assert_allclose(actual, desired)
 
     # ARMA(2, 2) + constant
     # Stata:
@@ -47,7 +47,7 @@ def test_sarimax():
     actual = mod.impulse_responses(params, steps=10)
     desired = [1, .234141, .021055, .17692, .00951, .133917, .002321, .101544,
                -.001951, .077133, -.004301]
-    assert_allclose(actual[:, 0], desired, atol=1e-6)
+    assert_allclose(actual, desired, atol=1e-6)
 
     # SARIMAX(1,1,1)x(1,0,1,4) + constant + exog
     # Stata:
@@ -65,7 +65,7 @@ def test_sarimax():
     actual = mod.impulse_responses(params, steps=10)
     desired = [1, .149215, .128899, .111349, -.038417, .063007, .054429,
                .047018, -.069598, .018641, .016103]
-    assert_allclose(actual[:, 0], desired, atol=1e-6)
+    assert_allclose(actual, desired, atol=1e-6)
 
 
 def test_structural():
@@ -76,7 +76,7 @@ def test_structural():
     phi = 0.5
     actual = mod.impulse_responses([1, phi], steps)
     desired = np.r_[[phi**i for i in range(steps + 1)]]
-    assert_allclose(actual[:, 0], desired)
+    assert_allclose(actual, desired)
 
     # ARX(1)
     # This is adequately tested in test_simulate.py, since in the time-varying
@@ -143,17 +143,17 @@ def test_structural():
     assert_allclose(actual, 1)
     # - shock the trend
     actual = mod.impulse_responses([1., 1., 1.], steps, impulse=1)
-    assert_allclose(actual[:, 0], np.arange(steps + 1))
+    assert_allclose(actual, np.arange(steps + 1))
 
     # Smooth trend
     mod = structural.UnobservedComponents([0], 'smooth trend')
     actual = mod.impulse_responses([1., 1.], steps)
-    assert_allclose(actual[:, 0], np.arange(steps + 1))
+    assert_allclose(actual, np.arange(steps + 1))
 
     # Random trend
     mod = structural.UnobservedComponents([0], 'random trend')
     actual = mod.impulse_responses([1., 1.], steps)
-    assert_allclose(actual[:, 0], np.arange(steps + 1))
+    assert_allclose(actual, np.arange(steps + 1))
 
     # Seasonal (deterministic)
     mod = structural.UnobservedComponents([0], 'irregular', seasonal=2,
@@ -165,7 +165,7 @@ def test_structural():
     mod = structural.UnobservedComponents([0], 'irregular', seasonal=2)
     actual = mod.impulse_responses([1., 1.], steps)
     desired = np.r_[1, np.tile([-1, 1], steps // 2)]
-    assert_allclose(actual[:, 0], desired)
+    assert_allclose(actual, desired)
 
     # Cycle (deterministic)
     mod = structural.UnobservedComponents([0], 'irregular', cycle=True)
@@ -184,7 +184,7 @@ def test_structural():
     for i in range(steps + 1):
         desired[i] += states[0]
         states = np.dot(T, states)
-    assert_allclose(actual[:, 0], desired)
+    assert_allclose(actual, desired)
 
 
 def test_varmax():
@@ -275,7 +275,8 @@ def test_varmax():
         warnings.simplefilter("ignore")
         mod = varmax.VARMAX(
             np.random.normal(size=(steps, 2)), order=(2, 2), trend='c',
-            exog=np.ones(steps), enforce_stationarity=False)
+            exog=np.ones(steps), enforce_stationarity=False,
+            enforce_invertibility=False)
     mod.impulse_responses(mod.start_params, steps)
 
 
@@ -288,8 +289,8 @@ def test_dynamic_factor():
     mod2 = sarimax.SARIMAX([0], order=(2, 0, 0))
     actual = mod1.impulse_responses([-0.9, 0.8, 1., 1., 0.5, 0.2], steps)
     desired = mod2.impulse_responses([0.5, 0.2, 1], steps)
-    assert_allclose(actual[:, 0], -0.9 * desired[:, 0])
-    assert_allclose(actual[:, 1], 0.8 * desired[:, 0])
+    assert_allclose(actual[:, 0], -0.9 * desired)
+    assert_allclose(actual[:, 1], 0.8 * desired)
 
     # DFM: 2 series, AR(2) factor, exog
     mod1 = dynamic_factor.DynamicFactor(np.zeros((steps, 2)), k_factors=1,
@@ -298,8 +299,8 @@ def test_dynamic_factor():
     actual = mod1.impulse_responses(
         [-0.9, 0.8, 5, -2, 1., 1., 0.5, 0.2], steps)
     desired = mod2.impulse_responses([0.5, 0.2, 1], steps)
-    assert_allclose(actual[:, 0], -0.9 * desired[:, 0])
-    assert_allclose(actual[:, 1], 0.8 * desired[:, 0])
+    assert_allclose(actual[:, 0], -0.9 * desired)
+    assert_allclose(actual[:, 1], 0.8 * desired)
 
     # DFM, 3 series, VAR(2) factor, exog, error VAR
     # TODO: This is just a smoke test

--- a/statsmodels/tsa/statespace/tests/test_representation.py
+++ b/statsmodels/tsa/statespace/tests/test_representation.py
@@ -1044,7 +1044,7 @@ def test_simulate():
 
     actual = res.simulate(
         nsimulations, measurement_shocks=measurement_shocks,
-        state_shocks=state_shocks)[0].squeeze()
+        state_shocks=state_shocks)
     desired = lfilter(
         res.polynomial_reduced_ma, res.polynomial_reduced_ar,
         np.r_[0, state_shocks[:-1]])
@@ -1218,11 +1218,11 @@ def test_impulse_responses():
     phi = 0.5
     mod.update([phi, 1])
 
-    desired = np.cumprod(np.r_[1, [phi]*10])[:, np.newaxis]
-    
+    desired = np.cumprod(np.r_[1, [phi]*10])
+
     # Test going through the model directly
     actual = mod.ssm.impulse_responses(steps=10)
-    assert_allclose(actual, desired)
+    assert_allclose(actual[:, 0], desired)
 
     # Test going through the results object
     res = mod.filter([phi, 1.])

--- a/statsmodels/tsa/statespace/tests/test_simulate.py
+++ b/statsmodels/tsa/statespace/tests/test_simulate.py
@@ -1,0 +1,140 @@
+"""
+Tests for simulation of time series
+
+Author: Chad Fulton
+License: Simplified-BSD
+"""
+
+from __future__ import division, absolute_import, print_function
+
+import numpy as np
+import pandas as pd
+import os
+from scipy.signal import lfilter
+
+from statsmodels.tsa.statespace import sarimax
+from statsmodels.tsa.statespace.tools import compatibility_mode
+from numpy.testing import (assert_allclose, assert_almost_equal, assert_equal,
+                           assert_raises)
+from nose.exc import SkipTest
+
+
+def test_arma_lfilter():
+    # Tests of an ARMA model simulation against scipy.signal.lfilter
+    # Note: the first elements of the generated SARIMAX datasets are based on
+    # the initial state, so we don't include them in the comparisons
+    np.random.seed(10239)
+    nobs = 100
+    eps = np.random.normal(size=nobs)
+
+    # AR(1)
+    mod = sarimax.SARIMAX([0], order=(1, 0, 0))
+    actual = mod.simulate([0.5, 1.], nobs + 1, state_shocks=np.r_[eps, 0])
+    desired = lfilter([1], [1, -0.5], eps)
+    assert_allclose(actual[0, 1:], desired)
+
+    # MA(1)
+    mod = sarimax.SARIMAX([0], order=(0, 0, 1))
+    actual = mod.simulate([0.5, 1.], nobs + 1, state_shocks=np.r_[eps, 0])
+    desired = lfilter([1, 0.5], [1], eps)
+    assert_allclose(actual[0, 1:], desired)
+
+    # ARMA(1, 1)
+    mod = sarimax.SARIMAX([0], order=(1, 0, 1))
+    actual = mod.simulate([0.5, 0.2, 1.], nobs + 1, state_shocks=np.r_[eps, 0])
+    desired = lfilter([1, 0.2], [1, -0.5], eps)
+    assert_allclose(actual[0, 1:], desired)
+
+
+def test_arma_direct():
+    # Tests of an ARMA model simulation against direct construction
+    # This is useful for e.g. trend components
+    # Note: the first elements of the generated SARIMAX datasets are based on
+    # the initial state, so we don't include them in the comparisons
+    np.random.seed(10239)
+    nobs = 100
+    eps = np.random.normal(size=nobs)
+    exog = np.random.normal(size=nobs)
+
+    # AR(1)
+    mod = sarimax.SARIMAX([0], order=(1, 0, 0))
+    actual = mod.simulate([0.5, 1.], nobs + 1, state_shocks=np.r_[eps, 0])
+    desired = np.zeros(nobs)
+    for i in range(nobs):
+        if i == 0:
+            desired[i] = eps[i]
+        else:
+            desired[i] = 0.5 * desired[i - 1] + eps[i]
+    assert_allclose(actual[0, 1:], desired)
+
+    # MA(1)
+    mod = sarimax.SARIMAX([0], order=(0, 0, 1))
+    actual = mod.simulate([0.5, 1.], nobs + 1, state_shocks=np.r_[eps, 0])
+    desired = np.zeros(nobs)
+    for i in range(nobs):
+        if i == 0:
+            desired[i] = eps[i]
+        else:
+            desired[i] = 0.5 * eps[i - 1] + eps[i]
+    assert_allclose(actual[0, 1:], desired)
+
+    # ARMA(1, 1)
+    mod = sarimax.SARIMAX([0], order=(1, 0, 1))
+    actual = mod.simulate([0.5, 0.2, 1.], nobs + 1, state_shocks=np.r_[eps, 0])
+    desired = np.zeros(nobs)
+    for i in range(nobs):
+        if i == 0:
+            desired[i] = eps[i]
+        else:
+            desired[i] = 0.5 * desired[i - 1] + 0.2 * eps[i - 1] + eps[i]
+    assert_allclose(actual[0, 1:], desired)
+
+    # ARMA(1, 1) + intercept
+    mod = sarimax.SARIMAX([0], order=(1, 0, 1), trend='c')
+    actual = mod.simulate([1.3, 0.5, 0.2, 1.], nobs + 1,
+                          state_shocks=np.r_[eps, 0])
+    desired = np.zeros(nobs)
+    for i in range(nobs):
+        trend = 1.3
+        if i == 0:
+            desired[i] = trend + eps[i]
+        else:
+            desired[i] = (trend + 0.5 * desired[i - 1] +
+                          0.2 * eps[i - 1] + eps[i])
+    assert_allclose(actual[0, 1:], desired)
+
+    # ARMA(1, 1) + intercept + time trend
+    # Note: to allow time-varying SARIMAX to simulate 101 observations, need to
+    # give it 101 observations up front
+    mod = sarimax.SARIMAX(np.zeros(nobs + 1), order=(1, 0, 1), trend='ct')
+    actual = mod.simulate([1.3, 0.2, 0.5, 0.2, 1.], nobs + 1,
+                          state_shocks=np.r_[eps, 0])
+    desired = np.zeros(nobs)
+    for i in range(nobs):
+        trend = 1.3 + 0.2 * (i + 1)
+        if i == 0:
+            desired[i] = trend + eps[i]
+        else:
+            desired[i] = (trend + 0.5 * desired[i - 1] +
+                          0.2 * eps[i - 1] + eps[i])
+    assert_allclose(actual[0, 1:], desired)
+
+    # ARMA(1, 1) + intercept + time trend
+    # Note: to allow time-varying SARIMAX to simulate 101 observations, need to
+    # give it 101 observations up front
+    # Note: the model is regression with SARIMAX errors, so the exog is
+    # introduced into the observation equation rather than the ARMA part
+    mod = sarimax.SARIMAX(np.zeros(nobs + 1), exog=np.r_[0, exog],
+                          order=(1, 0, 1), trend='ct')
+    actual = mod.simulate([1.3, 0.2, -0.5, 0.5, 0.2, 1.], nobs + 1,
+                          state_shocks=np.r_[eps, 0])
+    desired = np.zeros(nobs)
+    for i in range(nobs):
+        trend = 1.3 + 0.2 * (i + 1)
+        if i == 0:
+            desired[i] = trend + eps[i]
+        else:
+            desired[i] = (trend + 0.5 * desired[i - 1] +
+                          0.2 * eps[i - 1] + eps[i])
+    desired = desired - 0.5 * exog
+    assert_allclose(actual[0, 1:], desired)

--- a/statsmodels/tsa/statespace/tests/test_simulate.py
+++ b/statsmodels/tsa/statespace/tests/test_simulate.py
@@ -7,12 +7,14 @@ License: Simplified-BSD
 
 from __future__ import division, absolute_import, print_function
 
+import warnings
 import numpy as np
 import pandas as pd
 import os
 from scipy.signal import lfilter
 
-from statsmodels.tsa.statespace import sarimax
+from statsmodels.tsa.statespace import (sarimax, structural, varmax,
+                                        dynamic_factor)
 from statsmodels.tsa.statespace.tools import compatibility_mode
 from numpy.testing import (assert_allclose, assert_almost_equal, assert_equal,
                            assert_raises)
@@ -119,7 +121,7 @@ def test_arma_direct():
                           0.2 * eps[i - 1] + eps[i])
     assert_allclose(actual[0, 1:], desired)
 
-    # ARMA(1, 1) + intercept + time trend
+    # ARMA(1, 1) + intercept + time trend + exog
     # Note: to allow time-varying SARIMAX to simulate 101 observations, need to
     # give it 101 observations up front
     # Note: the model is regression with SARIMAX errors, so the exog is
@@ -138,3 +140,321 @@ def test_arma_direct():
                           0.2 * eps[i - 1] + eps[i])
     desired = desired - 0.5 * exog
     assert_allclose(actual[0, 1:], desired)
+
+
+def test_structural():
+    # Clear warnings
+    structural.__warningregistry__ = {}
+
+    np.random.seed(38947)
+    nobs = 100
+    eps = np.random.normal(size=nobs)
+    exog = np.random.normal(size=nobs)
+
+    eps1 = np.zeros(nobs)
+    eps2 = np.zeros(nobs)
+    eps2[49] = 1
+    eps3 = np.zeros(nobs)
+    eps3[50:] = 1
+
+    # AR(1)
+    mod1 = structural.UnobservedComponents([0], autoregressive=1)
+    mod2 = sarimax.SARIMAX([0], order=(1, 0, 0))
+    actual = mod1.simulate([1, 0.5], nobs, state_shocks=eps)
+    desired = mod2.simulate([0.5, 1], nobs, state_shocks=eps)
+    assert_allclose(actual, desired)
+
+    # ARX(1)
+    mod1 = structural.UnobservedComponents(np.zeros(nobs), exog=exog,
+                                           autoregressive=1)
+    mod2 = sarimax.SARIMAX(np.zeros(nobs), exog=exog, order=(1, 0, 0))
+    actual = mod1.simulate([1, 0.5, 0.2], nobs, state_shocks=eps)
+    desired = mod2.simulate([0.2, 0.5, 1], nobs, state_shocks=eps)
+    assert_allclose(actual, desired)
+
+    # Irregular
+    mod = structural.UnobservedComponents([0], 'irregular')
+    actual = mod.simulate([1.], nobs, measurement_shocks=eps)
+    assert_allclose(actual[0], eps)
+
+    # Fixed intercept
+    # (in practice this is a deterministic constant, because an irregular
+    #  component must be added)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        mod = structural.UnobservedComponents([0], 'fixed intercept')
+    actual = mod.simulate([1.], nobs, measurement_shocks=eps,
+                          initial_state=[10])
+    assert_allclose(actual[0], 10 + eps)
+
+    # Deterministic constant
+    mod = structural.UnobservedComponents([0], 'deterministic constant')
+    actual = mod.simulate([1.], nobs, measurement_shocks=eps,
+                          initial_state=[10])
+    assert_allclose(actual[0], 10 + eps)
+
+    # Local level
+    mod = structural.UnobservedComponents([0], 'local level')
+    actual = mod.simulate([1., 1.], nobs, measurement_shocks=eps,
+                          state_shocks=eps2)
+    assert_allclose(actual[0], eps + eps3)
+
+    # Random walk
+    mod = structural.UnobservedComponents([0], 'random walk')
+    actual = mod.simulate([1.], nobs, measurement_shocks=eps,
+                          state_shocks=eps2)
+    assert_allclose(actual[0], eps + eps3)
+
+    # Fixed slope
+    # (in practice this is a deterministic trend, because an irregular
+    #  component must be added)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        mod = structural.UnobservedComponents([0], 'fixed slope')
+    actual = mod.simulate([1., 1.], nobs, measurement_shocks=eps,
+                          state_shocks=eps2, initial_state=[0, 1])
+    assert_allclose(actual[0], eps + np.arange(100))
+
+    # Deterministic trend
+    mod = structural.UnobservedComponents([0], 'deterministic trend')
+    actual = mod.simulate([1.], nobs, measurement_shocks=eps,
+                          state_shocks=eps2, initial_state=[0, 1])
+    assert_allclose(actual[0], eps + np.arange(100))
+
+    # Local linear deterministic trend
+    mod = structural.UnobservedComponents(
+        [0], 'local linear deterministic trend')
+    actual = mod.simulate([1., 1.], nobs, measurement_shocks=eps,
+                          state_shocks=eps2, initial_state=[0, 1])
+    desired = eps + np.r_[np.arange(50), 1 + np.arange(50, 100)]
+    assert_allclose(actual[0], desired)
+
+    # Random walk with drift
+    mod = structural.UnobservedComponents([0], 'random walk with drift')
+    actual = mod.simulate([1.], nobs, state_shocks=eps2,
+                          initial_state=[0, 1])
+    desired = np.r_[np.arange(50), 1 + np.arange(50, 100)]
+    assert_allclose(actual[0], desired)
+
+    # Local linear trend
+    mod = structural.UnobservedComponents([0], 'local linear trend')
+    actual = mod.simulate([1., 1., 1.], nobs, measurement_shocks=eps,
+                          state_shocks=np.c_[eps2, eps1], initial_state=[0, 1])
+    desired = eps + np.r_[np.arange(50), 1 + np.arange(50, 100)]
+    assert_allclose(actual[0], desired)
+
+    actual = mod.simulate([1., 1., 1.], nobs, measurement_shocks=eps,
+                          state_shocks=np.c_[eps1, eps2], initial_state=[0, 1])
+    desired = eps + np.r_[np.arange(50), np.arange(50, 150, 2)]
+    assert_allclose(actual[0], desired)
+
+    # Smooth trend
+    mod = structural.UnobservedComponents([0], 'smooth trend')
+    actual = mod.simulate([1., 1.], nobs, measurement_shocks=eps,
+                          state_shocks=eps1, initial_state=[0, 1])
+    desired = eps + np.r_[np.arange(100)]
+    assert_allclose(actual[0], desired)
+
+    actual = mod.simulate([1., 1.], nobs, measurement_shocks=eps,
+                          state_shocks=eps2, initial_state=[0, 1])
+    desired = eps + np.r_[np.arange(50), np.arange(50, 150, 2)]
+    assert_allclose(actual[0], desired)
+
+    # Random trend
+    mod = structural.UnobservedComponents([0], 'random trend')
+    actual = mod.simulate([1., 1.], nobs,
+                          state_shocks=eps1, initial_state=[0, 1])
+    desired = np.r_[np.arange(100)]
+    assert_allclose(actual[0], desired)
+
+    actual = mod.simulate([1., 1.], nobs,
+                          state_shocks=eps2, initial_state=[0, 1])
+    desired = np.r_[np.arange(50), np.arange(50, 150, 2)]
+    assert_allclose(actual[0], desired)
+
+    # Seasonal (deterministic)
+    mod = structural.UnobservedComponents([0], 'irregular', seasonal=2,
+                                          stochastic_seasonal=False)
+    actual = mod.simulate([1.], nobs, measurement_shocks=eps,
+                          initial_state=[10])
+    desired = eps + np.tile([10, -10], 50)
+    assert_allclose(actual[0], desired)
+
+    # Seasonal (stochastic)
+    mod = structural.UnobservedComponents([0], 'irregular', seasonal=2)
+    actual = mod.simulate([1., 1.], nobs, measurement_shocks=eps,
+                          state_shocks=eps2, initial_state=[10])
+    desired = eps + np.r_[np.tile([10, -10], 25), np.tile([11, -11], 25)]
+    assert_allclose(actual[0], desired)
+
+    # Cycle (deterministic)
+    mod = structural.UnobservedComponents([0], 'irregular', cycle=True)
+    actual = mod.simulate([1., 1.2], nobs, measurement_shocks=eps,
+                          initial_state=[1, 0])
+    x1 = [np.cos(1.2), np.sin(1.2)]
+    x2 = [-np.sin(1.2), np.cos(1.2)]
+    T = np.array([x1, x2])
+    desired = eps
+    states = [1, 0]
+    for i in range(nobs):
+        desired[i] += states[0]
+        states = np.dot(T, states)
+    assert_allclose(actual[0], desired)
+
+    # Cycle (stochastic)
+    mod = structural.UnobservedComponents([0], 'irregular', cycle=True,
+                                          stochastic_cycle=True)
+    actual = mod.simulate([1., 1., 1.2], nobs, measurement_shocks=eps,
+                          state_shocks=np.c_[eps2, eps2], initial_state=[1, 0])
+    x1 = [np.cos(1.2), np.sin(1.2)]
+    x2 = [-np.sin(1.2), np.cos(1.2)]
+    T = np.array([x1, x2])
+    desired = eps
+    states = [1, 0]
+    for i in range(nobs):
+        desired[i] += states[0]
+        states = np.dot(T, states) + eps2[i]
+    assert_allclose(actual[0], desired)
+
+
+def test_varmax():
+    # Clear warnings
+    varmax.__warningregistry__ = {}
+
+    np.random.seed(371934)
+    nobs = 100
+    eps = np.random.normal(size=nobs)
+    exog = np.random.normal(size=(nobs, 1))
+
+    eps1 = np.zeros(nobs)
+    eps2 = np.zeros(nobs)
+    eps2[49] = 1
+    eps3 = np.zeros(nobs)
+    eps3[50:] = 1
+
+    # VAR(2) - single series
+    mod1 = varmax.VARMAX([[0]], order=(2, 0), trend='nc')
+    mod2 = sarimax.SARIMAX([0], order=(2, 0, 0))
+    actual = mod1.simulate([0.5, 0.2, 1], nobs, state_shocks=eps)
+    desired = mod2.simulate([0.5, 0.2, 1], nobs, state_shocks=eps)
+    assert_allclose(actual, desired)
+
+    # VMA(2) - single series
+    mod1 = varmax.VARMAX([[0]], order=(0, 2), trend='nc')
+    mod2 = sarimax.SARIMAX([0], order=(0, 0, 2))
+    actual = mod1.simulate([0.5, 0.2, 1], nobs, state_shocks=eps)
+    desired = mod2.simulate([0.5, 0.2, 1], nobs, state_shocks=eps)
+    assert_allclose(actual, desired)
+
+    # VARMA(2, 2) - single series
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        mod1 = varmax.VARMAX([[0]], order=(2, 2), trend='nc')
+    mod2 = sarimax.SARIMAX([0], order=(2, 0, 2))
+    actual = mod1.simulate([0.5, 0.2, 0.1, -0.2, 1], nobs, state_shocks=eps)
+    desired = mod2.simulate([0.5, 0.2, 0.1, -0.2, 1], nobs, state_shocks=eps)
+    assert_allclose(actual, desired)
+
+    # VARMA(2, 2) + trend - single series
+    mod1 = varmax.VARMAX([[0]], order=(2, 2), trend='c')
+    mod2 = sarimax.SARIMAX([0], order=(2, 0, 2), trend='c')
+    actual = mod1.simulate([10, 0.5, 0.2, 0.1, -0.2, 1], nobs,
+                           state_shocks=eps)
+    desired = mod2.simulate([10, 0.5, 0.2, 0.1, -0.2, 1], nobs,
+                            state_shocks=eps)
+    assert_allclose(actual, desired)
+
+    # VAR(1)
+    transition = np.array([[0.5,  0.1],
+                           [-0.1, 0.2]])
+
+    mod = varmax.VARMAX([[0, 0]], order=(1, 0), trend='nc')
+    actual = mod.simulate(np.r_[transition.ravel(), 1., 0, 1.], nobs,
+                          state_shocks=np.c_[eps1, eps1])
+    assert_allclose(actual, 0)
+
+    actual = mod.simulate(np.r_[transition.ravel(), 1., 0, 1.], nobs,
+                          state_shocks=np.c_[eps1, eps1], initial_state=[1, 1])
+    desired = np.zeros((2, nobs))
+    state = np.r_[1, 1]
+    for i in range(nobs):
+        desired[:, i] = state
+        state = np.dot(transition, state)
+    assert_allclose(actual, desired)
+
+    # VAR(1) + measurement error
+    mod = varmax.VARMAX([[0, 0]], order=(1, 0), trend='nc',
+                        measurement_error=True)
+    actual = mod.simulate(np.r_[transition.ravel(), 1., 0, 1., 1., 1.], nobs,
+                          measurement_shocks=np.c_[eps, eps],
+                          state_shocks=np.c_[eps1, eps1])
+    assert_allclose(actual, np.c_[eps, eps].T)
+
+    # VARX(1)
+    mod = varmax.VARMAX(np.zeros((nobs, 2)), order=(1, 0), trend='nc',
+                        exog=exog)
+    actual = mod.simulate(np.r_[transition.ravel(), 5, -2, 1., 0, 1.], nobs,
+                          state_shocks=np.c_[eps1, eps1], initial_state=[1, 1])
+    desired = np.zeros((2, nobs))
+    state = np.r_[1, 1]
+    for i in range(nobs):
+        desired[:, i] = state
+        state = exog[i] * [5, -2] + np.dot(transition, state)
+    assert_allclose(actual, desired)
+
+    # VMA(1)
+    # TODO: This is just a smoke test
+    mod = varmax.VARMAX(
+        np.random.normal(size=(nobs, 2)), order=(0, 1), trend='nc')
+    print(mod.start_params)
+    mod.simulate(mod.start_params, nobs)
+
+    # VARMA(2, 2) + trend + exog
+    # TODO: This is just a smoke test
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        mod = varmax.VARMAX(
+            np.random.normal(size=(nobs, 2)), order=(2, 2), trend='c',
+            exog=exog)
+    mod.simulate(mod.start_params, nobs)
+
+
+def test_dynamic_factor():
+    np.random.seed(93739)
+    nobs = 100
+    eps = np.random.normal(size=nobs)
+    exog = np.random.normal(size=(nobs, 1))
+
+    eps1 = np.zeros(nobs)
+    eps2 = np.zeros(nobs)
+    eps2[49] = 1
+    eps3 = np.zeros(nobs)
+    eps3[50:] = 1
+
+    # DFM: 2 series, AR(2) factor
+    mod1 = dynamic_factor.DynamicFactor([[0, 0]], k_factors=1, factor_order=2)
+    mod2 = sarimax.SARIMAX([0], order=(2, 0, 0))
+    actual = mod1.simulate([-0.9, 0.8, 1., 1., 0.5, 0.2], nobs,
+                           measurement_shocks=np.c_[eps1, eps1],
+                           state_shocks=eps)
+    desired = mod2.simulate([0.5, 0.2, 1], nobs, state_shocks=eps)
+    assert_allclose(actual[0], -0.9 * desired[0])
+    assert_allclose(actual[1], 0.8 * desired[0])
+
+    # DFM: 2 series, AR(2) factor, exog
+    mod1 = dynamic_factor.DynamicFactor(np.zeros((nobs, 2)), k_factors=1,
+                                        factor_order=2, exog=exog)
+    mod2 = sarimax.SARIMAX([0], order=(2, 0, 0))
+    actual = mod1.simulate([-0.9, 0.8, 5, -2, 1., 1., 0.5, 0.2], nobs,
+                           measurement_shocks=np.c_[eps1, eps1],
+                           state_shocks=eps)
+    desired = mod2.simulate([0.5, 0.2, 1], nobs, state_shocks=eps)
+    assert_allclose(actual[0], -0.9 * desired[0] + 5 * exog[:, 0])
+    assert_allclose(actual[1], 0.8 * desired[0] - 2 * exog[:, 0])
+
+    # DFM, 3 series, VAR(2) factor, exog, error VAR
+    # TODO: This is just a smoke test
+    mod = dynamic_factor.DynamicFactor(np.random.normal(size=(nobs, 3)),
+                                       k_factors=2, factor_order=2, exog=exog,
+                                       error_order=2, error_var=True)
+    mod.simulate(mod.start_params, nobs)

--- a/statsmodels/tsa/statespace/tests/test_simulate.py
+++ b/statsmodels/tsa/statespace/tests/test_simulate.py
@@ -33,19 +33,19 @@ def test_arma_lfilter():
     mod = sarimax.SARIMAX([0], order=(1, 0, 0))
     actual = mod.simulate([0.5, 1.], nobs + 1, state_shocks=np.r_[eps, 0])
     desired = lfilter([1], [1, -0.5], eps)
-    assert_allclose(actual[0, 1:], desired)
+    assert_allclose(actual[1:], desired)
 
     # MA(1)
     mod = sarimax.SARIMAX([0], order=(0, 0, 1))
     actual = mod.simulate([0.5, 1.], nobs + 1, state_shocks=np.r_[eps, 0])
     desired = lfilter([1, 0.5], [1], eps)
-    assert_allclose(actual[0, 1:], desired)
+    assert_allclose(actual[1:], desired)
 
     # ARMA(1, 1)
     mod = sarimax.SARIMAX([0], order=(1, 0, 1))
     actual = mod.simulate([0.5, 0.2, 1.], nobs + 1, state_shocks=np.r_[eps, 0])
     desired = lfilter([1, 0.2], [1, -0.5], eps)
-    assert_allclose(actual[0, 1:], desired)
+    assert_allclose(actual[1:], desired)
 
 
 def test_arma_direct():
@@ -67,7 +67,7 @@ def test_arma_direct():
             desired[i] = eps[i]
         else:
             desired[i] = 0.5 * desired[i - 1] + eps[i]
-    assert_allclose(actual[0, 1:], desired)
+    assert_allclose(actual[1:], desired)
 
     # MA(1)
     mod = sarimax.SARIMAX([0], order=(0, 0, 1))
@@ -78,7 +78,7 @@ def test_arma_direct():
             desired[i] = eps[i]
         else:
             desired[i] = 0.5 * eps[i - 1] + eps[i]
-    assert_allclose(actual[0, 1:], desired)
+    assert_allclose(actual[1:], desired)
 
     # ARMA(1, 1)
     mod = sarimax.SARIMAX([0], order=(1, 0, 1))
@@ -89,7 +89,7 @@ def test_arma_direct():
             desired[i] = eps[i]
         else:
             desired[i] = 0.5 * desired[i - 1] + 0.2 * eps[i - 1] + eps[i]
-    assert_allclose(actual[0, 1:], desired)
+    assert_allclose(actual[1:], desired)
 
     # ARMA(1, 1) + intercept
     mod = sarimax.SARIMAX([0], order=(1, 0, 1), trend='c')
@@ -103,7 +103,7 @@ def test_arma_direct():
         else:
             desired[i] = (trend + 0.5 * desired[i - 1] +
                           0.2 * eps[i - 1] + eps[i])
-    assert_allclose(actual[0, 1:], desired)
+    assert_allclose(actual[1:], desired)
 
     # ARMA(1, 1) + intercept + time trend
     # Note: to allow time-varying SARIMAX to simulate 101 observations, need to
@@ -119,7 +119,7 @@ def test_arma_direct():
         else:
             desired[i] = (trend + 0.5 * desired[i - 1] +
                           0.2 * eps[i - 1] + eps[i])
-    assert_allclose(actual[0, 1:], desired)
+    assert_allclose(actual[1:], desired)
 
     # ARMA(1, 1) + intercept + time trend + exog
     # Note: to allow time-varying SARIMAX to simulate 101 observations, need to
@@ -139,7 +139,7 @@ def test_arma_direct():
             desired[i] = (trend + 0.5 * desired[i - 1] +
                           0.2 * eps[i - 1] + eps[i])
     desired = desired - 0.5 * exog
-    assert_allclose(actual[0, 1:], desired)
+    assert_allclose(actual[1:], desired)
 
 
 def test_structural():
@@ -175,7 +175,7 @@ def test_structural():
     # Irregular
     mod = structural.UnobservedComponents([0], 'irregular')
     actual = mod.simulate([1.], nobs, measurement_shocks=eps)
-    assert_allclose(actual[0], eps)
+    assert_allclose(actual, eps)
 
     # Fixed intercept
     # (in practice this is a deterministic constant, because an irregular
@@ -185,25 +185,25 @@ def test_structural():
         mod = structural.UnobservedComponents([0], 'fixed intercept')
     actual = mod.simulate([1.], nobs, measurement_shocks=eps,
                           initial_state=[10])
-    assert_allclose(actual[0], 10 + eps)
+    assert_allclose(actual, 10 + eps)
 
     # Deterministic constant
     mod = structural.UnobservedComponents([0], 'deterministic constant')
     actual = mod.simulate([1.], nobs, measurement_shocks=eps,
                           initial_state=[10])
-    assert_allclose(actual[0], 10 + eps)
+    assert_allclose(actual, 10 + eps)
 
     # Local level
     mod = structural.UnobservedComponents([0], 'local level')
     actual = mod.simulate([1., 1.], nobs, measurement_shocks=eps,
                           state_shocks=eps2)
-    assert_allclose(actual[0], eps + eps3)
+    assert_allclose(actual, eps + eps3)
 
     # Random walk
     mod = structural.UnobservedComponents([0], 'random walk')
     actual = mod.simulate([1.], nobs, measurement_shocks=eps,
                           state_shocks=eps2)
-    assert_allclose(actual[0], eps + eps3)
+    assert_allclose(actual, eps + eps3)
 
     # Fixed slope
     # (in practice this is a deterministic trend, because an irregular
@@ -213,13 +213,13 @@ def test_structural():
         mod = structural.UnobservedComponents([0], 'fixed slope')
     actual = mod.simulate([1., 1.], nobs, measurement_shocks=eps,
                           state_shocks=eps2, initial_state=[0, 1])
-    assert_allclose(actual[0], eps + np.arange(100))
+    assert_allclose(actual, eps + np.arange(100))
 
     # Deterministic trend
     mod = structural.UnobservedComponents([0], 'deterministic trend')
     actual = mod.simulate([1.], nobs, measurement_shocks=eps,
                           state_shocks=eps2, initial_state=[0, 1])
-    assert_allclose(actual[0], eps + np.arange(100))
+    assert_allclose(actual, eps + np.arange(100))
 
     # Local linear deterministic trend
     mod = structural.UnobservedComponents(
@@ -227,50 +227,50 @@ def test_structural():
     actual = mod.simulate([1., 1.], nobs, measurement_shocks=eps,
                           state_shocks=eps2, initial_state=[0, 1])
     desired = eps + np.r_[np.arange(50), 1 + np.arange(50, 100)]
-    assert_allclose(actual[0], desired)
+    assert_allclose(actual, desired)
 
     # Random walk with drift
     mod = structural.UnobservedComponents([0], 'random walk with drift')
     actual = mod.simulate([1.], nobs, state_shocks=eps2,
                           initial_state=[0, 1])
     desired = np.r_[np.arange(50), 1 + np.arange(50, 100)]
-    assert_allclose(actual[0], desired)
+    assert_allclose(actual, desired)
 
     # Local linear trend
     mod = structural.UnobservedComponents([0], 'local linear trend')
     actual = mod.simulate([1., 1., 1.], nobs, measurement_shocks=eps,
                           state_shocks=np.c_[eps2, eps1], initial_state=[0, 1])
     desired = eps + np.r_[np.arange(50), 1 + np.arange(50, 100)]
-    assert_allclose(actual[0], desired)
+    assert_allclose(actual, desired)
 
     actual = mod.simulate([1., 1., 1.], nobs, measurement_shocks=eps,
                           state_shocks=np.c_[eps1, eps2], initial_state=[0, 1])
     desired = eps + np.r_[np.arange(50), np.arange(50, 150, 2)]
-    assert_allclose(actual[0], desired)
+    assert_allclose(actual, desired)
 
     # Smooth trend
     mod = structural.UnobservedComponents([0], 'smooth trend')
     actual = mod.simulate([1., 1.], nobs, measurement_shocks=eps,
                           state_shocks=eps1, initial_state=[0, 1])
     desired = eps + np.r_[np.arange(100)]
-    assert_allclose(actual[0], desired)
+    assert_allclose(actual, desired)
 
     actual = mod.simulate([1., 1.], nobs, measurement_shocks=eps,
                           state_shocks=eps2, initial_state=[0, 1])
     desired = eps + np.r_[np.arange(50), np.arange(50, 150, 2)]
-    assert_allclose(actual[0], desired)
+    assert_allclose(actual, desired)
 
     # Random trend
     mod = structural.UnobservedComponents([0], 'random trend')
     actual = mod.simulate([1., 1.], nobs,
                           state_shocks=eps1, initial_state=[0, 1])
     desired = np.r_[np.arange(100)]
-    assert_allclose(actual[0], desired)
+    assert_allclose(actual, desired)
 
     actual = mod.simulate([1., 1.], nobs,
                           state_shocks=eps2, initial_state=[0, 1])
     desired = np.r_[np.arange(50), np.arange(50, 150, 2)]
-    assert_allclose(actual[0], desired)
+    assert_allclose(actual, desired)
 
     # Seasonal (deterministic)
     mod = structural.UnobservedComponents([0], 'irregular', seasonal=2,
@@ -278,14 +278,14 @@ def test_structural():
     actual = mod.simulate([1.], nobs, measurement_shocks=eps,
                           initial_state=[10])
     desired = eps + np.tile([10, -10], 50)
-    assert_allclose(actual[0], desired)
+    assert_allclose(actual, desired)
 
     # Seasonal (stochastic)
     mod = structural.UnobservedComponents([0], 'irregular', seasonal=2)
     actual = mod.simulate([1., 1.], nobs, measurement_shocks=eps,
                           state_shocks=eps2, initial_state=[10])
     desired = eps + np.r_[np.tile([10, -10], 25), np.tile([11, -11], 25)]
-    assert_allclose(actual[0], desired)
+    assert_allclose(actual, desired)
 
     # Cycle (deterministic)
     mod = structural.UnobservedComponents([0], 'irregular', cycle=True)
@@ -299,7 +299,7 @@ def test_structural():
     for i in range(nobs):
         desired[i] += states[0]
         states = np.dot(T, states)
-    assert_allclose(actual[0], desired)
+    assert_allclose(actual, desired)
 
     # Cycle (stochastic)
     mod = structural.UnobservedComponents([0], 'irregular', cycle=True,
@@ -314,7 +314,7 @@ def test_structural():
     for i in range(nobs):
         desired[i] += states[0]
         states = np.dot(T, states) + eps2[i]
-    assert_allclose(actual[0], desired)
+    assert_allclose(actual, desired)
 
 
 def test_varmax():
@@ -375,10 +375,10 @@ def test_varmax():
 
     actual = mod.simulate(np.r_[transition.ravel(), 1., 0, 1.], nobs,
                           state_shocks=np.c_[eps1, eps1], initial_state=[1, 1])
-    desired = np.zeros((2, nobs))
+    desired = np.zeros((nobs, 2))
     state = np.r_[1, 1]
     for i in range(nobs):
-        desired[:, i] = state
+        desired[i] = state
         state = np.dot(transition, state)
     assert_allclose(actual, desired)
 
@@ -388,17 +388,17 @@ def test_varmax():
     actual = mod.simulate(np.r_[transition.ravel(), 1., 0, 1., 1., 1.], nobs,
                           measurement_shocks=np.c_[eps, eps],
                           state_shocks=np.c_[eps1, eps1])
-    assert_allclose(actual, np.c_[eps, eps].T)
+    assert_allclose(actual, np.c_[eps, eps])
 
     # VARX(1)
     mod = varmax.VARMAX(np.zeros((nobs, 2)), order=(1, 0), trend='nc',
                         exog=exog)
     actual = mod.simulate(np.r_[transition.ravel(), 5, -2, 1., 0, 1.], nobs,
                           state_shocks=np.c_[eps1, eps1], initial_state=[1, 1])
-    desired = np.zeros((2, nobs))
+    desired = np.zeros((nobs, 2))
     state = np.r_[1, 1]
     for i in range(nobs):
-        desired[:, i] = state
+        desired[i] = state
         state = exog[i] * [5, -2] + np.dot(transition, state)
     assert_allclose(actual, desired)
 
@@ -438,8 +438,8 @@ def test_dynamic_factor():
                            measurement_shocks=np.c_[eps1, eps1],
                            state_shocks=eps)
     desired = mod2.simulate([0.5, 0.2, 1], nobs, state_shocks=eps)
-    assert_allclose(actual[0], -0.9 * desired[0])
-    assert_allclose(actual[1], 0.8 * desired[0])
+    assert_allclose(actual[:, 0], -0.9 * desired)
+    assert_allclose(actual[:, 1], 0.8 * desired)
 
     # DFM: 2 series, AR(2) factor, exog
     mod1 = dynamic_factor.DynamicFactor(np.zeros((nobs, 2)), k_factors=1,
@@ -449,8 +449,8 @@ def test_dynamic_factor():
                            measurement_shocks=np.c_[eps1, eps1],
                            state_shocks=eps)
     desired = mod2.simulate([0.5, 0.2, 1], nobs, state_shocks=eps)
-    assert_allclose(actual[0], -0.9 * desired[0] + 5 * exog[:, 0])
-    assert_allclose(actual[1], 0.8 * desired[0] - 2 * exog[:, 0])
+    assert_allclose(actual[:, 0], -0.9 * desired + 5 * exog[:, 0])
+    assert_allclose(actual[:, 1], 0.8 * desired - 2 * exog[:, 0])
 
     # DFM, 3 series, VAR(2) factor, exog, error VAR
     # TODO: This is just a smoke test

--- a/statsmodels/tsa/statespace/tests/test_structural.py
+++ b/statsmodels/tsa/statespace/tests/test_structural.py
@@ -30,6 +30,7 @@ except ImportError:
 dta = macrodata.load_pandas().data
 dta.index = pd.date_range(start='1959-01-01', end='2009-07-01', freq='QS')
 
+
 def run_ucm(name):
     true = getattr(results_structural, name)
 
@@ -115,7 +116,9 @@ def test_irregular():
 
 
 def test_fixed_intercept():
-    warnings.simplefilter("always")
+    # Clear warnings
+    structural.__warningregistry__ = {}
+
     with warnings.catch_warnings(record=True) as w:
         run_ucm('fixed_intercept')
         message = ("Specified model does not contain a stochastic element;"
@@ -140,7 +143,9 @@ def test_fixed_slope():
 
 
 def test_fixed_slope():
-    warnings.simplefilter("always")
+    # Clear warnings
+    structural.__warningregistry__ = {}
+
     with warnings.catch_warnings(record=True) as w:
         run_ucm('fixed_slope')
         message = ("Specified model does not contain a stochastic element;"
@@ -211,11 +216,13 @@ def test_mle_reg():
 
 
 def test_specifications():
+    # Clear warnings
+    structural.__warningregistry__ = {}
+
     endog = [1, 2]
 
     # Test that when nothing specified, a warning is issued and the model that
     # is fit is one with irregular=True and nothing else.
-    warnings.simplefilter("always")
     with warnings.catch_warnings(record=True) as w:
         mod = UnobservedComponents(endog)
 

--- a/statsmodels/tsa/statespace/tests/test_varmax.py
+++ b/statsmodels/tsa/statespace/tests/test_varmax.py
@@ -751,6 +751,8 @@ def test_specifications():
 
 
 def test_misspecifications():
+    varmax.__warningregistry__ = {}
+
     # Tests for model specification and misspecification exceptions
     endog = np.arange(20).reshape(10,2)
 

--- a/statsmodels/tsa/statespace/varmax.py
+++ b/statsmodels/tsa/statespace/varmax.py
@@ -197,6 +197,10 @@ class VARMAX(MLEModel):
             endog, exog=exog, k_states=k_states, k_posdef=k_posdef, **kwargs
         )
 
+        # Set as time-varying model if we have time-trend or exog
+        if self.k_exog > 0 or self.k_trend > 1:
+            self.ssm._time_invariant = False
+
         # Initialize the parameters
         self.parameters = OrderedDict()
         self.parameters['trend'] = self.k_endog * self.k_trend


### PR DESCRIPTION
Primarily a PR to improve test coverage on `simulate` and `impulse_responses` methods. Also:

- Produces a backwards incompatible change in `simulate` and `impulse_responses`, where the returned dimensions did not match the documentation in the case of multivariate models
- Fixes a bug when simulation was run twice and the second simulation had fewer `nobs` than the first.
- Introduces a flag (`_time_invariant`) for state space models to explicitly flag they are time invariant (rather than having to detect based on system matrix shapes)