### PR TITLE
BUG: Set default lags for acf/pacf plots

### DIFF
--- a/lint.sh
+++ b/lint.sh
@@ -8,6 +8,8 @@ if [ "$LINT" == true ]; then
     echo "Linting all files with limited rules"
     flake8 statsmodels
     if [ $? -ne "0" ]; then
+        echo "Changed files failed linting using the required set of rules."
+        echo "Additions and changes must conform to Python code style rules."
         RET=1
     fi
 
@@ -20,6 +22,7 @@ if [ "$LINT" == true ]; then
         statsmodels/interface/ \
         statsmodels/iolib/smpickle.py \
         statsmodels.iolib/tests/test_pickle.py \
+        statsmodels/graphics/tsaplots.py \
         statsmodels/tsa/regime_switching \
         statsmodels/regression/mixed_linear_model.py \
         statsmodels/duration/__init__.py \
@@ -37,6 +40,7 @@ if [ "$LINT" == true ]; then
         statsmodels/conftest.py \
         setup.py
     if [ $? -ne "0" ]; then
+        echo "Previously passing files failed linting."
         RET=1
     fi
 
@@ -46,6 +50,7 @@ if [ "$LINT" == true ]; then
         echo "Linting newly added files with strict rules"
         flake8 --isolated $(eval echo $NEW_FILES)
         if [ $? -ne "0" ]; then
+            echo "New files failed linting."
             RET=1
         fi
     fi


### PR DESCRIPTION
Set a sensible default value for acf and pacf plot lags when not provided
using a method common to R based on the log of the number of observations.

closes #4663