### PR TITLE
BUG: Fix bus in location finding

### DIFF
--- a/statsmodels/tsa/base/tsa_model.py
+++ b/statsmodels/tsa/base/tsa_model.py
@@ -388,6 +388,7 @@ class TimeSeriesModel(base.LikelihoodModel):
                     loc = self.data.row_labels.get_loc(key)
                 else:
                     raise
+                loc = loc if np.isscalar(loc) else loc[0]
                 index = self.data.row_labels[:loc + 1]
                 index_was_expanded = False
             except:

--- a/statsmodels/tsa/base/tsa_model.py
+++ b/statsmodels/tsa/base/tsa_model.py
@@ -388,7 +388,7 @@ class TimeSeriesModel(base.LikelihoodModel):
                     loc = self.data.row_labels.get_loc(key)
                 else:
                     raise
-                loc = loc if np.isscalar(loc) else loc[0]
+                loc = loc[0]  # Require scalar
                 index = self.data.row_labels[:loc + 1]
                 index_was_expanded = False
             except:


### PR DESCRIPTION
Fix bug in location finding where only scalars can be
used for indexing in NumPy 1.12

closes #3474