### PR TITLE
xfail test instead of commenting it out

### DIFF
--- a/statsmodels/tsa/vector_ar/tests/test_var.py
+++ b/statsmodels/tsa/vector_ar/tests/test_var.py
@@ -245,12 +245,12 @@ class CheckFEVD(object):
     def test_fevd_summary(self):
         self.fevd.summary()
 
+    @pytest.mark.xfail(reason="FEVD.cov() is not implemented")
     def test_fevd_cov(self):
         # test does not crash
         # not implemented
-        # covs = self.fevd.cov()
+        covs = self.fevd.cov()
 
-        pass
 
 class TestVARResults(CheckIRF, CheckFEVD):
 


### PR DESCRIPTION
There are a whole mess of tests that are commented-out or mangled instead of being xfailed.  This makes it unnecessarily difficult to find tests that need attention.

(And uh, BTW, FEVD tests are 100% smoke tests)