### PR TITLE
Mark smoke tests

### DIFF
--- a/statsmodels/base/tests/test_optimize.py
+++ b/statsmodels/base/tests/test_optimize.py
@@ -1,3 +1,5 @@
+from nose.plugins.attrib import attr
+
 from numpy.testing import assert_
 from statsmodels.base.optimizer import (_fit_newton, _fit_nm,
                                         _fit_bfgs, _fit_cg,
@@ -30,6 +32,7 @@ def dummy_score(x):
 def dummy_hess(x):
     return [[2.]]
 
+@attr('smoke')
 def test_full_output_false():
     # just a smoke test
 

--- a/statsmodels/tools/tests/test_grouputils.py
+++ b/statsmodels/tools/tests/test_grouputils.py
@@ -5,9 +5,12 @@ from statsmodels.tools.tools import categorical
 from statsmodels.datasets import grunfeld, anes96
 from pandas.util import testing as ptesting
 
+from nose.plugins.attrib import attr
+
 
 class CheckGrouping(object):
 
+    @attr('smoke')
     def test_reindex(self):
         # smoke test
         self.grouping.reindex(self.grouping.index)
@@ -122,6 +125,7 @@ class CheckGrouping(object):
             np.testing.assert_allclose(transformed_slices, expected.values,
                                        rtol=1e-12, atol=1e-25)
 
+    @attr('smoke')
     def test_dummies_groups(self):
         # smoke test, calls dummy_sparse under the hood
         self.grouping.dummies_groups()

--- a/statsmodels/tsa/regime_switching/tests/test_markov_autoregression.py
+++ b/statsmodels/tsa/regime_switching/tests/test_markov_autoregression.py
@@ -14,6 +14,7 @@ import pandas as pd
 from statsmodels.tools import add_constant
 from statsmodels.tsa.regime_switching import markov_autoregression
 from numpy.testing import assert_equal, assert_allclose, assert_raises
+from nose.plugins.attrib import attr
 
 current_path = os.path.dirname(os.path.abspath(__file__))
 
@@ -232,6 +233,7 @@ class MarkovAutoregression(object):
         assert_allclose(res.llf, self.true['llf_fit'], atol=self.atol,
                         rtol=self.rtol)
 
+    @attr('smoke')
     def test_fit_em(self, **kwargs):
         # Test EM fitting (smoke test)
         res_em = self.model._fit_em(**kwargs)

--- a/statsmodels/tsa/regime_switching/tests/test_markov_regression.py
+++ b/statsmodels/tsa/regime_switching/tests/test_markov_regression.py
@@ -13,6 +13,7 @@ import pandas as pd
 from statsmodels.tsa.regime_switching import (markov_switching,
                                               markov_regression)
 from numpy.testing import assert_equal, assert_allclose, assert_raises
+from nose.plugins.attrib import attr
 
 
 current_path = os.path.dirname(os.path.abspath(__file__))
@@ -414,8 +415,10 @@ class MarkovRegression(object):
         cls.atol = atol
         cls.rtol = rtol
 
+    @attr('smoke')
+    def test_summary(self):
         # Smoke test for summary
-        cls.result.summary()
+        self.result.summary()
 
     def test_llf(self):
         assert_allclose(self.result.llf, self.true['llf'], atol=self.atol,
@@ -429,6 +432,7 @@ class MarkovRegression(object):
         assert_allclose(res.llf, self.true['llf_fit'], atol=self.atol,
                         rtol=self.rtol)
 
+    @attr('smoke')
     def test_fit_em(self, **kwargs):
         # Test EM fitting (smoke test)
         res_em = self.model._fit_em(**kwargs)

--- a/statsmodels/tsa/statespace/tests/test_dynamic_factor.py
+++ b/statsmodels/tsa/statespace/tests/test_dynamic_factor.py
@@ -6,6 +6,7 @@ License: Simplified-BSD
 """
 from __future__ import division, absolute_import, print_function
 from statsmodels.compat.testing import skip
+from nose.plugins.attrib import attr
 
 import numpy as np
 import pandas as pd
@@ -57,6 +58,7 @@ class CheckDynamicFactor(object):
         if filter:
             cls.results = cls.model.smooth(true['params'], cov_type=cov_type)
 
+    @attr('smoke')
     def test_params(self):
         # Smoke test to make sure the start_params are well-defined and
         # lead to a well-defined model
@@ -72,6 +74,7 @@ class CheckDynamicFactor(object):
         self.model.enforce_stationarity = True
         assert_allclose(actual, self.model.start_params)
 
+    @attr('smoke')
     def test_results(self):
         # Smoke test for creating the summary
         with warnings.catch_warnings():

--- a/statsmodels/tsa/statespace/tests/test_impulse_responses.py
+++ b/statsmodels/tsa/statespace/tests/test_impulse_responses.py
@@ -17,6 +17,7 @@ from statsmodels.tsa.statespace import (sarimax, structural, varmax,
                                         dynamic_factor)
 from numpy.testing import (assert_allclose, assert_almost_equal, assert_equal,
                            assert_raises)
+from nose.plugins.attrib import attr
 
 
 def test_sarimax():
@@ -186,6 +187,7 @@ def test_structural():
     assert_allclose(actual, desired)
 
 
+@attr('smoke')
 def test_varmax():
     steps = 10
 
@@ -279,6 +281,7 @@ def test_varmax():
     mod.impulse_responses(mod.start_params, steps)
 
 
+@attr('smoke')
 def test_dynamic_factor():
     steps = 10
     exog = np.random.normal(size=steps)

--- a/statsmodels/tsa/statespace/tests/test_mlemodel.py
+++ b/statsmodels/tsa/statespace/tests/test_mlemodel.py
@@ -20,6 +20,9 @@ from statsmodels.datasets import nile
 from numpy.testing import assert_almost_equal, assert_equal, assert_allclose, assert_raises
 from statsmodels.tsa.statespace.tests.results import results_sarimax, results_var_misc
 
+from nose.plugins.attrib import attr
+
+
 current_path = os.path.dirname(os.path.abspath(__file__))
 
 try:
@@ -322,6 +325,7 @@ def test_score_analytic_ar1():
                         analytic_hessian, atol=1e-1)
 
 
+@attr('smoke')
 def test_cov_params():
     mod, res = get_dummy_mod()
 
@@ -351,6 +355,7 @@ def test_cov_params():
         assert_raises(NotImplementedError, mod.fit, res.params, disp=-1, cov_type='invalid_cov_type')
 
 
+@attr('smoke')
 def test_transform():
     # The transforms in MLEModel are noops
     mod = MLEModel([1,2], **kwargs)
@@ -476,6 +481,7 @@ def test_forecast():
     assert_allclose(res.get_forecast(steps=10).predicted_mean, np.ones((10,)) * 2)
 
 
+@attr('smoke')
 def test_summary():
     dates = pd.date_range(start='1980-01-01', end='1984-01-01', freq='AS')
     endog = pd.Series([1,2,3,4,5], index=dates)
@@ -713,6 +719,8 @@ def test_pandas_endog():
     mod = check_endog(endog, k_endog=2, **kwargs2)
     mod.filter([])
 
+
+@attr('smoke')
 def test_diagnostics():
     mod, res = get_dummy_mod()
 
@@ -809,6 +817,8 @@ def test_diagnostics_nile_durbinkoopman():
     actual = res.test_heteroskedasticity(method='breakvar')[0, 0]
     assert_allclose(actual, [0.61], atol=1e-2)
 
+
+@attr('smoke')
 def test_prediction_results():
     # Just smoke tests for the PredictionResults class, which is copied from
     # elsewhere in Statsmodels

--- a/statsmodels/tsa/statespace/tests/test_pickle.py
+++ b/statsmodels/tsa/statespace/tests/test_pickle.py
@@ -27,6 +27,8 @@ from statsmodels.tsa.statespace.representation import Representation
 from statsmodels.tsa.statespace.structural import UnobservedComponents
 from .results import results_kalman_filter
 
+from nose.plugins.attrib import attr
+
 # Skip copy test on older NumPy since copy does not preserve order
 NP_LT_18 = LooseVersion(np.__version__).version[:2] < [1, 8]
 
@@ -57,6 +59,7 @@ def test_pickle_fit_sarimax():
     assert_allclose(res.impulse_responses(10), res.impulse_responses(10))
 
 
+@attr('smoke')
 def test_unobserved_components_pickle():
     # Tests for missing data
     nobs = 20

--- a/statsmodels/tsa/statespace/tests/test_representation.py
+++ b/statsmodels/tsa/statespace/tests/test_representation.py
@@ -27,6 +27,8 @@ from .results import results_kalman_filter
 from numpy.testing import assert_equal, assert_almost_equal, assert_raises, assert_allclose
 import pytest
 
+from nose.plugins.attrib import attr
+
 current_path = os.path.dirname(os.path.abspath(__file__))
 
 clark1989_path = 'results' + os.sep + 'results_clark1989_R.csv'
@@ -781,6 +783,7 @@ def test_loglike():
     assert_raises(RuntimeError, mod.loglikeobs)
 
 
+@attr('smoke')
 def test_predict():
     # Tests of invalid calls to the predict function
 

--- a/statsmodels/tsa/statespace/tests/test_sarimax.py
+++ b/statsmodels/tsa/statespace/tests/test_sarimax.py
@@ -17,6 +17,9 @@ from .results import results_sarimax
 from statsmodels.tools import add_constant
 from numpy.testing import assert_equal, assert_almost_equal, assert_raises, assert_allclose
 
+from nose.plugins.attrib import attr
+
+
 current_path = os.path.dirname(os.path.abspath(__file__))
 
 realgdp_path = 'results' + os.sep + 'results_realgdpar_stata.csv'
@@ -1946,6 +1949,7 @@ def test_results():
     assert_almost_equal(res.maparams, [-0.5])
 
 
+@attr('smoke')
 def test_misc_exog():
     # Tests for missing data
     nobs = 20

--- a/statsmodels/tsa/statespace/tests/test_simulate.py
+++ b/statsmodels/tsa/statespace/tests/test_simulate.py
@@ -19,6 +19,7 @@ from statsmodels.tsa.statespace.tools import compatibility_mode
 from numpy.testing import (assert_allclose, assert_almost_equal, assert_equal,
                            assert_raises)
 
+from nose.plugins.attrib import attr
 
 def test_arma_lfilter():
     # Tests of an ARMA model simulation against scipy.signal.lfilter
@@ -332,6 +333,7 @@ def test_structural():
     assert_allclose(actual, desired)
 
 
+@attr('smoke')
 def test_varmax():
     # Clear warnings
     varmax.__warningregistry__ = {}
@@ -443,6 +445,7 @@ def test_varmax():
     mod.simulate(mod.start_params, nobs)
 
 
+@attr('smoke')
 def test_dynamic_factor():
     np.random.seed(93739)
     nobs = 100

--- a/statsmodels/tsa/statespace/tests/test_structural.py
+++ b/statsmodels/tsa/statespace/tests/test_structural.py
@@ -17,6 +17,7 @@ from statsmodels.tsa.statespace.structural import UnobservedComponents
 from statsmodels.tsa.statespace.tests.results import results_structural
 from statsmodels.tools import add_constant
 from numpy.testing import assert_equal, assert_almost_equal, assert_raises, assert_allclose
+from nose.plugins.attrib import attr
 
 
 try:
@@ -30,6 +31,7 @@ dta = macrodata.load_pandas().data
 dta.index = pd.date_range(start='1959-01-01', end='2009-07-01', freq='QS')
 
 
+@attr('smoke')
 def run_ucm(name):
     true = getattr(results_structural, name)
 
@@ -296,6 +298,7 @@ def test_forecast():
     assert_allclose(actual, desired)
 
 
+@attr('smoke')
 def test_misc_exog():
     # Tests for missing data
     nobs = 20

--- a/statsmodels/tsa/statespace/tests/test_varmax.py
+++ b/statsmodels/tsa/statespace/tests/test_varmax.py
@@ -19,13 +19,15 @@ from numpy.testing import assert_equal, assert_almost_equal, assert_raises, asse
 import pytest
 from statsmodels.iolib.summary import forg
 
+from nose.plugins.attrib import attr
+
 current_path = os.path.dirname(os.path.abspath(__file__))
 
-var_path = 'results' + os.sep + 'results_var_stata.csv'
-var_results = pd.read_csv(current_path + os.sep + var_path)
+var_path = os.path.join('results', 'results_var_stata.csv')
+var_results = pd.read_csv(os.path.join(current_path, var_path))
 
-varmax_path = 'results' + os.sep + 'results_varmax_stata.csv'
-varmax_results = pd.read_csv(current_path + os.sep + varmax_path)
+varmax_path = os.path.join('results', 'results_varmax_stata.csv')
+varmax_results = pd.read_csv(os.path.join(current_path, varmax_path))
 
 
 class CheckVARMAX(object):
@@ -50,6 +52,7 @@ class CheckVARMAX(object):
             self.model.enforce_invertibility = True
             assert_allclose(results.llf, self.results.llf, rtol=1e-5)
 
+    @attr('smoke')
     def test_params(self):
         # Smoke test to make sure the start_params are well-defined and
         # lead to a well-defined model
@@ -67,6 +70,7 @@ class CheckVARMAX(object):
         self.model.enforce_invertibility = True
         assert_allclose(actual, self.model.start_params)
 
+    @attr('smoke')
     def test_results(self):
         # Smoke test for creating the summary
         self.results.summary()
@@ -259,6 +263,7 @@ class TestVAR_diagonal(CheckLutkepohl):
             assert_equal(re.search('%s +%.4f' % (names[i], params[i]), table) is None, False)
 
 
+@attr('smoke')
 class TestVAR_measurement_error(CheckLutkepohl):
     """
     Notes
@@ -786,6 +791,7 @@ def test_misspecifications():
     warnings.resetwarnings()
 
 
+@attr('smoke')
 def test_misc_exog():
     # Tests for missing data
     nobs = 20

--- a/statsmodels/tsa/tests/test_ar.py
+++ b/statsmodels/tsa/tests/test_ar.py
@@ -11,6 +11,8 @@ import numpy as np
 import numpy.testing as npt
 from pandas import Series, Index, DatetimeIndex, PeriodIndex
 
+from nose.plugins.attrib import attr
+
 
 DECIMAL_6 = 6
 DECIMAL_5 = 5
@@ -276,6 +278,7 @@ def test_ar_named_series():
     assert_(results.params.index.equals(Index(["const", "L1.foobar",
                                                "L2.foobar"])))
 
+@attr('smoke')
 def test_ar_start_params():
     # fix 236
     # smoke test
@@ -283,6 +286,7 @@ def test_ar_start_params():
     res = AR(data.endog).fit(maxlag=9, start_params=0.1*np.ones(10),
                              method="mle", disp=-1, maxiter=100)
 
+@attr('smoke')
 def test_ar_series():
     # smoke test for 773
     dta = sm.datasets.macrodata.load_pandas().data["cpi"].diff().dropna()

--- a/statsmodels/tsa/tests/test_arima.py
+++ b/statsmodels/tsa/tests/test_arima.py
@@ -4,6 +4,8 @@ from statsmodels.compat.testing import skip, skipif
 import os
 import warnings
 
+from nose.plugins.attrib import attr
+
 import numpy as np
 from numpy.testing import (assert_almost_equal, assert_, assert_allclose,
                            assert_raises, dec)
@@ -149,6 +151,7 @@ class CheckArmaResultsMixin(object):
         assert_almost_equal(self.res1.sigma2, self.res2.sigma2,
                 self.decimal_sigma2)
 
+    @attr('smoke')
     def test_summary(self):
         # smoke tests
         table = self.res1.summary()
@@ -1564,6 +1567,7 @@ def test_arima_wrapper():
     assert_equal(res.model.endog_names, 'D.cpi')
 
 
+@attr('smoke')
 def test_1dexog():
     # smoke test, this will raise an error if broken
     dta = load_macrodata_pandas().data
@@ -1719,6 +1723,7 @@ def test_arima_predict_exog():
     #assert_almost_equal(predict, predict_expected.values, 3)
 
 
+@attr('smoke')
 def test_arima_no_diff():
     # issue 736
     # smoke test, predict will break if we have ARIMAResults but
@@ -1733,6 +1738,7 @@ def test_arima_no_diff():
     res.predict()
 
 
+@attr('smoke')
 def test_arima_predict_noma():
     # issue 657
     # smoke test
@@ -1826,6 +1832,7 @@ def test_arima_small_data_bug():
     assert_raises(ValueError, mod.fit)
 
 
+@attr('smoke')
 def test_arima_dataframe_integer_name():
     # Smoke Test for Issue 1038
     from datetime import datetime

--- a/statsmodels/tsa/tests/test_stattools.py
+++ b/statsmodels/tsa/tests/test_stattools.py
@@ -1,5 +1,7 @@
 from statsmodels.compat.numpy import recarray_select
 
+from nose.plugins.attrib import attr
+
 from statsmodels.compat.python import lrange
 from statsmodels.tools.sm_exceptions import ColinearityWarning
 from statsmodels.tsa.stattools import (adfuller, acf, pacf_ols, pacf_yw,
@@ -533,6 +535,7 @@ def test_arma_order_select_ic():
     assert_(res.aic.columns.equals(aic.columns))
     assert_equal(res.aic_min_order, (1, 2))
 
+@attr('smoke')
 def test_arma_order_select_ic_failure():
     # this should trigger an SVD convergence failure, smoke test that it
     # returns, likely platform dependent failure...

--- a/statsmodels/tsa/vector_ar/tests/test_vecm.py
+++ b/statsmodels/tsa/vector_ar/tests/test_vecm.py
@@ -4,6 +4,8 @@ import numpy as np
 from numpy.testing import (assert_, assert_allclose, assert_raises,
                            assert_array_equal)
 
+from nose.plugins.attrib import attr
+
 import statsmodels.datasets.interest_inflation.data as e6
 from statsmodels.compat.python import range
 from statsmodels.tools.testing import assert_equal
@@ -1464,6 +1466,7 @@ def test_exceptions():
         pass             # can't import assert_raises_regex.
 
 
+@attr('smoke')
 def test_select_coint_rank():  # This is only a smoke test.
     if debug_mode:
         if "select_coint_rank" not in to_test:  # pragma: no cover


### PR DESCRIPTION
I'm going through and marking smoke tests with `@attr('smoke')` so that they can be skipped in specific runs.  The idea is that it would be helpful to know where we have "real" test coverage.

I used a pretty simple heuristic to choose what tests to mark: if it contains a comment about being a smoke test, it gets marked.  So some tests without comments likely got missed, and some tests where a smoky comment only applies to a few lines definitely got over-marked.  These can be refined in a follow-up.