### PR TITLE
ENH: add ultra-high screening with SCAD

### DIFF
--- a/statsmodels/base/_penalized.py
+++ b/statsmodels/base/_penalized.py
@@ -51,6 +51,8 @@ class PenalizedMixin(object):
             self.pen_weight = 0
 
         self._init_keys.extend(['penal', 'pen_weight'])
+        self._null_drop_keys = getattr(self, '_null_drop_keys', [])
+        self._null_drop_keys.extend(['penal'])
 
     def loglike(self, params, pen_weight=None, **kwds):
         if pen_weight is None:

--- a/statsmodels/base/_penalties.py
+++ b/statsmodels/base/_penalties.py
@@ -93,9 +93,14 @@ class Penalty(object):
 
     def _null_weights(self, params):
         """work around for Null model
+
+        This will not be needed anymore when we can use `self._null_drop_keys`
+        as in DiscreteModels.
+        TODO: check other models
         """
         if np.size(self.weights) > 1:
             if len(params) == 1:
+                raise  # raise to identify models where this would be needed
                 return 0.
 
         return self.weights

--- a/statsmodels/base/_screening.py
+++ b/statsmodels/base/_screening.py
@@ -1,0 +1,173 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Sat May 19 15:53:21 2018
+
+Author: Josef Perktold
+License: BSD-3
+"""
+
+from collections import defaultdict
+import numpy as np
+
+from statsmodels.base._penalties import SCADSmoothed
+
+
+class ScreeningResults(object):
+    def __init__(self, screener, **kwds):
+        self.screener = screener
+        self.__dict__.update(**kwds)
+
+
+class VariableScreening(object):
+    """Ultra-high, conditional sure independence screening
+
+    This is an adjusted version of Fan's sure independence screening.
+
+
+    TODO Notes
+    penalization weights need to be used to avoid penalizing always kept
+    exog. The length of weights vector depends on the number of variables
+    included in the candidate model.
+    This is not included yet. We SCAD penalize all parameters, but large
+    parameters are not penalized by the SCAD penalty function.
+
+    Does user provide Penalized class or base class?
+    -> refactor so we use Penalized class with pen_weight=0 as base class
+
+    pen_weight is currently not a tuning option that can be changed by user.
+
+    pearson_resid: inconsistency in whether penalized or half-trimmed params
+    are used. Related issue: GLM resid_pearson does not include freq_weights.
+
+    freq_weights are not supported in this. Candidate ranking uses
+    moment condition with resid_pearson without freq_weights.
+
+    fit_kwds are missing, e.g. we need to avoid irls in GLM
+
+    variable names: do we keep track of those?
+
+    currently only supports numpy arrays, now exog type check or conversion
+
+    extensions to lazy or patched exog.
+    Actually, that should work already by calling screen_vars with patches
+    of exog, and then with a combined exog of best subset exog.
+
+    currently only single columns are selected, no terms (multi column exog)
+
+    """
+
+    def __init__(self, model, base_class, **kwargs):
+
+        self.model = model
+        self.model_class = model.__class__
+        self.init_kwds = model._get_init_kwds()
+        # pen_weight and penal are explicitly included
+        # TODO: check what we want to do here
+        self.init_kwds.pop('pen_weight', None)
+        self.init_kwds.pop('penal', None)
+
+        self.endog = model.endog
+        self.exog_keep = model.exog
+        self.penal = SCADSmoothed(0.1, c0=0.0001)
+
+        # this is only needed for initial start_params
+        self.base_class = base_class
+
+        # option for screening algorithm
+        self.k_add = 5
+        self.k_max_add = 10
+        self.threshold_trim = 1e-4
+        self.k_max_included = 20
+
+    def screen_vars(self, exog, endog=None, maxiter=5, disp=0):
+        model_class = self.model_class
+        if endog is None:
+            # allow a different endog than used in model
+            endog = self.endog
+        x0 = self.exog_keep
+        x1 = exog
+        k0 = x0.shape[1]
+        # TODO: remove the need for x, use x1 separately from x0
+        # needs change to idx to be based on x1 (candidate variables)
+        x = np.column_stack((x0, x1))
+        nobs, k_vars = x.shape
+
+
+        history = defaultdict(list)
+        idx_nonzero = [0]
+        keep = np.array([True])
+        idx_excl = np.arange(1, k_vars)
+        #start_params = [endog.mean()]
+        res_pen = model_class(endog, x0, **self.init_kwds).fit(disp=disp)
+        start_params = res_pen.params
+
+        for _ in range(maxiter):
+            # This does not work, droping the Poisson fit creates problems
+            p = res_pen.params.copy()
+            p[~keep] = 0
+            if hasattr(res_pen, 'resid_pearson'):
+                # this is different from the else
+                # here we use the resid_pearson from res_pen which includes
+                # dropped variables/params
+                resid_pearson = res_pen.resid_pearson
+            else:
+                predicted = res_pen.model.predict(p)
+                # this is currently hardcoded for Poisson
+                resid_pearson = (endog - predicted) / np.sqrt(predicted)
+
+            mom_cond = np.abs(resid_pearson.dot(x1))**2
+            mcs = np.sort(mom_cond)[::-1]
+            #print(mcs[:10])
+
+            threshold = mcs[max((self.k_max_add, k0 + self.k_add))]
+            #idx = np.concatenate((idx_nonzero, np.nonzero(mom_cond > threshold)[0] + 1))
+            idx = np.concatenate((idx_nonzero, idx_excl[mom_cond > threshold]))
+            start_params2 = np.zeros(len(idx))
+            start_params2[:len(start_params)] = start_params
+
+            res_pen = model_class(endog, x[:, idx], penal=self.penal,
+                                       pen_weight=nobs * 10,
+                                       **self.init_kwds).fit(method='bfgs',
+                                                start_params=start_params2,
+                                                warn_convergence=False, disp=disp)
+
+            keep = np.abs(res_pen.params) > self.threshold_trim
+            # use largest params to keep
+            if len(res_pen.params) > self.k_max_included:
+                # TODO we can use now np.partition with partial sort
+                thresh_params = np.sort(np.abs(res_pen.params))[-self.k_max_included]
+                keep2 = np.abs(res_pen.params) > thresh_params
+                keep = np.logical_and(keep, keep2)
+            idx_nonzero = idx[keep]
+            # TODO: problem with order between using mask and indexing
+            #idx_nonzero.sort()
+
+            if disp:
+                print(idx_nonzero)
+            x0 = x[:, idx_nonzero]
+            start_params = res_pen.params[keep]
+
+            # use mask to get excluded
+            mask_excl = np.ones(k_vars, dtype=bool)
+            mask_excl[idx_nonzero] = False
+            idx_excl = np.nonzero(mask_excl)[0]
+            x1 = x[:, idx_excl]
+            history['idx_nonzero'].append(idx_nonzero)
+            history['keep'].append(keep)
+            history['params_keep'].append(start_params)
+
+        # final esimate
+        res_final = model_class(endog, x[:, idx_nonzero], penal=self.penal,
+                                pen_weight=nobs * 10,
+                                **self.init_kwds).fit(method='bfgs',
+                                          start_params=res_pen.params[keep],
+                                          warn_convergence=False, disp=disp)
+
+        res = ScreeningResults(self,
+                               results_pen = res_pen,
+                               results_final = res_final,
+                               idx_nonzero = idx_nonzero,
+                               idx_excl = idx_excl,
+                               start_params = start_params,
+                               history = history)
+        return res

--- a/statsmodels/base/_screening.py
+++ b/statsmodels/base/_screening.py
@@ -312,6 +312,7 @@ class VariableScreening(object):
 
             # Note: idx and keep are for current expansion model
             # idx_nonzero has indices of selected variables in full exog
+            keep[:k_keep] = True  # always keep exog_keep
             idx_nonzero = idx[keep]
 
             if disp:
@@ -338,6 +339,8 @@ class VariableScreening(object):
             idx_old = idx_nonzero
 
         # final esimate
+        # check that we still have exog_keep
+        assert np.all(idx_nonzero[:k_keep] == np.arange(k_keep))
         if self.use_weights:
             weights = np.ones(len(idx_nonzero))
             weights[:k_keep] = 0

--- a/statsmodels/base/_screening.py
+++ b/statsmodels/base/_screening.py
@@ -15,7 +15,51 @@ from statsmodels.base._penalties import SCADSmoothed
 class ScreeningResults(object):
     """Results for Variable Screening
 
