### PR TITLE
BUG: remove faux endog from results if constraints

### DIFF
--- a/statsmodels/regression/recursive_ls.py
+++ b/statsmodels/regression/recursive_ls.py
@@ -201,7 +201,7 @@ class RecursiveLS(MLEModel):
     @property
     def endog_names(self):
         endog_names = super(RecursiveLS, self).endog_names
-        return endog_names[0]
+        return endog_names[0] if isinstance(endog_names, list) else endog_names
 
     @property
     def param_names(self):
@@ -274,6 +274,13 @@ class RecursiveLSResults(MLEResults):
         self.specification = Bunch(**{
             'k_exog': self.model.k_exog,
             'k_constraints': self.model.k_constraints})
+
+        # Adjust results to remove "faux" endog from the constraints
+        if self.model._r_matrix is not None:
+            for name in ['forecasts', 'forecasts_error',
+                         'forecasts_error_cov', 'standardized_forecasts_error',
+                         'forecasts_error_diffuse_cov']:
+                setattr(self, name, getattr(self, name)[0:1])
 
     @property
     def recursive_coefficients(self):

--- a/statsmodels/tsa/statespace/mlemodel.py
+++ b/statsmodels/tsa/statespace/mlemodel.py
@@ -1986,7 +1986,7 @@ class MLEResults(tsbase.TimeSeriesModelResults):
         # This is a (k_endog x nobs array; don't want to squeeze in case of
         # the corner case where nobs = 1 (mostly a concern in the predict or
         # forecast functions, but here also to maintain consistency)
-        fittedvalues = self.filter_results.forecasts
+        fittedvalues = self.forecasts
         if fittedvalues.shape[0] == 1:
             fittedvalues = fittedvalues[0, :]
         else:
@@ -2041,7 +2041,7 @@ class MLEResults(tsbase.TimeSeriesModelResults):
         # This is a (k_endog x nobs array; don't want to squeeze in case of
         # the corner case where nobs = 1 (mostly a concern in the predict or
         # forecast functions, but here also to maintain consistency)
-        resid = self.filter_results.forecasts_error
+        resid = self.forecasts_error
         if resid.shape[0] == 1:
             resid = resid[0, :]
         else:


### PR DESCRIPTION
Another issue with `RecursiveLS` in the constraints case. One or more "faux" `endog` are added to enforce the constraints, and these should not be returned in the results object, for `resid`, `fittedvalues`, or filter results.