### PR TITLE
Simplify start_params generation for gradient optimization in GLM #4625

### DIFF
--- a/statsmodels/genmod/generalized_linear_model.py
+++ b/statsmodels/genmod/generalized_linear_model.py
@@ -1040,10 +1040,11 @@ class GLM(base.LikelihoodModel):
         if (max_start_irls > 0) and (start_params is None):
             irls_rslt = self._fit_irls(start_params=start_params,
                                        maxiter=max_start_irls,
-                                       tol=tol, scale=scale, cov_type=cov_type,
-                                       cov_kwds=cov_kwds, use_t=use_t,
+                                       tol=tol, scale=1., cov_type='nonrobust',
+                                       cov_kwds=None, use_t=None,
                                        **kwargs)
             start_params = irls_rslt.params
+            del irls_rslt
 
         rslt = super(GLM, self).fit(start_params=start_params, tol=tol,
                                     maxiter=maxiter, full_output=full_output,


### PR DESCRIPTION
This addresses part of #4625 that simplifies the use of IRLS in coming up with `start_params` for `fit_gradient` for GLM.