### PR TITLE
ENH: add score_factor, hessian_factor to discrete

### DIFF
--- a/statsmodels/base/_parameter_inference.py
+++ b/statsmodels/base/_parameter_inference.py
@@ -5,17 +5,11 @@ Created on Wed May 30 15:11:09 2018
 @author: josef
 """
 
-import time
 import numpy as np
 from scipy import stats
 
-from statsmodels.regression.linear_model import OLS
-from statsmodels.genmod.generalized_linear_model import GLM
-from statsmodels.genmod import families
-import statsmodels.stats._diagnostic_other as diao
 
-
-# this is a copy from stats._diagnostic_other
+# this is a copy from stats._diagnostic_other to avoid circular imports
 def _lm_robust(score, constraint_matrix, score_deriv_inv, cov_score,
                cov_params=None):
     '''general formula for score/LM test
@@ -220,7 +214,11 @@ def score_test(self, exog_extra=None, params_constrained=None,
         score = score_obs.sum(0)
         hessian_factor = model.hessian_factor(params_constrained,
                                               **hess_kwd)
-        hessian = -np.dot(ex.T * hessian_factor, ex)
+        # see #4714
+        from statsmodels.genmod.generalized_linear_model import GLM
+        if isinstance(model, GLM):
+            hessian_factor *= -1
+        hessian = np.dot(ex.T * hessian_factor, ex)
 
     if cov_type == 'nonrobust':
         cov_score_test = -hessian

--- a/statsmodels/discrete/discrete_model.py
+++ b/statsmodels/discrete/discrete_model.py
@@ -1289,7 +1289,7 @@ class Poisson(CountModel):
         exposure = getattr(self, "exposure", 0)
         X = self.exog
         L = np.exp(np.dot(X,params) + exposure + offset)
-        return L
+        return -L
 
 
 class GeneralizedPoisson(CountModel):
@@ -1555,6 +1555,32 @@ class GeneralizedPoisson(CountModel):
         else:
             return score
 
+    def score_factor(self, params):
+        if self._transparams:
+            alpha = np.exp(params[-1])
+        else:
+            alpha = params[-1]
+
+        params = params[:-1]
+        p = self.parameterization
+        exog = self.exog
+        y = self.endog[:,None]
+        mu = self.predict(params)[:,None]
+        mu_p = np.power(mu, p)
+        a1 = 1 + alpha * mu_p
+        a2 = mu + alpha * mu_p * y
+        a3 = alpha * p * mu ** (p - 1)
+        a4 = a3 * y
+        dmudb = mu
+
+        dalpha = (mu_p * (y * ((y - 1) / a2 - 2 / a1) + a2 / a1**2))
+        dparams = dmudb * (-a4 / a1 +
+                           a3 * a2 / (a1 ** 2) +
+                           (1 + a4) * ((y - 1) / a2 - 1 / a1) +
+                           1 / mu)
+
+        return np.column_stack((dparams, dalpha))
+
     def _score_p(self, params):
         """
         Generalized Poisson model derivative of the log-likelihood by p-parameter
@@ -1667,6 +1693,89 @@ class GeneralizedPoisson(CountModel):
         hess_arr[-1,-1] = dldada.sum()
 
         return hess_arr
