### PR TITLE
CLN: test_discrete: manual cleanup

### DIFF
--- a/statsmodels/discrete/tests/test_discrete.py
+++ b/statsmodels/discrete/tests/test_discrete.py
@@ -325,6 +325,7 @@ class CheckMargEff(object):
         assert_almost_equal(me.margeff_se,
                 self.res2.margeff_count_dummy_dydxmean_se, DECIMAL_4)
 
+
 class TestProbitNewton(CheckBinaryResults):
 
     @classmethod
@@ -340,6 +341,7 @@ class TestProbitNewton(CheckBinaryResults):
     #    assert_almost_equal(self.res1.model.predict(self.res1.params),
     #            self.res2.predict, DECIMAL_4)
 
+
 class TestProbitBFGS(CheckBinaryResults):
 
     @classmethod
@@ -354,6 +356,7 @@ class TestProbitBFGS(CheckBinaryResults):
 
 
 class TestProbitNM(CheckBinaryResults):
+
     @classmethod
     def setup_class(cls):
         data = sm.datasets.spector.load()
@@ -364,7 +367,9 @@ class TestProbitNM(CheckBinaryResults):
         cls.res1 = Probit(data.endog, data.exog).fit(method="nm",
             disp=0, maxiter=500)
 
+
 class TestProbitPowell(CheckBinaryResults):
+
     @classmethod
     def setup_class(cls):
         data = sm.datasets.spector.load()
@@ -375,7 +380,9 @@ class TestProbitPowell(CheckBinaryResults):
         cls.res1 = Probit(data.endog, data.exog).fit(method="powell",
             disp=0, ftol=1e-8)
 
+
 class TestProbitCG(CheckBinaryResults):
+
     @classmethod
     def setup_class(cls):
         data = sm.datasets.spector.load()
@@ -403,6 +410,7 @@ class TestProbitCG(CheckBinaryResults):
 
 
 class TestProbitNCG(CheckBinaryResults):
+
     @classmethod
     def setup_class(cls):
         data = sm.datasets.spector.load()
@@ -420,6 +428,7 @@ class TestProbitNCG(CheckBinaryResults):
                                                  'since basinhopping solver is '
                                                  'not available')
 class TestProbitBasinhopping(CheckBinaryResults):
+
     @classmethod
     def setup_class(cls):
         if not has_basinhopping:
@@ -434,7 +443,9 @@ class TestProbitBasinhopping(CheckBinaryResults):
         cls.res1 = fit(method="basinhopping", disp=0, niter=5,
                         minimizer={'method' : 'L-BFGS-B', 'tol' : 1e-8})
 
+
 class TestProbitMinimizeDefault(CheckBinaryResults):
+
     @classmethod
     def setup_class(cls):
         data = sm.datasets.spector.load()
@@ -445,7 +456,9 @@ class TestProbitMinimizeDefault(CheckBinaryResults):
         fit = Probit(data.endog, data.exog).fit
         cls.res1 = fit(method="minimize", disp=0, niter=5, tol = 1e-8)
 
+
 class TestProbitMinimizeDogleg(CheckBinaryResults):
+
     @classmethod
     def setup_class(cls):
         if not has_dogleg:
@@ -458,9 +471,12 @@ class TestProbitMinimizeDogleg(CheckBinaryResults):
         res2.probit()
         cls.res2 = res2
         fit = Probit(data.endog, data.exog).fit
-        cls.res1 = fit(method="minimize", disp=0, niter=5, tol = 1e-8, min_method = 'dogleg')
+        cls.res1 = fit(method="minimize", disp=0, niter=5, tol = 1e-8,
+                       min_method = 'dogleg')
+
 
 class TestProbitMinimizeAdditionalOptions(CheckBinaryResults):
+
     @classmethod
     def setup_class(cls):
         data = sm.datasets.spector.load()
@@ -469,7 +485,8 @@ class TestProbitMinimizeAdditionalOptions(CheckBinaryResults):
         res2.probit()
         cls.res2 = res2
         cls.res1 = Probit(data.endog, data.exog).fit(method="minimize", disp=0,
-                                                     maxiter=500, min_method='Nelder-Mead',
+                                                     maxiter=500,
+                                                     min_method='Nelder-Mead',
                                                      xtol=1e-4, ftol=1e-4)
 
 class CheckLikelihoodModelL1(object):
