### PR TITLE
WIP: Dimensions Mixins

### DIFF
--- a/statsmodels/base/dimensions.py
+++ b/statsmodels/base/dimensions.py
@@ -15,6 +15,7 @@ Examples:
 
 """
 import numpy as np
+import bottleneck as bn
 
 from statsmodels.tools.decorators import cache_readonly
 

--- a/statsmodels/base/dimensions.py
+++ b/statsmodels/base/dimensions.py
@@ -181,6 +181,7 @@ class KTrendMixin(object):
 		return kt
 
 
+# FIXME: What if self.exog exists but self.data has not been set yet?
 class KExogMixin(object):
 
 	# Note: making k_exog a cache_readonly breaks
@@ -189,6 +190,7 @@ class KExogMixin(object):
 	def k_exog(self):
 		try:
 			# FIXME: Could this be wrong depending on whether the user already passed a trend or constant?
+			# TODO: What about C_CONTIGUOUS/F_CONTIGUOUS?
 			return self.data.orig_exog.shape[1]
 			# For most models:
 			# 	equiv: self.exog.shape[1]
@@ -212,6 +214,19 @@ class KExogMixin(object):
 			# np.ndim(...) gives the desired measurement.
 			return np.ndim(self.data.orig_exog)
 			# FIXME: is this going to incorrectly return 0 when we have a scalar instead of an array?
+
+
+class MNDimensions(object):
+	@cache_readonly
+	def J(self):
+		# number of alternative choices
+		return self.wendog.shape[1]
+
+	# TODO: Is this equivalent to k_exog?
+	@cache_readonly
+	def K(self):
+		# number of variables
+		return self.exog.shape[1]
 
 
 class L1Estimator(object):

--- a/statsmodels/base/dimensions.py
+++ b/statsmodels/base/dimensions.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+
+dimensions.py defines mixin classes for pinning down Model/Results attributes
+in terms of each other.  In particular, these attributes are those
+that depend on the *shape* of the data or the estimation method being
+used, but *not* the data themselves.
+
+Examples:
+	df_model, df_resid
+	nobs
+	neqs
+	k_exog, k_endog
+
+"""
+import numpy as np
+
+from statsmodels.tools.decorators import cache_readonly
+
+
+
+def _get_k_constant(inst, assume_const, assert_const=False):
+	"""
+	There is a long-existing eyesore in statsmodels of adding 1.0
+	to `df_model` along with a comment "# assumes constant"
+
+	_get_k_constant exists to check that assumption, handle it
+	systematically, and eventually deprecate it.
+
+	The intention as designed is for `_assume_const` and `_assert_const` to
+	be class attributes belong to `inst`.  Then calling would look like
+
+	>>> k_const = _get_k_constant(self, self._assume_const, self._assert_const)
+
+	This pattern is encouraged but not required.
+
+
+	If `assume_const` argument is True, the value `1.0` is always returned.
+	Otherwise, `inst.k_constant` is returned.
+
+	**
+	The goal is for as many classes as possible to set `_assume_constant`
+	to `False`
+	**
+
+	If the `assert_const` argument is True, we assert that
+	`inst.k_constant == 1`.  If this assertion is made *and passes* then
+	we can infer that this class does not *need* to assume there is a
+	constant.  This class can be cleaned up by eliminating this behavior.
+	Retaining the `assert_const` in future runs behaves as a regression
+	test.
+
+
+	# See GH #1624, #1664, #1719, #1724, #1930, #3574
+	# Note 1624 is a semi-separate issue that is a *different* eyesore
+	"""
+	if assume_const:
+		k_const = 1.0
+	else:
+		k_const = inst.k_constant
+
+	if assert_const:
+		assert inst.k_constant == 1, inst.k_constant
+	return k_const
+
+
+# Inherited by Model and Results
+class NEQsMixin(object):
+	
+	@cache_readonly
+	def neqs(self):
+		try:
+			# Note: Recall that MLEModel and sub-classes have endog transposed
+			# TODO: does the above apply to any of DiscreteModel?
+			return self.endog.shape[1] # FIXME: does the MLEModel note above mean that this will be wrong?
+		except (AttributeError, IndexError):
+			# Note: np.ndim(None) is 0
+			return np.ndim(self.endog)
+
+	k_endog = neqs # TODO: Is this a misnomer for MultinomialModel, MNLogit?
+
+
+# Inherited by VARResults, Model, and Results
+class NobsMixin(object):
+	@cache_readonly
+	def _nobs_total(self):
+		"""
+		AR, ARIMA, VAR, ... models have `nobs` that is not always equal
+		to `len(endog)`.  `_nobs_total` gives the *total* observations,
+		including any that are dropped or "burned" like in these special
+		cases.
+		"""
+		try:
+			# regime_switching
+			return len(self.orig_endog) # TODO: should we use self.data.orig_endog?
+		except AttributeError:
+			return len(self.endog)
+			# FIXME: This may break in models where self.endog is messed with.
+
+	@cache_readonly
+	def nobs(self):
+		# Note: we could use endog.shape[0], but in at least
+		# one test case self.endog is a list
+		return len(self.endog)
+		# Notes from the GEE Case:
+		# v1 = sum([len(y) for y in self.endog_li])
+		# v2 = sum([len(y) for y in self.group_indices.values()])
+		# v3 = len(self.endog)
+		# assert v1 == v2, (v1, v2)
+		# assert v3 == v1, (v3, v1)
+
+
+class KarNobsMixin(object):
+	@property
+	def nobs(self):
+		# In markov_switching and markov_autoregression, _nobs_total comes
+		# from len(self.orig_endog).  markov_switching does not have a
+		# k_ar attribute, but markov_autoregression (which subclasses markov_swiching)
+		# does.
+		#
+		# In linear_model, this is equivalent to self.wexog.shape[0].
+		# For OLS, WLS, and GLS this is the same as _nobs_total, i.e.
+		# len(self.endog).  However for GLSAR the `whiten` method
+		# returns a `self.wexog` which is shorter than `self.endog` by `k_ar`,
+		# so we subtract that term to get `nobs`.
+		return self._nobs_total - getattr(self, 'k_ar', 0)
+
+
+class CssKarNobsMixin(object):
+	@property
+	def nobs(self):
+		n_totobs = self._nobs_total
+		if self.method in ["cmle", "css", "ols"]:
+			nobs = (n_totobs - self.k_ar)
+		else:
+			nobs = n_totobs
+		# ARModel used to set nobs = n_totobs iff method == "mle" and
+		# otherwise raise NotImplementedError
+		return float(nobs)
+
+
+class KTrendMixin(object):
+	# Note: making k_exog a cache_readonly or cached_property breaks
+	# a couple of ARIMA tests; not sure why.
+	@property
+	def k_trend(self): # Almost Equiv: tsa.vector_ar.util.get_trendorder(trend)
+		trend = self.trend
+		if trend in ['n', 'nc', None]:
+			kt = 0
+		elif trend == 'c': # I think only 0 and 1 are implemented  ## should this be related to k_constant?
+			kt = 1
+		elif trend == 't':  # TODO: not hit in tests
+			kt = 1
+		elif trend == 'ct':
+			kt = 2
+		elif isinstance(trend, (list, np.array)):
+			# e.g. SARIMAX
+			kt = sum(trend)
+		else:
+			raise NotImplementedError(trend)
+			#kt = 0
+		return kt
+
+
+class KExogMixin(object):
+
+	# Note: making k_exog a cache_readonly breaks
+	# a couple of ARIMA tests; not sure why.
+	@property
+	def k_exog(self):
+		try:
+			# FIXME: Could this be wrong depending on whether the user already passed a trend or constant?
+			return self.data.orig_exog.shape[1]
+			# For most models:
+			# 	equiv: self.exog.shape[1]
+			#
+			# For scalar AR/ARMA/ARIMA models:
+			# 	equiv: return self.exog.shape[1] - self.k_trend
+			#
+			# In these cases the `exog` attribute includes
+			# possible trend columns that are added internally
+			# (i.e. not part of the `exog` passed to __init__)
+			# To get at the intended `k_exog`, we need to subtract `k_trend`
+			# from self.exog.shape[1].  Alternatively, we can just check
+			# `self.data.orig_exog.shape[1]`
+		except AttributeError:
+			# There is no `self.exog` (or more specifically, `self.data.orig_exog`)
+			return 0
+		except IndexError:
+			# IndexError: tuple index out of range
+			# If orig_exog is 1-dimensional, we just want 1.  If it is
+			# zero-dimensional, we just want 0.  It is a coincidence that
+			# np.ndim(...) gives the desired measurement.
+			return np.ndim(self.data.orig_exog)
+			# FIXME: is this going to incorrectly return 0 when we have a scalar instead of an array?
+
+
+class L1Estimator(object):
+	_assume_const = True
+	_assert_const = True
+
+	@cache_readonly
+	def trimmed(self):
+		"""trimmed is a boolean array with T/F telling whether or not that
+		entry in params has been set zero'd out."""
+		return self.mle_retvals['trimmed']
+
+	@cache_readonly
+	def nnz_params(self):
+		"""Number of non-zero params"""
+		return (self.trimmed == False).sum()
+
+

