### PR TITLE
Document and cleanup bits of cython code

### DIFF
--- a/statsmodels/tsa/kalmanf/kalman_loglike.pyx
+++ b/statsmodels/tsa/kalmanf/kalman_loglike.pyx
@@ -37,11 +37,11 @@ cdef zgemv_t *zgemv = <zgemv_t*>Capsule_AsVoidPtr(scipy.linalg.blas.get_blas_fun
 @cython.wraparound(False)
 @cython.cdivision(True)
 def kalman_filter_double(double[:] y not None,
-                   unsigned int k, unsigned int p, unsigned int q,
-                  int r, unsigned int nobs,
-                         double[::1,:] Z_mat,
-                         double[::1,:] R_mat,
-                         double[::1,:] T_mat):
+                         unsigned int k, unsigned int p, unsigned int q,
+                         int r, unsigned int nobs,
+                         double[::1, :] Z_mat,
+                         double[::1, :] R_mat,
+                         double[::1, :] T_mat):
     """
     Cython version of the Kalman filter recursions for an ARMA process.
     """
@@ -102,7 +102,6 @@ def kalman_filter_double(double[:] y not None,
 
     #NOTE: not sure about just checking F_mat[0,0], didn't appear to work
     while not F_mat == 1. and i < nobs:
-        #print i
         # Predict
         #v_mat = ddot(&r, &Z_mat[0,0], &one, &alpha[0,0], &one)
         #v_mat = y[i] - v_mat # copies?
@@ -117,80 +116,82 @@ def kalman_filter_double(double[:] y not None,
         #Z_mat is just a selector matrix
         F_mat = P[0,0]
         F[i,0] = F_mat
-        Finv = 1./F_mat # always scalar for univariate series
-        # compute Kalman Gain, K
-        # K = dot(dot(dot(T_mat,P),Z_mat.T),Finv)
-        #   or K = dot(dot(dot(T_mat, P), Z_mat.T))*Finv
-        # tmp1 = dot(T_mat, P)
-        # tmp3 = dot(tmp1, Z_mat.T)
-        # K = dot(tmp3, Finv) or tmp3*Finv
+        Finv = 1. / F_mat  # always scalar for univariate series
 
-        #print "Finv: ", asarray(<DOUBLE[:1, :1] *> &Finv[0,0])
-        dgemm("N", "N", &r, &r, &r, &alph, &T_mat[0,0], &ldt, &P[0,0], &ldp,
-              &beta, &tmp1[0,0], &ldt1)
-        #print "tmp1: ", asarray(<DOUBLE[:r, :r] *> &tmp1[0,0])
-        # tmp1 . Z_mat.T
+        # compute Kalman Gain, K equivalent to:
+        #   K = np.dot(np.dot(np.dot(T_mat, P), Z_mat.T), Finv)
+        # in two steps:
+        #   tmp1 = np.dot(T_mat, P)
+        #   K = Finv * tmp1.dot(Z_mat.T)
+        dgemm("N", "N", &r, &r, &r, &alph, &T_mat[0, 0], &ldt, &P[0, 0], &ldp,
+              &beta, &tmp1[0, 0], &ldt1)
+        dgemv("N", &r, &r, &Finv, &tmp1[0, 0], &ldt1, &Z_mat[0, 0], &one, &beta,
+              &K[0, 0], &one)
 
-        dgemv("N", &r, &r, &Finv, &tmp1[0,0], &ldt1, &Z_mat[0,0], &one, &beta,
-              &K[0,0], &one)
-
-        # update state
-        #alpha = dot(T_mat, alpha) + dot(K, v_mat)
-        #alpha = dot(T_mat, alpha) + K*v_mat
-        #dot(T_mat, alpha)
-        dgemv("N", &r, &r, &alph, &T_mat[0,0], &ldt, &alpha[0,0], &one, &beta,
-              &tmp2[0,0], &one)
-
-        #dot(K, v_mat) + tmp2
+        # update state; equivalent to:
+        #   alpha = np.dot(T_mat, alpha) + np.dot(K, v_mat)
+        # in two steps:
+        #   tmp2 = np.dot(T_mat, alpha)
+        #   alpha = tmp2 + np.dot(K, v_mat)
+        dgemv("N", &r, &r, &alph, &T_mat[0, 0], &ldt, &alpha[0, 0], &one, &beta,
+              &tmp2[0, 0], &one)
         for ii in range(r):
-            alpha[ii,0] = K[ii,0]*v_mat + tmp2[ii,0]
+            alpha[ii, 0] = K[ii, 0] * v_mat + tmp2[ii, 0]
 
-        #L = T_mat - dot(K,Z_mat)
-        dgemm("N", "N", &r, &r, &one, &alph, &K[0,0], &ldk, &Z_mat[0,0], &ldz,
-              &beta, &L[0,0], &ldl)
-        # L = T_mat - L
-        # L = -(L - T_mat)
+        # The next block is equivalent to:
+        #   L = T_mat - np.dot(K, Z_mat)
+        # in two steps:
+        #   L = np.dot(K, Z_mat)
+        #   L = T_mat - L
+        dgemm("N", "N", &r, &r, &one, &alph, &K[0, 0], &ldk, &Z_mat[0, 0], &ldz,
+              &beta, &L[0, 0], &ldl)
         for jj in range(r):
             for kk in range(r):
-                L[jj,kk] = T_mat[jj,kk] - L[jj,kk]
+                L[jj, kk] = T_mat[jj, kk] - L[jj, kk]
 
-        #P = dot(dot(T_mat, P), L.T) + dot(R_mat, R_mat.T)
-        # tmp5 = dot(R_mat, R_mat.T)
-        # tmp3 = dot(T_mat, P)
-        # P = dot(tmp3, L.T) + tmp5
-        dgemm("N", "N", &r, &r, &r, &alph, &T_mat[0,0], &ldt, &P[0,0],
-              &ldp, &beta, &tmp3[0,0], &ldt3)
-        dgemm("N", "T", &r, &r, &one, &alph, &R_mat[0,0], &ldr, &R_mat[0,0],
-              &ldr, &beta, &P[0,0], &ldp)
-        dgemm("N", "T", &r, &r, &r, &alph, &tmp3[0,0], &ldt3, &L[0,0],
-              &ldl, &alph, &P[0,0], &ldp)
+        # The next block computes P equivalent to:
+        #   P = np.dot(np.dot(T_mat, P), L.T) + np.dot(R_mat, R_mat.T)
+        # in three steps:
+        #   tmp5 = np.dot(R_mat, R_mat.T)
+        #   tmp3 = np.dot(T_mat, P)
+        #   P = np.dot(tmp3, L.T) + tmp5
+        dgemm("N", "N", &r, &r, &r, &alph, &T_mat[0, 0], &ldt, &P[0, 0],
+              &ldp, &beta, &tmp3[0, 0], &ldt3)
+        dgemm("N", "T", &r, &r, &one, &alph, &R_mat[0, 0], &ldr, &R_mat[0, 0],
+              &ldr, &beta, &P[0, 0], &ldp)
+        dgemm("N", "T", &r, &r, &r, &alph, &tmp3[0, 0], &ldt3, &L[0, 0],
+              &ldl, &alph, &P[0, 0], &ldp)
 
         # 101 = c-order, 122 - lower triangular of R, "N" - no trans (XX')
         #dsyrk(101, 122, "N", r, 1, 1.0, &R_mat[0,0],
         #      &ldr, 1.0, &P[0,0], &ldp )
 
         loglikelihood += log(F_mat)
-        i+=1
+        i += 1
 
     for i in xrange(i,nobs):
         #v_mat = ddot(&r, &Z_mat[0,0], &one, &alpha[0,0], &one)
         #v_mat = y[i] - v_mat
-        v_mat = y[i] - alpha[0,0]
+        v_mat = y[i] - alpha[0, 0]
         v[i, 0] = v_mat
-        #alpha = dot(T_mat, alpha) + dot(K, v_mat)
-        dgemm("N", "N", &r, &one, &r, &alph, &T_mat[0,0], &ldt, &alpha[0,0],
-              &lda, &beta, &tmp2[0,0], &ldt2)
-        #dot(K, v_mat) + tmp2
+        # The next block is equivalent to:
+        #   alpha = np.dot(T_mat, alpha) + np.dot(K, v_mat)
+        # in two steps:
+        #   tmp2 = np.dot(T_mat, alpha)
+        #   alpha = np.dot(K, v_mat) + tmp2
+        dgemm("N", "N", &r, &one, &r, &alph, &T_mat[0, 0], &ldt, &alpha[0, 0],
+              &lda, &beta, &tmp2[0, 0], &ldt2)
         for ii in range(r):
-            alpha[ii,0] = K[ii,0]*v_mat + tmp2[ii,0]
+            alpha[ii, 0] = K[ii, 0] * v_mat + tmp2[ii, 0]
     return v, F, loglikelihood
+
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
 @cython.cdivision(True)
 def kalman_filter_complex(dcomplex[:] y,
-                   unsigned int k, unsigned int p, unsigned int q,
-                  int r, unsigned int nobs,
+                          unsigned int k, unsigned int p, unsigned int q,
+                          int r, unsigned int nobs,
                           dcomplex[::1,:] Z_mat,
                           dcomplex[::1,:] R_mat,
                           dcomplex[::1,:] T_mat):
@@ -214,7 +215,6 @@ def kalman_filter_complex(dcomplex[:] y,
         int ldt = T_mat.strides[1]/sizeof(dcomplex)
         int ldr = R_mat.strides[1]/sizeof(dcomplex)
         # forecast errors
-        #dcomplex[:,:] v = zeros((nobs,1), dtype=complex)
         ndarray[complex, ndim=2] v = PyArray_ZEROS(2, yshape, cnp.NPY_CDOUBLE,
                                                    FORTRAN)
         # store variance of forecast errors
@@ -262,71 +262,73 @@ def kalman_filter_complex(dcomplex[:] y,
         # Z_mat is just a selctor matrix so the below is equivalent
         F_mat = P[0,0]
         F[i,0] = F_mat
-        Finv = 1./F_mat # always scalar for univariate series
-        # compute Kalman Gain, K
-        # K = dot(dot(dot(T_mat,P),Z_mat.T),Finv)
-        # tmp1 = dot(T_mat, P)
-        # tmp3 = dot(tmp1, Z_mat.T)
-        # K = dot(tmp3, Finv)
+        Finv = 1. / F_mat  # always scalar for univariate series
 
-        # tmp1 = T_mat.dot(P)
-        zgemm("N", "N", &r, &r, &r, &alph, &T_mat[0,0], &ldt, &P[0,0], &ldp,
-              &beta, &tmp1[0,0], &ldt1)
-        # tmp3 = tmp1.dot(Z_mat.T)
-        zgemv("N", &r, &r, &Finv, &tmp1[0,0], &ldt1, &Z_mat[0,0], &one, &beta,
-              &K[0,0], &one)
+        # compute Kalman Gain K, equivalent to:
+        #   K = np.dot(np.dot(np.dot(T_mat, P), Z_mat.T), Finv)
+        # in two steps:
+        #   tmp1 = np.dot(T_mat, P)
+        #   K = Finv * tmp1.dot(Z_mat.T)
+        zgemm("N", "N", &r, &r, &r, &alph, &T_mat[0, 0], &ldt, &P[0, 0], &ldp,
+              &beta, &tmp1[0, 0], &ldt1)
+        zgemv("N", &r, &r, &Finv, &tmp1[0, 0], &ldt1, &Z_mat[0, 0], &one, &beta,
+              &K[0, 0], &one)
 
-        # K = tmp3.dot(Finv)
-        # update state
-        #alpha = dot(T_mat, alpha) + dot(K, v_mat)
-        #dot(T_mat, alpha)
-        zgemv("N", &r, &r, &alph, &T_mat[0,0], &ldt, &alpha[0,0], &one, &beta,
-              &tmp2[0,0], &one)
-        #dot(K, v_mat) + tmp2
-        # alpha += tmp2
+        # update state, equivalent to:
+        #   alpha = np.dot(T_mat, alpha) + np.dot(K, v_mat)
+        # in two steps:
+        #   tmp2 = np.dot(T_mat, alpha)
+        #   alpha = tmp2 + np.dot(K, v_mat)
+        zgemv("N", &r, &r, &alph, &T_mat[0, 0], &ldt, &alpha[0, 0], &one, &beta,
+              &tmp2[0, 0], &one)
         #daxpy(r, alph, &tmp2[0,0], 1, &alpha[0,0], 1)
         for ii in range(r):
-            alpha[ii,0] = K[ii,0]*v_mat + tmp2[ii,0]
-        #print "alpha:", asarray(<dcomplex[:m, :1] *> &alpha[0,0])
+            alpha[ii, 0] = K[ii, 0] * v_mat + tmp2[ii, 0]
 
-        #L = T_mat - dot(K,Z_mat)
-        zgemm("N", "N", &r, &r, &one, &alph, &K[0,0], &ldk, &Z_mat[0,0], &ldz,
-              &beta, &L[0,0], &ldl)
-
-        # L = T_mat - L
-        # L = -(L - T_mat)
+        # The next block is equivalent to:
+        #   L = T_mat - np.dot(K, Z_mat)
+        # in two steps:
+        #   L = np.dot(K, Z_mat)
+        #   L = T_mat - L
+        zgemm("N", "N", &r, &r, &one, &alph, &K[0, 0], &ldk, &Z_mat[0, 0], &ldz,
+              &beta, &L[0, 0], &ldl)
         for jj in range(r):
             for kk in range(r):
-                L[jj, kk] = T_mat[jj,kk] - L[jj,kk]
+                L[jj, kk] = T_mat[jj, kk] - L[jj, kk]
 
-        #P = dot(dot(T_mat, P), L.T) + dot(R_mat, R_mat.T)
-        # tmp5 = dot(R_mat, R_mat.T)
-        # tmp3 = dot(T_mat, P)
-        # P = dot(tmp3, L.T) + tmp5
-        zgemm("N", "N", &r, &r, &r, &alph, &T_mat[0,0], &ldt, &P[0,0], &ldp,
-              &beta, &tmp3[0,0], &ldt3)
-        zgemm("N", "T", &r, &r, &one, &alph, &R_mat[0,0], &ldr, &R_mat[0,0],
-              &ldr, &beta, &P[0,0], &ldp)
-        zgemm("N", "T", &r, &r, &r, &alph, &tmp3[0,0], &ldt3, &L[0,0], &ldl, &alph,
-              &P[0,0], &ldp)
+        # The next block computes P equivalent to:
+        #   P = np.dot(np.dot(T_mat, P), L.T) + np.dot(R_mat, R_mat.T)
+        # in three steps:
+        #   tmp5 = np.dot(R_mat, R_mat.T)
+        #   tmp3 = np.dot(T_mat, P)
+        #   P = np.dot(tmp3, L.T) + tmp5
+        zgemm("N", "N", &r, &r, &r, &alph, &T_mat[0, 0], &ldt, &P[0, 0], &ldp,
+              &beta, &tmp3[0, 0], &ldt3)
+        zgemm("N", "T", &r, &r, &one, &alph, &R_mat[0, 0], &ldr, &R_mat[0, 0],
+              &ldr, &beta, &P[0, 0], &ldp)
+        zgemm("N", "T", &r, &r, &r, &alph, &tmp3[0, 0], &ldt3, &L[0, 0], &ldl, &alph,
+              &P[0, 0], &ldp)
 
         loglikelihood += nplog(F_mat)
-        i+=1
+        i += 1
 
     for i in xrange(i,nobs):
         #v_mat = zdotu(&r, &Z_mat[0,0], &one, &alpha[0,0], &one)
-        #Z_mat is just a selector
-        v_mat = y[i] - alpha[0,0]
+        # Z_mat is just a selector
+        v_mat = y[i] - alpha[0, 0]
         v[i, 0] = v_mat
-        #alpha = dot(T_mat, alpha) + dot(K, v_mat)
-        zgemm("N", "N", &r, &one, &r, &alph, &T_mat[0,0], &ldt, &alpha[0,0], &lda,
-              &beta, &tmp2[0,0], &ldt2)
-        #dot(K, v_mat) + tmp2
-        # alpha += tmp2
+        # The next block is equivalent to:
+        #   alpha = np.dot(T_mat, alpha) + np.dot(K, v_mat)
+        # in two steps:
+        #   tmp2 = np.dot(T_mat, alpha)
+        #   alpha = np.dot(K, v_mat) + tmp2
+        zgemm("N", "N", &r, &one, &r, &alph, &T_mat[0, 0], &ldt, &alpha[0, 0], &lda,
+              &beta, &tmp2[0, 0], &ldt2)
         #daxpy(r, alph, &tmp2[0,0], 1, &alpha[0,0], 1)
         for ii in range(r):
-            alpha[ii,0] = K[ii,0]*v_mat + tmp2[ii,0]
+            alpha[ii, 0] = K[ii, 0] * v_mat + tmp2[ii, 0]
     return v, F, loglikelihood
+
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
@@ -344,6 +346,7 @@ def kalman_loglike_double(double[:] y, unsigned int k, unsigned int p,
     loglike = -.5 *(loglikelihood + nobs*log(sigma2))
     loglike -= nobs/2. * (log(2*pi) + 1)
     return loglike, sigma2
+
 
 @cython.boundscheck(False)
 @cython.wraparound(False)

--- a/statsmodels/tsa/kalmanf/kalman_loglike.pyx
+++ b/statsmodels/tsa/kalmanf/kalman_loglike.pyx
@@ -1,5 +1,5 @@
 import scipy.linalg.blas
-from numpy cimport float64_t, ndarray, complex128_t, complex64_t
+from numpy cimport float64_t, ndarray, complex128_t
 from numpy import log as nplog
 from numpy import (identity, dot, kron, pi, sum, zeros_like, ones, asarray,
                    complex128, float64, asfortranarray)
@@ -14,7 +14,6 @@ from numpy cimport PyArray_ZEROS
 
 ctypedef float64_t DOUBLE
 ctypedef complex128_t dcomplex
-ctypedef complex64_t COMPLEX64
 cdef int FORTRAN = 1
 
 cdef extern from "math.h":
@@ -217,8 +216,8 @@ def kalman_filter_complex(dcomplex[:] y,
         int ldt = T_mat.strides[1] / sizeof(dcomplex)
         int ldr = R_mat.strides[1] / sizeof(dcomplex)
         # forecast errors
-        ndarray[complex64_t, ndim=2] v = PyArray_ZEROS(2, yshape,
-                                                       cnp.NPY_CDOUBLE, FORTRAN)
+        ndarray[complex, ndim=2] v = PyArray_ZEROS(2, yshape,
+                                                   cnp.NPY_CDOUBLE, FORTRAN)
         # store variance of forecast errors
         dcomplex[::1, :] F = ones((nobs, 1), dtype=complex, order='F')
         dcomplex loglikelihood = 0 + 0j

--- a/statsmodels/tsa/kalmanf/kalman_loglike.pyx
+++ b/statsmodels/tsa/kalmanf/kalman_loglike.pyx
@@ -23,14 +23,21 @@ cdef extern from "math.h":
 cdef extern from "capsule.h":
     void* Capsule_AsVoidPtr(object ptr)
 
-from statsmodels.src.blas_lapack cimport dgemm_t, zgemm_t, ddot_t, dgemv_t, zgemv_t, zdotu_t
+from statsmodels.src.blas_lapack cimport (
+    dgemm_t, zgemm_t, ddot_t, dgemv_t, zgemv_t, zdotu_t)
 
-cdef dgemm_t *dgemm = <dgemm_t*>Capsule_AsVoidPtr(scipy.linalg.blas.get_blas_funcs('gemm', dtype=float64)._cpointer)
-cdef zgemm_t *zgemm = <zgemm_t*>Capsule_AsVoidPtr(scipy.linalg.blas.get_blas_funcs('gemm', dtype=complex128)._cpointer)
-cdef ddot_t *ddot = <ddot_t*>Capsule_AsVoidPtr(scipy.linalg.blas.get_blas_funcs('dot', dtype=float64)._cpointer)
-cdef dgemv_t *dgemv = <dgemv_t*>Capsule_AsVoidPtr(scipy.linalg.blas.get_blas_funcs('gemv', dtype=float64)._cpointer)
-cdef zdotu_t *zdotu = <zdotu_t*>Capsule_AsVoidPtr(scipy.linalg.blas.get_blas_funcs('dotu', dtype=complex128)._cpointer)
-cdef zgemv_t *zgemv = <zgemv_t*>Capsule_AsVoidPtr(scipy.linalg.blas.get_blas_funcs('gemv', dtype=complex128)._cpointer)
+cdef dgemm_t *dgemm = <dgemm_t*>Capsule_AsVoidPtr(
+    scipy.linalg.blas.get_blas_funcs('gemm', dtype=float64)._cpointer)
+cdef zgemm_t *zgemm = <zgemm_t*>Capsule_AsVoidPtr(
+    scipy.linalg.blas.get_blas_funcs('gemm', dtype=complex128)._cpointer)
+cdef ddot_t *ddot = <ddot_t*>Capsule_AsVoidPtr(
+    scipy.linalg.blas.get_blas_funcs('dot', dtype=float64)._cpointer)
+cdef dgemv_t *dgemv = <dgemv_t*>Capsule_AsVoidPtr(
+    scipy.linalg.blas.get_blas_funcs('gemv', dtype=float64)._cpointer)
+cdef zdotu_t *zdotu = <zdotu_t*>Capsule_AsVoidPtr(
+    scipy.linalg.blas.get_blas_funcs('dotu', dtype=complex128)._cpointer)
+cdef zgemv_t *zgemv = <zgemv_t*>Capsule_AsVoidPtr(
+    scipy.linalg.blas.get_blas_funcs('gemv', dtype=complex128)._cpointer)
 
 
 @cython.boundscheck(False)
@@ -56,65 +63,58 @@ def kalman_filter_double(double[:] y not None,
     r2shape[1] = <cnp.npy_intp> r
 
     cdef:
-        int one = 1 # univariate filter
-        int ldz = Z_mat.strides[1]/sizeof(DOUBLE)
-        int ldt = T_mat.strides[1]/sizeof(DOUBLE)
-        int ldr = R_mat.strides[1]/sizeof(DOUBLE)
+        int one = 1  # univariate filter
+        int ldz = Z_mat.strides[1] / sizeof(DOUBLE)
+        int ldt = T_mat.strides[1] / sizeof(DOUBLE)
+        int ldr = R_mat.strides[1] / sizeof(DOUBLE)
         # forecast errors
         ndarray[DOUBLE, ndim=2] v = PyArray_ZEROS(2, yshape, cnp.NPY_DOUBLE,
                                                   FORTRAN)
         # store variance of forecast errors
-        double[::1,:] F = ones((nobs,1), order='F') # variance of forecast errors
+        double[::1, :] F = ones((nobs,1), order='F')  # variance of forecast errors
         double loglikelihood = 0
         int i = 0
         # initial state
-        double[::1,:] alpha = PyArray_ZEROS(2, mshape, cnp.NPY_DOUBLE, FORTRAN)
-        int lda = alpha.strides[1]/sizeof(DOUBLE)
+        double[::1, :] alpha = PyArray_ZEROS(2, mshape, cnp.NPY_DOUBLE, FORTRAN)
+        int lda = alpha.strides[1] / sizeof(DOUBLE)
         # initial variance
-        double[::1,:] P = asfortranarray(dot(pinv(identity(r**2)-
-                                                  kron(T_mat, T_mat)),
-                                             dot(R_mat,
-                                                 R_mat.T).ravel('F')
-                                             ).reshape(r, r, order='F'))
-        int ldp = P.strides[1]/sizeof(DOUBLE)
+        double[::1, :] P = asfortranarray(dot(pinv(identity(r**2) -
+                                                   kron(T_mat, T_mat)),
+                                              dot(R_mat,
+                                                  R_mat.T).ravel('F')
+                                              ).reshape(r, r, order='F'))
+        int ldp = P.strides[1] / sizeof(DOUBLE)
         double F_mat = 0.
         double Finv = 0.
-        #ndarray[DOUBLE, ndim=2] v_mat = cnp.PyArray_Zeros(2, [1,1], cnp.NPY_FLOAT64,
-        #                                                   0)
         double v_mat = 0
-        double[::1,:] K = PyArray_ZEROS(2, r2shape, cnp.NPY_DOUBLE, FORTRAN)
+        double[::1, :] K = PyArray_ZEROS(2, r2shape, cnp.NPY_DOUBLE, FORTRAN)
         int ldk = K.strides[1] / sizeof(DOUBLE)
 
         # pre-allocate some tmp arrays for the dgemm calls
         # T_mat rows x P cols
-        double[::1,:] tmp1 = PyArray_ZEROS(2, r2shape, cnp.NPY_DOUBLE, FORTRAN)
-        int ldt1 = tmp1.strides[1]/sizeof(DOUBLE)
-        double[::1,:] tmp2 = zeros_like(alpha, order='F') # K rows x v_mat cols
-        int ldt2 = tmp2.strides[1]/sizeof(DOUBLE)
-        double[::1,:] L = zeros_like(T_mat, order='F')
-        int ldl = L.strides[1]/sizeof(DOUBLE)
+        double[::1, :] tmp1 = PyArray_ZEROS(2, r2shape, cnp.NPY_DOUBLE, FORTRAN)
+        int ldt1 = tmp1.strides[1] / sizeof(DOUBLE)
+        double[::1, :] tmp2 = zeros_like(alpha, order='F')  # K rows x v_mat cols
+        int ldt2 = tmp2.strides[1] / sizeof(DOUBLE)
+        double[::1, :] L = zeros_like(T_mat, order='F')
+        int ldl = L.strides[1] / sizeof(DOUBLE)
         # T_mat rows x P cols
-        double[::1,:] tmp3 = PyArray_ZEROS(2, r2shape, cnp.NPY_DOUBLE, FORTRAN)
-        int ldt3 = tmp3.strides[1]/sizeof(DOUBLE)
+        double[::1, :] tmp3 = PyArray_ZEROS(2, r2shape, cnp.NPY_DOUBLE, FORTRAN)
+        int ldt3 = tmp3.strides[1] / sizeof(DOUBLE)
 
         double alph = 1.0
         double beta = 0.0
 
-    #NOTE: not sure about just checking F_mat[0,0], didn't appear to work
+    # NOTE: not sure about just checking F_mat[0, 0], didn't appear to work
     while not F_mat == 1. and i < nobs:
         # Predict
-        #v_mat = ddot(&r, &Z_mat[0,0], &one, &alpha[0,0], &one)
-        #v_mat = y[i] - v_mat # copies?
         # Z_mat is just a selector matrix
-        v_mat = y[i] - alpha[0,0]
+        v_mat = y[i] - alpha[0, 0]
         v[i, 0] = v_mat
 
-        # one-step forecast error
-        #dgemm("N", "N", &one, &r, &r, &alph, &Z_mat[0,0], &ldz, &P[0,0], &ldp,
-        #      &beta, &tmp1[0,0], &ldt1)
-        #F_mat = ddot(&r, &tmp1[0,0], &one, &Z_mat[0,0], &one)
-        #Z_mat is just a selector matrix
-        F_mat = P[0,0]
+        # one-step forecast error covariance
+        # Z_mat is just a selector matrix
+        F_mat = P[0, 0]
         F[i,0] = F_mat
         Finv = 1. / F_mat  # always scalar for univariate series
 
@@ -123,18 +123,21 @@ def kalman_filter_double(double[:] y not None,
         # in two steps:
         #   tmp1 = np.dot(T_mat, P)
         #   K = Finv * tmp1.dot(Z_mat.T)
-        dgemm("N", "N", &r, &r, &r, &alph, &T_mat[0, 0], &ldt, &P[0, 0], &ldp,
+        dgemm("N", "N", &r, &r, &r,
+              &alph, &T_mat[0, 0], &ldt, &P[0, 0], &ldp,
               &beta, &tmp1[0, 0], &ldt1)
-        dgemv("N", &r, &r, &Finv, &tmp1[0, 0], &ldt1, &Z_mat[0, 0], &one, &beta,
-              &K[0, 0], &one)
+        dgemv("N", &r, &r,
+              &Finv, &tmp1[0, 0], &ldt1, &Z_mat[0, 0], &one,
+              &beta, &K[0, 0], &one)
 
         # update state; equivalent to:
         #   alpha = np.dot(T_mat, alpha) + np.dot(K, v_mat)
         # in two steps:
         #   tmp2 = np.dot(T_mat, alpha)
         #   alpha = tmp2 + np.dot(K, v_mat)
-        dgemv("N", &r, &r, &alph, &T_mat[0, 0], &ldt, &alpha[0, 0], &one, &beta,
-              &tmp2[0, 0], &one)
+        dgemv("N", &r, &r,
+              &alph, &T_mat[0, 0], &ldt, &alpha[0, 0], &one,
+              &beta, &tmp2[0, 0], &one)
         for ii in range(r):
             alpha[ii, 0] = K[ii, 0] * v_mat + tmp2[ii, 0]
 
@@ -143,7 +146,8 @@ def kalman_filter_double(double[:] y not None,
         # in two steps:
         #   L = np.dot(K, Z_mat)
         #   L = T_mat - L
-        dgemm("N", "N", &r, &r, &one, &alph, &K[0, 0], &ldk, &Z_mat[0, 0], &ldz,
+        dgemm("N", "N", &r, &r, &one,
+              &alph, &K[0, 0], &ldk, &Z_mat[0, 0], &ldz,
               &beta, &L[0, 0], &ldl)
         for jj in range(r):
             for kk in range(r):
@@ -155,23 +159,20 @@ def kalman_filter_double(double[:] y not None,
         #   tmp5 = np.dot(R_mat, R_mat.T)
         #   tmp3 = np.dot(T_mat, P)
         #   P = np.dot(tmp3, L.T) + tmp5
-        dgemm("N", "N", &r, &r, &r, &alph, &T_mat[0, 0], &ldt, &P[0, 0],
-              &ldp, &beta, &tmp3[0, 0], &ldt3)
-        dgemm("N", "T", &r, &r, &one, &alph, &R_mat[0, 0], &ldr, &R_mat[0, 0],
-              &ldr, &beta, &P[0, 0], &ldp)
-        dgemm("N", "T", &r, &r, &r, &alph, &tmp3[0, 0], &ldt3, &L[0, 0],
-              &ldl, &alph, &P[0, 0], &ldp)
-
-        # 101 = c-order, 122 - lower triangular of R, "N" - no trans (XX')
-        #dsyrk(101, 122, "N", r, 1, 1.0, &R_mat[0,0],
-        #      &ldr, 1.0, &P[0,0], &ldp )
+        dgemm("N", "N", &r, &r, &r,
+              &alph, &T_mat[0, 0], &ldt, &P[0, 0], &ldp,
+              &beta, &tmp3[0, 0], &ldt3)
+        dgemm("N", "T", &r, &r, &one,
+              &alph, &R_mat[0, 0], &ldr, &R_mat[0, 0], &ldr,
+              &beta, &P[0, 0], &ldp)
+        dgemm("N", "T", &r, &r, &r,
+              &alph, &tmp3[0, 0], &ldt3, &L[0, 0], &ldl,
+              &alph, &P[0, 0], &ldp)
 
         loglikelihood += log(F_mat)
         i += 1
 
     for i in xrange(i,nobs):
-        #v_mat = ddot(&r, &Z_mat[0,0], &one, &alpha[0,0], &one)
-        #v_mat = y[i] - v_mat
         v_mat = y[i] - alpha[0, 0]
         v[i, 0] = v_mat
         # The next block is equivalent to:
@@ -179,8 +180,9 @@ def kalman_filter_double(double[:] y not None,
         # in two steps:
         #   tmp2 = np.dot(T_mat, alpha)
         #   alpha = np.dot(K, v_mat) + tmp2
-        dgemm("N", "N", &r, &one, &r, &alph, &T_mat[0, 0], &ldt, &alpha[0, 0],
-              &lda, &beta, &tmp2[0, 0], &ldt2)
+        dgemm("N", "N", &r, &one, &r,
+              &alph, &T_mat[0, 0], &ldt, &alpha[0, 0], &lda,
+              &beta, &tmp2[0, 0], &ldt2)
         for ii in range(r):
             alpha[ii, 0] = K[ii, 0] * v_mat + tmp2[ii, 0]
     return v, F, loglikelihood
@@ -192,9 +194,9 @@ def kalman_filter_double(double[:] y not None,
 def kalman_filter_complex(dcomplex[:] y,
                           unsigned int k, unsigned int p, unsigned int q,
                           int r, unsigned int nobs,
-                          dcomplex[::1,:] Z_mat,
-                          dcomplex[::1,:] R_mat,
-                          dcomplex[::1,:] T_mat):
+                          dcomplex[::1, :] Z_mat,
+                          dcomplex[::1, :] R_mat,
+                          dcomplex[::1, :] T_mat):
     """
     Cython version of the Kalman filter recursions for an ARMA process.
     """
@@ -211,57 +213,55 @@ def kalman_filter_complex(dcomplex[:] y,
 
     cdef:
         int one = 1
-        int ldz = Z_mat.strides[1]/sizeof(dcomplex)
-        int ldt = T_mat.strides[1]/sizeof(dcomplex)
-        int ldr = R_mat.strides[1]/sizeof(dcomplex)
+        int ldz = Z_mat.strides[1] / sizeof(dcomplex)
+        int ldt = T_mat.strides[1] / sizeof(dcomplex)
+        int ldr = R_mat.strides[1] / sizeof(dcomplex)
         # forecast errors
-        ndarray[complex, ndim=2] v = PyArray_ZEROS(2, yshape, cnp.NPY_CDOUBLE,
-                                                   FORTRAN)
+        ndarray[complex64_t, ndim=2] v = PyArray_ZEROS(2, yshape,
+                                                       cnp.NPY_CDOUBLE, FORTRAN)
         # store variance of forecast errors
-        dcomplex[::1,:] F = ones((nobs,1), dtype=complex, order='F')
+        dcomplex[::1, :] F = ones((nobs, 1), dtype=complex, order='F')
         dcomplex loglikelihood = 0 + 0j
         int i = 0
         # initial state
-        dcomplex[::1,:] alpha = PyArray_ZEROS(2, mshape, cnp.NPY_CDOUBLE, FORTRAN)
-        int lda = alpha.strides[1]/sizeof(dcomplex)
+        dcomplex[::1, :] alpha = PyArray_ZEROS(2, mshape,
+                                               cnp.NPY_CDOUBLE, FORTRAN)
+        int lda = alpha.strides[1] / sizeof(dcomplex)
         # initial variance
-        dcomplex[::1,:] P = asfortranarray(dot(pinv(identity(r**2)-kron(T_mat, T_mat)),
-                                           dot(R_mat,R_mat.T).ravel('F')).reshape(r,r, order='F'))
-        int ldp = P.strides[1]/sizeof(dcomplex)
+        dcomplex[::1, :] P = asfortranarray(dot(pinv(identity(r**2) - kron(T_mat, T_mat)),
+                                            dot(R_mat, R_mat.T).ravel('F')).reshape(r, r, order='F'))
+        int ldp = P.strides[1] / sizeof(dcomplex)
         dcomplex F_mat = 0
         dcomplex Finv = 0
-        # dcomplex[:,:] v_mat = zeros((1,1), dtype=complex)
         dcomplex v_mat = 0
-        dcomplex[::1,:] K = PyArray_ZEROS(2, mshape, cnp.NPY_CDOUBLE, FORTRAN)
-        int ldk = K.strides[1]/sizeof(dcomplex)
+        dcomplex[::1, :] K = PyArray_ZEROS(2, mshape, cnp.NPY_CDOUBLE, FORTRAN)
+        int ldk = K.strides[1] / sizeof(dcomplex)
 
         # pre-allocate some tmp arrays for the dgemm calls
-        dcomplex[::1,:] tmp1 = PyArray_ZEROS(2, r2shape, cnp.NPY_CDOUBLE, FORTRAN)
-        int ldt1 = tmp1.strides[1]/sizeof(dcomplex)
-        dcomplex[::1,:] tmp2 = zeros_like(alpha, order='F')
-        int ldt2 = tmp2.strides[1]/sizeof(dcomplex)
-        dcomplex[::1,:] L = zeros_like(T_mat, dtype=complex, order='F')
-        int ldl = L.strides[1]/sizeof(dcomplex)
+        dcomplex[::1, :] tmp1 = PyArray_ZEROS(2, r2shape,
+                                              cnp.NPY_CDOUBLE, FORTRAN)
+        int ldt1 = tmp1.strides[1] / sizeof(dcomplex)
+        dcomplex[::1, :] tmp2 = zeros_like(alpha, order='F')
+        int ldt2 = tmp2.strides[1] / sizeof(dcomplex)
+        dcomplex[::1, :] L = zeros_like(T_mat, dtype=complex, order='F')
+        int ldl = L.strides[1] / sizeof(dcomplex)
         # T_mat rows x P cols
-        dcomplex[::1,:] tmp3 = PyArray_ZEROS(2, r2shape, cnp.NPY_CDOUBLE, FORTRAN)
-        int ldt3 = tmp3.strides[1]/sizeof(dcomplex)
+        dcomplex[::1, :] tmp3 = PyArray_ZEROS(2, r2shape,
+                                              cnp.NPY_CDOUBLE, FORTRAN)
+        int ldt3 = tmp3.strides[1] / sizeof(dcomplex)
 
-        dcomplex alph = 1+0j
+        dcomplex alph = 1 + 0j
         dcomplex beta = 0
 
-    while not F_mat == 1 and i < nobs:
-        #v_mat = zdotu(&r, &Z_mat[0,0], &one, &alpha[0,0], &one)
+    while F_mat != 1 and i < nobs:
         # Z_mat is just a selector matrix
         v_mat = y[i] - alpha[0,0]
         v[i, 0] = v_mat
 
-        # one-step forecast error
-        #zgemm("N", "N", &one, &r, &r, &alph, &Z_mat[0,0], &ldz, &P[0,0], &ldp,
-        #      &beta, &tmp1[0,0], &ldt1)
-        # F_mat = zdotu(&r, &tmp1[0,0], &one, &Z_mat[0,0], &one)
+        # one-step forecast error covariance
         # Z_mat is just a selctor matrix so the below is equivalent
-        F_mat = P[0,0]
-        F[i,0] = F_mat
+        F_mat = P[0, 0]
+        F[i, 0] = F_mat
         Finv = 1. / F_mat  # always scalar for univariate series
 
         # compute Kalman Gain K, equivalent to:
@@ -269,19 +269,21 @@ def kalman_filter_complex(dcomplex[:] y,
         # in two steps:
         #   tmp1 = np.dot(T_mat, P)
         #   K = Finv * tmp1.dot(Z_mat.T)
-        zgemm("N", "N", &r, &r, &r, &alph, &T_mat[0, 0], &ldt, &P[0, 0], &ldp,
+        zgemm("N", "N", &r, &r, &r,
+              &alph, &T_mat[0, 0], &ldt, &P[0, 0], &ldp,
               &beta, &tmp1[0, 0], &ldt1)
-        zgemv("N", &r, &r, &Finv, &tmp1[0, 0], &ldt1, &Z_mat[0, 0], &one, &beta,
-              &K[0, 0], &one)
+        zgemv("N", &r, &r,
+              &Finv, &tmp1[0, 0], &ldt1, &Z_mat[0, 0], &one,
+              &beta, &K[0, 0], &one)
 
         # update state, equivalent to:
         #   alpha = np.dot(T_mat, alpha) + np.dot(K, v_mat)
         # in two steps:
         #   tmp2 = np.dot(T_mat, alpha)
         #   alpha = tmp2 + np.dot(K, v_mat)
-        zgemv("N", &r, &r, &alph, &T_mat[0, 0], &ldt, &alpha[0, 0], &one, &beta,
-              &tmp2[0, 0], &one)
-        #daxpy(r, alph, &tmp2[0,0], 1, &alpha[0,0], 1)
+        zgemv("N", &r, &r,
+              &alph, &T_mat[0, 0], &ldt, &alpha[0, 0], &one,
+              &beta, &tmp2[0, 0], &one)
         for ii in range(r):
             alpha[ii, 0] = K[ii, 0] * v_mat + tmp2[ii, 0]
 
@@ -290,7 +292,8 @@ def kalman_filter_complex(dcomplex[:] y,
         # in two steps:
         #   L = np.dot(K, Z_mat)
         #   L = T_mat - L
-        zgemm("N", "N", &r, &r, &one, &alph, &K[0, 0], &ldk, &Z_mat[0, 0], &ldz,
+        zgemm("N", "N", &r, &r, &one,
+              &alph, &K[0, 0], &ldk, &Z_mat[0, 0], &ldz,
               &beta, &L[0, 0], &ldl)
         for jj in range(r):
             for kk in range(r):
@@ -302,18 +305,20 @@ def kalman_filter_complex(dcomplex[:] y,
         #   tmp5 = np.dot(R_mat, R_mat.T)
         #   tmp3 = np.dot(T_mat, P)
         #   P = np.dot(tmp3, L.T) + tmp5
-        zgemm("N", "N", &r, &r, &r, &alph, &T_mat[0, 0], &ldt, &P[0, 0], &ldp,
+        zgemm("N", "N", &r, &r, &r,
+              &alph, &T_mat[0, 0], &ldt, &P[0, 0], &ldp,
               &beta, &tmp3[0, 0], &ldt3)
-        zgemm("N", "T", &r, &r, &one, &alph, &R_mat[0, 0], &ldr, &R_mat[0, 0],
-              &ldr, &beta, &P[0, 0], &ldp)
-        zgemm("N", "T", &r, &r, &r, &alph, &tmp3[0, 0], &ldt3, &L[0, 0], &ldl, &alph,
-              &P[0, 0], &ldp)
+        zgemm("N", "T", &r, &r, &one,
+              &alph, &R_mat[0, 0], &ldr, &R_mat[0, 0], &ldr,
+              &beta, &P[0, 0], &ldp)
+        zgemm("N", "T", &r, &r, &r,
+              &alph, &tmp3[0, 0], &ldt3, &L[0, 0], &ldl,
+              &alph, &P[0, 0], &ldp)
 
         loglikelihood += nplog(F_mat)
         i += 1
 
-    for i in xrange(i,nobs):
-        #v_mat = zdotu(&r, &Z_mat[0,0], &one, &alpha[0,0], &one)
+    for i in xrange(i, nobs):
         # Z_mat is just a selector
         v_mat = y[i] - alpha[0, 0]
         v[i, 0] = v_mat
@@ -322,11 +327,12 @@ def kalman_filter_complex(dcomplex[:] y,
         # in two steps:
         #   tmp2 = np.dot(T_mat, alpha)
         #   alpha = np.dot(K, v_mat) + tmp2
-        zgemm("N", "N", &r, &one, &r, &alph, &T_mat[0, 0], &ldt, &alpha[0, 0], &lda,
+        zgemm("N", "N", &r, &one, &r,
+              &alph, &T_mat[0, 0], &ldt, &alpha[0, 0], &lda,
               &beta, &tmp2[0, 0], &ldt2)
-        #daxpy(r, alph, &tmp2[0,0], 1, &alpha[0,0], 1)
         for ii in range(r):
             alpha[ii, 0] = K[ii, 0] * v_mat + tmp2[ii, 0]
+
     return v, F, loglikelihood
 
 
@@ -335,16 +341,17 @@ def kalman_filter_complex(dcomplex[:] y,
 @cython.cdivision(True)
 def kalman_loglike_double(double[:] y, unsigned int k, unsigned int p,
                           unsigned int q, int r, unsigned int nobs,
-                          double[::1,:] Z_mat,
-                          double[::1,:] R_mat,
-                          double[::1,:] T_mat):
+                          double[::1, :] Z_mat,
+                          double[::1, :] R_mat,
+                          double[::1, :] T_mat):
     """
     Cython version of the Kalman filter recursions for an ARMA process.
     """
-    v, F, loglikelihood = kalman_filter_double(y,k,p,q,r,nobs,Z_mat,R_mat,T_mat)
-    sigma2 = 1./nobs * sum(v**2 / F)
-    loglike = -.5 *(loglikelihood + nobs*log(sigma2))
-    loglike -= nobs/2. * (log(2*pi) + 1)
+    v, F, loglikelihood = kalman_filter_double(y, k, p, q, r, nobs,
+                                               Z_mat, R_mat, T_mat)
+    sigma2 = 1. / nobs * sum(v**2 / F)
+    loglike = -.5 * (loglikelihood + nobs * log(sigma2))
+    loglike -= nobs / 2. * (log(2 * pi) + 1)
     return loglike, sigma2
 
 
@@ -353,14 +360,15 @@ def kalman_loglike_double(double[:] y, unsigned int k, unsigned int p,
 @cython.cdivision(True)
 def kalman_loglike_complex(dcomplex[:] y, unsigned int k, unsigned int p,
                            unsigned int q, int r, unsigned int nobs,
-                           dcomplex[::1,:] Z_mat,
-                           dcomplex[::1,:] R_mat,
-                           dcomplex[::1,:] T_mat):
+                           dcomplex[::1, :] Z_mat,
+                           dcomplex[::1, :] R_mat,
+                           dcomplex[::1, :] T_mat):
     """
     Cython version of the Kalman filter recursions for an ARMA process.
     """
-    v, F, loglikelihood = kalman_filter_complex(y,k,p,q,r,nobs,Z_mat,R_mat,T_mat)
-    sigma2 = 1./nobs * sum(v**2 / F)
-    loglike = -.5 *(loglikelihood + nobs*nplog(sigma2))
-    loglike -= nobs/2. * (log(2*pi) + 1)
+    v, F, loglikelihood = kalman_filter_complex(y, k, p, q, r, nobs,
+                                                Z_mat, R_mat, T_mat)
+    sigma2 = 1. / nobs * sum(v**2 / F)
+    loglike = -.5 * (loglikelihood + nobs * nplog(sigma2))
+    loglike -= nobs / 2. * (log(2 * pi) + 1)
     return loglike, sigma2

--- a/statsmodels/tsa/kalmanf/kalmanfilter.py
+++ b/statsmodels/tsa/kalmanf/kalmanfilter.py
@@ -17,7 +17,7 @@ This file follows Hamilton's notation pretty closely.
 The ARMA Model class follows Durbin and Koopman notation.
 Harvey uses Durbin and Koopman notation.
 """
-#Anderson and Moore `Optimal Filtering` provides a more efficient algorithm
+# Anderson and Moore `Optimal Filtering` provides a more efficient algorithm
 # namely the information filter
 # if the number of series is much greater than the number of states
 # e.g., with a DSGE model.  See also
@@ -27,12 +27,12 @@ Harvey uses Durbin and Koopman notation.
 from __future__ import print_function
 from statsmodels.compat.python import lzip, lmap, callable, range
 import numpy as np
-from numpy import dot, identity, kron, log, zeros, pi, exp, eye, issubdtype, ones
+from numpy import dot, identity, kron, log, zeros, pi, eye, issubdtype, ones
 from numpy.linalg import inv, pinv
 from statsmodels.tools.tools import chain_dot
 from . import kalman_loglike
 
-#Fast filtering and smoothing for multivariate state space models
+# Fast filtering and smoothing for multivariate state space models
 # and The Riksbank -- Strid and Walentin (2008)
 # Block Kalman filtering for large-scale DSGE models
 # but this is obviously macro model specific
@@ -465,6 +465,7 @@ def updatematrices(params, y, xi10, ntrain, penalty, upperbound, lowerbound):
     loglike = loglike + penalty*np.sum((paramsorig-params)**2)
     return loglike
 
+
 class KalmanFilter(object):
     """
     Kalman Filter code intended for use with the ARMA model.
@@ -485,7 +486,7 @@ class KalmanFilter(object):
     """
 
     @classmethod
-    def T(cls, params, r, k, p): # F in Hamilton
+    def T(cls, params, r, k, p):  # F in Hamilton
         """
         The coefficient matrix for the state vector in the state equation.
 
@@ -510,15 +511,16 @@ class KalmanFilter(object):
         # allows for complex-step derivative
         params_padded = zeros(r, dtype=params.dtype,
                               order="F")
-                        # handle zero coefficients if necessary
-        #NOTE: squeeze added for cg optimizer
-        params_padded[:p] = params[k:p+k]
-        arr[:,0] = params_padded   # first p params are AR coeffs w/ short params
-        arr[:-1,1:] = eye(r-1)
+        # handle zero coefficients if necessary
+        # NOTE: squeeze added for cg optimizer
+        params_padded[:p] = params[k:p + k]
+        arr[:, 0] = params_padded
+        # first p params are AR coeffs w/ short params
+        arr[:-1, 1:] = eye(r - 1)
         return arr
 
     @classmethod
-    def R(cls, params, r, k, q, p): # R is H in Hamilton
+    def R(cls, params, r, k, q, p):  # R is H in Hamilton
         """
         The coefficient matrix for the state vector in the observation equation.
 
@@ -542,9 +544,9 @@ class KalmanFilter(object):
         Durbin and Koopman Section 3.7.
         """
         arr = zeros((r, 1), dtype=params.dtype, order="F")
-                               # this allows zero coefficients
-                               # dtype allows for compl. der.
-        arr[1:q+1,:] = params[p+k:p+k+q][:,None]
+        # this allows zero coefficients
+        # dtype allows for compl. der.
+        arr[1:q + 1, :] = params[p + k:p + k + q][: ,None]
         arr[0] = 1.0
         return arr
 
@@ -564,8 +566,8 @@ class KalmanFilter(object):
         Currently only returns a 1 x r vector [1,0,0,...0].  Will need to
         be generalized when the Kalman Filter becomes more flexible.
         """
-        arr = zeros((1,r), order="F")
-        arr[:,0] = 1.
+        arr = zeros((1, r), order="F")
+        arr[:, 0] = 1.
         return arr
 
     @classmethod
@@ -575,11 +577,11 @@ class KalmanFilter(object):
         Returns just the errors of the Kalman Filter
         """
         if issubdtype(paramsdtype, np.float64):
-            return kalman_loglike.kalman_filter_double(y, k, k_ar, k_ma,
-                                k_lags, int(nobs), Z_mat, R_mat, T_mat)[0]
+            return kalman_loglike.kalman_filter_double(
+                y, k, k_ar, k_ma, k_lags, int(nobs), Z_mat, R_mat, T_mat)[0]
         elif issubdtype(paramsdtype, np.complex128):
-            return kalman_loglike.kalman_filter_complex(y, k, k_ar, k_ma,
-                                k_lags, int(nobs), Z_mat, R_mat, T_mat)[0]
+            return kalman_loglike.kalman_filter_complex(
+                y, k, k_ar, k_ma, k_lags, int(nobs), Z_mat, R_mat, T_mat)[0]
         else:
             raise TypeError("dtype %s is not supported "
                             "Please file a bug report" % paramsdtype)
@@ -608,11 +610,11 @@ class KalmanFilter(object):
 
         # system matrices
         Z_mat = cls.Z(k_lags)
-        m = Z_mat.shape[1] # r
+        m = Z_mat.shape[1]  # r
         R_mat = cls.R(newparams, k_lags, k, k_ma, k_ar)
         T_mat = cls.T(newparams, k_lags, k, k_ar)
         return (y, k, nobs, k_ar, k_ma, k_lags,
-               newparams, Z_mat, m, R_mat, T_mat, paramsdtype)
+                newparams, Z_mat, m, R_mat, T_mat, paramsdtype)
 
     @classmethod
     def loglike(cls, params, arma_model, set_sigma2=True):
@@ -638,20 +640,19 @@ class KalmanFilter(object):
         complex values being used to compute the numerical derivative. If
         available will use a Cython version of the Kalman Filter.
         """
-        #TODO: see section 3.4.6 in Harvey for computing the derivatives in the
+        # TODO: see section 3.4.6 in Harvey for computing the derivatives in the
         # recursion itself.
-        #TODO: this won't work for time-varying parameters
+        # TODO: this won't work for time-varying parameters
         (y, k, nobs, k_ar, k_ma, k_lags, newparams, Z_mat, m, R_mat, T_mat,
-                paramsdtype) = cls._init_kalman_state(params, arma_model)
+         paramsdtype) = cls._init_kalman_state(params, arma_model)
         if issubdtype(paramsdtype, np.float64):
-            loglike, sigma2 =  kalman_loglike.kalman_loglike_double(y, k,
-                                    k_ar, k_ma, k_lags, int(nobs), Z_mat,
-                                    R_mat, T_mat)
+            loglike, sigma2 =  kalman_loglike.kalman_loglike_double(
+                y, k, k_ar, k_ma, k_lags, int(nobs),
+                Z_mat, R_mat, T_mat)
         elif issubdtype(paramsdtype, np.complex128):
-            loglike, sigma2 =  kalman_loglike.kalman_loglike_complex(y, k,
-                                    k_ar, k_ma, k_lags, int(nobs),
-                                    Z_mat.astype(complex),
-                                    R_mat, T_mat)
+            loglike, sigma2 =  kalman_loglike.kalman_loglike_complex(
+                y, k, k_ar, k_ma, k_lags, int(nobs),
+                Z_mat.astype(complex), R_mat, T_mat)
         else:
             raise TypeError("This dtype %s is not supported "
                             " Please files a bug report." % paramsdtype)

--- a/statsmodels/tsa/statespace/_tools.pyx.in
+++ b/statsmodels/tsa/statespace/_tools.pyx.in
@@ -65,35 +65,6 @@ if prefix == 's':
     combined_cython_type = 'np.float64_t'
 }}
 
-# cpdef {{prefix}}solve_discrete_lyapunov({{cython_type}} [::1,:] a, {{cython_type}} [::1,:] q, int overwrite=False):
-#     cdef:
-#         int inc = 1
-#         int n = a.shape[0]
-#         int n2 = n**2
-#     cdef {{cython_type}} * _a
-#     cdef {{cython_type}} * _q
-#     cdef np.npy_intp dim[2]
-#     cdef {{cython_type}} [::1,:] a_copy, q_copy
-    
-#     if not overwrite:
-#         dim[0] = n; dim[1] = n;
-#         a_copy = np.PyArray_ZEROS(2, dim, {{typenum}}, FORTRAN)
-#         _a = &a_copy[0,0]
-#         blas.{{prefix}}copy(&n2, &a[0,0], &inc, _a, &inc)
-
-#         q_copy = np.PyArray_ZEROS(2, dim, {{typenum}}, FORTRAN)
-#         _q = &q_copy[0,0]
-#         blas.{{prefix}}copy(&n2, &q[0,0], &inc, _q, &inc)
-#     else:
-#         _a = &a[0,0]
-#         _q = &q[0,0]
-
-#     _{{prefix}}solve_discrete_lyapunov(_a, _q, n)
-
-#     if not overwrite:
-#         return np.array(q_copy)
-#     else:
-#         return np.array(q)
 
 cdef bint _{{prefix}}select1({{cython_type}} * a):
     return 0


### PR DESCRIPTION
@ChadFulton It took me a while to figure out what parts of kalman_loglike were doing, so I went ahead and wrote up comments to clarify it for the next reader.  In many cases the existing comments appear to be doing something similar, but I find this much clearer.

There is some remaining commented-out code that I'd like to document/clean up in a similar way, some of which I can do after looking up blas functions; other parts would require your input.

While I was at it I deleted a commented-out implementation of solve_discrete_lyapunov, since it has been replaced by a version immediately below it.