### PR TITLE
DISCUSS/BLD: Update minimum versions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,50 +18,57 @@ env:
 matrix:
   fast_finish: true
   include:
+  # Python 3.6 + cutting edge packages
   - python: 2.7
     env:
     - PYTHON=3.6
     - COVERAGE=true
+  # Python 2.7 + partially updated packages
   - python: 2.7
     env:
     - PYTHON=2.7
-    - NUMPY=1.11
-    - MATPLOTLIB=1.5
+    - NUMPY=1.13
+    - MATPLOTLIB=2.1
     - COVERAGE=true
+  # Python 3.5 + partially updated packages
   - python: 2.7
     env:
     - PYTHON=3.5
-    - NUMPY=1.10
-    - SCIPY=0.17
-    - PANDAS=0.18
-    - MATPLOTLIB=1.5
+    - NUMPY=1.13
+    - SCIPY=1.0
+    - PANDAS=0.22
+    - MATPLOTLIB=2.1
+  # Python 2.7 + baseline packages
   - python: 2.7
     env:
     - PYTHON=3.4
-    - NUMPY=1.10
-    - SCIPY=0.16
-    - PANDAS=0.16
-    - MATPLOTLIB=1.4
+    - NUMPY=1.12
+    - SCIPY=0.19
+    - PANDAS=0.20
+    - MATPLOTLIB=2.0
     - OPTIONAL="libgfortran=1.0"
+  # Documentation build (on Python 3.6 + cutting edge packages)
   - python: 2.7
     env:
     - PYTHON=3.6
     - DOCBUILD=true
+  # No Matplotlib (on Python 2.7 + baseline packages)
   - python: 2.7
     env:
     - PYTHON=2.7
-    - NUMPY=1.9
-    - SCIPY=0.15
-    - PANDAS=0.15
+    - NUMPY=1.12
+    - SCIPY=0.19
+    - PANDAS=0.20
     - USEMPL=false
     - OPTIONAL="libgfortran=1.0"
+  # Python 3.3 + baseline packages
   - python: 2.7
     env:
     - PYTHON=3.3
-    - NUMPY=1.9
-    - SCIPY=0.14
-    - MATPLOTLIB=1.4
-    - PANDAS=0.14
+    - NUMPY=1.12
+    - SCIPY=0.19
+    - MATPLOTLIB=2.0
+    - PANDAS=0.20
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,12 +23,12 @@ matrix:
     env:
     - PYTHON=3.6
     - COVERAGE=true
-  # Python 2.7 + partially updated packages
+  # Python 2.7 + partially updated numpy, mpl; cutting edge scipy, pandas
   - python: 2.7
     env:
     - PYTHON=2.7
     - NUMPY=1.13
-    - MATPLOTLIB=2.1
+    - MATPLOTLIB=2.0
     - COVERAGE=true
   # Python 3.5 + partially updated packages
   - python: 2.7
@@ -37,15 +37,23 @@ matrix:
     - NUMPY=1.13
     - SCIPY=1.0
     - PANDAS=0.22
-    - MATPLOTLIB=2.1
+    - MATPLOTLIB=2.0
   # Python 2.7 + baseline packages
   - python: 2.7
     env:
+    - PYTHON=2.7
+    - NUMPY=1.11
+    - SCIPY=0.18
+    - PANDAS=0.19
+    - MATPLOTLIB=1.5
+  # Python 3.4 + baseline packages
+  - python: 2.7
+    env:
     - PYTHON=3.4
-    - NUMPY=1.12
-    - SCIPY=0.19
-    - PANDAS=0.20
-    - MATPLOTLIB=2.0
+    - NUMPY=1.11
+    - SCIPY=0.18
+    - PANDAS=0.19
+    - MATPLOTLIB=1.5
     - OPTIONAL="libgfortran=1.0"
   # Documentation build (on Python 3.6 + cutting edge packages)
   - python: 2.7
@@ -56,19 +64,11 @@ matrix:
   - python: 2.7
     env:
     - PYTHON=2.7
-    - NUMPY=1.12
-    - SCIPY=0.19
-    - PANDAS=0.20
+    - NUMPY=1.11
+    - SCIPY=0.18
+    - PANDAS=0.19
     - USEMPL=false
     - OPTIONAL="libgfortran=1.0"
