### PR TITLE
Maximum likelihood factor analysis

### DIFF
--- a/statsmodels/iolib/summary2.py
+++ b/statsmodels/iolib/summary2.py
@@ -246,7 +246,7 @@ def _measure_tables(tables, settings):
     pad_index = []
 
     for i in range(len(tab)):
-        nsep = tables[i].shape[1] - 1
+        nsep = max(tables[i].shape[1] - 1, 1)
         pad = int((len_max - length[i]) / nsep)
         pad_sep.append(pad)
         len_new = length[i] + nsep * pad

--- a/statsmodels/multivariate/factor.py
+++ b/statsmodels/multivariate/factor.py
@@ -409,6 +409,12 @@ class FactorResults(object):
         1 - uniqueness
     loadings : ndarray
         Each column is the loading vector for one factor
+    loadings_no_rot : ndarray
+        Unrotated loadings, not available under maximum likelihood
+        analyis.
+    eigenvalues : ndarray
+        The eigenvalues for a factor analysis obtained using
+        principal components; not available under ML estimation.
     n_comp : int
         Number of components (factors)
     nbs : int
@@ -416,6 +422,8 @@ class FactorResults(object):
     fa_method : string
         The method used to obtain the decomposition, either 'pa' for
         'principal axes' or 'ml' for maximum likelihood.
+    df : int
+        Degrees of freedom of the factor model.
 
     Notes
     -----
@@ -453,8 +461,9 @@ class FactorResults(object):
         Parameters
         ----------
         method : string
-            rotation to be applied
-        -------
+            Rotation to be applied.  Allowed methods are varimax,
+            quartimax, biquartimax, equamax, oblimin, parsimax,
+            parsimony, biquartimin, promax.
         """
         self.rotation_method = method
         if method not in ['varimax', 'quartimax', 'biquartimax',
@@ -582,6 +591,9 @@ class FactorResults(object):
 
         These are asymptotic standard errors.  See Bai and Li (2012)
         for conditions under which the standard errors are valid.
+
+        The standard errors are only applicable to the original,
+        unrotated maximum likelihood solution.
         """
 
         if self.fa_method.lower() != "ml":
@@ -606,6 +618,9 @@ class FactorResults(object):
 
         These are asymptotic standard errors.  See Bai and Li (2012)
         for conditions under which the standard errors are valid.
