### PR TITLE
REF: State space: Use model_orders and _slices

### DIFF
--- a/statsmodels/tsa/statespace/dynamic_factor.py
+++ b/statsmodels/tsa/statespace/dynamic_factor.py
@@ -27,6 +27,8 @@ from statsmodels.tools.decorators import cache_readonly
 from statsmodels.tools.sm_exceptions import ValueWarning
 import statsmodels.base.wrapper as wrap
 
+from .initialization import initialize_error_cov
+
 
 class DynamicFactor(MLEModel):
     r"""
@@ -160,7 +162,7 @@ class DynamicFactor(MLEModel):
 
         # Exogenous data
         (self.k_exog, exog) = prepare_exog(exog)
-        
+
         # Note: at some point in the future might add state regression, as in
         # SARIMAX.
         self.mle_regression = self.k_exog > 0
@@ -219,23 +221,47 @@ class DynamicFactor(MLEModel):
         self._initialize_error_cov()
         self._initialize_factor_transition()
         self._initialize_error_transition()
-        self.k_params = sum(self.parameters.values())
-
-        # Cache parameter vector slices
-        def _slice(key, offset):
-            length = self.parameters[key]
-            param_slice = np.s_[offset:offset + length]
-            offset += length
-            return param_slice, offset
+        self.k_params = sum(self.model_orders.values())
 
         offset = 0
-        self._params_loadings, offset = _slice('factor_loadings', offset)
-        self._params_exog, offset = _slice('exog', offset)
-        self._params_error_cov, offset = _slice('error_cov', offset)
-        self._params_factor_transition, offset = (
-            _slice('factor_transition', offset))
-        self._params_error_transition, offset = (
-            _slice('error_transition', offset))
+        self._params_loadings = self._slices['factor_loadings']
+        self._params_exog = self._slices['exog']
+        self._params_error_cov = self._slices['error_cov']
+        self._params_factor_transition = self._slices['factor_transition']
+        self._params_error_transition = self._slices['error_transition']
+
+    @property
+    def model_orders(self):
+        orders = {}
+        orders['factor_loadings'] = self.k_endog * self.k_factors
+        orders['exog'] = self.k_exog * self.k_endog
+        orders['error_cov'] = initialize_error_cov(self.k_endog,
+                                                   self.error_cov_type)
+        orders['factor_transition'] = self.factor_order*self.k_factors**2
+
+        if self.error_order == 0:
+            orders['error_transition'] = 0
+        elif self.error_var:
+            orders['error_transition'] = self._error_order * self.k_endog
+        else:
+            orders['error_transition'] = self._error_order
+        return orders
+
+    params_complete = ['factor_loadings', 'exog', 'error_cov',
+                       'factor_transition', 'error_transition']
+
+    @cached_property
+    def _slices(self):
+        orders = self.model_orders
+
+        # Cache parameter vector slices
+        ret = {}
+        start = 0
+        for name in self.params_complete:
+            length = orders[name]
+            ret[name] = slice(start, start+length)
+            start += length
+        return ret
 
     def _initialize_loadings(self):
         # Initialize the parameters

--- a/statsmodels/tsa/statespace/dynamic_factor.py
+++ b/statsmodels/tsa/statespace/dynamic_factor.py
@@ -250,7 +250,7 @@ class DynamicFactor(MLEModel):
     params_complete = ['factor_loadings', 'exog', 'error_cov',
                        'factor_transition', 'error_transition']
 
-    @cached_property
+    @cache_readonly
     def _slices(self):
         orders = self.model_orders
 

--- a/statsmodels/tsa/statespace/initialization.py
+++ b/statsmodels/tsa/statespace/initialization.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+
+def _initialize_error_cov(k_endog, error_cov_type):
+    # equiv: scipy.misc.comb(k_endog, {'scalar': 0,
+    #                                   'diagonal': 1,
+    #                                   'unstructured': 2}[error_cov_type])
+    if error_cov_type == 'scalar':
+        nparams = 1
+    elif error_cov_type == 'diagonal':
+        nparams = k_endog
+    elif error_cov_type == 'unstructured':
+        nparams = int(k_endog * (k_endog + 1) / 2)
+    return nparams

--- a/statsmodels/tsa/statespace/mlemodel.py
+++ b/statsmodels/tsa/statespace/mlemodel.py
@@ -2852,27 +2852,26 @@ class PredictionResults(pred.PredictionResults):
         # TODO: this performs metadata wrapping, and that should be handled
         #       by attach_* methods. However, they don't currently support
         #       this use case.
-        conf_int = super(PredictionResults, self).conf_int(
-            method, alpha, **kwds)
+        conf_int = super(PredictionResults, self).conf_int(method, alpha,
+                                                           **kwds)
 
         # Create a dataframe
         if self.row_labels is not None:
-            conf_int = pd.DataFrame(conf_int, index=self.row_labels)
-
             # Attach the endog names
             ynames = self.model.data.ynames
             if not type(ynames) == list:
                 ynames = [ynames]
             names = (['lower %s' % name for name in ynames] +
                      ['upper %s' % name for name in ynames])
-            conf_int.columns = names
+
+            conf_int = pd.DataFrame(conf_int,
+                                    index=self.row_labels, columns=names)
 
         return conf_int
 
     def summary_frame(self, endog=0, what='all', alpha=0.05):
         # TODO: finish and cleanup
-        # import pandas as pd
-        from statsmodels.compat.collections import OrderedDict
+        from collections import OrderedDict
         # ci_obs = self.conf_int(alpha=alpha, obs=True) # need to split
         ci_mean = np.asarray(self.conf_int(alpha=alpha))
         to_include = OrderedDict()

--- a/statsmodels/tsa/statespace/sarimax.py
+++ b/statsmodels/tsa/statespace/sarimax.py
@@ -1165,6 +1165,36 @@ class SARIMAX(MLEModel):
             'variance': int(self.state_error),
         }
 
+    @cached_property
+    def _slices(self):
+        orders = self.model_orders
+        ret = {}
+        start = 0
+        for name in self.params_complete:
+            if name == 'exog' and not self.mle_regression:
+                continue
+            elif name == 'exog_variance' and not (self.state_regression and
+                                                  self.time_varying_regression):
+                continue
+            elif name == 'measurement_variance' and not self.measurement_error:
+                continue
+            #elif name in ['reduced_ar', 'reduced_ma']:
+            #   continue
+            elif name == 'ar':
+                length = self.k_ar_params
+            elif name == 'ma':
+                length = self.k_ma_params
+            elif name == 'seasonal_ar':
+                length = self.k_seasonal_ar_params
+            elif name == 'seasonal_ma':
+                length = self.k_seasonal_ma_params
+            else:
+                length = orders[name]
+            end = start + length
+            ret[name] = slice(start, end)
+            start += length
+        return ret
+
     @property
     def model_names(self):
         """