+
+    def hessian_factor(self, params):
+        """
+        Generalized Poisson model Hessian matrix of the loglikelihood
+
+        Parameters
+        ----------
+        params : array-like
+            The parameters of the model
+
+        Returns
+        -------
+        hess : ndarray, (nobs, 3)
+            The Hessian factor, second derivative of loglikelihood function
+            with respect to linear predictor and dispersion parameter
+            evaluated at `params`
+            The first column contains the second derivative w.r.t. linpred,
+            the second column contains the cross derivative, and the
+            third column contains the second derivative w.r.t. the dispersion
+            parameter.
+
+        """
+        if self._transparams:
+            alpha = np.exp(params[-1])
+        else:
+            alpha = params[-1]
+
+        params = params[:-1]
+        p = self.parameterization
+        exog = self.exog
+        y = self.endog #[:,None]
+        mu = self.predict(params)  # [:,None]
+        mu_p = np.power(mu, p)
+        a1 = 1 + alpha * mu_p
+        a2 = mu + alpha * mu_p * y
+        a3 = alpha * p * mu ** (p - 1)
+        a4 = a3 * y
+        a5 = p * mu ** (p - 1)
+        dmudb = mu
+
+        # for dl/dlinpred dparams
+        nobs, k_vars = exog.shape
+        hess_fact = np.empty((nobs, 3))
+
+
+        hess_fact[:, 0] = mu * (
+             mu * (a3 * a4 / a1**2 -
+                   2 * a3**2 * a2 / a1**3 +
+                   2 * a3 * (a4 + 1) / a1**2 -
+                   a4 * p / (mu * a1) +
+                   a3 * p * a2 / (mu * a1**2) +
+                   a4 / (mu * a1) -
+                   a3 * a2 / (mu * a1**2) +
+                   (y - 1) * a4 * (p - 1) / (a2 * mu) -
+                   (y - 1) * (1 + a4)**2 / a2**2 -
+                   a4 * (p - 1) / (a1 * mu) -
+                   1 / mu**2) +
+             (-a4 / a1 +
+              a3 * a2 / a1**2 +
+              (y - 1) * (1 + a4) / a2 -
+              (1 + a4) / a1 +
+              1 / mu))
+
+        # for dl/dlinpred dalpha
+        dldpda = ((2 * a4 * mu_p / a1**2 -
+                         2 * a3 * mu_p * a2 / a1**3 -
+                         mu_p * y * (y - 1) * (1 + a4) / a2**2 +
+                         mu_p * (1 + a4) / a1**2 +
+                         a5 * y * (y - 1) / a2 -
+                         2 * a5 * y / a1 +
+                         a5 * a2 / a1**2) * dmudb)
+
+        hess_fact[:, 1] = dldpda
+
+        # for dl/dalpha dalpha
+        dldada = mu_p**2 * (3 * y / a1**2 -
+                            (y / a2)**2. * (y - 1) -
+                            2 * a2 / a1**3)
+
+        hess_fact[:, 2] = dldada
+
+        return hess_fact
+
 
     def predict(self, params, exog=None, exposure=None, offset=None,
                 which='mean'):
@@ -1875,6 +1984,34 @@ class Logit(BinaryModel):
         L = self.cdf(np.dot(X, params))
         return (y - L)[:,None] * X
 
+    def score_factor(self, params):
+        """
+        Logit model derivative of the log-likelihood with respect to linpred
+
+        Parameters
+        ----------
+        params: array-like
+            The parameters of the model
+
+        Returns
+        -------
+        jac : array-like
+            The derivative of the loglikelihood for each observation evaluated
+            at `params`.
+
+        Notes
+        -----
+        .. math:: \\frac{\\partial\\ln L_{i}}{\\partial\\beta}=\\left(y_{i}-\\Lambda_{i}\\right)x_{i}
+
+        for observations :math:`i=1,...,n`
+
+        """
+
+        y = self.endog
+        X = self.exog
+        L = self.cdf(np.dot(X, params))
+        return (y - L)
+
     def hessian(self, params):
         """
         Logit model Hessian matrix of the log-likelihood
@@ -1897,6 +2034,30 @@ class Logit(BinaryModel):
         X = self.exog
         L = self.cdf(np.dot(X,params))
         return -np.dot(L*(1-L)*X.T,X)
+
+    def hessian_factor(self, params):
+        """
+        Logit model Hessian matrix of the log-likelihood
+
+        Parameters
+        ----------
+        params : array-like
+            The parameters of the model
+
+        Returns
+        -------
+        hess : ndarray, (k_vars, k_vars)
+            The Hessian, second derivative of loglikelihood function,
+            evaluated at `params`
+
+        Notes
+        -----
+        .. math:: \\frac{\\partial^{2}\\ln L}{\\partial\\beta\\partial\\beta^{\\prime}}=-\\sum_{i}\\Lambda_{i}\\left(1-\\Lambda_{i}\\right)x_{i}x_{i}^{\\prime}
+        """
+        X = self.exog
+        L = self.cdf(np.dot(X,params))
+        return -L * (1 - L)
+
 
     def fit(self, start_params=None, method='newton', maxiter=35,
             full_output=1, disp=1, callback=None, **kwargs):
@@ -2087,6 +2248,39 @@ class Probit(BinaryModel):
         L = q*self.pdf(q*XB)/np.clip(self.cdf(q*XB), FLOAT_EPS, 1 - FLOAT_EPS)
         return L[:,None] * X
 
+    def score_factor(self, params):
+        """
+        Probit model Jacobian for each observation
+
+        Parameters
+        ----------
+        params : array-like
+            The parameters of the model
+
+        Returns
+        -------
+        jac : array-like
+            The derivative of the loglikelihood for each observation evaluated
+            at `params`.
+
+        Notes
+        -----
+        .. math:: \\frac{\\partial\\ln L_{i}}{\\partial\\beta}=\\left[\\frac{q_{i}\\phi\\left(q_{i}x_{i}^{\\prime}\\beta\\right)}{\\Phi\\left(q_{i}x_{i}^{\\prime}\\beta\\right)}\\right]x_{i}
+
+        for observations :math:`i=1,...,n`
+
+        Where :math:`q=2y-1`. This simplification comes from the fact that the
+        normal distribution is symmetric.
+        """
+        y = self.endog
+        X = self.exog
+        XB = np.dot(X,params)
+        q = 2*y - 1
+        # clip to get rid of invalid divide complaint
+        L = q*self.pdf(q*XB)/np.clip(self.cdf(q*XB), FLOAT_EPS, 1 - FLOAT_EPS)
+        return L
+
+
     def hessian(self, params):
         """
         Probit model Hessian matrix of the log-likelihood
