### PR TITLE
ENH/REF: Glm allow complex step derivatives

### DIFF
--- a/statsmodels/genmod/families/varfuncs.py
+++ b/statsmodels/genmod/families/varfuncs.py
@@ -75,7 +75,7 @@ class Power(object):
 
     Formulas
     --------
-    V(mu) = numpy.fabs(mu)**power
+    V(mu) = numpy.abs(mu)**power
 
     Notes
     -----
@@ -102,7 +102,7 @@ class Power(object):
         variance : array
             numpy.fabs(mu)**self.power
         """
-        return np.power(np.fabs(mu), self.power)
+        return np.power(np.abs(mu), self.power)
 
     def deriv(self, mu):
         """
@@ -111,7 +111,7 @@ class Power(object):
         May be undefined at zero.
         """
 
-        der = self.power * np.fabs(mu) ** (self.power - 1)
+        der = self.power * np.abs(mu) ** (self.power - 1)
         ii = np.flatnonzero(mu < 0)
         der[ii] *= -1
         return der

--- a/statsmodels/tools/numdiff.py
+++ b/statsmodels/tools/numdiff.py
@@ -349,7 +349,7 @@ def approx_hess3(x, f, epsilon=None, args=(), kwargs={}):
             hess[i, j] = (f(*((x + ee[i, :] + ee[j, :],) + args), **kwargs)
                           - f(*((x + ee[i, :] - ee[j, :],) + args), **kwargs)
                           - (f(*((x - ee[i, :] + ee[j, :],) + args), **kwargs)
-                          - f(*((x - ee[i, :] - ee[j, :],) + args), **kwargs),)
+                          - f(*((x - ee[i, :] - ee[j, :],) + args), **kwargs))
                           )/(4.*hess[i, j])
             hess[j, i] = hess[i, j]
     return hess


### PR DESCRIPTION
currently just parking two commits that I needed for non-linear GLM in
https://github.com/statsmodels/statsmodels/issues/2179#issuecomment-362822388

use of `fabs` prevents the use of complex step derivatives from numdiff

extra comma removal in numdiff already has a PR
