### PR TITLE
BUG Fix random effects covariance getter for MixedLM

### DIFF
--- a/statsmodels/regression/mixed_linear_model.py
+++ b/statsmodels/regression/mixed_linear_model.py
@@ -2308,7 +2308,7 @@ class MixedLMResults(base.LikelihoodModelResults, base.ResultMixin):
             ex_r = self.model._aex_r[group_ix]
             ex2_r = self.model._aex_r2[group_ix]
             label = self.model.group_labels[group_ix]
-            vc_var = self.model._expand_vcomp(vcomp, group_ix)
+            vc_var = self.model._expand_vcomp(vcomp, label)
 
             solver = _smw_solver(self.scale, ex_r, ex2_r, cov_re_inv,
                                  1 / vc_var)
@@ -2325,7 +2325,7 @@ class MixedLMResults(base.LikelihoodModelResults, base.ResultMixin):
             v[0:m, 0:m] += self.cov_re
             ix = np.arange(m, v.shape[0])
             v[ix, ix] += vc_var
-            na = self._expand_re_names(group_ix)
+            na = self._expand_re_names(label)
             v = pd.DataFrame(v, index=na, columns=na)
             ranef_dict[label] = v
 

--- a/statsmodels/regression/tests/test_lme.py
+++ b/statsmodels/regression/tests/test_lme.py
@@ -1106,7 +1106,7 @@ def test_random_effects_getters():
         y.append(yy)
         x.append(xx)
         z.append(zz)
-        g.append(i * np.ones(m))
+        g.append(["g%d" % i] * m)
 
     y = np.concatenate(y)
     x = np.concatenate(x)
@@ -1142,12 +1142,12 @@ def test_random_effects_getters():
     result = model.fit()
 
     ref = result.random_effects
-    b0 = [ref[k][0:2] for k in range(ng)]
+    b0 = [ref["g%d" % k][0:2] for k in range(ng)]
     b0 = np.asarray(b0)
     assert (np.corrcoef(b0[:, 0], b[:, 0])[0, 1] > 0.8)
     assert (np.corrcoef(b0[:, 1], b[:, 1])[0, 1] > 0.8)
 
-    cf0 = [ref[k][2:6] for k in range(ng)]
+    cf0 = [ref["g%d" % k][2:6] for k in range(ng)]
     cf0 = np.asarray(cf0)
     for k in range(4):
         assert (np.corrcoef(cf0[:, k], cc[:, k])[0, 1] > 0.8)


### PR DESCRIPTION
This should fix #4413.  The bug was not detected by the tests because the group labels and the integer indices of the groups were the same.  So I changed the group labels from  ### to strings of the form g###.  The old code would have failed under the new tests.

Thanks @danlewis85
