### PR TITLE
BUG: pandas 0.19.2 compatibility - long versus integer in timestamp (0.8 version)

### DIFF
--- a/statsmodels/tsa/base/datetools.py
+++ b/statsmodels/tsa/base/datetools.py
@@ -80,7 +80,7 @@ def _date_from_idx(d1, idx, freq):
     This does not do any rounding to make sure that d1 is actually on the
     offset. For now, this needs to be taken care of before you get here.
     """
-    return _maybe_convert_period(d1) + idx * _freq_to_pandas[freq]
+    return _maybe_convert_period(d1) + int(idx) * _freq_to_pandas[freq]
 
 
 def _idx_from_dates(d1, d2, freq):


### PR DESCRIPTION
This is related to #3349, but as it applies to the pre-0.9 date handling code.

I can't replicate the failure on my machine with pandas 0.19.2, but hopefully this fixes it.