### PR TITLE
Fix GLM prediction with an exog and no weights

### DIFF
--- a/statsmodels/genmod/_prediction.py
+++ b/statsmodels/genmod/_prediction.py
@@ -210,6 +210,8 @@ def get_prediction_glm(self, exog=None, transform=True, weights=None,
         if (weights.size > 1 and
            (weights.ndim != 1 or weights.shape[0] == exog.shape[1])):
             raise ValueError('weights has wrong shape')
+    elif weights is None:
+        weights = np.ones(len(exog))
 
     ### end
 

--- a/statsmodels/genmod/_prediction.py
+++ b/statsmodels/genmod/_prediction.py
@@ -210,8 +210,6 @@ def get_prediction_glm(self, exog=None, transform=True, weights=None,
         if (weights.size > 1 and
            (weights.ndim != 1 or weights.shape[0] == exog.shape[1])):
             raise ValueError('weights has wrong shape')
-    elif weights is None:
-        weights = np.ones(len(exog))
 
     ### end
 
@@ -222,12 +220,15 @@ def get_prediction_glm(self, exog=None, transform=True, weights=None,
 
     link_deriv = self.model.family.link.inverse_deriv(linpred.predicted_mean)
     var_pred_mean = link_deriv**2 * (exog * np.dot(covb, exog.T).T).sum(1)
+    var_resid = self.scale  # self.mse_resid / weights
 
     # TODO: check that we have correct scale, Refactor scale #???
-    var_resid = self.scale / weights # self.mse_resid / weights
     # special case for now:
     if self.cov_type == 'fixed scale':
-        var_resid = self.cov_kwds['scale'] / weights
+        var_resid = self.cov_kwds['scale']
+
+    if weights is not None:
+        var_resid /= weights
 
     dist = ['norm', 't'][self.use_t]
     return PredictionResults(predicted_mean, var_pred_mean, var_resid,

--- a/statsmodels/regression/_prediction.py
+++ b/statsmodels/regression/_prediction.py
@@ -155,6 +155,8 @@ def get_prediction(self, exog=None, transform=True, weights=None,
         if (weights.size > 1 and
            (weights.ndim != 1 or weights.shape[0] == exog.shape[1])):
             raise ValueError('weights has wrong shape')
+    elif weights is None:
+        weights = np.ones(len(exog))
 
     ### end
 

--- a/statsmodels/regression/_prediction.py
+++ b/statsmodels/regression/_prediction.py
@@ -155,8 +155,6 @@ def get_prediction(self, exog=None, transform=True, weights=None,
         if (weights.size > 1 and
            (weights.ndim != 1 or weights.shape[0] == exog.shape[1])):
             raise ValueError('weights has wrong shape')
-    elif weights is None:
-        weights = np.ones(len(exog))
 
     ### end
 
@@ -166,12 +164,15 @@ def get_prediction(self, exog=None, transform=True, weights=None,
 
     covb = self.cov_params()
     var_pred_mean = (exog * np.dot(covb, exog.T).T).sum(1)
+    var_resid = self.scale  # self.mse_resid / weights
 
     # TODO: check that we have correct scale, Refactor scale #???
-    var_resid = self.scale / weights # self.mse_resid / weights
     # special case for now:
     if self.cov_type == 'fixed scale':
-        var_resid = self.cov_kwds['scale'] / weights
+        var_resid = self.cov_kwds['scale']
+
+    if weights is not None:
+        var_resid /= weights
 
     dist = ['norm', 't'][self.use_t]
     return PredictionResults(predicted_mean, var_pred_mean, var_resid,

--- a/statsmodels/regression/tests/tests_predict.py
+++ b/statsmodels/regression/tests/tests_predict.py
@@ -213,3 +213,7 @@ class TestWLSPrediction(object):
         ptt = pt.t_test()
         assert_allclose(ptt[0], res_glm.tvalues, rtol=1e-13)
         assert_allclose(ptt[1], res_glm.pvalues, rtol=1e-13)
+
+        # prediction with exog and no weights does not error
+        res_glm = mod_glm.fit()
+        pred_glm = res_glm.get_prediction(X)


### PR DESCRIPTION
The problem was, a weights value of `None` slipped through
to an arithmetic calculation, which lead to a `TypeError`.

With this patch, the code below does not raise an error

```python
import numpy as np
import statsmodels.api as sm

n = 100
x = np.arange(n)
y = x + 2*np.random.randn(n)
X = sm.add_constant(x)
model = sm.GLM(y, X)
results = model.fit()
pred = results.get_prediction(X)
```