### PR TITLE
BUG: Highly persistent test case for arma_acovf

### DIFF
--- a/statsmodels/tsa/arima_process.py
+++ b/statsmodels/tsa/arima_process.py
@@ -127,7 +127,9 @@ def arma_acovf(ar, ma, nobs=10):
         ir = arma_impulse_response(ar, ma, leads=nobs_ir)
     # again no idea where the speed break points are:
     if nobs_ir > 50000 and nobs < 1001:
-        acovf = np.array([np.dot(ir[:nobs - t], ir[t:nobs])
+        end = len(ir)
+        # Explitly slice from the end to avoid foo[:-0] returning an empty slice
+        acovf = np.array([np.dot(ir[:end-nobs-t], ir[t:end-nobs])
                           for t in range(nobs)])
     else:
         acovf = np.correlate(ir, ir, 'full')[len(ir) - 1:]

--- a/statsmodels/tsa/tests/test_arima_process.py
+++ b/statsmodels/tsa/tests/test_arima_process.py
@@ -7,7 +7,8 @@ from unittest import TestCase
 
 import numpy as np
 from numpy.testing import (assert_array_almost_equal, assert_almost_equal,
-                           assert_equal, assert_raises, assert_, dec)
+                        assert_allclose,
+                        assert_equal, assert_raises, assert_, dec)
 
 from statsmodels.tsa.arima_process import (arma_generate_sample, arma_acovf,
                                            arma_acf, arma_impulse_response, lpol_fiar, lpol_fima,
@@ -41,6 +42,24 @@ def test_arma_acovf():
     rep2 = [1. * sigma * phi ** i / (1 - phi ** 2) for i in range(N)]
     assert_almost_equal(rep1, rep2, 7)  # 7 is max precision here
 
+def test_arma_acovf_persistent():
+    # Test arma_acovf in case where there is a near-unit root.
+    # .999 is high enough to trigger the "while ir[-1] > 5*1e-5:" clause,
+    # but not high enough to trigger the "nobs_ir > 50000" clause.
+    ar = np.array([1, -.9995])
+    ma = np.array([1])
+    process = ArmaProcess(ar, ma)
+    res = process.acovf(10)
+
+    # Theoretical variance sig2 given by:
+    # sig2 = .9995**2 * sig2 + 1
+    sig2 = 1/(1-.9995**2)
+
+    corrs = np.array([.9995**n for n in range(10)])
+    expected = sig2*corrs
+    assert_(np.ndim(res) == 1)
+    assert_allclose(res, expected, 6)
+    # 7 decimals breaks at .999, worked at .995
 
 def test_arma_acf():
     # Check for specific AR(1)

--- a/statsmodels/tsa/tests/test_arima_process.py
+++ b/statsmodels/tsa/tests/test_arima_process.py
@@ -58,7 +58,7 @@ def test_arma_acovf_persistent():
     corrs = .9995**np.arange(10)
     expected = sig2*corrs
     assert_equal(res.ndim, 1)
-    assert_allclose(res, expected, atol=1e-10)
+    assert_allclose(res, expected, atol=1e-6)
     # atol=7 breaks at .999, worked at .995
 
 def test_arma_acf():

--- a/statsmodels/tsa/tests/test_arima_process.py
+++ b/statsmodels/tsa/tests/test_arima_process.py
@@ -7,8 +7,8 @@ from unittest import TestCase
 
 import numpy as np
 from numpy.testing import (assert_array_almost_equal, assert_almost_equal,
-                        assert_allclose,
-                        assert_equal, assert_raises, assert_, dec)
+                           assert_allclose,
+                           assert_equal, assert_raises, assert_, dec)
 
 from statsmodels.tsa.arima_process import (arma_generate_sample, arma_acovf,
                                            arma_acf, arma_impulse_response, lpol_fiar, lpol_fima,
@@ -55,11 +55,11 @@ def test_arma_acovf_persistent():
     # sig2 = .9995**2 * sig2 + 1
     sig2 = 1/(1-.9995**2)
 
-    corrs = np.array([.9995**n for n in range(10)])
+    corrs = .9995**np.arange(10)
     expected = sig2*corrs
-    assert_(np.ndim(res) == 1)
-    assert_allclose(res, expected, 6)
-    # 7 decimals breaks at .999, worked at .995
+    assert_equal(res.ndim, 1)
+    assert_allclose(res, expected, atol=1e-10)
+    # atol=7 breaks at .999, worked at .995
 
 def test_arma_acf():
     # Check for specific AR(1)


### PR DESCRIPTION
Addresses comments in #3666

The only material difference between this and the previous is the removal of assertions about the length of `res`.  That assertion is implicitly tested in `assert_allclose`. 

closes #3666 
