### PR TITLE
 BUG: Fix simulation smoothing with state intercept

### DIFF
--- a/statsmodels/tsa/statespace/_simulation_smoother.pyx.in
+++ b/statsmodels/tsa/statespace/_simulation_smoother.pyx.in
@@ -212,6 +212,8 @@ cdef class {{prefix}}SimulationSmoother(object):
         else:
             dim2[0] = self.model.k_endog; dim2[1] = self.model.obs_intercept.shape[1];
             self.simulated_model.obs_intercept = np.PyArray_ZEROS(2, dim2, {{typenum}}, FORTRAN)
+            dim2[0] = self.model.k_states; dim2[1] = self.model.state_intercept.shape[1];
+            self.simulated_model.state_intercept = np.PyArray_ZEROS(2, dim2, {{typenum}}, FORTRAN)
 
 
         # Initialize the simulated model memoryviews
@@ -388,7 +390,9 @@ cdef class {{prefix}}SimulationSmoother(object):
             self.cholesky(&self.model.initial_state_cov[0,0], self._tmp0, k_states)
             if not self.pretransformed_initial_state_variates:
                 self.transform_variates(&self.generated_state[0,0], self._tmp0, k_states)
-            blas.{{prefix}}axpy(&k_states, &alpha, &self.model.initial_state[0], &inc, &self.generated_state[0,0], &inc)
+            # In the case of no missing data, we want to keep the initial state at zero
+            if self.has_missing:
+                blas.{{prefix}}axpy(&k_states, &alpha, &self.model.initial_state[0], &inc, &self.generated_state[0,0], &inc)
 
 
         self.simulated_kfilter.seek(0) # reset the filter

--- a/statsmodels/tsa/statespace/tests/test_simulation_smoothing.py
+++ b/statsmodels/tsa/statespace/tests/test_simulation_smoothing.py
@@ -623,3 +623,19 @@ def test_simulation_smoothing_obs_intercept():
     sim.simulate(disturbance_variates=np.zeros(mod.nobs * 2),
                  initial_state_variates=np.zeros(1))
     assert_equal(sim.simulated_state[0], 0)
+
+
+def test_simulation_smoothing_state_intercept():
+    nobs = 10
+    intercept = 100
+    endog = np.ones(nobs) * intercept
+
+    mod = sarimax.SARIMAX(endog, order=(0, 0, 0), trend='c',
+                          measurement_error=True)
+    mod.initialize_known([100], [[0]])
+    mod.update([intercept, 1., 1.])
+
+    sim = mod.simulation_smoother()
+    sim.simulate(disturbance_variates=np.zeros(mod.nobs * 2),
+                 initial_state_variates=np.zeros(1))
+    assert_equal(sim.simulated_state[0], intercept)


### PR DESCRIPTION
This fixes a bug with simulation smoothing when there is a state intercept. It's basically the same underlying issue as was in #3305, but now in the state intercept case.

This issue and the fix is discussed in https://www.ecb.europa.eu/pub/pdf/scpwps/ecbwp1867.en.pdf