### PR TITLE
ENH: Allow expected hessian in scipy optimizer fits

### DIFF
--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -253,7 +253,7 @@ class LikelihoodModel(Model):
 
     def fit(self, start_params=None, method='newton', maxiter=100,
             full_output=True, disp=True, fargs=(), callback=None, retall=False,
-            skip_hessian=False, **kwargs):
+            skip_hessian=False, observed_hessian=True, **kwargs):
         """
         Fit method for likelihood based models
 
@@ -436,14 +436,17 @@ class LikelihoodModel(Model):
         nobs = self.endog.shape[0]
         f = lambda params, *args: -self.loglike(params, *args) / nobs
         score = lambda params, *args: -self.score(params, *args) / nobs
-        try:
+        if observed_hessian:
             hess = lambda params, *args: -self.hessian(params, *args) / nobs
-        except:
-            hess = None
+        else:
+            hess = lambda params, *args: -self.hessian(params, *args, observed=False) / nobs
 
         if method == 'newton':
             score = lambda params, *args: self.score(params, *args) / nobs
-            hess = lambda params, *args: self.hessian(params, *args) / nobs
+            if observed_hessian:
+                hess = lambda params, *args: self.hessian(params, *args) / nobs
+            else:
+                hess = lambda params, *args: self.hessian(params, *args, observed=False) / nobs
             #TODO: why are score and hess positive?
 
         warn_convergence = kwargs.pop('warn_convergence', True)

--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -253,7 +253,7 @@ class LikelihoodModel(Model):
 
     def fit(self, start_params=None, method='newton', maxiter=100,
             full_output=True, disp=True, fargs=(), callback=None, retall=False,
-            skip_hessian=False, observed_hessian=True, **kwargs):
+            skip_hessian=False, **kwargs):
         """
         Fit method for likelihood based models
 

--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -434,20 +434,24 @@ class LikelihoodModel(Model):
         # args in most (any?) of the optimize function
 
         nobs = self.endog.shape[0]
-        f = lambda params, *args: -self.loglike(params, *args) / nobs
-        score = lambda params, *args: -self.score(params, *args) / nobs
-        if observed_hessian:
-            hess = lambda params, *args: -self.hessian(params, *args) / nobs
-        else:
-            hess = lambda params, *args: -self.hessian(params, *args, observed=False) / nobs
+        # f = lambda params, *args: -self.loglike(params, *args) / nobs
+
+        def f(params, *args):
+            return -self.loglike(params, *args) / nobs
 
         if method == 'newton':
-            score = lambda params, *args: self.score(params, *args) / nobs
-            if observed_hessian:
-                hess = lambda params, *args: self.hessian(params, *args) / nobs
-            else:
-                hess = lambda params, *args: self.hessian(params, *args, observed=False) / nobs
-            #TODO: why are score and hess positive?
+            # TODO: why are score and hess positive?
+            def score(params, *args):
+                return self.score(params, *args) / nobs
+
+            def hess(params, *args):
+                return self.hessian(params, *args) / nobs
+        else:
+            def score(params, *args):
+                return -self.score(params, *args) / nobs
+
+            def hess(params, *args):
+                return -self.hessian(params, *args) / nobs
 
         warn_convergence = kwargs.pop('warn_convergence', True)
         optimizer = Optimizer()

--- a/statsmodels/genmod/generalized_linear_model.py
+++ b/statsmodels/genmod/generalized_linear_model.py
@@ -973,6 +973,14 @@ class GLM(base.LikelihoodModel):
             :math:`rtol * prior + atol > abs(current - prior)`
         tol_criterion : str, optional
             Defaults to ``'deviance'``. Can optionally be ``'params'``.
+
+        If a scipy optimizer is used, the following additional parameter is
+        available:
+
+        observed_hessian : bool, optional
+            When True, the default, the observed Hessian is used in fitting.
+            This may provide more stable fits, but adds assumption that the
+            Hessian is correctly specified.
         """
         self.scaletype = scale
 

--- a/statsmodels/genmod/generalized_linear_model.py
+++ b/statsmodels/genmod/generalized_linear_model.py
@@ -584,7 +584,7 @@ class GLM(base.LikelihoodModel):
 
         return oim_factor
 
-    def hessian(self, params, scale=None, observed=True):
+    def hessian(self, params, scale=None, observed=None):
         """Hessian, second derivative of loglikelihood function
 
         Parameters
