### PR TITLE
BUG: State space: standardized forecast error when using Cholesky methods with partial missing data

### DIFF
--- a/statsmodels/tsa/statespace/_filters/_inversions.pyx.in
+++ b/statsmodels/tsa/statespace/_filters/_inversions.pyx.in
@@ -193,7 +193,7 @@ cdef {{cython_type}} {{prefix}}inverse_cholesky({{prefix}}KalmanFilter kfilter, 
         # we want to solve the equation L_t' v_t^s = v_t)
         if not (kfilter.conserve_memory & MEMORY_NO_STD_FORECAST > 0):
             blas.{{prefix}}copy(&kfilter.k_endog, kfilter._forecast_error, &inc, kfilter._standardized_forecast_error, &inc)
-            lapack.{{prefix}}trtrs("U", "T", "N", &kfilter.k_endog, &inc,
+            lapack.{{prefix}}trtrs("U", "T", "N", &model._k_endog, &inc,
                                    kfilter._forecast_error_fac, &kfilter.k_endog,
                                    kfilter._standardized_forecast_error, &kfilter.k_endog, &info)
 
@@ -312,7 +312,7 @@ cdef {{cython_type}} {{prefix}}solve_cholesky({{prefix}}KalmanFilter kfilter, {{
     # we want to solve the equation L_t' v_t^s = v_t)
     if not (kfilter.conserve_memory & MEMORY_NO_STD_FORECAST > 0):
         blas.{{prefix}}copy(&kfilter.k_endog, kfilter._forecast_error, &inc, kfilter._standardized_forecast_error, &inc)
-        lapack.{{prefix}}trtrs("U", "T", "N", &kfilter.k_endog, &inc,
+        lapack.{{prefix}}trtrs("U", "T", "N", &model._k_endog, &inc,
                                kfilter._forecast_error_fac, &kfilter.k_endog,
                                kfilter._standardized_forecast_error, &kfilter.k_endog, &info)
 

--- a/statsmodels/tsa/statespace/_filters/_inversions.pyx.in
+++ b/statsmodels/tsa/statespace/_filters/_inversions.pyx.in
@@ -197,6 +197,11 @@ cdef {{cython_type}} {{prefix}}inverse_cholesky({{prefix}}KalmanFilter kfilter, 
                                    kfilter._forecast_error_fac, &kfilter.k_endog,
                                    kfilter._standardized_forecast_error, &kfilter.k_endog, &info)
 
+            if info != 0:
+                raise np.linalg.LinAlgError('Error computing standardized'
+                                            ' forecast error at period %d'
+                                            % kfilter.t)
+
         # Continue taking the inverse
         lapack.{{prefix}}potri("U", &model._k_endog, kfilter._forecast_error_fac, &kfilter.k_endog, &info)
 
@@ -315,6 +320,11 @@ cdef {{cython_type}} {{prefix}}solve_cholesky({{prefix}}KalmanFilter kfilter, {{
         lapack.{{prefix}}trtrs("U", "T", "N", &model._k_endog, &inc,
                                kfilter._forecast_error_fac, &kfilter.k_endog,
                                kfilter._standardized_forecast_error, &kfilter.k_endog, &info)
+
+        if info != 0:
+                raise np.linalg.LinAlgError('Error computing standardized'
+                                            ' forecast error at period %d'
+                                            % kfilter.t)
 
     # Solve the linear systems  
     # `tmp2` array used here, dimension $(p \times 1)$  


### PR DESCRIPTION
Computing the standardized forecast error within the Cython iterations would silently fail when using the Cholesky methods.

This didn't actually have much of an effect since the multivariate state space models use the LU factorization by default (so that the Cholesky part was done correctly in the Python construction of the results object), and since the univariate method isn't affected, but it's still good to have it fixed.