### PR TITLE
BUG: Handle non-invertible hessian from GLM scipy optimizers

### DIFF
--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -1055,7 +1055,14 @@ class LikelihoodModelResults(Results):
 
     @cache_readonly
     def bse(self):
-        return np.sqrt(np.diag(self.cov_params()))
+        # Issue 3299
+        if ((not hasattr(self, 'cov_params_default')) and
+                (self.normalized_cov_params is None)):
+            bse_ = np.empty(len(self.params))
+            bse_[:] = np.nan
+        else:
+            bse_ = np.sqrt(np.diag(self.cov_params()))
+        return bse_
 
     @cache_readonly
     def tvalues(self):

--- a/statsmodels/genmod/generalized_linear_model.py
+++ b/statsmodels/genmod/generalized_linear_model.py
@@ -938,8 +938,13 @@ class GLM(base.LikelihoodModel):
         mu = self.predict(rslt.params)
         scale = self.estimate_scale(mu)
 
+        if rslt.normalized_cov_params is None:
+            cov_p = None
+        else:
+            cov_p = rslt.normalized_cov_params / scale
+
         glm_results = GLMResults(self, rslt.params,
-                                 rslt.normalized_cov_params / scale,
+                                 cov_p,
                                  scale,
                                  cov_type=cov_type, cov_kwds=cov_kwds,
                                  use_t=use_t)

--- a/statsmodels/genmod/tests/test_glm.py
+++ b/statsmodels/genmod/tests/test_glm.py
@@ -1859,6 +1859,18 @@ def test_poisson_deviance():
     assert_allclose(d, lr, rtol=1e-12)
 
 
+def test_non_invertible_hessian_fails_summary():
+    # Test when the hessian fails the summary is still available.
+    import statsmodels.api as sm
+
+    data = sm.datasets.cpunish.load_pandas()
+
+    data.endog[:] = 1
+    mod = sm.GLM(data.endog, data.exog, family=sm.families.Gamma())
+    res = mod.fit(maxiter=1, method='bfgs', max_start_irls=0)
+    res.summary()
+
+
 if __name__ == "__main__":
     # run_module_suite()
     # taken from Fernando Perez:


### PR DESCRIPTION
Hello, 

In a GLM if you are using one of the scipy optimizer and the Hessian inversion fails (i.e., it is not positive definite), `None` is returned. When running `res.summary()` later, a matrix is divided by `None` which causes a crash. 

This fixes the problem by returning a matrix of `nan` of the same shape as `H`. 

Example fail:

```python
import statsmodels.api as sm

data = sm.datasets.cpunish.load_pandas()

data.endog[:] = 1
mod = sm.GLM(data.endog, data.exog, family=sm.families.Gamma())
res = mod.fit(maxiter=1, method='bfgs', max_start_irls=0)
res.summary()
```