### PR TITLE
BUG: _get_predict_end did not accept datetime (0.8 shim)

### DIFF
--- a/statsmodels/tsa/base/tests/test_base.py
+++ b/statsmodels/tsa/base/tests/test_base.py
@@ -4,6 +4,7 @@ import pandas as pd
 from statsmodels.tsa.base.datetools import _freq_to_pandas
 from statsmodels.tsa.base.tsa_model import TimeSeriesModel
 from statsmodels.tools.testing import assert_equal, assert_raises
+from datetime import datetime
 
 
 def test_pandas_nodates_index():
@@ -106,3 +107,17 @@ def test_pandas_dates():
     model = TimeSeriesModel(df['price'])
 
     assert_equal(model.data.dates, result.index)
+
+def test_get_predict_start_end():
+    index = pd.DatetimeIndex(start='1970-01-01', end='1990-01-01', freq='AS')
+    endog = pd.Series(np.zeros(10), index[:10])
+    model = TimeSeriesModel(endog)
+
+    predict_starts = [1, '1971-01-01', datetime(1971, 1, 1), index[1]]
+    predict_ends = [20, '1990-01-01', datetime(1990, 1, 1), index[-1]]
+
+    for start in predict_starts:
+        assert_equal(model._get_predict_start(start), 1)
+
+    for end in predict_ends:
+        assert_equal(model._get_predict_end(end), (9, 11))

--- a/statsmodels/tsa/base/tsa_model.py
+++ b/statsmodels/tsa/base/tsa_model.py
@@ -155,6 +155,9 @@ class TimeSeriesModel(base.LikelihoodModel):
         dates = self.data.dates
         freq = self.data.freq
 
+        if isinstance(end, datetime.datetime):
+            end = self._str_to_date(str(end))
+
         if isinstance(end, str) or (dates is not None
                                     and isinstance(end, type(dates[0]))):
             if dates is None:


### PR DESCRIPTION
Closes #2553

Shim in 0.8 for accepting `datetime.datetime` objects in `TimeSeriesModel._get_predict_end`. The strategy is the same as in `_get_predict_start` (i.e. convert to string, then use `_str_to_date`).

It \*appears\* to fix the issue (in the sense that I can use datetime objects in start and end of `predict` calls), and it seems very straightforward, but I don't know whether or not to merge it because:

1. it's pretty late in the process now, and
2. since I've already refactored the dates for 0.9 I don't want to spend a lot of time making sure it doesn't break corner cases or something

@josef-pkt what are your thoughts?