+
+        The standard errors are only applicable to the original,
+        unrotated maximum likelihood solution.
         """
 
         if self.fa_method.lower() != "ml":

--- a/statsmodels/multivariate/factor.py
+++ b/statsmodels/multivariate/factor.py
@@ -298,10 +298,11 @@ class Factor(Model):
     # vector of uniquenesses.
     def loglike(self, par):
 
-        if len(par) == 2:
-            par = self._pack(par[0], par[1])
+        if type(par) is np.ndarray:
+            sig2, gamma = self._unpack(par)
+        else:
+            gamma, sig2 = par[0], par[1]
 
-        sig2, gamma = self._unpack(par)
         sigam = gamma / sig2[:, None]
         gamtsigam = np.dot(gamma.T, sigam)
 

--- a/statsmodels/multivariate/factor.py
+++ b/statsmodels/multivariate/factor.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import division
 from statsmodels.base.model import Model
 from .factor_rotation import rotate_factors, promax
 import numpy as np

--- a/statsmodels/multivariate/factor.py
+++ b/statsmodels/multivariate/factor.py
@@ -2,9 +2,16 @@
 
 from statsmodels.base.model import Model
 from .factor_rotation import rotate_factors, promax
+import numpy as np
+from numpy.linalg import eigh, inv, norm, matrix_rank
+import pandas as pd
+from statsmodels.tools.decorators import cache_readonly
+from scipy.optimize import minimize
+from statsmodels.iolib import summary2
+import warnings
 
 try:
-    import matplotlib.pyplot as plt
+    import matplotlib.pyplot
     missing_matplotlib = False
 except ImportError:
     missing_matplotlib = True
@@ -12,11 +19,40 @@ except ImportError:
 if not missing_matplotlib:
     from .plots import plot_scree, plot_loadings
 
-import numpy as np
-from numpy.linalg import eigh, inv, norm, matrix_rank
-import pandas as pd
+# Factor analysis models can be hard to estimate, need stricter
+# conditions.
+_opt_defaults = {"gtol": 1e-8}
 
-from statsmodels.iolib import summary2
+
+def _check_args_1(endog, n_factor, corr, nobs):
+
+    msg = "Either endog or corr must be provided, but not both"
+    if endog is not None and corr is not None:
+        raise ValueError(msg)
+    if endog is None and corr is None:
+        raise ValueError(msg)
+
+    if n_factor <= 0:
+        raise ValueError('n_factor must be larger than 0! %d < 0' %
+                         (n_factor))
+
+    if nobs is not None and endog is not None:
+        warnings.warn("nobs is ignored when endog is provided")
+
+
+def _check_args_2(endog, n_factor, corr, nobs, k_endog):
+
+    if n_factor > k_endog:
+        raise ValueError('n_factor cannot be greater than the number'
+                         ' of variables! %d > %d' %
+                         (n_factor, k_endog))
+
+    if np.max(np.abs(np.diag(corr) - 1)) > 1e-10:
+        raise ValueError("corr must be a correlation matrix")
+
+    if corr.shape[0] != corr.shape[1]:
+        raise ValueError('Correlation matrix corr must be a square '
+                         '(rows %d != cols %d)' % corr.shape)
 
 
 class Factor(Model):
@@ -24,8 +60,8 @@ class Factor(Model):
     Factor analysis
     Status: experimental
 
-    .. [1] Hofacker, C. (2004). Exploratory Factor Analysis, Mathematical Marketing.
-    http://www.openaccesstexts.org/pdf/Quant_Chapter_11_efa.pdf
+    .. [1] Hofacker, C. (2004). Exploratory Factor Analysis, Mathematical
+    Marketing. http://www.openaccesstexts.org/pdf/Quant_Chapter_11_efa.pdf
 
     Supported rotations:
         'varimax', 'quartimax', 'biquartimax', 'equamax', 'oblimin',
@@ -34,61 +70,65 @@ class Factor(Model):
     Parameters
     ----------
     endog : array-like
-        Variables in columns, observations in rows
-        Could be `None` if `corr` is not `None`
+        Variables in columns, observations in rows.  May be `None` if
+        `corr` is not `None`.
     n_factor : int
         The number of factors to extract
     corr : array-like
-        Directly specify the correlation matrix instead of estimating from endog
-        If not `None`, `endog` will not be used
+        Directly specify the correlation matrix instead of estimating
+        it from `endog`.  If provided, `endog` is not used.
     method : str
-        Specify the method to extract factors
-        'pa' - Principal axis factor analysis
+        The method to extract factors, currently must be either 'pa'
+        for principal axis factor analysis or 'ml' for maximum
+        likelihood estimation.
     smc : True or False
-        Whether or not to apply squared multiple correlations
+        Whether or not to apply squared multiple correlations (method='pa')
     endog_names: str
-        Names of endogeous variables.
-        If specified, it will be used instead of the column names in endog
+        Names of endogeous variables.  If specified, it will be used
+        instead of the column names in endog
     nobs: int
-        The number of observations. To be used together with `corr`
-        Should be equals to the number of rows in `endog`.
+        The number of observations, not used if endog is present.
 
+    Notes
+    -----
+    If method='ml', the factors are rotated to satisfy condition IC3
+    of Bai and Li (2012).  This means that the scores have covariance
+    I, so the model for the covariance matrix is L * L' + diag(U),
+    where L are the loadings and U are the uniquenesses.  In addition,
+    L' * diag(U)^{-1} L must be diagonal.
+
+    References
+    ----------
+    J Bai, K Li (2012).  Statistical analysis of factor models of high
+    dimension.  Annals of Statistics. https://arxiv.org/pdf/1205.6617.pdf
     """
-    def __init__(self, endog, n_factor, corr=None, method='pa', smc=True,
-                 missing='drop', endog_names=None, nobs=None):
+    def __init__(self, endog=None, n_factor=1, corr=None, method='pa',
+                 smc=True, missing='drop', endog_names=None, nobs=None):
+
+        _check_args_1(endog, n_factor, corr, nobs)
+
         if endog is not None:
             k_endog = endog.shape[1]
+            nobs = endog.shape[0]
+            corr = np.corrcoef(endog, rowvar=0)
         elif corr is not None:
             k_endog = corr.shape[0]
+        else:
+            msg = "Either endog or corr must be provided, but not both"
+            raise ValueError(msg)
 
-        # Check validity of n_factor
-        if n_factor <= 0:
-            raise ValueError('n_factor must be larger than 0! %d < 0' %
-                             (n_factor))
-        if endog is not None and n_factor > k_endog:
-            raise ValueError('n_factor must be smaller or equal to the number'
-                             ' of columns of endog! %d > %d' %
-                             (n_factor, k_endog))
+        _check_args_2(endog, n_factor, corr, nobs, k_endog)
+
         self.n_factor = n_factor
