### PR TITLE
ENH: Implement _res_classes in statespace+regime_switching

### DIFF
--- a/statsmodels/tsa/regime_switching/markov_autoregression.py
+++ b/statsmodels/tsa/regime_switching/markov_autoregression.py
@@ -237,19 +237,10 @@ class MarkovAutoregression(markov_regression.MarkovRegression):
 
         return conditional_likelihoods
 
-    def filter(self, *args, **kwargs):
-        kwargs.setdefault('results_class', MarkovAutoregressionResults)
-        kwargs.setdefault('results_wrapper_class',
-                          MarkovAutoregressionResultsWrapper)
-        return super(MarkovAutoregression, self).filter(*args, **kwargs)
-    filter.__doc__ = markov_regression.MarkovRegression.filter.__doc__
-
-    def smooth(self, *args, **kwargs):
-        kwargs.setdefault('results_class', MarkovAutoregressionResults)
-        kwargs.setdefault('results_wrapper_class',
-                          MarkovAutoregressionResultsWrapper)
-        return super(MarkovAutoregression, self).smooth(*args, **kwargs)
-    smooth.__doc__ = markov_regression.MarkovRegression.smooth.__doc__
+    @property
+    def _res_classes(self):
+        return {'fit': (MarkovAutoregressionResults,
+                        MarkovAutoregressionResultsWrapper)}
 
     def _em_iteration(self, params0):
         """

--- a/statsmodels/tsa/regime_switching/markov_regression.py
+++ b/statsmodels/tsa/regime_switching/markov_regression.py
@@ -191,19 +191,10 @@ class MarkovRegression(markov_switching.MarkovSwitching):
 
         return conditional_likelihoods
 
-    def filter(self, *args, **kwargs):
-        kwargs.setdefault('results_class', MarkovRegressionResults)
-        kwargs.setdefault('results_wrapper_class',
-                          MarkovRegressionResultsWrapper)
-        return super(MarkovRegression, self).filter(*args, **kwargs)
-    filter.__doc__ = markov_switching.MarkovSwitching.filter.__doc__
-
-    def smooth(self, *args, **kwargs):
-        kwargs.setdefault('results_class', MarkovRegressionResults)
-        kwargs.setdefault('results_wrapper_class',
-                          MarkovRegressionResultsWrapper)
-        return super(MarkovRegression, self).smooth(*args, **kwargs)
-    smooth.__doc__ = markov_switching.MarkovSwitching.smooth.__doc__
+    @property
+    def _res_classes(self):
+        return {'fit': (MarkovRegressionResults,
+                        MarkovRegressionResultsWrapper)}
 
     def _em_iteration(self, params0):
         """

--- a/statsmodels/tsa/regime_switching/markov_switching.py
+++ b/statsmodels/tsa/regime_switching/markov_switching.py
@@ -982,23 +982,9 @@ class MarkovSwitching(tsbase.TimeSeriesModel):
             self, Bunch(**dict(zip(names, self._filter(params)))))
 
         # Wrap in a results object
