### PR TITLE
ENH: State space: allow concentrating scale out of log-likelihood

### DIFF
--- a/statsmodels/regression/recursive_ls.py
+++ b/statsmodels/regression/recursive_ls.py
@@ -108,6 +108,9 @@ class RecursiveLS(MLEModel):
         # Use univariate filtering by default
         self.ssm.filter_univariate = True
 
+        # Concentrate the scale out of the likelihood function
+        self.ssm.filter_concentrated = True
+
         # Setup the state space representation
         self['design'] = np.zeros((self.k_endog, self.k_states, self.nobs))
         self['design', 0] = self.exog[:, :, None].T
@@ -118,6 +121,7 @@ class RecursiveLS(MLEModel):
         # Notice that the filter output does not depend on the measurement
         # variance, so we set it here to 1
         self['obs_cov', 0, 0] = 1.
+        self['transition'] = np.eye(self.k_states)
 
         # Linear constraints are technically imposed by adding "fake" endog
         # variables that are used during filtering, but for all model- and
@@ -138,17 +142,12 @@ class RecursiveLS(MLEModel):
         -------
         RecursiveLSResults
         """
-        # Get the smoother results with an arbitrary measurement variance
         smoother_results = self.smooth(return_ssm=True)
-        # Compute the MLE of sigma2 (see Harvey, 1989 equation 4.2.5)
-        d = max(smoother_results.nobs_diffuse, self.loglikelihood_burn)
-        resid = smoother_results.standardized_forecasts_error[0, d:]
-        sigma2 = np.inner(resid, resid) / (self.nobs - d)
 
-        # Now construct a results class, where the params are the final
-        # estimates of the regression coefficients
-        self['obs_cov', 0, 0] = sigma2
-        return self.smooth()
+        with self.ssm.fixed_scale(smoother_results.scale):
+            res = self.smooth()
+
+        return res
 
     def filter(self, return_ssm=False, **kwargs):
         # Get the state space output

--- a/statsmodels/regression/recursive_ls.py
+++ b/statsmodels/regression/recursive_ls.py
@@ -255,7 +255,8 @@ class RecursiveLSResults(MLEResults):
 
         # Since we are overriding params with things that aren't MLE params,
         # need to adjust df's
-        self.df_model = self.k_diffuse_states - self.model.k_constraints
+        q = max(self.loglikelihood_burn, self.k_diffuse_states)
+        self.df_model = q - self.model.k_constraints
         self.df_resid = self.nobs_effective - self.df_model
 
         # Save _init_kwds
@@ -332,7 +333,7 @@ class RecursiveLSResults(MLEResults):
 
         """
         return (self.filter_results.standardized_forecasts_error[0] *
-                self.filter_results.obs_cov[0, 0]**0.5)
+                self.scale**0.5)
 
     @cache_readonly
     def cusum(self):
