### PR TITLE
Update broken link in docstring

### DIFF
--- a/statsmodels/stats/sandwich_covariance.py
+++ b/statsmodels/stats/sandwich_covariance.py
@@ -17,10 +17,10 @@ version 1: use pinv
 pinv(x) scale pinv(x)   used currently in linear_model, with scale is
 1d (or diagonal matrix)
 (x'x)^(-1) x' scale x (x'x)^(-1),  scale in general is (nobs, nobs) so
-pretty large
-general formulas for scale in cluster case are in
-http://pubs.amstat.org/doi/abstract/10.1198/jbes.2010.07136 which also
-has the second version
+pretty large general formulas for scale in cluster case are in [4],
+which can be found (as of 2017-05-20) at 
+http://www.tandfonline.com/doi/abs/10.1198/jbes.2010.07136
+This paper also has the second version.
 
 version 2:
 (x'x)^(-1) S (x'x)^(-1)    with S = x' scale x,    S is (kvar,kvars),
@@ -79,18 +79,18 @@ TODO
 
 References
 ----------
-John C. Driscoll and Aart C. Kraay, “Consistent Covariance Matrix Estimation
+[1] John C. Driscoll and Aart C. Kraay, “Consistent Covariance Matrix Estimation
 with Spatially Dependent Panel Data,” Review of Economics and Statistics 80,
 no. 4 (1998): 549-560.
 
-Daniel Hoechle, "Robust Standard Errors for Panel Regressions with
+[2] Daniel Hoechle, "Robust Standard Errors for Panel Regressions with
 Cross-Sectional Dependence", The Stata Journal
 
-Mitchell A. Petersen, “Estimating Standard Errors in Finance Panel Data
+[3] Mitchell A. Petersen, “Estimating Standard Errors in Finance Panel Data
 Sets: Comparing Approaches,” Review of Financial Studies 22, no. 1
 (January 1, 2009): 435 -480.
 
-A. Colin Cameron, Jonah B. Gelbach, and Douglas L. Miller, “Robust Inference
+[4] A. Colin Cameron, Jonah B. Gelbach, and Douglas L. Miller, “Robust Inference
 With Multiway Clustering,” Journal of Business and Economic Statistics 29
 (April 2011): 238-249.
 
@@ -159,6 +159,7 @@ __all__ = ['cov_cluster', 'cov_cluster_2groups', 'cov_hac', 'cov_nw_panel',
 
 '''
 
+# Note: HCCM stands for Heteroskedasticity Consistent Covariance Matrix
 def _HCCM(results, scale):
     '''
     sandwich with pinv(x) * diag(scale) * pinv(x).T


### PR DESCRIPTION
Also added label formatting to references and a comment about the HCCM acronym.

Closes #3680 