-        if not return_raw:
-            result_kwargs = {}
-            if cov_type is not None:
-                result_kwargs['cov_type'] = cov_type
-            if cov_kwds is not None:
-                result_kwargs['cov_kwds'] = cov_kwds
-
-            if results_class is None:
-                results_class = MarkovSwitchingResults
-            if results_wrapper_class is None:
-                results_wrapper_class = MarkovSwitchingResultsWrapper
-
-            result = results_wrapper_class(
-                results_class(self, params, result, **result_kwargs)
-            )
-
-        return result
+        return self._wrap_results(params, result, return_raw, cov_type,
+                                  cov_kwds, results_class,
+                                  results_wrapper_class)
 
     def _smooth(self, params, filtered_marginal_probabilities,
                 predicted_joint_probabilities,
@@ -1011,6 +997,29 @@ class MarkovSwitching(tsbase.TimeSeriesModel):
         return cy_kim_smoother(regime_transition,
                                predicted_joint_probabilities,
                                filtered_joint_probabilities)
+
+    @property
+    def _res_classes(self):
+        return {'fit': (MarkovSwitchingResults, MarkovSwitchingResultsWrapper)}
+
+    def _wrap_results(self, params, result, return_raw, cov_type=None,
+                      cov_kwds=None, results_class=None, wrapper_class=None):
+        if not return_raw:
+            # Wrap in a results object
+            result_kwargs = {}
+            if cov_type is not None:
+                result_kwargs['cov_type'] = cov_type
+            if cov_kwds is not None:
+                result_kwargs['cov_kwds'] = cov_kwds
+
+            if results_class is None:
+                results_class = self._res_classes['fit'][0]
+            if results_wrapper_class is None:
+                results_wrapper_class = self._res_classes['fit'][1]
+
+            res = results_class(self, params, result, **result_kwargs)
+            result = wrapper_class(res)
+        return result
 
     def smooth(self, params, transformed=True, cov_type=None, cov_kwds=None,
                return_raw=False, results_class=None,
@@ -1070,23 +1079,9 @@ class MarkovSwitching(tsbase.TimeSeriesModel):
         result = KimSmootherResults(self, result)
 
         # Wrap in a results object
-        if not return_raw:
-            result_kwargs = {}
-            if cov_type is not None:
-                result_kwargs['cov_type'] = cov_type
-            if cov_kwds is not None:
-                result_kwargs['cov_kwds'] = cov_kwds
-
-            if results_class is None:
-                results_class = MarkovSwitchingResults
-            if results_wrapper_class is None:
-                results_wrapper_class = MarkovSwitchingResultsWrapper
-
-            result = results_wrapper_class(
-                results_class(self, params, result, **result_kwargs)
-            )
-
-        return result
+        return self._wrap_results(params, result, return_raw, cov_type,
+                                  cov_kwds, results_class,
+                                  results_wrapper_class)
 
     def loglikeobs(self, params, transformed=True):
         """

--- a/statsmodels/tsa/regime_switching/markov_switching.py
+++ b/statsmodels/tsa/regime_switching/markov_switching.py
@@ -1014,8 +1014,8 @@ class MarkovSwitching(tsbase.TimeSeriesModel):
 
             if results_class is None:
                 results_class = self._res_classes['fit'][0]
-            if results_wrapper_class is None:
-                results_wrapper_class = self._res_classes['fit'][1]
+            if wrapper_class is None:
+                wrapper_class = self._res_classes['fit'][1]
 
             res = results_class(self, params, result, **result_kwargs)
             result = wrapper_class(res)

--- a/statsmodels/tsa/statespace/dynamic_factor.py
+++ b/statsmodels/tsa/statespace/dynamic_factor.py
@@ -424,15 +424,9 @@ class DynamicFactor(MLEModel):
         idx = idx[:, np.lexsort((idx[1], idx[0]))]
         self._idx_error_transition = np.s_['transition', idx[0], idx[1]]
 
-    def filter(self, params, **kwargs):
-        kwargs.setdefault('results_class', DynamicFactorResults)
-        kwargs.setdefault('results_wrapper_class', DynamicFactorResultsWrapper)
-        return super(DynamicFactor, self).filter(params, **kwargs)
-
-    def smooth(self, params, **kwargs):
-        kwargs.setdefault('results_class', DynamicFactorResults)
-        kwargs.setdefault('results_wrapper_class', DynamicFactorResultsWrapper)
-        return super(DynamicFactor, self).smooth(params, **kwargs)
+    @property
+    def _res_classes(self):
+        return {'fit': (DynamicFactorResults, DynamicFactorResultsWrapper)}
 
     @property
     def start_params(self):

--- a/statsmodels/tsa/statespace/mlemodel.py
+++ b/statsmodels/tsa/statespace/mlemodel.py
@@ -482,6 +482,29 @@ class MLEModel(tsbase.TimeSeriesModel):
 
             return res
 
+    @property
+    def _res_classes(self):
+        return {'fit': (MLEResults, MLEResultsWrapper)}
+
+    def _wrap_results(self, params, result, return_raw, cov_type=None,
+                      cov_kwds=None, results_class=None, wrapper_class=None):
+        if not return_raw:
+            # Wrap in a results object
+            result_kwargs = {}
+            if cov_type is not None:
+                result_kwargs['cov_type'] = cov_type
+            if cov_kwds is not None:
+                result_kwargs['cov_kwds'] = cov_kwds
+
+            if results_class is None:
+                results_class = self._res_classes['fit'][0]
+            if results_wrapper_class is None:
+                results_wrapper_class = self._res_classes['fit'][1]
+
+            res = results_class(self, params, result, **result_kwargs)
+            result = wrapper_class(res)
+        return result
+
     def filter(self, params, transformed=True, complex_step=False,
                cov_type=None, cov_kwds=None, return_ssm=False,
                results_class=None, results_wrapper_class=None, **kwargs):
@@ -524,23 +547,9 @@ class MLEModel(tsbase.TimeSeriesModel):
         result = self.ssm.filter(complex_step=complex_step, **kwargs)
 
         # Wrap in a results object
-        if not return_ssm:
-            result_kwargs = {}
-            if cov_type is not None:
-                result_kwargs['cov_type'] = cov_type
-            if cov_kwds is not None:
-                result_kwargs['cov_kwds'] = cov_kwds
-
-            if results_class is None:
-                results_class = MLEResults
-            if results_wrapper_class is None:
-                results_wrapper_class = MLEResultsWrapper
-
-            result = results_wrapper_class(
-                results_class(self, params, result, **result_kwargs)
-            )
-
-        return result
+        return self._wrap_results(params, result, return_ssm, cov_type,
+                                  cov_kwds, results_class,
+                                  results_wrapper_class)
 
     def smooth(self, params, transformed=True, complex_step=False,
                cov_type=None, cov_kwds=None, return_ssm=False,
@@ -584,23 +593,9 @@ class MLEModel(tsbase.TimeSeriesModel):
         result = self.ssm.smooth(complex_step=complex_step, **kwargs)
 
         # Wrap in a results object
-        if not return_ssm:
-            result_kwargs = {}
-            if cov_type is not None:
-                result_kwargs['cov_type'] = cov_type
-            if cov_kwds is not None:
-                result_kwargs['cov_kwds'] = cov_kwds
-
-            if results_class is None:
-                results_class = MLEResults
-            if results_wrapper_class is None:
-                results_wrapper_class = MLEResultsWrapper
-
-            result = results_wrapper_class(
-                results_class(self, params, result, **result_kwargs)
-            )
-
-        return result
+        return self._wrap_results(params, result, return_ssm, cov_type,
+                                  cov_kwds, results_class,
+                                  results_wrapper_class)
 
     _loglike_param_names = ['transformed', 'complex_step']
     _loglike_param_defaults = [True, False]

--- a/statsmodels/tsa/statespace/mlemodel.py
+++ b/statsmodels/tsa/statespace/mlemodel.py
@@ -498,8 +498,8 @@ class MLEModel(tsbase.TimeSeriesModel):
 
             if results_class is None:
                 results_class = self._res_classes['fit'][0]
-            if results_wrapper_class is None:
-                results_wrapper_class = self._res_classes['fit'][1]
+            if wrapper_class is None:
+                wrapper_class = self._res_classes['fit'][1]
 
             res = results_class(self, params, result, **result_kwargs)
             result = wrapper_class(res)

--- a/statsmodels/tsa/statespace/sarimax.py
+++ b/statsmodels/tsa/statespace/sarimax.py
@@ -873,15 +873,9 @@ class SARIMAX(MLEModel):
                 selection[-i, -i] = 1
         return selection
 
-    def filter(self, params, **kwargs):
-        kwargs.setdefault('results_class', SARIMAXResults)
-        kwargs.setdefault('results_wrapper_class', SARIMAXResultsWrapper)
-        return super(SARIMAX, self).filter(params, **kwargs)
-
-    def smooth(self, params, **kwargs):
-        kwargs.setdefault('results_class', SARIMAXResults)
-        kwargs.setdefault('results_wrapper_class', SARIMAXResultsWrapper)
-        return super(SARIMAX, self).smooth(params, **kwargs)
+    @property
+    def _res_classes(self):
+        return {'fit': (SARIMAXResults, SARIMAXResultsWrapper)}
 
     @staticmethod
     def _conditional_sum_squares(endog, k_ar, polynomial_ar, k_ma,

--- a/statsmodels/tsa/statespace/structural.py
+++ b/statsmodels/tsa/statespace/structural.py
@@ -672,17 +672,10 @@ class UnobservedComponents(MLEModel):
 
         self.ssm.initialize_known(initial_state, initial_state_cov)
 
-    def filter(self, params, **kwargs):
-        kwargs.setdefault('results_class', UnobservedComponentsResults)
-        kwargs.setdefault('results_wrapper_class',
-                          UnobservedComponentsResultsWrapper)
-        return super(UnobservedComponents, self).filter(params, **kwargs)
-
-    def smooth(self, params, **kwargs):
-        kwargs.setdefault('results_class', UnobservedComponentsResults)
-        kwargs.setdefault('results_wrapper_class',
-                          UnobservedComponentsResultsWrapper)
-        return super(UnobservedComponents, self).smooth(params, **kwargs)
+    @property
+    def _res_classes(self):
+        return {'fit': (UnobservedComponentsResults,
+                        UnobservedComponentsResultsWrapper)}
 
     @property
     def start_params(self):

--- a/statsmodels/tsa/statespace/varmax.py
+++ b/statsmodels/tsa/statespace/varmax.py
@@ -271,15 +271,9 @@ class VARMAX(MLEModel):
         self._params_state_cov, offset = _slice('state_cov', offset)
         self._params_obs_cov, offset = _slice('obs_cov', offset)
 
-    def filter(self, params, **kwargs):
-        kwargs.setdefault('results_class', VARMAXResults)
-        kwargs.setdefault('results_wrapper_class', VARMAXResultsWrapper)
-        return super(VARMAX, self).filter(params, **kwargs)
-
-    def smooth(self, params, **kwargs):
-        kwargs.setdefault('results_class', VARMAXResults)
-        kwargs.setdefault('results_wrapper_class', VARMAXResultsWrapper)
-        return super(VARMAX, self).smooth(params, **kwargs)
+    @property
+    def _res_classes(self):
+        return {'fit': (VARMAXResults, VARMAXResultsWrapper)}
 
     @property
     def start_params(self):


### PR DESCRIPTION
@ChadFulton When it rains it pours.

This PR implements a `_res_classes` property in `statespace` and `regime_switching` models.  Analogous to pandas' `_constructor` properties, these are used to describe the Results and Wrapper classes a Model should use.

As you can see, implementing this allows us to get rid of _a lot_ of boilerplate.  (This reduction is even more dramatic outside of tsa).

The `_wrap_results` methods defined in `markov_switching` and `mlemodel` are identical, should eventually be moved into a shared parent class (along with a bunch of other stuff).

`_res_classes` returns a dictionary because in e.g. discrete_model, `fit_regularized` or `fit_constrained` will have different Results/Wrapper classes.