### PR TITLE
BUG/MAINT unicode recarray error with recent pandas

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ matrix:
     env:
     - PYTHON=2.7
     - NUMPY=1.11
-    - PANDAS=0.19
     - MATPLOTLIB=1.5
     - COVERAGE=true
   - python: 2.7

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,6 @@ environment:
   matrix:
     - PY_MAJOR_VER: 2
       PYTHON_ARCH: "x86_64"
-      PANDAS: "0.19"
     - PY_MAJOR_VER: 2
       PYTHON_ARCH: "x86_64"
       SCIPY: "0.14"
@@ -28,8 +27,7 @@ build_script:
   - conda config --set always_yes yes
   - conda update conda --quiet
   - ps: If ($env:SCIPY) { conda install numpy scipy=$env:SCIPY cython pandas pip nose patsy --quiet } Else {
-        If ($env:PANDAS) { conda install numpy scipy cython pandas=$env:PANDAS pip nose patsy --quiet } Else {
-        conda install numpy scipy cython pandas pip nose patsy --quiet }}
+        conda install numpy scipy cython pandas pip nose patsy --quiet }
   - pip install "pytest<4" pytest-xdist
   - python setup.py develop
 

--- a/statsmodels/compat/numpy.py
+++ b/statsmodels/compat/numpy.py
@@ -44,7 +44,7 @@ from .scipy import NumpyVersion
 import numpy as np
 
 import sys
-_is_py2 = sys.version_info.major == 2
+PY3 = sys.version_info.major == 3
 
 np_matrix_rank = np.linalg.matrix_rank
 
@@ -193,7 +193,7 @@ def recarray_select(recarray, fields):
 
 def _bytelike_dtype_names(arr):
     # See # 3658
-    if _is_py2:
+    if not PY3:
         dtype = arr.dtype
         names = dtype.names
         names = [bytes(name) if isinstance(name, unicode) else name for name in names]

--- a/statsmodels/compat/numpy.py
+++ b/statsmodels/compat/numpy.py
@@ -40,13 +40,14 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 
 from __future__ import absolute_import
-from .scipy import NumpyVersion
 import numpy as np
 
-import sys
-PY3 = sys.version_info.major == 3
+from .python import PY3
+from .scipy import NumpyVersion
+
 
 np_matrix_rank = np.linalg.matrix_rank
+
 
 if NumpyVersion(np.__version__) >= '1.9.0':
     np_new_unique = np.unique

--- a/statsmodels/compat/numpy.py
+++ b/statsmodels/compat/numpy.py
@@ -43,6 +43,9 @@ from __future__ import absolute_import
 from .scipy import NumpyVersion
 import numpy as np
 
+import sys
+_is_py2 = sys.version_info.major == 2
+
 np_matrix_rank = np.linalg.matrix_rank
 
 if NumpyVersion(np.__version__) >= '1.9.0':
@@ -179,6 +182,19 @@ def recarray_select(recarray, fields):
     from pandas import DataFrame
     fields = [fields] if not isinstance(fields, (tuple, list)) else fields
     if len(fields) == len(recarray.dtype):
-        return recarray
-    recarray = DataFrame.from_records(recarray)
-    return recarray[fields].to_records(index=False)
+        selection = recarray
+    else:
+        recarray = DataFrame.from_records(recarray)
+        selection = recarray[fields].to_records(index=False)
+
+    _bytelike_dtype_names(selection)
+    return selection
+
+
+def _bytelike_dtype_names(arr):
+    # See # 3658
+    if _is_py2:
+        dtype = arr.dtype
+        names = dtype.names
+        names = [bytes(name) if isinstance(name, unicode) else name for name in names]
+        dtype.names = names

--- a/statsmodels/tsa/tsatools.py
+++ b/statsmodels/tsa/tsatools.py
@@ -1,6 +1,6 @@
-import sys
-from statsmodels.compat.python import range, lrange, lzip, long
-from statsmodels.compat.numpy import recarray_select, PY3
+
+from statsmodels.compat.python import range, lrange, lzip, long, PY3
+from statsmodels.compat.numpy import recarray_select
 
 import numpy as np
 import numpy.lib.recfunctions as nprf
@@ -11,9 +11,6 @@ from pandas.tseries.frequencies import to_offset
 
 from statsmodels.tools.sm_exceptions import ValueWarning
 from statsmodels.tools.data import _is_using_pandas, _is_recarray
-
-
-
 
 
 def add_trend(x, trend="c", prepend=False, has_constant='skip'):

--- a/statsmodels/tsa/tsatools.py
+++ b/statsmodels/tsa/tsatools.py
@@ -1,6 +1,6 @@
 import sys
 from statsmodels.compat.python import range, lrange, lzip, long
-from statsmodels.compat.numpy import recarray_select
+from statsmodels.compat.numpy import recarray_select, PY3
 
 import numpy as np
 import numpy.lib.recfunctions as nprf
