### PR TITLE
DOC: fix patsy.dmatrices np array example

### DIFF
--- a/docs/source/example_formulas.rst
+++ b/docs/source/example_formulas.rst
@@ -158,9 +158,11 @@ To generate ``numpy`` arrays:
 
     import patsy
     f = 'Lottery ~ Literacy * Wealth'
-    y, X = patsy.dmatrices(f, df, return_type='dataframe')
+    y, X = patsy.dmatrices(f, df, return_type='matrix')
     print(y[:5])
     print(X[:5])
+
+``y`` and ``X`` would be instances of ``patsy.DesignMatrix`` which is a subclass of ``numpy.ndarray``.
 
 To generate pandas data frames:
 

--- a/examples/notebooks/formulas.ipynb
+++ b/examples/notebooks/formulas.ipynb
@@ -330,7 +330,7 @@
    "source": [
     "import patsy\n",
     "f = 'Lottery ~ Literacy * Wealth'\n",
-    "y,X = patsy.dmatrices(f, df, return_type='dataframe')\n",
+    "y,X = patsy.dmatrices(f, df, return_type='matrix')\n",
     "print(y[:5])\n",
     "print(X[:5])"
    ]


### PR DESCRIPTION
Use return_type='matrix' instead of return_type='dataframe'.
Document that the former returns patsy.DesignMatrix, which is a
sub-class of np.ndarray.