### PR TITLE
BLD: Use older version of Pandas for docbuild

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,8 @@ matrix:
   - python: 2.7
     env:
     - PYTHON=3.6
+    # (can't use pandas=0.23 with pandas-datareader <= 0.6)
+    - PANDAS=0.22
     - DOCBUILD=true
   # No Matplotlib (on Python 2.7 + baseline packages)
   - python: 2.7


### PR DESCRIPTION
Temporary fix since pandas=0.23 is incompatible with pandas-datareader=0.6. We can remove this line once pandas-datareader is next released (0.6.1 or 0.7.0).