### PR TITLE
Share LikelihoodModel.fit.__doc__ with Optimizer._fit.__doc__

### DIFF
--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -13,7 +13,8 @@ from statsmodels.tools.sm_exceptions import ValueWarning, \
     HessianInversionWarning
 from statsmodels.formula import handle_formula_data
 from statsmodels.compat.numpy import np_matrix_rank
-from statsmodels.base.optimizer import Optimizer, _fit_doc_notes
+from statsmodels.base.optimizer import (Optimizer, _fit_doc_notes,
+                                        _fit_doc_params)
 
 
 _model_params_doc = """
@@ -258,45 +259,7 @@ class LikelihoodModel(Model):
 
         Parameters
         ----------
-        start_params : array-like, optional
-            Initial guess of the solution for the loglikelihood maximization.
-            The default is an array of zeros.
-        method : str, optional
-            The `method` determines which solver from `scipy.optimize`
-            is used, and it can be chosen from among the following strings:
-
-            - 'newton' for Newton-Raphson, 'nm' for Nelder-Mead
-            - 'bfgs' for Broyden-Fletcher-Goldfarb-Shanno (BFGS)
-            - 'lbfgs' for limited-memory BFGS with optional box constraints
-            - 'powell' for modified Powell's method
-            - 'cg' for conjugate gradient
-            - 'ncg' for Newton-conjugate gradient
-            - 'basinhopping' for global basin-hopping solver
-            - 'minimize' for generic wrapper of scipy minimize (BFGS by default)
-
-            The explicit arguments in `fit` are passed to the solver,
-            with the exception of the basin-hopping solver. Each
-            solver has several optional arguments that are not the same across
-            solvers. See the notes section below (or scipy.optimize) for the
-            available arguments and for the list of explicit arguments that the
-            basin-hopping solver supports.
-        maxiter : int, optional
-            The maximum number of iterations to perform.
-        full_output : bool, optional
-            Set to True to have all available output in the Results object's
-            mle_retvals attribute. The output is dependent on the solver.
-            See LikelihoodModelResults notes section for more information.
-        disp : bool, optional
-            Set to True to print convergence messages.
-        fargs : tuple, optional
-            Extra arguments passed to the likelihood function, i.e.,
-            loglike(x,*args)
-        callback : callable callback(xk), optional
-            Called after each iteration, as callback(xk), where xk is the
-            current parameter vector.
-        retall : bool, optional
-            Set to True to return list of solutions at each iteration.
-            Available in Results object's mle_retvals attribute.
+        %(fit_params)s
         skip_hessian : bool, optional
             If False (default), then the negative inverse hessian is calculated
             after the optimization. If True, then the hessian will not be
@@ -407,7 +370,8 @@ class LikelihoodModel(Model):
         mlefit.mle_settings = optim_settings
         return mlefit
 
-    fit.__doc__ = fit.__doc__ % {'doc_notes': _fit_doc_notes.strip()}
+    fit.__doc__ = fit.__doc__ % {'fit_params': _fit_doc_params,
+                                 'doc_notes': _fit_doc_notes.strip()}
 
 
 # TODO: the below is unfinished

--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -13,7 +13,7 @@ from statsmodels.tools.sm_exceptions import ValueWarning, \
     HessianInversionWarning
 from statsmodels.formula import handle_formula_data
 from statsmodels.compat.numpy import np_matrix_rank
-from statsmodels.base.optimizer import Optimizer
+from statsmodels.base.optimizer import Optimizer, _fit_doc_notes
 
 
 _model_params_doc = """
@@ -312,109 +312,7 @@ class LikelihoodModel(Model):
 
         Notes
         -----
