### PR TITLE
Update setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,7 @@ select=
     F822,
     # F882: undefined name name in __all__
     F823,
-    # F821: local variable name … referenced before assignment
+    # F821: local variable name ... referenced before assignment
     E111,
     # E111: Indentation is not a multiple of four
     E114


### PR DESCRIPTION
removed non-ascii character.
It crashed the installation for me due to encoding issues and is there for no good apparent reason?