### PR TITLE
FIX: Allow statespace models to be pickled in Python 3.6

### DIFF
--- a/statsmodels/tsa/statespace/_kalman_filter.pxd
+++ b/statsmodels/tsa/statespace/_kalman_filter.pxd
@@ -175,6 +175,7 @@ cdef class sKalmanFilter(object):
     cdef void numerical_stability(self)
     cdef void check_convergence(self)
     cdef void migrate_storage(self)
+    cdef void _reinitialize_pointers(self) except *
 
     cdef void _forecasting(self)
     cdef np.float32_t _inversion(self)
@@ -300,6 +301,7 @@ cdef class dKalmanFilter(object):
     cdef void numerical_stability(self)
     cdef void check_convergence(self)
     cdef void migrate_storage(self)
+    cdef void _reinitialize_pointers(self) except *
 
     cdef void _forecasting(self)
     cdef np.float64_t _inversion(self)
@@ -425,6 +427,7 @@ cdef class cKalmanFilter(object):
     cdef void numerical_stability(self)
     cdef void check_convergence(self)
     cdef void migrate_storage(self)
+    cdef void _reinitialize_pointers(self) except *
 
     cdef void _forecasting(self)
     cdef np.complex64_t _inversion(self)
@@ -550,6 +553,7 @@ cdef class zKalmanFilter(object):
     cdef void numerical_stability(self)
     cdef void check_convergence(self)
     cdef void migrate_storage(self)
+    cdef void _reinitialize_pointers(self) except *
 
     cdef void _forecasting(self)
     cdef np.complex128_t _inversion(self)

--- a/statsmodels/tsa/statespace/_kalman_filter.pxd
+++ b/statsmodels/tsa/statespace/_kalman_filter.pxd
@@ -89,9 +89,6 @@ cdef class sKalmanFilter(object):
     cdef readonly np.float32_t converged_determinant
 
     # ### Temporary arrays
-    cdef readonly np.float32_t [:] selected_obs
-    cdef readonly np.float32_t [:] selected_design
-    cdef readonly np.float32_t [:] selected_obs_cov
     cdef readonly np.float32_t [::1,:] forecast_error_fac
     cdef readonly int [:] forecast_error_ipiv
     cdef readonly np.float32_t [::1,:] forecast_error_work
@@ -217,9 +214,6 @@ cdef class dKalmanFilter(object):
     cdef readonly np.float64_t converged_determinant
 
     # ### Temporary arrays
-    cdef readonly np.float64_t [:] selected_obs
-    cdef readonly np.float64_t [:] selected_design
-    cdef readonly np.float64_t [:] selected_obs_cov
     cdef readonly np.float64_t [::1,:] forecast_error_fac
     cdef readonly int [:] forecast_error_ipiv
     cdef readonly np.float64_t [::1,:] forecast_error_work
@@ -345,9 +339,6 @@ cdef class cKalmanFilter(object):
     cdef readonly np.complex64_t converged_determinant
 
     # ### Temporary arrays
-    cdef readonly np.complex64_t [:] selected_obs
-    cdef readonly np.complex64_t [:] selected_design
-    cdef readonly np.complex64_t [:] selected_obs_cov
     cdef readonly np.complex64_t [::1,:] forecast_error_fac
     cdef readonly int [:] forecast_error_ipiv
     cdef readonly np.complex64_t [::1,:] forecast_error_work
@@ -473,9 +464,6 @@ cdef class zKalmanFilter(object):
     cdef readonly np.complex128_t converged_determinant
 
     # ### Temporary arrays
-    cdef readonly np.complex128_t [:] selected_obs
-    cdef readonly np.complex128_t [:] selected_design
-    cdef readonly np.complex128_t [:] selected_obs_cov
     cdef readonly np.complex128_t [::1,:] forecast_error_fac
     cdef readonly int [:] forecast_error_ipiv
     cdef readonly np.complex128_t [::1,:] forecast_error_work

--- a/statsmodels/tsa/statespace/_kalman_filter.pyx.in
+++ b/statsmodels/tsa/statespace/_kalman_filter.pyx.in
@@ -390,6 +390,12 @@ cdef class {{prefix}}KalmanFilter(object):
         self.converged = 0
         self.period_converged = 0
 
+    def __getnewargs__(self):
+        return (self.model, self.filter_method, self.inversion_method,
+                self.stability_method,  self.conserve_memory, self.filter_timing,
+                self.tolerance, self.loglikelihood_burn)
+
+
     cdef allocate_arrays(self):
         # Local variables
         cdef:

--- a/statsmodels/tsa/statespace/_kalman_filter.pyx.in
+++ b/statsmodels/tsa/statespace/_kalman_filter.pyx.in
@@ -390,10 +390,71 @@ cdef class {{prefix}}KalmanFilter(object):
         self.converged = 0
         self.period_converged = 0
 
