### PR TITLE
ENH/REF/BUG Discrete models llnull improvements

### DIFF
--- a/statsmodels/discrete/discrete_model.py
+++ b/statsmodels/discrete/discrete_model.py
@@ -1003,7 +1003,7 @@ class Poisson(CountModel):
     def _get_start_params_null(self):
         offset = getattr(self, "offset", 0)
         exposure = getattr(self, "exposure", 0)
-        const = self.endog.mean() / np.exp(offset + exposure)
+        const = (self.endog / np.exp(offset + exposure)).mean()
         params = [np.log(const)]
         return params
 

--- a/statsmodels/discrete/discrete_model.py
+++ b/statsmodels/discrete/discrete_model.py
@@ -725,6 +725,13 @@ class CountModel(DiscreteModel):
         if exposure is None:
             delattr(self, 'exposure')
 
+        # promote dtype to float64 if needed
+        dt = np.promote_types(self.endog.dtype, np.float64)
+        self.endog = np.asarray(self.endog, dt)
+        dt = np.promote_types(self.exog.dtype, np.float64)
+        self.exog = np.asarray(self.exog, dt)
+
+
     def _check_inputs(self, offset, exposure, endog):
         if offset is not None and offset.shape[0] != endog.shape[0]:
             raise ValueError("offset is not the same length as endog")

--- a/statsmodels/discrete/discrete_model.py
+++ b/statsmodels/discrete/discrete_model.py
@@ -1301,6 +1301,20 @@ class GeneralizedPoisson(CountModel):
         return (np.log(mu) + (endog - 1) * np.log(a2) - endog *
                 np.log(a1) - gammaln(endog + 1) - a2 / a1)
 
+    def _get_start_params_null(self):
+        offset = getattr(self, "offset", 0)
+        exposure = getattr(self, "exposure", 0)
+        q = self.parameterization
+
+        const = (self.endog / np.exp(offset + exposure)).mean()
+        params = [np.log(const)]
+        mu = const * np.exp(offset + exposure)
+        resid = self.endog - mu
+        a = ((np.abs(resid) / np.sqrt(mu) - 1) * mu**(-q)).mean()
+        params.append(a)
+
+        return np.array(params)
+
     def fit(self, start_params=None, method='bfgs', maxiter=35,
             full_output=1, disp=1, callback=None, use_transparams = False,
             cov_type='nonrobust', cov_kwds=None, use_t=None, **kwargs):
@@ -2979,6 +2993,20 @@ class NegativeBinomialP(CountModel):
         hess_arr[tri_idx] = hess_arr.T[tri_idx]
 
         return hess_arr
