### PR TITLE
BUG/REF: Weight anscombe residuals

### DIFF
--- a/statsmodels/genmod/families/family.py
+++ b/statsmodels/genmod/families/family.py
@@ -308,7 +308,7 @@ class Family(object):
         ll_obs = self.loglike_obs(endog, mu, var_weights, scale)
         return np.sum(ll_obs * freq_weights)
 
-    def resid_anscombe(self, endog, mu, scale=1.):
+    def resid_anscombe(self, endog, mu, var_weights=1., scale=1.):
         r"""
         The Anscombe residuals
 
@@ -318,6 +318,8 @@ class Family(object):
             The endogenous response variable
         mu : array
             The inverse of the link function at the linear predicted values.
+        var_weights : array-like
+            1d array of variance (anlaytic) weights. The default is 1.
         scale : float, optional
             An optional argument to divide the residuals by sqrt(scale).
             The default is 1.
@@ -448,16 +450,18 @@ class Poisson(Family):
         return var_weights / scale * (endog * np.log(mu) - mu -
                                       special.gammaln(endog + 1))
 
-    def resid_anscombe(self, endog, mu, scale=1.):
+    def resid_anscombe(self, endog, mu, var_weights=1., scale=1.):
         r"""
-        Anscombe residuals for the Poisson distribution
+        The Anscombe residuals
 
         Parameters
         ----------
-        endog : array-like
-            Endogenous response variable
-        mu : array-like
-            Fitted mean response variable
+        endog : array
+            The endogenous response variable
+        mu : array
+            The inverse of the link function at the linear predicted values.
+        var_weights : array-like
+            1d array of variance (anlaytic) weights. The default is 1.
         scale : float, optional
             An optional argument to divide the residuals by sqrt(scale).
             The default is 1.
@@ -475,7 +479,7 @@ class Poisson(Family):
            \mu_i^{1/6}
         """
         return ((3 / 2.) * (endog**(2 / 3.) - mu**(2 / 3.)) /
-                (mu ** (1 / 6.) * scale ** 0.5))
+                (mu ** (1 / 6.) * (scale / var_weights) ** 0.5))
 
 
 class Gaussian(Family):
@@ -588,16 +592,18 @@ class Gaussian(Family):
         ll_obs /= 2
         return ll_obs
 
-    def resid_anscombe(self, endog, mu, scale=1.):
+    def resid_anscombe(self, endog, mu, var_weights=1., scale=1.):
         r"""
-        The Anscombe residuals for the Gaussian distribution
+        The Anscombe residuals
 
         Parameters
         ----------
         endog : array
-            Endogenous response variable
+            The endogenous response variable
         mu : array
-            Fitted mean response variable
+            The inverse of the link function at the linear predicted values.
+        var_weights : array-like
+            1d array of variance (anlaytic) weights. The default is 1.
         scale : float, optional
             An optional argument to divide the residuals by sqrt(scale).
             The default is 1.
@@ -616,7 +622,7 @@ class Gaussian(Family):
 
            resid\_anscombe_i = (Y_i - \mu_i) / \sqrt{scale}
         """
-        return (endog - mu) / scale ** 0.5
+        return (endog - mu) / (scale / var_weights) ** 0.5
 
 
 class Gamma(Family):
@@ -722,16 +728,18 @@ class Gamma(Family):
         # in R it's the dispersion, though there is a loss of precision vs.
         # our results due to an assumed difference in implementation
 
-    def resid_anscombe(self, endog, mu, scale=1.):
+    def resid_anscombe(self, endog, mu, var_weights=1., scale=1.):
         r"""
-        The Anscombe residuals for Gamma distribution
+        The Anscombe residuals
 
         Parameters
         ----------
         endog : array
-            Endogenous response variable
+            The endogenous response variable
         mu : array
-            Fitted mean response variable
+            The inverse of the link function at the linear predicted values.
+        var_weights : array-like
+            1d array of variance (anlaytic) weights. The default is 1.
         scale : float, optional
             An optional argument to divide the residuals by sqrt(scale).
             The default is 1.
