### PR TITLE
MAINT/REF: wald_test_term, use data.design_info

### DIFF
--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -1577,7 +1577,7 @@ class LikelihoodModelResults(Results):
             extra_constraints = []
         if combine_terms is None:
             combine_terms = []
-        design_info = getattr(result.model.data.orig_exog, 'design_info', None)
+        design_info = getattr(result.model.data, 'design_info', None)
 
         if design_info is None and extra_constraints is None:
             raise ValueError('no constraints, nothing to do')

--- a/statsmodels/base/tests/test_generic_methods.py
+++ b/statsmodels/base/tests/test_generic_methods.py
@@ -453,7 +453,6 @@ class TestWaldAnovaOLSF(CheckAnovaMixin):
         mod = ols("np.log(Days+1) ~ C(Duration, Sum)*C(Weight, Sum)", cls.data)
         cls.res = mod.fit()  # default use_t=True
 
-
     def test_predict_missing(self):
         ex = self.data[:5].copy()
         ex.iloc[0, 1] = np.nan


### PR DESCRIPTION
 closes #2682

we moved/copied design_info to model.data, adjust code in wald_test_terms

I checked that a unit test fails before change if `orig_exog.design_info` is deleted