--- a/statsmodels/base/dimensions.py
+++ b/statsmodels/base/dimensions.py
@@ -140,6 +140,23 @@ class CssKarNobsMixin(object):
 		return float(nobs)
 
 
+class WNobsMixin(object):
+	"""
+
+	This mixin is specific to GLM Model, defines a `wnobs` property in
+	terms of the model's `freq_weights` attribute.
+
+	"""
+
+	@property
+	def wnobs(self):
+		if (self.freq_weights is not None) and (self.freq_weights.shape[0] == self.endog.shape[0]):
+			wnobs = bn.nansum(self.freq_weights) # self.freq_weights.sum()
+		else:
+			wnobs = self.exog.shape[0] ## wexog??  # TODO: not hit in tests
+		return wnobs
+
+
 class KTrendMixin(object):
 	# Note: making k_exog a cache_readonly or cached_property breaks
 	# a couple of ARIMA tests; not sure why.

--- a/statsmodels/base/initialization.py
+++ b/statsmodels/base/initialization.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+
+Common functions used in preparing or validating model inputs.
+
+"""
+
+import numpy as np
+import pandas as pd
+
+from statsmodels.tools.data import _is_using_pandas
+
+
+
+def prepare_exog(exog):
+    k_exog = 0
+    # Exogenous data
+    if exog is not None:
+        exog_is_using_pandas = _is_using_pandas(exog, None)
+        if not exog_is_using_pandas:
+            exog = np.asarray(exog)
+
+        # Make sure we have 2-dimensional array
+        if exog.ndim == 1:
+            if not exog_is_using_pandas:
+                exog = exog[:, None]
+            else:
+                exog = pd.DataFrame(exog)
+
+        k_exog = exog.shape[1]
+    return (k_exog, exog)
+

--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -1175,8 +1175,7 @@ class LikelihoodModelResults(Results):
             return cov_p
 
     #TODO: make sure this works as needed for GLMs
-    def t_test(self, r_matrix, cov_p=None, scale=None,
-               use_t=None):
+    def t_test(self, r_matrix, cov_p=None, scale=None, use_t=None):
         """
         Compute a t-test for a each linear hypothesis of the form Rb = q
 

