### PR TITLE
REF: State space: Consistent naming of seasonal_periods

### DIFF
--- a/statsmodels/tsa/statespace/sarimax.py
+++ b/statsmodels/tsa/statespace/sarimax.py
@@ -169,7 +169,7 @@ class SARIMAX(MLEModel):
         Highest moving average order in the model, zero-indexed.
     k_ma_params : int
         Number of moving average parameters to be estimated.
-    k_seasons : int
+    seasonal_periods : int
         Number of periods in a season.
     k_seasonal_ar : int
         Highest seasonal autoregressive order in the model, zero-indexed.
@@ -285,7 +285,7 @@ class SARIMAX(MLEModel):
                  hamilton_representation=False, **kwargs):
 
         # Model parameters
-        self.k_seasons = seasonal_order[3]
+        self.seasonal_periods = seasonal_order[3]
         self.measurement_error = measurement_error
         self.time_varying_regression = time_varying_regression
         self.mle_regression = mle_regression
@@ -324,27 +324,27 @@ class SARIMAX(MLEModel):
         if isinstance(seasonal_order[0], (int, long, np.integer)):
             self.polynomial_seasonal_ar = np.r_[
                 1.,  # constant
-                ([0] * (self.k_seasons - 1) + [1]) * seasonal_order[0]
+                ([0] * (self.seasonal_periods - 1) + [1]) * seasonal_order[0]
             ]
         else:
             self.polynomial_seasonal_ar = np.r_[
-                1., [0] * self.k_seasons * len(seasonal_order[0])
+                1., [0] * self.seasonal_periods * len(seasonal_order[0])
             ]
             for i in range(len(seasonal_order[0])):
-                self.polynomial_seasonal_ar[(i + 1) * self.k_seasons] = (
+                self.polynomial_seasonal_ar[(i + 1) * self.seasonal_periods] = (
                     seasonal_order[0][i]
                 )
         if isinstance(seasonal_order[2], (int, long, np.integer)):
             self.polynomial_seasonal_ma = np.r_[
                 1.,  # constant
-                ([0] * (self.k_seasons - 1) + [1]) * seasonal_order[2]
+                ([0] * (self.seasonal_periods - 1) + [1]) * seasonal_order[2]
             ]
         else:
             self.polynomial_seasonal_ma = np.r_[
-                1., [0] * self.k_seasons * len(seasonal_order[2])
+                1., [0] * self.seasonal_periods * len(seasonal_order[2])
             ]
             for i in range(len(seasonal_order[2])):
-                self.polynomial_seasonal_ma[(i + 1) * self.k_seasons] = (
+                self.polynomial_seasonal_ma[(i + 1) * self.seasonal_periods] = (
                     seasonal_order[2][i]
                 )
 
@@ -446,7 +446,7 @@ class SARIMAX(MLEModel):
         # Number of states
         k_states = self._k_order
         if not self.simple_differencing:
-            k_states += self.k_seasons * self._k_seasonal_diff + self._k_diff
+            k_states += self.seasonal_periods * self._k_seasonal_diff + self._k_diff
         if self.state_regression:
             k_states += self.k_exog
 
@@ -494,7 +494,7 @@ class SARIMAX(MLEModel):
 
         # Internally used in several locations
         self._k_states_diff = (
-            self._k_diff + self.k_seasons * self._k_seasonal_diff
+            self._k_diff + self.seasonal_periods * self._k_seasonal_diff
         )
 
         # Set some model variables now so they will be available for the
@@ -558,10 +558,10 @@ class SARIMAX(MLEModel):
             orig_length = endog.shape[0]
             # Perform simple differencing
             endog = diff(endog.copy(), self.orig_k_diff,
-                         self.orig_k_seasonal_diff, self.k_seasons)
+                         self.orig_k_seasonal_diff, self.seasonal_periods)
             if exog is not None:
                 exog = diff(exog.copy(), self.orig_k_diff,
-                            self.orig_k_seasonal_diff, self.k_seasons)
+                            self.orig_k_seasonal_diff, self.seasonal_periods)
 
             # Reset the ModelData datasets and cache
             self.data.endog, self.data.exog = (
@@ -749,7 +749,7 @@ class SARIMAX(MLEModel):
         # Basic design matrix
         design = np.r_[
             [1] * self._k_diff,
-            ([0] * (self.k_seasons - 1) + [1]) * self._k_seasonal_diff,
+            ([0] * (self.seasonal_periods - 1) + [1]) * self._k_seasonal_diff,
             [1] * self.state_error, [0] * (self._k_order - 1)
         ]
 
@@ -813,18 +813,18 @@ class SARIMAX(MLEModel):
         # Seasonal differencing component
         # T^*
         if self._k_seasonal_diff > 0:
-            seasonal_companion = companion_matrix(self.k_seasons).T
+            seasonal_companion = companion_matrix(self.seasonal_periods).T
             seasonal_companion[0, -1] = 1
             for d in range(self._k_seasonal_diff):
-                start = self._k_diff + d * self.k_seasons
-                end = self._k_diff + (d + 1) * self.k_seasons
+                start = self._k_diff + d * self.seasonal_periods
+                end = self._k_diff + (d + 1) * self.seasonal_periods
 
                 # T_c^*
                 transition[start:end, start:end] = seasonal_companion
 
                 # i
                 for i in range(d + 1, self._k_seasonal_diff):
-                    transition[start, end + self.k_seasons - 1] = 1
+                    transition[start, end + self.seasonal_periods - 1] = 1
 
                 # \iota
                 transition[start, self._k_states_diff] = 1
@@ -835,11 +835,11 @@ class SARIMAX(MLEModel):
             # T^**
             transition[idx] = 1
             # [0 1]
-            if self.k_seasons > 0:
+            if self.seasonal_periods > 0:
                 start = self._k_diff
                 end = self._k_states_diff
                 transition[:self._k_diff, start:end] = (
-                    ([0] * (self.k_seasons - 1) + [1]) * self._k_seasonal_diff
+                    ([0] * (self.seasonal_periods - 1) + [1]) * self._k_seasonal_diff
                 )
             # [1 0]
             column = self._k_states_diff
@@ -957,10 +957,10 @@ class SARIMAX(MLEModel):
         if not self.simple_differencing and (
            self._k_diff > 0 or self._k_seasonal_diff > 0):
             endog = diff(self.endog, self._k_diff,
-                         self._k_seasonal_diff, self.k_seasons)
+                         self._k_seasonal_diff, self.seasonal_periods)
             if self.exog is not None:
                 exog = diff(self.exog, self._k_diff,
-                            self._k_seasonal_diff, self.k_seasons)
+                            self._k_seasonal_diff, self.seasonal_periods)
             else:
                 exog = None
             trend_data = trend_data[:endog.shape[0], :]
