### PR TITLE
BUG: GLM-Gaussian fit_constrained, wrong bse

### DIFF
--- a/statsmodels/base/_constraints.py
+++ b/statsmodels/base/_constraints.py
@@ -302,7 +302,13 @@ def fit_constrained_wrap(model, constraints, start_params=None, **fit_kwds):
     res = self.fit(start_params=params, maxiter=0,
                    warn_convergence=False) # we get a wrapper back
     res._results.params = params
-    res._results.normalized_cov_params = cov
+    res._results.cov_params_default = cov
+    cov_type = fit_kwds.get('cov_type', 'nonrobust')
+    if cov_type == 'nonrobust':
+            res._results.normalized_cov_params = cov / res_constr.scale
+    else:
+            res._results.normalized_cov_params = None
+
     k_constr = len(q)
     res._results.df_resid += k_constr
     res._results.df_model -= k_constr

--- a/statsmodels/base/covtype.py
+++ b/statsmodels/base/covtype.py
@@ -136,6 +136,9 @@ def get_robustcov_results(self, cov_type='HC1', use_t=None, **kwds):
     if 'kernel' in kwds:
             kwds['weights_func'] = kwds.pop('kernel')
 
+    # pop because HCx raises if any kwds
+    sc_factor = kwds.pop('scaling_factor', None)
+
     # TODO: make separate function that returns a robust cov plus info
     use_self = kwds.pop('use_self', False)
     if use_self:
@@ -292,7 +295,7 @@ def get_robustcov_results(self, cov_type='HC1', use_t=None, **kwds):
                          'available options and spelling')
 
     # generic optional factor to scale covariance
-    sc_factor = kwds.get('scaling_factor', None)
+
     res.cov_kwds['scaling_factor'] = sc_factor
     if sc_factor is not None:
         res.cov_params_default *= sc_factor

--- a/statsmodels/discrete/discrete_model.py
+++ b/statsmodels/discrete/discrete_model.py
@@ -1116,7 +1116,12 @@ class Poisson(CountModel):
                                                         'iterations', np.nan)
         res.mle_retvals['converged'] = res_constr.mle_retvals['converged']
         res._results.params = params
-        res._results.normalized_cov_params = cov
+        res._results.cov_params_default = cov
+        cov_type = fit_kwds.get('cov_type', 'nonrobust')
+        if cov_type != 'nonrobust':
+            res._results.normalized_cov_params = cov # assume scale=1
+        else:
+            res._results.normalized_cov_params = None
         k_constr = len(q)
         res._results.df_resid += k_constr
         res._results.df_model -= k_constr

--- a/statsmodels/discrete/tests/test_constrained.py
+++ b/statsmodels/discrete/tests/test_constrained.py
@@ -491,6 +491,34 @@ class TestGLMLogitConstrained2(CheckGLMConstrainedMixin):
         assert_allclose(res_wrap.params, res2.params, rtol=1e-6)
 
 
+class TestGLMLogitConstrained2HC(CheckGLMConstrainedMixin):
+
+    @classmethod
+    def setup_class(cls):
+        cls.idx = slice(None)  # params sequence same as Stata
+        #res1ul = Logit(data.endog, data.exog).fit(method="newton", disp=0)
+        cls.res2 = reslogit.results_constraint2_robust
+
+        mod1 = GLM(spector_data.endog, spector_data.exog,
+                   family=families.Binomial())
+
+        # not used to match Stata for HC
+        # nobs, k_params = mod1.exog.shape
+        # k_params -= 1   # one constraint
+        cov_type = 'HC0'
+        cov_kwds = {'scaling_factor': 32/31}
+        # looks like nobs / (nobs - 1) and not (nobs - 1.) / (nobs - k_params)}
+        constr = 'x1 - x3 = 0'
+        cls.res1m = mod1.fit_constrained(constr, cov_type=cov_type,
+                                         cov_kwds=cov_kwds, atol=1e-10)
+
+        R, q = cls.res1m.constraints.coefs, cls.res1m.constraints.constants
+        cls.res1 = fit_constrained(mod1, R, q, fit_kwds={'atol': 1e-10,
+                                                         'cov_type': cov_type,
+                                                         'cov_kwds': cov_kwds})
+        cls.constraints_rq = (R, q)
+
+
 def junk():
     # Singular Matrix in mod1a.fit()
 

