### PR TITLE
REF: SARIMAX: only warn for non stationary starting params

### DIFF
--- a/statsmodels/tsa/statespace/sarimax.py
+++ b/statsmodels/tsa/statespace/sarimax.py
@@ -911,9 +911,9 @@ class SARIMAX(MLEModel):
             not is_invertible(np.r_[1, -params_ar])
         )
         if invalid_ar:
-            raise ValueError('Non-stationary starting autoregressive'
-                             ' parameters found with `enforce_stationarity`'
-                             ' set to True.')
+            warn('Non-stationary starting autoregressive parameters'
+                 ' found. Using zeros as starting parameters.')
+            params_ar *= 0
 
         # If we have estimated non-invertible start parameters but enforce
         # invertibility is on, raise an error
@@ -923,8 +923,9 @@ class SARIMAX(MLEModel):
             not is_invertible(np.r_[1, params_ma])
         )
         if invalid_ma:
-            raise ValueError('non-invertible starting MA parameters found'
-                             ' with `enforce_invertibility` set to True.')
+            warn('Non-invertible starting MA parameters found.'
+                 ' Using zeros as starting parameters.')
+            params_ma *= 0
 
         # Seasonal Parameters
         _, params_seasonal_ar, params_seasonal_ma, params_seasonal_variance = (
@@ -942,9 +943,10 @@ class SARIMAX(MLEModel):
             not is_invertible(np.r_[1, -params_seasonal_ar])
         )
         if invalid_seasonal_ar:
-            raise ValueError('Non-stationary starting autoregressive'
-                             ' parameters found with `enforce_stationarity`'
-                             ' set to True.')
+            warn('Non-stationary starting seasonal autoregressive'
+                 ' Using zeros as starting parameters.')
+            params_seasonal_ar *= 0
+
 
         # If we have estimated non-invertible start parameters but enforce
         # invertibility is on, raise an error
@@ -954,9 +956,9 @@ class SARIMAX(MLEModel):
             not is_invertible(np.r_[1, params_seasonal_ma])
         )
         if invalid_seasonal_ma:
-            raise ValueError('non-invertible starting seasonal moving average'
-                             ' parameters found with `enforce_invertibility`'
-                             ' set to True.')
+            warn('Non-invertible starting seasonal moving average'
+                 ' Using zeros as starting parameters.')
+            params_seasonal_ma *= 0
 
         # Variances
         params_exog_variance = []


### PR DESCRIPTION
Previously, if non-stationary (or non-invertible) starting parameters were found (e.g. computed via least squares on lags), the `start_params` computation raised an exception. This seems unnecessary, so this PR replaces it with a warning, and sets the starting parameters for the non-stationary or non-invertible components to zero.

Example:

```python
mod = sm.tsa.SARIMAX(dta['cpi'], order=(1, 0, 0))
res = mod.fit()
print(res.params[0])
print(res.summary())
```

yields a:

```
/Users/fulton/projects/statsmodels/statsmodels/tsa/statespace/sarimax.py:914:
UserWarning: Non-stationary starting autoregressive parameters found. Using zeros as starting parameters.
  warn('Non-stationary starting autoregressive parameters'
```

and returns output suggesting as close to a non-stationary model as the parameter transformations will allow:

```
0.9999651762842519

                          Statespace Model Results                           
==============================================================================
Dep. Variable:                    cpi   No. Observations:                  203
Model:               SARIMAX(1, 0, 0)   Log Likelihood                -343.960
Date:                Tue, 12 Jun 2018   AIC                            691.920
Time:                        20:47:28   BIC                            698.546
Sample:                    03-31-1959   HQIC                           694.600
                         - 09-30-2009                                         
Covariance Type:                  opg                                         
==============================================================================
                 coef    std err          z      P>|z|      [0.025      0.975]
------------------------------------------------------------------------------
ar.L1          1.0000   7.19e-05   1.39e+04      0.000       1.000       1.000
sigma2         1.6549      0.131     12.660      0.000       1.399       1.911
===================================================================================
Ljung-Box (Q):                      194.80   Jarque-Bera (JB):               748.38
Prob(Q):                              0.00   Prob(JB):                         0.00
Heteroskedasticity (H):               8.29   Skew:                            -0.45
Prob(H) (two-sided):                  0.00   Kurtosis:                        12.36
===================================================================================

Warnings:
[1] Covariance matrix calculated using the outer product of gradients (complex-step).
```

