### PR TITLE
Implement smoke-tests for IRF errbands

### DIFF
--- a/statsmodels/tsa/vector_ar/irf.py
+++ b/statsmodels/tsa/vector_ar/irf.py
@@ -344,7 +344,7 @@ class IRAnalysis(BaseIRAnalysis):
         return lower, upper
 
     def err_band_sz2(self, orth=False, repl=1000, signif=0.05,
-                     seed=None, burn=100, component=None):
+                     seed=None, burn=100, component=None, svar=False):
         """
         IRF Sims-Zha error band method 2.
 
@@ -413,7 +413,7 @@ class IRAnalysis(BaseIRAnalysis):
         return lower, upper
 
     def err_band_sz3(self, orth=False, repl=1000, signif=0.05,
-                     seed=None, burn=100, component=None):
+                     seed=None, burn=100, component=None, svar=False):
         """
         IRF Sims-Zha error band method 3. Does not assume symmetric error bands around mean.
 

--- a/statsmodels/tsa/vector_ar/irf.py
+++ b/statsmodels/tsa/vector_ar/irf.py
@@ -337,8 +337,9 @@ class IRAnalysis(BaseIRAnalysis):
         upper = np.copy(irfs)
         for i in range(neqs):
             for j in range(neqs):
-                lower[1:,i,j] = irfs[1:,i,j] + W[i,j,:,k[i,j]]*q*np.sqrt(eigva[i,j,k[i,j]])
-                upper[1:,i,j] = irfs[1:,i,j] - W[i,j,:,k[i,j]]*q*np.sqrt(eigva[i,j,k[i,j]])
+                kij = int(k[i, j])
+                lower[1:, i, j] = irfs[1:, i, j] + W[i, j, :, kij]*q*np.sqrt(eigva[i, j, kij])
+                upper[1:, i, j] = irfs[1:, i, j] - W[i, j, :, kij]*q*np.sqrt(eigva[i, j, kij])
 
 
         return lower, upper
@@ -398,17 +399,18 @@ class IRAnalysis(BaseIRAnalysis):
         for p in range(repl):
             for i in range(neqs):
                 for j in range(neqs):
-                    gamma[p,1:,i,j] = W[i,j,k[i,j],:] * irf_resim[p,1:,i,j]
+                    kij = int(k[i, j])
+                    gamma[p, 1:, i, j] = W[i, j, kij, :] * irf_resim[p, 1:, i, j]
 
         gamma_sort = np.sort(gamma, axis=0) #sort to get quantiles
-        indx = round(signif/2*repl)-1,round((1-signif/2)*repl)-1
+        indx = (int(round(signif/2*repl))-1, int(round((1-signif/2)*repl))-1)
 
         lower = np.copy(irfs)
         upper = np.copy(irfs)
         for i in range(neqs):
             for j in range(neqs):
-                lower[:,i,j] = irfs[:,i,j] + gamma_sort[indx[0],:,i,j]
-                upper[:,i,j] = irfs[:,i,j] + gamma_sort[indx[1],:,i,j]
+                lower[:, i, j] = irfs[:, i, j] + gamma_sort[indx[0], :, i, j]
+                upper[:, i, j] = irfs[:, i, j] + gamma_sort[indx[1], :, i, j]
 
         return lower, upper
 
@@ -475,26 +477,27 @@ class IRAnalysis(BaseIRAnalysis):
         #compute for eigen decomp for each stack
         for i in range(neqs):
             stack_cov[i] = np.cov(stack[i],rowvar=0)
-            W[i], eigva[i], k[i] = util.eigval_decomp(stack_cov[i])
+            (W[i], eigva[i], k[i]) = util.eigval_decomp(stack_cov[i])
 
         gamma = np.zeros((repl, periods+1, neqs, neqs))
         for p in range(repl):
-            c=0
+            c = 0
             for j in range(neqs):
                 for i in range(neqs):
-                        gamma[p,1:,i,j] = W[j,k[j],i*periods:(i+1)*periods] * irf_resim[p,1:,i,j]
-                        if i == neqs-1:
-                            gamma[p,1:,i,j] = W[j,k[j],i*periods:] * irf_resim[p,1:,i,j]
+                    kj = int(k[j])
+                    gamma[p, 1:, i, j] = W[j, kj, i*periods:(i+1)*periods] * irf_resim[p, 1:, i, j]
+                    if i == neqs-1:
+                        gamma[p, 1:, i, j] = W[j, kj, i*periods:] * irf_resim[p, 1:, i, j]
 
         gamma_sort = np.sort(gamma, axis=0) #sort to get quantiles
-        indx = round(signif/2*repl)-1,round((1-signif/2)*repl)-1
+        indx = (int(round(signif/2*repl))-1, int(round((1-signif/2)*repl))-1)
 
         lower = np.copy(irfs)
         upper = np.copy(irfs)
         for i in range(neqs):
             for j in range(neqs):
