### PR TITLE
Raise the correct errors at the correct time

### DIFF
--- a/statsmodels/discrete/discrete_model.py
+++ b/statsmodels/discrete/discrete_model.py
@@ -1040,7 +1040,7 @@ class Poisson(CountModel):
                 method=method, maxiter=maxiter, full_output=full_output,
                 disp=disp, callback=callback, **kwargs)
 
-        discretefit = PoissonResults(self, cntfit, **kwds)
+        discretefit = PoissonResults(self, cntfit)
         return PoissonResultsWrapper(discretefit)
     fit.__doc__ = DiscreteModel.fit.__doc__
 


### PR DESCRIPTION
Independent of the "should duplicated code be retained?" topic, this adjusts whitespace etc to turn effectively-identical chunks of code into copy/paste-identical chunks.

Also removes an unnecessary `if 'cov_type' in kwargs` block, and redundant/problematic exceptions.