### PR TITLE
BUG: update _get_init_kwds in GPP and NBP

### DIFF
--- a/statsmodels/discrete/discrete_model.py
+++ b/statsmodels/discrete/discrete_model.py
@@ -1218,6 +1218,11 @@ class GeneralizedPoisson(CountModel):
         self.k_extra = 1
         self._transparams = False
 
+    def _get_init_kwds(self):
+        kwds = super(GeneralizedPoisson, self)._get_init_kwds()
+        kwds['p'] = self.parameterization + 1
+        return kwds
+
     def loglike(self, params):
         """
         Loglikelihood of Generalized Poisson model
@@ -2740,6 +2745,11 @@ class NegativeBinomialP(CountModel):
         self.exog_names.append('alpha')
         self.k_extra = 1
         self._transparams = False
+
+    def _get_init_kwds(self):
+        kwds = super(NegativeBinomialP, self)._get_init_kwds()
+        kwds['p'] = self.parametrization
+        return kwds
 
     def loglike(self, params):
         """

--- a/statsmodels/discrete/tests/test_discrete.py
+++ b/statsmodels/discrete/tests/test_discrete.py
@@ -1726,6 +1726,12 @@ class TestGeneralizedPoisson_p1(object):
         assert_allclose((res_reg2.params[:-2]**2).mean(), 0.010672558641545994)
         assert_allclose((res_reg3.params[:-2]**2).mean(), 0.00035544919793048415)
 
+    def test_init_kwds(self):
+        kwds = self.res1.model._get_init_kwds()
+        assert_('p' in kwds)
+        assert_equal(kwds['p'], 1)
+
+
 class TestGeneralizedPoisson_underdispersion(object):
     @classmethod
     def setup_class(cls):
@@ -1990,6 +1996,12 @@ class TestNegativeBinomialPNB1BFGS(CheckModelResults):
         assert_allclose(self.res1.predict(which='linear')[:10],
                         self.res2.fittedvalues[:10],
                         atol=5e-3, rtol=5e-3)
+
+    def test_init_kwds(self):
+        kwds = self.res1.model._get_init_kwds()
+        assert_('p' in kwds)
+        assert_equal(kwds['p'], 1)
+
 
 class TestNegativeBinomialPL1Compatability(CheckL1Compatability):
     @classmethod


### PR DESCRIPTION
see #3887 
we need to add extra kwds to `_get_init_kwds`

llnull needs the extra keywords for `model.__init__`

(I don't remember if llnull in NegativeBinomial is correct, IIRC I came across that once)