### PR TITLE
BUG: Ensure coint works for perfectly colinearity

### DIFF
--- a/statsmodels/tools/sm_exceptions.py
+++ b/statsmodels/tools/sm_exceptions.py
@@ -115,3 +115,7 @@ class SpecificationWarning(UserWarning):
 
 class HessianInversionWarning(UserWarning):
     pass
+
+
+class ColinearityWarning(UserWarning):
+    pass

--- a/statsmodels/tsa/stattools.py
+++ b/statsmodels/tsa/stattools.py
@@ -1010,8 +1010,16 @@ def coint(y0, y1, trend='c', method='aeg', maxlag=None, autolag='aic',
 
     res_co = OLS(y0, xx).fit()
 
-    res_adf = adfuller(res_co.resid, maxlag=maxlag, autolag=None,
-                             regression='nc')
+    if res_co.rsquared < 1 - np.sqrt(np.finfo(np.double).eps):
+        res_adf = adfuller(res_co.resid, maxlag=maxlag, autolag=None,
+                           regression='nc')
+    else:
+        import warnings
+        warnings.warn("y0 and y1 are perfectly colinear.  Cointegration test "
+                      "is not reliable in this case.")
+        # Edge case where series are too similar
+        res_adf = (0,)
+
     # no constant or trend, see egranger in Stata and MacKinnon
     if trend == 'nc':
         crit = [np.nan] * 3  # 2010 critical values not available


### PR DESCRIPTION
Special case perfect colinearity since ADF is not reliable
when residual variance is very small

closes #3190