@@ -1090,10 +1090,10 @@ class SARIMAX(MLEModel):
         if self.k_seasonal_diff > 0:
             if self.k_seasonal_diff == 1:
                 seasonal_diff = (('\Delta_%d' if latex else 'DS%d') %
-                                 (self.k_seasons))
+                                 (self.seasonal_periods))
             else:
                 seasonal_diff = (('\Delta_%d^%d' if latex else 'D%dS%d') %
-                                 (self.k_seasonal_diff, self.k_seasons))
+                                 (self.k_seasonal_diff, self.seasonal_periods))
         endog_diff = self.simple_differencing
         if endog_diff and self.k_diff > 0 and self.k_seasonal_diff > 0:
             return (('%s%s %s' if latex else '%s.%s.%s') %
@@ -1738,7 +1738,7 @@ class SARIMAXResults(MLEResults):
         # Save model specification
         self.specification = Bunch(**{
             # Set additional model parameters
-            'k_seasons': self.model.k_seasons,
+            'seasonal_periods': self.model.seasonal_periods,
             'measurement_error': self.model.measurement_error,
             'time_varying_regression': self.model.time_varying_regression,
             'simple_differencing': self.model.simple_differencing,
@@ -1970,7 +1970,7 @@ class SARIMAXResults(MLEResults):
         if has_seasonal:
             if self.model.k_ar == self.model.k_ar_params:
                 order_seasonal_ar = (
-                    int(self.model.k_seasonal_ar / self.model.k_seasons)
+                    int(self.model.k_seasonal_ar / self.model.seasonal_periods)
                 )
             else:
                 order_seasonal_ar = (
@@ -1978,7 +1978,7 @@ class SARIMAXResults(MLEResults):
                 )
             if self.model.k_ma == self.model.k_ma_params:
                 order_seasonal_ma = (
-                    int(self.model.k_seasonal_ma / self.model.k_seasons)
+                    int(self.model.k_seasonal_ma / self.model.seasonal_periods)
                 )
             else:
                 order_seasonal_ma = (
@@ -1991,7 +1991,7 @@ class SARIMAXResults(MLEResults):
                 k_seasonal_diff = 0
             seasonal_order = ('(%s, %d, %s, %d)' %
                               (str(order_seasonal_ar), k_seasonal_diff,
-                               str(order_seasonal_ma), self.model.k_seasons))
+                               str(order_seasonal_ma), self.model.seasonal_periods))
             if not order == '':
                 order += 'x'
         model_name = (

--- a/statsmodels/tsa/statespace/structural.py
+++ b/statsmodels/tsa/statespace/structural.py
@@ -310,8 +310,8 @@ class UnobservedComponents(MLEModel):
         # Model options
         self.level = level
         self.trend = trend
-        self.seasonal_period = seasonal if seasonal is not None else 0
-        self.seasonal = self.seasonal_period > 0
+        self.seasonal_periods = seasonal if seasonal is not None else 0
+        self.seasonal = self.seasonal_periods > 0
         self.cycle = cycle
         self.ar_order = autoregressive if autoregressive is not None else 0
         self.autoregressive = self.ar_order > 0
@@ -421,7 +421,7 @@ class UnobservedComponents(MLEModel):
                  " irregular component added.", SpecificationWarning)
             self.irregular = True
 
-        if self.seasonal and self.seasonal_period < 2:
+        if self.seasonal and self.seasonal_periods < 2:
             raise ValueError('Seasonal component must have a seasonal period'
                              ' of at least 2.')
 
@@ -460,7 +460,7 @@ class UnobservedComponents(MLEModel):
         # Model parameters
         k_states = (
             self.level + self.trend +
-            (self.seasonal_period - 1) * self.seasonal +
+            (self.seasonal_periods - 1) * self.seasonal +
             self.cycle * 2 +
             self.ar_order +
             (not self.mle_regression) * self.k_exog
@@ -534,7 +534,7 @@ class UnobservedComponents(MLEModel):
         kwds = super(UnobservedComponents, self)._get_init_kwds()
 
         # Modifications
-        kwds['seasonal'] = self.seasonal_period
+        kwds['seasonal'] = self.seasonal_periods
         kwds['autoregressive'] = self.ar_order
 
         for key, value in kwds.items():
@@ -578,7 +578,7 @@ class UnobservedComponents(MLEModel):
                 j += 1
             i += 1
         if self.seasonal:
-            n = self.seasonal_period - 1
+            n = self.seasonal_periods - 1
             self.ssm['design', 0, i] = 1.
             self.ssm['transition', i:i + n, i:i + n] = (
                 companion_matrix(np.r_[1, [1] * n]).transpose()
@@ -654,7 +654,7 @@ class UnobservedComponents(MLEModel):
 
             start = (
                 self.level + self.trend +
-                (self.seasonal_period - 1) * self.seasonal +
+                (self.seasonal_periods - 1) * self.seasonal +
                 self.cycle * 2
             )
             end = start + self.ar_order
@@ -1001,7 +1001,7 @@ class UnobservedComponentsResults(MLEResults):
             # Model options
             'level': self.model.level,
             'trend': self.model.trend,
-            'seasonal_period': self.model.seasonal_period,
+            'seasonal_periods': self.model.seasonal_periods,
             'seasonal': self.model.seasonal,
             'cycle': self.model.cycle,
             'ar_order': self.model.ar_order,
@@ -1117,7 +1117,7 @@ class UnobservedComponentsResults(MLEResults):
         """
         # If present, seasonal always follows level/trend (if they are present)
         # Note that we return only the first seasonal state, but there are
-        # in fact seasonal_period-1 seasonal states, however latter states
+        # in fact seasonal_periods-1 seasonal states, however latter states
         # are just lagged versions of the first seasonal state.
         out = None
         spec = self.specification
@@ -1163,7 +1163,7 @@ class UnobservedComponentsResults(MLEResults):
         spec = self.specification
         if spec.cycle:
             offset = int(spec.trend + spec.level +
-                         spec.seasonal * (spec.seasonal_period - 1))
+                         spec.seasonal * (spec.seasonal_periods - 1))
             out = Bunch(filtered=self.filtered_state[offset],
                         filtered_cov=self.filtered_state_cov[offset, offset],
                         smoothed=None, smoothed_cov=None,
@@ -1202,7 +1202,7 @@ class UnobservedComponentsResults(MLEResults):
         spec = self.specification
         if spec.autoregressive:
             offset = int(spec.trend + spec.level +
-                         spec.seasonal * (spec.seasonal_period - 1) +
+                         spec.seasonal * (spec.seasonal_periods - 1) +
                          2 * spec.cycle)
             out = Bunch(filtered=self.filtered_state[offset],
                         filtered_cov=self.filtered_state_cov[offset, offset],
@@ -1250,7 +1250,7 @@ class UnobservedComponentsResults(MLEResults):
                               ' of the state vector.', OutputWarning)
             else:
                 offset = int(spec.trend + spec.level +
-                             spec.seasonal * (spec.seasonal_period - 1) +
+                             spec.seasonal * (spec.seasonal_periods - 1) +
                              spec.cycle * (1 + spec.stochastic_cycle) +
                              spec.ar_order)
                 start = offset
@@ -1542,7 +1542,7 @@ class UnobservedComponentsResults(MLEResults):
         model_name = [self.specification.trend_specification]
 
         if self.specification.seasonal:
-            seasonal_name = 'seasonal(%d)' % self.specification.seasonal_period
+            seasonal_name = 'seasonal(%d)' % self.specification.seasonal_periods
             if self.specification.stochastic_seasonal:
                 seasonal_name = 'stochastic ' + seasonal_name
             model_name.append(seasonal_name)

--- a/statsmodels/tsa/statespace/tests/test_tools.py
+++ b/statsmodels/tsa/statespace/tests/test_tools.py
@@ -46,11 +46,11 @@ class TestDiff(object):
         ([1,2,3], 1, None, 1, [1, 1]),
         # diff = 2
         (x, 2, None, 1, [0]*8),
-        # diff = 1, seasonal_diff=1, k_seasons=4
+        # diff = 1, seasonal_diff=1, seasonal_periods=4
         (x, 1, 1, 4, [0]*5),
         (x**2, 1, 1, 4, [8]*5),
         (x**3, 1, 1, 4, [60, 84, 108, 132, 156]),
-        # diff = 1, seasonal_diff=2, k_seasons=2
+        # diff = 1, seasonal_diff=2, seasonal_periods=2
         (x, 1, 2, 2, [0]*5),
         (x**2, 1, 2, 2, [0]*5),
         (x**3, 1, 2, 2, [24]*5),
@@ -59,10 +59,10 @@ class TestDiff(object):
 
     def test_cases(self):
         # Basic cases
-        for series, diff, seasonal_diff, k_seasons, result in self.cases:
+        for series, diff, seasonal_diff, seasonal_periods, result in self.cases:
             
             # Test numpy array
-            x = tools.diff(series, diff, seasonal_diff, k_seasons)
+            x = tools.diff(series, diff, seasonal_diff, seasonal_periods)
             assert_almost_equal(x, result)
 
             # Test as Pandas Series
@@ -73,12 +73,12 @@ class TestDiff(object):
             result = np.c_[result, result]
 
             # Test Numpy array
-            x = tools.diff(series, diff, seasonal_diff, k_seasons)
+            x = tools.diff(series, diff, seasonal_diff, seasonal_periods)
             assert_almost_equal(x, result)
 
             # Test as Pandas Dataframe
             series = pd.DataFrame(series)
-            x = tools.diff(series, diff, seasonal_diff, k_seasons)
+            x = tools.diff(series, diff, seasonal_diff, seasonal_periods)
             assert_almost_equal(x, result)
 
 class TestSolveDiscreteLyapunov(object):

--- a/statsmodels/tsa/statespace/tools.py
+++ b/statsmodels/tsa/statespace/tools.py
@@ -340,7 +340,7 @@ def companion_matrix(polynomial):
     return matrix
 
 
-def diff(series, k_diff=1, k_seasonal_diff=None, k_seasons=1):
+def diff(series, k_diff=1, k_seasonal_diff=None, seasonal_periods=1):
     r"""
     Difference a series simply and/or seasonally along the zero-th axis.
 
@@ -350,7 +350,7 @@ def diff(series, k_diff=1, k_seasonal_diff=None, k_seasons=1):
 
         \Delta^d \Delta_s^D y_t
 
-    where :math:`d =` `diff`, :math:`s =` `k_seasons`,
+    where :math:`d =` `diff`, :math:`s =` `seasonal_periods`,
     :math:`D =` `seasonal\_diff`, and :math:`\Delta` is the difference
     operator.
 
@@ -363,7 +363,7 @@ def diff(series, k_diff=1, k_seasonal_diff=None, k_seasons=1):
     seasonal_diff : int or None, optional
         The number of seasonal differences to perform. Default is no seasonal
         differencing.
-    k_seasons : int, optional
+    seasonal_periods : int, optional
         The seasonal lag. Default is 1. Unused if there is no seasonal
         differencing.
 
@@ -380,10 +380,10 @@ def diff(series, k_diff=1, k_seasonal_diff=None, k_seasons=1):
         while k_seasonal_diff > 0:
             if not pandas:
                 differenced = (
-                    differenced[k_seasons:] - differenced[:-k_seasons]
+                    differenced[seasonal_periods:] - differenced[:-seasonal_periods]
                 )
             else:
-                differenced = differenced.diff(k_seasons)[k_seasons:]
+                differenced = differenced.diff(seasonal_periods)[seasonal_periods:]
             k_seasonal_diff -= 1
 
     # Simple differencing


### PR DESCRIPTION
Makes naming consistent for seasonal periods in SARIMAX and UnobservedComponents models, as discussed in #3381.

Just want to get this in before we release these models in 0.8.