### PR TITLE
Only compute matrix_rank(exog) once in DiscreteModel.initialize

### DIFF
--- a/statsmodels/discrete/discrete_model.py
+++ b/statsmodels/discrete/discrete_model.py
@@ -178,9 +178,9 @@ class DiscreteModel(base.LikelihoodModel):
         and should contain any preprocessing that needs to be done for a model.
         """
         # assumes constant
-        self.df_model = float(np_matrix_rank(self.exog) - 1)
-        self.df_resid = (float(self.exog.shape[0] -
-                         np_matrix_rank(self.exog)))
+        rank = np_matrix_rank(self.exog)
+        self.df_model = float(rank - 1)
+        self.df_resid = float(self.exog.shape[0] - rank)
 
     def cdf(self, X):
         """


### PR DESCRIPTION
I was confused about why a script was taking >20% of total running
time inside DiscreteModel.initialize. It turns out that computing the
rank of exog can be pretty slow! It does seem vary a lot depending on
BLAS and threading settings, e.g. I get wildly different results for
OpenBLAS vs. MKL and OMP_NUM_THREADS=1 versus not. So part of the
issue is probably hitting pathological edge cases in BLAS libraries.

But there's definitely no reason to compute the rank *twice* in the
same function.