### PR TITLE
remove commented-out test code

### DIFF
--- a/statsmodels/base/tests/test_data.py
+++ b/statsmodels/base/tests/test_data.py
@@ -74,7 +74,6 @@ class TestArrays2dEndog(TestArrays):
         cls.endog = np.random.random((10,1))
         cls.exog = np.c_[np.ones(10), np.random.random((10,2))]
         cls.data = sm_data.handle_data(cls.endog, cls.exog)
-        #cls.endog = endog.squeeze()
 
     def test_endogexog(self):
         np.testing.assert_equal(self.data.endog, self.endog.squeeze())
@@ -729,7 +728,7 @@ class CheckHasConstant(object):
     def test_hasconst(self):
         for x, result in zip(self.exogs, self.results):
             mod = self.mod(self.y, x)
-            assert_equal(mod.k_constant, result[0]) #['k_constant'])
+            assert_equal(mod.k_constant, result[0])
             assert_equal(mod.data.k_constant, result[0])
             if result[1] is None:
                 assert_(mod.data.const_idx is None)

--- a/statsmodels/base/tests/test_generic_methods.py
+++ b/statsmodels/base/tests/test_generic_methods.py
@@ -104,8 +104,6 @@ class CheckGenericMixin(object):
         if summ2 is not None:
             assert_(string_use_t in summ2)
 
-    # TODO The following is not (yet) guaranteed across models
-    #@knownfailureif(True)
     def test_fitted(self):
         # ignore wrapper for isinstance check
         from statsmodels.genmod.generalized_linear_model import GLMResults
@@ -452,7 +450,7 @@ class TestGenericLogit(CheckGenericMixin):
         nobs = x.shape[0]
         np.random.seed(987689)
         y_bin = (np.random.rand(nobs) < 1.0 / (1 + np.exp(x.sum(1) - x.mean()))).astype(int)
-        model = sm.Logit(y_bin, x)  #, exposure=np.ones(nobs), offset=np.zeros(nobs)) #bug with default
+        model = sm.Logit(y_bin, x)
         # use start_params to converge faster
         start_params = np.array([-0.73403806, -1.00901514, -0.97754543, -0.95648212])
         self.results = model.fit(start_params=start_params, method='bfgs', disp=0)
@@ -521,7 +519,6 @@ class TestGenericGEEPoissonNaive(CheckGenericMixin):
         #fit for each test, because results will be changed by test
         x = self.exog
         np.random.seed(987689)
-        #y_count = np.random.poisson(np.exp(x.sum(1) - x.mean()))
         y_count = np.random.poisson(np.exp(x.sum(1) - x.sum(1).mean(0)))
         groups = np.random.randint(0, 4, size=x.shape[0])
         # use start_params to speed up test, difficult convergence not tested
@@ -540,7 +537,6 @@ class TestGenericGEEPoissonBC(CheckGenericMixin):
         #fit for each test, because results will be changed by test
         x = self.exog
         np.random.seed(987689)
-        #y_count = np.random.poisson(np.exp(x.sum(1) - x.mean()))
         y_count = np.random.poisson(np.exp(x.sum(1) - x.sum(1).mean(0)))
         groups = np.random.randint(0, 4, size=x.shape[0])
         # use start_params to speed up test, difficult convergence not tested

--- a/statsmodels/base/tests/test_shrink_pickle.py
+++ b/statsmodels/base/tests/test_shrink_pickle.py
@@ -53,7 +53,6 @@ class RemoveDataPickle(object):
         res = results.summary2()  # SMOKE test also summary2
 
         # uncomment the following to check whether tests run (7 failures now)
-        #np.testing.assert_equal(res, 1)
 
         #check pickle unpickle works on full results
         #TODO: drop of load save is tested
@@ -156,7 +155,7 @@ class TestRemoveDataPicklePoisson(RemoveDataPickle):
         x = self.exog
         np.random.seed(987689)
         y_count = np.random.poisson(np.exp(x.sum(1) - x.mean()))
