### PR TITLE
Implement "xname_fe" and "xname_re" arguments in MixedLM.summary()

### DIFF
--- a/statsmodels/iolib/tests/test_summary2.py
+++ b/statsmodels/iolib/tests/test_summary2.py
@@ -7,7 +7,6 @@ from numpy.testing import assert_equal
 from statsmodels.iolib.summary2 import summary_col
 from statsmodels.regression.linear_model import OLS, add_constant
 
-
 class TestSummaryLatex(object):
 
     def test_summarycol(self):
@@ -95,3 +94,5 @@ x1    & -0.7500  & -1.5769   \\
 \begin{tabular}'''
         result = string_to_find in actual
         assert(result is True)
+
+

--- a/statsmodels/regression/mixed_linear_model.py
+++ b/statsmodels/regression/mixed_linear_model.py
@@ -2382,6 +2382,18 @@ class MixedLMResults(base.LikelihoodModelResults, base.ResultMixin):
         info["Model:"] = "MixedLM"
         if yname is None:
             yname = self.model.endog_names
+        param_names = self.model.data.param_names[:]
+        k_fe_params = len(self.fe_params)
+        k_re_params = len(param_names) - len(self.fe_params)
+        if xname_fe is not None:
+            if len(xname_fe) != k_fe_params:
+                raise ValueError("xname_fe should be a list of length %d" % k_fe_params)
+            param_names[:k_fe_params] = xname_fe
+        if xname_re is not None:
+            if len(xname_re) != k_re_params:
+                raise ValueError("xname_re should be a list of length %d" % k_re_params)
+            param_names[k_fe_params:] = xname_re
+
         info["No. Observations:"] = str(self.model.n_totobs)
         info["No. Groups:"] = str(self.model.n_groups)
 
@@ -2433,7 +2445,7 @@ class MixedLMResults(base.LikelihoodModelResults, base.ResultMixin):
             sdf[jj, 1] = np.sqrt(self.scale) * self.bse[jj]
             jj += 1
 
-        sdf = pd.DataFrame(index=self.model.data.param_names, data=sdf)
+        sdf = pd.DataFrame(index=param_names, data=sdf)
         sdf.columns = ['Coef.', 'Std.Err.', 'z', 'P>|z|',
                        '[' + str(alpha/2), str(1-alpha/2) + ']']
         for col in sdf.columns:

--- a/statsmodels/regression/tests/test_lme.py
+++ b/statsmodels/regression/tests/test_lme.py
@@ -700,8 +700,47 @@ class TestMixedLM(object):
         mdf5 = md.fit_regularized(method=pen, alpha=1.)
         mdf5.summary()
 
+# ------------------------------------------------------------------
+
+class TestMixedLMSummary(object):
+    # Test various aspects of the MixedLM summary
+    @classmethod
+    def setup_class(cls):
+        # Setup the model and estimate it.
+        pid = np.repeat([0, 1], 5)
+        x0 = np.repeat([1], 10)
+        x1 = [1, 5, 7, 3, 5, 1, 2, 6, 9, 8]
+        x2 = [6, 2, 1, 0, 1, 4, 3, 8, 2, 1]
+        y = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        df = pd.DataFrame({"y": y, "pid": pid, "x0": x0, "x1": x1, "x2": x2})
+        endog = df["y"].values
+        exog = df[["x0", "x1", "x2"]].values
+        groups = df["pid"].values
+        cls.res = MixedLM(endog, exog, groups=groups).fit()
+
+    def test_summary(self):
+        # Test that the summary correctly includes all variables.
+        summ = self.res.summary()
+        desired = ["const", "x1", "x2", "Group Var"]
+        actual = summ.tables[1].index.values # Second table is summary of params
+        assert_equal(actual, desired)
+
+    def test_summary_xname_fe(self):
+        # Test that the `xname_fe` argument is reflected in the summary table.
+        summ = self.res.summary(xname_fe=["Constant", "Age", "Weight"])
+        desired = ["Constant", "Age", "Weight", "Group Var"]
+        actual = summ.tables[1].index.values # Second table is summary of params
+        assert_equal(actual, desired)
+
+    def test_summary_xname_re(self):
+        # Test that the `xname_re` argument is reflected in the summary table.
+        summ = self.res.summary(xname_re=["Random Effects"])
+        desired = ["const", "x1", "x2", "Random Effects"]
+        actual = summ.tables[1].index.values # Second table is summary of params
+        assert_equal(actual, desired)
 
 # ------------------------------------------------------------------
+
 
 # TODO: better name
 def do1(reml, irf, ds_ix):


### PR DESCRIPTION
The function `MixedLM.summary()` featured two arguments `xname_fe` and `xname_re` (respectively to change the display names of fixed effects and random effects), but the function did not use those values. As a consequence, those keywords did not have any impact.

This pull request implements those keywords. It tests that the length of the lists specified in `xname_fe` and `xname_re` match the number of fixed/random parameters, and insert them as index in the DataFrame used to summarize the results.