### PR TITLE
Bug fix for summary_col on summary2.py

### DIFF
--- a/statsmodels/iolib/summary2.py
+++ b/statsmodels/iolib/summary2.py
@@ -347,7 +347,7 @@ def summary_params(results, yname=None, xname=None, alpha=.05, use_t=True,
                         '[' + str(alpha/2), str(1-alpha/2) + ']']
 
     if not xname:
-        data.index = results.model.exog_names
+        data.index = results.model.data.param_names
     else:
         data.index = xname
 


### PR DESCRIPTION
The following returns an error with the master code:
```python
import statsmodels.formula.api as smf
import pandas as pd

ids = [1,1,1,1,1,2,2,2,2,3,3,3,3,3,3]
x = [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15]
y = [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15]

d = {'Y':y,'X':x,'IDS':ids}
d = pd.DataFrame(d)

results1 = smf.mixedlm('Y ~ X', d, groups=d ['IDS']).fit()
results2 = smf.mixedlm('X ~ Y', d, groups=d ['IDS']).fit()
    
out = summary_col([results1,results2],stars=True)
```
This only appears with the results from mixedlm, as far as I can say. The fix, as proposed by @josef-pkt, returns the expected output. I have tried this with various other formulas and datasets and it appears to work.