### PR TITLE
Mixin for L1 Results

### DIFF
--- a/statsmodels/discrete/discrete_model.py
+++ b/statsmodels/discrete/discrete_model.py
@@ -3634,7 +3634,21 @@ class GeneralizedPoissonResults(NegativeBinomialResults):
         mu = self.predict()
         return (1 + self.params[-1] * mu**p)**2
 
-class L1CountResults(DiscreteResults):
+
+class L1ResultsMixin(object):
+    @cache_readonly
+    def trimmed(self):
+        """trimmed is a boolean array with T/F telling whether or not that
+        entry in params has been set zero'd out."""
+        return self.mle_retvals['trimmed']
+
+    @cache_readonly
+    def nnz_params(self):
+        """Number of non-zero params"""
+        return (self.trimmed == False).sum()
+
+
+class L1CountResults(DiscreteResults, L1ResultsMixin):
     __doc__ = _discrete_results_docs % {"one_line_description" :
             "A results class for count data fit by l1 regularization",
             "extra_attr" : _l1_results_attr}
@@ -3642,10 +3656,6 @@ class L1CountResults(DiscreteResults):
 
     def __init__(self, model, cntfit):
         super(L1CountResults, self).__init__(model, cntfit)
-        # self.trimmed is a boolean array with T/F telling whether or not that
-        # entry in params has been set zero'd out.
-        self.trimmed = cntfit.mle_retvals['trimmed']
-        self.nnz_params = (self.trimmed == False).sum()
 
         # Set degrees of freedom.  In doing so,
         # adjust for extra parameter in NegativeBinomial nb1 and nb2
@@ -3872,16 +3882,12 @@ class ProbitResults(BinaryResults):
         cdf = model.cdf(XB)
         return endog * pdf/cdf - (1-endog)*pdf/(1-cdf)
 
-class L1BinaryResults(BinaryResults):
+class L1BinaryResults(BinaryResults, L1ResultsMixin):
     __doc__ = _discrete_results_docs % {"one_line_description" :
     "Results instance for binary data fit by l1 regularization",
     "extra_attr" : _l1_results_attr}
     def __init__(self, model, bnryfit):
         super(L1BinaryResults, self).__init__(model, bnryfit)
-        # self.trimmed is a boolean array with T/F telling whether or not that
-        # entry in params has been set zero'd out.
-        self.trimmed = bnryfit.mle_retvals['trimmed']
-        self.nnz_params = (self.trimmed == False).sum()
         self.df_model = self.nnz_params - 1
         self.df_resid = float(self.model.endog.shape[0] - self.nnz_params)
 
@@ -4019,17 +4025,12 @@ class MultinomialResults(DiscreteResults):
         return smry
 
 
-class L1MultinomialResults(MultinomialResults):
+class L1MultinomialResults(MultinomialResults, L1ResultsMixin):
     __doc__ = _discrete_results_docs % {"one_line_description" :
         "A results class for multinomial data fit by l1 regularization",
         "extra_attr" : _l1_results_attr}
     def __init__(self, model, mlefit):
         super(L1MultinomialResults, self).__init__(model, mlefit)
-        # self.trimmed is a boolean array with T/F telling whether or not that
-        # entry in params has been set zero'd out.
-        self.trimmed = mlefit.mle_retvals['trimmed']
-        self.nnz_params = (self.trimmed == False).sum()
-
         # Note: J-1 constants
         self.df_model = self.nnz_params - (self.model.J - 1)
         self.df_resid = float(self.model.endog.shape[0] - self.nnz_params)


### PR DESCRIPTION
This separates out a small part of #3725, de-duplicates some code, turns some comments into docstrings.

Ideally I'd like `L1ResultsMixin` to belong somewhere else, but for simplicity in the short term I kept it in `discrete_model` for now.