### PR TITLE
TST: Test types accepted by predict start / end

### DIFF
--- a/statsmodels/tsa/base/tests/test_base.py
+++ b/statsmodels/tsa/base/tests/test_base.py
@@ -3,6 +3,7 @@ import numpy.testing as npt
 import pandas as pd
 from statsmodels.tsa.base.tsa_model import TimeSeriesModel
 from statsmodels.tools.testing import assert_equal, assert_raises
+from datetime import datetime
 
 
 def test_pandas_nodates_index():
@@ -103,3 +104,16 @@ def test_pandas_dates():
     model = TimeSeriesModel(df['price'])
 
     assert_equal(model.data.dates, result.index)
+
+def test_get_predict_start_end():
+    index = pd.DatetimeIndex(start='1970-01-01', end='1990-01-01', freq='AS')
+    endog = pd.Series(np.zeros(10), index[:10])
+    model = TimeSeriesModel(endog)
+
+    predict_starts = [1, '1971-01-01', datetime(1971, 1, 1), index[1]]
+    predict_ends = [20, '1990-01-01', datetime(1990, 1, 1), index[-1]]
+
+    desired = (1, 9, 11)
+    for start in predict_starts:
+        for end in predict_ends:
+            assert_equal(model._get_prediction_index(start, end)[:3], desired)


### PR DESCRIPTION
This is the master counterpart of #3430, where I just add a unit test to make sure that the effect of that PR (to allow `datetime` objects as predict endpoints) is still valid in 0.9.