### PR TITLE
BUG: fix rdataset cache writing on py3

### DIFF
--- a/statsmodels/datasets/tests/test_utils.py
+++ b/statsmodels/datasets/tests/test_utils.py
@@ -8,6 +8,7 @@ from statsmodels.datasets import get_rdataset, webuse, check_internet, utils
 
 cur_dir = os.path.dirname(os.path.abspath(__file__))
 
+
 def test_get_rdataset():
     # smoke test
     test_url = "https://raw.githubusercontent.com/vincentarelbundock/Rdatasets/master/csv/datasets/cars.csv"
@@ -17,6 +18,17 @@ def test_get_rdataset():
     duncan = get_rdataset("Duncan", "car", cache=cur_dir)
     assert_(isinstance(duncan, utils.Dataset))
     assert_(duncan.from_cache)
+
+    # test writing and reading cache
+    guerry = get_rdataset("Guerry", "HistData", cache=cur_dir)
+    assert_(guerry.from_cache is False)
+    guerry2 = get_rdataset("Guerry", "HistData", cache=cur_dir)
+    assert_(guerry2.from_cache is True)
+    fn = "raw.github.com,vincentarelbundock,Rdatasets,master,csv,HistData,Guerry.csv.zip"
+    os.remove(os.path.join(cur_dir, fn))
+    fn = "raw.github.com,vincentarelbundock,Rdatasets,master,doc,HistData,rst,Guerry.rst.zip"
+    os.remove(os.path.join(cur_dir, fn))
+
 
 def test_webuse():
     # test copied and adjusted from iolib/tests/test_foreign

--- a/statsmodels/datasets/utils.py
+++ b/statsmodels/datasets/utils.py
@@ -171,6 +171,7 @@ def _cache_it(data, cache_path):
         # for some reason encode("zip") won't work for me in Python 3?
         import zlib
         # use protocol 2 so can open with python 2.x if cached in 3.x
+        data = data.decode('utf-8')
         open(cache_path, "wb").write(zlib.compress(cPickle.dumps(data,
                                                                  protocol=2)))
     else:


### PR DESCRIPTION
closes #3831

rdataset does not write-read roundtrip using cache on python 3.

The change here is to store the cache as strings (encoded in utf-8) instead of bytes in Python 3. 
A new unit test uses cache temporarily, instead of reusing already cached files.