### PR TITLE
Improved handling of power calculations when effect-size = 0

### DIFF
--- a/statsmodels/stats/power.py
+++ b/statsmodels/stats/power.py
@@ -249,7 +249,9 @@ class Power(object):
             start_value = self.start_ttp[key]
         except KeyError:
             start_value = 0.9
-            print('Warning: using default start_value for {0}'.format(key))
+            import warnings
+            from statsmodels.tools.sm_exceptions import ValueWarning
+            warnings.warn('Warning: using default start_value for {0}'.format(key), ValueWarning)
 
         fit_kwds = self.start_bqexp[key]
         fit_res = []

--- a/statsmodels/stats/power.py
+++ b/statsmodels/stats/power.py
@@ -219,6 +219,18 @@ class Power(object):
             del kwds['power']
             return self.power(**kwds)
 
+        if kwds['effect_size'] == 0:
+            import warnings
+            from statsmodels.tools.sm_exceptions import HypothesisTestWarning
+            warnings.warn('Warning: Effect size of 0 detected', HypothesisTestWarning)
+            if key == 'power':
+                return alpha
+            if key == 'alpha':
+                return power
+            else:
+                raise ValueError('Cannot detect an effect-size of 0. Try changing your effect-size.')
+
+
         self._counter = 0
         def func(x):
             kwds[key] = x

--- a/statsmodels/stats/tests/test_power.py
+++ b/statsmodels/stats/tests/test_power.py
@@ -728,10 +728,17 @@ def test_power_solver():
     assert_equal(nip.cache_fit_res[0], 1)
     assert_equal(len(nip.cache_fit_res), 4)
 
+    # Test our edge-case where effect_size = 0
+    es = nip.solve_power(nobs1=1600, alpha=0.01, effect_size=0, power=None)
+    assert_almost_equal(es, 0.01)
+
     # I let this case fail, could be fixed for some statistical tests
     # (we shouldn't get here in the first place)
     # effect size is negative, but last stage brentq uses [1e-8, 1-1e-8]
     assert_raises(ValueError, nip.solve_power, None, nobs1=1600, alpha=0.01,
+                  power=0.005, ratio=1, alternative='larger')
+
+    assert_raises(ValueError, nip.solve_power, nobs1=None, effect_size=0, alpha=0.01,
                   power=0.005, ratio=1, alternative='larger')
 
 @skipif(SM_GT_10, 'Known failure on modern SciPy')


### PR DESCRIPTION
Warn the user that no amount of power can detect an effect size of 0


First time contributor, open to suggestions! Also I had a lot of trouble with local installation and wasn't able to get tests to run locally. Seeing what happens with Travis....