### PR TITLE
BUG: State space: Simulation smoothing with observation intercept.

### DIFF
--- a/statsmodels/tsa/statespace/_simulation_smoother.pyx.in
+++ b/statsmodels/tsa/statespace/_simulation_smoother.pyx.in
@@ -205,6 +205,12 @@ cdef class {{prefix}}SimulationSmoother(object):
             self.secondary_simulated_smoother = {{prefix}}KalmanSmoother(
                 self.secondary_simulated_model, self.secondary_simulated_kfilter, smoother_output
             )
+        # In the case of non-missing data, the Kalman filter will actually
+        # be run over y_t^* = y_t - y_t^+, which means the observation equation
+        # intercept should be zero; make sure that it is
+        else:
+            dim2[0] = self.model.k_endog; dim2[1] = self.model.obs_intercept.shape[1];
+            self.simulated_model.obs_intercept = np.PyArray_ZEROS(2, dim2, {{typenum}}, FORTRAN)
 
 
         # Initialize the simulated model memoryviews
@@ -268,7 +274,8 @@ cdef class {{prefix}}SimulationSmoother(object):
 
     cpdef set_initial_state_variates(self, {{cython_type}} [:] variates):
         # TODO allow variates to be an iterator or callback
-        tools.validate_vector_shape('disturbance variates', &variates.shape[0],
+        tools.validate_vector_shape('initial state variates',
+                                    &variates.shape[0],
                                     self.n_initial_state_variates)
         self.initial_state_variates = variates
 

--- a/statsmodels/tsa/statespace/tests/test_simulation_smoothing.py
+++ b/statsmodels/tsa/statespace/tests/test_simulation_smoothing.py
@@ -11,7 +11,7 @@ import pandas as pd
 import os
 
 from statsmodels import datasets
-from statsmodels.tsa.statespace import mlemodel, sarimax
+from statsmodels.tsa.statespace import mlemodel, sarimax, structural
 from statsmodels.tsa.statespace.tools import compatibility_mode
 from statsmodels.tsa.statespace.kalman_filter import (
     FILTER_CONVENTIONAL, FILTER_COLLAPSED, FILTER_UNIVARIATE)
@@ -611,3 +611,15 @@ def test_misc():
     assert_equal(sim.simulation_output, SIMULATION_ALL)
     sim.simulate_all = False
     assert_equal(sim.simulation_output, 0)
+
+
+def test_simulation_smoothing_obs_intercept():
+    nobs = 10
+    intercept = 100
+    endog = np.ones(nobs) * intercept
+    mod = structural.UnobservedComponents(endog, 'rwalk', exog=np.ones(nobs))
+    mod.update([1, intercept])
+    sim = mod.simulation_smoother()
+    sim.simulate(disturbance_variates=np.zeros(mod.nobs * 2),
+                 initial_state_variates=np.zeros(1))
+    assert_equal(sim.simulated_state[0], 0)


### PR DESCRIPTION
This problem was caused due to using a short-cut for simulation smoothing where we filter the difference y_t - y_t^+ rather than separately filtering y_t and y_t^+ (see Durbin and Koopman, 2002). When filtering each separately, the `obs_intercept` should be kept as in the usual model, but when filtering the difference, the `obs_intercept` must be set to zero.

Durbin, J., and S. J. Koopman. 2002. “A Simple and Efficient Simulation Smoother for State Space Time Series Analysis.” Biometrika

Closes #3304 