--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -426,6 +426,7 @@ class LikelihoodModel(Model):
             elif self.exog is not None:
                 # fails for shape (K,)?
                 start_params = [0] * self.exog.shape[1]
+                # Note: self.k_exog is not guaranteed to exist at this point
             else:
                 raise ValueError("If exog is None, then start_params should "
                                  "be specified")
@@ -435,6 +436,7 @@ class LikelihoodModel(Model):
         # args in most (any?) of the optimize function
 
         nobs = self.endog.shape[0]
+        # Note: In most cases this is equivalent to `self.nobs`.
         f = lambda params, *args: -self.loglike(params, *args) / nobs
         score = lambda params, *args: -self.score(params, *args) / nobs
         try:
@@ -509,7 +511,7 @@ class LikelihoodModel(Model):
 
 
 #TODO: the below is unfinished
-class GenericLikelihoodModel(LikelihoodModel):
+class GenericLikelihoodModel(LikelihoodModel, dimensions.KExogMixin):
     """
     Allows the fitting of any likelihood function via maximum likelihood.
 
@@ -581,6 +583,7 @@ class GenericLikelihoodModel(LikelihoodModel):
         if exog is not None:
             #try:
             self.nparams = (exog.shape[1] if np.ndim(exog) == 2 else 1)
+            # TODO: Is this ever used?  Is it named k_params elsewhere?
 
         if extra_params_names is not None:
             self._set_extra_params_names(extra_params_names)
@@ -594,6 +597,7 @@ class GenericLikelihoodModel(LikelihoodModel):
                 self.data.xnames = extra_params_names
 
         self.nparams = len(self.exog_names)
+        # TODO: Is this used elsewhere?  Is it named k_params elsewhere?
 
     #this is redundant and not used when subclassing
     def initialize(self):
@@ -609,9 +613,9 @@ class GenericLikelihoodModel(LikelihoodModel):
         #and should contain any preprocessing that needs to be done for a model
         if self.exog is not None:
             # assume constant
-            er = np_matrix_rank(self.exog)
-            self.df_model = float(er - 1)
-            self.df_resid = float(self.exog.shape[0] - er)
+            rank = float(np_matrix_rank(self.exog))
+            self.df_model = rank - 1
+            self.df_resid = self.nobs - rank
         else:
             self.df_model = np.nan
             self.df_resid = np.nan
@@ -758,6 +762,7 @@ class Results(dimensions.NEQsMixin, dimensions.NobsMixin):
         parameter estimates from the fit model
     """
     def __init__(self, model, params, **kwd):
+        self.model = model
         self.__dict__.update(kwd)
         self.initialize(model, params, **kwd)
         self._data_attr = []
@@ -814,8 +819,7 @@ class Results(dimensions.NEQsMixin, dimensions.NobsMixin):
 
         if exog is not None:
             exog = np.asarray(exog)
-            if exog.ndim == 1 and (self.model.exog.ndim == 1 or
-                                   self.model.exog.shape[1] == 1):
+            if exog.ndim == 1 and (self.model.exog.ndim == 1 or self.exog.shape[1] == 1):
                 exog = exog[:, None]
             exog = np.atleast_2d(exog)  # needed in count model shape[1]
 
@@ -838,7 +842,7 @@ class Results(dimensions.NEQsMixin, dimensions.NobsMixin):
 
 
 #TODO: public method?
-class LikelihoodModelResults(Results):
+class LikelihoodModelResults(Results, dimensions.KExogMixin):
     """
     Class to contain results from likelihood models
 
@@ -1000,6 +1004,11 @@ class LikelihoodModelResults(Results):
 
     def __init__(self, model, params, normalized_cov_params=None, scale=1.,
                  **kwargs):
+
+        self.model = model
+        self.endog = model.endog
+        self.exog = model.exog
+
         super(LikelihoodModelResults, self).__init__(model, params)
         self.normalized_cov_params = normalized_cov_params
         self.scale = scale
@@ -1276,7 +1285,7 @@ class LikelihoodModelResults(Results):
             not hasattr(self, 'cov_params_default')):
             raise ValueError('Need covariance of parameters for computing '
                              'T statistics')
-        if num_params != self.params.shape[0]:
+        if num_params != self.params.shape[0]: # TODO: Should this more generally be params.size?
             raise ValueError('r_matrix and params are not aligned')
         if q_matrix is None:
             q_matrix = np.zeros(num_ttests)
@@ -1818,9 +1827,10 @@ class LikelihoodModelResults(Results):
             except AttributeError:
                 pass
 
+        extra_attrs = ['exog', 'endog', 'wexog']
         model_only = ['model.' + i for i in getattr(self, "_data_attr_model", [])]
         model_attr = ['model.' + i for i in self.model._data_attr]
-        for att in self._data_attr + model_attr + model_only:
+        for att in self._data_attr + model_attr + model_only + extra_attrs:
             #print('removing', att)
             wipe(self, att)
 
@@ -1991,7 +2001,7 @@ class ResultMixin(object):
         pass
 
 
-class GenericLikelihoodModelResults(LikelihoodModelResults, ResultMixin):
+class GenericLikelihoodModelResults(LikelihoodModelResults, ResultMixin, dimensions.KExogMixin):
     """
     A results class for the discrete dependent variable models.
 
