### PR TITLE
WIP ENH:  SURCompact

### DIFF
--- a/statsmodels/multivariate/sur_model.py
+++ b/statsmodels/multivariate/sur_model.py
@@ -1,0 +1,251 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Mon Nov 13 10:58:40 2017
+
+Author: Josef Perktold
+"""
+
+import numpy as np
+from scipy import sparse, stats
+from statsmodels.base.model import LikelihoodModelResults
+from statsmodels.tools.decorators import cache_readonly
+from statsmodels.stats.moment_helpers import cov2corr
+
+
+def cov_func_spherical(resid, ddof=None):
+    k = resid.shape[1]
+    if ddof is None:
+        ddof = k
+    # overall variance
+    var = resid.var(ddof=ddof)
+    cov = np.diag(var * np.ones(k))
+    return cov
+
+
+def cov_func_diagonal(resid, ddof=None):
+    k = resid.shape[1]
+    if ddof is None:
+        ddof = k
+    # overall variance
+    var = resid.var(ddof=ddof, axis=0)
+    cov = np.diag(var)
+    return cov
+
+
+class DataDummy(object):
+    # dummy data class because it is required in base LikelihoodModelResults
+
+    def __init__(self, param_names):
+        self.param_names = param_names
+
+def params2block(params, k_vars_list):
+    bs = np.split(params, np.cumsum(k_vars_list[:-1]))
+    B = sparse.block_diag(bs).tocsc()
+    return B
+
+def _default_names(k_vars_list):
+
+    names = ['eq%d_var%d' % (eq, k) for eq in range(len(k_vars_list))
+                                    for k in range(k_vars_list[eq])]
+    return names
+
+class SURCompact(object):
+    """Seemingly Unrelated Regression - compact version
+
+    Requires balanced data set, nobs for each equation is the same.
+
+    This is an experimental version that uses nobs x sum(k_vars) matrix for
+    exog, i.e. where the exog of all equations are column stacked.
+    """
+
+    def __init__(self, endog_list, exog_list, cov_func=None):
+        # this requires balanced dataset, all nobs the same
+        self.endog_cstacked = self.y_cstacked = np.column_stack(endog_list)
+        self.exog_cstacked = self.x_cstacked = np.column_stack(exog_list)
+        self.k_vars_list = [ex.shape[1] for ex in exog_list]
+        if cov_func is None:
+            self.cov_func = lambda x: np.cov(x, rowvar=0)
+        else:
+            self.cov_func = cov_func
+
+        self.n_eq = len(self.k_vars_list)
+        self.nobs, n_eq = self.endog_cstacked.shape
+        assert self.n_eq == n_eq
+        # TODO
+        self.data = DataDummy(_default_names(self.k_vars_list))
+
+    def _predict(self, params_block, x_cstacked=None):
+
+        if x_cstacked is None:
+            x_cstacked = self.x_cstacked
+
+        fitted = params_block.dot(x_cstacked.T).T
+        return fitted
+
+    def _resid(self, params):
+        B = params2block(params, self.k_vars_list)
+        fitted = self._predict(B)
+        resid = self.y_cstacked - fitted
+        return resid
+
+    def _cov_resid(self, params, inv=False):
+        resid = self._resid(params)
+
+        if inv is False:
+            return self.cov_func(resid)
+        else:
+            # replace with a direct method,
+            # e.g. for patterned, sparse or regularized inv cov
+            return np.linalg.pinv(self.cov_func(resid))
+
+    def chol_cov_resid(self, params, inv=False):
+        c = self._cov_resid(params=params, inv=inv)
+        chol = np.linalg.cholesky(c)
+        return chol
+
+    def _wscore(self,params):
+        x_cstacked = self.model.exog_cstacked
+        ks = self.model.k_vars_list
+
+        # there is some computation duplication
+        resid = self._resid(params)
+        cov_chol = self.chol_cov_resid(params, inv=False)
+        wresid = resid.dot(cov_chol)
+        wresid_expanded = np.repeat(wresid, ks, axis=1)
+        wxu = x_cstacked * wresid_expanded
+        return(wxu)
+
+
+    def _fit_once(self, covi):
+        y_cstacked = self.endog_cstacked
+        x_cstacked = self.exog_cstacked
+        ks = self.k_vars_list
+        # moment matrix stacked
+
+        #covi = np.eye(3)
+        covi_ex = np.repeat(np.repeat(covi, ks, axis=1), ks, axis=0)
+        covi_y = np.repeat(covi, ks, axis=0)
+
+        xx = x_cstacked.T.dot(x_cstacked)
+        wxx = covi_ex * xx
+        #xy = x_cstacked.T.dot(y_cstacked)
+        #xy = np.concatenate([xi.T.dot(yi) for yi, xi in zip(ys, xs)])
+        wxy = (covi_y * x_cstacked.T.dot(y_cstacked)).sum(1)
+
+        b = np.linalg.solve(wxx, wxy)
+        return b, wxx
+
+    def fit(self, start_params=None, maxiter=10, atol=1e-8, rtol=1e-5):
+
+        if start_params is None:
+            # start with OLS
+            covi = np.eye(self.n_eq)
+            params, wxx = self._fit_once(covi)
+            covi_old = covi
+        else:
+            params = start_params
+
+        converged = False
+        for it in range(maxiter):
+            covi = self._cov_resid(params, inv=True)
+            params, wxx = self._fit_once(covi)
+            if np.allclose(covi, covi_old, atol=atol, rtol=rtol):
+                converged = True
+                break
+
+            covi_old = covi
+
+        wxx_inv = np.linalg.pinv(wxx)
+        res = SURCompactResult(self, params, wxx_inv, converged=converged,
+                        covi_fit=covi)
+        return res
+
+
+class SURCompactResult(LikelihoodModelResults):
+
+    # no super calls yet
+
+    def __init__(self, model, params, normalized_cov_params, **kwargs):
+        self.model = model
+        self.params = params
+        self.normalized_cov_params = normalized_cov_params
+        self.scale = 1
+        self.params_block = params2block(params, model.k_vars_list)
+        self.__dict__.update(kwargs)
+
+        # just a guess
+        self.df_resid = self.model.nobs - max(self.model.k_vars_list)
+
+
+    @cache_readonly
+    def fittedvalues(self):
+        return self.predict()
+
+    @cache_readonly
+    def resid(self):
+        return self.model.endog_cstacked - self.fittedvalues
+
+    @cache_readonly
+    def cov_resid(self):
+        # attach with default options
+        return self.get_cov_resid()
+
+    def predict(self, exog=None):
+        if exog is None:
+            exog = self.model.exog_cstacked
+
+        predicted = self.model._predict(self.params_block, exog)
+        return predicted
+
+    def get_cov_resid(self, method='cov', ddof=None):
+        if method != 'cov':
+            print('not yet')
+        if ddof is not None:
+            raise NotImplementedError('df not yet available, using mle ddof=0')
+
+        return np.cov(self.resid, rowvar=0)
+
+    def lmtest_uncorr(self):
+        nobs = self.model.nobs
+        n_eq = self.model.n_eq
+        corr_resid = cov2corr(self.cov_resid)
+        # LM test for uncorrelated residuals
+        rs = corr_resid[np.tril_indices(n_eq, -1)]
+        lmstat = nobs * (rs**2).sum()
+        pvalue = stats.chi2.sf(lmstat, n_eq * (n_eq - 1) / 2)
+        return lmstat, pvalue
+
+    def _get_score_values(self, eq_scaling=False):
+        """column stacked score x u, cross sectional correlation ignored
+
+        This is just for trying out for HC cov_type.
+        """
+        x_cstacked = self.model.exog_cstacked
+        ks = self.model.k_vars_list
+        resid = self.resid
+        if eq_scaling:
+            # this is just a try to rescale resid to take se of cross-sectional
+            # correlation into account, maybe cholesky?
+            #resid /= (np.diag(self.cov_resid)) # why not np.sqrt ?
+            resid *= (np.diag(self.covi_fit))
+        resid_expanded = np.repeat(resid, ks, axis=1)
+        xu = x_cstacked * resid_expanded
+        return xu
+
+    def _cov_hc0(self, eq_scaling=True):
+        """experimental, just a try
+
+        not completely correct
+        does not use whithened residual, i.e. use x u not wx u, in cov(score)
+        scaling should be wrong in inner part of sandwich, i.e. inconsistent
+        with normalized_cov_params (outer part of sandwich)
+        """
+        h = self.normalized_cov_params
+        xu = self._get_score_values(eq_scaling=eq_scaling)
+        c = np.cov(xu, rowvar=0) * self.model.nobs
+        cov_hc0 = h.dot(c.dot(h))
+        return cov_hc0
+
+    @cache_readonly
+    def bse_hc0(self):
+        return np.sqrt(np.diag(self._cov_hc0()))

--- a/statsmodels/multivariate/tests/test_sur.py
+++ b/statsmodels/multivariate/tests/test_sur.py
@@ -1,0 +1,74 @@
+
+from __future__ import division
+
+import numpy as np
+from numpy.testing import assert_allclose
+from scipy import sparse
+
+from statsmodels.regression.linear_model import OLS
+from statsmodels.multivariate.sur_model import SURCompact, cov_func_spherical
+
+
+def test_sur_ex():
+    # just a dump of example
+    # currently mainly special case with spherical cov equivalence to OLS
+
+    # simulate data
+    nobs = 1000
+    ks = [2, 3, 4]
+    n_eq = len(ks)
+    np.random.seed(987125)
+
+    xs = [np.column_stack((np.ones(nobs), np.random.rand(nobs, ki-1)))
+          for ki in ks]
+    ys = [0.5 * x.sum(1) + 0.5 * np.random.randn(nobs) for x in xs]
+
+
+    # print('\nusing class')
+    mod = SURCompact(ys, xs)
+    res = mod.fit(maxiter=0)
+    # print(res.params_block.todense())
+    # print()
+    # print(res.cov_resid)
+    # print()
+    # print(res.lmtest_uncorr())
+    tt = res.t_test(np.eye(len(res.params)))
+    # print(tt.summary(xname=res.model.data.param_names))
+    # print()
+    tt = res.t_test((np.eye(len(res.params)), 0.5 * np.ones(len(res.params))))
+    # print(tt.summary(xname=['bias:%s' % s for s in res.model.data.param_names]))
+
+    # print('\nbse')
+    # print(res.bse)
+    cov_hc0 = res._cov_hc0()
+    bse_hc0 = np.sqrt(np.diag(cov_hc0))
+    ## print(bse_hc0)
+    # print(res.bse_hc0)
+    xu = res._get_score_values()
+    c = np.cov(xu, rowvar=0)
+    # print(np.max(np.abs(res.normalized_cov_params - np.linalg.inv(c) / nobs)))
+    # without demeaning score
+    # print(np.max(np.abs(res.normalized_cov_params - np.linalg.inv(xu.T.dot(xu)))))
+
+
+
+
+    mod_sph = SURCompact(ys, xs, cov_func=cov_func_spherical)
+    res_sph = mod_sph.fit(maxiter=1)
+
+    mod_ols = OLS(np.concatenate(ys), sparse.block_diag(xs).todense())
+    res_ols = mod_ols.fit()
+    time = np.tile(np.arange(nobs), len(ks))
+    res_ols_clu = mod_ols.fit(cov_type='cluster', cov_kwds={'groups':time})
+
+    # print(res_sph.bse_hc0 / res_ols_clu.bse)
+    # some degrees of freedom differences like
+    np.sqrt(((3000 - 9) / 3000) / ((1000 - 1) / 1000))
+
+    cov_func_spherical(res_ols.resid[:,None]) / res_ols.scale
+    fact = 0.99866533140389435   # regression number, df correction is not clear
+    assert_allclose(res_sph.bse_hc0, fact * res_ols_clu.bse, rtol=1e-7)
+    assert_allclose(res_sph.params, res_ols.params, rtol=1e-13)
+    fact = 0.99899849749536518
+    assert_allclose(res_sph.bse, fact * res_ols.bse, rtol=1e-13)
+


### PR DESCRIPTION
SUR model where exog differ across equations. Mainly a computational exercise to try out this data structure for the representation of the SUR model.

This is supposed to be an implementation with a compact exog, following in this case Green 7th edition, but AFAIR it is standard formulation in all text books. (maybe Davidson MacKinnon was my previous reference)

exog is column_stacked list of exog for all equations
cov_resid is expanded to stacke exog and multivariate endog
```
covi_ex = np.repeat(np.repeat(covi, ks, axis=1), ks, axis=0)
covi_y = np.repeat(covi, ks, axis=0)
```
where I stopped:
- the simple/general version is implemented, but not unit tests against Stata yet
- currently the code also seems to correctly handle cov_hc0 for a diagonal cov_resid, equivalent to OLS and cov_type = 'cluster'. score_obs is only correct for diagonal cov_resid
- the extension is to get a cholesky weighted score_obs. That has initial code but not tried out yet. The idea is to get the column_stacked version of score_obs so we can use any cov_type with it. see #4121.
  I guess we could then also use pinv on obs, instead of solving the moment conditions directly which I currently do.

also this has two representations of params, standard params is 1-D, second version params_block is sparse block diagonal for the multivariate representation. Y = X B + U, where Y and U are (nobs, k_endog) and X is column_stacked exogs with shape (nobs, sum(k_vars))

special feature: call back function for cov_resid. 
We don't hard code the way cov_resid is estimated, so we can use structured, regularized or robust cov_resid or inverse cov_resid similar to GEE, This makes it closer to GMM/GEE, i.e. structured working cov or GMM weights matrix and sandwich cov_params. e.g. #2942, i.e. GMM weights and cov_score in cov_params don't have to necessarily agree.


