### PR TITLE
cleanup setup.py

### DIFF
--- a/statsmodels/tsa/vector_ar/data/__init__.py
+++ b/statsmodels/tsa/vector_ar/data/__init__.py
@@ -1,0 +1,3 @@
+"""
+This file ensures that `find_packages` in setup.py includes this directory.
+"""


### PR DESCRIPTION
Tries to put all of the declarative-style (e.g. min_versions) in one place.

Where there is no risk of raising, moves stuff outside of `__main__` block.

Not handled in this PR but needs discussion:
- the `_have_setuptools` check I think is no longer relevant.  IIRC pandas removed it from their setup.py file a while back.  I'm guessing its an older-python compat, is that right?  If that check can be removed, a bunch of branching logic can be cleaned out.
- the min_versions listed in the setup.py file don't match those listed in the INSTALL.txt file.  They are also incredibly old and don't reflect what is actually tested in the CI.  @bashtage I think you've mentioned this.
- all of the `git_version` stuff can probably be outsourced.  Again bashtage is the authority.
- the cython exclusion stuff I'm pretty sure can now be handled by `cythonize`.  