--- a/statsmodels/tsa/statespace/sarimax.py
+++ b/statsmodels/tsa/statespace/sarimax.py
@@ -1165,7 +1165,7 @@ class SARIMAX(MLEModel):
             'variance': int(self.state_error),
         }
 
-    @cached_property
+    @cache_readonly
     def _slices(self):
         orders = self.model_orders
         ret = {}

--- a/statsmodels/tsa/statespace/varmax.py
+++ b/statsmodels/tsa/statespace/varmax.py
@@ -255,7 +255,7 @@ class VARMAX(MLEModel):
     params_complete = ['trend', 'ar', 'ma', 'regression',
                        'state_cov', 'obs_cov']
 
-    @cached_property
+    @cache_readonly
     def _slices(self):
         orders = self.model_orders
         ret = {}
@@ -268,7 +268,7 @@ class VARMAX(MLEModel):
             start += length
         return ret
 
-    @cached_property
+    @cache_readonly
     def _idx_slices(self):
         # Cache some indices
         k_endog = self.k_endog

--- a/statsmodels/tsa/statespace/varmax.py
+++ b/statsmodels/tsa/statespace/varmax.py
@@ -23,6 +23,8 @@ from statsmodels.tsa.vector_ar import var_model
 import statsmodels.base.wrapper as wrap
 from statsmodels.tools.sm_exceptions import (EstimationWarning, ValueWarning)
 
