### PR TITLE
REF/BUG: ARMA/ARIMA increase default maxiter in fit

### DIFF
--- a/statsmodels/base/optimizer.py
+++ b/statsmodels/base/optimizer.py
@@ -419,8 +419,10 @@ def _fit_lbfgs(f, score, start_params, fargs, kwargs, disp=True,
         converged = (warnflag == 0)
         gopt = d['grad']
         fcalls = d['funcalls']
+        iterations = d['nit']
         retvals = {'fopt': fopt, 'gopt': gopt, 'fcalls': fcalls,
-                   'warnflag': warnflag, 'converged': converged}
+                   'warnflag': warnflag, 'converged': converged,
+                   'iterations': iterations}
     else:
         xopt = retvals[0]
         retvals = None

--- a/statsmodels/tsa/arima_model.py
+++ b/statsmodels/tsa/arima_model.py
@@ -820,7 +820,7 @@ class ARMA(tsbase.TimeSeriesModel):
         return llf
 
     def fit(self, start_params=None, trend='c', method="css-mle",
-            transparams=True, solver='lbfgs', maxiter=50, full_output=1,
+            transparams=True, solver='lbfgs', maxiter=500, full_output=1,
             disp=5, callback=None, start_ar_lags=None, **kwargs):
         """
         Fits ARMA(p,q) model using exact maximum likelihood via Kalman filter.
@@ -1068,7 +1068,7 @@ class ARIMA(ARMA):
         return start, end, out_of_sample, prediction_index
 
     def fit(self, start_params=None, trend='c', method="css-mle",
-            transparams=True, solver='lbfgs', maxiter=50, full_output=1,
+            transparams=True, solver='lbfgs', maxiter=500, full_output=1,
             disp=5, callback=None, start_ar_lags=None, **kwargs):
         """
         Fits ARIMA(p,d,q) model by exact maximum likelihood via Kalman filter.

--- a/statsmodels/tsa/tests/test_arima.py
+++ b/statsmodels/tsa/tests/test_arima.py
@@ -2092,8 +2092,8 @@ def test_arima111_predict_exog_2127():
     # rescaling results in convergence failure
     #model = sm.tsa.ARIMA(np.array(ef)*100, (1,1,1), exog=ue)
     model = ARIMA(ef, (1,1,1), exog=ue)
-    res = model.fit(transparams=False, iprint=0, disp=0)
-
+    res = model.fit(transparams=False, pgtol=1e-8, iprint=0, disp=0)
+    assert_equal(res.mle_retvals['warnflag'],  0)
     predicts = res.predict(start=len(ef), end = len(ef)+10,
                            exog=ue[-11:], typ = 'levels')
 


### PR DESCRIPTION
closes #3980  test_arima111_predict_exog_2127 test fails again in some test environments


first try: Tighten pgtol for lbfgs optimization in test - pgtol was already at the tighter level
relevant change: increase maxiter in ARMA/ARIMA
bonus: add `iterations` to lbfgs mle_retvals

Note point of test was not precision issues, just that exog is transmitted properly.
If this doesn't work, then we just increase test tolerance again.

As check: gopt in mle_retvals is much smaller than the explicitly computed score with lbfgs.
However, the predictions agree with solver='newton' at an atol around 5e-7,  
solver='newton' works well starting from the lbfgs params and has very small score at optimum, in contrast to lbfgs. 

The newton predicts also agree with those used in the unit test at around atol 5e-7. so those are not very noisy.

I'm using scipy '0.18.1'
