### PR TITLE
implement cached_value, cached_data proof of concept

### DIFF
--- a/statsmodels/base/tests/test_shrink_pickle.py
+++ b/statsmodels/base/tests/test_shrink_pickle.py
@@ -212,6 +212,30 @@ class TestRemoveDataPickleGLM(RemoveDataPickle):
         y = x.sum(1) + np.random.randn(x.shape[0])
         self.results = sm.GLM(y, self.exog).fit()
 
+    def test_cached_data_removed(self):
+        res = self.results
+        # fill data-like members of the cache
+        names = ['resid_response', 'resid_deviance',
+                 'resid_pearson', 'resid_anscombe']
+        for name in names:
+            getattr(res, name)
+        # check that the attributes are present before calling remove_data
+        for name in names:
+            assert name in res._cache
+            assert res._cache[name] is not None
+
+        res.remove_data()
+        for name in names:
+            assert res._cache[name] is None
+
+    def test_cached_values_evaluated(self):
+        # check that value-like attributes are evaluated before data
+        # is removed
+        res = self.results
+        assert res._cache == {}
+        res.remove_data()
+        assert 'bic' in res._cache
+
 
 class TestPickleFormula(RemoveDataPickle):
     @classmethod

--- a/statsmodels/compat/pandas.py
+++ b/statsmodels/compat/pandas.py
@@ -5,7 +5,8 @@ from distutils.version import LooseVersion
 import pandas
 
 __all__ = ['assert_frame_equal', 'assert_index_equal', 'assert_series_equal',
-           'data_klasses', 'frequencies', 'is_numeric_dtype', 'testing']
+           'data_klasses', 'frequencies', 'is_numeric_dtype', 'testing',
+           'cache_readonly']
 
 version = LooseVersion(pandas.__version__)
 pandas_lt_25_0 = version < LooseVersion('0.25.0')
@@ -23,6 +24,11 @@ except ImportError:
 data_klasses = (pandas.Series, pandas.DataFrame)
 if pandas_lt_25_0:
     data_klasses += (pandas.Panel,)
+
+if version >= '0.20':
+    from pandas.util._decorators import cache_readonly
+else:
+    from pandas.util.decorators import cache_readonly
 
 try:
     import pandas.testing as testing

--- a/statsmodels/genmod/generalized_linear_model.py
+++ b/statsmodels/genmod/generalized_linear_model.py
@@ -19,7 +19,8 @@ McCullagh, P. and Nelder, J.A.  1989.  "Generalized Linear Models." 2nd ed.
 """
 import numpy as np
 from . import families
-from statsmodels.tools.decorators import cache_readonly
+from statsmodels.tools.decorators import (cache_readonly,
+                                          cached_data, cached_value)
 
 import statsmodels.base.model as base
 import statsmodels.regression.linear_model as lm
@@ -1472,7 +1473,7 @@ class GLMResults(base.LikelihoodModelResults):
             get_robustcov_results(self, cov_type=cov_type, use_self=True,
                                   use_t=use_t, **cov_kwds)
 
-    @cache_readonly
+    @cached_data
     def resid_response(self):
         """
         Respnose residuals.  The response residuals are defined as
@@ -1480,7 +1481,7 @@ class GLMResults(base.LikelihoodModelResults):
         """
         return self._n_trials * (self._endog-self.mu)
 
-    @cache_readonly
+    @cached_data
     def resid_pearson(self):
         """
         Pearson residuals.  The Pearson residuals are defined as
@@ -1492,7 +1493,7 @@ class GLMResults(base.LikelihoodModelResults):
                 np.sqrt(self._var_weights) /
                 np.sqrt(self.family.variance(self.mu)))
 
-    @cache_readonly
+    @cached_data
     def resid_working(self):
         """
         Working residuals.  The working residuals are defined as
@@ -1504,7 +1505,7 @@ class GLMResults(base.LikelihoodModelResults):
         val *= self._n_trials
         return val
 
-    @cache_readonly
+    @cached_data
     def resid_anscombe(self):
         """
         Anscombe residuals.  See statsmodels.families.family for distribution-
@@ -1518,7 +1519,7 @@ class GLMResults(base.LikelihoodModelResults):
                                           var_weights=self._var_weights,
                                           scale=1.)
 
-    @cache_readonly
+    @cached_data
     def resid_anscombe_scaled(self):
         """
         Scaled Anscombe residuals.  See statsmodels.families.family for
@@ -1528,7 +1529,7 @@ class GLMResults(base.LikelihoodModelResults):
                                           var_weights=self._var_weights,
                                           scale=self.scale)
 
-    @cache_readonly
+    @cached_data
     def resid_anscombe_unscaled(self):
         """
         Unscaled Anscombe residuals.  See statsmodels.families.family for
@@ -1538,7 +1539,7 @@ class GLMResults(base.LikelihoodModelResults):
                                           var_weights=self._var_weights,
                                           scale=1.)
 
-    @cache_readonly
+    @cached_data
     def resid_deviance(self):
         """
         Deviance residuals.  See statsmodels.families.family for distribution-
@@ -1549,7 +1550,7 @@ class GLMResults(base.LikelihoodModelResults):
                                     scale=1.)
         return dev
 
-    @cache_readonly
+    @cached_value
     def pearson_chi2(self):
         """
         Pearson's Chi-Squared statistic is defined as the sum of the squares
