### PR TITLE
ENH: Add pvalue_to_stars() with docs and tests. Closes #4258.

### DIFF
--- a/docs/source/iolib.rst
+++ b/docs/source/iolib.rst
@@ -34,7 +34,6 @@ Module Reference
    smpickle.save_pickle
    smpickle.load_pickle
 
-
 The following are classes and functions used to return the summary of
 estimation results, and mostly intended for internal use. There are currently
 two versions for creating summaries.
@@ -44,3 +43,10 @@ two versions for creating summaries.
 
    summary.Summary
    summary2.Summary
+
+Utilities to assist in the visual representation of numeric data are provided in the following class:
+
+.. autosummary::
+   :toctree: generated/
+
+   decorations.pvalue_to_stars

--- a/statsmodels/iolib/decorations.py
+++ b/statsmodels/iolib/decorations.py
@@ -1,0 +1,32 @@
+__all__ = [
+    'pvalue_to_stars'
+]
+
+
+def pvalue_to_stars(p):
+    """
+    Represent a p-value's significance with stars.
+
+    Parameters
+    ----------
+    p : float
+
+    Returns
+    -------
+    str
+        Representation of the p-value's significance.
+
+    """
+    if not 0 <= p <= 1:
+        raise ValueError('p must be in range [0, 1]')
+
+    if p <= 0.0001:
+        return '****'
+    elif p <= 0.001:
+        return '***'
+    elif p <= 0.01:
+        return '**'
+    elif p <= 0.05:
+        return '*'
+    else:
+        return ''

--- a/statsmodels/iolib/tests/test_decorations.py
+++ b/statsmodels/iolib/tests/test_decorations.py
@@ -1,0 +1,24 @@
+import numpy as np
+
+from numpy.testing import assert_equal, assert_raises
+
+from statsmodels.iolib.decorations import pvalue_to_stars
+
+
+def test_pvalue_to_stars():
+    assert_equal(pvalue_to_stars(0), '****')
+    assert_equal(pvalue_to_stars(np.nextafter(0.0001, 1)), '***')
+
+    assert_equal(pvalue_to_stars(0.001), '***')
+    assert_equal(pvalue_to_stars(np.nextafter(0.001, 1)), '**')
+
+    assert_equal(pvalue_to_stars(0.01), '**')
+    assert_equal(pvalue_to_stars(np.nextafter(0.01, 1)), '*')
+
+    assert_equal(pvalue_to_stars(0.05), '*')
+    assert_equal(pvalue_to_stars(np.nextafter(0.05, 1)), '')
+
+    assert_equal(pvalue_to_stars(1), '')
+
+    assert_raises(ValueError, lambda: pvalue_to_stars(np.nextafter(0, -1)))
+    assert_raises(ValueError, lambda: pvalue_to_stars(np.nextafter(1, 2)))


### PR DESCRIPTION
I confirm documentation and tests build and pass.

```python
>>> from statsmodels.iolib.decorations import pvalue_to_stars
>>> pvalue_to_stars(1e-2)
'**'
```

I could not figure out how to include this in `iolib.summary2._col_params()` since there were no tests for me to modify.

Maybe someone else, in another PR, can replace?

https://github.com/statsmodels/statsmodels/blob/cd48743a8d721dc5e53b3b72db659da6fa779a33/statsmodels/iolib/summary2.py#L382-L389

This closes #4258.