### PR TITLE
GLM vs GEE resid_working mismatch?

### DIFF
--- a/statsmodels/genmod/generalized_estimating_equations.py
+++ b/statsmodels/genmod/generalized_estimating_equations.py
@@ -1471,7 +1471,7 @@ class GEEResults(base.LikelihoodModelResults):
     @cache_readonly
     def resid_working(self):
         val = self.resid_response
-        val = val / self.family.link.deriv(self.fittedvalues)
+        val = val * self.family.link.deriv(self.fittedvalues)
         return val
 
     @cache_readonly


### PR DESCRIPTION
The definitions of `resid_working` in [GEE](https://github.com/statsmodels/statsmodels/blob/master/statsmodels/genmod/generalized_estimating_equations.py#L1472) and [GLM](https://github.com/statsmodels/statsmodels/blob/master/statsmodels/genmod/generalized_linear_model.py#L1318) are _almost_ identical.

#3164 changed the version in GLM from division to multiplication.  This PR just applies the exact same change to the GEE version.

Note that at the moment, the GEE version is not getting hit in tests.