### PR TITLE
ENH: Add support for RangeIndexes

### DIFF
--- a/statsmodels/tsa/base/tsa_model.py
+++ b/statsmodels/tsa/base/tsa_model.py
@@ -360,7 +360,7 @@ class TimeSeriesModel(base.LikelihoodModel):
             #   (e.g. a non-numeric string) will raise a ValueError if the
             #   index is RangeIndex (otherwise will raise an IndexError)
             #   (as of Pandas 0.22)
-            except IndexError, ValueError as e:
+            except (IndexError, ValueError) as e:
                 raise KeyError(str(e))
             loc = key
         else:

--- a/statsmodels/tsa/base/tsa_model.py
+++ b/statsmodels/tsa/base/tsa_model.py
@@ -352,8 +352,15 @@ class TimeSeriesModel(base.LikelihoodModel):
             try:
                 index[key]
             # We want to raise a KeyError in this case, to keep the exception
-            # consistent across index types
-            except IndexError as e:
+            # consistent across index types.
+            # - Attempting to index with an out-of-bound location (e.g.
+            #   index[10] on an index of length 9) will raise an IndexError
+            #   (as of Pandas 0.22)
+            # - Attemtping to index with a type that cannot be cast to integer
+            #   (e.g. a non-numeric string) will raise a ValueError if the
+            #   index is RangeIndex (otherwise will raise an IndexError)
+            #   (as of Pandas 0.22)
+            except IndexError, ValueError as e:
                 raise KeyError(str(e))
             loc = key
         else:

--- a/statsmodels/tsa/base/tsa_model.py
+++ b/statsmodels/tsa/base/tsa_model.py
@@ -229,7 +229,7 @@ class TimeSeriesModel(base.LikelihoodModel):
 
         if ((date_index and has_freq) or (int_index and is_increment) or
                 range_index):
-            _index = index.copy()
+            _index = index
         else:
             _index = increment
             index_generated = True
@@ -361,10 +361,6 @@ class TimeSeriesModel(base.LikelihoodModel):
 
         # Check if we now have a modified index
         index_was_expanded = index is not base_index
-
-        # (Never return the actual index object)
-        if not index_was_expanded:
-            index = index.copy()
 
         # Return the index through the end of the loc / slice
         if isinstance(loc, slice):

--- a/statsmodels/tsa/base/tsa_model.py
+++ b/statsmodels/tsa/base/tsa_model.py
@@ -7,12 +7,18 @@ import warnings
 import numpy as np
 from pandas import (to_datetime, Int64Index, DatetimeIndex, Period,
                     PeriodIndex, Timestamp, Series, Index)
+# RangeIndex only introduced in Pandas 0.18, so we include a shim until
+# Statsmodels requires that version.
+try:
+    from pandas import RangeIndex
+except ImportError:
+    class RangeIndex(object):
+        pass
 from pandas.tseries.frequencies import to_offset
 
 from statsmodels.base import data
 import statsmodels.base.model as base
 import statsmodels.base.wrapper as wrap
