### PR TITLE
WIP/BUG/REF: correlation_tools - fix value in clip_evals, add `fudge` term

### DIFF
--- a/statsmodels/stats/tests/test_corrpsd.py
+++ b/statsmodels/stats/tests/test_corrpsd.py
@@ -187,7 +187,8 @@ class TestCorrPSD1(CheckCorrPSDMixin):
         cls.res = cov1_r
 
 def test_corrpsd_threshold():
-    x = np.array([[1, -0.9, -0.9], [-0.9, 1, -0.9], [-0.9, -0.9, 1]])
+    #x = np.array([[1, -0.9, -0.9], [-0.9, 1, -0.9], [-0.9, -0.9, 1]])
+    x = np.array([[1, -0.5, -0.51], [-0.5, 1, -0.5], [-0.51, -0.5, 1]])
 
     #print np.linalg.eigvalsh(x)
     for threshold in [0, 1e-15, 1e-10, 1e-6]:
@@ -200,7 +201,7 @@ def test_corrpsd_threshold():
         y = corr_clipped(x, threshold=threshold)
         evals = np.linalg.eigvalsh(y)
         #print 'evals', evals, threshold
-        assert_allclose(evals[0], threshold, rtol=0.25, atol=1e-15)
+        assert_allclose(evals[0], threshold, rtol=0.0025, atol=1e-15)
 
         y = cov_nearest(x, method='nearest', n_fact=100, threshold=threshold)
         evals = np.linalg.eigvalsh(y)
@@ -212,7 +213,7 @@ def test_corrpsd_threshold():
         evals = np.linalg.eigvalsh(y)
         #print 'evals', evals, threshold
         #print evals[0] / threshold - 1
-        assert_allclose(evals[0], threshold, rtol=0.25, atol=1e-15)
+        assert_allclose(evals[0], threshold, rtol=0.0025, atol=1e-15)
 
 class Test_Factor(object):
 


### PR DESCRIPTION
This was supposed to fix #3227  value ignore in clip_evals.

Include fix for non or slow convergence in `tests\test_corrpsd.py:test_corrpsd_threshold` (test run print convergence warnings. I tried up to 1000 iterations, but we only seem to approach the threshold in the eigenvalue for corr_nearest from below.
- add extra convergence check directly on the trial corr matrix
- add a fudge term 1e-16

Now, convergence is very fast in test_corrpsd_threshold with smallest eigenvalue possibly a bit above threshold.

However, unit test against R fail now. I'm not sure it's really testing the same things, e.g. R has ones on diagonal, i.e. corr_nearest, while the test cases uses cov_nearest with diagonal values slightly above one.
distance to original matrix is smaller in the new version than in the R reference numbers.  
This looks more like a reason to adjust the unit tests, than the code.

About the fudge term (I just made it up):
- it is only relevant for eigenvalues around zero. multiplicative fudge factor doesn't work if threshold is zero
- idea is to adjust or clip eigenvalues to something slightly higher than the target threshold, so we cross the threshold instead of just approaching it slowly. This might introduce a small distortion in the converged result, but works well and fast in the test cases.


status: currently fails in comparison to R, I need to get the changes out of the way, and haven't looked and decided yet whether to adjust the unit tests or the code.




