### PR TITLE
move data_util functions to data_util

### DIFF
--- a/statsmodels/discrete/discrete_margins.py
+++ b/statsmodels/discrete/discrete_margins.py
@@ -5,6 +5,12 @@ import numpy as np
 from scipy.stats import norm
 from statsmodels.tools.decorators import cache_readonly, resettable_cache
 
+from statsmodels.tools.data import (get_const_index as _get_const_index,
+                                    iscount as _iscount,
+                                    get_count_index as _get_count_index,
+                                    isdummy as _isdummy,
+                                    get_dummy_index as _get_dummy_index)
+
 #### margeff helper functions ####
 #NOTE: todo marginal effects for group 2
 # group 2 oprobit, ologit, gologit, mlogit, biprobit
@@ -27,89 +33,6 @@ def _check_discrete_args(at, method):
     if at in ['median', 'zero']:
         raise ValueError("%s not allowed for discrete variables" % at)
 
-def _get_const_index(exog):
-    """
-    Returns a boolean array of non-constant column indices in exog and
-    an scalar array of where the constant is or None
-    """
-    effects_idx = exog.var(0) != 0
-    if np.any(~effects_idx):
-        const_idx = np.where(~effects_idx)[0]
-    else:
-        const_idx = None
-    return effects_idx, const_idx
-
-def _isdummy(X):
-    """
-    Given an array X, returns the column indices for the dummy variables.
-
-    Parameters
-    ----------
-    X : array-like
-        A 1d or 2d array of numbers
-
-    Examples
-    --------
-    >>> X = np.random.randint(0, 2, size=(15,5)).astype(float)
-    >>> X[:,1:3] = np.random.randn(15,2)
-    >>> ind = _isdummy(X)
-    >>> ind
-    array([0, 3, 4])
-    """
-    X = np.asarray(X)
-    if X.ndim > 1:
-        ind = np.zeros(X.shape[1]).astype(bool)
-    max = (np.max(X, axis=0) == 1)
-    min = (np.min(X, axis=0) == 0)
-    remainder = np.all(X % 1. == 0, axis=0)
-    ind = min & max & remainder
-    if X.ndim == 1:
-        ind = np.asarray([ind])
-    return np.where(ind)[0]
-
-def _get_dummy_index(X, const_idx):
-    dummy_ind = _isdummy(X)
-    dummy = True
-
-    if dummy_ind.size == 0: # don't waste your time
-        dummy = False
-        dummy_ind = None # this gets passed to stand err func
-    return dummy_ind, dummy
-
-def _iscount(X):
-    """
-    Given an array X, returns the column indices for count variables.
-
-    Parameters
-    ----------
-    X : array-like
-        A 1d or 2d array of numbers
-
-    Examples
-    --------
-    >>> X = np.random.randint(0, 10, size=(15,5)).astype(float)
-    >>> X[:,1:3] = np.random.randn(15,2)
-    >>> ind = _iscount(X)
-    >>> ind
-    array([0, 3, 4])
-    """
-    X = np.asarray(X)
-    remainder = np.logical_and(np.logical_and(np.all(X % 1. == 0, axis = 0),
-                               X.var(0) != 0), np.all(X >= 0, axis=0))
-    dummy = _isdummy(X)
-    remainder = np.where(remainder)[0].tolist()
-    for idx in dummy:
-        remainder.remove(idx)
-    return np.array(remainder)
-
-def _get_count_index(X, const_idx):
-    count_ind = _iscount(X)
-    count = True
-
-    if count_ind.size == 0: # don't waste your time
-        count = False
-        count_ind = None # for stand err func
-    return count_ind, count
 
 def _get_margeff_exog(exog, at, atexog, ind):
     if atexog is not None: # user supplied

