### PR TITLE
MAINT numy 1.12 compatibility integer division

### DIFF
--- a/statsmodels/regression/tests/test_lme.py
+++ b/statsmodels/regression/tests/test_lme.py
@@ -264,7 +264,7 @@ class TestMixedLM(object):
 
         # The random effects
         exog_re = np.random.normal(size=(n, 2))
-        slopes = np.random.normal(size=(n / 16, 2))
+        slopes = np.random.normal(size=(n // 16, 2))
         slopes = np.kron(slopes, np.ones((16, 1))) * exog_re
         errors += slopes.sum(1)
 


### PR DESCRIPTION
exception with float instead of integer in numpy 1.12 see test run in #3427

(not locally tested because I don't have numpy 1.12 yet)