@@ -425,7 +426,7 @@ class RecursiveLSResults(MLEResults):
         """
         from scipy.stats import norm
         return np.log(norm.pdf(self.resid_recursive, loc=0,
-                               scale=self.filter_results.obs_cov[0, 0]**0.5))
+                               scale=self.scale**0.5))
 
     @cache_readonly
     def llf_recursive(self):

--- a/statsmodels/tsa/statespace/_filters/_conventional.pxd
+++ b/statsmodels/tsa/statespace/_filters/_conventional.pxd
@@ -21,41 +21,49 @@ cdef int sforecast_missing_conventional(sKalmanFilter kfilter, sStatespace model
 cdef int supdating_missing_conventional(sKalmanFilter kfilter, sStatespace model)
 cdef np.float32_t sinverse_missing_conventional(sKalmanFilter kfilter, sStatespace model, np.float32_t determinant)  except *
 cdef np.float32_t sloglikelihood_missing_conventional(sKalmanFilter kfilter, sStatespace model, np.float32_t determinant)
+cdef np.float32_t sscale_missing_conventional(sKalmanFilter kfilter, sStatespace model)
 
 cdef int sforecast_conventional(sKalmanFilter kfilter, sStatespace model)
 cdef int supdating_conventional(sKalmanFilter kfilter, sStatespace model)
 cdef int sprediction_conventional(sKalmanFilter kfilter, sStatespace model)
 cdef np.float32_t sloglikelihood_conventional(sKalmanFilter kfilter, sStatespace model, np.float32_t determinant)
+cdef np.float32_t sscale_conventional(sKalmanFilter kfilter, sStatespace model)
 
 # Double precision
 cdef int dforecast_missing_conventional(dKalmanFilter kfilter, dStatespace model)
 cdef int dupdating_missing_conventional(dKalmanFilter kfilter, dStatespace model)
 cdef np.float64_t dinverse_missing_conventional(dKalmanFilter kfilter, dStatespace model, np.float64_t determinant)  except *
 cdef np.float64_t dloglikelihood_missing_conventional(dKalmanFilter kfilter, dStatespace model, np.float64_t determinant)
+cdef np.float64_t dscale_missing_conventional(dKalmanFilter kfilter, dStatespace model)
 
 cdef int dforecast_conventional(dKalmanFilter kfilter, dStatespace model)
 cdef int dupdating_conventional(dKalmanFilter kfilter, dStatespace model)
 cdef int dprediction_conventional(dKalmanFilter kfilter, dStatespace model)
 cdef np.float64_t dloglikelihood_conventional(dKalmanFilter kfilter, dStatespace model, np.float64_t determinant)
+cdef np.float64_t dscale_conventional(dKalmanFilter kfilter, dStatespace model)
 
 # Single precision complex
 cdef int cforecast_missing_conventional(cKalmanFilter kfilter, cStatespace model)
 cdef int cupdating_missing_conventional(cKalmanFilter kfilter, cStatespace model)
 cdef np.complex64_t cinverse_missing_conventional(cKalmanFilter kfilter, cStatespace model, np.complex64_t determinant)  except *
 cdef np.complex64_t cloglikelihood_missing_conventional(cKalmanFilter kfilter, cStatespace model, np.complex64_t determinant)
+cdef np.complex64_t cscale_missing_conventional(cKalmanFilter kfilter, cStatespace model)
 
 cdef int cforecast_conventional(cKalmanFilter kfilter, cStatespace model)
 cdef int cupdating_conventional(cKalmanFilter kfilter, cStatespace model)
 cdef int cprediction_conventional(cKalmanFilter kfilter, cStatespace model)
 cdef np.complex64_t cloglikelihood_conventional(cKalmanFilter kfilter, cStatespace model, np.complex64_t determinant)
+cdef np.complex64_t cscale_conventional(cKalmanFilter kfilter, cStatespace model)
 
 # Double precision complex
 cdef int zforecast_missing_conventional(zKalmanFilter kfilter, zStatespace model)
 cdef int zupdating_missing_conventional(zKalmanFilter kfilter, zStatespace model)
 cdef np.complex128_t zinverse_missing_conventional(zKalmanFilter kfilter, zStatespace model, np.complex128_t determinant)  except *
 cdef np.complex128_t zloglikelihood_missing_conventional(zKalmanFilter kfilter, zStatespace model, np.complex128_t determinant)
+cdef np.complex128_t zscale_missing_conventional(zKalmanFilter kfilter, zStatespace model)
 
 cdef int zforecast_conventional(zKalmanFilter kfilter, zStatespace model)
 cdef int zupdating_conventional(zKalmanFilter kfilter, zStatespace model)
 cdef int zprediction_conventional(zKalmanFilter kfilter, zStatespace model)
 cdef np.complex128_t zloglikelihood_conventional(zKalmanFilter kfilter, zStatespace model, np.complex128_t determinant)
+cdef np.complex128_t zscale_conventional(zKalmanFilter kfilter, zStatespace model)

--- a/statsmodels/tsa/statespace/_filters/_conventional.pyx.in
+++ b/statsmodels/tsa/statespace/_filters/_conventional.pyx.in
@@ -25,6 +25,8 @@ from statsmodels.src.math cimport *
 cimport scipy.linalg.cython_blas as blas
 cimport scipy.linalg.cython_lapack as lapack
 
+from statsmodels.tsa.statespace._kalman_filter cimport FILTER_CONCENTRATED
+
 
 {{for prefix, types in TYPES.items()}}
 {{py:cython_type, dtype, typenum = types}}
@@ -89,6 +91,9 @@ cdef {{cython_type}} {{prefix}}inverse_missing_conventional({{prefix}}KalmanFilt
     return 0.0
 
 cdef {{cython_type}} {{prefix}}loglikelihood_missing_conventional({{prefix}}KalmanFilter kfilter, {{prefix}}Statespace model, {{cython_type}} determinant):
+    return 0.0
+
+cdef {{cython_type}} {{prefix}}scale_missing_conventional({{prefix}}KalmanFilter kfilter, {{prefix}}Statespace model):
     return 0.0
 
 # ### Conventional Kalman filter
@@ -280,16 +285,37 @@ cdef {{cython_type}} {{prefix}}loglikelihood_conventional({{prefix}}KalmanFilter
 
     loglikelihood = -0.5*(model._k_endog*{{combined_prefix}}log(2*NPY_PI) + {{combined_prefix}}log(determinant))
 
+    if not kfilter.filter_method & FILTER_CONCENTRATED:
+        {{if combined_prefix == 'd'}}
+        loglikelihood = loglikelihood - 0.5*blas.{{prefix}}dot(&model._k_endog, kfilter._forecast_error, &inc, kfilter._tmp2, &inc)
+        {{else}}
+        blas.{{prefix}}gemv("N", &inc, &model._k_endog,
+                       &alpha, kfilter._forecast_error, &inc,
+                               kfilter._tmp2, &inc,
+                       &beta, kfilter._tmp0, &inc)
+        loglikelihood = loglikelihood - 0.5 * kfilter._tmp0[0]
+        {{endif}}
+
+    return loglikelihood
+
+cdef {{cython_type}} {{prefix}}scale_conventional({{prefix}}KalmanFilter kfilter, {{prefix}}Statespace model):
+    # Constants
+    cdef:
+        {{cython_type}} scale
+        int inc = 1
+        {{cython_type}} alpha = 1.0
+        {{cython_type}} beta = 0.0
+
     {{if combined_prefix == 'd'}}
-    loglikelihood = loglikelihood - 0.5*blas.{{prefix}}dot(&model._k_endog, kfilter._forecast_error, &inc, kfilter._tmp2, &inc)
+    scale = blas.{{prefix}}dot(&model._k_endog, kfilter._forecast_error, &inc, kfilter._tmp2, &inc)
     {{else}}
     blas.{{prefix}}gemv("N", &inc, &model._k_endog,
                    &alpha, kfilter._forecast_error, &inc,
                            kfilter._tmp2, &inc,
                    &beta, kfilter._tmp0, &inc)
-    loglikelihood = loglikelihood - 0.5 * kfilter._tmp0[0]
+    scale = kfilter._tmp0[0]
     {{endif}}
 
-    return loglikelihood
+    return scale
 
 {{endfor}}

--- a/statsmodels/tsa/statespace/_filters/_univariate.pxd
+++ b/statsmodels/tsa/statespace/_filters/_univariate.pxd
@@ -22,6 +22,7 @@ cdef int supdating_univariate(sKalmanFilter kfilter, sStatespace model)
 cdef int sprediction_univariate(sKalmanFilter kfilter, sStatespace model)
 cdef np.float32_t sinverse_noop_univariate(sKalmanFilter kfilter, sStatespace model, np.float32_t determinant) except *
 cdef np.float32_t sloglikelihood_univariate(sKalmanFilter kfilter, sStatespace model, np.float32_t determinant)
+cdef np.float32_t sscale_univariate(sKalmanFilter kfilter, sStatespace model)
 
 cdef void sforecast_error(sKalmanFilter kfilter, sStatespace model, int i)
 cdef np.float32_t sforecast_error_cov(sKalmanFilter kfilter, sStatespace model, int i)
@@ -38,6 +39,7 @@ cdef int dupdating_univariate(dKalmanFilter kfilter, dStatespace model)
 cdef int dprediction_univariate(dKalmanFilter kfilter, dStatespace model)
 cdef np.float64_t dinverse_noop_univariate(dKalmanFilter kfilter, dStatespace model, np.float64_t determinant) except *
 cdef np.float64_t dloglikelihood_univariate(dKalmanFilter kfilter, dStatespace model, np.float64_t determinant)
+cdef np.float64_t dscale_univariate(dKalmanFilter kfilter, dStatespace model)
 
 cdef void dforecast_error(dKalmanFilter kfilter, dStatespace model, int i)
 cdef np.float64_t dforecast_error_cov(dKalmanFilter kfilter, dStatespace model, int i)
@@ -54,6 +56,7 @@ cdef int cupdating_univariate(cKalmanFilter kfilter, cStatespace model)
 cdef int cprediction_univariate(cKalmanFilter kfilter, cStatespace model)
 cdef np.complex64_t cinverse_noop_univariate(cKalmanFilter kfilter, cStatespace model, np.complex64_t determinant) except *
 cdef np.complex64_t cloglikelihood_univariate(cKalmanFilter kfilter, cStatespace model, np.complex64_t determinant)
+cdef np.complex64_t cscale_univariate(cKalmanFilter kfilter, cStatespace model)
 
 cdef void cforecast_error(cKalmanFilter kfilter, cStatespace model, int i)
 cdef np.complex64_t cforecast_error_cov(cKalmanFilter kfilter, cStatespace model, int i)
@@ -70,6 +73,7 @@ cdef int zupdating_univariate(zKalmanFilter kfilter, zStatespace model)
 cdef int zprediction_univariate(zKalmanFilter kfilter, zStatespace model)
 cdef np.complex128_t zinverse_noop_univariate(zKalmanFilter kfilter, zStatespace model, np.complex128_t determinant) except *
 cdef np.complex128_t zloglikelihood_univariate(zKalmanFilter kfilter, zStatespace model, np.complex128_t determinant)
+cdef np.complex128_t zscale_univariate(zKalmanFilter kfilter, zStatespace model)
 
 cdef void zforecast_error(zKalmanFilter kfilter, zStatespace model, int i)
 cdef np.complex128_t zforecast_error_cov(zKalmanFilter kfilter, zStatespace model, int i)

--- a/statsmodels/tsa/statespace/_filters/_univariate.pyx.in
+++ b/statsmodels/tsa/statespace/_filters/_univariate.pyx.in
@@ -28,7 +28,7 @@ cimport scipy.linalg.cython_blas as blas
 cimport scipy.linalg.cython_lapack as lapack
 
 from statsmodels.tsa.statespace._kalman_filter cimport (
-    MEMORY_NO_LIKELIHOOD, MEMORY_NO_STD_FORECAST)
+    MEMORY_NO_LIKELIHOOD, MEMORY_NO_STD_FORECAST, FILTER_CONCENTRATED)
 
 {{for prefix, types in TYPES.items()}}
 {{py:cython_type, dtype, typenum = types}}
@@ -288,10 +288,13 @@ cdef void {{prefix}}filtered_state_cov({{prefix}}KalmanFilter kfilter, {{prefix}
 cdef void {{prefix}}loglikelihood({{prefix}}KalmanFilter kfilter, {{prefix}}Statespace model, int i, {{cython_type}} forecast_error_cov, {{cython_type}} forecast_error_cov_inv):
     kfilter._loglikelihood[0] = (
         kfilter._loglikelihood[0] - 0.5*(
-            {{combined_prefix}}log(2 * NPY_PI * forecast_error_cov) + 
-            kfilter._forecast_error[i]**2 * forecast_error_cov_inv
+            {{combined_prefix}}log(2 * NPY_PI * forecast_error_cov)
         )
     )
+    if kfilter.filter_method & FILTER_CONCENTRATED:
+        kfilter._scale[0] = kfilter._scale[0] + kfilter._forecast_error[i]**2 * forecast_error_cov_inv
+    else:
+        kfilter._loglikelihood[0] = kfilter._loglikelihood[0] - 0.5 * (kfilter._forecast_error[i]**2 * forecast_error_cov_inv)
 
 cdef int {{prefix}}updating_univariate({{prefix}}KalmanFilter kfilter, {{prefix}}Statespace model):
     # the updating step was performed in the forecast_univariate step
@@ -435,6 +438,9 @@ cdef {{cython_type}} {{prefix}}inverse_noop_univariate({{prefix}}KalmanFilter kf
     return 0
 
 cdef {{cython_type}} {{prefix}}loglikelihood_univariate({{prefix}}KalmanFilter kfilter, {{prefix}}Statespace model, {{cython_type}} determinant):
+    return 0
+
+cdef {{cython_type}} {{prefix}}scale_univariate({{prefix}}KalmanFilter kfilter, {{prefix}}Statespace model):
     return 0
 
 {{endfor}}

--- a/statsmodels/tsa/statespace/_filters/_univariate.pyx.in
+++ b/statsmodels/tsa/statespace/_filters/_univariate.pyx.in
@@ -122,6 +122,11 @@ cdef int {{prefix}}forecast_univariate({{prefix}}KalmanFilter kfilter, {{prefix}
             
             # #### Loglikelihood
             {{prefix}}loglikelihood(kfilter, model, i, forecast_error_cov, forecast_error_cov_inv)
+        else:
+            # Otherwise, we need to record that this observation is not associated
+            # with a loglikelihood step (so that it can be excluded in the denominator
+            # when computing the scale)
+            kfilter.nobs_kendog_univariate_singular = kfilter.nobs_kendog_univariate_singular + 1
 
     # Make final filtered_state_cov symmetric (is not currently symmetric
     # due to use of ?syr or ?her)

--- a/statsmodels/tsa/statespace/_filters/_univariate_diffuse.pyx.in
+++ b/statsmodels/tsa/statespace/_filters/_univariate_diffuse.pyx.in
@@ -28,7 +28,7 @@ cimport scipy.linalg.cython_blas as blas
 cimport scipy.linalg.cython_lapack as lapack
 
 from statsmodels.tsa.statespace._kalman_filter cimport (
-    MEMORY_NO_LIKELIHOOD, MEMORY_NO_STD_FORECAST)
+    FILTER_CONCENTRATED, MEMORY_NO_LIKELIHOOD, MEMORY_NO_STD_FORECAST)
 
 {{for prefix, types in TYPES.items()}}
 {{py:cython_type, dtype, typenum = types}}
@@ -148,6 +148,7 @@ cdef int {{prefix}}forecast_univariate_diffuse({{prefix}}KalmanFilter kfilter, {
                 kfilter._loglikelihood[0] - 0.5*(
                     {{combined_prefix}}log(2 * NPY_PI * forecast_error_diffuse_cov)))
         elif forecast_error_cov{{if combined_prefix == 'z'}}.real{{endif}} > kfilter.tolerance_diffuse:
+            kfilter.nobs_kendog_diffuse_nonsingular = kfilter.nobs_kendog_diffuse_nonsingular + 1
             forecast_error_cov_inv = 1.0 / forecast_error_cov
 
             # K0 = M[:, i:i+1] / F[i, i]
@@ -175,8 +176,12 @@ cdef int {{prefix}}forecast_univariate_diffuse({{prefix}}KalmanFilter kfilter, {
             if not forecast_error_cov == 0:
                 kfilter._loglikelihood[0] = (
                     kfilter._loglikelihood[0] - 0.5*(
-                        {{combined_prefix}}log(2 * NPY_PI * forecast_error_cov) + 
-                        kfilter._forecast_error[i]**2 * forecast_error_cov_inv))
+                        {{combined_prefix}}log(2 * NPY_PI * forecast_error_cov)))
+
+                if kfilter.filter_method & FILTER_CONCENTRATED:
+                    kfilter._scale[0] = kfilter._scale[0] + kfilter._forecast_error[i]**2 * forecast_error_cov_inv
+                else:
+                    kfilter._loglikelihood[0] = kfilter._loglikelihood[0] - 0.5 * (kfilter._forecast_error[i]**2 * forecast_error_cov_inv)
 
         # Kalman gain
         blas.{{prefix}}copy(&kfilter.k_states, kfilter._tmpK0, &inc, &kfilter._kalman_gain[i * kfilter.k_states], &inc)

--- a/statsmodels/tsa/statespace/_kalman_filter.pxd
+++ b/statsmodels/tsa/statespace/_kalman_filter.pxd
@@ -65,6 +65,7 @@ cdef class sKalmanFilter(object):
     cdef readonly int t
     cdef public np.float64_t tolerance, tolerance_diffuse
     cdef readonly int nobs_diffuse
+    cdef readonly int nobs_kendog_diffuse_nonsingular
     cdef readonly int converged
     cdef readonly int period_converged
     cdef readonly int time_invariant
@@ -213,6 +214,7 @@ cdef class dKalmanFilter(object):
     cdef readonly int t
     cdef public np.float64_t tolerance, tolerance_diffuse
     cdef readonly int nobs_diffuse
+    cdef readonly int nobs_kendog_diffuse_nonsingular
     cdef readonly int converged
     cdef readonly int period_converged
     cdef readonly int time_invariant
@@ -361,6 +363,7 @@ cdef class cKalmanFilter(object):
     cdef readonly int t
     cdef public np.float64_t tolerance, tolerance_diffuse
     cdef readonly int nobs_diffuse
+    cdef readonly int nobs_kendog_diffuse_nonsingular
     cdef readonly int converged
     cdef readonly int period_converged
     cdef readonly int time_invariant
@@ -509,6 +512,7 @@ cdef class zKalmanFilter(object):
     cdef readonly int t
     cdef public np.float64_t tolerance, tolerance_diffuse
     cdef readonly int nobs_diffuse
+    cdef readonly int nobs_kendog_diffuse_nonsingular
     cdef readonly int converged
     cdef readonly int period_converged
     cdef readonly int time_invariant

--- a/statsmodels/tsa/statespace/_kalman_filter.pxd
+++ b/statsmodels/tsa/statespace/_kalman_filter.pxd
@@ -66,6 +66,7 @@ cdef class sKalmanFilter(object):
     cdef public np.float64_t tolerance, tolerance_diffuse
     cdef readonly int nobs_diffuse
     cdef readonly int nobs_kendog_diffuse_nonsingular
+    cdef readonly int nobs_kendog_univariate_singular
     cdef readonly int converged
     cdef readonly int period_converged
     cdef readonly int time_invariant
@@ -215,6 +216,7 @@ cdef class dKalmanFilter(object):
     cdef public np.float64_t tolerance, tolerance_diffuse
     cdef readonly int nobs_diffuse
     cdef readonly int nobs_kendog_diffuse_nonsingular
+    cdef readonly int nobs_kendog_univariate_singular
     cdef readonly int converged
     cdef readonly int period_converged
     cdef readonly int time_invariant
@@ -364,6 +366,7 @@ cdef class cKalmanFilter(object):
     cdef public np.float64_t tolerance, tolerance_diffuse
     cdef readonly int nobs_diffuse
     cdef readonly int nobs_kendog_diffuse_nonsingular
+    cdef readonly int nobs_kendog_univariate_singular
     cdef readonly int converged
     cdef readonly int period_converged
     cdef readonly int time_invariant
@@ -513,6 +516,7 @@ cdef class zKalmanFilter(object):
     cdef public np.float64_t tolerance, tolerance_diffuse
     cdef readonly int nobs_diffuse
     cdef readonly int nobs_kendog_diffuse_nonsingular
+    cdef readonly int nobs_kendog_univariate_singular
     cdef readonly int converged
     cdef readonly int period_converged
     cdef readonly int time_invariant

--- a/statsmodels/tsa/statespace/_kalman_filter.pxd
+++ b/statsmodels/tsa/statespace/_kalman_filter.pxd
@@ -19,8 +19,7 @@ cdef int FILTER_UNIVARIATE       # ibid., Chapter 6.4
 cdef int FILTER_COLLAPSED        # ibid., Chapter 6.5
 cdef int FILTER_EXTENDED         # ibid., Chapter 10.2
 cdef int FILTER_UNSCENTED        # ibid., Chapter 10.3
-cdef int SMOOTHER_CLASSICAL      # ibid., Chapter 4.6.1
-cdef int SMOOTHER_ALTERNATIVE    # 
+cdef int FILTER_CONCENTRATED     # Harvey (1989), Chapter 3.4
 
 # ### Inversion methods
 # Methods by which the terms using the inverse of the forecast error
@@ -77,7 +76,7 @@ cdef class sKalmanFilter(object):
     cdef readonly int loglikelihood_burn
 
     # ### Kalman filter properties
-    cdef readonly np.float32_t [:] loglikelihood
+    cdef readonly np.float32_t [:] loglikelihood, scale
     cdef readonly np.float32_t [::1,:] filtered_state, predicted_state, forecast, forecast_error, standardized_forecast_error
     cdef readonly np.float32_t [::1,:,:] filtered_state_cov, predicted_state_cov, forecast_error_cov, predicted_diffuse_state_cov, forecast_error_diffuse_cov, M, M_inf
     cdef readonly np.float32_t [::1,:,:] kalman_gain
@@ -135,6 +134,7 @@ cdef class sKalmanFilter(object):
 
     cdef np.float32_t * _kalman_gain
     cdef np.float32_t * _loglikelihood
+    cdef np.float32_t * _scale
 
     cdef np.float32_t * _converged_forecast_error_cov
     cdef np.float32_t * _converged_filtered_state_cov
@@ -171,6 +171,9 @@ cdef class sKalmanFilter(object):
     )
     cdef np.float32_t (*calculate_loglikelihood)(
         sKalmanFilter, sStatespace, np.float32_t
+    )
+    cdef np.float32_t (*calculate_scale)(
+        sKalmanFilter, sStatespace
     )
     cdef int (*prediction)(
         sKalmanFilter, sStatespace
@@ -221,7 +224,7 @@ cdef class dKalmanFilter(object):
     cdef readonly int loglikelihood_burn
 
     # ### Kalman filter properties
-    cdef readonly np.float64_t [:] loglikelihood
+    cdef readonly np.float64_t [:] loglikelihood, scale
     cdef readonly np.float64_t [::1,:] filtered_state, predicted_state, forecast, forecast_error, standardized_forecast_error
     cdef readonly np.float64_t [::1,:,:] filtered_state_cov, predicted_state_cov, forecast_error_cov, predicted_diffuse_state_cov, forecast_error_diffuse_cov, M, M_inf
     cdef readonly np.float64_t [::1,:,:] kalman_gain
@@ -279,6 +282,7 @@ cdef class dKalmanFilter(object):
 
     cdef np.float64_t * _kalman_gain
     cdef np.float64_t * _loglikelihood
+    cdef np.float64_t * _scale
 
     cdef np.float64_t * _converged_forecast_error_cov
     cdef np.float64_t * _converged_filtered_state_cov
@@ -315,6 +319,9 @@ cdef class dKalmanFilter(object):
     )
     cdef np.float64_t (*calculate_loglikelihood)(
         dKalmanFilter, dStatespace, np.float64_t
+    )
+    cdef np.float64_t (*calculate_scale)(
+        dKalmanFilter, dStatespace
     )
     cdef int (*prediction)(
         dKalmanFilter, dStatespace
@@ -365,7 +372,7 @@ cdef class cKalmanFilter(object):
     cdef readonly int loglikelihood_burn
 
     # ### Kalman filter properties
-    cdef readonly np.complex64_t [:] loglikelihood
+    cdef readonly np.complex64_t [:] loglikelihood, scale
     cdef readonly np.complex64_t [::1,:] filtered_state, predicted_state, forecast, forecast_error, standardized_forecast_error
     cdef readonly np.complex64_t [::1,:,:] filtered_state_cov, predicted_state_cov, forecast_error_cov, predicted_diffuse_state_cov, forecast_error_diffuse_cov, M, M_inf
     cdef readonly np.complex64_t [::1,:,:] kalman_gain
@@ -423,6 +430,7 @@ cdef class cKalmanFilter(object):
 
     cdef np.complex64_t * _kalman_gain
     cdef np.complex64_t * _loglikelihood
+    cdef np.complex64_t * _scale
 
     cdef np.complex64_t * _converged_forecast_error_cov
     cdef np.complex64_t * _converged_filtered_state_cov
@@ -459,6 +467,9 @@ cdef class cKalmanFilter(object):
     )
     cdef np.complex64_t (*calculate_loglikelihood)(
         cKalmanFilter, cStatespace, np.complex64_t
+    )
+    cdef np.complex64_t (*calculate_scale)(
+        cKalmanFilter, cStatespace
     )
     cdef int (*prediction)(
         cKalmanFilter, cStatespace
@@ -509,7 +520,7 @@ cdef class zKalmanFilter(object):
     cdef readonly int loglikelihood_burn
 
     # ### Kalman filter properties
-    cdef readonly np.complex128_t [:] loglikelihood
+    cdef readonly np.complex128_t [:] loglikelihood, scale
     cdef readonly np.complex128_t [::1,:] filtered_state, predicted_state, forecast, forecast_error, standardized_forecast_error
     cdef readonly np.complex128_t [::1,:,:] filtered_state_cov, predicted_state_cov, forecast_error_cov, predicted_diffuse_state_cov, forecast_error_diffuse_cov, M, M_inf
     cdef readonly np.complex128_t [::1,:,:] kalman_gain
@@ -567,6 +578,7 @@ cdef class zKalmanFilter(object):
 
     cdef np.complex128_t * _kalman_gain
     cdef np.complex128_t * _loglikelihood
+    cdef np.complex128_t * _scale
 
     cdef np.complex128_t * _converged_forecast_error_cov
     cdef np.complex128_t * _converged_filtered_state_cov
@@ -603,6 +615,9 @@ cdef class zKalmanFilter(object):
     )
     cdef np.complex128_t (*calculate_loglikelihood)(
         zKalmanFilter, zStatespace, np.complex128_t
+    )
+    cdef np.complex128_t (*calculate_scale)(
+        zKalmanFilter, zStatespace
     )
     cdef int (*prediction)(
         zKalmanFilter, zStatespace

--- a/statsmodels/tsa/statespace/_kalman_filter.pyx.in
+++ b/statsmodels/tsa/statespace/_kalman_filter.pyx.in
@@ -746,6 +746,7 @@ cdef class {{prefix}}KalmanFilter(object):
         if reset:
             self.nobs_diffuse = 0
             self.nobs_kendog_diffuse_nonsingular = 0
+            self.nobs_kendog_univariate_singular = 0
             self.converged = 0
             self.period_converged = 0
 

--- a/statsmodels/tsa/statespace/_kalman_filter.pyx.in
+++ b/statsmodels/tsa/statespace/_kalman_filter.pyx.in
@@ -28,8 +28,7 @@ cdef int FILTER_UNIVARIATE = 0x10       # ibid., Chapter 6.4
 cdef int FILTER_COLLAPSED = 0x20        # ibid., Chapter 6.5
 cdef int FILTER_EXTENDED = 0x40         # ibid., Chapter 10.2
 cdef int FILTER_UNSCENTED = 0x80        # ibid., Chapter 10.3
-cdef int SMOOTHER_CLASSICAL = 0x100     # ibid., Chapter 4.6.1
-cdef int SMOOTHER_ALTERNATIVE = 0x200   # ibid., Chapter 4.6.1
+cdef int FILTER_CONCENTRATED = 0x100    # Harvey (1989), Chapter 3.4
 
 # ### Inversion methods
 # Methods by which the terms using the inverse of the forecast error
@@ -88,17 +87,20 @@ from statsmodels.tsa.statespace._filters._conventional cimport (
     {{prefix}}updating_missing_conventional,
     {{prefix}}inverse_missing_conventional,
     {{prefix}}loglikelihood_missing_conventional,
+    {{prefix}}scale_missing_conventional,
     {{prefix}}forecast_conventional,
     {{prefix}}updating_conventional,
     {{prefix}}prediction_conventional,
-    {{prefix}}loglikelihood_conventional
+    {{prefix}}loglikelihood_conventional,
+    {{prefix}}scale_conventional
 )
 from statsmodels.tsa.statespace._filters._univariate cimport (
     {{prefix}}forecast_univariate,
     {{prefix}}updating_univariate,
     {{prefix}}inverse_noop_univariate,
     {{prefix}}prediction_univariate,
-    {{prefix}}loglikelihood_univariate
+    {{prefix}}loglikelihood_univariate,
+    {{prefix}}scale_univariate
 )
 from statsmodels.tsa.statespace._filters._univariate_diffuse cimport (
     {{prefix}}forecast_univariate_diffuse,
@@ -591,6 +593,7 @@ cdef class {{prefix}}KalmanFilter(object):
             storage = self.model.nobs
         dim1[0] = storage
         self.loglikelihood = np.PyArray_ZEROS(1, dim1, {{typenum}}, FORTRAN)
+        self.scale = np.PyArray_ZEROS(1, dim1, {{typenum}}, FORTRAN)
 
         # Converged matrices
         dim2[0] = self.k_endog; dim2[1] = self.k_endog;
@@ -712,6 +715,10 @@ cdef class {{prefix}}KalmanFilter(object):
                                    ' state dimension is equal to or larger than the'
                                    ' dimension of the observation vector.')
 
+            if filter_method & FILTER_COLLAPSED and filter_method & FILTER_CONCENTRATED:
+                raise RuntimeError('Cannot apply a concentrated likelihood function'
+                                   ' with a collapsed observation vector.')
+
             # Change the smoother output flag
             self.filter_method = filter_method
 
@@ -780,6 +787,7 @@ cdef class {{prefix}}KalmanFilter(object):
         # Clear values
         if self.t == 0 or not (self.conserve_memory & MEMORY_NO_LIKELIHOOD):
             self.loglikelihood[self.t] = 0
+            self.scale[self.t] = 0
 
         # Initialize pointers to current-iteration objects
         self.initialize_statespace_object_pointers()
@@ -847,6 +855,8 @@ cdef class {{prefix}}KalmanFilter(object):
                 # self._calculate_loglikelihood() +
                 self.model.collapse_loglikelihood
             )
+        if self.filter_method & FILTER_CONCENTRATED:
+            self._scale[0] = self._scale[0] + self.calculate_scale(self, self.model)
 
         # Prediction step (default timing)
         if self.filter_timing == TIMING_INIT_PREDICTED:
@@ -983,6 +993,7 @@ cdef class {{prefix}}KalmanFilter(object):
         self._kalman_gain = &self.kalman_gain[0, 0, gain_t]
 
         self._loglikelihood = &self.loglikelihood[loglikelihood_t]
+        self._scale = &self.scale[loglikelihood_t]
 
         # Initialize object-level pointers to named temporary arrays
         self._tmp1 = &self.tmp1[0, 0, smoothing_t]
@@ -1008,13 +1019,14 @@ cdef class {{prefix}}KalmanFilter(object):
             self.updating = {{prefix}}updating_univariate
             self.inversion = {{prefix}}inverse_noop_univariate
             self.calculate_loglikelihood = {{prefix}}loglikelihood_univariate
-            self.prediction = {{prefix}}prediction_univariate                
-
+            self.calculate_scale = {{prefix}}scale_univariate
+            self.prediction = {{prefix}}prediction_univariate
         # Conventional method
         elif self.filter_method & FILTER_CONVENTIONAL:
             self.forecasting = {{prefix}}forecast_conventional
             self.updating = {{prefix}}updating_conventional
             self.calculate_loglikelihood = {{prefix}}loglikelihood_conventional
+            self.calculate_scale = {{prefix}}scale_conventional
             self.prediction = {{prefix}}prediction_conventional
 
             # Inversion method
@@ -1049,6 +1061,7 @@ cdef class {{prefix}}KalmanFilter(object):
 
             # Change the loglikelihood calculation to give zero.
             self.calculate_loglikelihood = {{prefix}}loglikelihood_missing_conventional
+            self.calculate_scale = {{prefix}}scale_missing_conventional
 
             # The prediction step is the same as the conventional Kalman
             # filter

--- a/statsmodels/tsa/statespace/_kalman_filter.pyx.in
+++ b/statsmodels/tsa/statespace/_kalman_filter.pyx.in
@@ -745,6 +745,7 @@ cdef class {{prefix}}KalmanFilter(object):
 
         if reset:
             self.nobs_diffuse = 0
+            self.nobs_kendog_diffuse_nonsingular = 0
             self.converged = 0
             self.period_converged = 0
 
@@ -1012,6 +1013,7 @@ cdef class {{prefix}}KalmanFilter(object):
             self.updating = {{prefix}}updating_univariate_diffuse
             self.inversion = {{prefix}}inverse_noop_univariate_diffuse
             self.calculate_loglikelihood = {{prefix}}loglikelihood_univariate_diffuse
+            self.calculate_scale = {{prefix}}scale_univariate
             self.prediction = {{prefix}}prediction_univariate_diffuse
         # Univariate method
         elif self.filter_method & FILTER_UNIVARIATE:

--- a/statsmodels/tsa/statespace/_kalman_filter.pyx.in
+++ b/statsmodels/tsa/statespace/_kalman_filter.pyx.in
@@ -855,8 +855,8 @@ cdef class {{prefix}}KalmanFilter(object):
                 # self._calculate_loglikelihood() +
                 self.model.collapse_loglikelihood
             )
-        if self.filter_method & FILTER_CONCENTRATED:
-            self._scale[0] = self._scale[0] + self.calculate_scale(self, self.model)
+            if self.filter_method & FILTER_CONCENTRATED:
+                self._scale[0] = self._scale[0] + self.calculate_scale(self, self.model)
 
         # Prediction step (default timing)
         if self.filter_timing == TIMING_INIT_PREDICTED:

--- a/statsmodels/tsa/statespace/kalman_filter.py
+++ b/statsmodels/tsa/statespace/kalman_filter.py
@@ -772,13 +772,16 @@ class KalmanFilter(Representation):
             state_cov = self['state_cov']
             self['obs_cov'] = scale * obs_cov
             self['state_cov'] = scale * state_cov
-        yield
-        # If a scale was provided, reset the model
-        if scale is not None:
-            self['state_cov'] = state_cov
-            self['obs_cov'] = obs_cov
-            self.filter_concentrated = True
-            self._scale = None
+        try:
+            yield
+        finally:
+            # If a scale was provided, reset the model
+            if scale is not None:
+                self['state_cov'] = state_cov
+                self['obs_cov'] = obs_cov
+                self.filter_concentrated = True
+                self._scale = None
+
 
     def _filter(self, filter_method=None, inversion_method=None,
                 stability_method=None, conserve_memory=None,

--- a/statsmodels/tsa/statespace/kalman_filter.py
+++ b/statsmodels/tsa/statespace/kalman_filter.py
@@ -1649,15 +1649,16 @@ class FilterResults(FrozenRepresentation):
             if self.missing_forecasts_error_cov is not None:
                 self.missing_forecasts_error_cov *= self.scale
 
+            if not self._compatibility_mode:
+                # Note: do not have to adjust the Kalman gain or tmp4
+                self.tmp1 *= self.scale
+                self.tmp2 /= self.scale
+                self.tmp3 /= self.scale
             if not self._compatibility_mode and not (
                     self.memory_no_std_forecast or
                     self.invert_lu or
                     self.solve_lu or
                     self.filter_collapsed):
-                # Note: do not have to adjust the Kalman gain or tmp4
-                self.tmp1 *= self.scale
-                self.tmp2 /= self.scale
-                self.tmp3 /= self.scale
                 self._standardized_forecasts_error /= self.scale**0.5
 
     @property

--- a/statsmodels/tsa/statespace/kalman_filter.py
+++ b/statsmodels/tsa/statespace/kalman_filter.py
@@ -1721,25 +1721,27 @@ class FilterResults(FrozenRepresentation):
                 scale_obs / self.scale)
 
             # Scale the filter output
-            self.obs_cov *= self.scale
-            self.state_cov *= self.scale
+            self.obs_cov = self.obs_cov * self.scale
+            self.state_cov = self.state_cov * self.scale
 
-            self.initial_state_cov *= self.scale
-            self.predicted_state_cov *= self.scale
-            self.filtered_state_cov *= self.scale
-            self.forecasts_error_cov *= self.scale
+            self.initial_state_cov = self.initial_state_cov * self.scale
+            self.predicted_state_cov = self.predicted_state_cov * self.scale
+            self.filtered_state_cov = self.filtered_state_cov * self.scale
+            self.forecasts_error_cov = self.forecasts_error_cov * self.scale
             if self.missing_forecasts_error_cov is not None:
-                self.missing_forecasts_error_cov *= self.scale
+                self.missing_forecasts_error_cov = (
+                    self.missing_forecasts_error_cov * self.scale)
 
             # Note: do not have to adjust the Kalman gain or tmp4
-            self.tmp1 *= self.scale
-            self.tmp2 /= self.scale
-            self.tmp3 /= self.scale
+            self.tmp1 = self.tmp1 * self.scale
+            self.tmp2 = self.tmp2 / self.scale
+            self.tmp3 = self.tmp3 / self.scale
             if not (self.memory_no_std_forecast or
                     self.invert_lu or
                     self.solve_lu or
                     self.filter_collapsed):
-                self._standardized_forecasts_error /= self.scale**0.5
+                self._standardized_forecasts_error = (
+                    self._standardized_forecasts_error / self.scale**0.5)
         # The self.model._scale value is only not None within a fixed_scale
         # context, in which case it is set and indicates that we should
         # generally view this results object as using a concentrated scale

--- a/statsmodels/tsa/statespace/kalman_filter.py
+++ b/statsmodels/tsa/statespace/kalman_filter.py
@@ -759,7 +759,6 @@ class KalmanFilter(Representation):
             state_cov = self['state_cov']
             self['obs_cov'] = scale * obs_cov
             self['state_cov'] = scale * state_cov
-            print(self['state_cov'])
         yield
         # If a scale was provided, reset the model
         if scale is not None:

--- a/statsmodels/tsa/statespace/kalman_filter.py
+++ b/statsmodels/tsa/statespace/kalman_filter.py
@@ -762,7 +762,7 @@ class KalmanFilter(Representation):
         """
         # If a scale was provided, use it and do not concentrate it out of the
         # loglikelihood
