### PR TITLE
REF: MLEModel De-duplication

### DIFF
--- a/statsmodels/tsa/regime_switching/markov_regression.py
+++ b/statsmodels/tsa/regime_switching/markov_regression.py
@@ -95,7 +95,7 @@ class MarkovRegression(markov_switching.MarkovSwitching):
         self.switching_variance = switching_variance
 
         # Exogenous data
-        self.k_exog, exog = markov_switching._prepare_exog(exog)
+        self.k_exog, exog = markov_switching.prepare_exog(exog)
 
         # Trend
         nobs = len(endog)

--- a/statsmodels/tsa/regime_switching/markov_switching.py
+++ b/statsmodels/tsa/regime_switching/markov_switching.py
@@ -15,7 +15,6 @@ from statsmodels.compat.collections import OrderedDict
 from scipy.misc import logsumexp
 from statsmodels.base.data import PandasData
 import statsmodels.tsa.base.tsa_model as tsbase
-from statsmodels.tools.data import _is_using_pandas
 from statsmodels.tools.tools import Bunch
 from statsmodels.tools.numdiff import approx_fprime_cs, approx_hess_cs
 from statsmodels.tools.decorators import cache_readonly, resettable_cache
@@ -25,7 +24,8 @@ from statsmodels.tools.sm_exceptions import EstimationWarning
 import statsmodels.base.wrapper as wrap
 
 
