### PR TITLE
ENH: multivariate mean tests and confint

### DIFF
--- a/statsmodels/stats/multivariate.py
+++ b/statsmodels/stats/multivariate.py
@@ -1,0 +1,154 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Sun Nov  5 14:48:19 2017
+
+Author: Josef Perktold
+License: BSD-3
+"""
+
+
+import numpy as np
+from scipy import stats
+
+from statsmodels.stats.base import HolderTuple
+
+
+def hotelling_1samp(data, mean_null=0, return_results=True):
+    """Hotellings test for multivariate mean in one sample
+
+    Parameters
+    ----------
+    data : array_like
+        data with observations in rows and variables in columns
+    mean_null : array_like
+        mean of the multivariate data under the null hypothesis
+    return_results : bool
+        If true, then a results instance is returned. If False, then only
+        the test statistic and pvalue are returned.
+
+    Returns
+    -------
+    results : instance of a results class with attributes
+        statistic, pvalue, t2 and df
+    (statistic, pvalue) : tuple
+        If return_results is false, then only the test statistic and the
+        pvalue are returned.
+
+    """
+    x = np.asarray(data)
+    nobs, k_vars = x.shape
+    mean = x.mean(0)
+    cov = np.cov(x, rowvar=False, ddof=1)
+    diff = mean - mean_null
+    t2 = nobs * diff.dot(np.linalg.solve(cov, diff))
+    factor = (nobs - 1) * k_vars / (nobs - k_vars)
+    statistic = t2 / factor
+    df = (k_vars, nobs - k_vars)
+    pvalue = stats.f.sf(statistic, df[0], df[1])
+    if return_results:
+        res = HolderTuple(statistic=statistic,
+                          pvalue=pvalue,
+                          df=df,
+                          t2=t2,
+                          distr="F")
+        return res
+    else:
+        return statistic, pvalue
+
+
+def mv_mean_conf_int_simult(data, lin_transf=None, alpha=0.5):
+    """simultaneous confidency interval for linear transformation
+
+    Parameters
+    ----------
+    data : array_like
+        data with observations in rows and variables in columns
+    lin_transf : array_like or None
+        The linear transformation or contrast matrix for transforming the
+        vector of means. If this is None, then the identity matrix is used
+        which specifies the means themselves.
+    alpha : float in (0, 1)
+        confidence level for the confidence interval, commonly used is
+        alpha=0.05.
+
+    Returns
+    -------
+    low : ndarray
+        lower confidence bound on the linear transformed
+    upp : ndarray
+        upper confidence bound on the linear transformed
+    values : ndarray
+        mean or their linear transformation, center of the confidence region
+
+
+    Result 5.3 page 225
+    """
+    x = np.asarray(data)
+    nobs, k_vars = x.shape
+    if lin_transf is None:
+        lin_transf = np.eye(k_vars)
+    mean = x.mean(0)
+    cov = np.cov(x, rowvar=False, ddof=1)
+
+    ci = mv_mean_conf_int_simult_stat(mean, cov, nobs,
+                                      lin_transf=lin_transf, alpha=alpha)
+    return ci
+
+
+def mv_mean_conf_int_simult_stat(mean, cov, nobs, lin_transf=None, alpha=0.05):
+    """simultaneous confidence interval for linear transformation
+
+    based on summary statistic
+
+    Parameters
+    ----------
+    mean
+    cov
+    nobs
+
+    Result 5.3 page 225
+    This looks like Sheffe simultaneous confidence intervals
+    """
+    mean = np.asarray(mean)
+    cov = np.asarray(cov)
+    c = np.atleast_2d(lin_transf)
+    k_vars = len(mean)
+
+    values = c.dot(mean)
+    quad_form = (c * cov.dot(c.T).T).sum(1)
+    factor = (nobs - 1) * k_vars / (nobs - k_vars) / nobs
+    df = (k_vars, nobs - k_vars)
+    f_critval = stats.f.isf(alpha, df[0], df[1])
+    ci_diff = np.sqrt(factor * quad_form * f_critval)
+    low = values - ci_diff
+    upp = values + ci_diff
+    return low, upp, values  # , (f_critval, factor, quad_form, df)
+
+
+def mv_mean_conf_int_pointwise_stat(mean, cov, nobs, lin_transf=None,
+                                    alpha=0.05):
+    """pointwise confidence interval for linear transformation
+
+    based on summary statistic
+
+    Parameters
+    ----------
+    mean
+    cov
+    nobs
+
+    Result 5.3 page 224
+
+    """
+    mean = np.asarray(mean)
+    cov = np.asarray(cov)
+    c = np.atleast_2d(lin_transf)
+
+    values = c.dot(mean)
+    quad_form = (c * cov.dot(c.T).T).sum(1)
+    df = nobs - 1  # k_vars
+    t_critval = stats.t.isf(alpha / 2, df)
+    ci_diff = np.sqrt(quad_form / df) * t_critval
+    low = values - ci_diff
+    upp = values + ci_diff
+    return low, upp, values

--- a/statsmodels/stats/tests/test_multivariate.py
+++ b/statsmodels/stats/tests/test_multivariate.py
@@ -1,0 +1,146 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Sun Nov  5 14:48:19 2017
+
+Author: Josef Perktold
+"""
+
+import numpy as np
+from numpy.testing import assert_allclose, assert_equal
+
+from statsmodels.stats import weightstats
+# import statsmodels.stats.multivariate as smmv
+from statsmodels.stats.multivariate import (
+    hotelling_1samp, mv_mean_conf_int_simult_stat,
+    mv_mean_conf_int_pointwise_stat)
+from statsmodels.tools.testing import Holder
+
+
+def test_mv_mean():
+    # names = ['id', 'mpg1', 'mpg2', 'add']
+    x = np.asarray([[1.0, 24.0, 23.5, 1.0],
+                    [2.0, 25.0, 24.5, 1.0],
+                    [3.0, 21.0, 20.5, 1.0],
+                    [4.0, 22.0, 20.5, 1.0],
+                    [5.0, 23.0, 22.5, 1.0],
+                    [6.0, 18.0, 16.5, 1.0],
+                    [7.0, 17.0, 16.5, 1.0],
+                    [8.0, 28.0, 27.5, 1.0],
+                    [9.0, 24.0, 23.5, 1.0],
+                    [10.0, 27.0, 25.5, 1.0],
+                    [11.0, 21.0, 20.5, 1.0],
+                    [12.0, 23.0, 22.5, 1.0],
+                    [1.0, 20.0, 19.0, 0.0],
+                    [2.0, 23.0, 22.0, 0.0],
+                    [3.0, 21.0, 20.0, 0.0],
+                    [4.0, 25.0, 24.0, 0.0],
+                    [5.0, 18.0, 17.0, 0.0],
+                    [6.0, 17.0, 16.0, 0.0],
+                    [7.0, 18.0, 17.0, 0.0],
+                    [8.0, 24.0, 23.0, 0.0],
+                    [9.0, 20.0, 19.0, 0.0],
+                    [10.0, 24.0, 22.0, 0.0],
+                    [11.0, 23.0, 22.0, 0.0],
+                    [12.0, 19.0, 18.0, 0.0]])
+
+    res = hotelling_1samp(x[:, 1:3], [21, 21])
+
+    res_stata = Holder(p_F=1.25062334808e-09,
+                       df_r=22,
+                       df_m=2,
+                       F=59.91609589041116,
+                       T2=125.2791095890415)
+
+    assert_allclose(res.statistic, res_stata.F, rtol=1e-10)
+    assert_allclose(res.pvalue, res_stata.p_F, rtol=1e-10)
+    assert_allclose(res.t2, res_stata.T2, rtol=1e-10)
+    assert_equal(res.df, [res_stata.df_m, res_stata.df_r])
+
+    # diff of paired sample
+    mask = x[:, -1] == 1
+    x1 = x[mask, 1:3]
+    x0 = x[~mask, 1:3]
+    res_p = hotelling_1samp(x1 - x0, [0, 0])
+
+    # result Stata hotelling
+    res_stata = Holder(T2=9.698067632850247,
+                       df=10,
+                       k=2,
+                       N=12,
+                       F=4.4082126,  # not in return List
+                       p_F=0.0424)  # not in return List
+
+    res = res_p
+    assert_allclose(res.statistic, res_stata.F, atol=5e-7)
+    assert_allclose(res.pvalue, res_stata.p_F, atol=5e-4)
+    assert_allclose(res.t2, res_stata.T2, rtol=1e-10)
+    assert_equal(res.df, [res_stata.k, res_stata.df])
+
+    # mvtest means diff1 diff2, zero
+    res_stata = Holder(p_F=.0423949782937231,
+                       df_r=10,
+                       df_m=2,
+                       F=4.408212560386478,
+                       T2=9.69806763285025)
+
+    assert_allclose(res.statistic, res_stata.F, rtol=1e-12)
+    assert_allclose(res.pvalue, res_stata.p_F, rtol=1e-12)
+    assert_allclose(res.t2, res_stata.T2, rtol=1e-12)
+    assert_equal(res.df, [res_stata.df_m, res_stata.df_r])
+
+    dw = weightstats.DescrStatsW(x)
+    ci0 = dw.tconfint_mean(alpha=0.05)
+
+    nobs = len(x[:, 1:])
+    ci1 = mv_mean_conf_int_pointwise_stat(dw.mean, np.diag(dw.var), nobs,
+                                          lin_transf=np.eye(4), alpha=0.05)
+    ci2 = mv_mean_conf_int_pointwise_stat(dw.mean, dw.cov, nobs,
+                                          lin_transf=np.eye(4), alpha=0.05)
+
+    assert_allclose(ci1[:2], ci0, rtol=1e-13)
+    assert_allclose(ci2[:2], ci0, rtol=1e-13)
+
+
+def test_confint_simult():
+    # example from book for simultaneous confint
+
+    m = [526.29, 54.69, 25.13]
+    cov = [[5808.06, 597.84, 222.03],
+           [597.84, 126.05, 23.39],
+           [222.03, 23.39, 23.11]]
+    nobs = 87
+    res_ci = mv_mean_conf_int_simult_stat(m, cov, nobs, lin_transf=np.eye(3))
+
+    cii = [mv_mean_conf_int_simult_stat(m, cov, nobs,
+                                        lin_transf=np.eye(3)[i])[:2]
+           for i in range(3)]
+    cii = np.array(cii).squeeze()
+    # these might use rounded numbers in intermediate computation
+    res_ci_book = np.array([[503.06, 550.12], [51.22, 58.16], [23.65, 26.61]])
+
+    assert_allclose(res_ci[0], res_ci_book[:, 0], rtol=1e-3)  # low
+    assert_allclose(res_ci[0], res_ci_book[:, 0], rtol=1e-3)  # upp
+
+    assert_allclose(res_ci[0], cii[:, 0], rtol=1e-13)
+    assert_allclose(res_ci[1], cii[:, 1], rtol=1e-13)
+
+    res_constr = mv_mean_conf_int_simult_stat(m, cov, nobs,
+                                              lin_transf=[0, 1, -1])
+
+    assert_allclose(res_constr[0], 29.56 - 3.12, rtol=1e-3)
+    assert_allclose(res_constr[1], 29.56 + 3.12, rtol=1e-3)
+
+    # TODO: this assumes separate constraints,
+    #       but we want multiplicity correction
+    # test if several constraints or transformations work
+    # original, flipping sign, multiply by 2
+    res_constr2 = mv_mean_conf_int_simult_stat(
+        m, cov, nobs, lin_transf=[[0, 1, -1], [0, -1, 1], [0, 2, -2]])
+
+    lows = res_constr[0], - res_constr[1], 2 * res_constr[0]
+    upps = res_constr[1], - res_constr[0], 2 * res_constr[1]
+    # TODO: check return dimensions
+    lows = np.asarray(lows).squeeze()
+    upps = np.asarray(upps).squeeze()
+    assert_allclose(res_constr2[0], lows, rtol=1e-13)
+    assert_allclose(res_constr2[1], upps, rtol=1e-13)

