### PR TITLE
BUG: outlier_test fix index with order 

### DIFF
--- a/statsmodels/regression/linear_model.py
+++ b/statsmodels/regression/linear_model.py
@@ -2556,7 +2556,8 @@ class OLSResults(RegressionResults):
         from statsmodels.stats.outliers_influence import OLSInfluence
         return OLSInfluence(self)
 
-    def outlier_test(self, method='bonf', alpha=.05):
+    def outlier_test(self, method='bonf', alpha=.05, labels=None,
+                 order=False, cutoff=None):
         """
         Test observations for outliers according to method
 
@@ -2576,6 +2577,16 @@ class OLSResults(RegressionResults):
             See `statsmodels.stats.multitest.multipletests` for details.
         alpha : float
             familywise error rate
+        labels : None or array_like
+            If `labels` is not None, then it will be used as index to the
+            returned pandas DataFrame. See also Returns below
+        order : bool
+            Whether or not to order the results by the absolute value of the
+            studentized residuals. If labels are provided they will also be sorted.
+        cutoff : None or float in [0, 1]
+            If cutoff is not None, then the return only includes observations with
+            multiple testing corrected p-values strictly below the cutoff. The
+            returned array or dataframe can be empty if t
 
         Returns
         -------
@@ -2591,7 +2602,8 @@ class OLSResults(RegressionResults):
         df = df_resid - 1.
         """
         from statsmodels.stats.outliers_influence import outlier_test
-        return outlier_test(self, method, alpha)
+        return outlier_test(self, method, alpha, labels=labels,
+                            order=order, cutoff=cutoff)
 
     def el_test(self, b0_vals, param_nums, return_weights=0,
                 ret_params=0, method='nm',

--- a/statsmodels/stats/outliers_influence.py
+++ b/statsmodels/stats/outliers_influence.py
@@ -18,7 +18,7 @@ from statsmodels.tools.tools import maybe_unwrap_results
 # outliers test convenience wrapper
 
 def outlier_test(model_results, method='bonf', alpha=.05, labels=None,
-                 order=False):
+                 order=False, cutoff=None):
     """
     Outlier Tests for RegressionResults instances.
 
@@ -38,9 +38,17 @@ def outlier_test(model_results, method='bonf', alpha=.05, labels=None,
         See `statsmodels.stats.multitest.multipletests` for details.
     alpha : float
         familywise error rate
+    labels : None or array_like
+        If `labels` is not None, then it will be used as index to the
+        returned pandas DataFrame. See also Returns below
     order : bool
         Whether or not to order the results by the absolute value of the
         studentized residuals. If labels are provided they will also be sorted.
+    cutoff : None or float in [0, 1]
+        If cutoff is not None, then the return only includes observations with
+        multiple testing corrected p-values strictly below the cutoff. The
+        returned array or dataframe can be empty if there are no outlier
+        candidates at the specified cutoff.
 
     Returns
     -------
@@ -68,18 +76,23 @@ def outlier_test(model_results, method='bonf', alpha=.05, labels=None,
         idx = np.abs(resid).argsort()[::-1]
         resid = resid[idx]
         if labels is not None:
-            labels = np.array(labels)[idx].tolist()
+            labels = np.asarray(labels)[idx]
     df = model_results.df_resid - 1
     unadj_p = stats.t.sf(np.abs(resid), df) * 2
     adj_p = multipletests(unadj_p, alpha=alpha, method=method)
 
     data = np.c_[resid, unadj_p, adj_p[1]]
+    if cutoff is not None:
+        mask = data[:, -1] < cutoff
+        data = data[mask]
+    else:
+        mask = slice(None)
 
     if labels is not None:
         from pandas import DataFrame
         return DataFrame(data,
                          columns=['student_resid', 'unadj_p', method+"(p)"],
-                         index=labels)
+                         index=np.asarray(labels)[mask])
     return data
 
 #influence measures

--- a/statsmodels/stats/outliers_influence.py
+++ b/statsmodels/stats/outliers_influence.py
@@ -56,6 +56,8 @@ def outlier_test(model_results, method='bonf', alpha=.05, labels=None,
     df = df_resid - 1.
     """
     from scipy import stats # lazy import
