### PR TITLE
BUG: IV2SLS set fvalue to nan if const_idx is None

### DIFF
--- a/statsmodels/sandbox/regression/gmm.py
+++ b/statsmodels/sandbox/regression/gmm.py
@@ -213,17 +213,21 @@ class IVRegressionResults(RegressionResults):
 
     @cache_readonly
     def fvalue(self):
-        k_vars = len(self.params)
-        restriction = np.eye(k_vars)
-        idx_noconstant = lrange(k_vars)
-        del idx_noconstant[self.model.data.const_idx]
-        fval = self.f_test(restriction[idx_noconstant]).fvalue # without constant
-        return fval
+        const_idx = self.model.data.const_idx
+        # if constant is implicit or missing, return nan see #2444, #3544
+        if const_idx is None:
+            return np.nan
+        else:
+            k_vars = len(self.params)
+            restriction = np.eye(k_vars)
+            idx_noconstant = lrange(k_vars)
+            del idx_noconstant[const_idx]
+            fval = self.f_test(restriction[idx_noconstant]).fvalue # without constant
+            return fval
 
 
     def spec_hausman(self, dof=None):
         '''Hausman's specification test
-
 
         See Also
         --------

--- a/statsmodels/sandbox/regression/tests/test_gmm.py
+++ b/statsmodels/sandbox/regression/tests/test_gmm.py
@@ -741,3 +741,12 @@ class TestIV2SLSSt1(CheckIV2SLS):
                     else:
                         assert_allclose(res.params, res2.params)
 
+def test_noconstant():
+    exog = exog_st[:, :-1]  # with const removed at end
+
+    mod = gmm.IV2SLS(endog, exog, instrument)
+    res = mod.fit()
+
+    assert_equal(res.fvalue, np.nan)
+    # smoke test
+    res.summary()


### PR DESCRIPTION
IV2SLS set fvalue to nan if const_idx is None, fix is similar to #2477 for RegressionResults
this allows summary to work instead of causing an exception

closes #3544