### PR TITLE
ENH: State space: Make initialization more flexible.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,7 @@ salary.table
 statsmodels/tsa/statespace/_statespace.pyx
 statsmodels/tsa/regime_switching/_hamilton_filter.pyx
 statsmodels/tsa/regime_switching/_kim_smoother.pyx
+statsmodels/tsa/statespace/_initialization.pyx
 statsmodels/tsa/statespace/_representation.pyx
 statsmodels/tsa/statespace/_kalman_filter.pyx
 statsmodels/tsa/statespace/_kalman_smoother.pyx

--- a/setup.py
+++ b/setup.py
@@ -377,6 +377,11 @@ ext_data = dict(
     )
 
 statespace_ext_data = dict(
+    _initialization = {"name" : "statsmodels/tsa/statespace/_initialization.c",
+              "include_dirs": ['statsmodels/src'] + npymath_info['include_dirs'],
+              "libraries": npymath_info['libraries'],
+              "library_dirs": npymath_info['library_dirs'],
+              "sources": []},
     _representation = {"name" : "statsmodels/tsa/statespace/_representation.c",
               "include_dirs": ['statsmodels/src'] + npymath_info['include_dirs'],
               "libraries": npymath_info['libraries'],

--- a/statsmodels/tsa/statespace/_initialization.pxd
+++ b/statsmodels/tsa/statespace/_initialization.pxd
@@ -1,0 +1,111 @@
+#cython: boundscheck=False
+#cython: wraparound=False
+#cython: cdivision=False
+"""
+State Space Models - Initialization declarations
+
+Author: Chad Fulton  
+License: Simplified-BSD
+"""
+
+cimport numpy as np
+
+from statsmodels.tsa.statespace._representation cimport (
+    sStatespace, dStatespace, cStatespace, zStatespace
+)
+
+cdef class sInitialization(object):
+    cdef readonly int k_states
+    cdef public np.float64_t approximate_diffuse_variance
+
+    cdef np.float32_t [:] constant
+    cdef np.float32_t [::1, :] stationary_cov
+    cdef np.float32_t [::1, :] _tmp_transition
+    cdef np.float32_t [::1, :] _tmp_selected_state_cov
+
+    cpdef int initialize(self, inititialization_type, int offset,
+                         sStatespace model,
+                         np.float32_t [:] initial_state_mean,
+                         np.float32_t [::1, :] initial_diffuse_state_cov,
+                         np.float32_t [::1, :] initial_stationary_state_cov,
+                         int complex_step=*) except 1
+    cdef int clear_constant(self, int offset, np.float32_t [:] initial_state_mean) except 1
+    cdef int clear_cov(self, int offset, np.float32_t [::1, :] cov) except 1
+    cdef int initialize_known_constant(self, int offset, np.float32_t [:] initial_state_mean) except 1
+    cdef int initialize_known_stationary_cov(self, int offset, np.float32_t [::1, :] initial_stationary_state_cov) except 1
+    cdef int initialize_diffuse(self, int offset, np.float32_t [::1, :] initial_diffuse_state_cov) except 1
+    cdef int initialize_approximate_diffuse(self, int offset, np.float32_t [::1, :] initial_stationary_state_cov) except 1
+    cdef int initialize_stationary_constant(self, int offset, sStatespace model, np.float32_t [:] initial_state_mean, int complex_step=*) except 1
+    cdef int initialize_stationary_stationary_cov(self, int offset, sStatespace model, np.float32_t [::1, :] initial_stationary_state_cov, int complex_step=*) except 1
+
+cdef class dInitialization(object):
+    cdef readonly int k_states
+    cdef public np.float64_t approximate_diffuse_variance
+
+    cdef np.float64_t [:] constant
+    cdef np.float64_t [::1, :] stationary_cov
+    cdef np.float64_t [::1, :] _tmp_transition
+    cdef np.float64_t [::1, :] _tmp_selected_state_cov
+
+    cpdef int initialize(self, inititialization_type, int offset,
+                         dStatespace model,
+                         np.float64_t [:] initial_state_mean,
+                         np.float64_t [::1, :] initial_diffuse_state_cov,
+                         np.float64_t [::1, :] initial_stationary_state_cov,
+                         int complex_step=*) except 1
+    cdef int clear_constant(self, int offset, np.float64_t [:] initial_state_mean) except 1
+    cdef int clear_cov(self, int offset, np.float64_t [::1, :] cov) except 1
+    cdef int initialize_known_constant(self, int offset, np.float64_t [:] initial_state_mean) except 1
+    cdef int initialize_known_stationary_cov(self, int offset, np.float64_t [::1, :] initial_stationary_state_cov) except 1
+    cdef int initialize_diffuse(self, int offset, np.float64_t [::1, :] initial_diffuse_state_cov) except 1
+    cdef int initialize_approximate_diffuse(self, int offset, np.float64_t [::1, :] initial_stationary_state_cov) except 1
+    cdef int initialize_stationary_constant(self, int offset, dStatespace model, np.float64_t [:] initial_state_mean, int complex_step=*) except 1
+    cdef int initialize_stationary_stationary_cov(self, int offset, dStatespace model, np.float64_t [::1, :] initial_stationary_state_cov, int complex_step=*) except 1
+
+cdef class cInitialization(object):
+    cdef readonly int k_states
+    cdef public np.float64_t approximate_diffuse_variance
+
+    cdef np.complex64_t [:] constant
+    cdef np.complex64_t [::1, :] stationary_cov
+    cdef np.complex64_t [::1, :] _tmp_transition
+    cdef np.complex64_t [::1, :] _tmp_selected_state_cov
+
+    cpdef int initialize(self, inititialization_type, int offset,
+                         cStatespace model,
+                         np.complex64_t [:] initial_state_mean,
+                         np.complex64_t [::1, :] initial_diffuse_state_cov,
+                         np.complex64_t [::1, :] initial_stationary_state_cov,
+                         int complex_step=*) except 1
+    cdef int clear_constant(self, int offset, np.complex64_t [:] initial_state_mean) except 1
+    cdef int clear_cov(self, int offset, np.complex64_t [::1, :] cov) except 1
+    cdef int initialize_known_constant(self, int offset, np.complex64_t [:] initial_state_mean) except 1
+    cdef int initialize_known_stationary_cov(self, int offset, np.complex64_t [::1, :] initial_stationary_state_cov) except 1
+    cdef int initialize_diffuse(self, int offset, np.complex64_t [::1, :] initial_diffuse_state_cov) except 1
+    cdef int initialize_approximate_diffuse(self, int offset, np.complex64_t [::1, :] initial_stationary_state_cov) except 1
+    cdef int initialize_stationary_constant(self, int offset, cStatespace model, np.complex64_t [:] initial_state_mean, int complex_step=*) except 1
+    cdef int initialize_stationary_stationary_cov(self, int offset, cStatespace model, np.complex64_t [::1, :] initial_stationary_state_cov, int complex_step=*) except 1
+
+cdef class zInitialization(object):
+    cdef readonly int k_states
+    cdef public np.float64_t approximate_diffuse_variance
+
+    cdef np.complex128_t [:] constant
+    cdef np.complex128_t [::1, :] stationary_cov
+    cdef np.complex128_t [::1, :] _tmp_transition
+    cdef np.complex128_t [::1, :] _tmp_selected_state_cov
+
+    cpdef int initialize(self, inititialization_type, int offset,
+                         zStatespace model,
+                         np.complex128_t [:] initial_state_mean,
+                         np.complex128_t [::1, :] initial_diffuse_state_cov,
+                         np.complex128_t [::1, :] initial_stationary_state_cov,
+                         int complex_step=*) except 1
+    cdef int clear_constant(self, int offset, np.complex128_t [:] initial_state_mean) except 1
+    cdef int clear_cov(self, int offset, np.complex128_t [::1, :] cov) except 1
+    cdef int initialize_known_constant(self, int offset, np.complex128_t [:] initial_state_mean) except 1
+    cdef int initialize_known_stationary_cov(self, int offset, np.complex128_t [::1, :] initial_stationary_state_cov) except 1
+    cdef int initialize_diffuse(self, int offset, np.complex128_t [::1, :] initial_diffuse_state_cov) except 1
+    cdef int initialize_approximate_diffuse(self, int offset, np.complex128_t [::1, :] initial_stationary_state_cov) except 1
+    cdef int initialize_stationary_constant(self, int offset, zStatespace model, np.complex128_t [:] initial_state_mean, int complex_step=*) except 1
+    cdef int initialize_stationary_stationary_cov(self, int offset, zStatespace model, np.complex128_t [::1, :] initial_stationary_state_cov, int complex_step=*) except 1

--- a/statsmodels/tsa/statespace/_initialization.pyx.in
+++ b/statsmodels/tsa/statespace/_initialization.pyx.in
@@ -209,7 +209,7 @@ cdef class {{prefix}}Initialization(object):
 
         # Create selected state covariance matrix
         tools._{{prefix}}select_cov(self.k_states, model.k_posdef, model.k_states,
-                             &self._tmp_transition[0,0],
+                             &model.tmp[0,0],
                              &model.selection[offset,0,0],
                              &model.state_cov[0,0,0],
                              &self._tmp_selected_state_cov[0,0])

--- a/statsmodels/tsa/statespace/_initialization.pyx.in
+++ b/statsmodels/tsa/statespace/_initialization.pyx.in
@@ -77,6 +77,17 @@ cdef class {{prefix}}Initialization(object):
         dim2[0] = self.k_states; dim2[1] = self.k_states;
         self._tmp_selected_state_cov = np.PyArray_ZEROS(2, dim2, {{typenum}}, FORTRAN)
 
+    def __reduce__(self):
+        init = (self.k_states, np.array(self.constant), np.array(self.stationary_cov),
+                self.approximate_diffuse_variance)
+        state = {'_tmp_transition': np.array(self._tmp_transition, copy=True, order='F'),
+                 '_tmp_selected_state_cov': np.array(self._tmp_selected_state_cov, copy=True, order='F')}
+        return (self.__class__, init, state)
+
+    def __setstate__(self, state):
+        self._tmp_transition = state['_tmp_transition']
+        self._tmp_selected_state_cov = state['_tmp_selected_state_cov']
+
     cpdef int initialize(self, initialization_type, int offset,
                          {{prefix}}Statespace model,
                          {{cython_type}} [:] initial_state_mean,

--- a/statsmodels/tsa/statespace/_initialization.pyx.in
+++ b/statsmodels/tsa/statespace/_initialization.pyx.in
@@ -72,9 +72,9 @@ cdef class {{prefix}}Initialization(object):
         tools.validate_matrix_shape('known covariance', &self.stationary_cov.shape[0], self.k_states, self.k_states, None)
 
         # Internal temporary matrices
-        dim2[0] = self.k_states; dim2[0] = self.k_states;
+        dim2[0] = self.k_states; dim2[1] = self.k_states;
         self._tmp_transition = np.PyArray_ZEROS(2, dim2, {{typenum}}, FORTRAN)
-        dim2[0] = self.k_states; dim2[0] = self.k_states;
+        dim2[0] = self.k_states; dim2[1] = self.k_states;
         self._tmp_selected_state_cov = np.PyArray_ZEROS(2, dim2, {{typenum}}, FORTRAN)
 
     cpdef int initialize(self, initialization_type, int offset,

--- a/statsmodels/tsa/statespace/_initialization.pyx.in
+++ b/statsmodels/tsa/statespace/_initialization.pyx.in
@@ -1,0 +1,237 @@
+#cython: boundscheck=False
+#cython: wraparound=False
+#cython: cdivision=False
+"""
+State Space Models - Initialization
+
+Author: Chad Fulton  
+License: Simplified-BSD
+"""
+
+{{py:
+
+TYPES = {
+    "s": ("np.float32_t", "np.float32", "np.NPY_FLOAT32"),
+    "d": ("np.float64_t", "float", "np.NPY_FLOAT64"),
+    "c": ("np.complex64_t", "np.complex64", "np.NPY_COMPLEX64"),
+    "z": ("np.complex128_t", "complex", "np.NPY_COMPLEX128"),
+}
+
+}}
+
+# Typical imports
+import numpy as np
+import warnings
+cimport numpy as np
+cimport cython
+
+np.import_array()
+
+from statsmodels.src.math cimport *
+cimport scipy.linalg.cython_blas as blas
+cimport scipy.linalg.cython_lapack as lapack
+cimport statsmodels.tsa.statespace._tools as tools
+
+{{for prefix, types in TYPES.items()}}
+from statsmodels.tsa.statespace._representation cimport {{prefix}}Statespace
+{{endfor}}
+
+cdef int FORTRAN = 1
+
+{{for prefix, types in TYPES.items()}}
+{{py:cython_type, dtype, typenum = types}}
+{{py:
+combined_prefix = prefix
+combined_cython_type = cython_type
+if prefix == 'c':
+    combined_prefix = 'z'
+    combined_cython_type = 'np.complex128_t'
+if prefix == 's':
+    combined_prefix = 'd'
+    combined_cython_type = 'np.float64_t'
+}}
+
+## State Space Initialization
+cdef class {{prefix}}Initialization(object):
+
+    def __init__(self, int k_states, {{cython_type}} [:] constant,
+                 {{cython_type}} [::1, :] stationary_cov,
+                 np.float64_t approximate_diffuse_variance=1e6):
+        cdef:
+            int k
+            np.npy_intp dim1[1]
+            np.npy_intp dim2[2]
+
+        self.k_states = k_states
+        self.constant = constant
+        self.stationary_cov = stationary_cov
+        self.approximate_diffuse_variance = approximate_diffuse_variance
+
+        # Validate
+        tools.validate_vector_shape('known constant', &self.constant.shape[0], self.k_states, None)
+        tools.validate_matrix_shape('known covariance', &self.stationary_cov.shape[0], self.k_states, self.k_states, None)
+
+        # Internal temporary matrices
+        dim2[0] = self.k_states; dim2[0] = self.k_states;
+        self._tmp_transition = np.PyArray_ZEROS(2, dim2, {{typenum}}, FORTRAN)
+        dim2[0] = self.k_states; dim2[0] = self.k_states;
+        self._tmp_selected_state_cov = np.PyArray_ZEROS(2, dim2, {{typenum}}, FORTRAN)
+
+    cpdef int initialize(self, initialization_type, int offset,
+                         {{prefix}}Statespace model,
+                         {{cython_type}} [:] initial_state_mean,
+                         {{cython_type}} [::1, :] initial_diffuse_state_cov,
+                         {{cython_type}} [::1, :] initial_stationary_state_cov,
+                         int complex_step=False) except 1:
+
+        if initialization_type == 'known':
+            self.initialize_known_constant(offset, initial_state_mean)
+            self.initialize_known_stationary_cov(offset, initial_stationary_state_cov)
+            self.clear_cov(offset, initial_diffuse_state_cov)
+        elif initialization_type == 'diffuse':
+            self.initialize_diffuse(offset, initial_diffuse_state_cov)
+            self.clear_constant(offset, initial_state_mean)
+            self.clear_cov(offset, initial_stationary_state_cov)
+        elif initialization_type == 'approximate_diffuse':
+            self.initialize_known_constant(offset, initial_state_mean)
+            self.initialize_approximate_diffuse(offset, initial_stationary_state_cov)
+            self.clear_cov(offset, initial_diffuse_state_cov)
+        elif initialization_type == 'stationary':
+            self.initialize_stationary_constant(offset, model, initial_state_mean, complex_step)
+            self.initialize_stationary_stationary_cov(offset, model, initial_stationary_state_cov, complex_step)
+            self.clear_cov(offset, initial_diffuse_state_cov)
+        else:
+            raise ValueError('Invalid initialization type')
+
+        return 0
+
+    cdef int clear_constant(self, int offset, {{cython_type}} [:] initial_state_mean) except 1:
+        initial_state_mean[offset:offset + self.k_states] = 0
+        return 0
+
+    cdef int clear_cov(self, int offset, {{cython_type}} [::1, :] cov) except 1:
+        cov[offset:offset + self.k_states, offset:offset + self.k_states] = 0
+        return 0
+
+    cdef int initialize_known_constant(self, int offset,
+                                        {{cython_type}} [:] initial_state_mean) except 1:
+        cdef int inc = 1
+        blas.{{prefix}}copy(&self.k_states, &self.constant[0], &inc,
+                                     &initial_state_mean[offset], &inc)
+
+        return 0
+
+    cdef int initialize_known_stationary_cov(self, int offset,
+                                              {{cython_type}} [::1, :] initial_stationary_state_cov) except 1:
+        cdef int i, inc = 1
+        # Copy columns
+        for i in range(self.k_states):
+            blas.{{prefix}}copy(&self.k_states, &self.stationary_cov[0, i], &inc,
+                                         &initial_stationary_state_cov[offset, offset + i], &inc)
+
+        return 0
+
+    cdef int initialize_diffuse(self, int offset,
+                                 {{cython_type}} [::1, :] initial_diffuse_state_cov) except 1:
+        cdef int i
+        for i in range(offset, offset + self.k_states):
+            initial_diffuse_state_cov[i, i] = 1
+
+        return 0
+
+    cdef int initialize_approximate_diffuse(self, int offset,
+                                             {{cython_type}} [::1, :] initial_stationary_state_cov) except 1:
+        cdef int i
+        for i in range(offset, offset + self.k_states):
+            initial_stationary_state_cov[i, i] = self.approximate_diffuse_variance
+
+        return 0
+
+    cdef int initialize_stationary_constant(self, int offset, {{prefix}}Statespace model,
+                                    {{cython_type}} [:] initial_state_mean,
+                                    int complex_step=False) except 1:
+
+        cdef:
+            np.npy_intp dim2[2]
+            int i, info, inc = 1
+            int k_states2 = self.k_states**2
+            np.float64_t asum, tol = 1e-9
+            cdef {{cython_type}} scalar
+            cdef int [::1,:] ipiv
+
+        # Clear the unconditional mean (for this block)
+        initial_state_mean[offset:offset + self.k_states] = 0
+
+        # Check if the state intercept is all zeros; if it is, then the
+        # unconditional mean is also all zeros
+        {{if combined_prefix == 'd'}}
+        asum = blas.{{prefix}}asum(&model.k_states, &model.state_intercept[0, 0], &inc)
+        {{elif prefix == 'c'}}
+        asum = blas.scasum(&model.k_states, &model.state_intercept[0, 0], &inc)
+        {{else}}
+        asum = blas.dzasum(&model.k_states, &model.state_intercept[0, 0], &inc)
+        {{endif}}
+
+        # If the state intercept is non-zero, compute the mean
+        if asum > tol:
+            dim2[0] = self.k_states
+            dim2[1] = self.k_states
+            ipiv = np.PyArray_ZEROS(2, dim2, np.NPY_INT32, FORTRAN)
+
+            # Create T - I
+            # (copy colummns)
+            for i in range(self.k_states):
+                blas.{{prefix}}copy(&self.k_states, &model.transition[offset,offset + i,0], &inc,
+                                                    &self._tmp_transition[0,i], &inc)
+                self._tmp_transition[i, i] = self._tmp_transition[i, i] - 1
+            # Multiply by -1 to get I - T
+            scalar = -1.0
+            blas.{{prefix}}scal(&k_states2, &scalar, &self._tmp_transition[0, 0], &inc)
+
+            # c
+            blas.{{prefix}}copy(&self.k_states, &model.state_intercept[offset,0], &inc,
+                                                &initial_state_mean[offset], &inc)
+
+            # Solve (I - T) x = c
+            lapack.{{prefix}}getrf(&self.k_states, &self.k_states, &self._tmp_transition[0, 0], &self.k_states,
+                                   &ipiv[0, 0], &info)
+            lapack.{{prefix}}getrs('N', &self.k_states, &inc, &self._tmp_transition[0, 0], &self.k_states,
+                                   &ipiv[0, 0], &initial_state_mean[offset], &self.k_states, &info)
+
+        return 0
+
+    cdef int initialize_stationary_stationary_cov(self, int offset, {{prefix}}Statespace model,
+                                        {{cython_type}} [::1, :] initial_stationary_state_cov,
+                                        int complex_step=False) except 1:
+        cdef:
+            int i, inc = 1
+            int k_states2 = self.k_states**2
+
+        # Create selected state covariance matrix
+        tools._{{prefix}}select_cov(self.k_states, model.k_posdef, model.k_states,
+                             &self._tmp_transition[0,0],
+                             &model.selection[offset,0,0],
+                             &model.state_cov[0,0,0],
+                             &self._tmp_selected_state_cov[0,0])
+
+        # Create a copy of the transition matrix
+        # (copy colummns)
+        for i in range(self.k_states):
+            blas.{{prefix}}copy(&self.k_states, &model.transition[offset,offset + i,0], &inc,
+                                                &self._tmp_transition[0,i], &inc)
+
+        # Solve the discrete Lyapunov equation to the get initial state
+        # covariance matrix
+        tools._{{prefix}}solve_discrete_lyapunov(
+            &self._tmp_transition[0,0], &self._tmp_selected_state_cov[0,0], self.k_states, complex_step)
+
+        # Copy into initial_stationary_state_cov
+        # (copy colummns)
+        for i in range(self.k_states):
+            blas.{{prefix}}copy(&self.k_states, &self._tmp_selected_state_cov[0,i], &inc,
+                                                &initial_stationary_state_cov[offset,offset + i], &inc)
+
+        return 0
+
+
+{{endfor}}

--- a/statsmodels/tsa/statespace/_representation.pxd
+++ b/statsmodels/tsa/statespace/_representation.pxd
@@ -17,7 +17,7 @@ cdef class sStatespace(object):
     # Statespace representation matrices
     cdef readonly np.float32_t [::1,:] obs, obs_intercept, state_intercept
     cdef readonly np.float32_t [:] initial_state
-    cdef readonly np.float32_t [::1,:] initial_state_cov
+    cdef readonly np.float32_t [::1,:] initial_state_cov, initial_diffuse_state_cov
     cdef readonly np.float32_t [::1,:,:] design, obs_cov, transition, selection, state_cov, selected_state_cov
 
     cdef readonly int [::1,:] missing
@@ -65,6 +65,7 @@ cdef class sStatespace(object):
     cdef np.float32_t * _selected_state_cov
     cdef np.float32_t * _initial_state
     cdef np.float32_t * _initial_state_cov
+    cdef np.float32_t * _initial_diffuse_state_cov
 
     # Current location
     cdef int t
@@ -90,7 +91,7 @@ cdef class dStatespace(object):
     # Statespace representation matrices
     cdef readonly np.float64_t [::1,:] obs, obs_intercept, state_intercept
     cdef readonly np.float64_t [:] initial_state
-    cdef readonly np.float64_t [::1,:] initial_state_cov
+    cdef readonly np.float64_t [::1,:] initial_state_cov, initial_diffuse_state_cov
     cdef readonly np.float64_t [::1,:,:] design, obs_cov, transition, selection, state_cov, selected_state_cov
 
     cdef readonly int [::1,:] missing
@@ -138,6 +139,7 @@ cdef class dStatespace(object):
     cdef np.float64_t * _selected_state_cov
     cdef np.float64_t * _initial_state
     cdef np.float64_t * _initial_state_cov
+    cdef np.float64_t * _initial_diffuse_state_cov
 
     # Current location
     cdef int t
@@ -163,7 +165,7 @@ cdef class cStatespace(object):
     # Statespace representation matrices
     cdef readonly np.complex64_t [::1,:] obs, obs_intercept, state_intercept
     cdef readonly np.complex64_t [:] initial_state
-    cdef readonly np.complex64_t [::1,:] initial_state_cov
+    cdef readonly np.complex64_t [::1,:] initial_state_cov, initial_diffuse_state_cov
     cdef readonly np.complex64_t [::1,:,:] design, obs_cov, transition, selection, state_cov, selected_state_cov
 
     cdef readonly int [::1,:] missing
@@ -211,6 +213,7 @@ cdef class cStatespace(object):
     cdef np.complex64_t * _selected_state_cov
     cdef np.complex64_t * _initial_state
     cdef np.complex64_t * _initial_state_cov
+    cdef np.complex64_t * _initial_diffuse_state_cov
 
     # Current location
     cdef int t
@@ -236,7 +239,7 @@ cdef class zStatespace(object):
     # Statespace representation matrices
     cdef readonly np.complex128_t [::1,:] obs, obs_intercept, state_intercept
     cdef readonly np.complex128_t [:] initial_state
-    cdef readonly np.complex128_t [::1,:] initial_state_cov
+    cdef readonly np.complex128_t [::1,:] initial_state_cov, initial_diffuse_state_cov
     cdef readonly np.complex128_t [::1,:,:] design, obs_cov, transition, selection, state_cov, selected_state_cov
 
     cdef readonly int [::1,:] missing
@@ -284,6 +287,7 @@ cdef class zStatespace(object):
     cdef np.complex128_t * _selected_state_cov
     cdef np.complex128_t * _initial_state
     cdef np.complex128_t * _initial_state_cov
+    cdef np.complex128_t * _initial_diffuse_state_cov
 
     # Current location
     cdef int t

--- a/statsmodels/tsa/statespace/_representation.pyx.in
+++ b/statsmodels/tsa/statespace/_representation.pyx.in
@@ -393,6 +393,9 @@ cdef class {{prefix}}Statespace(object):
                 self.initialize(block_init, offset=offset + block_index[0],
                                 complex_step=complex_step, clear=False)
 
+        if not self.initialized:
+            self.initialized = True
+
     # ## Initialize: known values
     #
     # Initialize the filter with specific values, assumed to be known with

--- a/statsmodels/tsa/statespace/_representation.pyx.in
+++ b/statsmodels/tsa/statespace/_representation.pyx.in
@@ -32,6 +32,10 @@ cimport scipy.linalg.cython_blas as blas
 cimport scipy.linalg.cython_lapack as lapack
 cimport statsmodels.tsa.statespace._tools as tools
 
+{{for prefix, types in TYPES.items()}}
+from statsmodels.tsa.statespace._initialization cimport {{prefix}}Initialization
+{{endfor}}
+
 cdef int FORTRAN = 1
 
 {{for prefix, types in TYPES.items()}}
@@ -265,6 +269,14 @@ cdef class {{prefix}}Statespace(object):
         dim2[0] = self.k_states; dim2[1] = self.k_states;
         self.tmp = np.PyArray_ZEROS(2, dim2, {{typenum}}, FORTRAN)
 
+        # Arrays for initialization
+        dim1[0] = self.k_states;
+        self.initial_state = np.PyArray_ZEROS(1, dim1, {{typenum}}, FORTRAN)
+        dim2[0] = self.k_states; dim2[1] = self.k_states;
+        self.initial_state_cov = np.PyArray_ZEROS(2, dim2, {{typenum}}, FORTRAN)
+        dim2[0] = self.k_states; dim2[1] = self.k_states;
+        self.initial_diffuse_state_cov = np.PyArray_ZEROS(2, dim2, {{typenum}}, FORTRAN)
+
         # Arrays for missing data
         dim1[0] = self.k_endog;
         self.selected_obs = np.PyArray_ZEROS(1, dim1, {{typenum}}, FORTRAN)
@@ -357,6 +369,29 @@ cdef class {{prefix}}Statespace(object):
         self.collapse_loglikelihood = state['collapse_loglikelihood']
         self.companion_transition = state['companion_transition']
         self.transform_determinant = state['transform_determinant']
+
+    def initialize(self, init, offset=0, complex_step=False, clear=True):
+        cdef {{prefix}}Initialization _init
+        # Clear initial arrays
+        if clear:
+            self.initial_state[:] = 0
+            self.initial_diffuse_state_cov[:] = 0
+            self.initial_state_cov[:] = 0
+
+        # If using global initialization, compute the actual elements and
+        # return them
+        if init.initialization_type is not None:
+            init._initialize_initialization(prefix='{{prefix}}')
+            _init = init._initializations['{{prefix}}']
+            _init.initialize(init.initialization_type, offset, self,
+                             self.initial_state,
+                             self.initial_diffuse_state_cov,
+                             self.initial_state_cov, complex_step)
+        # Otherwise, if using blocks, initialize each of the blocks
+        else:
+            for block_index, block_init in init.blocks.items():
+                self.initialize(block_init, offset=offset + block_index[0],
+                                complex_step=complex_step, clear=False)
 
     # ## Initialize: known values
     #

--- a/statsmodels/tsa/statespace/_tools.pxd
+++ b/statsmodels/tsa/statespace/_tools.pxd
@@ -118,3 +118,28 @@ cpdef int scopy_index_vector(np.float32_t [::1, :] A, np.float32_t [::1, :] B, i
 cpdef int dcopy_index_vector(np.float64_t [::1, :] A, np.float64_t [::1, :] B, int [::1, :] index) except *
 cpdef int ccopy_index_vector(np.complex64_t [::1, :] A, np.complex64_t [::1, :] B, int [::1, :] index) except *
 cpdef int zcopy_index_vector(np.complex128_t [::1, :] A, np.complex128_t [::1, :] B, int [::1, :] index) except *
+
+cdef int _sselect_cov(int k_states, int k_posdef, int k_states_total,
+                           np.float32_t * tmp,
+                           np.float32_t * selection,
+                           np.float32_t * cov,
+                           np.float32_t * selected_cov)
+
+cdef int _dselect_cov(int k_states, int k_posdef, int k_states_total,
+                           np.float64_t * tmp,
+                           np.float64_t * selection,
+                           np.float64_t * cov,
+                           np.float64_t * selected_cov)
+
+cdef int _cselect_cov(int k_states, int k_posdef, int k_states_total,
+                           np.complex64_t * tmp,
+                           np.complex64_t * selection,
+                           np.complex64_t * cov,
+                           np.complex64_t * selected_cov)
+
+cdef int _zselect_cov(int k_states, int k_posdef, int k_states_total,
+                           np.complex128_t * tmp,
+                           np.complex128_t * selection,
+                           np.complex128_t * cov,
+                           np.complex128_t * selected_cov)
+

--- a/statsmodels/tsa/statespace/_tools.pyx.in
+++ b/statsmodels/tsa/statespace/_tools.pyx.in
@@ -1095,4 +1095,43 @@ cpdef int {{prefix}}copy_index_vector({{cython_type}} [::1, :] A, {{cython_type}
             A_t = t
         _{{prefix}}copy_index_rows(&A[0, A_t], &B[0, t], &index[0, t], n, 1)
 
+cdef int _{{prefix}}select_cov(int k_states, int k_posdef, int k_states_total,
+                               {{cython_type}} * tmp,
+                               {{cython_type}} * selection,
+                               {{cython_type}} * cov,
+                               {{cython_type}} * selected_cov):
+    cdef:
+        int i, k_states2 = k_states**2
+        {{cython_type}} alpha = 1.0
+        {{cython_type}} beta = 0.0
+
+    # Only need to do something if there is a covariance matrix
+    # (i.e k_posdof == 0)
+    if k_posdef > 0:
+
+        # #### Calculate selected state covariance matrix  
+        # $Q_t^* = R_t Q_t R_t'$
+        # 
+        # Combine a selection matrix and a covariance matrix to get
+        # a simplified (but possibly singular) "selected" covariance
+        # matrix (see e.g. Durbin and Koopman p. 43)
+
+        # `tmp0` array used here, dimension $(m \times r)$  
+
+        # $\\#_0 = 1.0 * R_t Q_t$  
+        # $(m \times r) = (m \times r) (r \times r)$
+        blas.{{prefix}}gemm("N", "N", &k_states, &k_posdef, &k_posdef,
+              &alpha, selection, &k_states_total,
+                      cov, &k_posdef,
+              &beta, tmp, &k_states)
+        # $Q_t^* = 1.0 * \\#_0 R_t'$  
+        # $(m \times m) = (m \times r) (m \times r)'$
+        blas.{{prefix}}gemm("N", "T", &k_states, &k_states, &k_posdef,
+              &alpha, tmp, &k_states,
+                      selection, &k_states_total,
+              &beta, selected_cov, &k_states)
+    else:
+        for i in range(k_states2):
+            selected_cov[i] = 0
+
 {{endfor}}

--- a/statsmodels/tsa/statespace/initialization.py
+++ b/statsmodels/tsa/statespace/initialization.py
@@ -1,0 +1,547 @@
+"""
+State Space Representation - Initialization
+
+Author: Chad Fulton
+License: Simplified-BSD
+"""
+import warnings
+
+import numpy as np
+
+from .tools import solve_discrete_lyapunov
+
+
+class Initialization(object):
+    """
+    State space initialization
+
+    Parameters
+    ----------
+    k_states : int
+    exact_diffuse_initialization : bool, optional
+        Whether or not to use exact diffuse initialization; only has an effect
+        if some states are initialized as diffuse. Default is True.
+    approximate_diffuse_variance : float, optional
+        If using approximate diffuse initialization, the initial variance used.
+        Default is 1e6.
+
+    Notes
+    -----
+    As developed in Durbin and Koopman (2012), the state space recursions
+    must be initialized for the first time period. The general form of this
+    initialization is:
+
+    .. math::
+
+        \alpha_1 & = a + A \delta + R_0 \eta_0 \\
+        \delta & \sim N(0, \kappa I), \kappa \to \infty \\
+        \eta_0 & \sim N(0, Q_0)
+
+    Thus the state vector can be initialized with a known constant part
+    (elements of :math:`a`), with part modeled as a diffuse initial
+    distribution (as a part of :math:`\delta`), and with a part modeled as a
+    known (proper) initial distribution (as a part of :math:`\eta_0`).
+
+    There are two important restrictions:
+
+    1. An element of the state vector initialized as diffuse cannot be also
+       modeled with a stationary component. In the `validate` method,
+       violations of this cause an exception to be raised.
+    2. If an element of the state vector is initialized with both a known
+       constant part and with a diffuse initial distribution, the effect of
+       the diffuse initialization will essentially ignore the given known
+       constant value. In the `validate` method, violations of this cause a
+       warning to be given, since it is not technically invalid but may
+       indicate user error.
+
+    The :math:`\eta_0` compoenent is also referred to as the stationary part
+    because it is often set to the unconditional distribution of a stationary
+    process.
+
+    Initialization is specified for blocks (consecutive only, for now) of the
+    state vector, with the entire state vector and individual elements as
+    special cases. Denote the block in question as :math:`\alpha_1^{(i)}`. It
+    can be initialized in the following ways:
+
+    - 'known'
+    - 'diffuse' or 'exact_diffuse' or 'approximate_diffuse'
+    - 'stationary'
+    - 'mixed'
+
+    In the first three cases, the block's initialization is specified as an
+    instance of the `Initialization` class, with the `initialization_type`
+    attribute set to one of those three string values. In the 'mixed' cases,
+    the initialization is also an instance of the `Initialization` class, but
+    it will itself contain sub-blocks. Details of each type follow.
+
+    Regardless of the type, for each block, the following must be defined:
+    the `constant` array, an array `diffuse` with indices corresponding to
+    diffuse elements, an array `stationary` with indices corresponding to
+    stationary elements, and `stationary_cov`, a matrix with order equal to the
+    number of stationary elements in the block.
+
+    **Known**
+
+    If a block is initialized as known, then a known (possibly degenerate)
+    distribution is used; in particular, the block of states is understood to
+    be distributed
+    :math:`\alpha_1^{(i)} \sim N(a^{(i)}, Q_0^{(i)})`. Here, is is possible to
+    set :math:`a^{(i)} = 0`, and it is also possible that
+    :math:`Q_0^{(i)}` is only positive-semidefinite; i.e.
+    :math:`\alpha_1^{(i)}` may be degenerate. One particular example is
+    that if the entire block's initial values are known, then
+    :math:`R_0^{(i)} = 0`, and so `Var(\alpha_1^{(i)}) = 0`.
+
+    Here, `constant` must be provided (although it can be zeros), and
+    `stationary_cov` is optional (by default it is a matrix of zeros).
+
+    **Diffuse**
+
+    If a block is initialized as diffuse, then set
+    :math:`\alpha_1^{(i)} \sim N(a^{(i)}, \kappa^{(i)} I)`. If the block is
+    initialized using the exact diffuse initialization procedure, then it is
+    understood that :math:`\kappa^{(i)} \to \infty`.
+
+    If the block is initialized using the approximate diffuse initialization
+    procedure, then `\kappa^{(i)}` is set to some large value rather than
+    driven to infinity.
+
+    In the approximate diffuse initialization case, it is possible, although
+    unlikely, that a known constant value may have some effect on
+    initialization if :math:`\kappa^{(i)}` is not set large enough.
+
+    Here, `constant` may be provided, and `approximate_diffuse_variance` may be
+    provided.
+
+    **Stationary**
+
+    If a block is initialized as stationary, then the block of states is
+    understood to have the distribution
+    :math:`\alpha_1^{(i)} \sim N(a^{(i)}, Q_0^{(i)})`. :math:`a^{(i)}` is
+    the unconditional mean of the block, computed as
+    :math:`(I - T^{(i)})^{-1} c_t`. :math:`Q_0^{(i)}` is the unconditional
+    variance of the block, computed as the solution to the discrete Lyapunov
+    equation:
+
+    .. math::
+
+        T^{(i)} Q_0^{(i)} T^{(i)} + (R Q R')^{(i)} = Q_0^{(i)}
+
+    :math:`T^{(i)}` and :math:`(R Q R')^{(i)}` are the submatrices of
+    the corresponding state space system matrices corresponding to the given
+    block of states.
+
+    Here, no values can be provided.
+
+    **Mixed**
+
+    In this case, the block can be further broken down into sub-blocks.
+    Usually, only the top-level `Initialization` instance will be of 'mixed'
+    type, and in many cases, even the top-level instance will be purely
+    'known', 'diffuse', or 'stationary'.
+
+    For a block of type mixed, suppose that it has `J` sub-blocks,
+    :math:`\alpha_1^{(i,j)}`. Then
+    :math:`\alpha_1^{(i)} = a^{(i)} + A^{(i)} \delta + R_0^{(i)} \eta_0^{(i)}`.
+
+    Examples
+    --------
+
+    Basic examples have one specification for all of the states:
+
+    >>> Initialization(k_states=2, 'known', constant=[0, 1])
+    >>> Initialization(k_states=2, 'known', stationary_cov=np.eye(2))
+    >>> Initialization(k_states=2, 'known', constant=[0, 1],
+                       stationary_cov=np.eye(2))
+    >>> Initialization(k_states=2, 'diffuse')
+    >>> Initialization(k_states=2, 'approximate_diffuse',
+                       approximate_diffuse_variance=1e6)
+    >>> Initialization(k_states=2, 'stationary')
+
+    More complex examples initialize different blocks of states separately
+
+    >>> init = Initialization(k_states=3)
+    >>> init.set((0, 1), 'known', constant=[0, 1])
+    >>> init.set((0, 1), 'known', stationary_cov=np.eye(2))
+    >>> init.set((0, 1), 'known', constant=[0, 1],
+                 stationary_cov=np.eye(2))
+    >>> init.set((0, 1), 'diffuse')
+    >>> init.set((0, 1), 'approximate_diffuse',
+                 approximate_diffuse_variance=1e6)
+    >>> init.set((0, 1), 'stationary')
+
+    A still more complex example initializes a block using a previously
+    created `Initialization` object:
+
+    >>> init1 = Initialization(k_states=2, 'known', constant=[0, 1])
+    >>> init2 = Initialization(k_states=3)
+    >>> init2.set((1, 2), init1)
+
+    """
+
+    def __init__(self, k_states, initialization_type=None, **kwargs):
+        # Parameters
+        self.k_states = k_states
+
+        # Attributes handling blocks of states with different initializations
+        self._states = tuple(np.arange(k_states))
+        self._initialization = np.array([None] * k_states)
+        self.blocks = {}
+
+        # Attributes handling initialization of the entire set of states
+        # `constant` is a vector of constant values (i.e. it is the vector
+        # a from DK)
+        self.initialization_type = None
+        self.constant = None
+        self.stationary_cov = None
+        self.approximate_diffuse_variance = None
+
+        # If given a global initialization, use it now
+        if initialization_type is not None:
+            self.set(None, initialization_type, **kwargs)
+
+    def set(self, index, initialization_type, constant=None,
+            stationary_cov=None, approximate_diffuse_variance=None):
+        """
+        Set initialization for states, either globally or for a block
+
+        Parameters
+        ----------
+        index : tuple or int or None
+            Arguments used to create a `slice` of states. Can be a tuple with
+            `(start, stop)` (note that for `slice`, stop is not inclusive), or
+            an integer (to select a specific state), or None (to select all the
+            states).
+        initialization_type : str
+            The type of initialization used for the states selected by `index`.
+            Must be one of 'known', 'diffuse', 'approximate_diffuse', or
+            'stationary'.
+        constant : array-like, optional
+            A vector of constant values, denoted :math:`a`. Most often used
+            with 'known' initialization, but may also be used with
+            'approximate_diffuse' (although it will then likely have little
+            effect).
+        stationary_cov : array-like, optional
+            The covariance matrix of the stationary part, denoted :math:`Q_0`.
+            Only used with 'known' initialization.
+        approximate_diffuse_variance : float, optional
+            The approximate diffuse variance, denoted :math:`\kappa`. Only
+            applicable with 'approximate_diffuse' initialization. Default is
+            1e6.
+        """
+        # Construct the index, using a slice object as an intermediate step
+        # to enforce regularity
+        if isinstance(index, int):
+            if index < 0 or index >= self.k_states:
+                raise ValueError('Invalid index.')
+            index = (index, index + 1)
+        elif index is None:
+            index = (index,)
+        elif not isinstance(index, tuple):
+            raise ValueError('Invalid index.')
+        if len(index) > 2:
+            raise ValueError('Cannot include a slice step in `index`.')
+        index = self._states[slice(*index)]
+
+        # Make sure that we are not setting a block when global initialization
+        # was previously set
+        if self.initialization_type is not None and not index == self._states:
+            raise ValueError('Cannot set initialization for the block of'
+                             '  states %s because initialization was'
+                             ' previously performed globally. You must either'
+                             ' re-initialize globally or'
+                             ' else unset the global initialization before'
+                             ' initializing specific blocks of states.'
+                             % str(index))
+        # Make sure that we are not setting a block that *overlaps* with
+        # another block (although we are free to *replace* an entire block)
+        uninitialized = np.equal(self._initialization[index, ], None)
+        if index not in self.blocks and not np.all(uninitialized):
+            raise ValueError('Cannot set initialization for the state(s) %s'
+                             ' because they are a subset of a previously'
+                             ' initialized block. You must either'
+                             ' re-initialize the entire block as a whole or'
+                             ' else unset the entire block before'
+                             ' re-initializing the subset.'
+                             % str(np.array(index)[~uninitialized]))
+
+        # If setting for all states, set this object's initialization
+        # attributes
+        k_states = len(index)
+        if k_states == self.k_states:
+            self.initialization_type = initialization_type
+
+            # General validation
+            if (approximate_diffuse_variance is not None and
+                    not initialization_type == 'approximate_diffuse'):
+                raise ValueError('`approximate_diffuse_variance` can only be'
+                                 ' provided when using approximate diffuse'
+                                 ' initialization.')
+            if (stationary_cov is not None and
+                    not initialization_type == 'known'):
+                raise ValueError('`stationary_cov` can only be provided when'
+                                 ' using known initialization.')
+
+            # Specific initialization handling
+            if initialization_type == 'known':
+                # Make sure we were given some known initialization
+                if constant is None and stationary_cov is None:
+                    raise ValueError('Must specify either the constant vector'
+                                     ' or the stationary covariance matrix'
+                                     ' (or both) if using known'
+                                     ' initialization.')
+                # Defaults
+                if stationary_cov is None:
+                    stationary_cov = np.zeros((k_states, k_states))
+                else:
+                    stationary_cov = np.array(stationary_cov)
+
+                # Validate
+                if not stationary_cov.shape == (k_states, k_states):
+                    raise ValueError('Invalid stationary covariance matrix;'
+                                     ' given shape %s but require shape %s.'
+                                     % (str(stationary_cov.shape),
+                                        str((k_states, k_states))))
+
+                # Set values
+                self.stationary_cov = stationary_cov
+            elif initialization_type == 'diffuse':
+                if constant is not None:
+                    warnings.warn('Constant values provided, but they are'
+                                  ' ignored in exact diffuse initialization.')
+            elif initialization_type == 'approximate_diffuse':
+                if approximate_diffuse_variance is None:
+                    approximate_diffuse_variance = 1e6
+                self.approximate_diffuse_variance = (
+                    approximate_diffuse_variance)
+            elif initialization_type == 'stationary':
+                if constant is not None:
+                    raise ValueError('Constant values cannot be provided for'
+                                     ' stationary initialization.')
+            else:
+                raise ValueError('Invalid initialization type.')
+
+            # Handle constant
+            if constant is None:
+                constant = np.zeros(k_states)
+            else:
+                constant = np.array(constant)
+            if not constant.shape == (k_states,):
+                raise ValueError('Invalid constant vector; given shape %s'
+                                 ' but require shape %s.'
+                                 % (str(constant.shape), str((k_states,))))
+            self.constant = constant
+        # Otherwise, if setting a sub-block, construct the new initialization
+        # object
+        else:
+            init = Initialization(
+                k_states, initialization_type, constant=constant,
+                stationary_cov=stationary_cov,
+                approximate_diffuse_variance=approximate_diffuse_variance)
+
+            self.blocks[index] = init
+            for i in index:
+                self._initialization[i] = index
+
+    def unset(self, index):
+        """
+        Unset initialization for states, either globally or for a block
+
+        Parameters
+        ----------
+        index : tuple or int or None
+            Arguments used to create a `slice` of states. Can be a tuple with
+            `(start, stop)` (note that for `slice`, stop is not inclusive), or
+            an integer (to select a specific state), or None (to select all the
+            states).
+
+        Notes
+        -----
+        Note that this specifically unsets initializations previously created
+        using `set` with this same index. Thus you cannot use `index=None` to
+        unset all initializations, but only to unset a previously set global
+        initialization. To unset all initializations (including both global and
+        block level), use the `clear` method.
+        """
+        if isinstance(index, int):
+            if index < 0 or index > self.k_states:
+                raise ValueError('Invalid index.')
+            index = (index, index + 1)
+        elif index is None:
+            index = (index,)
+        elif not isinstance(index, tuple):
+            raise ValueError('Invalid index.')
+        if len(index) > 2:
+            raise ValueError('Cannot include a slice step in `index`.')
+        index = self._states[slice(*index)]
+
+        # Unset the values
+        k_states = len(index)
+        if k_states == self.k_states and self.initialization_type is not None:
+            self.initialization_type = None
+            self.constant = None
+            self.stationary_cov = None
+            self.approximate_diffuse_variance = None
+        elif index in self.blocks:
+            for i in index:
+                self._initialization[i] = None
+            del self.blocks[index]
+        else:
+            raise ValueError('The given index does not correspond to a'
+                             ' previously initialized block.')
+
+    def clear(self):
+        """
+        Clear all previously set initializations, either global or block level
+        """
+        # Clear initializations
+        for i in self._states:
+            self._initialization[i] = None
+
+        # Delete block initializations
+        keys = list(self.blocks.keys())
+        for key in keys:
+            del self.blocks[key]
+
+        # Clear global attributes
+        self.initialization_type = None
+        self.constant = None
+        self.stationary_cov = None
+        self.approximate_diffuse_variance = None
+
+    def __call__(self, model=None, state_intercept=None, transition=None,
+                 selected_state_cov=None, complex_step=False):
+        """
+        Construct initialization representation
+
+        Parameters
+        ----------
+        model : Representation, optional
+            A state space model representation object, optional if 'stationary'
+            initialization is used and ignored otherwise. See notes for
+            details in the stationary initialization case.
+        state_intercept : array, optional
+            The state intercept of the model, optional if 'stationary'
+            initialization is used and ignored otherwise. See notes for
+            details in the stationary initialization case.
+        transition : array, optional
+            The transition matrix of the model, optional if 'stationary'
+            initialization is used and ignored otherwise. See notes for
+            details in the stationary initialization case.
+        selected_state_cov : array, optional
+            The selected state covariance matrix of the model, optional if
+            'stationary' initialization is used and ignored otherwise. See
+            notes for details in the stationary initialization case.
+
+        Returns
+        -------
+        initial_state_mean : array
+            Initial state mean, :math:`a_1^{(0)} = a`
+        initial_diffuse_state_cov : array
+            Diffuse component of initial state covariance matrix,
+            :math:`P_\infty = A A'`
+        initial_stationary_state_cov : array
+            Stationary component of initial state covariance matrix,
+            :math:`P_* = R_0 Q_0 R_0'`
+
+        Notes
+        -----
+        If stationary initialization is used either globally or for any block
+        of states, then either `model` or all of `state_intercept`,
+        `transition`, `selection`, and `state_cov` must be provided.
+        """
+        # Check that all states are initialized somehow
+        if (self.initialization_type is None and
+                np.any(np.equal(self._initialization, None))):
+            raise ValueError('Cannot construct initialization representation'
+                             ' because not all states have been initialized.')
+
+        # Retrieve state_intercept, etc. if `model` was given
+        if model is not None:
+            state_intercept = model['state_intercept', :, 0]
+            transition = model['transition', :, :, 0]
+            selection = model['selection', :, :, 0]
+            state_cov = model['state_cov', :, :, 0]
+            selected_state_cov = np.dot(selection, state_cov).dot(selection.T)
+
+        # If we have any of the model elements, make sure we have them all
+        have_model = (state_intercept is not None or transition is not None or
+                      selected_state_cov is not None)
+        missing_model = (state_intercept is None or transition is None or
+                         selected_state_cov is None)
+        if have_model and missing_model:
+            raise ValueError('If any of the arguments `state_intercept`,'
+                             ' `transition`, or `selected_state_cov` are'
+                             ' provided, then all of them must be provided'
+                             ' (alternatively, the `model` argument may be'
+                             ' used).')
+
+        # If using global initialization, compute the actual elements and
+        # return them
+        if self.initialization_type is not None:
+            eye = np.eye(self.k_states)
+            zeros = np.zeros((self.k_states, self.k_states))
+
+            # General validation
+            if self.initialization_type == 'stationary' and not have_model:
+                raise ValueError('Stationary initialization requires passing'
+                                 ' either the `model` argument or all of the'
+                                 ' individual transition equation arguments.')
+            if self.initialization_type == 'stationary':
+                # TODO performance
+                eigvals = np.linalg.eigvals(transition)
+                threshold = 1. - 1e-10
+                if not np.max(np.abs(eigvals)) < threshold:
+                    raise ValueError('Transition equation is not stationary,'
+                                     ' and so stationary initialization cannot'
+                                     ' be used.')
+
+            # Set the initial state mean
+            if self.initialization_type == 'stationary':
+                # TODO performance
+                initial_state_mean = np.linalg.solve(eye - transition,
+                                                     state_intercept)
+            else:
+                initial_state_mean = self.constant
+
+            # Set the diffuse component
+            if self.initialization_type == 'diffuse':
+                initial_diffuse_state_cov = np.eye(self.k_states)
+            else:
+                initial_diffuse_state_cov = zeros
+
+            # Set the stationary component
+            if self.initialization_type == 'known':
+                initial_stationary_state_cov = self.stationary_cov
+            elif self.initialization_type == 'diffuse':
+                initial_stationary_state_cov = zeros
+            elif self.initialization_type == 'approximate_diffuse':
+                initial_stationary_state_cov = (
+                    eye * self.approximate_diffuse_variance)
+            elif self.initialization_type == 'stationary':
+                # TODO performance
+                initial_stationary_state_cov = solve_discrete_lyapunov(
+                    transition, selected_state_cov, complex_step=complex_step)
+        # Otherwise, if using blocks, combine the elements returned by each of
+        # the blocks and return those
+        else:
+            initial_state_mean = np.zeros(self.k_states)
+            cov_shape = (self.k_states, self.k_states)
+            initial_diffuse_state_cov = np.zeros(cov_shape)
+            initial_stationary_state_cov = np.zeros(cov_shape)
+
+            for index, init in self.blocks.items():
+                ix = np.ix_(index, index)
+                kwargs = {}
+                if have_model:
+                    kwargs['state_intercept'] = state_intercept[index, ]
+                    kwargs['transition'] = transition[ix]
+                    kwargs['selected_state_cov'] = selected_state_cov[ix]
+                out = init(**kwargs)
+
+                initial_state_mean[index, ] = out[0]
+                initial_diffuse_state_cov[ix] = out[1]
+                initial_stationary_state_cov[ix] = out[2]
+
+        return (initial_state_mean, initial_diffuse_state_cov,
+                initial_stationary_state_cov)

--- a/statsmodels/tsa/statespace/initialization.py
+++ b/statsmodels/tsa/statespace/initialization.py
@@ -181,7 +181,7 @@ class Initialization(object):
 
     def __init__(self, k_states, initialization_type=None,
                  initialization_classes=None, approximate_diffuse_variance=1e6,
-                 **kwargs):
+                 constant=None, stationary_cov=None):
         # Parameters
         self.k_states = k_states
 
@@ -207,7 +207,8 @@ class Initialization(object):
 
         # If given a global initialization, use it now
         if initialization_type is not None:
-            self.set(None, initialization_type, **kwargs)
+            self.set(None, initialization_type, constant=constant,
+                     stationary_cov=stationary_cov)
 
     def _initialize_initialization(self, prefix):
         dtype = tools.prefix_dtype_map[prefix]

--- a/statsmodels/tsa/statespace/initialization.py
+++ b/statsmodels/tsa/statespace/initialization.py
@@ -286,6 +286,11 @@ class Initialization(object):
             raise ValueError('Cannot include a slice step in `index`.')
         index = self._states[slice(*index)]
 
+        # Compatibility with zero-length slices (can make it easier to set up
+        # initialization without lots of if statements)
+        if len(index) == 0:
+            return
+
         # Make sure that we are not setting a block when global initialization
         # was previously set
         if self.initialization_type is not None and not index == self._states:
@@ -419,6 +424,11 @@ class Initialization(object):
         if len(index) > 2:
             raise ValueError('Cannot include a slice step in `index`.')
         index = self._states[slice(*index)]
+
+        # Compatibility with zero-length slices (can make it easier to set up
+        # initialization without lots of if statements)
+        if len(index) == 0:
+            return
 
         # Unset the values
         k_states = len(index)

--- a/statsmodels/tsa/statespace/initialization.py
+++ b/statsmodels/tsa/statespace/initialization.py
@@ -381,13 +381,16 @@ class Initialization(object):
         # Otherwise, if setting a sub-block, construct the new initialization
         # object
         else:
-            if approximate_diffuse_variance is None:
-                approximate_diffuse_variance = (
-                    self.approximate_diffuse_variance)
-            init = Initialization(
-                k_states, initialization_type, constant=constant,
-                stationary_cov=stationary_cov,
-                approximate_diffuse_variance=approximate_diffuse_variance)
+            if isinstance(initialization_type, Initialization):
+                init = initialization_type
+            else:
+                if approximate_diffuse_variance is None:
+                    approximate_diffuse_variance = (
+                        self.approximate_diffuse_variance)
+                init = Initialization(
+                    k_states, initialization_type, constant=constant,
+                    stationary_cov=stationary_cov,
+                    approximate_diffuse_variance=approximate_diffuse_variance)
 
             self.blocks[index] = init
             for i in index:

--- a/statsmodels/tsa/statespace/representation.py
+++ b/statsmodels/tsa/statespace/representation.py
@@ -10,6 +10,7 @@ import numpy as np
 from .tools import (
     find_best_blas_type, validate_matrix_shape, validate_vector_shape
 )
+from .initialization import Initialization
 from . import tools
 
 
@@ -698,6 +699,9 @@ class Representation(object):
         return prefix, dtype, create
 
     def _initialize_state(self, prefix=None, complex_step=False):
+        # TODO once the transition to using the Initialization objects is
+        # complete, this should be moved entirely to the _{{prefix}}Statespace
+        # object.
         if prefix is None:
             prefix = self.prefix
         dtype = tools.prefix_dtype_map[prefix]
@@ -714,6 +718,10 @@ class Representation(object):
             )
         elif self.initialization == 'stationary':
             self._statespaces[prefix].initialize_stationary(complex_step)
+        elif isinstance(self.initialization, Initialization):
+            if not self.initialization.initialized:
+                raise RuntimeError('Initialization is incomplete.')
+            self._statespaces[prefix].initialize(self.initialization)
         else:
             raise RuntimeError('Statespace model not initialized.')
 

--- a/statsmodels/tsa/statespace/representation.py
+++ b/statsmodels/tsa/statespace/representation.py
@@ -721,7 +721,8 @@ class Representation(object):
         elif isinstance(self.initialization, Initialization):
             if not self.initialization.initialized:
                 raise RuntimeError('Initialization is incomplete.')
-            self._statespaces[prefix].initialize(self.initialization)
+            self._statespaces[prefix].initialize(self.initialization,
+                                                 complex_step=complex_step)
         else:
             raise RuntimeError('Statespace model not initialized.')
 

--- a/statsmodels/tsa/statespace/sarimax.py
+++ b/statsmodels/tsa/statespace/sarimax.py
@@ -11,6 +11,7 @@ from warnings import warn
 
 import numpy as np
 import pandas as pd
+from .initialization import Initialization
 from .kalman_filter import KalmanFilter
 from .mlemodel import MLEModel, MLEResults, MLEResultsWrapper
 from .tools import (
@@ -504,20 +505,11 @@ class SARIMAX(MLEModel):
         if self.k_exog > 0 or len(self.polynomial_trend) > 1:
             self.ssm._time_invariant = False
 
-        # Handle kwargs specified initialization
-        if self.ssm.initialization is not None:
-            self._manual_initialization = True
-
         # Initialize the fixed components of the statespace model
         self.ssm['design'] = self.initial_design
         self.ssm['state_intercept'] = self.initial_state_intercept
         self.ssm['transition'] = self.initial_transition
         self.ssm['selection'] = self.initial_selection
-
-        # If we are estimating a simple ARMA model, then we can use a faster
-        # initialization method (unless initialization was already specified).
-        if k_diffuse_states == 0 and not self._manual_initialization:
-            self.initialize_stationary()
 
         # update _init_keys attached by super
         self._init_keys += ['order',  'seasonal_order', 'trend',
@@ -526,6 +518,10 @@ class SARIMAX(MLEModel):
                             'enforce_stationarity', 'enforce_invertibility',
                             'hamilton_representation'] + list(kwargs.keys())
         # TODO: I think the kwargs or not attached, need to recover from ???
+
+        # Initialize the state
+        if self.ssm.initialization is None:
+            self.initialize_default()
 
     def _get_init_kwds(self):
         kwds = super(SARIMAX, self)._get_init_kwds()
@@ -594,11 +590,6 @@ class SARIMAX(MLEModel):
         """
         super(SARIMAX, self).initialize()
 
-        # Internal flag for whether the default mixed approximate diffuse /
-        # stationary initialization has been overridden with a user-supplied
-        # initialization
-        self._manual_initialization = False
-
         # Cache the indexes of included polynomial orders (for update below)
         # (but we do not want the index of the constant term, so exclude the
         # first index)
@@ -644,105 +635,30 @@ class SARIMAX(MLEModel):
             self._exog_variance_idx = ('state_cov', idx[0][-self.k_exog:],
                                        idx[1][-self.k_exog:])
 
-    def initialize_known(self, initial_state, initial_state_cov):
-        self._manual_initialization = True
-        self.ssm.initialize_known(initial_state, initial_state_cov)
-    initialize_known.__doc__ = KalmanFilter.initialize_known.__doc__
+    def initialize_default(self, approximate_diffuse_variance=None):
+        if approximate_diffuse_variance is None:
+            approximate_diffuse_variance = self.ssm.initial_variance
 
-    def initialize_approximate_diffuse(self, variance=None):
-        self._manual_initialization = True
-        self.ssm.initialize_approximate_diffuse(variance)
-    initialize_approximate_diffuse.__doc__ = (
-        KalmanFilter.initialize_approximate_diffuse.__doc__
-    )
+        init = Initialization(
+            self.k_states,
+            approximate_diffuse_variance=approximate_diffuse_variance)
 
-    def initialize_stationary(self):
-        self._manual_initialization = True
-        self.ssm.initialize_stationary()
-    initialize_stationary.__doc__ = (
-        KalmanFilter.initialize_stationary.__doc__
-    )
-
-    def initialize_state(self, variance=None, complex_step=False):
-        """
-        Initialize state and state covariance arrays in preparation for the
-        Kalman filter.
-
-        Parameters
-        ----------
-        variance : float, optional
-            The variance for approximating diffuse initial conditions. Default
-            can be found in the Representation class documentation.
-
-        Notes
-        -----
-        Initializes the ARMA component of the state space to the typical
-        stationary values and the other components as approximate diffuse.
-
-        Can be overridden be calling one of the other initialization methods
-        before fitting the model.
-        """
-        # Check if a manual initialization has already been specified
-        if self._manual_initialization:
-            return
-
-        # If we're not enforcing stationarity, then we can't initialize a
+        if self.enforce_stationarity:
+            # Differencing operators are at the beginning
+            init.set((0, self._k_states_diff), 'approximate_diffuse')
+            # Stationary component in the middle
+            init.set((self._k_states_diff, self._k_states_diff + self._k_order),
+                     'stationary')
+            # Regression components at the end
+            init.set((self._k_states_diff + self._k_order,
+                      self._k_states_diff + self._k_order + self.k_exog),
+                     'approximate_diffuse')
+        # If we're not enforcing a stationarity, then we can't initialize a
         # stationary component
-        if not self.enforce_stationarity:
-            self.initialize_approximate_diffuse(variance)
-            return
-
-        # Otherwise, create the initial state and state covariance matrix
-        # as from a combination of diffuse and stationary components
-
-        # Create initialized non-stationary components
-        if variance is None:
-            variance = self.ssm.initial_variance
-
-        dtype = self.ssm.transition.dtype
-        initial_state = np.zeros(self.k_states, dtype=dtype)
-        initial_state_cov = np.eye(self.k_states, dtype=dtype) * variance
-
-        # Get the offsets (from the bottom or bottom right of the vector /
-        # matrix) for the stationary component.
-        if self.state_regression:
-            start = -(self.k_exog + self._k_order)
-            end = -self.k_exog if self.k_exog > 0 else None
         else:
-            start = -self._k_order
-            end = None
+            init.set(None, 'approximate_diffuse')
 
-        # Add in the initialized stationary components
-        if self._k_order > 0:
-            transition = self.ssm['transition', start:end, start:end, 0]
-
-            # Initial state
-            # In the Harvey representation, if we have a trend that
-            # is put into the state intercept and means we have a non-zero
-            # unconditional mean
-            if not self.hamilton_representation and self.k_trend > 0:
-                initial_intercept = (
-                    self['state_intercept', self._k_states_diff, 0])
-                initial_mean = (initial_intercept /
-                                (1 - np.sum(transition[:, 0])))
-                initial_state[self._k_states_diff] = initial_mean
-                _start = self._k_states_diff + 1
-                _end = _start + transition.shape[0] - 1
-                initial_state[_start:_end] = transition[1:, 0] * initial_mean
-
-            # Initial state covariance
-            selection_stationary = self.ssm['selection', start:end, :, 0]
-            selected_state_cov_stationary = np.dot(
-                np.dot(selection_stationary, self.ssm['state_cov', :, :, 0]),
-                selection_stationary.T)
-            initial_state_cov_stationary = solve_discrete_lyapunov(
-                transition, selected_state_cov_stationary,
-                complex_step=complex_step)
-
-            initial_state_cov[start:end, start:end] = (
-                initial_state_cov_stationary)
-
-        self.ssm.initialize_known(initial_state, initial_state_cov)
+        self.ssm.initialization = init
 
     @property
     def initial_design(self):
@@ -1677,10 +1593,6 @@ class SARIMAX(MLEModel):
             self.ssm['state_cov', 0, 0] = params_variance
             if self.state_regression and self.time_varying_regression:
                 self.ssm[self._exog_variance_idx] = params_exog_variance
-
-        # Initialize
-        if not self._manual_initialization:
-            self.initialize_state(complex_step=complex_step)
 
         return params
 

--- a/statsmodels/tsa/statespace/structural.py
+++ b/statsmodels/tsa/statespace/structural.py
@@ -13,6 +13,7 @@ import numpy as np
 import pandas as pd
 from statsmodels.tsa.filters.hp_filter import hpfilter
 from statsmodels.tsa.tsatools import lagmat
+from .initialization import Initialization
 from .mlemodel import MLEModel, MLEResults, MLEResultsWrapper
 from scipy.linalg import solve_discrete_lyapunov
 from statsmodels.tools.tools import Bunch
@@ -518,6 +519,9 @@ class UnobservedComponents(MLEModel):
                             'mle_regression'] + list(kwargs.keys())
         # TODO: I think the kwargs or not attached, need to recover from ???
 
+        # Initialize the state
+        self.initialize_default()
+
     def _get_init_kwds(self):
         # Get keywords based on model attributes
         kwds = super(UnobservedComponents, self)._get_init_kwds()
@@ -632,45 +636,28 @@ class UnobservedComponents(MLEModel):
         idx = np.diag_indices(self.ssm.k_posdef)
         self._idx_state_cov = ('state_cov', idx[0], idx[1])
 
-    def initialize_state(self):
-        # Initialize the AR component as stationary, the rest as approximately
-        # diffuse
-        initial_state = np.zeros(self.k_states)
-        initial_state_cov = (
-            np.eye(self.k_states, dtype=self.ssm.transition.dtype) *
-            self.ssm.initial_variance
-        )
+    def initialize_default(self, approximate_diffuse_variance=None):
+        if approximate_diffuse_variance is None:
+            approximate_diffuse_variance = self.ssm.initial_variance
+
+        init = Initialization(
+            self.k_states,
+            approximate_diffuse_variance=approximate_diffuse_variance)
 
         if self.autoregressive:
+            offset = (self.level + self.trend +
+                      (self.seasonal_periods - 1) * self.seasonal +
+                      self.cycle * 2)
+            length = self.ar_order
+            init.set((0, offset), 'approximate_diffuse')
+            init.set((offset, offset + length), 'stationary')
+            init.set((offset + length, self.k_states), 'approximate_diffuse')
+        # If we do not have an autoregressive component, then everything has
+        # a diffuse initialization
+        else:
+            init.set(None, 'approximate_diffuse')
 
-            start = (
-                self.level + self.trend +
-                (self.seasonal_periods - 1) * self.seasonal +
-                self.cycle * 2
-            )
-            end = start + self.ar_order
-            selection_stationary = self.ssm['selection', start:end, :, 0]
-            selected_state_cov_stationary = np.dot(
-                np.dot(selection_stationary, self.ssm['state_cov', :, :, 0]),
-                selection_stationary.T
-            )
-            try:
-                initial_state_cov_stationary = solve_discrete_lyapunov(
-                    self.ssm['transition', start:end, start:end, 0],
-                    selected_state_cov_stationary
-                )
-            except:
-                initial_state_cov_stationary = solve_discrete_lyapunov(
-                    self.ssm['transition', start:end, start:end, 0],
-                    selected_state_cov_stationary,
-                    method='direct'
-                )
-
-            initial_state_cov[start:end, start:end] = (
-                initial_state_cov_stationary
-            )
-
-        self.ssm.initialize_known(initial_state, initial_state_cov)
+        self.ssm.initialization = init
 
     def filter(self, params, **kwargs):
         kwargs.setdefault('results_class', UnobservedComponentsResults)
@@ -951,9 +938,6 @@ class UnobservedComponents(MLEModel):
                     params[offset:offset+self.k_exog]
                 )[None, :]
             offset += self.k_exog
-
-        # Initialize the state
-        self.initialize_state()
 
 
 class UnobservedComponentsResults(MLEResults):

--- a/statsmodels/tsa/statespace/tests/test_initialization.py
+++ b/statsmodels/tsa/statespace/tests/test_initialization.py
@@ -446,6 +446,3 @@ def test_invalid():
     assert_raises(ValueError, init)
     init = Initialization(2, 'stationary')
     assert_raises(ValueError, init)
-    assert_raises(ValueError, init, transition=np.diag([0.5, 0.5]))
-    assert_raises(ValueError, init, state_intercept=[0, 0],
-                  transition=np.diag([1, 1]), selected_state_cov=np.eye(2))

--- a/statsmodels/tsa/statespace/tests/test_initialization.py
+++ b/statsmodels/tsa/statespace/tests/test_initialization.py
@@ -1,0 +1,451 @@
+"""
+Tests for initialization
+
+Author: Chad Fulton
+License: Simplified-BSD
+"""
+
+from __future__ import division, absolute_import, print_function
+
+import warnings
+import numpy as np
+import pandas as pd
+import os
+from scipy.linalg import solve_discrete_lyapunov
+from scipy.signal import lfilter
+
+from statsmodels.tsa.statespace import (sarimax, structural, varmax,
+                                        dynamic_factor)
+from statsmodels.tsa.statespace.initialization import Initialization
+from statsmodels.tsa.statespace.tools import compatibility_mode
+from numpy.testing import (assert_allclose, assert_almost_equal, assert_equal,
+                           assert_raises)
+from nose.exc import SkipTest
+
+if compatibility_mode:
+    raise SkipTest
+
+
+def test_global_known():
+    # Test for global known initialization
+
+    # - 1-dimensional -
+    endog = np.zeros(10)
+    mod = sarimax.SARIMAX(endog, order=(1, 0, 0))
+
+    # Known, mean
+    init = Initialization(mod.k_states, 'known', constant=[1.5])
+    a, Pinf, Pstar = init()
+    assert_equal(a, [1.5])
+    assert_equal(Pinf, np.diag([0]))
+    assert_equal(Pstar, np.diag([0]))
+
+    # Known, covariance
+    init = Initialization(mod.k_states, 'known', stationary_cov=np.diag([1]))
+    a, Pinf, Pstar = init()
+    assert_equal(a, [0])
+    assert_equal(Pinf, np.diag([0]))
+    assert_equal(Pstar, np.diag([1]))
+
+    # Known, both
+    init = Initialization(mod.k_states, 'known', constant=[1.5],
+                          stationary_cov=np.diag([1]))
+    a, Pinf, Pstar = init()
+    assert_equal(a, [1.5])
+    assert_equal(Pinf, np.diag([0]))
+    assert_equal(Pstar, np.diag([1]))
+
+    # - n-dimensional -
+    endog = np.zeros(10)
+    mod = sarimax.SARIMAX(endog, order=(2, 0, 0))
+
+    # Known, mean
+    init = Initialization(mod.k_states, 'known', constant=[1.5, -0.2])
+    a, Pinf, Pstar = init()
+    assert_equal(a, [1.5, -0.2])
+    assert_equal(Pinf, np.diag([0, 0]))
+    assert_equal(Pstar, np.diag([0, 0]))
+
+    # Known, covariance
+    init = Initialization(mod.k_states, 'known',
+                          stationary_cov=np.diag([1, 4.2]))
+    a, Pinf, Pstar = init()
+    assert_equal(a, [0, 0])
+    assert_equal(Pinf, np.diag([0, 0]))
+    assert_equal(Pstar, np.diag([1, 4.2]))
+
+    # Known, both
+    init = Initialization(mod.k_states, 'known', constant=[1.5, -0.2],
+                          stationary_cov=np.diag([1, 4.2]))
+    a, Pinf, Pstar = init()
+    assert_equal(a, [1.5, -0.2])
+    assert_equal(Pinf, np.diag([0, 0]))
+    assert_equal(Pstar, np.diag([1, 4.2]))
+
+
+def test_global_diffuse():
+    # Test for global diffuse initialization
+
+    # - 1-dimensional -
+    endog = np.zeros(10)
+    mod = sarimax.SARIMAX(endog, order=(1, 0, 0))
+
+    init = Initialization(mod.k_states, 'diffuse')
+    a, Pinf, Pstar = init()
+    assert_equal(a, [0])
+    assert_equal(Pinf, np.eye(1))
+    assert_equal(Pstar, np.diag([0]))
+
+    # - n-dimensional -
+    endog = np.zeros(10)
+    mod = sarimax.SARIMAX(endog, order=(2, 0, 0))
+
+    init = Initialization(mod.k_states, 'diffuse')
+    a, Pinf, Pstar = init()
+    assert_equal(a, [0, 0])
+    assert_equal(Pinf, np.eye(2))
+    assert_equal(Pstar, np.diag([0, 0]))
+
+
+def test_global_approximate_diffuse():
+    # Test for global approximate diffuse initialization
+
+    # - 1-dimensional -
+    endog = np.zeros(10)
+    mod = sarimax.SARIMAX(endog, order=(1, 0, 0))
+
+    init = Initialization(mod.k_states, 'approximate_diffuse')
+    a, Pinf, Pstar = init()
+    assert_equal(a, [0])
+    assert_equal(Pinf, np.diag([0]))
+    assert_equal(Pstar, np.eye(1) * 1e6)
+
+    init = Initialization(mod.k_states, 'approximate_diffuse', constant=[1.2])
+    a, Pinf, Pstar = init()
+    assert_equal(a, [1.2])
+    assert_equal(Pinf, np.diag([0]))
+    assert_equal(Pstar, np.eye(1) * 1e6)
+
+    init = Initialization(mod.k_states, 'approximate_diffuse',
+                          approximate_diffuse_variance=1e10)
+    a, Pinf, Pstar = init()
+    assert_equal(a, [0])
+    assert_equal(Pinf, np.diag([0]))
+    assert_equal(Pstar, np.eye(1) * 1e10)
+
+    # - n-dimensional -
+    endog = np.zeros(10)
+    mod = sarimax.SARIMAX(endog, order=(2, 0, 0))
+
+    init = Initialization(mod.k_states, 'approximate_diffuse')
+    a, Pinf, Pstar = init()
+    assert_equal(a, [0, 0])
+    assert_equal(Pinf, np.diag([0, 0]))
+    assert_equal(Pstar, np.eye(2) * 1e6)
+
+    init = Initialization(mod.k_states, 'approximate_diffuse',
+                          constant=[1.2, -0.2])
+    a, Pinf, Pstar = init()
+    assert_equal(a, [1.2, -0.2])
+    assert_equal(Pinf, np.diag([0, 0]))
+    assert_equal(Pstar, np.eye(2) * 1e6)
+
+    init = Initialization(mod.k_states, 'approximate_diffuse',
+                          approximate_diffuse_variance=1e10)
+    a, Pinf, Pstar = init()
+    assert_equal(a, [0, 0])
+    assert_equal(Pinf, np.diag([0, 0]))
+    assert_equal(Pstar, np.eye(2) * 1e10)
+
+
+def test_global_stationary():
+    # Test for global approximate diffuse initialization
+
+    # - 1-dimensional -
+    endog = np.zeros(10)
+    mod = sarimax.SARIMAX(endog, order=(1, 0, 0), trend='c')
+
+    # no intercept
+    intercept = 0
+    phi = 0.5
+    sigma2 = 2.
+    mod.update(np.r_[intercept, phi, sigma2])
+    init = Initialization(mod.k_states, 'stationary')
+    a, Pinf, Pstar = init(mod)
+    assert_equal(a, [0])
+    assert_equal(Pinf, np.diag([0]))
+    assert_equal(Pstar, np.eye(1) * sigma2 / (1 - phi**2))
+
+    # intercept
+    intercept = 1.2
+    phi = 0.5
+    sigma2 = 2.
+    mod.update(np.r_[intercept, phi, sigma2])
+    init = Initialization(mod.k_states, 'stationary')
+    a, Pinf, Pstar = init(mod)
+    assert_equal(a, [intercept / (1 - phi)])
+    assert_equal(Pinf, np.diag([0]))
+    assert_equal(Pstar, np.eye(1) * sigma2 / (1 - phi**2))
+
+    # - n-dimensional -
+    endog = np.zeros(10)
+    mod = sarimax.SARIMAX(endog, order=(2, 0, 0), trend='c')
+
+    # no intercept
+    intercept = 0
+    phi = [0.5, -0.2]
+    sigma2 = 2.
+    mod.update(np.r_[intercept, phi, sigma2])
+    init = Initialization(mod.k_states, 'stationary')
+    a, Pinf, Pstar = init(mod)
+    assert_equal(a, [0, 0])
+    assert_equal(Pinf, np.diag([0, 0]))
+    T = np.array([[0.5, 1],
+                  [-0.2, 0]])
+    Q = np.diag([sigma2, 0])
+    desired_cov = solve_discrete_lyapunov(T, Q)
+    assert_allclose(Pstar, desired_cov)
+
+    # intercept
+    intercept = 1.2
+    phi = [0.5, -0.2]
+    sigma2 = 2.
+    mod.update(np.r_[intercept, phi, sigma2])
+    init = Initialization(mod.k_states, 'stationary')
+    a, Pinf, Pstar = init(mod)
+    desired_intercept = np.linalg.inv(np.eye(2) - T).dot([intercept, 0])
+    assert_allclose(a, desired_intercept)
+    assert_equal(Pinf, np.diag([0, 0]))
+    assert_allclose(Pstar, desired_cov)
+
+
+def test_mixed_basic():
+    # Performs a number of tests for setting different initialization for
+    # different blocks
+
+    # - 2-dimensional -
+    endog = np.zeros(10)
+    mod = sarimax.SARIMAX(endog, order=(2, 0, 0))
+    phi = [0.5, -0.2]
+    sigma2 = 2.
+    mod.update(np.r_[phi, sigma2])
+
+    # known has constant
+    init = Initialization(mod.k_states)
+    init.set(0, 'known', constant=[1.2])
+
+    # > known has constant
+    init.set(1, 'known', constant=[-0.2])
+    a, Pinf, Pstar = init()
+    assert_allclose(a, [1.2, -0.2])
+    assert_equal(Pinf, np.diag([0, 0]))
+    assert_allclose(Pstar, np.diag([0, 0]))
+
+    # > diffuse
+    init.unset(1)
+    init.set(1, 'diffuse')
+    a, Pinf, Pstar = init()
+
+    assert_allclose(a, [1.2, 0])
+    assert_equal(Pinf, np.diag([0, 1]))
+    assert_allclose(Pstar, np.diag([0, 0]))
+
+    # > approximate diffuse
+    init.unset(1)
+    init.set(1, 'approximate_diffuse')
+    a, Pinf, Pstar = init()
+
+    assert_allclose(a, [1.2, 0])
+    assert_equal(Pinf, np.diag([0, 0]))
+    assert_allclose(Pstar, np.diag([0, 1e6]))
+
+    # > stationary
+    init.unset(1)
+    init.set(1, 'stationary')
+    a, Pinf, Pstar = init(mod)
+
+    assert_allclose(a, [1.2, 0])
+    assert_equal(Pinf, np.diag([0, 0]))
+    assert_allclose(Pstar, np.diag([0, 0]))
+
+    # known has cov
+    init = Initialization(mod.k_states)
+    init.set(0, 'known', stationary_cov=np.diag([1]))
+    init.set(1, 'diffuse')
+    a, Pinf, Pstar = init()
+
+    assert_allclose(a, [0, 0])
+    assert_equal(Pinf, np.diag([0, 1]))
+    assert_allclose(Pstar, np.diag([1, 0]))
+
+    # known has both
+    init = Initialization(mod.k_states)
+    init.set(0, 'known', constant=[1.2], stationary_cov=np.diag([1]))
+    init.set(1, 'diffuse')
+    a, Pinf, Pstar = init()
+
+    assert_allclose(a, [1.2, 0])
+    assert_equal(Pinf, np.diag([0, 1]))
+    assert_allclose(Pstar, np.diag([1, 0]))
+
+    # - 3-dimensional -
+    endog = np.zeros(10)
+    mod = sarimax.SARIMAX(endog, order=(3, 0, 0))
+
+    # known has constant
+    init = Initialization(mod.k_states)
+    init.set((0, 2), 'known', constant=[1.2, -0.2])
+    init.set(2, 'diffuse')
+    a, Pinf, Pstar = init()
+
+    assert_allclose(a, [1.2, -0.2, 0])
+    assert_equal(Pinf, np.diag([0, 0, 1]))
+    assert_allclose(Pstar, np.diag([0, 0, 0]))
+
+    # known has cov
+    init = Initialization(mod.k_states)
+    init.set((0, 2), 'known', stationary_cov=np.diag([1, 4.2]))
+    init.set(2, 'diffuse')
+    a, Pinf, Pstar = init()
+
+    assert_allclose(a, [0, 0, 0])
+    assert_equal(Pinf, np.diag([0, 0, 1]))
+    assert_allclose(Pstar, np.diag([1, 4.2, 0]))
+
+    # known has both
+    init = Initialization(mod.k_states)
+    init.set((0, 2), 'known', constant=[1.2, -0.2],
+             stationary_cov=np.diag([1, 4.2]))
+    init.set(2, 'diffuse')
+    a, Pinf, Pstar = init()
+
+    assert_allclose(a, [1.2, -0.2, 0])
+    assert_equal(Pinf, np.diag([0, 0, 1]))
+    assert_allclose(Pstar, np.diag([1, 4.2, 0]))
+
+
+def test_mixed_stationary():
+    # More specific tests when one or more blocks are initialized as stationary
+    endog = np.zeros(10)
+    mod = sarimax.SARIMAX(endog, order=(2, 1, 0))
+    phi = [0.5, -0.2]
+    sigma2 = 2.
+    mod.update(np.r_[phi, sigma2])
+
+    init = Initialization(mod.k_states)
+    init.set(0, 'diffuse')
+    init.set((1, 3), 'stationary')
+    a, Pinf, Pstar = init(mod)
+
+    assert_allclose(a, [0, 0, 0])
+    assert_equal(Pinf, np.diag([1, 0, 0]))
+    desired_cov = np.zeros((3, 3))
+    T = np.array([[0.5, 1],
+                  [-0.2, 0]])
+    Q = np.diag([sigma2, 0])
+    desired_cov[1:, 1:] = solve_discrete_lyapunov(T, Q)
+    assert_allclose(Pstar, desired_cov)
+
+    init.clear()
+    init.set(0, 'diffuse')
+    init.set(1, 'stationary')
+    init.set(2, 'approximate_diffuse')
+    a, Pinf, Pstar = init(mod)
+
+    assert_allclose(a, [0, 0, 0])
+    assert_equal(Pinf, np.diag([1, 0, 0]))
+    T = np.array([[0.5]])
+    Q = np.diag([sigma2])
+    desired_cov = np.diag([0, solve_discrete_lyapunov(T, Q), 1e6])
+    assert_allclose(Pstar, desired_cov)
+
+    init.clear()
+    init.set(0, 'diffuse')
+    init.set(1, 'stationary')
+    init.set(2, 'stationary')
+    a, Pinf, Pstar = init(mod)
+
+    desired_cov[2, 2] = 0
+    assert_allclose(Pstar, desired_cov)
+
+    # Test with a VAR model
+    endog = np.zeros((10, 2))
+    mod = varmax.VARMAX(endog, order=(1, 0), )
+    intercept = [1.5, -0.1]
+    transition = np.array([[0.5, -0.2],
+                           [0.1, 0.8]])
+    cov = np.array([[1.2, -0.4],
+                    [-0.4, 0.4]])
+    tril = np.tril_indices(2)
+    params = np.r_[intercept, transition.ravel(),
+                   np.linalg.cholesky(cov)[tril]]
+    mod.update(params)
+
+    # > stationary, global
+    init = Initialization(mod.k_states, 'stationary')
+    a, Pinf, Pstar = init(mod)
+
+    desired_intercept = np.linalg.solve(np.eye(2) - transition, intercept)
+    desired_cov = solve_discrete_lyapunov(transition, cov)
+    assert_allclose(a, desired_intercept)
+    assert_equal(Pinf, np.diag([0, 0]))
+    assert_allclose(Pstar, desired_cov)
+
+    # > diffuse, global
+    init.set(None, 'diffuse')
+    a, Pinf, Pstar = init()
+    assert_allclose(a, [0, 0])
+    assert_equal(Pinf, np.eye(2))
+    assert_allclose(Pstar, np.diag([0, 0]))
+
+    # > stationary, individually
+    init.unset(None)
+    init.set(0, 'stationary')
+    init.set(1, 'stationary')
+    a, Pinf, Pstar = init(mod)
+    assert_allclose(a, [intercept[0] / (1 - transition[0, 0]),
+                        intercept[1] / (1 - transition[1, 1])])
+    assert_equal(Pinf, np.diag([0, 0]))
+    assert_allclose(Pstar, np.diag([cov[0, 0] / (1 - transition[0, 0]**2),
+                                    cov[1, 1] / (1 - transition[1, 1]**2)]))
+
+
+def test_invalid():
+    # Invalid initializations (also tests for some invalid calls to set)
+    assert_raises(ValueError, Initialization, 5, '')
+    assert_raises(ValueError, Initialization, 5, 'stationary', constant=[1, 2])
+    assert_raises(ValueError, Initialization, 5, 'stationary',
+                  stationary_cov=[1, 2])
+    assert_raises(ValueError, Initialization, 5, 'stationary',
+                  approximate_diffuse_variance=1e10)
+    assert_raises(ValueError, Initialization, 5, 'known')
+    assert_raises(ValueError, Initialization, 5, 'known', constant=[1])
+    assert_raises(ValueError, Initialization, 5, 'known', stationary_cov=[0])
+
+    # Invalid set() / unset() calls
+    init = Initialization(5)
+    assert_raises(ValueError, init.set, -1, 'diffuse')
+    assert_raises(ValueError, init.unset, -1)
+    assert_raises(ValueError, init.set, 5, 'diffuse')
+    assert_raises(ValueError, init.unset, 5)
+    assert_raises(ValueError, init.set, 'x', 'diffuse')
+    assert_raises(ValueError, init.unset, 'x')
+    assert_raises(ValueError, init.set, (1, 2, 3), 'diffuse')
+    assert_raises(ValueError, init.unset, (1, 2, 3))
+    init.set(None, 'diffuse')
+    assert_raises(ValueError, init.set, 1, 'diffuse')
+    init.clear()
+    init.set(1, 'diffuse')
+    assert_raises(ValueError, init.set, None, 'stationary')
+
+    init.clear()
+    assert_raises(ValueError, init.unset, 1)
+
+    # Invalid __call__
+    init = Initialization(2)
+    assert_raises(ValueError, init)
+    init = Initialization(2, 'stationary')
+    assert_raises(ValueError, init)
+    assert_raises(ValueError, init, transition=np.diag([0.5, 0.5]))
+    assert_raises(ValueError, init, state_intercept=[0, 0],
+                  transition=np.diag([1, 1]), selected_state_cov=np.eye(2))

--- a/statsmodels/tsa/statespace/tests/test_initialization.py
+++ b/statsmodels/tsa/statespace/tests/test_initialization.py
@@ -350,7 +350,6 @@ def test_invalid():
     assert_raises(ValueError, init.set, -1, 'diffuse')
     assert_raises(ValueError, init.unset, -1)
     assert_raises(ValueError, init.set, 5, 'diffuse')
-    assert_raises(ValueError, init.unset, 5)
     assert_raises(ValueError, init.set, 'x', 'diffuse')
     assert_raises(ValueError, init.unset, 'x')
     assert_raises(ValueError, init.set, (1, 2, 3), 'diffuse')

--- a/statsmodels/tsa/statespace/tests/test_initialization.py
+++ b/statsmodels/tsa/statespace/tests/test_initialization.py
@@ -171,7 +171,7 @@ def test_global_stationary():
     sigma2 = 2.
     mod.update(np.r_[intercept, phi, sigma2])
     init = Initialization(mod.k_states, 'stationary')
-    a, Pinf, Pstar = init(mod)
+    a, Pinf, Pstar = init(model=mod)
     assert_equal(a, [0])
     assert_equal(Pinf, np.diag([0]))
     assert_equal(Pstar, np.eye(1) * sigma2 / (1 - phi**2))
@@ -182,7 +182,7 @@ def test_global_stationary():
     sigma2 = 2.
     mod.update(np.r_[intercept, phi, sigma2])
     init = Initialization(mod.k_states, 'stationary')
-    a, Pinf, Pstar = init(mod)
+    a, Pinf, Pstar = init(model=mod)
     assert_equal(a, [intercept / (1 - phi)])
     assert_equal(Pinf, np.diag([0]))
     assert_equal(Pstar, np.eye(1) * sigma2 / (1 - phi**2))
@@ -197,7 +197,7 @@ def test_global_stationary():
     sigma2 = 2.
     mod.update(np.r_[intercept, phi, sigma2])
     init = Initialization(mod.k_states, 'stationary')
-    a, Pinf, Pstar = init(mod)
+    a, Pinf, Pstar = init(model=mod)
     assert_equal(a, [0, 0])
     assert_equal(Pinf, np.diag([0, 0]))
     T = np.array([[0.5, 1],
@@ -212,7 +212,7 @@ def test_global_stationary():
     sigma2 = 2.
     mod.update(np.r_[intercept, phi, sigma2])
     init = Initialization(mod.k_states, 'stationary')
-    a, Pinf, Pstar = init(mod)
+    a, Pinf, Pstar = init(model=mod)
     desired_intercept = np.linalg.inv(np.eye(2) - T).dot([intercept, 0])
     assert_allclose(a, desired_intercept)
     assert_equal(Pinf, np.diag([0, 0]))
@@ -262,7 +262,7 @@ def test_mixed_basic():
     # > stationary
     init.unset(1)
     init.set(1, 'stationary')
-    a, Pinf, Pstar = init(mod)
+    a, Pinf, Pstar = init(model=mod)
 
     assert_allclose(a, [1.2, 0])
     assert_equal(Pinf, np.diag([0, 0]))
@@ -335,7 +335,7 @@ def test_mixed_stationary():
     init = Initialization(mod.k_states)
     init.set(0, 'diffuse')
     init.set((1, 3), 'stationary')
-    a, Pinf, Pstar = init(mod)
+    a, Pinf, Pstar = init(model=mod)
 
     assert_allclose(a, [0, 0, 0])
     assert_equal(Pinf, np.diag([1, 0, 0]))
@@ -350,7 +350,7 @@ def test_mixed_stationary():
     init.set(0, 'diffuse')
     init.set(1, 'stationary')
     init.set(2, 'approximate_diffuse')
-    a, Pinf, Pstar = init(mod)
+    a, Pinf, Pstar = init(model=mod)
 
     assert_allclose(a, [0, 0, 0])
     assert_equal(Pinf, np.diag([1, 0, 0]))
@@ -363,7 +363,7 @@ def test_mixed_stationary():
     init.set(0, 'diffuse')
     init.set(1, 'stationary')
     init.set(2, 'stationary')
-    a, Pinf, Pstar = init(mod)
+    a, Pinf, Pstar = init(model=mod)
 
     desired_cov[2, 2] = 0
     assert_allclose(Pstar, desired_cov)
@@ -383,7 +383,7 @@ def test_mixed_stationary():
 
     # > stationary, global
     init = Initialization(mod.k_states, 'stationary')
-    a, Pinf, Pstar = init(mod)
+    a, Pinf, Pstar = init(model=mod)
 
     desired_intercept = np.linalg.solve(np.eye(2) - transition, intercept)
     desired_cov = solve_discrete_lyapunov(transition, cov)
@@ -402,7 +402,7 @@ def test_mixed_stationary():
     init.unset(None)
     init.set(0, 'stationary')
     init.set(1, 'stationary')
-    a, Pinf, Pstar = init(mod)
+    a, Pinf, Pstar = init(model=mod)
     assert_allclose(a, [intercept[0] / (1 - transition[0, 0]),
                         intercept[1] / (1 - transition[1, 1])])
     assert_equal(Pinf, np.diag([0, 0]))

--- a/statsmodels/tsa/statespace/tests/test_mlemodel.py
+++ b/statsmodels/tsa/statespace/tests/test_mlemodel.py
@@ -104,16 +104,16 @@ def test_wrapping():
     mod.initialize_default()  # no-op here
 
     mod.initialize_approximate_diffuse(1e5)
-    assert_equal(mod.initialization, 'approximate_diffuse')
-    assert_equal(mod.ssm._initial_variance, 1e5)
+    assert_equal(mod.initialization.initialization_type, 'approximate_diffuse')
+    assert_equal(mod.initialization.approximate_diffuse_variance, 1e5)
 
     mod.initialize_known([5.], [[40]])
-    assert_equal(mod.initialization, 'known')
-    assert_equal(mod.ssm._initial_state, [5.])
-    assert_equal(mod.ssm._initial_state_cov, [[40]])
+    assert_equal(mod.initialization.initialization_type, 'known')
+    assert_equal(mod.initialization.constant, [5.])
+    assert_equal(mod.initialization.stationary_cov, [[40]])
 
     mod.initialize_stationary()
-    assert_equal(mod.initialization, 'stationary')
+    assert_equal(mod.initialization.initialization_type, 'stationary')
 
     # Test that we can use the following wrapper methods: set_filter_method,
     # set_stability_method, set_conserve_memory, set_smoother_output

--- a/statsmodels/tsa/statespace/tests/test_mlemodel.py
+++ b/statsmodels/tsa/statespace/tests/test_mlemodel.py
@@ -96,15 +96,12 @@ def test_wrapping():
     # initialize_known, initialize_stationary, initialize_approximate_diffuse
 
     # Initialization starts off as none
-    assert_equal(mod.initialization, None)
+    assert_equal(isinstance(mod.initialization, object), True)
 
     # Since the SARIMAX model may be fully stationary or may have diffuse
     # elements, it uses a custom initialization by default, but it can be
     # overridden by users
-    mod.initialize_state()
-    # (The default initialization in this case is known because there is a non-
-    # stationary state corresponding to the time-varying regression parameter)
-    assert_equal(mod.initialization, 'known')
+    mod.initialize_default()  # no-op here
 
     mod.initialize_approximate_diffuse(1e5)
     assert_equal(mod.initialization, 'approximate_diffuse')

--- a/statsmodels/tsa/statespace/tests/test_representation.py
+++ b/statsmodels/tsa/statespace/tests/test_representation.py
@@ -666,8 +666,8 @@ def test_initialization():
     initial_state = np.zeros(2,) + 1.5
     initial_state_cov = np.eye(2) * 3.
     mod.initialize_known(initial_state, initial_state_cov)
-    assert_equal(mod._initial_state.sum(), 3)
-    assert_equal(mod._initial_state_cov.diagonal().sum(), 6)
+    assert_equal(mod.initialization.constant.sum(), 3)
+    assert_equal(mod.initialization.stationary_cov.diagonal().sum(), 6)
 
     # Test invalid initial_state
     initial_state = np.zeros(10,)

--- a/statsmodels/tsa/statespace/tests/test_sarimax.py
+++ b/statsmodels/tsa/statespace/tests/test_sarimax.py
@@ -1861,7 +1861,6 @@ def test_manual_stationary_initialization():
     mod2 = sarimax.SARIMAX(endog, order=(3,0,0))
     mod2.ssm.initialize_known(res1.filter_results.initial_state,
                               res1.filter_results.initial_state_cov)
-    mod2.initialize_state()  # a noop in this case (include for coverage)
     res2 = mod2.filter([0.5,0.2,0.1,1])
 
     # Create a third model with "known" initialization, but specified in kwargs
@@ -1900,7 +1899,6 @@ def test_manual_approximate_diffuse_initialization():
     mod2 = sarimax.SARIMAX(endog, order=(3,0,0))
     mod2.ssm.initialize_known(res1.filter_results.initial_state,
                               res1.filter_results.initial_state_cov)
-    mod2.initialize_state()  # a noop in this case (include for coverage)
     res2 = mod2.filter([0.5,0.2,0.1,1])
 
     # Create a third model with "known" initialization, but specified in kwargs

--- a/statsmodels/tsa/statespace/tools.py
+++ b/statsmodels/tsa/statespace/tools.py
@@ -19,6 +19,7 @@ has_trmm = True
 prefix_dtype_map = {
     's': np.float32, 'd': np.float64, 'c': np.complex64, 'z': np.complex128
 }
+prefix_initialization_map = {}
 prefix_statespace_map = {}
 prefix_kalman_filter_map = {}
 prefix_kalman_smoother_map = {}
@@ -56,10 +57,16 @@ def set_mode(compatibility=None):
     # Initialize the appropriate mode
     if not compatibility:
         from scipy.linalg import cython_blas
-        from . import (_representation, _kalman_filter, _kalman_smoother,
-                       _simulation_smoother, _tools)
+        from . import (_initialization, _representation, _kalman_filter,
+                       _kalman_smoother, _simulation_smoother, _tools)
         compatibility_mode = False
 
+        prefix_initialization_map.update({
+            's': _initialization.sInitialization,
+            'd': _initialization.dInitialization,
+            'c': _initialization.cInitialization,
+            'z': _initialization.zInitialization
+        })
         prefix_statespace_map.update({
             's': _representation.sStatespace, 'd': _representation.dStatespace,
             'c': _representation.cStatespace, 'z': _representation.zStatespace


### PR DESCRIPTION
Initializing the Kalman filter involves determining the distribution of the initial state vector, i.e. setting its mean and covariance matrices.


**Currently**, users are presented with three options:

- Known (set using known values)
- Approximate diffuse (mean = 0, covariance a diagonal matrix with large diagonal elements)
- Stationary (solve a discrete Lyapunov equation; this is currently done in Cython in the `_{{prefix}}Statespace.initialize_stationary` method)

Each of these sets the full mean and covariance matrix for the initial state vector. However, this can be inconvenient in models where e.g. some elements are stationary and some elements are non-stationary (for example, `SARIMAX` models and `UnobservedComponents` models often have this feature).

In practice, this has meant that if there are both types of states, the "Known" option has to be used, and the stationary component has to be computed manually (see e.g. `SARIMAX.initialize_state`). This is less than ideal for at least two reasons:

1. The discrete Lyapunov equation and solution has to be set up in each model, even though it's really the same each time.
2. It's slower to do this in Python space.

**In this PR**, I add the ability to specify initialization separately for separate (consecutive) blocks of the state vector, and convert all existing classes to use the new initialization system. See the docstring of the `Initialization` class for more details. This considerably simplifies initialization in `SARIMAX` and `UnobservedComponents`, and should improve performance somewhat.

**The other major benefit** of this PR is that it is one of the steps necessary to get exact diffuse initialization working.

Of course the downside is another Cython class and somehow I've managed to add 1600 lines.