### PR TITLE
BUG: seasonal_decompose, don't check inferred_freq if freq given, 

### DIFF
--- a/statsmodels/tsa/filters/_utils.py
+++ b/statsmodels/tsa/filters/_utils.py
@@ -35,7 +35,7 @@ def _maybe_get_pandas_wrapper(X, trim_head=None, trim_tail=None):
     if _is_using_pandas(X, None):
         return _get_pandas_wrapper(X, trim_head, trim_tail)
     else:
-        return
+        return lambda x : x
 
 
 def _maybe_get_pandas_wrapper_freq(X, trim=None):

--- a/statsmodels/tsa/seasonal.py
+++ b/statsmodels/tsa/seasonal.py
@@ -4,7 +4,8 @@ Seasonal Decomposition by Moving Averages
 from statsmodels.compat.python import lmap, range, iteritems
 import numpy as np
 from pandas.core.nanops import nanmean as pd_nanmean
-from .filters._utils import _maybe_get_pandas_wrapper_freq
+from .filters._utils import (_maybe_get_pandas_wrapper_freq,
+                             _maybe_get_pandas_wrapper)
 from .filters.filtertools import convolution_filter
 from statsmodels.tsa.tsatools import freq_to_period
 
@@ -65,7 +66,11 @@ def seasonal_decompose(x, model="additive", filt=None, freq=None, two_sided=True
     statsmodels.tsa.filters.hp_filter.hpfilter
     statsmodels.tsa.filters.convolution_filter
     """
-    _pandas_wrapper, pfreq = _maybe_get_pandas_wrapper_freq(x)
+    if freq is None:
+        _pandas_wrapper, pfreq = _maybe_get_pandas_wrapper_freq(x)
+    else:
+        _pandas_wrapper = _maybe_get_pandas_wrapper(x)
+        pfreq = None
     x = np.asanyarray(x).squeeze()
     nobs = len(x)
 

--- a/statsmodels/tsa/tests/test_seasonal.py
+++ b/statsmodels/tsa/tests/test_seasonal.py
@@ -1,5 +1,7 @@
 import numpy as np
-from numpy.testing import assert_almost_equal, assert_equal, assert_raises
+import pandas as pd
+from numpy.testing import (assert_almost_equal, assert_equal, assert_raises,
+                           assert_allclose)
 from statsmodels.tsa.seasonal import seasonal_decompose
 from pandas import DataFrame, DatetimeIndex
 
@@ -138,6 +140,21 @@ class TestDecompose:
         assert_equal(res_mult.seasonal.index.values.squeeze(),
                             self.data.index.values)
 
+    def test_pandas_nofreq(self):
+        # issue #3503
+        nobs = 100
+        dta = pd.Series([x%3 for x in range(nobs)] + np.random.randn(nobs))
+        res_np = seasonal_decompose(dta.values, freq=3)
+        res = seasonal_decompose(dta, freq=3)
+
+        atol = 1e-8
+        rtol = 1e-10
+        assert_allclose(res.seasonal.values.squeeze(), res_np.seasonal,
+                        atol=atol, rtol=rtol)
+        assert_allclose(res.trend.values.squeeze(), res_np.trend,
+                        atol=atol, rtol=rtol)
+        assert_allclose(res.resid.values.squeeze(), res_np.resid,
+                        atol=atol, rtol=rtol)
 
     def test_filt(self):
         filt = np.array([1/8., 1/4., 1./4, 1/4., 1/8.])


### PR DESCRIPTION
closes #3503

solution is about as discussed in #3503 avoiding freq check early in the function if freq is given
The two `_maybe_get_pandas_wrapper` functions overlap in code but I didn't merge them here.

```
+    if freq is None:
 +        _pandas_wrapper, pfreq = _maybe_get_pandas_wrapper_freq(x)
 +    else:
 +        _pandas_wrapper = _maybe_get_pandas_wrapper(x)
 +        pfreq = None
```