### PR TITLE
TST: pytest.mark.xfail seems to xfail all succeeding tests in module

### DIFF
--- a/statsmodels/genmod/tests/test_glm_weights.py
+++ b/statsmodels/genmod/tests/test_glm_weights.py
@@ -178,7 +178,6 @@ class TestGlmPoissonAwNr(CheckWeight):
 
 
 # prob_weights fail with HC, not properly implemented yet
-@pytest.mark.xfail
 class TestGlmPoissonPwNr(CheckWeight):
     @classmethod
     def setup_class(cls):
@@ -195,6 +194,14 @@ class TestGlmPoissonPwNr(CheckWeight):
         #modd = discrete.Poisson(cpunish_data.endog, cpunish_data.exog)
         cls.res2 = res_stata.results_poisson_pweight_nonrobust
 
+    @pytest.mark.xfail(reason='Known to fail')
+    def test_basic(cls):
+        super(cls, TestGlmPoissonPwNr).test_basic(cls)
+
+    @pytest.mark.xfail(reason='Known to fail')
+    def test_compare_optimizers(cls):
+        super(cls, TestGlmPoissonPwNr).test_compare_optimizers(cls)
+    
 
 class TestGlmPoissonFwHC(CheckWeight):
     @classmethod


### PR DESCRIPTION
So I noticed that on the `statsmodels.genmod.tests.test_glm_weights` there is an `@pytest.mark.xfail` decorator before a class. While I think the point of that is to mark for xfail just that class, it seems to mark xfail that class and all succeeding classes. 

Here, I'm explicitly labeling the classes for xfail. 

@bashtage You are much better than me at this whole pytest thing (and the whole python thing in general!). I think pytest is your area of expertise, so if you have a better way, let me know.  