### PR TITLE
DOC: Missing icons

### DIFF
--- a/docs/themes/statsmodels/layout.html
+++ b/docs/themes/statsmodels/layout.html
@@ -8,9 +8,13 @@
 {% block extrahead %}
 <link rel="stylesheet" href="{{ pathto('_static/examples.css', 1) }}" type="text/css" />
 <link rel="stylesheet" href="{{ pathto('_static/facebox.css', 1) }}" type="text/css" />
-<script type="text/javascript" src="{{pathto('_static/scripts.js', 1) }}">
+<script type="text/javascript" src="{{ pathto('_static/scripts.js', 1) }}">
 </script>
-<script type="text/javascript" src="{{pathto('_static/facebox.js', 1) }}">
+<script type="text/javascript" src="{{ pathto('_static/facebox.js', 1) }}">
+</script>
+<script type="text/javascript">
+$.facebox.settings.closeImage = "{{ pathto('_static/closelabel.png', 1) }}"
+$.facebox.settings.loadingImage = "{{ pathto('_static/loading.gif', 1) }}"
 </script>
 {% endblock %}
 {% set reldelim1 = ' |' %}


### PR DESCRIPTION
Hello,

In the official http://www.statsmodels.org docs, there is a missing "close" x whenever you open "View Code" facebox. 

I think the problem lies with this javascript.

(Fair warning... I don't understand all the intricacies of sphinx, so this may not be the best approach.)