### PR TITLE
ENH: add t_test_pairwise to LikelihoodModelResults

### DIFF
--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -1646,7 +1646,7 @@ class LikelihoodModelResults(Results):
         res.temp = constraints + combined_constraints + extra_constraints
         return res
 
-    def t_test_pairwise(self, term_name, method='hs',
+    def t_test_pairwise(self, term_name, method='hs', alpha=0.05,
                         factor_labels=None):
         """perform pairwise t_test with multiple testing corrected p-values
 
@@ -1664,6 +1664,8 @@ class LikelihoodModelResults(Results):
         method : str or list of strings
             multiple testing p-value correction, default is 'hs',
             see stats.multipletesting
+        alpha : float
+            significance level for multiple testing reject decision.
         factor_labels : None, list of str
             Labels for the factor levels used for pairwise labels. If not
             provided, then the labels from the formula design_info are used.
@@ -1705,7 +1707,7 @@ class LikelihoodModelResults(Results):
         3-2         1.130992   0.010212      True
 
         """
-        res = t_test_pairwise(self, term_name, method=method,
+        res = t_test_pairwise(self, term_name, method=method, alpha=alpha,
                               factor_labels=factor_labels)
         return res
 

--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -1647,9 +1647,66 @@ class LikelihoodModelResults(Results):
         return res
 
     def t_test_pairwise(self, term_name, method='hs',
-                        factor_labels=None, ignore=False):
+                        factor_labels=None):
+        """perform pairwise t_test with multiple testing corrected p-values
+
+        This uses the formula design_info encoding contrast matrix and should
+        work for all encodings of a main effect.
+
+        Parameters
+        ----------
+        result : result instance
+            The results of an estimated model with a categorical main effect.
+        term_name : str
+            name of the term for which pairwise comparisons are computed.
+            Term names for categorical effects are created by patsy and
+            correspond to the main part of the exog names.
+        method : str or list of strings
+            multiple testing p-value correction, default is 'hs',
+            see stats.multipletesting
+        factor_labels : None, list of str
+            Labels for the factor levels used for pairwise labels. If not
+            provided, then the labels from the formula design_info are used.
+
+        Returns
+        -------
+        results : instance of a simple Results class
+            The results are stored as attributes, the main attributes are the
+            following two. Other attributes are added for debugging purposes
+            or as background information.
+
+            - result_frame : pandas DataFrame with t_test results and multiple
+              testing corrected p-values.
+            - contrasts : matrix of constraints of the null hypothesis in the
+              t_test.
+
+        Notes
+        -----
+
+        Status: experimental. Currently only checked for treatment coding with
+        and without specified reference level.
+
+        Currently there are no multiple testing corrected confidence intervals
+        available.
+
+        Examples
+        --------
+        >>> res = ols("np.log(Days+1) ~ C(Weight) + C(Duration)", data).fit()
+        >>> pw = res.t_test_pairwise("C(Weight)")
+        >>> pw.result_frame
+                 coef   std err         t         P>|t|  Conf. Int. Low  \
+        2-1  0.632315  0.230003  2.749157  8.028083e-03        0.171563
+        3-1  1.302555  0.230003  5.663201  5.331513e-07        0.841803
+        3-2  0.670240  0.230003  2.914044  5.119126e-03        0.209488
+
+             Conf. Int. Upp.  pvalue-hs reject-hs
+        2-1         1.093067   0.010212      True
+        3-1         1.763307   0.000002      True
+        3-2         1.130992   0.010212      True
+
+        """
         res = t_test_pairwise(self, term_name, method=method,
-                              factor_labels=factor_labels, ignore=ignore)
+                              factor_labels=factor_labels)
         return res
 
     def conf_int(self, alpha=.05, cols=None, method='default'):

--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -5,7 +5,8 @@ from scipy import stats
 from statsmodels.base.data import handle_data
 from statsmodels.tools.data import _is_using_pandas
 from statsmodels.tools.tools import recipr, nan_dot
-from statsmodels.stats.contrast import ContrastResults, WaldTestResults
+from statsmodels.stats.contrast import (ContrastResults, WaldTestResults,
+                                        t_test_pairwise)
 from statsmodels.tools.decorators import resettable_cache, cache_readonly
 import statsmodels.base.wrapper as wrap
 from statsmodels.tools.numdiff import approx_fprime
