### PR TITLE
DOC: Fix a typo in an error message

### DIFF
--- a/statsmodels/tsa/seasonal.py
+++ b/statsmodels/tsa/seasonal.py
@@ -119,7 +119,7 @@ def seasonal_decompose(x, model="additive", filt=None, freq=None, two_sided=True
             freq = pfreq
         else:
             raise ValueError("You must specify a freq or x must be a "
-                             "pandas object with a timeseries index with"
+                             "pandas object with a timeseries index with "
                              "a freq not set to None")
 
     if filt is None:


### PR DESCRIPTION
This turns "timeseries index witha freq" into "timeseries index with a freq".