@@ -2117,6 +2311,37 @@ class Probit(BinaryModel):
         q = 2*self.endog - 1
         L = q*self.pdf(q*XB)/self.cdf(q*XB)
         return np.dot(-L*(L+XB)*X.T,X)
+
+    def hessian_factor(self, params):
+        """
+        Probit model Hessian factor of the log-likelihood
+
+        Parameters
+        ----------
+        params : array-like
+            The parameters of the model
+
+        Returns
+        -------
+        hess : ndarray, (nobs,)
+            The Hessian factor, second derivative of loglikelihood function
+            with respect to linear predictor evaluated at `params`
+
+        Notes
+        -----
+        .. math:: \\frac{\\partial^{2}\\ln L}{\\partial\\beta\\partial\\beta^{\\prime}}=-\\lambda_{i}\\left(\\lambda_{i}+x_{i}^{\\prime}\\beta\\right)x_{i}x_{i}^{\\prime}
+
+        where
+
+        .. math:: \\lambda_{i}=\\frac{q_{i}\\phi\\left(q_{i}x_{i}^{\\prime}\\beta\\right)}{\\Phi\\left(q_{i}x_{i}^{\\prime}\\beta\\right)}
+
+        and :math:`q=2y-1`
+        """
+        X = self.exog
+        XB = np.dot(X,params)
+        q = 2 * self.endog - 1
+        L = q * self.pdf(q * XB) / self.cdf(q * XB)
+        return -L * (L + XB)
 
     def fit(self, start_params=None, method='newton', maxiter=35,
             full_output=1, disp=1, callback=None, **kwargs):
@@ -3068,6 +3293,49 @@ class NegativeBinomialP(CountModel):
         else:
             return score
 