-
-        if corr is None and endog is None:
-            raise ValueError('Both endog and corr is None!')
-
         self.loadings = None
         self.communality = None
-        self.eigenvals = None
         self.method = method
         self.smc = smc
+        self.nobs = nobs
+        self.method = method
+        self.corr = corr
+        self.k_endog = k_endog
 
-        # Check validity of corr
-        if corr is not None:
-            if corr.shape[0] != corr.shape[1]:
-                raise ValueError('Correlation matrix corr must be a square '
-                                 '(rows %d != cols %d)' % corr.shape)
-            if endog is not None and k_endog != corr.shape[0]:
-                    raise ValueError('The number of columns in endog (=%d) must be '
-                                     'equal to the number of columns and rows corr (=%d)'
-                                     % (k_endog, corr.shape[0]))
         if endog_names is None:
             if hasattr(corr, 'index'):
                 endog_names = corr.index
@@ -101,13 +141,8 @@ class Factor(Model):
         else:
             self.corr = None
 
-        # Check validity of n_obs
-        if nobs is not None:
-            if endog is not None and endog.shape[0] != nobs:
-                raise ValueError('n_obs must be equal to the number of rows in endog')
-
-        # Do not preprocess endog if None
         if endog is not None:
+            # Do not preprocess endog if None
             super(Factor, self).__init__(endog, exog=None, missing=missing)
         else:
             self.endog = None
@@ -126,42 +161,52 @@ class Factor(Model):
                 while n > 0:
                     d += 1
                     n //= 10
-                return [('var%0' + str(d) + 'd') % i for i in range(self.corr.shape[0])]
+                return [('var%0' + str(d) + 'd') % i
+                        for i in range(self.corr.shape[0])]
 
     @endog_names.setter
     def endog_names(self, value):
         # Check validity of endog_names:
         if value is not None:
-            if self.corr is not None and len(value) != self.corr.shape[0]:
-                raise ValueError('The number of elements in endog_names must '
-                                 'be equal to the number of columns and rows in corr')
-            if self.endog is not None and len(value) != self.endog.shape[1]:
-                raise ValueError('The number of elements in endog_names must '
-                                 'be equal to the number of columns in endog')
+            if len(value) != self.corr.shape[0]:
+                raise ValueError('The length of `endog_names` must '
+                                 'equal the number of variables.')
             self._endog_names = np.asarray(value)
         else:
             self._endog_names = None
 
-    def fit(self, maxiter=50, tol=1e-8):
+    def fit(self, maxiter=50, tol=1e-8, start=None, opt_method='bfgs',
+            opt=None):
         """
-        Extract factors
+        Estimate factor model parameters.
 
         Parameters
         ----------
         maxiter : int
             Maximum number of iterations for iterative estimation algorithms
         tol : float
-            Stopping critera (error tolerance) for iterative estimation algorithms
+            Stopping critera (error tolerance) for iterative estimation
+            algorithms
+        start : array-like
+            Starting values, currently only used for ML estimation
+        opt_method : string
+            Optimization method for ML estimation
+        opt : dict-like
+            Keyword arguments passed to optimizer, only used for ML estimation
 
         Returns
         -------
         results: FactorResults
 
         """
-        if self.method == 'pa':
+        method = self.method.lower()
+        if method == 'pa':
             return self._fit_pa(maxiter=maxiter, tol=tol)
+        elif method == 'ml':
+            return self._fit_ml(start, opt_method, opt)
         else:
