### PR TITLE
Demonstrate idea for _results_class property

### DIFF
--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -74,6 +74,9 @@ class Model(object):
         if hasconst is not None:
             self._init_keys.append('hasconst')
 
+    @property
+    def _results_class(self):
+        return (Results, wrap.ResultsWrapper)
 
     def _get_init_kwds(self):
         """return dictionary with extra keys used in model.__init__
@@ -222,6 +225,10 @@ class LikelihoodModel(Model):
 
     # TODO: if the intent is to re-initialize the model with new data then this
     # method needs to take inputs...
+
+    @property
+    def _results_class(self):
+        return (LikelihoodModelResults, LikelihoodResultsWrapper)
 
     def loglike(self, params):
         """

--- a/statsmodels/discrete/discrete_model.py
+++ b/statsmodels/discrete/discrete_model.py
@@ -207,7 +207,9 @@ class DiscreteModel(base.LikelihoodModel):
                 method=method, maxiter=maxiter, full_output=full_output,
                 disp=disp, callback=callback, **kwargs)
 
-        return mlefit # up to subclasses to wrap results
+        (res_cls, wrap_cls) = self._results_class
+        cls_fit = res_cls(mlefit)
+        return wrap_cls(cls_fit)
 
     fit.__doc__ += base.LikelihoodModel.fit.__doc__
 
@@ -591,9 +593,15 @@ class MultinomialModel(BinaryModel):
                 method=method, maxiter=maxiter, full_output=full_output,
                 disp=disp, callback=callback, **kwargs)
         mnfit.params = mnfit.params.reshape(self.K, -1, order='F')
-        mnfit = MultinomialResults(self, mnfit)
-        return MultinomialResultsWrapper(mnfit)
+
+        (res_cls, wrap_cls) = self._results_class
+        mnfit = res_cls(self, mnfit)
+        return wrap_cls(mnfit)
     fit.__doc__ = DiscreteModel.fit.__doc__
+
+    @property
+    def _results_class(self):
+        return (MultinomialResults, MultinomialResultsWrapper)
 
     def fit_regularized(self, start_params=None, method='l1',
             maxiter='defined_by_method', full_output=1, disp=1, callback=None,
@@ -823,14 +831,9 @@ class CountModel(DiscreteModel):
                     self, params)
         return margeff
 
-    def fit(self, start_params=None, method='newton', maxiter=35,
-            full_output=1, disp=1, callback=None, **kwargs):
-        cntfit = super(CountModel, self).fit(start_params=start_params,
-                method=method, maxiter=maxiter, full_output=full_output,
-                disp=disp, callback=callback, **kwargs)
-        discretefit = CountResults(self, cntfit)
-        return CountResultsWrapper(discretefit)
-    fit.__doc__ = DiscreteModel.fit.__doc__
+    @property
+    def _results_class(self):
+        return (CountResults, CountResultsWrapper)
 
     def fit_regularized(self, start_params=None, method='l1',
             maxiter='defined_by_method', full_output=1, disp=1, callback=None,
@@ -999,27 +1002,34 @@ class Poisson(CountModel):
 
         if 'cov_type' in kwargs:
             cov_kwds = kwargs.get('cov_kwds', {})
-            kwds = {'cov_type':kwargs['cov_type'], 'cov_kwds':cov_kwds}
+            kwds = {'cov_type': kwargs['cov_type'], 'cov_kwds': cov_kwds}
         else:
             kwds = {}
-        discretefit = PoissonResults(self, cntfit, **kwds)
-        return PoissonResultsWrapper(discretefit)
+
+        (res_cls, wrap_cls) = self._results_class
+        discretefit = res_cls(self, cntfit, **kwds)
+        return wrap_cls(discretefit)
     fit.__doc__ = DiscreteModel.fit.__doc__
+
+    @property
+    def _results_class(self):
+        return (PoissonResults, PoissonResultsWrapper)
 
     def fit_regularized(self, start_params=None, method='l1',
             maxiter='defined_by_method', full_output=1, disp=1, callback=None,
             alpha=0, trim_mode='auto', auto_trim_tol=0.01, size_trim_tol=1e-4,
             qc_tol=0.03, **kwargs):
+        if method not in ['l1', 'l1_cvxopt_cp']:
+            raise Exception(
+                    "argument method == %s, which is not handled" % method)
+
         cntfit = super(CountModel, self).fit_regularized(
                 start_params=start_params, method=method, maxiter=maxiter,
                 full_output=full_output, disp=disp, callback=callback,
                 alpha=alpha, trim_mode=trim_mode, auto_trim_tol=auto_trim_tol,
                 size_trim_tol=size_trim_tol, qc_tol=qc_tol, **kwargs)
-        if method in ['l1', 'l1_cvxopt_cp']:
-            discretefit = L1PoissonResults(self, cntfit)
-        else:
-            raise Exception(
-                    "argument method == %s, which is not handled" % method)
+        
+        discretefit = L1PoissonResults(self, cntfit)
         return L1PoissonResultsWrapper(discretefit)
 
     fit_regularized.__doc__ = DiscreteModel.fit_regularized.__doc__
@@ -1320,9 +1330,8 @@ class GeneralizedPoisson(CountModel):
         gpfit = GeneralizedPoissonResults(self, mlefit._results)
         result = GeneralizedPoissonResultsWrapper(gpfit)
 
-        if cov_kwds is None:
-            cov_kwds = {}
-
+        cov_kwds = cov_kwds or {}
+        # TODO: Shouldn't this be done in e.g. GeneralizedPoissonResultsWrapper.__init__?
         result._get_robustcov_results(cov_type=cov_type,
                                       use_self=True, use_t=use_t, **cov_kwds)
         return result
@@ -1334,6 +1343,10 @@ class GeneralizedPoisson(CountModel):
             alpha=0, trim_mode='auto', auto_trim_tol=0.01, size_trim_tol=1e-4,
             qc_tol=0.03, **kwargs):
         
