### PR TITLE
Settings for coverage reports

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,6 +3,8 @@
 branch = False
 
 [report]
+show_missing = True
+
 # Regexes for lines to exclude from consideration
 exclude_lines =
     # Have to re-enable the standard pragma

--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,10 @@ marks.bzr
 .DS_Store
 help
 
+# Coverage report output
+.coverage
+coverage_html_report/
+
 # Project specific
 statsmodels/version.py
 cythonize.dat


### PR DESCRIPTION
Recent versions of coverage [require](http://stackoverflow.com/a/37746141/2957943) the show_missing setting to be made explicit.  Apparently it was accidentally the default for a while.

Added to .gitignore the coverage report information.