### PR TITLE
TST: Loosening tolerance for mac/openblas

### DIFF
--- a/statsmodels/base/tests/test_generic_methods.py
+++ b/statsmodels/base/tests/test_generic_methods.py
@@ -207,26 +207,26 @@ class CheckGenericMixin(object):
 
         res2 = self._get_constrained(keep_index, keep_index_p)
 
-        assert_allclose(res1.params[keep_index_p], res2.params, rtol=1e-10)
+        assert_allclose(res1.params[keep_index_p], res2.params, rtol=1e-8)
         assert_equal(res1.params[drop_index], 0)
-        assert_allclose(res1.bse[keep_index_p], res2.bse, rtol=1e-10)
+        assert_allclose(res1.bse[keep_index_p], res2.bse, rtol=1e-8)
         assert_equal(res1.bse[drop_index], 0)
-        assert_allclose(res1.tvalues[keep_index_p], res2.tvalues, rtol=1e-10)
-        assert_allclose(res1.pvalues[keep_index_p], res2.pvalues, rtol=1e-10)
+        assert_allclose(res1.tvalues[keep_index_p], res2.tvalues, rtol=1e-8)
+        assert_allclose(res1.pvalues[keep_index_p], res2.pvalues, rtol=1e-8)
 
         if hasattr(res1, 'resid'):
             # discrete models, Logit don't have `resid` yet
-            assert_allclose(res1.resid, res2.resid, rtol=1e-10)
+            assert_allclose(res1.resid, res2.resid, rtol=1e-8)
 
         ex = self.results.model.exog.mean(0)
         predicted1 = res1.predict(ex, **self.predict_kwds)
         predicted2 = res2.predict(ex[keep_index], **self.predict_kwds)
-        assert_allclose(predicted1, predicted2, rtol=1e-10)
+        assert_allclose(predicted1, predicted2, rtol=1e-8)
 
         ex = self.results.model.exog[:5]
         predicted1 = res1.predict(ex, **self.predict_kwds)
         predicted2 = res2.predict(ex[:, keep_index], **self.predict_kwds)
-        assert_allclose(predicted1, predicted2, rtol=1e-10)
+        assert_allclose(predicted1, predicted2, rtol=1e-8)
 
     def _get_constrained(self, keep_index, keep_index_p):
         # override in some test classes, no fit_kwds yet, e.g. cov_type


### PR DESCRIPTION
This is another test that is failing (for me at least) with openblas on a Mac. Also failing on Matthew Brett's statsmodels-wheels repo [here](https://travis-ci.org/MacPython/statsmodels-wheels/jobs/386618313#L4734)

This is very unstable. Sometimes I can run and it passes, sometimes, it doesn't pass. Only way to make it pass all the time was increase `rtol`.