### PR TITLE
PERF: Declare temporary output for hessian

### DIFF
--- a/statsmodels/genmod/generalized_linear_model.py
+++ b/statsmodels/genmod/generalized_linear_model.py
@@ -608,9 +608,11 @@ class GLM(base.LikelihoodModel):
             else:
                 observed = True
 
+        tmp = getattr(self, '_tmp_like_exog', np.empty_like(self.exog))
+
         factor = self.hessian_factor(params, scale=scale, observed=observed)
-        hess = -np.dot(self.exog.T * factor, self.exog)
-        return hess
+        np.multiply(self.exog.T, factor, out=tmp.T)
+        return -tmp.T.dot(self.exog)
 
     def information(self, params, scale=None):
         """
@@ -1068,6 +1070,7 @@ class GLM(base.LikelihoodModel):
                                   cov_kwds=cov_kwds, use_t=use_t, **kwargs)
         else:
             self._optim_hessian = kwargs.get('optim_hessian')
+            self._tmp_like_exog = np.empty_like(self.exog)
             fit_ = self._fit_gradient(start_params=start_params,
                                       method=method,
                                       maxiter=maxiter,
@@ -1078,6 +1081,7 @@ class GLM(base.LikelihoodModel):
                                       max_start_irls=max_start_irls,
                                       **kwargs)
             self._optim_hessian = None
+            self._tmp_like_exog = None
             return fit_
 
     def _fit_gradient(self, start_params=None, method="newton",

--- a/statsmodels/genmod/generalized_linear_model.py
+++ b/statsmodels/genmod/generalized_linear_model.py
@@ -1080,8 +1080,8 @@ class GLM(base.LikelihoodModel):
                                       cov_kwds=cov_kwds, use_t=use_t,
                                       max_start_irls=max_start_irls,
                                       **kwargs)
-            self._optim_hessian = None
-            self._tmp_like_exog = None
+            del self._optim_hessian
+            del self._tmp_like_exog
             return fit_
 
     def _fit_gradient(self, start_params=None, method="newton",


### PR DESCRIPTION
So taking this code:

```python
%matplotlib inline

from __future__ import print_function

import numpy as np
import scipy as sp
from scipy.stats.distributions import poisson
import statsmodels.api as sm

# Number of parameters for model
p = 25

# Number of simulated observations
n = 5000000

np.random.seed(43)
exog = np.random.rand(n, p - 1)
exog = np.hstack((np.ones((n, 1)), exog))
beta = np.concatenate(([-100], np.random.randint(-100, 100, p - 1))) / 100
eta = np.dot(exog, beta)
mu = np.exp(eta)

endog = poisson.rvs(mu)

model = sm.GLM(endog, exog, sm.families.Poisson(sm.families.links.log()))
```

And the money line...

`res = model.fit(method='newton', max_start_irls=0)`

On this simulated data, this PR is about 22 seconds vs. 24 seconds without. (Did a few `%%timeits`). 

Not sure if this is worth it...