### PR TITLE
ENH: Revise loglike/deviance to correctly handle scale

### DIFF
--- a/statsmodels/genmod/families/family.py
+++ b/statsmodels/genmod/families/family.py
@@ -59,7 +59,6 @@ class Family(object):
         if not isinstance(link, L.Link):
             raise TypeError("The input should be a valid Link object.")
         if hasattr(self, "links"):
-            validlink = link in self.links
             validlink = max([isinstance(link, _) for _ in self.links])
             if not validlink:
                 errmsg = "Invalid link for family, should be in %s. (got %s)"

--- a/statsmodels/genmod/families/family.py
+++ b/statsmodels/genmod/families/family.py
@@ -816,7 +816,7 @@ class Gamma(Family):
         weight_scale = var_weights / scale
         ll_obs = weight_scale * np.log(weight_scale * endog_mu)
         ll_obs -= weight_scale * endog_mu
-        ll_obs -= special.gammaln(weight_scale) - np.log(endog)
+        ll_obs -= special.gammaln(weight_scale) + np.log(endog)
         return ll_obs
         """
         endog_mu = self._clean(endog / mu)
@@ -1070,8 +1070,7 @@ class Binomial(Family):
         original number of successes.
         """
         if np.shape(self.n) == () and self.n == 1:
-            return np.sum((endog * np.log(mu/(1 - mu)) +
-                           np.log(1 - mu)) * var_weights)
+            return (endog * np.log(mu/(1 - mu)) + np.log(1 - mu)) * var_weights
         else:
             y = endog * self.n  # convert back to successes
             # note that mu is still in (0,1), i.e. not convertet back

--- a/statsmodels/genmod/families/family.py
+++ b/statsmodels/genmod/families/family.py
@@ -133,7 +133,7 @@ class Family(object):
     def deviance(self, endog, mu, var_weights=1., freq_weights=1., scale=1.):
         r"""
         The deviance function evaluated at (endog, mu, var_weights,
-        freq_weights, mu) for the distribution.
+        freq_weights, scale) for the distribution.
 
         Deviance is usually defined as twice the loglikelihood ratio.
 
@@ -264,9 +264,9 @@ class Family(object):
         Notes
         -----
         This is defined for each family. endog and mu are not restricted to
-        ``endog`` and ``mu`` respectively.  For instance, the deviance function
-        calls both ``loglike(endog, endog)`` and ``loglike(endog, mu)`` to get
-        the likelihood ratio.
+        ``endog`` and ``mu`` respectively.  For instance, you could call
+        both ``loglike(endog, endog)`` and ``loglike(endog, mu)`` to get the
+        log-likelihood ratio.
         """
         raise NotImplementedError
 
@@ -300,10 +300,10 @@ class Family(object):
         .. math::
            ll = \sum(ll_i * freq\_weights_i)
 
-        ``logliek`` is defined for each family. ``endog`` and ``mu`` are not
-        restricted to ``endog`` and ``mu`` respectively.  For instance, the
-        deviance function calls both ``loglike(endog, endog)`` and
-        ``loglike(endog, mu)`` to get the likelihood ratio.
+        ``ll_i`` is defined for each family. endog and mu are not restricted
+        to ``endog`` and ``mu`` respectively.  For instance, you could call
+        both ``loglike(endog, endog)`` and ``loglike(endog, mu)`` to get the
+        log-likelihood ratio.
         """
         ll_obs = self.loglike_obs(endog, mu, var_weights, scale)
         return np.sum(ll_obs * freq_weights)
@@ -362,7 +362,7 @@ class Poisson(Family):
     ----------
     link : a link instance, optional
         The default link for the Poisson family is the log link. Available
-        links are log, identity, and sqrt. See statsmodels.family.links for
+        links are log, identity, and sqrt. See statsmodels.families.links for
         more information.
 
     Attributes
@@ -370,8 +370,8 @@ class Poisson(Family):
     Poisson.link : a link instance
         The link function of the Poisson instance.
     Poisson.variance : varfuncs instance
-        `variance` is an instance of
-        statsmodels.genmod.families.family.varfuncs.mu
+        ``variance`` is an instance of
+        statsmodels.genmod.families.varfuncs.mu
 
     See also
     --------
@@ -487,14 +487,15 @@ class Gaussian(Family):
     link : a link instance, optional
         The default link for the Gaussian family is the identity link.
         Available links are log, identity, and inverse.
-        See statsmodels.family.links for more information.
+        See statsmodels.genmod.families.links for more information.
 
     Attributes
     ----------
     Gaussian.link : a link instance
         The link function of the Gaussian instance
     Gaussian.variance : varfunc instance
-        `variance` is an instance of statsmodels.family.varfuncs.constant
+        ``variance`` is an instance of
+        statsmodels.genmod.families.varfuncs.constant
 
     See also
     --------
@@ -627,14 +628,15 @@ class Gamma(Family):
     link : a link instance, optional
         The default link for the Gamma family is the inverse link.
         Available links are log, identity, and inverse.
-        See statsmodels.family.links for more information.
+        See statsmodels.genmod.families.links for more information.
 
     Attributes
     ----------
     Gamma.link : a link instance
         The link function of the Gamma instance
     Gamma.variance : varfunc instance
-        `variance` is an instance of statsmodels.family.varfuncs.mu_squared
+        ``variance`` is an instance of
+        statsmodels.genmod.family.varfuncs.mu_squared
 
     See also
     --------
@@ -758,14 +760,15 @@ class Binomial(Family):
     link : a link instance, optional
         The default link for the Binomial family is the logit link.
         Available links are logit, probit, cauchy, log, and cloglog.
-        See statsmodels.family.links for more information.
+        See statsmodels.genmod.families.links for more information.
 
     Attributes
     ----------
     Binomial.link : a link instance
         The link function of the Binomial instance
     Binomial.variance : varfunc instance
-        `variance` is an instance of statsmodels.family.varfuncs.binary
+        ``variance`` is an instance of
+        statsmodels.genmod.families.varfuncs.binary
 
     See also
     --------
@@ -982,14 +985,15 @@ class InverseGaussian(Family):
         The default link for the inverse Gaussian family is the
         inverse squared link.
         Available links are inverse_squared, inverse, log, and identity.
-        See statsmodels.family.links for more information.
+        See statsmodels.genmod.families.links for more information.
 
     Attributes
     ----------
     InverseGaussian.link : a link instance
         The link function of the inverse Gaussian instance
     InverseGaussian.variance : varfunc instance
-        ``variance`` is an instance of statsmodels.family.varfuncs.mu_cubed
+        ``variance`` is an instance of
+        statsmodels.genmod.families.varfuncs.mu_cubed
 
     See also
     --------
@@ -1113,10 +1117,10 @@ class NegativeBinomial(Family):
     link : a link instance, optional
         The default link for the negative binomial family is the log link.
         Available links are log, cloglog, identity, nbinom and power.
-        See statsmodels.family.links for more information.
+        See statsmodels.genmod.families.links for more information.
     alpha : float, optional
         The ancillary parameter for the negative binomial distribution.
-        For now `alpha` is assumed to be nonstochastic.  The default value
+        For now ``alpha`` is assumed to be nonstochastic.  The default value
         is 1.  Permissible values are usually assumed to be between .01 and 2.
 
     Attributes
@@ -1124,7 +1128,8 @@ class NegativeBinomial(Family):
     NegativeBinomial.link : a link instance
         The link function of the negative binomial instance
     NegativeBinomial.variance : varfunc instance
-        `variance` is an instance of statsmodels.family.varfuncs.nbinom
+        ``variance`` is an instance of
+        statsmodels.genmod.families.varfuncs.nbinom
 
     See also
     --------
@@ -1294,7 +1299,7 @@ class Tweedie(Family):
     link : a link instance, optional
         The default link for the Tweedie family is the log link.
         Available links are log and Power.
-        See statsmodels.family.links for more information.
+        See statsmodels.genmod.families.links for more information.
     var_power : float, optional
         The variance power. The default is 1.
 
@@ -1303,7 +1308,8 @@ class Tweedie(Family):
     Tweedie.link : a link instance
         The link function of the Tweedie instance
     Tweedie.variance : varfunc instance
-        `variance` is an instance of statsmodels.family.varfuncs.Power
+        ``variance`` is an instance of
+        statsmodels.genmod.families.varfuncs.Power
     Tweedie.var_power : float
         The power of the variance function.
 
@@ -1311,13 +1317,12 @@ class Tweedie(Family):
     --------
     statsmodels.genmod.families.family.Family
     :ref:`links`
-
     Notes
     -----
     Logliklihood function not implemented because of the complexity of
     calculating an infinite series of summations. The variance power can be
     estimated using the ``estimate_tweedie_power`` function that is part of the
-    statsmodels.genmod.GLM class.
+    statsmodels.genmod.generalized_linear_model.GLM class.
     """
     links = [L.log, L.Power]
     variance = V.Power

--- a/statsmodels/genmod/families/family.py
+++ b/statsmodels/genmod/families/family.py
@@ -176,7 +176,7 @@ class Family(object):
         analytically defined for each family.
 
         Internally, we calculate deviance as:
-            
+
         .. math:
             D = \sum_i freq\_weights_i * resid\_dev_i  / scale
         """
@@ -594,6 +594,8 @@ class Gaussian(Family):
            ll_i = -1 / 2 \sum_i  * iweights_i * ((Y_i - mu_i)^2 / scale +
                                                 \log(2 * \pi * scale))
         """
