### PR TITLE
ENH: Add extra lines to summary HTML output

### DIFF
--- a/statsmodels/iolib/summary.py
+++ b/statsmodels/iolib/summary.py
@@ -874,7 +874,7 @@ class Summary(object):
 
         Parameters
         ----------
-        etext : string
+        etext : list[str]
             string with lines that are added to the text output.
 
         '''
@@ -909,7 +909,10 @@ class Summary(object):
         tables.
 
         '''
-        return summary_return(self.tables, return_fmt='latex')
+        latex = summary_return(self.tables, return_fmt='latex')
+        if not self.extra_txt is None:
+            latex = latex + '\n\n' + self.extra_txt.replace('\n', ' \\newline\n ')
+        return latex
 
     def as_csv(self):
         '''return tables as string
@@ -920,7 +923,10 @@ class Summary(object):
             concatenated summary tables in comma delimited format
 
         '''
-        return summary_return(self.tables, return_fmt='csv')
+        csv = summary_return(self.tables, return_fmt='csv')
+        if not self.extra_txt is None:
+            csv = csv + '\n\n' + self.extra_txt
+        return csv
 
     def as_html(self):
         '''return tables as string
@@ -931,7 +937,10 @@ class Summary(object):
             concatenated summary tables in HTML format
 
         '''
-        return summary_return(self.tables, return_fmt='html')
+        html = summary_return(self.tables, return_fmt='html')
+        if not self.extra_txt is None:
+            html = html + '<br/><br/>' + self.extra_txt.replace('\n', '<br/>')
+        return html
 
 
 if __name__ == "__main__":

--- a/statsmodels/regression/tests/test_regression.py
+++ b/statsmodels/regression/tests/test_regression.py
@@ -990,7 +990,12 @@ def test_summary():
 \\bottomrule
 \\end{tabular}
 %\\caption{OLS Regression Results}
-\\end{center}"""
+\\end{center}
+
+Warnings: \\newline
+ [1] Standard Errors assume that the covariance matrix of the errors is correctly specified. \\newline
+ [2] The condition number is large, 4.86e+09. This might indicate that there are \\newline
+ strong multicollinearity or other numerical problems."""
     assert_equal(table, expected)
 
 


### PR DESCRIPTION
Ensure extra text is written to html for use in IPython