### PR TITLE
BUG: Cast Series to DataFrame before predicting

### DIFF
--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -769,6 +769,7 @@ class Results(object):
 
         if transform and hasattr(self.model, 'formula') and exog is not None:
             from patsy import dmatrix
+            exog = pd.DataFrame(exog)  # user may pass series, if one predictor
             exog = dmatrix(self.model.data.design_info.builder,
                            exog, return_type="dataframe")
             if len(exog) < len(exog_index):

--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -770,6 +770,8 @@ class Results(object):
         if transform and hasattr(self.model, 'formula') and exog is not None:
             from patsy import dmatrix
             exog = pd.DataFrame(exog)  # user may pass series, if one predictor
+            if exog_index is None:  # user passed in a dictionary
+                exog_index = exog.index
             exog = dmatrix(self.model.data.design_info.builder,
                            exog, return_type="dataframe")
             if len(exog) < len(exog_index):

--- a/statsmodels/formula/tests/test_formula.py
+++ b/statsmodels/formula/tests/test_formula.py
@@ -101,3 +101,21 @@ def test_formula_predict():
     results = ols(formula, dta).fit()
     npt.assert_almost_equal(results.fittedvalues.values,
                             results.predict(data.exog), 8)
+
+
+def test_formula_predict_series():
+    import pandas as pd
+    import pandas.util.testing as tm
+    data = pd.DataFrame({"y": [1, 2, 3], "x": [1, 2, 3]}, index=[5, 3, 1])
+    results = ols('y ~ x', data).fit()
+
+    result = results.predict(data)
+    expected = pd.Series([1., 2., 3.], index=[5, 3, 1])
+    tm.assert_series_equal(result, expected)
+
+    result = results.predict(data.x)
+    tm.assert_series_equal(result, expected)
+
+    result = results.predict(pd.Series([1, 2, 3], index=[1, 2, 3], name='x'))
+    expected = pd.Series([1., 2., 3.], index=[1, 2, 3])
+    tm.assert_series_equal(result, expected)

--- a/statsmodels/formula/tests/test_formula.py
+++ b/statsmodels/formula/tests/test_formula.py
@@ -119,3 +119,7 @@ def test_formula_predict_series():
     result = results.predict(pd.Series([1, 2, 3], index=[1, 2, 3], name='x'))
     expected = pd.Series([1., 2., 3.], index=[1, 2, 3])
     tm.assert_series_equal(result, expected)
+
+    result = results.predict({"x": [1, 2, 3]})
+    expected = pd.Series([1., 2., 3.], index=[0, 1, 2])
+    tm.assert_series_equal(result, expected)


### PR DESCRIPTION
patsy is expecting a DataFrame, but users may pass
a Series if their model has a single predictor.

Closes #3409
Closes #3182

should be back ported to 0.8.x