### PR TITLE
COMPAT/CI: remove Widepanel and pandas dev

### DIFF
--- a/statsmodels/compat/pandas.py
+++ b/statsmodels/compat/pandas.py
@@ -13,7 +13,8 @@ if version >= LooseVersion('0.17.0'):
         return df.sort_values(*args, **kwargs)
 else:
     def sort_values(df, *args, **kwargs):
-        kwargs.setdefault('inplace', False)  # always set inplace with 'False' as default
+        # always set inplace with 'False' as default
+        kwargs.setdefault('inplace', False)
         return df.sort(*args, **kwargs)
 
 try:
@@ -45,8 +46,12 @@ except ImportError:
 
 if version >= '0.20':
     from pandas.tseries import frequencies
+    data_klasses = (pandas.Series, pandas.DataFrame, pandas.Panel)
 else:
     try:
         import pandas.tseries.frequencies as frequencies
     except ImportError:
-        from pandas.core import datetools as frequencies
+        from pandas.core import datetools as frequencies  # noqa
+
+    data_klasses = (pandas.Series, pandas.DataFrame, pandas.Panel,
+                    pandas.WidePanel)

--- a/statsmodels/tools/data.py
+++ b/statsmodels/tools/data.py
@@ -97,8 +97,7 @@ def _is_using_ndarray(endog, exog):
 
 
 def _is_using_pandas(endog, exog):
-    # TODO: Remove WidePanel when finished with it
-    klasses = (pd.Series, pd.DataFrame, pd.WidePanel, pd.Panel)
+    from statsmodels.compat.pandas import data_klasses as klasses
     return (isinstance(endog, klasses) or isinstance(exog, klasses))
 
 


### PR DESCRIPTION
There are a couple stray WidePanel uses in sandbox, but I wasn't able to run those anyway since my matplotlib is too new

```bash
statsmodels/compat/pandas.py:34:    data_klasses = (pandas.Series, pandas.DataFrame, pandas.WidePanel,
statsmodels/sandbox/examples/thirdparty/findow_0.py:11:uses DataFrame and WidePanel to hold data downloaded from yahoo using matplotlib.
statsmodels/sandbox/examples/thirdparty/findow_0.py:57:# combine into WidePanel
statsmodels/sandbox/examples/thirdparty/findow_0.py:58:pawp = pa.WidePanel.fromDict(dmall)
statsmodels/sandbox/examples/thirdparty/findow_1.py:11:uses DataFrame and WidePanel to hold data downloaded from yahoo using matplotlib.
statsmodels/sandbox/examples/thirdparty/findow_1.py:61:# combine into WidePanel
statsmodels/sandbox/examples/thirdparty/findow_1.py:62:pawp = pa.WidePanel.fromDict(dmall)
```

I've also changed the CI run using pandas 0.14 to instead use pandas' [daily wheels](https://mail.google.com/mail/u/1/#search/daily+wheels/15af30f4fb754e5e) so that we can catch these ahead of time.

Closes statsmodels#3580