### PR TITLE
Fix a bunch of NameErrors by adding missing imports etc

### DIFF
--- a/statsmodels/tsa/arima_process.py
+++ b/statsmodels/tsa/arima_process.py
@@ -888,7 +888,7 @@ __all__ = ['arma_acf', 'arma_acovf', 'arma_generate_sample',
 
 if __name__ == '__main__':
 
-
+    from statsmodels.tsa.arima_model import ARIMA
     # Simulate AR(1)
     #--------------
     # ar * y = ma * eta

--- a/statsmodels/tsa/kalmanf/kalmanfilter.py
+++ b/statsmodels/tsa/kalmanf/kalmanfilter.py
@@ -29,6 +29,7 @@ from statsmodels.compat.python import lzip, lmap, callable, range
 import numpy as np
 from numpy import dot, identity, kron, log, zeros, pi, exp, eye, issubdtype, ones
 from numpy.linalg import inv, pinv
+from scipy import optimize
 from statsmodels.tools.tools import chain_dot
 from . import kalman_loglike
 
@@ -331,7 +332,7 @@ class StateSpaceModel(object):
         """
         # determine if
         if self.p == 1:
-            return _univariatefilter(init_state, init_var)
+            return self._univariatefilter(params, init_state, init_var)
         else:
             raise ValueError("No multivariate filter written yet")
 

--- a/statsmodels/tsa/vector_ar/irf.py
+++ b/statsmodels/tsa/vector_ar/irf.py
@@ -343,7 +343,7 @@ class IRAnalysis(BaseIRAnalysis):
 
         return lower, upper
 
-    def err_band_sz2(self, orth=False, repl=1000, signif=0.05,
+    def err_band_sz2(self, orth=False, svar=False, repl=1000, signif=0.05,
                      seed=None, burn=100, component=None):
         """
         IRF Sims-Zha error band method 2.
@@ -412,7 +412,7 @@ class IRAnalysis(BaseIRAnalysis):
 
         return lower, upper
 
-    def err_band_sz3(self, orth=False, repl=1000, signif=0.05,
+    def err_band_sz3(self, orth=False, svar=False, repl=1000, signif=0.05,
                      seed=None, burn=100, component=None):
         """
         IRF Sims-Zha error band method 3. Does not assume symmetric error bands around mean.

--- a/statsmodels/tsa/vector_ar/svar_model.py
+++ b/statsmodels/tsa/vector_ar/svar_model.py
@@ -708,7 +708,7 @@ class SVARResults(SVARProcess, VARResults):
                         mean_AB = np.mean(g_list, axis = 0)
                         split = len(A_pass[A_mask])
                         opt_A = mean_AB[:split]
-                        opt_A = mean_AB[split:]
+                        opt_B = mean_AB[split:]
                     ma_coll[i] = SVAR(sim, svar_type=s_type, A=A_pass,
                                  B=B_pass).fit(maxlags=k_ar,\
                                  A_guess=opt_A, B_guess=opt_B).\

--- a/statsmodels/tsa/vector_ar/tests/example_svar.py
+++ b/statsmodels/tsa/vector_ar/tests/example_svar.py
@@ -2,6 +2,8 @@ import numpy as np
 import statsmodels.api as sm
 import pandas as pd
 
+from statsmodels.tsa.vector_ar.svar_model import SVAR
+
 mdatagen = sm.datasets.macrodata.load().data
 mdata = mdatagen[['realgdp','realcons','realinv']]
 names = mdata.dtype.names

--- a/statsmodels/tsa/vector_ar/var_model.py
+++ b/statsmodels/tsa/vector_ar/var_model.py
@@ -339,6 +339,7 @@ class VAR(tsbase.TimeSeriesModel):
         """
         Returns in-sample predictions or forecasts
         """
+        k_ar = lags
         if start is None:
             start = k_ar
 
@@ -353,7 +354,6 @@ class VAR(tsbase.TimeSeriesModel):
 
         k_trend = util.get_trendorder(trend)
         k = self.neqs
-        k_ar = lags
 
         predictedvalues = np.zeros((end + 1 - start + out_of_sample, k))
         if k_trend != 0:


### PR DESCRIPTION
Ran:

flake8 --filename=./statsmodels/tsa/* | grep undefined

and went through to fix everything it turned up.  In most cases it was just a matter of a missing import.  In a couple there were method definitions missing keyword arguments that could be inferred by context.

The two cases most deserving double-checking are

1) tsa.kalmanf.StateSpaceModel.kalmanfilter --> Assumed that call to _univariatefilter was intended to be self._univariatefilter defined two methods earlier.
2) tsa.vector_ar.SVARResults.sirf_errband_mc --> Assumed that definition of opt_B should mirror the case 19 lines later.

One case left un-handled was calls to ARIMAProcess in tsa.arima_process.  Didn't want to guess what was intended there.

For now just looked at tsa/*, will do the same for other directories if this PR is OK.