+    def score_factor(self, params):
+        """
+        Generalized Negative Binomial (NB-P) model score (gradient) vector of the log-likelihood for each observations.
+
+        Parameters
+        ----------
+        params : array-like
+            The parameters of the model
+
+        Returns
+        -------
+        score : ndarray, 1-D
+            The score vector of the model, i.e. the first derivative of the
+            loglikelihood function, evaluated at `params`
+        """
+        if self._transparams:
+            alpha = np.exp(params[-1])
+        else:
+            alpha = params[-1]
+
+        params = params[:-1]
+        p = 2 - self.parameterization
+        y = self.endog
+
+        mu = self.predict(params)
+        mu_p = mu**p
+        a1 = mu_p / alpha
+        a2 = mu + a1
+        a3 = y + a1
+        a4 = p * a1 / mu
+
+        dgpart = digamma(a3) - digamma(a1)
+
+        dparams = ((a4 * dgpart -
+                   a3 / a2) +
+                   y / mu + a4 * (1 - a3 / a2 + np.log(a1 / a2)))
+        dparams = (mu * dparams).T
+        dalpha = (-a1 / alpha * (dgpart +
+                                 np.log(a1 / a2) +
+                                 1 - a3 / a2))
+
+        return np.column_stack((dparams, dalpha))
+
     def hessian(self, params):
         """
         Generalized Negative Binomial (NB-P) model hessian maxtrix of the log-likelihood
@@ -3139,6 +3407,73 @@ class NegativeBinomialP(CountModel):
         hess_arr[tri_idx] = hess_arr.T[tri_idx]
 
         return hess_arr
+
+    def hessian_factor(self, params):
+        """
+        Generalized Negative Binomial (NB-P) model hessian maxtrix of the log-likelihood
+
+        Parameters
+        ----------
+        params : array-like
+            The parameters of the model
+
+        Returns
+        -------
+        hessian : ndarray, 2-D
+            The hessian matrix of the model.
+        """
+        if self._transparams:
+            alpha = np.exp(params[-1])
+        else:
+            alpha = params[-1]
+        params = params[:-1]
+
+        p = 2 - self.parameterization
+        y = self.endog
+        exog = self.exog
+        mu = self.predict(params)
+
+        mu_p = mu**p
+        a1 = mu_p / alpha
+        a2 = mu + a1
+        a3 = y + a1
+        a4 = p * a1 / mu
+        a5 = a4 * p / mu
+
+        dgpart = digamma(a3) - digamma(a1)
+
+        nobs = exog.shape[0]
+        hess_fact = np.zeros((nobs, 3))
+
+        coeff = mu**2 * (((1 + a4)**2 * a3 / a2**2 -
+                          a3 * (a5 - a4 / mu) / a2 -
+                          y / mu**2 -
+                          2 * a4 * (1 + a4) / a2 +
+                          a5 * (np.log(a1) - np.log(a2) + dgpart + 2) -
+                          a4 * (np.log(a1) - np.log(a2) + dgpart + 1) / mu -
+                          a4**2 * (polygamma(1, a1) - polygamma(1, a3))) +
+                         (-(1 + a4) * a3 / a2 +
+                          y / mu +
+                          a4 * (np.log(a1) - np.log(a2) + dgpart + 1)) / mu)
+
+        hess_fact[:, 0] = coeff
+
+        hess_fact[:, 1] = (mu * a1 *
+                ((1 + a4) * (1 - a3 / a2) / a2 -
+                 p * (np.log(a1 / a2) + dgpart + 2) / mu +
+                 p * (a3 / mu + a4) / a2 +
+                 a4 * (polygamma(1, a1) - polygamma(1, a3))) / alpha)
+
+        da2 = (a1 * (2 * np.log(a1 / a2) +
+                     2 * dgpart + 3 -
+                     2 * a3 / a2 - a1 * polygamma(1, a1) +
+                     a1 * polygamma(1, a3) - 2 * a1 / a2 +
+                     a1 * a3 / a2**2) / alpha**2)
+
+        hess_fact[:, 2] = da2
+
+        return hess_fact
+
 
     def _get_start_params_null(self):
         offset = getattr(self, "offset", 0)

--- a/statsmodels/discrete/discrete_model.py
+++ b/statsmodels/discrete/discrete_model.py
@@ -40,6 +40,7 @@ import statsmodels.base.wrapper as wrap
 from statsmodels.base.data import handle_data  # for mnlogit
 from statsmodels.base.l1_slsqp import fit_l1_slsqp
 from statsmodels.base._constraints import fit_constrained_wrap
+import statsmodels.base._parameter_inference as infer
 import statsmodels.regression.linear_model as lm
 from statsmodels.compat.numpy import np_matrix_rank
 from statsmodels.distributions import genpoisson_p
@@ -3865,6 +3866,22 @@ class DiscreteResults(base.LikelihoodModelResults):
     @cache_readonly
     def bic(self):
         return -2*self.llf + np.log(self.nobs)*(self.df_model+1)
+
+
+    def score_test(self, exog_extra=None, params_constrained=None,
+                   hypothesis='joint', cov_type=None, cov_kwds=None,
+                   k_constraints=None, observed=True):
+
+        res = infer.score_test(self, exog_extra=exog_extra,
+                               params_constrained=params_constrained,
+                               hypothesis=hypothesis,
+                               cov_type=cov_type, cov_kwds=cov_kwds,
+                               k_constraints=k_constraints,
+                               observed=observed)
+        return res
+
+    score_test.__doc__ = infer.score_test.__doc__
+
 
     def _get_endog_name(self, yname, yname_list):
         if yname is None:

--- a/statsmodels/discrete/discrete_model.py
+++ b/statsmodels/discrete/discrete_model.py
@@ -36,13 +36,14 @@ from statsmodels.tools.decorators import resettable_cache, cache_readonly
 from statsmodels.tools.sm_exceptions import PerfectSeparationError
 from statsmodels.tools.numdiff import approx_fprime_cs
 import statsmodels.base.model as base
-from statsmodels.base.data import handle_data  # for mnlogit
-import statsmodels.regression.linear_model as lm
 import statsmodels.base.wrapper as wrap
-from statsmodels.compat.numpy import np_matrix_rank
-
+from statsmodels.base.data import handle_data  # for mnlogit
 from statsmodels.base.l1_slsqp import fit_l1_slsqp
+from statsmodels.base._constraints import fit_constrained_wrap
+import statsmodels.regression.linear_model as lm
+from statsmodels.compat.numpy import np_matrix_rank
 from statsmodels.distributions import genpoisson_p
+
 
 try:
     import cvxopt  # noqa:F401
@@ -475,6 +476,14 @@ class BinaryModel(DiscreteModel):
                     "argument method == %s, which is not handled" % method)
         return L1BinaryResultsWrapper(discretefit)
     fit_regularized.__doc__ = DiscreteModel.fit_regularized.__doc__
+
+    def fit_constrained(self, constraints, start_params=None, **fit_kwds):
+
+        res = fit_constrained_wrap(self, constraints, start_params=None,
+                                   **fit_kwds)
+        return res
+
+    fit_constrained.__doc__ = fit_constrained_wrap.__doc__
 
     def _derivative_predict(self, params, exog=None, transform='dydx',
                             offset=None):

--- a/statsmodels/discrete/discrete_model.py
+++ b/statsmodels/discrete/discrete_model.py
@@ -414,14 +414,16 @@ class DiscreteModel(base.LikelihoodModel):
 
 class BinaryModel(DiscreteModel):
 
-    def __init__(self, endog, exog, **kwargs):
-        super(BinaryModel, self).__init__(endog, exog, **kwargs)
+    def __init__(self, endog, exog, offset=None, **kwargs):
+        super(BinaryModel, self).__init__(endog, exog, offset=offset, **kwargs)
         if (not issubclass(self.__class__, MultinomialModel) and
                 not np.all((self.endog >= 0) & (self.endog <= 1))):
             raise ValueError("endog must be in the unit interval.")
+        if offset is None:
+            delattr(self, 'offset')
 
 
-    def predict(self, params, exog=None, linear=False):
+    def predict(self, params, exog=None, linear=False, offset=None):
         """
         Predict response variable of a model given exogenous variables.
 