-    def __getnewargs__(self):
-        return (self.model, self.filter_method, self.inversion_method,
+    def __reduce__(self):
+        args = (self.model, self.filter_method, self.inversion_method,
                 self.stability_method,  self.conserve_memory, self.filter_timing,
                 self.tolerance, self.loglikelihood_burn)
+        state = {'t': self.t,
+                 'converged' : self.converged ,
+                 'converged_determinant' : self.converged_determinant,
+                 'determinant' : self.determinant,
+                 'period_converged' : self.period_converged,
+                 'converged_filtered_state_cov': np.asarray(self.converged_filtered_state_cov),
+                 'converged_forecast_error_cov': np.asarray(self.converged_forecast_error_cov),
+                 'converged_kalman_gain': np.asarray(self.converged_kalman_gain),
+                 'converged_predicted_state_cov': np.asarray(self.converged_predicted_state_cov),
+                 'filtered_state': np.asarray(self.filtered_state),
+                 'filtered_state_cov': np.asarray(self.filtered_state_cov),
+                 'forecast': np.asarray(self.forecast),
+                 'forecast_error': np.asarray(self.forecast_error),
+                 'forecast_error_cov': np.asarray(self.forecast_error_cov),
+                 'forecast_error_fac': np.asarray(self.forecast_error_fac),
+                 'forecast_error_ipiv': np.asarray(self.forecast_error_ipiv),
+                 'forecast_error_work': np.asarray(self.forecast_error_work),
+                 'kalman_gain': np.asarray(self.kalman_gain),
+                 'loglikelihood': np.asarray(self.loglikelihood),
+                 'predicted_state': np.asarray(self.predicted_state),
+                 'predicted_state_cov': np.asarray(self.predicted_state_cov),
+                 'standardized_forecast_error': np.asarray(self.standardized_forecast_error),
+                 'tmp0': np.asarray(self.tmp0),
+                 'tmp00': np.asarray(self.tmp00),
+                 'tmp1': np.asarray(self.tmp1),
+                 'tmp2': np.asarray(self.tmp2),
+                 'tmp3': np.asarray(self.tmp3),
+                 'tmp4': np.asarray(self.tmp4)
+                 }
+
+        return (self.__class__, args, state)
+
+    def __setstate__(self, state):
+        self.t = state['t']
+        self.converged  = state['converged']
+        self.converged_determinant = state['converged_determinant']
+        self.determinant = state['determinant']
+        self.period_converged = state['period_converged']
+        self.converged_filtered_state_cov = state['converged_filtered_state_cov']
+        self.converged_forecast_error_cov = state['converged_forecast_error_cov']
+        self.converged_kalman_gain = state['converged_kalman_gain']
+        self.converged_predicted_state_cov = state['converged_predicted_state_cov']
+        self.filtered_state = state['filtered_state']
+        self.filtered_state_cov = state['filtered_state_cov']
+        self.forecast = state['forecast']
+        self.forecast_error = state['forecast_error']
+        self.forecast_error_cov = state['forecast_error_cov']
+        self.forecast_error_fac = state['forecast_error_fac']
+        self.forecast_error_ipiv = state['forecast_error_ipiv']
+        self.forecast_error_work = state['forecast_error_work']
+        self.kalman_gain = state['kalman_gain']
+        self.loglikelihood = state['loglikelihood']
+        self.predicted_state = state['predicted_state']
+        self.predicted_state_cov = state['predicted_state_cov']
+        self.standardized_forecast_error = state['standardized_forecast_error']
+        self.tmp0 = state['tmp0']
+        self.tmp00 = state['tmp00']
+        self.tmp1 = state['tmp1']
+        self.tmp2 = state['tmp2']
+        self.tmp3 = state['tmp3']
+        self.tmp4 = state['tmp4']
 
 
     cdef allocate_arrays(self):

--- a/statsmodels/tsa/statespace/_kalman_filter.pyx.in
+++ b/statsmodels/tsa/statespace/_kalman_filter.pyx.in
@@ -399,29 +399,29 @@ cdef class {{prefix}}KalmanFilter(object):
                  'converged_determinant' : self.converged_determinant,
                  'determinant' : self.determinant,
                  'period_converged' : self.period_converged,
-                 'converged_filtered_state_cov': np.asarray(self.converged_filtered_state_cov),
-                 'converged_forecast_error_cov': np.asarray(self.converged_forecast_error_cov),
-                 'converged_kalman_gain': np.asarray(self.converged_kalman_gain),
-                 'converged_predicted_state_cov': np.asarray(self.converged_predicted_state_cov),
-                 'filtered_state': np.asarray(self.filtered_state),
-                 'filtered_state_cov': np.asarray(self.filtered_state_cov),
-                 'forecast': np.asarray(self.forecast),
-                 'forecast_error': np.asarray(self.forecast_error),
-                 'forecast_error_cov': np.asarray(self.forecast_error_cov),
-                 'forecast_error_fac': np.asarray(self.forecast_error_fac),
-                 'forecast_error_ipiv': np.asarray(self.forecast_error_ipiv),
-                 'forecast_error_work': np.asarray(self.forecast_error_work),
-                 'kalman_gain': np.asarray(self.kalman_gain),
-                 'loglikelihood': np.asarray(self.loglikelihood),
-                 'predicted_state': np.asarray(self.predicted_state),
-                 'predicted_state_cov': np.asarray(self.predicted_state_cov),
-                 'standardized_forecast_error': np.asarray(self.standardized_forecast_error),
-                 'tmp0': np.asarray(self.tmp0),
-                 'tmp00': np.asarray(self.tmp00),
-                 'tmp1': np.asarray(self.tmp1),
-                 'tmp2': np.asarray(self.tmp2),
-                 'tmp3': np.asarray(self.tmp3),
-                 'tmp4': np.asarray(self.tmp4)
+                 'converged_filtered_state_cov': np.array(self.converged_filtered_state_cov, copy=True, order='F'),
+                 'converged_forecast_error_cov': np.array(self.converged_forecast_error_cov, copy=True, order='F'),
+                 'converged_kalman_gain': np.array(self.converged_kalman_gain, copy=True, order='F'),
+                 'converged_predicted_state_cov': np.array(self.converged_predicted_state_cov, copy=True, order='F'),
+                 'filtered_state': np.array(self.filtered_state, copy=True, order='F'),
+                 'filtered_state_cov': np.array(self.filtered_state_cov, copy=True, order='F'),
+                 'forecast': np.array(self.forecast, copy=True, order='F'),
+                 'forecast_error': np.array(self.forecast_error, copy=True, order='F'),
+                 'forecast_error_cov': np.array(self.forecast_error_cov, copy=True, order='F'),
+                 'forecast_error_fac': np.array(self.forecast_error_fac, copy=True, order='F'),
+                 'forecast_error_ipiv': np.array(self.forecast_error_ipiv, copy=True, order='F'),
+                 'forecast_error_work': np.array(self.forecast_error_work, copy=True, order='F'),
+                 'kalman_gain': np.array(self.kalman_gain, copy=True, order='F'),
+                 'loglikelihood': np.array(self.loglikelihood, copy=True, order='F'),
+                 'predicted_state': np.array(self.predicted_state, copy=True, order='F'),
+                 'predicted_state_cov': np.array(self.predicted_state_cov, copy=True, order='F'),
+                 'standardized_forecast_error': np.array(self.standardized_forecast_error, copy=True, order='F'),
+                 'tmp0': np.array(self.tmp0, copy=True, order='F'),
+                 'tmp00': np.array(self.tmp00, copy=True, order='F'),
+                 'tmp1': np.array(self.tmp1, copy=True, order='F'),
+                 'tmp2': np.array(self.tmp2, copy=True, order='F'),
+                 'tmp3': np.array(self.tmp3, copy=True, order='F'),
+                 'tmp4': np.array(self.tmp4, copy=True, order='F')
                  }
 
         return (self.__class__, args, state)
@@ -455,7 +455,18 @@ cdef class {{prefix}}KalmanFilter(object):
         self.tmp2 = state['tmp2']
         self.tmp3 = state['tmp3']
         self.tmp4 = state['tmp4']
+        self._reinitialize_pointers()
 
+    cdef void _reinitialize_pointers(self) except *:
+        self._converged_forecast_error_cov = &self.converged_forecast_error_cov[0,0]
+        self._converged_filtered_state_cov = &self.converged_filtered_state_cov[0,0]
+        self._converged_predicted_state_cov = &self.converged_predicted_state_cov[0,0]
+        self._converged_kalman_gain = &self.converged_kalman_gain[0,0]
+        self._forecast_error_fac = &self.forecast_error_fac[0,0]
+        self._forecast_error_work = &self.forecast_error_work[0,0]
+        self._forecast_error_ipiv = &self.forecast_error_ipiv[0]
+        self._tmp0 = &self.tmp0[0, 0]
+        self._tmp00 = &self.tmp00[0, 0]
 
     cdef allocate_arrays(self):
         # Local variables

--- a/statsmodels/tsa/statespace/_kalman_smoother.pxd
+++ b/statsmodels/tsa/statespace/_kalman_smoother.pxd
@@ -129,6 +129,7 @@ cdef class sKalmanSmoother(object):
     cdef void initialize_filter_object_pointers(self)
     cdef void initialize_smoother_object_pointers(self) except *
     cdef void initialize_function_pointers(self) except *
+    cdef void _initialize_temp_pointers(self) except *
 
 # Double precision
 cdef class dKalmanSmoother(object):
@@ -229,6 +230,7 @@ cdef class dKalmanSmoother(object):
     cdef void initialize_filter_object_pointers(self)
     cdef void initialize_smoother_object_pointers(self) except *
     cdef void initialize_function_pointers(self) except *
+    cdef void _initialize_temp_pointers(self) except *
 
 # Single precision complex
 cdef class cKalmanSmoother(object):
@@ -329,6 +331,7 @@ cdef class cKalmanSmoother(object):
     cdef void initialize_filter_object_pointers(self)
     cdef void initialize_smoother_object_pointers(self) except *
     cdef void initialize_function_pointers(self) except *
+    cdef void _initialize_temp_pointers(self) except *
 
 # Double precision complex
 cdef class zKalmanSmoother(object):
@@ -429,3 +432,4 @@ cdef class zKalmanSmoother(object):
     cdef void initialize_filter_object_pointers(self)
     cdef void initialize_smoother_object_pointers(self) except *
     cdef void initialize_function_pointers(self) except *
+    cdef void _initialize_temp_pointers(self) except *

