### PR TITLE
REF: State space: Backport: Consistent naming of seasonal_periods.

### DIFF
--- a/statsmodels/tsa/statespace/structural.py
+++ b/statsmodels/tsa/statespace/structural.py
@@ -310,8 +310,8 @@ class UnobservedComponents(MLEModel):
         # Model options
         self.level = level
         self.trend = trend
-        self.seasonal_period = seasonal if seasonal is not None else 0
-        self.seasonal = self.seasonal_period > 0
+        self.seasonal_periods = seasonal if seasonal is not None else 0
+        self.seasonal = self.seasonal_periods > 0
         self.cycle = cycle
         self.ar_order = autoregressive if autoregressive is not None else 0
         self.autoregressive = self.ar_order > 0
@@ -421,7 +421,7 @@ class UnobservedComponents(MLEModel):
                  " irregular component added.", SpecificationWarning)
             self.irregular = True
 
-        if self.seasonal and self.seasonal_period < 2:
+        if self.seasonal and self.seasonal_periods < 2:
             raise ValueError('Seasonal component must have a seasonal period'
                              ' of at least 2.')
 
@@ -460,7 +460,7 @@ class UnobservedComponents(MLEModel):
         # Model parameters
         k_states = (
             self.level + self.trend +
-            (self.seasonal_period - 1) * self.seasonal +
+            (self.seasonal_periods - 1) * self.seasonal +
             self.cycle * 2 +
             self.ar_order +
             (not self.mle_regression) * self.k_exog
@@ -534,7 +534,7 @@ class UnobservedComponents(MLEModel):
         kwds = super(UnobservedComponents, self)._get_init_kwds()
 
         # Modifications
-        kwds['seasonal'] = self.seasonal_period
+        kwds['seasonal'] = self.seasonal_periods
         kwds['autoregressive'] = self.ar_order
 
         for key, value in kwds.items():
@@ -578,7 +578,7 @@ class UnobservedComponents(MLEModel):
                 j += 1
             i += 1
         if self.seasonal:
-            n = self.seasonal_period - 1
+            n = self.seasonal_periods - 1
             self.ssm['design', 0, i] = 1.
             self.ssm['transition', i:i + n, i:i + n] = (
                 companion_matrix(np.r_[1, [1] * n]).transpose()
@@ -654,7 +654,7 @@ class UnobservedComponents(MLEModel):
 
             start = (
                 self.level + self.trend +
-                (self.seasonal_period - 1) * self.seasonal +
+                (self.seasonal_periods - 1) * self.seasonal +
                 self.cycle * 2
             )
             end = start + self.ar_order
@@ -1001,7 +1001,7 @@ class UnobservedComponentsResults(MLEResults):
             # Model options
             'level': self.model.level,
             'trend': self.model.trend,
-            'seasonal_period': self.model.seasonal_period,
+            'seasonal_periods': self.model.seasonal_periods,
             'seasonal': self.model.seasonal,
             'cycle': self.model.cycle,
             'ar_order': self.model.ar_order,
@@ -1117,7 +1117,7 @@ class UnobservedComponentsResults(MLEResults):
         """
         # If present, seasonal always follows level/trend (if they are present)
         # Note that we return only the first seasonal state, but there are
-        # in fact seasonal_period-1 seasonal states, however latter states
+        # in fact seasonal_periods-1 seasonal states, however latter states
         # are just lagged versions of the first seasonal state.
         out = None
         spec = self.specification
@@ -1163,7 +1163,7 @@ class UnobservedComponentsResults(MLEResults):
         spec = self.specification
         if spec.cycle:
             offset = int(spec.trend + spec.level +
-                         spec.seasonal * (spec.seasonal_period - 1))
+                         spec.seasonal * (spec.seasonal_periods - 1))
             out = Bunch(filtered=self.filtered_state[offset],
                         filtered_cov=self.filtered_state_cov[offset, offset],
                         smoothed=None, smoothed_cov=None,
@@ -1202,7 +1202,7 @@ class UnobservedComponentsResults(MLEResults):
         spec = self.specification
         if spec.autoregressive:
             offset = int(spec.trend + spec.level +
-                         spec.seasonal * (spec.seasonal_period - 1) +
+                         spec.seasonal * (spec.seasonal_periods - 1) +
                          2 * spec.cycle)
             out = Bunch(filtered=self.filtered_state[offset],
                         filtered_cov=self.filtered_state_cov[offset, offset],
@@ -1250,7 +1250,7 @@ class UnobservedComponentsResults(MLEResults):
                               ' of the state vector.', OutputWarning)
             else:
                 offset = int(spec.trend + spec.level +
-                             spec.seasonal * (spec.seasonal_period - 1) +
+                             spec.seasonal * (spec.seasonal_periods - 1) +
                              spec.cycle * (1 + spec.stochastic_cycle) +
                              spec.ar_order)
                 start = offset
@@ -1542,7 +1542,7 @@ class UnobservedComponentsResults(MLEResults):
         model_name = [self.specification.trend_specification]
 
         if self.specification.seasonal:
-            seasonal_name = 'seasonal(%d)' % self.specification.seasonal_period
+            seasonal_name = 'seasonal(%d)' % self.specification.seasonal_periods
             if self.specification.stochastic_seasonal:
                 seasonal_name = 'stochastic ' + seasonal_name
             model_name.append(seasonal_name)

--- a/statsmodels/tsa/statespace/tests/test_tools.py
+++ b/statsmodels/tsa/statespace/tests/test_tools.py
@@ -46,11 +46,11 @@ class TestDiff(object):
         ([1,2,3], 1, None, 1, [1, 1]),
         # diff = 2
         (x, 2, None, 1, [0]*8),
-        # diff = 1, seasonal_diff=1, k_seasons=4
+        # diff = 1, seasonal_diff=1, seasonal_periods=4
         (x, 1, 1, 4, [0]*5),
         (x**2, 1, 1, 4, [8]*5),
         (x**3, 1, 1, 4, [60, 84, 108, 132, 156]),
-        # diff = 1, seasonal_diff=2, k_seasons=2
+        # diff = 1, seasonal_diff=2, seasonal_periods=2
         (x, 1, 2, 2, [0]*5),
         (x**2, 1, 2, 2, [0]*5),
         (x**3, 1, 2, 2, [24]*5),
@@ -59,10 +59,10 @@ class TestDiff(object):
 
     def test_cases(self):
         # Basic cases
-        for series, diff, seasonal_diff, k_seasons, result in self.cases:
+        for series, diff, seasonal_diff, seasonal_periods, result in self.cases:
             
             # Test numpy array
-            x = tools.diff(series, diff, seasonal_diff, k_seasons)
+            x = tools.diff(series, diff, seasonal_diff, seasonal_periods)
             assert_almost_equal(x, result)
 
             # Test as Pandas Series
@@ -73,12 +73,12 @@ class TestDiff(object):
             result = np.c_[result, result]
 
             # Test Numpy array
-            x = tools.diff(series, diff, seasonal_diff, k_seasons)
+            x = tools.diff(series, diff, seasonal_diff, seasonal_periods)
             assert_almost_equal(x, result)
 
             # Test as Pandas Dataframe
             series = pd.DataFrame(series)
-            x = tools.diff(series, diff, seasonal_diff, k_seasons)
+            x = tools.diff(series, diff, seasonal_diff, seasonal_periods)
             assert_almost_equal(x, result)
 
 class TestSolveDiscreteLyapunov(object):

--- a/statsmodels/tsa/statespace/tools.py
+++ b/statsmodels/tsa/statespace/tools.py
@@ -178,7 +178,7 @@ def companion_matrix(polynomial):
     return matrix
 
 
-def diff(series, k_diff=1, k_seasonal_diff=None, k_seasons=1):
+def diff(series, k_diff=1, k_seasonal_diff=None, seasonal_periods=1):
     r"""
     Difference a series simply and/or seasonally along the zero-th axis.
 
@@ -188,7 +188,7 @@ def diff(series, k_diff=1, k_seasonal_diff=None, k_seasons=1):
 
         \Delta^d \Delta_s^D y_t
 
-    where :math:`d =` `diff`, :math:`s =` `k_seasons`,
+    where :math:`d =` `diff`, :math:`s =` `seasonal_periods`,
     :math:`D =` `seasonal\_diff`, and :math:`\Delta` is the difference
     operator.
 
@@ -201,7 +201,7 @@ def diff(series, k_diff=1, k_seasonal_diff=None, k_seasons=1):
     seasonal_diff : int or None, optional
         The number of seasonal differences to perform. Default is no seasonal
         differencing.
-    k_seasons : int, optional
+    seasonal_periods : int, optional
         The seasonal lag. Default is 1. Unused if there is no seasonal
         differencing.
 
@@ -218,10 +218,10 @@ def diff(series, k_diff=1, k_seasonal_diff=None, k_seasons=1):
         while k_seasonal_diff > 0:
             if not pandas:
                 differenced = (
-                    differenced[k_seasons:] - differenced[:-k_seasons]
+                    differenced[seasonal_periods:] - differenced[:-seasonal_periods]
                 )
             else:
-                differenced = differenced.diff(k_seasons)[k_seasons:]
+                differenced = differenced.diff(seasonal_periods)[seasonal_periods:]
             k_seasonal_diff -= 1
 
     # Simple differencing


### PR DESCRIPTION
Backport of #3437.