### PR TITLE
BUG Fix ARIMA pickling for ndarrays (no dates, freq) 

### DIFF
--- a/statsmodels/tsa/arima_model.py
+++ b/statsmodels/tsa/arima_model.py
@@ -989,9 +989,13 @@ class ARIMA(ARMA):
             return mod
 
     def __getnewargs__(self):
+        # using same defaults as in __init__
+        dates = getattr(self, 'dates', None)
+        freq = getattr(self, 'freq', None)
+        missing = getattr(self, 'missing', 'none')
         return ((self.endog),
                 (self.k_lags, self.k_diff, self.k_ma),
-                self.exog, self.dates, self.freq, self.missing)
+                self.exog, dates, freq, missing)
 
     def __init__(self, endog, order, exog=None, dates=None, freq=None,
                  missing='none'):

--- a/statsmodels/tsa/tests/test_arima.py
+++ b/statsmodels/tsa/tests/test_arima.py
@@ -2272,7 +2272,7 @@ def test_arma_pickle():
 
 def test_arima_pickle():
     endog = y_arma[:, 6]
-    mod = ARIMA(endog, (1, 0, 1))
+    mod = ARIMA(endog, (1, 1, 1))
     pkl_mod = cPickle.loads(cPickle.dumps(mod))
 
     res = mod.fit(trend="c", disp=-1)


### PR DESCRIPTION
closes #3733 

`__getnewargs__`
use defaults if attributes are not available for ARIMA pickling

changed unit test fails without and passes with changes