--- a/statsmodels/tsa/statespace/_kalman_smoother.pyx.in
+++ b/statsmodels/tsa/statespace/_kalman_smoother.pyx.in
@@ -329,6 +329,9 @@ cdef class {{prefix}}KalmanSmoother(object):
         # dim1[0] = self.kfilter.k_endog2;
         # self.selected_obs_cov = np.PyArray_ZEROS(1, dim1, {{typenum}}, FORTRAN)
 
+    def __getnewargs__(self):
+        return (self.model, self.kfilter, self.smoother_output, self.smooth_method)
+
     cdef int check_filter_method_changed(self):
         return not self.kfilter.filter_method == self.filter_method
 

--- a/statsmodels/tsa/statespace/_kalman_smoother.pyx.in
+++ b/statsmodels/tsa/statespace/_kalman_smoother.pyx.in
@@ -329,8 +329,59 @@ cdef class {{prefix}}KalmanSmoother(object):
         # dim1[0] = self.kfilter.k_endog2;
         # self.selected_obs_cov = np.PyArray_ZEROS(1, dim1, {{typenum}}, FORTRAN)
 
-    def __getnewargs__(self):
-        return (self.model, self.kfilter, self.smoother_output, self.smooth_method)
+    def __reduce__(self):
+        state = {
+            't': self.t,
+            '_smooth_method': self._smooth_method,
+            'scaled_smoothed_estimator': np.array(self.scaled_smoothed_estimator, copy=True, order='F'),
+            'scaled_smoothed_estimator_cov': np.array(self.scaled_smoothed_estimator_cov, copy=True, order='F'),
+            'smoothing_error': np.array(self.smoothing_error, copy=True, order='F'),
+            'smoothed_state': np.array(self.smoothed_state, copy=True, order='F'),
+            'smoothed_state_cov': np.array(self.smoothed_state_cov, copy=True, order='F'),
+            'smoothed_measurement_disturbance': np.array(self.smoothed_measurement_disturbance, copy=True, order='F'),
+            'smoothed_state_disturbance': np.array(self.smoothed_state_disturbance, copy=True, order='F'),
+            'smoothed_measurement_disturbance_cov': np.array(self.smoothed_measurement_disturbance_cov, copy=True, order='F'),
+            'smoothed_state_disturbance_cov': np.array(self.smoothed_state_disturbance_cov, copy=True, order='F'),
+            'smoothed_state_autocov': np.array(self.smoothed_state_autocov, copy=True, order='F'),
+            'tmp_autocov': np.array(self.tmp_autocov, copy=True, order='F'),
+            'tmpL': np.array(self.tmpL, copy=True, order='F'),
+            'tmpL2': np.array(self.tmpL2, copy=True, order='F'),
+            'tmp0': np.array(self.tmp0, copy=True, order='F'),
+            'tmp00': np.array(self.tmp00, copy=True, order='F'),
+            'tmp000': np.array(self.tmp000, copy=True, order='F')
+        }
+        args = (self.model, self.kfilter, self.smoother_output, self.smooth_method)
+        return (self.__class__, args, state)
+
+    def __setstate__(self, state):
+        self.t = state['t']
+        self._smooth_method = state['_smooth_method']
+        self.scaled_smoothed_estimator = state['scaled_smoothed_estimator']
+        self.scaled_smoothed_estimator_cov = state['scaled_smoothed_estimator_cov']
+        self.smoothing_error = state['smoothing_error']
+        self.smoothed_state = state['smoothed_state']
+        self.smoothed_state_cov = state['smoothed_state_cov']
+        self.smoothed_measurement_disturbance = state['smoothed_measurement_disturbance']
+        self.smoothed_state_disturbance = state['smoothed_state_disturbance']
+        self.smoothed_measurement_disturbance_cov = state['smoothed_measurement_disturbance_cov']
+        self.smoothed_state_disturbance_cov = state['smoothed_state_disturbance_cov']
+        self.smoothed_state_autocov = state['smoothed_state_autocov']
+        self.tmp_autocov = state['tmp_autocov']
+        self.tmpL = state['tmpL']
+        self.tmpL2 = state['tmpL2']
+        self.tmp0 = state['tmp0']
+        self.tmp00 = state['tmp00']
+        self.tmp000 = state['tmp000']
+        self.initialize_smoother_object_pointers()
+        self._initialize_temp_pointers()
+
+    cdef void _initialize_temp_pointers(self) except *:
+        self._tmpL = &self.tmpL[0, 0]
+        self._tmpL2 = &self.tmpL2[0, 0]
+        self._tmp0 = &self.tmp0[0, 0]
+        self._tmp00 = &self.tmp00[0, 0]
+        self._tmp000 = &self.tmp000[0, 0]
+        self._tmp_autocov = &self.tmp_autocov[0, 0]
 
     cdef int check_filter_method_changed(self):
         return not self.kfilter.filter_method == self.filter_method

--- a/statsmodels/tsa/statespace/_representation.pyx.in
+++ b/statsmodels/tsa/statespace/_representation.pyx.in
@@ -294,6 +294,12 @@ cdef class {{prefix}}Statespace(object):
         # Initialize dimensions
         self.set_dimensions(self.k_endog, self.k_states, self.k_posdef)
 
+    def __getnewargs__(self):
+        return (np.asarray(self.obs), np.asarray(self.design), np.asarray(self.obs_intercept), np.asarray(self.obs_cov),
+                np.asarray(self.transition), np.asarray(self.state_intercept), np.asarray(self.selection),
+                np.asarray(self.state_cov), self.diagonal_obs_cov)
+
+
     # ## Initialize: known values
     #
     # Initialize the filter with specific values, assumed to be known with

--- a/statsmodels/tsa/statespace/_representation.pyx.in
+++ b/statsmodels/tsa/statespace/_representation.pyx.in
@@ -297,37 +297,39 @@ cdef class {{prefix}}Statespace(object):
         self.set_dimensions(self.k_endog, self.k_states, self.k_posdef)
 
     def __reduce__(self):
-        init = (np.asarray(self.obs), np.asarray(self.design), np.asarray(self.obs_intercept), np.asarray(self.obs_cov),
-                np.asarray(self.transition), np.asarray(self.state_intercept), np.asarray(self.selection),
-                np.asarray(self.state_cov), self.diagonal_obs_cov)
+        init = (np.array(self.obs, copy=True, order='F'), np.array(self.design, copy=True, order='F'),
+                np.array(self.obs_intercept, copy=True, order='F'), np.array(self.obs_cov, copy=True, order='F'),
+                np.array(self.transition, copy=True, order='F'), np.array(self.state_intercept, copy=True, order='F'),
+                np.array(self.selection, copy=True, order='F'), np.array(self.state_cov, copy=True, order='F'),
+                self.diagonal_obs_cov)
         state = {'initialized': self.initialized,
                  'initial_state': None,
                  'initial_state_cov': None,
-                 'missing': np.asarray(self.missing),
-                 'nmissing': np.asarray(self.nmissing),
+                 'missing': np.array(self.missing, copy=True, order='F'),
+                 'nmissing': np.array(self.nmissing, copy=True, order='F'),
                  'has_missing': self.has_missing,
-                 'tmp': np.asarray(self.tmp),
-                 'selected_state_cov': np.asarray(self.selected_state_cov),
-                 'selected_obs': np.asarray(self.selected_obs),
-                 'selected_obs_intercept': np.asarray(self.selected_obs_intercept),
-                 'selected_design': np.asarray(self.selected_design),
-                 'selected_obs_cov': np.asarray(self.selected_obs_cov),
-                 'transform_cholesky': np.asarray(self.transform_cholesky),
-                 'transform_obs_cov': np.asarray(self.transform_obs_cov),
-                 'transform_design': np.asarray(self.transform_design),
-                 'collapse_obs': np.asarray(self.collapse_obs),
-                 'collapse_obs_tmp': np.asarray(self.collapse_obs_tmp),
-                 'collapse_design': np.asarray(self.collapse_design),
-                 'collapse_obs_cov': np.asarray(self.collapse_obs_cov),
-                 'collapse_cholesky': np.asarray(self.collapse_cholesky),
+                 'tmp': np.array(self.tmp, copy=True, order='F'),
+                 'selected_state_cov': np.array(self.selected_state_cov, copy=True, order='F'),
+                 'selected_obs': np.array(self.selected_obs, copy=True, order='F'),
+                 'selected_obs_intercept': np.array(self.selected_obs_intercept, copy=True, order='F'),
+                 'selected_design': np.array(self.selected_design, copy=True, order='F'),
+                 'selected_obs_cov': np.array(self.selected_obs_cov, copy=True, order='F'),
+                 'transform_cholesky': np.array(self.transform_cholesky, copy=True, order='F'),
+                 'transform_obs_cov': np.array(self.transform_obs_cov, copy=True, order='F'),
+                 'transform_design': np.array(self.transform_design, copy=True, order='F'),
+                 'collapse_obs': np.array(self.collapse_obs, copy=True, order='F'),
+                 'collapse_obs_tmp': np.array(self.collapse_obs_tmp, copy=True, order='F'),
+                 'collapse_design': np.array(self.collapse_design, copy=True, order='F'),
+                 'collapse_obs_cov': np.array(self.collapse_obs_cov, copy=True, order='F'),
+                 'collapse_cholesky': np.array(self.collapse_cholesky, copy=True, order='F'),
                  't': self.t,
                  'collapse_loglikelihood': self.collapse_loglikelihood,
                  'companion_transition': self.companion_transition,
                  'transform_determinant': self.transform_determinant,
                  }
         if self.initialized:
-            state['initial_state'] = np.asarray(self.initial_state)
-            state['initial_state_cov'] = np.asarray(self.initial_state_cov)
+            state['initial_state'] = np.array(self.initial_state, copy=True, order='F')
+            state['initial_state_cov'] = np.array(self.initial_state_cov, copy=True, order='F')
         return (self.__class__, init, state)
 
     def __setstate__(self, state):

--- a/statsmodels/tsa/statespace/_representation.pyx.in
+++ b/statsmodels/tsa/statespace/_representation.pyx.in
@@ -232,6 +232,8 @@ cdef class {{prefix}}Statespace(object):
 
         # Set the flag for initialization to be false
         self.initialized = False
+        self.initial_state = None
+        self.initial_state_cov = None
 
         # Unless it is specified, check for a diagonal covariance matrix
         if diagonal_obs_cov == -1:
@@ -294,11 +296,65 @@ cdef class {{prefix}}Statespace(object):
         # Initialize dimensions
         self.set_dimensions(self.k_endog, self.k_states, self.k_posdef)
 
-    def __getnewargs__(self):
-        return (np.asarray(self.obs), np.asarray(self.design), np.asarray(self.obs_intercept), np.asarray(self.obs_cov),
+    def __reduce__(self):
+        init = (np.asarray(self.obs), np.asarray(self.design), np.asarray(self.obs_intercept), np.asarray(self.obs_cov),
                 np.asarray(self.transition), np.asarray(self.state_intercept), np.asarray(self.selection),
                 np.asarray(self.state_cov), self.diagonal_obs_cov)
+        state = {'initialized': self.initialized,
+                 'initial_state': None,
+                 'initial_state_cov': None,
+                 'missing': np.asarray(self.missing),
+                 'nmissing': np.asarray(self.nmissing),
+                 'has_missing': self.has_missing,
+                 'tmp': np.asarray(self.tmp),
+                 'selected_state_cov': np.asarray(self.selected_state_cov),
+                 'selected_obs': np.asarray(self.selected_obs),
+                 'selected_obs_intercept': np.asarray(self.selected_obs_intercept),
+                 'selected_design': np.asarray(self.selected_design),
+                 'selected_obs_cov': np.asarray(self.selected_obs_cov),
+                 'transform_cholesky': np.asarray(self.transform_cholesky),
+                 'transform_obs_cov': np.asarray(self.transform_obs_cov),
+                 'transform_design': np.asarray(self.transform_design),
+                 'collapse_obs': np.asarray(self.collapse_obs),
+                 'collapse_obs_tmp': np.asarray(self.collapse_obs_tmp),
+                 'collapse_design': np.asarray(self.collapse_design),
+                 'collapse_obs_cov': np.asarray(self.collapse_obs_cov),
+                 'collapse_cholesky': np.asarray(self.collapse_cholesky),
+                 't': self.t,
+                 'collapse_loglikelihood': self.collapse_loglikelihood,
+                 'companion_transition': self.companion_transition,
+                 'transform_determinant': self.transform_determinant,
+                 }
+        if self.initialized:
+            state['initial_state'] = np.asarray(self.initial_state)
+            state['initial_state_cov'] = np.asarray(self.initial_state_cov)
+        return (self.__class__, init, state)
 
+    def __setstate__(self, state):
+        self.initial_state = state['initial_state']
+        self.initial_state_cov = state['initial_state_cov']
+        self.initialized = state['initialized']
+        self.selected_state_cov = state['selected_state_cov']
+        self.missing = state['missing']
+        self.nmissing =state['nmissing']
+        self.has_missing = state['has_missing']
+        self.tmp = state['tmp']
+        self.selected_obs  = state['selected_obs']
+        self.selected_obs_intercept  = state['selected_obs_intercept']
+        self.selected_design  = state['selected_design']
+        self.selected_obs_cov  =state['selected_obs_cov']
+        self.transform_cholesky  = state['transform_cholesky']
+        self.transform_obs_cov  = state['transform_obs_cov']
+        self.transform_design = state['transform_design']
+        self.collapse_obs = state['collapse_obs']
+        self.collapse_obs_tmp = state['collapse_obs_tmp']
+        self.collapse_design = state['collapse_design']
+        self.collapse_obs_cov = state['collapse_obs_cov']
+        self.collapse_cholesky = state['collapse_cholesky']
+        self.t = state['t']
+        self.collapse_loglikelihood = state['collapse_loglikelihood']
+        self.companion_transition = state['companion_transition']
+        self.transform_determinant = state['transform_determinant']
 
     # ## Initialize: known values
     #

--- a/statsmodels/tsa/statespace/_simulation_smoother.pxd
+++ b/statsmodels/tsa/statespace/_simulation_smoother.pxd
@@ -94,6 +94,7 @@ cdef class sSimulationSmoother(object):
     cdef np.float32_t generate_state(self, int t, np.float32_t * state, np.float32_t * input_state, np.float32_t * variates)
     cdef void cholesky(self, np.float32_t * source, np.float32_t * destination, int n)
     cdef void transform_variates(self, np.float32_t * variates, np.float32_t * cholesky_factor, int n)
+    cdef void _reinitialize_temp_pointers(self) except *
 
 # Double precision
 cdef class dSimulationSmoother(object):
@@ -162,6 +163,7 @@ cdef class dSimulationSmoother(object):
     cdef np.float64_t generate_state(self, int t, np.float64_t * state, np.float64_t * input_state, np.float64_t * variates)
     cdef void cholesky(self, np.float64_t * source, np.float64_t * destination, int n)
     cdef void transform_variates(self, np.float64_t * variates, np.float64_t * cholesky_factor, int n)
+    cdef void _reinitialize_temp_pointers(self) except *
 
 # Single precision complex
 cdef class cSimulationSmoother(object):
@@ -230,6 +232,7 @@ cdef class cSimulationSmoother(object):
     cdef np.complex64_t generate_state(self, int t, np.complex64_t * state, np.complex64_t * input_state, np.complex64_t * variates)
     cdef void cholesky(self, np.complex64_t * source, np.complex64_t * destination, int n)
     cdef void transform_variates(self, np.complex64_t * variates, np.complex64_t * cholesky_factor, int n)
+    cdef void _reinitialize_temp_pointers(self) except *
 
 # Double precision complex
 cdef class zSimulationSmoother(object):
@@ -298,3 +301,4 @@ cdef class zSimulationSmoother(object):
     cdef np.complex128_t generate_state(self, int t, np.complex128_t * state, np.complex128_t * input_state, np.complex128_t * variates)
     cdef void cholesky(self, np.complex128_t * source, np.complex128_t * destination, int n)
     cdef void transform_variates(self, np.complex128_t * variates, np.complex128_t * cholesky_factor, int n)
+    cdef void _reinitialize_temp_pointers(self) except *

--- a/statsmodels/tsa/statespace/_simulation_smoother.pyx.in
+++ b/statsmodels/tsa/statespace/_simulation_smoother.pyx.in
@@ -260,6 +260,42 @@ cdef class {{prefix}}SimulationSmoother(object):
         self._tmp1 = &self.tmp1[0,0]
         self._tmp2 = &self.tmp2[0,0]
 
+    def __reduce__(self):
+        args = (self.model, self.filter_method, self.inversion_method,
+                self.stability_method, self.conserve_memory, self.filter_timing,
+                self.tolerance, self.loglikelihood_burn, self.smoother_output,
+                self.simulation_output, self.nobs, self.pretransformed_variates)
+        state = {
+            'disturbance_variates': np.array(self.disturbance_variates, copy=True, order='F'),
+            'initial_state_variates': np.array(self.initial_state_variates, copy=True, order='F'),
+            'simulated_measurement_disturbance': np.array(self.simulated_measurement_disturbance, copy=True, order='F'),
+            'simulated_state_disturbance': np.array(self.simulated_state_disturbance, copy=True, order='F'),
+            'simulated_state': np.array(self.simulated_state, copy=True, order='F'),
+            'generated_obs': np.array(self.generated_obs, copy=True, order='F'),
+            'generated_state': np.array(self.generated_state, copy=True, order='F'),
+            'tmp0': np.array(self.tmp0, copy=True, order='F'),
+            'tmp2': np.array(self.tmp2, copy=True, order='F'),
+            'tmp1': np.array(self.tmp1, copy=True, order='F')
+        }
+        return (self.__class__, args, state)
+
+    def __setstate__(self, state):
+        self.disturbance_variates = state['disturbance_variates']
+        self.initial_state_variates = state['initial_state_variates']
+        self.simulated_measurement_disturbance  = state['simulated_measurement_disturbance']
+        self.simulated_state_disturbance = state['simulated_state_disturbance']
+        self.simulated_state = state['simulated_state']
+        self.generated_obs = state['generated_obs']
+        self.generated_state = state['generated_state']
+        self.tmp0 = state['tmp0']
+        self.tmp2 = state['tmp2']
+        self.tmp1 = state['tmp1']
+
+    cdef void _reinitialize_temp_pointers(self) except *:
+        self._tmp0 = &self.tmp0[0,0]
+        self._tmp1 = &self.tmp1[0,0]
+        self._tmp2 = &self.tmp2[0,0]
+
 
     cpdef draw_disturbance_variates(self):
         self.disturbance_variates = np.random.normal(size=self.n_disturbance_variates)

--- a/statsmodels/tsa/statespace/_statespace.pyx.in
+++ b/statsmodels/tsa/statespace/_statespace.pyx.in
@@ -323,6 +323,8 @@ cdef class {{prefix}}Statespace(object):
 
         # Set the flag for initialization to be false
         self.initialized = False
+        self.initial_state = None
+        self.initial_state_cov = None
 
         # Allocate selected state covariance matrix
         dim3[0] = self.k_states; dim3[1] = self.k_states; dim3[2] = 1;
@@ -339,6 +341,26 @@ cdef class {{prefix}}Statespace(object):
         # Holds arrays of dimension $(m \times m)$
         dim2[0] = self.k_states; dim2[1] = self.k_states;
         self.tmp = np.PyArray_ZEROS(2, dim2, {{typenum}}, FORTRAN)
+
+    def __reduce__(self):
+        args = (np.array(self.obs, copy=True, order='F'), np.array(self.design, copy=True, order='F'),
+                np.array(self.obs_intercept, copy=True, order='F'), np.array(self.obs_cov, copy=True, order='F'),
+                np.array(self.transition, copy=True, order='F'), np.array(self.state_intercept, copy=True, order='F'),
+                np.array(self.selection, copy=True, order='F'), np.array(self.state_cov, copy=True, order='F'))
+        state = {'initialized': self.initialized,
+                 'initial_state': self.initial_state,
+                 'initial_state_cov': self.initial_state_cov,
+                 }
+        if self.initialized:
+            state['initial_state'] =  np.array(self.initial_state, copy=True, order='F')
+            state['initial_state_cov'] = np.array(self.initial_state_cov, copy=True, order='F')
+
+        return (self.__class__, args, state)
+
+    def __setstate__(self, state):
+        self.initialized = state['initialized']
+        self.initial_state = state['initial_state']
+        self.initial_state_cov = state['initial_state_cov']
 
     # ## Initialize: known values
     #
@@ -1341,6 +1363,83 @@ cdef class {{prefix}}KalmanFilter(object):
         self.t = 0
         self.converged = 0
         self.period_converged = 0
+
+    def __reduce__(self):
+        args = (self.model, self.filter_method, self.inversion_method,
+                self.stability_method, self.conserve_memory, self.filter_timing,
+                 self.tolerance, self.loglikelihood_burn)
+        state = {
+            'converged_determinant': self.converged_determinant,
+            'determinant': self.determinant,
+            'converged': self.converged,
+            'period_converged': self.period_converged,
+            't': self.t,
+            'converged_filtered_state_cov': np.array(self.converged_filtered_state_cov, copy=True, order='F'),
+            'converged_forecast_error_cov': np.array(self.converged_forecast_error_cov, copy=True, order='F'),
+            'converged_predicted_state_cov': np.array(self.converged_predicted_state_cov, copy=True, order='F'),
+            'filtered_state': np.array(self.filtered_state, copy=True, order='F'),
+            'filtered_state_cov': np.array(self.filtered_state_cov, copy=True, order='F'),
+            'forecast': np.array(self.forecast, copy=True, order='F'),
+            'forecast_error': np.array(self.forecast_error, copy=True, order='F'),
+            'forecast_error_cov': np.array(self.forecast_error_cov, copy=True, order='F'),
+            'forecast_error_fac': np.array(self.forecast_error_fac, copy=True, order='F'),
+            'forecast_error_ipiv': np.array(self.forecast_error_ipiv, copy=True, order='F'),
+            'forecast_error_work': np.array(self.forecast_error_work, copy=True, order='F'),
+            'loglikelihood': np.array(self.loglikelihood, copy=True, order='F'),
+            'predicted_state': np.array(self.predicted_state, copy=True, order='F'),
+            'predicted_state_cov': np.array(self.predicted_state_cov, copy=True, order='F'),
+            'selected_design': np.array(self.selected_design, copy=True, order='F'),
+            'selected_obs': np.array(self.selected_obs, copy=True, order='F'),
+            'selected_obs_cov': np.array(self.selected_obs_cov, copy=True, order='F'),
+            'selected_obs_intercept': np.array(self.selected_obs_intercept, copy=True, order='F'),
+            'tmp0': np.array(self.tmp0, copy=True, order='F'),
+            'tmp1': np.array(self.tmp1, copy=True, order='F'),
+            'tmp2': np.array(self.tmp2, copy=True, order='F'),
+            'tmp3': np.array(self.tmp3, copy=True, order='F')
+        }
+        return (self.__class__, args, state)
+
+    def __setstate__(self, state):
+        self.converged_determinant = state['converged_determinant']
+        self.determinant = state['determinant']
+        self.converged = state['converged']
+        self.period_converged = state['period_converged']
+        self.t = state['t']
+        self.converged_filtered_state_cov = state['converged_filtered_state_cov']
+        self.converged_forecast_error_cov = state['converged_forecast_error_cov']
+        self.converged_predicted_state_cov = state['converged_predicted_state_cov']
+        self.filtered_state = state['filtered_state']
+        self.filtered_state_cov = state['filtered_state_cov']
+        self.forecast = state['forecast']
+        self.forecast_error = state['forecast_error']
+        self.forecast_error_cov = state['forecast_error_cov']
+        self.forecast_error_fac = state['forecast_error_fac']
+        self.forecast_error_ipiv = state['forecast_error_ipiv']
+        self.forecast_error_work = state['forecast_error_work']
+        self.loglikelihood = state['loglikelihood']
+        self.predicted_state = state['predicted_state']
+        self.predicted_state_cov = state['predicted_state_cov']
+        self.selected_design = state['selected_design']
+        self.selected_obs = state['selected_obs']
+        self.selected_obs_cov = state['selected_obs_cov']
+        self.selected_obs_intercept = state['selected_obs_intercept']
+        self.tmp0 = state['tmp0']
+        self.tmp1 = state['tmp1']
+        self.tmp2 = state['tmp2']
+        self.tmp3 = state['tmp3']
+        self._reinitialize_pointers()
+
+    cdef void _reinitialize_pointers(self) except *:
+        self._converged_forecast_error_cov = &self.converged_forecast_error_cov[0,0]
+        self._converged_filtered_state_cov = &self.converged_filtered_state_cov[0,0]
+        self._converged_predicted_state_cov = &self.converged_predicted_state_cov[0,0]
+        self._forecast_error_fac = &self.forecast_error_fac[0,0]
+        self._forecast_error_work = &self.forecast_error_work[0,0]
+        self._forecast_error_ipiv = &self.forecast_error_ipiv[0]
+        self._tmp0 = &self.tmp0[0, 0]
+        self._tmp1 = &self.tmp1[0, 0]
+        self._tmp2 = &self.tmp2[0]
+        self._tmp3 = &self.tmp3[0, 0]
 
     cpdef set_filter_method(self, int filter_method, int force_reset=True):
         """

--- a/statsmodels/tsa/statespace/kalman_filter.py
+++ b/statsmodels/tsa/statespace/kalman_filter.py
@@ -748,6 +748,8 @@ class KalmanFilter(Representation):
 
         # Run the filter
         kfilter()
+        tmp = np.array(kfilter.loglikelihood)
+        tmp2 = np.array(kfilter.predicted_state)
 
         return kfilter
 
@@ -793,7 +795,7 @@ class KalmanFilter(Representation):
         kfilter = self._filter(
             filter_method, inversion_method, stability_method, conserve_memory,
             filter_timing, tolerance, loglikelihood_burn, complex_step)
-
+        tmp = np.array(kfilter.loglikelihood)
         # Create the results object
         results = self.results_class(self)
         results.update_representation(self)

--- a/statsmodels/tsa/statespace/tests/test_kalman.py
+++ b/statsmodels/tsa/statespace/tests/test_kalman.py
@@ -17,6 +17,9 @@ Time Series Analysis.
 Princeton, N.J.: Princeton University Press.
 """
 from __future__ import division, absolute_import, print_function
+from statsmodels.compat import cPickle
+
+import copy
 
 import numpy as np
 import pandas as pd
@@ -190,6 +193,27 @@ class Clark1987(object):
             self.result['state'][3][self.true['start']:],
             self.true_states.iloc[:, 2], 4
         )
