### PR TITLE
Re-enable LazyDicts in predict

### DIFF
--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -165,7 +165,7 @@ class Model(object):
                         cols.remove(col)
                     except ValueError:
                         pass  # OK if not present
-                design_info = design_info.builder.subset(cols).design_info
+                design_info = design_info.subset(cols).design_info
 
         kwargs.update({'missing_idx': missing_idx,
                        'missing': missing,
@@ -797,14 +797,16 @@ class Results(object):
         """
         import pandas as pd
 
-        exog_index = exog.index if _is_using_pandas(exog, None) else None
+        is_pandas = _is_using_pandas(exog, None)
+
+        exog_index = exog.index if is_pandas else None
 
         if transform and hasattr(self.model, 'formula') and (exog is not None):
             from patsy import dmatrix
             if isinstance(exog, pd.Series):
                 exog = pd.DataFrame(exog)
             orig_exog_len = len(exog)
-            exog = dmatrix(self.model.data.design_info.builder,
+            exog = dmatrix(self.model.data.design_info,
                            exog, return_type="dataframe")
             if orig_exog_len > len(exog):
                 import warnings

--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -801,10 +801,8 @@ class Results(object):
 
         if transform and hasattr(self.model, 'formula') and (exog is not None):
             from patsy import dmatrix
-            if hasattr(exog, 'ndim') and exog.ndim == 1:
-                # user may pass series, if one predictor
+            if isinstance(exog, pd.Series):
                 exog = pd.DataFrame(exog)
-            exog_index = getattr(exog, 'index', None)
             exog = dmatrix(self.model.data.design_info.builder,
                            exog, return_type="dataframe")
             if (exog_index is not None) and (len(exog) < len(exog_index)):
@@ -819,9 +817,11 @@ class Results(object):
                 exog = exog[:, None]
             exog = np.atleast_2d(exog)  # needed in count model shape[1]
 
-        predict_results = self.model.predict(self.params, exog, *args, **kwargs)
+        predict_results = self.model.predict(self.params, exog, *args,
+                                             **kwargs)
 
-        if exog_index is not None and not hasattr(predict_results, 'predicted_values'):
+        if exog_index is not None and not hasattr(predict_results,
+                                                  'predicted_values'):
             if predict_results.ndim == 1:
                 return pd.Series(predict_results, index=exog_index)
             else:

--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -806,15 +806,12 @@ class Results(object):
             orig_exog_len = len(exog)
             exog = dmatrix(self.model.data.design_info.builder,
                            exog, return_type="dataframe")
-            if (exog_index is None) and (orig_exog_len > len(exog)):
+            if orig_exog_len > len(exog):
                 import warnings
-                warnings.warn('nan values have been dropped', ValueWarning)
-            if (exog_index is not None) and (len(exog) < len(exog_index)):
-                # missing values, rows have been dropped
-                import warnings
-                exog = exog.reindex(exog_index)
-                warnings.warn('nan values have been preserved and reindex',
-                              ValueWarning)
+                if exog_index is None:
+                    warnings.warn('nan values have been dropped', ValueWarning)
+                else:
+                    exog = exog.reindex(exog_index)
             exog_index = exog.index
 
         if exog is not None:

--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -803,11 +803,18 @@ class Results(object):
             from patsy import dmatrix
             if isinstance(exog, pd.Series):
                 exog = pd.DataFrame(exog)
+            orig_exog_len = len(exog)
             exog = dmatrix(self.model.data.design_info.builder,
                            exog, return_type="dataframe")
+            if (exog_index is None) and (orig_exog_len > len(exog)):
+                import warnings
+                warnings.warn('nan values have been dropped', ValueWarning)
             if (exog_index is not None) and (len(exog) < len(exog_index)):
                 # missing values, rows have been dropped
+                import warnings
                 exog = exog.reindex(exog_index)
+                warnings.warn('nan values have been preserved and reindex',
+                              ValueWarning)
             exog_index = exog.index
 
         if exog is not None:

--- a/statsmodels/formula/tests/test_formula.py
+++ b/statsmodels/formula/tests/test_formula.py
@@ -154,17 +154,17 @@ def test_patsy_missing_data():
     data = cpunish.load_pandas().data
     data['INCOME'].loc[0] = None
     res = ols('EXECUTIONS ~ SOUTH + INCOME', data=data).fit()
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter("always")
-        res2 = res.predict(data)
-        assert len(w) > 0
-    assert_equal(res.fittedvalues, res2[1:])  # First record will be dropped
+    res2 = res.predict(data)
+    # First record will be dropped during fit, but not during predict
+    assert_equal(res.fittedvalues, res2[1:])
 
     # Non-pandas version
     data = cpunish.load_pandas().data
     data['INCOME'].loc[0] = None
     data = data.to_records(index=False)
-
-    res = ols('EXECUTIONS ~ SOUTH + INCOME', data=data).fit()
-    res2 = res.predict(data)
-    assert_equal(res.fittedvalues, res2)  # No records wiill be dropped
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        res2 = res.predict(data)
+        assert_equal(len(w), 1)
+    # Frist record will be dropped in both cases
+    assert_equal(res.fittedvalues, res2)

--- a/statsmodels/formula/tests/test_formula.py
+++ b/statsmodels/formula/tests/test_formula.py
@@ -166,8 +166,5 @@ def test_patsy_missing_data():
     data = data.to_records(index=False)
 
     res = ols('EXECUTIONS ~ SOUTH + INCOME', data=data).fit()
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter("always")
-        res2 = res.predict(data)
-        assert len(w) > 0
+    res2 = res.predict(data)
     assert_equal(res.fittedvalues, res2)  # No records wiill be dropped

--- a/statsmodels/formula/tests/test_formula.py
+++ b/statsmodels/formula/tests/test_formula.py
@@ -147,13 +147,4 @@ def test_patsy_lazy_dict():
     res = smf.ols('EXECUTIONS ~ SOUTH + INCOME', data=data).fit()
 
     res2 = res.predict(data)
-    assert_equal(len(res.fittedvalues) + 1, len(res2))  # Should lose a record
-
-    data = sm.datasets.cpunish.load_pandas().data
-    data['INCOME'].loc[0] = None
-
-    data = LazyDict(data)
-    res = smf.ols('EXECUTIONS ~ SOUTH + INCOME', data=data).fit()
-
-    res2 = res.predict(data)
-    npt.assert_allclose(res.fittedvalues, res2)
+    assert_equal(len(res.fittedvalues), len(res2))  # Should lose a record


### PR DESCRIPTION
Hello,

I wrote  a quick PR here to close #3609.

I think this keeps all the current functionality, but allows `predict` to use the "lazy" dict concept 

Happy to hear comments. 

I've also removed a few lines from the `predict` method that, as far as I could tell, was unreachable. So that explains why the `warning` bit goes away. 