### PR TITLE
ENH: Add nan- and inf-protected matrix_rank

### DIFF
--- a/examples/notebooks/distributed_estimation.ipynb
+++ b/examples/notebooks/distributed_estimation.ipynb
@@ -9,7 +9,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
@@ -52,7 +52,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
     "collapsed": true
    },
@@ -74,7 +74,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
@@ -94,7 +94,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
@@ -118,7 +118,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {
     "collapsed": true
    },
@@ -142,7 +142,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {
     "collapsed": true
    },
@@ -161,21 +161,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python [conda root]",
    "language": "python",
-   "name": "python2"
+   "name": "conda-root-py"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.10"
+   "pygments_lexer": "ipython3",
+   "version": "3.5.2"
   }
  },
  "nbformat": 4,

--- a/statsmodels/base/data.py
+++ b/statsmodels/base/data.py
@@ -3,12 +3,13 @@ Base tools for handling various kinds of data structures, attaching metadata to
 results, and doing data cleaning
 """
 from statsmodels.compat.python import reduce, iteritems, lmap, zip, range
-from statsmodels.compat.numpy import np_matrix_rank
+
 import numpy as np
 from pandas import DataFrame, Series, isnull
 from statsmodels.tools.decorators import (resettable_cache, cache_readonly,
                                           cache_writable)
 import statsmodels.tools.data as data_util
+from statsmodels.tools.tools import matrix_rank_safe
 from statsmodels.tools.sm_exceptions import MissingDataError
 
 
@@ -169,8 +170,8 @@ class ModelData(object):
                 # Compute rank of augmented matrix
                 augmented_exog = np.column_stack(
                             (np.ones(self.exog.shape[0]), self.exog))
-                rank_augm = np_matrix_rank(augmented_exog)
-                rank_orig = np_matrix_rank(self.exog)
+                rank_augm = matrix_rank_safe(augmented_exog)
+                rank_orig = matrix_rank_safe(self.exog)
                 self.k_constant = int(rank_orig == rank_augm)
                 self.const_idx = None
 

--- a/statsmodels/tools/tests/test_tools.py
+++ b/statsmodels/tools/tests/test_tools.py
@@ -567,3 +567,31 @@ class TestEnsure2d(TestCase):
         results = tools._ensure_2d(self.ndarray[:,0])
         assert_array_equal(results[0], self.ndarray[:,[0]])
         assert_equal(results[1], None)
+
+
+class TestMatrixRankSafe(object):
+    @classmethod
+    def setup_class(cls):
+        np.random.seed(12345)
+        cls.mat = np.random.random_sample((20, 10))
+
+    def test_nonans(self):
+        assert_equal(np.linalg.matrix_rank(self.mat),
+                     tools.matrix_rank_safe(self.mat))
+        assert_equal(10, tools.matrix_rank_safe(self.mat))
+
+    def test_allnans(self):
+        mat = self.mat.copy()
+        mat[0, :] = np.nan
+        assert_equal(0, tools.matrix_rank_safe(mat))
+
+    def test_all_inf(self):
+        mat = self.mat.copy()
+        mat[0, :] = np.inf
+        assert_equal(0, tools.matrix_rank_safe(mat))
+
+    def test_mixed_nan_inf(self):
+        mat = self.mat.copy()
+        mat[5, ::3] = np.inf
+        mat[2, ::4] = np.nan
+        assert_equal(4, tools.matrix_rank_safe(mat))

--- a/statsmodels/tools/tools.py
+++ b/statsmodels/tools/tools.py
@@ -533,3 +533,36 @@ def _ensure_2d(x, ndarray=False):
         return np.asarray(x)[:, None], name
     else:
         return pd.DataFrame(x), name
+
+def matrix_rank_safe(mat, tol=None):
+    """
+    Shallow wrapper for NumPy's matrix_rank that protects against inf and non
+    
+    Parameters
+    ----------
+    mat : {(m,), (m,n}}, array
+        array of <=2 dimensions
+    tol : {None, float}, options
+        threshold below which SVD values are considered zero. If `tol` is
+        None, and ``S`` is an array with singular values for `M`, and
+        ``eps`` is the epsilon value for datatype of ``S``, then `tol` is
+        set to ``S.max() * max(M.shape) * eps``.
+    
+    Returns
+    -------
+    rank : int
+        Rank of mat
+    
+    Notes
+    -----
+    Columns containins infinite or NaN values are dropped before computing 
+    the rank, so that the rank returned is the rank of remaining columns
+    """
+    if np.ndim(mat) == 1:
+        mat = mat[:,None]
+
+    loc = np.all(np.isfinite(mat), axis=0)
+    if loc.sum() > 0:
+        return np_matrix_rank(mat[:, loc], tol)
+    else:
+        return 0


### PR DESCRIPTION
Add a matrix rank that protects against inf anf nan to
prevent LinearAlgebraErrors in NumPy