### PR TITLE
BUG: AR undefined mu if trend='nc'

### DIFF
--- a/statsmodels/tsa/ar_model.py
+++ b/statsmodels/tsa/ar_model.py
@@ -211,6 +211,8 @@ class AR(tsbase.TimeSeriesModel):
         if method == 'mle':  # use Kalman Filter to get initial values
             if k_trend:
                 mu = params[0]/(1-np.sum(params[k_trend:]))
+            else:
+                mu = 0
 
             # modifies predictedvalues in place
             if start < k_ar:

--- a/statsmodels/tsa/tests/test_ar.py
+++ b/statsmodels/tsa/tests/test_ar.py
@@ -4,6 +4,7 @@ Test AR Model
 import statsmodels.api as sm
 from statsmodels.compat.python import range
 from statsmodels.tsa.ar_model import AR
+from statsmodels.tsa.arima_model import ARMA
 from numpy.testing import (assert_almost_equal, assert_allclose, assert_)
 from statsmodels.tools.testing import assert_equal
 from .results import results_ar
@@ -85,7 +86,7 @@ class TestAROLSNoConstant(CheckARMixin):
     @classmethod
     def setup_class(cls):
         data = sm.datasets.sunspots.load()
-        cls.res1 = AR(data.endog).fit(maxlag=9,method='cmle',trend='nc')
+        cls.res1 = AR(data.endog).fit(maxlag=9, method='cmle', trend='nc')
         cls.res2 = results_ar.ARResultsOLS(constant=False)
 
     def test_predict(self):
@@ -114,7 +115,18 @@ class TestAROLSNoConstant(CheckARMixin):
         assert_almost_equal(model.predict(params, start=308, end=327),
                 self.res2.FVOLSn15start312, DECIMAL_4)
 
-        #class TestARMLEConstant(CheckAR):
+    def test_mle(self):
+        # check predict with no constant, #3945
+        res1 = self.res1
+        endog = res1.model.endog
+        res0 = AR(endog).fit(maxlag=9, method='mle', trend='nc', disp=0)
+        assert_allclose(res0.fittedvalues[-10:], res0.fittedvalues[-10:],
+                        rtol=0.015)
+
+        res_arma = ARMA(endog, (9, 0)).fit(method='mle', trend='nc', disp=0)
+        assert_allclose(res0.params, res_arma.params, atol=5e-6)
+        assert_allclose(res0.fittedvalues[-10:], res_arma.fittedvalues[-10:],
+                        rtol=1e-4)
 
 
 class TestARMLEConstant(object):


### PR DESCRIPTION
closes #3945

this uses the fix proposed in 3945
`UnboundLocalError: local variable 'mu' referenced before assignment`

unit tests against ARMA(9, 0) at optimization precision