-  # Python 3.3 + baseline packages
-  - python: 2.7
-    env:
-    - PYTHON=3.3
-    - NUMPY=1.12
-    - SCIPY=0.19
-    - MATPLOTLIB=2.0
-    - PANDAS=0.20
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,6 @@ matrix:
     - SCIPY=0.18
     - PANDAS=0.19
     - MATPLOTLIB=1.5
-    - OPTIONAL="libgfortran=1.0"
   # Documentation build (on Python 3.6 + cutting edge packages)
   - python: 2.7
     env:
@@ -68,7 +67,6 @@ matrix:
     - SCIPY=0.18
     - PANDAS=0.19
     - USEMPL=false
-    - OPTIONAL="libgfortran=1.0"
 
 notifications:
   email:

--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -5,15 +5,15 @@ python >= 2.7
 
     www.python.org
 
-numpy >= 1.12
+numpy >= 1.11
 
     www.numpy.org
 
-scipy >= 0.19
+scipy >= 0.18
     
     www.scipy.org
 
-pandas >= 0.20
+pandas >= 0.19
 
     pandas.pydata.org
 
@@ -43,7 +43,7 @@ X-12-ARIMA or X-13ARIMA-SEATS
     appropriate executable on your PATH or set the X12PATH or X13PATH 
     environmental variable to take advantage.
 
-matplotlib >= 2.0
+matplotlib >= 1.5
 
     http://matplotlib.org/
 

--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -5,19 +5,19 @@ python >= 2.7
 
     www.python.org
 
-numpy >= 1.8
+numpy >= 1.12
 
     www.numpy.org
 
-scipy >= 0.14
+scipy >= 0.19
     
     www.scipy.org
 
-pandas >= 0.14
+pandas >= 0.20
 
     pandas.pydata.org
 
-patsy >= 0.3.0
+patsy >= 0.4.0
 
     patsy.readthedocs.org
 
@@ -43,7 +43,7 @@ X-12-ARIMA or X-13ARIMA-SEATS
     appropriate executable on your PATH or set the X12PATH or X13PATH 
     environmental variable to take advantage.
 
-matplotlib >= 1.3
+matplotlib >= 2.0
 
     http://matplotlib.org/
 
@@ -56,11 +56,11 @@ sphinx >= 1.3
 
     Sphinx is used to build the documentation.
 
-nose >= 1.3
+pytest >= 3.0
 
-    http://readthedocs.org/docs/nose/en/latest/
+    http://readthedocs.org/docs/pytest/en/latest/
 
-    Nose is needed to run the tests.
+    Pytest is needed to run the tests.
 
 IPython >= 3.0
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,7 @@ environment:
       PYTHON_ARCH: "x86_64"
     - PY_MAJOR_VER: 2
       PYTHON_ARCH: "x86_64"
-      SCIPY: "0.14"
+      SCIPY: "1.0"
     - PY_MAJOR_VER: 3
       PYTHON_ARCH: "x86_64"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,7 @@ environment:
       PYTHON_ARCH: "x86_64"
     - PY_MAJOR_VER: 2
       PYTHON_ARCH: "x86_64"
-      SCIPY: "1.0"
+      SCIPY: "0.18"
     - PY_MAJOR_VER: 3
       PYTHON_ARCH: "x86_64"
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -143,18 +143,27 @@ Replace `/x64` with `/x86` and `v7.0` with `v7.1` as needed.
 Dependencies
 ~~~~~~~~~~~~
 
-* `Python <https://www.python.org>`__ >= 2.7, including Python 3.x
-* `NumPy <http://www.scipy.org/>`__ >= 1.8
-* `SciPy <http://www.scipy.org/>`__ >= 0.14
-* `Pandas <http://pandas.pydata.org/>`__ >= 0.14
-* `Patsy <https://patsy.readthedocs.io/en/latest/>`__ >= 0.3.0
+The current minimum dependencies are:
+
+* `Python <https://www.python.org>`__ >= 2.7, including Python 3.4+
+* `NumPy <http://www.scipy.org/>`__ >= 1.11
+* `SciPy <http://www.scipy.org/>`__ >= 0.18
+* `Pandas <http://pandas.pydata.org/>`__ >= 0.19
+* `Patsy <https://patsy.readthedocs.io/en/latest/>`__ >= 0.4.0
 * `Cython <http://cython.org/>`__ >= 0.24 is required to build the code from
   github but not from a source distribution.