@@ -2047,7 +2057,6 @@ class GenericLikelihoodModelResults(LikelihoodModelResults, ResultMixin):
         self.model = model
         self.endog = model.endog
         self.exog = model.exog
-        self.nobs = model.endog.shape[0]
 
         # TODO: possibly move to model.fit()
         #       and outsource together with patching names
@@ -2061,7 +2070,7 @@ class GenericLikelihoodModelResults(LikelihoodModelResults, ResultMixin):
         if hasattr(model, 'df_resid'):
             self.df_resid = model.df_resid
         else:
-            self.df_resid = self.endog.shape[0] - self.df_model
+            self.df_resid = self.nobs - self.df_model
             # retrofitting the model, used in t_test TODO: check design
             self.model.df_resid = self.df_resid
 

--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -15,6 +15,7 @@ from statsmodels.formula import handle_formula_data
 from statsmodels.compat.numpy import np_matrix_rank
 from statsmodels.base.optimizer import Optimizer
 
+from statsmodels.base import dimensions
 
 _model_params_doc = """
     Parameters
@@ -41,7 +42,7 @@ _extra_param_doc = """
 """
 
 
-class Model(object):
+class Model(dimensions.NEQsMixin, dimensions.NobsMixin):
     __doc__ = """
     A (predictive) statistical model. Intended to be subclassed not used.
 
@@ -745,7 +746,7 @@ class GenericLikelihoodModel(LikelihoodModel):
     #fit.__doc__ += LikelihoodModel.fit.__doc__
 
 
-class Results(object):
+class Results(dimensions.NEQsMixin, dimensions.NobsMixin):
     """
     Class to contain model results
 

--- a/statsmodels/discrete/discrete_model.py
+++ b/statsmodels/discrete/discrete_model.py
@@ -40,6 +40,8 @@ import statsmodels.base.wrapper as wrap
 from statsmodels.compat.numpy import np_matrix_rank
 from pandas.core.api import get_dummies
 
+from statsmodels.base import dimensions
+
 from statsmodels.base.l1_slsqp import fit_l1_slsqp
 try:
     import cvxopt
@@ -2650,7 +2652,7 @@ class NegativeBinomialResults(CountResults):
         return -2*self.llf + np.log(self.nobs)*(self.df_model +
                                                 self.k_constant + k_extra)
 
-class L1CountResults(DiscreteResults):
+class L1CountResults(dimensions.L1Estimator, DiscreteResults):
     __doc__ = _discrete_results_docs % {"one_line_description" :
             "A results class for count data fit by l1 regularization",
             "extra_attr" : _l1_results_attr}
@@ -2658,10 +2660,6 @@ class L1CountResults(DiscreteResults):
 
     def __init__(self, model, cntfit):
         super(L1CountResults, self).__init__(model, cntfit)
-        # self.trimmed is a boolean array with T/F telling whether or not that
-        # entry in params has been set zero'd out.
-        self.trimmed = cntfit.mle_retvals['trimmed']
-        self.nnz_params = (self.trimmed == False).sum()
         # update degrees of freedom
         self.model.df_model = self.nnz_params - 1
         self.model.df_resid = float(self.model.endog.shape[0] - self.nnz_params)
@@ -2887,16 +2885,12 @@ class ProbitResults(BinaryResults):
         cdf = model.cdf(XB)
         return endog * pdf/cdf - (1-endog)*pdf/(1-cdf)
 
-class L1BinaryResults(BinaryResults):
+class L1BinaryResults(dimensions.L1Estimator, BinaryResults):
     __doc__ = _discrete_results_docs % {"one_line_description" :
     "Results instance for binary data fit by l1 regularization",
     "extra_attr" : _l1_results_attr}
     def __init__(self, model, bnryfit):
         super(L1BinaryResults, self).__init__(model, bnryfit)
-        # self.trimmed is a boolean array with T/F telling whether or not that
-        # entry in params has been set zero'd out.
-        self.trimmed = bnryfit.mle_retvals['trimmed']
-        self.nnz_params = (self.trimmed == False).sum()
         self.model.df_model = self.nnz_params - 1
         self.model.df_resid = float(self.model.endog.shape[0] - self.nnz_params)
         self.df_model = self.model.df_model
@@ -3036,17 +3030,12 @@ class MultinomialResults(DiscreteResults):
         return smry
 
 
-class L1MultinomialResults(MultinomialResults):
+class L1MultinomialResults(dimensions.L1Estimator, MultinomialResults):
     __doc__ = _discrete_results_docs % {"one_line_description" :
         "A results class for multinomial data fit by l1 regularization",
         "extra_attr" : _l1_results_attr}
     def __init__(self, model, mlefit):
         super(L1MultinomialResults, self).__init__(model, mlefit)
-        # self.trimmed is a boolean array with T/F telling whether or not that
-        # entry in params has been set zero'd out.
-        self.trimmed = mlefit.mle_retvals['trimmed']
-        self.nnz_params = (self.trimmed == False).sum()
-
         #Note: J-1 constants
         self.model.df_model = self.nnz_params - (self.model.J - 1)
         self.model.df_resid = float(self.model.endog.shape[0] - self.nnz_params)

--- a/statsmodels/duration/hazard_regression.py
+++ b/statsmodels/duration/hazard_regression.py
@@ -327,7 +327,6 @@ class PHReg(model.LikelihoodModel):
         self.surv = PHSurvivalTime(self.endog, self.status,
                                     self.exog, self.strata,
                                     self.entry, self.offset)
-        self.nobs = len(self.endog)
         self.groups = None
 
         # TODO: not used?

--- a/statsmodels/genmod/_prediction.py
+++ b/statsmodels/genmod/_prediction.py
@@ -193,7 +193,7 @@ def get_prediction_glm(self, exog=None, transform=True, weights=None,
 
         exog = np.asarray(exog)
         if exog.ndim == 1 and (self.model.exog.ndim == 1 or
-                               self.model.exog.shape[1] == 1):
+                               self.model.k_exog == 1):
             exog = exog[:, None]
         exog = np.atleast_2d(exog)  # needed in count model shape[1]
     else:

--- a/statsmodels/genmod/cov_struct.py
+++ b/statsmodels/genmod/cov_struct.py
@@ -1,3 +1,5 @@
+from __future__ import division
+
 from statsmodels.compat.python import iterkeys, itervalues, zip, range
 from statsmodels.stats.correlation_tools import cov_nearest
 import numpy as np

--- a/statsmodels/genmod/generalized_linear_model.py
+++ b/statsmodels/genmod/generalized_linear_model.py
@@ -28,6 +28,7 @@ import statsmodels.regression.linear_model as lm
 import statsmodels.base.wrapper as wrap
 import statsmodels.regression._tools as reg_tools
 
+from statsmodels.base import dimensions
 
 from statsmodels.graphics._regressionplots_doc import (
     _plot_added_variable_doc,
@@ -48,7 +49,7 @@ def _check_convergence(criterion, iteration, atol, rtol):
                        atol=atol, rtol=rtol)
 
 
-class GLM(base.LikelihoodModel):
+class GLM(dimensions.WNobsMixin, base.LikelihoodModel):
     __doc__ = """
     Generalized Linear Models class
 