-        model = sm.Poisson(y_count, x)  #, exposure=np.ones(nobs), offset=np.zeros(nobs)) #bug with default
+        model = sm.Poisson(y_count, x)
         # use start_params to converge faster
         start_params = np.array([0.75334818, 0.99425553, 1.00494724, 1.00247112])
         self.results = model.fit(start_params=start_params, method='bfgs',
@@ -185,7 +184,7 @@ class TestRemoveDataPickleLogit(RemoveDataPickle):
         nobs = x.shape[0]
         np.random.seed(987689)
         y_bin = (np.random.rand(nobs) < 1.0 / (1 + np.exp(x.sum(1) - x.mean()))).astype(int)
-        model = sm.Logit(y_bin, x)  #, exposure=np.ones(nobs), offset=np.zeros(nobs)) #bug with default
+        model = sm.Logit(y_bin, x)
         # use start_params to converge faster
         start_params = np.array([-0.73403806, -1.00901514, -0.97754543, -0.95648212])
         self.results = model.fit(start_params=start_params, method='bfgs', disp=0)
@@ -270,7 +269,6 @@ class TestPickleFormula5(TestPickleFormula2):
 
     def setup(self):
         # if we import here, then unpickling fails -> exception in test
-        #from numpy import log
         self.results = sm.OLS.from_formula("Y ~ log(abs(A) + 1) + B * C", data=self.data).fit()
 
 

--- a/statsmodels/discrete/tests/test_constrained.py
+++ b/statsmodels/discrete/tests/test_constrained.py
@@ -170,15 +170,12 @@ class TestPoissonConstrained1b(CheckPoissonConstrainedMixin):
     def setup_class(cls):
 
         cls.res2 = results.results_exposure_constraint
-        #cls.idx = [3, 4, 5, 6, 0, 1]  # 2 is dropped baseline for categorical
         cls.idx = [6, 2, 3, 4, 5, 0]  # 2 is dropped baseline for categorical
 
         # example without offset
         formula = 'deaths ~ smokes + C(agecat)'
         mod = Poisson.from_formula(formula, data=data,
-                                   #offset=np.log(data['pyears'].values))
                                    exposure=data['pyears'].values)
-        #res1a = mod1a.fit()
         constr = 'C(agecat)[T.4] = C(agecat)[T.5]'
         lc = patsy.DesignInfo(mod.exog_names).linear_constraint(constr)
         cls.res1 = fit_constrained(mod, lc.coefs, lc.constants,
@@ -197,14 +194,12 @@ class TestPoissonConstrained1c(CheckPoissonConstrainedMixin):
     def setup_class(cls):
 
         cls.res2 = results.results_exposure_constraint
-        #cls.idx = [3, 4, 5, 6, 0, 1]  # 2 is dropped baseline for categorical
         cls.idx = [6, 2, 3, 4, 5, 0]  # 2 is dropped baseline for categorical
 
         # example without offset
         formula = 'deaths ~ smokes + C(agecat)'
         mod = Poisson.from_formula(formula, data=data,
                                    offset=np.log(data['pyears'].values))
-        #res1a = mod1a.fit()
         constr = 'C(agecat)[T.4] = C(agecat)[T.5]'
         lc = patsy.DesignInfo(mod.exog_names).linear_constraint(constr)
         cls.res1 = fit_constrained(mod, lc.coefs, lc.constants,
@@ -228,7 +223,6 @@ class TestPoissonNoConstrained(CheckPoissonConstrainedMixin):
         # example without offset
         formula = 'deaths ~ smokes + C(agecat)'
         mod = Poisson.from_formula(formula, data=data,
-                                   #exposure=data['pyears'].values)
                                    offset=np.log(data['pyears'].values))
         res1 = mod.fit(disp=0)._results
         # res1 is duplicate check, so we can follow the same pattern
@@ -274,15 +268,12 @@ class TestPoissonConstrained2b(CheckPoissonConstrainedMixin):
     def setup_class(cls):
 
         cls.res2 = results.results_exposure_constraint2
-        #cls.idx = [3, 4, 5, 6, 0, 1]  # 2 is dropped baseline for categorical
         cls.idx = [6, 2, 3, 4, 5, 0]  # 2 is dropped baseline for categorical
 
         # example without offset
         formula = 'deaths ~ smokes + C(agecat)'
         mod = Poisson.from_formula(formula, data=data,
-                                   #offset=np.log(data['pyears'].values))
                                    exposure=data['pyears'].values)
-        #res1a = mod1a.fit()
         constr = 'C(agecat)[T.5] - C(agecat)[T.4] = 0.5'
         lc = patsy.DesignInfo(mod.exog_names).linear_constraint(constr)
         cls.res1 = fit_constrained(mod, lc.coefs, lc.constants,
@@ -302,7 +293,6 @@ class TestPoissonConstrained2c(CheckPoissonConstrainedMixin):
     def setup_class(cls):
 
         cls.res2 = results.results_exposure_constraint2
-        #cls.idx = [3, 4, 5, 6, 0, 1]  # 2 is dropped baseline for categorical
         cls.idx = [6, 2, 3, 4, 5, 0]  # 2 is dropped baseline for categorical
 
         # example without offset
@@ -377,7 +367,6 @@ class TestGLMPoissonConstrained1b(CheckPoissonConstrainedMixin):
 
         formula = 'deaths ~ smokes + C(agecat)'
         mod = Poisson.from_formula(formula, data=data,
-                                   #offset=np.log(data['pyears'].values))
                                    exposure=data['pyears'].values)
 
         constr = 'C(agecat)[T.4] = C(agecat)[T.5]'
@@ -430,7 +419,6 @@ class TestGLMLogitConstrained1(CheckGLMConstrainedMixin):
         # params sequence same as Stata, but Stata reports param = nan
         # and we have param = value = 0
 
-        #res1ul = Logit(data.endog, data.exog).fit(method="newton", disp=0)
         cls.res2 = reslogit.results_constraint1
 
         mod1 = GLM(spector_data.endog, spector_data.exog,
@@ -448,7 +436,6 @@ class TestGLMLogitConstrained2(CheckGLMConstrainedMixin):
     @classmethod
     def setup_class(cls):
         cls.idx = slice(None)  # params sequence same as Stata
-        #res1ul = Logit(data.endog, data.exog).fit(method="newton", disp=0)
         cls.res2 = reslogit.results_constraint2
 
         mod1 = GLM(spector_data.endog, spector_data.exog,

--- a/statsmodels/discrete/tests/test_margins.py
+++ b/statsmodels/discrete/tests/test_margins.py
@@ -44,7 +44,6 @@ class TestPoissonMargin(CheckMarginMixin):
                         -5.0529]
         mod_poi = Poisson(endog, exog)
         res_poi = mod_poi.fit(start_params=start_params)
-        #res_poi = mod_poi.fit(maxiter=100)
         marge_poi = res_poi.get_margeff()
         cls.res = res_poi
         cls.margeff = marge_poi

--- a/statsmodels/discrete/tests/test_sandwich_cov.py
+++ b/statsmodels/discrete/tests/test_sandwich_cov.py
@@ -32,7 +32,6 @@ filepath = os.path.join(cur_dir, "results", "ships.csv")
 data_raw = pd.read_csv(filepath, index_col=False)
 data = data_raw.dropna()
 
-#mod = smd.Poisson.from_formula('accident ~ yr_con + op_75_79', data=dat)
 # Don't use formula for tests against Stata because intercept needs to be last
 endog = data['accident']
 exog_data = data['yr_con op_75_79'.split()]
@@ -71,7 +70,6 @@ class CheckCountRobustMixin(object):
 
         nobs, k_vars = res1.model.exog.shape
         k_params = len(res1.params)
-        #n_groups = len(np.unique(group))
         corr_fact = (nobs-1.) / float(nobs - k_params)
         # for bse we need sqrt of correction factor
         cls.corr_fact = np.sqrt(corr_fact)
@@ -122,18 +120,16 @@ class TestPoissonCluGeneric(CheckCountRobustMixin):
 
         from statsmodels.base.covtype import get_robustcov_results
 
-        #res_hc0_ = cls.res1.get_robustcov_results('HC1')
         get_robustcov_results(cls.res1._results, 'cluster',
                                                   groups=group,
                                                   use_correction=True,
                                                   df_correction=True,  #TODO has no effect
-                                                  use_t=False, #True,
+                                                  use_t=False,
                                                   use_self=True)
         cls.bse_rob = cls.res1.bse
 
         nobs, k_vars = res1.model.exog.shape
         k_params = len(res1.params)
-        #n_groups = len(np.unique(group))
         corr_fact = (nobs-1.) / float(nobs - k_params)
         # for bse we need sqrt of correction factor
         cls.corr_fact = np.sqrt(corr_fact)
@@ -149,7 +145,6 @@ class TestPoissonHC1Generic(CheckCountRobustMixin):
 
         from statsmodels.base.covtype import get_robustcov_results
 
-        #res_hc0_ = cls.res1.get_robustcov_results('HC1')
         get_robustcov_results(cls.res1._results, 'HC1', use_self=True)
         cls.bse_rob = cls.res1.bse
         nobs, k_vars = mod.exog.shape
@@ -177,7 +172,7 @@ class TestPoissonCluFit(CheckCountRobustMixin):
                                          use_correction=True,
                                          scaling_factor=1. / sc_fact,
                                          df_correction=True),  #TODO has no effect
-                           use_t=False, #True,
+                           use_t=False,
                            )
 
         # The model results, t_test, ... should also work without
@@ -254,18 +249,16 @@ class TestPoissonCluExposureGeneric(CheckCountRobustMixin):
 
         from statsmodels.base.covtype import get_robustcov_results
 
-        #res_hc0_ = cls.res1.get_robustcov_results('HC1')
         get_robustcov_results(cls.res1._results, 'cluster',
                                                   groups=group,
                                                   use_correction=True,
                                                   df_correction=True,  #TODO has no effect
-                                                  use_t=False, #True,
+                                                  use_t=False,
                                                   use_self=True)
-        cls.bse_rob = cls.res1.bse #sw.se_cov(cov_clu)
+        cls.bse_rob = cls.res1.bse
 
         nobs, k_vars = res1.model.exog.shape
         k_params = len(res1.params)
-        #n_groups = len(np.unique(group))
         corr_fact = (nobs-1.) / float(nobs - k_params)
         # for bse we need sqrt of correction factor
         cls.corr_fact = np.sqrt(corr_fact)
@@ -294,13 +287,12 @@ class TestGLMPoissonCluGeneric(CheckCountRobustMixin):
                                                   groups=group,
                                                   use_correction=True,
                                                   df_correction=True,  #TODO has no effect
-                                                  use_t=False, #True,
+                                                  use_t=False,
                                                   use_self=True)
         cls.bse_rob = cls.res1.bse
 
         nobs, k_vars = res1.model.exog.shape
         k_params = len(res1.params)
-        #n_groups = len(np.unique(group))
         corr_fact = (nobs-1.) / float(nobs - k_params)
         # for bse we need sqrt of correction factor
         cls.corr_fact = np.sqrt(corr_fact)
@@ -314,7 +306,6 @@ class TestGLMPoissonHC1Generic(CheckCountRobustMixin):
         mod = GLM(endog, exog, family=families.Poisson())
         cls.res1 = mod.fit()
 
-        #res_hc0_ = cls.res1.get_robustcov_results('HC1')
         get_robustcov_results(cls.res1._results, 'HC1', use_self=True)
         cls.bse_rob = cls.res1.bse
         nobs, k_vars = mod.exog.shape
@@ -334,7 +325,7 @@ class TestGLMPoissonCluFit(CheckCountRobustMixin):
                                   cov_kwds=dict(groups=group,
                                                 use_correction=True,
                                                 df_correction=True),  #TODO has no effect
-                                  use_t=False, #True,
+                                  use_t=False,
                                                 )
 
         # The model results, t_test, ... should also work without
@@ -346,7 +337,6 @@ class TestGLMPoissonCluFit(CheckCountRobustMixin):
 
         nobs, k_vars = mod.exog.shape
         k_params = len(cls.res1.params)
-        #n_groups = len(np.unique(group))
         corr_fact = (nobs-1.) / float(nobs - k_params)
         # for bse we need sqrt of correction factor
         cls.corr_fact = np.sqrt(corr_fact)
@@ -387,20 +377,6 @@ class TestNegbinCluExposure(CheckCountRobustMixin):
         cls.get_robust_clu()
 
 
-#        mod_nbe = smd.NegativeBinomial(endog, exog, exposure=data['service'])
-#        res_nbe = mod_nbe.fit()
-#        mod_nb = smd.NegativeBinomial(endog, exog)
-#        res_nb = mod_nb.fit()
-#
-#        cov_clu_nb = sw.cov_cluster(res_nb, group)
-#        k_params = k_vars + 1
-#        print sw.se_cov(cov_clu_nb / ((nobs-1.) / float(nobs - k_params)))
-#
-#        wt = res_nb.wald_test(np.eye(len(res_nb.params))[1:3], cov_p=cov_clu_nb/((nobs-1.) / float(nobs - k_params)))
-#        print wt
-#
-#        print dir(results_st)
-
 class TestNegbinCluGeneric(CheckCountRobustMixin):
 
     @classmethod
@@ -413,13 +389,12 @@ class TestNegbinCluGeneric(CheckCountRobustMixin):
                                                   groups=group,
                                                   use_correction=True,
                                                   df_correction=True,  #TODO has no effect
-                                                  use_t=False, #True,
+                                                  use_t=False,
                                                   use_self=True)
         cls.bse_rob = cls.res1.bse
 
         nobs, k_vars = mod.exog.shape
         k_params = len(cls.res1.params)