@@ -1643,6 +1644,12 @@ class LikelihoodModelResults(Results):
         res = WaldTestResults(None, distribution, None, table=table)
         # TODO: remove temp again, added for testing
         res.temp = constraints + combined_constraints + extra_constraints
+        return res
+
+    def t_test_pairwise(self, term_name, method='hs',
+                        factor_labels=None, ignore=False):
+        res = t_test_pairwise(self, term_name, method=method,
+                              factor_labels=factor_labels, ignore=ignore)
         return res
 
     def conf_int(self, alpha=.05, cols=None, method='default'):

--- a/statsmodels/base/tests/test_generic_methods.py
+++ b/statsmodels/base/tests/test_generic_methods.py
@@ -518,5 +518,38 @@ class T_estWaldAnovaOLSNoFormula(object):
         cls.res = mod.fit()  # default use_t=True
 
 
+class CheckPairwise(object):
+
+    def test_default(self):
+        res = self.res
+
+        tt = res.t_test(self.constraints)
+
+        pw = res.t_test_pairwise(self.term_name)
+        pw_frame = pw.result_frame
+        assert_allclose(pw_frame.iloc[:, :6].values,
+                        tt.summary_frame().values)
+
+
+class TestTTestPairwiseOLS(CheckPairwise):
+
+    @classmethod
+    def setup_class(cls):
+        from statsmodels.formula.api import ols
+        import statsmodels.stats.tests.test_anova as ttmod
+
+        test = ttmod.TestAnova3()
+        test.setup_class()
+        cls.data = test.data.drop([0,1,2])
+
+        mod = ols("np.log(Days+1) ~ C(Duration) + C(Weight)", cls.data)
+        cls.res = mod.fit()
+        cls.term_name = "C(Weight)"
+        cls.constraints = ['C(Weight)[T.2]',
+                           'C(Weight)[T.3]',
+                           'C(Weight)[T.3] - C(Weight)[T.2]']
+
+
+
 if __name__ == '__main__':
     pass

--- a/statsmodels/base/tests/test_generic_methods.py
+++ b/statsmodels/base/tests/test_generic_methods.py
@@ -606,5 +606,25 @@ class TestTTestPairwiseOLS4(CheckPairwise):
                            'C(Weight, Treatment(2))[T.3]',]
 
 
+class TestTTestPairwisePoisson(CheckPairwise):
+
+    @classmethod
+    def setup_class(cls):
+        from statsmodels.discrete.discrete_model import Poisson
+        import statsmodels.stats.tests.test_anova as ttmod
+
+        test = ttmod.TestAnova3()
+        test.setup_class()
+        cls.data = test.data.drop([0,1,2])
+
+        mod = Poisson.from_formula("Days ~ C(Duration) + C(Weight)", cls.data)
+        cls.res = mod.fit(cov_type='HC0')
+        cls.term_name = "C(Weight)"
+        cls.constraints = ['C(Weight)[T.2]',
+                           'C(Weight)[T.3]',
+                           'C(Weight)[T.3] - C(Weight)[T.2]']
+
+
+
 if __name__ == '__main__':
     pass

--- a/statsmodels/base/tests/test_generic_methods.py
+++ b/statsmodels/base/tests/test_generic_methods.py
@@ -550,6 +550,61 @@ class TestTTestPairwiseOLS(CheckPairwise):
                            'C(Weight)[T.3] - C(Weight)[T.2]']
 
 
