### PR TITLE
WIP/ TSTS/BUG/ENH Gee margins dummy

### DIFF
--- a/statsmodels/discrete/discrete_margins.py
+++ b/statsmodels/discrete/discrete_margins.py
@@ -70,9 +70,7 @@ def _isdummy(X):
 def _get_dummy_index(X, const_idx):
     dummy_ind = _isdummy(X)
     dummy = True
-    # adjust back for a constant because effects doesn't have one
-    if const_idx is not None:
-        dummy_ind[dummy_ind > const_idx] -= 1
+
     if dummy_ind.size == 0: # don't waste your time
         dummy = False
         dummy_ind = None # this gets passed to stand err func

--- a/statsmodels/discrete/discrete_margins.py
+++ b/statsmodels/discrete/discrete_margins.py
@@ -105,9 +105,7 @@ def _iscount(X):
 def _get_count_index(X, const_idx):
     count_ind = _iscount(X)
     count = True
-    # adjust back for a constant because effects doesn't have one
-    if const_idx is not None:
-        count_ind[count_ind > const_idx] -= 1
+
     if count_ind.size == 0: # don't waste your time
         count = False
         count_ind = None # for stand err func

--- a/statsmodels/discrete/tests/test_discrete.py
+++ b/statsmodels/discrete/tests/test_discrete.py
@@ -889,6 +889,55 @@ class TestLogitNewton(CheckBinaryResults, CheckMargEff):
         assert_almost_equal(me.margeff_se,
                 self.res2.margeff_dummy_atexog2_se, DECIMAL_4)
 
+
+class TestLogitNewtonPrepend(object):
+    # same as previous version but adjusted vor add_constant prepend=True
+    # bug #3695
+    @classmethod
+    def setup_class(cls):
+        data = sm.datasets.spector.load()
+        data.exog = sm.add_constant(data.exog, prepend=True)
+        cls.res1 = Logit(data.endog, data.exog).fit(method="newton", disp=0)
+        res2 = Spector()
+        res2.logit()
+        cls.res2 = res2
+        cls.slice = np.roll(np.arange(len(cls.res1.params)), 1) #.astype(int)
+
+    def test_resid_pearson(self):
+        assert_almost_equal(self.res1.resid_pearson,
+                            self.res2.resid_pearson, 5)
+
+    def test_nodummy_exog1(self):
+        me = self.res1.get_margeff(atexog={1 : 2.0, 3 : 1.})
+        assert_almost_equal(me.margeff,
+                self.res2.margeff_nodummy_atexog1, DECIMAL_4)
+        assert_almost_equal(me.margeff_se,
+                self.res2.margeff_nodummy_atexog1_se, DECIMAL_4)
+
+    def test_nodummy_exog2(self):
+        me = self.res1.get_margeff(atexog={2 : 21., 3 : 0}, at='mean')
+        assert_almost_equal(me.margeff,
+                self.res2.margeff_nodummy_atexog2, DECIMAL_4)
+        assert_almost_equal(me.margeff_se,
+                self.res2.margeff_nodummy_atexog2_se, DECIMAL_4)
+
+    def test_dummy_exog1(self):
+        me = self.res1.get_margeff(atexog={1 : 2.0, 3 : 1.}, dummy=True)
+        assert_almost_equal(me.margeff,
+                self.res2.margeff_dummy_atexog1, DECIMAL_4)
+        assert_almost_equal(me.margeff_se,
+                self.res2.margeff_dummy_atexog1_se, DECIMAL_4)
+
+    def test_dummy_exog2(self):
+        me = self.res1.get_margeff(atexog={2 : 21., 3 : 0}, at='mean',
+                dummy=True)
+        assert_almost_equal(me.margeff,
+                self.res2.margeff_dummy_atexog2, DECIMAL_4)
+        assert_almost_equal(me.margeff_se,
+                self.res2.margeff_dummy_atexog2_se, DECIMAL_4)
+
+
+
 class TestLogitBFGS(CheckBinaryResults, CheckMargEff):
     @classmethod
     def setupClass(cls):

--- a/statsmodels/discrete/tests/test_discrete.py
+++ b/statsmodels/discrete/tests/test_discrete.py
@@ -891,7 +891,7 @@ class TestLogitNewton(CheckBinaryResults, CheckMargEff):
 
 
 class TestLogitNewtonPrepend(CheckMargEff):
-    # same as previous version but adjusted vor add_constant prepend=True
+    # same as previous version but adjusted for add_constant prepend=True
     # bug #3695
     @classmethod
     def setup_class(cls):
@@ -901,7 +901,6 @@ class TestLogitNewtonPrepend(CheckMargEff):
         res2 = Spector()
         res2.logit()
         cls.res2 = res2
-        cls.slice = np.roll(np.arange(len(cls.res1.params)), 1) #.astype(int)
 
     def test_resid_pearson(self):
         assert_almost_equal(self.res1.resid_pearson,
@@ -936,6 +935,38 @@ class TestLogitNewtonPrepend(CheckMargEff):
         assert_almost_equal(me.margeff_se,
                 self.res2.margeff_dummy_atexog2_se, DECIMAL_4)
 
+
+class TestGEELogitNoPrepend(CheckMargEff):
+    # trying to test GEE Margins against Logit Margins
+    # bug #3695
+    @classmethod
+    def setup_class(cls):
+        data = sm.datasets.spector.load()
+        data.exog = sm.add_constant(data.exog, prepend=False)
+        groups = np.ones(data.exog.shape[0], int)
+        mod = sm.GEE(data.endog, data.exog, groups, family=sm.families.Binomial())
+        cls.res1 = mod.fit(cov_type='naive')
+        mod._derivative_predict = mod._derivative_exog
+        res2 = Spector()
+        res2.logit()
+        cls.res2 = res2
+
+
+class TestGEELogitPrepend(TestLogitNewtonPrepend):
+    # trying to test GEE Margins against Logit Margins
+    # same as previous version but adjusted for add_constant prepend=True
+    # bug #3695
+    @classmethod
+    def setup_class(cls):
+        data = sm.datasets.spector.load()
+        data.exog = sm.add_constant(data.exog, prepend=True)
+        groups = np.ones(data.exog.shape[0], int)
+        mod = sm.GEE(data.endog, data.exog, groups, family=sm.families.Binomial())
+        cls.res1 = mod.fit(cov_type='naive')
+        mod._derivative_predict = mod._derivative_exog
+        res2 = Spector()
+        res2.logit()
+        cls.res2 = res2
 
 
 class TestLogitBFGS(CheckBinaryResults, CheckMargEff):

--- a/statsmodels/discrete/tests/test_discrete.py
+++ b/statsmodels/discrete/tests/test_discrete.py
@@ -890,7 +890,7 @@ class TestLogitNewton(CheckBinaryResults, CheckMargEff):
                 self.res2.margeff_dummy_atexog2_se, DECIMAL_4)
 
 
-class TestLogitNewtonPrepend(object):
+class TestLogitNewtonPrepend(CheckMargEff):
     # same as previous version but adjusted vor add_constant prepend=True
     # bug #3695
     @classmethod


### PR DESCRIPTION
see #3704 missing support for dummy and count argument

adds unit tests for GEEMargins similar to Logit tests in #3696
no attempt to fix the issue (I didn't look at the details, missing `_derivative_predict`

needs rebase: 
- I branched off 3696 so it can be rebased after that is merged
- includes one incorrect monkey patching in unit tests, just to see what the results are

currently fails, this was written to check what's going on with GEE Margins
