### PR TITLE
var_model flake8

### DIFF
--- a/statsmodels/tsa/vector_ar/var_model.py
+++ b/statsmodels/tsa/vector_ar/var_model.py
@@ -166,7 +166,7 @@ def _var_acf(coefs, sig_u):
     return acf
 
 
-def mse(ma_coefs, sigma_u, steps):
+def forecast_cov(ma_coefs, sigma_u, steps):
     """
     Compute theoretical forecast error variance matrices
 
@@ -196,7 +196,7 @@ def mse(ma_coefs, sigma_u, steps):
     return forc_covs
 
 
-forecast_cov = mse
+mse = forecast_cov
 
 
 def forecast(y, coefs, trend_coefs, steps, exog=None):


### PR DESCRIPTION
flake8 fixes, mostly whitespace-related

A handful of TODO notes for things that I had to restrain myself from doing in this PR.

The only non-aesthetic edit made here is deleting `forecast_cov` function, which was identical to `mse`.

The remaining style-based change I'd like to make -- but kept out of this PR because it will take more reviewer effort-- is getting rid of single-letter variables `p` and `k` and replacing them with their more informative counterparts `k_ar` and `neqs`.