@@ -500,6 +517,7 @@ class CheckLikelihoodModelL1(object):
 
 
 class TestProbitL1(CheckLikelihoodModelL1):
+
     @classmethod
     def setup_class(cls):
         data = sm.datasets.spector.load()
@@ -518,6 +536,7 @@ class TestProbitL1(CheckLikelihoodModelL1):
 
 
 class TestMNLogitL1(CheckLikelihoodModelL1):
+
     @classmethod
     def setup_class(cls):
         anes_data = sm.datasets.anes96.load()
@@ -535,6 +554,7 @@ class TestMNLogitL1(CheckLikelihoodModelL1):
 
 
 class TestLogitL1(CheckLikelihoodModelL1):
+
     @classmethod
     def setup_class(cls):
         data = sm.datasets.spector.load()
@@ -555,6 +575,7 @@ class TestLogitL1(CheckLikelihoodModelL1):
 @pytest.mark.skipif(not has_cvxopt, reason='Skipped test_cvxopt since cvxopt '
                                            'is not available')
 class TestCVXOPT(object):
+
     @classmethod
     def setup_class(cls):
         if not has_cvxopt:
@@ -574,9 +595,8 @@ class TestCVXOPT(object):
         assert_almost_equal(res_slsqp.params, res_cvxopt.params, DECIMAL_4)
 
 
-
-
 class TestSweepAlphaL1(object):
+
     @classmethod
     def setup_class(cls):
         data = sm.datasets.spector.load()
@@ -654,6 +674,7 @@ class CheckL1Compatability(object):
 
 
 class TestPoissonL1Compatability(CheckL1Compatability):
+
     @classmethod
     def setup_class(cls):
         cls.kvars = 10 # Number of variables
@@ -674,6 +695,7 @@ class TestPoissonL1Compatability(CheckL1Compatability):
 
 
 class TestNegativeBinomialL1Compatability(CheckL1Compatability):
+
     @classmethod
     def setup_class(cls):
         cls.kvars = 10 # Number of variables
@@ -699,6 +721,7 @@ class TestNegativeBinomialL1Compatability(CheckL1Compatability):
 
 
 class TestNegativeBinomialGeoL1Compatability(CheckL1Compatability):
+
     @classmethod
     def setup_class(cls):
         cls.kvars = 10 # Number of variables
@@ -724,6 +747,7 @@ class TestNegativeBinomialGeoL1Compatability(CheckL1Compatability):
 
 
 class TestLogitL1Compatability(CheckL1Compatability):
+
     @classmethod
     def setup_class(cls):
         cls.kvars = 4 # Number of variables
@@ -741,6 +765,7 @@ class TestLogitL1Compatability(CheckL1Compatability):
 
 
 class TestMNLogitL1Compatability(CheckL1Compatability):
+
     @classmethod
     def setup_class(cls):
         cls.kvars = 4 # Number of variables
@@ -772,6 +797,7 @@ class TestMNLogitL1Compatability(CheckL1Compatability):
 
 
 class TestProbitL1Compatability(CheckL1Compatability):
+
     @classmethod
     def setup_class(cls):
         cls.kvars = 4 # Number of variables
