### PR TITLE
Backport merges 08

### DIFF
--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -5,15 +5,15 @@ python >= 2.6
 
     www.python.org
 
-numpy >= 1.5.1
+numpy >= 1.6
 
     www.numpy.org
 
-scipy >= 0.9.0
-
+scipy >= 0.11
+    
     www.scipy.org
 
-pandas >= 0.7.1
+pandas >= 0.14
 
     pandas.pydata.org
 
@@ -21,16 +21,15 @@ patsy >= 0.3.0
 
     patsy.readthedocs.org
 
-
-cython >= 0.20.1
+cython >= 0.24
 
     http://cython.org/
 
     Cython is required if you are building the source from github. However,
-    if you have are building from source distribution archive then the
-    generated C files are included and Cython is not necessary. If you are
-    building for Python 3.4, then you must use Cython >= 0.20.1. Earlier
-    versions may be ok for Python < 3.4.
+    if you have are building from source distribution archive then the 
+    generated C files are included and Cython is not necessary. If you are 
+    building for Python 3.4, then you must use Cython >= 0.24. Earlier
+    versions may be ok for earlier versions of Python.
 
 Optional Dependencies
 ---------------------
@@ -44,41 +43,39 @@ X-12-ARIMA or X-13ARIMA-SEATS
     appropriate executable on your PATH or set the X12PATH or X13PATH
     environmental variable to take advantage.
 
-matplotlib >= 1.1
+matplotlib >= 1.3
 
-    http://matplotlib.sf.net/
+    http://matplotlib.org/
 
     Matplotlib is needed for plotting functionality and running many of the
     examples.
 
-sphinx >= 1.0.0
+sphinx >= 1.3
 
     http://sphinx.pocoo.org/
 
     Sphinx is used to build the documentation.
 
-nose >= 1.0.0
+nose >= 1.3
 
     http://readthedocs.org/docs/nose/en/latest/
 
     Nose is needed to run the tests.
 
-IPython >= 1.0
+IPython >= 3.0
 
     Needed to build the docs.
 
 
-Easy Install
-------------
+Installing
+----------
 
-To get the latest release using easy_install you need setuptools (easy_install):
+To get the latest release using pip
 
-    http://peak.telecommunity.com/DevCenter/EasyInstall
+    pip install statsmodels --upgrade-strategy only-if-needed
 
-Then you can do (with proper permissions):
-
-    easy_install -U statsmodels
-
+The additional parameter pip --upgrade-strategy only-if-needed will ensure
+that dependencies, e.g. NumPy or pandas, are not upgraded unless required.
 
 Ubuntu/Debian
 -------------
@@ -86,8 +83,7 @@ Ubuntu/Debian
 On Ubuntu you can get dependencies through:
 
     sudo apt-get install python python-dev python-setuptools python-numpy python-scipy
-    easy_install -U pandas
-    easy_install -U cython
+    pip install cython pandas
 
 Alternatively, you can install from the NeuroDebian repository:
 
@@ -108,7 +104,6 @@ Or clone the bleeding edge code from our repository on github at
 
 In the statsmodels directory do (with proper permissions)
 
-    python setup.py build
     python setup.py install
 
 You will need a C compiler installed.
@@ -116,7 +111,7 @@ You will need a C compiler installed.
 Installing from Source on Windows
 ---------------------------------
 
-See http://statsmodels.sf.net/devel/install.html#windows.
+See http://www.statsmodels.org/devel/install.html#windows.
 
 
 Documentation
@@ -125,4 +120,4 @@ Documentation
 You may find more information about the project and installation in our
 documentation
 
-http://statsmodels.sf.net/devel/install.html
+http://www.statsmodels.org/devel/install.html

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -319,3 +319,13 @@ github_project_url = "https://github.com/statsmodels/statsmodels"
 import json
 example_context = json.load(open('examples/landing.json'))
 html_context = {'examples': example_context }
+
+# --------------- DOCTEST -------------------
+doctest_global_setup = """
+import statsmodels.api as sm
+import statsmodels.formula.api as smf
+import numpy as np
+import scipy.stats as stats
+import matplotlib.pyplot as plt
+import pandas as pd
+"""

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -8,22 +8,26 @@ Installation
 Using setuptools
 ~~~~~~~~~~~~~~~~
 
-To obtain the latest released version of statsmodels using `setuptools <https://pypi.python.org/pypi/setuptools>`__::
+To obtain the latest released version of statsmodels using pip
 
     pip install -U statsmodels
 
-Or follow `this link to our PyPI page <https://pypi.python.org/pypi/statsmodels>`__.
+Or follow `this link to our PyPI page <https://pypi.python.org/pypi/statsmodels>`__, download
+the wheel or source and install.
 
-Statsmodels is also available in `Anaconda <https://www.continuum.io/downloads>`__::
+Statsmodels is also available in through conda provided by
+`Anaconda <https://www.continuum.io/downloads>`__. The latest release can
+be installed using
 
-    conda install statsmodels
+    conda install -c conda-forge statsmodels
 
 Obtaining the Source
 ~~~~~~~~~~~~~~~~~~~~
 
 We do not release very often but the master branch of our source code is 
 usually fine for everyday use. You can get the latest source from our 
-`github repository <https://github.com/statsmodels/statsmodels>`__. Or if you have git installed::
+`github repository <https://github.com/statsmodels/statsmodels>`__. Or if you
+have git installed::
 
     git clone git://github.com/statsmodels/statsmodels.git
 
@@ -36,12 +40,19 @@ in the statsmodels directory.
 Windows Nightly Binaries
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-If you are not able to follow the build instructions below, we upload nightly builds of the GitHub repository to `http://www.statsmodels.org/binaries/ <http://www.statsmodels.org/binaries/>`__.
+If you are not able to follow the build instructions below, we occasionally
+upload builds of the GitHub repository to
+`https://anaconda.org/statsmodels/statsmodels <https://anaconda.org/statsmodels/statsmodels/>`__.
+This version can be installed using conda
+
+    conda install -c statsmodels statsmodels=0.8.0_dev
 
 Installation from Source
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-You will need a C compiler installed to build statsmodels. If you are building from the github source and not a source release, then you will also need Cython. You can follow the instructions below to get a C compiler setup for Windows.
+You will need a C compiler installed to build statsmodels. If you are building
+from the github source and not a source release, then you will also need
+Cython. You can follow the instructions below to get a C compiler setup for Windows.
 
 Linux
 ^^^^^
@@ -58,6 +69,27 @@ Or::
 Windows
 ^^^^^^^
 
