### PR TITLE
Fix and lint for indentation in comments E115,E116

### DIFF
--- a/docs/sphinxext/ipython_directive.py
+++ b/docs/sphinxext/ipython_directive.py
@@ -404,8 +404,8 @@ class EmbeddedSphinxShell(object):
         input_lines = input.split('\n')
         if len(input_lines) > 1:
             if input_lines[-1] != "":
-                input_lines.append('')  # make sure there's a blank line
-                                        # so splitter buffer gets reset
+                # make sure there's a blank line so splitter buffer gets reset
+                input_lines.append('')
 
         continuation = '   %s:'%''.join(['.']*(len(str(lineno))+2))
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -111,7 +111,18 @@ select=
     # F901: raise NotImplemented should be raise NotImplementedError
     E306,
     # E306: expected 1 blank line before a nested definition, found 0
+    E115,
+    # E115 expected an indented block (comment)
+    E116,
+    # E116 unexpected indentation (comment)
 
 
     E272
     # E272: multiple spaces before keyword
+
+
+
+
+
+
+

--- a/statsmodels/discrete/discrete_model.py
+++ b/statsmodels/discrete/discrete_model.py
@@ -2844,7 +2844,7 @@ class NegativeBinomial(CountModel):
                         maxiter=maxiter, method=method, disp=disp,
                         full_output=full_output, callback=callback,
                         **kwargs)
-                        # TODO: Fix NBin _check_perfect_pred
+        # TODO: Fix NBin _check_perfect_pred
         if self.loglike_method.startswith('nb'):
             # mlefit is a wrapped counts results
             self._transparams = False # don't need to transform anymore now
@@ -3741,7 +3741,6 @@ class L1CountResults(DiscreteResults):
     __doc__ = _discrete_results_docs % {"one_line_description" :
             "A results class for count data fit by l1 regularization",
             "extra_attr" : _l1_results_attr}
-        #discretefit = CountResults(self, cntfit)
 
     def __init__(self, model, cntfit):
         super(L1CountResults, self).__init__(model, cntfit)

--- a/statsmodels/discrete/tests/results/results_discrete.py
+++ b/statsmodels/discrete/tests/results/results_discrete.py
@@ -611,7 +611,6 @@ class Spector(object):
         # don't know why margeff is different, but trust official results
         self.margeff_count_dummy_dydxoverall_se = [.1094379569,   .0177869773,
                                                     .1420034]