+    if labels is None:
+        labels = getattr(model_results.model.data, 'row_labels', None)
     infl = getattr(model_results, 'get_influence', None)
     if infl is None:
         results = maybe_unwrap_results(model_results)
@@ -72,8 +74,7 @@ def outlier_test(model_results, method='bonf', alpha=.05, labels=None,
     adj_p = multipletests(unadj_p, alpha=alpha, method=method)
 
     data = np.c_[resid, unadj_p, adj_p[1]]
-    if labels is None:
-        labels = getattr(model_results.model.data, 'row_labels', None)
+
     if labels is not None:
         from pandas import DataFrame
         return DataFrame(data,

--- a/statsmodels/stats/tests/test_diagnostic.py
+++ b/statsmodels/stats/tests/test_diagnostic.py
@@ -18,7 +18,8 @@ import os
 import numpy as np
 
 from numpy.testing import (assert_, assert_almost_equal, assert_equal,
-                           assert_approx_equal, assert_allclose)
+                           assert_approx_equal, assert_allclose,
+                           assert_array_equal)
 import pytest
 
 from statsmodels.regression.linear_model import OLS, GLSAR
@@ -326,7 +327,7 @@ class TestDiagnosticG(object):
         res = self.res
 
         #general test
-        
+
         #> bt = Box.test(residuals(fm), lag=4, type = "Ljung-Box")
         #> mkhtest(bt, "ljung_box_4", "chi2")
         ljung_box_4 = dict(statistic=5.23587172795227, pvalue=0.263940335284713,
@@ -365,7 +366,7 @@ class TestDiagnosticG(object):
     def test_acorr_ljung_box_small_default(self):
         res = self.res
         #test with small dataset and default lag
-        
+
         #> bt = Box.test(residuals(fm), type = "Ljung-Box")
         #> mkhtest(bt, "ljung_box_small", "chi2")
         ljung_box_small = dict(statistic=9.61503968281915, pvalue=0.72507000996945,
@@ -919,6 +920,22 @@ def test_outlier_test():
     res = oi.outlier_test(ndarray_mod, method='b', labels=labels, order=True)
     np.testing.assert_almost_equal(res.values, res2, 7)
     np.testing.assert_equal(res.index.tolist(), sorted_labels)  # pylint: disable-msg=E1103
+
+    import pandas as pd
+    data = pd.DataFrame(np.column_stack((endog, exog)),
+                        columns='y const var1 var2'.split(),
+                        index=labels)
+
+    # check `order` with pandas bug in #3971
+    res_pd = OLS.from_formula('y ~ const + var1 + var2 - 0', data).fit()
+    res_outl1 = res_pd.outlier_test(method='b')
+    res_outl1 = res_outl1.sort_values(['unadj_p'], ascending=True)
+    res_outl2 = oi.outlier_test(res_pd, method='b', order=True)
+    assert_almost_equal(res_outl1.values, res2, 7)
+    assert_equal(res_outl1.index.tolist(), sorted_labels)
+    assert_almost_equal(res_outl2.values, res2, 7)
+    assert_equal(res_outl2.index.tolist(), sorted_labels)
+    assert_array_equal(res_outl2.index, res_outl1.index)
 
 
 if __name__ == '__main__':

--- a/statsmodels/stats/tests/test_diagnostic.py
+++ b/statsmodels/stats/tests/test_diagnostic.py
@@ -937,6 +937,12 @@ def test_outlier_test():
     assert_equal(res_outl2.index.tolist(), sorted_labels)
     assert_array_equal(res_outl2.index, res_outl1.index)
 
+    # additional keywords in method
+    res_outl3 = res_pd.outlier_test(method='b', order=True)
+    assert_equal(res_outl3.index.tolist(), sorted_labels)
+    res_outl4 = res_pd.outlier_test(method='b', order=True, cutoff=0.15)
+    assert_equal(res_outl4.index.tolist(), sorted_labels[:1])
+
 
 if __name__ == '__main__':
     import pytest


### PR DESCRIPTION
closes #3971

pandas index is not sorted if order is true
This just moves the label access to the model row_labels to the beginning of the function before sorting occurs.

