### PR TITLE
TST: Add older scipy to Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,8 +7,12 @@ environment:
   matrix:
     - PY_MAJOR_VER: 2
       PYTHON_ARCH: "x86_64"
+    - PY_MAJOR_VER: 2
+      PYTHON_ARCH: "x86_64"
+      SCIPY: "0.14"
     - PY_MAJOR_VER: 3
       PYTHON_ARCH: "x86_64"
+
 
 platform:
     - x64
@@ -19,9 +23,8 @@ build_script:
   - SET PATH=C:\Py;C:\Py\Scripts;C:\Py\Library\bin;%PATH%
   - conda config --set always_yes yes
   - conda update conda --quiet
-  - conda install numpy scipy cython pandas pip nose patsy --quiet
+  - ps: If ($env:SCIPY) { conda install numpy scipy=$env:SCIPY cython pandas pip nose patsy --quiet } Else { conda install numpy scipy cython pandas pip nose patsy --quiet }
   - python setup.py develop
-  - set "GIT_DIR=%cd%"
 
 test_script:
   - cd ..


### PR DESCRIPTION
Add SciPy 0.14 to Appveyor to catch any Windows-specific issues