### PR TITLE
MAINT: gitignore univariate_diffuse pyx files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,8 +80,10 @@ statsmodels/tsa/statespace/_tools.pyx
 statsmodels/tsa/statespace/_filters/_conventional.pyx
 statsmodels/tsa/statespace/_filters/_inversions.pyx
 statsmodels/tsa/statespace/_filters/_univariate.pyx
+statsmodels/tsa/statespace/_filters/_univariate_diffuse.pyx
 statsmodels/tsa/statespace/_smoothers/_conventional.pyx
 statsmodels/tsa/statespace/_smoothers/_univariate.pyx
+statsmodels/tsa/statespace/_smoothers/_univariate_diffuse.pyx
 statsmodels/tsa/statespace/_smoothers/_alternative.pyx
 statsmodels/tsa/statespace/_smoothers/_classical.pyx
 


### PR DESCRIPTION
Closes #4765 

Adds the tempita compiled intermediate files `_univariate_diffuse.pyx` under `_filters` and `_smoothers` to .gitignore.