+It is strongly recommended to use 64-bit Python if possible.
+
+Python 2.7
+~~~~~~~~~~
+Obtain
+`Microsoft Visual C++ Compiler for Python 2.7 <https://www.microsoft.com/en-gb/download/details.aspx?id=44266>`__
+and then install using
+
+    python setup.py install
+
+Python 3.5
+~~~~~~~~~~
+Download and install the most recent version of
+`Visual Studio Community Edition <https://www.visualstudio.com/vs/community/>`__
+and then install using
+
+    python setup.py install
+
+
+32-bit or other versions of Python
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 You can build 32-bit version of the code on windows using mingw32.
 
 First, get and install `mingw32 <http://www.mingw.org/>`__. Then, you'll need to edit distutils.cfg. This is usually found somewhere like C:\Python27\Lib\distutils\distutils.cfg. Add these lines::
@@ -72,15 +104,23 @@ Then in the statsmodels directory do::
 
 OR
 
-You can build 32-bit or 64-bit versions of the code using the Microsoft SDK. Detailed instructions can be found on the Cython wiki `here <http://wiki.cython.org/64BitCythonExtensionsOnWindows>`__. The gist of these instructions follow. You will need to download the free Windows SDK C/C++ compiler from Microsoft. You must use the **Microsoft Windows SDK for Windows 7 and .NET Framework 3.5 SP1** to be comptible with Python 2.6, 2.7, 3.1, and 3.2. The link for the 3.5 SP1 version is
+You can build 32-bit Microsoft SDK. Detailed instructions can be found on the
+Cython wiki `here <http://wiki.cython.org/64BitCythonExtensionsOnWindows>`__.
+The gist of these instructions follow. You will need to download the free
+Windows SDK C/C++ compiler from Microsoft. You must use
+the **Microsoft Windows SDK for Windows 7 and .NET Framework 3.5 SP1** to be
+comptible with Python 2.7, 3.1, and 3.2. The link for the 3.5 SP1 version is
 
 `http://www.microsoft.com/downloads/en/details.aspx?familyid=71DEB800-C591-4F97-A900-BEA146E4FAE1&displaylang=en <http://www.microsoft.com/downloads/en/details.aspx?familyid=71DEB800-C591-4F97-A900-BEA146E4FAE1&displaylang=en>`__
 
-For Python 3.3, you need to use the **Microsoft Windows SDK for Windows 7 and .NET Framework 4**, available from
+For Python 3.3, you need to use the **Microsoft Windows SDK for Windows 7 and .NET Framework 4**,
+available from
 
 `http://www.microsoft.com/en-us/download/details.aspx?id=8279 <http://www.microsoft.com/en-us/download/details.aspx?id=8279>`__
 
-For 7.0, get the ISO file GRMSDKX_EN_DVD.iso for AMD64. After you install this, open the SDK Command Shell (Start -> All Programs -> Microsoft Windows SDK v7.0 -> CMD Shell). CD to the statsmodels directory and type::
+For 7.0, get the ISO file GRMSDKX_EN_DVD.iso for AMD64. After you install this,
+open the SDK Command Shell (Start -> All Programs ->
+Microsoft Windows SDK v7.0 -> CMD Shell). CD to the statsmodels directory and type::
 
     set DISTUTILS_USE_SDK=1
 
@@ -97,9 +137,11 @@ The prompt should change colors to green. Then proceed as usual to install::
     python setup.py build
     python setup.py install
 
-For 7.1, the instructions are exactly the same, except you use the download link provided above and make sure you are using SDK 7.1.
+For 7.1, the instructions are exactly the same, except you use the download
+link provided above and make sure you are using SDK 7.1.
 
-If you want to accomplish the same without opening up the SDK CMD SHELL, then you can use these commands at the CMD Prompt or in a batch file.::
+If you want to accomplish the same without opening up the SDK CMD SHELL, then
+you can use these commands at the CMD Prompt or in a batch file.::
 
     setlocal EnableDelayedExpansion
     CALL "C:\Program Files\Microsoft SDKs\Windows\v7.0\Bin\SetEnv.cmd" /x64 /release
@@ -111,17 +153,24 @@ Replace `/x64` with `/x86` and `v7.0` with `v7.1` as needed.
 Dependencies
 ~~~~~~~~~~~~
 
-* `Python <https://www.python.org>`__ >= 2.6, including Python 3.x 
-* `NumPy <http://www.scipy.org/>`__ >= 1.5.1
-* `SciPy <http://www.scipy.org/>`__ >= 0.9.0
-* `Pandas <http://pandas.pydata.org/>`__ >= 0.7.1
+* `Python <https://www.python.org>`__ >= 2.6, including Python 3.x
+* `NumPy <http://www.scipy.org/>`__ >= 1.6
+* `SciPy <http://www.scipy.org/>`__ >= 0.11
+* `Pandas <http://pandas.pydata.org/>`__ >= 0.14
 * `Patsy <https://patsy.readthedocs.org>`__ >= 0.3.0
-* `Cython <http://cython.org/>`__ >= 20.1, Needed if you want to build the code from github and not a source distribution. You must use Cython >= 0.20.1 if you're on Python 3.4. Earlier versions may work for Python < 3.4.
+* `Cython <http://cython.org/>`__ >= 0.24 is required to build the code from
+  github but not from a source distribution. Earlier versions may work, although
+  you must use Cython >= 0.20.1 if you're on Python 3.4.
 
 Optional Dependencies
 ~~~~~~~~~~~~~~~~~~~~~
 
-* `Matplotlib <http://matplotlib.org/>`__ >= 1.1 is needed for plotting functions and running many of the examples. 
-* If installed, `X-12-ARIMA <http://www.census.gov/srd/www/x13as/>`__ or `X-13ARIMA-SEATS <http://www.census.gov/srd/www/x13as/>`__ can be used for time-series analysis.
-* `Nose <https://nose.readthedocs.org/en/latest>`__ is required to run the test suite.
-* `IPython <http://ipython.org>`__ >= 1.0 is required to build the docs locally.
+* `Matplotlib <http://matplotlib.org/>`__ >= 1.3 is needed for plotting
+  functions and running many of the examples.
+* If installed, `X-12-ARIMA <http://www.census.gov/srd/www/x13as/>`__ or
+  `X-13ARIMA-SEATS <http://www.census.gov/srd/www/x13as/>`__ can be used
+  for time-series analysis.
+* `Nose <https://nose.readthedocs.org/en/latest>`__ is required to run
+  the test suite.
+* `IPython <http://ipython.org>`__ >= 3.0 is required to build the
+  docs locally or to use the notebooks.

--- a/docs/source/release/version0.7.rst
+++ b/docs/source/release/version0.7.rst
@@ -35,7 +35,7 @@ sandbox.  This change bring a number of new features, including:
 .. code-block:: python
 
    import statsmodels.api as sm
-   from statsmodels.tools.pca import PCA
+   from statsmodels.multivariate.pca import PCA
 
    data = sm.datasets.fertility.load_pandas().data
 

--- a/docs/source/release/version0.8.rst
+++ b/docs/source/release/version0.8.rst
@@ -120,42 +120,6 @@ Other improvements to the state space framework include:
 * Ongoing refactoring and bug fixes in fringes and corner cases
 
 