+        if isinstance(self.link, L.Power) and self.link.power == 1:
+            scale = np.sum(var_weights * (endog - mu) ** 2 / len(endog))
         ll_obs = -var_weights * (endog - mu) ** 2 / scale
         ll_obs += -np.log(scale / var_weights) - np.log(2 * np.pi)
         ll_obs /= 2

--- a/statsmodels/genmod/families/family.py
+++ b/statsmodels/genmod/families/family.py
@@ -36,25 +36,18 @@ class Family(object):
     # TODO: change these class attributes, use valid somewhere...
     valid = [-np.inf, np.inf]
     links = []
-    family_doc = 'Base'
-    loglike_obs_doc = """
-        Notes
-        -----
-        This is defined for each family.  endog and mu are not restricted to
-        `endog` and `mu` respectively.  For instance, the deviance function
-        calls both loglike(endog,endog) and loglike(endog,mu) to get the
-        likelihood ratio."""
 
     def _setlink(self, link):
         """
         Helper method to set the link for a family.
 
-        Raises a ValueError exception if the link is not available. Note that
-        the error message might not be that informative because it tells you
-        that the link should be in the base class for the link function.
+        Raises a ``ValueError`` exception if the link is not available. Note
+        that  the error message might not be that informative because it tells
+        you that the link should be in the base class for the link function.
 
-        See glm.GLM for a list of appropriate links for each family but note
-        that not all of these are currently available.
+        See statsmodels.genmod.generalized_linear_model.GLM for a list of
+        appropriate links for each family but note that not all of these are
+        currently available.
         """
         # TODO: change the links class attribute in the families to hold
         # meaningful information instead of a list of links instances such as
@@ -169,16 +162,16 @@ class Family(object):
 
         .. math::
 
-           D = 2\sum_i (iweights_i * (llf(Y_i, Y_i) -
-               llf(Y_i, \mu_i)))
+           D = 2\sum_i (freq\_weights_i * (llf(endog_i, endog_i) -
+               llf(endog_i, \mu_i)))
 
         where y is the endogenous variable. The deviance functions are
         analytically defined for each family.
 
         Internally, we calculate deviance as:
 
-        .. math:
-            D = \sum_i freq\_weights_i * resid\_dev_i  / scale
+        .. math::
+           D = \sum_i freq\_weights_i * resid\_dev_i  / scale
         """
         resid_dev = self.resid_dev(endog, mu, var_weights)
         return np.sum(resid_dev * freq_weights / scale)
@@ -207,20 +200,19 @@ class Family(object):
         observation i to the deviance as
 
         .. math::
-
            resid\_dev_i = sign(y_i-\mu_i) \sqrt{D_i}
         """
         raise NotImplementedError
 
     def fitted(self, lin_pred):
-        """
+        r"""
         Fitted values based on linear predictors lin_pred.
 
         Parameters
         -----------
         lin_pred : array
             Values of the linear predictor of the model.
-            dot(X,beta) in a classical linear model.
+            :math:`X \cdot \beta` in a classical linear model.
 
         Returns
         --------
@@ -266,16 +258,16 @@ class Family(object):
 
         Returns
         -------
-        lli : float
+        ll_i : float
             The value of the loglikelihood evaluated at
             (endog, mu, var_weights, scale) as defined below.
 
         Notes
         -----
         This is defined for each family. endog and mu are not restricted to
-        `endog` and `mu` respectively.  For instance, the deviance function
-        calls both loglike(endog,endog) and loglike(endog,mu) to get the
-        likelihood ratio.
+        ``endog`` and ``mu`` respectively.  For instance, the deviance function
+        calls both ``loglike(endog, endog)`` and ``loglike(endog, mu)`` to get
+        the likelihood ratio.
         """
         raise NotImplementedError
 
@@ -306,18 +298,18 @@ class Family(object):
         -----
         Where :math:`ll_i` is the by-observation log-likelihood:
 
-        .. math:
-            ll = \sum(ll_i * freq\_weights_i)
+        .. math::
+           ll = \sum(ll_i * freq\_weights_i)
 
-        :math:`ll_i` is defined for each family. endog and mu are not
-        restricted to `endog` and `mu` respectively.  For instance, the
-        deviance function calls both loglike(endog,endog) and loglike(endog,mu)
-        to get the likelihood ratio.
+        ``logliek`` is defined for each family. ``endog`` and ``mu`` are not
+        restricted to ``endog`` and ``mu`` respectively.  For instance, the
+        deviance function calls both ``loglike(endog, endog)`` and
+        ``loglike(endog, mu)`` to get the likelihood ratio.
         """
         ll_obs = self.loglike_obs(endog, mu, var_weights, scale)
         return np.sum(ll_obs * freq_weights)
 
-    def resid_anscombe(self, endog, mu, iweights=1., scale=1.):
+    def resid_anscombe(self, endog, mu, scale=1.):
         r"""
         The Anscombe residuals
 
@@ -327,8 +319,6 @@ class Family(object):
             The endogenous response variable
         mu : array
             The inverse of the link function at the linear predicted values.
-        iweights : array-like
-            1d array of frequency weights. The default is 1.
         scale : float, optional
             An optional argument to divide the residuals by sqrt(scale).
             The default is 1.
@@ -343,7 +333,6 @@ class Family(object):
         Anscombe residuals are defined by
 
         .. math::
-
            resid\_anscombe_i = \frac{A(y)-A(\mu)}{A'(\mu)\sqrt{Var[\mu]}}
 
         where :math:`A'(y)=v(y)^{-\frac{1}{3}}` and :math:`v(\mu)` is the
@@ -453,9 +442,9 @@ class Poisson(Family):
 
         Notes
         -----
-        .. math:
+        .. math::
             ll_i = var\_weights_i / scale * (endog_i * \ln(\mu_i) - \mu_i -
-            \ln \Gamma(endog_i + 1)
+            \ln \Gamma(endog_i + 1))
         """
         return var_weights / scale * (endog * np.log(mu) - mu -
                                       special.gammaln(endog + 1))
@@ -483,7 +472,8 @@ class Poisson(Family):
         -----
         .. math::
 
-           resid\_anscombe_i = (3/2) * (Y_i^{2/3} - \mu_i^{2/3}) / \mu_i^{1/6}
+           resid\_anscombe_i = (3/2) * (endog_i^{2/3} - \mu_i^{2/3}) /
+           \mu_i^{1/6}
         """
         return ((3 / 2.) * (endog**(2 / 3.) - mu**(2 / 3.)) /
                 (mu ** (1 / 6.) * scale ** 0.5))
@@ -511,7 +501,6 @@ class Gaussian(Family):
     --------
     statsmodels.genmod.families.family.Family
     :ref:`links`
-
     """
 
     links = [L.log, L.identity, L.inverse_power]
@@ -545,7 +534,7 @@ class Gaussian(Family):
         --------
         .. math::
 
-           resid\_dev_i = var\_weights_i * (endog_i - \mu_i)
+           resid\_dev_i = var\_weights_i * (endog_i - \mu_i) ** 2
         """
         return var_weights * (endog - mu) ** 2
 
@@ -591,11 +580,9 @@ class Gaussian(Family):
 
         .. math::
 
-           ll_i = -1 / 2 \sum_i  * iweights_i * ((Y_i - mu_i)^2 / scale +
+           ll_i = -1 / 2 \sum_i  * var\_weights * ((Y_i - mu_i)^2 / scale +
                                                 \log(2 * \pi * scale))
         """
-        if isinstance(self.link, L.Power) and self.link.power == 1:
-            scale = np.sum(var_weights * (endog - mu) ** 2 / len(endog))
         ll_obs = -var_weights * (endog - mu) ** 2 / scale
         ll_obs += -np.log(scale / var_weights) - np.log(2 * np.pi)
         ll_obs /= 2
@@ -629,7 +616,7 @@ class Gaussian(Family):
 
            resid\_anscombe_i = (Y_i - \mu_i) / \sqrt{scale}
         """
-        return (endog - mu) / scale**(0.5)
+        return (endog - mu) / scale ** 0.5
 
 
 class Gamma(Family):
@@ -687,7 +674,7 @@ class Gamma(Family):
         .. math::
 
            resid\_dev_i = 2 * var\_weights_i * ((endog_i - \mu_i) / \mu_i -
-           \log(endog i / \mu_i))
+           \log(endog_i / \mu_i))
         """
         endog_mu = self._clean(endog / mu)
         resid_dev = -np.log(endog_mu) + (endog - mu) / mu
@@ -757,7 +744,7 @@ class Gamma(Family):
         -----
         .. math::
 
-           resid\_anscombe_i = 3 * (Y_i^{1/3} - \mu_i^{1/3}) / \mu_i^{1/3}
+           resid\_anscombe_i = 3 * (endog_i^{1/3} - \mu_i^{1/3}) / \mu_i^{1/3}
            / \sqrt{scale}
         """
         return 3 * (endog**(1/3.) - mu**(1/3.)) / mu**(1/3.) / scale**(0.5)
@@ -789,7 +776,6 @@ class Binomial(Family):
     Notes
     -----
     endog for Binomial can be specified in one of three ways.
-
     """
 
     links = [L.logit, L.probit, L.cauchy, L.log, L.cloglog, L.identity]
