### PR TITLE
REF: Replace pd.TimeSeries to Series

### DIFF
--- a/examples/incomplete/arma2.py
+++ b/examples/incomplete/arma2.py
@@ -23,6 +23,6 @@ y = arma_generate_sample(ar, ma, nobs)
 # we'll use a pandas time series.
 import pandas as pd
 dates = sm.tsa.datetools.dates_from_range('1980m1', length=nobs)
-y = pd.TimeSeries(y, index=dates)
+y = pd.Series(y, index=dates)
 arma_mod = sm.tsa.ARMA(y, order=(2, 2))
 arma_res = arma_mod.fit(trend='nc', disp=-1)

--- a/examples/incomplete/dates.py
+++ b/examples/incomplete/dates.py
@@ -16,8 +16,8 @@ dates = sm.tsa.datetools.dates_from_range('1700', length=len(data.endog))
 # Using Pandas
 # ------------
 
-# Make a pandas TimeSeries or DataFrame
-endog = pd.TimeSeries(data.endog, index=dates)
+# Make a pandas Series or DataFrame with DatetimeIndex
+endog = pd.Series(data.endog, index=dates)
 
 # and instantiate the model
 ar_model = sm.tsa.AR(endog, freq='A')

--- a/examples/python/tsa_arma_1.py
+++ b/examples/python/tsa_arma_1.py
@@ -26,7 +26,6 @@ y = arma_generate_sample(arparams, maparams, nobs)
 
 import pandas as pd
 dates = sm.tsa.datetools.dates_from_range('1980m1', length=nobs)
-y = pd.TimeSeries(y, index=dates)
+y = pd.Series(y, index=dates)
 arma_mod = sm.tsa.ARMA(y, order=(2,2))
 arma_res = arma_mod.fit(trend='nc', disp=-1)
-

--- a/examples/python/tsa_dates.py
+++ b/examples/python/tsa_dates.py
@@ -18,9 +18,9 @@ dates = sm.tsa.datetools.dates_from_range('1700', length=len(data.endog))
 
 # ## Using Pandas
 #
-# Make a pandas TimeSeries or DataFrame
+# Make a pandas Series or DataFrame with DatetimeIndex
 
-endog = pd.TimeSeries(data.endog, index=dates)
+endog = pd.Series(data.endog, index=dates)
 
 
 # Instantiate the model


### PR DESCRIPTION
Remove ``pd.TimeSeries`` which has been alias of ``Series`` for a while, and dropped in 0.20. 