-from statsmodels.tsa.statespace.tools import find_best_blas_type
+from statsmodels.tsa.statespace.tools import find_best_blas_type, prepare_exog
+
 from statsmodels.tsa.regime_switching._hamilton_filter import (
     shamilton_filter, dhamilton_filter, chamilton_filter, zhamilton_filter)
 from statsmodels.tsa.regime_switching._kim_smoother import (
@@ -42,22 +42,6 @@ prefix_kim_smoother_map = {
 }
 
 
-def _prepare_exog(exog):
-    k_exog = 0
-    if exog is not None:
-        exog_is_using_pandas = _is_using_pandas(exog, None)
-        if not exog_is_using_pandas:
-            exog = np.asarray(exog)
-
-        # Make sure we have 2-dimensional array
-        if exog.ndim == 1:
-            if not exog_is_using_pandas:
-                exog = exog[:, None]
-            else:
-                exog = pd.DataFrame(exog)
-
-        k_exog = exog.shape[1]
-    return k_exog, exog
 
 
 def _logistic(x):
@@ -675,7 +659,7 @@ class MarkovSwitching(tsbase.TimeSeriesModel):
 
         # Exogenous data
         # TODO add checks for exog_tvtp consistent shape and indices
-        self.k_tvtp, self.exog_tvtp = _prepare_exog(exog_tvtp)
+        self.k_tvtp, self.exog_tvtp = prepare_exog(exog_tvtp)
 
         # Initialize the base model
         super(MarkovSwitching, self).__init__(endog, exog, dates=dates,

--- a/statsmodels/tsa/statespace/dynamic_factor.py
+++ b/statsmodels/tsa/statespace/dynamic_factor.py
@@ -13,7 +13,7 @@ import numpy as np
 import pandas as pd
 from .mlemodel import MLEModel, MLEResults, MLEResultsWrapper
 from .tools import (
-    is_invertible,
+    is_invertible, prepare_exog,
     constrain_stationary_univariate, unconstrain_stationary_univariate,
     constrain_stationary_multivariate, unconstrain_stationary_multivariate
 )
@@ -159,21 +159,8 @@ class DynamicFactor(MLEModel):
         self.error_cov_type = error_cov_type
 
         # Exogenous data
-        self.k_exog = 0
-        if exog is not None:
-            exog_is_using_pandas = _is_using_pandas(exog, None)
-            if not exog_is_using_pandas:
-                exog = np.asarray(exog)
-
-            # Make sure we have 2-dimensional array
-            if exog.ndim == 1:
-                if not exog_is_using_pandas:
-                    exog = exog[:, None]
-                else:
-                    exog = pd.DataFrame(exog)
-
-            self.k_exog = exog.shape[1]
-
+        (self.k_exog, exog) = prepare_exog(exog)
+        
         # Note: at some point in the future might add state regression, as in
         # SARIMAX.
         self.mle_regression = self.k_exog > 0

--- a/statsmodels/tsa/statespace/sarimax.py
+++ b/statsmodels/tsa/statespace/sarimax.py
@@ -15,7 +15,8 @@ from .kalman_filter import KalmanFilter
 from .mlemodel import MLEModel, MLEResults, MLEResultsWrapper
 from .tools import (
     companion_matrix, diff, is_invertible, constrain_stationary_univariate,
-    unconstrain_stationary_univariate, solve_discrete_lyapunov
+    unconstrain_stationary_univariate, solve_discrete_lyapunov,
+    prepare_exog
 )
 from statsmodels.tools.tools import Bunch
 from statsmodels.tools.data import _is_using_pandas
@@ -412,20 +413,8 @@ class SARIMAX(MLEModel):
                 self._k_order = 0
 
         # Exogenous data
-        self.k_exog = 0
-        if exog is not None:
-            exog_is_using_pandas = _is_using_pandas(exog, None)
-            if not exog_is_using_pandas:
-                exog = np.asarray(exog)
+        (self.k_exog, exog) = prepare_exog(exog)
 
-            # Make sure we have 2-dimensional array
-            if exog.ndim < 2:
-                if not exog_is_using_pandas:
-                    exog = np.atleast_2d(exog).T
-                else:
-                    exog = pd.DataFrame(exog)
-
-            self.k_exog = exog.shape[1]
         # Redefine mle_regression to be true only if it was previously set to
         # true and there are exogenous regressors
         self.mle_regression = (

--- a/statsmodels/tsa/statespace/structural.py
+++ b/statsmodels/tsa/statespace/structural.py
@@ -12,7 +12,6 @@ from statsmodels.compat.collections import OrderedDict
 import numpy as np
 import pandas as pd
 from statsmodels.tsa.filters.hp_filter import hpfilter
-from statsmodels.tools.data import _is_using_pandas
 from statsmodels.tsa.tsatools import lagmat
 from .mlemodel import MLEModel, MLEResults, MLEResultsWrapper
 from scipy.linalg import solve_discrete_lyapunov
@@ -21,7 +20,8 @@ from statsmodels.tools.sm_exceptions import (ValueWarning, OutputWarning,
                                              SpecificationWarning)
 from .tools import (
     companion_matrix, constrain_stationary_univariate,
-    unconstrain_stationary_univariate
+    unconstrain_stationary_univariate,
+    prepare_exog
 )
 import statsmodels.base.wrapper as wrap
 
@@ -442,20 +442,8 @@ class UnobservedComponents(MLEModel):
             self.trend_specification = _mask_map.get(self.trend_mask, None)
 
         # Exogenous component
-        self.k_exog = 0
-        if exog is not None:
-            exog_is_using_pandas = _is_using_pandas(exog, None)
-            if not exog_is_using_pandas:
-                exog = np.asarray(exog)
+        (self.k_exog, exog) = prepare_exog(exog)
 
-            # Make sure we have 2-dimensional array
-            if exog.ndim < 2:
-                if not exog_is_using_pandas:
-                    exog = np.atleast_2d(exog).T
-                else:
-                    exog = pd.DataFrame(exog)
-
-            self.k_exog = exog.shape[1]
         self.regression = self.k_exog > 0
 
         # Model parameters

--- a/statsmodels/tsa/statespace/tools.py
+++ b/statsmodels/tsa/statespace/tools.py
@@ -34,9 +34,7 @@ prefix_copy_index_vector_map = {}
 
 
 def set_mode(compatibility=None):
-    global compatibility_mode, has_trmm, prefix_statespace_map,        \
-        prefix_kalman_filter_map, prefix_kalman_smoother_map,          \
-        prefix_simulation_smoother_map, prefix_pacf_map, prefix_sv_map
+    global compatibility_mode, has_trmm
 
     # Determine mode automatically if none given
     if compatibility is None:

--- a/statsmodels/tsa/statespace/tools.py
+++ b/statsmodels/tsa/statespace/tools.py
@@ -1896,3 +1896,22 @@ def copy_index_vector(a, b, index, inplace=False, prefix=None):
     copy(a, b, np.asfortranarray(index))
 
     return b
+
+
+
+def prepare_exog(exog):
+    k_exog = 0
+    if exog is not None:
+        exog_is_using_pandas = _is_using_pandas(exog, None)
+        if not exog_is_using_pandas:
+            exog = np.asarray(exog)
+
+        # Make sure we have 2-dimensional array
+        if exog.ndim == 1:
+            if not exog_is_using_pandas:
+                exog = exog[:, None]
+            else:
+                exog = pd.DataFrame(exog)
+
+        k_exog = exog.shape[1]
+    return (k_exog, exog)

--- a/statsmodels/tsa/statespace/varmax.py
+++ b/statsmodels/tsa/statespace/varmax.py
@@ -14,7 +14,7 @@ import numpy as np
 from .kalman_filter import (INVERT_UNIVARIATE, SOLVE_LU)
 from .mlemodel import MLEModel, MLEResults, MLEResultsWrapper
 from .tools import (
-    is_invertible,
+    is_invertible, prepare_exog
     constrain_stationary_multivariate, unconstrain_stationary_multivariate
 )
 from statsmodels.tools.tools import Bunch
@@ -151,20 +151,7 @@ class VARMAX(MLEModel):
                  EstimationWarning)
 
         # Exogenous data
-        self.k_exog = 0
-        if exog is not None:
-            exog_is_using_pandas = _is_using_pandas(exog, None)
-            if not exog_is_using_pandas:
-                exog = np.asarray(exog)
-
-            # Make sure we have 2-dimensional array
-            if exog.ndim == 1:
-                if not exog_is_using_pandas:
-                    exog = exog[:, None]
-                else:
-                    exog = pd.DataFrame(exog)
-
-            self.k_exog = exog.shape[1]
+        (self.k_exog, exog) = prepare_exog(exog)
 
         # Note: at some point in the future might add state regression, as in
         # SARIMAX.

--- a/statsmodels/tsa/statespace/varmax.py
+++ b/statsmodels/tsa/statespace/varmax.py
@@ -14,7 +14,7 @@ import numpy as np
 from .kalman_filter import (INVERT_UNIVARIATE, SOLVE_LU)
 from .mlemodel import MLEModel, MLEResults, MLEResultsWrapper
 from .tools import (
-    is_invertible, prepare_exog
+    is_invertible, prepare_exog,
     constrain_stationary_multivariate, unconstrain_stationary_multivariate
 )
 from statsmodels.tools.tools import Bunch


### PR DESCRIPTION
`tsa.regime_switching.markov_switching._prepare_exog` is repeated verbatim in each of four `statespace` models.  This PR moves that function to `statespace.tools.prepare_exog` and calls it from each of those models.

`statespace.tools.set_mode` declares `global foo` for a handful of module-level dictionaries.  The "global" is perfunctory.

`var_model` imports some names that do not match the conventions used elsewhere.  The last commit here cleans that up.