+
+    def test_copied_filter(self):
+        copied = copy.deepcopy(self.filter)
+        pickled = cPickle.loads(cPickle.dumps(self.filter))
+        #  Run the filters
+        self.filter()
+        copied()
+        pickled()
+
+        assert id(filter) != id(copied)
+        assert id(filter) != id(pickled)
+
+        assert_allclose(np.array(self.filter.filtered_state),
+                        np.array(copied.filtered_state))
+        assert_allclose(np.array(self.filter.filtered_state),
+                        np.array(pickled.filtered_state))
+
+        assert_allclose(np.array(self.filter.loglikelihood),
+                        np.array(copied.loglikelihood))
+        assert_allclose(np.array(self.filter.loglikelihood),
+                        np.array(pickled.loglikelihood))
 
 
 class TestClark1987Single(Clark1987):

--- a/statsmodels/tsa/statespace/tests/test_kalman.py
+++ b/statsmodels/tsa/statespace/tests/test_kalman.py
@@ -19,6 +19,7 @@ Princeton, N.J.: Princeton University Press.
 from __future__ import division, absolute_import, print_function
 from statsmodels.compat import cPickle
 
+from distutils.version import LooseVersion
 import copy
 
 import numpy as np
@@ -44,7 +45,11 @@ from statsmodels.tsa.statespace.sarimax import SARIMAX
 from statsmodels.tsa.statespace import _statespace as ss
 from .results import results_kalman_filter
 from numpy.testing import assert_almost_equal, assert_allclose