-        The 'basinhopping' solver ignores `maxiter`, `retall`, `full_output`
-        explicit arguments.
-
-        Optional arguments for solvers (see returned Results.mle_settings)::
-
-            'newton'
-                tol : float
-                    Relative error in params acceptable for convergence.
-            'nm' -- Nelder Mead
-                xtol : float
-                    Relative error in params acceptable for convergence
-                ftol : float
-                    Relative error in loglike(params) acceptable for
-                    convergence
-                maxfun : int
-                    Maximum number of function evaluations to make.
-            'bfgs'
-                gtol : float
-                    Stop when norm of gradient is less than gtol.
-                norm : float
-                    Order of norm (np.Inf is max, -np.Inf is min)
-                epsilon
-                    If fprime is approximated, use this value for the step
-                    size. Only relevant if LikelihoodModel.score is None.
-            'lbfgs'
-                m : int
-                    This many terms are used for the Hessian approximation.
-                factr : float
-                    A stop condition that is a variant of relative error.
-                pgtol : float
-                    A stop condition that uses the projected gradient.
-                epsilon
-                    If fprime is approximated, use this value for the step
-                    size. Only relevant if LikelihoodModel.score is None.
-                maxfun : int
-                    Maximum number of function evaluations to make.
-                bounds : sequence
-                    (min, max) pairs for each element in x,
-                    defining the bounds on that parameter.
-                    Use None for one of min or max when there is no bound
-                    in that direction.
-            'cg'
-                gtol : float
-                    Stop when norm of gradient is less than gtol.
-                norm : float
-                    Order of norm (np.Inf is max, -np.Inf is min)
-                epsilon : float
-                    If fprime is approximated, use this value for the step
-                    size. Can be scalar or vector.  Only relevant if
-                    Likelihoodmodel.score is None.
-            'ncg'
-                fhess_p : callable f'(x,*args)
-                    Function which computes the Hessian of f times an arbitrary
-                    vector, p.  Should only be supplied if
-                    LikelihoodModel.hessian is None.
-                avextol : float
-                    Stop when the average relative error in the minimizer
-                    falls below this amount.
-                epsilon : float or ndarray
-                    If fhess is approximated, use this value for the step size.
-                    Only relevant if Likelihoodmodel.hessian is None.
-            'powell'
-                xtol : float
-                    Line-search error tolerance
-                ftol : float
-                    Relative error in loglike(params) for acceptable for
-                    convergence.
-                maxfun : int
-                    Maximum number of function evaluations to make.
-                start_direc : ndarray
-                    Initial direction set.
-            'basinhopping'
-                niter : integer
-                    The number of basin hopping iterations.
-                niter_success : integer
-                    Stop the run if the global minimum candidate remains the
-                    same for this number of iterations.
-                T : float
-                    The "temperature" parameter for the accept or reject
-                    criterion. Higher "temperatures" mean that larger jumps
-                    in function value will be accepted. For best results
-                    `T` should be comparable to the separation (in function
-                    value) between local minima.
-                stepsize : float
-                    Initial step size for use in the random displacement.
-                interval : integer
-                    The interval for how often to update the `stepsize`.
-                minimizer : dict
-                    Extra keyword arguments to be passed to the minimizer
-                    `scipy.optimize.minimize()`, for example 'method' - the
-                    minimization method (e.g. 'L-BFGS-B'), or 'tol' - the
-                    tolerance for termination. Other arguments are mapped from
-                    explicit argument of `fit`:
-                      - `args` <- `fargs`
-                      - `jac` <- `score`
-                      - `hess` <- `hess`
-            'minimize'
-                min_method : str, optional
-                    Name of minimization method to use.
-                    Any method specific arguments can be passed directly.
-                    For a list of methods and their arguments, see
-                    documentation of `scipy.optimize.minimize`.
-                    If no method is specified, then BFGS is used.
+        %(doc_notes)s
         """
         Hinv = None  # JP error if full_output=0, Hinv not defined
 
@@ -508,6 +406,8 @@ class LikelihoodModel(Model):
 
         mlefit.mle_settings = optim_settings
         return mlefit
+
+    fit.__doc__ = fit.__doc__ % {'doc_notes': _fit_doc_notes.strip()}
 
 
 # TODO: the below is unfinished

--- a/statsmodels/base/optimizer.py
+++ b/statsmodels/base/optimizer.py
@@ -13,6 +13,48 @@ def _check_method(method, methods):
         raise ValueError(message)
 
 
+_fit_doc_params = """
+        start_params : array-like, optional
+            Initial guess of the solution for the loglikelihood maximization.
+            The default is an array of zeros.
+        method : str, optional
+            The `method` determines which solver from `scipy.optimize`
+            is used, and it can be chosen from among the following strings:
+
+            - 'newton' for Newton-Raphson, 'nm' for Nelder-Mead
+            - 'bfgs' for Broyden-Fletcher-Goldfarb-Shanno (BFGS)
+            - 'lbfgs' for limited-memory BFGS with optional box constraints
+            - 'powell' for modified Powell's method
+            - 'cg' for conjugate gradient
+            - 'ncg' for Newton-conjugate gradient
+            - 'basinhopping' for global basin-hopping solver
+            - 'minimize' for generic wrapper of scipy minimize (BFGS by default)
+
+            The explicit arguments in `fit` are passed to the solver,
+            with the exception of the basin-hopping solver. Each
+            solver has several optional arguments that are not the same across
+            solvers. See the notes section below (or scipy.optimize) for the
+            available arguments and for the list of explicit arguments that the
+            basin-hopping solver supports.
+        maxiter : int, optional
+            The maximum number of iterations to perform.
+        full_output : bool, optional
+            Set to True to have all available output in the Results object's
+            mle_retvals attribute. The output is dependent on the solver.
+            See LikelihoodModelResults notes section for more information.
+        disp : bool, optional
+            Set to True to print convergence messages.
+        fargs : tuple, optional
+            Extra arguments passed to the likelihood function, i.e.,
+            loglike(x,*args)
+        callback : callable callback(xk), optional
+            Called after each iteration, as callback(xk), where xk is the
+            current parameter vector.
+        retall : bool, optional
+            Set to True to return list of solutions at each iteration.
+            Available in Results object's mle_retvals attribute.
+"""
+
 _fit_doc_notes = """\
         The 'basinhopping' solver ignores `maxiter`, `retall`, `full_output`
         explicit arguments.
