### PR TITLE
TST: Add OpenBlas testing for Windows  

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,11 +7,17 @@ environment:
   matrix:
     - PY_MAJOR_VER: 2
       PYTHON_ARCH: "x86_64"
+      BLAS: "nomkl"
+    - PY_MAJOR_VER: 2
+      PYTHON_ARCH: "x86"
+      BLAS: "nomkl"
     - PY_MAJOR_VER: 2
       PYTHON_ARCH: "x86_64"
       SCIPY: "0.18"
+      BLAS: mkl
     - PY_MAJOR_VER: 3
       PYTHON_ARCH: "x86_64"
+      BLAS: mkl
 
 
 platform:
@@ -26,8 +32,8 @@ build_script:
   - SET PATH=C:\Py;C:\Py\Scripts;C:\Py\Library\bin;%PATH%
   - conda config --set always_yes yes
   - conda update conda --quiet
-  - ps: If ($env:SCIPY) { conda install numpy scipy=$env:SCIPY cython pandas pip nose patsy --quiet } Else {
-        conda install numpy scipy cython pandas pip nose patsy --quiet }
+  - ps: If ($env:SCIPY) { conda install ($env:BLAS) numpy scipy=$env:SCIPY cython pandas pip nose patsy --quiet } Else {
+        conda install ($env:BLAS) numpy scipy cython pandas pip nose patsy --quiet }
   - pip install "pytest<4" pytest-xdist
   - python setup.py develop
 


### PR DESCRIPTION
Add pip runs using pip wheels so that Windows tests also use OpenBlas
Failing since the HoltWinters tests are not valid since the optimizer does not converge. 