@@ -1560,7 +1561,7 @@ class GLMResults(base.LikelihoodModelResults):
         chisqsum = np.sum(chisq)
         return chisqsum
 
-    @cache_readonly
+    @cached_data
     def fittedvalues(self):
         """
         Linear predicted values for the fitted model.
@@ -1568,7 +1569,7 @@ class GLMResults(base.LikelihoodModelResults):
         """
         return self.mu
 
-    @cache_readonly
+    @cached_data
     def mu(self):
         """
         See GLM docstring.
@@ -1621,7 +1622,7 @@ class GLMResults(base.LikelihoodModelResults):
                                    freq_weights=self._freq_weights,
                                    scale=self.scale)
 
-    @cache_readonly
+    @cached_value
     def llf(self):
         """
         Value of the loglikelihood function evalued at params.
@@ -1642,7 +1643,7 @@ class GLMResults(base.LikelihoodModelResults):
                                    scale=scale)
         return val
 
-    @cache_readonly
+    @cached_value
     def aic(self):
         """
         Akaike Information Criterion
@@ -1650,7 +1651,7 @@ class GLMResults(base.LikelihoodModelResults):
         """
         return -2 * self.llf + 2 * (self.df_model + 1)
 
-    @cache_readonly
+    @cached_value
     def bic(self):
         """
         Bayes Information Criterion

--- a/statsmodels/tools/decorators.py
+++ b/statsmodels/tools/decorators.py
@@ -68,6 +68,21 @@ class cache_writable(_cache_readonly):
                                        cachename=self.cachename)
 
 
+# cached_value and cached_data behave identically to cache_readonly, but
+# are used by `remove_data` to
+#   a) identify array-like attributes to remove (cached_data)
+#   b) make sure certain values are evaluated before caching (cached_value)
+from pandas._libs.properties import cache_readonly as CR
+
+
+class cached_data(CR):
+    pass
+
+
+class cached_value(CR):
+    pass
+
+
 def nottest(fn):
     fn.__test__ = False
     return fn

--- a/statsmodels/tools/decorators.py
+++ b/statsmodels/tools/decorators.py
@@ -1,5 +1,7 @@
 from __future__ import print_function
 from statsmodels.tools.sm_exceptions import CacheWriteWarning
+from statsmodels.compat.pandas import cache_readonly as CR
+
 import warnings
 
 __all__ = ['cache_readonly', 'cache_writable']
@@ -72,8 +74,6 @@ class cache_writable(_cache_readonly):
 # are used by `remove_data` to
 #   a) identify array-like attributes to remove (cached_data)
 #   b) make sure certain values are evaluated before caching (cached_value)
-from pandas.util._decorators import cache_readonly as CR
-
 class cached_data(CR):
     pass
 

--- a/statsmodels/tools/decorators.py
+++ b/statsmodels/tools/decorators.py
@@ -72,8 +72,7 @@ class cache_writable(_cache_readonly):
 # are used by `remove_data` to
 #   a) identify array-like attributes to remove (cached_data)
 #   b) make sure certain values are evaluated before caching (cached_value)
-from pandas._libs.properties import cache_readonly as CR
-
+from pandas.util._decorators import cache_readonly as CR
 
 class cached_data(CR):
     pass

--- a/statsmodels/tools/decorators.py
+++ b/statsmodels/tools/decorators.py
@@ -1,6 +1,6 @@
 from __future__ import print_function
 from statsmodels.tools.sm_exceptions import CacheWriteWarning
-from statsmodels.compat.pandas import cache_readonly as CR
+from statsmodels.compat.pandas import cache_readonly as PandasCacheReadonly
 
 import warnings
 
@@ -74,11 +74,11 @@ class cache_writable(_cache_readonly):
 # are used by `remove_data` to
 #   a) identify array-like attributes to remove (cached_data)
 #   b) make sure certain values are evaluated before caching (cached_value)
-class cached_data(CR):
+class cached_data(PandasCacheReadonly):
     pass
 
 
-class cached_value(CR):
+class cached_value(PandasCacheReadonly):
     pass
 
 


### PR DESCRIPTION
The existing approach to `remove_data` is haphazard, lets a lot of things fall through the cracks.  For the purpose of this Proof Of Concept, the things falling through the cracks are `GLMResults.resid_response`, `resid_deviance`, `resid_pearson`, ... Because these are not listed in `GLM.__init__` when extending `self._data_attr`, they do not get removed when `remove_data` is called.

On the flip side, there are a number of summary statistics that we would like to retain when pickling but will not if a `cache_readonly` attribute has not been evaluated.

The suggestion here is to add two variants of `cache_readonly`: `cached_value` and `cached_data`.  `cached_data` attributes are treated as data-like for the purposes of `remove_data`, so will be removed.  `cached_value` attributes on the other hand will be evaluated before any data is removed, so they can be recovered reliably.

Unit tests that would currently fail are included.

The actual implementation of `cached_data` and `cached_value` is a stub for demonstration purposes.  A real version would need to avoid an import from pandas internals.