### PR TITLE
Delete unused classes within smf

### DIFF
--- a/statsmodels/formula/api.py
+++ b/statsmodels/formula/api.py
@@ -1,33 +1,39 @@
 from statsmodels.regression.linear_model import GLS
-gls = GLS.from_formula
 from statsmodels.regression.linear_model import WLS
-wls = WLS.from_formula
 from statsmodels.regression.linear_model import OLS
-ols = OLS.from_formula
 from statsmodels.regression.linear_model import GLSAR
-glsar = GLSAR.from_formula
 from statsmodels.regression.mixed_linear_model import MixedLM
-mixedlm = MixedLM.from_formula
 from statsmodels.genmod.generalized_linear_model import GLM
-glm = GLM.from_formula
 from statsmodels.robust.robust_linear_model import RLM
-rlm = RLM.from_formula
 from statsmodels.discrete.discrete_model import MNLogit
-mnlogit = MNLogit.from_formula
 from statsmodels.discrete.discrete_model import Logit
-logit = Logit.from_formula
 from statsmodels.discrete.discrete_model import Probit
-probit = Probit.from_formula
 from statsmodels.discrete.discrete_model import Poisson
-poisson = Poisson.from_formula
 from statsmodels.discrete.discrete_model import NegativeBinomial
-negativebinomial = NegativeBinomial.from_formula
 from statsmodels.regression.quantile_regression import QuantReg
-quantreg = QuantReg.from_formula
 from statsmodels.duration.hazard_regression import PHReg
-phreg = PHReg.from_formula
 from statsmodels.genmod.generalized_estimating_equations import (GEE,
      OrdinalGEE, NominalGEE)
+
+gls = GLS.from_formula
+wls = WLS.from_formula
+ols = OLS.from_formula
+glsar = GLSAR.from_formula
+mixedlm = MixedLM.from_formula
+glm = GLM.from_formula
+rlm = RLM.from_formula
+mnlogit = MNLogit.from_formula
+logit = Logit.from_formula
+probit = Probit.from_formula
+poisson = Poisson.from_formula
+negativebinomial = NegativeBinomial.from_formula
+quantreg = QuantReg.from_formula
+phreg = PHReg.from_formula
 gee = GEE.from_formula
 ordinal_gee = OrdinalGEE.from_formula
 nominal_gee = NominalGEE.from_formula
+
+del GLS, WLS, OLS, GLSAR, MixedLM, GLM, \
+RLM, MNLogit, Logit, Probit, Poisson, \
+NegativeBinomial, QuantReg, PHReg, \
+GEE, OrdinalGEE, NominalGEE


### PR DESCRIPTION
Removes unused classes from the `smf` namespace, closes #4947 