### PR TITLE
MAINT: at timeout to urlopen rdatasets

### DIFF
--- a/statsmodels/datasets/utils.py
+++ b/statsmodels/datasets/utils.py
@@ -210,7 +210,7 @@ def _urlopen_cached(url, cache):
 
     # not using the cache or didn't find it in cache
     if not from_cache:
-        data = urlopen(url).read()
+        data = urlopen(url, timeout=3).read()
         if cache is not None:  # then put it in the cache
             _cache_it(data, cache_path)
     return data, from_cache


### PR DESCRIPTION
this is just a guess.

travis in master is often hanging now with no response received.
AFAICS, the default timeout for urlopen is None, so urlopen might wait forever if there are problems.

```
>>> repr(urllib.request.socket.getdefaulttimeout())
'None'
```

This PR just add a timeout of 3 seconds.
The usage of rdataset in the unit test is protected by a hasinternet check, so this is not a problem if no internet at all is available.