### PR TITLE
Default implementations for loglike, score, fittedvalues

### DIFF
--- a/statsmodels/base/elastic_net.py
+++ b/statsmodels/base/elastic_net.py
@@ -344,14 +344,7 @@ def _opt_1d(func, grad, hess, model, start, L1_wt, tol,
 
 
 class RegularizedResults(Results):
-
-    def __init__(self, model, params):
-        super(RegularizedResults, self).__init__(model, params)
-
-    @cache_readonly
-    def fittedvalues(self):
-        return self.model.predict(self.params)
-
+    pass
 
 class RegularizedResultsWrapper(wrap.ResultsWrapper):
     _attrs = {

--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -253,7 +253,14 @@ class LikelihoodModel(Model):
         Base class implementation sums over score_obs; more efficient
         implementations are often available.
         """
-        return self.score_obs(params, **kwargs).sum()
+        try:
+            # If an analytic score_obs is available, try this first before
+            # falling back to numerical differentiation below
+            return self.score_obs(params, **kwargs).sum(0)
+        except NotImplementedError:
+            # Fallback in case a `loglike` is implemented but `loglikeobs`
+            # is not.
+            return approx_fprime(params, self.loglike, **kwargs)
 
     def information(self, params):
         """

--- a/statsmodels/genmod/generalized_linear_model.py
+++ b/statsmodels/genmod/generalized_linear_model.py
@@ -475,27 +475,6 @@ class GLM(base.LikelihoodModel):
         score_factor = self.score_factor(params, scale=scale)
         return score_factor[:, None] * self.exog
 
-    def score(self, params, scale=None):
-        """score, first derivative of the loglikelihood function
-
-        Parameters
-        ----------
-        params : ndarray
-            parameter at which score is evaluated
-        scale : None or float
-            If scale is None, then the default scale will be calculated.
-            Default scale is defined by `self.scaletype` and set in fit.
-            If scale is not None, then it is used as a fixed scale.
-
-        Returns
-        -------
-        score : ndarray_1d
-            The first derivative of the loglikelihood function calculated as
-            the sum of `score_obs`
-
-        """
-        return self.score_obs(params, scale=scale).sum(0)
-
     def score_factor(self, params, scale=None):
         """weights for score for each observation
 
@@ -1516,12 +1495,8 @@ class GLMResults(base.LikelihoodModelResults):
         return chisqsum
 
     @cache_readonly
-    def fittedvalues(self):
-        return self.mu
-
-    @cache_readonly
     def mu(self):
-        return self.model.predict(self.params)
+        return self.fittedvalues
 
     @cache_readonly
     def null(self):

--- a/statsmodels/regression/linear_model.py
+++ b/statsmodels/regression/linear_model.py
@@ -1490,10 +1490,6 @@ class RegressionResults(base.LikelihoodModelResults):
         return float(self.model.wexog.shape[0])
 
     @cache_readonly
-    def fittedvalues(self):
-        return self.model.predict(self.params, self.model.exog)
-
-    @cache_readonly
     def wresid(self):
         return self.model.wendog - self.model.predict(
             self.params, self.model.wexog)

--- a/statsmodels/robust/robust_linear_model.py
+++ b/statsmodels/robust/robust_linear_model.py
@@ -134,9 +134,6 @@ class RLM(base.LikelihoodModel):
     def score(self, params):
         raise NotImplementedError
 
-    def information(self, params):
-        raise NotImplementedError
-
     def predict(self, params, exog=None):
         """
         Return linear predicted values from a design matrix.
@@ -397,10 +394,6 @@ class RLMResults(base.LikelihoodModelResults):
 
         self.cov_params_default = self.bcov_scaled
         #TODO: "pvals" should come from chisq on bse?
-
-    @cache_readonly
-    def fittedvalues(self):
-        return np.dot(self.model.exog, self.params)
 
     @cache_readonly
     def resid(self):

--- a/statsmodels/sandbox/regression/gmm.py
+++ b/statsmodels/sandbox/regression/gmm.py
@@ -1618,11 +1618,6 @@ class IVGMMResults(GMMResults):
     # this assumes that we have an additive error model `(y - f(x, params))`
 
     @cache_readonly
-    def fittedvalues(self):
-        return self.model.predict(self.params)
-
-
-    @cache_readonly
     def resid(self):
         return self.model.endog - self.fittedvalues
 

--- a/statsmodels/tsa/ar_model.py
+++ b/statsmodels/tsa/ar_model.py
@@ -364,19 +364,6 @@ class AR(tsbase.TimeSeriesModel):
         loglike = self.loglike
         return approx_fprime(params, loglike, epsilon=1e-8)
 
-    def information(self, params):
-        """
-        Not Implemented Yet
-        """
-        return
-
-    def hessian(self, params):
-        """
-        Returns numerical hessian for now.
-        """
-        loglike = self.loglike
-        return approx_hess(params, loglike)
-
     def _stackX(self, k_ar, trend):
         """
         Private method to build the RHS matrix for estimation.
@@ -783,10 +770,6 @@ class ARResults(tsbase.TimeSeriesModelResults):
     def roots(self):
         k = self.k_trend
         return np.roots(np.r_[1, -self.params[k:]]) ** -1
-
-    @cache_readonly
-    def fittedvalues(self):
-        return self.model.predict(self.params)
 
     def predict(self, start=None, end=None, dynamic=False):
         params = self.params

--- a/statsmodels/tsa/arima_model.py
+++ b/statsmodels/tsa/arima_model.py
@@ -1438,10 +1438,6 @@ class ARMAResults(tsbase.TimeSeriesModelResults):
         return self.params[k+k_ar:]
 
     @cache_readonly
-    def llf(self):
-        return self.model.loglike(self.params)
-
-    @cache_readonly
     def bse(self):
         params = self.params
         hess = self.model.hessian(params)

--- a/statsmodels/tsa/regime_switching/markov_switching.py
+++ b/statsmodels/tsa/regime_switching/markov_switching.py
@@ -2009,33 +2009,12 @@ class MarkovSwitchingResults(tsbase.TimeSeriesModelResults):
         return cov_params
 
     @cache_readonly
-    def fittedvalues(self):
-        """
-        (array) The predicted values of the model. An (nobs x k_endog) array.
-        """
-        return self.model.predict(self.params)
-
-    @cache_readonly
     def hqic(self):
         """
         (float) Hannan-Quinn Information Criterion
         """
         # return -2*self.llf + 2*np.log(np.log(self.nobs))*self.params.shape[0]
         return hqic(self.llf, self.nobs, self.params.shape[0])
-
-    @cache_readonly
-    def llf_obs(self):
-        """
-        (float) The value of the log-likelihood function evaluated at `params`.
-        """
-        return self.model.loglikeobs(self.params)
-
-    @cache_readonly
-    def llf(self):
-        """
-        (float) The value of the log-likelihood function evaluated at `params`.
-        """
-        return self.model.loglike(self.params)
 
     @cache_readonly
     def resid(self):

--- a/statsmodels/tsa/statespace/mlemodel.py
+++ b/statsmodels/tsa/statespace/mlemodel.py
@@ -1989,13 +1989,6 @@ class MLEResults(tsbase.TimeSeriesModelResults):
         return hqic(self.llf, self.nobs_effective, self.df_model)
 
     @cache_readonly
-    def llf_obs(self):
-        """
-        (float) The value of the log-likelihood function evaluated at `params`.
-        """
-        return self.model.loglikeobs(self.params)
-
-    @cache_readonly
     def llf(self):
         """
         (float) The value of the log-likelihood function evaluated at `params`.

--- a/statsmodels/tsa/vector_ar/svar_model.py
+++ b/statsmodels/tsa/vector_ar/svar_model.py
@@ -316,14 +316,6 @@ class SVAR(tsbase.TimeSeriesModel):
         loglike = self.loglike
         return approx_fprime(AB_mask, loglike, epsilon=1e-8)
 
-
-    def hessian(self, AB_mask):
-        """
-        Returns numerical hessian.
-        """
-        loglike = self.loglike
-        return approx_hess(AB_mask, loglike)
-
     def _solve_AB(self, start_params, maxiter, maxfun, override=False,
             solver='bfgs'):
         """


### PR DESCRIPTION
Somewhat scaled back variant of #4411.

Less is more.

Improved some docstrings.

The only actual change is that `AR.information` now correctly raises `NotImplementedError` instead of incorrectly returning `None`.