-                #.1574340751 ]
 
         # from new margeff
         self.margeff_count_dummy_dydxmean = [0.533849340033768,

--- a/statsmodels/emplike/aft_el.py
+++ b/statsmodels/emplike/aft_el.py
@@ -137,9 +137,9 @@ class OptAFT(_OptFuncts):
             # See Zhou 2005, section 3.
             self.model._fit_weights = wts
             new_opt_res = self._opt_wtd_nuis_regress(to_test)
-                # ^ Uncensored weights' contribution to likelihood value.
+            # ^ Uncensored weights' contribution to likelihood value.
             F = self.new_weights
-                # ^ M step
+            # ^ M step
             diff = np.abs(new_opt_res - opt_res)
             opt_res = new_opt_res
             iters = iters + 1

--- a/statsmodels/genmod/tests/results/results_glm.py
+++ b/statsmodels/genmod/tests/results/results_glm.py
@@ -82,8 +82,10 @@ class Longley(object):
         self.bic_Stata = 836399.1760177979 # no bic in R?
         self.df_model = 6
         self.df_resid = 9
-        self.chi2 = 1981.711859508729    #TODO: taken from Stata not available
-                                        # in sm yet
+
+        # TODO: taken from Stata since not available in sm yet
+        self.chi2 = 1981.711859508729
+
 #        self.pearson_chi2 = 836424.1293162981   # from Stata (?)
         self.fittedvalues = np.array([60055.659970240202, 61216.013942398131,
                      60124.71283224225, 61597.114621930756, 62911.285409240052,
@@ -98,7 +100,6 @@ class GaussianLog(object):
     Uses generated data.  These results are from R and Stata.
     """
     def __init__(self):
-#        self.resids = np.genfromtxt('./glm_gaussian_log_resid.csv', ',')
         self.resids = np.array([[3.20800000e-04, 3.20800000e-04,
             8.72100000e-04, 3.20800000e-04,   3.20800000e-04],
            [  8.12100000e-04,   8.12100000e-04,   2.16350000e-03,
@@ -3822,15 +3823,17 @@ class Wfs(object):
                     .0324963, .0283292, .0226563, .0309871, .0552107, .0549118]
         self.aic_R = 522.14215776 # R adds 2 for dof to AIC
         self.aic_Stata = 7.459173652869477  # stata divides by nobs
-#        self.deviance = 70.6652992116034   # from Stata
+        # self.deviance = 70.6652992116034   # from Stata
         self.deviance = 70.665301270867 # from R
         self.scale = 1.0
         self.llf = -250.0710778504317 # from Stata, ours with scale=1
         self.bic_Stata = -179.9959200693088 # no bic in R?
         self.df_model = 10
         self.df_resid = 59
-        self.chi2 = 2699.138063147485   #TODO: taken from Stata not available
-                                        # in sm yet
+
+        # TODO: taken from Stata not available in sm yet
+        self.chi2 = 2699.138063147485   
+
         self.fittedvalues = [7.11599,19.11356,33.76075,33.26743,11.94399,
                 27.49849,35.07923,37.22563,64.18037,108.0408,100.0948,35.67896,
                 24.10508,73.99577,52.2802,38.88975,35.06507,102.1198,107.251,
@@ -3891,15 +3894,17 @@ class CpunishTweediePower15(object):
         self.bse = [0.0000246888, 3.5288126173]
         # self.aic_R = 522.14215776 # R adds 2 for dof to AIC
         # self.aic_Stata = 7.459173652869477  # stata divides by nobs
-#        self.deviance = 70.6652992116034   # from Stata
+        # self.deviance = 70.6652992116034   # from Stata
         self.deviance = 36.087307138233 # from R
         # self.scale = 1.0
         # self.llf = -250.0710778504317 # from Stata, ours with scale=1
         # self.bic_Stata = -179.9959200693088 # no bic in R?
         self.df_model = 1
         self.df_resid = 15
-        # self.chi2 = 2699.138063147485     #TODO: taken from Stata not available
-                                            # in sm yet
+
+        # TODO: taken from Stata not available in sm yet
+        # self.chi2 = 2699.138063147485
+
         self.fittedvalues = [8.09501758000751, 8.42856326056927,
                              1.68642881732415, 7.74178229423817,
                              7.95441118875248, 1.53333978161934,
@@ -3959,15 +3964,17 @@ class CpunishTweediePower2(object):
         self.bse = [1.86839521185429e-05, 3.83231672422612]
         # self.aic_R = 522.14215776 # R adds 2 for dof to AIC
         # self.aic_Stata = 7.459173652869477  # stata divides by nobs
-#        self.deviance = 70.6652992116034   # from Stata
+        # self.deviance = 70.6652992116034   # from Stata
         self.deviance = 15.7840685407599 # from R
         # self.scale = 1.0
         # self.llf = -250.0710778504317 # from Stata, ours with scale=1
         # self.bic_Stata = -179.9959200693088 # no bic in R?
         self.df_model = 1
         self.df_resid = 15
-        # self.chi2 = 2699.138063147485     #TODO: taken from Stata not available
-                                            # in sm yet
+
+        # TODO: taken from Stata not available in sm yet
+        # self.chi2 = 2699.138063147485
+
         self.fittedvalues = [8.06024318838318, 8.39480078450791,
                              1.69154512871877, 7.7059362524505,
                              7.91921022348665, 1.53799164935069,
@@ -4029,15 +4036,17 @@ class CpunishTweedieLog1(object):
         self.bse = [1.81044999017907e-05, 0.725739640176733]
         # self.aic_R = 522.14215776 # R adds 2 for dof to AIC
         # self.aic_Stata = 7.459173652869477  # stata divides by nobs
-#        self.deviance = 70.6652992116034   # from Stata
+        # self.deviance = 70.6652992116034   # from Stata
         self.deviance = 95.0325613464258 # from R
         # self.scale = 1.0
         # self.llf = -250.0710778504317 # from Stata, ours with scale=1
         # self.bic_Stata = -179.9959200693088 # no bic in R?
         self.df_model = 1
         self.df_resid = 15
-        # self.chi2 = 2699.138063147485     #TODO: taken from Stata not available
-                                            # in sm yet
+
+        # TODO: taken from Stata not available in sm yet
+        # self.chi2 = 2699.138063147485
+
         self.fittedvalues = [8.27689906137016, 9.30731835845648,
                              1.80984539843424, 7.30975297068573,
                              7.87746969906705, 1.71495822007233,
@@ -4110,15 +4119,17 @@ class FairTweedieLog15(object):
                     0.00893580175352525]
         # self.aic_R = 522.14215776 # R adds 2 for dof to AIC
         # self.aic_Stata = 7.459173652869477  # stata divides by nobs
-#        self.deviance = 70.6652992116034   # from Stata
+        # self.deviance = 70.6652992116034   # from Stata
         self.deviance = 20741.82  # from R
         # self.scale = 1.0
         # self.llf = -250.0710778504317 # from Stata, ours with scale=1
         # self.bic_Stata = -179.9959200693088 # no bic in R?
         self.df_model = 2
         self.df_resid = 6363
-        # self.chi2 = 2699.138063147485     #TODO: taken from Stata not available
-                                            # in sm yet
+
+        # TODO: taken from Stata since not available in sm yet
+        # self.chi2 = 2699.138063147485
+
         self.fittedvalues = [1.10897954981504, 0.537938133372725,
                              0.722602160018842, 0.507247757370731,
                              0.364216335344828, 0.537493243830281,

--- a/statsmodels/iolib/foreign.py
+++ b/statsmodels/iolib/foreign.py
@@ -993,9 +993,6 @@ def genfromdta(fname, missing_flt=-999., encoding=None, pandas=False,
                         "(got %s instead)" % type(fname))
     else:
         fhd = StataReader(fname, missing_values=False, encoding=encoding)
-#    validate_names = np.lib._iotools.NameValidator(excludelist=excludelist,
-#                                    deletechars=deletechars,
-#                                    case_sensitive=case_sensitive)
 
     #TODO: This needs to handle the byteorder?
     header = fhd.file_headers()
@@ -1005,8 +1002,9 @@ def genfromdta(fname, missing_flt=-999., encoding=None, pandas=False,
     varnames = header['varlist']
     fmtlist = header['fmtlist']
     dataname = header['data_label']
-    labels = header['vlblist']  # labels are thrown away unless DataArray
-                                # type is used
+    labels = header['vlblist']
+    # labels are thrown away unless DataArray type is used
+
     data = np.zeros((nobs,numvars))
     stata_dta = fhd.dataset()
 

--- a/statsmodels/iolib/summary.py
+++ b/statsmodels/iolib/summary.py
@@ -8,7 +8,7 @@ from statsmodels.iolib.tableformatting import (gen_fmt, fmt_2,
 
 def forg(x, prec=3):
     if prec == 3:
-    #for 3 decimals
+        # for 3 decimals
         if (abs(x) >= 1e4) or (abs(x) < 1e-4):
             return '%9.3g' % x
         else:
@@ -862,8 +862,6 @@ class Summary(object):
             table = summary_params(res, yname=yname, xname=xname, alpha=alpha,
                                    use_t=use_t)
         elif res.params.ndim == 2:
-#            _, table = summary_params_2dflat(res, yname=yname, xname=xname,
-#                                             alpha=alpha, use_t=use_t)
             _, table = summary_params_2dflat(res, endog_names=yname,
                                              exog_names=xname,
                                              alpha=alpha, use_t=use_t)

--- a/statsmodels/iolib/tableformatting.py
+++ b/statsmodels/iolib/tableformatting.py
@@ -21,8 +21,8 @@ gen_fmt = dict(
         stubs_align = "l",
         fmt = 'txt'
         )
-        # Note table_1l_fmt over rides the below formating unless it is not
-        # appended to table_1l
+# Note table_1l_fmt overrides the below formating unless it is not
+# appended to table_1l
 fmt_1_right = dict(
         data_fmts = ["%s", "%s", "%s", "%s", "%s"],
         empty_cell = '',

--- a/statsmodels/iolib/tests/test_table.py
+++ b/statsmodels/iolib/tests/test_table.py
@@ -175,6 +175,7 @@ stub R2 C2  40.95038  40.65765
         test1c_stubs = ('>stub1%', 'stub_2')
         test1c_header = ('#header1$', 'header&|')
         tbl_c = SimpleTable(table1c_data, test1c_header, test1c_stubs, ltx_fmt=ltx_fmt1)
+
         def test_ltx_special_chars(self):
             # Test for special characters (latex) in headers and stubs
             desired = r"""
@@ -189,7 +190,9 @@ stub R2 C2  40.95038  40.65765
 """
             actual = '\n%s\n' % tbl_c.as_latex_tabular(center=False)
             assert_equal(actual, desired)
+
         test_ltx_special_chars(self)
+
     def test_regression_with_tuples(self):
         i = pandas.Series( [1,2,3,4]*10 , name="i")
         y = pandas.Series( [1,2,3,4,5]*8, name="y")

--- a/statsmodels/iolib/tests/test_table.py
+++ b/statsmodels/iolib/tests/test_table.py
@@ -166,7 +166,7 @@ stub R2 C2  40.95038  40.65765
         test_ltx_fmt1(self)
         test_html_fmt1(self)
     def test_SimpleTable_special_chars(self):
-    # Simple table with characters: (%, >, |, _, $, &, #)
+        # Simple table with characters: (%, >, |, _, $, &, #)
         cell0c_data = 22
         cell1c_data = 1053
         row0c_data = [cell0c_data, cell1c_data]
@@ -176,7 +176,7 @@ stub R2 C2  40.95038  40.65765
         test1c_header = ('#header1$', 'header&|')
         tbl_c = SimpleTable(table1c_data, test1c_header, test1c_stubs, ltx_fmt=ltx_fmt1)
         def test_ltx_special_chars(self):
-        # Test for special characters (latex) in headers and stubs
+            # Test for special characters (latex) in headers and stubs
             desired = r"""
 \begin{tabular}{lcc}
 \toprule

--- a/statsmodels/miscmodels/nonlinls.py
+++ b/statsmodels/miscmodels/nonlinls.py
@@ -254,14 +254,14 @@ class NonlinearLS(Model):  #or subclass a model
 
 class Myfunc(NonlinearLS):
 
-    #predict model.Model has a different signature
-##    def predict(self, params, exog=None):
-##        if not exog is None:
-##            x = exog
-##        else:
-##            x = self.exog
-##        a, b, c = params
-##        return a*np.exp(-b*x) + c
+    # Note: predict model.Model has a different signature
+    #def predict(self, params, exog=None):
+    #    if not exog is None:
+    #        x = exog
+    #    else:
+    #        x = self.exog
+    #    a, b, c = params
+    #    return a*np.exp(-b*x) + c
 
     def _predict(self, params):
         x = self.exog

--- a/statsmodels/miscmodels/try_mlecov.py
+++ b/statsmodels/miscmodels/try_mlecov.py
@@ -29,7 +29,7 @@ def mvn_loglike_sum(x, sigma):
     llf = -np.log(SSR) * nobs2      # concentrated likelihood
     llf -= (1+np.log(np.pi/nobs2))*nobs2  # with likelihood constant
     if np.any(sigma) and sigma.ndim == 2:
-    #FIXME: robust-enough check?  unneeded if _det_sigma gets defined
+        # FIXME: robust-enough check?  unneeded if _det_sigma gets defined
         llf -= .5*np.log(np.linalg.det(sigma))
     return llf
 

--- a/statsmodels/nonparametric/kde.py
+++ b/statsmodels/nonparametric/kde.py
@@ -147,8 +147,9 @@ class KDEUnivariate(object):
         self.density = density
         self.support = grid
         self.bw = bw
-        self.kernel = kernel_switch[kernel](h=bw) # we instantiate twice,
-                                                # should this passed to funcs?
+        self.kernel = kernel_switch[kernel](h=bw)
+        # TODO: we instantiate twice, should this passed to funcs?
+
         # put here to ensure empty cache after re-fit with new options
         self.kernel.weights = weights
         if weights is not None:
@@ -445,8 +446,9 @@ def kdensityfft(X, kernel="gau", bw="normal_reference", weights=None, gridsize=N
         Series C. 31.2, 93-9.
     """
     X = np.asarray(X)
-    X = X[np.logical_and(X > clip[0], X < clip[1])] # won't work for two columns.
-                                                # will affect underlying data?
+    X = X[np.logical_and(X > clip[0], X < clip[1])]
+    # won't work for two columns.
+    # TODO: will affect underlying data?
 
     # Get kernel object corresponding to selection
     kern = kernel_switch[kernel]()
@@ -493,10 +495,12 @@ def kdensityfft(X, kernel="gau", bw="normal_reference", weights=None, gridsize=N
     # step 3 and 4 for optimal bw compute zstar and the density estimate f
     # don't have to redo the above if just changing bw, ie., for cross val
 
-#NOTE: silverman_transform is the closed form solution of the FFT of the
-#gaussian kernel. Not yet sure how to generalize it.
-    zstar = silverman_transform(bw, gridsize, RANGE)*y # 3.49 in Silverman
-                                                    # 3.50 w Gaussian kernel
+    # NOTE: silverman_transform is the closed form solution of the FFT of the
+    # gaussian kernel. Not yet sure how to generalize it.
+    zstar = silverman_transform(bw, gridsize, RANGE)*y
+    # 3.49 in Silverman
+    # 3.50 w Gaussian kernel
+
     f = revrt(zstar)
     if retgrid:
         return f, grid, bw
@@ -545,6 +549,6 @@ if __name__ == "__main__":
 #        dens = revrt(SMOOTH)
 
     except:
-#        ft = np.loadtxt('./ft_silver.csv')
-#        smooth = np.loadtxt('./smooth_silver.csv')
+        #ft = np.loadtxt('./ft_silver.csv')
+        #smooth = np.loadtxt('./smooth_silver.csv')
         print("Didn't get the estimates from the Silverman algorithm")

--- a/statsmodels/robust/robust_linear_model.py
+++ b/statsmodels/robust/robust_linear_model.py
@@ -437,7 +437,7 @@ class RLMResults(base.LikelihoodModelResults):
             # [W_jk]^-1 = [SUM(psi_deriv(Sr_i)*x_ij*x_jk)]^-1
             # where Sr are the standardized residuals
             if model.cov == "H2":
-            # These are correct, based on Huber (1973) 8.13
+                # These are correct, based on Huber (1973) 8.13
                 return k*(1/self.df_resid)*np.sum(\
                     model.M.psi(self.sresid)**2)*self.scale**2\
                     /((1/self.nobs)*np.sum(\
@@ -573,8 +573,8 @@ class RLMResultsWrapper(lm.RegressionResultsWrapper):
 wrap.populate_wrapper(RLMResultsWrapper, RLMResults)
 
 if __name__=="__main__":
-#NOTE: This is to be removed
-#Delivery Time Data is taken from Montgomery and Peck
+    # NOTE: This is to be removed
+    # Delivery Time Data is taken from Montgomery and Peck
     import statsmodels.api as sm
 
 #delivery time(minutes)

--- a/statsmodels/robust/tests/test_rlm.py
+++ b/statsmodels/robust/tests/test_rlm.py
@@ -114,9 +114,6 @@ class TestRlm(CheckRlmResultsMixin):
 
 
     def setup(self):
-#        r.library('MASS')
-#        self.res2 = RModel(self.data.endog, self.data.exog,
-#                        r.rlm, psi="psi.huber")
         from .results.results_rlm import Huber
         self.res2 = Huber()
 
@@ -144,8 +141,6 @@ class TestHampel(TestRlm):
         cls.res1.h3 = h3
 
     def setup(self):
-#        self.res2 = RModel(self.data.endog[:,None], self.data.exog,
-#        r.rlm, psi="psi.hampel") #, init="lts")
         from .results.results_rlm import Hampel
         self.res2 = Hampel()
 
@@ -171,8 +166,6 @@ class TestRlmBisquare(TestRlm):
         cls.res1.h3 = h3
 
     def setup(self):
-#        self.res2 = RModel(self.data.endog, self.data.exog,
-#                        r.rlm, psi="psi.bisquare")
         from .results.results_rlm import BiSquare
         self.res2 = BiSquare()
 
@@ -315,9 +308,6 @@ class TestRlmSresid(CheckRlmResultsMixin):
 
 
     def setup(self):
-#        r.library('MASS')
-#        self.res2 = RModel(self.data.endog, self.data.exog,
-#                        r.rlm, psi="psi.huber")
         from .results.results_rlm import Huber
         self.res2 = Huber()
 

--- a/statsmodels/sandbox/descstats.py
+++ b/statsmodels/sandbox/descstats.py
@@ -36,8 +36,8 @@ def descstats(data, cols=None, axis=0):
 
     x = np.array(data)  # or rather, the data we're interested in
     if cols is None:
-#       if isinstance(x, np.recarray):
-#            cols = np.array(len(x.dtype.names))
+        #if isinstance(x, np.recarray):
+        #     cols = np.array(len(x.dtype.names))
         if not isinstance(x, np.recarray) and x.ndim == 1:
             x = x[:,None]
 

--- a/statsmodels/sandbox/distributions/examples/matchdist.py
+++ b/statsmodels/sandbox/distributions/examples/matchdist.py
@@ -218,8 +218,8 @@ if __name__ == '__main__':
             tail_prob = stats.t.sf(crit,dgp_arg,scale=dgp_scale)
             print('crit, prob', quant, crit, tail_prob)
             #if distname == 'norm':
-                #plothist(rvs,loc_est,scale_est)
-                #args = tuple()
+            #    plothist(rvs,loc_est,scale_est)
+            #    args = tuple()
             results.append([distname,ks_stat, ks_pval,arg_est,loc_est,scale_est,crit,tail_prob ])
             #plothist(rvs,distfn,arg_est,loc_est,scale_est)
 

--- a/statsmodels/sandbox/distributions/extras.py
+++ b/statsmodels/sandbox/distributions/extras.py
@@ -521,13 +521,13 @@ class Transf_gen(distributions.rv_continuous):
         a = kwargs.pop('a', -np.inf)
         b = kwargs.pop('b', np.inf)
         self.decr = kwargs.pop('decr', False)
-            #defines whether it is a decreasing (True)
-            #       or increasing (False) monotonic transformation
+        # descr defines whether it is a decreasing (True)
+        #   or increasing (False) monotonic transformation
 
 
         self.u_args, self.u_kwargs = get_u_argskwargs(**kwargs)
         self.kls = kls  #(self.u_args, self.u_kwargs)
-                        # possible to freeze the underlying distribution
+        # possible to freeze the underlying distribution
 
         super(Transf_gen,self).__init__(a=a, b=b, name = name,
                                 longname = longname, extradoc = extradoc)
@@ -726,13 +726,13 @@ class TransfTwo_gen(distributions.rv_continuous):
         a = kwargs.pop('a', -np.inf) # attached to self in super
         b = kwargs.pop('b', np.inf)  # self.a, self.b would be overwritten
         self.shape = kwargs.pop('shape', False)
-            #defines whether it is a `u` shaped or `hump' shaped
-            #       transformation
+        # shape defines whether it is a `u` shaped or `hump' shaped
+        #       transformation
 
 
         self.u_args, self.u_kwargs = get_u_argskwargs(**kwargs)
         self.kls = kls  #(self.u_args, self.u_kwargs)
-                        # possible to freeze the underlying distribution
+        # possible to freeze the underlying distribution
 
         super(TransfTwo_gen,self).__init__(a=a, b=b, name = name,
                                 shapes = kls.shapes,
@@ -763,7 +763,7 @@ class TransfTwo_gen(distributions.rv_continuous):
 
         return signpdf * (self.derivplus(x)*self.kls._pdf(self.funcinvplus(x),*args, **kwargs) -
                    self.derivminus(x)*self.kls._pdf(self.funcinvminus(x),*args, **kwargs))
-            #note scipy _cdf only take *args not *kwargs
+        # note scipy _cdf only take *args not *kwargs
 
     def _cdf(self,x,*args, **kwargs):
         #print args
@@ -824,7 +824,6 @@ squarenormalg = TransfTwo_gen(stats.norm, sqfunc.squarefunc, sqfunc.inverseplus,
                 numargs = 0, name = 'squarenorm', longname = 'squared normal distribution',
                 extradoc = '\ndistribution of the square of a normal random variable' +\
                            ' y=x**2 with x N(0.0,1)')
-                        #u_loc=l, u_scale=s)
 squaretg = TransfTwo_gen(stats.t, sqfunc.squarefunc, sqfunc.inverseplus,
                 sqfunc.inverseminus, sqfunc.derivplus, sqfunc.derivminus,
                 shape='u', a=0.0, b=np.inf,
@@ -854,7 +853,7 @@ negsquarenormalg = TransfTwo_gen(stats.norm, negsquarefunc, inverseplus, inverse
                 numargs = 0, name = 'negsquarenorm', longname = 'negative squared normal distribution',
                 extradoc = '\ndistribution of the negative square of a normal random variable' +\
                            ' y=-x**2 with x N(0.0,1)')
-                        #u_loc=l, u_scale=s)
+
 
 def inverseplus(x):
     return x

--- a/statsmodels/sandbox/distributions/tests/_est_fit.py
+++ b/statsmodels/sandbox/distributions/tests/_est_fit.py
@@ -50,8 +50,8 @@ def check_cont_fit(distname,arg):
         raise AssertionError('nan returned in fit')
     else:
         if np.any((np.abs(diff) - diffthreshold) > 0.0):
-##            txt = 'WARNING - diff too large with small sample'
-##            print 'parameter diff =', diff - diffthreshold, txt
+            #txt = 'WARNING - diff too large with small sample'
+            #print 'parameter diff =', diff - diffthreshold, txt
             rvs = np.concatenate([rvs,distfn.rvs(size=n_repl2-n_repl1,*arg)])
             est = distfn.fit(rvs) #,*arg)
             truearg = np.hstack([arg,[0.0,1.0]])

--- a/statsmodels/sandbox/distributions/tests/distparams.py
+++ b/statsmodels/sandbox/distributions/tests/distparams.py
@@ -112,9 +112,12 @@ distdiscrete = [
     ['poisson',  (0.6,)],
     ['randint',  (7, 31)],
     ['skellam',  (15, 8)],
-    ['zipf',     (4,)] ]    # arg=4 is ok,
-                            # Zipf broken for arg = 2, e.g. weird .stats
-                            # looking closer, mean, var should be inf for arg=2
+
+    # arg=4 is ok,
+    # Zipf is broken for arg = 2, e.g. weird .stats
+    # looking closer, mean, var should be inf for arg=2
+    ['zipf',     (4,)] ]
+
 
 distslow = ['rdist', 'gausshyper', 'recipinvgauss', 'ksone', 'genexpon',
             'vonmises', 'rice', 'mielke', 'semicircular', 'cosine', 'invweibull',

--- a/statsmodels/sandbox/distributions/tests/test_transf.py
+++ b/statsmodels/sandbox/distributions/tests/test_transf.py
@@ -103,7 +103,7 @@ class Test_Transf2(object):
     def test_equivalent(self):
         xx, ppfq = self.xx, self.ppfq
         for d1,d2 in self.dist_equivalents:
-##            print d1.name
+            #print d1.name
             assert_almost_equal(d1.cdf(xx), d2.cdf(xx), err_msg='cdf'+d1.name)
             assert_almost_equal(d1.pdf(xx), d2.pdf(xx),
                                 err_msg='pdf '+d1.name+d2.name)

--- a/statsmodels/sandbox/distributions/transformed.py
+++ b/statsmodels/sandbox/distributions/transformed.py
@@ -73,13 +73,13 @@ class Transf_gen(distributions.rv_continuous):
         a = kwargs.pop('a', -np.inf)
         b = kwargs.pop('b', np.inf)
         self.decr = kwargs.pop('decr', False)
-            #defines whether it is a decreasing (True)
-            #       or increasing (False) monotonic transformation
+        # descr defines whether it is a decreasing (True)
+        #   or increasing (False) monotonic transformation
 
 
         self.u_args, self.u_kwargs = get_u_argskwargs(**kwargs)
         self.kls = kls  #(self.u_args, self.u_kwargs)
-                        # possible to freeze the underlying distribution
+        # possible to freeze the underlying distribution
 
         super(Transf_gen,self).__init__(a=a, b=b, name = name,
                                         shapes=kls.shapes,
@@ -315,13 +315,13 @@ class TransfTwo_gen(distributions.rv_continuous):
         a = kwargs.pop('a', -np.inf) # attached to self in super
         b = kwargs.pop('b', np.inf)  # self.a, self.b would be overwritten
         self.shape = kwargs.pop('shape', False)
-            #defines whether it is a `u` shaped or `hump' shaped
-            #       transformation
+        # shape defines whether it is a `u` shaped or `hump' shaped
+        #       transformation
 
 
         self.u_args, self.u_kwargs = get_u_argskwargs(**kwargs)
         self.kls = kls  #(self.u_args, self.u_kwargs)
-                        # possible to freeze the underlying distribution
+        # possible to freeze the underlying distribution
 
         super(TransfTwo_gen,self).__init__(a=a, b=b,
                                            name = name,
@@ -344,7 +344,7 @@ class TransfTwo_gen(distributions.rv_continuous):
 
         return signpdf * (self.derivplus(x)*self.kls._pdf(self.funcinvplus(x),*args, **kwargs) -
                    self.derivminus(x)*self.kls._pdf(self.funcinvminus(x),*args, **kwargs))
-            #note scipy _cdf only take *args not *kwargs
+        # note scipy _cdf only take *args not *kwargs
 
     def _cdf(self,x,*args, **kwargs):
         #print(args
@@ -405,7 +405,7 @@ squarenormalg = TransfTwo_gen(stats.norm, sqfunc.squarefunc, sqfunc.inverseplus,
                 numargs = 0, name = 'squarenorm', longname = 'squared normal distribution',
                 extradoc = '\ndistribution of the square of a normal random variable' +\
                            ' y=x**2 with x N(0.0,1)')
-                        #u_loc=l, u_scale=s)
+
 squaretg = TransfTwo_gen(stats.t, sqfunc.squarefunc, sqfunc.inverseplus,
                 sqfunc.inverseminus, sqfunc.derivplus, sqfunc.derivminus,
                 shape='u', a=0.0, b=np.inf,
@@ -434,7 +434,7 @@ negsquarenormalg = TransfTwo_gen(stats.norm, negsquarefunc, inverseplus, inverse
                 numargs = 0, name = 'negsquarenorm', longname = 'negative squared normal distribution',
                 extradoc = '\ndistribution of the negative square of a normal random variable' +\
                            ' y=-x**2 with x N(0.0,1)')
-                        #u_loc=l, u_scale=s)
+
 
 def inverseplus(x):
     return x

--- a/statsmodels/sandbox/examples/bayesprior.py
+++ b/statsmodels/sandbox/examples/bayesprior.py
@@ -135,7 +135,7 @@ y1y2pairsp2 = np.zeros((draws,2))
 # prior 2
 theta12_2 = []
 for draw in range(draws):
-#    y1 = np.random.uniform(-4,6)
+    #y1 = np.random.uniform(-4,6)
     theta1 = np.random.uniform(0,1)
     theta2 = np.random.normal(mu_*(1-theta1), lambda_**2*(1-theta1)**2)
     theta12_2.append([theta1,theta2])

--- a/statsmodels/sandbox/examples/example_nbin.py
+++ b/statsmodels/sandbox/examples/example_nbin.py
@@ -306,14 +306,14 @@ alpha          4.57898241 0.22015968 20.7984603  4.14746943  5.01049539
 '''
 
 #def test_nb1():
-    #y, X = patsy.dmatrices('los ~ C(type) + hmo + white', medpar)
-    #y = np.array(y)[:,0]
-    ## TODO: Test fails with some of the other optimization methods
-    #nb1 = NBin(y,X,'nb1').fit(method='ncg', maxiter=10000, maxfun=5000)
-    #assert_almost_equal(nb1.params,
-                        #[2.34918407014186, 0.161754714412848, 0.418792569970658,
-                        # -0.0453356614650342, -0.129512952033423, 4.57898241219275],
-                        #decimal=2)
+#    y, X = patsy.dmatrices('los ~ C(type) + hmo + white', medpar)
+#    y = np.array(y)[:,0]
+#    # TODO: Test fails with some of the other optimization methods
+#    nb1 = NBin(y,X,'nb1').fit(method='ncg', maxiter=10000, maxfun=5000)
+#    assert_almost_equal(nb1.params,
+#                        [2.34918407014186, 0.161754714412848, 0.418792569970658,
+#                         -0.0453356614650342, -0.129512952033423, 4.57898241219275],
+#                        decimal=2)
 
 # NB-Geometric
 '''
@@ -351,13 +351,13 @@ Number of Fisher Scoring iterations: 5
 '''
 
 #def test_geom():
-    #y, X = patsy.dmatrices('los ~ C(type) + hmo + white', medpar)
-    #y = np.array(y)[:,0]
-    ## TODO: remove alph from geom params
-    #geom = NBin(y,X,'geom').fit(maxiter=10000, maxfun=5000)
-    #assert_almost_equal(geom.params,
-                        #[2.3084850946241, 0.221206159108742, 0.705986369841159,
-                        # -0.0677871843613577, -0.127088772164963],
-                        #decimal=4)
+#    y, X = patsy.dmatrices('los ~ C(type) + hmo + white', medpar)
+#    y = np.array(y)[:,0]
+#    # TODO: remove alph from geom params
+#    geom = NBin(y,X,'geom').fit(maxiter=10000, maxfun=5000)
+#    assert_almost_equal(geom.params,
+#                        [2.3084850946241, 0.221206159108742, 0.705986369841159,
+#                         -0.0677871843613577, -0.127088772164963],
+#                        decimal=4)
 
 test_nb2()

--- a/statsmodels/sandbox/examples/example_sysreg.py
+++ b/statsmodels/sandbox/examples/example_sysreg.py
@@ -176,9 +176,12 @@ TableF5-1.txt', names=True)
         y[:-1]))
     instruments = sm.add_constant(instruments, prepend=False)
     sem_mod = Sem2SLS(sys3, indep_endog = indep_endog, instruments=instruments)
-    sem_params = sem_mod.fit()  # first equation is right, but not second?
-                                # should y_t in the diff be instrumented?
-                                # how would R know this in the script?
+
+    sem_params = sem_mod.fit()
+    # first equation is right, but not second?
+    # should y_t in the diff be instrumented?
+    # how would R know this in the script?
+
     # well, let's check...
     y_instr = sem_mod.wexog[0][:,0]
     wyd = y_instr - y[:-1]

--- a/statsmodels/sandbox/examples/thirdparty/ex_ratereturn.py
+++ b/statsmodels/sandbox/examples/thirdparty/ex_ratereturn.py
@@ -117,7 +117,6 @@ if has_sklearn:
     normcolor = None
     fig = plt.figure()
     for i, c in enumerate([rrcorr, corr_lw, corr_oas, corr_mcd]):
-    #for i, c in enumerate([np.cov(rr, rowvar=0), cov_lw, cov_oas, cov_mcd]):
         ax = fig.add_subplot(2,2,i+1)
         plot_corr(c, xnames=None, title=titles[i],
               normcolor=normcolor, ax=ax)

--- a/statsmodels/sandbox/gam.py
+++ b/statsmodels/sandbox/gam.py
@@ -330,7 +330,6 @@ class AdditiveModel(object):
         return self.results
 
 class Model(GLM, AdditiveModel):
-#class Model(AdditiveModel):
     #TODO: what does GLM do? Is it actually used ?
     #only used in __init__, dropping it doesn't change results
     #but where gets family attached now? - weird, it's Gaussian in this case now
@@ -341,10 +340,6 @@ class Model(GLM, AdditiveModel):
 
     #niter = 2
 
-#    def __init__(self, exog, smoothers=None, family=family.Gaussian()):
-#        GLM.__init__(self, exog, family=family)
-#        AdditiveModel.__init__(self, exog, smoothers=smoothers)
-#        self.family = family
     def __init__(self, endog, exog, smoothers=None, family=families.Gaussian()):
         #self.family = family
         #TODO: inconsistent super __init__
@@ -398,7 +393,6 @@ class Model(GLM, AdditiveModel):
         resid = Y - self.results.mu
         return (np.power(resid, 2) / self.family.variance(self.results.mu)).sum() \
                     / self.df_resid   #TODO check this
-                    #/ AdditiveModel.df_resid(self)  #what is the class doing here?
 
 
     def fit(self, Y, rtol=1.0e-06, maxiter=30):

--- a/statsmodels/sandbox/mcevaluate/arma.py
+++ b/statsmodels/sandbox/mcevaluate/arma.py
@@ -63,13 +63,6 @@ def mc_summary(res, rt=None):
 
 
 if __name__ == '__main__':
-
-#short version
-#    true, est, bse = mcarma22(niter=50)
-#    print(true
-#    #print(est
-#    print(est.mean(0)
-
     ''' niter 50, sample size=1000, 2 runs
     [-0.55 -0.1   0.3   0.2 ]
     [-0.542401   -0.09904305  0.30840599  0.2052473 ]

--- a/statsmodels/sandbox/nonparametric/smoothers.py
+++ b/statsmodels/sandbox/nonparametric/smoothers.py
@@ -16,8 +16,10 @@ from . import kernels
 #from scipy.linalg import solveh_banded
 #from scipy.optimize import golden
 
-#from models import _hbspline        # Need to alter setup to be able to import
-                                    # extension from models or drop for scipy
+#from models import _hbspline
+# Need to alter setup to be able to import
+# extension from models or drop for scipy
+
 #from models.bspline import BSpline, _band2array
 
 class KernelSmoother(object):

--- a/statsmodels/sandbox/panel/panelmod.py
+++ b/statsmodels/sandbox/panel/panelmod.py
@@ -105,10 +105,6 @@ class PanelModel(object):
     def __init__(self, endog=None, exog=None, panel=None, time=None,
             xtnames=None, equation=None, panel_data=None):
         if panel_data == None:
-#            if endog == None and exog == None and panel == None and \
-#                    time == None:
-#                raise ValueError("If pandel_data is False then endog, exog, \
-#panel_arr, and time_arr cannot be None.")
             self.initialize(endog, exog, panel, time, xtnames, equation)
 #        elif aspandas != False:
 #            if not isinstance(endog, str):

--- a/statsmodels/sandbox/regression/gmm.py
+++ b/statsmodels/sandbox/regression/gmm.py
@@ -1151,11 +1151,6 @@ class GMMResults(LikelihoodModelResults):
         # this should use by default whatever options have been specified in
         # fit
 
-        # TODO: don't do this when we want to change options
-#         if hasattr(self, '_cov_params'):
-#             #replace with decorator later
-#             return self._cov_params
-
         # set defaults based on fit arguments
         if not 'wargs' in kwds:
             # Note: we don't check the keys in wargs, use either all or nothing

--- a/statsmodels/sandbox/regression/tests/test_gmm.py
+++ b/statsmodels/sandbox/regression/tests/test_gmm.py
@@ -79,7 +79,8 @@ pvalues = np.array([  1.72360000e-33,   7.57025400e-16,   5.55625000e-02,
          5.83809900e-05,   2.85474400e-01,   3.53813900e-01,
          3.40336100e-03,   3.91575100e-03,   9.36840200e-02,
          1.06401300e-01])
-    #-----------------
+# -----------------
+
 
 def test_iv2sls_r():
 
@@ -340,7 +341,7 @@ class TestGMMStOnestep(CheckGMM):
         # try other versions for bse,
         # TODO: next two produce the same as before (looks like)
         bse = np.sqrt(np.diag((res1._cov_params(has_optimal_weights=False))))
-                                            #weights=res1.weights))))
+
         # TODO: doesn't look different
         #assert_allclose(res1.bse, res2.bse, rtol=5e-06, atol=0)
         #nobs = instrument.shape[0]

--- a/statsmodels/sandbox/regression/tests/test_gmm_poisson.py
+++ b/statsmodels/sandbox/regression/tests/test_gmm_poisson.py
@@ -46,8 +46,8 @@ def moment_exponential_add(params, exog, exp=True):
     if exp:
         predicted = np.exp(np.dot(exog, params))
         #if not np.isfinite(predicted).all():
-            #print "invalid predicted", predicted
-            #raise RuntimeError('invalid predicted')
+        #    #print "invalid predicted", predicted
+        #    #raise RuntimeError('invalid predicted')
         predicted = np.clip(predicted, 0, 1e100)  # try to avoid inf
     else:
         predicted = np.dot(exog, params)

--- a/statsmodels/sandbox/regression/treewalkerclass.py
+++ b/statsmodels/sandbox/regression/treewalkerclass.py
@@ -369,7 +369,6 @@ class RU2NMNL(object):
                     print('parent', parent)
                 self.branchleaves[parent].extend(self.branchleaves[name])
             if 0:  #not name == 'top':  # not used anymore !!! ???
-            #if not name == 'top':
                 #TODO: do I need this only on the lowest branches ?
                 tmpsum = 0
                 for k in self.branchleaves[name]:
@@ -387,8 +386,8 @@ class RU2NMNL(object):
                     if np.size(self.datadict[name])>0:
                         #not used yet, might have to move one indentation level
                         #self.probs[k] = self.probs[k] / tmpsum
-##                            np.exp(-self.datadict[name] *
-##                             np.sum(self.recursionparams[self.parinddict[name]]))
+                        #      np.exp(-self.datadict[name] *
+                        #       np.sum(self.recursionparams[self.parinddict[name]]))
                         if DEBUG:
                             print('self.datadict[name], self.probs[k]')
                             print(self.datadict[name], self.probs[k])

--- a/statsmodels/sandbox/stats/diagnostic.py
+++ b/statsmodels/sandbox/stats/diagnostic.py
@@ -1222,7 +1222,7 @@ def recursive_olsresiduals(olsresults, skip=None, lamda=0.0, alpha=0.95):
     rresid_scaled = rresid/np.sqrt(rvarraw)   #this is N(0,sigma2) distributed
     nrr = nobs-skip
     #sigma2 = rresid_scaled[skip-1:].var(ddof=1)  #var or sum of squares ?
-            #Greene has var, jplv and Ploberger have sum of squares (Ass.:mean=0)
+    # Greene has var, jplv and Ploberger have sum of squares (Ass.:mean=0)
     #Gretl uses: by reverse engineering matching their numbers
     sigma2 = rresid_scaled[skip:].var(ddof=1)
     rresid_standardized = rresid_scaled/np.sqrt(sigma2) #N(0,1) distributed

--- a/statsmodels/sandbox/stats/multicomp.py
+++ b/statsmodels/sandbox/stats/multicomp.py
@@ -178,10 +178,10 @@ def get_tukeyQcrit2(k, df, alpha=0.05):
 
 def Tukeythreegene(first,second,third):
     #Performing the Tukey HSD post-hoc test for three genes
-##   qwb = xlrd.open_workbook('F:/Lab/bioinformatics/qcrittable.xls')
-##    #opening the workbook containing the q crit table
-##   qwb.sheet_names()
-##   qcrittable = qwb.sheet_by_name(u'Sheet1')
+    #qwb = xlrd.open_workbook('F:/Lab/bioinformatics/qcrittable.xls')
+    #opening the workbook containing the q crit table
+    #qwb.sheet_names()
+    #qcrittable = qwb.sheet_by_name(u'Sheet1')
 
     firstmean = numpy.mean(first) #means of the three arrays
     secondmean = numpy.mean(second)

--- a/statsmodels/sandbox/sysreg.py
+++ b/statsmodels/sandbox/sysreg.py
@@ -100,10 +100,12 @@ exogenous variables.  Got length %s" % len(sys))
         self._dfk = dfk
         M = len(sys[1::2])
         self._M = M
-#        exog = np.zeros((M,M), dtype=object)
-#        for i,eq in enumerate(sys[1::2]):
-#            exog[i,i] = np.asarray(eq)  # not sure this exog is needed
-                                        # used to compute resids for now
+        #exog = np.zeros((M,M), dtype=object)
+        #for i,eq in enumerate(sys[1::2]):
+        #    exog[i,i] = np.asarray(eq)
+        #   # not sure this exog is needed
+        #   # used to compute resids for now
+
         exog = np.column_stack(np.asarray(sys[1::2][i]) for i in range(M))
 #       exog = np.vstack(np.asarray(sys[1::2][i]) for i in range(M))
         self.exog = exog # 2d ndarray exog is better
@@ -312,7 +314,7 @@ exogenous variables.  Got length %s" % len(sys))
             try:
                 iter(indep_endog[eq_key])
             except:
-#                eq_key = [eq_key]
+                #eq_key = [eq_key]
                 raise TypeError("The values of the indep_exog dict must be\
  iterable. Got type %s for converter %s" % (type(del_col)))
 #            for del_col in indep_endog[eq_key]:

--- a/statsmodels/sandbox/tsa/garch.py
+++ b/statsmodels/sandbox/tsa/garch.py
@@ -106,7 +106,7 @@ def normloglike(x, mu=0, sigma2=1, returnlls=False, axis=0):
 
     x = x - mu  # assume can be broadcasted
     if returnlls:
-    #Compute the individual log likelihoods if needed
+        # Compute the individual log likelihoods if needed
         lls = -0.5*(np.log(2*np.pi) + np.log(sigma2) + x**2/sigma2)
         # Use these to comput the LL
         LL = np.sum(lls,axis)
@@ -712,7 +712,7 @@ class AR(LikelihoodModel):
                 .5 * np.log(1-params**2) - .5*diffsumsq/sigma2 -\
                 ylag[0]**2 * (1-params**2)/(2*sigma2)
         if usepenalty:
-        # subtract a quadratic penalty since we min the negative of loglike
+            # subtract a quadratic penalty since we min the negative of loglike
             loglike -= 1000 *(oldparams-.9999)**2
         return loglike
 

--- a/statsmodels/sandbox/tsa/try_var_convolve.py
+++ b/statsmodels/sandbox/tsa/try_var_convolve.py
@@ -130,9 +130,9 @@ def arfilter_old(x, a):
 
     elif a.ndim == 3:
         # case: vector autoregressive with lag matrices
-#        #not necessary:
-#        if np.any(a.shape[1:] != nvar):
-#            raise ValueError('if 3d shape of a has to be (nobs,nvar,nvar)')
+        #not necessary:
+        #if np.any(a.shape[1:] != nvar):
+        #    raise ValueError('if 3d shape of a has to be (nobs,nvar,nvar)')
         yf = signal.convolve(x[:,:,None], a)
         yvalid = yf[ntrim:-ntrim, yf.shape[1]//2,:]
         return yvalid

--- a/statsmodels/sandbox/tsa/varma.py
+++ b/statsmodels/sandbox/tsa/varma.py
@@ -69,9 +69,9 @@ def VAR(x,B, const=0):
     T = x.shape[0]
     xhat = np.zeros(x.shape)
     for t in range(p,T): #[p+2]:#
-##        print(p,T)
-##        print(x[t-p:t,:,np.newaxis].shape)
-##        print(B.shape)
+        #print(p,T)
+        #print(x[t-p:t,:,np.newaxis].shape)
+        #print(B.shape)
         #print(x[t-p:t,:,np.newaxis])
         xhat[t,:] = const + (x[t-p:t,:,np.newaxis]*B).sum(axis=1).sum(axis=0)
     return xhat
@@ -94,9 +94,9 @@ def VARMA(x,B,C, const=0):
     e = np.zeros(x.shape)
     start = max(P,Q)
     for t in range(start,T): #[p+2]:#
-##        print(p,T
-##        print(x[t-p:t,:,np.newaxis].shape
-##        print(B.shape
+        #print(p,T
+        #print(x[t-p:t,:,np.newaxis].shape
+        #print(B.shape
         #print(x[t-p:t,:,np.newaxis]
         xhat[t,:] =  const + (x[t-P:t,:,np.newaxis]*B).sum(axis=1).sum(axis=0) + \
                      (e[t-Q:t,:,np.newaxis]*C).sum(axis=1).sum(axis=0)

--- a/statsmodels/stats/descriptivestats.py
+++ b/statsmodels/stats/descriptivestats.py
@@ -110,19 +110,19 @@ class Describe(object):
             #sign_test_P = [self.sign_test_p, None, None]
         )
 
-        #TODO: Basic stats for strings
-        #self.strings = dict(
-            #unique = [np.unique, None, None],
-            #number_uniq = [len(
-            #most = [
-            #least = [
+        # TODO: Basic stats for strings
+        # self.strings = dict(
+        #    unique = [np.unique, None, None],
+        #    number_uniq = [len(
+        #    most = [
+        #    least = [
 
-        #TODO: Multivariate
-        #self.multivariate = dict(
-            #corrcoef(x[, y, rowvar, bias]),
-            #cov(m[, y, rowvar, bias]),
-            #histogram2d(x, y[, bins, range, normed, weights])
-            #)
+        # TODO: Multivariate
+        # self.multivariate = dict(
+        #    corrcoef(x[, y, rowvar, bias]),
+        #    cov(m[, y, rowvar, bias]),
+        #    histogram2d(x, y[, bins, range, normed, weights])
+        #    )
         self._arraytype = None
         self._columns_list = None
 
@@ -152,8 +152,8 @@ class Describe(object):
         unknown. `numpy.lib._iotools._is_string_like`
         """
         def string_like():
-        #TODO: not sure what the result is if the first item is some type of
-        #      missing value
+            # TODO: not sure what the result is if the first item is some
+            #       type of missing value
             try:
                 self.dataset[col][0] + ''
             except (TypeError, ValueError):
@@ -245,7 +245,7 @@ class Describe(object):
                     self._columns_list = self.dataset.dtype.names
                     #self._columns_list = [col for col in
                     #                      self.dataset.dtype.names if
-                            #(self._is_dtype_like(col)=='number')]
+                    #        (self._is_dtype_like(col)=='number')]
                 else:
                     self._columns_list = lrange(self.dataset.shape[1])
             else:
@@ -306,9 +306,9 @@ class Describe(object):
     #TODO: There must be a better way but formating the stats of a fuction that
     #      returns 2 values is a problem.
     #def sign_test_m(samp,mu0=0):
-        #return self.sign_test(samp,mu0)[0]
+    #    return self.sign_test(samp,mu0)[0]
     #def sign_test_p(samp,mu0=0):
-        #return self.sign_test(samp,mu0)[1]
+    #    return self.sign_test(samp,mu0)[1]
 
 if __name__ == "__main__":
     #unittest.main()

--- a/statsmodels/stats/multitest.py
+++ b/statsmodels/stats/multitest.py
@@ -231,10 +231,10 @@ def multipletests(pvals, alpha=0.05, method='hs', is_sorted=False,
 
     elif method.lower() in ['fdr_gbs']:
         #adaptive stepdown in Gavrilov, Benjamini, Sarkar, Annals of Statistics 2009
-##        notreject = pvals > alphaf / np.arange(ntests, 0, -1) #alphacSidak
-##        notrejectmin = np.min(np.nonzero(notreject))
-##        notreject[notrejectmin:] = True
-##        reject = ~notreject
+        #notreject = pvals > alphaf / np.arange(ntests, 0, -1) #alphacSidak
+        #notrejectmin = np.min(np.nonzero(notreject))
+        #notreject[notrejectmin:] = True
+        #reject = ~notreject
 
         ii = np.arange(1, ntests + 1)
         q = (ntests + 1. - ii)/ii * pvals / (1. - pvals)

--- a/statsmodels/stats/tests/results/results_proportion.py
+++ b/statsmodels/stats/tests/results/results_proportion.py
@@ -110,7 +110,7 @@ res_binom[(29, 30)].ci_upp = np.array([
     0.9980676, 0.9982575, 0.9940914])
 
 # > bci = binom.confint(x = c(0), n = 30, tol = 1e-8)
-    # this ci_low clips one negative value to 0
+# Note: this ci_low clips one negative value to 0
 res_binom[(0, 30)].ci_low = np.zeros(11)
 res_binom[(0, 30)].ci_upp = np.array([
     0.13471170, 0.00000000, 0.06151672, 0.11570331,
@@ -122,5 +122,5 @@ res_binom[(30, 30)].ci_low = np.array([
     0.8652883, 1.0000000, 0.9384833, 0.8842967,
     0.8842967, 0.8842967, 0.8842967, 0.8959711,
     0.9379822, 0.8586795, 0.8864866])
-    # this ci_upp clips one value > 1
+# Note: this ci_upp clips one value > 1
 res_binom[(30, 30)].ci_upp = np.ones(11)

--- a/statsmodels/tools/tests/test_numdiff.py
+++ b/statsmodels/tools/tests/test_numdiff.py
@@ -99,7 +99,7 @@ class TestGradMNLogit(CheckGradLoglikeMixin):
         cls.mod = sm.MNLogit(data.endog, exog)
 
         #def loglikeflat(cls, params):
-            #reshapes flattened params
+        #    # reshapes flattened params
         #    return cls.loglike(params.reshape(6,6))
         #cls.mod.loglike = loglikeflat  #need instance method
         #cls.params = [np.ones((6,6)).ravel()]
@@ -270,7 +270,6 @@ class TestDerivativeFun2(CheckDerivativeMixin):
     def gradtrue(self, params):
         y, x = self.y, self.x
         return (-x*2*(y-np.dot(x, params))[:,None]).sum(0)
-                #2*(y-np.dot(x, params)).sum(0)
 
     def hesstrue(self, params):
         x = self.x

--- a/statsmodels/tools/tests/test_tools.py
+++ b/statsmodels/tools/tests/test_tools.py
@@ -290,51 +290,54 @@ class TestCategoricalNumerical(object):
         assert_array_equal(test_dum, self.dummy)
         assert_equal(len(dum.dtype.names), 5)
 
-#    def test_arraylike2d(self):
-#        des = tools.categorical(self.structdes.tolist(), col=2)
-#        test_des = des[:,-5:]
-#        assert_array_equal(test_des, self.dummy)
-#        assert_equal(des.shape[1], 9)
+    # TODO: Why are these commented-out?  similar tests commented-out below
+    #    have a comment saying it is "until we have type coercsion";
+    #    what does that mean?
+    #def test_arraylike2d(self):
+    #    des = tools.categorical(self.structdes.tolist(), col=2)
+    #    test_des = des[:,-5:]
+    #    assert_array_equal(test_des, self.dummy)
+    #    assert_equal(des.shape[1], 9)
 
-#    def test_arraylike1d(self):
-#        instr = self.structdes['instrument'].tolist()
-#        dum = tools.categorical(instr)
-#        test_dum = dum[:,-5:]
-#        assert_array_equal(test_dum, self.dummy)
-#        assert_equal(dum.shape[1], 6)
+    #def test_arraylike1d(self):
+    #    instr = self.structdes['instrument'].tolist()
+    #    dum = tools.categorical(instr)
+    #    test_dum = dum[:,-5:]
+    #    assert_array_equal(test_dum, self.dummy)
+    #    assert_equal(dum.shape[1], 6)
 
-#    def test_arraylike2d_drop(self):
-#        des = tools.categorical(self.structdes.tolist(), col=2, drop=True)
-#        test_des = des[:,-5:]
-#        assert_array_equal(test__des, self.dummy)
-#        assert_equal(des.shape[1], 8)
+    #def test_arraylike2d_drop(self):
+    #    des = tools.categorical(self.structdes.tolist(), col=2, drop=True)
+    #    test_des = des[:,-5:]
+    #    assert_array_equal(test__des, self.dummy)
+    #    assert_equal(des.shape[1], 8)
 
-#    def test_arraylike1d_drop(self):
-#        instr = self.structdes['instrument'].tolist()
-#        dum = tools.categorical(instr, drop=True)
-#        assert_array_equal(dum, self.dummy)
-#        assert_equal(dum.shape[1], 5)
+    #def test_arraylike1d_drop(self):
+    #    instr = self.structdes['instrument'].tolist()
+    #    dum = tools.categorical(instr, drop=True)
+    #    assert_array_equal(dum, self.dummy)
+    #    assert_equal(dum.shape[1], 5)
 
 
 class TestCategoricalString(TestCategoricalNumerical):
 
-# comment out until we have type coercion
-#    def test_array2d(self):
-#        des = np.column_stack((self.des, self.instr, self.des))
-#        des = tools.categorical(des, col=2)
-#        assert_array_equal(des[:,-5:], self.dummy)
-#        assert_equal(des.shape[1],10)
+    # TODO: comment out until we have type coercion
+    #def test_array2d(self):
+    #    des = np.column_stack((self.des, self.instr, self.des))
+    #    des = tools.categorical(des, col=2)
+    #    assert_array_equal(des[:,-5:], self.dummy)
+    #    assert_equal(des.shape[1],10)
 
-#    def test_array1d(self):
-#        des = tools.categorical(self.instr)
-#        assert_array_equal(des[:,-5:], self.dummy)
-#        assert_equal(des.shape[1],6)
+    #def test_array1d(self):
+    #    des = tools.categorical(self.instr)
+    #    assert_array_equal(des[:,-5:], self.dummy)
+    #    assert_equal(des.shape[1],6)
 
-#    def test_array2d_drop(self):
-#        des = np.column_stack((self.des, self.instr, self.des))
-#        des = tools.categorical(des, col=2, drop=True)
-#        assert_array_equal(des[:,-5:], self.dummy)
-#        assert_equal(des.shape[1],9)
+    #def test_array2d_drop(self):
+    #    des = np.column_stack((self.des, self.instr, self.des))
+    #    des = tools.categorical(des, col=2, drop=True)
+    #    assert_array_equal(des[:,-5:], self.dummy)
+    #    assert_equal(des.shape[1],9)
 
     def test_array1d_drop(self):
         des = tools.categorical(self.string_var, drop=True)

--- a/statsmodels/tsa/arima_model.py
+++ b/statsmodels/tsa/arima_model.py
@@ -1498,7 +1498,7 @@ class ARMAResults(tsbase.TimeSeriesModelResults):
 
     @cache_readonly
     def pvalues(self):
-    #TODO: same for conditional and unconditional?
+        # TODO: same for conditional and unconditional?
         df_resid = self.df_resid
         return t.sf(np.abs(self.tvalues), df_resid) * 2
 

--- a/statsmodels/tsa/kalmanf/kalmanfilter.py
+++ b/statsmodels/tsa/kalmanf/kalmanfilter.py
@@ -379,24 +379,6 @@ class StateSpaceModel(object):
             loglike += penalty * np.sum((paramsorig-params)**2)
         return loglike
 
-#        r = self.r
-#        n = self.n
-#        F = np.diagonal(np.ones(r-1), k=-1) # think this will be wrong for VAR
-                                            # cf. 13.1.22 but think VAR
-#        F[0] = params[:p] # assumes first p start_params are coeffs
-                                # of obs. vector, needs to be nxp for VAR?
-#        self.F = F
-#        cholQ = np.diag(start_params[p:]) # fails for bivariate
-                                                        # MA(1) section
-                                                        # 13.4.2
-#        Q = np.dot(cholQ,cholQ.T)
-#        self.Q = Q
-#        HT = np.zeros((n,r))
-#        xi10 = self.xi10
-#        y = self.endog
-#        ntrain = self.ntrain
-#        loglike = kalmanfilter(F,H,y,xi10,Q,ntrain)
-
     def fit_kalman(self, start_params, xi10, ntrain=1, F=None, A=None, H=None,
             Q=None,
             R=None, method="bfgs", penalty=True, upperbounds=None,
@@ -782,8 +764,8 @@ if __name__ == "__main__":
     for i in range(1,nobs):
         xihistory[:,i] = np.dot(F,xihistory[:,i-1]) + \
                 np.dot(cholQ,np.random.randn(2,1)).squeeze()
-                # this makes an ARMA process?
-                # check notes, do the math
+        # TODO: this makes an ARMA process?; check notes, do the math
+
     y = np.dot(H.T, xihistory)
     y = y.T
 

--- a/statsmodels/tsa/tests/results/results_arma.py
+++ b/statsmodels/tsa/tests/results/results_arma.py
@@ -291,7 +291,7 @@ class Y_arma50(object):
             self.forecast = forecast_results['fc50']
             self.forecasterr = forecast_results['fe50']
         elif method =="css":
-#NOTE: some results use x-12 arima because gretl uses LS estimates for AR CSS
+            # NOTE: some results use x-12 arima because gretl uses LS estimates for AR CSS
             self.params = [0.725706505843, -0.305501865989, 0.320719417706,
                     0.226552951649, -0.089852608091                    ]
 #            self.aic = 674.817286564674
@@ -339,7 +339,7 @@ class Y_arma02(object):
             self.tvalues = [3.433, -13.53]
             self.sigma2 = 1.122887152869 ** 2
         elif method =="css":
-# bse, cov_params, tvalues taken from R
+            # bse, cov_params, tvalues taken from R
             self.params = [0.175605240783, -0.688421349504]
             self.aic = 773.725350463014
             self.bic = 784.289733216601
@@ -387,9 +387,9 @@ class Y_arma11c(object):
             self.forecast = forecast_results['fc11c']
             self.forecasterr = forecast_results['fe11c']
         elif method =="css":
-#            self.params = [1.625462134333, 0.666386002049, 0.409512270580]
-#NOTE: gretl gives the intercept not the mean, x-12-arima and R agree with us
-#NOTE: params, bse, cov_params, tvals from R
+            #self.params = [1.625462134333, 0.666386002049, 0.409512270580]
+            # NOTE: gretl gives the intercept not the mean, x-12-arima and R agree with us
+            # NOTE: params, bse, cov_params, tvals from R
             self.params = [4.872477127267, 0.666395534262, 0.409517026658]
             self.aic = 734.613526514951
             self.bic = 748.683338100810
@@ -445,9 +445,9 @@ class Y_arma14c(object):
             self.tvalues = [29.67, 3.895, 2.106, -5.013, 1.796, 4.966]
             self.sigma2 = 0.990262659233 ** 2
         elif method =="css":
-#NOTE: params, bse, cov_params, and tvalues from R
-#            self.params = [1.502401748545, 0.683090744792, 0.197636417391,
-#                    -0.763847295045, 0.137000823589, 0.304781097398]
+            # NOTE: params, bse, cov_params, and tvalues from R
+            #self.params = [1.502401748545, 0.683090744792, 0.197636417391,
+            #        -0.763847295045, 0.137000823589, 0.304781097398]
             self.params = [4.740785760452, 0.683056278882,  0.197681128402,
                            -0.763804443884, 0.136991271488, 0.304776424257]
             self.aic = 719.977407193363
@@ -515,9 +515,9 @@ class Y_arma41c(object):
             self.forecast = forecast_results['fc41c']
             self.forecasterr = forecast_results['fe41c']
         elif method =="css":
-#            self.params = [-0.077068926631, 0.763816531155, -0.270949972390,
-#                    -0.284496499726, 0.757135838677, 0.225247299659]
-#NOTE: params, cov_params, bse, and tvalues from R
+            #self.params = [-0.077068926631, 0.763816531155, -0.270949972390,
+            #        -0.284496499726, 0.757135838677, 0.225247299659]
+            # NOTE: params, cov_params, bse, and tvalues from R
             self.params = [-2.234160612756, 0.763815335585, -0.270946894536,
                            -0.284497190744, 0.757136686518, 0.225260672575]
             self.aic = 668.907200379791
@@ -581,9 +581,9 @@ class Y_arma22c(object):
             self.tvalues = [99.41,  10.06, -5.120,  0.5184, -9.900]
             self.sigma2 = 1.196309833136 ** 2
         elif method =="css":
-#NOTE: params, bse, cov_params, and tvalues from R
-#            self.params = [2.571274348147, 0.793030965872, -0.363511071688,
-#                    0.033543918525, -0.702593972949]
+            # NOTE: params, bse, cov_params, and tvalues from R
+            #self.params = [2.571274348147, 0.793030965872, -0.363511071688,
+            #        0.033543918525, -0.702593972949]
             self.params = [4.507207454494, 0.793055048760, -0.363521072479,
                             0.033519062805, -0.702595834943]
             self.aic = 806.807171655455
@@ -648,10 +648,10 @@ class Y_arma50c(object):
             self.forecast = forecast_results['fc50c']
             self.forecasterr = forecast_results['fe50c']
         elif method =="css":
-#NOTE: params, bse, cov_params, tvalues from R
-#likelihood based results from x-12 arima
-#            self.params = [0.843173779572, 0.755433266689, -0.296886816205,
-#                    0.253572751789, 0.276975022313, -0.172637420881]
+            # NOTE: params, bse, cov_params, tvalues from R
+            #   likelihood based results from x-12 arima
+            #self.params = [0.843173779572, 0.755433266689, -0.296886816205,
+            #        0.253572751789, 0.276975022313, -0.172637420881]
             self.params = [4.593494860193, 0.755427402630, -0.296867127441,
                            0.253556723526, 0.276987447724, -0.172647993470]
 #            self.aic = 694.843378847617
@@ -714,7 +714,7 @@ class Y_arma02c(object):
             self.tvalues = [117.7, 4.063, -13.15]
             self.sigma2 = 1.081406299967 ** 2
         elif method =="css":
-#NOTE: cov_params and tvalues taken from R
+            # NOTE: cov_params and tvalues taken from R
             self.params = [4.519869870853, 0.202414429306, -0.647482560461]
             self.aic = 756.679105324347
             self.bic = 770.764948995796

--- a/statsmodels/tsa/tests/test_ar.py
+++ b/statsmodels/tsa/tests/test_ar.py
@@ -23,8 +23,9 @@ class CheckARMixin(object):
         assert_almost_equal(self.res1.params, self.res2.params, DECIMAL_6)
 
     def test_bse(self):
-        bse = np.sqrt(np.diag(self.res1.cov_params())) # no dof correction
-                                            # for compatability with Stata
+        bse = np.sqrt(np.diag(self.res1.cov_params()))
+        # no dof correction for compatability with Stata
+
         assert_almost_equal(bse, self.res2.bse_stata, DECIMAL_6)
         assert_almost_equal(self.res1.bse, self.res2.bse_gretl, DECIMAL_5)
 

--- a/statsmodels/tsa/tests/test_stattools.py
+++ b/statsmodels/tsa/tests/test_stattools.py
@@ -98,9 +98,12 @@ class TestADFNoConstant(CheckADF):
         cls.res1 = adfuller(cls.x, regression="nc", autolag=None,
                 maxlag=4)
         cls.teststat = 3.5227498
-        cls.pvalue = .99999 # Stata does not return a p-value for noconstant.
-                        # Tau^max in MacKinnon (1994) is missing, so it is
-                        # assumed that its right-tail is well-behaved
+
+        cls.pvalue = .99999
+        # Stata does not return a p-value for noconstant.
+        # Tau^max in MacKinnon (1994) is missing, so it is
+        # assumed that its right-tail is well-behaved
+
         cls.critvalues = [-2.587, -1.950, -1.617]
 
 

--- a/statsmodels/tsa/varma_process.py
+++ b/statsmodels/tsa/varma_process.py
@@ -127,9 +127,9 @@ def varfilter(x, a):
 
     elif a.ndim == 3:
         # case: vector autoregressive with lag matrices
-#        #not necessary:
-#        if np.any(a.shape[1:] != nvar):
-#            raise ValueError('if 3d shape of a has to be (nobs,nvar,nvar)')
+        #not necessary:
+        #if np.any(a.shape[1:] != nvar):
+        #    raise ValueError('if 3d shape of a has to be (nobs,nvar,nvar)')
         yf = signal.convolve(x[:,:,None], a)
         yvalid = yf[ntrim:-ntrim, yf.shape[1]//2,:]
         return yvalid

--- a/statsmodels/tsa/vector_ar/tests/results/results_var.py
+++ b/statsmodels/tsa/vector_ar/tests/results/results_var.py
@@ -45,8 +45,10 @@ class MacrodataResults(object):
         self.fpe = 7.421287668357018e-13
         self.detsig = 6.01498432283e-13
         self.llf = 1962.572126661708
-        self.chi2_1 = 75.44775165699033 # don't know how they calculate this
-                                        # it's not -2 * (ll1 - ll0)
+
+        self.chi2_1 = 75.44775165699033
+        # don't know how they calculate this; it's not -2 * (ll1 - ll0)
+        
         self.chi2_2 = 33.19878716815366
         self.chi2_3 = 83.90568280242312
         bse = [.1666662376, .1704584393, .1289691456, .1433308696, .0257313781,

--- a/statsmodels/tsa/vector_ar/tests/test_vecm.py
+++ b/statsmodels/tsa/vector_ar/tests/test_vecm.py
@@ -1312,7 +1312,7 @@ def test_exceptions():
                     deterministic="co").fit()
     # ##### exog_fc not passed as argument:
     assert_raises_regex(ValueError, "exog_fc is None.*", vecm_res.predict)
-        # ##### exog_fc is too short:
+    # ##### exog_fc is too short:
     exog_fc = np.ones(STEPS)
     assert_raises_regex(ValueError, ".*exog_fc must have at least steps elements.*",
                         vecm_res.predict, 5, None, exog_fc[:2])  # [:2] shortens exog_fc


### PR DESCRIPTION
In a handful of cases I deleted commented-out code.  For the most part this keeps the commented-out bits, just cleans up the indentation.