### PR TITLE
DOC: Update install instructions

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -8,15 +8,16 @@ Installation
 Using setuptools
 ~~~~~~~~~~~~~~~~
 
-To obtain the latest released version of statsmodels using `setuptools <https://pypi.python.org/pypi/setuptools>`__::
+To obtain the latest released version of statsmodels using `setuptools <https://pypi.python.org/pypi/setuptools>`__,
+ensure that your version of `pip` is at least 9.0.0 and use::
 
-    pip install -U statsmodels
+    pip install --upgrade statsmodels --upgrade-strategy="only-if-needed"
 
 Or follow `this link to our PyPI page <https://pypi.python.org/pypi/statsmodels>`__.
 
-Statsmodels is also available in `Anaconda <https://www.continuum.io/downloads>`__::
+Statsmodels is also available in `Anaconda <https://www.continuum.io/downloads>`__ and on conda-forge::
 
-    conda install statsmodels
+    conda install -c conda-forge statsmodels
 
 Obtaining the Source
 ~~~~~~~~~~~~~~~~~~~~

--- a/docs/themes/statsmodels/indexsidebar.html
+++ b/docs/themes/statsmodels/indexsidebar.html
@@ -9,11 +9,11 @@ released yet. Grab the source code from <a href="https://github.com/statsmodels/
 
 <p>This documentation is for the <b>{{ release }}</b> release. You can install it with pip:
 
-  <pre style="margin:0px 1px">pip install --upgrade --no-deps statsmodels</pre>
+  <pre style="margin:0px 1px">pip install -U statsmodels --upgrade-strategy="only-if-needed"</pre>
 
   or conda:
 
-  <pre style="margin:0px 1px">conda install statsmodels</pre>
+  <pre style="margin:0px 1px">conda install -c conda-forge statsmodels</pre>
 Documentation for the current development version is <a href="http://www.statsmodels.org/devel/">here</a>.</p>
 
 {% endif %}


### PR DESCRIPTION
Use the new upgrade-strategy option to pip, and recommend the
conda-forge channel.

This will be backported to 0.8.x