### PR TITLE
ENH: add wls_method option, mle_settings to GLM fit IRLS

### DIFF
--- a/statsmodels/genmod/generalized_linear_model.py
+++ b/statsmodels/genmod/generalized_linear_model.py
@@ -986,6 +986,10 @@ class GLM(base.LikelihoodModel):
             specifies which linear algebra function to use for the irls
             optimization. Default is `lstsq` which uses the same underlying
             svd based approach as 'pinv', but is faster during iterations.
+            'lstsq' and 'pinv' regularize the estimate in singular and
+            near-singular cases by truncating small singular values based
+            on `rcond` of the respective numpy.linalg function. 'qr' is
+            only valied for cases that are not singular nor near-singular.
 
         If a scipy optimizer is used, the following additional parameter is
         available:
@@ -994,6 +998,15 @@ class GLM(base.LikelihoodModel):
             When 'oim', the default, the observed Hessian is used in fitting.
             'eim' is the expected Hessian. This may provide more stable fits,
             but adds assumption that the Hessian is correctly specified.
+
+        Notes
+        -----
+        If method is 'IRLS', then an additional keyword 'attach_wls' is
+        availble. This is currently for internal use only and might change
+        in future versions. If attach_wls' is true, then the final WLS
+        instance of the IRLS iteration is attached to the results instance
+        as `results_wls` attribute.
+
         """
         self.scaletype = scale
 

--- a/statsmodels/genmod/tests/test_glm.py
+++ b/statsmodels/genmod/tests/test_glm.py
@@ -1170,6 +1170,35 @@ def test_gradient_irls_eim():
                                     atol=5e-5)
 
 
+def test_glm_irls_method():
+    nobs, k_vars = 50, 4
+    np.random.seed(987126)
+    x = np.random.randn(nobs, k_vars - 1)
+    exog = add_constant(x, has_constant='add')
+    y = exog.sum(1) + np.random.randn(nobs)
+
+    mod = GLM(y, exog)
+    res1 = mod.fit()
+    res2 = mod.fit(wls_method='pinv', attach_wls=True)
+    res3 = mod.fit(wls_method='qr', attach_wls=True)
+    # fit_gradient does not attach mle_settings
+    res_g1 = mod.fit(start_params=res1.params, method='bfgs')
+
+    for r in [res1, res2, res3]:
+        assert_equal(r.mle_settings['optimizer'], 'IRLS')
+        assert_equal(r.method, 'IRLS')
+
+    assert_equal(res1.mle_settings['wls_method'], 'lstsq')
+    assert_equal(res2.mle_settings['wls_method'], 'pinv')
+    assert_equal(res3.mle_settings['wls_method'], 'qr')
+
+    assert_(hasattr(res2.results_wls.model, 'pinv_wexog'))
+    assert_(hasattr(res3.results_wls.model, 'exog_Q'))
+
+    # fit_gradient currently does not attach mle_settings
+    assert_equal(res_g1.method, 'bfgs')
+
+
 class CheckWtdDuplicationMixin(object):
     decimal_params = DECIMAL_4
 
@@ -1261,7 +1290,7 @@ class CheckWtdDuplicationMixin(object):
 
 
 class TestWtdGlmPoisson(CheckWtdDuplicationMixin):
-    
+
     @classmethod
     def setup_class(cls):
         '''


### PR DESCRIPTION
closes #4001
add `wls_method` fit option
adds `mle_settings` to results in fit_irls  see comments in #2401

(started out to investigate differences across linear algebra functions, but should be good to merge)

extra keyword introduced for testing
`attach_wls` to attach the final WLS results to the GLMResults instance.
not included in docstring
(used in unit tests, and will be useful for future development, e.g. for diagnostics. 
It is doubtful whether this will be in the final API, e.g. WLS results are not available with fit_gradient.)



