### PR TITLE
MAINT: numpy python 2.7 compat in VARProcess irf_errband_mc

### DIFF
--- a/statsmodels/tsa/vector_ar/var_model.py
+++ b/statsmodels/tsa/vector_ar/var_model.py
@@ -1536,9 +1536,11 @@ class VARResults(VARProcess):
             ma_coll[i, :, :, :] = fill_coll(sim)
 
         ma_sort = np.sort(ma_coll, axis=0)  # sort to get quantiles
-        index = round(signif/2*repl)-1, round((1-signif/2)*repl)-1
-        lower = ma_sort[index[0], :, :, :]
-        upper = ma_sort[index[1], :, :, :]
+        # python 2: round returns float
+        low_idx = int(round(signif / 2 * repl) - 1)
+        upp_idx = int(round((1 - signif / 2) * repl) - 1)
+        lower = ma_sort[low_idx, :, :, :]
+        upper = ma_sort[upp_idx, :, :, :]
         return lower, upper
 
     def irf_resim(self, orth=False, repl=1000, T=10,


### PR DESCRIPTION
closes #4584
In python 2.7 with numpy 1.14.2 an indexing error shows up,
most likely because of float, in Python 2.7 Python's round returns a float, in python 3 an int.

(tested on travis in #4576 which has the failing numpy python combination)

this just adds int to python round and is not necessary on python 3, i.e. could be removed again when we drop python 2 support