@@ -298,15 +299,7 @@ class GLM(base.LikelihoodModel):
                                             np.transpose(self.pinv_wexog))
 
         self.df_model = np_matrix_rank(self.exog) - 1
-
-
-        if (self.freq_weights is not None) and \
-           (self.freq_weights.shape[0] == self.endog.shape[0]):
-            self.wnobs = self.freq_weights.sum()
-            self.df_resid = self.wnobs - self.df_model - 1
-        else:
-            self.wnobs = self.exog.shape[0]
-            self.df_resid = self.exog.shape[0] - self.df_model - 1
+        self.df_resid = self.wnobs - self.df_model - 1
 
     def _check_inputs(self, family, offset, exposure, endog, freq_weights):
 

--- a/statsmodels/imputation/mice.py
+++ b/statsmodels/imputation/mice.py
@@ -1160,6 +1160,8 @@ to obtain summary:
     def __init__(self, model_formula, model_class, data, n_skip=3,
                  init_kwds=None, fit_kwds=None):
 
+        self.endog = None
+        self.exog = None
         self.model_formula = model_formula
         self.model_class = model_class
         self.n_skip = n_skip

--- a/statsmodels/miscmodels/count.py
+++ b/statsmodels/miscmodels/count.py
@@ -214,7 +214,7 @@ class PoissonZiGMLE(GenericLikelihoodModel):
         #TODO: it's not standard pattern to use default exog
         if exog is None:
             self.exog = np.ones((self.nobs,1))
-        self.nparams = self.exog.shape[1]
+        self.nparams = self.k_exog # TODO: use k_params?
         #what's the shape in regression for exog if only constant
         self.start_params = np.hstack((np.ones(self.nparams), 0))
         self.cloneattr = ['start_params']

--- a/statsmodels/miscmodels/tmodel.py
+++ b/statsmodels/miscmodels/tmodel.py
@@ -58,7 +58,6 @@ class TLinearModel(GenericLikelihoodModel):
 
     def initialize(self):
         # TODO: here or in __init__
-        self.k_vars = self.exog.shape[1]
         if not hasattr(self, 'fix_df'):
             self.fix_df = False
 
@@ -66,12 +65,12 @@ class TLinearModel(GenericLikelihoodModel):
             # df will be estimated, no parameter restrictions
             self.fixed_params = None
             self.fixed_paramsmask = None
-            self.k_params = self.exog.shape[1] + 2
+            self.k_params = self.k_exog + 2
             extra_params_names = ['df', 'scale']
         else:
             # df fixed
-            self.k_params = self.exog.shape[1] + 1
-            fixdf = np.nan * np.zeros(self.exog.shape[1] + 2)
+            self.k_params = self.k_exog + 1
+            fixdf = np.nan * np.zeros(self.k_exog + 2)
             fixdf[-2] = self.fix_df
             self.fixed_params = fixdf
             self.fixed_paramsmask = np.isnan(fixdf)
@@ -89,7 +88,7 @@ class TLinearModel(GenericLikelihoodModel):
             from statsmodels.regression.linear_model import OLS
             res_ols = OLS(self.endog, self.exog).fit()
             start_params = 0.1*np.ones(self.k_params)
-            start_params[:self.k_vars] = res_ols.params
+            start_params[:self.k_exog] = res_ols.params
 
             if self.fix_df is False:
 
@@ -160,7 +159,7 @@ class TLinearModel(GenericLikelihoodModel):
     def predict(self, params, exog=None):
         if exog is None:
             exog = self.exog
-        return np.dot(exog, params[:self.exog.shape[1]])
+        return np.dot(exog, params[:self.k_exog])
 
 
 from scipy import stats

