### PR TITLE
DOC: Fix small typo in unit root testing example

### DIFF
--- a/examples/notebooks/tsa_arma_0.ipynb
+++ b/examples/notebooks/tsa_arma_0.ipynb
@@ -541,7 +541,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "P-value of the unit-root test, resoundly rejects the null of no unit-root."
+    "P-value of the unit-root test, resoundingly rejects the null of a unit-root."
    ]
   },
   {


### PR DESCRIPTION
Fix typo about null of adfuller

closes #4764

[skip ci]