### PR TITLE
DOC: Equation typo in DFM notebook

### DIFF
--- a/examples/notebooks/statespace_dfm_coincident.ipynb
+++ b/examples/notebooks/statespace_dfm_coincident.ipynb
@@ -178,7 +178,7 @@
     "\\begin{align}\n",
     "y_t & = \\Lambda f_t + B x_t + u_t \\\\\n",
     "f_t & = A_1 f_{t-1} + \\dots + A_p f_{t-p} + \\eta_t \\qquad \\eta_t \\sim N(0, I)\\\\\n",
-    "u_t & = C_1 u_{t-1} + \\dots + C_1 u_{t-q} + \\varepsilon_t \\qquad \\varepsilon_t \\sim N(0, \\Sigma)\n",
+    "u_t & = C_1 u_{t-1} + \\dots + C_q u_{t-q} + \\varepsilon_t \\qquad \\varepsilon_t \\sim N(0, \\Sigma)\n",
     "\\end{align}\n",
     "$$\n",
     "\n",

--- a/examples/notebooks/statespace_dfm_coincident.ipynb
+++ b/examples/notebooks/statespace_dfm_coincident.ipynb
@@ -178,7 +178,7 @@
     "\\begin{align}\n",
     "y_t & = \\Lambda f_t + B x_t + u_t \\\\\n",
     "f_t & = A_1 f_{t-1} + \\dots + A_p f_{t-p} + \\eta_t \\qquad \\eta_t \\sim N(0, I)\\\\\n",
-    "u_t & = C_1 u_{t-1} + \\dots + C_1 f_{t-q} + \\varepsilon_t \\qquad \\varepsilon_t \\sim N(0, \\Sigma)\n",
+    "u_t & = C_1 u_{t-1} + \\dots + C_1 u_{t-q} + \\varepsilon_t \\qquad \\varepsilon_t \\sim N(0, \\Sigma)\n",
     "\\end{align}\n",
     "$$\n",
     "\n",


### PR DESCRIPTION
I believe that this is a typo - since this part of the equation is handling the autoregression for the constant `u_t`