@@ -748,7 +756,8 @@ class Gamma(Family):
            resid\_anscombe_i = 3 * (endog_i^{1/3} - \mu_i^{1/3}) / \mu_i^{1/3}
            / \sqrt{scale}
         """
-        return 3 * (endog**(1/3.) - mu**(1/3.)) / mu**(1/3.) / scale**(0.5)
+        return (3 * (endog**(1/3.) - mu**(1/3.)) / mu**(1/3.) /
+                (scale / var_weights) ** 0.5)
 
 
 class Binomial(Family):
@@ -915,16 +924,18 @@ class Binomial(Family):
                 special.gammaln(n - y + 1) + y * np.log(mu / (1 - mu)) +
                 n * np.log(1 - mu)) * var_weights
 
-    def resid_anscombe(self, endog, mu, scale=1.):
+    def resid_anscombe(self, endog, mu, var_weights=1., scale=1.):
         r'''
         The Anscombe residuals
 
         Parameters
         ----------
-        endog : array-like
-            Endogenous response variable
-        mu : array-like
-            Fitted mean response variable
+        endog : array
+            The endogenous response variable
+        mu : array
+            The inverse of the link function at the linear predicted values.
+        var_weights : array-like
+            1d array of variance (anlaytic) weights. The default is 1.
         scale : float, optional
             An optional argument to divide the residuals by sqrt(scale).
             The default is 1.
@@ -972,7 +983,8 @@ class Binomial(Family):
 
         return (self.n ** (2/3.) * (cox_snell(endog * 1. / self.n) -
                                     cox_snell(mu * 1. / self.n)) /
-                (mu * (1 - mu * 1. / self.n) * scale ** 3) ** (1 / 6.))
+                (mu * (1 - mu * 1. / self.n) *
+                 (scale / var_weights) ** 3) ** (1 / 6.))
 
 
 class InverseGaussian(Family):
@@ -1079,16 +1091,18 @@ class InverseGaussian(Family):
         ll_obs /= 2
         return ll_obs
 
-    def resid_anscombe(self, endog, mu, scale=1.):
+    def resid_anscombe(self, endog, mu, var_weights=1., scale=1.):
         r"""
-        The Anscombe residuals for the inverse Gaussian distribution
+        The Anscombe residuals
 
         Parameters
         ----------
         endog : array
-            Endogenous response variable
+            The endogenous response variable
         mu : array
-            Fitted mean response variable
+            The inverse of the link function at the linear predicted values.
+        var_weights : array-like
+            1d array of variance (anlaytic) weights. The default is 1.
         scale : float, optional
             An optional argument to divide the residuals by sqrt(scale).
             The default is 1.
@@ -1105,7 +1119,7 @@ class InverseGaussian(Family):
 
            resid\_anscombe_i = \log(Y_i / \mu_i) / \sqrt{\mu_i * scale}
         """
-        return np.log(endog / mu) / np.sqrt(mu * scale)
+        return np.log(endog / mu) / np.sqrt(mu * scale / var_weights)
 
 
 class NegativeBinomial(Family):
@@ -1247,16 +1261,18 @@ class NegativeBinomial(Family):
         ll_obs -= special.gammaln(endog + 1)
         return var_weights / scale * ll_obs
 
-    def resid_anscombe(self, endog, mu, scale=1.):
+    def resid_anscombe(self, endog, mu, var_weights=1., scale=1.):
         r"""
-        The Anscombe residuals for the negative binomial family
+        The Anscombe residuals
 
         Parameters
         ----------
-        endog : array-like
-            Endogenous response variable
-        mu : array-like
-            Fitted mean response variable
+        endog : array
+            The endogenous response variable
+        mu : array
+            The inverse of the link function at the linear predicted values.
+        var_weights : array-like
+            1d array of variance (anlaytic) weights. The default is 1.
         scale : float, optional
             An optional argument to divide the residuals by sqrt(scale).
             The default is 1.
@@ -1287,7 +1303,8 @@ class NegativeBinomial(Family):
 
         return (3 / 2. * (endog ** (2 / 3.) * hyp2f1(-self.alpha * endog) -
                           mu ** (2 / 3.) * hyp2f1(-self.alpha * mu)) /
-                (mu * (1 + self.alpha * mu) * scale ** 3) ** (1 / 6.))
+                (mu * (1 + self.alpha * mu) *
+                 (scale / var_weights) ** 3) ** (1 / 6.))
 
 
 class Tweedie(Family):
@@ -1431,16 +1448,18 @@ class Tweedie(Family):
         """
         return np.nan
 
-    def resid_anscombe(self, endog, mu, scale=1.):
+    def resid_anscombe(self, endog, mu, var_weights=1., scale=1.):
         r"""
-        The Anscombe residuals for the Tweedie family
+        The Anscombe residuals
 
         Parameters
         ----------
-        endog : array-like
-            Endogenous response variable
-        mu : array-like
-            Fitted mean response variable
+        endog : array
+            The endogenous response variable
+        mu : array
+            The inverse of the link function at the linear predicted values.
+        var_weights : array-like
+            1d array of variance (anlaytic) weights. The default is 1.
         scale : float, optional
             An optional argument to divide the residuals by sqrt(scale).
             The default is 1.
@@ -1474,4 +1493,4 @@ class Tweedie(Family):
         else:
             c = (3. - self.var_power) / 3.
             return ((1. / c) * (endog ** c - mu ** c) /
-                    mu ** (self.var_power / 6.)) / scale**(0.5)
+                    mu ** (self.var_power / 6.)) / (scale / var_weights) ** 0.5

--- a/statsmodels/genmod/generalized_linear_model.py
+++ b/statsmodels/genmod/generalized_linear_model.py
@@ -206,7 +206,7 @@ class GLM(base.LikelihoodModel):
     +---------------+----------------------------------+
     | Residual Type | Applicable weights               |
     +===============+==================================+
-    | Anscombe      | Unweighted                       |
+    | Anscombe      | ``var_weights``                  |
     +---------------+----------------------------------+
     | Deviance      | ``var_weights``                  |
     +---------------+----------------------------------+
