### PR TITLE
BUG/ENH: Recursive LS: fix bug w/ multiple constraints

### DIFF
--- a/statsmodels/regression/recursive_ls.py
+++ b/statsmodels/regression/recursive_ls.py
@@ -96,7 +96,7 @@ class RecursiveLS(MLEModel):
             self.k_constraints = self._r_matrix.shape[0]
 
             endog = np.c_[endog, np.zeros((len(endog), len(self._r_matrix)))]
-            endog[:, 1:] = self._q_matrix
+            endog[:, 1:] = self._q_matrix[:, 0]
 
         # Handle coefficient initialization
         kwargs.setdefault('initialization', 'diffuse')

--- a/statsmodels/regression/recursive_ls.py
+++ b/statsmodels/regression/recursive_ls.py
@@ -19,6 +19,7 @@ from statsmodels.tools.data import _is_using_pandas
 from statsmodels.tsa.statespace.mlemodel import (
     MLEModel, MLEResults, MLEResultsWrapper, PredictionResults,
     PredictionResultsWrapper)
+from statsmodels.tsa.statespace.tools import concat
 from statsmodels.tools.tools import Bunch
 from statsmodels.tools.decorators import cache_readonly, resettable_cache
 import statsmodels.base.wrapper as wrap
@@ -67,7 +68,8 @@ class RecursiveLS(MLEModel):
     """
     def __init__(self, endog, exog, constraints=None, **kwargs):
         # Standardize data
-        if not _is_using_pandas(endog, None):
+        endog_using_pandas = _is_using_pandas(endog, None)
+        if not endog_using_pandas:
             endog = np.asanyarray(endog)
 
         exog_is_using_pandas = _is_using_pandas(exog, None)
@@ -95,8 +97,14 @@ class RecursiveLS(MLEModel):
             self._r_matrix, self._q_matrix = LC.coefs, LC.constants
             self.k_constraints = self._r_matrix.shape[0]
 
-            endog = np.c_[endog, np.zeros((len(endog), len(self._r_matrix)))]
-            endog[:, 1:] = self._q_matrix[:, 0]
+            constraint_endog = np.zeros((len(endog), len(self._r_matrix)))
+            if endog_using_pandas:
+                constraint_endog = pd.DataFrame(constraint_endog,
+                                                index=endog.index)
+                endog = concat([endog, constraint_endog], axis=1)
+                endog.values[:, 1:] = self._q_matrix[:, 0]
+            else:
+                endog[:, 1:] = self._q_matrix[:, 0]
 
         # Handle coefficient initialization
         kwargs.setdefault('initialization', 'diffuse')
@@ -194,6 +202,11 @@ class RecursiveLS(MLEModel):
             )
 
         return result
+
+    @property
+    def endog_names(self):
+        endog_names = super(RecursiveLS, self).endog_names
+        return endog_names[0]
 
     @property
     def param_names(self):

--- a/statsmodels/regression/tests/test_recursive_ls.py
+++ b/statsmodels/regression/tests/test_recursive_ls.py
@@ -468,7 +468,7 @@ def test_multiple_constraints():
     # See tests/results/test_rls.do
     desired = [.4699552366, .0005369357, .0005369357, 0]
     assert_allclose(res.bse[0], desired[0], atol=1e-1)
-    assert_allclose(res.bse[1:], desired[1:], atol=1e-4)
+    assert_allclose(res.bse[1:-1], desired[1:-1], atol=1e-4)
 
     # See tests/results/test_rls.do
     desired = -534.4292052931121

--- a/statsmodels/tsa/statespace/mlemodel.py
+++ b/statsmodels/tsa/statespace/mlemodel.py
@@ -2740,10 +2740,13 @@ class MLEResults(tsbase.TimeSeriesModelResults):
         top_right = [
             ('No. Observations:', [self.nobs]),
             ('Log Likelihood', ["%#5.3f" % self.llf]),
+        ]
+        if hasattr(self, 'rsquared'):
+            top_right.append(('R-squared:', ["%#8.3f" % self.rsquared]))
+        top_right += [
             ('AIC', ["%#5.3f" % self.aic]),
             ('BIC', ["%#5.3f" % self.bic]),
-            ('HQIC', ["%#5.3f" % self.hqic])
-        ]
+            ('HQIC', ["%#5.3f" % self.hqic])]
         if self.filter_results.filter_concentrated:
             top_right.append(('Scale', ["%#5.3f" % self.scale]))
 


### PR DESCRIPTION
See the title. The main impetus for the PR was a bug that raised an exception if multiple constraints were used. This also improves the display of endog names in the case of constraints.