### PR TITLE
DOC: Fixed some pep8 violations, arr.size instead of len(arr)

### DIFF
--- a/statsmodels/nonparametric/bandwidths.py
+++ b/statsmodels/nonparametric/bandwidths.py
@@ -4,8 +4,6 @@ import numpy as np
 from scipy.stats import scoreatpercentile as sap
 from statsmodels.sandbox.nonparametric import kernels
 
-#from scipy.stats import norm
-
 def _select_sigma(X):
     """
     Returns the smaller of std(X, ddof=1) or normalized IQR(X) over axis 0.

--- a/statsmodels/nonparametric/kdetools.py
+++ b/statsmodels/nonparametric/kdetools.py
@@ -3,23 +3,23 @@ from __future__ import division
 from statsmodels.compat.python import range
 import numpy as np
 
-def forrt(X,m=None):
+def forrt(X, m=None):
     """
     RFFT with order like Munro (1976) FORTT routine.
     """
     if m is None:
         m = len(X)
-    y = np.fft.rfft(X,m)/m
-    return np.r_[y.real,y[1:-1].imag]
+    y = np.fft.rfft(X, m) / m
+    return np.r_[y.real, y[1:-1].imag]
 
-def revrt(X,m=None):
+def revrt(X, m=None):
     """
     Inverse of forrt. Equivalent to Munro (1976) REVRT routine.
     """
     if m is None:
         m = len(X)
-    i = int(m // 2+1)
-    y = X[:i] + np.r_[0,X[i:],0]*1j
+    i = int(m // 2 + 1)
+    y = X[:i] + np.r_[0, X[i:], 0] * 1j
     return np.fft.irfft(y)*m
 
 def silverman_transform(bw, M, RANGE):
@@ -33,12 +33,12 @@ def silverman_transform(bw, M, RANGE):
     J = np.arange(M/2+1)
     FAC1 = 2*(np.pi*bw/RANGE)**2
     JFAC = J**2*FAC1
-    BC = 1 - 1./3 * (J*1./M*np.pi)**2
+    BC = 1 - 1. / 3 * (J * 1./M*np.pi)**2
     FAC = np.exp(-JFAC)/BC
-    kern_est = np.r_[FAC,FAC[1:-1]]
+    kern_est = np.r_[FAC, FAC[1:-1]]
     return kern_est
 
-def counts(x,v):
+def counts(x, v):
     """
     Counts the number of elements of x that fall within the grid points v
 
@@ -46,12 +46,12 @@ def counts(x,v):
     -----
     Using np.digitize and np.bincount
     """
-    idx = np.digitize(x,v)
+    idx = np.digitize(x, v)
     try: # numpy 1.6
         return np.bincount(idx, minlength=len(v))
     except:
         bc = np.bincount(idx)
-        return np.r_[bc,np.zeros(len(v)-len(bc))]
+        return np.r_[bc, np.zeros(len(v) - len(bc))]
 
-def kdesum(x,axis=0):
+def kdesum(x, axis=0):
     return np.asarray([np.sum(x[i] - x, axis) for i in range(len(x))])


### PR DESCRIPTION
I read through some files in ``statsmodels/nonparametric`` and found some pep8 violations which I fixed. Very small stufff, mostly spaces. Remoted a few unused imports. Made one change to the code: using ``arr.size`` is faster than ``len(arr)``.

Comments very welcome.