### PR TITLE
BUG/REF: GMM fix exog_names, summary

### DIFF
--- a/statsmodels/iolib/summary.py
+++ b/statsmodels/iolib/summary.py
@@ -463,6 +463,9 @@ def summary_params(results, yname=None, xname=None, alpha=.05, use_t=True,
 
     _, xname = _getnames(results, yname=yname, xname=xname)
 
+    if len(xname) != len(params):
+        raise ValueError('xnames and params do not have the same length')
+
     params_stubs = xname
 
     exog_idx = lrange(len(xname))

--- a/statsmodels/sandbox/regression/gmm.py
+++ b/statsmodels/sandbox/regression/gmm.py
@@ -528,8 +528,32 @@ class GMM(Model):
                 # cut in front for poisson multiplicative
                 self.data.xnames = xnames[-len(params):]
             elif len(params) > len(xnames):
-                # cut at the end
-                self.data.xnames = xnames[:len(params)]
+                # use generic names
+                self.data.xnames = ['p%2d' % i for i in range(len(params))]
+
+    def set_param_names(self, param_names, k_params=None):
+        """set the parameter names in the model
+
+        Parameters
+        ----------
+        param_names : list of strings
+            param_names should have the same length as the number of params
+        k_params : None or int
+            If k_params is None, then the k_params attribute is used, unless
+            it is None.
+            If k_params is not None, then it will also set the k_params
+            attribute.
+        """
+        if k_params is not None:
+            self.k_params = k_params
+        else:
+            k_params = self.k_params
+
+        if k_params == len(param_names):
+            self.data.xnames = param_names
+        else:
+            raise ValueError('param_names has the wrong length')
+
 
     def fit(self, start_params=None, maxiter=10, inv_weights=None,
                   weights_method='cov', wargs=(),

--- a/statsmodels/sandbox/regression/tests/test_gmm.py
+++ b/statsmodels/sandbox/regression/tests/test_gmm.py
@@ -237,6 +237,12 @@ class CheckGMM(object):
         # Smoke test for Wald
         res_wald = res1.wald_test(restriction[:-1])
 
+    def test_smoke(self):
+        res1 = self.res1
+        summ = res1.summary()
+        # len + 1 is for header line
+        assert_equal(len(summ.tables[1]), len(res1.params) + 1)
+
 
 class TestGMMSt1(CheckGMM):
 
@@ -678,7 +684,8 @@ class CheckIV2SLS(object):
 
     def test_smoke(self):
         res1 = self.res1
-        res1.summary()
+        summ = res1.summary()
+        assert_equal(len(summ.tables[1]), len(res1.params) + 1)
 
 
 
@@ -752,4 +759,45 @@ def test_noconstant():
 
     assert_equal(res.fvalue, np.nan)
     # smoke test
-    res.summary()
+    summ = res.summary()
+    assert_equal(len(summ.tables[1]), len(res.params) + 1)
+
+
+def test_gmm_basic():
+    # this currently tests mainly the param names, exog_names
+    # see #4340
+    cd = np.array([1.5, 1.5, 1.7, 2.2, 2.0, 1.8, 1.8, 2.2, 1.9, 1.6, 1.8, 2.2,
+                   2.0, 1.5, 1.1, 1.5, 1.4, 1.7, 1.42, 1.9])
+    dcd = np.array([0, 0.2 ,0.5, -0.2, -0.2, 0, 0.4, -0.3, -0.3, 0.2, 0.4,
+                    -0.2, -0.5, -0.4, 0.4, -0.1, 0.3, -0.28, 0.48, 0.2])
+    inst = np.column_stack((np.ones(len(cd)), cd))
+
+    class GMMbase(gmm.GMM):
+        def momcond(self, params):
+            p0, p1, p2, p3 = params
+            endog = self.endog[:, None]
+            exog = self.exog
+            inst = self.instrument
+
+            mom0 = (endog - p0 - p1 * exog) * inst
+            mom1 = ((endog - p0 - p1 * exog)**2 -
+                    p2 * (exog**(2 * p3)) / 12) * inst
+            g = np.column_stack((mom0, mom1))
+            return g
+
+    beta0 = np.array([0.1, 0.1, 0.01, 1])
+    res = GMMbase(endog=dcd, exog=cd, instrument=inst, k_moms=4,
+                  k_params=4).fit(beta0, optim_args={'disp': 0})
+    summ = res.summary()
+    assert_equal(len(summ.tables[1]), len(res.params) + 1)
+    pnames = ['p%2d' % i for i in range(len(res.params))]
+    assert_equal(res.model.exog_names, pnames)
+
+    # check set_param_names method
+    mod = GMMbase(endog=dcd, exog=cd, instrument=inst, k_moms=4,
+                  k_params=4)
+    # use arbitrary names
+    pnames = ['beta', 'gamma', 'psi', 'phi']
+    mod.set_param_names(pnames)
+    res1 = mod.fit(beta0, optim_args={'disp': 0})
+    assert_equal(res1.model.exog_names, pnames)

--- a/statsmodels/sandbox/regression/tests/test_gmm_poisson.py
+++ b/statsmodels/sandbox/regression/tests/test_gmm_poisson.py
@@ -119,7 +119,8 @@ class CheckGMM(object):
 
     def test_smoke(self):
         res1 = self.res1
-        res1.summary()
+        summ = res1.summary()
+        assert_equal(len(summ.tables[1]), len(res1.params) + 1)
 
 
 class TestGMMAddOnestep(CheckGMM):


### PR DESCRIPTION
 closes #4340 

bug fix with a bit of refactoring/enhancements

- fixes the exog_names in GMM, use generic names if xnames from data too short
- also adds a new method `set_param_names` for users to override the default names.  
  currently only in GMM class, but we might want to have something like this more generally.
- also summary `summary_params` raises now an exception if params and exog_names have a length mismatch, instead of silently truncating the params tabel

I opened #4426 for more general param_names/xnames/exog_names inconsistencies