-            raise ValueError("Unknown factor extraction approach '%s'" % self.method)
+            msg = "Unknown factor extraction approach '%s'" % self.method
+            raise ValueError(msg)
 
     def _fit_pa(self, maxiter=50, tol=1e-8):
         """
@@ -230,8 +275,111 @@ class Factor(Model):
 
         self.eigenvals = eigenvals
         self.communality = c
+        self.uniqueness = 1 - c
         self.loadings = A
         return FactorResults(self)
+
+    # Unpacks the model parameters from a flat vector, used for ML
+    # estimation.  The first k_endog elements of par are the standard
+    # deviations of the uniquenesses.  The remaining elements are the
+    # factor loadings, packed one factor at a time.
+    def _unpack(self, par):
+        return (par[0:self.k_endog]**2,
+                np.reshape(par[self.k_endog:], (-1, self.k_endog)).T)
+
+    # Packs the model parameters into a flat parameter, used for ML
+    # estimation.
+    def _pack(self, gamma, sigma):
+        return np.concatenate((np.sqrt(sigma), gamma.T.flat))
+
+    # The log-likelihood function.  The input can be either a packed
+    # representation of the model parameters or a 2-tuple containing a
+    # `k_endog x n_factor` matrix of factor loadings and a `k_endog`
+    # vector of uniquenesses.
+    def loglike(self, par):
+
+        if len(par) == 2:
+            par = self._pack(par[0], par[1])
+
+        sig2, gamma = self._unpack(par)
+        sigam = gamma / sig2[:, None]
+        gamtsigam = np.dot(gamma.T, sigam)
+
+        # log|GG' + S|
+        # Using matrix determinant lemma:
+        # |GG' + S| = |I + G'S^{-1}G|*|S|
+        gamtsigam.flat[::gamtsigam.shape[0]+1] += 1
+        _, ld = np.linalg.slogdet(gamtsigam)
+        v = np.sum(np.log(sig2)) + ld
+
+        # tr((GG' + S)^{-1}C)
+        # Using Sherman-Morrison-Woodbury
+        w = np.sum(1 / sig2)
+        b = np.dot(gamma.T, self.corr / sig2[:, None])
+        b = np.linalg.solve(gamtsigam, b)
+        b = np.dot(gamma, b) / sig2[:, None]
+        w -= np.trace(b)
+
+        # Negative log-likelihood
+        return (v + w) / (2*self.k_endog)
+
+    # Maximum likelihood factor analysis.
+    def _fit_ml(self, start, opt_method, opt):
+
+        corr = self.corr
+        n_factor = self.n_factor
+
+        # Dimension of the problem
+        k_endog = corr.shape[0]
+
+        # Starting values
+        if start is None:
+            # Use simple PCA procedure for starting values.
+            u, s, _ = np.linalg.svd(corr, 0)
+            u *= np.sqrt(s)
+            u = u[:, 0:n_factor]
+            f = 1 - s[0:n_factor].sum() / k_endog
+            start1 = f * np.ones(k_endog)
+            start = np.concatenate((start1, u.T.flat))
+        elif len(start) == 2:
+            if len(start[1]) != start[0].shape[0]:
+                msg = "Starting values have incompatible dimensions"
+                raise ValueError(msg)
+            start = self._pack(start[0], start[1])
+        else:
+            raise ValueError("Invalid starting values")
+
+        # Do the optimization
+        def qloglike(par):
+            return self.loglike(par)
+
+        if opt is not None:
+            opt = dict(opt)
+        else:
+            opt = {}
+        opt.update(_opt_defaults)
+        r = minimize(qloglike, start, method=opt_method, options=opt)
+        par = r.x
+        uniq, load = self._unpack(par)
+
+        # Rotate solution to satisfy IC3 of Bai and Li
+        if uniq.min() > 1e-10:
+            load = _rotate(load, uniq)
+        else:
+            warnings.warn("some error variances are nearly zero, " +
+                          "skipping rotation")
+
+        self.uniqueness = uniq
+        self.communality = 1 - uniq
+        self.loadings = load
+
+        return FactorResults(self)
+
+
+def _rotate(load, uniq, type="ic3"):
+    qm = np.dot(load.T, load / uniq[:, None])
+    _, b = np.linalg.eig(qm)
+    return np.dot(load, b)
 
 
 class FactorResults(object):
@@ -247,17 +395,21 @@ class FactorResults(object):
 
     """
     def __init__(self, factor):
-        if not isinstance(factor, Factor):
-            raise ValueError('Input must be a `Factor` class. Got %s instead'
-                             % (factor.__str__))
         self.endog_names = factor.endog_names
         self.loadings_no_rot = factor.loadings
         self.loadings = factor.loadings
-        self.eigenvals = factor.eigenvals
+        if hasattr(factor, "eigenvals"):
+            self.eigenvals = factor.eigenvals
         self.communality = factor.communality
+        self.uniqueness = factor.uniqueness
         self.rotation_method = None
         self.fa_method = factor.method
-        self.n_comp = factor.n_comp
+        self.n_comp = factor.loadings.shape[1]
+        self.nobs = factor.nobs
+        self._factor = factor
+
+        p, k = self.loadings.shape
+        self.df = ((p - k)**2 - (p + k)) // 2
 
     def __str__(self):
         return self.summary().__str__()
@@ -282,7 +434,8 @@ class FactorResults(object):
                       'parsimax', 'parsimony', 'biquartimin']:
             self.loadings, T = rotate_factors(self.loadings_no_rot, method)
         elif method == 'oblimin':
