### PR TITLE
gofplots.ProbPlot: Allow fit=False to contain loc/scale in distargs

### DIFF
--- a/statsmodels/graphics/gofplots.py
+++ b/statsmodels/graphics/gofplots.py
@@ -144,9 +144,17 @@ class ProbPlot(object):
             else:
                 self.dist = dist(loc=0, scale=1)
         elif distargs or loc == 0 or scale == 1:
-            self.dist = dist(*distargs, **dict(loc=loc, scale=scale))
-            self.loc = loc
-            self.scale = scale
+            if len(distargs) > 2:
+                self.loc = distargs[-2]
+                self.scale = distargs[-1]
+            else:
+                self.loc = loc
+                self.scale = scale
+
+            # We can't pass both loc/scale as a kwarg *and* an arg from
+            # distargs, or we'll get TypeError due to conflict
+            shape = distargs[0]
+            self.dist = dist(shape, loc=self.loc, scale=self.scale)
         else:
             self.dist = dist
             self.loc = loc


### PR DESCRIPTION
When using `distargs` with `loc` and `scale` contained, passing to a
ProbPlot where we do not explicitly set `loc` and `scale` in the
ProbPlot arguments results in a TypeError due to the way that overrides
are done:

    ---------------------------------------------------------------------------
    TypeError                                 Traceback (most recent call last)
    <ipython-input-131-73aae8b54cbd> in <module>()
         10 pp = sgg.ProbPlot(logR['price'], dist=stats.genextreme, distargs=fake_distargs, fit=False, loc=loc, scale=scale)
         11 fig = pp.qqplot(line='45')
    ---> 12 pp = sgg.ProbPlot(logR['price'], dist=stats.genextreme, distargs=gen_para, fit=False, loc=loc, scale=scale)
         13 fig = pp.qqplot(line='45')
         14

    ~/.pyenv/versions/3.6.3/lib/python3.6/site-packages/statsmodels/graphics/gofplots.py in __init__(self, data, dist, fit, distargs, a, loc, scale)
        145                 self.dist = dist(loc=0, scale=1)
        146         elif distargs or loc == 0 or scale == 1:
    --> 147             self.dist = dist(*distargs, **dict(loc=loc, scale=scale))
        148             self.loc = loc
        149             self.scale = scale

    ~/.pyenv/versions/3.6.3/lib/python3.6/site-packages/scipy/stats/_distn_infrastructure.py in __call__(self, *args, **kwds)
        770
        771     def __call__(self, *args, **kwds):
    --> 772         return self.freeze(*args, **kwds)
        773     __call__.__doc__ = freeze.__doc__
        774

    ~/.pyenv/versions/3.6.3/lib/python3.6/site-packages/scipy/stats/_distn_infrastructure.py in freeze(self, *args, **kwds)
        767
        768         """
    --> 769         return rv_frozen(self, *args, **kwds)
        770
        771     def __call__(self, *args, **kwds):

    ~/.pyenv/versions/3.6.3/lib/python3.6/site-packages/scipy/stats/_distn_infrastructure.py in __init__(self, dist, *args, **kwds)
        435
        436         # a, b may be set in _argcheck, depending on *args, **kwds. Ouch.
    --> 437         shapes, _, _ = self.dist._parse_args(*args, **kwds)
        438         self.dist._argcheck(*shapes)
        439         self.a, self.b = self.dist.a, self.dist.b

    TypeError: _parse_args() got multiple values for argument 'loc'

This is because, in line 147 in gofplots.py, we rely on being able to
override `loc` and `scale` explicitly as keyword arguments, but we
already pass them as positional arguments as part of `distargs`, which
seems legitimate since it's the kind of thing we'd get out of
`scipy.stats.genextreme`, for example.

The only way I could find to work around this it to use `fit=False` with
a tuple of only one element -- the shape, and then pass loc and scale
manually as extracted from distargs prior to passing to `ProbPlot`.

I don't really understand some of the logic in ProbPlot (eg. I'm not
sure why we also include `loc == 0 or scale == 1` when checking for
distargs in `ProbPlot.__init__`, but this seems to fix the issue without
causing changes to other logic.

Problem originally reported to me by @linsallyzhao.