-        #n_groups = len(np.unique(group))
         corr_fact = (nobs-1.) / float(nobs - k_params)
         # for bse we need sqrt of correction factor
         cls.corr_fact = np.sqrt(corr_fact)
@@ -435,13 +410,12 @@ class TestNegbinCluFit(CheckCountRobustMixin):
                                   cov_kwds=dict(groups=group,
                                                 use_correction=True,
                                                 df_correction=True),  #TODO has no effect
-                                  use_t=False, #True,
+                                  use_t=False,
                                   gtol=1e-7)
         cls.bse_rob = cls.res1.bse
 
         nobs, k_vars = mod.exog.shape
         k_params = len(cls.res1.params)
-        #n_groups = len(np.unique(group))
         corr_fact = (nobs-1.) / float(nobs - k_params)
         # for bse we need sqrt of correction factor
         cls.corr_fact = np.sqrt(corr_fact)
@@ -457,13 +431,12 @@ class TestNegbinCluExposureFit(CheckCountRobustMixin):
                                   cov_kwds=dict(groups=group,
                                                 use_correction=True,
                                                 df_correction=True),  #TODO has no effect
-                                  use_t=False, #True,
+                                  use_t=False,
                                   )
         cls.bse_rob = cls.res1.bse
 
         nobs, k_vars = mod.exog.shape
         k_params = len(cls.res1.params)
-        #n_groups = len(np.unique(group))
         corr_fact = (nobs-1.) / float(nobs - k_params)
         # for bse we need sqrt of correction factor
         cls.corr_fact = np.sqrt(corr_fact)


### PR DESCRIPTION
Commented-out code may be useful for the person who commented it out as a temporary measure years ago, but it is harmful for any other reader unless it is accompanied by an explanation or instructions for conditions under which to restore it.