@@ -12,7 +12,6 @@ from pandas.tseries.frequencies import to_offset
 from statsmodels.tools.sm_exceptions import ValueWarning
 from statsmodels.tools.data import _is_using_pandas, _is_recarray
 
-_is_py2 = sys.version_info.major == 2
 
 
 
@@ -127,7 +126,7 @@ def add_trend(x, trend="c", prepend=False, has_constant='skip'):
         else:
             descr = descr + new_descr[-extra_col:]
 
-        if _is_py2:
+        if not PY3:
             # See 3658
             names = [entry[0] for entry in descr]
             dtypes = [entry[1] for entry in descr]
@@ -189,7 +188,7 @@ def add_lag(x, col=None, lags=1, drop=False, insert=True):
             col = names[0]
         if isinstance(col, (int, long)):
             col = x.dtype.names[col]
-        if _is_py2:
+        if not PY3:
             # TODO: Get rid of this kludge.  See GH # 3658
             names = [bytes(name) if isinstance(name, unicode) else name for name in names]
             # Fail loudly if there is a non-ascii name.

--- a/statsmodels/tsa/tsatools.py
+++ b/statsmodels/tsa/tsatools.py
@@ -1,3 +1,4 @@
+import sys
 from statsmodels.compat.python import range, lrange, lzip, long
 from statsmodels.compat.numpy import recarray_select
 
@@ -10,6 +11,10 @@ from pandas.tseries.frequencies import to_offset
 
 from statsmodels.tools.sm_exceptions import ValueWarning
 from statsmodels.tools.data import _is_using_pandas, _is_recarray
+
+_is_py2 = sys.version_info.major == 2
+
+
 
 
 def add_trend(x, trend="c", prepend=False, has_constant='skip'):
@@ -117,7 +122,19 @@ def add_trend(x, trend="c", prepend=False, has_constant='skip'):
         x = x.to_records(index=False, convert_datetime64=False)
         new_descr = x.dtype.descr
         extra_col = len(new_descr) - len(descr)
-        descr = new_descr[:extra_col] + descr if prepend else descr + new_descr[-extra_col:]
+        if prepend:
+            descr = new_descr[:extra_col] + descr
+        else:
+            descr = descr + new_descr[-extra_col:]
+
+        if _is_py2:
+            # See 3658
+            names = [entry[0] for entry in descr]
+            dtypes = [entry[1] for entry in descr]
+            names = [bytes(name) for name in names]
+            # Fail loudly if there is a non-ascii name
+            descr = list(zip(names, dtypes))
+
         x = x.astype(np.dtype(descr))
 
     return x
@@ -172,10 +189,18 @@ def add_lag(x, col=None, lags=1, drop=False, insert=True):
             col = names[0]
         if isinstance(col, (int, long)):
             col = x.dtype.names[col]
+        if _is_py2:
+            # TODO: Get rid of this kludge.  See GH # 3658
+            names = [bytes(name) if isinstance(name, unicode) else name for name in names]
+            # Fail loudly if there is a non-ascii name.
+            x.dtype.names = names
+            if isinstance(col, unicode):
+                col = bytes(col)
+
         contemp = x[col]
 
         # make names for lags
-        tmp_names = [col + '_'+'L(%i)' % i for i in range(1,lags+1)]
+        tmp_names = [col + '_'+'L(%i)' % i for i in range(1, lags+1)]
         ndlags = lagmat(contemp, maxlag=lags, trim='Both')
 
         # get index for return
@@ -202,8 +227,9 @@ def add_lag(x, col=None, lags=1, drop=False, insert=True):
         if first_names: # only do this if x isn't "empty"
             # Workaround to avoid NumPy FutureWarning
             _x = recarray_select(x, first_names)
-            first_arr = nprf.append_fields(_x[lags:],tmp_names, ndlags.T,
+            first_arr = nprf.append_fields(_x[lags:], tmp_names, ndlags.T,
                                            usemask=False)
+
         else:
             first_arr = np.zeros(len(x)-lags, dtype=lzip(tmp_names,
                 (x[col].dtype,)*lags))

--- a/statsmodels/tsa/vector_ar/tests/test_var.py
+++ b/statsmodels/tsa/vector_ar/tests/test_var.py
@@ -448,6 +448,7 @@ class TestVARResults(CheckIRF, CheckFEVD):
     def test_pickle(self):
         fh = BytesIO()
         #test wrapped results load save pickle
+        del self.res.model.data.orig_endog
         self.res.save(fh)
         fh.seek(0,0)
         res_unpickled = self.res.__class__.load(fh)


### PR DESCRIPTION

this currently reverts #3662 and #3667 which pin pandas version to older non-failing version
chery-picks commits from #3739 
drop recarray before pickling in tests_var

see https://github.com/statsmodels/statsmodels/pull/3739#issuecomment-332689724

closes #3658, closes #3739