### PR TITLE
De-duplicate a bunch of identical code

### DIFF
--- a/statsmodels/tsa/vector_ar/irf.py
+++ b/statsmodels/tsa/vector_ar/irf.py
@@ -79,6 +79,14 @@ class BaseIRAnalysis(object):
         else:
             self._A = util.comp_matrix(model.coefs)
 
+    def _choose_irfs(self, orth=False, svar=False):
+        if orth:
+            return self.orth_irfs
+        elif svar:
+            return self.svar_irfs
+        else:
+            return self.irfs
+
     def cov(self, *args, **kwargs):
         raise NotImplementedError
 
@@ -125,15 +133,13 @@ class BaseIRAnalysis(object):
         if orth and svar:
             raise ValueError("For SVAR system, set orth=False")
 
+        irfs = self._choose_irfs(orth, svar)
         if orth:
             title = 'Impulse responses (orthogonalized)'
-            irfs = self.orth_irfs
         elif svar:
             title = 'Impulse responses (structural)'
-            irfs = self.svar_irfs
         else:
             title = 'Impulse responses'
-            irfs = self.irfs
 
         if plot_stderr == False:
             stderr = None
@@ -322,12 +328,7 @@ class IRAnalysis(BaseIRAnalysis):
 
         model = self.model
         periods = self.periods
-        if orth:
-            irfs = self.orth_irfs
-        elif svar:
-            irfs = self.svar_irfs
-        else:
-            irfs = self.irfs
+        irfs = self._choose_irfs(orth, svar)
         neqs = self.neqs
         irf_resim = model.irf_resim(orth=orth, repl=repl, T=periods, seed=seed,
                                    burn=100)
@@ -385,12 +386,7 @@ class IRAnalysis(BaseIRAnalysis):
         """
         model = self.model
         periods = self.periods
-        if orth:
-            irfs = self.orth_irfs
-        elif svar:
-            irfs = self.svar_irfs
-        else:
-            irfs = self.irfs
+        irfs = self._choose_irfs(orth, svar)
         neqs = self.neqs
         irf_resim = model.irf_resim(orth=orth, repl=repl, T=periods, seed=seed,
                                    burn=100)
@@ -453,12 +449,7 @@ class IRAnalysis(BaseIRAnalysis):
 
         model = self.model
         periods = self.periods
-        if orth:
-            irfs = self.orth_irfs
-        elif svar:
-            irfs = self.svar_irfs
-        else:
-            irfs = self.irfs
+        irfs = self._choose_irfs(orth, svar)
         neqs = self.neqs
         irf_resim = model.irf_resim(orth=orth, repl=repl, T=periods, seed=seed,
                                    burn=100)

--- a/statsmodels/tsa/vector_ar/var_model.py
+++ b/statsmodels/tsa/vector_ar/var_model.py
@@ -1383,30 +1383,9 @@ class VARResults(VARProcess):
         Returns
         -------
         Tuple of lower and upper arrays of ma_rep monte carlo standard errors
-
         """
-        neqs = self.neqs
-        # mean = self.mean()
-        k_ar = self.k_ar
-        coefs = self.coefs
-        sigma_u = self.sigma_u
-        intercept = self.intercept
-        # df_model = self.df_model
-        nobs = self.nobs
-
-        ma_coll = np.zeros((repl, T+1, neqs, neqs))
-
-        def fill_coll(sim):
-            ret = VAR(sim, exog=self.exog).fit(maxlags=k_ar, trend=self.trend)
-            ret = ret.orth_ma_rep(maxn=T) if orth else ret.ma_rep(maxn=T)
-            return ret.cumsum(axis=0) if cum else ret
-
-        for i in range(repl):
-            # discard first hundred to eliminate correct for starting bias
-            sim = util.varsim(coefs, intercept, sigma_u,
-                              seed=seed, steps=nobs+burn)
-            sim = sim[burn:]
-            ma_coll[i, :, :, :] = fill_coll(sim)
+        ma_coll = self.irf_resim(orth=orth, repl=repl, T=T,
+                                 seed=seed, burn=burn, cum=cum)
 
         ma_sort = np.sort(ma_coll, axis=0)  # sort to get quantiles
         index = round(signif/2*repl)-1, round((1-signif/2)*repl)-1


### PR DESCRIPTION
The first half of `irf_errband_mc` is copy/paste identical to `irf_resim`, so let's go ahead and use that instead.

Also make a helper method for a commonly-used expression in irf.

This does _not_:
- clean up any formatting
- fix the `AttributeError` that `irf_errband_mc` or `irf_resim` would raise if it were ever called.
- fix the `TypeError` that `irf_errband_mc` would raise if it that `AttributeError` were fixed.
