### PR TITLE
MAINT: deprecation warnings

### DIFF
--- a/statsmodels/genmod/tests/results/results_glm.py
+++ b/statsmodels/genmod/tests/results/results_glm.py
@@ -13,6 +13,8 @@ import os
 from statsmodels.api import add_constant, categorical
 
 # for genfromtxt changes
+import sys
+PY2 = (sys.version_info[0] < 3)
 from distutils.version import LooseVersion
 NUMPY_LT_113 = LooseVersion(np.__version__) < '1.13.0'
 
@@ -691,7 +693,7 @@ class Lbw(object):
             "stata_lbw_glm.csv")
 
         # https://github.com/statsmodels/statsmodels/pull/4432#issuecomment-379279617
-        if NUMPY_LT_113:
+        if NUMPY_LT_113 or PY2:
             data=np.recfromcsv(open(filename, 'rb'))
             vfunc = np.vectorize(lambda x: x.strip(asbytes("\"")))
             data['race'] = vfunc(data['race'])

--- a/statsmodels/genmod/tests/results/results_glm.py
+++ b/statsmodels/genmod/tests/results/results_glm.py
@@ -12,6 +12,10 @@ from . import glm_test_resids
 import os
 from statsmodels.api import add_constant, categorical
 
+# for genfromtxt changes
+from distutils.version import LooseVersion
+NUMPY_LT_113 = LooseVersion(np.__version__) < '1.13.0'
+
 # Test Precisions
 DECIMAL_4 = 4
 DECIMAL_3 = 3
@@ -685,7 +689,14 @@ class Lbw(object):
         # data set up for data not in datasets
         filename = os.path.join(os.path.dirname(os.path.abspath(__file__)),
             "stata_lbw_glm.csv")
-        data = pd.read_csv(filename).to_records()
+
+        # https://github.com/statsmodels/statsmodels/pull/4432#issuecomment-379279617
+        if NUMPY_LT_113:
+            data=np.recfromcsv(open(filename, 'rb'))
+            vfunc = np.vectorize(lambda x: x.strip(asbytes("\"")))
+            data['race'] = vfunc(data['race'])
+        else:
+            data = pd.read_csv(filename).to_records()
         # categorical does not work with pandas
         data = categorical(data, col='race', drop=True)
         self.endog = data.low
@@ -3834,11 +3845,11 @@ class CpunishTweediePower15(object):
     # From R
     setwd('c:/workspace')
     data <- read.csv('cpunish.csv', sep=",")
-    
+
     library(statmod)
     library(tweedie)
