### PR TITLE
MAINT: numpy compat, keep old rcond in lstsq

### DIFF
--- a/statsmodels/nonparametric/smoothers_lowess_old.py
+++ b/statsmodels/nonparametric/smoothers_lowess_old.py
@@ -169,7 +169,7 @@ def _lowess_initial_fit(x_copy, y_copy, k, n):
         X[:,1] = x_copy[nn_indices[0]:nn_indices[1]]
         y_i = weights[i,:] * y_copy[nn_indices[0]:nn_indices[1]]
 
-        beta = lstsq(weights[i,:].reshape(k,1) * X, y_i)[0]
+        beta = lstsq(weights[i,:].reshape(k,1) * X, y_i, rcond=-1)[0]
         fitted[i] = beta[0] + beta[1]*x_copy[i]
 
         _lowess_update_nn(x_copy, nn_indices, i+1)
@@ -255,7 +255,7 @@ def _lowess_robustify_fit(x_copy, y_copy, fitted, weights, k, n):
         y_i = total_weights * y_copy[nn_indices[0]:nn_indices[1]]
         total_weights.shape = (k,1)
 
-        beta = lstsq(total_weights * X, y_i)[0]
+        beta = lstsq(total_weights * X, y_i, rcond=-1)[0]
 
         fitted[i] = beta[0] + beta[1] * x_copy[i]
 

--- a/statsmodels/regression/_tools.py
+++ b/statsmodels/regression/_tools.py
@@ -89,7 +89,8 @@ class _MinimalWLS(object):
             Q, R = np.linalg.qr(self.wexog)
             params = np.linalg.solve(R, np.dot(Q.T, self.wendog))
         else:
-            params, _, _, _ = np.linalg.lstsq(self.wexog, self.wendog)
+            params, _, _, _ = np.linalg.lstsq(self.wexog, self.wendog,
+                                              rcond=-1)
 
         fitted_values = self.exog.dot(params)
         resid = self.endog - fitted_values

--- a/statsmodels/sandbox/nonparametric/smoothers.py
+++ b/statsmodels/sandbox/nonparametric/smoothers.py
@@ -195,7 +195,7 @@ class PolySmoother(object):
         _y = y * _w#[:,None]
         #self.coef = np.dot(L.pinv(X).T, _y[:,None])
         #self.coef = np.dot(L.pinv(X), _y)
-        self.coef = np.linalg.lstsq(X, _y)[0]
+        self.coef = np.linalg.lstsq(X, _y, rcond=-1)[0]
         self.params = np.squeeze(self.coef)
 
 

--- a/statsmodels/sandbox/panel/mixed.py
+++ b/statsmodels/sandbox/panel/mixed.py
@@ -415,7 +415,7 @@ class OneWayMixed(object):
     def initialize(self):
         S = sum([np.dot(unit.X.T, unit.X) for unit in self.units])
         Y = sum([np.dot(unit.X.T, unit.Y) for unit in self.units])
-        self.a = L.lstsq(S, Y)[0]
+        self.a = L.lstsq(S, Y, rcond=-1)[0]
 
         D = 0
         t = 0
@@ -423,10 +423,10 @@ class OneWayMixed(object):
         for unit in self.units:
             unit.r = unit.Y - np.dot(unit.X, self.a)
             if self.q > 1:
-                unit.b = L.lstsq(unit.Z, unit.r)[0]
+                unit.b = L.lstsq(unit.Z, unit.r, rcond=-1)[0]
             else:
                 Z = unit.Z.reshape((unit.Z.shape[0], 1))