-            self.loadings, T = rotate_factors(self.loadings_no_rot, 'quartimin')
+            self.loadings, T = rotate_factors(self.loadings_no_rot,
+                                              'quartimin')
         elif method == 'promax':
             self.loadings, T = promax(self.loadings_no_rot)
 
@@ -295,10 +448,12 @@ class FactorResults(object):
                      for i in range(self.loadings_no_rot.shape[1])],
             index=self.endog_names
         )
-        eigenvals = pd.DataFrame([self.eigenvals], columns=self.endog_names,
-                                 index=[''])
-        summ.add_dict({'': 'Eigenvalues'})
-        summ.add_df(eigenvals)
+        if hasattr(self, "eigenvals"):
+            # eigenvals not available for ML method
+            eigenvals = pd.DataFrame(
+                [self.eigenvals], columns=self.endog_names, index=[''])
+            summ.add_dict({'': 'Eigenvalues'})
+            summ.add_df(eigenvals)
         communality = pd.DataFrame([self.communality],
                                    columns=self.endog_names, index=[''])
         summ.add_dict({'': ''})
@@ -372,3 +527,55 @@ class FactorResults(object):
         return plot_loadings(loadings, loading_pairs=loading_pairs,
                              title=title, row_names=self.endog_names,
                              percent_variance=var_explained)
+
+    """
+    Returns the fitted covariance matrix.
+    """
+    @cache_readonly
+    def fitted_cov(self):
+        c = np.dot(self.loadings, self.loadings.T)
+        c.flat[::c.shape[0]+1] += self.uniqueness
+        return c
+
+    """
+    The standard errors of the uniquenesses.
+
+    If excess kurtosis is known, provide as `kurt`.  Standard errors
+    are only available if the model was fit using maximum likelihood.
+    If `endog` is not provided, `nobs`must be provided to obtain
+    standard errors.
+    """
+    @cache_readonly
+    def uniq_stderr(self, kurt=0):
+
+        if self.fa_method.lower() != "ml":
+            msg = "Standard errors only available under ML estimation"
+            raise ValueError(msg)
+
+        if self.nobs is None:
+            msg = "nobs is required to obtain standard errors."
+            raise ValueError(msg)
+
+        v = self.uniqueness**2 * (2 + kurt) / self.nobs
+        return np.sqrt(v)
+
+    """
+    The standard errors of the loadings.
+
+    Standard errors are only available if the model was fit using
+    maximim likelihood.  If `endog` is not provided, `nobs`must be
+    provided to obtain standard errors.
+    """
+    @cache_readonly
+    def load_stderr(self, kurt=0):
+
+        if self.fa_method.lower() != "ml":
+            msg = "Standard errors only available under ML estimation"
+            raise ValueError(msg)
+
+        if self.nobs is None:
+            msg = "nobs is required to obtain standard errors."
+            raise ValueError(msg)
+
+        v = np.outer(self.uniqueness, np.ones(self.loadings.shape[1]))
+        return np.sqrt(v)

--- a/statsmodels/multivariate/factor.py
+++ b/statsmodels/multivariate/factor.py
@@ -409,8 +409,6 @@ class FactorResults(object):
         1 - uniqueness
     loadings : ndarray
         Each column is the loading vector for one factor
-    loadings_canonical : ndarray
-        A rotation of the loadings, see notes
     n_comp : int
         Number of components (factors)
     nbs : int
@@ -422,13 +420,11 @@ class FactorResults(object):
     Notes
     -----
     Under ML estimation, the default rotation (used for `loadings`) is
