### PR TITLE
ENH: state space: more flexible return options in MLEModel.fit

### DIFF
--- a/statsmodels/tsa/statespace/mlemodel.py
+++ b/statsmodels/tsa/statespace/mlemodel.py
@@ -368,7 +368,8 @@ class MLEModel(tsbase.TimeSeriesModel):
             current parameter vector.
         return_params : boolean, optional
             Whether or not to return only the array of maximizing parameters.
-            Default is False.
+            Default is False. This argument is deprecated; you should use
+            `results='params'` instead.
         results : {'params', 'mlefit', 'filter', 'smooth'}
             The type of results to return. Default is 'smooth'.
         optim_score : {'harvey', 'approx'} or None, optional


### PR DESCRIPTION
Deprecates the `return_params` argument to `MLEModel.fit` and adds a new argument `results` which can be `params`, `mlefit`, `filter`, or `smooth`. Previously, it always returned smoothed results unless `return_params=True` in which is just returned a vector of parameters. Sometimes we may want a middle ground.