@@ -132,20 +174,25 @@ class Optimizer(object):
         start_params : array-like, optional
             Initial guess of the solution for the loglikelihood maximization.
             The default is an array of zeros.
-        method : str {'newton','nm','bfgs','powell','cg','ncg','basinhopping',
-            'minimize'}
-            Method can be 'newton' for Newton-Raphson, 'nm' for Nelder-Mead,
-            'bfgs' for Broyden-Fletcher-Goldfarb-Shanno, 'powell' for modified
-            Powell's method, 'cg' for conjugate gradient, 'ncg' for Newton-
-            conjugate gradient, 'basinhopping' for global basin-hopping
-            solver, if available or a generic 'minimize' which is a wrapper for
-            scipy.optimize.minimize. `method` determines which solver from
-            scipy.optimize is used. The explicit arguments in `fit` are passed
-            to the solver, with the exception of the basin-hopping solver. Each
+        method : str, optional
+            The `method` determines which solver from `scipy.optimize`
+            is used, and it can be chosen from among the following strings:
+
+            - 'newton' for Newton-Raphson, 'nm' for Nelder-Mead
+            - 'bfgs' for Broyden-Fletcher-Goldfarb-Shanno (BFGS)
+            - 'lbfgs' for limited-memory BFGS with optional box constraints
+            - 'powell' for modified Powell's method
+            - 'cg' for conjugate gradient
+            - 'ncg' for Newton-conjugate gradient
+            - 'basinhopping' for global basin-hopping solver
+            - 'minimize' for generic wrapper of scipy minimize (BFGS by default)
+
+            The explicit arguments in `fit` are passed to the solver,
+            with the exception of the basin-hopping solver. Each
             solver has several optional arguments that are not the same across
             solvers. See the notes section below (or scipy.optimize) for the
             available arguments and for the list of explicit arguments that the
-            basin-hopping solver supports..
+            basin-hopping solver supports.
         maxiter : int, optional
             The maximum number of iterations to perform.
         full_output : bool, optional
@@ -220,7 +267,8 @@ class Optimizer(object):
         # set as attributes or return?
         return xopt, retvals, optim_settings
 
