### PR TITLE
BUG/REF: fix GLM `null`, init keywords 

### DIFF
--- a/statsmodels/genmod/tests/test_glm.py
+++ b/statsmodels/genmod/tests/test_glm.py
@@ -718,6 +718,7 @@ class TestGlmPoissonOffset(CheckModelResultsMixin):
         mod2 = GLM(endog, exog, family=sm.families.Poisson(),
                    offset=offset2).fit()
         assert_almost_equal(mod1.params, mod2.params)
+        assert_allclose(mod1.null, mod2.null, rtol=1e-10)
 
         # test recreating model
         mod1_ = mod1.model


### PR DESCRIPTION
closes #4597
this fixes GLM.null and consequently null_deviance, llnull if exposure is used independent of family, and if offset is used in the binomial count case.

There are some unit tests for null_deviance, More unit test in my penalized #4576 where I initially ran into this bug.

more general: 
see #4599
fixes recreating models for Binomial count, by addin `n_trials` to `__init__` kwargs and init keys
This will fix most likely other bugs, or adds support for cases that are not supported yet, 
e.g. fit_constrained and fit_regularized for Binomial counts #4600
but I didn't check and test those cases yet.


If current unit tests work with these changes, then I might add some more unit tests.
