### PR TITLE
WIP ENH: stats._random.py add simulate conditional contingency tables

### DIFF
--- a/statsmodels/stats/_random.py
+++ b/statsmodels/stats/_random.py
@@ -1,0 +1,149 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Thu Mar 16 11:40:25 2017
+
+Author: Josef Perktold
+
+"""
+from __future__ import division
+
+import numpy as np
+from scipy.special import gammaln
+
+
+def _logfactsum(x, axis=None):
+    """compute sum of log factorial of array x
+
+    This is just a convenience function using scipy.special.gammaln
+    """
+    x = np.atleast_1d(x)
+    return gammaln(x + 1).sum(axis)
+
+
+def simulate_table_permutation_gen(n_row, n_col):
+    """generator for random contingency table by permutation
+
+    This is a generator, that yields the next random table.
+    The contingency table is generated under the assumption of independence
+    with fixed margins.
+
+    Parameters
+    ----------
+    n_row : array_like, int
+        row margin, count of observations for each row
+    n_row : array_like, int
+        row margin, count of observations for each row
+
+    Returns
+    -------
+    gen : generator
+        The generator is of infinite length, use `next(gen)` to obtain
+        the next random contingency table with given row and column margins
+
+    Notes
+    -----
+    This implements a simple permutation and np.bincount. Time will largely
+    depend on the number of observations and less on the number of cells.
+    This could be extended to more than two dimensional contingency tables.
+
+    """
+    n_row = np.asarray(n_row, np.int64)
+    n_col = np.asarray(n_col, np.int64)
+    k_rows = len(n_row)
+    k_cols = len(n_col)
+
+    g1 = np.repeat(np.arange(k_rows), n_row)
+    g2 = np.repeat(np.arange(k_cols), n_col)
+    while True:
+        np.random.shuffle(g2)
+        table = np.bincount(g1 * k_cols + g2, minlength=k_rows * k_cols
+                            ).reshape(k_rows, k_cols)
+        yield table
+
+
+def simulate_table_conditional(n_row, n_col):
+    """simulate a contingency table with given margins
+
+    This implementation cannot be vectorized and is not a very
+    fast algorithm
+
+    Parameters
+    ----------
+    n_row : array_like, int
+        row margin, count of observations for each row
+    n_row : array_like, int
+        row margin, count of observations for each row
+
+    Returns
+    -------
+    table : ndarray, 2-D
+        random contingency table with given row and column margins
+
+    Notes
+    -----
+    This implements the algorithm in Boyett 1979 using searchsorted and
+    bincount.
+
+    Boyett 1979
+    """
+    n_row = np.asarray(n_row, np.int64)
+    n_col = np.asarray(n_col, np.int64)
+    transpose = False
+    if len(n_row) > len(n_col):
+        # swap to loop over shorter dimension
+        n_row, n_col = n_col, n_row
+        transpose = True
+    k_rows = len(n_row)
+    k_cols = len(n_col)
+    nobs = sum(n_row)
+    assert nobs == sum(n_col)
+
+    colcumsum = np.cumsum(np.concatenate(([0], n_col)))
+    rowcumsum = np.cumsum(np.concatenate(([0], n_row)))
+
+    x = np.arange(1, nobs + 1, dtype=np.int64)
+    np.random.shuffle(x)
+    rvs_table = np.zeros((k_rows, k_cols), dtype=np.int64)
+    for i_row in range(k_rows):
+        row_int = x[rowcumsum[i_row]:rowcumsum[i_row+1]]
+        # process one group/row
+        # this should be same as histogram, for int
+        ix = np.searchsorted(colcumsum, row_int)
+        x_row = np.bincount(ix, minlength=k_cols+1)
+        rvs_table[i_row] = x_row[1:]
+
+    if transpose:
+        rvs_table = rvs_table.T
+    return rvs_table
+
+
+def p_table(table):
+    """conditional probability of a contingency table under independence
+
+    The probability of table i
+
+    Parameters
+    ----------
+    table : array_like, 2-D
+        contingency table with counts in each cell
+
+    Returns
+    -------
+    prob : float
+        probability that table is
+
+    Notes
+    -----
+    This could be extended to more than two dimensional contingency tables.
+
+
+    """
+    table = np.asarray(table)
+    if table.ndim != 2:
+        raise ValueError('table needs to be 2 dimensional')
+    n_row = table.sum(1)
+    n_col = table.sum(0)
+    nobs = n_col.sum()
+    prob = np.exp(_logfactsum(n_row) + _logfactsum(n_col) -
+                  _logfactsum(nobs) - _logfactsum(table))
+    return prob

--- a/statsmodels/stats/tests/test_random.py
+++ b/statsmodels/stats/tests/test_random.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Thu Mar 16 11:40:25 2017
+
+Author: Josef Perktold
+
+"""
+from __future__ import division
+
+import numpy as np
+from numpy.testing import assert_allclose
+from statsmodels.stats._random import (p_table, simulate_table_permutation_gen,
+                                       simulate_table_conditional)
+
+def check_table_distribution(res_mc):
+    k_rows, k_cols = res_mc[0].shape
+    res_mc2 = res_mc.reshape(res_mc.shape[0], -1)
+    uni = set(tuple(i) for i in res_mc2)
+    uniques = np.asarray(list(uni))
+    for u in uniques:
+        prob = p_table(u.reshape(k_rows, k_cols))
+        freq = (res_mc2 == u).all(1).mean()
+
+    return prob, freq
+
+
+class CheckRandomTable(object):
+
+    def test_random(self):
+        n_repl = 1000
+        np.random.seed(987126)
+        res_mc = [simulate_table_conditional(self.n_row, self.n_col) for i in range(n_repl)]
+        res_mc = np.asarray(res_mc)
+        prob, freq = check_table_distribution(res_mc)
+        # maybe need tol based on standard deviation of proportion
+        assert_allclose(freq, prob, rtol=0.5)
+
+
+    def test_random_gen(self):
+        n_repl = 1000
+        np.random.seed(987126)
+        it = simulate_table_permutation_gen(self.n_row, self.n_col)
+        res_mc = [next(it) for _ in range(n_repl)]
+        res_mc = np.asarray(res_mc)
+        prob, freq = check_table_distribution(res_mc)
+        # maybe need tol based on standard deviation of proportion
+        assert_allclose(freq, prob, rtol=0.5)
+
+
+class TestRandomTable1(CheckRandomTable):
+
+    @classmethod
+    def setup_class(cls):
+        cls.n_row = [2, 4, 1]
+        cls.n_col = [4, 1, 2]
+
+
+class TestRandomTable2(CheckRandomTable):
+
+    @classmethod
+    def setup_class(cls):
+        cls.n_row = [2, 4, 1]
+        cls.n_col = [4, 1, 2]


### PR DESCRIPTION
see #3557  (see also #3571 for similar idea for GLM in regression setting)

a brief exercise in simulating 2-dim contingency tables with fixed margins under independence.

related #2932 for Monte Carlo p-values for unconditional multinomial sampling 
see #2936 for general sampling space assumptions in contingency tables, rates and proportions.

This turned out to be just a permutation structure, first version is based on Boyett, but then I added just plain permutation case.
Permutation needs the nobs arrays, but loops for one random sample are in numpython (i.e. in C, with shuffle and bincount.) Neither shuffle nor bincount can be vectorized, so we need a loop over samples in a Monte Carlo run. One function uses a generator to yield and infinite sequence of random tables.

In contrast Patefield loops over cells and computes a random count variable in each cell. That algorithm is faster for large nobs and not very large number of cells. However, the count distribution (conditional on left over items) is more difficult to compute, and I didn't figure out the shortcut that Patefield uses, which starts at the expected cell count and then loops to increase or decrease. This extra loop wouldn't be fast in python without some vectorization.

There is no application for this yet. The target would be Kim, Agresti 1997 and similar see #3557