-    condition IC3 of Bai and Li (2012).  The standard errors are only
-    applicable under this rotation.  An alternative rotation is the
-    'canonical loadings' given by `loadings_canonical`.  Under the
-    canonical loadings, the factor scores are iid and standardized.
-    If `G` is the canonical loadings and `U` is the vector of
-    uniquenesses, then the covariance matrix implied by the factor
-    analysis is `GG' + diag(U)`.
+    condition IC3 of Bai and Li (2012).  Under this rotation, the
+    factor scores are iid and standardized.  If `G` is the canonical
+    loadings and `U` is the vector of uniquenesses, then the
+    covariance matrix implied by the factor analysis is `GG' +
+    diag(U)`.
     """
     def __init__(self, factor):
         self.endog_names = factor.endog_names
@@ -436,8 +432,6 @@ class FactorResults(object):
         self.loadings = factor.loadings
         if hasattr(factor, "eigenvals"):
             self.eigenvals = factor.eigenvals
-        if hasattr(factor, "loadings_unrotated"):
-            self.loadings_unrotated = factor.loadings_unrotated
         self.communality = factor.communality
         self.uniqueness = factor.uniqueness
         self.rotation_method = None

--- a/statsmodels/multivariate/tests/test_factor.py
+++ b/statsmodels/multivariate/tests/test_factor.py
@@ -32,15 +32,9 @@ X = pd.DataFrame([['Minas Graes', 2.068, 2.070, 1.580, 1, 0],
                  columns=['Loc', 'Basal', 'Occ', 'Max', 'id', 'alt'])
 
 
-def test_specify_nobs():
-    # Test specifying nobs
-    Factor(np.zeros([10, 3]), 2, nobs=10)
-    assert_raises(ValueError, Factor, np.zeros([10, 3]), 2, nobs=9)
-
-
 def test_auto_col_name():
     # Test auto generated variable names when endog_names is None
-    mod = Factor(None, 2, corr=np.zeros([11, 11]), endog_names=None,
+    mod = Factor(None, 2, corr=np.eye(11), endog_names=None,
                  smc=False)
     assert_array_equal(mod.endog_names,
                        ['var00', 'var01', 'var02', 'var03', 'var04', 'var05',
@@ -149,23 +143,23 @@ def test_example_compare_to_R_output():
     desired = (
 """   Factor analysis results
 =============================
-      Eigenvalues            
+      Eigenvalues
 -----------------------------
- Basal   Occ    Max      id  
+ Basal   Occ    Max      id
 -----------------------------
  2.9609 0.3209 0.0000 -0.0000
 -----------------------------
-                             
+
 -----------------------------
-      Communality            
+      Communality
 -----------------------------
-  Basal   Occ    Max     id  
+  Basal   Occ    Max     id
 -----------------------------
   0.9926 0.9727 0.9654 0.3511
 -----------------------------
-                             
+
 -----------------------------
-   Pre-rotated loadings      
+   Pre-rotated loadings
 -----------------------------------
             factor 0       factor 1
 -----------------------------------
@@ -174,9 +168,9 @@ Occ           0.9711         0.1721
 Max           0.9619        -0.2004
 id            0.3757        -0.4582
 -----------------------------
-                             
+
 -----------------------------
-   varimax rotated loadings  
+   varimax rotated loadings
 -----------------------------------
             factor 0       factor 1
 -----------------------------------
@@ -187,6 +181,7 @@ id            0.2060        -0.5556
 =============================
 """)
     actual = results.summary().as_text()
+    actual = "\n".join(line.rstrip() for line in actual.splitlines()) + "\n"
     assert_equal(actual, desired)
 
 

--- a/statsmodels/multivariate/tests/test_ml_factor.py
+++ b/statsmodels/multivariate/tests/test_ml_factor.py
@@ -3,6 +3,22 @@ from statsmodels.multivariate.factor import Factor
 from numpy.testing import assert_allclose, assert_equal
 
 
+def test_loglike():
+
+    uniq = np.r_[4, 9, 16]
+    gamma = np.asarray([[3, 1, 2], [2, 5, 8]]).T
+    par = np.r_[2, 3, 4, 3, 1, 2, 2, 5, 8]
+
+    corr = np.asarray([[1, .5, .25], [.5, 1, .5], [.25, .5, 1]])
+    fa = Factor(n_factor=2, corr=corr)
+
+    # Two ways of passing the parameters to loglike
+    ll1 = fa.loglike((gamma, uniq))
+    ll2 = fa.loglike(par)
+
+    assert_allclose(ll1, ll2)
+
+
 def test_exact():
     # Test if we can recover exact factor-structured matrices with
     # default starting values.

--- a/statsmodels/multivariate/tests/test_ml_factor.py
+++ b/statsmodels/multivariate/tests/test_ml_factor.py
@@ -71,7 +71,8 @@ def test_1factor():
     ii = outer(ii, ii, "-")
     ii = abs(ii)
     cm = r^ii
-    factanal(covmat=cm, factors=1)
+    fa = factanal(covmat=cm, factors=1)
+    print(fa, digits=10)
     """
 
     r = 0.4
@@ -85,9 +86,19 @@ def test_1factor():
     if rslt.loadings[0, 0] < 0:
         rslt.loadings[:, 0] *= -1
 
