### PR TITLE
use pytest.raises context

### DIFF
--- a/statsmodels/discrete/tests/test_count_model.py
+++ b/statsmodels/discrete/tests/test_count_model.py
@@ -2,7 +2,7 @@
 from __future__ import division
 import os
 import numpy as np
-from numpy.testing import (assert_, assert_raises, assert_almost_equal,
+from numpy.testing import (assert_, assert_almost_equal,
                            assert_equal, assert_array_equal, assert_allclose,
                            assert_array_less)
 

--- a/statsmodels/discrete/tests/test_discrete.py
+++ b/statsmodels/discrete/tests/test_discrete.py
@@ -15,7 +15,7 @@ import warnings
 
 import numpy as np
 import pandas as pd
-from numpy.testing import (assert_, assert_raises, assert_almost_equal,
+from numpy.testing import (assert_, assert_almost_equal,
                            assert_equal, assert_array_equal, assert_allclose,
                            assert_array_less)
 import pytest
@@ -670,7 +670,8 @@ class CheckL1Compatability(object):
 
     def test_bad_r_matrix(self):
         kvars = self.kvars
-        assert_raises(ValueError, self.res_reg.f_test, np.eye(kvars) )
+        with pytest.raises(ValueError):
+            self.res_reg.f_test(np.eye(kvars))
 
 
 class TestPoissonL1Compatability(CheckL1Compatability):
@@ -1452,7 +1453,9 @@ def test_perfect_prediction():
     y = y[y != 2]
     X = sm.add_constant(X, prepend=True)
     mod = Logit(y,X)
-    assert_raises(PerfectSeparationError, mod.fit, maxiter=1000)
+    with pytest.raises(PerfectSeparationError):
+        mod.fit(maxiter=1000)
+
     #turn off raise PerfectSeparationError
     mod.raise_on_perfect_prediction = False
     # this will raise if you set maxiter high enough with a singular matrix
@@ -1549,7 +1552,8 @@ def test_isdummy():
 def test_non_binary():
     y = [1, 2, 1, 2, 1, 2]
     X = np.random.randn(6, 2)
-    np.testing.assert_raises(ValueError, Logit, y, X)
+    with pytest.raises(ValueError):
+        Logit(y, X)
 
 
 def test_mnlogit_factor():
@@ -1587,9 +1591,8 @@ def test_formula_missing_exposure():
     # make sure this raises
     exposure = pd.Series(np.random.uniform(size=5))
     df.loc[3, 'Bar'] = 4   # nan not relevant for ValueError for shape mismatch
-    assert_raises(ValueError, sm.Poisson, df.Foo, df[['constant', 'Bar']],
-                  exposure=exposure)
-
+    with pytest.raises(ValueError):
+        sm.Poisson(df.Foo, df[['constant', 'Bar']], exposure=exposure)
 
 def test_predict_with_exposure():
     # Case where CountModel.predict is called with exog = None and exposure

--- a/statsmodels/distributions/tests/test_discrete.py
+++ b/statsmodels/distributions/tests/test_discrete.py
@@ -2,7 +2,7 @@ import os
 import numpy as np
 import statsmodels.api as sm
 from scipy.stats import poisson, nbinom
-from numpy.testing import (assert_, assert_raises, assert_almost_equal,
+from numpy.testing import (assert_, assert_almost_equal,
                            assert_equal, assert_array_equal, assert_allclose,
                            assert_array_less)
 

--- a/statsmodels/genmod/tests/test_glm.py
+++ b/statsmodels/genmod/tests/test_glm.py
@@ -7,7 +7,7 @@ from statsmodels.compat.testing import skipif
 
 import os
 import numpy as np
-from numpy.testing import (assert_almost_equal, assert_equal, assert_raises,
+from numpy.testing import (assert_almost_equal, assert_equal,
                            assert_allclose, assert_, assert_array_less, dec)
 from scipy import stats
 import statsmodels.api as sm
@@ -770,7 +770,8 @@ def test_perfect_pred():
     y = y[y != 2]
     X = add_constant(X, prepend=True)
     glm = GLM(y, X, family=sm.families.Binomial())
-    assert_raises(PerfectSeparationError, glm.fit)
+    with pytest.raises(PerfectSeparationError):
+        glm.fit()
 
 
 def test_score_test_OLS():
@@ -875,10 +876,14 @@ def test_formula_missing_exposure():
 
     exposure = pd.Series(np.random.uniform(size=5))
     df.loc[3, 'Bar'] = 4   # nan not relevant for Valueerror for shape mismatch
-    assert_raises(ValueError, smf.glm, "Foo ~ Bar", data=df,
-                  exposure=exposure, family=family)
-    assert_raises(ValueError, GLM, df.Foo, df[['constant', 'Bar']],
-                  exposure=exposure, family=family)
+
+    with pytest.raises(ValueError):
+        smf.glm("Foo ~ Bar", data=df,
+                exposure=exposure, family=family)
+
+    with pytest.raises(ValueError):
+        GLM(df.Foo, df[['constant', 'Bar']],
+            exposure=exposure, family=family)
 
 
 @skipif(not have_matplotlib, reason='matplotlib not available')

--- a/statsmodels/tsa/regime_switching/tests/test_markov_autoregression.py
+++ b/statsmodels/tsa/regime_switching/tests/test_markov_autoregression.py
@@ -13,7 +13,7 @@ import numpy as np
 import pandas as pd
 from statsmodels.tools import add_constant
 from statsmodels.tsa.regime_switching import markov_autoregression
-from numpy.testing import assert_equal, assert_allclose, assert_raises
+from numpy.testing import assert_equal, assert_allclose
 
 current_path = os.path.dirname(os.path.abspath(__file__))
 

--- a/statsmodels/tsa/regime_switching/tests/test_markov_regression.py
+++ b/statsmodels/tsa/regime_switching/tests/test_markov_regression.py
@@ -12,7 +12,7 @@ import numpy as np
 import pandas as pd
 from statsmodels.tsa.regime_switching import (markov_switching,
                                               markov_regression)
-from numpy.testing import assert_equal, assert_allclose, assert_raises
+from numpy.testing import assert_equal, assert_allclose
 
 
 current_path = os.path.dirname(os.path.abspath(__file__))

--- a/statsmodels/tsa/statespace/tests/test_impulse_responses.py
+++ b/statsmodels/tsa/statespace/tests/test_impulse_responses.py
@@ -15,8 +15,7 @@ from scipy.signal import lfilter
 
 from statsmodels.tsa.statespace import (sarimax, structural, varmax,
                                         dynamic_factor)
-from numpy.testing import (assert_allclose, assert_almost_equal, assert_equal,
-                           assert_raises)
+from numpy.testing import assert_allclose, assert_almost_equal, assert_equal
 
 
 def test_sarimax():

--- a/statsmodels/tsa/statespace/tests/test_prediction.py
+++ b/statsmodels/tsa/statespace/tests/test_prediction.py
@@ -12,7 +12,7 @@ import pandas as pd
 
 import warnings
 from statsmodels.tsa.statespace import sarimax
-from numpy.testing import assert_equal, assert_allclose, assert_raises
+from numpy.testing import assert_equal, assert_allclose
 
 
 def test_predict_dates():

--- a/statsmodels/tsa/statespace/tests/test_simulate.py
+++ b/statsmodels/tsa/statespace/tests/test_simulate.py
@@ -16,8 +16,7 @@ from scipy.signal import lfilter
 from statsmodels.tsa.statespace import (sarimax, structural, varmax,
                                         dynamic_factor)
 from statsmodels.tsa.statespace.tools import compatibility_mode
-from numpy.testing import (assert_allclose, assert_almost_equal, assert_equal,
-                           assert_raises)
+from numpy.testing import assert_allclose, assert_almost_equal, assert_equal
 
 
 def test_arma_lfilter():

--- a/statsmodels/tsa/statespace/tests/test_simulation_smoothing.py
+++ b/statsmodels/tsa/statespace/tests/test_simulation_smoothing.py
@@ -21,7 +21,7 @@ from statsmodels.tsa.statespace.kalman_smoother import (
     SMOOTH_UNIVARIATE)
 from statsmodels.tsa.statespace.simulation_smoother import (
     SIMULATION_STATE, SIMULATION_DISTURBANCE, SIMULATION_ALL)
-from numpy.testing import assert_allclose, assert_almost_equal, assert_equal, assert_raises
+from numpy.testing import assert_allclose, assert_almost_equal, assert_equal
 import pytest
 
 current_path = os.path.dirname(os.path.abspath(__file__))

--- a/statsmodels/tsa/statespace/tests/test_smoothing.py
+++ b/statsmodels/tsa/statespace/tests/test_smoothing.py
@@ -28,7 +28,7 @@ from statsmodels.tsa.statespace.kalman_filter import (
 from statsmodels.tsa.statespace.kalman_smoother import (
     SMOOTH_CONVENTIONAL, SMOOTH_CLASSICAL, SMOOTH_ALTERNATIVE,
     SMOOTH_UNIVARIATE)
-from numpy.testing import assert_allclose, assert_almost_equal, assert_equal, assert_raises
+from numpy.testing import assert_allclose, assert_almost_equal, assert_equal
 
 current_path = os.path.dirname(os.path.abspath(__file__))
 

--- a/statsmodels/tsa/tests/test_arima.py
+++ b/statsmodels/tsa/tests/test_arima.py
@@ -1808,11 +1808,13 @@ def test_bad_start_params():
          801.1112548 ,   796.16163313,   817.2496376 ,   857.73046447,
          838.849345  ,   761.92338873,   731.7842242 ,   770.4641844 ])
     mod = ARMA(endog, (15, 0))
-    assert_raises(ValueError, mod.fit)
+    with pytest.raises(ValueError):
+        mod.fit()
 
     inv = load_macrodata().data['realinv']
     arima_mod = ARIMA(np.log(inv), (1,1,2))
-    assert_raises(ValueError, mod.fit)
+    with pytest.raises(ValueError):
+        mod.fit()
 
 
 def test_arima_small_data_bug():
@@ -1826,7 +1828,8 @@ def test_arima_small_data_bug():
     ts = pd.Series(vals, index=dr)
     df = pd.DataFrame(ts)
     mod = sm.tsa.ARIMA(df, (2, 0, 2))
-    assert_raises(ValueError, mod.fit)
+    with pytest.raises(ValueError):
+        mod.fit()
 
 
 def test_arima_dataframe_integer_name():
@@ -1950,7 +1953,8 @@ class TestARMA00(object):
 
     def test_arma_00_nc(self):
         arma_00 = ARMA(self.y, order=(0, 0))
-        assert_raises(ValueError, arma_00.fit, trend='nc', disp=-1)
+        with pytest.raises(ValueError):
+            arma_00.fit(trend='nc', disp=-1)
 
     def test_css(self):
         arma = ARMA(self.y, order=(0, 0))
@@ -2003,7 +2007,8 @@ def test_arma_missing():
     # bug 1343
     y = np.random.random(40)
     y[-1] = np.nan
-    assert_raises(MissingDataError, ARMA, y, (1, 0), missing='raise')
+    with pytest.raises(MissingDataError):
+        ARMA(y, (1, 0), missing='raise')
 
 
 @skipif(not have_matplotlib, reason='matplotlib not available')
@@ -2270,7 +2275,8 @@ def test_long_ar_start_params():
     res = model.fit(method='css',start_ar_lags=10, disp=0)
     res = model.fit(method='css-mle',start_ar_lags=10, disp=0)
     res = model.fit(method='mle',start_ar_lags=10, disp=0)
-    assert_raises(ValueError, model.fit, start_ar_lags=nobs+5, disp=0)
+    with pytest.raises(ValueError):
+        model.fit(start_ar_lags=nobs + 5, disp=0)
 
 
 def test_arma_pickle():
@@ -2308,7 +2314,8 @@ def test_arima_pickle():
 def test_arima_not_implemented():
     formula = ' WUE ~ 1 + SFO3 '
     data = [-1214.360173, -1848.209905, -2100.918158]
-    assert_raises(NotImplementedError, ARIMA.from_formula, formula, data)
+    with pytest.raises(NotImplementedError):
+        ARIMA.from_formula(formula, data)
 
 
 if __name__ == "__main__":

--- a/statsmodels/tsa/tests/test_bds.py
+++ b/statsmodels/tsa/tests/test_bds.py
@@ -16,7 +16,7 @@ import os
 import numpy as np
 import pandas as pd
 from statsmodels.tsa.stattools import bds
-from numpy.testing import assert_almost_equal, assert_equal, assert_raises
+from numpy.testing import assert_almost_equal, assert_equal
 from numpy import genfromtxt
 
 DECIMAL_8 = 8

--- a/statsmodels/tsa/tests/test_holtwinters.py
+++ b/statsmodels/tsa/tests/test_holtwinters.py
@@ -6,7 +6,7 @@ Created on Wed Jul 12 09:44:01 2017
 
 import numpy as np
 import pandas as pd
-from numpy.testing import assert_almost_equal, assert_equal, assert_raises
+from numpy.testing import assert_almost_equal, assert_equal,
 from statsmodels.tsa.holtwinters import (ExponentialSmoothing,
                                          SimpleExpSmoothing, Holt)
 from pandas import DataFrame, DatetimeIndex

--- a/statsmodels/tsa/tests/test_tsa_indexes.py
+++ b/statsmodels/tsa/tests/test_tsa_indexes.py
@@ -17,8 +17,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from numpy.testing import (assert_allclose, assert_almost_equal, assert_equal,
-                           assert_raises)
+from numpy.testing import assert_allclose, assert_almost_equal, assert_equal
 
 from statsmodels.tsa.base import tsa_model
 
@@ -265,8 +264,8 @@ def test_instantiation_valid():
         # Since only supported indexes are valid `dates` arguments, everything
         # else is invalid here
         for ix, freq in supported_increment_indexes + unsupported_indexes:
-            assert_raises(ValueError, tsa_model.TimeSeriesModel, endog,
-                          dates=ix)
+            with pytest.raises(ValueError):
+                tsa_model.TimeSeriesModel(endog, dates=ix)
 
     # Test pandas (Series, DataFrame); with index (no dates/freq argument)
     for base_endog in dta[2:4]:
@@ -432,26 +431,26 @@ def test_instantiation_valid():
 
     # Test (invalid) freq with no index
     endog = dta[0]
-    assert_raises(ValueError, tsa_model.TimeSeriesModel, endog,
-                  freq=date_indexes[1][0].freq)
+    with pytest.raises(ValueError):
+        tsa_model.TimeSeriesModel(endog, freq=date_indexes[1][0].freq)
 
     # Test conflicting index, freq specifications
     endog = dta[2].copy()
     endog.index = date_indexes[0][0]
-    assert_raises(ValueError, tsa_model.TimeSeriesModel, endog,
-                  freq=date_indexes[1][0].freq)
+    with pytest.raises(ValueError):
+        tsa_model.TimeSeriesModel(endog, freq=date_indexes[1][0].freq)
 
     # Test unsupported index, but a freq specification
     endog = dta[2].copy()
     endog.index = unsupported_indexes[0][0]
-    assert_raises(ValueError, tsa_model.TimeSeriesModel, endog,
-                  freq=date_indexes[1][0].freq)
+    with pytest.raises(ValueError):
+        tsa_model.TimeSeriesModel(endog, freq=date_indexes[1][0].freq)
 
     # Test index that can coerce to date time but incorrect freq
     endog = dta[2].copy()
     endog.index = numpy_datestr_indexes[0][0]
-    assert_raises(ValueError, tsa_model.TimeSeriesModel, endog,
-                  freq=date_indexes[1][0].freq)
+    with pytest.raises(ValueError):
+        tsa_model.TimeSeriesModel(endog, freq=date_indexes[1][0].freq)
 
 
 def test_prediction_increment_unsupported():
@@ -755,5 +754,5 @@ def test_custom_index():
     assert_equal(prediction_index.equals(pd.Index(['f', 'g'])), True)
 
     # Test invalid custom index
-    assert_raises(ValueError, mod._get_prediction_index, start_key, end_key,
-                  index=['f', 'g', 'h'])
+    with pytest.raises(ValueError):
+        mod._get_prediction_index(start_key, end_key, index=['f', 'g', 'h'])


### PR DESCRIPTION
only in modules where pytest is already imported.  Trying to pre-empt off-the-wall objections.