### PR TITLE
Fixed non-utf8 character in data.

### DIFF
--- a/statsmodels/tsa/vector_ar/data/e6.dat
+++ b/statsmodels/tsa/vector_ar/data/e6.dat
@@ -1,7 +1,7 @@
 /*
 sample: 1972Q2 -- 1998Q4 
 West German data until 1990Q2, all of Germany aferwards
-Dp - \Delta log gdp deflator (source: Deutsches Institut für Wirtschaftsforschung,
+Dp - \Delta log gdp deflator (source: Deutsches Institut fÃ¼r Wirtschaftsforschung,
                               Volkswirtschaftliche Gesamtrechnung)
 R - nominal long term interest rate (Umlaufsrendite) 
                    (source: Monatsberichte der Deutschen Bundesbank,


### PR DESCRIPTION
One of the files had a non-utf8 character that under Python 3.6 was causing a Python error

> UnicodeDecodeError: 'utf-8' codec can't decode byte 0xfc in position 143: invalid start byte

I just replaced the character for its utf8-equivalent.