-    load = np.r_[0.401, 0.646, 0.646, 0.401]
-    uniq = np.r_[0.839, 0.582, 0.582, 0.839]
-    assert_allclose(load, rslt.loadings[:, 0], rtol=1e-3, atol=1e-3)
+    # R solution, but our likelihood is higher
+    # uniq = np.r_[0.8392472054, 0.5820958187, 0.5820958187, 0.8392472054]
+    # load = np.asarray([[0.4009399224, 0.6464550935, 0.6464550935,
+    #                     0.4009399224]]).T
+    # l1 = fa.loglike(fa._pack(load, uniq))
+    # l2 = fa.loglike(fa._pack(rslt.loadings, rslt.uniqueness))
+
+    # So use a smoke test
+    uniq = np.r_[0.85290232,  0.60916033,  0.55382266,  0.82610666]
+    load = np.asarray([[0.38353316], [0.62517171], [0.66796508],
+                       [0.4170052]])
+
+    assert_allclose(load, rslt.loadings, rtol=1e-3, atol=1e-3)
     assert_allclose(uniq, rslt.uniqueness, rtol=1e-3, atol=1e-3)
 
     assert_equal(rslt.df, 2)
@@ -130,8 +141,10 @@ def test_2factor():
     assert_equal(rslt.df, 4)
 
     # Smoke test for standard errors
-    e = np.asarray([0.11056836, 0.05191071, 0.09836349, 0.09836349, 0.05191071, 0.11056836])
+    e = np.asarray([0.11056836, 0.05191071, 0.09836349,
+                    0.09836349, 0.05191071, 0.11056836])
     assert_allclose(rslt.uniq_stderr, e, atol=1e-4)
-    e = np.asarray([[0.08842151, 0.08842151], [0.06058582, 0.06058582], [0.08339874, 0.08339874],
-                    [0.08339874, 0.08339874], [0.06058582, 0.06058582], [0.08842151, 0.08842151]])
+    e = np.asarray([[0.08842151, 0.08842151], [0.06058582, 0.06058582],
+                    [0.08339874, 0.08339874], [0.08339874, 0.08339874],
+                    [0.06058582, 0.06058582], [0.08842151, 0.08842151]])
     assert_allclose(rslt.load_stderr, e, atol=1e-4)

--- a/statsmodels/multivariate/tests/test_ml_factor.py
+++ b/statsmodels/multivariate/tests/test_ml_factor.py
@@ -130,5 +130,8 @@ def test_2factor():
     assert_equal(rslt.df, 4)
 
     # Smoke test for standard errors
-    rslt.uniq_stderr
-    rslt.load_stderr
+    e = np.asarray([0.11056836, 0.05191071, 0.09836349, 0.09836349, 0.05191071, 0.11056836])
+    assert_allclose(rslt.uniq_stderr, e, atol=1e-4)
+    e = np.asarray([[0.08842151, 0.08842151], [0.06058582, 0.06058582], [0.08339874, 0.08339874],
+                    [0.08339874, 0.08339874], [0.06058582, 0.06058582], [0.08842151, 0.08842151]])
+    assert_allclose(rslt.load_stderr, e, atol=1e-4)

