### PR TITLE
Add absolute import for pyinstaller compatibility

### DIFF
--- a/statsmodels/__init__.py
+++ b/statsmodels/__init__.py
@@ -5,7 +5,7 @@ from numpy import errstate
 from numpy.testing import Tester
 
 from warnings import simplefilter
-from .tools.sm_exceptions import (ConvergenceWarning, CacheWriteWarning,
+from statsmodels.tools.sm_exceptions import (ConvergenceWarning, CacheWriteWarning,
                                   IterationLimitWarning, InvalidTestWarning)
 
 


### PR DESCRIPTION
Adding an absolute import here solves an [error](https://github.com/pyinstaller/pyinstaller/issues/2183) when compiling apps with [pyinstaller](https://github.com/pyinstaller/pyinstaller) that use statsmodels.
