### PR TITLE
DOC: Make custom function take effect

### DIFF
--- a/docs/source/example_formulas.rst
+++ b/docs/source/example_formulas.rst
@@ -18,6 +18,7 @@ Loading modules and functions
 
 .. ipython:: python
 
+    import statsmodels.api as sm
     import statsmodels.formula.api as smf
     import numpy as np
     import pandas
@@ -133,7 +134,8 @@ Define a custom function:
 .. ipython:: python
 
     def log_plus_1(x):
-        return np.log(x) + 1.
+        return np.log(x) + 1.0
+
     res = smf.ols(formula='Lottery ~ log_plus_1(Literacy)', data=df).fit()
     print(res.params)
 

--- a/docs/source/example_formulas.rst
+++ b/docs/source/example_formulas.rst
@@ -23,8 +23,9 @@ Loading modules and functions
     import numpy as np
     import pandas
 
-Notice that we called ``statsmodels.formula.api`` instead of the usual
-``statsmodels.api``. The ``formula.api`` hosts many of the same
+Notice that we called ``statsmodels.formula.api`` in addition to the usual
+``statsmodels.api``. In fact, ``statsmodels.api`` is used here only to load
+the dataset. The ``formula.api`` hosts many of the same
 functions found in ``api`` (e.g. OLS, GLM), but it also holds lower case
 counterparts for most of these models. In general, lower case models
 accept ``formula`` and ``df`` arguments, whereas upper case ones take


### PR DESCRIPTION
Because of the function definition, the line where the custom function
was actually applied was gobbled up and did not show up in the
documentation. Adding a newline solved the problem.