+    Note: Indices except for exog_idx and in the iterated case also
+    idx_nonzero_batches are based on the combined [exog_keep, exog] array.
 
+    **Attributes**
+
+    results_final : instance
+        Results instance returned by the final fit of the penalized model, i.e.
+        after trimming exog with params below trimming threshold.
+    results_pen : results instance
+        Results instance of the penalized model before trimming. This includes
+        variables from the last forward selection
+    idx_nonzero
+        index of exog columns in the final selection including exog_keep
+    idx_exog
+        index of exog columns in the final selection for exog candidates, i.e.
+        without exog_keep
+    idx_excl
+        idx of excluded exog based on combined [exog_keep, exog] array. This is
+        the complement of idx_nonzero
+    converged : boolean
+        True if the iteration has converged and stopped before maxiter has been
+        reached. False if maxiter has been reached.
+    iterations : int
+        number of iterations in the screening process. Each iteration consists
+        of a forward selection step and a trimming step.
+    history : dict of lists
+        results collected for each iteration during the screening process
+        'idx_nonzero' 'params_keep'].append(start_params)
+            history['idx_added'].append(idx)
+
+    The ScreeningResults returned by `screen_exog_iterator` has additional
+    attributes:
+
+    idx_nonzero_batches : ndarray 2-D
+        Two-dimensional array with batch index in the first column and variable
+        index withing batch in the second column. They can be used jointly as
+        index for the data in the exog_iterator.
+    exog_final_names : list of strings
+        'var<bidx>_<idx>' where `bidx` is the batch index and `idx` is the
+        index of the selected column withing batch `bidx`.
+    history_batches : dict of lists
+        This provides information about the selected variables within each
+        batch during the first round screening
+        'idx_nonzero' is based ond the array that includes exog_keep, while
+        'idx_exog' is the index based on the exog of the batch.
 
     """
     def __init__(self, screener, **kwds):
@@ -31,7 +75,9 @@ class VariableScreening(object):
     Parameters
     ----------
     model : instance of penalizing model
-        examples: GLMPenalized, PoissonPenalized and LogitPenalized
+        examples: GLMPenalized, PoissonPenalized and LogitPenalized.
+        The attributes of the model instance `pen_weight` and `penal` will be
+        ignored.
     pen_weight : None or float
         penalization weight use in SCAD penalized MLE
     k_add : int
@@ -48,7 +94,7 @@ class VariableScreening(object):
         This determines the result attribute or model method that is used for
         the ranking of exog to include. The availability of attributes depends
         on the model.
-        Default is 'resid_pearson', 'score_factor' can be used in GLM.
+        Default is 'resid_pearson', 'model.score_factor' can be used in GLM.
     ranking_project : bool
         If ranking_project is True, then the exog candidates for inclusion are
         first projected on the already included exog before the computation
@@ -67,24 +113,32 @@ class VariableScreening(object):
     present, then the number of included exog can be larger than specified
     by k_add, k_max_add and k_max_included.
 
+    The screening algorithm works similar to step wise regression. Each
+    iteration of the screening algorithm includes a forward selection step
+    where variables are added to the model, and a backwards selection step
+    where variables are removed. In contrast to step wise regression, we add
+    a fixed number of variables at each forward selection step. The
+    backwards selection step is based on SCAD penalized estimation and
+    trimming of variables with estimated coefficients below a threshold.
+    The tuning parameters can be used to adjust the number of variables to add
+    and to include depending on the size of the dataset.
+
+    There is currently no automatic tuning parameter selection. Candidate
+    explanatory variables should be standardized or should be on a similar
+    scale because penalization and trimming are based on the absolute values
+    of the parameters.
+
 
     TODOs and current limitations:
 
-    penalization weights need to be used to avoid penalizing always kept
-    exog. The length of weights vector depends on the number of variables
-    included in the candidate model.
-    This is not included yet. We SCAD penalize all parameters, but large
-    parameters are not penalized by the SCAD penalty function.
-
-    pearson_resid: GLM resid_pearson does not include freq_weights.
-
     freq_weights are not supported in this. Candidate ranking uses
     moment condition with resid_pearson or others without freq_weights.
+    pearson_resid: GLM resid_pearson does not include freq_weights.
 
     fit_kwds are missing, e.g. we need to avoid irls in GLM, this is done
     by using start_params and a gradient fit_method.
 
-    variable names: do we keep track of those?
+    variable names: do we keep track of those? currently made-up names
 
     currently only supports numpy arrays, no exog type check or conversion
 
@@ -164,7 +218,7 @@ class VariableScreening(object):
             mom_cond = np.abs(resid_factor.dot(exog))**2
         return mom_cond
 
-    def screen_exog(self, exog, endog=None, maxiter=5, method='bfgs',
+    def screen_exog(self, exog, endog=None, maxiter=100, method='bfgs',
                     disp=False):
         """screen and select variables (columns) in exog
 
