### PR TITLE
Refactor SaveLoadMixin used by both Wrapper and Results

### DIFF
--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -844,7 +844,9 @@ class Results(object):
 
 
 #TODO: public method?
-class LikelihoodModelResults(Results):
+# TODO: is it redundant to have Results inherit SaveLoadMixin given that
+#   ResultsWrapper already inherits it?
+class LikelihoodModelResults(Results, wrap.SaveLoadMixin):
     """
     Class to contain results from likelihood models
 
@@ -1181,8 +1183,7 @@ class LikelihoodModelResults(Results):
             return cov_p
 
     #TODO: make sure this works as needed for GLMs
-    def t_test(self, r_matrix, cov_p=None, scale=None,
-               use_t=None):
+    def t_test(self, r_matrix, cov_p=None, scale=None, use_t=None):
         """
         Compute a t-test for a each linear hypothesis of the form Rb = q
 
@@ -1733,111 +1734,7 @@ class LikelihoodModelResults(Results):
             upper = self.params[cols] + q * bse[cols]
         return np.asarray(lzip(lower, upper))
 
-    def save(self, fname, remove_data=False):
-        '''
-        save a pickle of this instance
 
-        Parameters
-        ----------
-        fname : string or filehandle
-            fname can be a string to a file path or filename, or a filehandle.
-        remove_data : bool
-            If False (default), then the instance is pickled without changes.
-            If True, then all arrays with length nobs are set to None before
-            pickling. See the remove_data method.
-            In some cases not all arrays will be set to None.
-
-        Notes
-        -----
-        If remove_data is true and the model result does not implement a
-        remove_data method then this will raise an exception.
-
-        '''
-
-        from statsmodels.iolib.smpickle import save_pickle
-
-        if remove_data:
-            self.remove_data()
-
-        save_pickle(self, fname)
-
-    @classmethod
-    def load(cls, fname):
-        '''
-        load a pickle, (class method)
-
-        Parameters
-        ----------
-        fname : string or filehandle
-            fname can be a string to a file path or filename, or a filehandle.
-
-        Returns
-        -------
-        unpickled instance
-
-        '''
-
-        from statsmodels.iolib.smpickle import load_pickle
-        return load_pickle(fname)
-
-    def remove_data(self):
-        '''remove data arrays, all nobs arrays from result and model
-
-        This reduces the size of the instance, so it can be pickled with less
-        memory. Currently tested for use with predict from an unpickled
-        results and model instance.
-
-        .. warning:: Since data and some intermediate results have been removed
-           calculating new statistics that require them will raise exceptions.
-           The exception will occur the first time an attribute is accessed
-           that has been set to None.
-
-        Not fully tested for time series models, tsa, and might delete too much
-        for prediction or not all that would be possible.
-
-        The lists of arrays to delete are maintained as attributes of
-        the result and model instance, except for cached values. These
-        lists could be changed before calling remove_data.
-
-        The attributes to remove are named in:
-
-        model._data_attr : arrays attached to both the model instance
-            and the results instance with the same attribute name.
-
-        result.data_in_cache : arrays that may exist as values in
-            result._cache (TODO : should privatize name)
-
-        result._data_attr_model : arrays attached to the model
-            instance but not to the results instance
-        '''
-        def wipe(obj, att):
-            #get to last element in attribute path
-            p = att.split('.')
-            att_ = p.pop(-1)
-            try:
-                obj_ = reduce(getattr, [obj] + p)
-
-                #print(repr(obj), repr(att))
-                #print(hasattr(obj_, att_))
-                if hasattr(obj_, att_):
-                    #print('removing3', att_)
-                    setattr(obj_, att_, None)
-            except AttributeError:
-                pass
-
-        model_only = ['model.' + i for i in getattr(self, "_data_attr_model", [])]
-        model_attr = ['model.' + i for i in self.model._data_attr]
-        for att in self._data_attr + model_attr + model_only:
-            #print('removing', att)
-            wipe(self, att)
-
-        data_in_cache = getattr(self, 'data_in_cache', [])
-        data_in_cache += ['fittedvalues', 'resid', 'wresid']
-        for key in data_in_cache:
-            try:
-                self._cache[key] = None
-            except (AttributeError, KeyError):
-                pass
 
 
 class LikelihoodResultsWrapper(wrap.ResultsWrapper):

