### PR TITLE
CLN: Remove test noise from vecm

### DIFF
--- a/statsmodels/tsa/vector_ar/tests/test_var_jmulti.py
+++ b/statsmodels/tsa/vector_ar/tests/test_var_jmulti.py
@@ -31,9 +31,9 @@ to_test = all_tests  #["coefs", "det", "Sigma_u", "log_like", "fc", "causality"]
 
 
 def load_data(dataset, data_dict):
-    dtset = dataset.load()
+    dtset = dataset.load_pandas()
     variables = dataset.variable_names
-    loaded = dtset.data[variables].view(float, type=np.ndarray)
+    loaded = dtset.data[variables].astype(float).values
     data_dict[dataset] = loaded.reshape((-1, len(variables)))
 
 

--- a/statsmodels/tsa/vector_ar/vecm.py
+++ b/statsmodels/tsa/vector_ar/vecm.py
@@ -867,6 +867,7 @@ class VECM(tsbase.TimeSeriesModel):
         s00, s01, s10, s11, s11_, _, v = _sij(delta_x, delta_y_1_T, y_lag1)
 
         beta_tilde = (v[:, :self.coint_rank].T.dot(s11_)).T
+        beta_tilde = np.real_if_close(beta_tilde)
         # normalize beta tilde such that eye(r) forms the first r rows of it:
         beta_tilde = np.dot(beta_tilde, inv(beta_tilde[:self.coint_rank]))
         alpha_tilde = s01.dot(beta_tilde).dot(


### PR DESCRIPTION
Replace recarray with pandas for testing
Remove 0 imag components where they should be 0