### PR TITLE
CLN: Provide better name for pooled risk ratio

### DIFF
--- a/statsmodels/stats/contingency_tables.py
+++ b/statsmodels/stats/contingency_tables.py
@@ -916,7 +916,7 @@ class StratifiedTable(object):
         An estimate of the pooled log odds ratio.  This is the
         Mantel-Haenszel estimate of an odds ratio that is common to
         all the tables.
-    log_oddsratio_se : float
+    logodds_pooled_se : float
         The estimated standard error of the pooled log odds ratio,
         following Robins, Breslow and Greenland (Biometrics
         42:311-323).
@@ -1058,20 +1058,15 @@ class StratifiedTable(object):
 
     @cache_readonly
     def oddsratio_pooled(self):
-        # doc for cached attributes in init above
-
         odds_ratio = np.sum(self._ad / self._n) / np.sum(self._bc / self._n)
         return odds_ratio
 
     @cache_readonly
     def logodds_pooled(self):
-        # doc for cached attributes in init above
-
         return np.log(self.oddsratio_pooled)
 
     @cache_readonly
     def riskratio_pooled(self):
-        # doc for cached attributes in init above
 
         acd = self.table[0, 0, :] * self._cpd
         cab = self.table[1, 0, :] * self._apb
@@ -1086,7 +1081,6 @@ class StratifiedTable(object):
 
     @cache_readonly
     def logodds_pooled_se(self):
-        # doc for cached attributes in init above
 
         adns = np.sum(self._ad / self._n)
         bcns = np.sum(self._bc / self._n)

--- a/statsmodels/stats/contingency_tables.py
+++ b/statsmodels/stats/contingency_tables.py
@@ -30,8 +30,9 @@ from statsmodels.tools.decorators import cache_readonly, resettable_cache
 import numpy as np
 from scipy import stats
 import pandas as pd
+import warnings
 from statsmodels import iolib
-from statsmodels.tools.sm_exceptions import SingularMatrixWarning
+from statsmodels.tools import sm_exceptions
 
 
 def _make_df_square(table):
@@ -618,9 +619,8 @@ class SquareTable(Table):
         try:
             statistic = n_obs * np.dot(d, np.linalg.solve(vmat, d))
         except np.linalg.LinAlgError:
-            import warnings
             warnings.warn("Unable to invert covariance matrix",
-                          SingularMatrixWarning)
+                          sm_exceptions.SingularMatrixWarning)
             b = _Bunch()
             b.statistic = np.nan
             b.pvalue = np.nan
@@ -1126,11 +1126,22 @@ class StratifiedTable(object):
 
     @cache_readonly
     def oddsratio_pooled(self):
+        """
+        The pooled odds ratio.
+
+        The value is an estimate of a common odds ratio across all of the
+        stratified tables.
+        """
         odds_ratio = np.sum(self._ad / self._n) / np.sum(self._bc / self._n)
         return odds_ratio
 
     @cache_readonly
     def logodds_pooled(self):
+        """
+        Returns the logarithm of the pooled odds ratio.
+
+        See oddsratio_pooled for more information.
+        """
         return np.log(self.oddsratio_pooled)
 
     @cache_readonly
@@ -1145,6 +1156,8 @@ class StratifiedTable(object):
     @cache_readonly
     def risk_pooled(self):
         # Deprecated due to name being misleading
+        msg = "'risk_pooled' is deprecated, use 'riskratio_pooled' instead"
+        warnings.warn(msg, DeprecationWarning)
         return self.riskratio_pooled
 
     @cache_readonly

--- a/statsmodels/stats/contingency_tables.py
+++ b/statsmodels/stats/contingency_tables.py
@@ -923,9 +923,11 @@ class StratifiedTable(object):
         An estimate of the pooled odds ratio.  This is the
         Mantel-Haenszel estimate of an odds ratio that is common to
         all tables.
-    risk_pooled : float
+    riskratio_pooled : float
         An estimate of the pooled risk ratio.  This is an estimate of
         a risk ratio that is common to all the tables.
