### PR TITLE
[TST/CLN] Turn decorators __main__ section into tests

### DIFF
--- a/lint.sh
+++ b/lint.sh
@@ -24,6 +24,8 @@ if [ "$LINT" == true ]; then
         statsmodels/regression/recursive_ls.py \
         statsmodels/tools/linalg.py \
         statsmodels/tools/tests/test_linalg.py \
+        statsmodels/tools/decorators.py \
+        statsmodels/tools/tests/test_decorators.py \
         conftest.py
     if [ $? -ne "0" ]; then
         RET=1

--- a/statsmodels/tools/decorators.py
+++ b/statsmodels/tools/decorators.py
@@ -1,6 +1,5 @@
 from __future__ import print_function
 from statsmodels.tools.sm_exceptions import CacheWriteWarning
-from numpy.testing import assert_equal
 from statsmodels.compat.python import get_function_name
 import warnings
 
@@ -58,14 +57,6 @@ class ResettableCache(dict):
         dict.__delitem__(self, key)
         for mustreset in self._resetdict.get(key, []):
             del(self[mustreset])
-
-#    def __getstate__(self):
-#        print('pickling wrapper', self.__dict__)
-#        return self.__dict__
-#
-#    def __setstate__(self, dict_):
-#        print('unpickling wrapper', dict_)
-#        self.__dict__.update(dict_)
 
 
 resettable_cache = ResettableCache
@@ -141,6 +132,8 @@ class _cache_readonly(object):
         return CachedAttribute(func,
                                cachename=self.cachename,
                                resetlist=self.resetlist)
+
+
 cache_readonly = _cache_readonly()
 
 
@@ -195,80 +188,7 @@ class OneTimeProperty(object):
         setattr(obj, self.name, val)
         return val
 
+
 def nottest(fn):
     fn.__test__ = False
     return fn
-
-
-if __name__ == "__main__":
-    # Tests resettable_cache --------------------------------------------
-    reset = dict(a=('b',), b=('c',))
-    cache = resettable_cache(a=0, b=1, c=2, reset=reset)
-    assert_equal(cache, dict(a=0, b=1, c=2))
-    #
-    print("Try resetting a")
-    cache['a'] = 1
-    assert_equal(cache, dict(a=1, b=None, c=None))
-    cache['c'] = 2
-    assert_equal(cache, dict(a=1, b=None, c=2))
-    cache['b'] = 0
-    assert_equal(cache, dict(a=1, b=0, c=None))
-    #
-    print("Try deleting b")
-    del(cache['a'])
-    assert_equal(cache, {})
-    # --------------------------------------------------------------------
-
-    class Example(object):
-        def __init__(self):
-            self._cache = resettable_cache()
-            self.a = 0
-
-        @cache_readonly
-        def b(self):
-            return 1
-
-        @cache_writable(resetlist='d')
-        def c(self):
-            return 2
-
-        @cache_writable(resetlist=('e', 'f'))
-        def d(self):
-            return self.c + 1
-
-        @cache_readonly
-        def e(self):
-            return 4
-
-        @cache_readonly
-        def f(self):
-            return self.e + 1
-
-    ex = Example()
-    print("(attrs  : %s)" % str(ex.__dict__))
-    print("(cached : %s)" % str(ex._cache))
-    print("Try a   :", ex.a)
-    print("Try accessing/setting a readonly attribute")
-    assert_equal(ex.__dict__, dict(a=0, _cache={}))
-    print("Try b #1:", ex.b)
-    b = ex.b
-    assert_equal(b, 1)
-    assert_equal(ex.__dict__, dict(a=0, _cache=dict(b=1,)))
-    # assert_equal(ex.__dict__, dict(a=0, b=1, _cache=dict(b=1)))
-    ex.b = -1
-    print("Try dict", ex.__dict__)
-    assert_equal(ex._cache, dict(b=1,))
-    #
-    print("Try accessing/resetting a cachewritable attribute")
-    c = ex.c
-    assert_equal(c, 2)
-    assert_equal(ex._cache, dict(b=1, c=2))
-    d = ex.d
-    assert_equal(d, 3)
-    assert_equal(ex._cache, dict(b=1, c=2, d=3))
-    ex.c = 0
-    assert_equal(ex._cache, dict(b=1, c=0, d=None, e=None, f=None))
-    d = ex.d
-    assert_equal(ex._cache, dict(b=1, c=0, d=1, e=None, f=None))
-    ex.d = 5
-    assert_equal(ex._cache, dict(b=1, c=0, d=5, e=None, f=None))

--- a/statsmodels/tools/tests/test_decorators.py
+++ b/statsmodels/tools/tests/test_decorators.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+
+import pytest
+from numpy.testing import assert_equal
+
+from statsmodels.tools.decorators import (
+    resettable_cache, cache_readonly, cache_writable, CacheWriteWarning)
+
+
+def test_resettable_cache():
+    # This test was taken from the old __main__ section of decorators.py
+
+    reset = dict(a=('b',), b=('c',))
+    cache = resettable_cache(a=0, b=1, c=2, reset=reset)
+    assert_equal(cache, dict(a=0, b=1, c=2))
+
+    # Try resetting a
+    cache['a'] = 1
+    assert_equal(cache, dict(a=1, b=None, c=None))
+    cache['c'] = 2
+    assert_equal(cache, dict(a=1, b=None, c=2))
+    cache['b'] = 0
+    assert_equal(cache, dict(a=1, b=0, c=None))
+
+    # Try deleting b
+    del cache['a']
+    assert_equal(cache, {})
+
+
+def test_cache_readonly():
+
+    class Example(object):
+        def __init__(self):
+            self._cache = resettable_cache()
+            self.a = 0
+
+        @cache_readonly
+        def b(self):
+            return 1
+
+        @cache_writable(resetlist='d')
+        def c(self):
+            return 2
+
+        @cache_writable(resetlist=('e', 'f'))
+        def d(self):
+            return self.c + 1
+
+        @cache_readonly
+        def e(self):
+            return 4
+
+        @cache_readonly
+        def f(self):
+            return self.e + 1
+
+    ex = Example()
+
+    # Try accessing/setting a readonly attribute
+    assert_equal(ex.__dict__, dict(a=0, _cache={}))
+
+    b = ex.b
+    assert_equal(b, 1)
+    assert_equal(ex.__dict__, dict(a=0, _cache=dict(b=1,)))
+    # assert_equal(ex.__dict__, dict(a=0, b=1, _cache=dict(b=1)))
+
+    with pytest.warns(CacheWriteWarning):
+        ex.b = -1
+
+    assert_equal(ex._cache, dict(b=1,))
+
+    # Try accessing/resetting a cachewritable attribute
+    c = ex.c
+    assert_equal(c, 2)
+    assert_equal(ex._cache, dict(b=1, c=2))
+    d = ex.d
+    assert_equal(d, 3)
+    assert_equal(ex._cache, dict(b=1, c=2, d=3))
+    ex.c = 0
+    assert_equal(ex._cache, dict(b=1, c=0, d=None, e=None, f=None))
+    d = ex.d
+    assert_equal(ex._cache, dict(b=1, c=0, d=1, e=None, f=None))
+    ex.d = 5
+    assert_equal(ex._cache, dict(b=1, c=0, d=5, e=None, f=None))


### PR DESCRIPTION
Add both the decorators module and the test module to the lint-fully list.