--- a/statsmodels/multivariate/manova.py
+++ b/statsmodels/multivariate/manova.py
@@ -7,14 +7,17 @@ author: Yichuan Liu
 from __future__ import division
 
 import numpy as np
+
 from statsmodels.base.model import Model
+from statsmodels.base import dimensions
+
 from .multivariate_ols import _multivariate_ols_test, _hypotheses_doc
 from .multivariate_ols import _multivariate_ols_fit
 from .multivariate_ols import MultivariateTestResults
 __docformat__ = 'restructuredtext en'
 
 
-class MANOVA(Model):
+class MANOVA(Model, dimensions.KExogMixin):
     """
     Multivariate analysis of variance
     The implementation of MANOVA is based on multivariate regression and does
@@ -60,13 +63,13 @@ class MANOVA(Model):
                 terms = self.data.design_info.term_name_slices
                 hypotheses = []
                 for key in terms:
-                    L_contrast = np.eye(self.exog.shape[1])[terms[key], :]
+                    L_contrast = np.eye(self.k_exog)[terms[key], :]
                     hypotheses.append([key, L_contrast, None])
             else:
                 hypotheses = []
-                for i in range(self.exog.shape[1]):
+                for i in range(self.k_exog):
                     name = 'x%d' % (i)
-                    L = np.zeros([1, self.exog.shape[1]])
+                    L = np.zeros([1, self.k_exog])
                     L[i] = 1
                     hypotheses.append([name, L, None])
 

--- a/statsmodels/regression/_prediction.py
+++ b/statsmodels/regression/_prediction.py
@@ -138,7 +138,7 @@ def get_prediction(self, exog=None, transform=True, weights=None,
 
         exog = np.asarray(exog)
         if exog.ndim == 1 and (self.model.exog.ndim == 1 or
-                               self.model.exog.shape[1] == 1):
+                               self.model.k_exog == 1):
             exog = exog[:, None]
         exog = np.atleast_2d(exog)  # needed in count model shape[1]
     else:

--- a/statsmodels/robust/robust_linear_model.py
+++ b/statsmodels/robust/robust_linear_model.py
@@ -13,6 +13,8 @@ PJ Huber.  1973,  'The 1972 Wald Memorial Lectures: Robust Regression:
 R Venables, B Ripley. 'Modern Applied Statistics in S'  Springer, New York,
     2002.
 """
+from __future__ import division
+
 from statsmodels.compat.python import string_types
 import numpy as np
 import scipy.stats as stats
@@ -110,6 +112,8 @@ class RLM(base.LikelihoodModel):
 
     def __init__(self, endog, exog, M=norms.HuberT(), missing='none',
                  **kwargs):
+        self.endog = endog
+        self.exog = exog
         self.M = M
         super(base.LikelihoodModel, self).__init__(endog, exog,
                 missing=missing, **kwargs)
@@ -129,7 +133,6 @@ class RLM(base.LikelihoodModel):
         self.df_resid = (np.float(self.exog.shape[0] -
                          np_matrix_rank(self.exog)))
         self.df_model = np.float(np_matrix_rank(self.exog)-1)
-        self.nobs = float(self.endog.shape[0])
 
     def score(self, params):
         raise NotImplementedError
@@ -390,9 +393,10 @@ class RLMResults(base.LikelihoodModelResults):
         super(RLMResults, self).__init__(model, params,
                 normalized_cov_params, scale)
         self.model = model
+        self.endog = model.endog
+        self.exog = model.exog
         self.df_model = model.df_model
         self.df_resid = model.df_resid
-        self.nobs = model.nobs
         self._cache = resettable_cache()
         #for remove_data
         self.data_in_cache = ['sresid']

--- a/statsmodels/sandbox/regression/gmm.py
+++ b/statsmodels/sandbox/regression/gmm.py
@@ -493,7 +493,6 @@ class GMM(Model):
 #         self.endog = endog
 #         self.exog = exog
 #         self.instrument = instrument
-        self.nobs = endog.shape[0]
         if k_moms is not None:
             self.nmoms = k_moms
         elif instrument is not None:
@@ -1109,8 +1108,8 @@ class GMMResults(LikelihoodModelResults):
     def __init__(self, *args, **kwds):
         self.__dict__.update(kwds)
 
-        self.nobs = self.model.nobs
         self.df_resid = np.inf
+        self.endog = self.model.endog
 
         self.cov_params_default = self._cov_params()
 

--- a/statsmodels/tsa/base/tsa_model.py
+++ b/statsmodels/tsa/base/tsa_model.py
@@ -15,6 +15,8 @@ import statsmodels.base.wrapper as wrap
 from statsmodels.tsa.base import datetools
 from statsmodels.tools.sm_exceptions import ValueWarning
 
