### PR TITLE
[TST/MAINT] de-duplicate get_correction_factor code

### DIFF
--- a/statsmodels/discrete/discrete_model.py
+++ b/statsmodels/discrete/discrete_model.py
@@ -3743,7 +3743,6 @@ class L1CountResults(DiscreteResults):
     __doc__ = _discrete_results_docs % {"one_line_description" :
             "A results class for count data fit by l1 regularization",
             "extra_attr" : _l1_results_attr}
-        #discretefit = CountResults(self, cntfit)
 
     def __init__(self, model, cntfit):
         super(L1CountResults, self).__init__(model, cntfit)


### PR DESCRIPTION
ATM the `get_robust_clu` classmethod calculates a correction factor and then a bunch of classes have that code copy/pasted into their `setup_class`.  A bunch of _other_ classes have a slightly-changed variant of that calculation, with no documentation as to why the slight change was made (IIRC the answer is "to make it match Stata/R").

This de-duplicates all that code by implementing `get_correction_factor`.