@@ -912,8 +898,8 @@ class Binomial(Family):
         .. math::
 
            ll_i = \sum_i var\_weights_i * (\ln \Gamma(n+1) -
-                 \ln \Gamma(y_i + 1) - \ln \Gamma(n_i - y_i +1) + y_i *
-                 \log(\mu_i / (n_i - \mu_i)) + n * \log(1 - \mu_i/n_i))
+                  \ln \Gamma(y_i + 1) - \ln \Gamma(n_i - y_i +1) + y_i *
+                  \log(\mu_i / (n_i - \mu_i)) + n * \log(1 - \mu_i/n_i))
 
         where :math:`y_i = Y_i * n_i` with :math:`Y_i` and :math:`n_i` as
         defined in Binomial initialize.  This simply makes :math:`y_i` the
@@ -951,8 +937,8 @@ class Binomial(Family):
         -----
         .. math::
 
-            n^{2/3}*(cox_snell(endog)-cox_snell(mu))
-            / (mu*(1-mu/n)*scale^3)^{1/6}
+            n^{2/3}*(cox\_snell(endog)-cox\_snell(mu)) /
+            (mu*(1-mu/n)*scale^3)^{1/6}
 
         where cox_snell is defined as
         cox_snell(x) = betainc(2/3., 2/3., x)*betainc(2/3.,2/3.)
@@ -963,7 +949,7 @@ class Binomial(Family):
         The name 'cox_snell' is idiosyncratic and is simply used for
         convenience following the approach suggested in Cox and Snell (1968).
         Further note that
-        :math:`cox_snell(x) = \frac{3}{2}*x^{2/3} *
+        :math:`cox\_snell(x) = \frac{3}{2}*x^{2/3} *
         hyp2f1(2/3.,1/3.,5/3.,x)`
         where hyp2f1 is the hypergeometric 2f1 function.  The Anscombe
         residuals are sometimes defined in the literature using the
@@ -980,11 +966,12 @@ class Binomial(Family):
         endog = endog * self.n  # convert back to successes
         mu = mu * self.n  # convert back to successes
 
-        cox_snell = lambda x: (special.betainc(2/3., 2/3., x)
-                               * special.beta(2/3., 2/3.))
-        return self.n**(2/3.) * (cox_snell(endog*1./self.n) \
-                            - cox_snell(mu*1./self.n)) \
-                            / (mu * (1 - mu*1./self.n) * scale**3)**(1/6.)
+        def cox_snell(x):
+            return special.betainc(2/3., 2/3., x) * special.beta(2/3., 2/3.)
+
+        return (self.n ** (2/3.) * (cox_snell(endog * 1. / self.n) -
+                                    cox_snell(mu * 1. / self.n)) /
+                (mu * (1 - mu * 1. / self.n) * scale ** 3) ** (1 / 6.))
 
 
 class InverseGaussian(Family):
@@ -1004,7 +991,7 @@ class InverseGaussian(Family):
     InverseGaussian.link : a link instance
         The link function of the inverse Gaussian instance
     InverseGaussian.variance : varfunc instance
-        `variance` is an instance of statsmodels.family.varfuncs.mu_cubed
+        ``variance`` is an instance of statsmodels.family.varfuncs.mu_cubed
 
     See also
     --------
@@ -1051,7 +1038,7 @@ class InverseGaussian(Family):
         .. math::
 
            resid\_dev_i = var\_weights_i / (endog_i * \mu_i^2) * (endog_i -
-           \mu_i)^2
+                          \mu_i)^2
         """
         return var_weights / (endog * mu ** 2) * (endog - mu) ** 2
 
@@ -1134,7 +1121,6 @@ class NegativeBinomial(Family):
         For now `alpha` is assumed to be nonstochastic.  The default value
         is 1.  Permissible values are usually assumed to be between .01 and 2.
 
-
     Attributes
     ----------
     NegativeBinomial.link : a link instance
@@ -1151,9 +1137,10 @@ class NegativeBinomial(Family):
     -----
     Power link functions are not yet supported.
 
-    Parameterization for :math:`y=0,1,2,\ldots` is
+    Parameterization for :math:`y=0, 1, 2, \ldots` is
 
-     :math:`f(y) = \frac{\Gamma(y+\frac{1}{\alpha})}{y!\Gamma(\frac{1}{\alpha})}
+     :math:`f(y) = \frac{\Gamma(y+\frac{1}{\alpha})}
+                        {y!\Gamma(\frac{1}{\alpha})}
      \left(\frac{1}{1+\alpha\mu}\right)^{\frac{1}{\alpha}}
      \left(\frac{\alpha\mu}{1+\alpha\mu}\right)^y`
 
@@ -1285,17 +1272,19 @@ class NegativeBinomial(Family):
 
         .. math::
 
-            resid_anscombe_i = \frac{3}{2} *
+            resid\_anscombe_i = \frac{3}{2} *
             (Y_i^(2/3)*H2F1(-\alpha*Y_i) - \mu_i^(2/3)*H2F1(-\alpha*\mu_i))
             / (\mu_i * (1+\alpha*\mu_i) * scale^3)^(1/6)
 
         Note that for the (unregularized) Beta function, one has
         :math:`Beta(z,a,b) = z^a/a * H2F1(a,1-b,a+1,z)`
         """
-        hyp2f1 = lambda x: special.hyp2f1(2 / 3., 1 / 3., 5 / 3., x)
-        return 3/2. * (endog**(2/3.) * hyp2f1(-self.alpha * endog) -
-                        mu**(2/3.) * hyp2f1(-self.alpha * mu)) \
-                    / (mu * (1+self.alpha * mu)*scale**3)**(1/6)
+        def hyp2f1(x):
+            return special.hyp2f1(2 / 3., 1 / 3., 5 / 3., x)
+
+        return (3 / 2. * (endog ** (2 / 3.) * hyp2f1(-self.alpha * endog) -
+                          mu ** (2 / 3.) * hyp2f1(-self.alpha * mu)) /
+                (mu * (1 + self.alpha * mu) * scale ** 3) ** (1 / 6.))
 
 
 class Tweedie(Family):
@@ -1329,8 +1318,8 @@ class Tweedie(Family):
     -----
     Logliklihood function not implemented because of the complexity of
     calculating an infinite series of summations. The variance power can be
-    estimated using the `estimate_tweedie_power` function that is part of the
-    `GLM` class.
+    estimated using the ``estimate_tweedie_power`` function that is part of the
+    statsmodels.genmod.GLM class.
     """
     links = [L.log, L.Power]
     variance = V.Power
@@ -1464,7 +1453,7 @@ class Tweedie(Family):
 
         .. math::
 
-            resid\_anscombe_i = \log(Y_i / \mu_i) / \sqrt{\mu_i * scale}
+            resid\_anscombe_i = \log(endog_i / \mu_i) / \sqrt{\mu_i * scale}
 
         Otherwise,
 
@@ -1474,7 +1463,7 @@ class Tweedie(Family):
 
         .. math::
 
-            resid\_anscombe_i = (1 / c) * (Y_i^c - \mu_i^c) / \mu_i^{p / 6}
+            resid\_anscombe_i = (1 / c) * (endog_i^c - \mu_i^c) / \mu_i^{p / 6}
             / \sqrt{scale}
         """
         if self.var_power == 3:

--- a/statsmodels/genmod/families/family.py
+++ b/statsmodels/genmod/families/family.py
@@ -905,14 +905,13 @@ class Binomial(Family):
         defined in Binomial initialize.  This simply makes :math:`y_i` the
         original number of successes.
         """
