### PR TITLE
Simplify MLEResults.cov_params_xyz methods

### DIFF
--- a/statsmodels/tsa/statespace/mlemodel.py
+++ b/statsmodels/tsa/statespace/mlemodel.py
@@ -1801,7 +1801,7 @@ class MLEResults(tsbase.TimeSeriesModelResults):
     def _cov_params_opg(self, approx_complex_step=True, approx_centered=False):
         nobs = (self.model.nobs - self.filter_results.loglikelihood_burn)
 
-        evaluated_hessian = nobs * self.model.hessian_opg(self.params,
+        evaluated_hessian = nobs * self.model._hessian_opg(self.params,
                                         transformed=True,
                                         approx_complex_step=approx_complex_step,
                                         approx_centered=approx_centered)


### PR DESCRIPTION
by calling hessian with kwargs instead of calling _hessian_xyz.

In the existing code, `cov_params_xyz` checks `approx_complex_step` and based on that calls the correct `model._hessian_abc`.  That dispatch is already built in to `model.hessian` if the `approx_complex_step` kwarg is passed.

In `model.hessian` there are two cases with `method == 'approx'` that are not currently covered.  By redirecting cov_params calls through `hessian`, this PR gets those covered.

There are a couple of cases in the cov_params_xyz that are a) not currently covered and b) removed by this PR.  Comments indicate where those used to be.

There are two changes that are *not* in this PR but that merit discussion.

1) Small functions that could go somewhere like (the unfortunately-neglected) `base.cov_types`:

```
# TODO: Better name?
def cov_params_oim(hess):
	(neg_cov, singular_values) = linalg.pinv_extended(hess)
	cov_params = -neg_cov
	return (cov_params, singular_values)

# TODO: Better name?
def cov_params_robust_oim(hess, cov_opg):
	pinv_input = np.dot(np.dot(hess, cov_opg), hess)
	# TODO: can we reasonably call "pinv_input" something like "oim"?
	(cov_params, singular_values) = linalg.pinv_extended(pinv_input)
	return (cov_params, singular_values)
```

If implemented, these could be called 3 and 4 times, respectively.

2) Change `_cov_params_xyz` default kwargs for `approx_complex_step` and `approx_centered` to None instead of True/False.  Then set defaults with:

```
if approx_complex_step is None:
     approx_complex_step = self._cov_approx_complex_step
if approx_centered is None:
    approx_centered = self._cov_approx_centered
```

The *real* reason for this is that then the cached versions e.g. `cov_params_robust_oim` could dispatch to `self._cov_params_robust_oim()` instead of `self._cov_params_robust_oim(self._cov_approx_complex_step, self._cov_approx_centered)`.  This would then allow us to de-duplicate a bunch of code in `markov_switching`.  Discussed a bit in #3675.