-                lower[:,i,j] = irfs[:,i,j] + gamma_sort[indx[0],:,i,j]
-                upper[:,i,j] = irfs[:,i,j] + gamma_sort[indx[1],:,i,j]
+                lower[:, i, j] = irfs[:, i, j] + gamma_sort[indx[0], :, i, j]
+                upper[:, i, j] = irfs[:, i, j] + gamma_sort[indx[1], :, i, j]
 
         return lower, upper
 
@@ -513,7 +516,7 @@ class IRAnalysis(BaseIRAnalysis):
         cov_hold = np.zeros((neqs, neqs, periods, periods))
         for i in range(neqs):
             for j in range(neqs):
-                cov_hold[i,j,:,:] = np.cov(irf_resim[:,1:,i,j],rowvar=0)
+                cov_hold[i, j, :, :] = np.cov(irf_resim[:, 1:, i, j],rowvar=0)
 
         W = np.zeros((neqs, neqs, periods, periods))
         eigva = np.zeros((neqs, neqs, periods, 1))
@@ -521,7 +524,7 @@ class IRAnalysis(BaseIRAnalysis):
 
         for i in range(neqs):
             for j in range(neqs):
-                W[i,j,:,:], eigva[i,j,:,0], k[i,j] = util.eigval_decomp(cov_hold[i,j,:,:])
+                (W[i, j, :, :], eigva[i, j, :, 0], k[i, j]) = util.eigval_decomp(cov_hold[i, j, :, :])
         return W, eigva, k
 
     @cache_readonly

--- a/statsmodels/tsa/vector_ar/irf.py
+++ b/statsmodels/tsa/vector_ar/irf.py
@@ -280,6 +280,7 @@ class IRAnalysis(BaseIRAnalysis):
             return model.irf_errband_mc(orth=orth, repl=repl, T=periods,
                                         signif=signif, seed=seed,
                                         burn=burn, cum=False)
