### PR TITLE
MAINT: travisci fix pandas version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ matrix:
     env:
     - PYTHON=2.7
     - NUMPY=1.11
+    - PANDAS=0.19
     - MATPLOTLIB=1.5
     - COVERAGE=true
   - python: 2.7


### PR DESCRIPTION
see #3658  error in test cases with one numpy/pandas combination

This is a, at least temporary, work-around to get TravisCI green again.
I didn't look at the actual errors, and whether there is a proper fix for them.