-        if scale is not None:
+        if scale is not None and scale != 1:
             if not self.filter_concentrated:
                 raise ValueError('Cannot provide scale if filter method does'
                                  ' not include FILTER_CONCENTRATED.')
@@ -776,7 +776,7 @@ class KalmanFilter(Representation):
             yield
         finally:
             # If a scale was provided, reset the model
-            if scale is not None:
+            if scale is not None and scale != 1:
                 self['state_cov'] = state_cov
                 self['obs_cov'] = obs_cov
                 self.filter_concentrated = True

--- a/statsmodels/tsa/statespace/kalman_smoother.py
+++ b/statsmodels/tsa/statespace/kalman_smoother.py
@@ -683,6 +683,18 @@ class SmootherResults(FilterResults):
         self._smoothed_forecasts_error = None
         self._smoothed_forecasts_error_cov = None
 
+        # Note: if we concentrated out the scale, need to adjust the
+        # loglikelihood values and all of the covariance matrices and the
+        # values that depend on the covariance matrices
+        if self.filter_concentrated:
+            self.smoothed_state_cov *= self.scale
+            self.smoothed_state_autocov *= self.scale
+            self.smoothed_state_disturbance_cov *= self.scale
+            self.smoothed_measurement_disturbance_cov *= self.scale
+            self.scaled_smoothed_estimator /= self.scale
+            self.scaled_smoothed_estimator_cov /= self.scale
+            self.smoothing_error /= self.scale
+
     def _get_smoothed_forecasts(self):
         if self._smoothed_forecasts is None:
             # Initialize empty arrays