@@ -441,12 +443,21 @@ class BinaryModel(DiscreteModel):
         array
             Fitted values at exog.
         """
+        # Use fit offset if appropriate
+        if offset is None and exog is None and hasattr(self, 'offset'):
+            offset = self.offset
+        elif offset is None:
+            offset = 0.
+
         if exog is None:
             exog = self.exog
+
+        linpred = np.dot(exog, params) + offset
+
         if not linear:
-            return self.cdf(np.dot(exog, params))
+            return self.cdf(linpred)
         else:
-            return np.dot(exog, params)
+            return linpred
 
     def fit_regularized(self, start_params=None, method='l1',
             maxiter='defined_by_method', full_output=1, disp=1, callback=None,
@@ -465,7 +476,8 @@ class BinaryModel(DiscreteModel):
         return L1BinaryResultsWrapper(discretefit)
     fit_regularized.__doc__ = DiscreteModel.fit_regularized.__doc__
 
-    def _derivative_predict(self, params, exog=None, transform='dydx'):
+    def _derivative_predict(self, params, exog=None, transform='dydx',
+                            offset=None):
         """
         For computing marginal effects standard errors.
 
@@ -478,13 +490,14 @@ class BinaryModel(DiscreteModel):
         """
         if exog is None:
             exog = self.exog
-        dF = self.pdf(np.dot(exog, params))[:,None] * exog
+        linpred = self.predict(params, exog, offset=offset, linear=True)
+        dF = self.pdf(linpred)[:,None] * exog
         if 'ey' in transform:
-            dF /= self.predict(params, exog)[:,None]
+            dF /= self.predict(params, exog, offset=offset)[:,None]
         return dF
 
     def _derivative_exog(self, params, exog=None, transform='dydx',
-            dummy_idx=None, count_idx=None):
+                         dummy_idx=None, count_idx=None, offset=None):
         """
         For computing marginal effects returns dF(XB) / dX where F(.) is
         the predicted probabilities
