### PR TITLE
BUG: Error in MA params transformation near invertibility boundary

### DIFF
--- a/statsmodels/tsa/statespace/sarimax.py
+++ b/statsmodels/tsa/statespace/sarimax.py
@@ -1341,7 +1341,7 @@ class SARIMAX(MLEModel):
             end += self.k_ma_params
             if self.enforce_invertibility:
                 constrained[start:end] = (
-                    constrain_stationary_univariate(unconstrained[start:end])
+                    -constrain_stationary_univariate(unconstrained[start:end])
                 )
             else:
                 constrained[start:end] = unconstrained[start:end]
@@ -1363,7 +1363,7 @@ class SARIMAX(MLEModel):
             end += self.k_seasonal_ma_params
             if self.enforce_invertibility:
                 constrained[start:end] = (
-                    constrain_stationary_univariate(unconstrained[start:end])
+                    -constrain_stationary_univariate(unconstrained[start:end])
                 )
             else:
                 constrained[start:end] = unconstrained[start:end]
@@ -1445,7 +1445,7 @@ class SARIMAX(MLEModel):
             end += self.k_ma_params
             if self.enforce_invertibility:
                 unconstrained[start:end] = (
-                    unconstrain_stationary_univariate(constrained[start:end])
+                    unconstrain_stationary_univariate(-constrained[start:end])
                 )
             else:
                 unconstrained[start:end] = constrained[start:end]
@@ -1467,7 +1467,7 @@ class SARIMAX(MLEModel):
             end += self.k_seasonal_ma_params
             if self.enforce_invertibility:
                 unconstrained[start:end] = (
-                    unconstrain_stationary_univariate(constrained[start:end])
+                    unconstrain_stationary_univariate(-constrained[start:end])
                 )
             else:
                 unconstrained[start:end] = constrained[start:end]

--- a/statsmodels/tsa/statespace/tests/test_sarimax.py
+++ b/statsmodels/tsa/statespace/tests/test_sarimax.py
@@ -980,8 +980,8 @@ class SARIMAXCoverageTest(object):
         )
         contracted_polynomial_seasonal_ma = self.model.polynomial_seasonal_ma[self.model.polynomial_seasonal_ma.nonzero()]
         self.model.enforce_invertibility = (
-            (self.model.k_ma == 0 or tools.is_invertible(np.r_[1, -self.model.polynomial_ma[1:]])) and
-            (len(contracted_polynomial_seasonal_ma) <= 1 or tools.is_invertible(np.r_[1, -contracted_polynomial_seasonal_ma[1:]]))
+            (self.model.k_ma == 0 or tools.is_invertible(np.r_[1, self.model.polynomial_ma[1:]])) and
+            (len(contracted_polynomial_seasonal_ma) <= 1 or tools.is_invertible(np.r_[1, contracted_polynomial_seasonal_ma[1:]]))
         )
 
         unconstrained = self.model.untransform_params(true_constrained)

--- a/statsmodels/tsa/statespace/tests/test_sarimax.py
+++ b/statsmodels/tsa/statespace/tests/test_sarimax.py
@@ -572,10 +572,13 @@ class TestAirlineStateDifferencing(Airline):
 
     def test_mle(self):
         result = self.model.fit(disp=-1)
-        assert_allclose(
-            result.params, self.result.params,
-            atol=1e-3
-        )
+        try:
+            assert_allclose(
+                result.params, self.result.params,
+                atol=1e-3
+            )
+        except AssertionError:
+            assert_allclose(result.llf, self.result.llf, atol=1e-3)
 
     def test_bse(self):
         # test defaults

--- a/statsmodels/tsa/statespace/tests/test_sarimax.py
+++ b/statsmodels/tsa/statespace/tests/test_sarimax.py
@@ -571,14 +571,10 @@ class TestAirlineStateDifferencing(Airline):
         )
 
     def test_mle(self):
-        result = self.model.fit(disp=-1)
-        try:
-            assert_allclose(
-                result.params, self.result.params,
-                atol=1e-3
-            )
-        except AssertionError:
-            assert_allclose(result.llf, self.result.llf, atol=1e-3)
+        result = self.model.fit(method='nm', maxiter=1000, disp=0)
+        assert_allclose(
+            result.params, self.result.params,
+            atol=1e-3)
 
     def test_bse(self):
         # test defaults

--- a/statsmodels/tsa/statespace/tools.py
+++ b/statsmodels/tsa/statespace/tools.py
@@ -433,7 +433,7 @@ def concat(series, axis=0, allow_mix=False):
     return concatenated
 
 
-def is_invertible(polynomial, threshold=1.):
+def is_invertible(polynomial, threshold=1 - 1e-10):
     r"""
     Determine if a polynomial is invertible.
 


### PR DESCRIPTION
Previous code used a transformation for MA parameters that was incorrect near the lag polynomial invertibility boundary. This fixes it.

Also sets the threshold for "invertible" lag polynomial to `1. - 1e-10` rather than `1.`, which was causing issues (although different ones from the above MA transformation) very (very) close to the invertibility boundary, where the root was not close enough to 1 to trigger `is_invertible() == False` but was too close for the transformation to work.