--- a/statsmodels/tsa/statespace/kalman_smoother.py
+++ b/statsmodels/tsa/statespace/kalman_smoother.py
@@ -688,7 +688,7 @@ class SmootherResults(FilterResults):
         # Note: if we concentrated out the scale, need to adjust the
         # loglikelihood values and all of the covariance matrices and the
         # values that depend on the covariance matrices
-        if self.filter_concentrated:
+        if self.filter_concentrated and self.model._scale is None:
             self.smoothed_state_cov *= self.scale
             self.smoothed_state_autocov *= self.scale
             self.smoothed_state_disturbance_cov *= self.scale

--- a/statsmodels/tsa/statespace/kalman_smoother.py
+++ b/statsmodels/tsa/statespace/kalman_smoother.py
@@ -352,7 +352,7 @@ class KalmanSmoother(KalmanFilter):
         return smoother
 
     def smooth(self, smoother_output=None, smooth_method=None, results=None,
-               run_filter=True, prefix=None, complex_step=False, scale=None,
+               run_filter=True, prefix=None, complex_step=False,
                **kwargs):
         """
         Apply the Kalman smoother to the statespace model.
@@ -378,25 +378,22 @@ class KalmanSmoother(KalmanFilter):
         -------
         SmootherResults object
         """
-        # If a scale was provided, use it and do not concentrate it out of the
-        # loglikelihood
-        with self._handle_fixed_scale(scale):
 