+from numpy.testing.decorators import skipif
 from nose.exc import SkipTest
+
+# Skip copy test on older NumPy since deepcopy does not copy order
+NP_LT_18 = LooseVersion(np.__version__).version[:2] < [1, 8]
 
 prefix_statespace_map = {
     's': ss.sStatespace, 'd': ss.dStatespace,
@@ -194,27 +199,32 @@ class Clark1987(object):
             self.true_states.iloc[:, 2], 4
         )
 
-    def test_copied_filter(self):
-        copied = copy.deepcopy(self.filter)
+    @skipif(NP_LT_18)
+    def test_pickled_filter(self):
         pickled = cPickle.loads(cPickle.dumps(self.filter))
         #  Run the filters
         self.filter()
-        copied()
         pickled()
 
-        assert id(filter) != id(copied)
         assert id(filter) != id(pickled)
-
-        assert_allclose(np.array(self.filter.filtered_state),
-                        np.array(copied.filtered_state))
         assert_allclose(np.array(self.filter.filtered_state),
                         np.array(pickled.filtered_state))
-
-        assert_allclose(np.array(self.filter.loglikelihood),
-                        np.array(copied.loglikelihood))
         assert_allclose(np.array(self.filter.loglikelihood),
                         np.array(pickled.loglikelihood))
 