--- a/statsmodels/discrete/discrete_model.py
+++ b/statsmodels/discrete/discrete_model.py
@@ -126,35 +126,9 @@ params : ndarray
 """
 
 # helper for MNLogit (will be generally useful later)
-
-def _numpy_to_dummies(endog):
-    if endog.dtype.kind in ['S', 'O']:
-        endog_dummies, ynames = tools.categorical(endog, drop=True,
-                                                  dictnames=True)
-    elif endog.ndim == 2:
-        endog_dummies = endog
-        ynames = range(endog.shape[1])
-    else:
-        endog_dummies, ynames = tools.categorical(endog, drop=True,
-                                                  dictnames=True)
-    return endog_dummies, ynames
-
-
-def _pandas_to_dummies(endog):
-    if endog.ndim == 2:
-        if endog.shape[1] == 1:
-            yname = endog.columns[0]
-            endog_dummies = get_dummies(endog.iloc[:, 0])
-        else:  # series
-            yname = 'y'
-            endog_dummies = endog
-    else:
-        yname = endog.name
-        endog_dummies = get_dummies(endog)
-    ynames = endog_dummies.columns.tolist()
-
-    return endog_dummies, ynames, yname
-
+# aliases for backwards-compat
+_numpy_to_dummies = data_tools.numpy_to_dummies
+_pandas_to_dummies = data_tools.pandas_to_dummies
 
 #### Private Model Classes ####
 

--- a/statsmodels/tools/data.py
+++ b/statsmodels/tools/data.py
@@ -6,6 +6,125 @@ import numpy as np
 import pandas as pd
 
 
+def numpy_to_dummies(endog):
+    from statsmodels.tools.tools import categorical
+    if endog.dtype.kind in ['S', 'O']:
+        endog_dummies, ynames = categorical(endog, drop=True, dictnames=True)
+    elif endog.ndim == 2:
+        endog_dummies = endog
+        ynames = range(endog.shape[1])
+    else:
+        endog_dummies, ynames = categorical(endog, drop=True, dictnames=True)
+    return endog_dummies, ynames
+
+
+def pandas_to_dummies(endog):
+    if endog.ndim == 2:
+        if endog.shape[1] == 1:
+            yname = endog.columns[0]
+            endog_dummies = pd.get_dummies(endog.iloc[:, 0])
+        else:
+            # series
+            yname = 'y'
+            endog_dummies = endog
+    else:
+        yname = endog.name
+        endog_dummies = pd.get_dummies(endog)
+    ynames = endog_dummies.columns.tolist()
+
+    return endog_dummies, ynames, yname
+
+
+def get_const_index(exog):
+    """
+    Returns a boolean array of non-constant column indices in exog and
+    an scalar array of where the constant is or None
+    """
+    effects_idx = exog.var(0) != 0
+    if np.any(~effects_idx):
+        const_idx = np.where(~effects_idx)[0]
+    else:
+        const_idx = None
+    return effects_idx, const_idx
+
+
+def isdummy(X):
+    """
+    Given an array X, returns the column indices for the dummy variables.
+
+    Parameters
+    ----------
+    X : array-like
+        A 1d or 2d array of numbers
+
+    Examples
+    --------
+    >>> X = np.random.randint(0, 2, size=(15,5)).astype(float)
+    >>> X[:,1:3] = np.random.randn(15,2)
+    >>> ind = _isdummy(X)
+    >>> ind
+    array([0, 3, 4])
+    """
+    X = np.asarray(X)
+    if X.ndim > 1:
+        ind = np.zeros(X.shape[1]).astype(bool)
+
+    max_mask = (np.max(X, axis=0) == 1)
+    min_mask = (np.min(X, axis=0) == 0)
+    remainder = np.all(X % 1. == 0, axis=0)
+    ind = min_mask & max_mask & remainder
+    if X.ndim == 1:
+        ind = np.asarray([ind])
+    return np.where(ind)[0]
+
+
+def get_dummy_index(X, const_idx):
+    dummy_ind = isdummy(X)
+    dummy = True
+
+    if dummy_ind.size == 0:  # don't waste your time
+        dummy = False
+        dummy_ind = None  # this gets passed to stand err func
+    return dummy_ind, dummy
+
+
+def iscount(X):
+    """
+    Given an array X, returns the column indices for count variables.
+
+    Parameters
+    ----------
+    X : array-like
+        A 1d or 2d array of numbers
+
+    Examples
+    --------
+    >>> X = np.random.randint(0, 10, size=(15,5)).astype(float)
+    >>> X[:,1:3] = np.random.randn(15,2)
+    >>> ind = _iscount(X)
+    >>> ind
+    array([0, 3, 4])
+    """
+    X = np.asarray(X)
+    remainder = np.logical_and(np.logical_and(np.all(X % 1. == 0, axis = 0),
+                               X.var(0) != 0), np.all(X >= 0, axis=0))
+    dummy = _isdummy(X)
+    remainder = np.where(remainder)[0].tolist()
+    for idx in dummy:
+        remainder.remove(idx)
+    return np.array(remainder)
+
+
+def get_count_index(X, const_idx):
+    count_ind = iscount(X)
+    count = True
+
+    if count_ind.size == 0:  # don't waste your time
+        count = False
+        count_ind = None  # for stand err func
+    return count_ind, count
+
+
 def _check_period_index(x, freq="M"):
     from pandas import PeriodIndex, DatetimeIndex
     if not isinstance(x.index, (DatetimeIndex, PeriodIndex)):

--- a/statsmodels/tools/data.py
+++ b/statsmodels/tools/data.py
@@ -61,7 +61,7 @@ def isdummy(X):
     --------
     >>> X = np.random.randint(0, 2, size=(15,5)).astype(float)
     >>> X[:,1:3] = np.random.randn(15,2)
-    >>> ind = _isdummy(X)
+    >>> ind = isdummy(X)
     >>> ind
     array([0, 3, 4])
     """
@@ -108,7 +108,7 @@ def iscount(X):
     X = np.asarray(X)
     remainder = np.logical_and(np.logical_and(np.all(X % 1. == 0, axis = 0),
                                X.var(0) != 0), np.all(X >= 0, axis=0))
-    dummy = _isdummy(X)
+    dummy = isdummy(X)
     remainder = np.where(remainder)[0].tolist()
     for idx in dummy:
         remainder.remove(idx)


### PR DESCRIPTION
If broadly-useful functions go in thematically appropriate modules, then people will know where to look for them instead of re-writing them again and again.