### PR TITLE
Vectorize _score_obs_harvey and information_matrix

### DIFF
--- a/statsmodels/tsa/statespace/mlemodel.py
+++ b/statsmodels/tsa/statespace/mlemodel.py
@@ -875,27 +875,26 @@ class MLEModel(tsbase.TimeSeriesModel):
         # Compute the information matrix
         tmp = np.zeros((self.k_endog, self.k_endog, self.nobs, n), dtype=dtype)
 
+        ifecs = np.linalg.inv(res.forecasts_error_cov.T).T
         information_matrix = np.zeros((n, n), dtype=dtype)
         for t in range(self.ssm.loglikelihood_burn, self.nobs):
-            inv_forecasts_error_cov[:, :, t] = (
-                np.linalg.inv(res.forecasts_error_cov[:, :, t])
-            )
-            for i in range(n):
-                tmp[:, :, t, i] = np.dot(
-                    inv_forecasts_error_cov[:, :, t],
-                    partials_forecasts_error_cov[:, :, t, i]
+            ifec = ifecs[:, :, t]
+            # Equiv: ifec = np.linalg.inv(res.forecasts_error_cov[:, :, t])
+            pfet = partials_forecasts_error[:, t, :]
+
+            tmp  = np.tensordot(ifec,
+                partials_forecasts_error_cov[:, :, t, :],
+                axes=[[1], [0]]
                 )
-            for i in range(n):
-                for j in range(n):
-                    information_matrix[i, j] += (
-                        0.5 * np.trace(np.dot(tmp[:, :, t, i],
-                                              tmp[:, :, t, j]))
-                    )
-                    information_matrix[i, j] += np.inner(
-                        partials_forecasts_error[:, t, i],
-                        np.dot(inv_forecasts_error_cov[:, :, t],
-                               partials_forecasts_error[:, t, j])
-                    )
+            ijdot = np.tensordot(tmp, tmp, axes=[[1], [0]])
+            traced = np.trace(ijdot, axis1=0, axis2=2)
+                
+            pfidot = np.tensordot(ifec, pfet, axes=[[1], [0]])
+            inner = np.tensordot(pfet, pfidot, axes=[[0], [0]])
+            # inner[i, j] --> np.inner(pfet[:, i], np.dot(ifec, pfet[:, j]))
+                
+            information_matrix[:, :] += 0.5*traced + inner
+
         return information_matrix / (self.nobs - self.ssm.loglikelihood_burn)
 
     def opg_information_matrix(self, params, transformed=True,
@@ -996,27 +995,35 @@ class MLEModel(tsbase.TimeSeriesModel):
                 approx_complex_step=approx_complex_step,
                 approx_centered=approx_centered, res=res, **kwargs))
 
+        ifecs = np.linalg.inv(res.forecasts_error_cov.T).T
+        # Broadcast np.linalg.inv along 3rd dim
+        keye = np.eye(self.k_endog)
+
         # Compute partial derivatives w.r.t. likelihood function
         partials = np.zeros((self.nobs, n))
-        k_endog = self.k_endog
+        
         for t in range(self.nobs):
-            for i in range(n):
-                inv_forecasts_error_cov = np.linalg.inv(
-                    res.forecasts_error_cov[:, :, t])
-                partials[t, i] += np.trace(np.dot(
-                    np.dot(inv_forecasts_error_cov,
-                           partials_forecasts_error_cov[:, :, t, i]),
-                    (np.eye(k_endog) -
-                     np.dot(inv_forecasts_error_cov,
-                            np.outer(res.forecasts_error[:, t],
-                                     res.forecasts_error[:, t])))))
-                # 2 * dv / di * F^{-1} v_t
-                # where x = F^{-1} v_t or F x = v
-                partials[t, i] += 2 * np.dot(
-                    partials_forecasts_error[:, t, i],
-                    np.dot(inv_forecasts_error_cov, res.forecasts_error[:, t]))
+            ifec = ifecs[:, :, t]
+            # Equiv: ifec = np.linalg.inv(res.forecasts_error_cov[:, :, t])
+            pfet = partials_forecasts_error[:, t, :]
+            rfet = res.forecasts_error[:, t]
+            irdot = np.dot(ifec, rfet)
 
-        return -partials / 2.
+            rfet_outer = np.outer(rfet, rfet)
+            iro_outer = np.dot(ifec, rfet_outer)
+
+            tmp = np.tensordot(ifec,
+                partials_forecasts_error_cov[:, :, t, :],
+                axes=[[1], [0]]
+                )
+            ikdots = np.tensordot(tmp, keye - iro_outer, axes=[[1], [0]])
+            traced = np.trace(ikdots, axis1=0, axis2=2)
+
+            dotteds = np.tensordot(pfet, irdot, axes=[[0], [0]])
+
+            partials[t, :] += 0.5 * traced + dotteds
+
+        return -partials
 
     _score_param_names = ['transformed', 'score_method',
                           'approx_complex_step', 'approx_centered']


### PR DESCRIPTION
Replaced for-loops with vectorized versions of _score_obs_harvey and information_matrix methods in mle_model.py.

Included a test to check the equivalence of the versions.

Timing results from the test case:

```
>>> timeit.timeit(information_matrix_loop, number=100) # original version
7.3974268436431885
>>> timeit.timeit(information_matrix_tensor, number=100) # new version
1.0604560375213623

>>> timeit.timeit(_score_obs_harvey_loop, number=100)
4.597056865692139
>>> tvec = timeit.timeit(_score_obs_harvey_tensor, number=100)
1.1562490463256836
```

Figured I'd do something useful in between bugging you with questions/issues.