+    @skipif(NP_LT_18)
+    def test_copied_filter(self):
+        copied = copy.deepcopy(self.filter)
+        #  Run the filters
+        self.filter()
+        copied()
+
+        assert id(filter) != id(copied)
+        assert_allclose(np.array(self.filter.filtered_state),
+                        np.array(copied.filtered_state))
+
+        assert_allclose(np.array(self.filter.loglikelihood),
+                        np.array(copied.loglikelihood))
 
 class TestClark1987Single(Clark1987):
     """

--- a/statsmodels/tsa/statespace/tests/test_pickle.py
+++ b/statsmodels/tsa/statespace/tests/test_pickle.py
@@ -1,0 +1,154 @@
+"""
+Tests for python wrapper of state space representation and filtering
+
+Author: Chad Fulton
+License: Simplified-BSD
+
+References
+----------
+
+Kim, Chang-Jin, and Charles R. Nelson. 1999.
+"State-Space Models with Regime Switching:
+Classical and Gibbs-Sampling Approaches with Applications".
+MIT Press Books. The MIT Press.
+"""
+from __future__ import division, absolute_import, print_function
+
+from distutils.version import LooseVersion
+
+import numpy as np
+import pandas as pd
+from nose import SkipTest
+from numpy.testing import assert_equal, assert_allclose
+
+from statsmodels.compat import cPickle
+from statsmodels.tsa.statespace import sarimax
+from statsmodels.tsa.statespace.kalman_filter import KalmanFilter
+from statsmodels.tsa.statespace.representation import Representation
+from statsmodels.tsa.statespace.structural import UnobservedComponents
+from .results import results_kalman_filter
+
+# Skip copy test on older NumPy since copy does not preserve order
+NP_LT_18 = LooseVersion(np.__version__).version[:2] < [1, 8]
+
+if NP_LT_18:
+    raise SkipTest("Old NumPy doesn't preserve matrix order when copying")
+
+true = results_kalman_filter.uc_uni
+data = pd.DataFrame(
+    true['data'],
+    index=pd.date_range('1947-01-01', '1995-07-01', freq='QS'),
+    columns=['GDP']
+)
+data['lgdp'] = np.log(data['GDP'])
+
+
+def test_pickle_fit_sarimax():
+    # Fit an ARIMA(1,1,0) to log GDP
+    mod = sarimax.SARIMAX(data['lgdp'], order=(1, 1, 0))
+    pkl_mod = cPickle.loads(cPickle.dumps(mod))
+
+    res = mod.fit(disp=-1)
+    pkl_res = pkl_mod.fit(disp=-1)
+
+    assert_allclose(res.llf_obs, pkl_res.llf_obs)
+    assert_allclose(res.tvalues, pkl_res.tvalues)
+    assert_allclose(res.smoothed_state, pkl_res.smoothed_state)
+    assert_allclose(res.resid.values, pkl_res.resid.values)
+    assert_allclose(res.impulse_responses(10), res.impulse_responses(10))
+
+
+def test_unobserved_components_pickle():
+    # Tests for missing data
+    nobs = 20
+    k_endog = 1
+    np.random.seed(1208)
+    endog = np.random.normal(size=(nobs, k_endog))
+    endog[:4, 0] = np.nan
+    exog2 = np.random.normal(size=(nobs, 2))
+
+    index = pd.date_range('1970-01-01', freq='QS', periods=nobs)
+    endog_pd = pd.DataFrame(endog, index=index)
+    exog2_pd = pd.DataFrame(exog2, index=index)
+
+    models = [
+        UnobservedComponents(endog, 'llevel', exog=exog2),
+        UnobservedComponents(endog_pd, 'llevel', exog=exog2_pd),
+    ]
+
+    for mod in models:
+        # Smoke tests
+        pkl_mod = cPickle.loads(cPickle.dumps(mod))
+        assert_equal(mod.start_params, pkl_mod.start_params)
+        res = mod.fit(disp=False)
+        pkl_res = pkl_mod.fit(disp=False)
+
+        assert_allclose(res.llf_obs, pkl_res.llf_obs)
+        assert_allclose(res.tvalues, pkl_res.tvalues)
+        assert_allclose(res.smoothed_state, pkl_res.smoothed_state)
+        assert_allclose(res.resid, pkl_res.resid)
+        assert_allclose(res.impulse_responses(10), res.impulse_responses(10))
+
+
+def test_kalman_filter_pickle():
+    # Construct the statespace representation
+    k_states = 4
+    model = KalmanFilter(k_endog=1, k_states=k_states)
+    model.bind(data['lgdp'].values)
+
+    model.design[:, :, 0] = [1, 1, 0, 0]
+    model.transition[([0, 0, 1, 1, 2, 3],
+                      [0, 3, 1, 2, 1, 3],
+                      [0, 0, 0, 0, 0, 0])] = [1, 1, 0, 0, 1, 1]
+    model.selection = np.eye(model.k_states)
+
+    # Update matrices with given parameters
+    (sigma_v, sigma_e, sigma_w, phi_1, phi_2) = np.array(
+        true['parameters']
+    )
+    model.transition[([1, 1], [1, 2], [0, 0])] = [phi_1, phi_2]
+    model.state_cov[
+        np.diag_indices(k_states) + (np.zeros(k_states, dtype=int),)] = [
+        sigma_v ** 2, sigma_e ** 2, 0, sigma_w ** 2
+    ]
+
+    # Initialization
+    initial_state = np.zeros((k_states,))
+    initial_state_cov = np.eye(k_states) * 100
+
+    # Initialization: modification
+    initial_state_cov = np.dot(
+        np.dot(model.transition[:, :, 0], initial_state_cov),
+        model.transition[:, :, 0].T
+    )
+    model.initialize_known(initial_state, initial_state_cov)
+    pkl_mod = cPickle.loads(cPickle.dumps(model))
+
+    results = model.filter()
+    pkl_results = pkl_mod.filter()
+
+    assert_allclose(results.llf_obs[true['start']:].sum(),
+                    pkl_results.llf_obs[true['start']:].sum())
+    assert_allclose(results.filtered_state[0][true['start']:],
+                    pkl_results.filtered_state[0][true['start']:])
+    assert_allclose(results.filtered_state[1][true['start']:],
+                    pkl_results.filtered_state[1][true['start']:])
+    assert_allclose(results.filtered_state[3][true['start']:],
+                    pkl_results.filtered_state[3][true['start']:])
+
+
+def test_representation_pickle():
+    nobs = 10
+    k_endog = 2
+    endog = np.asfortranarray(np.arange(nobs * k_endog).reshape(k_endog, nobs) * 1.)
+    mod = Representation(endog, k_states=2)
+    pkl_mod = cPickle.loads(cPickle.dumps(mod))
+
+    assert_equal(mod.nobs, pkl_mod.nobs)
+    assert_equal(mod.k_endog, pkl_mod.k_endog)
+
+    mod._initialize_representation()
+    pkl_mod._initialize_representation()
+    assert_equal(mod.design, pkl_mod.design)
+    assert_equal(mod.obs_intercept, pkl_mod.obs_intercept)
+    assert_equal(mod.initial_variance, pkl_mod.initial_variance)

--- a/statsmodels/tsa/statespace/tests/test_save.py
+++ b/statsmodels/tsa/statespace/tests/test_save.py
@@ -8,7 +8,11 @@ from statsmodels.compat import cPickle
 from unittest import SkipTest
 import numpy as np
 import pandas as pd
+from distutils.version import LooseVersion
 import os
+from nose import SkipTest
+
+import numpy as np
 
 from statsmodels import datasets
 from statsmodels.tsa.statespace import (sarimax, structural, varmax,
@@ -16,11 +20,25 @@ from statsmodels.tsa.statespace import (sarimax, structural, varmax,
 from numpy.testing import assert_allclose
 macrodata = datasets.macrodata.load_pandas().data
 
-import sys
-if sys.version_info >= (3,6):
-    raise SkipTest('pickling statespace models does not work on Python >= 3.6')
+# Skip copy test on older NumPy since copy does not preserve order
+NP_LT_18 = LooseVersion(np.__version__).version[:2] < [1, 8]
+
+if NP_LT_18:
+    raise SkipTest("Old NumPy doesn't preserve matrix order when copying")
 
 def test_sarimax():
+    mod = sarimax.SARIMAX(macrodata['realgdp'].values, order=(4, 1, 0))
+    res = mod.smooth(mod.start_params)
+    res.summary()
+    res.save('test_save_sarimax.p')
+    res2 = sarimax.SARIMAXResults.load('test_save_sarimax.p')
+    assert_allclose(res.params, res2.params)
+    assert_allclose(res.bse, res2.bse)
+    assert_allclose(res.llf, res2.llf)
+    os.unlink('test_save_sarimax.p')
+
+
+def test_sarimax_pickle():
     mod = sarimax.SARIMAX(macrodata['realgdp'].values, order=(4, 1, 0))
     pkl_mod = cPickle.loads(cPickle.dumps(mod))
 
@@ -31,16 +49,22 @@ def test_sarimax():
     assert_allclose(res.bse, pkl_res.bse)
     assert_allclose(res.llf, pkl_res.llf)
 
+
+def test_structural():
+    mod = structural.UnobservedComponents(
+        macrodata['realgdp'].values, 'llevel')
+    res = mod.smooth(mod.start_params)
     res.summary()
-    res.save('test_save_sarimax.p')
-    res2 = sarimax.SARIMAXResults.load('test_save_sarimax.p')
+    res.save('test_save_structural.p')
+    res2 = structural.UnobservedComponentsResults.load(
+        'test_save_structural.p')
     assert_allclose(res.params, res2.params)
     assert_allclose(res.bse, res2.bse)
     assert_allclose(res.llf, res2.llf)
-    os.unlink('test_save_sarimax.p')
+    os.unlink('test_save_structural.p')
 
 
-def test_structural():
+def test_structural_pickle():
     mod = structural.UnobservedComponents(
         macrodata['realgdp'].values, 'llevel')
     pkl_mod = cPickle.loads(cPickle.dumps(mod))
@@ -52,29 +76,12 @@ def test_structural():
     assert_allclose(res.bse, pkl_res.bse)
     assert_allclose(res.llf, pkl_res.llf)
 
-    res.summary()
-    res.save('test_save_structural.p')
-    res2 = structural.UnobservedComponentsResults.load(
-        'test_save_structural.p')
-    assert_allclose(res.params, res2.params)
-    assert_allclose(res.bse, res2.bse)
-    assert_allclose(res.llf, res2.llf)
-    os.unlink('test_save_structural.p')
-
 
 def test_dynamic_factor():
     mod = dynamic_factor.DynamicFactor(
         macrodata[['realgdp', 'realcons']].diff().iloc[1:].values, k_factors=1,
         factor_order=1)
-    pkl_mod = cPickle.loads(cPickle.dumps(mod))
-
     res = mod.smooth(mod.start_params)
-    pkl_res = pkl_mod.smooth(pkl_mod.start_params)
-
-    assert_allclose(res.params, pkl_res.params)
-    assert_allclose(res.bse, pkl_res.bse)
-    assert_allclose(res.llf, pkl_res.llf)
-
     res.summary()
     res.save('test_save_dynamic_factor.p')
     res2 = dynamic_factor.DynamicFactorResults.load(
@@ -85,7 +92,7 @@ def test_dynamic_factor():
     os.unlink('test_save_dynamic_factor.p')
 
 
-def test_varmax():
+def test_dynamic_factor_pickle():
     mod = varmax.VARMAX(
         macrodata[['realgdp', 'realcons']].diff().iloc[1:].values,
         order=(1, 0))
@@ -97,6 +104,37 @@ def test_varmax():
     assert_allclose(res.params, pkl_res.params)
     assert_allclose(res.bse, pkl_res.bse)
     assert_allclose(res.llf, pkl_res.llf)
+
+    res.summary()
+    res.save('test_save_varmax.p')
+    res2 = varmax.VARMAXResults.load(
+        'test_save_varmax.p')
+    assert_allclose(res.params, res2.params)
+    assert_allclose(res.bse, res2.bse)
+    assert_allclose(res.llf, res2.llf)
+    os.unlink('test_save_varmax.p')
+
+
+def test_varmax():
+    mod = varmax.VARMAX(
+        macrodata[['realgdp', 'realcons']].diff().iloc[1:].values,
+        order=(1, 0))
+    res = mod.smooth(mod.start_params)
+    res.summary()
+    res.save('test_save_varmax.p')
+    res2 = varmax.VARMAXResults.load(
+        'test_save_varmax.p')
+    assert_allclose(res.params, res2.params)
+    assert_allclose(res.bse, res2.bse)
+    assert_allclose(res.llf, res2.llf)
+    os.unlink('test_save_varmax.p')
+
+
+def test_varmax_pickle():
+    mod = varmax.VARMAX(
+        macrodata[['realgdp', 'realcons']].diff().iloc[1:].values,
+        order=(1, 0))
+    res = mod.smooth(mod.start_params)
 
     res.summary()
     res.save('test_save_varmax.p')

--- a/statsmodels/tsa/statespace/tests/test_save.py
+++ b/statsmodels/tsa/statespace/tests/test_save.py
@@ -3,6 +3,7 @@ Tests of save / load / remove_data state space functionality.
 """
 
 from __future__ import division, absolute_import, print_function
