### PR TITLE
TST: test_arima111_predict_exog_2127 increase tolerance

### DIFF
--- a/statsmodels/tsa/tests/test_arima.py
+++ b/statsmodels/tsa/tests/test_arima.py
@@ -2110,7 +2110,7 @@ def test_arima111_predict_exog_2127():
             0.02372018,  0.02374833,  0.02367407,  0.0236443 ,  0.02362868,
             0.02362312])
 
-    assert_allclose(predicts, predicts_res, atol=1e-6)
+    assert_allclose(predicts, predicts_res, atol=5e-6)
 
 
 def test_ARIMA_exog_predict():


### PR DESCRIPTION
 closes #3950

this should remove a test failure that shows up now in one environment on appveyor, no problems in other cases and I don't have a fail locally with the versions in my dev environment

required atol was 1e-6, actual error according to test log is 3e-6