@@ -1364,7 +1364,14 @@ class GLMResults(base.LikelihoodModelResults):
         The two-tailed p-values for the parameters.
     resid_anscombe : array
         Anscombe residuals.  See statsmodels.families.family for distribution-
-        specific Anscombe residuals.
+        specific Anscombe residuals. Currently, the unscaled residuals are
+        provided. In a future version, the scaled residuals will be provided.
+    resid_anscombe_scaled : array
+        Scaled Anscombe residuals.  See statsmodels.families.family for
+        distribution-specific Anscombe residuals.
+    resid_anscombe_unscaled : array
+        Unscaled Anscombe residuals.  See statsmodels.families.family for
+        distribution-specific Anscombe residuals.
     resid_deviance : array
         Deviance residuals.  See statsmodels.families.family for distribution-
         specific deviance residuals.
@@ -1475,7 +1482,24 @@ class GLMResults(base.LikelihoodModelResults):
 
     @cache_readonly
     def resid_anscombe(self):
-        return self.family.resid_anscombe(self._endog, self.fittedvalues)
+        import warnings
+        warnings.warn('Anscombe residuals currently unscaled. In a future '
+                      'release, they will be scaled.')
+        return self.family.resid_anscombe(self._endog, self.fittedvalues,
+                                          var_weights=self._var_weights,
+                                          scale=1.)
+
+    @cache_readonly
+    def resid_anscombe_scaled(self):
+        return self.family.resid_anscombe(self._endog, self.fittedvalues,
+                                          var_weights=self._var_weights,
+                                          scale=self.scale)
+
+    @cache_readonly
+    def resid_anscombe_unscaled(self):
+        return self.family.resid_anscombe(self._endog, self.fittedvalues,
+                                          var_weights=self._var_weights,
+                                          scale=1.)
 
     @cache_readonly
     def resid_deviance(self):

--- a/statsmodels/genmod/tests/test_glm_weights.py
+++ b/statsmodels/genmod/tests/test_glm_weights.py
@@ -876,3 +876,33 @@ def test_incompatible_input():
                   freq_weights=[weights, weights])
     assert_raises(ValueError, GLM, endog, exog, family=family,
                   var_weights=[weights, weights])
+
+
+def test_poisson_residuals():
+    nobs, k_exog = 100, 5
+    np.random.seed(987125)
+    x = np.random.randn(nobs, k_exog - 1)
+    x = add_constant(x)
+
+    y_true = x.sum(1) / 2
+    y = y_true + 2 * np.random.randn(nobs)
+    exposure = 1 + np.arange(nobs) // 4
+
+    yp = np.random.poisson(np.exp(y_true) * exposure)
+    yp[10:15] += 10
+
+    fam = sm.families.Poisson()
+    mod_poi_e = GLM(yp, x, family=fam, exposure=exposure)
+    res_poi_e = mod_poi_e.fit()
+
+    mod_poi_w = GLM(yp / exposure, x, family=fam, var_weights=exposure)
+    res_poi_w = mod_poi_w.fit()
+
+    assert_allclose(res_poi_e.resid_response / exposure,
+                    res_poi_w.resid_response)
+    assert_allclose(res_poi_e.resid_pearson, res_poi_w.resid_pearson)
+    assert_allclose(res_poi_e.resid_deviance, res_poi_w.resid_deviance)
+    assert_allclose(res_poi_e.resid_anscombe, res_poi_w.resid_anscombe)
+    assert_allclose(res_poi_e.resid_anscombe_unscaled,
+                    res_poi_w.resid_anscombe)
+

--- a/statsmodels/genmod/tests/test_glm_weights.py
+++ b/statsmodels/genmod/tests/test_glm_weights.py
@@ -104,7 +104,9 @@ class CheckWeight(object):
         assert_allclose(res1.resid_working, resid_all['resid_working'], atol= 1e-6, rtol=2e-6)
         if resid_all.get('resid_anscombe') is None:
             return None
-        assert_allclose(res1.resid_anscombe, resid_all['resid_anscombe'], atol= 1e-6, rtol=2e-6)
+        # Stata doesn't use var_weights in anscombe residuals, it seems. 
+        # Adjust residuals to match our approach.
+        assert_allclose(res1.resid_anscombe, resid_all['resid_anscombe'] * np.sqrt(res1._var_weights), atol= 1e-6, rtol=2e-6)
 
     def test_compare_optimizers(self):
         res1 = self.res1
@@ -201,7 +203,7 @@ class TestGlmPoissonPwNr(CheckWeight):
     @pytest.mark.xfail(reason='Known to fail')
     def test_compare_optimizers(cls):
         super(cls, TestGlmPoissonPwNr).test_compare_optimizers(cls)
-    
+
 
 class TestGlmPoissonFwHC(CheckWeight):
     @classmethod


### PR DESCRIPTION
We are currently not weighting `resid_anscombe` in GLM. This will enable that. Adjusted unit test vs stata to match. 

xref #3856 comment about `resid_anscombe`. 

[Gist showing match](https://gist.github.com/thequackdaddy/c03ea9b293760175024267e6e686067c)