@@ -191,7 +245,7 @@ class VariableScreening(object):
             with the final model selection.
             `idx_nonzero` contains the index of the selected exog in the full
             exog, combined exog that are always kept plust exog_candidates.
-
+            see ScreeningResults for a full description
 
         """
         model_class = self.model_class
@@ -199,6 +253,7 @@ class VariableScreening(object):
             # allow a different endog than used in model
             endog = self.endog
         x0 = self.exog_keep
+        k_keep = self.k_keep
         x1 = exog
         k_current = x0.shape[1]
         # TODO: remove the need for x, use x1 separately from x0
@@ -229,7 +284,7 @@ class VariableScreening(object):
 
             if self.use_weights:
                 weights = np.ones(len(idx))
-                weights[:self.k_keep] = 0
+                weights[:k_keep] = 0
                 # modify Penalty instance attached to self
                 # damgerous if res_pen is reused
                 self.penal.weights = weights
@@ -244,7 +299,7 @@ class VariableScreening(object):
 
             keep = np.abs(res_pen.params) > self.threshold_trim
             # use largest params to keep
-            if len(res_pen.params) > self.k_max_included:
+            if keep.sum() > self.k_max_included:
                 # TODO we can use now np.partition with partial sort
                 thresh_params = np.sort(np.abs(res_pen.params))[
                                                         -self.k_max_included]
@@ -256,6 +311,7 @@ class VariableScreening(object):
             idx_nonzero = idx[keep]
 
             if disp:
+                print(keep)
                 print(idx_nonzero)
             # x0 is exog of currently selected model, not used in iteration
             # x0 = x[:, idx_nonzero]
@@ -282,7 +338,7 @@ class VariableScreening(object):
         # final esimate
         if self.use_weights:
             weights = np.ones(len(idx_nonzero))
-            weights[:self.k_keep] = 0
+            weights[:k_keep] = 0
             # create new Penalty instance to avoide sharing attached penal
             penal = self._get_penal(weights=weights)
         else:
@@ -295,16 +351,20 @@ class VariableScreening(object):
         res_final = mod_final.fit(method=method,
                                   start_params=start_params,
                                   warn_convergence=False, disp=disp)
+        # set exog_names for final model
+        xnames = ['var%4d' % ii for ii in idx_nonzero]
+        res_final.model.exog_names[k_keep:] = xnames[k_keep:]
 
         res = ScreeningResults(self,
                                results_pen = res_pen,
                                results_final = res_final,
                                idx_nonzero = idx_nonzero,
+                               idx_exog = idx_nonzero[k_keep:] - k_keep,
                                idx_excl = idx_excl,
-                               start_params = start_params,
                                history = history,
                                converged = converged,
-                               iterations = it)
+                               iterations = it + 1  # it is 0-based
+                               )
         return res
 
     def screen_exog_iterator(self, exog_iterator):
@@ -332,9 +392,10 @@ class VariableScreening(object):
             more information about the batched selection process.
             The index of final nonzero variables is
             `idx_nonzero_batches` which is a 2-dimensional array with batch
-            index in the first column and variable index withing batch in the
+            index in the first column and variable index within batch in the
             second column. They can be used jointly as index for the data
             in the exog_iterator.
+            see ScreeningResults for a full description
 
         """
         k_keep = self.k_keep