+class TestTTestPairwiseOLS2(CheckPairwise):
+
+    @classmethod
+    def setup_class(cls):
+        from statsmodels.formula.api import ols
+        import statsmodels.stats.tests.test_anova as ttmod
+
+        test = ttmod.TestAnova3()
+        test.setup_class()
+        cls.data = test.data.drop([0,1,2])
+
+        mod = ols("np.log(Days+1) ~ C(Weight) + C(Duration)", cls.data)
+        cls.res = mod.fit()
+        cls.term_name = "C(Weight)"
+        cls.constraints = ['C(Weight)[T.2]',
+                           'C(Weight)[T.3]',
+                           'C(Weight)[T.3] - C(Weight)[T.2]']
+
+
+class TestTTestPairwiseOLS3(CheckPairwise):
+
+    @classmethod
+    def setup_class(cls):
+        from statsmodels.formula.api import ols
+        import statsmodels.stats.tests.test_anova as ttmod
+
+        test = ttmod.TestAnova3()
+        test.setup_class()
+        cls.data = test.data.drop([0,1,2])
+
+        mod = ols("np.log(Days+1) ~ C(Weight) + C(Duration) - 1", cls.data)
+        cls.res = mod.fit()
+        cls.term_name = "C(Weight)"
+        cls.constraints = ['C(Weight)[2] - C(Weight)[1]',
+                           'C(Weight)[3] - C(Weight)[1]',
+                           'C(Weight)[3] - C(Weight)[2]']
+
+class TestTTestPairwiseOLS4(CheckPairwise):
+
+    @classmethod
+    def setup_class(cls):
+        from statsmodels.formula.api import ols
+        import statsmodels.stats.tests.test_anova as ttmod
+
+        test = ttmod.TestAnova3()
+        test.setup_class()
+        cls.data = test.data.drop([0,1,2])
+
+        mod = ols("np.log(Days+1) ~ C(Weight, Treatment(2)) + C(Duration)", cls.data)
+        cls.res = mod.fit()
+        cls.term_name = "C(Weight, Treatment(2))"
+        cls.constraints = ['-C(Weight, Treatment(2))[T.1]',
+                           'C(Weight, Treatment(2))[T.3] - C(Weight, Treatment(2))[T.1]',
+                           'C(Weight, Treatment(2))[T.3]',]
+
 
 if __name__ == '__main__':
     pass

--- a/statsmodels/base/tests/test_generic_methods.py
+++ b/statsmodels/base/tests/test_generic_methods.py
@@ -550,6 +550,22 @@ class TestTTestPairwiseOLS(CheckPairwise):
                            'C(Weight)[T.3] - C(Weight)[T.2]']
 
 
+    def test_alpha(self):
+        pw1 = self.res.t_test_pairwise(self.term_name, method='hommel',
+                                       factor_labels='A B C'.split())
+        pw2 = self.res.t_test_pairwise(self.term_name, method='hommel',
+                                       alpha=0.01)
+        assert_allclose(pw1.result_frame.iloc[:, :7].values,
+                        pw2.result_frame.iloc[:, :7].values, rtol=1e-10)
+        assert_equal(pw1.result_frame.iloc[:, -1].values,
+                     [True]*3)
+        assert_equal(pw2.result_frame.iloc[:, -1].values,
+                     [False, True, False])
+
+        assert_equal(pw1.result_frame.index.values,
+                     np.array(['B-A', 'C-A', 'C-B'], dtype=object))
+
+
 class TestTTestPairwiseOLS2(CheckPairwise):
 
     @classmethod

--- a/statsmodels/stats/contrast.py
+++ b/statsmodels/stats/contrast.py
@@ -469,23 +469,25 @@ def _contrast_pairs(k_params, k_level, idx_start):
     return contrasts
 
 
