### PR TITLE
TST: Revert 'not slow' test

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,4 +35,4 @@ build_script:
 
 test_script:
   # Remove xdist (-n auto) until warning reporting is working
-  - pytest statsmodels
+  - pytest statsmodels -k "not slow" 


### PR DESCRIPTION
So prior to the switchover the `pytest`, we ran (essentially) `nosetests statsmodels -a "not slow"`. See [here](https://github.com/statsmodels/statsmodels/blob/b39e39c0c28095c3f1b6ea3a371e91f4f4f47f6e/appveyor.yml#L34). 

Conveniently, that made it so #3860 wasn't a problem. I think the switch to pytest manifested that. 

Not sure if we really want to merge this, but this explains why this wasn't caught before. It will get appveyor to pass, however. 
