### PR TITLE
BUG: State space: Eliminate sometimes invalid copy operation in simulation.

### DIFF
--- a/statsmodels/tsa/statespace/_simulation_smoother.pyx.in
+++ b/statsmodels/tsa/statespace/_simulation_smoother.pyx.in
@@ -400,7 +400,13 @@ cdef class {{prefix}}SimulationSmoother(object):
             self.secondary_simulated_kfilter.seek(0) # reset the filter
         measurement_idx = 0
         state_idx = nobs_endog
-        if not self.has_missing:
+        # Note: it is only when we are simulating a series that we might have
+        # self.model.nobs != self.simulated_model.nobs, and in that case we do
+        # not need to copy over the observations.
+        # TODO: Need more explicit support for the pure simulation case, both
+        # to avoid errors (like the copy statement below) and because we can
+        # probably speed up the process by not running the filter parts.
+        if not self.has_missing and (self.model.nobs == self.simulated_model.nobs):
             # reset the obs data in the primary simulated model
             # (but only if there is not missing data - in that case we will
             # combine the actual data with the generated data in the primary
@@ -540,6 +546,14 @@ cdef class {{prefix}}SimulationSmoother(object):
             {{cython_type}} alpha = 1.0
 
         # Get indices for possibly time-varying arrays
+        # Note that this would be problematic if simulating a
+        # time-varying system if the number of simulated observations was
+        # greater than the number of observations in the model (because then
+        # e.g. self.model.design[0,0,design_t] would be an invalid memory
+        # location).
+        # However, this problem is ruled out in the constructor since for
+        # time-varying systems, the number of simulated observations must be
+        # less than the number of observations in the model.
         if not self.model.time_invariant:
             if self.model.design.shape[2] > 1:             design_t = t
             if self.model.obs_intercept.shape[1] > 1:      obs_intercept_t = t

--- a/statsmodels/tsa/statespace/tests/test_simulate.py
+++ b/statsmodels/tsa/statespace/tests/test_simulate.py
@@ -20,9 +20,7 @@ from statsmodels.tsa.statespace.tools import compatibility_mode
 from numpy.testing import (assert_allclose, assert_almost_equal, assert_equal)
 from statsmodels.compat.testing import skipif
 
-WIN = sys.platform.startswith("win")
 
-@skipif(WIN, 'Windows')
 def test_arma_lfilter():
     # Tests of an ARMA model simulation against scipy.signal.lfilter
     # Note: the first elements of the generated SARIMAX datasets are based on
@@ -53,7 +51,6 @@ def test_arma_lfilter():
     assert_allclose(actual[1:], desired)
 
 
-@skipif(WIN, 'Windows')
 def test_arma_direct():
     # Tests of an ARMA model simulation against direct construction
     # This is useful for e.g. trend components
@@ -154,7 +151,6 @@ def test_arma_direct():
     assert_allclose(actual[1:], desired)
 
 
-@skipif(WIN, 'Windows')
 def test_structural():
     # Clear warnings
     structural.__warningregistry__ = {}
@@ -337,7 +333,6 @@ def test_structural():
     assert_allclose(actual, desired)
 
 
-@skipif(WIN, 'Windows')
 def test_varmax():
     # Clear warnings
     varmax.__warningregistry__ = {}
@@ -449,7 +444,6 @@ def test_varmax():
     mod.simulate(mod.start_params, nobs)
 
 
-@skipif(WIN, 'Windows')
 def test_dynamic_factor():
     np.random.seed(93739)
     nobs = 100


### PR DESCRIPTION
This fixes a segmentation fault (illegal memory access) when simulating time series from a time-invariant state space model, where the number of simulations exceeds the number of observations in the base model.

(It is possible that #3386 is closed by this PR, but since I can't replicate those test failures *per se*, I guess we'll have to wait and see).