### PR TITLE
BUG: Pandas date indexes in MarkovAutoregression

### DIFF
--- a/statsmodels/tsa/regime_switching/markov_switching.py
+++ b/statsmodels/tsa/regime_switching/markov_switching.py
@@ -1904,8 +1904,8 @@ class MarkovSwitchingResults(tsbase.TimeSeriesModelResults):
 
         # Make into Pandas arrays if using Pandas data
         if isinstance(self.data, PandasData):
-            index = self.data.row_labels[self.order:]
-            if self.expected_durations.ndim > 1:                
+            index = self.data.row_labels
+            if self.expected_durations.ndim > 1:
                 self.expected_durations = pd.DataFrame(
                     self.expected_durations, index=index)
             self.predicted_marginal_probabilities = pd.DataFrame(

--- a/statsmodels/tsa/regime_switching/tests/test_markov_autoregression.py
+++ b/statsmodels/tsa/regime_switching/tests/test_markov_autoregression.py
@@ -845,3 +845,46 @@ class TestFilardo(MarkovAutoregression):
         assert_allclose(self.result.expected_durations,
                         self.mar_filardo[['duration0', 'duration1']].iloc[5:],
                         rtol=1e-5, atol=1e-7)
+
+
+class TestFilardoPandas(MarkovAutoregression):
+    @classmethod
+    def setup_class(cls):
+        path = os.path.join(current_path, 'results', 'mar_filardo.csv')
+        cls.mar_filardo = pd.read_csv(path)
+        cls.mar_filardo.index = pd.date_range('1948-02-01', '1991-04-01',
+                                              freq='MS')
+        true = {
+            'params': np.r_[4.35941747, -1.6493936, 1.7702123, 0.9945672,
+                            0.517298, -0.865888,
+                            np.exp(-0.362469)**2,
+                            0.189474, 0.079344, 0.110944, 0.122251],
+            'llf': -586.5718,
+            'llf_fit': -586.5718,
+            'llf_fit_em': -586.5718
+        }
+        endog = cls.mar_filardo['dlip'].iloc[1:]
+        exog_tvtp = add_constant(
+            cls.mar_filardo['dmdlleading'].iloc[:-1])
+        super(TestFilardoPandas, cls).setup_class(
+            true, endog, k_regimes=2, order=4, switching_ar=False,
+            exog_tvtp=exog_tvtp)
+
+    def test_fit(self, **kwargs):
+        raise SkipTest
+
+    def test_fit_em(self):
+        raise SkipTest
+
+    def test_filtered_regimes(self):
+        assert_allclose(self.result.filtered_marginal_probabilities[0],
+                        self.mar_filardo['filtered_0'].iloc[5:], atol=1e-5)
+
+    def test_smoothed_regimes(self):
+        assert_allclose(self.result.smoothed_marginal_probabilities[0],
+                        self.mar_filardo['smoothed_0'].iloc[5:], atol=1e-5)
+
+    def test_expected_durations(self):
+        assert_allclose(self.result.expected_durations,
+                        self.mar_filardo[['duration0', 'duration1']].iloc[5:],
+                        rtol=1e-5, atol=1e-7)


### PR DESCRIPTION
Bug in attaching pandas indexes to data in results object.

(Ideally this would be done in a wrapper, but the data is such that the wrapper system isn't well setup to handle it).