### PR TITLE
MAINT: Replace WarningManager with catch_warnings and other numpy 1.14.0 issues

### DIFF
--- a/statsmodels/formula/tests/test_formula.py
+++ b/statsmodels/formula/tests/test_formula.py
@@ -8,7 +8,6 @@ from statsmodels.datasets.longley import load, load_pandas
 
 import numpy.testing as npt
 from statsmodels.tools.testing import assert_equal
-from numpy.testing.utils import WarningManager
 
 
 longley_formula = 'TOTEMP ~ GNPDEFL + GNP + UNEMP + ARMED + POP + YEAR'
@@ -34,14 +33,10 @@ class CheckFormulaOLS(object):
 
     def test_summary(self):
         # smoke test
-        warn_ctx = WarningManager()
-        warn_ctx.__enter__()
-        try:
+        with warnings.catch_warnings():
             warnings.filterwarnings("ignore",
                                     "kurtosistest only valid for n>=20")
             self.model.fit().summary()
-        finally:
-            warn_ctx.__exit__()
 
 
 class TestFormulaPandas(CheckFormulaOLS):

--- a/statsmodels/genmod/tests/results/results_glm.py
+++ b/statsmodels/genmod/tests/results/results_glm.py
@@ -684,7 +684,9 @@ class Lbw(object):
         # data set up for data not in datasets
         filename = os.path.join(os.path.dirname(os.path.abspath(__file__)),
             "stata_lbw_glm.csv")
-        data=np.recfromcsv(open(filename, 'rb'), converters={4: lambda s: s.strip(asbytes("\""))})
+        data=np.recfromcsv(open(filename, 'rb'))
+        vfunc = np.vectorize(lambda x: x.strip(asbytes("\"")))
+        data['race'] = vfunc(data['race'])
         data = categorical(data, col='race', drop=True)
         self.endog = data.low
         design = np.column_stack((data['age'], data['lwt'],
@@ -2191,7 +2193,9 @@ class Medpar1(object):
     def __init__(self):
         filename = os.path.join(os.path.dirname(os.path.abspath(__file__)),
             "stata_medpar1_glm.csv")
-        data = np.recfromcsv(open(filename, 'rb'), converters ={1: lambda s: s.strip(asbytes("\""))})
+        data = np.recfromcsv(open(filename, 'rb'))
+        vfunc = np.vectorize(lambda x: x.strip(asbytes('\"')))
+        data['admitype'] = vfunc(data['admitype'])
         self.endog = data.los
         design = np.column_stack((data.admitype, data.codes))
         design = categorical(design, col=0, drop=True)

--- a/statsmodels/stats/tests/test_contingency_tables.py
+++ b/statsmodels/stats/tests/test_contingency_tables.py
@@ -61,7 +61,8 @@ def test_SquareTable_from_data():
                  rslt3.summary().as_text())
 
     s = str(rslt1)
-    assert_equal(s.startswith('A 5x5 contingency table with counts:\n[[ 8.'), True)
+    assert_equal(s.startswith('A 5x5 contingency table with counts:'), True)
+    assert_equal(rslt1.table[0, 0], 8.)
 
 
 def test_SquareTable_nonsquare():

--- a/statsmodels/tsa/tests/test_stattools.py
+++ b/statsmodels/tsa/tests/test_stattools.py
@@ -7,9 +7,9 @@ from statsmodels.tsa.stattools import (adfuller, acf, pacf_ols, pacf_yw,
                                                coint, acovf, kpss, ResultsStore,
                                                arma_order_select_ic)
 import numpy as np
+import pandas as pd
 from numpy.testing import (assert_almost_equal, assert_equal, assert_warns,
                            assert_raises, dec, assert_, assert_allclose)
-from numpy import genfromtxt
 from statsmodels.datasets import macrodata, sunspots
 from pandas import Series, DatetimeIndex, DataFrame
 import os
@@ -130,7 +130,7 @@ class CheckCorrGram(object):
     x = data.data['realgdp']
     filename = os.path.dirname(os.path.abspath(__file__))+\
             "/results/results_corrgram.csv"
-    results = genfromtxt(open(filename, "rb"), delimiter=",", names=True,dtype=float)
+    results = pd.read_csv(filename, delimiter=',')
 
     #not needed: add 1. for lag zero
     #self.results['acvar'] = np.concatenate(([1.], self.results['acvar']))
@@ -146,8 +146,8 @@ class TestACF(CheckCorrGram):
         #cls.acf = np.concatenate(([1.], cls.acf))
         cls.qstat = cls.results['Q1']
         cls.res1 = acf(cls.x, nlags=40, qstat=True, alpha=.05)
-        cls.confint_res = cls.results[['acvar_lb','acvar_ub']].view((float,
-                                                                            2))
+        cls.confint_res = cls.results[['acvar_lb','acvar_ub']].as_matrix()
+
     def test_acf(self):
         assert_almost_equal(self.res1[0][1:41], self.acf, DECIMAL_8)
 


### PR DESCRIPTION
I think bumpy's WarningManager has gone the way of the Monty Python parrot. 

This is causing AppVeyor to not run.