### PR TITLE
fix numpy issue #3584

### DIFF
--- a/statsmodels/sandbox/stats/multicomp.py
+++ b/statsmodels/sandbox/stats/multicomp.py
@@ -728,7 +728,7 @@ class TukeyHSDResults(object):
         else:
             if comparison_name not in self.groupsunique:
                 raise ValueError('comparison_name not found in group names.')
-            midx = np.where(self.groupsunique==comparison_name)[0]
+            midx = np.where(self.groupsunique==comparison_name)[0][0]
             for i in range(len(means)):
                 if self.groupsunique[i] == comparison_name:
                     continue


### PR DESCRIPTION
fixes #3584

line 731 in statsmodels/sandbox/stats/multicomp.py
midx = np.where(self.groupsunique==comparison_name)[0]
changed to
midx = np.where(self.groupsunique==comparison_name)[0][0]