### PR TITLE
TST: Restore incorrectly disabled test

### DIFF
--- a/statsmodels/regression/tests/test_lme.py
+++ b/statsmodels/regression/tests/test_lme.py
@@ -17,9 +17,6 @@ import nose.tools
 
 # TODO: add tests with unequal group sizes
 
-v = scipy.__version__.split(".")[1]
-old_scipy = int(v) < 16
-
 
 class R_Results(object):
     """
@@ -223,8 +220,6 @@ class TestMixedLM(object):
             dist_high=0.5,
             num_high=3)
 
-    # Fails on old versions of scipy/numpy
-    @pytest.mark.skipif(old_scipy, reason='SciPy too old')
     def test_vcomp_1(self):
         # Fit the same model using constrained random effects and
         # variance components.
@@ -325,7 +320,6 @@ class TestMixedLM(object):
         assert_allclose(
             result1.bse.iloc[0:3], [0.12610, 0.03938, 0.03848], rtol=1e-3)
 
-    @pytest.mark.skipif(old_scipy, reason='SciPy too old')
     def test_vcomp_3(self):
         # Test a model with vcomp but no other random effects, using formulas.
 
@@ -352,7 +346,6 @@ class TestMixedLM(object):
             np.r_[-0.101549, 0.028613, -0.224621, -0.126295],
             rtol=1e-3)
 
-    @pytest.mark.skipif(old_scipy, reason='SciPy too old')
     def test_sparse(self):
 
         cur_dir = os.path.dirname(os.path.abspath(__file__))
@@ -707,7 +700,6 @@ class TestMixedLM(object):
             rslt5 = mod5.fit()
         assert_almost_equal(rslt4.params, rslt5.params)
 
-    @pytest.mark.skipif(old_scipy, reason='SciPy too old')
     def test_regularized(self):
 
         np.random.seed(3453)


### PR DESCRIPTION
Skip-if condition was not correct, resulting in test being skipped
on modern SciPy