@@ -365,7 +426,7 @@ class VariableScreening(object):
         final_names = np.array(exog_winner_names)[ex_final_idx]
         res_screen_final.idx_nonzero_batches = np.array(idx_full)[ex_final_idx]
         res_screen_final.exog_final_names = final_names
-        history = {'res_idx': res_idx,
-                   'exog_idx': exog_idx}
-        res_screen_final.history = history
+        history = {'idx_nonzero': res_idx,
+                   'idx_exog': exog_idx}
+        res_screen_final.history_batches = history
         return res_screen_final

--- a/statsmodels/base/_screening.py
+++ b/statsmodels/base/_screening.py
@@ -23,41 +23,64 @@ class VariableScreening(object):
 
     This is an adjusted version of Fan's sure independence screening.
 
+    Parameters
+    ----------
+    model : instance of penalizing model
+        examples: GLMPenalized, PoissonPenalized and LogitPenalized
+    pen_weight : None or float
+        penalization weight use in SCAD penalized MLE
+    k_add : int
+        number of exog to add
+    k_max_add : int
+        maximum number of variables to add during variable addition, i.e.
+        forward selection. default is 30
+    threshold_trim : float
+        threshold for trimming parameters to zero, default is 1e-4
+    k_max_included : int
+        maximum total number of variables to include in model.
+    ranking_attr : str
+        This determines the result attribute or model method that is used for
+        the ranking of exog to include. The availability of attributes depends
+        on the model.
+        Default is 'resid_pearson', 'score_factor' can be used in GLM.
+    ranking_project : bool
+        If ranking_project is True, then the exog candidates for inclusion are
+        first projected on the already included exog before the computation
+        of the ranking measure. This brings the ranking measure closer to
+        the statistic of a score test for variable addition.
 
-    TODO Notes
+    Notes
+    -----
+    Status: experimental, tested only on a limited set of models and
+    with a limited set of model options.
+
+    TODOs and current limitations:
+
     penalization weights need to be used to avoid penalizing always kept
     exog. The length of weights vector depends on the number of variables
     included in the candidate model.
     This is not included yet. We SCAD penalize all parameters, but large
     parameters are not penalized by the SCAD penalty function.
 
-    Does user provide Penalized class or base class?
-    -> refactor so we use Penalized class with pen_weight=0 as base class
-
-    pen_weight is currently not a tuning option that can be changed by user.
-
-    pearson_resid: inconsistency in whether penalized or half-trimmed params
-    are used. Related issue: GLM resid_pearson does not include freq_weights.
+    pearson_resid: GLM resid_pearson does not include freq_weights.
 
     freq_weights are not supported in this. Candidate ranking uses
-    moment condition with resid_pearson without freq_weights.
+    moment condition with resid_pearson or others without freq_weights.
 
-    fit_kwds are missing, e.g. we need to avoid irls in GLM
+    fit_kwds are missing, e.g. we need to avoid irls in GLM, this is done
+    by using start_params and a gradient fit_method.
 
     variable names: do we keep track of those?
 