+    risk_pooled : float
+        Same as riskratio_pooled, deprecated.
 
     Notes
     -----
@@ -1067,7 +1069,7 @@ class StratifiedTable(object):
         return np.log(self.oddsratio_pooled)
 
     @cache_readonly
-    def risk_pooled(self):
+    def riskratio_pooled(self):
         # doc for cached attributes in init above
 
         acd = self.table[0, 0, :] * self._cpd
@@ -1075,6 +1077,11 @@ class StratifiedTable(object):
 
         rr = np.sum(acd / self._n) / np.sum(cab / self._n)
         return rr
+
+    @cache_readonly
+    def risk_pooled(self):
+        # Deprecated due to name being misleading
+        return riskratio_pooled
 
     @cache_readonly
     def logodds_pooled_se(self):
@@ -1233,7 +1240,7 @@ class StratifiedTable(object):
         stubs = ["Pooled odds", "Pooled log odds", "Pooled risk ratio", ""]
         data = [[fmt(x) for x in [self.oddsratio_pooled, co_lcb, co_ucb]],
                 [fmt(x) for x in [self.logodds_pooled, clo_lcb, clo_ucb]],
-                [fmt(x) for x in [self.risk_pooled, "", ""]],
+                [fmt(x) for x in [self.riskratio_pooled, "", ""]],
                 ['', '', '']]
         tab1 = iolib.SimpleTable(data, headers, stubs, data_aligns="r",
                                  table_dec_above='')

--- a/statsmodels/stats/contingency_tables.py
+++ b/statsmodels/stats/contingency_tables.py
@@ -294,7 +294,16 @@ class Table(object):
 
     @cache_readonly
     def marginal_probabilities(self):
-        # docstring for cached attributes in init above
+        """
+        Estimate marginal probability distributions for the rows and columns.
+
+        Returns
+        -------
+        row : ndarray
+            Marginal row probabilities
+        col : ndarray
+            Marginal column probabilities
+        """
 
         n = self.table.sum()
         row = self.table.sum(1) / n
@@ -308,7 +317,13 @@ class Table(object):
 
     @cache_readonly
     def independence_probabilities(self):
-        # docstring for cached attributes in init above
+        """
+        Returns fitted joint probabilities under independence.
+
+        The returned table is outer(row, column), where row and
+        column are the estimated marginal distributions
+        of the rows and columns.
+        """
 
         row, col = self.marginal_probabilities
         itab = np.outer(row, col)
@@ -321,7 +336,12 @@ class Table(object):
 
     @cache_readonly
     def fittedvalues(self):
-        # docstring for cached attributes in init above
+        """
+        Returns fitted cell counts under independence.
+
+        The returned cell counts are estimates under a model
+        where the rows and columns of the table are independent.
+        """
 
         probs = self.independence_probabilities
         fit = self.table.sum() * probs
@@ -329,7 +349,12 @@ class Table(object):
 
     @cache_readonly
     def resid_pearson(self):
-        # docstring for cached attributes in init above
+        """
+        Returns Pearson residuals.
+
+        The Pearson residuals are calculated under a model where
+        the rows and columns of the table are independent.
+        """
 
         fit = self.fittedvalues
         resids = (self.table - fit) / np.sqrt(fit)
@@ -337,7 +362,9 @@ class Table(object):
 
     @cache_readonly
     def standardized_resids(self):
-        # docstring for cached attributes in init above
+        """
+        Returns standardized residuals under independence.
+        """
 
         row, col = self.marginal_probabilities
         sresids = self.resid_pearson / np.sqrt(np.outer(1 - row, 1 - col))
@@ -345,13 +372,24 @@ class Table(object):
 
     @cache_readonly
     def chi2_contribs(self):
-        # docstring for cached attributes in init above
+        """
+        Returns the contributions to the chi^2 statistic for independence.
+
+        The returned table contains the contribution of each cell to the chi^2
+        test statistic for the null hypothesis that the rows and columns
+        are independent.
+        """
 
         return self.resid_pearson**2
 
     @cache_readonly
     def local_log_oddsratios(self):
