### PR TITLE
Implement deprecated_alias, with tests

### DIFF
--- a/statsmodels/tools/decorators.py
+++ b/statsmodels/tools/decorators.py
@@ -9,6 +9,28 @@ __all__ = ['resettable_cache', 'cache_readonly', 'cache_writable',
 
 
 def deprecated_alias(old_name, new_name, remove_version=None):
+    """
+    Older or less-used classes may not conform to statsmodels naming
+    conventions.  `deprecated_alias` lets us bring them into conformance
+    without breaking backward-compatibility.
+
+    Example
+    -------
+    Instances of the `Foo` class have a `nvars` attribute, but it _should_
+    be called `neqs`:
+
+    class Foo(object):
+        nvars = deprecated_alias('nvars', 'neqs')
+
+        def __init__(self, neqs):
+            self.neqs = neqs
+
+    >>> foo = Foo(3)
+    >>> foo.nvars
+    __main__:1: FutureWarning: nvars is a deprecated alias for neqs
+    3
+
+    """
     msg = '%s is a deprecated alias for %s' % (old_name, new_name)
     if remove_version is not None:
         msg += ', will be removed in version %s' % remove_version

--- a/statsmodels/tools/decorators.py
+++ b/statsmodels/tools/decorators.py
@@ -14,11 +14,11 @@ def deprecated_alias(old_name, new_name, remove_version=None):
         msg += ', will be removed in version %s' % remove_version
 
     def fget(self):
-        warnings.warn(msg)
+        warnings.warn(msg, DeprecationWarning, stacklevel=2)
         return getattr(self, new_name)
 
     def fset(self, value):
-        warnings.warn(msg)
+        warnings.warn(msg, DeprecationWarning, stacklevel=2)
         setattr(self, new_name, value)
 
     res = property(fget=fget, fset=fset)

--- a/statsmodels/tools/decorators.py
+++ b/statsmodels/tools/decorators.py
@@ -14,11 +14,11 @@ def deprecated_alias(old_name, new_name, remove_version=None):
         msg += ', will be removed in version %s' % remove_version
 
     def fget(self):
-        warnings.warn(msg, DeprecationWarning, stacklevel=2)
+        warnings.warn(msg, FutureWarning, stacklevel=2)
         return getattr(self, new_name)
 
     def fset(self, value):
-        warnings.warn(msg, DeprecationWarning, stacklevel=2)
+        warnings.warn(msg, FutureWarning, stacklevel=2)
         setattr(self, new_name, value)
 
     res = property(fget=fget, fset=fset)

--- a/statsmodels/tools/decorators.py
+++ b/statsmodels/tools/decorators.py
@@ -4,7 +4,26 @@ from numpy.testing import assert_equal
 from statsmodels.compat.python import get_function_name
 import warnings
 
-__all__ = ['resettable_cache', 'cache_readonly', 'cache_writable']
+__all__ = ['resettable_cache', 'cache_readonly', 'cache_writable',
+           'deprecated_alias']
+
+
+def deprecated_alias(old_name, new_name, remove_version=None):
+    msg = '%s is a deprecated alias for %s' % (old_name, new_name)
+    if remove_version is not None:
+        msg += ', will be removed in version %s' % remove_version
+
+    def fget(self):
+        warnings.warn(msg)
+        return getattr(self, new_name)
+
+    def fset(self, value):
+        warnings.warn(msg)
+        setattr(self, new_name, value)
+
+    res = property(fget=fget, fset=fset)
+    return res
+
 
 
 class ResettableCache(dict):

--- a/statsmodels/tools/tests/test_decorators.py
+++ b/statsmodels/tools/tests/test_decorators.py
@@ -34,7 +34,7 @@ class TestDeprecatedAlias(object):
     def test_set(self):
         inst = self.Dummy(4)
 
-        with pytest.deprecated_call() as context:            
+        with pytest.deprecated_call() as context:
             inst.y = 5
             captured = context._list
 

--- a/statsmodels/tools/tests/test_decorators.py
+++ b/statsmodels/tools/tests/test_decorators.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import warnings
 
+import pytest
 from numpy.testing import assert_
 
 from statsmodels.tools.decorators import deprecated_alias
@@ -22,18 +23,21 @@ class TestDeprecatedAlias(object):
 
     def test_get(self):
         inst = self.Dummy(4)
-        with warnings.catch_warnings(record=True) as record:
-            assert_(inst.y == 4)
 
-        assert_(len(record) == 1)
-        assert_('is a deprecated alias' in str(record[0]))
+        with pytest.deprecated_call() as context:
+            assert_(inst.y == 4)
+            captured = context._list
+
+        assert_(len(captured) == 1)
+        assert_('is a deprecated alias' in str(captured[0]))
 
     def test_set(self):
         inst = self.Dummy(4)
 
-        with warnings.catch_warnings(record=True) as record:
+        with pytest.deprecated_call() as context:            
             inst.y = 5
+            captured = context._list
 
-        assert_(len(record) == 1)
-        assert_('is a deprecated alias' in str(record[0]))
+        assert_(len(captured) == 1)
+        assert_('is a deprecated alias' in str(captured[0]))
         assert_(inst.x == 5)

--- a/statsmodels/tools/tests/test_decorators.py
+++ b/statsmodels/tools/tests/test_decorators.py
@@ -8,32 +8,32 @@ from statsmodels.tools.decorators import deprecated_alias
 
 class TestDeprecatedAlias(object):
 
-	@classmethod
-	def setup_class(cls):
-		
-		class Dummy(object):
+    @classmethod
+    def setup_class(cls):
+        
+        class Dummy(object):
 
-			y = deprecated_alias('y', 'x', '0.11.0')
+            y = deprecated_alias('y', 'x', '0.11.0')
 
-			def __init__(self, y):
-				self.x = y
+            def __init__(self, y):
+                self.x = y
 
-		cls.Dummy = Dummy
+        cls.Dummy = Dummy
 
-	def test_get(self):
-		inst = self.Dummy(4)
-		with warnings.catch_warnings(record=True) as record:
-			assert_(inst.y == 4)
+    def test_get(self):
+        inst = self.Dummy(4)
+        with warnings.catch_warnings(record=True) as record:
+            assert_(inst.y == 4)
 
-		assert_(len(record) == 1)
-		assert_('is a deprecated alias' in str(record[0]))
+        assert_(len(record) == 1)
+        assert_('is a deprecated alias' in str(record[0]))
 
-	def test_set(self):
-		inst = self.Dummy(4)
+    def test_set(self):
+        inst = self.Dummy(4)
 
-		with warnings.catch_warnings(record=True) as record:
-			inst.y = 5
+        with warnings.catch_warnings(record=True) as record:
+            inst.y = 5
 
-		assert_(len(record) == 1)
-		assert_('is a deprecated alias' in str(record[0]))
-		assert_(inst.x == 5)
+        assert_(len(record) == 1)
+        assert_('is a deprecated alias' in str(record[0]))
+        assert_(inst.x == 5)

--- a/statsmodels/tools/tests/test_decorators.py
+++ b/statsmodels/tools/tests/test_decorators.py
@@ -24,20 +24,18 @@ class TestDeprecatedAlias(object):
     def test_get(self):
         inst = self.Dummy(4)
 
-        with pytest.deprecated_call() as context:
-            assert_(inst.y == 4)
-            captured = context._list
+        with warnings.catch_warnings(record=True) as record:
+            assert inst.y == 4
 
-        assert_(len(captured) == 1)
-        assert_('is a deprecated alias' in str(captured[0]))
+        assert len(record) == 1, record
+        assert 'is a deprecated alias' in str(record[0])
 
     def test_set(self):
         inst = self.Dummy(4)
 
-        with pytest.deprecated_call() as context:
+        with warnings.catch_warnings(record=True) as record:
             inst.y = 5
-            captured = context._list
 
-        assert_(len(captured) == 1)
-        assert_('is a deprecated alias' in str(captured[0]))
-        assert_(inst.x == 5)
+        assert len(record) == 1, record
+        assert 'is a deprecated alias' in str(record[0])
+        assert inst.x == 5

--- a/statsmodels/tools/tests/test_decorators.py
+++ b/statsmodels/tools/tests/test_decorators.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+import warnings
+
+from numpy.testing import assert_
+
+from statsmodels.tools.decorators import deprecated_alias
+
+
+class TestDeprecatedAlias(object):
+
+	@classmethod
+	def setup_class(cls):
+		
+		class Dummy(object):
+
+			y = deprecated_alias('y', 'x', '0.11.0')
+
+			def __init__(self, y):
+				self.x = y
+
+		cls.Dummy = Dummy
+
+	def test_get(self):
+		inst = self.Dummy(4)
+		with warnings.catch_warnings(record=True) as record:
+			assert_(inst.y == 4)
+
+		assert_(len(record) == 1)
+		assert_('is a deprecated alias' in str(record[0]))
+
+	def test_set(self):
+		inst = self.Dummy(4)
+
+		with warnings.catch_warnings(record=True) as record:
+			inst.y = 5
+
+		assert_(len(record) == 1)
+		assert_('is a deprecated alias' in str(record[0]))
+		assert_(inst.x == 5)

--- a/statsmodels/tsa/varma_process.py
+++ b/statsmodels/tsa/varma_process.py
@@ -37,6 +37,8 @@ from scipy.signal.signaltools import _centered as trim_centered
 
 from statsmodels.tsa.tsatools import lagmat
 
+from statsmodels.tools.decorators import deprecated_alias
+
 
 def varfilter(x, a):
     '''apply an autoregressive filter to a series x
@@ -464,11 +466,14 @@ class VarmaPoly(object):
 
 
     '''
+
+    nvars = deprecated_alias('nvars', 'neqs', '0.11.0')
+
     def __init__(self, ar, ma=None):
         self.ar = ar
         self.ma = ma
         nlags, nvarall, nvars = ar.shape
-        self.nlags, self.nvarall, self.nvars = nlags, nvarall, nvars
+        self.nlags, self.nvarall, self.neqs = nlags, nvarall, nvars
         self.isstructured = not (ar[0,:nvars] == np.eye(nvars)).all()
         if self.ma is None:
             self.ma = np.eye(nvars)[None,...]


### PR DESCRIPTION
Inconsistent names are An Issue.  But we're not willing to go through and excise names that don't conform to current naming conventions.

This PR implements a `deprecated_alias` property-like attribute that warns on access but otherwise behaves normally.  i.e. we can bring some consistency to the world, warn users of coming deprecations and maybe even eventually follow up on those deprecations.

One example is implemented in the basically-unmaintained `tsa.varma_process`.  `VarmaPoly.nvars` corresponds to what we would now call `neqs`.