### PR TITLE
MAINT: appveyor pin pandas version 

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,7 @@ environment:
   matrix:
     - PY_MAJOR_VER: 2
       PYTHON_ARCH: "x86_64"
+      PANDAS: "0.19"
     - PY_MAJOR_VER: 2
       PYTHON_ARCH: "x86_64"
       SCIPY: "0.14"
@@ -23,7 +24,9 @@ build_script:
   - SET PATH=C:\Py;C:\Py\Scripts;C:\Py\Library\bin;%PATH%
   - conda config --set always_yes yes
   - conda update conda --quiet
-  - ps: If ($env:SCIPY) { conda install numpy scipy=$env:SCIPY cython pandas pip nose patsy --quiet } Else { conda install numpy scipy cython pandas pip nose patsy --quiet }
+  - ps: If ($env:SCIPY) { conda install numpy scipy=$env:SCIPY cython pandas pip nose patsy --quiet } Else {
+        If ($env:PANDAS) { conda install numpy scipy cython pandas=$env:PANDAS pip nose patsy --quiet } Else {
+        conda install numpy scipy cython pandas pip nose patsy --quiet }}
   - python setup.py develop
 
 test_script:


### PR DESCRIPTION
see #3658 
avoid pandas-numpy version combination that causes test errors

make change to appveyor same as travisci
