### PR TITLE
MAINT/REF: use integer division in NominalGEEResults see #3332

### DIFF
--- a/statsmodels/genmod/generalized_estimating_equations.py
+++ b/statsmodels/genmod/generalized_estimating_equations.py
@@ -2392,7 +2392,7 @@ class NominalGEEResults(GEEResults):
         exog_names = [x.split("[")[0] for x in exog_names]
 
         params = np.reshape(self.params,
-                            (ncut, len(self.params) / ncut))
+                            (ncut, len(self.params) // ncut))
 
         for ev in exog_values:
 


### PR DESCRIPTION
This fixes the numpy compatibility error when running the test suite with numpy 1.12
see #3332

This does not address the FutureWarnings