### PR TITLE
TST: allclose instead of exact match for floats and use machine precision

### DIFF
--- a/statsmodels/tsa/vector_ar/hypothesis_test_results.py
+++ b/statsmodels/tsa/vector_ar/hypothesis_test_results.py
@@ -1,4 +1,5 @@
 from statsmodels.iolib.table import SimpleTable
+import numpy as np
 
 
 class HypothesisTestResults(object):
@@ -66,10 +67,10 @@ class HypothesisTestResults(object):
     def __eq__(self, other):
         if not isinstance(other, self.__class__):
             return False
-        return (self.test_statistic == other.test_statistic) \
-            and (self.crit_value == other.crit_value) \
-            and (self.pvalue == other.pvalue) \
-            and (self.signif == other.signif)
+        return np.allclose(self.test_statistic, other.test_statistic) \
+            and np.allclose(self.crit_value, other.crit_value) \
+            and np.allclose(self.pvalue, other.pvalue) \
+            and np.allclose(self.signif, other.signif)
 
 
 class CausalityTestResults(HypothesisTestResults):

--- a/statsmodels/tsa/vector_ar/var_model.py
+++ b/statsmodels/tsa/vector_ar/var_model.py
@@ -687,7 +687,7 @@ class VAR(tsbase.TimeSeriesModel):
 
         y_sample = endog[lags:]
         # Lütkepohl p75, about 5x faster than stated formula
-        params = np.linalg.lstsq(z, y_sample, rcond=-1)[0]
+        params = np.linalg.lstsq(z, y_sample, rcond=1e-15)[0]
         resid = y_sample - np.dot(z, params)
 
         # Unbiased estimate of covariance matrix $\Sigma_u$ of the white noise


### PR DESCRIPTION
I noticed that some tests are failing.

Here's an attempt to fix a couple issues.

I changed a comparison of floats to `np.allclose` because on a Windows setup I have with the pypi numpy/scipy, it fails. I saw this under [Matthew Brett's appveyor](https://ci.appveyor.com/project/matthew-brett/statsmodels-wheels/build/job/4pnmaa46p34sb1ju) (see `test_granger_causality` and `test_inst_causality`

Also in `var_model` during `test_lag_order_selection` under certain scenarios the parameters coming out of `lstsq` are huge. I think there is a near-zero problem. 