### PR TITLE
BUG: delay evaluation of fit results in ProbPlot

### DIFF
--- a/statsmodels/graphics/gofplots.py
+++ b/statsmodels/graphics/gofplots.py
@@ -134,13 +134,13 @@ class ProbPlot(object):
         if isinstance(dist, string_types):
             dist = getattr(stats, dist)
 
-        self.fit_params = dist.fit(data)
+        self._unfrozen_dist = dist
         if fit:
             self.loc = self.fit_params[-2]
             self.scale = self.fit_params[-1]
             if len(self.fit_params) > 2:
                 self.dist = dist(*self.fit_params[:-2],
-                                 **dict(loc = 0, scale = 1))
+                                 **dict(loc=0, scale=1))
             else:
                 self.dist = dist(loc=0, scale=1)
         elif distargs or loc == 0 or scale == 1:
@@ -154,6 +154,10 @@ class ProbPlot(object):
 
         # propertes
         self._cache = resettable_cache()
+
+    @cache_readonly
+    def fit_params(self):
+        return self._unfrozen_dist.fit(self.data)
 
     @cache_readonly
     def theoretical_percentiles(self):


### PR DESCRIPTION
Currently, graphics.gofplots.ProbPlot always calls the fit() method of
the scipy.stats distribution during initialization, and save the
return values as the fit_params attribute.  However, this is not always
necessary.

This patch delays the evaluation of fit_params by converting it to a
property.  To do this, a new (private) attribute is added to ProbPlot,
namely _unfrozen_dist that references the unfrozen scipy.stats
distribution.

Fixes #3547