### PR TITLE
Fix summary col 3767

### DIFF
--- a/statsmodels/iolib/summary2.py
+++ b/statsmodels/iolib/summary2.py
@@ -488,7 +488,7 @@ def summary_col(results, float_format='%.4f', model_names=(), stars=False,
         order = ordered + list(np.unique(unordered))
 
         f = lambda idx: sum([[x + 'coef', x + 'stde'] for x in idx], [])
-        summ.index = f(np.unique(varnames))
+        summ.index = f(pd.unique(varnames))
         summ = summ.reindex(f(order))
         summ.index = [x[:-4] for x in summ.index]
         if drop_omitted:

--- a/statsmodels/iolib/tests/test_summary2.py
+++ b/statsmodels/iolib/tests/test_summary2.py
@@ -1,6 +1,7 @@
 import warnings
 
 import numpy as np
+import pandas as pd
 from numpy.testing import assert_equal
 
 from statsmodels.iolib.summary2 import summary_col
@@ -61,17 +62,19 @@ x1    & -0.7500  & -1.5769   \\
         x = [1, 5, 7, 3, 5]
         x = add_constant(x)
         x2 = np.concatenate([x, np.array([[3], [9], [-1], [4], [0]])], 1)
+        x2 = pd.DataFrame(x2, columns=['const', 'b', 'a'])
         y1 = [6, 4, 2, 7, 4]
         y2 = [8, 5, 0, 12, 4]
         reg1 = OLS(y1, x2).fit()
         reg2 = OLS(y2, x2).fit()
+
         info_dict = {'R2': lambda x: '{:.3f}'.format(int(x.rsquared)),
                      'N': lambda x: '{0:d}'.format(int(x.nobs))}
         original = actual = summary_col([reg1, reg2], float_format='%0.4f')
-        actual = summary_col([reg1, reg2], regressor_order=['x2', 'x1'],
+        actual = summary_col([reg1, reg2], regressor_order=['a', 'b'],
                              float_format='%0.4f',
                              info_dict=info_dict)
-        variables = ('const', 'x1', 'x2')
+        variables = ('const', 'b', 'a')
         for line in str(original).split('\n'):
             for variable in variables:
                 if line.startswith(variable):


### PR DESCRIPTION
Keep regressors aligned with coefficients in summary_col by using pandas.unique (retains order) instead of numpy.unique (sorts alphabetically).

Also modify applicable test so that it catches the issue.

See: https://github.com/statsmodels/statsmodels/issues/3767