-    currently only supports numpy arrays, now exog type check or conversion
-
-    extensions to lazy or patched exog.
-    Actually, that should work already by calling screen_vars with patches
-    of exog, and then with a combined exog of best subset exog.
+    currently only supports numpy arrays, no exog type check or conversion
 
     currently only single columns are selected, no terms (multi column exog)
 
     """
 
-    def __init__(self, model, base_class, k_add=5, k_max_add=0,
-                 threshold_trim=1e-4, k_max_included=20, **kwargs):
+    def __init__(self, model, pen_weight=None, k_add=5, k_max_add=30,
+                 threshold_trim=1e-4, k_max_included=20,
+                 ranking_attr='resid_pearson', ranking_project=True):
 
         self.model = model
         self.model_class = model.__class__
@@ -69,29 +92,35 @@ class VariableScreening(object):
 
         self.endog = model.endog
         self.exog_keep = model.exog
+        self.k_keep = model.exog.shape[1]
         self.nobs = len(self.endog)
         self.penal = SCADSmoothed(0.1, c0=0.0001)
 
-        # this is only needed for initial start_params
-        self.base_class = base_class
+        if pen_weight is not None:
+            self.pen_weight = pen_weight
+        else:
+            self.pen_weight = self.nobs * 10
 
-        self.pen_weight = kwargs.pop('pen_weight', self.nobs * 10)
         # option for screening algorithm
         self.k_add = k_add
         self.k_max_add = k_max_add
         self.threshold_trim = threshold_trim
         self.k_max_included = k_max_included
-        self.ranking_attr = kwargs.get('ranking_attr', 'resid_pearson')
+        self.ranking_attr = ranking_attr
+        self.ranking_project = ranking_project
 
-    def ranking_measure(self, res_pen, exog, keep=None, project=True):
+    def ranking_measure(self, res_pen, exog, keep=None):
+        """compute measure for ranking exog candidates for inclusion
+
+        """
         endog = self.endog
 
-        if project:
+        if self.ranking_project:
             ex_incl = res_pen.model.exog[:, keep]
             exog = exog - ex_incl.dot(np.linalg.pinv(ex_incl).dot(exog))
 
-        if self.ranking_attr == 'predicted':
-            # I keep the following for more experiments
+        if self.ranking_attr == 'predicted_poisson':
+            # I keep this for more experiments
 
             # TODO: does it really help to change/trim params
             # we are not reestimating with trimmed model
@@ -115,7 +144,36 @@ class VariableScreening(object):
             mom_cond = np.abs(resid_factor.dot(exog))**2
         return mom_cond
 
-    def screen_exog(self, exog, endog=None, maxiter=5, disp=0):
+    def screen_exog(self, exog, endog=None, maxiter=5, method='bfgs',
+                    disp=False):
+        """screen and select variables (columns) in exog
+
+        Parameters
+        ----------
+        exog : ndarray
+            candidate explanatory variables that are screened for inclusion in
+            the model
+        endog : ndarray (optional)
+            use a new endog in the screening model.
+            This is not tested yet, and might not work correctly
+        maxiter : int
+            number of screening iterations
+        method : str
+            optimization method to use in fit, needs to be only of the gradient
+            optimizers
+        disp : bool
+            display option for fit during optimization
+
+        Returns
+        -------
+        res_screen : instance of ScreeningResults
+            The attribute `results_final` contains is the results instance
+            with the final model selection.
+            `idx_nonzero` contains the index of the selected exog in the full
+            exog, combined exog that are always kept plust exog_candidates.
+
+
+        """
         model_class = self.model_class
         if endog is None:
             # allow a different endog than used in model
@@ -141,17 +199,15 @@ class VariableScreening(object):
 
             mom_cond = self.ranking_measure(res_pen, x1, keep=keep)
             mcs = np.sort(mom_cond)[::-1]
-            #print(mcs[:10])
 
             threshold = mcs[max((self.k_max_add, k0 + self.k_add))]
-            #idx = np.concatenate((idx_nonzero, np.nonzero(mom_cond > threshold)[0] + 1))
             idx = np.concatenate((idx_nonzero, idx_excl[mom_cond > threshold]))
             start_params2 = np.zeros(len(idx))
             start_params2[:len(start_params)] = start_params
 
             res_pen = model_class(endog, x[:, idx], penal=self.penal,
                                        pen_weight=self.pen_weight,
-                                       **self.init_kwds).fit(method='bfgs',
+                                       **self.init_kwds).fit(method=method,
                                                 start_params=start_params2,
                                                 warn_convergence=False, disp=disp,
                                                 skip_hessian=True)
@@ -164,8 +220,6 @@ class VariableScreening(object):
                 keep2 = np.abs(res_pen.params) > thresh_params
                 keep = np.logical_and(keep, keep2)
             idx_nonzero = idx[keep]
-            # TODO: problem with order between using mask and indexing
-            #idx_nonzero.sort()
 
             if disp:
                 print(idx_nonzero)
@@ -185,7 +239,7 @@ class VariableScreening(object):
         # final esimate
         res_final = model_class(endog, x[:, idx_nonzero], penal=self.penal,
                                 pen_weight=self.pen_weight,
-                                **self.init_kwds).fit(method='bfgs',
+                                **self.init_kwds).fit(method=method,
                                           start_params=start_params,
                                           warn_convergence=False, disp=disp)
 
@@ -199,13 +253,43 @@ class VariableScreening(object):
         return res
 
     def screen_exog_iterator(self, exog_iterator):
-        res_batches = []
+        """
+        batched version of screen exog
+
+        This screens variables in a two step process:
+
+        In the first step screen_exog is used on each element of the
+        exog_iterator, and the batch winners are collected.
+
+        In the second step all batch winners are combined into a new array
+        of exog candidates and `screen_exog` is used to select a final
+        model.
+
+        Parameters
+        ----------
+        exog_iterator : iterator over ndarrays
+
+        Returns
+        -------
+        res_screen_final : instance of ScreeningResults
+            This is the instance returned by the second round call to
+            `screen_exog`. Additional attributes are added to provide
+            more information about the batched selection process.
+            The index of final nonzero variables is
+            `idx_nonzero_batches` which is a 2-dimensional array with batch
+            index in the first column and variable index withing batch in the
+            second column. They can be used jointly as index for the data
+            in the exog_iterator.
+
+        """
+        # res_batches = []
         res_idx = []
         exog_winner = []
         exog_idx = []
         for ex in exog_iterator:
             res_screen = self.screen_exog(ex, maxiter=20)
-            res_batches.append(res_screen)
+            # avoid storing res_screen, only for debugging
+            # res_batches.append(res_screen)
             res_idx.append(res_screen.idx_nonzero)
             exog_winner.append(ex[:, res_screen.idx_nonzero[1:] - 1])
             exog_idx.append(res_screen.idx_nonzero[1:] - 1)

--- a/statsmodels/base/_screening.py
+++ b/statsmodels/base/_screening.py
@@ -241,6 +241,7 @@ class VariableScreening(object):
                 break
             idx_old = idx_nonzero
 
+
         # final esimate
         res_final = model_class(endog, x[:, idx_nonzero], penal=self.penal,
                                 pen_weight=self.pen_weight,
@@ -255,7 +256,8 @@ class VariableScreening(object):
                                idx_excl = idx_excl,
                                start_params = start_params,
                                history = history,
-                               converged = converged)
+                               converged = converged,
+                               iterations = it)
         return res
 
     def screen_exog_iterator(self, exog_iterator):

--- a/statsmodels/base/tests/test_screening.py
+++ b/statsmodels/base/tests/test_screening.py
@@ -21,7 +21,7 @@ class PoissonPenalized(PenalizedMixin, Poisson):
 
 
 def test_poisson_screening():
-    # this is mostly a dump of my trial notebook
+    # this is mostly a dump of my development notebook
     # number of exog candidates is reduced to 500 to reduce time
     np.random.seed(987865)
 
@@ -30,7 +30,7 @@ def test_poisson_screening():
     x = (np.random.rand(nobs, k_vars) + 1.* (np.random.rand(nobs, 1)-0.5)) * 2 - 1
     x *= 1.2
 
-    x = (x - x.mean()) / x.std(0)
+    x = (x - x.mean(0)) / x.std(0)
     x[:, 0] = 1
     beta = np.zeros(k_vars)
     idx_non_zero_true = [0, 100, 300, 400, 411]
@@ -53,7 +53,7 @@ def test_poisson_screening():
 
     screener = VariableScreening(mod_initial, base_class)
     exog_candidates = x[:, 1:]
-    res_screen = screener.screen_vars(exog_candidates, maxiter=10)
+    res_screen = screener.screen_exog(exog_candidates, maxiter=10)
 
     res_screen.idx_nonzero
 

--- a/statsmodels/base/tests/test_screening.py
+++ b/statsmodels/base/tests/test_screening.py
@@ -6,17 +6,25 @@ Author: Josef Perktold
 
 """
 
