### PR TITLE
replace common algebraic expressions; implement _score_obs_geom

### DIFF
--- a/statsmodels/discrete/discrete_model.py
+++ b/statsmodels/discrete/discrete_model.py
@@ -2510,8 +2510,8 @@ class NegativeBinomial(CountModel):
 
     def _score_obs_geom(self, params):
         exog = self.exog
-        y = self.endog[:, None]
-        mu = self.predict(params)[:, None]
+        y = self.endog[:,None]
+        mu = self.predict(params)[:,None]
         dparams = exog * (y-mu)/(mu+1)
         return dparams
 

--- a/statsmodels/discrete/discrete_model.py
+++ b/statsmodels/discrete/discrete_model.py
@@ -2530,6 +2530,9 @@ class NegativeBinomial(CountModel):
         a1 = 1/alpha * mu**Q
 
         prob = a1 / (a1+mu)
+        if alpha == 0:
+            # See discussion in GH#4026
+            prob = 1
         if Q: # nb1
             # Note: 1/(alpha+1) == (mu/alpha) / (mu+mu/alpha) == a1/(mu+a1)
             dparams = exog * a1 * (np.log(prob) +

--- a/statsmodels/discrete/discrete_model.py
+++ b/statsmodels/discrete/discrete_model.py
@@ -2596,6 +2596,9 @@ class NegativeBinomial(CountModel):
 
         prob = a1 / (a1+mu)
         # Note: 1/(alpha+1) == (mu/alpha) / (mu + mu/alpha) == a1/(mu+a1)
+        if alpha == 0:
+            # See discussion in GH#4026
+            prob = 1
 
         # for dl/dparams dparams
         dim = exog.shape[1]
@@ -2663,6 +2666,9 @@ class NegativeBinomial(CountModel):
         mu = self.predict(params)[:,None]
 
         prob = a1 / (a1+mu)
+        if alpha == 0:
+            # See discussion in GH#4026
+            prob = 1
 
         # for dl/dparams dparams
         dim = exog.shape[1]


### PR DESCRIPTION
Tailored so as to be orthogonal+complementary to #4023.

There is a TODO comment above NegativeBinomial.score_obs `#TODO: replace this with analytic where is it used?`.  This implements it for one of three cases.  The other two can be done in a follow-up, just amount to _not_ taking the sum currently taken at the end of `_score_bin`.  Not doing that in this PR because there's already a non-trivial amount of algebraic substitution in the diff.