### PR TITLE
Remove un-picklable method in __getstate__

### DIFF
--- a/statsmodels/base/tests/test_shrink_pickle.py
+++ b/statsmodels/base/tests/test_shrink_pickle.py
@@ -271,9 +271,22 @@ class TestPickleFormula5(TestPickleFormula2):
         self.results = sm.OLS.from_formula("Y ~ log(A) + B * C", data=self.data).fit()
 
 
+class TestRemoveDataPicklePoissonRegularized(RemoveDataPickle):
+
+    def setup(self):
+        #fit for each test, because results will be changed by test
+        x = self.exog
+        np.random.seed(987689)
+        y_count = np.random.poisson(np.exp(x.sum(1) - x.mean()))
+        model = sm.Poisson(y_count, x)
+        self.results = model.fit_regularized(method='l1', disp=0, alpha=10)
+
+
+
 if __name__ == '__main__':
     for cls in [TestRemoveDataPickleOLS, TestRemoveDataPickleWLS,
                 TestRemoveDataPicklePoisson,
+                TestRemoveDataPicklePoissonRegularized,
                 TestRemoveDataPickleNegativeBinomial,
                 TestRemoveDataPickleLogit, TestRemoveDataPickleRLM,
                 TestRemoveDataPickleGLM]:

--- a/statsmodels/discrete/discrete_model.py
+++ b/statsmodels/discrete/discrete_model.py
@@ -2371,11 +2371,10 @@ class DiscreteResults(base.LikelihoodModelResults):
 
 
     def __getstate__(self):
-        try:
-            #remove unpicklable callback
-            self.mle_settings['callback'] = None
-        except (AttributeError, KeyError):
-            pass
+        # remove unpicklable methods
+        self.mle_settings['callback'] = None
+        if 'cov_params_func' in self.mle_settings:
+            self.mle_settings['cov_params_func'] = None
         return self.__dict__
 
     @cache_readonly


### PR DESCRIPTION
Add a test that fails without this fix.  In particular, cov_params_func key gets set in fit_regularized.

The test is taken directly from GH #2686