-            # Run the filter
-            kfilter = self._filter(**kwargs)
+        # Run the filter
+        kfilter = self._filter(**kwargs)
 
-            # Create the results object
-            results = self.results_class(self)
-            results.update_representation(self)
-            results.update_filter(kfilter)
+        # Create the results object
+        results = self.results_class(self)
+        results.update_representation(self)
+        results.update_filter(kfilter)
 
-            # Run the smoother
-            if smoother_output is None:
-                smoother_output = self.smoother_output
-            smoother = self._smooth(smoother_output, results=results, **kwargs)
+        # Run the smoother
+        if smoother_output is None:
+            smoother_output = self.smoother_output
+        smoother = self._smooth(smoother_output, results=results, **kwargs)
 
-            # Update the results
-            results.update_smoother(smoother)
+        # Update the results
+        results.update_smoother(smoother)
 
         return results
 

--- a/statsmodels/tsa/statespace/kalman_smoother.py
+++ b/statsmodels/tsa/statespace/kalman_smoother.py
@@ -380,41 +380,23 @@ class KalmanSmoother(KalmanFilter):
         """
         # If a scale was provided, use it and do not concentrate it out of the
         # loglikelihood
-        if scale is not None:
-            if not self.filter_concentrated:
-                raise ValueError('Cannot provide scale if filter method does'
-                                 ' not include FILTER_CONCENTRATED.')
-            self.filter_concentrated = False
-            obs_cov = self['obs_cov']
-            state_cov = self['state_cov']
-            self['obs_cov'] = scale * self['obs_cov']
-            self['state_cov'] = scale * self['state_cov']
+        with self._handle_fixed_scale(scale):
 
-        # Run the filter
-        kfilter = self._filter(**kwargs)
+            # Run the filter
+            kfilter = self._filter(**kwargs)
 
-        # Create the results object
-        results = self.results_class(self)
-        results.update_representation(self)
-        results.update_filter(kfilter)
+            # Create the results object
+            results = self.results_class(self)
+            results.update_representation(self)
+            results.update_filter(kfilter)
 
-        # Run the smoother
-        if smoother_output is None:
-            smoother_output = self.smoother_output
-        smoother = self._smooth(smoother_output, results=results, **kwargs)
+            # Run the smoother
+            if smoother_output is None:
+                smoother_output = self.smoother_output
+            smoother = self._smooth(smoother_output, results=results, **kwargs)
 
-        # Update the results
-        results.update_smoother(smoother)
-
-        # If a scale was provided, reset the model and update the results
-        # object
-        if scale is not None:
-            self['state_cov'] = state_cov
-            self['obs_cov'] = obs_cov
-            self.filter_concentrated = True
-
-            results.filter_concentrated = True
-            results.scale = scale
+            # Update the results
+            results.update_smoother(smoother)
 
         return results
 

--- a/statsmodels/tsa/statespace/mlemodel.py
+++ b/statsmodels/tsa/statespace/mlemodel.py
@@ -1573,7 +1573,8 @@ class MLEResults(tsbase.TimeSeriesModelResults):
     params : array
         The parameters of the model.
     scale : float
-        This is currently set to 1.0 and not used by the model or its results.
+        This is currently set to 1.0 unless the model uses concentrated
+        filtering.
 
     See Also
     --------
@@ -2554,9 +2555,12 @@ class MLEResults(tsbase.TimeSeriesModelResults):
         simulated_obs : array
             An (nsimulations x k_endog) array of simulated observations.
         """
-        return self.model.simulate(self.params, nsimulations,
-                                   measurement_shocks, state_shocks,
-                                   initial_state)
+        scale = self.scale if self.filter_results.filter_concentrated else None
+        with self.model.ssm.fixed_scale(scale):
+            sim = self.model.simulate(self.params, nsimulations,
+                                      measurement_shocks, state_shocks,
+                                      initial_state)
+        return sim
 
     def impulse_responses(self, steps=1, impulse=0, orthogonalized=False,
                           cumulative=False, **kwargs):
@@ -2601,9 +2605,12 @@ class MLEResults(tsbase.TimeSeriesModelResults):
         calculating impulse responses.
 
         """
-        return self.model.impulse_responses(self.params, steps, impulse,
-                                            orthogonalized, cumulative,
-                                            **kwargs)
+        scale = self.scale if self.filter_results.filter_concentrated else None
+        with self.model.ssm.fixed_scale(scale):
+            irfs = self.model.impulse_responses(self.params, steps, impulse,
+                                                orthogonalized, cumulative,
+                                                **kwargs)
+        return irfs
 
     def plot_diagnostics(self, variable=0, lags=10, fig=None, figsize=None):
         """

--- a/statsmodels/tsa/statespace/mlemodel.py
+++ b/statsmodels/tsa/statespace/mlemodel.py
@@ -1747,11 +1747,7 @@ class MLEResults(tsbase.TimeSeriesModelResults):
         """
         (float) Akaike Information Criterion
         """
-<<<<<<< c911d882025194c55204af185adebe63dfa92787
         # return -2 * self.llf + 2 * self.df_model
-=======
-        # return -2 * self.llf + 2 * self.df_mdoel
->>>>>>> REF: Add effective nobs (nobs - burned periods)
         return aic(self.llf, self.nobs_effective, self.df_model)
 
     @cache_readonly

--- a/statsmodels/tsa/statespace/mlemodel.py
+++ b/statsmodels/tsa/statespace/mlemodel.py
@@ -1557,6 +1557,11 @@ class MLEResults(tsbase.TimeSeriesModelResults):
         # Dimensions
         self.nobs = self.filter_results.nobs
         self.nobs_diffuse = self.filter_results.nobs_diffuse
+        if self.nobs_diffuse > 0 and self.loglikelihood_burn > 0:
+            warnings.warn('Care should be used when applying a loglikelihood'
+                          ' burn to a model with exact diffuse initialization.'
+                          ' Some results objects, e.g. degrees of freedom,'
+                          ' expect only one of the two to be set.')
         # This only excludes explicitly burned (usually approximate diffuse)
         # periods but does not exclude approximate diffuse periods. This is
         # because the loglikelihood remains valid for the initial periods in

--- a/statsmodels/tsa/statespace/mlemodel.py
+++ b/statsmodels/tsa/statespace/mlemodel.py
@@ -2043,14 +2043,14 @@ class MLEResults(tsbase.TimeSeriesModelResults):
         """
         (float) The value of the log-likelihood function evaluated at `params`.
         """
-        return self.model.loglikeobs(self.params)
+        return self.filter_results.llf_obs
 
     @cache_readonly
     def llf(self):
         """
         (float) The value of the log-likelihood function evaluated at `params`.
         """
-        return self.llf_obs.sum()
+        return self.llf_obs[self.filter_results.loglikelihood_burn:].sum()
 
     @cache_readonly
     def loglikelihood_burn(self):

--- a/statsmodels/tsa/statespace/mlemodel.py
+++ b/statsmodels/tsa/statespace/mlemodel.py
@@ -1538,12 +1538,12 @@ class MLEResults(tsbase.TimeSeriesModelResults):
     statsmodels.tsa.statespace.representation.FrozenRepresentation
     """
     def __init__(self, model, params, results, cov_type='opg',
-                 cov_kwds=None, **kwargs):
+                 cov_kwds=None, scale=1, **kwargs):
         self.data = model.data
 
         tsbase.TimeSeriesModelResults.__init__(self, model, params,
                                                normalized_cov_params=None,
-                                               scale=1.)
+                                               scale=scale)
 
         # Save the state space representation output
         self.filter_results = results
@@ -2005,7 +2005,7 @@ class MLEResults(tsbase.TimeSeriesModelResults):
         """
         (float) The value of the log-likelihood function evaluated at `params`.
         """
-        return self.llf_obs[self.filter_results.loglikelihood_burn:].sum()
+        return self.llf_obs.sum()
 
     @cache_readonly
     def loglikelihood_burn(self):
@@ -2730,6 +2730,8 @@ class MLEResults(tsbase.TimeSeriesModelResults):
             ('BIC', ["%#5.3f" % self.bic]),
             ('HQIC', ["%#5.3f" % self.hqic])
         ]
+        if self.filter_results.filter_concentrated:
+            top_right.append(('Scale', ["%#5.3f" % self.scale]))
 
         if hasattr(self, 'cov_type'):
             top_left.append(('Covariance Type:', [self.cov_type]))

--- a/statsmodels/tsa/statespace/mlemodel.py
+++ b/statsmodels/tsa/statespace/mlemodel.py
@@ -596,53 +596,9 @@ class MLEModel(tsbase.TimeSeriesModel):
         result = self.ssm.smooth(complex_step=complex_step, **kwargs)
 
         # Wrap in a results object
-<<<<<<< e422acda25f30d507cdfd697d715f265d8b0b027
         return self._wrap_results(params, result, return_ssm, cov_type,
                                   cov_kwds, results_class,
                                   results_wrapper_class)
-=======
-        if not return_ssm:
-            result_kwargs = {}
-            if cov_type is not None:
-                result_kwargs['cov_type'] = cov_type
-            if cov_kwds is not None:
-                result_kwargs['cov_kwds'] = cov_kwds
-
-            if results_class is None:
-                results_class = MLEResults
-            if results_wrapper_class is None:
-                results_wrapper_class = MLEResultsWrapper
-
-            result = results_wrapper_class(
-                results_class(self, params, result, **result_kwargs)
-            )
-
-        return result
-
-    def _handle_args(self, names, defaults, *args, **kwargs):
-        output_args = []
-        # We need to handle positional arguments in two ways, in case this was
-        # called by a Scipy optimization routine
-        if len(args) > 0:
-            # the fit() method will pass a dictionary
-            if isinstance(args[0], dict):
-                flags = args[0]
-            # otherwise, a user may have just used positional arguments...
-            else:
-                flags = dict(zip(names, args))
-            for i in range(len(names)):
-                output_args.append(flags.get(names[i], defaults[i]))
-
-            for name, value in flags.items():
-                if name in kwargs:
-                    raise TypeError("loglike() got multiple values for keyword"
-                                    " argument '%s'" % name)
-        else:
-            for i in range(len(names)):
-                output_args.append(kwargs.pop(names[i], defaults[i]))
-
-        return tuple(output_args) + (kwargs,)
->>>>>>> REF: Allow passing scale to filter, smooth
 
     _loglike_param_names = ['transformed', 'complex_step']
     _loglike_param_defaults = [True, False]
@@ -1616,7 +1572,8 @@ class MLEResults(tsbase.TimeSeriesModelResults):
         self.k_diffuse_states = 0 if P is None else np.sum(np.diagonal(P) == 1)
 
         # Degrees of freedom (see DK 2012, section 7.4)
-        self.df_model = self.params.size + self.k_diffuse_states
+        self.df_model = (self.params.size + self.k_diffuse_states +
+                         self.filter_results.filter_concentrated)
         self.df_resid = self.nobs_effective - self.df_model
 
         # Setup covariance matrix notes dictionary
@@ -1790,7 +1747,11 @@ class MLEResults(tsbase.TimeSeriesModelResults):
         """
         (float) Akaike Information Criterion
         """
+<<<<<<< c911d882025194c55204af185adebe63dfa92787
         # return -2 * self.llf + 2 * self.df_model
+=======
+        # return -2 * self.llf + 2 * self.df_mdoel
+>>>>>>> REF: Add effective nobs (nobs - burned periods)
         return aic(self.llf, self.nobs_effective, self.df_model)
 
     @cache_readonly

--- a/statsmodels/tsa/statespace/sarimax.py
+++ b/statsmodels/tsa/statespace/sarimax.py
@@ -313,15 +313,6 @@ class SARIMAX(MLEModel):
                              ' state vector, so that `mle_regression` must'
                              ' be set to False.')
 
-        # So far, can't guarantee that the concentrated scale with time-varying
-        # regression model is correctly specified (the log-likelihood is
-        # very slightly different than in the non-concentrated model) so don't
-        # allow it right now.
-        if self.time_varying_regression and self.concentrate_scale:
-            raise ValueError('Time-varying regression is not supported when'
-                             ' concentrating the scale out of the likelihood'
-                             ' function.')
-
         # Lag polynomials
         # Assume that they are given from lowest degree to highest, that all
         # degrees except for the constant are included, and that they are

--- a/statsmodels/tsa/statespace/sarimax.py
+++ b/statsmodels/tsa/statespace/sarimax.py
@@ -258,6 +258,17 @@ class SARIMAX(MLEModel):
     Stata and R require using it along with simple differencing (as Stata
     does).
 
+    If `filter_concentrated = True` is used, then the scale of the model is
+    concentrated out of the likelihood. A benefit of this is that there the
+    dimension of the parameter vector is reduced so that numerical maximization
+    of the log-likelihood function may be faster and more stable. If this
+    option in a model with measurement error, it is important to note that the
+    estimated measurement error parameter will be relative to the scale, and
+    is named "snr.measurement_error" instead of "var.measurement_error". To
+    compute the variance of the measurement error in this case one would
+    multiply `snr.measurement_error` parameter by the scale.
+
+
     Detailed information about state space models can be found in [1]_. Some
     specific references are:
 

--- a/statsmodels/tsa/statespace/sarimax.py
+++ b/statsmodels/tsa/statespace/sarimax.py
@@ -516,10 +516,10 @@ class SARIMAX(MLEModel):
             self.ssm._time_invariant = False
 
         # Initialize the fixed components of the statespace model
-        self.ssm.design = self.initial_design
-        self.ssm.state_intercept = self.initial_state_intercept
-        self.ssm.transition = self.initial_transition
-        self.ssm.selection = self.initial_selection
+        self.ssm['design'] = self.initial_design
+        self.ssm['state_intercept'] = self.initial_state_intercept
+        self.ssm['transition'] = self.initial_transition
+        self.ssm['selection'] = self.initial_selection
         if self.concentrate_scale:
             self.ssm['state_cov', 0, 0] = 1.
 

--- a/statsmodels/tsa/statespace/tests/test_concentrated.py
+++ b/statsmodels/tsa/statespace/tests/test_concentrated.py
@@ -15,11 +15,7 @@ from .results import results_varmax
 from statsmodels.tsa.statespace import (
     sarimax, structural, dynamic_factor, varmax)
 from numpy.testing import assert_equal, assert_raises, assert_allclose
-from statsmodels.tsa.statespace.tools import compatibility_mode
 from nose.exc import SkipTest
-
-if compatibility_mode:
-    raise SkipTest
 
 
 def get_sarimax_models(endog, filter_univariate=False, **kwargs):

--- a/statsmodels/tsa/statespace/tests/test_concentrated.py
+++ b/statsmodels/tsa/statespace/tests/test_concentrated.py
@@ -6,7 +6,7 @@ Note: the univariate cases is well tested in test_sarimax.py
 Author: Chad Fulton
 License: Simplified-BSD
 """