--- a/statsmodels/base/tests/test_shrink_pickle.py
+++ b/statsmodels/base/tests/test_shrink_pickle.py
@@ -13,6 +13,7 @@ import warnings
 import numpy as np
 from numpy.testing import assert_, assert_equal
 import pandas as pd
+from pandas.util.testing import assert_series_equal
 
 import statsmodels.api as sm
 
@@ -44,25 +45,22 @@ class RemoveDataPickle(object):
         self.l_max = 20000
 
     def test_remove_data_pickle(self):
-        import pandas as pd
-        from pandas.util.testing import assert_series_equal
-
         results = self.results
         xf = self.xf
         pred_kwds = self.predict_kwds
         pred1 = results.predict(xf, **pred_kwds)
-        #create some cached attributes
+        # create some cached attributes
         results.summary()
         res = results.summary2()  # SMOKE test also summary2
 
         # uncomment the following to check whether tests run (7 failures now)
         #np.testing.assert_equal(res, 1)
 
-        #check pickle unpickle works on full results
+        # check pickle unpickle works on full results
         #TODO: drop of load save is tested
         res, l = check_pickle(results._results)
 
-        #remove data arrays, check predict still works
+        # remove data arrays, check predict still works
         with warnings.catch_warnings(record=True) as w:
             results.remove_data()
 
@@ -75,13 +73,13 @@ class RemoveDataPickle(object):
         else:
             np.testing.assert_equal(pred2, pred1)
 
-        #pickle, unpickle reduced array
+        # pickle, unpickle reduced array
         res, l = check_pickle(results._results)
 
         #for testing attach res
         self.res = res
 
-        #Note: l_max is just a guess for the limit on the length of the pickle
+        # Note: l_max is just a guess for the limit on the length of the pickle
         l_max = self.l_max
         assert_(l < l_max, msg='pickle length not %d < %d' % (l, l_max))
 

--- a/statsmodels/base/wrapper.py
+++ b/statsmodels/base/wrapper.py
@@ -4,7 +4,116 @@ import functools
 import numpy as np
 from statsmodels.compat.python import get_function_name, iteritems, getargspec
 