+from statsmodels.base import dimensions
+
 _tsa_doc = """
     %(model)s
 
@@ -37,7 +39,7 @@ _generic_params = base._model_params_doc
 _missing_param_doc = base._missing_param_doc
 
 
-class TimeSeriesModel(base.LikelihoodModel):
+class TimeSeriesModel(dimensions.KExogMixin, base.LikelihoodModel):
 
     __doc__ = _tsa_doc % {"model": _model_doc, "params": _generic_params,
                           "extra_params": _missing_param_doc,

--- a/statsmodels/tsa/kalmanf/kalmanfilter.py
+++ b/statsmodels/tsa/kalmanf/kalmanfilter.py
@@ -593,7 +593,7 @@ class KalmanFilter(object):
         paramsdtype = params.dtype
         y = arma_model.endog.copy().astype(paramsdtype)
         k = arma_model.k_exog + arma_model.k_trend
-        nobs = arma_model.nobs
+        nobs = len(y) # Try to avoid the need to get a reliable `nobs` attribute from the model
         k_ar = arma_model.k_ar
         k_ma = arma_model.k_ma
         k_lags = arma_model.k_lags

--- a/statsmodels/tsa/regime_switching/markov_autoregression.py
+++ b/statsmodels/tsa/regime_switching/markov_autoregression.py
@@ -118,7 +118,7 @@ class MarkovAutoregression(markov_regression.MarkovRegression):
             missing=missing)
 
         # Sanity checks
-        if self.nobs <= self.order:
+        if self._nobs_total <= self.order:
             raise ValueError('Must have more observations than the order of'
                              ' the autoregression.')
 
@@ -126,7 +126,7 @@ class MarkovAutoregression(markov_regression.MarkovRegression):
         self.exog_ar = lagmat(endog, self.order)[self.order:]
 
         # Reshape other datasets
-        self.nobs -= self.order
+        #self.nobs -= self.order
         self.orig_endog = self.endog
         self.endog = self.endog[self.order:]
         if self._k_exog > 0:

--- a/statsmodels/tsa/regime_switching/markov_regression.py
+++ b/statsmodels/tsa/regime_switching/markov_regression.py
@@ -95,12 +95,13 @@ class MarkovRegression(markov_switching.MarkovSwitching):
         self.switching_variance = switching_variance
 
         # Exogenous data
-        self.k_exog, exog = markov_switching._prepare_exog(exog)
-
+        k_exog, exog = markov_switching._prepare_exog(exog)
+        # Note: At this juncture, k_exog is not the same as self.k_exog
+        
         # Trend
         nobs = len(endog)
         self.k_trend = 0
-        self._k_exog = self.k_exog
+        self._k_exog = k_exog
         trend_exog = None
         if trend == 'c':
             trend_exog = np.ones((nobs, 1))
@@ -127,8 +128,8 @@ class MarkovRegression(markov_switching.MarkovSwitching):
         elif not len(self.switching_trend) == self.k_trend:
             raise ValueError('Invalid iterable passed to `switching_trend`.')
         if self.switching_exog is True or self.switching_exog is False:
-            self.switching_exog = [self.switching_exog] * self.k_exog
-        elif not len(self.switching_exog) == self.k_exog:
+            self.switching_exog = [self.switching_exog] * k_exog
+        elif not len(self.switching_exog) == k_exog:
             raise ValueError('Invalid iterable passed to `switching_exog`.')
 
         self.switching_coeffs = (

--- a/statsmodels/tsa/statespace/dynamic_factor.py
+++ b/statsmodels/tsa/statespace/dynamic_factor.py
@@ -11,7 +11,7 @@ from statsmodels.compat.collections import OrderedDict
 
 import numpy as np
 import pandas as pd
-from .mlemodel import MLEModel, MLEResults, MLEResultsWrapper
+from .mlemodel import prepare_exog, MLEModel, MLEResults, MLEResultsWrapper
 from .tools import (
     is_invertible,
     constrain_stationary_univariate, unconstrain_stationary_univariate,
@@ -159,24 +159,15 @@ class DynamicFactor(MLEModel):
         self.error_cov_type = error_cov_type
 
         # Exogenous data
-        self.k_exog = 0
-        if exog is not None:
-            exog_is_using_pandas = _is_using_pandas(exog, None)
-            if not exog_is_using_pandas:
-                exog = np.asarray(exog)
+        (k_exog, exog) = prepare_exog(exog)
+        # Until exog gets attached to self, we need to use `k_exog`
+        # and *not* self.k_exog
 
-            # Make sure we have 2-dimensional array
-            if exog.ndim == 1:
-                if not exog_is_using_pandas:
-                    exog = exog[:, None]
-                else:
-                    exog = pd.DataFrame(exog)
 
-            self.k_exog = exog.shape[1]
 
         # Note: at some point in the future might add state regression, as in
         # SARIMAX.
-        self.mle_regression = self.k_exog > 0
+        self.mle_regression = k_exog > 0
 
         # We need to have an array or pandas at this point
         if not _is_using_pandas(endog, None):

--- a/statsmodels/tsa/statespace/mlemodel.py
+++ b/statsmodels/tsa/statespace/mlemodel.py
@@ -7,6 +7,7 @@ License: Simplified-BSD
 """
 from __future__ import division, absolute_import, print_function
 from statsmodels.compat.python import long
+import warnings
 
 import numpy as np
 import pandas as pd
@@ -25,7 +26,15 @@ from statsmodels.tools.tools import pinv_extended, Bunch
 from statsmodels.tools.sm_exceptions import PrecisionWarning
 import statsmodels.genmod._prediction as pred
 from statsmodels.genmod.families.links import identity
-import warnings
+
+from statsmodels.base.initialization import prepare_exog
+
+from statsmodels.base import dimensions
+
+
+
+
+
 
 
 class MLEModel(tsbase.TimeSeriesModel):
@@ -91,7 +100,6 @@ class MLEModel(tsbase.TimeSeriesModel):
         self.endog, self.exog = self.prepare_data()
 
         # Dimensions
-        self.nobs = self.endog.shape[0]
         self.k_states = k_states
 
         # Initialize the state-space representation
@@ -132,8 +140,6 @@ class MLEModel(tsbase.TimeSeriesModel):
         # Bind the data to the model
         self.ssm.bind(endog)
 
-        # Other dimensions, now that `ssm` is available
-        self.k_endog = self.ssm.k_endog
 
     def __setitem__(self, key, value):
         return self.ssm.__setitem__(key, value)
