### PR TITLE
TST: use pytest.warns instead of npt.assert_warns

### DIFF
--- a/statsmodels/miscmodels/tests/test_poisson.py
+++ b/statsmodels/miscmodels/tests/test_poisson.py
@@ -2,6 +2,7 @@
 
 
 '''
+import pytest
 import numpy as np
 from numpy.testing import assert_almost_equal
 import statsmodels.api as sm
@@ -176,6 +177,6 @@ class TestPoissonZi(CompareMixin):
     def test_exog_names_warning(self):
         mod = self.res.model
         mod1 = PoissonOffsetGMLE(mod.endog, mod.exog, offset=mod.offset)
-        from numpy.testing import assert_warns
         mod1.data.xnames = mod1.data.xnames * 2
-        assert_warns(ValueWarning, mod1.fit, disp=0)
+        with pytest.warns(ValueWarning):
+            mod1.fit(disp=0)

--- a/statsmodels/regression/tests/test_robustcov.py
+++ b/statsmodels/regression/tests/test_robustcov.py
@@ -5,11 +5,11 @@ Created on Mon Oct 28 15:25:14 2013
 
 Author: Josef Perktold
 """
-
+import pytest
 import numpy as np
 from scipy import stats
 
-from numpy.testing import (assert_allclose, assert_equal, assert_warns,
+from numpy.testing import (assert_allclose, assert_equal,
                            assert_raises)
 
 
@@ -269,7 +269,8 @@ class TestOLSRobust2SmallNew(TestOLSRobust1, CheckOLSRobustNewMixin):
         r_pval =  .0307306938402991
         r_chi2 =  4.667944083588736
         r_df =  1
-        assert_warns(InvalidTestWarning, res1.compare_lr_test, res_ols2)
+        with pytest.warns(InvalidTestWarning):
+            res1.compare_lr_test(res_ols2)
         import warnings
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
@@ -278,7 +279,8 @@ class TestOLSRobust2SmallNew(TestOLSRobust1, CheckOLSRobustNewMixin):
         assert_allclose(pval, r_pval, rtol=1e-11)
         assert_equal(df, r_df)
 
-        assert_warns(InvalidTestWarning, res1.compare_f_test, res_ols2)
+        with pytest.warns(InvalidTestWarning):
+            res1.compare_f_test(res_ols2)
         #fva, pval, df = res1.compare_f_test(res_ols2)
 
 

--- a/statsmodels/regression/tests/test_theil.py
+++ b/statsmodels/regression/tests/test_theil.py
@@ -10,7 +10,7 @@ import numpy as np
 import pandas as pd
 from scipy import stats
 
-from numpy.testing import assert_allclose, assert_equal, assert_warns
+from numpy.testing import assert_allclose, assert_equal
 
 from statsmodels.regression.linear_model import OLS, WLS, GLS
 from statsmodels.tools.tools import add_constant

--- a/statsmodels/stats/tests/test_anova_rm.py
+++ b/statsmodels/stats/tests/test_anova_rm.py
@@ -2,7 +2,7 @@ import pandas as pd
 import numpy as np
 from statsmodels.stats.anova import AnovaRM
 from numpy.testing import (assert_array_almost_equal, assert_raises,
-                           assert_warns, assert_equal)
+                           assert_equal)
 from pandas.util.testing import assert_frame_equal
 
 

--- a/statsmodels/stats/tests/test_power.py
+++ b/statsmodels/stats/tests/test_power.py
@@ -16,7 +16,7 @@ from distutils.version import LooseVersion
 
 import numpy as np
 from numpy.testing import (assert_almost_equal, assert_allclose, assert_raises,
-                           assert_equal, assert_warns, dec)
+                           assert_equal, dec)
 import pytest
 import scipy
 
@@ -763,8 +763,9 @@ def test_power_solver_warn():
     nip.start_ttp['nobs1'] = np.nan
 
     from statsmodels.tools.sm_exceptions import ConvergenceWarning
-    assert_warns(ConvergenceWarning, nip.solve_power, 0.1, nobs1=None,
-                  alpha=0.01, power=pow_, ratio=1, alternative='larger')
+    with pytest.warns(ConvergenceWarning):
+        nip.solve_power(0.1, nobs1=None,
+                        alpha=0.01, power=pow_, ratio=1, alternative='larger')
     # this converges with scipy 0.11  ???
     # nip.solve_power(0.1, nobs1=None, alpha=0.01, power=pow_, ratio=1, alternative='larger')
 

--- a/statsmodels/tools/testing.py
+++ b/statsmodels/tools/testing.py
@@ -17,7 +17,7 @@ def strip_rc(version):
 from numpy.testing import (assert_allclose, assert_almost_equal,
      assert_approx_equal, assert_array_almost_equal,
      assert_array_almost_equal_nulp, assert_array_equal, assert_array_less,
-     assert_array_max_ulp, assert_raises, assert_string_equal, assert_warns)
+     assert_array_max_ulp, assert_raises, assert_string_equal)
 
 
 # adjusted functions

--- a/statsmodels/tsa/tests/test_stattools.py
+++ b/statsmodels/tsa/tests/test_stattools.py
@@ -483,7 +483,8 @@ class TestKPSS(SetupKPSS):
         with warnings.catch_warnings(record=True) as w:
             kpss_stat, pval, lags, crits = kpss(self.x, 'c')
         assert_equal(lags, int(np.ceil(12. * np.power(len(self.x) / 100., 1 / 4.))))
-        # assert_warns(UserWarning, kpss, self.x)
+        #with pytest.warns(UserWarning):
+        #    kpss(self.x)
 
 
 def test_pandasacovf():


### PR DESCRIPTION
Also uses more readable contextmanager syntax.