-    
-    summary(glm(EXECUTIONS ~ INCOME + SOUTH - 1, 
+
+    summary(glm(EXECUTIONS ~ INCOME + SOUTH - 1,
                 family=tweedie(var.power=1.5, link.power=1),
                 data=data))
     """
@@ -3901,11 +3912,11 @@ class CpunishTweediePower2(object):
     # From R
     setwd('c:/workspace')
     data <- read.csv('cpunish.csv', sep=",")
-    
+
     library(statmod)
     library(tweedie)
-    
-    summary(glm(EXECUTIONS ~ INCOME + SOUTH - 1, 
+
+    summary(glm(EXECUTIONS ~ INCOME + SOUTH - 1,
                 family=tweedie(var.power=2, link.power=1),
                 data=data))
     """
@@ -3969,11 +3980,11 @@ class CpunishTweedieLog1(object):
     # From R
     setwd('c:/workspace')
     data <- read.csv('cpunish.csv', sep=",")
-    
+
     library(statmod)
     library(tweedie)
-    
-    summary(glm(EXECUTIONS ~ INCOME + SOUTH - 1, 
+
+    summary(glm(EXECUTIONS ~ INCOME + SOUTH - 1,
                 family=tweedie(var.power=1, link.power=0),
                 data=data))
     """

--- a/statsmodels/genmod/tests/results/results_glm.py
+++ b/statsmodels/genmod/tests/results/results_glm.py
@@ -694,11 +694,12 @@ class Lbw(object):
 
         # https://github.com/statsmodels/statsmodels/pull/4432#issuecomment-379279617
         if NUMPY_LT_113 or PY2:
-            data=np.recfromcsv(open(filename, 'rb'))
+            with open(filename, 'rb') as datafile:
+                data=np.recfromcsv(datafile)
             vfunc = np.vectorize(lambda x: x.strip(asbytes("\"")))
             data['race'] = vfunc(data['race'])
         else:
-            data = pd.read_csv(filename).to_records()
+            data = pd.read_csv(filename).to_records(index=False)
         # categorical does not work with pandas
         data = categorical(data, col='race', drop=True)
         self.endog = data.low

--- a/statsmodels/genmod/tests/results/results_glm.py
+++ b/statsmodels/genmod/tests/results/results_glm.py
@@ -6,6 +6,7 @@ Stata may be because Stata uses ML by default unless you specifically ask for
 IRLS.
 """
 import numpy as np
+import pandas as pd
 from statsmodels.compat.python import asbytes
 from . import glm_test_resids
 import os
@@ -684,9 +685,8 @@ class Lbw(object):
         # data set up for data not in datasets
         filename = os.path.join(os.path.dirname(os.path.abspath(__file__)),
             "stata_lbw_glm.csv")
-        data=np.recfromcsv(open(filename, 'rb'))
-        vfunc = np.vectorize(lambda x: x.strip(asbytes("\"")))
-        data['race'] = vfunc(data['race'])
+        data = pd.read_csv(filename).to_records()
+        # categorical does not work with pandas
         data = categorical(data, col='race', drop=True)
         self.endog = data.low
         design = np.column_stack((data['age'], data['lwt'],
@@ -2193,9 +2193,7 @@ class Medpar1(object):
     def __init__(self):
         filename = os.path.join(os.path.dirname(os.path.abspath(__file__)),
             "stata_medpar1_glm.csv")
-        data = np.recfromcsv(open(filename, 'rb'))
-        vfunc = np.vectorize(lambda x: x.strip(asbytes('\"')))
-        data['admitype'] = vfunc(data['admitype'])
+        data = pd.read_csv(filename).to_records()
         self.endog = data.los
         design = np.column_stack((data.admitype, data.codes))
         design = categorical(design, col=0, drop=True)
@@ -2210,7 +2208,7 @@ class InvGaussLog(Medpar1):
         super(InvGaussLog, self).__init__()
         filename = os.path.join(os.path.dirname(os.path.abspath(__file__)),
             "medparlogresids.csv")
-        self.resids = np.genfromtxt(open(filename, 'rb'), delimiter=",")
+        self.resids = pd.read_csv(filename, sep=',', header=None).values
         self.null_deviance = 335.1539777981053 # from R, Rpy bug
         self.params = np.array([ 0.09927544, -0.19161722,  1.05712336])
         self.bse = np.array([ 0.00600728,  0.02632126,  0.04915765])
@@ -2973,7 +2971,7 @@ class InvGaussIdentity(Medpar1):
         self.bse = np.array([ 0.02586783,  0.13830023,  0.20834864])
         filename = os.path.join(os.path.dirname(os.path.abspath(__file__)),
             "igaussident_resids.csv")
-        self.resids = np.genfromtxt(open(filename, 'rb'), delimiter=",")
+        self.resids = pd.read_csv(filename, sep=',', header=None).values
         self.null_deviance = 335.1539777981053  # from R, Rpy bug
         self.df_null = 3675
         self.deviance = 305.33661191013988

--- a/statsmodels/graphics/boxplots.py
+++ b/statsmodels/graphics/boxplots.py
@@ -125,6 +125,7 @@ def violinplot(data, ax=None, labels=None, positions=None, side='both',
     """
     fig, ax = utils.create_mpl_ax(ax)
 
+    data = list(map(np.asarray, data))
     if positions is None:
         positions = np.arange(len(data)) + 1
 
@@ -325,6 +326,7 @@ def beanplot(data, ax=None, labels=None, positions=None, side='both',
     """
     fig, ax = utils.create_mpl_ax(ax)
 
+    data = list(map(np.asarray, data))
     if positions is None:
         positions = np.arange(len(data)) + 1
 
@@ -383,7 +385,6 @@ def beanplot(data, ax=None, labels=None, positions=None, side='both',
 
 def _jitter_envelope(pos_data, xvals, violin, side):
     """Determine envelope for jitter markers."""
-    pos_data = np.asarray(pos_data)
     if side == 'both':
         low, high = (-1., 1.)
     elif side == 'right':

--- a/statsmodels/graphics/boxplots.py
+++ b/statsmodels/graphics/boxplots.py
@@ -383,6 +383,7 @@ def beanplot(data, ax=None, labels=None, positions=None, side='both',
 
 def _jitter_envelope(pos_data, xvals, violin, side):
     """Determine envelope for jitter markers."""
+    pos_data = np.asarray(pos_data)
     if side == 'both':
         low, high = (-1., 1.)
     elif side == 'right':

--- a/statsmodels/imputation/tests/test_ros.py
+++ b/statsmodels/imputation/tests/test_ros.py
@@ -204,7 +204,7 @@ class Test__ros_sort(object):
 
     def test_censored_greater_than_max(self):
         df = self.df.copy()
-        max_row = df['conc'].argmax()
+        max_row = df['conc'].idxmax()
         df.loc[max_row, 'censored'] = True
         result = ros._ros_sort(df, 'conc', 'censored')
         pdtest.assert_frame_equal(result, self.expected_with_warning)
@@ -254,9 +254,9 @@ class Test__detection_limit_index(object):
         assert_equal(ros._detection_limit_index(None, self.empty_cohn), 0)
 
     def test_populated(self):
-         assert_equal(ros._detection_limit_index(3.5, self.cohn), 0)
-         assert_equal(ros._detection_limit_index(6.0, self.cohn), 3)
-         assert_equal(ros._detection_limit_index(12.0, self.cohn), 5)
+        assert_equal(ros._detection_limit_index(3.5, self.cohn), 0)
+        assert_equal(ros._detection_limit_index(6.0, self.cohn), 3)
+        assert_equal(ros._detection_limit_index(12.0, self.cohn), 5)
 
     def test_out_of_bounds(self):
         with pytest.raises(IndexError):

--- a/statsmodels/regression/tests/test_theil.py
+++ b/statsmodels/regression/tests/test_theil.py
@@ -7,6 +7,7 @@ Author: Josef Perktold
 
 import os
 import numpy as np
+import pandas as pd
 from scipy import stats
 
 from numpy.testing import assert_allclose, assert_equal, assert_warns
@@ -24,8 +25,9 @@ class TestTheilTextile(object):
     def setup_class(cls):
 
         cur_dir = os.path.dirname(os.path.abspath(__file__))
-        filepath = os.path.join(cur_dir, "results", "theil_textile_predict.csv")
-        cls.res_predict = np.recfromtxt(filepath, delimiter=",")
+        filepath = os.path.join(cur_dir, "results",
+                                "theil_textile_predict.csv")
+        cls.res_predict = pd.read_csv(filepath, sep=",")
 
         names = "year	lconsump	lincome	lprice".split()
 
@@ -90,7 +92,11 @@ class TestTheilTextile(object):
 
         # Note: tgmixed is using k_exog for df_resid
         corr_fact = self.res1.df_resid / self.res2.df_r
-        assert_allclose(np.sqrt(self.res1.mse_resid * corr_fact), self.res2.rmse, rtol=2e-6)
+        assert_allclose(np.sqrt(self.res1.mse_resid * corr_fact),
+                        self.res2.rmse, rtol=2e-6)
+
+        assert_allclose(self.res1.fittedvalues,
+                        self.res_predict['fittedvalues'], atol=5e7)
 
     def test_other(self):
         tc = self.res1.test_compatibility()

--- a/statsmodels/tsa/statespace/mlemodel.py
+++ b/statsmodels/tsa/statespace/mlemodel.py
@@ -2607,7 +2607,9 @@ class MLEResults(tsbase.TimeSeriesModelResults):
         # elements
         resid_nonmissing = resid[~(np.isnan(resid))]
         ax = fig.add_subplot(222)
-        ax.hist(resid_nonmissing, normed=True, label='Hist')
+        # temporarily disable Deprecation warning, normed -> density
+        with warnings.catch_warnings(record=True) as w:
+            ax.hist(resid_nonmissing, normed=True, label='Hist')
         from scipy.stats import gaussian_kde, norm
         kde = gaussian_kde(resid_nonmissing)
         xlim = (-1.96*2, 1.96*2)

--- a/statsmodels/tsa/statespace/mlemodel.py
+++ b/statsmodels/tsa/statespace/mlemodel.py
@@ -2608,6 +2608,7 @@ class MLEResults(tsbase.TimeSeriesModelResults):
         resid_nonmissing = resid[~(np.isnan(resid))]
         ax = fig.add_subplot(222)
         # temporarily disable Deprecation warning, normed -> density
+        # hist needs to use `density` in future when minimum matplotlib has it
         with warnings.catch_warnings(record=True) as w:
             ax.hist(resid_nonmissing, normed=True, label='Hist')
         from scipy.stats import gaussian_kde, norm


### PR DESCRIPTION
this fixes or silences almost all deprecation warnings
several of the changes will need a follow-up when more recent changes make old code obsolete, or needs a proper solutions

- histogram normed -> density  
  weignore deprecation warning histogram `normed`
  https://github.com/statsmodels/statsmodels/issues/4228#issuecomment-379075961
  We need to switch to `density` keyword in hist when matplotlib minimum is >= 2.1.x (I think)

- dataset genfromtxt and similar: see #4435

- this PR includes genfromtxt usage in test_glm conditional on numpy and python version 
