### PR TITLE
xfail tests that had been disabled via name-mangling

### DIFF
--- a/statsmodels/base/tests/test_generic_methods.py
+++ b/statsmodels/base/tests/test_generic_methods.py
@@ -10,17 +10,18 @@ Created on Wed Oct 30 14:01:27 2013
 
 Author: Josef Perktold
 """
-from statsmodels.compat.python import range
-import numpy as np
-import pandas as pd
-import statsmodels.api as sm
-from statsmodels.compat.scipy import NumpyVersion
-from statsmodels.compat.testing import SkipTest
+import platform
 
+import pytest
+import pandas as pd
+import numpy as np
 from numpy.testing import (assert_, assert_allclose, assert_equal,
                            assert_array_equal)
 
-import platform
+from statsmodels.compat.scipy import NumpyVersion
+from statsmodels.compat.testing import SkipTest
+from statsmodels.compat.python import range
+import statsmodels.api as sm
 
 
 class CheckGenericMixin(object):
@@ -507,7 +508,8 @@ class TestWaldAnovaNegBin1(CheckAnovaMixin):
         cls.res = mod.fit(cov_type='HC0')
 
 
-class T_estWaldAnovaOLSNoFormula(object):
+@pytest.mark.xfail
+class TestWaldAnovaOLSNoFormula(object):
 
     @classmethod
     def initialize(cls):

--- a/statsmodels/discrete/tests/test_constrained.py
+++ b/statsmodels/discrete/tests/test_constrained.py
@@ -154,6 +154,7 @@ class TestPoissonConstrained1a(CheckPoissonConstrainedMixin):
         cls.res1m = mod.fit_constrained(constr, start_params=start_params,
                                         method='bfgs', disp=0)
 
+    @pytest.mark.smoke
     def test_smoke(self):
         # trailing text in summary, assumes it's the first extra string
         #NOTE: see comment about convergence in llnull for self.res1m
@@ -471,7 +472,7 @@ class TestGLMLogitConstrained2(CheckGLMConstrainedMixin):
         assert_allclose(res1.mu, predicted, rtol=1e-10)
         assert_allclose(res1.fittedvalues, predicted, rtol=1e-10)
 
-
+    @pytest.mark.smoke
     def test_smoke(self):
         # trailing text in summary, assumes it's the first extra string
         summ = self.res1m.summary()

--- a/statsmodels/discrete/tests/test_count_model.py
+++ b/statsmodels/discrete/tests/test_count_model.py
@@ -61,6 +61,7 @@ class CheckGeneric(object):
         assert_equal(exog_null.ptp(), 0)
         assert_equal(exog_infl_null.ptp(), 0)
 
+    @pytest.mark.smoke
     def test_summary(self):
         # SMOKE test
         self.res1.summary()
@@ -233,6 +234,7 @@ class TestZeroInflatedPoisson_predict(object):
             res.predict(), 0.05).T
         assert_allclose(pr, pr2, rtol=0.05, atol=0.05)
 
+
 class TestZeroInflatedGeneralizedPoisson(CheckGeneric):
     @classmethod
     def setup_class(cls):
@@ -301,6 +303,7 @@ class TestZeroInflatedGeneralizedPoisson(CheckGeneric):
         # skip, res_bh reports converged is false but params agree
         #assert_(res_bh.mle_retvals['converged'] is True)
 
+
 class TestZeroInflatedGeneralizedPoisson_predict(object):
     @classmethod
     def setup_class(cls):
@@ -332,6 +335,7 @@ class TestZeroInflatedGeneralizedPoisson_predict(object):
         pr2 = sm.distributions.zinegbin.pmf(np.arange(12)[:,None],
             res.predict(), 0.5, 2, 0.5).T
         assert_allclose(pr, pr2, rtol=0.08, atol=0.05)
+
 
 class TestZeroInflatedNegativeBinomialP(CheckGeneric):
     @classmethod

--- a/statsmodels/discrete/tests/test_count_model.py
+++ b/statsmodels/discrete/tests/test_count_model.py
@@ -1,6 +1,8 @@
 
 from __future__ import division
 import os
+
+import pytest
 import numpy as np
 from numpy.testing import (assert_, assert_raises, assert_almost_equal,
                            assert_equal, assert_array_equal, assert_allclose,

--- a/statsmodels/discrete/tests/test_sandwich_cov.py
+++ b/statsmodels/discrete/tests/test_sandwich_cov.py
@@ -11,6 +11,7 @@ import os
 import pandas as pd
 import numpy as np
 from numpy.testing import assert_allclose, assert_equal, assert_
+import pytest
 
 import statsmodels.discrete.discrete_model as smd
 from statsmodels.genmod.generalized_linear_model import GLM

--- a/statsmodels/discrete/tests/test_sandwich_cov.py
+++ b/statsmodels/discrete/tests/test_sandwich_cov.py
@@ -7,8 +7,11 @@ Author: Josef Perktold
 """
 
 import os
