### PR TITLE
BUG: Prevent abline from updating non-existent line

### DIFF
--- a/examples/notebooks/robust_models_1.ipynb
+++ b/examples/notebooks/robust_models_1.ipynb
@@ -877,7 +877,9 @@
    },
    "outputs": [],
    "source": [
-    "del ax.lines[-1]"
+    "l =  ax.lines[-1]\n",
+    "l.remove()\n",
+    "del l"
    ]
   },
   {

--- a/statsmodels/graphics/tests/test_regressionplots.py
+++ b/statsmodels/graphics/tests/test_regressionplots.py
@@ -166,7 +166,7 @@ class TestPlotFormula(TestPlotPandas):
 class TestABLine(object):
 
     @classmethod
-    def setupClass(cls):
+    def setup_class(cls):
         np.random.seed(12345)
         X = sm.add_constant(np.random.normal(0, 20, size=30))
         y = np.dot(X, [25, 3.5]) + np.random.normal(0, 30, size=30)
@@ -207,9 +207,23 @@ class TestABLine(object):
         fig = abline_plot(intercept=intercept, slope=slope, ax=ax)
         close_or_save(pdf, fig)
 
+    @dec.skipif(not have_matplotlib)
+    def test_abline_remove(self):
+        mod = self.mod
+        intercept, slope = mod.params
+        fig = plt.figure()
+        ax = fig.add_subplot(111)
+        ax.scatter(self.X[:,1], self.y)
+        abline_plot(intercept=intercept, slope=slope, ax=ax)
+        abline_plot(intercept=intercept, slope=2*slope, ax=ax)
+        lines = ax.get_lines()
+        lines.pop(0).remove()
+        close_or_save(pdf, fig)
+
+
 class TestABLinePandas(TestABLine):
     @classmethod
-    def setupClass(cls):
+    def setup_class(cls):
         np.random.seed(12345)
         X = sm.add_constant(np.random.normal(0, 20, size=30))
         y = np.dot(X, [25, 3.5]) + np.random.normal(0, 30, size=30)


### PR DESCRIPTION
Prevent abline form updating non-existant line
Fixes a bug that appears in robust_models_1 notebook