### PR TITLE
Smoke-test for SVAR fit with ic

### DIFF
--- a/statsmodels/tsa/vector_ar/svar_model.py
+++ b/statsmodels/tsa/vector_ar/svar_model.py
@@ -15,7 +15,7 @@ from numpy.linalg import slogdet
 from statsmodels.tools.numdiff import (approx_hess, approx_fprime)
 from statsmodels.tools.decorators import cache_readonly
 from statsmodels.tsa.vector_ar.irf import IRAnalysis
-from statsmodels.tsa.vector_ar.var_model import VARProcess, \
+from statsmodels.tsa.vector_ar.var_model import VAR, VARProcess, \
                                                         VARResults
 
 import statsmodels.tsa.vector_ar.util as util
@@ -31,7 +31,7 @@ def svar_ckerr(svar_type, A, B):
 
         raise ValueError('SVAR of type B or AB but B array not given.')
 
-class SVAR(tsbase.TimeSeriesModel):
+class SVAR(VAR):
     r"""
     Fit VAR and then estimate structural components of A and B, defined:
 
@@ -259,7 +259,11 @@ class SVAR(tsbase.TimeSeriesModel):
                             names=self.endog_names, trend=trend,
                             dates=self.data.dates, model=self,
                            A=A, B=B, A_mask=A_mask, B_mask=B_mask)
-
+    
+    _estimate = _estimate_svar
+    # We need this alias so that the appropriate method gets called when we
+    # call select_order, which is inherited from VAR
+    
     def loglike(self, params):
         """
         Loglikelihood for SVAR model
@@ -365,7 +369,7 @@ class SVAR(tsbase.TimeSeriesModel):
         else: #TODO: change to a warning?
             print("Order/rank conditions have not been checked")
 
-        retvals = super(SVAR, self).fit(start_params=start_params,
+        retvals = tsbase.TimeSeriesModel.fit(self, start_params=start_params,
                     method=solver, maxiter=maxiter,
                     maxfun=maxfun, ftol=1e-20, disp=0).params
 

--- a/statsmodels/tsa/vector_ar/tests/test_svar.py
+++ b/statsmodels/tsa/vector_ar/tests/test_svar.py
@@ -22,13 +22,18 @@ class TestSVAR(object):
         data = np.diff(np.log(data), axis=0)
         A = np.asarray([[1, 0, 0],['E', 1, 0],['E', 'E', 1]])
         B = np.asarray([['E', 0, 0], [0, 'E', 0], [0, 0, 'E']])
-        results = SVAR(data, svar_type='AB', A=A, B=B).fit(maxlags=3)
+        model = SVAR(data, svar_type='AB', A=A, B=B)
+        results = model.fit(maxlags=3)
+        cls.model = model
         cls.res1 = results
         #cls.res2 = results_svar.SVARdataResults()
         from .results import results_svar_st
         cls.res2 = results_svar_st.results_svar1_small
 
-
+    def test_fit_with_ic(self): # Smoke-test to check on #3664
+        model = self.model
+        aic_res = model.fit(maxlags=3, ic='aic')
+        
     def _reformat(self, x):
         return x[[1, 4, 7, 2, 5, 8, 3, 6, 9, 0], :].ravel("F")
 

--- a/statsmodels/tsa/vector_ar/var_model.py
+++ b/statsmodels/tsa/vector_ar/var_model.py
@@ -478,6 +478,8 @@ class VAR(tsbase.TimeSeriesModel):
         varfit = VARResults(y, z, params, omega, lags, names=self.endog_names,
                           trend=trend, dates=self.data.dates, model=self)
         return VARResultsWrapper(varfit)
+      
+    _estimate = _estimate_var
 
     def select_order(self, maxlags=None, verbose=True):
         """
@@ -502,7 +504,7 @@ class VAR(tsbase.TimeSeriesModel):
         for p in range(maxlags + 1):
             # exclude some periods to same amount of data used for each lag
             # order
-            result = self._estimate_var(p, offset=maxlags-p)
+            result = self._estimate(p, offset=maxlags-p)
 
             for k, v in iteritems(result.info_criteria):
                 ics[k].append(v)


### PR DESCRIPTION
See #3664.  I think that this test will break with an AttributeError, since calling `fit` with an `ic` will call `select_order`, which is a `VAR` method but not a `SVAR` method.  If this test passes, than #3664 can be closed/ignored.