### PR TITLE
remove unused resetlist

### DIFF
--- a/statsmodels/base/data.py
+++ b/statsmodels/base/data.py
@@ -5,8 +5,7 @@ results, and doing data cleaning
 from statsmodels.compat.python import reduce, iteritems, lmap, zip, range
 import numpy as np
 from pandas import DataFrame, Series, isnull
-from statsmodels.tools.decorators import (resettable_cache, cache_readonly,
-                                          cache_writable)
+from statsmodels.tools.decorators import cache_readonly, cache_writable
 import statsmodels.tools.data as data_util
 from statsmodels.tools.sm_exceptions import MissingDataError
 
@@ -77,7 +76,7 @@ class ModelData(object):
         # this has side-effects, attaches k_constant and const_idx
         self._handle_constant(hasconst)
         self._check_integrity()
-        self._cache = resettable_cache()
+        self._cache = {}
 
     def __getstate__(self):
         from copy import copy

--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -7,7 +7,7 @@ from statsmodels.tools.data import _is_using_pandas
 from statsmodels.tools.tools import recipr, nan_dot
 from statsmodels.stats.contrast import (ContrastResults, WaldTestResults,
                                         t_test_pairwise)
-from statsmodels.tools.decorators import resettable_cache, cache_readonly
+from statsmodels.tools.decorators import cache_readonly
 import statsmodels.base.wrapper as wrap
 from statsmodels.tools.numdiff import approx_fprime
 from statsmodels.tools.sm_exceptions import ValueWarning, \
@@ -2318,7 +2318,7 @@ class GenericLikelihoodModelResults(LikelihoodModelResults, ResultMixin):
             # retrofitting the model, used in t_test TODO: check design
             self.model.df_resid = self.df_resid
 
-        self._cache = resettable_cache()
+        self._cache = {}
         self.__dict__.update(mlefit.__dict__)
 
     def summary(self, yname=None, xname=None, title=None, alpha=.05):