-class ResultsWrapper(object):
+
+
+class SaveLoadMixin(object):
+    def __getstate__(self):
+        return self.__dict__
+
+    def __setstate__(self, dict_):
+        self.__dict__.update(dict_)
+
+    def save(self, fname, remove_data=False):
+        """save a pickle of this instance
+
+        Parameters
+        ----------
+        fname : string or filehandle
+            fname can be a string to a file path or filename, or a filehandle.
+        remove_data : bool
+            If False (default), then the instance is pickled without changes.
+            If True, then all arrays with length nobs are set to None before
+            pickling. See the remove_data method.
+            In some cases not all arrays will be set to None.
+
+        """
+        from statsmodels.iolib.smpickle import save_pickle
+
+        if remove_data:
+            self.remove_data()
+
+        save_pickle(self, fname)
+
+    @classmethod
+    def load(cls, fname):
+        """
+        load a pickle, (class method)
+
+        Parameters
+        ----------
+        fname : string or filehandle
+            fname can be a string to a file path or filename, or a filehandle.
+
+        Returns
+        -------
+        unpickled instance
+
+        """
+        from statsmodels.iolib.smpickle import load_pickle
+        return load_pickle(fname)
+
+    def remove_data(self):
+        """remove data arrays, all nobs arrays from result and model
+
+        This reduces the size of the instance, so it can be pickled with less
+        memory. Currently tested for use with predict from an unpickled
+        results and model instance.
+
+        .. warning:: Since data and some intermediate results have been removed
+           calculating new statistics that require them will raise exceptions.
+           The exception will occur the first time an attribute is accessed
+           that has been set to None.
+
+        Not fully tested for time series models, tsa, and might delete too much
+        for prediction or not all that would be possible.
+
+        The lists of arrays to delete are maintained as attributes of
+        the result and model instance, except for cached values. These
+        lists could be changed before calling remove_data.
+
+        The attributes to remove are named in:
+
+        model._data_attr : arrays attached to both the model instance
+            and the results instance with the same attribute name.
+
+        result.data_in_cache : arrays that may exist as values in
+            result._cache (TODO : should privatize name)
+
+        result._data_attr_model : arrays attached to the model
+            instance but not to the results instance
+        """
+        model_only = ['model.' + i for i in getattr(self, "_data_attr_model", [])]
+        model_attr = ['model.' + i for i in self.model._data_attr]
+        for att in self._data_attr + model_attr + model_only:
+            _wipe(self, att)
+
+        data_in_cache = getattr(self, 'data_in_cache', [])
+        data_in_cache += ['fittedvalues', 'resid', 'wresid']
+        for key in data_in_cache:
+            try:
+                self._cache[key] = None
+            except (AttributeError, KeyError):
+                pass
+
+
+def _wipe(obj, att):
+    """_wipe is a private function intended only to be called from within
+    SaveLoadMixin.remove_data.
+    """
+    # get to last element in attribute path
+    p = att.split('.')
+    att_ = p.pop(-1)
+    try:
+        obj_ = reduce(getattr, [obj] + p)
+
+        if hasattr(obj_, att_):
+            setattr(obj_, att_, None)
+    except AttributeError:
+        pass
+
+
+
+class ResultsWrapper(SaveLoadMixin):
     """
     Class which wraps a statsmodels estimation Results class and steps in to
     reattach metadata to results (if available)
@@ -42,39 +151,6 @@ class ResultsWrapper(object):
 
         return obj
 
-    def __getstate__(self):
-        #print 'pickling wrapper', self.__dict__
-        return self.__dict__
-
-    def __setstate__(self, dict_):
-        #print 'unpickling wrapper', dict_
-        self.__dict__.update(dict_)
-
-    def save(self, fname, remove_data=False):
-        '''save a pickle of this instance
-
-        Parameters
-        ----------
-        fname : string or filehandle
-            fname can be a string to a file path or filename, or a filehandle.
-        remove_data : bool
-            If False (default), then the instance is pickled without changes.
-            If True, then all arrays with length nobs are set to None before
-            pickling. See the remove_data method.
-            In some cases not all arrays will be set to None.
-
-        '''
-        from statsmodels.iolib.smpickle import save_pickle
-
-        if remove_data:
-            self.remove_data()
-
-        save_pickle(self, fname)
-
-    @classmethod
-    def load(cls, fname):
-        from statsmodels.iolib.smpickle import load_pickle
-        return load_pickle(fname)
 
 
 def union_dicts(*dicts):

--- a/statsmodels/base/wrapper.py
+++ b/statsmodels/base/wrapper.py
@@ -2,7 +2,8 @@ import inspect
 import functools
 
 import numpy as np
-from statsmodels.compat.python import get_function_name, iteritems, getargspec
+from statsmodels.compat.python import (reduce, get_function_name,
+                                       iteritems, getargspec)
 
 
 

--- a/statsmodels/base/wrapper.py
+++ b/statsmodels/base/wrapper.py
@@ -83,6 +83,10 @@ class SaveLoadMixin(object):
         result._data_attr_model : arrays attached to the model
             instance but not to the results instance
         """
+        if hasattr(self, '_results'):
+            # kludge
+            return self._results.remove_data()
+
         model_only = ['model.' + i for i in getattr(self, "_data_attr_model", [])]
         model_attr = ['model.' + i for i in self.model._data_attr]
         for att in self._data_attr + model_attr + model_only:
@@ -111,7 +115,6 @@ def _wipe(obj, att):
             setattr(obj_, att_, None)
     except AttributeError:
         pass
-
 
 
 class ResultsWrapper(SaveLoadMixin):


### PR DESCRIPTION
`save` and `load` methods are essentially identical in ResultsWrapper and LikelihoodModelResults.  

This PR merges them, along with `remove_data` into a `SaveLoadMixin` class in wrapper.py.  Besides de-duplicating code this is part of an effort to reduce the number of points-of-contact for the model.data object.

This is the first of several small PRs to address topics discussed in #3570.

