### PR TITLE
Fix false convergence cycle warning

### DIFF
--- a/statsmodels/regression/quantile_regression.py
+++ b/statsmodels/regression/quantile_regression.py
@@ -185,8 +185,8 @@ class QuantReg(RegressionModel):
                 for ii in range(2, 10):
                     if np.all(beta == history['params'][-ii]):
                         cycle = True
+                        warnings.warn("Convergence cycle detected", ConvergenceWarning)
                         break
-                warnings.warn("Convergence cycle detected", ConvergenceWarning)
 
         if n_iter == max_iter:
             warnings.warn("Maximum number of iterations (" + str(max_iter) + 


### PR DESCRIPTION
For now convergence cycle warning in quantile regression is printed every 100 iterations after 300, even if there were no real cycle detected which may be pretty annoying when training with more iterations.

In this patch I move warning to print it only if convergence cycle was really detected.