### PR TITLE
BUG: VAR, VECM forecast horizon, season dummies

### DIFF
--- a/statsmodels/tsa/vector_ar/tests/test_vecm.py
+++ b/statsmodels/tsa/vector_ar/tests/test_vecm.py
@@ -1,7 +1,8 @@
 from __future__ import absolute_import, print_function
 
 import numpy as np
-from numpy.testing import assert_, assert_allclose, assert_raises
+from numpy.testing import (assert_, assert_allclose, assert_raises,
+                           assert_array_equal)
 
 import statsmodels.datasets.interest_inflation.data as e6
 from statsmodels.compat.python import range
@@ -1486,10 +1487,52 @@ def setup():
             DataSet(e6, [0, 4], [0, 1], ["Dp", "R"]),
             # DataSet(...) TODO: append more data sets for more test cases.
     )
-    
+
     for ds in datasets:
         load_data(ds, data)
         results_ref[ds] = load_results_jmulti(ds)
         results_sm[ds] = load_results_statsmodels(ds)
         results_sm_exog[ds] = load_results_statsmodels_exog(ds)
         results_sm_exog_coint[ds] = load_results_statsmodels_exog_coint(ds)
+
+
+def test_VECM_seasonal_forecast():
+    # timing of seasonal dummies, VAR forecast horizon
+    np.random.seed(964255)
+    nobs = 200
+    seasons = 6
+    fact = np.cumsum(0.1 + np.random.randn(nobs, 2),0)
+
+    xx = np.random.randn(nobs+2, 3)
+    xx = xx[2:] + 0.6 * xx[1:-1] + 0.25 * xx[:-2]
+    xx[:,:2] += fact[:,0][:,None]
+    xx[:,2:] += fact[:,1][:,None]
+    # add large seasonal effect
+    xx += 3 * np.log(0.1 + (np.arange(nobs)[:, None] % seasons))
+
+    res0 = VECM(xx, k_ar_diff=0, coint_rank=2, deterministic='co', seasons=seasons, first_season=0).fit()
+    res2 = VECM(xx, k_ar_diff=2, coint_rank=2, deterministic='co', seasons=seasons, first_season=0).fit()
+    res4 = VECM(xx, k_ar_diff=4, coint_rank=2, deterministic='co', seasons=seasons, first_season=0).fit()
+
+
+    # check that seasonal dummy are independent of number of lags
+    assert_allclose(res2._delta_x.T[-2 * seasons:, -seasons:],
+                    res0._delta_x.T[-2 * seasons:, -seasons:], rtol=1e-10)
+    assert_allclose(res4._delta_x.T[-2 * seasons:, -seasons:],
+                    res0._delta_x.T[-2 * seasons:, -seasons:], rtol=1e-10)
+
+    # check location of smallest seasonal coefficient
+    assert_array_equal(np.argmin(res0.det_coef, axis=1), [1, 1, 1])
+    assert_array_equal(np.argmin(res2.det_coef, axis=1), [1, 1, 1])
+    assert_array_equal(np.argmin(res4.det_coef, axis=1), [1, 1, 1])
+
+    # predict 3 cycles, check location of dips
+    dips_true = np.array([[ 4,  4,  4],
+                       [10, 10, 10],
+                       [16, 16, 16]])
+    for res in [res0, res2, res4]:
+        forecast = res.predict(steps=3*seasons)
+        dips = np.sort(np.argsort(forecast, axis=0)[:3], axis=0)
+        assert_array_equal(dips, dips_true)
+
+    # res2.plot_forecast(steps=18, alpha=0.1, n_last_obs=4*seasons)

--- a/statsmodels/tsa/vector_ar/var_model.py
+++ b/statsmodels/tsa/vector_ar/var_model.py
@@ -305,7 +305,7 @@ def forecast_interval(y, coefs, trend_coefs, sig_u, steps=5, alpha=0.05,
     q = util.norm_signif_level(alpha)
 
     point_forecast = forecast(y, coefs, trend_coefs, steps, exog)
-    ma_coefs = ma_rep(coefs, 10)
+    ma_coefs = ma_rep(coefs, steps)
     sigma = np.sqrt(_forecast_vars(steps, ma_coefs, sig_u))
 
     forc_lower = point_forecast - q * sigma

--- a/statsmodels/tsa/vector_ar/vecm.py
+++ b/statsmodels/tsa/vector_ar/vecm.py
@@ -318,7 +318,7 @@ def _endog_matrices(endog, exog, exog_coint, diff_lags, deterministic,
         delta_x_stack.append(np.ones(T))
     if seasons > 0:
         delta_x_stack.append(seasonal_dummies(seasons, delta_x.shape[1],
-                                              first_period=first_season,
+                                              first_period=first_season + diff_lags + 1,
                                               centered=True).T)
     if "lo" in deterministic:
         delta_x_stack.append(_linear_trend(T, p))


### PR DESCRIPTION
fixes two bug in forecasting, see #3775

- hardcoded number of terms in ma-rep limited forecast horizon
- seasonal indices in VECM deterministic did not adjust season_start for trimming initial observations in arrays

vecm.py has also a function _deterministic_to_exog that creates seasonal dummies. The first_season argument will need to be adjusted if there is trimming of initial observations. I didn't check this function
It's only in the causality tests to create the VAR model which I guess uses the full arrays without trimming of initial observations.