+from statsmodels.compat import cPickle
 
 from unittest import SkipTest
 import numpy as np
@@ -21,7 +22,15 @@ if sys.version_info >= (3,6):
 
 def test_sarimax():
     mod = sarimax.SARIMAX(macrodata['realgdp'].values, order=(4, 1, 0))
+    pkl_mod = cPickle.loads(cPickle.dumps(mod))
+
     res = mod.smooth(mod.start_params)
+    pkl_res = pkl_mod.smooth(mod.start_params)
+
+    assert_allclose(res.params, pkl_res.params)
+    assert_allclose(res.bse, pkl_res.bse)
+    assert_allclose(res.llf, pkl_res.llf)
+
     res.summary()
     res.save('test_save_sarimax.p')
     res2 = sarimax.SARIMAXResults.load('test_save_sarimax.p')
@@ -34,7 +43,15 @@ def test_sarimax():
 def test_structural():
     mod = structural.UnobservedComponents(
         macrodata['realgdp'].values, 'llevel')
+    pkl_mod = cPickle.loads(cPickle.dumps(mod))
+
     res = mod.smooth(mod.start_params)
+    pkl_res = pkl_mod.smooth(pkl_mod.start_params)
+
+    assert_allclose(res.params, pkl_res.params)
+    assert_allclose(res.bse, pkl_res.bse)
+    assert_allclose(res.llf, pkl_res.llf)
+
     res.summary()
     res.save('test_save_structural.p')
     res2 = structural.UnobservedComponentsResults.load(
@@ -49,7 +66,15 @@ def test_dynamic_factor():
     mod = dynamic_factor.DynamicFactor(
         macrodata[['realgdp', 'realcons']].diff().iloc[1:].values, k_factors=1,
         factor_order=1)
+    pkl_mod = cPickle.loads(cPickle.dumps(mod))
+
     res = mod.smooth(mod.start_params)
+    pkl_res = pkl_mod.smooth(pkl_mod.start_params)
+
+    assert_allclose(res.params, pkl_res.params)
+    assert_allclose(res.bse, pkl_res.bse)
+    assert_allclose(res.llf, pkl_res.llf)
+
     res.summary()
     res.save('test_save_dynamic_factor.p')
     res2 = dynamic_factor.DynamicFactorResults.load(
@@ -64,7 +89,15 @@ def test_varmax():
     mod = varmax.VARMAX(
         macrodata[['realgdp', 'realcons']].diff().iloc[1:].values,
         order=(1, 0))
+    pkl_mod = cPickle.loads(cPickle.dumps(mod))
+
     res = mod.smooth(mod.start_params)
+    pkl_res = pkl_mod.smooth(mod.start_params)
+
+    assert_allclose(res.params, pkl_res.params)
+    assert_allclose(res.bse, pkl_res.bse)
+    assert_allclose(res.llf, pkl_res.llf)
+
     res.summary()
     res.save('test_save_varmax.p')
     res2 = varmax.VARMAXResults.load(


### PR DESCRIPTION
Minimal patch to allow pickling.
Likely is not correct in the sense that the pickled objects would
not behave the same after pickling.