### PR TITLE
implement setup.cfg, flake8 fixups in __init__ and info.py

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,38 @@
+[flake8]
+max-line-length = 80
+max-complexity = 10
+
+exclude =
+    .tox,
+    *.egg,
+    build,
+
+    statsmodels/base,
+    statsmodels/compat,
+    statsmodels/datasets,
+    statsmodels/discrete,
+    statsmodels/distributions,
+    statsmodels/duration,
+    statsmodels/emplike,
+    statsmodels/examples,
+    statsmodels/formula,
+    statsmodels/genmod,
+    statsmodels/graphics,
+    statsmodels/imputation,
+    statsmodels/iolib,
+    statsmodels/miscmodels,
+    statsmodels/multivariate,
+    statsmodels/nonparametric,
+    statsmodels/regression,
+    statsmodels/robust,
+    statsmodels/sandbox,
+    statsmodels/stats,
+    statsmodels/tools,
+    statsmodels/tsa,
+    statsmodels/api.py,
+    setup.py,
+    tools,
+    docs,
+    examples
+
+ignore =

--- a/statsmodels/__init__.py
+++ b/statsmodels/__init__.py
@@ -7,8 +7,9 @@ import os
 import sys
 
 from warnings import simplefilter
-from statsmodels.tools.sm_exceptions import (ConvergenceWarning, CacheWriteWarning,
-                                             IterationLimitWarning, InvalidTestWarning)
+from statsmodels.tools.sm_exceptions import (
+    ConvergenceWarning, CacheWriteWarning,
+    IterationLimitWarning, InvalidTestWarning)
 
 simplefilter("always", (ConvergenceWarning, CacheWriteWarning,
                         IterationLimitWarning, InvalidTestWarning))
@@ -16,7 +17,7 @@ simplefilter("always", (ConvergenceWarning, CacheWriteWarning,
 debug_warnings = False
 
 if debug_warnings:
-    import sys, warnings
+    import warnings
 
     warnings.simplefilter("default")
     # use the following to raise an exception for debugging specific warnings
@@ -41,7 +42,8 @@ class PytestTester(object):
             import pytest
             if not LooseVersion(pytest.__version__) >= LooseVersion('3.0'):
                 raise ImportError
-            extra_args = ['--tb=short','--disable-pytest-warnings'] if extra_args is None else extra_args
+            if extra_args is None:
+                extra_args = ['--tb=short', '--disable-pytest-warnings']
             cmd = [self.package_path] + extra_args
             print('Running pytest ' + ' '.join(cmd))
             pytest.main(cmd)

--- a/statsmodels/info.py
+++ b/statsmodels/info.py
@@ -21,6 +21,6 @@ Statistical models
 __docformat__ = 'restructuredtext en'
 
 depends = ['numpy',
-        'scipy']
+           'scipy']
 
 postpone_import = True


### PR DESCRIPTION
Implements setup.cfg and tells flake8 to ignore _almost_ everything.  The idea is that we can clean things up file-by-file, making it stricter as we go.

Related:
#4768 which applies high-priority checks to _all_ files.  I think this can be run in combination with that by running a plain `flake8` after the more specific command currently in that PR.  (@cclauss is that correct?
#4668 also implements setup.cfg (and should be merged)
