### PR TITLE
TST: arima test_start_params, add large start_ar_lags

### DIFF
--- a/statsmodels/tsa/tests/test_arima.py
+++ b/statsmodels/tsa/tests/test_arima.py
@@ -534,7 +534,7 @@ def test_start_params_bug():
     1600, 1876, 1885, 1962, 2280, 2711, 2591, 2411])
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
-        res = ARMA(data, order=(4,1)).fit(disp=-1)
+        res = ARMA(data, order=(4,1)).fit(start_ar_lags=5, disp=-1)
 
 
 class Test_ARIMA101(CheckArmaResultsMixin):


### PR DESCRIPTION
just trying out a fit option. I cannot replicate the error locally.

appveyor errors with SVD not converge in arima test on 2 out of 3 test environments
