### PR TITLE
ENH/BUG: GLM link/family misc numerical improvements

### DIFF
--- a/statsmodels/genmod/families/family.py
+++ b/statsmodels/genmod/families/family.py
@@ -731,9 +731,10 @@ class Gamma(Family):
                  (scale -1) * \log(Y) + \log(scale) + scale *
                  \ln \Gamma(1 / scale))
         """
-        return - 1./scale * np.sum((endog/mu + np.log(mu) + (scale - 1) *
-                                    np.log(endog) + np.log(scale) + scale *
-                                   special.gammaln(1./scale)) * freq_weights)
+        endog_mu = self._clean(endog / mu)
+        return - np.sum((endog_mu - np.log(endog_mu) + scale *
+                         np.log(endog) + np.log(scale) + scale *
+                         special.gammaln(1./scale)) * freq_weights) / scale
 
         # in Stata scale is set to equal 1 for reporting llf
         # in R it's the dispersion, though there is a loss of precision vs.
@@ -1431,9 +1432,9 @@ class NegativeBinomial(Family):
         hyp2f1(x) = hyp2f1(2/3.,1/3.,5/3.,x)
         """
 
-        hyp2f1 = lambda x : special.hyp2f1(2 / 3., 1 / 3., 5 / 3., x)
+        hyp2f1 = lambda x: special.hyp2f1(2 / 3., 1 / 3., 5 / 3., x)
         return ((hyp2f1(-self.alpha * endog) - hyp2f1(-self.alpha * mu) +
-                 1.5 * ( endog**(2 / 3.) - mu**(2 / 3.))) /
+                 1.5 * (endog**(2 / 3.) - mu**(2 / 3.))) /
                 (mu + self.alpha * mu**2)**(1 / 6.))
 
 

--- a/statsmodels/genmod/families/links.py
+++ b/statsmodels/genmod/families/links.py
@@ -211,7 +211,6 @@ class Logit(Link):
         t = np.exp(z)
         return t/(1 + t)**2
 
-
     def deriv2(self, p):
         """
         Second derivative of the logit function.
@@ -228,6 +227,7 @@ class Logit(Link):
         """
         v = p * (1 - p)
         return (2*p - 1) / v**2
+
 
 class logit(Logit):
     pass
@@ -272,9 +272,10 @@ class Power(Link):
         -----
         g(p) = x**self.power
         """
-
-        z = np.power(p, self.power)
-        return z
+        if self.power == 1:
+            return p
+        else:
+            return np.power(p, self.power)
 
     def inverse(self, z):
         """
@@ -294,9 +295,10 @@ class Power(Link):
         -----
         g^(-1)(z`) = `z`**(1/`power`)
         """
-
-        p = np.power(z, 1. / self.power)
-        return p
+        if self.power == 1:
+            return z
+        else:
+            return np.power(z, 1. / self.power)
 
     def deriv(self, p):
         """
@@ -316,7 +318,10 @@ class Power(Link):
         -----
         g'(`p`) = `power` * `p`**(`power` - 1)
         """
-        return self.power * np.power(p, self.power - 1)
+        if self.power == 1:
+            return np.ones_like(p)
+        else:
+            return self.power * np.power(p, self.power - 1)
 
     def deriv2(self, p):
         """
@@ -336,7 +341,10 @@ class Power(Link):
         -----
         g''(`p`) = `power` * (`power` - 1) * `p`**(`power` - 2)
         """
-        return self.power * (self.power - 1) * np.power(p, self.power - 2)
+        if self.power == 1:
+            return np.zeros_like(p)
+        else:
+            return self.power * (self.power - 1) * np.power(p, self.power - 2)
 
     def inverse_deriv(self, z):
         """
@@ -353,7 +361,10 @@ class Power(Link):
             The value of the derivative of the inverse of the power transform
         function
         """
-        return np.power(z, (1 - self.power)/self.power) / self.power
+        if self.power == 1:
+            return np.ones_like(z)
+        else:
+            return np.power(z, (1 - self.power)/self.power) / self.power
 
 
 class inverse_power(Power):
@@ -693,6 +704,7 @@ class cauchy(CDFLink):
         d2 = 2 * np.pi**2 * np.sin(a) / np.cos(a)**3
         return d2
 
+
 class CLogLog(Logit):
     """
     The complementary log-log transform
@@ -897,7 +909,7 @@ class NegativeBinomial(object):
         '''
         return 1/(p + self.alpha * p**2)
 
-    def deriv2(self,p):
+    def deriv2(self, p):
         '''
         Second derivative of the negative binomial link function.
 


### PR DESCRIPTION
* We use power with exponent=1 for the identity link, but especially in the derivatives this creates problems when evaluating at 0.  So I split these out as special cases.  

* I rearranged some terms in the Gamma log likelihood to eliminate some numerical warnings.  

* Small flake8 edits