### PR TITLE
Correct spelling error in linearl_model.py

### DIFF
--- a/statsmodels/regression/linear_model.py
+++ b/statsmodels/regression/linear_model.py
@@ -1318,7 +1318,7 @@ class RegressionResults(base.LikelihoodModelResults):
     cov_type
         Parameter covariance estimator used for standard errors and t-stats
     df_model
-        Model degress of freedom. The number of regressors `p`. Does not
+        Model degrees of freedom. The number of regressors `p`. Does not
         include the constant if one is present
     df_resid
         Residual degrees of freedom. `n - p - 1`, if a constant is present.


### PR DESCRIPTION
Line 1321: "Model degress of freedom" -> "Model degrees of freedom"