### PR TITLE
BUG: nan fvalue for constant-only regression with robust cov_type

### DIFF
--- a/statsmodels/regression/linear_model.py
+++ b/statsmodels/regression/linear_model.py
@@ -1580,6 +1580,8 @@ class RegressionResults(base.LikelihoodModelResults):
                 idx = lrange(k_params)
                 idx.pop(const_idx)
                 mat = mat[idx]  # remove constant
+                if mat.size == 0:  # see  #3642
+                    return np.nan
             ft = self.f_test(mat)
             # using backdoor to set another attribute that we already have
             self._cache['f_pvalue'] = ft.pvalue

--- a/statsmodels/regression/tests/test_regression.py
+++ b/statsmodels/regression/tests/test_regression.py
@@ -1128,6 +1128,7 @@ def test_missing_formula_predict():
 
 
 def test_fvalue_implicit_constant():
+    # if constant is implicit, return nan see #2444
     nobs = 100
     np.random.seed(2)
     x = np.random.randn(nobs, 1)
@@ -1137,6 +1138,26 @@ def test_fvalue_implicit_constant():
     from statsmodels.regression.linear_model import OLS, WLS
 
     res = OLS(y, x).fit(cov_type='HC1')
+    assert_(np.isnan(res.fvalue))
+    assert_(np.isnan(res.f_pvalue))
+    res.summary()
+
+    res = WLS(y, x).fit(cov_type='HC1')
+    assert_(np.isnan(res.fvalue))
+    assert_(np.isnan(res.f_pvalue))
+    res.summary()
+
+
+def test_fvalue_only_constant():
+    # if only constant in model, return nan see #3642
+    nobs = 20
+    np.random.seed(2)
+    x = np.ones(nobs)
+    y = np.random.randn(nobs)
+
+    from statsmodels.regression.linear_model import OLS, WLS
+
+    res = OLS(y, x).fit(cov_type='hac', cov_kwds={'maxlags': 3})
     assert_(np.isnan(res.fvalue))
     assert_(np.isnan(res.f_pvalue))
     res.summary()


### PR DESCRIPTION
closes #3642

if constant is the only regressor, than fvalue has no slope parameters to check. constraint is empty. (*)
return nan for fvalue, 
avoids exception in summary

similar to #2444


(*) this is for fvalue base on wald_null if covtype is robust

with nonrobust cov_type, the behavior is  
(I never checked whether that makes sense, needs maybe a new issue)
```
>>> res_diff.fvalue
inf
>>> res_diff.f_pvalue
nan
```