### PR TITLE
BUG: tsa coint, nearly perfect colinearity, return (-inf, 0, ...)

### DIFF
--- a/statsmodels/tsa/tests/test_stattools.py
+++ b/statsmodels/tsa/tests/test_stattools.py
@@ -359,23 +359,22 @@ def test_coint_identical_series():
     with warnings.catch_warnings(record=True) as w:
         c = coint(y, y, trend="c", maxlag=0, autolag=None)
     assert_equal(len(w), 1)
-    assert_equal(c[0], 0.0)
-    # Limit of table
-    assert_(c[1] > .98)
+    assert_equal(c[1], 0.0)
+    assert_(np.isneginf(c[0]))
 
 
 def test_coint_perfect_collinearity():
+    # test uses nearly perfect collinearity
     nobs = 200
     scale_e = 1
     np.random.seed(123)
     x = scale_e * np.random.randn(nobs, 2)
-    y = 1 + x.sum(axis=1)
+    y = 1 + x.sum(axis=1) + 1e-7 * np.random.randn(nobs)
     warnings.simplefilter('always', ColinearityWarning)
     with warnings.catch_warnings(record=True) as w:
         c = coint(y, x, trend="c", maxlag=0, autolag=None)
-    assert_equal(c[0], 0.0)
-    # Limit of table
-    assert_(c[1] > .98)
+    assert_equal(c[1], 0.0)
+    assert_(np.isneginf(c[0]))
 
 
 class TestGrangerCausality(object):


### PR DESCRIPTION
 closes #4237

sets test statistic to -inf instead of 0, which will result in p-value = 0.

loosens the threshold for near collinearity a bit. #4222 