@@ -794,10 +820,13 @@ class CompareL1(object):
     """
     def test_basic_results(self):
         assert_almost_equal(self.res1.params, self.res2.params, DECIMAL_4)
-        assert_almost_equal(self.res1.cov_params(), self.res2.cov_params(), DECIMAL_4)
-        assert_almost_equal(self.res1.conf_int(), self.res2.conf_int(), DECIMAL_4)
+        assert_almost_equal(self.res1.cov_params(), self.res2.cov_params(),
+                            DECIMAL_4)
+        assert_almost_equal(self.res1.conf_int(), self.res2.conf_int(),
+                            DECIMAL_4)
         assert_almost_equal(self.res1.pvalues, self.res2.pvalues, DECIMAL_4)
-        assert_almost_equal(self.res1.pred_table(), self.res2.pred_table(), DECIMAL_4)
+        assert_almost_equal(self.res1.pred_table(), self.res2.pred_table(),
+                            DECIMAL_4)
         assert_almost_equal(self.res1.bse, self.res2.bse, DECIMAL_4)
         assert_almost_equal(self.res1.llf, self.res2.llf, DECIMAL_4)
         assert_almost_equal(self.res1.aic, self.res2.aic, DECIMAL_4)
@@ -818,9 +847,8 @@ class CompareL11D(CompareL1):
 
 
 class TestL1AlphaZeroLogit(CompareL11D):
-    """
-    Compares l1 model with alpha = 0 to the unregularized model.
-    """
+    # Compares l1 model with alpha = 0 to the unregularized model.
+
     @classmethod
     def setup_class(cls):
         data = sm.datasets.spector.load()
@@ -832,9 +860,8 @@ class TestL1AlphaZeroLogit(CompareL11D):
 
 
 class TestL1AlphaZeroProbit(CompareL11D):
-    """
-    Compares l1 model with alpha = 0 to the unregularized model.
-    """
+    # Compares l1 model with alpha = 0 to the unregularized model.
+
     @classmethod
     def setup_class(cls):
         data = sm.datasets.spector.load()
@@ -846,6 +873,7 @@ class TestL1AlphaZeroProbit(CompareL11D):
 
 
 class TestL1AlphaZeroMNLogit(CompareL1):
+
     @classmethod
     def setup_class(cls):
         data = sm.datasets.anes96.load()
@@ -859,6 +887,7 @@ class TestL1AlphaZeroMNLogit(CompareL1):
 
 
 class TestLogitNewton(CheckBinaryResults, CheckMargEff):
+
     @classmethod
     def setup_class(cls):
         data = sm.datasets.spector.load()
@@ -903,8 +932,9 @@ class TestLogitNewton(CheckBinaryResults, CheckMargEff):
 
 
 class TestLogitNewtonPrepend(CheckMargEff):
-    # same as previous version but adjusted vor add_constant prepend=True
+    # same as previous version but adjusted for add_constant prepend=True
     # bug #3695
+
     @classmethod
     def setup_class(cls):
         data = sm.datasets.spector.load()
@@ -949,8 +979,8 @@ class TestLogitNewtonPrepend(CheckMargEff):
                 self.res2.margeff_dummy_atexog2_se, DECIMAL_4)
 
 
-
 class TestLogitBFGS(CheckBinaryResults, CheckMargEff):
+
     @classmethod
     def setup_class(cls):
         data = sm.datasets.spector.load()
@@ -960,7 +990,9 @@ class TestLogitBFGS(CheckBinaryResults, CheckMargEff):
         cls.res2 = res2
         cls.res1 = Logit(data.endog, data.exog).fit(method="bfgs", disp=0)
 
+
 class TestPoissonNewton(CheckModelResults):
+
     @classmethod
     def setup_class(cls):
         data = sm.datasets.randhie.load()
@@ -996,7 +1028,9 @@ class TestPoissonNewton(CheckModelResults):
         probs = self.res1.predict_prob()[:100]
         assert_almost_equal(probs, probs_res, 8)
 
+
 class TestNegativeBinomialNB2Newton(CheckModelResults):
+
     @classmethod
     def setup_class(cls):
         data = sm.datasets.randhie.load()
@@ -1048,7 +1082,9 @@ class TestNegativeBinomialNB2Newton(CheckModelResults):
 
     test_jac = no_info
 
+
 class TestNegativeBinomialNB1Newton(CheckModelResults):
+
     @classmethod
     def setup_class(cls):
         data = sm.datasets.randhie.load()
@@ -1088,7 +1124,9 @@ class TestNegativeBinomialNB1Newton(CheckModelResults):
     def test_predict_xb(self):
         pass
 
+
 class TestNegativeBinomialNB2BFGS(CheckModelResults):
+
     @classmethod
     def setup_class(cls):
         data = sm.datasets.randhie.load()
@@ -1144,6 +1182,7 @@ class TestNegativeBinomialNB2BFGS(CheckModelResults):
 
 
 class TestNegativeBinomialNB1BFGS(CheckModelResults):
+
     @classmethod
     def setup_class(cls):
         data = sm.datasets.randhie.load()
@@ -1184,17 +1223,18 @@ class TestNegativeBinomialNB1BFGS(CheckModelResults):
 
 
 class TestNegativeBinomialGeometricBFGS(CheckModelResults):
-    """
-    Cannot find another implementation of the geometric to cross-check results
-    we only test fitted values because geometric has fewer parameters than nb1 and nb2
-    and we want to make sure that predict() np.dot(exog, params) works
-    """
+    # Cannot find another implementation of the geometric to cross-check results
+    # we only test fitted values because geometric has fewer parameters
+    # than nb1 and nb2
+    # and we want to make sure that predict() np.dot(exog, params) works
+
 
     @classmethod
     def setup_class(cls):
         data = sm.datasets.randhie.load()
         exog = sm.add_constant(data.exog, prepend=False)
-        cls.res1 = NegativeBinomial(data.endog, exog, 'geometric').fit(method='bfgs', disp=0)
+        mod = NegativeBinomial(data.endog, exog, 'geometric')
+        cls.res1 = mod.fit(method='bfgs', disp=0)
         res2 = RandHIE()
         res2.negativebinomial_geometric_bfgs()
         cls.res2 = res2
@@ -1208,22 +1248,26 @@ class TestNegativeBinomialGeometricBFGS(CheckModelResults):
         assert_almost_equal(self.res1.bic, self.res2.bic, DECIMAL_3)
 
     def test_conf_int(self):
-        assert_almost_equal(self.res1.conf_int(), self.res2.conf_int, DECIMAL_3)
+        assert_almost_equal(self.res1.conf_int(), self.res2.conf_int,
+                            DECIMAL_3)
 
     def test_fittedvalues(self):
-        assert_almost_equal(self.res1.fittedvalues[:10], self.res2.fittedvalues[:10], DECIMAL_3)
+        assert_almost_equal(self.res1.fittedvalues[:10],
+                            self.res2.fittedvalues[:10], DECIMAL_3)
 
     def test_jac(self):
         pass
 
     def test_predict(self):
-        assert_almost_equal(self.res1.predict()[:10], np.exp(self.res2.fittedvalues[:10]), DECIMAL_3)
+        assert_almost_equal(self.res1.predict()[:10],
+                            np.exp(self.res2.fittedvalues[:10]), DECIMAL_3)
 
     def test_params(self):
         assert_almost_equal(self.res1.params, self.res2.params, DECIMAL_3)
 
     def test_predict_xb(self):
-        assert_almost_equal(self.res1.predict(linear=True)[:10], self.res2.fittedvalues[:10], DECIMAL_3)
+        assert_almost_equal(self.res1.predict(linear=True)[:10],
+                            self.res2.fittedvalues[:10], DECIMAL_3)
 
     def test_zstat(self): # Low precision because Z vs. t
         assert_almost_equal(self.res1.tvalues, self.res2.z, DECIMAL_1)
@@ -1366,6 +1410,7 @@ class TestMNLogitNewtonBaseZero(CheckMNLogitBaseZero):
         res2.mnlogit_basezero()
         cls.res2 = res2
 
+
 class TestMNLogitLBFGSBaseZero(CheckMNLogitBaseZero):
     @classmethod
     def setup_class(cls):
@@ -1407,6 +1452,7 @@ def test_perfect_prediction():
         warnings.simplefilter('always')
         mod.fit(disp=False, maxiter=50)  # should not raise but does warn
 
+
 def test_poisson_predict():
     #GH: 175, make sure poisson predict works without offset and exposure
     data = sm.datasets.randhie.load()
@@ -1423,6 +1469,7 @@ def test_poisson_predict():
     pred3 = res.predict(exog, offset=np.log(2), exposure=1)
     assert_almost_equal(2*pred1, pred3)
 
+
 def test_poisson_newton():
     #GH: 24, Newton doesn't work well sometimes
     nobs = 10000
@@ -1437,6 +1484,7 @@ def test_poisson_newton():
         warnings.simplefilter('always')
         res = mod.fit(start_params=-np.ones(4), method='newton', disp=0)
     assert_(not res.mle_retvals['converged'])
+
 
 def test_issue_339():
     # make sure MNLogit summary works for J != K.
@@ -1467,6 +1515,7 @@ def test_issue_341():
     np.testing.assert_equal(res1.predict(x).shape, (1,7))
     np.testing.assert_equal(res1.predict(x[None]).shape, (1,7))
 
+
 def test_iscount():
     X = np.random.random((50, 10))
     X[:,2] = np.random.randint(1, 10, size=50)
@@ -1475,6 +1524,7 @@ def test_iscount():
     X[:,1] = np.random.randint(-10, 10, size=50) # not integers
     count_ind = _iscount(X)
     assert_equal(count_ind, [2, 6])
+
 
 def test_isdummy():
     X = np.random.random((50, 10))
@@ -1529,6 +1579,7 @@ def test_formula_missing_exposure():
     assert_raises(ValueError, sm.Poisson, df.Foo, df[['constant', 'Bar']],
                   exposure=exposure)
 
+
 def test_predict_with_exposure():
     # Case where CountModel.predict is called with exog = None and exposure
     # or offset not-None
@@ -1541,7 +1592,8 @@ def test_predict_with_exposure():
          'x': [1, 3, 2, 1.5]}
     df = pd.DataFrame(d)
 
-    mod1 = CountModel.from_formula('Foo ~ Bar', data=df, exposure=df['exposure'])
+    mod1 = CountModel.from_formula('Foo ~ Bar', data=df,
+                                   exposure=df['exposure'])
 
     params = np.array([1, .4])
     pred = mod1.predict(params, linear=True)
@@ -1574,14 +1626,14 @@ def test_binary_pred_table_zeros():
 
 
 class TestGeneralizedPoisson_p2(object):
-    """
-    Test Generalized Poisson model
-    """
+    # Test Generalized Poisson model
+
     @classmethod
     def setup_class(cls):
         data = sm.datasets.randhie.load()
         data.exog = sm.add_constant(data.exog, prepend=False)
-        cls.res1 = GeneralizedPoisson(data.endog, data.exog, p=2).fit(method='newton')
+        mod = GeneralizedPoisson(data.endog, data.exog, p=2)
+        cls.res1 = mod.fit(method='newton')
         res2 = RandHIE()
         res2.generalizedpoisson_gp2()
         cls.res2 = res2
@@ -1623,10 +1675,10 @@ class TestGeneralizedPoisson_p2(object):
         t_test = self.res1.t_test(unit_matrix)
         assert_allclose(self.res1.tvalues, t_test.tvalue)
 
+
 class TestGeneralizedPoisson_transparams(object):
-    """
-    Test Generalized Poisson model
-    """
+    # Test Generalized Poisson model
+
     @classmethod
     def setup_class(cls):
         data = sm.datasets.randhie.load()
@@ -1664,10 +1716,10 @@ class TestGeneralizedPoisson_transparams(object):
     def test_llf(self):
         assert_allclose(self.res1.llf, self.res2.llf)
 
+
 class TestGeneralizedPoisson_p1(object):
-    """
-    Test Generalized Poisson model
-    """
+    # Test Generalized Poisson model
+
     @classmethod
     def setup_class(cls):
         cls.data = sm.datasets.randhie.load()
@@ -1734,6 +1786,7 @@ class TestGeneralizedPoisson_p1(object):
 
 
 class TestGeneralizedPoisson_underdispersion(object):
+
     @classmethod
     def setup_class(cls):
         cls.expected_params = [1, -0.5, -0.05]
@@ -1745,7 +1798,8 @@ class TestGeneralizedPoisson_underdispersion(object):
         cls.endog = sm.distributions.genpoisson_p.rvs(mu_true,
             cls.expected_params[-1], 1, size=len(mu_true))
         model_gp = sm.GeneralizedPoisson(cls.endog, exog, p=1)
-        cls.res = model_gp.fit(method='nm', xtol=1e-6, maxiter=5000, maxfun=5000)
+        cls.res = model_gp.fit(method='nm', xtol=1e-6, maxiter=5000,
+                               maxfun=5000)
 
     def test_basic(self):
         res = self.res
@@ -1792,12 +1846,15 @@ class TestGeneralizedPoisson_underdispersion(object):
         assert_allclose(chi2[:], (0.64628806058715882, 0.98578597726324468),
                         rtol=0.01)
 
+
 class TestNegativeBinomialPNB2Newton(CheckModelResults):
+
     @classmethod
     def setup_class(cls):
         data = sm.datasets.randhie.load()
         exog = sm.add_constant(data.exog, prepend=False)
-        cls.res1 = NegativeBinomialP(data.endog, exog, p=2).fit(method='newton', disp=0)
+        mod = NegativeBinomialP(data.endog, exog, p=2)
+        cls.res1 = mod.fit(method='newton', disp=0)
         res2 = RandHIE()
         res2.negativebinomial_nb2_bfgs()
         cls.res2 = res2
@@ -1838,15 +1895,16 @@ class TestNegativeBinomialPNB2Newton(CheckModelResults):
         assert_allclose(self.res1.predict(which='linear')[:10],
                         self.res2.fittedvalues[:10])
 
+
 class TestNegativeBinomialPNB1Newton(CheckModelResults):
+
     @classmethod
     def setup_class(cls):
         data = sm.datasets.randhie.load()
         exog = sm.add_constant(data.exog, prepend=False)
-        cls.res1 = NegativeBinomialP(data.endog, exog, p=1).fit(method="newton",
-                                                                 maxiter=100,
-                                                                 disp=0,
-                                                                 use_transparams=True)
+        mod = NegativeBinomialP(data.endog, exog, p=1)
+        cls.res1 = mod.fit(method="newton", maxiter=100, disp=0,
+                           use_transparams=True)
         res2 = RandHIE()
         res2.negativebinomial_nb1_bfgs()
         cls.res2 = res2
@@ -1882,6 +1940,7 @@ class TestNegativeBinomialPNB1Newton(CheckModelResults):
 
 
 class TestNegativeBinomialPNB2BFGS(CheckModelResults):
+
     @classmethod
     def setup_class(cls):
         data = sm.datasets.randhie.load()
@@ -1936,6 +1995,7 @@ class TestNegativeBinomialPNB2BFGS(CheckModelResults):
 
 
 class TestNegativeBinomialPNB1BFGS(CheckModelResults):
+
     @classmethod
     def setup_class(cls):
         data = sm.datasets.randhie.load()
@@ -2028,6 +2088,7 @@ class TestNegativeBinomialPL1Compatability(CheckL1Compatability):
             trim_mode='auto')
         cls.k_extra = 1  # 1 extra parameter in nb2
 
+
 class  TestNegativeBinomialPPredictProb(object):
 
     def test_predict_prob_p1(self):
@@ -2078,6 +2139,7 @@ class  TestNegativeBinomialPPredictProb(object):
             nbinom.pmf(np.arange(8)[:,None], size, prob).T,
             atol=1e-2, rtol=1e-2)
 
+
 class CheckNull(object):
 
     @classmethod
@@ -2119,9 +2181,11 @@ class TestNegativeBinomialNB1Null(CheckNull):
     def setup_class(cls):
         endog, exog = cls._get_data()
         cls.model = NegativeBinomial(endog, exog, loglike_method='nb1')
-        cls.model_null = NegativeBinomial(endog, exog[:, 0], loglike_method='nb1')
+        cls.model_null = NegativeBinomial(endog, exog[:, 0],
+                                          loglike_method='nb1')
         cls.res_null = cls.model_null.fit(start_params=[8, 1000],
-                                          method='bfgs', gtol=1e-08, maxiter=300)
+                                          method='bfgs', gtol=1e-08,
+                                          maxiter=300)
         # for convergence with bfgs, I needed to round down alpha start_params
         cls.start_params = np.array([7.730452, 2.01633068e-02, 1763.0])
 
@@ -2132,10 +2196,12 @@ class TestNegativeBinomialNB2Null(CheckNull):
     def setup_class(cls):
         endog, exog = cls._get_data()
         cls.model = NegativeBinomial(endog, exog, loglike_method='nb2')
-        cls.model_null = NegativeBinomial(endog, exog[:, 0], loglike_method='nb2')
+        cls.model_null = NegativeBinomial(endog, exog[:, 0],
+                                          loglike_method='nb2')
         cls.res_null = cls.model_null.fit(start_params=[8, 0.5],
-                                          method='bfgs', gtol=1e-06, maxiter=300)
-        cls.start_params = np.array([ 8.07216448,  0.01087238,  0.44024134])
+                                          method='bfgs', gtol=1e-06,
+                                          maxiter=300)
+        cls.start_params = np.array([8.07216448, 0.01087238, 0.44024134])
 
 
 class TestNegativeBinomialNBP2Null(CheckNull):
@@ -2146,8 +2212,9 @@ class TestNegativeBinomialNBP2Null(CheckNull):
         cls.model = NegativeBinomialP(endog, exog, p=2)
         cls.model_null = NegativeBinomialP(endog, exog[:, 0], p=2)
         cls.res_null = cls.model_null.fit(start_params=[8, 1],
-                                          method='bfgs', gtol=1e-06, maxiter=300)
-        cls.start_params = np.array([ 8.07216448,  0.01087238,  0.44024134])
+                                          method='bfgs', gtol=1e-06,
+                                          maxiter=300)
+        cls.start_params = np.array([8.07216448, 0.01087238, 0.44024134])
 
     def test_start_null(self):
         endog, exog = self.model.endog, self.model.exog
@@ -2165,7 +2232,8 @@ class TestNegativeBinomialNBP1Null(CheckNull):
         cls.model = NegativeBinomialP(endog, exog, p=1.)
         cls.model_null = NegativeBinomialP(endog, exog[:, 0], p=1)
         cls.res_null = cls.model_null.fit(start_params=[8, 1],
-                                          method='bfgs', gtol=1e-06, maxiter=300)
+                                          method='bfgs', gtol=1e-06,
+                                          maxiter=300)
         cls.start_params = np.array([7.730452, 2.01633068e-02, 1763.0])
 
     def test_start_null(self):
@@ -2184,8 +2252,10 @@ class TestGeneralizedPoissonNull(CheckNull):
         cls.model = GeneralizedPoisson(endog, exog, p=1.5)
         cls.model_null = GeneralizedPoisson(endog, exog[:, 0], p=1.5)
         cls.res_null = cls.model_null.fit(start_params=[8.4, 1],
-                                          method='bfgs', gtol=1e-08, maxiter=300)
+                                          method='bfgs', gtol=1e-08,
+                                          maxiter=300)
         cls.start_params = np.array([6.91127148, 0.04501334, 0.88393736])
+
 
 def test_null_options():
     # this is a "nice" case because we only check that options are used
@@ -2201,13 +2271,15 @@ def test_null_options():
     res.set_null_options(attach_results=True)
     # default optimization
     lln = res.llnull  # access to trigger computation
-    assert_allclose(res.res_null.mle_settings['start_params'], np.log(endog.mean()), rtol=1e-10)
+    assert_allclose(res.res_null.mle_settings['start_params'],
+                    np.log(endog.mean()), rtol=1e-10)
     assert_equal(res.res_null.mle_settings['optimizer'], 'bfgs')
     assert_allclose(lln, llnull0)
 
     res.set_null_options(attach_results=True, start_params=[0.5], method='nm')
     lln = res.llnull  # access to trigger computation
-    assert_allclose(res.res_null.mle_settings['start_params'], [0.5], rtol=1e-10)
+    assert_allclose(res.res_null.mle_settings['start_params'], [0.5],
+                    rtol=1e-10)
     assert_equal(res.res_null.mle_settings['optimizer'], 'nm')
 
     res.summary()  # call to fill cache
@@ -2246,7 +2318,8 @@ def test_optim_kwds_prelim():
     model = NegativeBinomial(y, exog, offset=offset)
     res = model.fit(disp=0, optim_kwds_prelim=optim_kwds_prelim)
 
-    assert_allclose(res.mle_settings['start_params'][:-1], res_poi.params, rtol=1e-4)
+    assert_allclose(res.mle_settings['start_params'][:-1], res_poi.params,
+                    rtol=1e-4)
     assert_equal(res.mle_settings['optim_kwds_prelim'], optim_kwds_prelim)
     assert_allclose(res.predict().mean(), y.mean(), rtol=0.1)
 
@@ -2255,7 +2328,8 @@ def test_optim_kwds_prelim():
     model = NegativeBinomialP(y, exog, offset=offset, p=2)
     res = model.fit(disp=0, optim_kwds_prelim=optim_kwds_prelim)
 
-    assert_allclose(res.mle_settings['start_params'][:-1], res_poi.params, rtol=1e-4)
+    assert_allclose(res.mle_settings['start_params'][:-1], res_poi.params,
+                    rtol=1e-4)
     assert_equal(res.mle_settings['optim_kwds_prelim'], optim_kwds_prelim)
     assert_allclose(res.predict().mean(), y.mean(), rtol=0.1)
 
@@ -2264,7 +2338,8 @@ def test_optim_kwds_prelim():
     model = GeneralizedPoisson(y, exog, offset=offset, p=1.5)
     res = model.fit(disp=0, maxiter=200, optim_kwds_prelim=optim_kwds_prelim )
 
-    assert_allclose(res.mle_settings['start_params'][:-1], res_poi.params, rtol=1e-4)
+    assert_allclose(res.mle_settings['start_params'][:-1], res_poi.params,
+                    rtol=1e-4)
     assert_equal(res.mle_settings['optim_kwds_prelim'], optim_kwds_prelim)
     # rough check that convergence makes sense
     assert_allclose(res.predict().mean(), y.mean(), rtol=0.1)


### PR DESCRIPTION
not a full pep-8 cleaning, just some fixes that I had started in another PR
lline length, empty lines, use `#` instead of docstrings in test classes