+        if method not in ['l1', 'l1_cvxopt_cp']:
+            raise Exception(
+                    "argument method == %s, which is not handled" % method)
+
         if np.size(alpha) == 1 and alpha != 0:
             k_params = self.exog.shape[1] + self.k_extra
             alpha = alpha * np.ones(k_params)
@@ -1359,12 +1372,7 @@ class GeneralizedPoisson(CountModel):
                 alpha=alpha, trim_mode=trim_mode, auto_trim_tol=auto_trim_tol,
                 size_trim_tol=size_trim_tol, qc_tol=qc_tol, **kwargs)
 
-        if method in ['l1', 'l1_cvxopt_cp']:
-            discretefit = L1GeneralizedPoissonResults(self, cntfit)
-        else:
-            raise Exception(
-                    "argument method == %s, which is not handled" % method)
-
+        discretefit = L1GeneralizedPoissonResults(self, cntfit)
         return L1GeneralizedPoissonResultsWrapper(discretefit)
 
     fit_regularized.__doc__ = DiscreteModel.fit_regularized.__doc__
@@ -1739,21 +1747,16 @@ class Logit(BinaryModel):
         L = self.cdf(np.dot(X,params))
         return -np.dot(L*(1-L)*X.T,X)
 
-    def fit(self, start_params=None, method='newton', maxiter=35,
-            full_output=1, disp=1, callback=None, **kwargs):
-        bnryfit = super(Logit, self).fit(start_params=start_params,
-                method=method, maxiter=maxiter, full_output=full_output,
-                disp=disp, callback=callback, **kwargs)
+    @property
+    def _results_class(self):
+        return (LogitResults, BinaryResultsWrapper)
 
-        discretefit = LogitResults(self, bnryfit)
-        return BinaryResultsWrapper(discretefit)
-    fit.__doc__ = DiscreteModel.fit.__doc__
 
 class Probit(BinaryModel):
     __doc__ = """
     Binary choice Probit model
 
-%(params)s
+    %(params)s
     %(extra_params)s
 
     Attributes
@@ -1959,14 +1962,9 @@ class Probit(BinaryModel):
         L = q*self.pdf(q*XB)/self.cdf(q*XB)
         return np.dot(-L*(L+XB)*X.T,X)
 
-    def fit(self, start_params=None, method='newton', maxiter=35,
-            full_output=1, disp=1, callback=None, **kwargs):
-        bnryfit = super(Probit, self).fit(start_params=start_params,
-                method=method, maxiter=maxiter, full_output=full_output,
-                disp=disp, callback=callback, **kwargs)
-        discretefit = ProbitResults(self, bnryfit)
-        return BinaryResultsWrapper(discretefit)
-    fit.__doc__ = DiscreteModel.fit.__doc__
+    @property
+    def _results_class(self):
+        return (ProbitResults, BinaryResultsWrapper)
 
 class MNLogit(MultinomialModel):
     __doc__ = """
