### PR TITLE
Fix the roots table of ARMA

### DIFF
--- a/statsmodels/tsa/arima_model.py
+++ b/statsmodels/tsa/arima_model.py
@@ -1656,15 +1656,16 @@ class ARMAResults(tsbase.TimeSeriesModelResults):
         if len(stubs):  # not 0, 0
             modulus = np.abs(roots)
             data = np.column_stack((roots.real, roots.imag, modulus, freq))
-            roots_table = SimpleTable(data,
-                                      headers=['           Real',
+            roots_table = SimpleTable([('%17.4f' % row[0],
+                                        '%+17.4fj' % row[1],
+                                        '%17.4f' % row[2],
+                                        '%17.4f' % row[3]) for row in data],
+                                      headers=['            Real',
                                                '         Imaginary',
                                                '         Modulus',
                                                '        Frequency'],
                                       title="Roots",
-                                      stubs=stubs,
-                                      data_fmts=["%17.4f", "%+17.4fj",
-                                                 "%17.4f", "%17.4f"])
+                                      stubs=stubs)
 
             smry.tables.append(roots_table)
         return smry


### PR DESCRIPTION
The roots table wasn't formatted correctly. I fixed it according to https://github.com/statsmodels/statsmodels/blob/master/statsmodels/iolib/summary.py#L473 .

**Before**

![before_html](https://user-images.githubusercontent.com/594141/38404093-361bf00a-399a-11e8-8774-ab4a45821909.png)
![before_txt](https://user-images.githubusercontent.com/594141/38404092-35f35c9e-399a-11e8-9347-504b265fe840.png)


**After**

![after_html](https://user-images.githubusercontent.com/594141/38404098-3d063eb6-399a-11e8-8c5e-0a63b85fe1f1.png)
![after_txt](https://user-images.githubusercontent.com/594141/38404097-3cdf3848-399a-11e8-8fd5-215d8fa337cf.png)