### PR TITLE
BLD: Fix linting and move coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,12 +30,12 @@ matrix:
   - python: 2.7
     env:
     - PYTHON=3.7
+    - COVERAGE=true
   # Python 3.6 + cutting edge packages
   - python: 2.7
     env:
     - PYTHON=3.6
     - BLAS="nomkl blas=*=openblas"
-    - COVERAGE=true
   # Python 2.7 + partially updated numpy, mpl; cutting edge scipy, pandas
   - python: 2.7
     env:

--- a/lint.sh
+++ b/lint.sh
@@ -4,7 +4,7 @@ echo "inside $0"
 
 RET=0
 
-if [ "$LINT" ]; then
+if [ "$LINT" = true ]; then
     flake8 statsmodels
     if [ $? -ne "0" ]; then
         RET=1


### PR DESCRIPTION
Ensure linting only runs when asked for (shaves ~1 minute from most builds)
Move coverage to Python 3.7 to reduce risks of timing out