@@ -2271,7 +2269,7 @@ class MNLogit(MultinomialModel):
 #        return hess(params)
 #
 #    def fit(self, start_params=None, method='newton', maxiter=35, tol=1e-08):
-## The example had problems with all zero start values, Hessian = 0
+#        # The example had problems with all zero start values, Hessian = 0
 #        if start_params is None:
 #            start_params = OLS(self.endog, self.exog).fit().params
 #        mlefit = super(Weibull, self).fit(start_params=start_params,
@@ -2655,8 +2653,7 @@ class NegativeBinomial(CountModel):
         else:
             result = mlefit
 
-        if cov_kwds is None:
-            cov_kwds = {}  #TODO: make this unnecessary ?
+        cov_kwds = cov_kwds or {} # TODO: make this unnecessary ?
         result._get_robustcov_results(cov_type=cov_type,
                                     use_self=True, use_t=use_t, **cov_kwds)
         return result
@@ -2666,6 +2663,10 @@ class NegativeBinomial(CountModel):
             maxiter='defined_by_method', full_output=1, disp=1, callback=None,
             alpha=0, trim_mode='auto', auto_trim_tol=0.01, size_trim_tol=1e-4,
             qc_tol=0.03, **kwargs):
+
+        if method not in ['l1', 'l1_cvxopt_cp']:
+            raise Exception(
+                    "argument method == %s, which is not handled" % method)
 
         if self.loglike_method.startswith('nb') and (np.size(alpha) == 1 and
                                                      alpha != 0):
@@ -2698,12 +2699,8 @@ class NegativeBinomial(CountModel):
                 full_output=full_output, disp=disp, callback=callback,
                 alpha=alpha, trim_mode=trim_mode, auto_trim_tol=auto_trim_tol,
                 size_trim_tol=size_trim_tol, qc_tol=qc_tol, **kwargs)
-        if method in ['l1', 'l1_cvxopt_cp']:
-            discretefit = L1NegativeBinomialResults(self, cntfit)
-        else:
-            raise Exception(
-                    "argument method == %s, which is not handled" % method)
-
+        
+        discretefit = L1NegativeBinomialResults(self, cntfit)
         return L1NegativeBinomialResultsWrapper(discretefit)
 
 

--- a/statsmodels/tsa/regime_switching/markov_switching.py
+++ b/statsmodels/tsa/regime_switching/markov_switching.py
@@ -983,20 +983,8 @@ class MarkovSwitching(tsbase.TimeSeriesModel):
 
         # Wrap in a results object
         if not return_raw:
-            result_kwargs = {}
-            if cov_type is not None:
-                result_kwargs['cov_type'] = cov_type
-            if cov_kwds is not None:
-                result_kwargs['cov_kwds'] = cov_kwds
+            result = self._wrap_results(result, params, cov_type, cov_kwds, results_class, results_wrapper_class)
 
-            if results_class is None:
-                results_class = MarkovSwitchingResults
-            if results_wrapper_class is None:
-                results_wrapper_class = MarkovSwitchingResultsWrapper
-
-            result = results_wrapper_class(
-                results_class(self, params, result, **result_kwargs)
-            )
 
         return result
 
@@ -1071,22 +1059,27 @@ class MarkovSwitching(tsbase.TimeSeriesModel):
 
         # Wrap in a results object
         if not return_raw:
-            result_kwargs = {}
-            if cov_type is not None:
-                result_kwargs['cov_type'] = cov_type
-            if cov_kwds is not None:
-                result_kwargs['cov_kwds'] = cov_kwds
-
-            if results_class is None:
-                results_class = MarkovSwitchingResults
-            if results_wrapper_class is None:
-                results_wrapper_class = MarkovSwitchingResultsWrapper
-
-            result = results_wrapper_class(
-                results_class(self, params, result, **result_kwargs)
-            )
+            result = self._wrap_results(result, params, cov_type, cov_kwds, results_class, results_wrapper_class)
 
         return result