--- a/statsmodels/discrete/count_model.py
+++ b/statsmodels/discrete/count_model.py
@@ -18,7 +18,7 @@ from statsmodels.discrete.discrete_model import (DiscreteModel, CountModel,
 from statsmodels.distributions import zipoisson, zigenpoisson, zinegbin
 from statsmodels.tools.numdiff import (approx_fprime, approx_hess,
                                        approx_hess_cs, approx_fprime_cs)
-from statsmodels.tools.decorators import (resettable_cache, cache_readonly)
+from statsmodels.tools.decorators import cache_readonly
 from statsmodels.tools.sm_exceptions import ConvergenceWarning
 
 

--- a/statsmodels/discrete/discrete_margins.py
+++ b/statsmodels/discrete/discrete_margins.py
@@ -3,7 +3,7 @@
 from statsmodels.compat.python import lzip, range
 import numpy as np
 from scipy.stats import norm
-from statsmodels.tools.decorators import cache_readonly, resettable_cache
+from statsmodels.tools.decorators import cache_readonly
 
 #### margeff helper functions ####
 #NOTE: todo marginal effects for group 2
@@ -367,13 +367,13 @@ class Margins(object):
     """
     def __init__(self, results, get_margeff, derivative, dist=None,
                        margeff_args=()):
-        self._cache = resettable_cache()
+        self._cache = {}
         self.results = results
         self.dist = dist
         self.get_margeff(margeff_args)
 
     def _reset(self):
-        self._cache = resettable_cache()
+        self._cache = {}
 
     def get_margeff(self, *args, **kwargs):
         self._reset()
@@ -420,12 +420,12 @@ class DiscreteMargins(object):
         results.get_margeff. See there for more information.
     """
     def __init__(self, results, args, kwargs={}):
-        self._cache = resettable_cache()
+        self._cache = {}
         self.results = results
         self.get_margeff(*args, **kwargs)
 
     def _reset(self):
-        self._cache = resettable_cache()
+        self._cache = {}
 
     @cache_readonly
     def tvalues(self):

--- a/statsmodels/discrete/discrete_model.py
+++ b/statsmodels/discrete/discrete_model.py
@@ -32,7 +32,7 @@ from scipy.stats import nbinom
 
 import statsmodels.tools.tools as tools
 from statsmodels.tools import data as data_tools
-from statsmodels.tools.decorators import resettable_cache, cache_readonly
+from statsmodels.tools.decorators import cache_readonly
 from statsmodels.tools.sm_exceptions import PerfectSeparationError
 from statsmodels.tools.numdiff import approx_fprime_cs
 import statsmodels.base.model as base
@@ -3353,7 +3353,7 @@ class DiscreteResults(base.LikelihoodModelResults):
         self.model = model
         self.df_model = model.df_model
         self.df_resid = model.df_resid
-        self._cache = resettable_cache()
+        self._cache = {}
         self.nobs = model.exog.shape[0]
         self.__dict__.update(mlefit.__dict__)
 

--- a/statsmodels/genmod/generalized_estimating_equations.py
+++ b/statsmodels/genmod/generalized_estimating_equations.py
@@ -30,8 +30,7 @@ from scipy import stats
 import pandas as pd
 import patsy
 
-from statsmodels.tools.decorators import (cache_readonly,
-                                          resettable_cache)
+from statsmodels.tools.decorators import cache_readonly
 import statsmodels.base.model as base
 # used for wrapper:
 import statsmodels.regression.linear_model as lm
@@ -3015,12 +3014,12 @@ class GEEMargins(object):
     """
 
     def __init__(self, results, args, kwargs={}):
-        self._cache = resettable_cache()
+        self._cache = {}
         self.results = results
         self.get_margeff(*args, **kwargs)
 
     def _reset(self):
-        self._cache = resettable_cache()
+        self._cache = {}
 
     @cache_readonly
     def tvalues(self):

--- a/statsmodels/genmod/generalized_linear_model.py
+++ b/statsmodels/genmod/generalized_linear_model.py
@@ -19,7 +19,7 @@ McCullagh, P. and Nelder, J.A.  1989.  "Generalized Linear Models." 2nd ed.
 """
 import numpy as np
 from . import families
-from statsmodels.tools.decorators import cache_readonly, resettable_cache
+from statsmodels.tools.decorators import cache_readonly
 
 import statsmodels.base.model as base
 import statsmodels.regression.linear_model as lm
@@ -1522,7 +1522,7 @@ class GLMResults(base.LikelihoodModelResults):
             self._n_trials = 1
         self.df_resid = model.df_resid
         self.df_model = model.df_model
-        self._cache = resettable_cache()
+        self._cache = {}
         # are these intermediate results needed or can we just
         # call the model's attributes?
 

--- a/statsmodels/graphics/gofplots.py
+++ b/statsmodels/graphics/gofplots.py
@@ -3,8 +3,7 @@ import numpy as np
 from scipy import stats
 from statsmodels.regression.linear_model import OLS
 from statsmodels.tools.tools import add_constant
-from statsmodels.tools.decorators import (resettable_cache,
-                                          cache_readonly,
+from statsmodels.tools.decorators import (cache_readonly,
                                           cache_writable)
 
 from . import utils
@@ -153,7 +152,7 @@ class ProbPlot(object):
             self.scale = scale
 
         # propertes
-        self._cache = resettable_cache()
+        self._cache = {}
 
     @cache_readonly
     def theoretical_percentiles(self):

--- a/statsmodels/nonparametric/kde.py
+++ b/statsmodels/nonparametric/kde.py
@@ -16,7 +16,7 @@ from statsmodels.compat.python import range
 import numpy as np
 from scipy import integrate, stats
 from statsmodels.sandbox.nonparametric import kernels
-from statsmodels.tools.decorators import (cache_readonly, resettable_cache)
+from statsmodels.tools.decorators import cache_readonly
 from . import bandwidths
 from .kdetools import (forrt, revrt, silverman_transform)
 from .linbin import fast_linbin
@@ -153,7 +153,7 @@ class KDEUnivariate(object):
         self.kernel.weights = weights
         if weights is not None:
             self.kernel.weights /= weights.sum()
-        self._cache = resettable_cache()
+        self._cache = {}
 
     @cache_readonly
     def cdf(self):

--- a/statsmodels/regression/linear_model.py
+++ b/statsmodels/regression/linear_model.py
@@ -41,8 +41,7 @@ from scipy import stats
 from scipy import optimize
 
 from statsmodels.tools.tools import add_constant, chain_dot, pinv_extended
-from statsmodels.tools.decorators import (resettable_cache,
-                                          cache_readonly,
+from statsmodels.tools.decorators import (cache_readonly,
                                           cache_writable)
 import statsmodels.base.model as base
 import statsmodels.base.wrapper as wrap
@@ -1551,7 +1550,7 @@ class RegressionResults(base.LikelihoodModelResults):
         super(RegressionResults, self).__init__(
             model, params, normalized_cov_params, scale)
 
-        self._cache = resettable_cache()
+        self._cache = {}
         if hasattr(model, 'wexog_singular_values'):
             self._wexog_singular_values = model.wexog_singular_values
         else:

--- a/statsmodels/robust/robust_linear_model.py
+++ b/statsmodels/robust/robust_linear_model.py
@@ -16,7 +16,7 @@ R Venables, B Ripley. 'Modern Applied Statistics in S'  Springer, New York,
 import numpy as np
 import scipy.stats as stats
 
-from statsmodels.tools.decorators import cache_readonly, resettable_cache
+from statsmodels.tools.decorators import cache_readonly
 import statsmodels.regression.linear_model as lm
 import statsmodels.regression._tools as reg_tools
 import statsmodels.robust.norms as norms
@@ -390,7 +390,7 @@ class RLMResults(base.LikelihoodModelResults):
         self.df_model = model.df_model
         self.df_resid = model.df_resid
         self.nobs = model.nobs
-        self._cache = resettable_cache()
+        self._cache = {}
         #for remove_data
         self.data_in_cache = ['sresid']
 

--- a/statsmodels/sandbox/regression/gmm.py
+++ b/statsmodels/sandbox/regression/gmm.py
@@ -60,7 +60,7 @@ from statsmodels.base.model import (Model,
 from statsmodels.regression.linear_model import (OLS, RegressionResults,
                                                  RegressionResultsWrapper)
 import statsmodels.stats.sandwich_covariance as smcov
-from statsmodels.tools.decorators import (resettable_cache, cache_readonly)
+from statsmodels.tools.decorators import cache_readonly
 from statsmodels.tools.tools import _ensure_2d
 
 DEBUG = 0

--- a/statsmodels/stats/contingency_tables.py
+++ b/statsmodels/stats/contingency_tables.py
@@ -26,7 +26,7 @@ identically distributed.
 """
 
 from __future__ import division
-from statsmodels.tools.decorators import cache_readonly, resettable_cache
+from statsmodels.tools.decorators import cache_readonly
 import numpy as np
 from scipy import stats
 import pandas as pd
@@ -954,7 +954,7 @@ class StratifiedTable(object):
 
         self.table = table
 
-        self._cache = resettable_cache()
+        self._cache = {}
 
         # Quantities to precompute.  Table entries are [[a, b], [c,
         # d]], 'ad' is 'a * d', 'apb' is 'a + b', 'dma' is 'd - a',

--- a/statsmodels/tools/decorators.py
+++ b/statsmodels/tools/decorators.py
@@ -2,56 +2,7 @@ from __future__ import print_function
 from statsmodels.tools.sm_exceptions import CacheWriteWarning
 import warnings
 
-__all__ = ['resettable_cache', 'cache_readonly', 'cache_writable']
-
-
-class ResettableCache(dict):
-    """
-    Dictionary whose elements mey depend one from another.
-
-    If entry `B` depends on entry `A`, changing the values of entry `A` will
-    reset the value of entry `B` to a default (None); deleteing entry `A` will
-    delete entry `B`.  The connections between entries are stored in a
-    `_resetdict` private attribute.
-
-    Parameters
-    ----------
-    reset : dictionary, optional
-        An optional dictionary, associated a sequence of entries to any key
-        of the object.
-    items : var, optional
-        An optional dictionary used to initialize the dictionary
-
-    Examples
-    --------
-    >>> reset = dict(a=('b',), b=('c',))
-    >>> cache = resettable_cache(a=0, b=1, c=2, reset=reset)
-    >>> assert_equal(cache, dict(a=0, b=1, c=2))
-
-    >>> print("Try resetting a")
-    >>> cache['a'] = 1
-    >>> assert_equal(cache, dict(a=1, b=None, c=None))
-    >>> cache['c'] = 2
-    >>> assert_equal(cache, dict(a=1, b=None, c=2))
-    >>> cache['b'] = 0
-    >>> assert_equal(cache, dict(a=1, b=0, c=None))
-
-    >>> print("Try deleting b")
-    >>> del(cache['a'])
-    >>> assert_equal(cache, {})
-    """
-
-    def __init__(self, reset=None, **items):
-        dict.__init__(self, **items)
-
-    def __setitem__(self, key, value):
-        dict.__setitem__(self, key, value)
-
-    def __delitem__(self, key):
-        dict.__delitem__(self, key)
-
-
-resettable_cache = ResettableCache
+__all__ = ['cache_readonly', 'cache_writable']
 
 
 class CachedAttribute(object):
@@ -68,7 +19,7 @@ class CachedAttribute(object):
         _cachename = self.cachename
         _cache = getattr(obj, _cachename, None)
         if _cache is None:
-            setattr(obj, _cachename, resettable_cache())
+            setattr(obj, _cachename, {})
             _cache = getattr(obj, _cachename)
         # Get the name of the attribute to set and cache
         name = self.name

--- a/statsmodels/tools/tests/test_decorators.py
+++ b/statsmodels/tools/tests/test_decorators.py
@@ -4,7 +4,7 @@ import pytest
 from numpy.testing import assert_equal
 
 from statsmodels.tools.decorators import (
-    cache_readonly, cache_writable, CacheWriteWarning)
+    cache_readonly, CacheWriteWarning)
 
 
 def test_cache_readonly():

--- a/statsmodels/tools/tests/test_decorators.py
+++ b/statsmodels/tools/tests/test_decorators.py
@@ -4,47 +4,19 @@ import pytest
 from numpy.testing import assert_equal
 
 from statsmodels.tools.decorators import (
-    resettable_cache, cache_readonly, cache_writable, CacheWriteWarning)
-
-
-def test_resettable_cache():
-    # This test was taken from the old __main__ section of decorators.py
-
-    reset = dict(a=('b',), b=('c',))
-    cache = resettable_cache(a=0, b=1, c=2, reset=reset)
-    assert_equal(cache, dict(a=0, b=1, c=2))
-
-    # Try resetting a
-    cache['a'] = 1
-    assert_equal(cache, dict(a=1, b=None, c=None))
-    cache['c'] = 2
-    assert_equal(cache, dict(a=1, b=None, c=2))
-    cache['b'] = 0
-    assert_equal(cache, dict(a=1, b=0, c=None))
-
-    # Try deleting b
-    del cache['a']
-    assert_equal(cache, {})
+    cache_readonly, cache_writable, CacheWriteWarning)
 
 
 def test_cache_readonly():
 
     class Example(object):
         def __init__(self):
-            self._cache = resettable_cache()
+            self._cache = {}
             self.a = 0
 
         @cache_readonly
         def b(self):
             return 1
-
-        @cache_writable(resetlist='d')
-        def c(self):
-            return 2
-
-        @cache_writable(resetlist=('e', 'f'))
-        def d(self):
-            return self.c + 1
 
         @cache_readonly
         def e(self):
@@ -68,17 +40,3 @@ def test_cache_readonly():
         ex.b = -1
 
     assert_equal(ex._cache, dict(b=1,))
-
-    # Try accessing/resetting a cachewritable attribute
-    c = ex.c
-    assert_equal(c, 2)
-    assert_equal(ex._cache, dict(b=1, c=2))
-    d = ex.d
-    assert_equal(d, 3)
-    assert_equal(ex._cache, dict(b=1, c=2, d=3))
-    ex.c = 0
-    assert_equal(ex._cache, dict(b=1, c=0, d=None, e=None, f=None))
-    d = ex.d
-    assert_equal(ex._cache, dict(b=1, c=0, d=1, e=None, f=None))
-    ex.d = 5
-    assert_equal(ex._cache, dict(b=1, c=0, d=5, e=None, f=None))

--- a/statsmodels/tsa/ar_model.py
+++ b/statsmodels/tsa/ar_model.py
@@ -11,8 +11,7 @@ from statsmodels.tsa.tsatools import (lagmat, add_trend,
                                       _ar_transparams, _ar_invtransparams)
 import statsmodels.tsa.base.tsa_model as tsbase
 import statsmodels.base.model as base
-from statsmodels.tools.decorators import (resettable_cache,
-                                          cache_readonly, cache_writable)
+from statsmodels.tools.decorators import cache_readonly, cache_writable
 from statsmodels.tools.numdiff import approx_fprime, approx_hess
 from statsmodels.tsa.kalmanf.kalmanfilter import KalmanFilter
 import statsmodels.base.wrapper as wrap
@@ -680,7 +679,7 @@ class ARResults(tsbase.TimeSeriesModelResults):
     def __init__(self, model, params, normalized_cov_params=None, scale=1.):
         super(ARResults, self).__init__(model, params, normalized_cov_params,
                                         scale)
-        self._cache = resettable_cache()
+        self._cache = {}
         self.nobs = model.nobs
         n_totobs = len(model.endog)
         self.n_totobs = n_totobs

--- a/statsmodels/tsa/arima_model.py
+++ b/statsmodels/tsa/arima_model.py
@@ -17,8 +17,7 @@ from scipy.signal import lfilter
 from numpy import dot, log, zeros, pi
 from numpy.linalg import inv
 
-from statsmodels.tools.decorators import (cache_readonly,
-                                          resettable_cache)
+from statsmodels.tools.decorators import cache_readonly
 import statsmodels.tsa.base.tsa_model as tsbase
 import statsmodels.base.wrapper as wrap
 from statsmodels.regression.linear_model import yule_walker, OLS
@@ -1393,7 +1392,7 @@ class ARMAResults(tsbase.TimeSeriesModelResults):
         self._ic_df_model = df_model + 1
         self.df_model = df_model
         self.df_resid = self.nobs - df_model
-        self._cache = resettable_cache()
+        self._cache = {}
 
     @cache_readonly
     def arroots(self):

--- a/statsmodels/tsa/regime_switching/markov_switching.py
+++ b/statsmodels/tsa/regime_switching/markov_switching.py
@@ -15,7 +15,7 @@ import pandas as pd
 
 from statsmodels.tools.tools import Bunch
 from statsmodels.tools.numdiff import approx_fprime_cs, approx_hess_cs
-from statsmodels.tools.decorators import cache_readonly, resettable_cache
+from statsmodels.tools.decorators import cache_readonly
 from statsmodels.tools.eval_measures import aic, bic, hqic
 from statsmodels.tools.tools import pinv_extended
 from statsmodels.tools.sm_exceptions import EstimationWarning
@@ -1871,7 +1871,7 @@ class MarkovSwitchingResults(tsbase.TimeSeriesModelResults):
         self.cov_type = cov_type
 
         # Setup the cache
-        self._cache = resettable_cache()
+        self._cache = {}
 
         # Handle covariance matrix calculation
         if cov_kwds is None:

--- a/statsmodels/tsa/statespace/mlemodel.py
+++ b/statsmodels/tsa/statespace/mlemodel.py
@@ -18,7 +18,7 @@ from statsmodels.tools.tools import pinv_extended, Bunch
 from statsmodels.tools.sm_exceptions import PrecisionWarning
 from statsmodels.tools.numdiff import (_get_epsilon, approx_hess_cs,
                                        approx_fprime_cs, approx_fprime)
-from statsmodels.tools.decorators import cache_readonly, resettable_cache
+from statsmodels.tools.decorators import cache_readonly
 from statsmodels.tools.eval_measures import aic, bic, hqic
 
 import statsmodels.base.wrapper as wrap
@@ -1594,7 +1594,7 @@ class MLEResults(tsbase.TimeSeriesModelResults):
         self.cov_type = cov_type
 
         # Setup the cache
-        self._cache = resettable_cache()
+        self._cache = {}
 
         # Handle covariance matrix calculation
         if cov_kwds is None:


### PR DESCRIPTION
The "resettable" part of ResettableCache is never actually used.  By removing it we make it easier to reason about the behavior of the code.