### PR TITLE
BUG/ENH: cov_type hac_panel missing asarray

### DIFF
--- a/statsmodels/base/covtype.py
+++ b/statsmodels/base/covtype.py
@@ -248,10 +248,12 @@ def get_robustcov_results(self, cov_type='HC1', use_t=None, **kwds):
         res.cov_kwds['weights_func'] = weights_func
         # TODO: clumsy time index in cov_nw_panel
         if groups is not None:
+            groups = np.asarray(groups)
             tt = (np.nonzero(groups[:-1] != groups[1:])[0] + 1).tolist()
             nobs_ = len(groups)
         elif time is not None:
             # TODO: clumsy time index in cov_nw_panel
+            time = np.asarray(time)
             tt = (np.nonzero(time[1:] < time[:-1])[0] + 1).tolist()
             nobs_ = len(time)
         else:

--- a/statsmodels/discrete/tests/test_sandwich_cov.py
+++ b/statsmodels/discrete/tests/test_sandwich_cov.py
@@ -647,7 +647,7 @@ class TestGLMGaussHACPanelGroups(CheckDiscreteGLM):
         # time index is just made up to have a test case
         groups = np.repeat(np.arange(5), 7)[:-1]
         mod1 = GLM(endog.copy(), exog.copy(), family=families.Gaussian())
-        kwds = dict(groups=groups,
+        kwds = dict(groups=pd.Series(groups),  # check for #3606
                     maxlags=2,
                     kernel=sw.weights_uniform,
                     use_correction='hac',
@@ -666,7 +666,7 @@ class TestGLMGaussHACGroupsum(CheckDiscreteGLM):
         # time index is just made up to have a test case
         time = np.tile(np.arange(7), 5)[:-1]
         mod1 = GLM(endog, exog, family=families.Gaussian())
-        kwds = dict(time=time,
+        kwds = dict(time=pd.Series(time),  # check for #3606
                     maxlags=2,
                     use_correction='hac',
                     df_correction=False)

--- a/statsmodels/regression/linear_model.py
+++ b/statsmodels/regression/linear_model.py
@@ -2240,9 +2240,11 @@ class RegressionResults(base.LikelihoodModelResults):
             weights_func = kwds.get('weights_func', sw.weights_bartlett)
             res.cov_kwds['weights_func'] = weights_func
             if groups is not None:
+                groups = np.asarray(groups)
                 tt = (np.nonzero(groups[:-1] != groups[1:])[0] + 1).tolist()
                 nobs_ = len(groups)
             elif time is not None:
+                time = np.asarray(time)
                 # TODO: clumsy time index in cov_nw_panel
                 tt = (np.nonzero(time[1:] < time[:-1])[0] + 1).tolist()
                 nobs_ = len(time)


### PR DESCRIPTION
closes #3606 

add asarray to hac_panel group and time  
adjust one test for this case (fails before, succeeds after change)