-def t_test_multi(result, contrasts, method='hs', ci_method=None,
+def t_test_multi(result, contrasts, method='hs', alpha=0.05, ci_method=None,
                  contrast_names=None):
     """perform t_test and add multiplicity correction to results dataframe
 
     Parameters
     ----------
     result results instance
-       results of an estimated model
+        results of an estimated model
     contrasts : ndarray
         restriction matrix for t_test
     method : string or list of strings
-       method for multiple testing p-value correction, default is'hs'.
+        method for multiple testing p-value correction, default is'hs'.
+    alpha : float
+        significance level for multiple testing reject decision.
     ci_method : None
-       not used yet, will be for multiplicity corrected confidence intervals
+        not used yet, will be for multiplicity corrected confidence intervals
     contrast_names : list of strings or None
-       If contrast_names are provided, then they are used in the index of the
-       returned dataframe, otherwise some generic default names are created.
+        If contrast_names are provided, then they are used in the index of the
+        returned dataframe, otherwise some generic default names are created.
 
     Returns
     -------
@@ -500,7 +502,7 @@ def t_test_multi(result, contrasts, method='hs', ci_method=None,
     if type(method) is not list:
         method = [method]
     for meth in method:
-        mt = multipletests(tt.pvalue, method=meth)
+        mt = multipletests(tt.pvalue, method=meth, alpha=alpha)
         res_df['pvalue-%s' % meth] = mt[1]
         res_df['reject-%s' % meth] = mt[0]
     return res_df
@@ -597,8 +599,8 @@ def _constraints_factor(encoding_matrix, comparison='pairwise', k_params=None,
     return contrasts
 
 
-def t_test_pairwise(result, term_name, method='hs', factor_labels=None,
-                    ignore=False):
+def t_test_pairwise(result, term_name, method='hs', alpha=0.05,
+                    factor_labels=None, ignore=False):
     """perform pairwise t_test with multiple testing corrected p-values
 
     This uses the formula design_info encoding contrast matrix and should
@@ -615,6 +617,8 @@ def t_test_pairwise(result, term_name, method='hs', factor_labels=None,
     method : str or list of strings
         multiple testing p-value correction, default is 'hs',
         see stats.multipletesting
+    alpha : float
+        significance level for multiple testing reject decision.
     factor_labels : None, list of str
         Labels for the factor levels used for pairwise labels. If not
         provided, then the labels from the formula design_info are used.
@@ -670,7 +674,7 @@ def t_test_pairwise(result, term_name, method='hs', factor_labels=None,
     contrasts_sub = c_all_pairs.dot(cm)
     contrasts = _embed_constraints(contrasts_sub, k_params, idx_start)
     res_df = t_test_multi(result, contrasts, method=method, ci_method=None,
-                          contrast_names=labels)
+                          alpha=alpha, contrast_names=labels)
     res = MultiCompResult(result_frame=res_df,
                           contrasts=contrasts,
                           term=term,

--- a/statsmodels/stats/contrast.py
+++ b/statsmodels/stats/contrast.py
@@ -550,6 +550,53 @@ def _embed_constraints(contrasts, k_params, idx_start, index=None):
     return c
 
 
+def _constraints_factor(encoding_matrix, comparison='pairwise', k_params=None,
+                        idx_start=None):
+    """helper function to create constraints based on encoding matrix
+
+    Parameters
+    ----------
+    encoding_matrix : ndarray
+        contrast matrix for the encoding of a factor as defined by patsy.
+        The number of rows should be equal to the number of levels or categories
+        of the factor, the number of columns should be equal to the number
+        of parameters for this factor.
+    comparison : str
+        Currently only 'pairwise' is implemented. The restriction matrix
+        can be used for testing the hypothesis that all pairwise differences
+        are zero.
+    k_params : int
+        number of parameters
+    idx_start : int
+        Index of the first parameter of this factor. The restrictions on the
+        factor are inserted as a block in the full restriction matrix starting
+        at column with index `idx_start`.
+
+    Returns
+    -------
+    contrast : ndarray
+        Contrast or restriction matrix that can be used in hypothesis test
+        of model results. The number of columns is k_params.
+    """
+
+    cm = encoding_matrix
+    k_level, k_p = cm.shape
+
+    import statsmodels.sandbox.stats.multicomp as mc
+    if comparison in ['pairwise', 'pw', 'pairs']:
+        c_all = -mc.contrast_allpairs(k_level)
+    else:
+        raise NotImplementedError('currentlyonly pairwise comparison')
+
+    contrasts = c_all.dot(cm)
+    if k_params is not None:
+        if idx_start is None:
+            raise ValueError("if k_params is not None, then idx_start is "
+                             "required")
+        contrasts = _embed_constraints(contrasts, k_params, idx_start)
+    return contrasts
+
+
 def t_test_pairwise(result, term_name, method='hs', factor_labels=None,
                     ignore=False):
     """perform pairwise t_test with multiple testing corrected p-values

--- a/statsmodels/stats/contrast.py
+++ b/statsmodels/stats/contrast.py
@@ -461,15 +461,14 @@ class MultiCompResult(object):
         self.__dict__.update(kwargs)
 
 
-def _embed_constraints(contrasts, k_params, idx_start):
+def _embed_constraints(contrasts, k_params, idx_start, index=None):
 
     k_c, k_p = contrasts.shape
     c = np.zeros((k_c, k_params))
-    if isinstance(idx_start, int):
-        # no ducks, int_likes supported yet
+    if index is None:
         c[:, idx_start : idx_start + k_p] = contrasts
     else:
-        c[:, idx_start] = contrasts
+        c[:, index] = contrasts
     return c
 
 

--- a/statsmodels/stats/tests/test_anova.py
+++ b/statsmodels/stats/tests/test_anova.py
@@ -72,7 +72,7 @@ kidney_table = StringIO("""Days      Duration Weight ID
 """)
 
 kidney_table.seek(0)
-kidney_table = read_table(kidney_table, sep="\s+")
+kidney_table = read_table(kidney_table, sep="\s+").astype(int)
 
 class TestAnovaLM(object):
     @classmethod

--- a/statsmodels/stats/tests/test_contrast.py
+++ b/statsmodels/stats/tests/test_contrast.py
@@ -2,6 +2,8 @@ import numpy as np
 import numpy.random as R
 from numpy.testing import assert_almost_equal, assert_equal
 from statsmodels.stats.contrast import Contrast
+import statsmodels.stats.contrast as smc
+
 
 class TestContrast(object):
     @classmethod
@@ -36,3 +38,31 @@ class TestContrast(object):
         c = Contrast(self.X[:,5],X2)
         #TODO: I don't think this should be estimable?  isestimable correct?
 
+
+def test_constraints():
+    cm_ = np.eye(4, 3, k=-1)
+    cpairs = np.array([[ 1.,  0.,  0.],
+                       [ 0.,  1.,  0.],
+                       [ 0.,  0.,  1.],
+                       [-1.,  1.,  0.],
+                       [-1.,  0.,  1.],
+                       [ 0., -1.,  1.]])
+    c0 = smc._constraints_factor(cm_)
+    assert_equal(c0, cpairs)
+
+    c1 = smc._contrast_pairs(3, 4, 0)
+    assert_equal(c1, cpairs)
+
+    # embedded
+    cpairs2 = np.array([[ 0.,  1.,  0.,  0.,  0.,  0.],
+                        [ 0.,  0.,  1.,  0.,  0.,  0.],
+                        [ 0.,  0.,  0.,  1.,  0.,  0.],
+                        [ 0., -1.,  1.,  0.,  0.,  0.],
+                        [ 0., -1.,  0.,  1.,  0.,  0.],
+                        [ 0.,  0., -1.,  1.,  0.,  0.]])
+
+    c0 = smc._constraints_factor(cm_, k_params=6, idx_start=1)
+    assert_equal(c0, cpairs2)
+
+    c1 = smc._contrast_pairs(6, 4, 1)  # k_params, k_level, idx_start
+    assert_equal(c1, cpairs2)


### PR DESCRIPTION
this is related to #4361, and #4323 as a model analogue of tukeyhsd (with general multipletesting p-value correction)

pairwise comparison for the main effect of a categorical exog.
Also, this should be similar to Stata pairwise option, but I haven't compared yet.

This uses now the encoding contrast matrix from design_info. Therefore it should be independent of the contrast/categorical encoding.
I checked Treatment encoding with and without reference in my examples and it looks good.

Only one minimal unit test comparing t_test_pairwise with t_test with explicitly provided constraints.

`t_test_pairwise` is added as a method of LikelihoodModelResults, but actual function is in stats.contrasts.py

todo for now

- check api, maybe privatize some method
- more unit tests, (I have more examples in my developing notebook)

todo later
- improved results, more than just returning dataframe
- generalize to other target restrictions than pairwise, e.g. deviation from mean (?)
- generalize to other params besides main effect
- add api and interface for non-formula exog
- related: add multiple pvalue correction in t_test ContrastResults  (it's easy to do by users for dataframe as done in here)
- maybe: add tukeyhsd pvalues for special of balanced, orthogonal contrasts #4323 (which triggered this round)
