### PR TITLE
[MAINT/TST] remove np.testing.dec unused imports (nose dependency)

### DIFF
--- a/statsmodels/graphics/tests/test_mosaicplot.py
+++ b/statsmodels/graphics/tests/test_mosaicplot.py
@@ -1,7 +1,7 @@
 from __future__ import division
 from statsmodels.compat.python import iterkeys, zip, lrange, iteritems, range
 
-from numpy.testing import assert_, assert_raises, dec
+from numpy.testing import assert_, assert_raises
 from numpy.testing import run_module_suite
 import pytest
 

--- a/statsmodels/imputation/tests/test_mice.py
+++ b/statsmodels/imputation/tests/test_mice.py
@@ -3,7 +3,7 @@ import pandas as pd
 import pytest
 from statsmodels.imputation import mice
 import statsmodels.api as sm
-from numpy.testing import assert_equal, assert_allclose, dec
+from numpy.testing import assert_equal, assert_allclose
 
 try:
     import matplotlib.pyplot as plt  #makes plt available for test functions

--- a/statsmodels/iolib/tests/test_foreign.py
+++ b/statsmodels/iolib/tests/test_foreign.py
@@ -7,7 +7,7 @@ import os
 import warnings
 from datetime import datetime
 
-from numpy.testing import assert_array_equal, assert_, assert_equal, dec
+from numpy.testing import assert_array_equal, assert_, assert_equal
 import numpy as np
 from pandas import DataFrame, isnull
 import pandas.util.testing as ptesting

--- a/statsmodels/sandbox/tests/test_predict_functional.py
+++ b/statsmodels/sandbox/tests/test_predict_functional.py
@@ -3,7 +3,6 @@ import numpy as np
 import pandas as pd
 import pytest
 import statsmodels.api as sm
-from numpy.testing import dec
 
 # If true, the output is written to a multi-page pdf file.
 pdf_output = False

--- a/statsmodels/stats/tests/test_power.py
+++ b/statsmodels/stats/tests/test_power.py
@@ -16,7 +16,7 @@ from distutils.version import LooseVersion
 
 import numpy as np
 from numpy.testing import (assert_almost_equal, assert_allclose, assert_raises,
-                           assert_equal, assert_warns, dec)
+                           assert_equal, assert_warns)
 import pytest
 import scipy
 


### PR DESCRIPTION
`np.testing.dec` is imported in 5 places, never used, and requires `nose`, which we're trying to move away from.  This just deletes those imports.

Broken off from #4875