### PR TITLE
BUG/REF: use boolean for converged in discrete fit_regularized closes…

### DIFF
--- a/statsmodels/base/l1_cvxopt.py
+++ b/statsmodels/base/l1_cvxopt.py
@@ -122,11 +122,12 @@ def fit_l1_cvxopt_cp(
         gopt = float('nan')  # Objective is non-differentiable
         hopt = float('nan')
         iterations = float('nan')
-        converged = 'True' if results['status'] == 'optimal'\
-            else results['status']
+        converged = (results['status'] == 'optimal')
+        warnflag = results['status']
         retvals = {
             'fopt': fopt, 'converged': converged, 'iterations': iterations,
-            'gopt': gopt, 'hopt': hopt, 'trimmed': trimmed}
+            'gopt': gopt, 'hopt': hopt, 'trimmed': trimmed,
+            'warnflag': warnflag}
     else:
         x = np.array(results['x']).ravel()
         params = x[:k_params]

--- a/statsmodels/base/l1_slsqp.py
+++ b/statsmodels/base/l1_slsqp.py
@@ -99,13 +99,15 @@ def fit_l1_slsqp(
     if full_output:
         x_full, fx, its, imode, smode = results
         fopt = func(np.asarray(x_full))
-        converged = 'True' if imode == 0 else smode
+        converged = (imode == 0)
+        warnflag = str(imode) + ' ' + smode
         iterations = its
         gopt = float('nan')     # Objective is non-differentiable
         hopt = float('nan')
         retvals = {
             'fopt': fopt, 'converged': converged, 'iterations': iterations,
-            'gopt': gopt, 'hopt': hopt, 'trimmed': trimmed}
+            'gopt': gopt, 'hopt': hopt, 'trimmed': trimmed,
+            'warnflag': warnflag}
 
     ### Return
     if full_output:

--- a/statsmodels/discrete/tests/test_discrete.py
+++ b/statsmodels/discrete/tests/test_discrete.py
@@ -833,6 +833,8 @@ class CompareL1(object):
         assert_almost_equal(self.res1.bic, self.res2.bic, DECIMAL_4)
         assert_almost_equal(self.res1.pvalues, self.res2.pvalues, DECIMAL_4)
 
+        assert_(self.res1.mle_retvals['converged'] is True)
+
 
 class CompareL11D(CompareL1):
     """
@@ -857,6 +859,14 @@ class TestL1AlphaZeroLogit(CompareL11D):
                 method="l1", alpha=0, disp=0, acc=1e-15, maxiter=1000,
                 trim_mode='auto', auto_trim_tol=0.01)
         cls.res2 = Logit(data.endog, data.exog).fit(disp=0, tol=1e-15)
+
+    def test_converged(self):
+        res = self.res1.model.fit_regularized(
+                method="l1", alpha=0, disp=0, acc=1e-15, maxiter=1,
+                trim_mode='auto', auto_trim_tol=0.01)
+
+        # see #2857
+        assert_(res.mle_retvals['converged'] is False)
 
 
 class TestL1AlphaZeroProbit(CompareL11D):


### PR DESCRIPTION
closes #2857
this is a new version to fix 2857, return boolean instead of string "True" for "convergence"
previous PRs #3730, #3781

motivation for solution in comments in #3781

convert `mle_retvals['converged']` to boolean, `True` if converged, `False` anything else as reported by optimizer
add `mle_retvals['warnflag']` similar to other optimizers in fit, with the convergence message (string in this case). Given that the warnflag is taken from whatever the optimizer returns, I guess there is no fixed type. slsqp has imode and smode, I used as string concatenation

The Logit example in the test case has warnflag `0` at convergence
