### PR TITLE
DOC/REF: Markov Autoregression notebook: use Stata dataset rather than from tests

### DIFF
--- a/examples/notebooks/markov_autoregression.ipynb
+++ b/examples/notebooks/markov_autoregression.ipynb
@@ -76,8 +76,9 @@
    "outputs": [],
    "source": [
     "# Get the RGNP data to replicate Hamilton\n",
-    "from statsmodels.tsa.regime_switching.tests.test_markov_autoregression import rgnp\n",
-    "dta_hamilton = pd.Series(rgnp, index=pd.date_range('1951-04-01', '1984-10-01', freq='QS'))\n",
+    "dta = pd.read_stata('http://www.stata-press.com/data/r14/rgnp.dta').iloc[1:]\n",
+    "dta.index = pd.DatetimeIndex(dta.date, freq='QS')\n",
+    "dta_hamilton = dta.rgnp\n",
     "\n",
     "# Plot the data\n",
     "dta_hamilton.plot(title='Growth rate of Real GNP', figsize=(12,3))\n",


### PR DESCRIPTION
Closes #3761.

One possibility for fixing this issue is to download the (identical) dataset from Stata for this notebook, Instead of getting the data from the unit test folder. This PR makes that change.