### PR TITLE
COMPAT: is_numeric_dtype deprecation in Pandas

### DIFF
--- a/statsmodels/compat/pandas.py
+++ b/statsmodels/compat/pandas.py
@@ -34,17 +34,20 @@ except ImportError:
     RangeIndex = tuple()
 
 try:
-    from pandas.core.common import is_numeric_dtype
+    from pandas.api.types import is_numeric_dtype
 except ImportError:
-    # Pandas <= 0.14
-    def is_numeric_dtype(arr_or_dtype):
-        # Crude implementation only suitable for array-like types
-        try:
-            tipo = arr_or_dtype.dtype.type
-        except AttributeError:
-            tipo = type(None)
-        return (issubclass(tipo, (np.number, np.bool_)) and
-                not issubclass(tipo, (np.datetime64, np.timedelta64)))
+    try:
+        from pandas.core.common import is_numeric_dtype
+    except ImportError:
+        # Pandas <= 0.14
+        def is_numeric_dtype(arr_or_dtype):
+            # Crude implementation only suitable for array-like types
+            try:
+                tipo = arr_or_dtype.dtype.type
+            except AttributeError:
+                tipo = type(None)
+            return (issubclass(tipo, (np.number, np.bool_)) and
+                    not issubclass(tipo, (np.datetime64, np.timedelta64)))
 
 try:
     import pandas.tseries.tools as datetools


### PR DESCRIPTION
This addresses the Pandas deprecation in #3427.