### PR TITLE
DOC: Add pandas-datareader to doc setup requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -550,7 +550,8 @@ if __name__ == "__main__":
                        'ipykernel',
                        'matplotlib',
                        'nbformat>=4.0.1',
-                       'numpydoc>=0.6.0']}
+                       'numpydoc>=0.6.0',
+                       'pandas-datareader']}
 
     setup(name = DISTNAME,
           version = VERSION,


### PR DESCRIPTION
Used in some of the statespace examples.

Closes https://github.com/statsmodels/statsmodels/issues/3517

[ci skip]