### PR TITLE
ENH: Allow SARIMAX models with no AR or MA parts

### DIFF
--- a/statsmodels/tsa/statespace/tests/test_sarimax.py
+++ b/statsmodels/tsa/statespace/tests/test_sarimax.py
@@ -2017,6 +2017,8 @@ def test_predict_custom_index():
 
 
 def test_arima000():
+    from statsmodels.tsa.statespace.tools import compatibility_mode
+
     # Test an ARIMA(0,0,0) with measurement error model (i.e. just estimating
     # a variance term)
     np.random.seed(328423)
@@ -2040,6 +2042,11 @@ def test_arima000():
     error = np.random.normal(size=nobs)
     endog = np.ones(nobs) * 10 + error
     exog = np.ones(nobs)
+
+    # We need univariate filtering here, to guarantee we won't hit singular
+    # forecast error covariance matrices.
+    if compatibility_mode:
+        return
 
     # OLS
     mod = sarimax.SARIMAX(endog, order=(0, 0, 0), exog=exog)

--- a/statsmodels/tsa/statespace/tests/test_sarimax.py
+++ b/statsmodels/tsa/statespace/tests/test_sarimax.py
@@ -2014,3 +2014,19 @@ def test_predict_custom_index():
     res = mod.smooth(mod.start_params)
     out = res.predict(start=1, end=1, index=['a'])
     assert_equal(out.index.equals(pd.Index(['a'])), True)
+
+
+def test_arima000():
+    # Test an ARIMA(0,0,0) with measurement error model (i.e. just estimating
+    # a variance term)
+    np.random.seed(328423)
+    endog = pd.DataFrame(np.random.normal(size=50))
+    mod = sarimax.SARIMAX(endog, order=(0, 0, 0), measurement_error=True)
+    res = mod.smooth(mod.start_params)
+
+    # Test an invalid model: ARIMA(0, 0, 0) without measurement error
+    assert_raises(ValueError, sarimax.SARIMAX, endog, order=(0, 0, 0))
+
+    # ARIMA(0, 1, 0)
+    mod = sarimax.SARIMAX(endog, order=(0, 1, 0), measurement_error=True)
+    res = mod.smooth(mod.start_params)


### PR DESCRIPTION
This is just a corner case, which may be useful e.g. when doing some automatic model selection things.

Basically this just allows e.g. using SARIMAX to fit regression models.