--- a/statsmodels/multivariate/tests/test_ml_factor.py
+++ b/statsmodels/multivariate/tests/test_ml_factor.py
@@ -1,0 +1,107 @@
+import numpy as np
+from statsmodels.multivariate.factor import Factor, _rotate
+from numpy.testing import assert_allclose, assert_equal
+
+
+def test_rotate():
+
+    np.random.seed(23324)
+
+    gamma = np.random.normal(size=(10, 4))
+    sigma = np.linspace(1, 3, 10)
+    g = _rotate(gamma, sigma)
+    f = np.dot(g.T, g/sigma[:, None])
+    f -= np.diag(np.diag(f))
+    assert_allclose(f, np.zeros_like(f), rtol=1e-8, atol=1e-8)
+
+
+def test_exact():
+    # Test if we can recover exact factor-structured matrices with
+    # default starting values.
+
+    np.random.seed(23324)
+
+    # Works for larger k_var but slow for routine testing.
+    for k_var in 5, 10, 25:
+        for n_factor in 1, 2, 3:
+            gamma = np.random.normal(size=(k_var, n_factor))
+            sigma2 = np.linspace(1, 2, k_var)
+            gamma = _rotate(gamma, sigma2)
+            c = np.dot(gamma, gamma.T)
+            c.flat[::c.shape[0]+1] += sigma2
+            s = np.sqrt(np.diag(c))
+            c /= np.outer(s, s)
+            fa = Factor(corr=c, n_factor=n_factor, method='ml')
+            rslt = fa.fit()
+            assert_allclose(rslt.fitted_cov, c, rtol=1e-4, atol=1e-4)
+            # print(rslt.summary()) # DEBUG
+
+
+def test_1factor():
+    """
+    # R code:
+    r = 0.4
+    p = 4
+    ii = seq(0, p-1)
+    ii = outer(ii, ii, "-")
+    ii = abs(ii)
+    cm = r^ii
+    factanal(covmat=cm, factors=1)
+    """
+
+    r = 0.4
+    p = 4
+    ii = np.arange(p)
+    cm = r ** np.abs(np.subtract.outer(ii, ii))
+
+    fa = Factor(corr=cm, n_factor=1, method='ml')
+    rslt = fa.fit()
+
+    if rslt.loadings[0, 0] < 0:
+        rslt.loadings[:, 0] *= -1
+
+    load = np.r_[0.401, 0.646, 0.646, 0.401]
+    uniq = np.r_[0.839, 0.582, 0.582, 0.839]
+    assert_allclose(load, rslt.loadings[:, 0], rtol=1e-3, atol=1e-3)
+    assert_allclose(uniq, rslt.uniqueness, rtol=1e-3, atol=1e-3)
+
+    assert_equal(rslt.df, 2)
+
+
+def test_2factor():
+    """
+    # R code:
+    r = 0.4
+    p = 6
+    ii = seq(0, p-1)
+    ii = outer(ii, ii, "-")
+    ii = abs(ii)
+    cm = r^ii
+    factanal(covmat=cm, factors=2)
+    """
+
+    r = 0.4
+    p = 6
+    ii = np.arange(p)
+    cm = r ** np.abs(np.subtract.outer(ii, ii))
+
+    fa = Factor(corr=cm, n_factor=2, nobs=100, method='ml')
+    rslt = fa.fit()
+
+    for j in 0, 1:
+        if rslt.loadings[0, j] < 0:
+            rslt.loadings[:, j] *= -1
+
+    uniq = np.r_[0.782, 0.367, 0.696, 0.696, 0.367, 0.782]
+    assert_allclose(uniq, rslt.uniqueness, rtol=1e-3, atol=1e-3)
+
+    load = np.r_[0.323, 0.586, 0.519, 0.519, 0.586, 0.323]
+    assert_allclose(load, rslt.loadings[:, 0], rtol=1e-3, atol=1e-3)
+    load = np.r_[0.337, 0.538, 0.187, -0.187, -0.538, -0.337]
+    assert_allclose(load, rslt.loadings[:, 1], rtol=1e-3, atol=1e-3)
+
+    assert_equal(rslt.df, 4)
+
+    # Smoke test for standard errors
+    rslt.uniq_stderr
+    rslt.load_stderr

--- a/statsmodels/multivariate/tests/test_ml_factor.py
+++ b/statsmodels/multivariate/tests/test_ml_factor.py
@@ -21,7 +21,7 @@ def test_exact():
             fa = Factor(corr=c, n_factor=n_factor, method='ml')
             rslt = fa.fit()
             assert_allclose(rslt.fitted_cov, c, rtol=1e-4, atol=1e-4)
-            rslt.summary() # smoke test
+            rslt.summary()  # smoke test
 
 
 def test_1factor():
@@ -84,10 +84,10 @@ def test_2factor():
 
     loads = [np.r_[0.323, 0.586, 0.519, 0.519, 0.586, 0.323],
              np.r_[0.337, 0.538, 0.187, -0.187, -0.538, -0.337]]
-    for k in 0,1:
-        if np.dot(loads[k], rslt.loadings_unrotated[:, k]) < 0:
+    for k in 0, 1:
+        if np.dot(loads[k], rslt.loadings[:, k]) < 0:
             loads[k] *= -1
-        assert_allclose(loads[k], rslt.loadings_unrotated[:, k], rtol=1e-3, atol=1e-3)
+        assert_allclose(loads[k], rslt.loadings[:, k], rtol=1e-3, atol=1e-3)
 
     assert_equal(rslt.df, 4)
 


### PR DESCRIPTION
This is an implementation of maximum likelihood factor analysis.  It probably would need to be integrated with #3294.  

The main reference for me was Bai and Li:

https://arxiv.org/pdf/1205.6617.pdf

They focus more on estimation in high dimensions, less on issues relating to model assessment which are very important in psychometrics.  Specialized methods for the latter are not included here.

This uses direct numerical optimization of the log-likelihood.  The gradient is not provided but scipy minimize seems to do OK without it here.  EM is also common and we could provide that as an optional algorithm.