@@ -1550,8 +1556,8 @@ class MLEResults(tsbase.TimeSeriesModelResults):
             self.smoother_results = None
 
         # Dimensions
-        self.nobs = self.filter_results.nobs
         self.nobs_effective = self.nobs - self.loglikelihood_burn
+        # TODO: This attribute only exists if **kwargs has the expected keys
 
         # Degrees of freedom
         self.df_model = self.params.size

--- a/statsmodels/tsa/statespace/structural.py
+++ b/statsmodels/tsa/statespace/structural.py
@@ -14,7 +14,7 @@ import pandas as pd
 from statsmodels.tsa.filters.hp_filter import hpfilter
 from statsmodels.tools.data import _is_using_pandas
 from statsmodels.tsa.tsatools import lagmat
-from .mlemodel import MLEModel, MLEResults, MLEResultsWrapper
+from .mlemodel import prepare_exog, MLEModel, MLEResults, MLEResultsWrapper
 from scipy.linalg import solve_discrete_lyapunov
 from statsmodels.tools.tools import Bunch
 from statsmodels.tools.sm_exceptions import (ValueWarning, OutputWarning,
@@ -442,21 +442,12 @@ class UnobservedComponents(MLEModel):
             self.trend_specification = _mask_map.get(self.trend_mask, None)
 
         # Exogenous component
-        self.k_exog = 0
-        if exog is not None:
-            exog_is_using_pandas = _is_using_pandas(exog, None)
-            if not exog_is_using_pandas:
-                exog = np.asarray(exog)
+        (k_exog, exog) = prepare_exog(exog)
+        # Until exog gets attached to self, we need to use `k_exog`
+        # and *not* self.k_exog
 
-            # Make sure we have 2-dimensional array
-            if exog.ndim < 2:
-                if not exog_is_using_pandas:
-                    exog = np.atleast_2d(exog).T
-                else:
-                    exog = pd.DataFrame(exog)
 
-            self.k_exog = exog.shape[1]
-        self.regression = self.k_exog > 0
+        self.regression = k_exog > 0
 
         # Model parameters
         k_states = (
@@ -464,7 +455,7 @@ class UnobservedComponents(MLEModel):
             (self.seasonal_periods - 1) * self.seasonal +
             self.cycle * 2 +
             self.ar_order +
-            (not self.mle_regression) * self.k_exog
+            (not self.mle_regression) * k_exog
         )
         k_posdef = (
             self.stochastic_level * self.level +

--- a/statsmodels/tsa/statespace/tests/test_sarimax.py
+++ b/statsmodels/tsa/statespace/tests/test_sarimax.py
@@ -248,6 +248,7 @@ class TestARIMAStationary(ARIMA):
         assert_allclose(oim_bse[1], self.true['se_ar_oim'], atol=1e-3)
         assert_allclose(oim_bse[2], self.true['se_ma_oim'], atol=1e-2)
 
+
     def test_bse_robust(self):
         robust_oim_bse = self.result.cov_params_robust_oim.diagonal()**0.5
         robust_approx_bse = self.result.cov_params_robust_approx.diagonal()**0.5
@@ -811,9 +812,11 @@ class TestFriedmanStateRegression(Friedman):
 
     def test_bse_oim(self):
         # OIM covariance type
+
         bse = self.result._cov_params_oim().diagonal()**0.5
         assert_allclose(bse[0], self.true['se_ar_oim'], atol=1e-1)
         assert_allclose(bse[1], self.true['se_ma_oim'], atol=1e-1)
+        # TODO: are these tolerances tight enough?
 
 
 class TestFriedmanPredict(Friedman):


### PR DESCRIPTION
Follow-up to discussion in #1664.  This PR is for exposition purposes only, i.e. it will cause many test failures.

To hold this to a reasonable size, this includes dimension-related attributes and holds off on`df_resid` and `df_model` for the time being.

There are three Mixin classes that define a `nobs` property, plus one that defines a `wnobs` property.  Between these they cover every case in the subset of code I've worked through to date*.  In some cases applying them requires normalizing names as discussed in #3689.  (e.g. `sandbox.tsa.garch` and `tsa.arma_mle` use `nar` and `nma` instead of `k_ar` and `k_ma`)

Formalizing `nobs` avoids the need for kludges like setting `nobs` dynamically in `VAR.fit`, `AR.fit` or `ARMA.loglike_css`.  These examples are all special cases that don't quite fit into the class hierarchy; this helps bring them into line.

Note that `VARResults` does not inherit from the base Results class, so `NobsMixin` needs to be added in directly.  Other than that mixing it in to `model.Model` and `model.Results` is it.

`_nobs_total` is based on a similar attribute `ntotobs` that is defined for `VARResults`.

`KExogMixin` and `L1Estimator` should be self-explanatory.  `NEQsMixin` sets `neqs=1` in many cases.  There are a handful of places where that generalizes logic between univariate and multivariate cases (the most obvious cases being in information criteria).

Note that `NEQsMixin` also defines `k_endog`, but with a note that I may need to go double-check the Multinomial case.

`KTrendMixin` is largely self-explanatory.  SARIMAX defines `k_trend` as `int(np.sum(self.polynomial_trend))`; `KTrendMixin` handles this case, but requires shuffling around some names inside SARIMAX.

Finally `_get_k_constant` is a preview for the next installment, which will discuss `df_model` and `df_resid`.

\* Directories not worked through are `duration`, `multivariate`, `nonparametric`, and non-tsa portions of `sandbox`.

