### PR TITLE
FIX: discrepancy without bounds

### DIFF
--- a/statsmodels/tools/sequences.py
+++ b/statsmodels/tools/sequences.py
@@ -3,7 +3,7 @@ from __future__ import division
 import numpy as np
 
 
-def discrepancy(sample, bounds=(0, 1)):
+def discrepancy(sample, bounds=None):
     """Discrepancy.
 
     Compute the centered discrepancy on a given sample.
@@ -15,7 +15,9 @@ def discrepancy(sample, bounds=(0, 1)):
     sample : array_like (n_samples, k_vars)
         The sample to compute the discrepancy from.
     bounds : tuple or array_like ([min, k_vars], [max, k_vars])
-        Desired range of transformed data.
+        Desired range of transformed data. The transformation apply the bounds
+        on the sample and not the theoretical space, unit cube. Thus min and
+        max values of the sample will coincide with the bounds.
 
     Returns
     -------
@@ -33,9 +35,10 @@ def discrepancy(sample, bounds=(0, 1)):
     n_sample, dim = sample.shape
 
     # Sample scaling from bounds to unit hypercube
-    min_ = bounds.min(axis=0)
-    max_ = bounds.max(axis=0)
-    sample = (sample - min_) / (max_ - min_)
+    if bounds is not None:
+        min_ = bounds.min(axis=0)
+        max_ = bounds.max(axis=0)
+        sample = (sample - min_) / (max_ - min_)
 
     abs_ = abs(sample - 0.5)
     disc1 = np.sum(np.prod(1 + 0.5 * abs_ - 0.5 * abs_ ** 2, axis=1))

--- a/statsmodels/tools/tests/test_sequences.py
+++ b/statsmodels/tools/tests/test_sequences.py
@@ -4,10 +4,13 @@ from statsmodels.tools import sequences
 
 
 def test_discrepancy():
+    space_0 = [[0.1, 0.5], [0.2, 0.4], [0.3, 0.3], [0.4, 0.2], [0.5, 0.1]]
     space_1 = [[1, 3], [2, 6], [3, 2], [4, 5], [5, 1], [6, 4]]
     space_2 = [[1, 5], [2, 4], [3, 3], [4, 2], [5, 1], [6, 6]]
 
     corners = np.array([[0.5, 0.5], [6.5, 6.5]])
+
+    npt.assert_allclose(sequences.discrepancy(space_0), 0.1353, atol=1e-4)
 
     # From Fang et al. Design and modeling for computer experiments, 2006
     npt.assert_allclose(sequences.discrepancy(space_1, corners), 0.0081, atol=1e-4)


### PR DESCRIPTION
If `bounds` is not set, it raises an issue as the tuple does not have `min` nor `max` method from numpy.