+    
     def err_band_sz1(self, orth=False, svar=False, repl=1000,
                      signif=0.05, seed=None, burn=100, component=None):
         """

--- a/statsmodels/tsa/vector_ar/svar_model.py
+++ b/statsmodels/tsa/vector_ar/svar_model.py
@@ -66,7 +66,8 @@ class SVAR(tsbase.TimeSeriesModel):
         self.neqs = self.endog.shape[1]
 
         types = ['A', 'B', 'AB']
-        if str(svar_type) not in types:
+        svar_type = str(svar_type)
+        if svar_type not in types:
             raise ValueError('SVAR type not recognized, must be in '
                              + str(types))
         self.svar_type = svar_type

--- a/statsmodels/tsa/vector_ar/svar_model.py
+++ b/statsmodels/tsa/vector_ar/svar_model.py
@@ -80,12 +80,14 @@ class SVAR(tsbase.TimeSeriesModel):
             A = np.identity(self.neqs)
             self.A_mask = A_mask = np.zeros(A.shape, dtype=bool)
         else:
+            A = A.astype(bytes)
             A_mask = np.logical_or(A == b'E', A == b'e')
             self.A_mask = A_mask
         if B is None:
             B = np.identity(self.neqs)
             self.B_mask = B_mask = np.zeros(B.shape, dtype=bool)
         else:
+            B = B.astype(bytes)
             B_mask = np.logical_or(B == b'E', B == b'e')
             self.B_mask = B_mask
 

--- a/statsmodels/tsa/vector_ar/svar_model.py
+++ b/statsmodels/tsa/vector_ar/svar_model.py
@@ -66,7 +66,7 @@ class SVAR(tsbase.TimeSeriesModel):
         self.neqs = self.endog.shape[1]
 
         types = ['A', 'B', 'AB']
-        if svar_type not in types:
+        if str(svar_type) not in types:
             raise ValueError('SVAR type not recognized, must be in '
                              + str(types))
         self.svar_type = svar_type
@@ -79,13 +79,13 @@ class SVAR(tsbase.TimeSeriesModel):
             A = np.identity(self.neqs)
             self.A_mask = A_mask = np.zeros(A.shape, dtype=bool)
         else:
-            A_mask = np.logical_or(A == 'E', A == 'e')
+            A_mask = np.logical_or(A == b'E', A == b'e')
             self.A_mask = A_mask
         if B is None:
             B = np.identity(self.neqs)
             self.B_mask = B_mask = np.zeros(B.shape, dtype=bool)
         else:
-            B_mask = np.logical_or(B == 'E', B == 'e')
+            B_mask = np.logical_or(B == b'E', B == b'e')
             self.B_mask = B_mask
 
         # convert A and B to numeric
@@ -678,8 +678,8 @@ class SVARResults(SVARProcess, VARResults):
         B_pass = np.zeros(B.shape, dtype='|S1')
         A_pass[~A_mask] = A[~A_mask]
         B_pass[~B_mask] = B[~B_mask]
-        A_pass[A_mask] = 'E'
-        B_pass[B_mask] = 'E'
+        A_pass[A_mask] = b'E'
+        B_pass[B_mask] = b'E' # TODO: Careful about other places with bytes/unicode comparison
         if A_mask.sum() == 0:
             s_type = 'B'
         elif B_mask.sum() == 0:

--- a/statsmodels/tsa/vector_ar/svar_model.py
+++ b/statsmodels/tsa/vector_ar/svar_model.py
@@ -734,8 +734,8 @@ class SVARResults(SVARProcess, VARResults):
                                  svar_ma_rep(maxn=T)
 
         ma_sort = np.sort(ma_coll, axis=0) #sort to get quantiles
-        index = round(signif/2*repl)-1,round((1-signif/2)*repl)-1
-        lower = ma_sort[index[0],:, :, :]
-        upper = ma_sort[index[1],:, :, :]
+        index = (int(round(signif/2*repl))-1, int(round((1-signif/2)*repl))-1)
+        lower = ma_sort[index[0], :, :, :]
+        upper = ma_sort[index[1], :, :, :]
         return lower, upper
 

--- a/statsmodels/tsa/vector_ar/tests/test_svar.py
+++ b/statsmodels/tsa/vector_ar/tests/test_svar.py
@@ -61,3 +61,13 @@ class TestSVAR(object):
         assert_allclose(res1.aic - corr_const, res2.aic_var, atol=1e-12)
         assert_allclose(res1.bic - corr_const, res2.sbic_var, atol=1e-12)
         assert_allclose(res1.hqic - corr_const, res2.hqic_var, atol=1e-12)
+
+
+    def test_irf(self):
+        # Note: this is a smoketest
+        _ = self.res1.irf()
+
+    def test_sirf_errband_mc(self):
+        # Note: this is a smoketest
+        _ = self.res1.sirf_errband_mc()
+

--- a/statsmodels/tsa/vector_ar/tests/test_var.py
+++ b/statsmodels/tsa/vector_ar/tests/test_var.py
@@ -375,6 +375,31 @@ class TestVARResults(CheckIRF, CheckFEVD):
         irf = self.irf
         err_band_sz3 = irf.err_band_sz3()
 
+    def test_cum_errband_mc(self): # TODO: Check Correctness, these are just smoke tests
+        irf = self.irf
+        cemc = irf.cum_errband_mc()
+
+    def test_irf_plots(self): # TODO: Check Correctness, these are just smoke tests
+        irf = self.irf
+
+        for stderr_type in ['asym', 'mc', 'sz1', 'sz2', 'sz3']:
+            _ = irf.plot(stderr_type=stderr_type)
+
+    # In this branch, VARResults has no predict method
+    #def test_predict(self):  # TODO: Check Correctness, these are just smoke tests
+    #    res = self.res
+    #    pred = res.predict(res.params) # TODO: Check that these match fittedvalues?
+
+    def test_plot_sample_acorr(self):  # TODO: Check Correctness, these are just smoke tests
+        res = self.res
+        _ = res.plot_sample_acorr()
+
+    def test_normality(self): # TODO: Check Correctness, these are just smoke tests
+        # smoke test
+        res = self.res
+        norm = res.test_normality()
+
+
     def test_causality(self):
         causedby = self.ref.causality['causedby']
 

--- a/statsmodels/tsa/vector_ar/tests/test_var.py
+++ b/statsmodels/tsa/vector_ar/tests/test_var.py
@@ -380,8 +380,10 @@ class TestVARResults(CheckIRF, CheckFEVD):
         cemc = irf.cum_errband_mc()
 
     def test_irf_plots(self): # TODO: Check Correctness, these are just smoke tests
-        irf = self.irf
+        if not have_matplotlib():
+            raise nose.SkipTest
 
+        irf = self.irf
         for stderr_type in ['asym', 'mc', 'sz1', 'sz2', 'sz3']:
             _ = irf.plot(stderr_type=stderr_type)
 
@@ -391,6 +393,9 @@ class TestVARResults(CheckIRF, CheckFEVD):
     #    pred = res.predict(res.params) # TODO: Check that these match fittedvalues?
 
     def test_plot_sample_acorr(self):  # TODO: Check Correctness, these are just smoke tests
+        if not have_matplotlib():
+            raise nose.SkipTest
+        
         res = self.res
         _ = res.plot_sample_acorr()
 

--- a/statsmodels/tsa/vector_ar/tests/test_var.py
+++ b/statsmodels/tsa/vector_ar/tests/test_var.py
@@ -355,6 +355,26 @@ class TestVARResults(CheckIRF, CheckFEVD):
     #--------------------------------------------------
     # Lots of tests to make sure stuff works...need to check correctness
 
+    def test_errband_mc(self): # TODO: Check Correctness, these are just smoke tests
+        res = self.res
+        irf = self.irf
+        errband_mc = irf.errband_mc()
+
+    def test_sz1(self): # TODO: Check Correctness, these are just smoke tests
+        res = self.res
+        irf = self.irf
+        err_band_sz1 = irf.err_band_sz1()
+    
+    def test_sz2(self): # TODO: Check Correctness, these are just smoke tests
+        res = self.res
+        irf = self.irf
+        err_band_sz2 = irf.err_band_sz2()
+
+    def test_sz3(self): # TODO: Check Correctness, these are just smoke tests
+        res = self.res
+        irf = self.irf
+        err_band_sz3 = irf.err_band_sz3()
+
     def test_causality(self):
         causedby = self.ref.causality['causedby']
 

--- a/statsmodels/tsa/vector_ar/var_model.py
+++ b/statsmodels/tsa/vector_ar/var_model.py
@@ -1107,12 +1107,12 @@ class VARResults(VARProcess):
             sim = util.varsim(coefs, intercept, sigma_u,
                               seed=seed, steps=nobs+burn)
             sim = sim[burn:]
-            ma_coll[i,:,:,:] = fill_coll(sim)
+            ma_coll[i, :, :, :] = fill_coll(sim)
 
-        ma_sort = np.sort(ma_coll, axis=0) #sort to get quantiles
-        index = round(signif/2*repl)-1,round((1-signif/2)*repl)-1
-        lower = ma_sort[index[0],:, :, :]
-        upper = ma_sort[index[1],:, :, :]
+        ma_sort = np.sort(ma_coll, axis=0) # sort to get quantiles
+        index = (int(round(signif/2*repl))-1, int(round((1-signif/2)*repl))-1)
+        lower = ma_sort[index[0], :, :, :]
+        upper = ma_sort[index[1], :, :, :]
         return lower, upper
 
     def irf_resim(self, orth=False, repl=1000, T=10,


### PR DESCRIPTION
Implemented smoke tests to call each of the `irf.err_band_XXX` methods, four of them break:

```
======================================================================
ERROR: statsmodels.tsa.vector_ar.tests.test_var.TestVARResults.test_errband_mc
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "irf_smoketests/statsmodels/tsa/vector_ar/tests/test_var.py", line 361, in test_errband_mc
    errband_mc = irf.errband_mc()
  File "irf_smoketests/statsmodels/tsa/vector_ar/irf.py", line 282, in errband_mc
    burn=burn, cum=False)
  File "irf_smoketests/statsmodels/tsa/vector_ar/var_model.py", line 1114, in irf_errband_mc
    lower = ma_sort[index[0],:, :, :]
IndexError: only integers, slices (`:`), ellipsis (`...`), numpy.newaxis (`None`) and integer or boolean arrays are valid indices

======================================================================
ERROR: statsmodels.tsa.vector_ar.tests.test_var.TestVARResults.test_sz1
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "irf_smoketests/statsmodels/tsa/vector_ar/tests/test_var.py", line 366, in test_sz1
    err_band_sz1 = irf.err_band_sz1()
  File "irf_smoketests/statsmodels/tsa/vector_ar/irf.py", line 340, in err_band_sz1
    lower[1:,i,j] = irfs[1:,i,j] + W[i,j,:,k[i,j]]*q*np.sqrt(eigva[i,j,k[i,j]])
IndexError: only integers, slices (`:`), ellipsis (`...`), numpy.newaxis (`None`) and integer or boolean arrays are valid indices

======================================================================
ERROR: statsmodels.tsa.vector_ar.tests.test_var.TestVARResults.test_sz2
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "irf_smoketests/statsmodels/tsa/vector_ar/tests/test_var.py", line 371, in test_sz2
    err_band_sz2 = irf.err_band_sz2()
  File "irf_smoketests/statsmodels/tsa/vector_ar/irf.py", line 379, in err_band_sz2
    elif svar:
NameError: global name 'svar' is not defined

======================================================================
ERROR: statsmodels.tsa.vector_ar.tests.test_var.TestVARResults.test_sz3
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "irf_smoketests/statsmodels/tsa/vector_ar/tests/test_var.py", line 376, in test_sz3
    err_band_sz3 = irf.err_band_sz3()
  File "irf_smoketests/statsmodels/tsa/vector_ar/irf.py", line 447, in err_band_sz3
    elif svar:
NameError: global name 'svar' is not defined
```

I'll make some more commits shortly with fixes for these, but first wanted to make sure they were documented here.
