### PR TITLE
TST/COMPAT: Compatibility with newer Pandas

### DIFF
--- a/statsmodels/graphics/tests/test_tsaplots.py
+++ b/statsmodels/graphics/tests/test_tsaplots.py
@@ -91,8 +91,8 @@ def test_plot_month():
     dta = sm.datasets.elnino.load_pandas().data
     dta['YEAR'] = dta.YEAR.astype(int).apply(str)
     dta = dta.set_index('YEAR').T.unstack()
-    dates = lmap(lambda x : pd.datetools.parse_time_string('1 '+' '.join(x))[0],
-                                                           dta.index.values)
+    dates = lmap(lambda x: pd.tseries.tools.parse_time_string('1 '+' '.join(x))[0],
+                 dta.index.values)
 
     # test dates argument
     fig = month_plot(dta.values, dates=dates, ylabel='el nino')
@@ -104,7 +104,7 @@ def test_plot_month():
     plt.close(fig)
 
     # w freq
-    dta.index = pd.DatetimeIndex(dates, freq='M')
+    dta.index = pd.DatetimeIndex(dates, freq='MS')
     fig = month_plot(dta)
     plt.close(fig)
 
@@ -123,7 +123,7 @@ def test_plot_quarter():
     plt.close('all')
 
     # test with a DatetimeIndex with no freq
-    parser = pd.datetools.parse_time_string
+    parser = pd.tseries.tools.parse_time_string
     dta.set_index(pd.DatetimeIndex((x[0] for x in map(parser, dates))),
                   inplace=True)
     quarter_plot(dta.unemp)


### PR DESCRIPTION
Closes #3283 

- Fix tests to correctly use `'MS'` frequency.
- Replace deprecated `pd.datetools.parse_time_string` with `pd.tseries.tools.parse_time_string`.