-from __future__ import division, absolute_import #, print_function
+from __future__ import division, absolute_import, print_function
 
 import numpy as np
 import pandas as pd

--- a/statsmodels/tsa/statespace/tests/test_concentrated.py
+++ b/statsmodels/tsa/statespace/tests/test_concentrated.py
@@ -1,0 +1,130 @@
+"""
+Tests for concentrating the scale out of the loglikelihood function
+
+Note: the univariate cases is well tested in test_sarimax.py
+
+Author: Chad Fulton
+License: Simplified-BSD
+"""
+from __future__ import division, absolute_import, print_function
+
+import numpy as np
+import pandas as pd
+from .results import results_varmax
+from statsmodels.tsa.statespace import varmax
+from numpy.testing import assert_equal, assert_raises, assert_allclose
+
+
+def check_concentrated_scale(filter_univariate=False, **kwargs):
+    # Test that concentrating the scale out of the likelihood function works
+    index = pd.date_range('1960-01-01', '1982-10-01', freq='QS')
+    dta = pd.DataFrame(results_varmax.lutkepohl_data,
+                       columns=['inv', 'inc', 'consump'], index=index)
+    dta['dln_inv'] = np.log(dta['inv']).diff()
+    dta['dln_inc'] = np.log(dta['inc']).diff()
+    dta['dln_consump'] = np.log(dta['consump']).diff()
+
+    endog = dta.ix['1960-04-01':'1978-10-01', ['dln_inv', 'dln_inc']]
+
+    # Sometimes we can have slight differences if the Kalman filters
+    # converge at different observations, so disable convergence.
+    kwargs.update({'tolerance': 0})
+
+    mod_orig = varmax.VARMAX(endog, **kwargs)
+    mod_conc = varmax.VARMAX(endog, concentrate_scale=True, **kwargs)
+
+    mod_orig.ssm.filter_univariate = filter_univariate
+    mod_conc.ssm.filter_univariate = filter_univariate
+
+    # Since VARMAX doesn't explicitly allow concentrating out the scale, for
+    # now we will simulate it by setting the first variance to be 1.
+    # Note that start_scale will not be the scale used for the non-concentrated
+    # model, because we need to use the MLE scale estimated by the
+    # concentrated model.
+    conc_params = mod_conc.start_params
+    start_scale = conc_params[mod_conc._params_state_cov][0]
+    if kwargs.get('error_cov_type', 'unstructured') == 'diagonal':
+        conc_params[mod_conc._params_state_cov] /= start_scale
+    else:
+        conc_params[mod_conc._params_state_cov] /= start_scale**0.5
+
+    # Concentrated model smoothing
+    res_conc = mod_conc.smooth(conc_params)
+    scale = res_conc.scale
+
+    # Map the concentrated parameters to the non-concentrated model
+    orig_params = conc_params.copy()
+    if kwargs.get('error_cov_type', 'unstructured') == 'diagonal':
+        orig_params[mod_orig._params_state_cov] *= scale
+    else:
+        orig_params[mod_orig._params_state_cov] *= scale**0.5
+
+    # Measurement error variances also get rescaled
+    orig_params[mod_orig._params_obs_cov] *= scale
+
+    # Non-oncentrated model smoothing
+    res_orig = mod_orig.smooth(orig_params)
+
+    # Test loglike
+    # Need to reduce the tolerance when we have measurement error.
+    assert_allclose(res_conc.llf, res_orig.llf)
+
+    # Test state space representation matrices
+    for name in mod_conc.ssm.shapes:
+        if name == 'obs':
+            continue
+        assert_allclose(getattr(res_conc.filter_results, name),
+                        getattr(res_orig.filter_results, name))
+
+    # Test filter / smoother output
+    scale = res_conc.scale
+    d = res_conc.loglikelihood_burn
+
+    filter_attr = ['predicted_state', 'filtered_state', 'forecasts',
+                   'forecasts_error', 'kalman_gain']
+
+    for name in filter_attr:
+        actual = getattr(res_conc.filter_results, name)
+        desired = getattr(res_orig.filter_results, name)
+        assert_allclose(actual, desired)
+
+    # Note: don't want to compare the elements from any diffuse
+    # initialization for things like covariances, so only compare for
+    # periods past the loglikelihood_burn period
+    filter_attr_burn = ['standardized_forecasts_error',
+                        'predicted_state_cov', 'filtered_state_cov',
+                        'tmp1', 'tmp2', 'tmp3', 'tmp4']
+
+    for name in filter_attr_burn:
+        actual = getattr(res_conc.filter_results, name)[..., d:]
+        desired = getattr(res_orig.filter_results, name)[..., d:]
+        assert_allclose(actual, desired)
+
+    smoothed_attr = ['smoothed_state', 'smoothed_state_cov',
+                     'smoothed_state_autocov',
+                     'smoothed_state_disturbance',
+                     'smoothed_state_disturbance_cov',
+                     'smoothed_measurement_disturbance',
+                     'smoothed_measurement_disturbance_cov',
+                     'scaled_smoothed_estimator',
+                     'scaled_smoothed_estimator_cov', 'smoothing_error',
+                     'smoothed_forecasts', 'smoothed_forecasts_error',
+                     'smoothed_forecasts_error_cov']
+
+    for name in smoothed_attr:
+        actual = getattr(res_conc.filter_results, name)
+        desired = getattr(res_orig.filter_results, name)
+        assert_allclose(actual, desired)
+
+
+def test_concentrated_scale_conventional():
+    check_concentrated_scale(filter_univariate=False)
+    check_concentrated_scale(filter_univariate=False, measurement_error=True)
+    check_concentrated_scale(filter_univariate=False,
+                             error_cov_type='diagonal')
+
+
+def test_concentrated_scale_univariate():
+    check_concentrated_scale(filter_univariate=True)
+    check_concentrated_scale(filter_univariate=True, measurement_error=False)
+    check_concentrated_scale(filter_univariate=True, error_cov_type='diagonal')