+from .initialization import initialize_error_cov
+
 
 class VARMAX(MLEModel):
     r"""
@@ -186,22 +188,7 @@ class VARMAX(MLEModel):
         if self.k_exog > 0 or self.k_trend > 1:
             self.ssm._time_invariant = False
 
-        # Initialize the parameters
-        self.parameters = OrderedDict()
-        self.parameters['trend'] = self.k_endog * self.k_trend
-        self.parameters['ar'] = self.k_endog**2 * self.k_ar
-        self.parameters['ma'] = self.k_endog**2 * self.k_ma
-        self.parameters['regression'] = self.k_endog * self.k_exog
-        if self.error_cov_type == 'diagonal':
-            self.parameters['state_cov'] = self.k_endog
-        # These parameters fill in a lower-triangular matrix which is then
-        # dotted with itself to get a positive definite matrix.
-        elif self.error_cov_type == 'unstructured':
-            self.parameters['state_cov'] = (
-                int(self.k_endog * (self.k_endog + 1) / 2)
-            )
-        self.parameters['obs_cov'] = self.k_endog * self.measurement_error
-        self.k_params = sum(self.parameters.values())
+        self.k_params = sum(self.model_orders.values())
 
         # Initialize known elements of the state space matrices
 
@@ -239,37 +226,76 @@ class VARMAX(MLEModel):
         if self.k_ma > 0:
             self.ssm[('selection',) + idx] = 1
 
+        self._idx_state_intercept = self._idx_slices['state_intercept']
+        self._idx_transition = self._idx_slices['transition']
+        self._idx_state_cov = self._idx_slices['state_cov']
+        self._idx_lower_state_cov = self._idx_slices['lower_state_cov']
+        self._idx_obs_cov = self._idx_slices['obs_cov']
+
+        self._params_trend = self._slices['trend']
+        self._params_ar = self._slices['ar']
+        self._params_ma = self._slices['ma']
+        self._params_regression = self._slices['regression']
+        self._params_state_cov = self._slices['state_cov']
+        self._params_obs_cov = self._slices['obs_cov']
+
+    @property
+    def model_orders(self):
+        orders = {
+            'state_cov': initialize_error_cov(self.k_endog,
+                                              self.error_cov_type),
+            'obs_cov': self.k_endog * self.measurement_error,
+            'trend': self.k_endog * self.k_trend,
+            'ma': self.k_endog**2 * self.k_ma,
+            'ar': self.k_endog**2 * self.k_ar,
+            'regression': self.k_endog * self.k_exog,
+            }
+        return orders
+
+    params_complete = ['trend', 'ar', 'ma', 'regression',
+                       'state_cov', 'obs_cov']
+
+    @cached_property
+    def _slices(self):
+        orders = self.model_orders
+        ret = {}
+        start = 0
+        for name in self.params_complete:
+            if name in orders:
+                length = orders[name]
+            end = start + length
+            ret[name] = slice(start, end)
+            start += length
+        return ret
+
+    @cached_property
+    def _idx_slices(self):
         # Cache some indices
+        k_endog = self.k_endog
+
+        idxs = {}
         if self.trend == 'c' and self.k_exog == 0:
-            self._idx_state_intercept = np.s_['state_intercept', :k_endog]
+            idxs['state_intercept'] = np.s_['state_intercept', :k_endog]
         elif self.k_exog > 0:
-            self._idx_state_intercept = np.s_['state_intercept', :k_endog, :]
+            idxs['state_intercept'] = np.s_['state_intercept', :k_endog, :]
+
         if self.k_ar > 0:
-            self._idx_transition = np.s_['transition', :k_endog, :]
+            idxs['transition'] = np.s_['transition', :k_endog, :]
         else:
-            self._idx_transition = np.s_['transition', :k_endog, k_endog:]
+            idxs['transition'] = np.s_['transition', :k_endog, k_endog:]
+
         if self.error_cov_type == 'diagonal':
-            self._idx_state_cov = (
-                ('state_cov',) + np.diag_indices(self.k_endog))
+            idxs['state_cov'] = ('state_cov',) + np.diag_indices(k_endog)
+            idxs['lower_state_cov'] = None
         elif self.error_cov_type == 'unstructured':
-            self._idx_lower_state_cov = np.tril_indices(self.k_endog)
+            idxs['lower_state_cov'] = np.tril_indices(k_endog)
+            idxs['state_cov'] = None
+
         if self.measurement_error:
-            self._idx_obs_cov = ('obs_cov',) + np.diag_indices(self.k_endog)
-
-        # Cache some slices
-        def _slice(key, offset):
-            length = self.parameters[key]
-            param_slice = np.s_[offset:offset + length]
-            offset += length
-            return param_slice, offset
-
-        offset = 0
-        self._params_trend, offset = _slice('trend', offset)
-        self._params_ar, offset = _slice('ar', offset)
-        self._params_ma, offset = _slice('ma', offset)
-        self._params_regression, offset = _slice('regression', offset)
-        self._params_state_cov, offset = _slice('state_cov', offset)
-        self._params_obs_cov, offset = _slice('obs_cov', offset)
+            idxs['obs_cov'] = ('obs_cov',) + np.diag_indices(k_endog)
+        else:
+            idxs['obs_cov'] = None
+        return idxs
 
     def filter(self, params, **kwargs):
         kwargs.setdefault('results_class', VARMAXResults)


### PR DESCRIPTION
@ChadFulton One really nice design pattern you implemented in sarimax is the `model_orders` property.  I'd like to implement that pattern in the other statespace modules too.  This PR does a bit of that, then also demonstrates a related pattern I'd ask you to consider: using `_slices` and `_idx_slices` to a) get rid of a bunch of index-incrementing bookkeeping, b) reduce namespace proliferation (i.e. in varmax I would advocate replacing `self._params_trend` with `self._slices['trend']` etc) , and c) facilitate eventual sharing of similar code transform/untransform/update code via a base class.

If you're on board, I'll start make a real PR that _just_ implements `model_orders`, then one for `_slices` and then one for `_idx_slices`.

noci