-from statsmodels.tsa.base import datetools
 from statsmodels.tools.sm_exceptions import ValueWarning
 
 _tsa_doc = """
@@ -204,12 +210,13 @@ class TimeSeriesModel(base.LikelihoodModel):
         has_index = index is not None
         date_index = isinstance(index, (DatetimeIndex, PeriodIndex))
         int_index = isinstance(index, Int64Index)
+        range_index = isinstance(index, RangeIndex)
         has_freq = index.freq is not None if date_index else None
         increment = Int64Index(np.arange(self.endog.shape[0]))
         is_increment = index.equals(increment) if int_index else None
 
         # Issue warnings for unsupported indexes
-        if has_index and not (date_index or is_increment):
+        if has_index and not (date_index or range_index or is_increment):
             warnings.warn('An unsupported index was provided and will be'
                           ' ignored when e.g. forecasting.', ValueWarning)
         if date_index and not has_freq:
@@ -220,7 +227,8 @@ class TimeSeriesModel(base.LikelihoodModel):
         # Construct the internal index
         index_generated = False
 
-        if (date_index and has_freq) or (int_index and is_increment):
+        if ((date_index and has_freq) or (int_index and is_increment) or
+                range_index):
             _index = index.copy()
         else:
             _index = increment
@@ -270,11 +278,25 @@ class TimeSeriesModel(base.LikelihoodModel):
 
         index = base_index
         date_index = isinstance(base_index, (PeriodIndex, DatetimeIndex))
+        int_index = isinstance(base_index, Int64Index)
+        range_index = isinstance(base_index, RangeIndex)
         index_class = type(base_index)
         nobs = len(index)
 
+        # Special handling for RangeIndex
+        if range_index and isinstance(key, (int, long, np.integer)):
+            # Negative indices (that lie in the Index)
+            if key < 0 and -key <= nobs:
+                key = nobs + key
+            # Out-of-sample (note that we include key itself in the new index)
+            elif key > nobs - 1:
+                stop = base_index._start + (key + 1) * base_index._step
+                index = RangeIndex(start=base_index._start,
+                                   stop=stop,
+                                   step=base_index._step)
+
         # Special handling for Int64Index
-        if (isinstance(index, Int64Index) and not date_index and
+        if (not range_index and int_index and not date_index and
                 isinstance(key, (int, long, np.integer))):
             # Negative indices (that lie in the Index)
             if key < 0 and -key <= nobs:
@@ -319,9 +341,23 @@ class TimeSeriesModel(base.LikelihoodModel):
                                             periods=len(index) + 1,
                                             freq=base_index.freq)
 
-        # Get the location (note that get_loc will throw a KeyError if key is
-        # invalid)
-        loc = index.get_loc(key)
+        # Get the location
+        if date_index:
+            # (note that get_loc will throw a KeyError if key is invalid)
+            loc = index.get_loc(key)
+        elif int_index or range_index:
+            # For Int64Index and RangeIndex, key is assumed to be the location
+            # and not an index value (this assumption is required to support
+            # RangeIndex)
+            try:
+                index[key]
+            # We want to raise a KeyError in this case, to keep the exception
+            # consistent across index types
+            except IndexError as e:
+                raise KeyError(str(e))
+            loc = key
+        else:
+            loc = index.get_loc(key)
 
         # Check if we now have a modified index
         index_was_expanded = index is not base_index

--- a/statsmodels/tsa/base/tsa_model.py
+++ b/statsmodels/tsa/base/tsa_model.py
@@ -212,7 +212,7 @@ class TimeSeriesModel(base.LikelihoodModel):
         int_index = isinstance(index, Int64Index)
         range_index = isinstance(index, RangeIndex)
         has_freq = index.freq is not None if date_index else None
-        increment = Int64Index(np.arange(self.endog.shape[0]))
+        increment = Index(range(self.endog.shape[0]))
         is_increment = index.equals(increment) if int_index else None
 
         # Issue warnings for unsupported indexes

--- a/statsmodels/tsa/tests/test_tsa_indexes.py
+++ b/statsmodels/tsa/tests/test_tsa_indexes.py
@@ -24,7 +24,8 @@ try:
     from pandas import RangeIndex
     has_range_index = True
 except ImportError:
-    pass
+    class RangeIndex(object):
+        pass
 
 from numpy.testing import (assert_allclose, assert_almost_equal, assert_equal,
                            assert_raises)
@@ -209,7 +210,7 @@ def test_instantiation_valid():
 
             mod = tsa_model.TimeSeriesModel(endog)
             assert_equal(isinstance(mod._index,
-                                    (pd.Int64Index, pd.RangeIndex)), True)
+                                    (pd.Int64Index, RangeIndex)), True)
             assert_equal(mod._index_none, True)
             assert_equal(mod._index_dates, False)
             assert_equal(mod._index_generated, True)
@@ -329,7 +330,7 @@ def test_instantiation_valid():
             endog.index = supported_increment_indexes[1][0]
 
             mod = tsa_model.TimeSeriesModel(endog)
-            assert_equal(type(mod._index) == pd.RangeIndex, True)
+            assert_equal(type(mod._index) == RangeIndex, True)
             assert_equal(mod._index_none, False)
             assert_equal(mod._index_dates, False)
             assert_equal(mod._index_generated, False)
@@ -429,7 +430,7 @@ def test_instantiation_valid():
                 endog.index = ix
                 mod = tsa_model.TimeSeriesModel(endog)
                 assert_equal(isinstance(mod._index,
-                             (pd.Int64Index, pd.RangeIndex)), True)
+                             (pd.Int64Index, RangeIndex)), True)
                 assert_equal(mod._index_none, False)
                 assert_equal(mod._index_dates, False)
                 assert_equal(mod._index_generated, True)
@@ -452,7 +453,7 @@ def test_instantiation_valid():
                 endog.index = ix
                 mod = tsa_model.TimeSeriesModel(endog)
                 assert_equal(isinstance(mod._index,
-                             (pd.Int64Index, pd.RangeIndex)), True)
+                             (pd.Int64Index, RangeIndex)), True)
                 assert_equal(mod._index_none, False)
                 assert_equal(mod._index_dates, False)
                 assert_equal(mod._index_generated, True)

--- a/statsmodels/tsa/tests/test_tsa_indexes.py
+++ b/statsmodels/tsa/tests/test_tsa_indexes.py
@@ -450,7 +450,8 @@ def test_instantiation_valid():
                 endog = base_endog.copy()
                 endog.index = ix
                 mod = tsa_model.TimeSeriesModel(endog)
-                assert_equal(type(mod._index) == pd.Int64Index, True)
+                assert_equal(isinstance(mod._index,
+                             (pd.Int64Index, pd.RangeIndex)), True)
                 assert_equal(mod._index_none, False)
                 assert_equal(mod._index_dates, False)
                 assert_equal(mod._index_generated, True)

--- a/statsmodels/tsa/tests/test_tsa_indexes.py
+++ b/statsmodels/tsa/tests/test_tsa_indexes.py
@@ -208,7 +208,8 @@ def test_instantiation_valid():
             warnings.simplefilter('error')
 
             mod = tsa_model.TimeSeriesModel(endog)
-            assert_equal(type(mod._index) == pd.Int64Index, True)
+            assert_equal(isinstance(mod._index,
+                                    (pd.Int64Index, pd.RangeIndex)), True)
             assert_equal(mod._index_none, True)
             assert_equal(mod._index_dates, False)
             assert_equal(mod._index_generated, True)

--- a/statsmodels/tsa/tests/test_tsa_indexes.py
+++ b/statsmodels/tsa/tests/test_tsa_indexes.py
@@ -150,10 +150,11 @@ def test_instantiation_valid():
     #
     # Each pandas index (of `endog`, `exog`, or passed to `dates`) can be:
     # 0. None
-    # 1. Int64Index with values exactly equal to 0, 1, ..., nobs-1
-    # 2. DatetimeIndex with frequency
-    # 3. PeriodIndex with frequency
-    # 4. Anything that doesn't fall into the above categories also should
+    # 1. RangeIndex (if applicable; i.e. if Pandas >= 0.18)
+    # 2. Int64Index with values exactly equal to 0, 1, ..., nobs-1
+    # 3. DatetimeIndex with frequency
+    # 4. PeriodIndex with frequency
+    # 5. Anything that doesn't fall into the above categories also should
     #    only raise an exception if it was passed to dates, and may trigger
     #    a warning otherwise.
     #

--- a/statsmodels/tsa/tests/test_tsa_indexes.py
+++ b/statsmodels/tsa/tests/test_tsa_indexes.py
@@ -24,8 +24,7 @@ try:
     from pandas import RangeIndex
     has_range_index = True
 except ImportError:
-    class RangeIndex(object):
-        pass
+    pass
 
 from numpy.testing import (assert_allclose, assert_almost_equal, assert_equal,
                            assert_raises)

--- a/statsmodels/tsa/tests/test_tsa_indexes.py
+++ b/statsmodels/tsa/tests/test_tsa_indexes.py
@@ -492,6 +492,9 @@ def test_prediction_increment_unsupported():
         warnings.simplefilter('ignore')
         mod = tsa_model.TimeSeriesModel(endog)
 
+    # Tests three common use cases: basic prediction, negative indexes, and
+    # out-of-sample indexes.
+
     # Basic prediction: [0, end]; notice that since this is an in-sample
     # prediction, the index returned is the (unsupported) original index
     start_key = 0
@@ -542,6 +545,9 @@ def test_prediction_increment_nonpandas():
     endog = dta[0]
     mod = tsa_model.TimeSeriesModel(endog)
 
+    # Tests three common use cases: basic prediction, negative indexes, and
+    # out-of-sample indexes.
+
     # Basic prediction: [0, end]; since there was no index at all and the data
     # is not Pandas, the returned prediction_index is None
     start_key = 0
@@ -582,6 +588,9 @@ def test_prediction_increment_nonpandas():
 def test_prediction_increment_pandas_noindex():
     endog = dta[2].copy()
     mod = tsa_model.TimeSeriesModel(endog)
+
+    # Tests three common use cases: basic prediction, negative indexes, and
+    # out-of-sample indexes.
 
     # Basic prediction: [0, end]; since there was no index and the data is
     # Pandas, the index is the generated incrementing index, and no warning is
@@ -628,6 +637,9 @@ def test_prediction_increment_pandas_dates():
     endog = dta[2].copy()
     endog.index = date_indexes[0][0]  # Daily, 1950-01-01, 1950-01-02, ...
     mod = tsa_model.TimeSeriesModel(endog)
+
+    # Tests three common use cases: basic prediction, negative indexes, and
+    # out-of-sample indexes.
 
     # Basic prediction: [0, end]; the index is the date index
     start_key = 0
@@ -689,6 +701,9 @@ def test_prediction_increment_pandas_dates_nanosecond():
         mod = tsa_model.TimeSeriesModel(endog)
     except:
         raise SkipTest
+
+    # Tests three common use cases: basic prediction, negative indexes, and
+    # out-of-sample indexes.
 
     # Basic prediction: [0, end]; the index is the date index
     start_key = 0
@@ -759,6 +774,9 @@ def test_prediction_rangeindex():
     endog = pd.Series(dta[0], index=index)
     mod = tsa_model.TimeSeriesModel(endog)
 
+    # Tests three common use cases: basic prediction, negative indexes, and
+    # out-of-sample indexes.
+
     # Basic prediction: [0, end]
     start_key = 0
     end_key = None
@@ -801,6 +819,9 @@ def test_prediction_rangeindex_withstep():
     index = supported_increment_indexes[3][0]
     endog = pd.Series(dta[0], index=index)
     mod = tsa_model.TimeSeriesModel(endog)
+
+    # Tests three common use cases: basic prediction, negative indexes, and
+    # out-of-sample indexes.
 
     # Basic prediction: [0, end]
     start_key = 0

--- a/statsmodels/tsa/tests/test_tsa_indexes.py
+++ b/statsmodels/tsa/tests/test_tsa_indexes.py
@@ -428,7 +428,8 @@ def test_instantiation_valid():
                 endog = base_endog.copy()
                 endog.index = ix
                 mod = tsa_model.TimeSeriesModel(endog)
-                assert_equal(type(mod._index) == pd.Int64Index, True)
+                assert_equal(isinstance(mod._index,
+                             (pd.Int64Index, pd.RangeIndex)), True)
                 assert_equal(mod._index_none, False)
                 assert_equal(mod._index_dates, False)
                 assert_equal(mod._index_generated, True)


### PR DESCRIPTION
As of Pandas 0.18, the default index is `RangeIndex` rather than `Int64Index`. We only directly supported `Int64Index` (along with date indexes) so a warning would be issued by tsa models that the index would be ignored.

This adds direct support for `RangeIndex`es of all types.