--- a/statsmodels/tsa/statespace/tests/test_concentrated.py
+++ b/statsmodels/tsa/statespace/tests/test_concentrated.py
@@ -6,18 +6,159 @@ Note: the univariate cases is well tested in test_sarimax.py
 Author: Chad Fulton
 License: Simplified-BSD
 """
-from __future__ import division, absolute_import, print_function
+from __future__ import division, absolute_import #, print_function
 
 import numpy as np
 import pandas as pd
+from statsmodels.tools.tools import Bunch
 from .results import results_varmax
-from statsmodels.tsa.statespace import varmax
+from statsmodels.tsa.statespace import (
+    sarimax, structural, dynamic_factor, varmax)
 from numpy.testing import assert_equal, assert_raises, assert_allclose
 from statsmodels.tsa.statespace.tools import compatibility_mode
 from nose.exc import SkipTest
 
 if compatibility_mode:
     raise SkipTest
+
+
+def get_sarimax_models(endog, filter_univariate=False, **kwargs):
+    kwargs.setdefault('tolerance', 0)
+    # Construct a concentrated version of the given SARIMAX model, and get
+    # the estimate of the scale
+    mod_conc = sarimax.SARIMAX(endog, **kwargs)
+    mod_conc.ssm.filter_concentrated = True
+    mod_conc.ssm.filter_univariate = filter_univariate
+    params_conc = mod_conc.start_params
+    params_conc[-1] = 1
+    res_conc = mod_conc.smooth(params_conc)
+    scale = res_conc.scale
+
+    # Construct the non-concentrated version
+    mod_orig = sarimax.SARIMAX(endog, **kwargs)
+    mod_orig.ssm.filter_univariate = filter_univariate
+    params_orig = params_conc.copy()
+    k_vars = 1 + kwargs.get('measurement_error', False)
+    params_orig[-k_vars:] = scale * params_conc[-k_vars:]
+    res_orig = mod_orig.smooth(params_orig)
+
+    return Bunch(**{'mod_conc': mod_conc, 'params_conc': params_conc,
+                    'mod_orig': mod_orig, 'params_orig': params_orig,
+                    'res_conc': res_conc, 'res_orig': res_orig,
+                    'scale': scale})
+
+
+def test_concentrated_loglike_sarimax():
+    # Note: we won't use the "concentrate_scale" option to SARIMAX for this
+    # test, which is a lower-level test of the Kalman filter using the SARIMAX
+    # model as an example
+    nobs = 30
+    np.random.seed(28953)
+    endog = np.random.normal(size=nobs)
+    kwargs = {}
+
+    # Typical model
+    out = get_sarimax_models(endog)
+    assert_allclose(out.res_conc.llf, out.res_orig.llf)
+    assert_allclose(out.res_conc.llf_obs, out.res_orig.llf_obs)
+    assert_allclose(out.mod_conc.loglike(out.params_conc),
+                    out.mod_orig.loglike(out.params_orig))
+    assert_allclose(out.mod_conc.loglikeobs(out.params_conc),
+                    out.mod_orig.loglikeobs(out.params_orig))
+
+    # Add missing entries
+    endog[2:10] = np.nan
+    out = get_sarimax_models(endog)
+    assert_allclose(out.res_conc.llf, out.res_orig.llf)
+    assert_allclose(out.res_conc.llf_obs, out.res_orig.llf_obs)
+    assert_allclose(out.mod_conc.loglike(out.params_conc),
+                    out.mod_orig.loglike(out.params_orig))
+    assert_allclose(out.mod_conc.loglikeobs(out.params_conc),
+                    out.mod_orig.loglikeobs(out.params_orig))
+
+    # Add seasonal differencing
+    # Note: now, due to differences in approximate diffuse initialization,
+    # we may have differences in the first 2 observations (but notice that
+    # this does not affect the computed joint log-likelihood because those
+    # observations are not included there)
+    kwargs['seasonal_order'] = (1, 1, 1, 2)
+    out = get_sarimax_models(endog, **kwargs)
+    assert_allclose(out.res_conc.llf, out.res_orig.llf)
+    assert_allclose(out.res_conc.llf_obs[2:], out.res_orig.llf_obs[2:])
+    assert_allclose(out.mod_conc.loglike(out.params_conc),
+                    out.mod_orig.loglike(out.params_orig))
+    assert_allclose(out.mod_conc.loglikeobs(out.params_conc)[2:],
+                    out.mod_orig.loglikeobs(out.params_orig)[2:])
+
+    # Add loglikelihood burn, trend, and exog
+    kwargs['loglikelihood_burn'] = 5
+    kwargs['trend'] = 'c'
+    kwargs['exog'] = np.ones(nobs)
+    out = get_sarimax_models(endog, **kwargs)
+    assert_allclose(out.res_conc.llf, out.res_orig.llf)
+    assert_allclose(out.res_conc.llf_obs[2:], out.res_orig.llf_obs[2:])
+    assert_allclose(out.mod_conc.loglike(out.params_conc),
+                    out.mod_orig.loglike(out.params_orig))
+    assert_allclose(out.mod_conc.loglikeobs(out.params_conc)[2:],
+                    out.mod_orig.loglikeobs(out.params_orig)[2:])
+
+
+def test_concentrated_predict_sarimax():
+    # Note: we won't use the "concentrate_scale" option to SARIMAX for this
+    # test, which is a lower-level test of the Kalman filter using the SARIMAX
+    # model as an example
+    nobs = 30
+    np.random.seed(28953)
+    endog = np.random.normal(size=nobs)
+    kwargs = {}
+
+    # Typical model
+    out = get_sarimax_models(endog)
+    assert_allclose(out.res_conc.predict(), out.res_orig.predict())
+    assert_allclose(out.res_conc.forecast(5), out.res_orig.forecast(5))
+    assert_allclose(out.res_conc.predict(start=0, end=45, dynamic=10),
+                    out.res_orig.predict(start=0, end=45, dynamic=10))
+
+
+def test_fixed_scale_sarimax():
+    # Test that the fixed_scale context manager works
+    nobs = 30
+    np.random.seed(28953)
+    endog = np.random.normal(size=nobs)
+    kwargs = {
+        'seasonal_order': (1, 1, 1, 2),
+        'trend': 'ct',
+        'exog': np.ones(nobs)
+    }
+
+    # Construct a concentrated version of the given SARIMAX model
+    mod_conc = sarimax.SARIMAX(endog, concentrate_scale=True, **kwargs)
+
+    # Construct the non-concentrated version
+    mod_orig = sarimax.SARIMAX(endog, **kwargs)
+
+    # Modify the scale parameter
+    params = mod_orig.start_params
+    params[-1] *= 1.2
+
+    # Test that these are not equal in the default computation
+    assert_raises(AssertionError, assert_allclose,
+                  mod_conc.loglike(params[:-1]), mod_orig.loglike(params))
+
+    # Now test that the llf is equal when we use the fixed_scale decorator
+    with mod_conc.ssm.fixed_scale(params[-1]):
+        res1 = mod_conc.smooth(params[:-1])
+        llf1 = mod_conc.loglike(params[:-1])
+        llf_obs1 = mod_conc.loglikeobs(params[:-1])
+
+    res2 = mod_orig.smooth(params)
+    llf2 = mod_orig.loglike(params)
+    llf_obs2 = mod_orig.loglikeobs(params)
+
+    assert_allclose(res1.llf, res2.llf)
+    assert_allclose(res1.llf_obs[2:], res2.llf_obs[2:])
+    assert_allclose(llf1, llf2)
+    assert_allclose(llf_obs1, llf_obs2)
 
 
 def check_concentrated_scale(filter_univariate=False, missing=False, **kwargs):
@@ -42,7 +183,8 @@ def check_concentrated_scale(filter_univariate=False, missing=False, **kwargs):
     kwargs.update({'tolerance': 0})
 
     mod_orig = varmax.VARMAX(endog, **kwargs)
-    mod_conc = varmax.VARMAX(endog, concentrate_scale=True, **kwargs)
+    mod_conc = varmax.VARMAX(endog, **kwargs)
+    mod_conc.ssm.filter_concentrated = True
 
     mod_orig.ssm.filter_univariate = filter_univariate
     mod_conc.ssm.filter_univariate = filter_univariate
@@ -97,7 +239,7 @@ def check_concentrated_scale(filter_univariate=False, missing=False, **kwargs):
     for name in filter_attr:
         actual = getattr(res_conc.filter_results, name)
         desired = getattr(res_orig.filter_results, name)
-        assert_allclose(actual, desired)
+        assert_allclose(actual, desired, atol=1e-7)
 
     # Note: don't want to compare the elements from any diffuse
     # initialization for things like covariances, so only compare for
@@ -109,7 +251,7 @@ def check_concentrated_scale(filter_univariate=False, missing=False, **kwargs):
     for name in filter_attr_burn:
         actual = getattr(res_conc.filter_results, name)[..., d:]
         desired = getattr(res_orig.filter_results, name)[..., d:]
-        assert_allclose(actual, desired)
+        assert_allclose(actual, desired, atol=1e-7)
 
     smoothed_attr = ['smoothed_state', 'smoothed_state_cov',
                      'smoothed_state_autocov',
@@ -125,7 +267,15 @@ def check_concentrated_scale(filter_univariate=False, missing=False, **kwargs):
     for name in smoothed_attr:
         actual = getattr(res_conc.filter_results, name)
         desired = getattr(res_orig.filter_results, name)
-        assert_allclose(actual, desired)
+        assert_allclose(actual, desired, atol=1e-7)
+
+    # Test prediction output
+    nobs = mod_conc.nobs
+    pred_conc = res_conc.get_prediction(start=10, end=nobs + 50, dynamic=40)
+    pred_orig = res_conc.get_prediction(start=10, end=nobs + 50, dynamic=40)
+
+    assert_allclose(pred_conc.predicted_mean, pred_orig.predicted_mean)
+    assert_allclose(pred_conc.se_mean, pred_orig.se_mean)
 
 
 def test_concentrated_scale_conventional():
@@ -134,6 +284,8 @@ def test_concentrated_scale_conventional():
     check_concentrated_scale(filter_univariate=False,
                              error_cov_type='diagonal')
     check_concentrated_scale(filter_univariate=False, missing=True)
+    check_concentrated_scale(filter_univariate=False, missing=True,
+                             loglikelihood_burn=10)
 
 
 def test_concentrated_scale_univariate():
@@ -141,3 +293,5 @@ def test_concentrated_scale_univariate():
     check_concentrated_scale(filter_univariate=True, measurement_error=True)
     check_concentrated_scale(filter_univariate=True, error_cov_type='diagonal')
     check_concentrated_scale(filter_univariate=True, missing=True)
+    check_concentrated_scale(filter_univariate=True, missing=True,
+                             loglikelihood_burn=10)

--- a/statsmodels/tsa/statespace/tests/test_concentrated.py
+++ b/statsmodels/tsa/statespace/tests/test_concentrated.py
@@ -13,6 +13,7 @@ import pandas as pd
 from .results import results_varmax
 from statsmodels.tsa.statespace import varmax
 from numpy.testing import assert_equal, assert_raises, assert_allclose
+from statsmodels.tsa.statespace.tools import compatibility_mode
 
 
 def check_concentrated_scale(filter_univariate=False, **kwargs):
@@ -125,6 +126,8 @@ def test_concentrated_scale_conventional():
 
 
 def test_concentrated_scale_univariate():
+    if compatibility_mode:
+        return
     check_concentrated_scale(filter_univariate=True)
     check_concentrated_scale(filter_univariate=True, measurement_error=False)
     check_concentrated_scale(filter_univariate=True, error_cov_type='diagonal')

--- a/statsmodels/tsa/statespace/tests/test_dynamic_factor.py
+++ b/statsmodels/tsa/statespace/tests/test_dynamic_factor.py
@@ -105,11 +105,14 @@ class CheckDynamicFactor(object):
         self.model.enforce_stationarity = True
         assert_allclose(results.llf, self.results.llf, rtol=1e-5)
 
-    def test_mle(self):
+    def test_mle(self, init_powell=True):
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter('always')
-            results = self.model.fit(method='powell', maxiter=100, disp=False)
-            results = self.model.fit(results.params, maxiter=1000, disp=False)
+            start_params = self.model.start_params
+            if init_powell:
+                results = self.model.fit(method='powell', maxiter=100, disp=False)
+                start_params = results.params
+            results = self.model.fit(start_params, maxiter=1000, disp=False)
             results = self.model.fit(results.params, method='nm', maxiter=1000,
                                      disp=False)
             if not results.llf > self.results.llf:
@@ -609,6 +612,9 @@ class TestSUR_autocorrelated_errors(CheckDynamicFactor):
     def test_dynamic_predict(self):
         exog = np.c_[np.ones((16, 1)), (np.arange(75, 75+16) + 2)[:, np.newaxis]]
         super(TestSUR_autocorrelated_errors, self).test_dynamic_predict(exog=exog)
+
+    def test_mle(self):
+        super(TestSUR_autocorrelated_errors, self).test_mle(init_powell=False)
 
 
 def test_misspecification():

--- a/statsmodels/tsa/statespace/tests/test_options.py
+++ b/statsmodels/tsa/statespace/tests/test_options.py
@@ -19,6 +19,7 @@ from statsmodels.tsa.statespace.kalman_filter import (
     FILTER_COLLAPSED,
     FILTER_EXTENDED,
     FILTER_UNSCENTED,
+    FILTER_CONCENTRATED,
 
     INVERT_UNIVARIATE,
     SOLVE_LU,
@@ -101,7 +102,7 @@ class TestOptions(Options):
             model.filter_method,
             FILTER_CONVENTIONAL | FILTER_EXACT_INITIAL | FILTER_AUGMENTED |
             FILTER_SQUARE_ROOT | FILTER_UNIVARIATE | FILTER_COLLAPSED |
-            FILTER_EXTENDED | FILTER_UNSCENTED
+            FILTER_EXTENDED | FILTER_UNSCENTED | FILTER_CONCENTRATED
         )
         for name in model.filter_methods:
             setattr(model, name, False)

--- a/statsmodels/tsa/statespace/tests/test_sarimax.py
+++ b/statsmodels/tsa/statespace/tests/test_sarimax.py
@@ -2093,7 +2093,6 @@ def check_concentrated_scale(filter_univariate=False):
                                      measurement_errors,
                                      time_varying_regressions,
                                      simple_differencings):
-
         kwargs = dict(zip(names, element))
         if kwargs.get('time_varying_regression', False):
             kwargs['mle_regression'] = False
@@ -2142,8 +2141,8 @@ def check_concentrated_scale(filter_univariate=False):
             k_snr += 1
 
         atol = 1e-5
-        if kwargs['seasonal_order'] == seasonal_orders[1] or kwargs['measurement_error']:
-            atol = 1e-3
+        if kwargs['measurement_error']:
+            atol = 1e-4
 
         orig_params = np.r_[orig_params[:-k_snr],
                             res_conc.scale * orig_params[-k_snr:]]
@@ -2196,8 +2195,8 @@ def check_concentrated_scale(filter_univariate=False):
                          'smoothed_forecasts_error_cov']
 
         for name in smoothed_attr:
-            actual = getattr(res_conc.filter_results, name)
-            desired = getattr(res_orig.filter_results, name)
+            actual = getattr(res_conc.filter_results, name)[..., d:]
+            desired = getattr(res_orig.filter_results, name)[..., d:]
             assert_allclose(actual, desired, atol=atol)
 
 

--- a/statsmodels/tsa/statespace/tests/test_sarimax.py
+++ b/statsmodels/tsa/statespace/tests/test_sarimax.py
@@ -2195,7 +2195,7 @@ def check_concentrated_scale(filter_univariate=False):
         for name in smoothed_attr:
             actual = getattr(res_conc.filter_results, name)
             desired = getattr(res_orig.filter_results, name)
-            assert_allclose(actual, desired, atol=1e-4)
+            assert_allclose(actual, desired, atol=1e-3)
 
 
 def test_concentrated_scale_conventional():

--- a/statsmodels/tsa/statespace/tests/test_sarimax.py
+++ b/statsmodels/tsa/statespace/tests/test_sarimax.py
@@ -16,6 +16,7 @@ from statsmodels.tsa import arima_model as arima
 from .results import results_sarimax
 from statsmodels.tools import add_constant
 from numpy.testing import assert_equal, assert_almost_equal, assert_raises, assert_allclose
+from nose.exc import SkipTest
 
 current_path = os.path.dirname(os.path.abspath(__file__))
 

--- a/statsmodels/tsa/statespace/tests/test_sarimax.py
+++ b/statsmodels/tsa/statespace/tests/test_sarimax.py
@@ -2143,7 +2143,7 @@ def check_concentrated_scale(filter_univariate=False):
 
         atol = 1e-5
         if kwargs['measurement_error'] or kwargs['time_varying_regression']:
-            atol = 1e-4
+            atol = 1e-3
 
         orig_params = np.r_[orig_params[:-k_snr],
                             res_conc.scale * orig_params[-k_snr:]]

--- a/statsmodels/tsa/statespace/tests/test_sarimax.py
+++ b/statsmodels/tsa/statespace/tests/test_sarimax.py
@@ -2070,3 +2070,137 @@ def test_arima000():
     mod.initialize_known([10.], np.diag([0.]))
     res = mod.smooth([0., 1.])
     assert_allclose(res.smoothed_state[0], 10, atol=1e-10)
+
+
+def check_concentrated_scale(filter_univariate=False):
+    # Test that concentrating the scale out of the likelihood function works
+    endog = np.diff(results_sarimax.wpi1_data)
+
+    orders = [(1, 0, 0), (2, 2, 2)]
+    seasonal_orders = [(0, 0, 0, 0), (1, 1, 1, 4)]
+
+    simple_differencings = [True, False]
+    exogs = [None, np.ones_like(endog)]
+    trends = [None, 't']
+    # Disabled, see discussion below in setting k_snr for details
+    time_varying_regressions = [False]
+    measurement_errors = [True, False]
+
+    import itertools
+    names = ['exog', 'order', 'seasonal_order', 'trend', 'measurement_error',
+             'time_varying_regression', 'simple_differencing']
+    for element in itertools.product(exogs, orders, seasonal_orders, trends,
+                                     measurement_errors,
+                                     time_varying_regressions,
+                                     simple_differencings):
+
+        kwargs = dict(zip(names, element))
+        if kwargs.get('time_varying_regression', False):
+            kwargs['mle_regression'] = False
+
+        # Sometimes we can have slight differences if the Kalman filters
+        # converge at different observations, so disable convergence.
+        kwargs['tolerance'] = 0
+
+        mod_orig = sarimax.SARIMAX(endog, **kwargs)
+        mod_conc = sarimax.SARIMAX(endog, concentrate_scale=True, **kwargs)
+
+        mod_orig.ssm.filter_univariate = filter_univariate
+        mod_conc.ssm.filter_univariate = filter_univariate
+
+        # The base parameters are the starting parameters from the concentrated
+        # model
+        conc_params = mod_conc.start_params
+        res_conc = mod_conc.smooth(conc_params)
+
+        # We need to map the concentrated parameters to the non-concentrated
+        # model
+        # The first thing is to add an additional parameter for the scale
+        # (here set to 1 because we will multiply by res_conc.scale below, but
+        # because the scale is factored out of the entire obs_cov and state_cov
+        # matrices we may need to multiply more parameters by res_conc.scale
+        # also)
+        orig_params = np.r_[conc_params, 1]
+        k_snr = 1
+
+        # If we have time-varying regressions, then in the concentrated model
+        # we actually are computing signal-to-noise ratios, and we
+        # need to multiply it by the scale to get the variances
+        # the non-concentrated model will expect as parameters
+        # if kwargs['time_varying_regression'] and kwargs['exog'] is not None:
+        #     k_snr += 1
+        # Note: the log-likelihood isn't exactly the same between concentrated
+        # and non-concentrated models with time-varying regression, so this
+        # combinations raises NotImplementedError.
+
+        # If we have measurement error, then in the concentrated model
+        # we actually are computing the signal-to-noise ratio, and we
+        # need to multiply it by the scale to get the measurement error
+        # variance that the non-concentrated model will expect as a
+        # parameter
+        if kwargs['measurement_error']:
+            k_snr += 1
+
+        orig_params = np.r_[orig_params[:-k_snr],
+                            res_conc.scale * orig_params[-k_snr:]]
+        res_orig = mod_orig.smooth(orig_params)
+
+        # Test loglike
+        # Need to reduce the tolerance when we have measurement error.
+        atol = 1e-5 if kwargs['measurement_error'] else 0
+        assert_allclose(res_conc.llf, res_orig.llf, atol=atol)
+
+        # Test state space representation matrices
+        for name in mod_conc.ssm.shapes:
+            if name == 'obs':
+                continue
+            assert_allclose(getattr(res_conc.filter_results, name),
+                            getattr(res_orig.filter_results, name))
+
+        # Test filter / smoother output
+        scale = res_conc.scale
+        d = res_conc.loglikelihood_burn
+
+        filter_attr = ['predicted_state', 'filtered_state', 'forecasts',
+                       'forecasts_error', 'kalman_gain']
+
+        for name in filter_attr:
+            actual = getattr(res_conc.filter_results, name)
+            desired = getattr(res_orig.filter_results, name)
+            assert_allclose(actual, desired, atol=1e-4)
+
+        # Note: don't want to compare the elements from any diffuse
+        # initialization for things like covariances, so only compare for
+        # periods past the loglikelihood_burn period
+        filter_attr_burn = ['standardized_forecasts_error',
+                            'predicted_state_cov', 'filtered_state_cov',
+                            'tmp1', 'tmp2', 'tmp3', 'tmp4']
+
+        for name in filter_attr_burn:
+            actual = getattr(res_conc.filter_results, name)[..., d:]
+            desired = getattr(res_orig.filter_results, name)[..., d:]
+            assert_allclose(actual, desired, atol=1e-4)
+
+        smoothed_attr = ['smoothed_state', 'smoothed_state_cov',
+                         'smoothed_state_autocov',
+                         'smoothed_state_disturbance',
+                         'smoothed_state_disturbance_cov',
+                         'smoothed_measurement_disturbance',
+                         'smoothed_measurement_disturbance_cov',
+                         'scaled_smoothed_estimator',
+                         'scaled_smoothed_estimator_cov', 'smoothing_error',
+                         'smoothed_forecasts', 'smoothed_forecasts_error',
+                         'smoothed_forecasts_error_cov']
+
+        for name in smoothed_attr:
+            actual = getattr(res_conc.filter_results, name)
+            desired = getattr(res_orig.filter_results, name)
+            assert_allclose(actual, desired, atol=1e-4)
+
+
+def test_concentrated_scale_conventional():
+    check_concentrated_scale(filter_univariate=False)
+
+
+def test_concentrated_scale_univariate():
+    check_concentrated_scale(filter_univariate=True)

--- a/statsmodels/tsa/statespace/tests/test_sarimax.py
+++ b/statsmodels/tsa/statespace/tests/test_sarimax.py
@@ -2203,4 +2203,7 @@ def test_concentrated_scale_conventional():
 
 
 def test_concentrated_scale_univariate():
+    from statsmodels.tsa.statespace.tools import compatibility_mode
+    if compatibility_mode:
+        return
     check_concentrated_scale(filter_univariate=True)


### PR DESCRIPTION
Adds the ability to perform filtering where the scale is concentrated out of the log-likelihood function, but is computed along with the filtering recursions.

Also adds an argument `concentrate_scale` to SARIMAX to allow estimating the model with the scale concentrated out. From very quick tests, it appears that we can get a higher optimized log-likelihood if there are a lot of parameters.

The filter output between the concentrated and non-concentrated models is the same, since they just need to be rescaled (and I do the relevant rescaling when constructing the filter results).

Not really an "essential" feature, but may be useful.