### PR TITLE
PKG: Remove directory from manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -10,7 +10,6 @@ include tools/hash_funcs.py
 include tools/cythonize.py
 
 graft statsmodels/datasets
-graft statsmodels/tests
 graft statsmodels/sandbox/regression/data
 graft statsmodels/sandbox/tests
 graft statsmodels/sandbox/tsa/examples


### PR DESCRIPTION
I don't know if this is relevant or not, but [this travis build](https://travis-ci.org/MacPython/statsmodels-wheels/jobs/199070534#L337) failed on the `python setup.py egg_info` step. Not 100% sure why it failed on that one, and not others, but I don't think removing this line should cause any issues.