--- a/statsmodels/stats/tests/test_multivariate.py
+++ b/statsmodels/stats/tests/test_multivariate.py
@@ -9,10 +9,11 @@ import numpy as np
 from numpy.testing import assert_allclose, assert_equal
 
 from statsmodels.stats import weightstats
-# import statsmodels.stats.multivariate as smmv
-from statsmodels.stats.multivariate import (
-    hotelling_1samp, mv_mean_conf_int_simult_stat,
-    mv_mean_conf_int_pointwise_stat)
+import statsmodels.stats.multivariate as smmv  # pytest cannot import test_xxx
+from statsmodels.stats.multivariate import confint_mvmean_fromstats
+#     hotelling_1samp,
+#     mv_mean_conf_int_simult_stat,
+#     mv_mean_conf_int_pointwise_stat)
 from statsmodels.tools.testing import Holder
 
 
@@ -43,7 +44,7 @@ def test_mv_mean():
                     [11.0, 23.0, 22.0, 0.0],
                     [12.0, 19.0, 18.0, 0.0]])
 
-    res = hotelling_1samp(x[:, 1:3], [21, 21])
+    res = smmv.test_mvmean(x[:, 1:3], [21, 21])
 
     res_stata = Holder(p_F=1.25062334808e-09,
                        df_r=22,
@@ -60,7 +61,7 @@ def test_mv_mean():
     mask = x[:, -1] == 1
     x1 = x[mask, 1:3]
     x0 = x[~mask, 1:3]
-    res_p = hotelling_1samp(x1 - x0, [0, 0])
+    res_p = smmv.test_mvmean(x1 - x0, [0, 0])
 
     # result Stata hotelling
     res_stata = Holder(T2=9.698067632850247,
@@ -92,13 +93,17 @@ def test_mv_mean():
     ci0 = dw.tconfint_mean(alpha=0.05)
 
     nobs = len(x[:, 1:])
-    ci1 = mv_mean_conf_int_pointwise_stat(dw.mean, np.diag(dw.var), nobs,
-                                          lin_transf=np.eye(4), alpha=0.05)
-    ci2 = mv_mean_conf_int_pointwise_stat(dw.mean, dw.cov, nobs,
-                                          lin_transf=np.eye(4), alpha=0.05)
+    ci1 = confint_mvmean_fromstats(dw.mean, np.diag(dw.var), nobs,
+                                   lin_transf=np.eye(4), alpha=0.05)
+    ci2 = confint_mvmean_fromstats(dw.mean, dw.cov, nobs,
+                                   lin_transf=np.eye(4), alpha=0.05)
 
     assert_allclose(ci1[:2], ci0, rtol=1e-13)
     assert_allclose(ci2[:2], ci0, rtol=1e-13)
+
+    # test from data
+    res = smmv.confint_mvmean(x, lin_transf=np.eye(4), alpha=0.05)
+    assert_allclose(res, ci2, rtol=1e-13)
 
 
 def test_confint_simult():
@@ -109,10 +114,11 @@ def test_confint_simult():
            [597.84, 126.05, 23.39],
            [222.03, 23.39, 23.11]]
     nobs = 87
-    res_ci = mv_mean_conf_int_simult_stat(m, cov, nobs, lin_transf=np.eye(3))
+    res_ci = confint_mvmean_fromstats(m, cov, nobs, lin_transf=np.eye(3),
+                                      simult=True)
 
-    cii = [mv_mean_conf_int_simult_stat(m, cov, nobs,
-                                        lin_transf=np.eye(3)[i])[:2]
+    cii = [confint_mvmean_fromstats(
+                m, cov, nobs, lin_transf=np.eye(3)[i], simult=True)[:2]
            for i in range(3)]
     cii = np.array(cii).squeeze()
     # these might use rounded numbers in intermediate computation
@@ -124,8 +130,8 @@ def test_confint_simult():
     assert_allclose(res_ci[0], cii[:, 0], rtol=1e-13)
     assert_allclose(res_ci[1], cii[:, 1], rtol=1e-13)
 
-    res_constr = mv_mean_conf_int_simult_stat(m, cov, nobs,
-                                              lin_transf=[0, 1, -1])
+    res_constr = confint_mvmean_fromstats(m, cov, nobs, lin_transf=[0, 1, -1],
+                                          simult=True)
 
     assert_allclose(res_constr[0], 29.56 - 3.12, rtol=1e-3)
     assert_allclose(res_constr[1], 29.56 + 3.12, rtol=1e-3)
@@ -134,8 +140,9 @@ def test_confint_simult():
     #       but we want multiplicity correction
     # test if several constraints or transformations work
     # original, flipping sign, multiply by 2
-    res_constr2 = mv_mean_conf_int_simult_stat(
-        m, cov, nobs, lin_transf=[[0, 1, -1], [0, -1, 1], [0, 2, -2]])
+    lt = [[0, 1, -1], [0, -1, 1], [0, 2, -2]]
+    res_constr2 = confint_mvmean_fromstats(m, cov, nobs, lin_transf=lt,
+                                           simult=True)
 
     lows = res_constr[0], - res_constr[1], 2 * res_constr[0]
     upps = res_constr[1], - res_constr[0], 2 * res_constr[1]


### PR DESCRIPTION
see e.g. #3208

I thought I already wrote something like this but don't find anything.
This is currently just a short exercise writing some basic multivariate mean tests to get started.

plans for implementation

There is a lot of repeated computation if we provide and use separate function that all start from data. Those standalone functions are good to get started but need better structure. 
Most likely the pattern will or should follow weightstats with a mixture of classes and standalone functions. One useful pattern is to have the functions based on summary statistics, so we have to compute those only once.

Reference for this time is Johnson and Wichern Applied Multivariate Statistical Analysis 6th edition. (I started to browse it by chance.)

Stata mvtests has good functions with almost complete formulas. However, I didn't see anything about mv confidence intervals. The simulataneous confidence intervals here use an example from Johnson and Wickern. They look similar to or the same as the Sheffe intervals added by Kerby.
Pointwise confidence intervals are compared to weightstats.

Stata doesn't have any kurtosis correction in mvtests, AFAICS. (see elliptical issues)



 


