### PR TITLE
DOC: Move reference to non-sandbox modules

### DIFF
--- a/docs/source/stats.rst
+++ b/docs/source/stats.rst
@@ -216,13 +216,19 @@ to one way ANOVA, but still in developement
 .. module:: statsmodels.sandbox.stats.multicomp
    :synopsis: Experimental methods for controlling size while performing multiple comparisons
 
-.. currentmodule:: statsmodels.sandbox.stats.multicomp
+
+.. currentmodule:: statsmodels.stats.multitest
 
 .. autosummary::
    :toctree: generated/
 
    multipletests
-   fdrcorrection0
+   fdrcorrection
+
+.. currentmodule:: statsmodels.sandbox.stats.multicomp
+
+.. autosummary::
+   :toctree: generated/
 
    GroupsStats
    MultiComparison


### PR DESCRIPTION
Move documentation for promoted functions to point to correct location

closes #3442