### PR TITLE
use loc/scale in ProbPlot if provided by the user

### DIFF
--- a/statsmodels/graphics/gofplots.py
+++ b/statsmodels/graphics/gofplots.py
@@ -143,7 +143,7 @@ class ProbPlot(object):
                                  **dict(loc = 0, scale = 1))
             else:
                 self.dist = dist(loc=0, scale=1)
-        elif distargs or loc == 0 or scale == 1:
+        elif distargs or loc != 0 or scale != 1:
             self.dist = dist(*distargs, **dict(loc=loc, scale=scale))
             self.loc = loc
             self.scale = scale

--- a/statsmodels/graphics/tests/test_gofplots.py
+++ b/statsmodels/graphics/tests/test_gofplots.py
@@ -1,5 +1,6 @@
 import numpy as np
 from numpy.testing import dec
+from nose.tools import assert_equal
 
 import statsmodels.api as sm
 from statsmodels.graphics.gofplots import qqplot, qqline, ProbPlot
@@ -143,6 +144,33 @@ class TestProbPlotRandomNormalLocScale(BaseProbplotMixin):
         self.prbplt = sm.ProbPlot(self.data, loc=8.25, scale=3.25)
         self.line = '45'
         self.base_setup()
+
+    def test_loc_set(self):
+        assert_equal(self.prbplt.loc, 8.25)
+
+    def test_scale_set(self):
+        assert_equal(self.prbplt.scale, 3.25)
+
+
+class TestProbPlotRandomNormalLocScaleDist(BaseProbplotMixin):
+    def setup(self):
+        np.random.seed(5)
+        self.data = np.random.normal(loc=8.25, scale=3.25, size=37)
+        self.prbplt = sm.ProbPlot(self.data, loc=8, scale=3)
+        self.line = '45'
+        self.base_setup()
+
+    def test_loc_set(self):
+        assert_equal(self.prbplt.loc, 8)
+
+    def test_scale_set(self):
+        assert_equal(self.prbplt.scale, 3)
+
+    def test_loc_set_in_dist(self):
+        assert_equal(self.prbplt.dist.mean(), 8.)
+
+    def test_scale_set_in_dist(self):
+        assert_equal(self.prbplt.dist.var(), 9.)
 
 
 class TestTopLevel(object):


### PR DESCRIPTION
This resolves most of the issue in #3254.
The code now allows to pass custom loc/scale parameters to the gofplots ProbPlot.

However, `self.fit_params` is still called even if `fit` is `False`, since it may be used in `ProbPlot.sample_quantiles`.