@@ -498,7 +511,8 @@ class BinaryModel(DiscreteModel):
         ## group 1 probit, logit, logistic, cloglog, heckprob, xtprobit
         if exog is None:
             exog = self.exog
-        margeff = np.dot(self.pdf(np.dot(exog, params))[:,None],
+        linpred = self.predict(params, exog, offset=offset, linear=True)
+        margeff = np.dot(self.pdf(linpred)[:,None],
                                                           params[None,:])
         if 'ex' in transform:
             margeff *= exog
@@ -1829,7 +1843,14 @@ class Logit(BinaryModel):
     exog : array
         A reference to the exogenous design.
     """ % {'params' : base._model_params_doc,
-           'extra_params' : base._missing_param_doc}
+           'extra_params' :
+           """offset : array_like
+        Offset is added to the linear prediction with coefficient equal to 1.
+    exposure : array_like
+        Log(exposure) is added to the linear prediction with coefficient
+        equal to 1.
+
+    """ + base._missing_param_doc}
 
     def cdf(self, X):
         """
@@ -1901,7 +1922,8 @@ class Logit(BinaryModel):
         """
         q = 2*self.endog - 1
         X = self.exog
-        return np.sum(np.log(self.cdf(q*np.dot(X,params))))
+        linpred = self.predict(params, linear=True)
+        return np.sum(np.log(self.cdf(q * linpred)))
 
     def loglikeobs(self, params):
         """
@@ -1929,7 +1951,8 @@ class Logit(BinaryModel):
         """
         q = 2*self.endog - 1
         X = self.exog
-        return np.log(self.cdf(q*np.dot(X,params)))
+        linpred = self.predict(params, linear=True)
+        return np.log(self.cdf(q * linpred))
 
     def score(self, params):
         """
@@ -1953,8 +1976,8 @@ class Logit(BinaryModel):
 
         y = self.endog
         X = self.exog
-        L = self.cdf(np.dot(X,params))
-        return np.dot(y - L,X)
+        fitted = self.predict(params)
+        return np.dot(y - fitted, X)
 
     def score_obs(self, params):
         """
@@ -1981,8 +2004,8 @@ class Logit(BinaryModel):
 
         y = self.endog
         X = self.exog
-        L = self.cdf(np.dot(X, params))
-        return (y - L)[:,None] * X
+        fitted = self.predict(params)
+        return (y - fitted)[:,None] * X
 
     def score_factor(self, params):
         """
@@ -2009,8 +2032,8 @@ class Logit(BinaryModel):
 
         y = self.endog
         X = self.exog
-        L = self.cdf(np.dot(X, params))
-        return (y - L)
+        fitted = self.predict(params)
+        return (y - fitted)
 
     def hessian(self, params):
         """
@@ -2032,7 +2055,7 @@ class Logit(BinaryModel):
         .. math:: \\frac{\\partial^{2}\\ln L}{\\partial\\beta\\partial\\beta^{\\prime}}=-\\sum_{i}\\Lambda_{i}\\left(1-\\Lambda_{i}\\right)x_{i}x_{i}^{\\prime}
         """
         X = self.exog
-        L = self.cdf(np.dot(X,params))
+        L = self.predict(params)
         return -np.dot(L*(1-L)*X.T,X)
 
     def hessian_factor(self, params):
@@ -2055,7 +2078,7 @@ class Logit(BinaryModel):
         .. math:: \\frac{\\partial^{2}\\ln L}{\\partial\\beta\\partial\\beta^{\\prime}}=-\\sum_{i}\\Lambda_{i}\\left(1-\\Lambda_{i}\\right)x_{i}x_{i}^{\\prime}
         """
         X = self.exog
-        L = self.cdf(np.dot(X,params))
+        L = self.predict(params)
         return -L * (1 - L)
 
 
@@ -2083,7 +2106,14 @@ class Probit(BinaryModel):
     exog : array
         A reference to the exogenous design.
     """ % {'params' : base._model_params_doc,
-           'extra_params' : base._missing_param_doc}
+           'extra_params' :
+           """offset : array_like
+        Offset is added to the linear prediction with coefficient equal to 1.
+    exposure : array_like
+        Log(exposure) is added to the linear prediction with coefficient
+        equal to 1.
+
+    """ + base._missing_param_doc}
 
     def cdf(self, X):
         """
@@ -2152,9 +2182,8 @@ class Probit(BinaryModel):
         """
 
         q = 2*self.endog - 1
