### PR TITLE
ENH: inter_rater add randolph's kappa to fleiss_kappa

### DIFF
--- a/statsmodels/stats/inter_rater.py
+++ b/statsmodels/stats/inter_rater.py
@@ -35,7 +35,7 @@ convenience functions to create required data format from raw data
 
 """
 
-
+from __future__ import division
 import numpy as np
 from scipy import stats  #get rid of this? need only norm.sf
 
@@ -192,27 +192,57 @@ def to_table(data, bins=None):
 
     return tt[0], bins_
 
-def fleiss_kappa(table):
-    '''Fleiss' kappa multi-rater agreement measure
+def fleiss_kappa(table, method='fleiss'):
+    """Fleiss' and Randolph's kappa multi-rater agreement measure
 
     Parameters
     ----------
     table : array_like, 2-D
         assumes subjects in rows, and categories in columns
+    method : string
+        Method 'fleiss' returns Fleiss' kappa which uses the sample margin
+        to define the chance outcome.
+        Method 'randolph' or 'uniform' (only first 4 letters are needed)
+        returns Randolph's (2005) multirater kappa which assumes a uniform
+        distribution of the categories to define the chance outcome.
 
     Returns
     -------
     kappa : float
-        Fleiss's kappa statistic for inter rater agreement
+        Fleiss's or Randolph's kappa statistic for inter rater agreement
 
     Notes
     -----
-    coded from Wikipedia page
-    http://en.wikipedia.org/wiki/Fleiss%27_kappa
+    no variance or hypothesis tests yet
 
-    no variance or tests yet
+    Interrater agreement measures like Fleiss's kappa measure agreement relative
+    to chance agreement. Different authors have proposed ways of defining
+    these chance agreements. Fleiss' is based on the marginal sample distribution
+    of categories, while Randolph uses a uniform distribution of categories as
+    benchmark. Warrens (2010) showed that Randolph's kappa is always larger or
+    equal to Fleiss' kappa. Under some commonly observed condition, Fleiss' and
+    Randolph's kappa provide lower and upper bounds for two similar kappa_like
+    measures by Light (1971) and Hubert (1977).
 
-    '''
+    References
+    ----------
+    Wikipedia http://en.wikipedia.org/wiki/Fleiss%27_kappa
+
+    Fleiss, Joseph L. 1971. "Measuring Nominal Scale Agreement among Many
+    Raters." Psychological Bulletin 76 (5): 378-82.
+    https://doi.org/10.1037/h0031619.
+
+    Randolph, Justus J. 2005 "Free-Marginal Multirater Kappa (multirater
+    K [free]): An Alternative to Fleiss' Fixed-Marginal Multirater Kappa."
+    Presented at the Joensuu Learning and Instruction Symposium, vol. 2005
+    https://eric.ed.gov/?id=ED490661
+
+    Warrens, Matthijs J. 2010. "Inequalities between Multi-Rater Kappas."
+    Advances in Data Analysis and Classification 4 (4): 271-86.
+    https://doi.org/10.1007/s11634-010-0073-4.
+
+    """
+
     table = 1.0 * np.asarray(table)   #avoid integer division
     n_sub, n_cat =  table.shape
     n_total = table.sum()
@@ -228,7 +258,10 @@ def fleiss_kappa(table):
     p_rat = (table2.sum(1) - n_rat) / (n_rat * (n_rat - 1.))
     p_mean = p_rat.mean()
 
-    p_mean_exp = (p_cat*p_cat).sum()
+    if method == 'fleiss':
+        p_mean_exp = (p_cat*p_cat).sum()
+    elif method.startswith('rand') or method.startswith('unif'):
+        p_mean_exp = 1 / n_cat
 
     kappa = (p_mean - p_mean_exp) / (1- p_mean_exp)
     return kappa

--- a/statsmodels/stats/tests/test_inter_rater.py
+++ b/statsmodels/stats/tests/test_inter_rater.py
@@ -7,7 +7,7 @@ Author: Josef Perktold
 """
 
 import numpy as np
-from numpy.testing import assert_almost_equal, assert_equal
+from numpy.testing import assert_almost_equal, assert_equal, assert_allclose
 
 from statsmodels.stats.inter_rater import (fleiss_kappa, cohens_kappa,
                                            to_table, aggregate_raters)
@@ -74,6 +74,41 @@ def test_fleiss_kappa():
     #currently only example from Wikipedia page
     kappa_wp = 0.210
     assert_almost_equal(fleiss_kappa(table1), kappa_wp, decimal=3)
+
+
+def test_fleis_randolph():
+    # reference numbers from online calculator
+    # http://justusrandolph.net/kappa/#dInfo
+    table = [[7, 0], [7, 0]]
+    assert_equal(fleiss_kappa(table, method='unif'), 1)
+
+    table = [[6.99, 0.01], [6.99, 0.01]]
+    # % Overall Agreement 0.996671
+    # Fixed Marginal Kappa: -0.166667
+    # Free Marginal Kappa: 0.993343
+    assert_allclose(fleiss_kappa(table), -0.166667, atol=6e-6)
+    assert_allclose(fleiss_kappa(table, method='unif'), 0.993343, atol=6e-6)
+
+    table = [[7, 1], [3, 5]]
+    # % Overall Agreement 0.607143
+    # Fixed Marginal Kappa: 0.161905
+    # Free Marginal Kappa: 0.214286
+    assert_allclose(fleiss_kappa(table, method='fleiss'), 0.161905, atol=6e-6)
+    assert_allclose(fleiss_kappa(table, method='randolph'), 0.214286, atol=6e-6)
+
+    table = [[7, 0], [0, 7]]
+    # % Overall Agreement 1.000000
+    # Fixed Marginal Kappa: 1.000000
+    # Free Marginal Kappa: 1.000000
+    assert_allclose(fleiss_kappa(table), 1)
+    assert_allclose(fleiss_kappa(table, method='uniform'), 1)
+
+    table = [[6, 1, 0], [0, 7, 0]]
+    # % Overall Agreement 0.857143
+    # Fixed Marginal Kappa: 0.708333
+    # Free Marginal Kappa: 0.785714
+    assert_allclose(fleiss_kappa(table), 0.708333, atol=6e-6)
+    assert_allclose(fleiss_kappa(table, method='rand'), 0.785714, atol=6e-6)
 
 
 class CheckCohens(object):
@@ -316,9 +351,3 @@ def test_aggregate_raters():
     resf = aggregate_raters(data)
     colsum = np.array([26, 26, 30, 55, 43])
     assert_equal(resf[0].sum(0), colsum)
-
-
-if __name__ == '__main__':
-    import pytest
-    pytest.main([__file__, '-vvs', '-x', '--pdb'])
-


### PR DESCRIPTION
 see #4387 especially https://github.com/statsmodels/statsmodels/issues/4387#issuecomment-375893090

adds a method argument to get randolph's kappa
is backwards compatible

handles degenerate case without special code

unit tests against http://justusrandolph.net/kappa/#dInfo

