### PR TITLE
Build slower jobs first to speed up build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,33 @@ matrix:
   include:
   - python: 2.7
     env:
+    - PYTHON=3.6
+    - COVERAGE=true
+  - python: 2.7
+    env:
     - PYTHON=2.7
     - NUMPY=1.11
     - MATPLOTLIB=1.5
     - COVERAGE=true
+  - python: 2.7
+    env:
+    - PYTHON=3.5
+    - NUMPY=1.10
+    - SCIPY=0.17
+    - PANDAS=0.18
+    - MATPLOTLIB=1.5
+  - python: 2.7
+    env:
+    - PYTHON=3.4
+    - NUMPY=1.10
+    - SCIPY=0.16
+    - PANDAS=0.16
+    - MATPLOTLIB=1.4
+    - OPTIONAL="libgfortran=1.0"
+  - python: 2.7
+    env:
+    - PYTHON=3.6
+    - DOCBUILD=true
   - python: 2.7
     env:
     - PYTHON=2.7
@@ -39,29 +62,6 @@ matrix:
     - SCIPY=0.14
     - MATPLOTLIB=1.4
     - PANDAS=0.14
-  - python: 2.7
-    env:
-    - PYTHON=3.4
-    - NUMPY=1.10
-    - SCIPY=0.16
-    - PANDAS=0.16
-    - MATPLOTLIB=1.4
-    - OPTIONAL="libgfortran=1.0"
-  - python: 2.7
-    env:
-    - PYTHON=3.5
-    - NUMPY=1.10
-    - SCIPY=0.17
-    - PANDAS=0.18
-    - MATPLOTLIB=1.5
-  - python: 2.7
-    env:
-    - PYTHON=3.6
-    - COVERAGE=true
-  - python: 2.7
-    env:
-    - PYTHON=3.6
-    - DOCBUILD=true
 
 notifications:
   email:


### PR DESCRIPTION
As the CI takes quite a long time, this is an experiment to try make start-to-finish times quicker by having slower jobs run first, to make full use of the five available parallel jobs, so we don't need to wait for them to run at the end.

Looking at the seven jobs, and representing them in roughly five minute blocks, based on some recent master builds:
```
xxxxx
xxx
xxx
xxxx
xxxxx
   xxxxxx
   xxxx
--------- 9*5=45
```

If we put the slower ones first, in theory we should be waiting less time for the last to finish:
```
xxxxx
xxxxx
xxxxx
xxxx
xxxx
    xxx
    xxx
------- 7*5=35
```