--- a/statsmodels/discrete/tests/test_constrained.py
+++ b/statsmodels/discrete/tests/test_constrained.py
@@ -6,6 +6,7 @@ Author: Josef Perktold
 License: BSD-3
 
 """
+from __future__ import division
 
 from statsmodels.compat.python import StringIO
 from statsmodels.compat.testing import SkipTest

--- a/statsmodels/genmod/generalized_linear_model.py
+++ b/statsmodels/genmod/generalized_linear_model.py
@@ -1279,7 +1279,13 @@ class GLM(base.LikelihoodModel):
         #create dummy results Instance, TODO: wire up properly
         res = self.fit(start_params=params, maxiter=0) # we get a wrapper back
         res._results.params = params
-        res._results.normalized_cov_params = cov
+        res._results.cov_params_default = cov
+        cov_type = fit_kwds.get('cov_type', 'nonrobust')
+        if cov_type != 'nonrobust':
+            res._results.normalized_cov_params = cov / res_constr.scale
+        else:
+            res._results.normalized_cov_params = None
+        res._results.scale = res_constr.scale
         k_constr = len(q)
         res._results.df_resid += k_constr
         res._results.df_model -= k_constr

--- a/statsmodels/genmod/tests/test_constrained.py
+++ b/statsmodels/genmod/tests/test_constrained.py
@@ -83,19 +83,6 @@ class TestGLMGaussianConstrained(ConstrainedCompareMixin):
         cls.res1 = mod.fit_constrained('x1=0.5')
 
 
-class TestGLMGaussianConstrained1(ConstrainedCompareMixin):
-
-    @classmethod
-    def init(cls):
-        cls.res2 = cls.mod2.fit()
-        mod = GLM(cls.endog, cls.exog)
-        mod.exog_names[:] = ['const', 'x1', 'x2', 'x3', 'x4']
-        cls.res1 = mod.fit_constrained('x1=0.5')
-        cls.res1._results.cov_params_default = cls.res1.normalized_cov_params
-        # setting scale also works instead of setting cov_params_default
-        #cls.res1._results.scale = 1
-
-
 class TestGLMGaussianOffsetHC(ConstrainedCompareMixin):
 
     @classmethod
@@ -118,4 +105,3 @@ class TestGLMGaussianConstrainedHC(ConstrainedCompareMixin):
         mod = GLM(cls.endog, cls.exog)
         mod.exog_names[:] = ['const', 'x1', 'x2', 'x3', 'x4']
         cls.res1 = mod.fit_constrained('x1=0.5', cov_type=cov_type)
-        cls.res1._results.cov_params_default = cls.res1.normalized_cov_params

--- a/statsmodels/genmod/tests/test_constrained.py
+++ b/statsmodels/genmod/tests/test_constrained.py
@@ -1,0 +1,121 @@
+# -*- coding: utf-8 -*-
+"""
+Unit tests for fit_constrained
+Tests for Poisson and Binomial are in discrete
+
+
+Created on Sun Jan  7 09:21:39 2018
+
+Author: Josef Perktold
+"""
+
+
+import numpy as np
+from numpy.testing import assert_allclose, assert_equal
+from statsmodels.tools.tools import add_constant
+from statsmodels.regression.linear_model import OLS
+from statsmodels.genmod.generalized_linear_model import GLM
+
+
+class ConstrainedCompareMixin(object):
+
+    @classmethod
+    def setup_class(cls):
+        nobs, k_exog = 100, 5
+        np.random.seed(987125)
+        x = np.random.randn(nobs, k_exog - 1)
+        x = add_constant(x)
+
+        y_true = x.sum(1) / 2
+        y = y_true + 2 * np.random.randn(nobs)
+        cls.endog = y
+        cls.exog = x
+        cls.idx_uc = [0, 2, 3, 4]
+        cls.idx_p_uc = np.array(cls.idx_uc)
+        cls.idx_c = [1]
+        cls.exogc = xc = x[:, cls.idx_uc]
+        mod_ols_c = OLS(y - 0.5 * x[:, 1], xc)
+        mod_ols_c.exog_names[:] = ['const', 'x2', 'x3', 'x4']
+        cls.mod2 = mod_ols_c
+        cls.init()
+
+    def test_params(self):
+        res1 = self.res1
+        res2 = self.res2
+        assert_allclose(res1.params[self.idx_p_uc], res2.params, rtol=1e-10)
+
+    def test_se(self):
+        res1 = self.res1
+        res2 = self.res2
+
+        assert_equal(res1.df_resid, res2.df_resid)
+        # why does scale differ
+        assert_allclose(res1.scale, res2.scale, rtol=0.05)
+        assert_allclose(res1.bse[self.idx_p_uc], res2.bse, rtol=1e-10)
+        assert_allclose(res1.cov_params()[self.idx_p_uc[:,None], self.idx_p_uc],
+                        res2.cov_params(), rtol=1e-10)
+
+    def test_resid(self):
+        res1 = self.res1
+        res2 = self.res2
+        assert_allclose(res1.resid_response, res2.resid, rtol=1e-10)
+
+
+class TestGLMGaussianOffset(ConstrainedCompareMixin):
+
+    @classmethod
+    def init(cls):
+        cls.res2 = cls.mod2.fit()
+        mod = GLM(cls.endog, cls.exogc,
+                  offset=0.5 * cls.exog[:, cls.idx_c].squeeze())
+        mod.exog_names[:] = ['const', 'x2', 'x3', 'x4']
+        cls.res1 = mod.fit()
+        cls.idx_p_uc = np.arange(cls.exogc.shape[1])
+
+
+class TestGLMGaussianConstrained(ConstrainedCompareMixin):
+
+    @classmethod
+    def init(cls):
+        cls.res2 = cls.mod2.fit()
+        mod = GLM(cls.endog, cls.exog)
+        mod.exog_names[:] = ['const', 'x1', 'x2', 'x3', 'x4']
+        cls.res1 = mod.fit_constrained('x1=0.5')
+
+
+class TestGLMGaussianConstrained1(ConstrainedCompareMixin):
+
+    @classmethod
+    def init(cls):
+        cls.res2 = cls.mod2.fit()
+        mod = GLM(cls.endog, cls.exog)
+        mod.exog_names[:] = ['const', 'x1', 'x2', 'x3', 'x4']
+        cls.res1 = mod.fit_constrained('x1=0.5')
+        cls.res1._results.cov_params_default = cls.res1.normalized_cov_params
+        # setting scale also works instead of setting cov_params_default
+        #cls.res1._results.scale = 1
+
+
+class TestGLMGaussianOffsetHC(ConstrainedCompareMixin):
+
+    @classmethod
+    def init(cls):
+        cov_type = 'HC0'
+        cls.res2 = cls.mod2.fit(cov_type=cov_type)
+        mod = GLM(cls.endog, cls.exogc,
+                  offset=0.5 * cls.exog[:, cls.idx_c].squeeze())
+        mod.exog_names[:] = ['const', 'x2', 'x3', 'x4']
+        cls.res1 = mod.fit(cov_type=cov_type)
+        cls.idx_p_uc = np.arange(cls.exogc.shape[1])
+
+
+class TestGLMGaussianConstrainedHC(ConstrainedCompareMixin):
+
+    @classmethod
+    def init(cls):
+        cov_type = 'HC0'
+        cls.res2 = cls.mod2.fit(cov_type=cov_type)
+        mod = GLM(cls.endog, cls.exog)
+        mod.exog_names[:] = ['const', 'x1', 'x2', 'x3', 'x4']
+        cls.res1 = mod.fit_constrained('x1=0.5', cov_type=cov_type)
+        cls.res1._results.cov_params_default = cls.res1.normalized_cov_params


### PR DESCRIPTION
issue #4193

This currently adds unit tests for Gaussian compared to OLS for a single parameter constraint, inlcudes cov_type='HC0' test.

There is one test failure with master, bug not yet fixed.
The work around is to assign cov_params_default which doesn't fail the unit tests.

cov_type='HC0' looks correct with `fit_constrained`, tests don't fail

bug fix which most likely works is
to assign directly to cov_params_default in fit_regularized

side issue: OLS and GLM don't agree on scale with master (in this branch), difference in example is around 1%
I got agreement between OLS and GLM-Gaussian for scale when I worked on top of #3856 which looks like fixes the scale difference.

Aside: fit_constrained never got a follow-up #1749, see comments in original PR #1714

  