### PR TITLE
Bisect Test case that is breaking in appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,7 @@ build_script:
   - conda update conda --quiet
   - ps: If ($env:SCIPY) { conda install numpy scipy=$env:SCIPY cython pandas pip nose patsy --quiet } Else {
         If ($env:PANDAS) { conda install numpy scipy cython pandas=$env:PANDAS pip nose patsy --quiet } Else {
-        conda install numpy scipy cython pandas pip nose patsy --quiet }}
+        conda install numpy scipy cython pandas pip nose patsy faulthandler --quiet }}
   - python setup.py develop
 
 test_script:

--- a/statsmodels/tsa/statespace/tests/test_simulate.py
+++ b/statsmodels/tsa/statespace/tests/test_simulate.py
@@ -201,7 +201,7 @@ def test_structural():
                           initial_state=[10])
     assert_allclose(actual, 10 + eps)
 
-    #raise RuntimeError('The error appears to be after this point.')
+    #raise RuntimeError('The error appears to be *before* this point.', 1)
     
     # Deterministic constant
     mod = structural.UnobservedComponents([0], 'deterministic constant')
@@ -222,7 +222,9 @@ def test_structural():
                           state_shocks=eps2,
                           initial_state=np.zeros(mod.k_states))
     assert_allclose(actual, eps + eps3)
-
+    
+    raise RuntimeError('The error appears to be *before* this point.', 2)
+    
     # Fixed slope
     # (in practice this is a deterministic trend, because an irregular
     #  component must be added)
@@ -239,7 +241,7 @@ def test_structural():
                           state_shocks=eps2, initial_state=[0, 1])
     assert_allclose(actual, eps + np.arange(100))
 
-    raise RuntimeError('The error appears to be after this point.', 2)
+    raise RuntimeError('The error appears to be *before* this point.', 3)
     
     # Local linear deterministic trend
     mod = structural.UnobservedComponents(

--- a/statsmodels/tsa/statespace/tests/test_simulate.py
+++ b/statsmodels/tsa/statespace/tests/test_simulate.py
@@ -201,7 +201,7 @@ def test_structural():
                           initial_state=[10])
     assert_allclose(actual, 10 + eps)
 
-    #raise RuntimeError('The error appears to be *before* this point.', 1)
+    #raise RuntimeError('If this exception is raised, then the real problem is *after* this point.', 1)
     
     # Deterministic constant
     mod = structural.UnobservedComponents([0], 'deterministic constant')
@@ -223,7 +223,7 @@ def test_structural():
                           initial_state=np.zeros(mod.k_states))
     assert_allclose(actual, eps + eps3)
     
-    raise RuntimeError('The error appears to be *before* this point.', 2)
+    #raise RuntimeError('If this exception is raised, then the real problem is *after* this point.', 2)
     
     # Fixed slope
     # (in practice this is a deterministic trend, because an irregular
@@ -234,14 +234,16 @@ def test_structural():
     actual = mod.simulate([1., 1.], nobs, measurement_shocks=eps,
                           state_shocks=eps2, initial_state=[0, 1])
     assert_allclose(actual, eps + np.arange(100))
-
+    
+    raise RuntimeError('If this exception is raised, then the real problem is *after* this point.', 2.5)
+    
     # Deterministic trend
     mod = structural.UnobservedComponents([0], 'deterministic trend')
     actual = mod.simulate([1.], nobs, measurement_shocks=eps,
                           state_shocks=eps2, initial_state=[0, 1])
     assert_allclose(actual, eps + np.arange(100))
 
-    raise RuntimeError('The error appears to be *before* this point.', 3)
+    raise RuntimeError('If this exception is raised, then the real problem is *after* this point.', 3)
     
     # Local linear deterministic trend
     mod = structural.UnobservedComponents(

--- a/statsmodels/tsa/statespace/tests/test_simulate.py
+++ b/statsmodels/tsa/statespace/tests/test_simulate.py
@@ -7,6 +7,9 @@ License: Simplified-BSD
 
 from __future__ import division, absolute_import, print_function
 
+import faulthandler
+faulthandler.enable()
+
 import warnings
 import numpy as np
 import pandas as pd

--- a/statsmodels/tsa/statespace/tests/test_simulate.py
+++ b/statsmodels/tsa/statespace/tests/test_simulate.py
@@ -201,6 +201,8 @@ def test_structural():
                           initial_state=[10])
     assert_allclose(actual, 10 + eps)
 
+    raise RuntimeError('The error appears to be after this point.')
+    
     # Deterministic constant
     mod = structural.UnobservedComponents([0], 'deterministic constant')
     actual = mod.simulate([1.], nobs, measurement_shocks=eps,

--- a/statsmodels/tsa/statespace/tests/test_simulate.py
+++ b/statsmodels/tsa/statespace/tests/test_simulate.py
@@ -201,7 +201,7 @@ def test_structural():
                           initial_state=[10])
     assert_allclose(actual, 10 + eps)
 
-    raise RuntimeError('The error appears to be after this point.')
+    #raise RuntimeError('The error appears to be after this point.')
     
     # Deterministic constant
     mod = structural.UnobservedComponents([0], 'deterministic constant')
@@ -239,6 +239,8 @@ def test_structural():
                           state_shocks=eps2, initial_state=[0, 1])
     assert_allclose(actual, eps + np.arange(100))
 
+    raise RuntimeError('The error appears to be after this point.', 2)
+    
     # Local linear deterministic trend
     mod = structural.UnobservedComponents(
         [0], 'local linear deterministic trend')


### PR DESCRIPTION
I checked two log files from appveyor and the last messages were:

[00:10:34] statsmodels.tsa.statespace.tests.test_simulate.test_structural ... Command exited with code -1073741819

[00:10:25] statsmodels.tsa.statespace.tests.test_simulate.test_structural ... Command exited with code -1073741819

For lack of a better idea, let's cut the test in half and see if the problem persists.

My understanding is that appveyor (or at least the two log files im looking at) are windows-specific, so I can't reproduce this locally.