### PR TITLE
TST pandas compat, skip test_simulate on WIN

### DIFF
--- a/statsmodels/multivariate/tests/test_factor.py
+++ b/statsmodels/multivariate/tests/test_factor.py
@@ -223,8 +223,13 @@ def test_getframe_smoke():
     except ImportError:
         return
 
+    try:
+        from pandas.io import formats as pd_formats
+    except ImportError:
+        from pandas import formats as pd_formats
+
     ldf = res.get_loadings_frame(style='display')
-    assert_(isinstance(ldf, pd.formats.style.Styler))
+    assert_(isinstance(ldf, pd_formats.style.Styler))
     assert_(isinstance(ldf.data, pd.DataFrame))
 
     res.get_loadings_frame(style='display', decimals=3, threshold=0.2)

--- a/statsmodels/tsa/statespace/tests/test_simulate.py
+++ b/statsmodels/tsa/statespace/tests/test_simulate.py
@@ -11,13 +11,16 @@ import warnings
 import numpy as np
 import pandas as pd
 import os
+import sys
 from scipy.signal import lfilter
 
 from statsmodels.tsa.statespace import (sarimax, structural, varmax,
                                         dynamic_factor)
 from statsmodels.tsa.statespace.tools import compatibility_mode
 from numpy.testing import (assert_allclose, assert_almost_equal, assert_equal)
+from statsmodels.compat.testing import skipif
 
+WIN = sys.platform.startswith("win")
 
 def test_arma_lfilter():
     # Tests of an ARMA model simulation against scipy.signal.lfilter
@@ -149,6 +152,7 @@ def test_arma_direct():
     assert_allclose(actual[1:], desired)
 
 
+@skipif(WIN, 'Windows')
 def test_structural():
     # Clear warnings
     structural.__warningregistry__ = {}
@@ -442,6 +446,7 @@ def test_varmax():
     mod.simulate(mod.start_params, nobs)
 
 
+@skipif(WIN, 'Windows')
 def test_dynamic_factor():
     np.random.seed(93739)
     nobs = 100


### PR DESCRIPTION
some final fixes for 0.9rc1

see comments in #3386
- test_simulate still sometimes segfaults in a non-replicable way on Windows
  I skip two of the tests that AFAIR showed up sometimes on appveyor
- pandas compat in test, import path for `formats` changed across pandas version
  AFAICS it only affects the unit test, not the method the Factor class