### PR TITLE
TST: Fix pandas 0.19.0

### DIFF
--- a/statsmodels/stats/tests/test_anova.py
+++ b/statsmodels/stats/tests/test_anova.py
@@ -71,13 +71,15 @@ kidney_table = StringIO("""Days      Duration Weight ID
     1.0      2      3     10
 """)
 
+kidney_table.seek(0)
+kidney_table = read_table(kidney_table, sep="\s+")
+
 class TestAnovaLM(object):
     @classmethod
     def setupClass(cls):
         # kidney data taken from JT's course
         # don't know the license
-        kidney_table.seek(0)
-        cls.data = read_table(kidney_table, sep="\s+")
+        cls.data = kidney_table
         cls.kidney_lm = ols('np.log(Days+1) ~ C(Duration) * C(Weight)',
                         data=cls.data).fit()
 
@@ -100,8 +102,7 @@ class TestAnovaLMNoconstant(object):
     def setupClass(cls):
         # kidney data taken from JT's course
         # don't know the license
-        kidney_table.seek(0)
-        cls.data = read_table(kidney_table, sep="\s+")
+        cls.data = kidney_table
         cls.kidney_lm = ols('np.log(Days+1) ~ C(Duration) * C(Weight) - 1',
                         data=cls.data).fit()
 


### PR DESCRIPTION
In test_anova.py, `read_table` will be run globally at the module level which should account for the fact that read_table now closes `StringIO`

I ran this locally on my windows anaconda with python 3.5 and pandas 0.19.0. 

Follow-up to #3239 

Closes #3228 