+
+Given the long release cycle, Statsmodels follows a loose time-based policy for
+dependencies: minimal dependencies are lagged about one and a half to two
+years. Our next planned update of minimum versions in `setup.py` is expected in
+September 2018, when we will update to reflect Numpy >= 1.12 (released January
+2017), Scipy >= 0.19 (released March 2017) and Pandas >= 0.20 (released May
+2017).
 
 Optional Dependencies
 ~~~~~~~~~~~~~~~~~~~~~
 
-* `Matplotlib <http://matplotlib.org/>`__ >= 1.4 is needed for plotting
+* `Matplotlib <http://matplotlib.org/>`__ >= 1.5 is needed for plotting
   functions and running many of the examples.
 * If installed, `X-12-ARIMA <http://www.census.gov/srd/www/x13as/>`__ or
   `X-13ARIMA-SEATS <http://www.census.gov/srd/www/x13as/>`__ can be used

--- a/setup.py
+++ b/setup.py
@@ -496,10 +496,11 @@ if __name__ == "__main__":
         os.unlink('MANIFEST')
 
     min_versions = {
-        'numpy' : '1.9',
-        'scipy' : '0.14',
-        'pandas' : '0.14',
-        'patsy' : '0.4.0',
+        'numpy' : '1.12',   # released January 2017
+        'scipy' : '0.19',   # released March 2017
+        'pandas' : '0.20',  # released May 2017
+        'patsy' : '0.4.0',  # released July 2015
+        # 'matplotlib': '2.0.0',   #  released January 2017
                    }
 
     (setup_requires,

--- a/setup.py
+++ b/setup.py
@@ -496,11 +496,11 @@ if __name__ == "__main__":
         os.unlink('MANIFEST')
 
     min_versions = {
-        'numpy' : '1.12',   # released January 2017
-        'scipy' : '0.19',   # released March 2017
-        'pandas' : '0.20',  # released May 2017
+        'numpy' : '1.11',   # released March 2016
+        'scipy' : '0.18',   # released July 2016
+        'pandas' : '0.19',  # released October 2016
         'patsy' : '0.4.0',  # released July 2015
-        # 'matplotlib': '2.0.0',   #  released January 2017
+        # 'matplotlib': '1.5.0',   #  released October 2015
                    }
 
     (setup_requires,


### PR DESCRIPTION
This  PR updates the minimum versions (in `setup.py`) to:

```python
min_versions = {
        'numpy' : '1.12',   # released January 2017
        'scipy' : '0.19',   # released March 2017
        'pandas' : '0.20',  # released May 2017
        'patsy' : '0.4.0',  # released July 2015
        # 'matplotlib': '2.0.0',   #  released January 2017
}
```

and changes the Travis build strategy to roughly incorporate:

- Baseline (on Python 2.7, 3.3, and 3.5, with the package versions above)
- Partially updated (on Python 2.7 and Python 3.5 with incrementally updated packages)
- Cutting edge (Python 3.6 + latest packages)

along with one documentation build and one build with no Matplotlib at all.

```yml
# Python 3.6 + cutting edge packages
  - python: 2.7
    env:
    - PYTHON=3.6
    - COVERAGE=true
  # Python 2.7 + partially updated packages
  - python: 2.7
    env:
    - PYTHON=2.7
    - NUMPY=1.13
    - MATPLOTLIB=2.1
    - COVERAGE=true
  # Python 3.5 + partially updated packages
  - python: 2.7
    env:
    - PYTHON=3.5
    - NUMPY=1.13
    - SCIPY=1.0
    - PANDAS=0.22
    - MATPLOTLIB=2.1
  # Python 2.7 + baseline packages
  - python: 2.7
    env:
    - PYTHON=3.4
    - NUMPY=1.12
    - SCIPY=0.19
    - PANDAS=0.20
    - MATPLOTLIB=2.0
    - OPTIONAL="libgfortran=1.0"
  # Documentation build (on Python 3.6 + cutting edge packages)
  - python: 2.7
    env:
    - PYTHON=3.6
    - DOCBUILD=true
  # No Matplotlib (on Python 2.7 + baseline packages)
  - python: 2.7
    env:
    - PYTHON=2.7
    - NUMPY=1.12
    - SCIPY=0.19
    - PANDAS=0.20
    - USEMPL=false
    - OPTIONAL="libgfortran=1.0"
  # Python 3.3 + baseline packages
  - python: 2.7
    env:
    - PYTHON=3.3
    - NUMPY=1.12
    - SCIPY=0.19
    - MATPLOTLIB=2.0
    - PANDAS=0.20
```

And for Appveyor I only changed the second Appveyor to select the baseline scipy version, scipy=0.19.

Discussion?