### PR TITLE
ENH: RecursiveLS: Add recursive t-test

### DIFF
--- a/statsmodels/regression/recursive_ls.py
+++ b/statsmodels/regression/recursive_ls.py
@@ -248,6 +248,10 @@ class RecursiveLSResults(MLEResults):
         super(RecursiveLSResults, self).__init__(
             model, params, filter_results, cov_type, **kwargs)
 
+        # Typically we don't use t distribution by default in state space
+        # models, but we should here for comparison with typical OLS models
+        self.use_t = True
+
         # Since we are overriding params with things that aren't MLE params,
         # need to adjust df's
         q = max(self.loglikelihood_burn, self.k_diffuse_states)

--- a/statsmodels/regression/recursive_ls.py
+++ b/statsmodels/regression/recursive_ls.py
@@ -142,12 +142,7 @@ class RecursiveLS(MLEModel):
         -------
         RecursiveLSResults
         """
-        smoother_results = self.smooth(return_ssm=True)
-
-        with self.ssm.fixed_scale(smoother_results.scale):
-            res = self.smooth()
-
-        return res
+        return self.smooth()
 
     def filter(self, return_ssm=False, **kwargs):
         # Get the state space output

--- a/statsmodels/regression/recursive_ls.py
+++ b/statsmodels/regression/recursive_ls.py
@@ -405,9 +405,13 @@ class RecursiveLSResults(MLEResults):
             # Rescale the covariance parameters based on the scale estiamted
             # as of observation t
             d = max(self.loglikelihood_burn, self.nobs_diffuse)
-            scale = np.sum(self.filter_results.scale_obs[d:t + 1]) / t
+            nmissing = np.sum(self.filter_results.nmissing[d:t + 1])
+            n = (t + 1 - d) - nmissing
+            scale = (np.sum(self.filter_results.scale_obs[d:t + 1]) / n)
             cov_p *= scale / self.scale
         else:
+            t = self.model.nobs
+            nmissing = np.sum(self.filter_results.nmissing[d:])
             params = self.params
 
         _effect = np.dot(r_matrix, params)
@@ -420,7 +424,7 @@ class RecursiveLSResults(MLEResults):
             _sd = np.sqrt(self.cov_params(r_matrix=r_matrix, cov_p=cov_p))
         _t = (_effect - q_matrix) * recipr(_sd)
 
-        nobs_effective = (t + 1) - self.loglikelihood_burn
+        nobs_effective = (t + 1) - nmissing - self.loglikelihood_burn
         df_resid = nobs_effective - self.df_model
 
         if use_t:

--- a/statsmodels/tsa/statespace/kalman_filter.py
+++ b/statsmodels/tsa/statespace/kalman_filter.py
@@ -1693,6 +1693,7 @@ class FilterResults(FrozenRepresentation):
         # Note: concentrated computation is not permitted with collapsed
         # version, so we do not need to modify collapsed arrays.
         self.scale = 1.
+        self.scale_obs = None
         if self.filter_concentrated and self.model._scale is None:
             d = max(self.loglikelihood_burn, self.nobs_diffuse)
             # Compute the scale
@@ -1703,8 +1704,8 @@ class FilterResults(FrozenRepresentation):
             # associated with a singular forecast error covariance matrix
             nobs_k_endog -= kalman_filter.nobs_kendog_univariate_singular
 
-            scale_obs = np.array(kalman_filter.scale, copy=True)
-            self.scale = np.sum(scale_obs[d:]) / nobs_k_endog
+            self.scale_obs = np.array(kalman_filter.scale, copy=True)
+            self.scale = np.sum(self.scale_obs[d:]) / nobs_k_endog
 
             # Need to modify this for diffuse initialization, since for
             # diffuse periods we only need to add in the scale value if the
@@ -1721,7 +1722,7 @@ class FilterResults(FrozenRepresentation):
             # defaults on the adjustment)
             self.llf_obs += -0.5 * (
                 (self.k_endog - nmissing - nsingular) * np.log(self.scale) +
-                scale_obs / self.scale)
+                self.scale_obs / self.scale)
 
             # Scale the filter output
             self.obs_cov = self.obs_cov * self.scale

--- a/statsmodels/tsa/statespace/mlemodel.py
+++ b/statsmodels/tsa/statespace/mlemodel.py
@@ -1126,7 +1126,7 @@ class MLEModel(tsbase.TimeSeriesModel):
 
         if method == 'harvey':
             score = self._score_obs_harvey(
-                params, transformed=transformed,
+                params,
                 approx_complex_step=approx_complex_step, **kwargs)
         elif method == 'approx' and approx_complex_step:
             # the default epsilon can be too small


### PR DESCRIPTION
Along with some improvements / fixes, adds the ability to compute a t-test for any subset of the data after estimating a model via `RecursiveLS`. For example:

```python
dta = sm.datasets.macrodata.load_pandas().data
dta.index = pd.PeriodIndex(start='1959Q1', end='2009Q3', freq='Q')
endog = dta.infl
exog = sm.add_constant(dta[['m1', 'unemp']])

# Run RecursiveLS over the entire model
mod = sm.RecursiveLS(endog, exog)
res = mod.fit()

# Compute the t-test using the first 100 observations
t = 99
restriction = 'm1 + unemp = 1, const = 0.5'
ttest_rls = res.t_test(restriction, loc=t)

# Now, run OLS over the restricted sample and compute the t-test
mod_ols = sm.OLS(endog[:t], exog[:t])
res_ols = mod_ols.fit()
ttest_ols = res_ols.t_test(restriction)

# Compare the results
print(ttest_rls)
print(ttest_ols)
```

yields

```
                             Test for Constraints                             
==============================================================================
                 coef    std err          t      P>|t|      [0.025      0.975]
------------------------------------------------------------------------------
c0            -1.4091      0.227    -10.628      0.000      -1.859      -0.959
c1             4.2860      0.985      3.845      0.000       2.332       6.240
==============================================================================
                             Test for Constraints                             
==============================================================================
                 coef    std err          t      P>|t|      [0.025      0.975]
------------------------------------------------------------------------------
c0            -1.4091      0.227    -10.628      0.000      -1.859      -0.959
c1             4.2860      0.985      3.845      0.000       2.332       6.240
==============================================================================
```