-import numpy as np
+
 import pandas as pd
+import numpy as np
+from numpy.testing import assert_allclose, assert_equal, assert_
+
 import statsmodels.discrete.discrete_model as smd
 from statsmodels.genmod.generalized_linear_model import GLM
 from statsmodels.genmod import families
@@ -20,7 +23,6 @@ import statsmodels.stats.sandwich_covariance as sw
 from statsmodels.tools.tools import add_constant
 
 
-from numpy.testing import assert_allclose, assert_equal, assert_
 import statsmodels.tools._testing as smt
 
 
@@ -503,7 +505,8 @@ class TestGLMLogit(CheckDiscreteGLM):
         cls.res2 = mod1.fit(cov_type='cluster', cov_kwds=dict(groups=group))
 
 
-class T_estGLMProbit(CheckDiscreteGLM):
+@pytest.mark.xfail
+class TestGLMProbit(CheckDiscreteGLM):
     # invalid link. What's Probit as GLM?
 
     @classmethod

--- a/statsmodels/genmod/tests/test_glm.py
+++ b/statsmodels/genmod/tests/test_glm.py
@@ -6,17 +6,19 @@ from statsmodels.compat import range
 from statsmodels.compat.testing import skipif
 
 import os
+import warnings
+
+import pytest
 import numpy as np
 from numpy.testing import (assert_almost_equal, assert_equal, assert_raises,
                            assert_allclose, assert_, assert_array_less, dec)
 from scipy import stats
+
 import statsmodels.api as sm
 from statsmodels.genmod.generalized_linear_model import GLM
 from statsmodels.tools.tools import add_constant
 from statsmodels.tools.sm_exceptions import PerfectSeparationError
 from statsmodels.discrete import discrete_model as discrete
-import pytest
-import warnings
 
 # Test Precisions
 DECIMAL_4 = 4
@@ -162,6 +164,7 @@ class CheckModelResultsMixin(object):
             assert_allclose(self.res1.pearson_chi2, self.res2.pearson_chi2,
                             atol=1e-6, rtol=1e-6)
 
+    @pytest.mark.smoke
     def test_summary(self):
         #SMOKE test
         self.res1.summary()
@@ -945,6 +948,7 @@ def gen_endog(lin_pred, family_class, link, binom_version=0):
     return endog
 
 
+@pytest.mark.smoke
 def test_summary():
     # Smoke test for summary.
 

--- a/statsmodels/genmod/tests/test_glm_weights.py
+++ b/statsmodels/genmod/tests/test_glm_weights.py
@@ -7,10 +7,10 @@ from statsmodels.compat.testing import SkipTest
 import warnings
 
 import nose
+import pytest
+import pandas as pd
 import numpy as np
 from numpy.testing import (assert_raises, assert_allclose)
-import pandas as pd
-import pytest
 
 import statsmodels.api as sm
 from statsmodels.genmod.generalized_linear_model import GLM
@@ -80,7 +80,8 @@ class CheckWeight(object):
             return None
         assert_allclose(res1.resid_anscombe, resid_all['resid_anscombe'], atol= 1e-6, rtol=2e-6)
 
-    def t_est_compare_bfgs(self):
+    @pytest.mark.xfail
+    def test_compare_bfgs(self):
         res1 = self.res1
         if isinstance(res1.model.family, sm.families.Tweedie):
             # Can't do this on Tweedie as loglikelihood is too complex


### PR DESCRIPTION
I looked through base, datasets, and discrete.  Still a bunch more directories to hunt these down in.