-
+import pytest
 import numpy as np
 from numpy.testing import assert_allclose, assert_equal
 import pandas as pd
 
-from statsmodels.discrete.discrete_model import Poisson
+from statsmodels.discrete.discrete_model import Poisson, Logit
+from statsmodels.genmod.generalized_linear_model import GLM
+from statsmodels.genmod.families import family
 from statsmodels.base._penalized import PenalizedMixin
 from statsmodels.base._screening import VariableScreening
 
 
 class PoissonPenalized(PenalizedMixin, Poisson):
+    pass
+
+class LogitPenalized(PenalizedMixin, Logit):
+    pass
+
+class GLMPenalized(PenalizedMixin, GLM):
     pass
 
 
@@ -121,3 +129,111 @@ def test_screen_iterated():
                          [ 2, 10],
                          [ 3, 10]], dtype=np.int64)
     assert_equal(final.idx_nonzero_batches, idx_full)
+
+def _get_logit_data():
+    np.random.seed(987865)
+
+    nobs, k_vars = 300, 500
+    k_nonzero = 5
+    x = (np.random.rand(nobs, k_vars) + 0.01* (np.random.rand(nobs, 1)-0.5)) * 2 - 1
+    x *= 1.2
+
+    x = (x - x.mean(0)) / x.std(0)
+    x[:, 0] = 1
+    beta = np.zeros(k_vars)
+    idx_non_zero_true = [0, 100, 300, 400, 411]
+    beta[idx_non_zero_true] = 1. / np.arange(1, k_nonzero + 1)
+    beta = np.sqrt(beta)  # make small coefficients larger
+    linpred = x.dot(beta)
+    mu = 1 / (1 + np.exp(-linpred))
+    y = (np.random.rand(len(mu)) < mu).astype(int)
+    return y, x, idx_non_zero_true, beta
+
+
+@pytest.mark.xfail
+def test_logit_screening():
+
+    y, x, idx_non_zero_true, beta = _get_logit_data()
+    nobs = len(y)
+    # test uses
+    screener_kwds = dict(pen_weight=nobs * 0.7, threshold_trim=1e-3)
+
+    xnames_true = ['var%4d' % ii for ii in idx_non_zero_true]
+    xnames_true[0] = 'const'
+    parameters = pd.DataFrame(beta[idx_non_zero_true], index=xnames_true, columns=['true'])
+
+    xframe_true = pd.DataFrame(x[:, idx_non_zero_true], columns=xnames_true)
+    res_oracle = Logit(y, xframe_true).fit()
+    parameters['oracle'] = res_oracle.params
+
+    mod_initial = LogitPenalized(y, np.ones(nobs), pen_weight=nobs * 0.5)
+    base_class = Logit
+
+    screener = VariableScreening(mod_initial, base_class, **screener_kwds)
+    screener.k_max_add = 30
+    exog_candidates = x[:, 1:]
+    res_screen = screener.screen_exog(exog_candidates, maxiter=30)
+
+    res_screen.idx_nonzero
+
+    res_screen.results_final
+
+
+    xnames = ['var%4d' % ii for ii in res_screen.idx_nonzero]
+    xnames[0] = 'const'
+
+    # smoke test
+    res_screen.results_final.summary(xname=xnames)
+    res_screen.results_pen.summary()
+    assert_equal(res_screen.results_final.mle_retvals['converged'], True)
+
+    ps = pd.Series(res_screen.results_final.params, index=xnames, name='final')
+    parameters = parameters.join(ps, how='outer')
+
+    assert_allclose(parameters['oracle'], parameters['final'], atol=5e-6)
+
+
+@pytest.mark.xfail
+def test_glmlogit_screening():
+
+    y, x, idx_non_zero_true, beta = _get_logit_data()
+    nobs = len(y)
+
+    # test uses
+    screener_kwds = dict(pen_weight=nobs * 0.7, threshold_trim=1e-3,
+                         ranking_attr='model.score_factor')
+
+    xnames_true = ['var%4d' % ii for ii in idx_non_zero_true]
+    xnames_true[0] = 'const'
+    parameters = pd.DataFrame(beta[idx_non_zero_true], index=xnames_true, columns=['true'])
+
+    xframe_true = pd.DataFrame(x[:, idx_non_zero_true], columns=xnames_true)
+    res_oracle = GLMPenalized(y, xframe_true, family=family.Binomial()).fit()
+    parameters['oracle'] = res_oracle.params
+
+    #mod_initial = LogitPenalized(y, np.ones(nobs), pen_weight=nobs * 0.5)
+    mod_initial = GLMPenalized(y, np.ones(nobs), family=family.Binomial())
+    base_class = GLMPenalized
+
+    screener = VariableScreening(mod_initial, base_class, **screener_kwds)
+    screener.k_max_add = 30
+    exog_candidates = x[:, 1:]
+    res_screen = screener.screen_exog(exog_candidates, maxiter=30)
+
+    res_screen.idx_nonzero
+
+    res_screen.results_final
+
+
+    xnames = ['var%4d' % ii for ii in res_screen.idx_nonzero]
+    xnames[0] = 'const'
+
+    # smoke test
+    res_screen.results_final.summary(xname=xnames)
+    res_screen.results_pen.summary()
+    assert_equal(res_screen.results_final.mle_retvals['converged'], True)
+
+    ps = pd.Series(res_screen.results_final.params, index=xnames, name='final')
+    parameters = parameters.join(ps, how='outer')
+
+    assert_allclose(parameters['oracle'], parameters['final'], atol=5e-6)