-        # docstring for cached attributes in init above
+        """
+        Returns local log odds ratios.
+
+        The local log odds ratios are the log odds ratios
+        calculated for contiguous 2x2 sub-tables.
+        """
 
         ta = self.table.copy()
         a = ta[0:-1, 0:-1]
@@ -371,13 +409,25 @@ class Table(object):
 
     @cache_readonly
     def local_oddsratios(self):
-        # docstring for cached attributes in init above
+        """
+        Returns local odds ratios.
+
+        See documentation for local_log_oddsratios.
+        """
 
         return np.exp(self.local_log_oddsratios)
 
     @cache_readonly
     def cumulative_log_oddsratios(self):
-        # docstring for cached attributes in init above
+        """
+        Returns cumulative log odds ratios.
+
+        The cumulative log odds ratios for a contingency table
+        with ordered rows and columns are calculated by collapsing
+        all cells to the left/right and above/below a given point,
+        to obtain a 2x2 table from which a log odds ratio can be
+        calculated.
+        """
 
         ta = self.table.cumsum(0).cumsum(1)
 
@@ -399,7 +449,11 @@ class Table(object):
 
     @cache_readonly
     def cumulative_oddsratios(self):
-        # docstring for cached attributes in init above
+        """
+        Returns the cumulative odds ratios for a contingency table.
+
+        See documentation for cumulative_log_oddsratio.
+        """
 
         return np.exp(self.cumulative_log_oddsratios)
 
@@ -687,21 +741,27 @@ class Table2x2(SquareTable):
 
     @cache_readonly
     def log_oddsratio(self):
-        # docstring for cached attributes in init above
+        """
+        Returns the log odds ratio for a 2x2 table.
+        """
 
         f = self.table.flatten()
         return np.dot(np.log(f), np.r_[1, -1, -1, 1])
 
     @cache_readonly
     def oddsratio(self):
-        # docstring for cached attributes in init above
+        """
+        Returns the odds ratio for a 2x2 table.
+        """
 
         return (self.table[0, 0] * self.table[1, 1] /
                 (self.table[0, 1] * self.table[1, 0]))
 
     @cache_readonly
     def log_oddsratio_se(self):
-        # docstring for cached attributes in init above
+        """
+        Returns the standard error for the log odds ratio.
+        """
 
         return np.sqrt(np.sum(1 / self.table))
 
@@ -770,20 +830,28 @@ class Table2x2(SquareTable):
 
     @cache_readonly
     def riskratio(self):
-        # docstring for cached attributes in init above
+        """
+        Returns the risk ratio for a 2x2 table.
+
+        The risk ratio is calcuoated with respec to the rows.
+        """
 
         p = self.table[:, 0] / self.table.sum(1)
         return p[0] / p[1]
 
     @cache_readonly
     def log_riskratio(self):
-        # docstring for cached attributes in init above
+        """
+        Returns the log od the risk ratio.
+        """
 
         return np.log(self.riskratio)
 
     @cache_readonly
     def log_riskratio_se(self):
-        # docstring for cached attributes in init above
+        """
+        Returns the standard error of the log of the risk ratio.
+        """
 
         n = self.table.sum(1)
         p = self.table[:, 0] / n

--- a/statsmodels/stats/contingency_tables.py
+++ b/statsmodels/stats/contingency_tables.py
@@ -148,7 +148,8 @@ class Table(object):
             self.table = self.table + 0.5
 
     def __str__(self):
-        s = "A %dx%d contingency table with counts:\n" % tuple(self.table.shape)
+        s = ("A %dx%d contingency table with counts:\n" %
+             tuple(self.table.shape))
         s += np.array_str(self.table)
         return s
 
@@ -1081,7 +1082,7 @@ class StratifiedTable(object):
     @cache_readonly
     def risk_pooled(self):
         # Deprecated due to name being misleading
-        return riskratio_pooled
+        return self.riskratio_pooled
 
     @cache_readonly
     def logodds_pooled_se(self):


### PR DESCRIPTION
Add an alternative, more proper name for the pooled risk ratio in a collection of stratified contingency tables.  The original name can remain for compatability.