+
+    def _get_start_params_null(self):
+        offset = getattr(self, "offset", 0)
+        exposure = getattr(self, "exposure", 0)
+        q = self.parameterization - 1
+
+        const = (self.endog / np.exp(offset + exposure)).mean()
+        params = [np.log(const)]
+        mu = const * np.exp(offset + exposure)
+        resid = self.endog - mu
+        a = ((resid**2 / mu - 1) * mu**(-q)).mean()
+        params.append(a)
+
+        return np.array(params)
 
     def fit(self, start_params=None, method='bfgs', maxiter=35,
             full_output=1, disp=1, callback=None, use_transparams = False,

--- a/statsmodels/discrete/discrete_model.py
+++ b/statsmodels/discrete/discrete_model.py
@@ -2634,7 +2634,7 @@ class NegativeBinomial(CountModel):
 
         # Note: don't let super handle robust covariance because it has
         # transformed params
-
+        self._transparams = False # always define attribute
         if self.loglike_method.startswith('nb') and method not in ['newton',
                                                                    'ncg']:
             self._transparams = True # in case same Model instance is refit
@@ -2651,6 +2651,11 @@ class NegativeBinomial(CountModel):
             start_params = mod_poi.fit(disp=0).params
             if self.loglike_method.startswith('nb'):
                 start_params = np.append(start_params, 0.1)
+        else:
+            if self._transparams is True:
+                # transform user provided start_params dispersion, see #3918
+                start_params = start_params.copy()
+                start_params[-1] = np.log(start_params[-1])
 
         if callback is None:
             # work around perfect separation callback #3895

--- a/statsmodels/discrete/discrete_model.py
+++ b/statsmodels/discrete/discrete_model.py
@@ -2648,7 +2648,7 @@ class NegativeBinomial(CountModel):
             params.append(a)
         else: #self.loglike_method == 'nb1':
             params.append((resid**2 / mu - 1).mean())
-        return params
+        return np.array(params)
 
     def fit(self, start_params=None, method='bfgs', maxiter=35,
             full_output=1, disp=1, callback=None,
@@ -2676,7 +2676,7 @@ class NegativeBinomial(CountModel):
         else:
             if self._transparams is True:
                 # transform user provided start_params dispersion, see #3918
-                start_params = start_params.copy()
+                start_params = np.array(start_params, copy=True)
                 start_params[-1] = np.log(start_params[-1])
 
         if callback is None:

--- a/statsmodels/discrete/discrete_model.py
+++ b/statsmodels/discrete/discrete_model.py
@@ -114,6 +114,17 @@ _l1_results_attr = """    nnz_params : Integer
     trimmed : Boolean array
         trimmed[i] == True if the ith parameter was trimmed from the model."""
 
+_get_start_params_null_docs = """
+Compute one-step moment estimator for null (constant-only) model
+
+This is a preliminary estimator used as start_params.
+
+Returns
+-------
+params : ndarray
+    parameter estimate based one one-step moment matching
+
+"""
 
 # helper for MNLogit (will be generally useful later)
 
@@ -1007,6 +1018,8 @@ class Poisson(CountModel):
         params = [np.log(const)]
         return params
 
+    _get_start_params_null.__doc__ = _get_start_params_null_docs
+
     def fit(self, start_params=None, method='newton', maxiter=35,
             full_output=1, disp=1, callback=None, **kwargs):
         cntfit = super(CountModel, self).fit(start_params=start_params,
@@ -1314,6 +1327,8 @@ class GeneralizedPoisson(CountModel):
         params.append(a)
 
         return np.array(params)
+
+    _get_start_params_null.__doc__ = _get_start_params_null_docs
 
     def fit(self, start_params=None, method='bfgs', maxiter=35,
             full_output=1, disp=1, callback=None, use_transparams = False,
@@ -2664,6 +2679,8 @@ class NegativeBinomial(CountModel):
             params.append((resid**2 / mu - 1).mean())
         return np.array(params)
 
+    _get_start_params_null.__doc__ = _get_start_params_null_docs
+
     def fit(self, start_params=None, method='bfgs', maxiter=35,
             full_output=1, disp=1, callback=None,
             cov_type='nonrobust', cov_kwds=None, use_t=None, **kwargs):
@@ -3008,6 +3025,8 @@ class NegativeBinomialP(CountModel):
 
         return np.array(params)
 
+    _get_start_params_null.__doc__ = _get_start_params_null_docs
+
     def fit(self, start_params=None, method='bfgs', maxiter=35,
             full_output=1, disp=1, callback=None, use_transparams = False,
             cov_type='nonrobust', cov_kwds=None, use_t=None, **kwargs):
@@ -3231,17 +3250,19 @@ class DiscreteResults(base.LikelihoodModelResults):
     def set_null_options(self, llnull=None, attach_results=True, **kwds):
         """set fit options for Null (constant-only) model
 
-        This resets the cache for related attributes which is potentially fragile.
+        This resets the cache for related attributes which is potentially
+        fragile. This only sets the option, the null model is estimated
+        when llnull is accessed, if llnull is not yet in cache.
 
         Parameters
         ----------
         llnull : None or float
-            If llnull is not None, than the value will be directly assigned to
+            If llnull is not None, then the value will be directly assigned to
             the cached attribute "llnull".
-        attach_results : Bool
-            Sets and internal flag whether the results instance of the null
-            model is attached. By default without calling this method, the
-            null model results are not attached and only the loglikelihood
+        attach_results : bool
+            Sets an internal flag whether the results instance of the null
+            model should be attached. By default without calling this method,
+            thenull model results are not attached and only the loglikelihood
             value llnull is stored.
         kwds : keyword arguments
             `kwds` are directly used as fit keyword arguments for the null

--- a/statsmodels/discrete/discrete_model.py
+++ b/statsmodels/discrete/discrete_model.py
@@ -3247,7 +3247,10 @@ class DiscreteResults(base.LikelihoodModelResults):
         else:
             sp_null = None
 
-        res_null = mod_null.fit(start_params=sp_null, method='bfgs',
+        res_null = mod_null.fit(start_params=sp_null, method='nm',
+                                warn_convergence=False,
+                                maxiter=10000, disp=0)
+        res_null = mod_null.fit(start_params=res_null.params, method='bfgs',
                                 warn_convergence=False,
                                 maxiter=10000, disp=0)
         if getattr(self, '_attach_nullmodel', False) is not False:

--- a/statsmodels/discrete/discrete_model.py
+++ b/statsmodels/discrete/discrete_model.py
@@ -1522,7 +1522,7 @@ class GeneralizedPoisson(CountModel):
         hess_arr[:-1,-1] = dldpda
 
         # for dl/dalpha dalpha
-        dldada = mu_p**2 * (3 * y / a1**2 - y**2 * (y - 1) / a2**2 - 2 * a2 /
+        dldada = mu_p**2 * (3 * y / a1**2 - (y / a2)**2. * (y - 1) - 2 * a2 /
                             a1**3)
 
         hess_arr[-1,-1] = dldada.sum()

--- a/statsmodels/discrete/tests/test_discrete.py
+++ b/statsmodels/discrete/tests/test_discrete.py
@@ -2137,6 +2137,56 @@ class TestNegativeBinomialNB2Null(CheckNull):
         cls.start_params = np.array([ 8.07216448,  0.01087238,  0.44024134])
 
 
+class TestNegativeBinomialNBP2Null(CheckNull):
+
+    @classmethod
+    def setup_class(cls):
+        endog, exog = cls._get_data()
+        cls.model = NegativeBinomialP(endog, exog, p=2)
+        cls.model_null = NegativeBinomialP(endog, exog[:, 0], p=2)
+        cls.res_null = cls.model_null.fit(start_params=[8, 1],
+                                          method='bfgs', gtol=1e-08, maxiter=300)
+        cls.start_params = np.array([ 8.07216448,  0.01087238,  0.44024134])
+
+    def test_start_null(self):
+        endog, exog = self.model.endog, self.model.exog
+        model_nb2 = NegativeBinomial(endog, exog, loglike_method='nb2')
+        sp1 = model_nb2._get_start_params_null()
+        sp0 = self.model._get_start_params_null()
+        assert_allclose(sp0, sp1, rtol=1e-12)
+
+
+class TestNegativeBinomialNBP1Null(CheckNull):
+
+    @classmethod
+    def setup_class(cls):
+        endog, exog = cls._get_data()
+        cls.model = NegativeBinomialP(endog, exog, p=1.)
+        cls.model_null = NegativeBinomialP(endog, exog[:, 0], p=1)
+        cls.res_null = cls.model_null.fit(start_params=[8, 1],
+                                          method='bfgs', gtol=1e-08, maxiter=300)
+        cls.start_params = np.array([7.730452, 2.01633068e-02, 1763.0])
+
+    def test_start_null(self):
+        endog, exog = self.model.endog, self.model.exog
+        model_nb2 = NegativeBinomial(endog, exog, loglike_method='nb1')
+        sp1 = model_nb2._get_start_params_null()
+        sp0 = self.model._get_start_params_null()
+        assert_allclose(sp0, sp1, rtol=1e-12)
+
+
+class TestGeneralizedPoissonNull(CheckNull):
+
+    @classmethod
+    def setup_class(cls):
+        endog, exog = cls._get_data()
+        cls.model = GeneralizedPoisson(endog, exog, p=1.5)
+        cls.model_null = GeneralizedPoisson(endog, exog[:, 0], p=1.5)
+        cls.res_null = cls.model_null.fit(start_params=[7., 1],
+                                          method='bfgs', gtol=1e-08, maxiter=300)
+        cls.start_params = np.array([6.91127148, 0.04501334, 0.88393736])
+
+
 if __name__ == "__main__":
     import pytest
     pytest.main([__file__, '-vvs', '-x', '--pdb'])

--- a/statsmodels/discrete/tests/test_discrete.py
+++ b/statsmodels/discrete/tests/test_discrete.py
@@ -1779,7 +1779,7 @@ class TestGeneralizedPoisson_underdispersion(object):
     def test_predict_prob(self):
         res = self.res
         endog = res.model.endog
-        freq = np.bincount(endog)
+        freq = np.bincount(endog.astype(int))
 
         pr = res.predict(which='prob')
         pr2 = sm.distributions.genpoisson_p.pmf(np.arange(6)[:, None],

--- a/statsmodels/discrete/tests/test_discrete.py
+++ b/statsmodels/discrete/tests/test_discrete.py
@@ -2098,7 +2098,7 @@ class CheckNull(object):
         assert_allclose(llf0, res_null1.llf, rtol=1e-6)
         # Note default convergence tolerance doesn't get lower rtol
         # from different starting values (using bfgs)
-        assert_allclose(res_null0.params, res_null1.params, rtol=1e-5)
+        assert_allclose(res_null0.params, res_null1.params, rtol=5e-5)
 
 
 class TestPoissonNull(CheckNull):
@@ -2132,8 +2132,8 @@ class TestNegativeBinomialNB2Null(CheckNull):
         endog, exog = cls._get_data()
         cls.model = NegativeBinomial(endog, exog, loglike_method='nb2')
         cls.model_null = NegativeBinomial(endog, exog[:, 0], loglike_method='nb2')
-        cls.res_null = cls.model_null.fit(start_params=[8, 1],
-                                          method='bfgs', gtol=1e-08, maxiter=300)
+        cls.res_null = cls.model_null.fit(start_params=[8, 0.5],
+                                          method='bfgs', gtol=1e-06, maxiter=300)
         cls.start_params = np.array([ 8.07216448,  0.01087238,  0.44024134])
 
 
@@ -2145,7 +2145,7 @@ class TestNegativeBinomialNBP2Null(CheckNull):
         cls.model = NegativeBinomialP(endog, exog, p=2)
         cls.model_null = NegativeBinomialP(endog, exog[:, 0], p=2)
         cls.res_null = cls.model_null.fit(start_params=[8, 1],
-                                          method='bfgs', gtol=1e-08, maxiter=300)
+                                          method='bfgs', gtol=1e-06, maxiter=300)
         cls.start_params = np.array([ 8.07216448,  0.01087238,  0.44024134])
 
     def test_start_null(self):
@@ -2164,7 +2164,7 @@ class TestNegativeBinomialNBP1Null(CheckNull):
         cls.model = NegativeBinomialP(endog, exog, p=1.)
         cls.model_null = NegativeBinomialP(endog, exog[:, 0], p=1)
         cls.res_null = cls.model_null.fit(start_params=[8, 1],
-                                          method='bfgs', gtol=1e-08, maxiter=300)
+                                          method='bfgs', gtol=1e-06, maxiter=300)
         cls.start_params = np.array([7.730452, 2.01633068e-02, 1763.0])
 
     def test_start_null(self):
@@ -2182,7 +2182,7 @@ class TestGeneralizedPoissonNull(CheckNull):
         endog, exog = cls._get_data()
         cls.model = GeneralizedPoisson(endog, exog, p=1.5)
         cls.model_null = GeneralizedPoisson(endog, exog[:, 0], p=1.5)
-        cls.res_null = cls.model_null.fit(start_params=[7., 1],
+        cls.res_null = cls.model_null.fit(start_params=[8.4, 1],
                                           method='bfgs', gtol=1e-08, maxiter=300)
         cls.start_params = np.array([6.91127148, 0.04501334, 0.88393736])
 


### PR DESCRIPTION
This PR refactors llnull to use start_params provide by `model._get_start_params_null`.
The start_params for the null model can be obtained by moment estimators, which should make it more robust.
closes related issues: 
#3533 second part is for llnull, first part is convergence failure with defaults (where users can work around)
#3476 Poisson llnull, mailing list thread has also discussion on MNLogit
#3572 NB2 llnull

related issue #3751 (is more general, e.g. penalization, constraints. I don't know yet what should/needs to be done)

This also includes now refactoring and fixes that I ran into:

#3919 avoid integer overflow in GP hessian, REF set endog, exog dtypes to at least float64
#3918 start_params needed to to provide transformed params if transformparams is used internally

`closes #3533, closes #3476, closes#3572, closes #3919`   ("closes" is needed each time)