### PR TITLE
BF: DataTimeIndex.to_datetime removed in pandas

### DIFF
--- a/statsmodels/datasets/co2/data.py
+++ b/statsmodels/datasets/co2/data.py
@@ -62,8 +62,7 @@ def load_pandas():
     data = load()
     # pandas <= 0.12.0 fails in the to_datetime regex on Python 3
     index = pd.DatetimeIndex(start=data.data['date'][0].decode('utf-8'),
-                             periods=len(data.data), format='%Y%m%d',
-                             freq='W-SAT')
+                             periods=len(data.data), freq='W-SAT')
     dataset = pd.DataFrame(data.data['co2'], index=index, columns=['co2'])
     #NOTE: this is how I got the missing values in co2.csv
     #new_index = pd.DatetimeIndex(start='1958-3-29', end=index[-1],

--- a/statsmodels/genmod/tests/test_glm.py
+++ b/statsmodels/genmod/tests/test_glm.py
@@ -204,7 +204,7 @@ class CheckComparisonMixin(object):
         score1 = res1.model.score(res1.params * 0.98)
         assert_allclose(score1, score_obs1.sum(0), atol=1e-20)
         score0 = res1.model.score(res1.params)
-        assert_allclose(score0, np.zeros(score_obs1.shape[1]), atol=1e-7)
+        assert_allclose(score0, np.zeros(score_obs1.shape[1]), atol=5e-7)
 
         hessian1 = res1.model.hessian(res1.params * 0.98, observed=False)
         hessiand = resd.model.hessian(resd.params * 0.98)

--- a/statsmodels/tsa/statespace/tests/test_mlemodel.py
+++ b/statsmodels/tsa/statespace/tests/test_mlemodel.py
@@ -669,7 +669,7 @@ def test_pandas_endog():
     mod.filter([])
 
     # Example : pandas.Series, string datatype
-    endog = pd.Series(['a'], index=dates)
+    endog = pd.Series(['a', 'b'], index=dates)
     # raises error due to direct type casting check in Statsmodels base classes
     assert_raises(ValueError, check_endog, endog, **kwargs)
 

--- a/statsmodels/tsa/tests/test_tsa_indexes.py
+++ b/statsmodels/tsa/tests/test_tsa_indexes.py
@@ -85,7 +85,7 @@ series_datestr_indexes = [
     (pd.Series(x), y) for x, y in list_datestr_indexes]
 
 numpy_datetime_indexes = [
-    (x.to_datetime().to_pydatetime(), x.freq)
+    (pd.to_datetime(x).to_pydatetime(), x.freq)
     for x in base_date_indexes]
 list_datetime_indexes = [
     (x.tolist(), y) for x, y in numpy_datetime_indexes]


### PR DESCRIPTION
https://github.com/pandas-dev/pandas/commit/537c06d150d0942454494b08773567eb245dd200
removed the to_datetime method from DateTimeIndex.  Use pd.to_datetime
instead.

This leads to

```
E   AttributeError: 'DatetimeIndex' object has no attribute 'to_datetime'
```

on test collection.