### PR TITLE
Highly persistent test case for arma_acovf

### DIFF
--- a/statsmodels/tsa/arima_process.py
+++ b/statsmodels/tsa/arima_process.py
@@ -156,7 +156,9 @@ def arma_acovf(ar, ma, nobs=10):
         ir = arma_impulse_response(ar, ma, nobs=nobs_ir)
     #again no idea where the speed break points are:
     if nobs_ir > 50000 and nobs < 1001:
-        acovf = np.array([np.dot(ir[:nobs-t], ir[t:nobs])
+        end = len(ir)
+        # Explitly slice from the end to avoid foo[:-0] returning an empty slice
+        acovf = np.array([np.dot(ir[:end-nobs-t], ir[t:end-nobs])
                           for t in range(nobs)])
     else:
         acovf = np.correlate(ir, ir, 'full')[len(ir)-1:]

--- a/statsmodels/tsa/tests/test_arima_process.py
+++ b/statsmodels/tsa/tests/test_arima_process.py
@@ -40,7 +40,7 @@ def test_arma_acovf_persistent():
     ar = np.array([1, -.9995])
     ma = np.array([1])
     process = ArmaProcess(ar, ma)
-    res = process.acovf(lags=10)
+    res = process.acovf(10)
 
     # Theoretical variance sig2 given by:
     # sig2 = .9995**2 * sig2 + 1

--- a/statsmodels/tsa/tests/test_arima_process.py
+++ b/statsmodels/tsa/tests/test_arima_process.py
@@ -33,6 +33,25 @@ def test_arma_acovf():
     rep2 = [1.*sigma*phi**i/(1-phi**2) for i in range(N)];
     assert_almost_equal(rep1, rep2, 7); # 7 is max precision here
 
+def test_arma_acovf_persistent():
+    # Test arma_acovf in case where there is a near-unit root.
+    # .999 is high enough to trigger the "while ir[-1] > 5*1e-5:" clause,
+    # but not high enough to trigger the "nobs_ir > 50000" clause.
+    ar = np.array([1, -.9995])
+    ma = np.array([1])
+    process = ArmaProcess(ar, ma)
+    res = process.acovf(lags=10)
+
+    # Theoretical variance sig2 given by:
+    # sig2 = .9995**2 * sig2 + 1
+    sig2 = 1/(1-.9995**2)
+
+    corrs = np.array([.9995**n for n in range(10)])
+    expected = sig2*corrs
+    assert len(res) == 10, len(res)
+    assert np.ndim(res) == 1
+    assert_almost_equal(res, expected, 6)
+    # 7 decimals breaks at .999, worked at .995
 
 def test_arma_acf():
     # Check for specific AR(1)


### PR DESCRIPTION
arma_covf has special handling for highly persistent cases, which does not currently have test coverage.  This PR adds a test for such a case.  I believe this test uncovers a bug in this special case code.  Specifically, in the highly-persistent case `acovf` gets defined as:

```
acovf = np.array([np.dot(ir[:lags-t], ir[t:lags]) for t in range(lags)])
```

in order to match the manually computed answer (and the answer produced by np.correlate without the special-case handling) this will need to be changed to 

```
acovf = np.array([np.dot(ir[:-lags-t], ir[t:-lags]) for t in range(lags)])
```

I'll add that as a separate commit after confirming that the test fails.