### PR TITLE
ENH: Added plotkwargs to top level version of qqplot in statsmodels.graphics.gofplots

### DIFF
--- a/statsmodels/graphics/gofplots.py
+++ b/statsmodels/graphics/gofplots.py
@@ -404,7 +404,7 @@ class ProbPlot(object):
         return fig
 
 def qqplot(data, dist=stats.norm, distargs=(), a=0, loc=0, scale=1, fit=False,
-           line=None, ax=None):
+           line=None, ax=None, **plotkwargs):
     """
     Q-Q plot of the quantiles of x versus the quantiles/ppf of a distribution.
 
@@ -449,6 +449,9 @@ def qqplot(data, dist=stats.norm, distargs=(), a=0, loc=0, scale=1, fit=False,
     ax : Matplotlib AxesSubplot instance, optional
         If given, this subplot is used to plot in instead of a new figure being
         created.
+
+    **plotkwargs : additional matplotlib arguments to be passed to the
+            `plot` command.
 
     Returns
     -------
@@ -501,7 +504,7 @@ def qqplot(data, dist=stats.norm, distargs=(), a=0, loc=0, scale=1, fit=False,
     """
     probplot = ProbPlot(data, dist=dist, distargs=distargs,
                          fit=fit, a=a, loc=loc, scale=scale)
-    fig = probplot.qqplot(ax=ax, line=line)
+    fig = probplot.qqplot(ax=ax, line=line, **plotkwargs)
     return fig
 
 def qqplot_2samples(data1, data2, xlabel=None, ylabel=None, line=None, ax=None):

--- a/statsmodels/graphics/tests/test_gofplots.py
+++ b/statsmodels/graphics/tests/test_gofplots.py
@@ -164,6 +164,13 @@ class TestTopLevel(object):
         fig = sm.qqplot(self.res, line='r')
 
     @skipif(not have_matplotlib, reason='matplotlib not available')
+    def test_qqplot_pltkwargs(self):
+        fig = sm.qqplot(self.res, line='r', marker='d',
+                                      markerfacecolor='cornflowerblue',
+                                      markeredgecolor='white',
+                                      alpha=0.5)
+
+    @skipif(not have_matplotlib, reason='matplotlib not available')
     def test_qqplot_2samples_ProbPlotObjects(self):
         # also tests all values for line
         for line in ['r', 'q', '45', 's']:


### PR DESCRIPTION
I added plotkwargs as an input to the top level version of qqplot from statsmodel.api which did not accept additional matplotlib arguments. I also added a test for this and enabled Travis CI on my fork. Seems to build fine.