### PR TITLE
Require absolute imports in the compat.collections module.

### DIFF
--- a/statsmodels/compat/collections.py
+++ b/statsmodels/compat/collections.py
@@ -1,6 +1,7 @@
 '''backported compatibility functions for Python's collections
 
 '''
+from __future__ import absolute_import
 
 try:
     #python >= 2.7


### PR DESCRIPTION
Fixes #3975.