-        X = self.exog
-        return np.sum(np.log(np.clip(self.cdf(q*np.dot(X,params)),
-            FLOAT_EPS, 1)))
+        linpred = self.predict(params, linear=True)
+        return np.sum(np.log(np.clip(self.cdf(q * linpred), FLOAT_EPS, 1)))
 
     def loglikeobs(self, params):
         """
@@ -2183,7 +2212,8 @@ class Probit(BinaryModel):
 
         q = 2*self.endog - 1
         X = self.exog
-        return np.log(np.clip(self.cdf(q*np.dot(X,params)), FLOAT_EPS, 1))
+        linpred = self.predict(params, linear=True)
+        return np.log(np.clip(self.cdf(q*linpred), FLOAT_EPS, 1))
 
 
     def score(self, params):
@@ -2210,7 +2240,7 @@ class Probit(BinaryModel):
         """
         y = self.endog
         X = self.exog
-        XB = np.dot(X,params)
+        XB = self.predict(params, linear=True)
         q = 2*y - 1
         # clip to get rid of invalid divide complaint
         L = q*self.pdf(q*XB)/np.clip(self.cdf(q*XB), FLOAT_EPS, 1 - FLOAT_EPS)
@@ -2242,7 +2272,7 @@ class Probit(BinaryModel):
         """
         y = self.endog
         X = self.exog
-        XB = np.dot(X,params)
+        XB = self.predict(params, linear=True)
         q = 2*y - 1
         # clip to get rid of invalid divide complaint
         L = q*self.pdf(q*XB)/np.clip(self.cdf(q*XB), FLOAT_EPS, 1 - FLOAT_EPS)
@@ -2274,7 +2304,7 @@ class Probit(BinaryModel):
         """
         y = self.endog
         X = self.exog
-        XB = np.dot(X,params)
+        XB = self.predict(params, linear=True)
         q = 2*y - 1
         # clip to get rid of invalid divide complaint
         L = q*self.pdf(q*XB)/np.clip(self.cdf(q*XB), FLOAT_EPS, 1 - FLOAT_EPS)
@@ -2307,7 +2337,7 @@ class Probit(BinaryModel):
         and :math:`q=2y-1`
         """
         X = self.exog
-        XB = np.dot(X,params)
+        XB = self.predict(params, linear=True)
         q = 2*self.endog - 1
         L = q*self.pdf(q*XB)/self.cdf(q*XB)
         return np.dot(-L*(L+XB)*X.T,X)
@@ -2338,7 +2368,7 @@ class Probit(BinaryModel):
         and :math:`q=2y-1`
         """
         X = self.exog
-        XB = np.dot(X,params)
+        XB = self.predict(params, linear=True)
         q = 2 * self.endog - 1
         L = q * self.pdf(q * XB) / self.cdf(q * XB)
         return -L * (L + XB)

--- a/statsmodels/discrete/tests/test_sandwich_cov.py
+++ b/statsmodels/discrete/tests/test_sandwich_cov.py
@@ -548,6 +548,20 @@ class TestGLMLogit(CheckDiscreteGLM):
         cls.res2 = mod1.fit(cov_type='cluster', cov_kwds=dict(groups=group))
 
 
