### PR TITLE
BUG: state space: exact diffuse filtering in complex data type case

### DIFF
--- a/statsmodels/tsa/statespace/_filters/_univariate_diffuse.pyx.in
+++ b/statsmodels/tsa/statespace/_filters/_univariate_diffuse.pyx.in
@@ -232,7 +232,7 @@ cdef {{cython_type}} {{prefix}}forecast_error_diffuse_cov({{prefix}}KalmanFilter
                    &alpha, &kfilter._M_inf[i * kfilter.k_states], &inc,
                            &model._design[i], &model._k_endog,
                    &beta, kfilter._tmp0, &inc)
-    forecast_error_cov = kfilter._tmp0[0]
+    forecast_error_diffuse_cov = kfilter._tmp0[0]
     {{endif}}
     kfilter._forecast_error_diffuse_cov[i + i*kfilter.k_endog] = forecast_error_diffuse_cov
     return forecast_error_diffuse_cov


### PR DESCRIPTION
Bug causes the exact diffuse filter to never transition to the usual Kalman filter.