### PR TITLE
MAINT: Use more recent miniconda for travis, numpy 1.14 has broken genfromtext

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,8 +77,7 @@ before_install:
   - export NUMEXPR_NUM_THREADS=1
   - export OMP_NUM_THREADS=1
   - conda config --set always_yes yes
-  # Temporarily disabled until conda is fixed
-  # - conda update --quiet conda
+  - conda update --quiet conda
   # Fix for headless TravisCI
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,11 +69,10 @@ notifications:
 
 # Setup anaconda
 before_install:
-  - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
+  - wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
   - chmod +x miniconda.sh
-  - ./miniconda.sh -b
+  - ./miniconda.sh -b -p /home/travis/miniconda
   - export PATH=/home/travis/miniconda/bin:$PATH
-  - export PATH=/home/travis/miniconda2/bin:$PATH
   - export MKL_NUM_THREADS=1
   - export NUMEXPR_NUM_THREADS=1
   - export OMP_NUM_THREADS=1

--- a/examples/notebooks/distributed_estimation.ipynb
+++ b/examples/notebooks/distributed_estimation.ipynb
@@ -9,13 +9,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "import numpy as np\n",
+    "from scipy.stats.distributions import norm\n",
     "from statsmodels.base.distributed_estimation import DistributedModel\n",
     "\n",
     "def _exog_gen(exog, partitions):\n",
@@ -52,16 +51,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "X = np.random.normal(size=(1000, 25))\n",
     "beta = np.random.normal(size=25)\n",
     "beta *= np.random.randint(0, 2, size=25)\n",
-    "y = X.dot(beta) + np.random.normal(size=1000)\n",
+    "y = norm.rvs(loc=X.dot(beta))\n",
     "m = 5"
    ]
   },
@@ -74,10 +71,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "debiased_OLS_mod = DistributedModel(m)\n",
@@ -94,17 +89,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "scrolled": false
    },
    "outputs": [],
    "source": [
     "from statsmodels.genmod.generalized_linear_model import GLM\n",
-    "from statsmodels.genmod.families import Binomial\n",
+    "from statsmodels.genmod.families import Gaussian\n",
     "\n",
     "debiased_GLM_mod = DistributedModel(m, model_class=GLM,\n",
-    "                                    init_kwds={\"family\": Binomial()})\n",
+    "                                    init_kwds={\"family\": Gaussian()})\n",
     "debiased_GLM_fit = debiased_GLM_mod.fit(zip(_endog_gen(y, m), _exog_gen(X, m)),\n",
     "                                        fit_kwds={\"alpha\": 0.2})"
    ]
@@ -118,10 +113,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "from statsmodels.base.distributed_estimation import _est_regularized_naive, _join_naive\n",
@@ -142,10 +135,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "from statsmodels.base.distributed_estimation import _est_unregularized_naive, DistributedResults\n",
@@ -175,7 +166,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.10"
+   "version": "2.7.14"
   }
  },
  "nbformat": 4,

--- a/statsmodels/tsa/vector_ar/util.py
+++ b/statsmodels/tsa/vector_ar/util.py
@@ -9,6 +9,7 @@ from statsmodels.compat.pandas import frequencies
 import numpy as np
 import scipy.stats as stats
 import scipy.linalg.decomp as decomp
+import pandas as pd
 
 import statsmodels.tsa.tsatools as tsa
 
@@ -108,6 +109,7 @@ def comp_matrix(coefs):
 #-------------------------------------------------------------------------------
 # Miscellaneous stuff
 
+
 def parse_lutkepohl_data(path): # pragma: no cover
     """
     Parse data files from Lütkepohl (2005) book
@@ -137,7 +139,8 @@ def parse_lutkepohl_data(path): # pragma: no cover
             year, freq, start_point = m.groups()
             break
 
-    data = np.genfromtxt(path, names=True, skip_header=to_skip+1)
+    data = (pd.read_csv(path, delimiter=r"\s+", header=to_skip+1)
+            .to_records(index=False))
 
     n = len(data)
 


### PR DESCRIPTION
Hello,

I'm noting that travis fails on the docbuild. 

I think running `conda update conda` fixes it. It looks like there are some new dependencies that `conda` that is shipped with miniconda can't seem to handle.