--- a/statsmodels/base/tests/test_screening.py
+++ b/statsmodels/base/tests/test_screening.py
@@ -222,8 +222,8 @@ def test_logit_screening():
     mask = np.abs(res_screen.results_final.params) > 0.1
     assert_equal(np.sort(res_screen.idx_nonzero[mask]), idx_nonzero_true)
     # regression test
-    idx_r = np.array([  0, 100, 163, 300, 400, 411,  74])
-    assert_equal(res_screen.idx_nonzero, idx_r)
+    idx_r = np.array([0, 74, 100, 163, 300, 400, 411])
+    assert_equal(np.sort(res_screen.idx_nonzero), idx_r)
 
     xnames = ['var%4d' % ii for ii in res_screen.idx_nonzero]
     xnames[0] = 'const'

--- a/statsmodels/base/tests/test_screening.py
+++ b/statsmodels/base/tests/test_screening.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Wed May 23 12:53:27 2018
+
+Author: Josef Perktold
+
+"""
+
+
+import numpy as np
+from numpy.testing import assert_allclose, assert_equal
+import pandas as pd
+
+from statsmodels.discrete.discrete_model import Poisson
+from statsmodels.base._penalized import PenalizedMixin
+from statsmodels.base._screening import VariableScreening
+
+
+class PoissonPenalized(PenalizedMixin, Poisson):
+    pass
+
+
+def test_poisson_screening():
+    # this is mostly a dump of my trial notebook
+    # number of exog candidates is reduced to 500 to reduce time
+    np.random.seed(987865)
+
+    nobs, k_vars = 100, 500
+    k_nonzero = 5
+    x = (np.random.rand(nobs, k_vars) + 1.* (np.random.rand(nobs, 1)-0.5)) * 2 - 1
+    x *= 1.2
+
+    x = (x - x.mean()) / x.std(0)
+    x[:, 0] = 1
+    beta = np.zeros(k_vars)
+    idx_non_zero_true = [0, 100, 300, 400, 411]
+    beta[idx_non_zero_true] = 1. / np.arange(1, k_nonzero + 1)
+    beta = np.sqrt(beta)  # make small coefficients larger
+    linpred = x.dot(beta)
+    mu = np.exp(linpred)
+    y = np.random.poisson(mu)
+
+    xnames_true = ['var%4d' % ii for ii in idx_non_zero_true]
+    xnames_true[0] = 'const'
+    parameters = pd.DataFrame(beta[idx_non_zero_true], index=xnames_true, columns=['true'])
+
+    xframe_true = pd.DataFrame(x[:, idx_non_zero_true], columns=xnames_true)
+    res_oracle = Poisson(y, xframe_true).fit()
+    parameters['oracle'] = res_oracle.params
+
+    mod_initial = PoissonPenalized(y, np.ones(nobs), pen_weight=nobs * 5)
+    base_class = Poisson
+
+    screener = VariableScreening(mod_initial, base_class)
+    exog_candidates = x[:, 1:]
+    res_screen = screener.screen_vars(exog_candidates, maxiter=10)
+
+    res_screen.idx_nonzero
+
+    res_screen.results_final
+
+
+    xnames = ['var%4d' % ii for ii in res_screen.idx_nonzero]
+    xnames[0] = 'const'
+
+    # smoke test
+    res_screen.results_final.summary(xname=xnames)
+    res_screen.results_pen.summary()
+    assert_equal(res_screen.results_final.mle_retvals['converged'], True)
+
+    ps = pd.Series(res_screen.results_final.params, index=xnames, name='final')
+    parameters = parameters.join(ps, how='outer')
+
+    assert_allclose(parameters['oracle'], parameters['final'], atol=5e-6)

--- a/statsmodels/base/tests/test_screening.py
+++ b/statsmodels/base/tests/test_screening.py
@@ -6,7 +6,6 @@ Author: Josef Perktold
 
 """
 
