### PR TITLE
remove brackets from caption in latex output

### DIFF
--- a/statsmodels/iolib/summary2.py
+++ b/statsmodels/iolib/summary2.py
@@ -204,7 +204,7 @@ class Summary(object):
         settings = self.settings
         title = self.title
         if title is not None:
-            title = '\\caption{' + title + '} \\\\'
+            title = '\\caption{' + title + '}'
         else:
             title = '\\caption{}'
 


### PR DESCRIPTION
These brackets in the output of `.as_latex()` were causing the latex output to not compile if you added a caption using `table.add_title()`