### PR TITLE
BUG: Incorrect init kwds for UnobservedComponents

### DIFF
--- a/statsmodels/tsa/statespace/structural.py
+++ b/statsmodels/tsa/statespace/structural.py
@@ -530,7 +530,12 @@ class UnobservedComponents(MLEModel):
         # TODO: I think the kwargs or not attached, need to recover from ???
 
     def _get_init_kwds(self):
+        # Get keywords based on model attributes
         kwds = super(UnobservedComponents, self)._get_init_kwds()
+
+        # Modifications
+        kwds['seasonal'] = self.seasonal_period
+        kwds['autoregressive'] = self.ar_order
 
         for key, value in kwds.items():
             if value is None and hasattr(self.ssm, key):

--- a/statsmodels/tsa/statespace/tests/test_structural.py
+++ b/statsmodels/tsa/statespace/tests/test_structural.py
@@ -289,11 +289,11 @@ def test_forecast():
     endog = np.arange(50) + 10
     exog = np.arange(50)
 
-    mod = UnobservedComponents(endog, exog=exog, level='dconstant')
-    res = mod.smooth([1e-15, 1])
+    mod = UnobservedComponents(endog, exog=exog, level='dconstant', seasonal=4)
+    res = mod.smooth([1e-15, 0, 1])
 
     actual = res.forecast(10, exog=np.arange(50,60)[:,np.newaxis])
-    desired = np.arange(50,60) + 10
+    desired = np.arange(50, 60) + 10
     assert_allclose(actual, desired)
 
 


### PR DESCRIPTION
 Seasonal and AR piece of _init_kwds incorrectly set (b/c the class level attributes don't correspond exactly to the kwargs parameters).

Updates a test, and fixes the problem.