+
+    def _wrap_results(self, result, params, cov_type, cov_kwds, results_class, results_wrapper_class):
+        result_kwargs = {}
+        if cov_type is not None:
+            result_kwargs['cov_type'] = cov_type
+        if cov_kwds is not None:
+            result_kwargs['cov_kwds'] = cov_kwds
+
+        results_class = results_class or self._results_class[0]
+        results_wrapper_class = results_wrapper_class or self._results_class[1]
+
+        result = results_class(self, params, result, **result_kwargs)
+        wrapped = results_wrapper_class(result)
+        return wrapped
+
+    @property
+    def _results_class(self):
+        return (MarkovSwitchingResults, MarkovSwitchingResultsWrapper)
 
     def loglikeobs(self, params, transformed=True):
         """

--- a/statsmodels/tsa/statespace/mlemodel.py
+++ b/statsmodels/tsa/statespace/mlemodel.py
@@ -497,20 +497,7 @@ class MLEModel(tsbase.TimeSeriesModel):
 
         # Wrap in a results object
         if not return_ssm:
-            result_kwargs = {}
-            if cov_type is not None:
-                result_kwargs['cov_type'] = cov_type
-            if cov_kwds is not None:
-                result_kwargs['cov_kwds'] = cov_kwds
-
-            if results_class is None:
-                results_class = MLEResults
-            if results_wrapper_class is None:
-                results_wrapper_class = MLEResultsWrapper
-
-            result = results_wrapper_class(
-                results_class(self, params, result, **result_kwargs)
-            )
+            result = self._wrap_results(result, params, cov_type, cov_kwds, results_class, results_wrapper_class)
 
         return result
 
@@ -557,22 +544,27 @@ class MLEModel(tsbase.TimeSeriesModel):
 
         # Wrap in a results object
         if not return_ssm:
-            result_kwargs = {}
-            if cov_type is not None:
-                result_kwargs['cov_type'] = cov_type
-            if cov_kwds is not None:
-                result_kwargs['cov_kwds'] = cov_kwds
-
-            if results_class is None:
-                results_class = MLEResults
-            if results_wrapper_class is None:
-                results_wrapper_class = MLEResultsWrapper
-
-            result = results_wrapper_class(
-                results_class(self, params, result, **result_kwargs)
-            )
+            result = self._wrap_results(result, params, cov_type, cov_kwds, results_class, results_wrapper_class)
 
         return result
+
+    def _wrap_results(self, result, params, cov_type, cov_kwds, results_class, results_wrapper_class):
+        result_kwargs = {}
+        if cov_type is not None:
+            result_kwargs['cov_type'] = cov_type
+        if cov_kwds is not None:
+            result_kwargs['cov_kwds'] = cov_kwds
+
+        results_class = results_class or self._results_class[0]
+        results_wrapper_class = results_wrapper_class or self._results_class[1]
+
+        result = results_class(self, params, result, **result_kwargs)
+        wrapped = results_wrapper_class(result)
+        return wrapped
+
+    @property
+    def _results_class(self):
+        return (MLEResults, MLEResultsWrapper)
 
     def _handle_args(self, names, defaults, *args, **kwargs):
         output_args = []


### PR DESCRIPTION
This is not intended as a real PR, but a demonstration of an idea to discuss.

It would be helpful to be able to associate a `Model` subclass with the appropriate `Results` and `ResultsWrapper` subclasses.  (In some cases there are also L1 variants of these classes, presumably a long tail of other cases I'm forgetting).  The obvious option is not viable:

```
class SomeModel(LikelihoodModel):
    _results_cls = (SomeModelResults, SomeModelResultsWrapper)
```
because in most cases `SomeModelResults` is not yet defined.  We _could_ change that by shifting stuff around, but the option I'm leaning towards is based on `pandas` `_constructor` property:

```
class SomeModel(LikelihoodModel):
    @property
    def _results_class(self):
        return (SomeModelResults, SomeModelResultsWrapper)        
```

The upshot of this is that we can unify a bunch of wrapping logic and move things up the class hierarchy.  I did a quick pass at demonstrating this for `MLEModel` and `DiscreteModel` for this PR.

#noci