### PR TITLE
REF: raise in has constant check if exog is not finite.

### DIFF
--- a/statsmodels/base/data.py
+++ b/statsmodels/base/data.py
@@ -128,7 +128,10 @@ class ModelData(object):
         else:
             # detect where the constant is
             check_implicit = False
-            const_idx = np.where(self.exog.ptp(axis=0) == 0)[0].squeeze()
+            ptp_ = self.exog.ptp(axis=0)
+            if not np.isfinite(ptp_).all():
+                raise MissingDataError('exog contains inf or nans')
+            const_idx = np.where(ptp_ == 0)[0].squeeze()
             self.k_constant = const_idx.size
 
             if self.k_constant == 1:

--- a/statsmodels/base/tests/test_data.py
+++ b/statsmodels/base/tests/test_data.py
@@ -891,6 +891,20 @@ def test_formula_missing_extra_arrays():
     assert_raises(ValueError, sm_data.handle_data, endog, exog, **kwargs)
 
 
+def test_raise_nonfinite_exog():
+    # we raise now in the has constant check before hitting the linear algebra
+    from statsmodels.regression.linear_model import OLS
+    from statsmodels.tools.sm_exceptions import MissingDataError
+    x = np.arange(10)[:,None]**([0., 1.])
+    # random numbers for y
+    y = np.array([-0.6, -0.1, 0., -0.7, -0.5, 0.5, 0.1, -0.8, -2., 1.1])
+
+    x[1, 1] = np.inf
+    assert_raises(MissingDataError, OLS, y, x)
+    x[1, 1] = np.nan
+    assert_raises(MissingDataError, OLS, y, x)
+
+
 if __name__ == "__main__":
     import pytest
     pytest.main([__file__, '-vvs', '-x', '--pdb'])

--- a/statsmodels/discrete/tests/test_discrete.py
+++ b/statsmodels/discrete/tests/test_discrete.py
@@ -1588,7 +1588,8 @@ def test_formula_missing_exposure():
     assert_(type(mod1.exposure) is np.ndarray, msg='Exposure is not ndarray')
 
     # make sure this raises
-    exposure = pd.Series(np.random.randn(5))
+    exposure = pd.Series(np.random.uniform(size=5))
+    df.loc[3, 'Bar'] = 4   # nan not relevant for Valueerror for shape mismatch
     assert_raises(ValueError, sm.Poisson, df.Foo, df[['constant', 'Bar']],
                   exposure=exposure)
 

--- a/statsmodels/genmod/tests/test_glm.py
+++ b/statsmodels/genmod/tests/test_glm.py
@@ -859,6 +859,7 @@ def test_formula_missing_exposure():
     assert_(type(mod.exposure) is np.ndarray, msg='Exposure is not ndarray')
 
     exposure = pd.Series(np.random.uniform(size=5))
+    df.loc[3, 'Bar'] = 4   # nan not relevant for Valueerror for shape mismatch
     assert_raises(ValueError, smf.glm, "Foo ~ Bar", data=df,
                   exposure=exposure, family=family)
     assert_raises(ValueError, GLM, df.Foo, df[['constant', 'Bar']],


### PR DESCRIPTION
related to #3483 

this raises before we hit the linear algebra and might hang.

the check and raise is in has constant handling of the data. It can still be worked around or does not apply if the keyword is explicitly specified.

I want to merge this into master to see what is going on and prevent nans or infs that might be accidentally created in the internal code.
Will need review before next release, e.g. 
- should we make it in general code even if has_const is specified
- are there use cases where we don't want to raise? 
   We need to raise before we hit BLAS/LAPACK. But generic data handling might not be the right point, if we allow for imputation of missing values in exog in a model.

Note: this is more basic and cheaper than the `missing='raise'` keyword
- we use just ptp which is cheaper (and has been already computed at the current code)
- we only check exog, and not endog or other arrays.
