### PR TITLE
BUG: coint use autolag in adfuller call

### DIFF
--- a/statsmodels/tsa/stattools.py
+++ b/statsmodels/tsa/stattools.py
@@ -933,6 +933,10 @@ def coint(y0, y1, trend='c', method='aeg', maxlag=None, autolag='aic',
     Constant or trend is included in 1st stage regression, i.e. in
     cointegrating equation.
 
+    **Warning:** The autolag default has changed compared to statsmodels 0.8.
+    In 0.8 autolag was always None, no the keyword is used and defaults to
+    'aic'. Use `autolag=None` to avoid the lag search.
+
     Parameters
     ----------
     y1 : array_like, 1d
@@ -952,6 +956,13 @@ def coint(y0, y1, trend='c', method='aeg', maxlag=None, autolag='aic',
         keyword for `adfuller`, largest or given number of lags
     autolag : string
         keyword for `adfuller`, lag selection criterion.
+        * if None, then maxlag lags are used without lag search
+        * if 'AIC' (default) or 'BIC', then the number of lags is chosen
+          to minimize the corresponding information criterion
+        * 't-stat' based choice of maxlag.  Starts with maxlag and drops a
+          lag until the t-statistic on the last lag length is significant
+          using a 5%-sized test
+
     return_results : bool
         for future compatibility, currently only tuple available.
         If True, then a results instance is returned. Otherwise, a tuple
@@ -1017,7 +1028,7 @@ def coint(y0, y1, trend='c', method='aeg', maxlag=None, autolag='aic',
     res_co = OLS(y0, xx).fit()
 
     if res_co.rsquared < 1 - 100 * SQRTEPS:
-        res_adf = adfuller(res_co.resid, maxlag=maxlag, autolag=None,
+        res_adf = adfuller(res_co.resid, maxlag=maxlag, autolag=autolag,
                            regression='nc')
     else:
         import warnings

--- a/statsmodels/tsa/tests/test_stattools.py
+++ b/statsmodels/tsa/tests/test_stattools.py
@@ -349,6 +349,13 @@ def test_coint():
             r1 = res1[i][2]
             assert_allclose(r1, r2, rtol=0, atol=6e-7)
 
+    # use default autolag #4490
+    res1_0 = coint(y[:, 0], y[:, 1], trend='ct', maxlag=4)
+    assert_allclose(res1_0[2], res_egranger['ct'][0][1:], rtol=0, atol=6e-7)
+    # the following is just a regression test
+    assert_allclose(res1_0[:2], [-13.992946638547112, 2.270898990540678e-27],
+                    rtol=1e-10, atol=1e-27)
+
 
 def test_coint_identical_series():
     nobs = 200


### PR DESCRIPTION
 closes #4490

don't ignore autolag keyword in `coint`

Note, this changes the default autolag to the same as the adfuller default, aic instead of None used in statsmodels 0.8