### PR TITLE
ENH: Add formula support to MI multiple imputation

### DIFF
--- a/statsmodels/imputation/tests/test_bayes_mi.py
+++ b/statsmodels/imputation/tests/test_bayes_mi.py
@@ -69,15 +69,18 @@ def test_MI():
     x[[2, 11, 21], 2] = np.nan
     x[[11, 22, 99], 3] = np.nan
 
-    def model_args(x):
+    def model_args_fn(x):
         # Return endog, exog
         # Regress x0 on x1 and x2
-        return (x[:, 0], x[:, 1:])
+        if type(x) is np.ndarray:
+            return (x[:, 0], x[:, 1:])
+        else:
+            return (x.iloc[:, 0].values, x.iloc[:, 1:].values)
 
     for j in (0, 1):
         np.random.seed(2342)
         imp = BayesGaussMI(x.copy())
-        mi = MI(imp, sm.OLS, model_args, burn=0)
+        mi = MI(imp, sm.OLS, model_args_fn, burn=0)
         r = mi.fit()
         r.summary()  # smoke test
         # TODO: why does the test tolerance need to be so slack?
@@ -133,3 +136,31 @@ def test_MI_stat():
         # Check the FMI
         d = np.abs(r.fmi[0] - fmi[j])
         assert(d < 0.05)
+
+
+def test_mi_formula():
+
+    np.random.seed(414)
+    x = np.random.normal(size=(200, 4))
+    x[[1, 3, 9], 0] = np.nan
+    x[[1, 4, 3], 1] = np.nan
+    x[[2, 11, 21], 2] = np.nan
+    x[[11, 22, 99], 3] = np.nan
+    df = pd.DataFrame({"y": x[:, 0], "x1": x[:, 1],
+                       "x2": x[:, 2], "x3": x[:, 3]})
+    fml = "y ~ 0 + x1 + x2 + x3"
+
+    np.random.seed(2342)
+    imp = BayesGaussMI(df.copy())
+    mi = MI(imp, sm.OLS, formula=fml, burn=0)
+    r = mi.fit()
+    r.summary()  # smoke test
+    # TODO: why does the test tolerance need to be so slack?
+    # There is unexpected variation across versions on travis.
+    assert_allclose(r.params, np.r_[
+            -0.05347919, -0.02479701, 0.10075517], 0.25, 0)
+
+    c = np.asarray([[0.00418232, 0.00029746, -0.00035057],
+                    [0.00029746, 0.00407264, 0.00019496],
+                    [-0.00035057, 0.00019496, 0.00509413]])
+    assert_allclose(r.cov_params(), c, 0.3, 0)


### PR DESCRIPTION
1. Allow MI to work with formulas

2. If BayesMI is given a DataFrame, it saves the column names and returns the imputed results as a DataFrame (previously it always returned an ndarray).

3. Docstring fixes and improvements