-        if np.shape(self.n) == () and self.n == 1:
-            return (endog * np.log(mu/(1 - mu)) + np.log(1 - mu)) * var_weights
-        else:
-            y = endog * self.n  # convert back to successes
-            # note that mu is still in (0,1), i.e. not convertet back
-            return (special.gammaln(self.n + 1) - special.gammaln(y + 1) -
-                    special.gammaln(self.n - y + 1) + y * np.log(mu/(1 - mu)) +
-                    self.n * np.log(1 - mu)) * var_weights
+        n = self.n     # Number of trials
+        y = endog * n  # Number of successes
+
+        # note that mu is still in (0,1), i.e. not converted back
+        return (special.gammaln(n + 1) - special.gammaln(y + 1) -
+                special.gammaln(n - y + 1) + y * np.log(mu / (1 - mu)) +
+                n * np.log(1 - mu)) * var_weights
 
     def resid_anscombe(self, endog, mu, scale=1.):
         r'''

--- a/statsmodels/genmod/generalized_linear_model.py
+++ b/statsmodels/genmod/generalized_linear_model.py
@@ -432,8 +432,8 @@ class GLM(base.LikelihoodModel):
         """
         Evaluate the log-likelihood for a generalized linear model.
         """
-        return self.family.loglike(mu, self.endog, self.exog, self.iweights,
-                                   scale)
+        return self.family.loglike(mu, self.endog, self.exog, self.var_weights,
+                                   self.freq_weights, scale)
 
     def loglike(self, params, scale=None):
         """
@@ -443,7 +443,8 @@ class GLM(base.LikelihoodModel):
         expval = self.family.link.inverse(lin_pred)
         if scale is None:
             scale = self.estimate_scale(expval)
-        llf = self.family.loglike(self.endog, expval, self.iweights, scale)
+        llf = self.family.loglike(self.endog, expval, self.var_weights,
+                                  self.freq_weights, scale)
         return llf
 
     def score_obs(self, params, scale=None):

--- a/statsmodels/genmod/generalized_linear_model.py
+++ b/statsmodels/genmod/generalized_linear_model.py
@@ -156,16 +156,19 @@ class GLM(base.LikelihoodModel):
 
     Notes
     -----
-    Only the following combinations make sense for family and link ::
+    Only the following combinations make sense for family and link:
 
-                   + ident log logit probit cloglog pow opow nbinom loglog logc
-      Gaussian     |   x    x                        x
-      inv Gaussian |   x    x                        x
-      binomial     |   x    x    x     x       x     x    x           x      x
-      Poission     |   x    x                        x
-      neg binomial |   x    x                        x          x
-      gamma        |   x    x                        x
-      Tweedie      |   x    x                        x
+     ============= ===== === ===== ====== ======= === ==== ====== ====== ====
+     Family        ident log logit probit cloglog pow opow nbinom loglog logc
+     ============= ===== === ===== ====== ======= === ==== ====== ====== ====
+     Gaussian      x     x   x     x      x       x   x     x      x
+     inv Gaussian  x     x                        x
+     binomial      x     x   x     x      x       x   x           x      x
+     Poission      x     x                        x
+     neg binomial  x     x                        x        x
+     gamma         x     x                        x
+     Tweedie       x     x                        x
+     ============= ===== === ===== ====== ======= === ==== ====== ====== ====
 
     Not all of these link functions are currently available.
 
@@ -214,12 +217,12 @@ class GLM(base.LikelihoodModel):
     | Working       | ``n_trials``                     |
     +---------------+----------------------------------+
 
-    WARNING: Loglikelihood, llf, deviance, etc. is not valid in models where
+    WARNING: Loglikelihood and deviance are not valid in models where
     scale is equal to 1 (i.e., ``Binomial``, ``NegativeBinomial``, and
     ``Poisson``). If variance weights are specified, then results such as
     ``loglike`` and ``deviance`` are based on a quasi-likelihood
     interpretation. The loglikelihood is not correctly specified in this case,
-    and statistics based on it, such AIC or likelihood ratio tests, are not\
+    and statistics based on it, such AIC or likelihood ratio tests, are not
     appropriate.
 
     Attributes

--- a/statsmodels/genmod/generalized_linear_model.py
+++ b/statsmodels/genmod/generalized_linear_model.py
@@ -735,7 +735,8 @@ class GLM(base.LikelihoodModel):
         information
         """
         if not self.scaletype:
-            if isinstance(self.family, (families.Binomial, families.Poisson)):
+            if isinstance(self.family, (families.Binomial, families.Poisson,
+                                        families.NegativeBinomial)):
                 return 1.
             else:
                 return self._estimate_x2_scale(mu)

--- a/statsmodels/genmod/generalized_linear_model.py
+++ b/statsmodels/genmod/generalized_linear_model.py
@@ -1431,7 +1431,7 @@ class GLMResults(base.LikelihoodModelResults):
             self.use_t = use_t
 
         # temporary warning
-        ct = (cov_type == 'nonrobust') or (cov_type.startswith('HC'))
+        ct = (cov_type == 'nonrobust') or (cov_type.upper().startswith('HC'))
         if self.model._has_freq_weights and not ct:
             import warnings
             from statsmodels.tools.sm_exceptions import SpecificationWarning
@@ -1686,6 +1686,9 @@ class GLMResults(base.LikelihoodModelResults):
                      ('Deviance:', ["%#8.5g" % self.deviance]),
                      ('Pearson chi2:', ["%#6.3g" % self.pearson_chi2])
                      ]
+
+        if hasattr(self, 'cov_type'):
+            top_right.append(('Covariance Type:', [self.cov_type]))
 
         if title is None:
             title = "Generalized Linear Model Regression Results"

--- a/statsmodels/genmod/generalized_linear_model.py
+++ b/statsmodels/genmod/generalized_linear_model.py
@@ -1681,7 +1681,7 @@ class GLMResults(base.LikelihoodModelResults):
         top_right = [('No. Observations:', None),
                      ('Df Residuals:', None),
                      ('Df Model:', None),
-                     ('Scale:', [self.scale]),
+                     ('Scale:', ["%#8.5g" % self.scale]),
                      ('Log-Likelihood:', None),
                      ('Deviance:', ["%#8.5g" % self.deviance]),
                      ('Pearson chi2:', ["%#6.3g" % self.pearson_chi2])

--- a/statsmodels/genmod/generalized_linear_model.py
+++ b/statsmodels/genmod/generalized_linear_model.py
@@ -434,7 +434,7 @@ class GLM(base.LikelihoodModel):
         """
         Evaluate the log-likelihood for a generalized linear model.
         """
-        return self.family.loglike(mu, self.endog, self.exog, self.var_weights,
+        return self.family.loglike(self.endog, mu, self.var_weights,
                                    self.freq_weights, scale)
 
     def loglike(self, params, scale=None):

--- a/statsmodels/genmod/generalized_linear_model.py
+++ b/statsmodels/genmod/generalized_linear_model.py
@@ -75,9 +75,9 @@ class GLM(base.LikelihoodModel):
         An offset to be included in the model.  If provided, must be
         an array whose length is the number of rows in exog.
     exposure : array-like or None
-        Log(exposure) will be added to the linear prediction in the model. Exposure
-        is only valid if the log link is used. If provided, it must be an array
-        with the same length as endog.
+        Log(exposure) will be added to the linear prediction in the model.
+        Exposure is only valid if the log link is used. If provided, it must be
+        an array with the same length as endog.
     freq_weights : array-like
         1d array of frequency weights. The default is None. If None is selected
         or a blank value, then the algorithm will replace with an array of 1's
@@ -165,6 +165,7 @@ class GLM(base.LikelihoodModel):
       Poission     |   x    x                        x
       neg binomial |   x    x                        x          x
       gamma        |   x    x                        x
+      Tweedie      |   x    x                        x
 
     Not all of these link functions are currently available.
 
@@ -289,16 +290,19 @@ class GLM(base.LikelihoodModel):
         The value of the weights after the last iteration of fit.  Only
         available after fit is called.  See statsmodels.families.family for
         the specific distribution weighting functions.
-    """ % {'extra_params' : base._missing_param_doc}
+    """ % {'extra_params': base._missing_param_doc}
 
     def __init__(self, endog, exog, family=None, offset=None,
                  exposure=None, freq_weights=None, var_weights=None,
                  missing='none', **kwargs):
 
-        if (family is not None) and not isinstance(family.link, tuple(family.safe_links)):
+        if (family is not None) and not isinstance(family.link,
+                                                   tuple(family.safe_links)):
             import warnings
-            warnings.warn("The %s link function does not respect the domain of the %s family." %
-                          (family.link.__class__.__name__, family.__class__.__name__),
+            warnings.warn(("The %s link function does not respect the domain "
+                           "of the %s family.") %
+                          (family.link.__class__.__name__,
+                           family.__class__.__name__),
                           DomainWarning)
 
         if exposure is not None:
@@ -347,22 +351,20 @@ class GLM(base.LikelihoodModel):
 
         self.scaletype = None
 
-
     def initialize(self):
         """
         Initialize a generalized linear model.
         """
         # TODO: intended for public use?
-        self.history = {'fittedvalues' : [],
-                        'params' : [np.inf],
-                        'deviance' : [np.inf]}
+        self.history = {'fittedvalues': [],
+                        'params': [np.inf],
+                        'deviance': [np.inf]}
 
         self.pinv_wexog = np.linalg.pinv(self.exog)
         self.normalized_cov_params = np.dot(self.pinv_wexog,
                                             np.transpose(self.pinv_wexog))
 
         self.df_model = np_matrix_rank(self.exog) - 1
-
 
         if (self.freq_weights is not None) and \
            (self.freq_weights.shape[0] == self.endog.shape[0]):
@@ -470,7 +472,6 @@ class GLM(base.LikelihoodModel):
         score_factor = self.score_factor(params, scale=scale)
         return score_factor[:, None] * self.exog
 
-
     def score(self, params, scale=None):
         """score, first derivative of the loglikelihood function
 
@@ -491,7 +492,6 @@ class GLM(base.LikelihoodModel):
 
         """
         return self.score_obs(params, scale=scale).sum(0)
-
 
     def score_factor(self, params, scale=None):
         """weights for score for each observation
@@ -526,7 +526,6 @@ class GLM(base.LikelihoodModel):
             score_factor /= scale
 
         return score_factor
-
 
     def hessian_factor(self, params, scale=None, observed=True):
         """Weights for calculating Hessian
@@ -607,7 +606,7 @@ class GLM(base.LikelihoodModel):
             Hessian, i.e. observed information, or expected information matrix.
         """
         if observed is None:
-            if hasattr(self, '_optim_hessian') and (self._optim_hessian == 'eim'):
+            if getattr(self, '_optim_hessian', None) == 'eim':
                 observed = False
             else:
                 observed = True
@@ -616,13 +615,11 @@ class GLM(base.LikelihoodModel):
         hess = -np.dot(self.exog.T * factor, self.exog)
         return hess
 
-
     def information(self, params, scale=None):
         """
         Fisher information matrix.
         """
         return self.hessian(params, scale=scale, observed=False)
-
 
     def score_test(self, params_constrained, k_constraints=None,
                    exog_extra=None, observed=True):
@@ -676,7 +673,7 @@ class GLM(base.LikelihoodModel):
             hessian = self.hessian(params_constrained, observed=observed)
 
         else:
-            #exog_extra = np.asarray(exog_extra)
+            # exog_extra = np.asarray(exog_extra)
             if k_constraints is None:
                 k_constraints = 0
 
@@ -689,14 +686,12 @@ class GLM(base.LikelihoodModel):
                                                  observed=observed)
             hessian = -np.dot(ex.T * hessian_factor, ex)
 
-
         from scipy import stats
         # TODO check sign, why minus?
         chi2stat = -score.dot(np.linalg.solve(hessian, score[:, None]))
         pval = stats.chi2.sf(chi2stat, k_constraints)
         # return a stats results instance instead?  Contrast?
         return chi2stat, pval, k_constraints
-
 
     def _update_history(self, tmp_result, mu, history):
         """
@@ -843,7 +838,8 @@ class GLM(base.LikelihoodModel):
 
         if exposure is not None and not isinstance(self.family.link,
                                                    families.links.Log):
-            raise ValueError("exposure can only be used with the log link function")
+            raise ValueError("exposure can only be used with the log link "
+                             "function")
 
         # Use fit exposure if appropriate
         if exposure is None and exog is None and hasattr(self, 'exposure'):
@@ -910,7 +906,8 @@ class GLM(base.LikelihoodModel):
             return dist.gamma(alpha, scale=scale)
 
         else:
-            raise ValueError("get_distribution not implemented for %s" % self.family.name)
+            raise ValueError("get_distribution not implemented for %s" %
+                             self.family.name)
 
     def _setup_binomial(self):
         # this checks what kind of data is given for Binomial.
@@ -1041,9 +1038,11 @@ class GLM(base.LikelihoodModel):
         """
 
         if (max_start_irls > 0) and (start_params is None):
-            irls_rslt = self._fit_irls(start_params=start_params, maxiter=max_start_irls,
+            irls_rslt = self._fit_irls(start_params=start_params,
+                                       maxiter=max_start_irls,
                                        tol=tol, scale=scale, cov_type=cov_type,
-                                       cov_kwds=cov_kwds, use_t=use_t, **kwargs)
+                                       cov_kwds=cov_kwds, use_t=use_t,
+                                       **kwargs)
             start_params = irls_rslt.params
 
         rslt = super(GLM, self).fit(start_params=start_params, tol=tol,
@@ -1074,7 +1073,6 @@ class GLM(base.LikelihoodModel):
         glm_results.fit_history = history
 
         return GLMResultsWrapper(glm_results)
-
 
     def _fit_irls(self, start_params=None, maxiter=100, tol=1e-8,
                   scale=None, cov_type='nonrobust', cov_kwds=None,
@@ -1124,9 +1122,12 @@ class GLM(base.LikelihoodModel):
                             self.family.weights(mu))
             wlsendog = (lin_pred + self.family.link.deriv(mu) * (self.endog-mu)
                         - self._offset_exposure)
-            wls_model = reg_tools._MinimalWLS(wlsendog, wlsexog, self.weights)
-            wls_results = wls_model.fit(method=wls_method)
-            lin_pred = np.dot(self.exog, wls_results.params) + self._offset_exposure
+            wls_results = reg_tools._MinimalWLS(
+                    wlsendog,
+                    wlsexog,
+                    self.weights).fit(method='lstsq')
+            lin_pred = np.dot(self.exog, wls_results.params)
+            lin_pred += self._offset_exposure
             mu = self.family.fitted(lin_pred)
             history = self._update_history(wls_results, mu, history)
             self.scale = self.estimate_scale(mu)
@@ -1160,7 +1161,6 @@ class GLM(base.LikelihoodModel):
         glm_results.fit_history = history
         glm_results.converged = converged
         return GLMResultsWrapper(glm_results)
-
 
     def fit_regularized(self, method="elastic_net", alpha=0.,
                         start_params=None, refit=False, **kwargs):
@@ -1220,8 +1220,8 @@ class GLM(base.LikelihoodModel):
         if method != "elastic_net":
             raise ValueError("method for fit_regularied must be elastic_net")
 
-        defaults = {"maxiter" : 50, "L1_wt" : 1, "cnvrg_tol" : 1e-10,
-                    "zero_tol" : 1e-10}
+        defaults = {"maxiter": 50, "L1_wt": 1, "cnvrg_tol": 1e-10,
+                    "zero_tol": 1e-10}
         defaults.update(kwargs)
 
         result = fit_elasticnet(self, method=method,
@@ -1234,7 +1234,6 @@ class GLM(base.LikelihoodModel):
         self.scale = self.estimate_scale(self.mu)
 
         return result
-
 
     def fit_constrained(self, constraints, start_params=None, **fit_kwds):
         """fit the model subject to linear equality constraints
@@ -1280,8 +1279,8 @@ class GLM(base.LikelihoodModel):
         params, cov, res_constr = fit_constrained(self, R, q,
                                                   start_params=start_params,
                                                   fit_kwds=fit_kwds)
-        #create dummy results Instance, TODO: wire up properly
-        res = self.fit(start_params=params, maxiter=0) # we get a wrapper back
+        # create dummy results Instance, TODO: wire up properly
+        res = self.fit(start_params=params, maxiter=0)  # we get a wrapper back
         res._results.params = params
         res._results.cov_params_default = cov
         cov_type = fit_kwds.get('cov_type', 'nonrobust')
@@ -1391,9 +1390,11 @@ class GLMResults(base.LikelihoodModelResults):
 
     def __init__(self, model, params, normalized_cov_params, scale,
                  cov_type='nonrobust', cov_kwds=None, use_t=None):
-        super(GLMResults, self).__init__(model, params,
-                                         normalized_cov_params=
-                                         normalized_cov_params, scale=scale)
+        super(GLMResults, self).__init__(
+                model,
+                params,
+                normalized_cov_params=normalized_cov_params,
+                scale=scale)
         self.family = model.family
         self._endog = model.endog
         self.nobs = model.endog.shape[0]
@@ -1442,8 +1443,8 @@ class GLMResults(base.LikelihoodModelResults):
 
         if cov_type == 'nonrobust':
             self.cov_type = 'nonrobust'
-            self.cov_kwds = {'description' : 'Standard Errors assume that the ' +
-                             'covariance matrix of the errors is correctly ' +
+            self.cov_kwds = {'description': 'Standard Errors assume that the' +
+                             ' covariance matrix of the errors is correctly ' +
                              'specified.'}
 
         else:
@@ -1505,7 +1506,8 @@ class GLMResults(base.LikelihoodModelResults):
         if hasattr(model, 'exposure'):
             kwargs['exposure'] = model.exposure
         if len(kwargs) > 0:
-            return GLM(endog, exog, family=self.family, **kwargs).fit().fittedvalues
+            return GLM(endog, exog, family=self.family,
+                       **kwargs).fit().fittedvalues
         else:
             wls_model = lm.WLS(endog, exog,
                                weights=self._iweights * self._n_trials)
@@ -1531,10 +1533,17 @@ class GLMResults(base.LikelihoodModelResults):
     @cache_readonly
     def llf(self):
         _modelfamily = self.family
+        if (isinstance(self.family, families.Gaussian) and
+                isinstance(self.family.link, families.links.Power) and
+                (self.family.link.power == 1.)):
+            scale = (np.power(self._endog - self.mu, 2) * self._iweights).sum()
+            scale /= self.model.wnobs
+        else:
+            scale = self.scale
         val = _modelfamily.loglike(self._endog, self.mu,
                                    var_weights=self._var_weights,
                                    freq_weights=self._freq_weights,
-                                   scale=self.scale)
+                                   scale=scale)
         return val
 
     @cache_readonly
@@ -1556,8 +1565,10 @@ class GLMResults(base.LikelihoodModelResults):
         pred_kwds = {'exposure': exposure, 'offset': offset, 'linear': True}
 
         # two calls to a get_prediction duplicates exog generation if patsy
-        res_linpred = linpred.get_prediction(self, exog=exog, transform=transform,
-                              row_labels=row_labels, pred_kwds=pred_kwds)
+        res_linpred = linpred.get_prediction(self, exog=exog,
+                                             transform=transform,
+                                             row_labels=row_labels,
+                                             pred_kwds=pred_kwds)
 
         pred_kwds['linear'] = False
         res = pred.get_prediction_glm(self, exog=exog, transform=transform,
@@ -1568,17 +1579,15 @@ class GLMResults(base.LikelihoodModelResults):
 
         return res
 
-
     get_prediction.__doc__ = pred.get_prediction_glm.__doc__
 
-
     def remove_data(self):
-        #GLM has alias/reference in result instance
+        # GLM has alias/reference in result instance
         self._data_attr.extend([i for i in self.model._data_attr
-                                if not '_data.' in i])
+                                if '_data.' not in i])
         super(self.__class__, self).remove_data()
 
-        #TODO: what are these in results?
+        # TODO: what are these in results?
         self._endog = None
         self._freq_weights = None
         self._var_weights = None
@@ -1602,7 +1611,7 @@ class GLMResults(base.LikelihoodModelResults):
         return fig
 
     plot_added_variable.__doc__ = _plot_added_variable_doc % {
-        'extra_params_doc' : ''}
+        'extra_params_doc': ''}
 
     def plot_partial_residuals(self, focus_exog, ax=None):
         # Docstring attached below
@@ -1612,7 +1621,7 @@ class GLMResults(base.LikelihoodModelResults):
         return plot_partial_residuals(self, focus_exog, ax=ax)
 
     plot_partial_residuals.__doc__ = _plot_partial_residuals_doc % {
-        'extra_params_doc' : ''}
+        'extra_params_doc': ''}
 
     def plot_ceres_residuals(self, focus_exog, frac=0.66, cond_means=None,
                              ax=None):
@@ -1624,7 +1633,7 @@ class GLMResults(base.LikelihoodModelResults):
                                     cond_means=cond_means, ax=ax)
 
     plot_ceres_residuals.__doc__ = _plot_ceres_residuals_doc % {
-        'extra_params_doc' : ''}
+        'extra_params_doc': ''}
 
     def summary(self, yname=None, xname=None, title=None, alpha=.05):
         """
@@ -1678,7 +1687,7 @@ class GLMResults(base.LikelihoodModelResults):
         if title is None:
             title = "Generalized Linear Model Regression Results"
 
-        #create summary tables
+        # create summary tables
         from statsmodels.iolib.summary import Summary
         smry = Summary()
         smry.add_table_2cols(self, gleft=top_left, gright=top_right,  # [],
@@ -1688,12 +1697,12 @@ class GLMResults(base.LikelihoodModelResults):
 
         if hasattr(self, 'constraints'):
             smry.add_extra_txt(['Model has been estimated subject to linear '
-                          'equality constraints.'])
+                                'equality constraints.'])
 
-        #diagnostic table is not used yet:
-        #smry.add_table_2cols(self, gleft=diagn_left, gright=diagn_right,
-        #                  yname=yname, xname=xname,
-        #                  title="")
+        # diagnostic table is not used yet:
+        # smry.add_table_2cols(self, gleft=diagn_left, gright=diagn_right,
+        #                   yname=yname, xname=xname,
+        #                   title="")
 
         return smry
 
@@ -1742,25 +1751,27 @@ class GLMResults(base.LikelihoodModelResults):
 
 class GLMResultsWrapper(lm.RegressionResultsWrapper):
     _attrs = {
-        'resid_anscombe' : 'rows',
-        'resid_deviance' : 'rows',
-        'resid_pearson' : 'rows',
-        'resid_response' : 'rows',
-        'resid_working' : 'rows'
+        'resid_anscombe': 'rows',
+        'resid_deviance': 'rows',
+        'resid_pearson': 'rows',
+        'resid_response': 'rows',
+        'resid_working': 'rows'
     }
     _wrap_attrs = wrap.union_dicts(lm.RegressionResultsWrapper._wrap_attrs,
                                    _attrs)
+
+
 wrap.populate_wrapper(GLMResultsWrapper, GLMResults)
 
 if __name__ == "__main__":
     import statsmodels.api as sm
     data = sm.datasets.longley.load()
-    #data.exog = add_constant(data.exog)
+    # data.exog = add_constant(data.exog)
     GLMmod = GLM(data.endog, data.exog).fit()
     GLMT = GLMmod.summary(returns='tables')
-##    GLMT[0].extend_right(GLMT[1])
-##    print(GLMT[0])
-##    print(GLMT[2])
+    # GLMT[0].extend_right(GLMT[1])
+    # print(GLMT[0])
+    # print(GLMT[2])
     GLMTp = GLMmod.summary(title='Test GLM')
 
     """
@@ -1798,29 +1809,29 @@ Log likelihood   = -76.94564525                    BIC             =  10.20398
 ------------------------------------------------------------------------------
 """
 
-    #NOTE: wfs dataset has been removed due to a licensing issue
+    # NOTE: wfs dataset has been removed due to a licensing issue
     # example of using offset
-    #data = sm.datasets.wfs.load()
+    # data = sm.datasets.wfs.load()
     # get offset
-    #offset = np.log(data.exog[:,-1])
-    #exog = data.exog[:,:-1]
+    # offset = np.log(data.exog[:,-1])
+    # exog = data.exog[:,:-1]
 
     # convert dur to dummy
-    #exog = sm.tools.categorical(exog, col=0, drop=True)
+    # exog = sm.tools.categorical(exog, col=0, drop=True)
     # drop reference category
     # convert res to dummy
-    #exog = sm.tools.categorical(exog, col=0, drop=True)
+    # exog = sm.tools.categorical(exog, col=0, drop=True)
     # convert edu to dummy
-    #exog = sm.tools.categorical(exog, col=0, drop=True)
+    # exog = sm.tools.categorical(exog, col=0, drop=True)
     # drop reference categories and add intercept
-    #exog = sm.add_constant(exog[:,[1,2,3,4,5,7,8,10,11,12]])
+    # exog = sm.add_constant(exog[:,[1,2,3,4,5,7,8,10,11,12]])
 
-    #endog = np.round(data.endog)
-    #mod = sm.GLM(endog, exog, family=sm.families.Poisson()).fit()
+    # endog = np.round(data.endog)
+    # mod = sm.GLM(endog, exog, family=sm.families.Poisson()).fit()
 
-    #res1 = GLM(endog, exog, family=sm.families.Poisson(),
-    #                        offset=offset).fit(tol=1e-12, maxiter=250)
-    #exposuremod = GLM(endog, exog, family=sm.families.Poisson(),
-    #                        exposure = data.exog[:,-1]).fit(tol=1e-12,
-    #                                                        maxiter=250)
-    #assert(np.all(res1.params == exposuremod.params))
+    # res1 = GLM(endog, exog, family=sm.families.Poisson(),
+    #                         offset=offset).fit(tol=1e-12, maxiter=250)
+    # exposuremod = GLM(endog, exog, family=sm.families.Poisson(),
+    #                   exposure = data.exog[:,-1]).fit(tol=1e-12,
+    #                                                   maxiter=250)
+    # assert(np.all(res1.params == exposuremod.params))

--- a/statsmodels/genmod/tests/test_constrained.py
+++ b/statsmodels/genmod/tests/test_constrained.py
@@ -13,7 +13,7 @@ Author: Josef Perktold
 import numpy as np
 from numpy.testing import assert_allclose, assert_equal
 from statsmodels.tools.tools import add_constant
-from statsmodels.regression.linear_model import OLS
+from statsmodels.regression.linear_model import OLS, WLS
 from statsmodels.genmod.generalized_linear_model import GLM
 
 
@@ -49,11 +49,10 @@ class ConstrainedCompareMixin(object):
         res2 = self.res2
 
         assert_equal(res1.df_resid, res2.df_resid)
-        # why does scale differ
-        assert_allclose(res1.scale, res2.scale, rtol=0.05)
+        assert_allclose(res1.scale, res2.scale, rtol=1e-10)
         assert_allclose(res1.bse[self.idx_p_uc], res2.bse, rtol=1e-10)
-        assert_allclose(res1.cov_params()[self.idx_p_uc[:,None], self.idx_p_uc],
-                        res2.cov_params(), rtol=1e-10)
+        assert_allclose(res1.cov_params()[self.idx_p_uc[:, None],
+                        self.idx_p_uc], res2.cov_params(), rtol=1e-10)
 
     def test_resid(self):
         res1 = self.res1
@@ -103,5 +102,77 @@ class TestGLMGaussianConstrainedHC(ConstrainedCompareMixin):
         cov_type = 'HC0'
         cls.res2 = cls.mod2.fit(cov_type=cov_type)
         mod = GLM(cls.endog, cls.exog)
+        mod.exog_names[:] = ['const', 'x1', 'x2', 'x3', 'x4']
+        cls.res1 = mod.fit_constrained('x1=0.5', cov_type=cov_type)
+
+
+class ConstrainedCompareWtdMixin(ConstrainedCompareMixin):
+
+    @classmethod
+    def setup_class(cls):
+        nobs, k_exog = 100, 5
+        np.random.seed(987125)
+        x = np.random.randn(nobs, k_exog - 1)
+        x = add_constant(x)
+        cls.aweights = np.random.randint(1, 10, nobs)
+
+        y_true = x.sum(1) / 2
+        y = y_true + 2 * np.random.randn(nobs)
+        cls.endog = y
+        cls.exog = x
+        cls.idx_uc = [0, 2, 3, 4]
+        cls.idx_p_uc = np.array(cls.idx_uc)
+        cls.idx_c = [1]
+        cls.exogc = xc = x[:, cls.idx_uc]
+        mod_ols_c = WLS(y - 0.5 * x[:, 1], xc, weights=cls.aweights)
+        mod_ols_c.exog_names[:] = ['const', 'x2', 'x3', 'x4']
+        cls.mod2 = mod_ols_c
+        cls.init()
+
+
+class TestGLMWtdGaussianOffset(ConstrainedCompareWtdMixin):
+
+    @classmethod
+    def init(cls):
+        cls.res2 = cls.mod2.fit()
+        mod = GLM(cls.endog, cls.exogc,
+                  offset=0.5 * cls.exog[:, cls.idx_c].squeeze(),
+                  var_weights=cls.aweights)
+        mod.exog_names[:] = ['const', 'x2', 'x3', 'x4']
+        cls.res1 = mod.fit()
+        cls.idx_p_uc = np.arange(cls.exogc.shape[1])
+
+
+class TestGLMWtdGaussianConstrained(ConstrainedCompareWtdMixin):
+
+    @classmethod
+    def init(cls):
+        cls.res2 = cls.mod2.fit()
+        mod = GLM(cls.endog, cls.exog, var_weights=cls.aweights)
+        mod.exog_names[:] = ['const', 'x1', 'x2', 'x3', 'x4']
+        cls.res1 = mod.fit_constrained('x1=0.5')
+
+
+class TestGLMWtdGaussianOffsetHC(ConstrainedCompareWtdMixin):
+
+    @classmethod
+    def init(cls):
+        cov_type = 'HC0'
+        cls.res2 = cls.mod2.fit(cov_type=cov_type)
+        mod = GLM(cls.endog, cls.exogc,
+                  offset=0.5 * cls.exog[:, cls.idx_c].squeeze(),
+                  var_weights=cls.aweights)
+        mod.exog_names[:] = ['const', 'x2', 'x3', 'x4']
+        cls.res1 = mod.fit(cov_type=cov_type)
+        cls.idx_p_uc = np.arange(cls.exogc.shape[1])
+
+
+class TestGLMWtdGaussianConstrainedHC(ConstrainedCompareWtdMixin):
+
+    @classmethod
+    def init(cls):
+        cov_type = 'HC0'
+        cls.res2 = cls.mod2.fit(cov_type=cov_type)
+        mod = GLM(cls.endog, cls.exog, var_weights=cls.aweights)
         mod.exog_names[:] = ['const', 'x1', 'x2', 'x3', 'x4']
         cls.res1 = mod.fit_constrained('x1=0.5', cov_type=cov_type)

--- a/statsmodels/genmod/tests/test_glm.py
+++ b/statsmodels/genmod/tests/test_glm.py
@@ -98,7 +98,10 @@ class CheckModelResultsMixin(object):
         if isinstance(self.res1.model.family, (sm.families.Gamma,
             sm.families.InverseGaussian)):
             llf = self.res1.model.family.loglike(self.res1.model.endog,
-                                                 self.res1.mu, self.res1.model.freq_weights, scale=1)
+                                                 self.res1.mu,
+                                                 self.res1.model.var_weights,
+                                                 self.res1.model.freq_weights,
+                                                 scale=1)
             aic = (-2*llf+2*(self.res1.df_model+1))/self.res1.nobs
         else:
             aic = self.res1.aic/self.res1.nobs
@@ -121,7 +124,10 @@ class CheckModelResultsMixin(object):
         if isinstance(self.res1.model.family, (sm.families.Gamma,
             sm.families.InverseGaussian)):
             llf = self.res1.model.family.loglike(self.res1.model.endog,
-                                                 self.res1.mu, self.res1.model.freq_weights, scale=1)
+                                                 self.res1.mu,
+                                                 self.res1.model.var_weights,
+                                                 self.res1.model.freq_weights,
+                                                 scale=1)
         else:
             llf = self.res1.llf
         assert_almost_equal(llf, self.res2.llf, self.decimal_loglike)

--- a/statsmodels/genmod/tests/test_glm.py
+++ b/statsmodels/genmod/tests/test_glm.py
@@ -80,8 +80,8 @@ class CheckModelResultsMixin(object):
                 self.res1.resid_anscombe, self.res1.resid_response))
         assert_allclose(resids, resid2, rtol=1e-6, atol=atol)
 
-
     decimal_aic_R = DECIMAL_4
+
     def test_aic_R(self):
         # R includes the estimation of the scale as a lost dof
         # Doesn't with Gamma though
@@ -89,14 +89,23 @@ class CheckModelResultsMixin(object):
             dof = 2
         else:
             dof = 0
-        assert_almost_equal(self.res1.aic+dof, self.res2.aic_R,
+        if isinstance(self.res1.model.family, (sm.families.NegativeBinomial)):
+            llf = self.res1.model.family.loglike(self.res1.model.endog,
+                                                 self.res1.mu,
+                                                 self.res1.model.var_weights,
+                                                 self.res1.model.freq_weights,
+                                                 scale=1)
+            aic = (-2*llf+2*(self.res1.df_model+1))
+        else:
+            aic = self.res1.aic
+        assert_almost_equal(aic+dof, self.res2.aic_R,
                 self.decimal_aic_R)
 
     decimal_aic_Stata = DECIMAL_4
     def test_aic_Stata(self):
         # Stata uses the below llf for aic definition for these families
         if isinstance(self.res1.model.family, (sm.families.Gamma,
-            sm.families.InverseGaussian)):
+            sm.families.InverseGaussian, sm.families.NegativeBinomial)):
             llf = self.res1.model.family.loglike(self.res1.model.endog,
                                                  self.res1.mu,
                                                  self.res1.model.var_weights,
@@ -122,7 +131,7 @@ class CheckModelResultsMixin(object):
         # Stata uses the below llf for these families
         # We differ with R for them
         if isinstance(self.res1.model.family, (sm.families.Gamma,
-            sm.families.InverseGaussian)):
+            sm.families.InverseGaussian, sm.families.NegativeBinomial)):
             llf = self.res1.model.family.loglike(self.res1.model.endog,
                                                  self.res1.mu,
                                                  self.res1.model.var_weights,
@@ -638,7 +647,7 @@ class TestGlmNegbinomial(CheckModelResultsMixin):
         cls.data.exog = np.column_stack((cls.data.exog,interaction))
         cls.data.exog = add_constant(cls.data.exog, prepend=False)
         cls.res1 = GLM(cls.data.endog, cls.data.exog,
-                family=sm.families.NegativeBinomial()).fit()
+                family=sm.families.NegativeBinomial()).fit(scale='x2')
         from .results.results_glm import Committee
         res2 = Committee()
         res2.aic_R += 2 # They don't count a degree of freedom for the scale

--- a/statsmodels/genmod/tests/test_glm_weights.py
+++ b/statsmodels/genmod/tests/test_glm_weights.py
@@ -19,7 +19,7 @@ TestRepeatedvsAggregated          statsmodels.GLM        X      X               
 TestRepeatedvsAverage             statsmodels.GLM        X      X                                                                                                                        bfgs
 TestTweedieRepeatedvsAggregated   statsmodels.GLM        X      X                                                                                                                        bfgs
 TestTweedieRepeatedvsAverage      statsmodels.GLM        X      X                                                                                                                        bfgs
-TestBinomial0RepeatedvsAverage    statsmodels.GLM        X      X                                                                                                                        newton
+TestBinomial0RepeatedvsAverage    statsmodels.GLM        X      X
 TestBinomial0RepeatedvsDuplicated statsmodels.GLM        X      X                                                                                                                        bfgs
 TestBinomialVsVarWeights          statsmodels.GLM        X      X                     X                                                                                                  bfgs
 TestGlmGaussianWLS                statsmodels.WLS        X      X                     X                                                                                                  bfgs
@@ -108,15 +108,15 @@ class CheckWeight(object):
 
     def test_compare_optimizers(self):
         res1 = self.res1
-        if (isinstance(res1.model.family, sm.families.Tweedie) or
-                isinstance(self, TestBinomial0RepeatedvsAverage)):
+        if isinstance(res1.model.family, sm.families.Tweedie):
             method = 'newton'
             optim_hessian = 'eim'
         else:
             method = 'bfgs'
             optim_hessian = 'oim'
         if isinstance(self, (TestGlmPoissonFwHC, TestGlmPoissonAwHC,
-                             TestGlmPoissonFwClu)):
+                             TestGlmPoissonFwClu,
+                             TestBinomial0RepeatedvsAverage)):
             return None
         res2 = self.res1.model.fit(method=method, optim_hessian=optim_hessian)
         assert_allclose(res1.params, res2.params, atol=1e-3, rtol=2e-3)

--- a/statsmodels/genmod/tests/test_glm_weights.py
+++ b/statsmodels/genmod/tests/test_glm_weights.py
@@ -742,14 +742,14 @@ def test_warnings_raised():
         assert len(w) >= 1
 
 
-weights = [1, 1, 1, 2, 2, 2, 3, 3, 3, 1, 1, 1, 2, 2, 2, 3, 3]
-# TODO: Re-enable once nose is permanently dropped
-@nose.tools.nottest
-@pytest.mark.parametrize('formatted', [weights, np.asarray(weights), pd.Series(weights)],
-                         ids=['list', 'ndarray', 'Series'])
-def test_weights_different_formats(formatted):
-    check_weights_as_formats(formatted)
+def test_weights_different_formats_all():
+    weights = [1, 1, 1, 2, 2, 2, 3, 3, 3, 1, 1, 1, 2, 2, 2, 3, 3]
+    check_weights_as_formats(weights)
+    check_weights_as_formats(np.asarray(weights))
+    check_weights_as_formats(pd.Series(weights))
 
+
+def check_weights_as_formats(weights):
 
 # TODO: Remove once nose is permanently dropped
 def test_weights_different_formats_all():

--- a/statsmodels/genmod/tests/test_glm_weights.py
+++ b/statsmodels/genmod/tests/test_glm_weights.py
@@ -6,23 +6,23 @@ Below is a table outlining the test coverage.
 ================================= ====================== ====== ===================== === ======= ======== ============== ============= ============== ============= ============== ==== =========
 Test                              Compared To            params normalized_cov_params bse loglike deviance resid_response resid_pearson resid_deviance resid_working resid_anscombe chi2 optimizer
 ================================= ====================== ====== ===================== === ======= ======== ============== ============= ============== ============= ============== ==== =========
-TestGlmPoissonPlain               stata                  X                            X   X       X        X              X             X              X             X              X    X
-TestGlmPoissonFwNr                stata                  X                            X   X       X        X              X             X              X             X              X    X
-TestGlmPoissonAwNr                stata                  X                            X   X       X        X              X             X              X             X              X    X
+TestGlmPoissonPlain               stata                  X                            X   X       X        X              X             X              X             X              X    bfgs
+TestGlmPoissonFwNr                stata                  X                            X   X       X        X              X             X              X             X              X    bfgs
+TestGlmPoissonAwNr                stata                  X                            X   X       X        X              X             X              X             X              X    bfgs
 TestGlmPoissonFwHC                stata                  X                            X   X       X                                                                                 X
 TestGlmPoissonAwHC                stata                  X                            X   X       X                                                                                 X
 TestGlmPoissonFwClu               stata                  X                            X   X       X                                                                                 X
-TestGlmTweedieAwNr                R                      X                            X           X        X              X             X              X                                 X
-TestGlmGammaAwNr                  R                      X                            X   special X        X              X             X              X                                 X
-TestGlmGaussianAwNr               R                      X                            X   special X        X              X             X              X                                 X
-TestRepeatedvsAggregated          statsmodels.GLM        X      X                                                                                                                        X
-TestRepeatedvsAverage             statsmodels.GLM        X      X                                                                                                                        X
-TestTweedieRepeatedvsAggregated   statsmodels.GLM        X      X                                                                                                                        X
-TestTweedieRepeatedvsAverage      statsmodels.GLM        X      X                                                                                                                        X
-TestBinomial0RepeatedvsAverage    statsmodels.GLM        X      X
-TestBinomial0RepeatedvsDuplicated statsmodels.GLM        X      X                                                                                                                        X
-TestBinomialVsVarWeights          statsmodels.GLM        X      X                     X                                                                                                  X
-TestGlmGaussianWLS                statsmodels.WLS        X      X                     X                                                                                                  X
+TestGlmTweedieAwNr                R                      X                            X           X        X              X             X              X                                 newton
+TestGlmGammaAwNr                  R                      X                            X   special X        X              X             X              X                                 bfgs
+TestGlmGaussianAwNr               R                      X                            X   special X        X              X             X              X                                 bfgs
+TestRepeatedvsAggregated          statsmodels.GLM        X      X                                                                                                                        bfgs
+TestRepeatedvsAverage             statsmodels.GLM        X      X                                                                                                                        bfgs
+TestTweedieRepeatedvsAggregated   statsmodels.GLM        X      X                                                                                                                        bfgs
+TestTweedieRepeatedvsAverage      statsmodels.GLM        X      X                                                                                                                        bfgs
+TestBinomial0RepeatedvsAverage    statsmodels.GLM        X      X                                                                                                                        newton
+TestBinomial0RepeatedvsDuplicated statsmodels.GLM        X      X                                                                                                                        bfgs
+TestBinomialVsVarWeights          statsmodels.GLM        X      X                     X                                                                                                  bfgs
+TestGlmGaussianWLS                statsmodels.WLS        X      X                     X                                                                                                  bfgs
 ================================= ====================== ====== ===================== === ======= ======== ============== ============= ============== ============= ============== ==== =========
 """
 from __future__ import division
@@ -108,15 +108,15 @@ class CheckWeight(object):
 
     def test_compare_optimizers(self):
         res1 = self.res1
-        if isinstance(res1.model.family, sm.families.Tweedie):
+        if (isinstance(res1.model.family, sm.families.Tweedie) or
+                isinstance(self, TestBinomial0RepeatedvsAverage)):
             method = 'newton'
             optim_hessian = 'eim'
         else:
             method = 'bfgs'
             optim_hessian = 'oim'
         if isinstance(self, (TestGlmPoissonFwHC, TestGlmPoissonAwHC,
-                             TestGlmPoissonFwClu,
-                             TestBinomial0RepeatedvsAverage)):
+                             TestGlmPoissonFwClu)):
             return None
         res2 = self.res1.model.fit(method=method, optim_hessian=optim_hessian)
         assert_allclose(res1.params, res2.params, atol=1e-3, rtol=2e-3)

--- a/statsmodels/genmod/tests/test_glm_weights.py
+++ b/statsmodels/genmod/tests/test_glm_weights.py
@@ -756,7 +756,6 @@ def test_weights_different_formats_all():
     check_weights_as_formats(weights)
     check_weights_as_formats(np.asarray(weights))
     check_weights_as_formats(pd.Series(weights))
-def check_weights_as_formats(weights):
     res = GLM(cpunish_data.endog, cpunish_data.exog,
               family=sm.families.Poisson(), freq_weights=weights
               ).fit()

--- a/statsmodels/genmod/tests/test_glm_weights.py
+++ b/statsmodels/genmod/tests/test_glm_weights.py
@@ -1,5 +1,29 @@
-"""Test for weights in GLM, Poisson and OLS/WLS, continuous test_glm.py
+"""
+Test for weights in GLM, Poisson and OLS/WLS, continuous test_glm.py
 
+
+Below is a table outlining the test coverage.
+================================= ====================== ====== ===================== === ======= ======== ============== ============= ============== ============= ============== ====
+Test                              Compared To            params normalized_cov_params bse loglike deviance resid_response resid_pearson resid_deviance resid_working resid_anscombe chi2
+================================= ====================== ====== ===================== === ======= ======== ============== ============= ============== ============= ============== ====
+TestGlmPoissonPlain               stata                  X                            X   X       X        X              X             X              X             X              X
+TestGlmPoissonFwNr                stata                  X                            X   X       X        X              X             X              X             X              X
+TestGlmPoissonAwNr                stata                  X                            X   X       X        X              X             X              X             X              X
+TestGlmPoissonFwHC                stata                  X                            X   X       X                                                                                 X
+TestGlmPoissonAwHC                stata                  X                            X   X       X                                                                                 X
+TestGlmPoissonFwClu               stata                  X                            X   X       X                                                                                 X
+TestGlmTweedieAwNr                R                      X                            X           X        X              X             X              X
+TestGlmGammaAwNr                  R                      X                            X   special X        X              X             X              X
+TestGlmGaussianAwNr               R                      X                            X   special X        X              X             X              X
+TestRepeatedvsAggregated          statsmodels.GLM        X      X
+TestRepeatedvsAverage             statsmodels.GLM        X      X
+TestTweedieRepeatedvsAggregated   statsmodels.GLM        X      X
+TestTweedieRepeatedvsAverage      statsmodels.GLM        X      X
+TestBinomial0RepeatedvsAverage    statsmodels.GLM        X      X
+TestBinomial0RepeatedvsDuplicated statsmodels.GLM        X      X
+TestBinomialVsVarWeights          statsmodels.GLM        X      X                     X
+TestGlmGaussianWLS                statsmodels.WLS        X      X                     X
+================================= ====================== ====== ===================== === ======= ======== ============== ============= ============== ============= ============== ====
 """
 from __future__ import division
 from statsmodels.compat.testing import SkipTest

--- a/statsmodels/genmod/tests/test_glm_weights.py
+++ b/statsmodels/genmod/tests/test_glm_weights.py
@@ -742,20 +742,25 @@ def test_warnings_raised():
         assert len(w) >= 1
 
 
-def test_weights_different_formats_all():
-    weights = [1, 1, 1, 2, 2, 2, 3, 3, 3, 1, 1, 1, 2, 2, 2, 3, 3]
-    check_weights_as_formats(weights)
-    check_weights_as_formats(np.asarray(weights))
-    check_weights_as_formats(pd.Series(weights))
+weights = [1, 1, 1, 2, 2, 2, 3, 3, 3, 1, 1, 1, 2, 2, 2, 3, 3]
 
 
-def check_weights_as_formats(weights):
+# TODO: Re-enable once nose is permanently dropped
+@nose.tools.nottest
+@pytest.mark.parametrize('formatted', [weights, np.asarray(weights), pd.Series(weights)],
+                         ids=['list', 'ndarray', 'Series'])
+def test_weights_different_formats(formatted):
+    check_weights_as_formats(formatted)
+
 
 # TODO: Remove once nose is permanently dropped
 def test_weights_different_formats_all():
     check_weights_as_formats(weights)
     check_weights_as_formats(np.asarray(weights))
     check_weights_as_formats(pd.Series(weights))
+
+
+def check_weights_as_formats(weights):
     res = GLM(cpunish_data.endog, cpunish_data.exog,
               family=sm.families.Poisson(), freq_weights=weights
               ).fit()

--- a/statsmodels/genmod/tests/test_glm_weights.py
+++ b/statsmodels/genmod/tests/test_glm_weights.py
@@ -3,6 +3,7 @@ Test for weights in GLM, Poisson and OLS/WLS, continuous test_glm.py
 
 
 Below is a table outlining the test coverage.
+
 ================================= ====================== ====== ===================== === ======= ======== ============== ============= ============== ============= ============== ==== =========
 Test                              Compared To            params normalized_cov_params bse loglike deviance resid_response resid_pearson resid_deviance resid_working resid_anscombe chi2 optimizer
 ================================= ====================== ====== ===================== === ======= ======== ============== ============= ============== ============= ============== ==== =========
@@ -41,7 +42,6 @@ import statsmodels.api as sm
 from statsmodels.genmod.generalized_linear_model import GLM
 from statsmodels.tools.tools import add_constant
 from statsmodels.discrete import discrete_model as discrete
-import pytest
 
 from .results import results_glm_poisson_weights as res_stata
 from .results import res_R_var_weight as res_r


### PR DESCRIPTION
xref #3773 

I apologize for this taking longer than had hoped, but my busy period was exacerbated by some unforeseen events. But I'm somewhat back now.

This is the first step to solving the above issue. 

Still a lot is missing... I've only really gotten `loglike` to work for all the families except `Gamma`, `Binomial`, `Gaussian`, and `Tweedie` (which has never had `loglike`). I also need to re-work the docstrings. I'm thinking its more logical to have a `loglike_obs` function called in each family and then have a `loglike` function in the `Family` class so that `loglike` will simply be inherited. I think you the doctrings could be elegantly written to handle this too. 

I'm thinking I will work on deviance next and then ciricle back to `loglike`... I feel like R takes some computational shortcuts...