### PR TITLE
BUG: ExponentialSmoothing AICC Divide By Zero Error

### DIFF
--- a/statsmodels/tsa/holtwinters.py
+++ b/statsmodels/tsa/holtwinters.py
@@ -732,7 +732,10 @@ class ExponentialSmoothing(TimeSeriesModel):
         # (s0 + gamma) + (b0 + beta) + (l0 + alpha) + phi
         k = m * seasoning + 2 * trending + 2 + 1 * damped
         aic = self.nobs * np.log(sse / self.nobs) + (k) * 2
-        aicc = aic + (2 * (k + 2) * (k + 3)) / (self.nobs - k - 3)
+        try: 
+            aicc = aic + (2 * (k + 2) * (k + 3)) / (self.nobs - k - 3)
+        except ZeroDivisionError: 
+            aicc = np.inf
         bic = self.nobs * np.log(sse / self.nobs) + (k) * np.log(self.nobs)
         resid = data - fitted[:-h - 1]
         if remove_bias:


### PR DESCRIPTION
ExponentialSmoothing can fail in some circumstances due to AICC having zero in the denominator when calculating. This simply catches a ZeroDivisionError when calculating AICC and sets AICC to np.inf in those cases. Custom build appears to be working (building and running yes but also giving good results) where it would simply fail before.

See #4796