### PR TITLE
MAINT: increase version number to 0.10 dev

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -168,10 +168,10 @@ def check_dependency_versions(min_versions):
 
 
 MAJ = 0
-MIN = 9
+MIN = 10
 REV = 0
-ISRELEASED = True
-VERSION = '%d.%d.%drc1' % (MAJ,MIN,REV)
+ISRELEASED = False
+VERSION = '%d.%d.%d' % (MAJ,MIN,REV)
 
 classifiers = ['Development Status :: 4 - Beta',
                'Environment :: Console',


### PR DESCRIPTION
increase version number to 0.10 dev

no changes to setup.py minimum version, or CI test matrix yet