-New functionality in statistics
--------------------------------
-
-Contingency Tables #2418 (Kerby Shedden)
-
-Local FDR, multiple testing #2297 (Kerby Shedden)
-
-Mediation Analysis #2352 (Kerby Shedden)
-
-other:
-
-* weighted quantiles in DescrStatsW #2707 (Kerby Shedden)
-
-
-Duration
---------
-
-Kaplan Meier Survival Function #2614 (Kerby Shedden)
-
-Cumulative incidence rate function #3016 (Kerby Shedden)
-
-other:
-
-* frequency weights in Kaplan-Meier #2992 (Kerby Shedden)
-
-
-Imputation
-----------
-
-new subpackage in `statsmodels.imputation`
-
-MICE #2076  (Frank Cheng GSOC 2014 and Kerby Shedden)
-
-Imputation by regression on Order Statistic  #3019 (Paul Hobson)
-
-
 Time Series Analysis
 --------------------
 
@@ -174,6 +138,47 @@ Statistics
 * KPSS stationarity, unit root test #2775 (N-Wouda)
 * The Brock Dechert Scheinkman (BDS) test for nonlinear dependence is now
   available (introduced in #934 by Chad Fulton)
+* Augmented Engle/Granger cointegration test (refactor hidden function) #3146 (Josef Perktold)
+
+
+New functionality in statistics
+-------------------------------
+
+Contingency Tables #2418 (Kerby Shedden)
+
+Local FDR, multiple testing #2297 (Kerby Shedden)
+
+Mediation Analysis #2352 (Kerby Shedden)
+
+Confidence intervals for multinomial proportions #3162 (Sébastien Lerique, Josef Perktold)
+
+other:
+
+* weighted quantiles in DescrStatsW #2707 (Kerby Shedden)
+
+
+Duration
+--------
+
+Kaplan Meier Survival Function #2614 (Kerby Shedden)
+
+Cumulative incidence rate function #3016 (Kerby Shedden)
+
+other:
+
+* frequency weights in Kaplan-Meier #2992 (Kerby Shedden)
+* entry times for Kaplan-Meier #3126 (Kerby Shedden)
+* intercept handling for PHReg #3095 (Kerby Shedden)
+
+
+Imputation
+----------
+
+new subpackage in `statsmodels.imputation`
+
+MICE #2076  (Frank Cheng GSOC 2014 and Kerby Shedden)
+
+Imputation by regression on Order Statistic  #3019 (Paul Hobson)
 
 
 Penalized Estimation
@@ -218,9 +223,12 @@ several existing functions have received improvements
 * tools add_constant, add_trend: refactoring and pandas compatibility #2240 (Kevin Sheppard)
 * acf, pacf, acovf: option for missing handling #3020 (joesnacks ?)
 * acf, pacf plots: allow array of lags #2989 (Kevin Sheppard)
+* pickling support for ARIMA #3412 (zaemyung)
 * io SimpleTable (summary): allow names with special characters #3015 (tvanessa ?)
 * tsa tools lagmat, lagmat2ds: pandas support #2310 #3042 (Kevin Sheppard)
 * CompareMeans: from_data, summary methods #2754 (Valery Tyumen)
+* API cleanup for robust, sandwich covariances #3162 (Josef Perktold)
+* influence plot used swapped arguments (bug) #3158
 
 
 
@@ -229,11 +237,18 @@ Major Bugs fixed
 
 * see github issues
 
+While most bugs are usability problems, there is now a new label `type-bug-wrong`
+for bugs that cause that silently incorrect numbers are returned.
+https://github.com/statsmodels/statsmodels/issues?q=label%3Atype-bug-wrong+is%3Aclosed
+
+
+
 Backwards incompatible changes and deprecations
 -----------------------------------------------
 
 * ???
-* predict now returns a pandas Series if the exog argument is a DataFrame
+* predict now returns a pandas Series if the exog argument is a DataFrame,
+  including missing/NaN values
 * PCA moved to multivariate compared to 0.7
 
 
@@ -254,7 +269,7 @@ and the general maintainer and code reviewer
 Additionally, many users contributed by participation in github issues and
 providing feedback.
 
-Thanks to all of the contributors for the 0.8 release:
+Thanks to all of the contributors for the 0.8 release (based on git log):
 
 .. note::
 
@@ -264,6 +279,7 @@ Thanks to all of the contributors for the 0.8 release:
    * BrianLondon
    * Chad Fulton
    * Chris Fonnesbeck
+   * Christian Lorentzen
    * Christoph T. Weidemann
    * James Kerns
    * Josef Perktold
@@ -284,6 +300,7 @@ Thanks to all of the contributors for the 0.8 release:
    * ValeryTyumen
    * Vanessa
    * Yaroslav Halchenko
+   * dhpiyush
    * joesnacks
    * kokes
    * matiumerca

--- a/docs/source/stats.rst
+++ b/docs/source/stats.rst
@@ -210,6 +210,15 @@ to one way ANOVA, but still in developement
 
    pairwise_tukeyhsd
 
+.. currentmuodule:: statsmodels.stats.multitest
+
+.. autosummary::
+   :toctree: generated/
+
+   local_fdr
+   fdrcorrection_twostage
+   NullDistribution
+
 The following functions are not (yet) public
 
 .. currentmodule:: statsmodels.sandbox.stats.multicomp
@@ -390,3 +399,24 @@ kurtosis and cummulants.
    corr2cov
    se_cov
 
+
+Mediation Analysis
+------------------
+
+Mediation analysis focuses on the relationships among three key variables:
+an 'outcome', a 'treatment', and a 'mediator'. Since mediation analysis is a
+form of causal inference, there are several assumptions involved that are
+difficult or impossible to verify. Ideally, mediation analysis is conducted in
+the context of an experiment such as this one in which the treatment is
+randomly assigned. It is also common for people to conduct mediation analyses
+using observational data in which the treatment may be thought of as an
+'exposure'. The assumptions behind mediation analysis are even more difficult
+to verify in an observational setting.
+
+.. currentmodule:: statsmodels.stats.mediation
+
+.. autosummary::
+   :toctree: generated/
+
+   Mediation
+   MediationResults

--- a/docs/source/stats.rst
+++ b/docs/source/stats.rst
@@ -362,9 +362,13 @@ positive definite and close to the original matrix.
 .. autosummary::
    :toctree: generated/
 
-	corr_nearest
-	corr_clipped
-	cov_nearest
+   corr_clipped
+   corr_nearest
+   corr_nearest_factor
+   corr_thresholded
+   cov_nearest
+   cov_nearest_factor_homog
+   FactoredPSDMatrix
 
 These are utility functions to convert between central and non-central moments, skew,
 kurtosis and cummulants.

--- a/docs/source/tsa.rst
+++ b/docs/source/tsa.rst
@@ -75,6 +75,7 @@ Descriptive Statistics and Tests
    stattools.periodogram
    stattools.adfuller
    stattools.kpss
+   stattools.coint
    stattools.bds
    stattools.q_stat
    stattools.grangercausalitytests

--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -1519,9 +1519,9 @@ class LikelihoodModelResults(Results):
         C(Weight, Sum)                    12.432445  3.99943118767e-05              2        51
         C(Duration, Sum):C(Weight, Sum)    0.176002      0.83912310946              2        51
 
-        >>> res_poi = Poisson.from_formula("Days ~ C(Weight) * C(Duration)",
+        >>> res_poi = Poisson.from_formula("Days ~ C(Weight) * C(Duration)", \
                                            data).fit(cov_type='HC0')
-        >>> wt = res_poi.wald_test_terms(skip_single=False,
+        >>> wt = res_poi.wald_test_terms(skip_single=False, \
                                          combine_terms=['Duration', 'Weight'])
         >>> print(wt)
                                     chi2             P>chi2  df constraint

--- a/statsmodels/compat/numpy.py
+++ b/statsmodels/compat/numpy.py
@@ -457,12 +457,9 @@ def recarray_select(recarray, fields):
     Work-around for changes in NumPy 1.13 that return views for recarray
     multiple column selection
     """
+    from pandas import DataFrame
     fields = [fields] if not isinstance(fields, (tuple, list)) else fields
     if len(fields) == len(recarray.dtype):
         return recarray
-    import numpy.lib.recfunctions as nprf
-    subset = recarray[[fields[0]]].copy()
-    for field in fields[1:]:
-        subset = nprf.append_fields(subset, field, recarray[field])
-    subset.dtype.names = [field for field in fields]
-    return subset
+    recarray = DataFrame.from_records(recarray)
+    return recarray[fields].to_records(index=False)

--- a/statsmodels/datasets/tests/test_data.py
+++ b/statsmodels/datasets/tests/test_data.py
@@ -17,7 +17,7 @@ def test_co2_python3():
 class TestDatasets(object):
 
     @classmethod
-    def setUpClass(cls):
+    def setup_class(cls):
         exclude = ['check_internet', 'clear_data_home', 'get_data_home',
                    'get_rdataset', 'tests', 'utils', 'webuse']
         cls.sets = []

--- a/statsmodels/discrete/tests/test_constrained.py
+++ b/statsmodels/discrete/tests/test_constrained.py
@@ -338,9 +338,10 @@ class TestGLMPoissonConstrained1a(CheckPoissonConstrainedMixin):
 
         constr = 'C(agecat)[T.4] = C(agecat)[T.5]'
         lc = patsy.DesignInfo(mod.exog_names).linear_constraint(constr)
-        cls.res1 = fit_constrained(mod, lc.coefs, lc.constants)
+        cls.res1 = fit_constrained(mod, lc.coefs, lc.constants,
+                                   fit_kwds={'atol': 1e-10})
         cls.constraints = lc
-        cls.res1m = mod.fit_constrained(constr)
+        cls.res1m = mod.fit_constrained(constr, atol=1e-10)
 
 
 class TestGLMPoissonConstrained1b(CheckPoissonConstrainedMixin):
@@ -386,7 +387,7 @@ class TestGLMPoissonConstrained1b(CheckPoissonConstrainedMixin):
 
         # basic, just as check that we have the same model
         assert_allclose(res1.params, res2.params, rtol=1e-12)
-        assert_allclose(res1.bse, res2.bse, rtol=1e-12)
+        assert_allclose(res1.bse, res2.bse, rtol=1e-11)
 
         # check predict, fitted, ...
 

--- a/statsmodels/genmod/families/family.py
+++ b/statsmodels/genmod/families/family.py
@@ -369,7 +369,9 @@ class Poisson(Family):
            D = 2 * \sum_i (freq\_weights_i * Y_i * \log(Y_i / \mu_i))/ scale
         '''
         endog_mu = self._clean(endog / mu)
-        return 2 * np.sum(endog * freq_weights * np.log(endog_mu)) / scale
+        return 2 * np.sum(freq_weights * (endog * np.log(endog_mu) -
+                                          (endog - mu))) / scale
+
 
     def loglike(self, endog, mu, freq_weights=1., scale=1.):
         r"""

--- a/statsmodels/genmod/generalized_estimating_equations.py
+++ b/statsmodels/genmod/generalized_estimating_equations.py
@@ -382,7 +382,7 @@ _gee_example = """
     >>> import statsmodels.api as sm
     >>> fam = sm.families.Poisson()
     >>> ind = sm.cov_struct.Independence()
-    >>> model = sm.GEE.from_formula("y ~ age + trt + base", "subject",
+    >>> model = sm.GEE.from_formula("y ~ age + trt + base", "subject", \
                                  data, cov_struct=ind, family=fam)
     >>> result = model.fit()
     >>> print(result.summary())
@@ -393,7 +393,7 @@ _gee_example = """
     >>> import statsmodels.formula.api as smf
     >>> fam = sm.families.Poisson()
     >>> ind = sm.cov_struct.Independence()
-    >>> model = smf.gee("y ~ age + trt + base", "subject",
+    >>> model = smf.gee("y ~ age + trt + base", "subject", \
                     data, cov_struct=ind, family=fam)
     >>> result = model.fit()
     >>> print(result.summary())

--- a/statsmodels/graphics/gofplots.py
+++ b/statsmodels/graphics/gofplots.py
@@ -550,7 +550,7 @@ def qqplot_2samples(data1, data2, xlabel=None, ylabel=None, line=None, ax=None):
     >>> y = np.random.normal(loc=8.0, scale=3.0, size=37)
     >>> pp_x = sm.ProbPlot(x)
     >>> pp_y = sm.ProbPlot(y)
-    >>> qqplot_2samples(data1, data2, xlabel=None, ylabel=None, line=None, ax=None):
+    >>> qqplot_2samples(pp_x, pp_y)
 
     Notes
     -----

--- a/statsmodels/graphics/mosaicplot.py
+++ b/statsmodels/graphics/mosaicplot.py
@@ -596,9 +596,9 @@ def mosaic(data, index=None, ax=None, horizontal=True, gap=0.005,
 
     >>> data = {'a': 10, 'b': 15, 'c': 16}
     >>> props = lambda key: {'color': 'r' if 'a' in key else 'gray'}
-    >>> labelizer = lambda k: {('a',): 'first', ('b',): 'second',
+    >>> labelizer = lambda k: {('a',): 'first', ('b',): 'second', \
                                ('c',): 'third'}[k]
-    >>> mosaic(data, title='colored dictionary',
+    >>> mosaic(data, title='colored dictionary', \
                 properties=props, labelizer=labelizer)
     >>> pylab.show()
 

--- a/statsmodels/graphics/tsaplots.py
+++ b/statsmodels/graphics/tsaplots.py
@@ -273,7 +273,7 @@ def month_plot(x, dates=None, ylabel=None, ax=None):
     >>> dates = pd.to_datetime(list(map(lambda x : '-'.join(x) + '-1',
     ...                                        dta.index.values)))
 
-    >>> dta.index = pd.DatetimeIndex(dates, freq='M')
+    >>> dta.index = pd.DatetimeIndex(dates, freq='MS')
     >>> fig = sm.graphics.tsa.month_plot(dta)
 
     .. plot:: plots/graphics_month_plot.py

--- a/statsmodels/imputation/mice.py
+++ b/statsmodels/imputation/mice.py
@@ -128,15 +128,15 @@ _mice_data_example_1 = """
     >>> imp = mice.MICEData(data)
     >>> imp.set_imputer('x1', formula='x2 + np.square(x2) + x3')
     >>> for j in range(20):
-            imp.update_all()
-            imp.data.to_csv('data%02d.csv' % j)"""
+    ...     imp.update_all()
+    ...     imp.data.to_csv('data%02d.csv' % j)"""
 
 _mice_data_example_2 = """
     >>> imp = mice.MICEData(data)
     >>> j = 0
     >>> for data in imp:
-            imp.data.to_csv('data%02d.csv' % j)
-            j += 1"""
+    ...     imp.data.to_csv('data%02d.csv' % j)
+    ...     j += 1"""
 
 
 class PatsyFormula(object):

--- a/statsmodels/multivariate/pca.py
+++ b/statsmodels/multivariate/pca.py
@@ -335,6 +335,10 @@ class PCA(object):
         else:
             raise ValueError('missing method is not known.')
 
+        if self._index is not None:
+            self._columns = self._columns[self.cols]
+            self._index = self._index[self.rows]
+
         # Check adjusted data size
         if self._adjusted_data.size == 0:
             raise ValueError('Removal of missing values has eliminated all data.')
@@ -471,7 +475,7 @@ class PCA(object):
             return self.data
 
         # 1. Standardized data as needed
-        data = self.transformed_data = self._prepare_data()
+        data = self.transformed_data = np.asarray(self._prepare_data())
 
         ncomp = self._ncomp
 
@@ -503,7 +507,7 @@ class PCA(object):
             self._compute_eig()
             # Call function to compute factors and projection
             self._compute_pca_from_eig()
-            projection = self.project(transform=False, unweight=False)
+            projection = np.asarray(self.project(transform=False, unweight=False))
             projection_masked = projection[mask]
             data[mask] = projection_masked
             delta = last_projection_masked - projection_masked
@@ -511,7 +515,7 @@ class PCA(object):
             _iter += 1
         # Must copy to avoid overwriting original data since replacing values
         data = self._adjusted_data + 0.0
-        projection = self.project()
+        projection = np.asarray(self.project())
         data[mask] = projection[mask]
 
         return data
@@ -656,10 +660,12 @@ class PCA(object):
                           index=index)
         self.projection = df
         # Weights
-        df = pd.DataFrame(self.coeff, index=cols, columns=self._columns)
+        df = pd.DataFrame(self.coeff, index=cols,
+                          columns=self._columns)
         self.coeff = df
         # Loadings
-        df = pd.DataFrame(self.loadings, index=self._columns, columns=cols)
+        df = pd.DataFrame(self.loadings,
+                          index=self._columns, columns=cols)
         self.loadings = df
         # eigenvals
         self.eigenvals = pd.Series(self.eigenvals)

--- a/statsmodels/multivariate/pca.py
+++ b/statsmodels/multivariate/pca.py
@@ -125,9 +125,9 @@ class PCA(object):
     Basic PCA using the correlation matrix of the data
 
     >>> import numpy as np
-    >>> from statsmodels.tools.pca import PCA
+    >>> from statsmodels.multivariate.pca import PCA
     >>> x = np.random.randn(100)[:, None]
-    >>> x = x + np.random.randn((100, 100))
+    >>> x = x + np.random.randn(100, 100)
     >>> pc = PCA(x)
 
     Note that the principal components are computed using a SVD and so the

--- a/statsmodels/regression/linear_model.py
+++ b/statsmodels/regression/linear_model.py
@@ -368,7 +368,7 @@ class GLS(RegressionModel):
 
     >>> gls_model = sm.GLS(data.endog, data.exog, sigma=sigma)
     >>> gls_results = gls_model.fit()
-    >>> print(gls_results.summary()))
+    >>> print(gls_results.summary())
 
     """ % {'params' : base._model_params_doc,
            'extra_params' : base._missing_param_doc + base._extra_param_doc}
@@ -614,7 +614,7 @@ class OLS(WLS):
     array([ 2.14285714,  0.25      ])
     >>> results.tvalues
     array([ 1.87867287,  0.98019606])
-    >>> print(results.t_test([1, 0])))
+    >>> print(results.t_test([1, 0]))
     <T test: effect=array([ 2.14285714]), sd=array([[ 1.14062282]]), t=array([[ 1.87867287]]), p=array([[ 0.05953974]]), df_denom=5>
     >>> print(results.f_test(np.identity(2)))
     <F test: F=array([[ 19.46078431]]), p=[[ 0.00437251]], df_denom=5, df_num=2>
@@ -1088,7 +1088,7 @@ def yule_walker(X, order=1, method="unbiased", df=None, inv=False, demean=True):
     >>> from statsmodels.datasets.sunspots import load
     >>> data = load()
     >>> rho, sigma = sm.regression.yule_walker(data.endog,
-                                       order=4, method="mle")
+    ...                                        order=4, method="mle")
 
     >>> rho
     array([ 1.28310031, -0.45240924, -0.20770299,  0.04794365])
@@ -2483,8 +2483,8 @@ class OLSResults(RegressionResults):
         >>> fitted.rsquared
         >>> 0.91357690446068196
         >>> # Test that the slope on the first variable is 0
-        >>> fitted.test_beta([0], [1])
-        >>> (1.7894660442330235e-07, 27.248146353709153)
+        >>> fitted.el_test([0], [1])
+        >>> (27.248146353888796, 1.7894660442330235e-07)
         """
         params = np.copy(self.params)
         opt_fun_inst = _ELRegOpts() # to store weights

--- a/statsmodels/regression/mixed_linear_model.py
+++ b/statsmodels/regression/mixed_linear_model.py
@@ -573,7 +573,7 @@ class MixedLM(base.LikelihoodModel):
     A mixed model with fixed effects for the columns of ``exog`` and
     independent random coefficients for the columns of ``exog_re``:
 
-    >>> free = MixedLMParams.from_components(fe_params=np.ones(exog.shape[1]),
+    >>> free = MixedLMParams.from_components(fe_params=np.ones(exog.shape[1]), \
                      cov_re=np.eye(exog_re.shape[1]))
     >>> model = sm.MixedLM(endog, exog, groups, exog_re=exog_re)
     >>> result = model.fit(free=free)
@@ -829,7 +829,7 @@ class MixedLM(base.LikelihoodModel):
         the schools.
 
         >>> vc = {'classroom': '0 + C(classroom)'}
-        >>> MixedLM.from_formula('test_score ~ age', vc_formula=vc,
+        >>> MixedLM.from_formula('test_score ~ age', vc_formula=vc, \
                                   re_formula='1', groups='school', data=data)
 
         Now suppose we also have a previous test score called
@@ -838,7 +838,7 @@ class MixedLM(base.LikelihoodModel):
         specify a random slope for the pretest score
 
         >>> vc = {'classroom': '0 + C(classroom)', 'pretest': '0 + pretest'}
-        >>> MixedLM.from_formula('test_score ~ age + pretest', vc_formula=vc,
+        >>> MixedLM.from_formula('test_score ~ age + pretest', vc_formula=vc, \
                                   re_formula='1', groups='school', data=data)
 
         The following model is almost equivalent to the previous one,
@@ -846,8 +846,8 @@ class MixedLM(base.LikelihoodModel):
         be correlated.
 
         >>> vc = {'classroom': '0 + C(classroom)'}
-        >>> MixedLM.from_formula('test_score ~ age + pretest', vc_formula=vc,
-                                  re_formula='1 + pretest', groups='school',
+        >>> MixedLM.from_formula('test_score ~ age + pretest', vc_formula=vc, \
+                                  re_formula='1 + pretest', groups='school', \
                                   data=data)
         """
 

--- a/statsmodels/regression/tests/test_lme.py
+++ b/statsmodels/regression/tests/test_lme.py
@@ -264,7 +264,7 @@ class TestMixedLM(object):
 
         # The random effects
         exog_re = np.random.normal(size=(n, 2))
-        slopes = np.random.normal(size=(n / 16, 2))
+        slopes = np.random.normal(size=(n // 16, 2))
         slopes = np.kron(slopes, np.ones((16, 1))) * exog_re
         errors += slopes.sum(1)
 

--- a/statsmodels/robust/robust_linear_model.py
+++ b/statsmodels/robust/robust_linear_model.py
@@ -87,7 +87,7 @@ class RLM(base.LikelihoodModel):
     >>> import statsmodels.api as sm
     >>> data = sm.datasets.stackloss.load()
     >>> data.exog = sm.add_constant(data.exog)
-    >>> rlm_model = sm.RLM(data.endog, data.exog,
+    >>> rlm_model = sm.RLM(data.endog, data.exog, \
                            M=sm.robust.norms.HuberT())
 
     >>> rlm_results = rlm_model.fit()
@@ -100,11 +100,8 @@ class RLM(base.LikelihoodModel):
     array([  0.82938433,   0.92606597,  -0.12784672, -41.02649835])
     >>> rlm_results_HC2.bse
     array([ 0.11945975,  0.32235497,  0.11796313,  9.08950419])
-    >>>
-    >>> rlm_hamp_hub = sm.RLM(data.endog, data.exog,
-                          M=sm.robust.norms.Hampel()).fit(
-                          sm.robust.scale.HuberScale())
-
+    >>> mod = sm.RLM(data.endog, data.exog, M=sm.robust.norms.Hampel())
+    >>> rlm_hamp_hub = mod.fit(scale_est=sm.robust.scale.HuberScale())
     >>> rlm_hamp_hub.params
     array([  0.73175452,   1.25082038,  -0.14794399, -40.27122257])
     """ % {'params' : base._model_params_doc,

--- a/statsmodels/sandbox/distributions/extras.py
+++ b/statsmodels/sandbox/distributions/extras.py
@@ -1015,17 +1015,17 @@ def mvstdnormcdf(lower, upper, corrcoef, **kwds):
     Examples
     --------
 
-    >>> print mvstdnormcdf([-np.inf,-np.inf], [0.0,np.inf], 0.5)
+    >>> print(mvstdnormcdf([-np.inf,-np.inf], [0.0,np.inf], 0.5))
     0.5
     >>> corr = [[1.0, 0, 0.5],[0,1,0],[0.5,0,1]]
-    >>> print mvstdnormcdf([-np.inf,-np.inf,-100.0], [0.0,0.0,0.0], corr, abseps=1e-6)
+    >>> print(mvstdnormcdf([-np.inf,-np.inf,-100.0], [0.0,0.0,0.0], corr, abseps=1e-6))
     0.166666399198
-    >>> print mvstdnormcdf([-np.inf,-np.inf,-100.0],[0.0,0.0,0.0],corr, abseps=1e-8)
+    >>> print(mvstdnormcdf([-np.inf,-np.inf,-100.0],[0.0,0.0,0.0],corr, abseps=1e-8))
     something wrong completion with ERROR > EPS and MAXPTS function values used;
                         increase MAXPTS to decrease ERROR; 1.048330348e-006
     0.166666546218
-    >>> print mvstdnormcdf([-np.inf,-np.inf,-100.0],[0.0,0.0,0.0], corr,
-                            maxpts=100000, abseps=1e-8)
+    >>> print(mvstdnormcdf([-np.inf,-np.inf,-100.0],[0.0,0.0,0.0], corr, \
+                            maxpts=100000, abseps=1e-8))
     0.166666588293
 
     '''

--- a/statsmodels/stats/api.py
+++ b/statsmodels/stats/api.py
@@ -39,7 +39,7 @@ from .proportion import (binom_test_reject_interval, binom_test,
             proportion_confint, proportion_effectsize,
             proportions_chisquare, proportions_chisquare_allpairs,
             proportions_chisquare_pairscontrol, proportions_ztest,
-            proportions_ztost)
+            proportions_ztost, multinomial_proportions_confint)
 
 from .power import (TTestPower, TTestIndPower, GofChisquarePower,
                     NormalIndPower, FTestAnovaPower, FTestPower,
@@ -50,7 +50,9 @@ from .descriptivestats import Describe
 from .anova import anova_lm
 
 from . import moment_helpers
-from .correlation_tools import corr_nearest, corr_clipped, cov_nearest
+from .correlation_tools import (corr_clipped, corr_nearest,
+            corr_nearest_factor, corr_thresholded, cov_nearest,
+            cov_nearest_factor_homog, FactoredPSDMatrix)
 
 from statsmodels.sandbox.stats.runs import (Runs, runstest_1samp, runstest_2samp)
 

--- a/statsmodels/stats/api.py
+++ b/statsmodels/stats/api.py
@@ -14,7 +14,8 @@ from .diagnostic import (
             )
 
 from . import multicomp
-from .multitest import (multipletests, fdrcorrection, fdrcorrection_twostage)
+from .multitest import (multipletests, fdrcorrection, fdrcorrection_twostage,
+                        local_fdr, NullDistribution)
 from .multicomp import tukeyhsd
 from . import gof
 from .gof import (powerdiscrepancy, gof_chisquare_discrete,
@@ -61,3 +62,4 @@ from statsmodels.stats.contingency_tables import (mcnemar, cochrans_q,
                                                   Table2x2,
                                                   Table,
                                                   StratifiedTable)
+from .mediation import Mediation

--- a/statsmodels/stats/multitest.py
+++ b/statsmodels/stats/multitest.py
@@ -591,7 +591,7 @@ class NullDistribution(object):
         # Extract the null z-scores
         ii = np.flatnonzero((zscores >= null_lb) & (zscores <= null_ub))
         if len(ii) == 0:
-            raise RunTimeError("No Z-scores fall between null_lb and null_ub")
+            raise RuntimeError("No Z-scores fall between null_lb and null_ub")
         zscores0 = zscores[ii]
 
         # Number of Z-scores, and null Z-scores

--- a/statsmodels/stats/tests/test_pairwise.py
+++ b/statsmodels/stats/tests/test_pairwise.py
@@ -6,8 +6,11 @@ Created on Wed Mar 28 15:34:18 2012
 Author: Josef Perktold
 """
 import warnings
-from nose.tools import assert_true
 from statsmodels.compat.python import BytesIO, asbytes, range
+from statsmodels.compat.numpy import recarray_select
+
+from nose.tools import assert_true
+
 import numpy as np
 from numpy.testing import (assert_almost_equal, assert_equal, assert_,
                            assert_raises, assert_allclose)
@@ -318,7 +321,8 @@ class TestTuckeyHSD3(CheckTuckeyHSDMixin):
         #CheckTuckeyHSD.setup_class_()
 
         self.meandiff2 = sas_['mean']
-        self.confint2 = sas_[['lower','upper']].view(float).reshape((3,2))
+        self.confint2 = recarray_select(sas_, ['lower','upper']).view(float).reshape((3,2))
+
         self.reject2 = sas_['sig'] == asbytes('***')
 
 

--- a/statsmodels/tools/tools.py
+++ b/statsmodels/tools/tools.py
@@ -109,9 +109,11 @@ def categorical(data, col=None, dictnames=False, drop=False, ):
     Univariate examples
 
     >>> import string
-    >>> string_var = [string.lowercase[0:5], string.lowercase[5:10],   \
-                string.lowercase[10:15], string.lowercase[15:20],   \
-                string.lowercase[20:25]]
+    >>> string_var = [string.ascii_lowercase[0:5], \
+                      string.ascii_lowercase[5:10], \
+                      string.ascii_lowercase[10:15], \
+                      string.ascii_lowercase[15:20],   \
+                      string.ascii_lowercase[20:25]]
     >>> string_var *= 5
     >>> string_var = np.asarray(sorted(string_var))
     >>> design = sm.tools.categorical(string_var, drop=True)

--- a/statsmodels/tsa/filters/bk_filter.py
+++ b/statsmodels/tsa/filters/bk_filter.py
@@ -52,8 +52,7 @@ def bkfilter(X, low=6, high=32, K=12):
     >>> import statsmodels.api as sm
     >>> import pandas as pd
     >>> dta = sm.datasets.macrodata.load_pandas().data
-    >>> dates = sm.tsa.datetools.dates_from_range('1959Q1', '2009Q3')
-    >>> index = pd.DatetimeIndex(dates)
+    >>> index = pd.DatetimeIndex(start='1959Q1', end='2009Q4', freq='Q')
     >>> dta.set_index(index, inplace=True)
 
     >>> cycles = sm.tsa.filters.bkfilter(dta[['realinv']], 6, 24, 12)

--- a/statsmodels/tsa/filters/cf_filter.py
+++ b/statsmodels/tsa/filters/cf_filter.py
@@ -44,8 +44,7 @@ def cffilter(X, low=6, high=32, drift=True):
     >>> import statsmodels.api as sm
     >>> import pandas as pd
     >>> dta = sm.datasets.macrodata.load_pandas().data
-    >>> dates = sm.tsa.datetools.dates_from_range('1959Q1', '2009Q3')
-    >>> index = pd.DatetimeIndex(dates)
+    >>> index = pd.DatetimeIndex(start='1959Q1', end='2009Q4', freq='Q')
     >>> dta.set_index(index, inplace=True)
 
     >>> cf_cycles, cf_trend = sm.tsa.filters.cffilter(dta[["infl", "unemp"]])

--- a/statsmodels/tsa/filters/hp_filter.py
+++ b/statsmodels/tsa/filters/hp_filter.py
@@ -32,8 +32,7 @@ def hpfilter(X, lamb=1600):
     >>> import statsmodels.api as sm
     >>> import pandas as pd
     >>> dta = sm.datasets.macrodata.load_pandas().data
-    >>> dates = sm.tsa.datetools.dates_from_range('1959Q1', '2009Q3')
-    >>> index = pd.DatetimeIndex(dates)
+    >>> index = pd.DatetimeIndex(start='1959Q1', end='2009Q4', freq='Q')
     >>> dta.set_index(index, inplace=True)
 
     >>> cycle, trend = sm.tsa.filters.hpfilter(dta.realgdp, 1600)

--- a/statsmodels/tsa/filters/tests/test_filters.py
+++ b/statsmodels/tsa/filters/tests/test_filters.py
@@ -11,9 +11,7 @@ from statsmodels.tsa.filters.api import (bkfilter, hpfilter, cffilter,
 
 
 def test_bking1d():
-    """
-    Test Baxter King band-pass filter. Results are taken from Stata
-    """
+    # Test Baxter King band-pass filter. Results are taken from Stata
     bking_results = array([7.320813, 2.886914, -6.818976, -13.49436,
                 -13.27936, -9.405913, -5.691091, -5.133076, -7.273468,
                 -9.243364, -8.482916, -4.447764, 2.406559, 10.68433,
@@ -55,9 +53,7 @@ def test_bking1d():
     assert_almost_equal(Y,bking_results,4)
 
 def test_bking2d():
-    """
-    Test Baxter-King band-pass filter with 2d input
-    """
+    # Test Baxter-King band-pass filter with 2d input
     bking_results = array([[7.320813,-.0374475], [2.886914,-.0430094],
         [-6.818976,-.053456], [-13.49436,-.0620739], [-13.27936,-.0626929],
         [-9.405913,-.0603022], [-5.691091,-.0630016], [-5.133076,-.0832268],
@@ -119,14 +115,12 @@ def test_bking2d():
         [67.06026,-.1766731], [91.87247,.3898467], [124.4591,.8135461],
         [151.2402,.9644226], [163.0648,.6865934], [154.6432,.0115685]])
 
-    X = macrodata.load().data[['realinv','cpi']].view((float,2))
+    X = macrodata.load_pandas().data[['realinv','cpi']].values.astype(np.float)
     Y = bkfilter(X, 6, 32, 12)
     assert_almost_equal(Y,bking_results,4)
 
 def test_hpfilter():
-    """
-    Test Hodrick-Prescott Filter. Results taken from Stata.
-    """
+    # Test Hodrick-Prescott Filter. Results taken from Stata.
     hpfilt_res = array([[3.951191484487844718e+01,2.670837085155121713e+03],
         [8.008853245681075350e+01,2.698712467543189177e+03],
         [4.887545512195401898e+01,2.726612544878045810e+03],
@@ -330,15 +324,13 @@ def test_hpfilter():
         [-3.490477058718843182e+02,1.327445770587188417e+04],
         [-3.975570728533530200e+02,1.329906107285335383e+04],
         [-3.331152428080622485e+02,1.332345624280806260e+04]])
-    dta = macrodata.load().data['realgdp']
+    dta = macrodata.load_pandas().data['realgdp'].values
     res = column_stack((hpfilter(dta,1600)))
     assert_almost_equal(res,hpfilt_res,6)
 
 def test_cfitz_filter():
-    """
-    Test Christiano-Fitzgerald Filter. Results taken from R.
-    """
-    #NOTE: The Stata mata code and the matlab code it's based on are wrong.
+    # Test Christiano-Fitzgerald Filter. Results taken from R.
+    # NOTE: The Stata mata code and the matlab code it's based on are wrong.
     cfilt_res = array([[0.712599537179426,0.439563468233128],
                         [1.06824041304411,0.352886666575907],
                         [1.19422467791128,0.257297004260607],
@@ -541,7 +533,7 @@ def test_cfitz_filter():
                         [-1.59657420180451,-4.18499132634584],
                         [-1.45489013276495,-1.81759097305637],
                         [-1.21309542313047,0.722029457352468]])
-    dta = macrodata.load().data[['tbilrate','infl']].view((float,2))[1:]
+    dta = macrodata.load_pandas().data[['tbilrate','infl']].values[1:]
     cyc, trend = cffilter(dta)
     assert_almost_equal(cyc, cfilt_res, 8)
     #do 1d

--- a/statsmodels/tsa/statespace/kalman_filter.py
+++ b/statsmodels/tsa/statespace/kalman_filter.py
@@ -336,19 +336,27 @@ class KalmanFilter(Representation):
         Examples
         --------
         >>> mod = sm.tsa.statespace.SARIMAX(range(10))
-        >>> mod.filter_method
+        >>> mod.ssm.filter_method
         1
-        >>> mod.filter_conventional
+        >>> mod.ssm.filter_conventional
         True
-        >>> mod.set_filter_method(filter_method=1)
-        >>> mod.filter_method
-        1
-        >>> mod.set_filter_method(filter_conventional=True)
-        >>> mod.filter_method
-        1
-        >>> mod.filter_conventional = True
-        >>> mod.filter_method
-        1
+        >>> mod.ssm.filter_univariate = True
+        >>> mod.ssm.filter_method
+        17
+        >>> mod.ssm.set_filter_method(filter_univariate=False,
+        ...                           filter_collapsed=True)
+        >>> mod.ssm.filter_method
+        33
+        >>> mod.ssm.set_filter_method(filter_method=1)
+        >>> mod.ssm.filter_conventional
+        True
+        >>> mod.ssm.filter_univariate
+        False
+        >>> mod.ssm.filter_collapsed
+        False
+        >>> mod.ssm.filter_univariate = True
+        >>> mod.ssm.filter_method
+        17
         """
         if filter_method is not None:
             self.filter_method = filter_method
@@ -417,20 +425,20 @@ class KalmanFilter(Representation):
         Examples
         --------
         >>> mod = sm.tsa.statespace.SARIMAX(range(10))
-        >>> mod.inversion_method
+        >>> mod.ssm.inversion_method
         1
-        >>> mod.solve_cholesky
+        >>> mod.ssm.solve_cholesky
         True
-        >>> mod.invert_univariate
+        >>> mod.ssm.invert_univariate
         True
-        >>> mod.invert_lu
+        >>> mod.ssm.invert_lu
         False
-        >>> mod.invert_univariate = False
-        >>> mod.inversion_method
+        >>> mod.ssm.invert_univariate = False
+        >>> mod.ssm.inversion_method
         8
-        >>> mod.set_inversion_method(solve_cholesky=False,
-                                     invert_cholesky=True)
-        >>> mod.inversion_method
+        >>> mod.ssm.set_inversion_method(solve_cholesky=False,
+        ...                              invert_cholesky=True)
+        >>> mod.ssm.inversion_method
         16
         """
         if inversion_method is not None:
@@ -483,12 +491,12 @@ class KalmanFilter(Representation):
         Examples
         --------
         >>> mod = sm.tsa.statespace.SARIMAX(range(10))
-        >>> mod.stability_method
+        >>> mod.ssm.stability_method
         1
-        >>> mod.stability_force_symmetry
+        >>> mod.ssm.stability_force_symmetry
         True
-        >>> mod.stability_force_symmetry = False
-        >>> mod.stability_method
+        >>> mod.ssm.stability_force_symmetry = False
+        >>> mod.ssm.stability_method
         0
         """
         if stability_method is not None:
@@ -555,16 +563,16 @@ class KalmanFilter(Representation):
         Examples
         --------
         >>> mod = sm.tsa.statespace.SARIMAX(range(10))
-        >>> mod.conserve_memory
+        >>> mod.ssm..conserve_memory
         0
-        >>> mod.memory_no_predicted
+        >>> mod.ssm.memory_no_predicted
         False
-        >>> mod.memory_no_predicted = True
-        >>> mod.conserve_memory
+        >>> mod.ssm.memory_no_predicted = True
+        >>> mod.ssm.conserve_memory
         2
-        >>> mod.set_conserve_memory(memory_no_filtered=True,
-                                    memory_no_forecast=True)
-        >>> mod.conserve_memory
+        >>> mod.ssm.set_conserve_memory(memory_no_filtered=True,
+        ...                             memory_no_forecast=True)
+        >>> mod.ssm.conserve_memory
         7
         """
         if conserve_memory is not None:

--- a/statsmodels/tsa/statespace/kalman_smoother.py
+++ b/statsmodels/tsa/statespace/kalman_smoother.py
@@ -400,7 +400,8 @@ class KalmanSmoother(KalmanFilter):
 
         Examples
         --------
-        >>> mod = sm.tsa.statespace.KalmanSmoother(1,1)
+        >>> import statsmodels.tsa.statespace.kalman_smoother as ks
+        >>> mod = ks.KalmanSmoother(1,1)
         >>> mod.smoother_output
         15
         >>> mod.set_smoother_output(smoother_output=0)


### PR DESCRIPTION
add missing backport merges

merge conflicts in #3425 resolved, kalman filter has more changes in conflict that I am not familiar with

merge conflict in #3352 update installation instructions, easy to fix, but I used it the set version requirements of python, numpy and scipy to travis 2.6 version.