-                unit.b = L.lstsq(Z, unit.r)[0]
+                unit.b = L.lstsq(Z, unit.r, rcond=-1)[0]
 
             sigmasq += (np.power(unit.Y, 2).sum() -
                         (self.a * np.dot(unit.X.T, unit.Y)).sum() -

--- a/statsmodels/sandbox/stats/contrast_tools.py
+++ b/statsmodels/sandbox/stats/contrast_tools.py
@@ -388,8 +388,8 @@ class DummyTransform(object):
 
         should be (x, z) in arguments ?
         '''
-        self.transf_matrix = np.linalg.lstsq(d1, d2)[0]
-        self.invtransf_matrix = np.linalg.lstsq(d2, d1)[0]
+        self.transf_matrix = np.linalg.lstsq(d1, d2, rcond=-1)[0]
+        self.invtransf_matrix = np.linalg.lstsq(d2, d1, rcond=-1)[0]
 
     def dot_left(self, a):
         ''' b = C a
@@ -684,8 +684,8 @@ if __name__ == '__main__':
     params_df_df = resols_dropf_dropf.params
 
 
-    tr_of = np.linalg.lstsq(dd_dropf, dd_full)[0]
-    tr_fo = np.linalg.lstsq(dd_full, dd_dropf)[0]
+    tr_of = np.linalg.lstsq(dd_dropf, dd_full, rcond=-1)[0]
+    tr_fo = np.linalg.lstsq(dd_full, dd_dropf, rcond=-1)[0]
     print(np.dot(tr_fo, params_df_df) - params_df_f)
     print(np.dot(tr_of, params_f_f) - params_f_df)
 

--- a/statsmodels/sandbox/tsa/diffusion.py
+++ b/statsmodels/sandbox/tsa/diffusion.py
@@ -319,7 +319,7 @@ class OUprocess(AffineDiffusion):
         # brute force, no parameter estimation errors
         nobs = len(data)-1
         exog = np.column_stack((np.ones(nobs), data[:-1]))
-        parest, res, rank, sing = np.linalg.lstsq(exog, data[1:])
+        parest, res, rank, sing = np.linalg.lstsq(exog, data[1:], rcond=-1)
         const, slope = parest
         errvar = res/(nobs-2.)
         lambd = -np.log(slope)/dt
@@ -373,7 +373,7 @@ class SchwartzOne(ExactDiffusion):
         # brute force, no parameter estimation errors
         nobs = len(data)-1
         exog = np.column_stack((np.ones(nobs),np.log(data[:-1])))
-        parest, res, rank, sing = np.linalg.lstsq(exog, np.log(data[1:]))
+        parest, res, rank, sing = np.linalg.lstsq(exog, np.log(data[1:]), rcond=-1)
         const, slope = parest
         errvar = res/(nobs-2.)  #check denominator estimate, of sigma too low
         kappa = -np.log(slope)/dt

--- a/statsmodels/tsa/seasonal.py
+++ b/statsmodels/tsa/seasonal.py
@@ -33,7 +33,7 @@ def _extrapolate_trend(trend, npoints):
 
     k, n = np.linalg.lstsq(
         np.c_[np.arange(front, front_last), np.ones(front_last - front)],
-        trend[front:front_last])[0]
+        trend[front:front_last], rcond=-1)[0]
     extra = (np.arange(0, front) * np.c_[k] + np.c_[n]).T
     if trend.ndim == 1:
         extra = extra.squeeze()
@@ -41,7 +41,7 @@ def _extrapolate_trend(trend, npoints):
 
     k, n = np.linalg.lstsq(
         np.c_[np.arange(back_first, back), np.ones(back - back_first)],
-        trend[back_first:back])[0]
+        trend[back_first:back], rcond=-1)[0]
     extra = (np.arange(back + 1, trend.shape[0]) * np.c_[k] + np.c_[n]).T
     if trend.ndim == 1:
         extra = extra.squeeze()

--- a/statsmodels/tsa/varma_process.py
+++ b/statsmodels/tsa/varma_process.py
@@ -381,7 +381,7 @@ class _Var(object):
         lmat = lagmat(self.y, nlags, trim='both', original='in')
         self.yred = lmat[:,:nvars]
         self.xred = lmat[:,nvars:]
-        res = np.linalg.lstsq(self.xred, self.yred)
+        res = np.linalg.lstsq(self.xred, self.yred, rcond=-1)
         self.estresults = res
         self.arlhs = res[0].reshape(nlags, nvars, nvars)
         self.arhat = ar2full(self.arlhs)
@@ -677,7 +677,7 @@ if __name__ == "__main__":
     ut = np.random.randn(1000,2)
     ar2s = vargenerate(a22,ut)
     #res = np.linalg.lstsq(lagmat(ar2s,1)[:,1:], ar2s)
-    res = np.linalg.lstsq(lagmat(ar2s,1), ar2s)
+    res = np.linalg.lstsq(lagmat(ar2s,1), ar2s, rcond=-1)
     bhat = res[0].reshape(1,2,2)
     arhat = ar2full(bhat)
     #print(maxabs(arhat - a22)

--- a/statsmodels/tsa/vector_ar/svar_model.py
+++ b/statsmodels/tsa/vector_ar/svar_model.py
@@ -229,7 +229,7 @@ class SVAR(tsbase.TimeSeriesModel):
         y_sample = y[lags:]
 
         # Lutkepohl p75, about 5x faster than stated formula
-        var_params = np.linalg.lstsq(z, y_sample)[0]
+        var_params = np.linalg.lstsq(z, y_sample, rcond=-1)[0]
         resid = y_sample - np.dot(z, var_params)
 
         # Unbiased estimate of covariance matrix $\Sigma_u$ of the white noise

--- a/statsmodels/tsa/vector_ar/var_model.py
+++ b/statsmodels/tsa/vector_ar/var_model.py
@@ -686,7 +686,7 @@ class VAR(tsbase.TimeSeriesModel):
 
         y_sample = endog[lags:]
         # Lütkepohl p75, about 5x faster than stated formula
-        params = np.linalg.lstsq(z, y_sample)[0]
+        params = np.linalg.lstsq(z, y_sample, rcond=-1)[0]
         resid = y_sample - np.dot(z, params)
 
         # Unbiased estimate of covariance matrix $\Sigma_u$ of the white noise


### PR DESCRIPTION
see #3994 numpy changes default rcond in lstsq

we get many warnings in the unit tests with recent numpy
"To use the future default and silence this warning we advise to pass `rcond=None`, to keep using the old, explicitly pass `rcond=-1`."

This PR adds `rcond=-1` to maintain the old behavior.

More generally, we might want to switch to a different behavior with rcond proportional to sqrt(nobs)
but this PR is just maintenance.

aside: There is a copy of a lstsq function in statsmodels.tools.linalg based on scipy linalg, which I guess is currently not in use. uses cond instead of rcond. I didn't make any changes there.
