### PR TITLE
Use `self.J-1` instead of defining `J`

### DIFF
--- a/statsmodels/discrete/discrete_model.py
+++ b/statsmodels/discrete/discrete_model.py
@@ -1831,10 +1831,10 @@ class MNLogit(MultinomialModel):
         X = self.exog
         pr = self.cdf(np.dot(X,params))
         partials = []
-        J = self.wendog.shape[1] - 1
-        K = self.exog.shape[1]
-        for i in range(J):
-            for j in range(J): # this loop assumes we drop the first col.
+        J = self.J
+        K = self.K
+        for i in range(J-1):
+            for j in range(J-1): # this loop assumes we drop the first col.
                 if i == j:
                     partials.append(\
                         -np.dot(((pr[:,i+1]*(1-pr[:,j+1]))[:,None]*X).T,X))
@@ -1842,7 +1842,7 @@ class MNLogit(MultinomialModel):
                     partials.append(-np.dot(((pr[:,i+1]*-pr[:,j+1])[:,None]*X).T,X))
         H = np.array(partials)
         # the developer's notes on multinomial should clear this math up
-        H = np.transpose(H.reshape(J,J,K,K), (0,2,1,3)).reshape(J*K,J*K)
+        H = np.transpose(H.reshape(J-1, J-1, K, K), (0, 2, 1, 3)).reshape((J-1)*K, (J-1)*K)
         return H
 
 


### PR DESCRIPTION
in `MNLogit.hessian`.

Relates to #3725.  While not an actual bug, the current behavior is definitely misleading.  The code currently defines `J` in a way that equals `self.J - 1`.  The variable name is sufficiently distinctive that a reader (i.e. me an hour ago) can easily make the incorrect inference that `J == self.J`.  This PR just fixes that.