-import pytest
 import numpy as np
 from numpy.testing import assert_allclose, assert_equal
 import pandas as pd
@@ -21,8 +20,10 @@ from statsmodels.base._screening import VariableScreening
 class PoissonPenalized(PenalizedMixin, Poisson):
     pass
 
+
 class LogitPenalized(PenalizedMixin, Logit):
     pass
+
 
 class GLMPenalized(PenalizedMixin, GLM):
     pass
@@ -57,9 +58,8 @@ def test_poisson_screening():
     parameters['oracle'] = res_oracle.params
 
     mod_initial = PoissonPenalized(y, np.ones(nobs), pen_weight=nobs * 5)
-    base_class = Poisson
 
-    screener = VariableScreening(mod_initial, base_class)
+    screener = VariableScreening(mod_initial)
     exog_candidates = x[:, 1:]
     res_screen = screener.screen_exog(exog_candidates, maxiter=10)
 
@@ -117,8 +117,7 @@ def test_screen_iterated():
             yield x
 
     mod_initial = PoissonPenalized(y, np.ones(nobs), pen_weight=nobs * 500)
-    base_class = Poisson
-    screener = VariableScreening(mod_initial, base_class)
+    screener = VariableScreening(mod_initial)
     screener.k_max_add = 30
 
     final = screener.screen_exog_iterator(exog_iterator())
@@ -166,9 +165,7 @@ def test_logit_screening():
     parameters['oracle'] = res_oracle.params
 
     mod_initial = LogitPenalized(y, np.ones(nobs), pen_weight=nobs * 0.5)
-    base_class = Logit
-
-    screener = VariableScreening(mod_initial, base_class, **screener_kwds)
+    screener = VariableScreening(mod_initial, **screener_kwds)
     screener.k_max_add = 30
     exog_candidates = x[:, 1:]
     res_screen = screener.screen_exog(exog_candidates, maxiter=30)
@@ -213,9 +210,8 @@ def test_glmlogit_screening():
 
     #mod_initial = LogitPenalized(y, np.ones(nobs), pen_weight=nobs * 0.5)
     mod_initial = GLMPenalized(y, np.ones(nobs), family=family.Binomial())
-    base_class = GLMPenalized
 
-    screener = VariableScreening(mod_initial, base_class, **screener_kwds)
+    screener = VariableScreening(mod_initial, **screener_kwds)
     screener.k_max_add = 10
     exog_candidates = x[:, 1:]
     res_screen = screener.screen_exog(exog_candidates, maxiter=30)

--- a/statsmodels/discrete/discrete_model.py
+++ b/statsmodels/discrete/discrete_model.py
@@ -3690,6 +3690,7 @@ class L1CountResults(DiscreteResults):
         self.df_resid = float(self.model.endog.shape[0] - self.nnz_params) + k_extra
 
 class PoissonResults(CountResults):
+
     def predict_prob(self, n=None, exog=None, exposure=None, offset=None,
                      transform=True):
         """
@@ -3718,6 +3719,27 @@ class PoissonResults(CountResults):
                           transform=transform, linear=False)[:,None]
         # uses broadcasting
         return stats.poisson.pmf(counts, mu)
+
+    @property
+    def resid_pearson(self):
+        """
+        Pearson residuals
+
+        Notes
+        -----
+        Pearson residuals are defined to be
+
+        .. math:: r_j = \\frac{(y - M_jp_j)}{\\sqrt{M_jp_j(1-p_j)}}
+
+        where :math:`p_j=cdf(X\\beta)` and :math:`M_j` is the total number of
+        observations sharing the covariate pattern :math:`j`.
+
+        For now :math:`M_j` is always set to 1.
+        """
+        # Pearson residuals
+        p = self.predict()  # fittedvalues is still linear
+        return (self.model.endog - p)/np.sqrt(p)
+
 
 class L1PoissonResults(L1CountResults, PoissonResults):
     pass


### PR DESCRIPTION
selecting variables for k_vars >> nobs

This is a generic function that takes a model or model class as argument to find and estimate the final model with selected exog.
requires a model with PenalizedMixing merged in #4576
Currently checked for Poisson and GLM-Poisson. 

example (used for test case)
https://gist.github.com/josef-pkt/a90eb8be076276874a0d026ad6c7efa0
and GLM version
https://gist.github.com/josef-pkt/df6ef0dcf42d99dee4afeb968f4f4c94

unit tests will most likely be: "it works" and not verified against other packages

TODOs and limitations in class docstring.
API not clear yet

I'm not sure whether I want to merge a basic version or add more options.