+class TestGLMLogitOffset(CheckDiscreteGLM):
+
+    @classmethod
+    def setup_class(cls):
+        endog_bin = (endog > endog.mean()).astype(int)
+        cls.cov_type = 'cluster'
+        offset = np.ones(endog_bin.shape[0])
+
+        mod1 = GLM(endog_bin, exog, family=families.Binomial(), offset=offset)
+        cls.res1 = mod1.fit(cov_type='cluster', cov_kwds=dict(groups=group))
+
+        mod1 = smd.Logit(endog_bin, exog, offset=offset)
+        cls.res2 = mod1.fit(cov_type='cluster', cov_kwds=dict(groups=group))
+
 class TestGLMProbit(CheckDiscreteGLM):
 
     @classmethod
@@ -574,6 +588,25 @@ class TestGLMProbit(CheckDiscreteGLM):
         hess1 = res1.model.hessian(res1.params)
         hess2 = res2.model.hessian(res1.params)
         assert_allclose(hess1, hess2, rtol=1e-10)
+
+
+class TestGLMProbitOffset(CheckDiscreteGLM):
+
+    @classmethod
+    def setup_class(cls):
+        endog_bin = (endog > endog.mean()).astype(int)
+        cls.cov_type = 'cluster'
+        offset = np.ones(endog_bin.shape[0])
+
+        mod1 = GLM(endog_bin, exog,
+                   family=families.Binomial(link=links.probit()),
+                   offset=offset)
+        cls.res1 = mod1.fit(method='newton',
+                            cov_type='cluster', cov_kwds=dict(groups=group))
+
+        mod1 = smd.Probit(endog_bin, exog, offset=offset)
+        cls.res2 = mod1.fit(cov_type='cluster', cov_kwds=dict(groups=group))
+        cls.rtol = 1e-6
 
 
 class TestGLMGaussNonRobust(CheckDiscreteGLM):

--- a/statsmodels/discrete/tests/test_sandwich_cov.py
+++ b/statsmodels/discrete/tests/test_sandwich_cov.py
@@ -517,6 +517,20 @@ class CheckDiscreteGLM(object):
         hessf2 = res2.model.hessian_factor(res1.params, **kwds)
         assert_allclose(sgn * hessf1, hessf2, rtol=1e-10)
 
+    def test_score_test(self):
+        res1 = self.res1
+        res2 = self.res2
+
+        if isinstance(res2.model, OLS):
+            # skip
+            return
+
+        fitted = self.res1.fittedvalues
+        exog_extra = np.column_stack((fitted**2, fitted**3))
+        res_lm1 = res1.score_test(exog_extra, cov_type='nonrobust')
+        res_lm2 = res2.score_test(exog_extra, cov_type='nonrobust')
+        assert_allclose(np.hstack(res_lm1), np.hstack(res_lm2), rtol=5e-7)
+
 
 class TestGLMPoisson(CheckDiscreteGLM):
 

--- a/statsmodels/genmod/generalized_linear_model.py
+++ b/statsmodels/genmod/generalized_linear_model.py
@@ -26,6 +26,7 @@ from statsmodels.tools.decorators import cache_readonly, resettable_cache
 import statsmodels.base.model as base
 import statsmodels.regression.linear_model as lm
 import statsmodels.base.wrapper as wrap
+import statsmodels.base._parameter_inference as infer
 import statsmodels.regression._tools as reg_tools
 
 from statsmodels.graphics._regressionplots_doc import (
@@ -1657,6 +1658,20 @@ class GLMResults(base.LikelihoodModelResults):
         return res
 
     get_prediction.__doc__ = pred.get_prediction_glm.__doc__
+
+    def score_test(self, exog_extra=None, params_constrained=None,
+                   hypothesis='joint', cov_type=None, cov_kwds=None,
+                   k_constraints=None, observed=True):
+
+        res = infer.score_test(self, exog_extra=exog_extra,
+                               params_constrained=params_constrained,
+                               hypothesis=hypothesis,
+                               cov_type=cov_type, cov_kwds=cov_kwds,
+                               k_constraints=k_constraints,
+                               observed=observed)
+        return res
+
+    score_test.__doc__ = infer.score_test.__doc__
 
     def get_hat_matrix_diag(self, observed=True):
         """


### PR DESCRIPTION
first step towards #2107

see also #4714 sign convention in hessian_factor

score_factor and hessian_factor are copy/paste/adjust. 
Unit tests verify that adjustment is correct, but need to be changed when we DRY out score and hessian by reusing the factor methods. How to recover score_obs and hessian is in the unit tests.

first target application is to make score_test from #2096 available for discrete distributions