-    _fit.__doc__ = _fit.__doc__ % {'doc_notes': _fit_doc_notes.strip()}
+    _fit.__doc__ = _fit.__doc__ % {'fit_params': _fit_doc_params.strip(),
+                                   'doc_notes': _fit_doc_notes.strip()}
 
     def _fit_constrained(self, params):
         """

--- a/statsmodels/base/optimizer.py
+++ b/statsmodels/base/optimizer.py
@@ -55,7 +55,7 @@ _fit_doc_params = """
             Available in Results object's mle_retvals attribute.
 """
 
-_fit_doc_notes = """\
+_fit_doc_notes = """
         The 'basinhopping' solver ignores `maxiter`, `retall`, `full_output`
         explicit arguments.
 

--- a/statsmodels/base/optimizer.py
+++ b/statsmodels/base/optimizer.py
@@ -13,67 +13,11 @@ def _check_method(method, methods):
         raise ValueError(message)
 
 
-class Optimizer(object):
-    def _fit(self, objective, gradient, start_params, fargs, kwargs,
-             hessian=None, method='newton', maxiter=100, full_output=True,
-             disp=True, callback=None, retall=False):
-        """
-        Fit function for any model with an objective function.
-
-        Parameters
-        ----------
-        start_params : array-like, optional
-            Initial guess of the solution for the loglikelihood maximization.
-            The default is an array of zeros.
-        method : str {'newton','nm','bfgs','powell','cg','ncg','basinhopping',
-            'minimize'}
-            Method can be 'newton' for Newton-Raphson, 'nm' for Nelder-Mead,
-            'bfgs' for Broyden-Fletcher-Goldfarb-Shanno, 'powell' for modified
-            Powell's method, 'cg' for conjugate gradient, 'ncg' for Newton-
-            conjugate gradient, 'basinhopping' for global basin-hopping
-            solver, if available or a generic 'minimize' which is a wrapper for
-            scipy.optimize.minimize. `method` determines which solver from
-            scipy.optimize is used. The explicit arguments in `fit` are passed
-            to the solver, with the exception of the basin-hopping solver. Each
-            solver has several optional arguments that are not the same across
-            solvers. See the notes section below (or scipy.optimize) for the
-            available arguments and for the list of explicit arguments that the
-            basin-hopping solver supports..
-        maxiter : int
-            The maximum number of iterations to perform.
-        full_output : bool
-            Set to True to have all available output in the Results object's
-            mle_retvals attribute. The output is dependent on the solver.
-            See LikelihoodModelResults notes section for more information.
-        disp : bool
-            Set to True to print convergence messages.
-        fargs : tuple
-            Extra arguments passed to the likelihood function, i.e.,
-            loglike(x,*args)
-        callback : callable callback(xk)
-            Called after each iteration, as callback(xk), where xk is the
-            current parameter vector.
-        retall : bool
-            Set to True to return list of solutions at each iteration.
-            Available in Results object's mle_retvals attribute.
-
-        Returns
-        -------
-        xopt : array
-            The solution to the objective function
-        retvals : dict, None
-            If `full_output` is True then this is a dictionary which holds
-            information returned from the solver used. If it is False, this is
-            None.
-        optim_settings : dict
-            A dictionary that contains the parameters passed to the solver.
-
-        Notes
-        -----
+_fit_doc_notes = """\
         The 'basinhopping' solver ignores `maxiter`, `retall`, `full_output`
         explicit arguments.
 
-        Optional arguments for the solvers (available in Results.mle_settings)::
+        Optional arguments for the solvers (available in Results.mle_settings):
 
             'newton'
                 tol : float
@@ -94,6 +38,23 @@ class Optimizer(object):
                 epsilon
                     If fprime is approximated, use this value for the step
                     size. Only relevant if LikelihoodModel.score is None.
+            'lbfgs'
+                m : int
+                    This many terms are used for the Hessian approximation.
+                factr : float
+                    A stop condition that is a variant of relative error.
+                pgtol : float
+                    A stop condition that uses the projected gradient.
+                epsilon
+                    If fprime is approximated, use this value for the step
+                    size. Only relevant if LikelihoodModel.score is None.
+                maxfun : int
+                    Maximum number of function evaluations to make.
+                bounds : sequence
+                    (min, max) pairs for each element in x,
+                    defining the bounds on that parameter.
+                    Use None for one of min or max when there is no bound
+                    in that direction.
             'cg'
                 gtol : float
                     Stop when norm of gradient is less than gtol.
@@ -146,9 +107,9 @@ class Optimizer(object):
                     minimization method (e.g. 'L-BFGS-B'), or 'tol' - the
                     tolerance for termination. Other arguments are mapped from
                     explicit argument of `fit`:
-                    - `args` <- `fargs`
-                    - `jac` <- `score`
-                    - `hess` <- `hess`
+                      - `args` <- `fargs`
+                      - `jac` <- `score`
+                      - `hess` <- `hess`
             'minimize'
                 min_method : str, optional
                     Name of minimization method to use.
@@ -156,6 +117,67 @@ class Optimizer(object):
                     For a list of methods and their arguments, see
                     documentation of `scipy.optimize.minimize`.
                     If no method is specified, then BFGS is used.
+"""
+
+
+class Optimizer(object):
+    def _fit(self, objective, gradient, start_params, fargs, kwargs,
+             hessian=None, method='newton', maxiter=100, full_output=True,
+             disp=True, callback=None, retall=False):
+        """
+        Fit function for any model with an objective function.
+
+        Parameters
+        ----------
+        start_params : array-like, optional
+            Initial guess of the solution for the loglikelihood maximization.
+            The default is an array of zeros.
+        method : str {'newton','nm','bfgs','powell','cg','ncg','basinhopping',
+            'minimize'}
+            Method can be 'newton' for Newton-Raphson, 'nm' for Nelder-Mead,
+            'bfgs' for Broyden-Fletcher-Goldfarb-Shanno, 'powell' for modified
+            Powell's method, 'cg' for conjugate gradient, 'ncg' for Newton-
+            conjugate gradient, 'basinhopping' for global basin-hopping
+            solver, if available or a generic 'minimize' which is a wrapper for
+            scipy.optimize.minimize. `method` determines which solver from
+            scipy.optimize is used. The explicit arguments in `fit` are passed
+            to the solver, with the exception of the basin-hopping solver. Each
+            solver has several optional arguments that are not the same across
+            solvers. See the notes section below (or scipy.optimize) for the
+            available arguments and for the list of explicit arguments that the
+            basin-hopping solver supports..
+        maxiter : int, optional
+            The maximum number of iterations to perform.
+        full_output : bool, optional
+            Set to True to have all available output in the Results object's
+            mle_retvals attribute. The output is dependent on the solver.
+            See LikelihoodModelResults notes section for more information.
+        disp : bool, optional
+            Set to True to print convergence messages.
+        fargs : tuple, optional
+            Extra arguments passed to the likelihood function, i.e.,
+            loglike(x,*args)
+        callback : callable callback(xk), optional
+            Called after each iteration, as callback(xk), where xk is the
+            current parameter vector.
+        retall : bool, optional
+            Set to True to return list of solutions at each iteration.
+            Available in Results object's mle_retvals attribute.
+
+        Returns
+        -------
+        xopt : array
+            The solution to the objective function
+        retvals : dict, None
+            If `full_output` is True then this is a dictionary which holds
+            information returned from the solver used. If it is False, this is
+            None.
+        optim_settings : dict
+            A dictionary that contains the parameters passed to the solver.
+
+        Notes
+        -----
+        %(doc_notes)s
         """
         #TODO: generalize the regularization stuff
         # Extract kwargs specific to fit_regularized calling fit
@@ -197,6 +219,8 @@ class Optimizer(object):
         optim_settings.update(kwargs)
         # set as attributes or return?
         return xopt, retvals, optim_settings
+
+    _fit.__doc__ = _fit.__doc__ % {'doc_notes': _fit_doc_notes.strip()}
 
     def _fit_constrained(self, params):
         """


### PR DESCRIPTION
`LikelihoodModel.fit.__doc__` shares about 150 lines with `Optimizer._fit.__doc__` in the handful of places where they differ, the Optimizer version is out of date.  This PR makes them share the relevant portions of the docstring.

Notes on where changes have been made:

- The parameter entries in `Optimizer._fit` version say e.g. `maxiter : int` instead of `maxiter : int, optional`.  The ", optional" now matches the `LikelihoodModel.fot` version.
- The entry on the `method` parameter has the same content but better formatting/wording in `LikelihoodModel.fit.__doc__`.  That wording is now shared.
- Indententation in the 'basinhopping' entry for the "`- `args` <- `fargs`" line and the two following lines is slightly different.  Now standardized on the LikelihoodModel.fit version.
- A double colon on line 318 in optimizer is fixed.
- `Optimizer._fit` version is missing entry for `'lbfgs'`.  That is rectified.