@@ -596,16 +596,19 @@ class GLM(base.LikelihoodModel):
             Default scale is defined by `self.scaletype` and set in fit.
             If scale is not None, then it is used as a fixed scale.
         observed : bool
-            If True, then the observed Hessian is returned. If false then the
-            expected information matrix is returned.
+            If True, then the observed Hessian is returned (default).
+            If false then the expected information matrix is returned.
 
         Returns
         -------
         hessian : ndarray
             Hessian, i.e. observed information, or expected information matrix.
         """
-        if hasattr(self, '_optim_hessian') and self._optim_hessian == 'eim':
-            observed = False
+        if observed is None:
+            if hasattr(self, '_optim_hessian') and (self._optim_hessian == 'eim'):
+                observed = False
+            else:
+                observed = True
 
         factor = self.hessian_factor(params, scale=scale, observed=observed)
         hess = -np.dot(self.exog.T * factor, self.exog)

--- a/statsmodels/genmod/tests/test_glm.py
+++ b/statsmodels/genmod/tests/test_glm.py
@@ -1043,8 +1043,8 @@ def test_gradient_irls():
                    assert_allclose(gradient_bse, rslt_irls.bse, rtol=1e-6, atol=5e-5)
 
 
-def test_gradient_irls_expected_hessian():
-    # Compare the results when using gradient optimization and IRLS.
+def test_gradient_irls_eim():
+    # Compare the results when using eime gradient optimization and IRLS.
 
     # TODO: Find working examples for inverse_squared link
 
@@ -1122,7 +1122,7 @@ def test_gradient_irls_expected_hessian():
                    rslt_gradient = mod_gradient.fit(max_start_irls=max_start_irls,
                                                     start_params=start_params,
                                                     method="newton",
-                                                    observed_hessian=False)
+                                                    optim_hessian='eim')
 
                    assert_allclose(rslt_gradient.params,
                                    rslt_irls.params, rtol=1e-6, atol=5e-5)

--- a/statsmodels/genmod/tests/test_glm.py
+++ b/statsmodels/genmod/tests/test_glm.py
@@ -1043,6 +1043,104 @@ def test_gradient_irls():
                    assert_allclose(gradient_bse, rslt_irls.bse, rtol=1e-6, atol=5e-5)
 
 
+def test_gradient_irls_expected_hessian():
+    # Compare the results when using gradient optimization and IRLS.
+
+    # TODO: Find working examples for inverse_squared link
+
+    np.random.seed(87342)
+
+    fam = sm.families
+    lnk = sm.families.links
+    families = [(fam.Binomial, [lnk.logit, lnk.probit, lnk.cloglog, lnk.log, lnk.cauchy]),
+                (fam.Poisson, [lnk.log, lnk.identity, lnk.sqrt]),
+                (fam.Gamma, [lnk.log, lnk.identity, lnk.inverse_power]),
+                (fam.Gaussian, [lnk.identity, lnk.log, lnk.inverse_power]),
+                (fam.InverseGaussian, [lnk.log, lnk.identity, lnk.inverse_power, lnk.inverse_squared]),
+                (fam.NegativeBinomial, [lnk.log, lnk.inverse_power, lnk.inverse_squared, lnk.identity])]
+
+    n = 100
+    p = 3
+    exog = np.random.normal(size=(n, p))
+    exog[:, 0] = 1
+
+    skip_one = False
+    for family_class, family_links in families:
+       for link in family_links:
+           for binom_version in 0,1:
+
+               if family_class != fam.Binomial and binom_version == 1:
+                   continue
+
+               if (family_class, link) == (fam.Poisson, lnk.identity):
+                   lin_pred = 20 + exog.sum(1)
+               elif (family_class, link) == (fam.Binomial, lnk.log):
+                   lin_pred = -1 + exog.sum(1) / 8
+               elif (family_class, link) == (fam.Poisson, lnk.sqrt):
+                   lin_pred = 2 + exog.sum(1)
+               elif (family_class, link) == (fam.InverseGaussian, lnk.log):
+                   #skip_zero = True
+                   lin_pred = -1 + exog.sum(1)
+               elif (family_class, link) == (fam.InverseGaussian, lnk.identity):
+                   lin_pred = 20 + 5*exog.sum(1)
+                   lin_pred = np.clip(lin_pred, 1e-4, np.inf)
+               elif (family_class, link) == (fam.InverseGaussian, lnk.inverse_squared):
+                   lin_pred = 0.5 + exog.sum(1) / 5
+                   continue # skip due to non-convergence
+               elif (family_class, link) == (fam.InverseGaussian, lnk.inverse_power):
+                   lin_pred = 1 + exog.sum(1) / 5
+               elif (family_class, link) == (fam.NegativeBinomial, lnk.identity):
+                   lin_pred = 20 + 5*exog.sum(1)
+                   lin_pred = np.clip(lin_pred, 1e-4, np.inf)
+               elif (family_class, link) == (fam.NegativeBinomial, lnk.inverse_squared):
+                   lin_pred = 0.1 + np.random.uniform(size=exog.shape[0])
+                   continue # skip due to non-convergence
+               elif (family_class, link) == (fam.NegativeBinomial, lnk.inverse_power):
+                   lin_pred = 1 + exog.sum(1) / 5
+
+               elif (family_class, link) == (fam.Gaussian, lnk.inverse_power):
+                   # adding skip because of convergence failure
+                   skip_one = True
+               else:
+                   lin_pred = np.random.uniform(size=exog.shape[0])
+
+               endog = gen_endog(lin_pred, family_class, link, binom_version)
+
+               with warnings.catch_warnings():
+                   warnings.simplefilter("ignore")
+                   mod_irls = sm.GLM(endog, exog, family=family_class(link=link()))
+               rslt_irls = mod_irls.fit(method="IRLS")
+
+               # Try with and without starting values.
+               for max_start_irls, start_params in (0, rslt_irls.params), (3, None):
+                   # TODO: skip convergence failures for now
+                   if max_start_irls > 0 and skip_one:
+                       continue
+                   with warnings.catch_warnings():
+                       warnings.simplefilter("ignore")
+                       mod_gradient = sm.GLM(endog, exog, family=family_class(link=link()))
+                   rslt_gradient = mod_gradient.fit(max_start_irls=max_start_irls,
+                                                    start_params=start_params,
+                                                    method="newton",
+                                                    observed_hessian=False)
+
+                   assert_allclose(rslt_gradient.params,
+                                   rslt_irls.params, rtol=1e-6, atol=5e-5)
+
+                   assert_allclose(rslt_gradient.llf, rslt_irls.llf,
+                                   rtol=1e-6, atol=1e-6)
+
+                   assert_allclose(rslt_gradient.scale, rslt_irls.scale,
+                                   rtol=1e-6, atol=1e-6)
+
+                   # Get the standard errors using expected information.
+                   gradient_bse = rslt_gradient.bse
+                   ehess = mod_gradient.hessian(rslt_gradient.params, observed=False)
+                   gradient_bse = np.sqrt(-np.diag(np.linalg.inv(ehess)))
+
+                   assert_allclose(gradient_bse, rslt_irls.bse, rtol=1e-6, atol=5e-5)
+
+
 class CheckWtdDuplicationMixin(object):
     decimal_params = DECIMAL_4
 

--- a/statsmodels/genmod/tests/test_glm.py
+++ b/statsmodels/genmod/tests/test_glm.py
@@ -1052,12 +1052,16 @@ def test_gradient_irls_eim():
 
     fam = sm.families
     lnk = sm.families.links
-    families = [(fam.Binomial, [lnk.logit, lnk.probit, lnk.cloglog, lnk.log, lnk.cauchy]),
+    families = [(fam.Binomial, [lnk.logit, lnk.probit, lnk.cloglog, lnk.log,
+                                lnk.cauchy]),
                 (fam.Poisson, [lnk.log, lnk.identity, lnk.sqrt]),
                 (fam.Gamma, [lnk.log, lnk.identity, lnk.inverse_power]),
                 (fam.Gaussian, [lnk.identity, lnk.log, lnk.inverse_power]),
-                (fam.InverseGaussian, [lnk.log, lnk.identity, lnk.inverse_power, lnk.inverse_squared]),
-                (fam.NegativeBinomial, [lnk.log, lnk.inverse_power, lnk.inverse_squared, lnk.identity])]
+                (fam.InverseGaussian, [lnk.log, lnk.identity,
+                                       lnk.inverse_power,
+                                       lnk.inverse_squared]),
+                (fam.NegativeBinomial, [lnk.log, lnk.inverse_power,
+                                        lnk.inverse_squared, lnk.identity])]
 
     n = 100
     p = 3
@@ -1066,79 +1070,91 @@ def test_gradient_irls_eim():
 
     skip_one = False
     for family_class, family_links in families:
-       for link in family_links:
-           for binom_version in 0,1:
+        for link in family_links:
+            for binom_version in 0, 1:
 
-               if family_class != fam.Binomial and binom_version == 1:
-                   continue
+                if family_class != fam.Binomial and binom_version == 1:
+                    continue
 
-               if (family_class, link) == (fam.Poisson, lnk.identity):
-                   lin_pred = 20 + exog.sum(1)
-               elif (family_class, link) == (fam.Binomial, lnk.log):
-                   lin_pred = -1 + exog.sum(1) / 8
-               elif (family_class, link) == (fam.Poisson, lnk.sqrt):
-                   lin_pred = 2 + exog.sum(1)
-               elif (family_class, link) == (fam.InverseGaussian, lnk.log):
-                   #skip_zero = True
-                   lin_pred = -1 + exog.sum(1)
-               elif (family_class, link) == (fam.InverseGaussian, lnk.identity):
-                   lin_pred = 20 + 5*exog.sum(1)
-                   lin_pred = np.clip(lin_pred, 1e-4, np.inf)
-               elif (family_class, link) == (fam.InverseGaussian, lnk.inverse_squared):
-                   lin_pred = 0.5 + exog.sum(1) / 5
-                   continue # skip due to non-convergence
-               elif (family_class, link) == (fam.InverseGaussian, lnk.inverse_power):
-                   lin_pred = 1 + exog.sum(1) / 5
-               elif (family_class, link) == (fam.NegativeBinomial, lnk.identity):
-                   lin_pred = 20 + 5*exog.sum(1)
-                   lin_pred = np.clip(lin_pred, 1e-4, np.inf)
-               elif (family_class, link) == (fam.NegativeBinomial, lnk.inverse_squared):
-                   lin_pred = 0.1 + np.random.uniform(size=exog.shape[0])
-                   continue # skip due to non-convergence
-               elif (family_class, link) == (fam.NegativeBinomial, lnk.inverse_power):
-                   lin_pred = 1 + exog.sum(1) / 5
+                if (family_class, link) == (fam.Poisson, lnk.identity):
+                    lin_pred = 20 + exog.sum(1)
+                elif (family_class, link) == (fam.Binomial, lnk.log):
+                    lin_pred = -1 + exog.sum(1) / 8
+                elif (family_class, link) == (fam.Poisson, lnk.sqrt):
+                    lin_pred = 2 + exog.sum(1)
+                elif (family_class, link) == (fam.InverseGaussian, lnk.log):
+                    # skip_zero = True
+                    lin_pred = -1 + exog.sum(1)
+                elif (family_class, link) == (fam.InverseGaussian,
+                                              lnk.identity):
+                    lin_pred = 20 + 5*exog.sum(1)
+                    lin_pred = np.clip(lin_pred, 1e-4, np.inf)
+                elif (family_class, link) == (fam.InverseGaussian,
+                                              lnk.inverse_squared):
+                    lin_pred = 0.5 + exog.sum(1) / 5
+                    continue  # skip due to non-convergence
+                elif (family_class, link) == (fam.InverseGaussian,
+                                              lnk.inverse_power):
+                    lin_pred = 1 + exog.sum(1) / 5
+                elif (family_class, link) == (fam.NegativeBinomial,
+                                              lnk.identity):
+                    lin_pred = 20 + 5*exog.sum(1)
+                    lin_pred = np.clip(lin_pred, 1e-4, np.inf)
+                elif (family_class, link) == (fam.NegativeBinomial,
+                                              lnk.inverse_squared):
+                    lin_pred = 0.1 + np.random.uniform(size=exog.shape[0])
+                    continue  # skip due to non-convergence
+                elif (family_class, link) == (fam.NegativeBinomial,
+                                              lnk.inverse_power):
+                    lin_pred = 1 + exog.sum(1) / 5
 
-               elif (family_class, link) == (fam.Gaussian, lnk.inverse_power):
-                   # adding skip because of convergence failure
-                   skip_one = True
-               else:
-                   lin_pred = np.random.uniform(size=exog.shape[0])
+                elif (family_class, link) == (fam.Gaussian, lnk.inverse_power):
+                    # adding skip because of convergence failure
+                    skip_one = True
+                else:
+                    lin_pred = np.random.uniform(size=exog.shape[0])
 
-               endog = gen_endog(lin_pred, family_class, link, binom_version)
+                endog = gen_endog(lin_pred, family_class, link, binom_version)
 
-               with warnings.catch_warnings():
-                   warnings.simplefilter("ignore")
-                   mod_irls = sm.GLM(endog, exog, family=family_class(link=link()))
-               rslt_irls = mod_irls.fit(method="IRLS")
+                with warnings.catch_warnings():
+                    warnings.simplefilter("ignore")
+                    mod_irls = sm.GLM(endog, exog,
+                                      family=family_class(link=link()))
+                rslt_irls = mod_irls.fit(method="IRLS")
 
-               # Try with and without starting values.
-               for max_start_irls, start_params in (0, rslt_irls.params), (3, None):
-                   # TODO: skip convergence failures for now
-                   if max_start_irls > 0 and skip_one:
-                       continue
-                   with warnings.catch_warnings():
-                       warnings.simplefilter("ignore")
-                       mod_gradient = sm.GLM(endog, exog, family=family_class(link=link()))
-                   rslt_gradient = mod_gradient.fit(max_start_irls=max_start_irls,
-                                                    start_params=start_params,
-                                                    method="newton",
-                                                    optim_hessian='eim')
+                # Try with and without starting values.
+                for max_start_irls, start_params in ((0, rslt_irls.params),
+                                                     (3, None)):
+                    # TODO: skip convergence failures for now
+                    if max_start_irls > 0 and skip_one:
+                        continue
+                    with warnings.catch_warnings():
+                        warnings.simplefilter("ignore")
+                        mod_gradient = sm.GLM(endog, exog,
+                                              family=family_class(link=link()))
+                    rslt_gradient = mod_gradient.fit(
+                            max_start_irls=max_start_irls,
+                            start_params=start_params,
+                            method="newton",
+                            optim_hessian='eim'
+                    )
 
-                   assert_allclose(rslt_gradient.params,
-                                   rslt_irls.params, rtol=1e-6, atol=5e-5)
+                    assert_allclose(rslt_gradient.params, rslt_irls.params,
+                                    rtol=1e-6, atol=5e-5)
 
-                   assert_allclose(rslt_gradient.llf, rslt_irls.llf,
-                                   rtol=1e-6, atol=1e-6)
+                    assert_allclose(rslt_gradient.llf, rslt_irls.llf,
+                                    rtol=1e-6, atol=1e-6)
 
-                   assert_allclose(rslt_gradient.scale, rslt_irls.scale,
-                                   rtol=1e-6, atol=1e-6)
+                    assert_allclose(rslt_gradient.scale, rslt_irls.scale,
+                                    rtol=1e-6, atol=1e-6)
 
-                   # Get the standard errors using expected information.
-                   gradient_bse = rslt_gradient.bse
-                   ehess = mod_gradient.hessian(rslt_gradient.params, observed=False)
-                   gradient_bse = np.sqrt(-np.diag(np.linalg.inv(ehess)))
+                    # Get the standard errors using expected information.
+                    ehess = mod_gradient.hessian(rslt_gradient.params,
+                                                 observed=False)
+                    gradient_bse = np.sqrt(-np.diag(np.linalg.inv(ehess)))
 
-                   assert_allclose(gradient_bse, rslt_irls.bse, rtol=1e-6, atol=5e-5)
+                    assert_allclose(gradient_bse, rslt_irls.bse, rtol=1e-6,
+                                    atol=5e-5)
 
 
 class CheckWtdDuplicationMixin(object):


### PR DESCRIPTION
Hello,

I think this is a rather simple approach to exposing the expected Hessian for scipy optimizer fits. 

I thought about using functools `partial` but ran into some obstacles. The real issue is that context matters and not all the `hessian` methods have an `observed` parameter. So this was as simple as I could make it without much effort. 

xref #3257