### PR TITLE
[BUG/MAINT] Fix NameErrors caused by missing kwargs

### DIFF
--- a/statsmodels/miscmodels/nonlinls.py
+++ b/statsmodels/miscmodels/nonlinls.py
@@ -214,10 +214,10 @@ class NonlinearLS(Model):  #or subclass a model
         self._results = lfit
         return lfit
 
-    def fit_minimal(self, start_value):
+    def fit_minimal(self, start_value, **kwargs):
         '''minimal fitting with no extra calculations'''
         func = self.geterrors
-        res = optimize.leastsq(func, start_value, full_output=0, **kw)
+        res = optimize.leastsq(func, start_value, full_output=0, **kwargs)
         return res
 
     def fit_random(self, ntries=10, rvs_generator=None, nparams=None):

--- a/statsmodels/stats/power.py
+++ b/statsmodels/stats/power.py
@@ -224,9 +224,9 @@ class Power(object):
             from statsmodels.tools.sm_exceptions import HypothesisTestWarning
             warnings.warn('Warning: Effect size of 0 detected', HypothesisTestWarning)
             if key == 'power':
-                return alpha
+                return kwds['alpha']
             if key == 'alpha':
-                return power
+                return kwds['power']
             else:
                 raise ValueError('Cannot detect an effect-size of 0. Try changing your effect-size.')
 


### PR DESCRIPTION
In one case just reader-confusion caused by obscure namespace behavior