### PR TITLE
BUG: fix RegressionResults.__str__ returning None

### DIFF
--- a/statsmodels/regression/linear_model.py
+++ b/statsmodels/regression/linear_model.py
@@ -361,7 +361,8 @@ class RegressionModel(base.LikelihoodModel):
         dist_class : class
             A random number generator class.  Must take 'loc' and 'scale'
             as arguments and return a random number generator implementing
-            an ``rvs`` method for simulating random values. Defaults to Gaussian.
+            an ``rvs`` method for simulating random values. Defaults to
+            Gaussian.
 
         Returns
         -------
@@ -643,7 +644,7 @@ class WLS(RegressionModel):
     If the weights are a function of the data, then the post estimation
     statistics such as fvalue and mse_model might not be correct, as the
     package does not yet support no-constant regression.
-    """ % {'params': base._model_params_doc,
+    """ % {'params': base._model_params_doc,  # noqa:E501
            'extra_params': base._missing_param_doc + base._extra_param_doc}
 
     def __init__(self, endog, exog, weights=1., missing='none', hasconst=None,
@@ -809,7 +810,7 @@ class OLS(WLS):
     Notes
     -----
     No constant is added by the model unless you are using formulas.
-    """ % {'params': base._model_params_doc,
+    """ % {'params': base._model_params_doc,  # noqa:E501
            'extra_params': base._missing_param_doc + base._extra_param_doc}
 
     # TODO: change example to use datasets.  This was the point of datasets!
@@ -1090,7 +1091,7 @@ class GLSAR(GLS):
     GLSAR is considered to be experimental.
     The linear autoregressive process of order p--AR(p)--is defined as:
     TODO
-    """ % {'params': base._model_params_doc,
+    """ % {'params': base._model_params_doc,  # noqa:E501
            'extra_params': base._missing_param_doc + base._extra_param_doc}
 
     def __init__(self, endog, exog=None, rho=1, missing='none', **kwargs):
@@ -1266,9 +1267,9 @@ def yule_walker(X, order=1, method="unbiased", df=None, inv=False,
     n = df or X.shape[0]
 
     if method == "unbiased":        # this is df_resid ie., n - p
-        denom = lambda k: n - k
+        denom = lambda k: n - k  # noqa:E731
     else:
-        denom = lambda k: n
+        denom = lambda k: n  # noqa:E731
     if X.ndim > 1 and X.shape[1] != 1:
         raise ValueError("expecting a vector to estimate AR parameters")
     r = np.zeros(order+1, np.float64)
@@ -1511,7 +1512,7 @@ class RegressionResults(base.LikelihoodModelResults):
             setattr(self, key, kwargs[key])
 
     def __str__(self):
-        self.summary()
+        return self.summary()
 
     def conf_int(self, alpha=.05, cols=None):
         """
@@ -2129,7 +2130,7 @@ class RegressionResults(base.LikelihoodModelResults):
             - `kernel` callable or str (optional) : kernel
                   currently available kernels are ['bartlett', 'uniform'],
                   default is Bartlett
-            - `use_correction` False or string in ['hac', 'cluster'] (optional) :
+            - `use_correction` False or string in ['hac', 'cluster'] (optional)
                   If False the the sandwich covariance is calulated without
                   small sample correction.
                   If `use_correction = 'cluster'` (default), then the same
@@ -2156,7 +2157,7 @@ class RegressionResults(base.LikelihoodModelResults):
             - `kernel` callable or str (optional) : kernel
                   currently available kernels are ['bartlett', 'uniform'],
                   default is Bartlett
-            - `use_correction` False or string in ['hac', 'cluster'] (optional) :
+            - `use_correction` False or string in ['hac', 'cluster'] (optional)
                   If False the sandwich covariance is calculated without
                   small sample correction.
             - `df_correction` bool (optional)
@@ -2312,9 +2313,10 @@ class RegressionResults(base.LikelihoodModelResults):
                 raise ValueError('either time or groups needs to be given')
             groupidx = lzip([0] + tt, tt + [nobs_])
             self.n_groups = n_groups = len(groupidx)
-            res.cov_params_default = sw.cov_nw_panel(self, maxlags, groupidx,
-                                                     weights_func=weights_func,
-                                                     use_correction=use_correction)
+            res.cov_params_default = sw.cov_nw_panel(
+                self, maxlags, groupidx,
+                weights_func=weights_func,
+                use_correction=use_correction)
             res.cov_kwds['description'] = (
                 'Standard Errors are robust to' +
                 'cluster correlation ' + '(' + cov_type + ')')
@@ -2414,8 +2416,8 @@ class RegressionResults(base.LikelihoodModelResults):
                     ('Date:', None),
                     ('Time:', None),
                     ('No. Observations:', None),
-                    ('Df Residuals:', None),  # [self.df_resid]), TODO: spelling
-                    ('Df Model:', None),  # [self.df_model])
+                    ('Df Residuals:', None),
+                    ('Df Model:', None),
                     ]
 
         if hasattr(self, 'cov_type'):
@@ -2425,7 +2427,7 @@ class RegressionResults(base.LikelihoodModelResults):
                      ('Adj. R-squared:', ["%#8.3f" % self.rsquared_adj]),
                      ('F-statistic:', ["%#8.4g" % self.fvalue]),
                      ('Prob (F-statistic):', ["%#6.3g" % self.f_pvalue]),
-                     ('Log-Likelihood:', None),  # ["%#6.4g" % self.llf]),
+                     ('Log-Likelihood:', None),
                      ('AIC:', ["%#8.4g" % self.aic]),
                      ('BIC:', ["%#8.4g" % self.bic])
                      ]
@@ -2489,19 +2491,6 @@ class RegressionResults(base.LikelihoodModelResults):
 
         return smry
 
-        #  top = summary_top(self, gleft=topleft, gright=diagn_left, #[],
-        #                    yname=yname, xname=xname,
-        #                    title=self.model.__class__.__name__ + ' ' +
-        #                    "Regression Results")
-        #  par = summary_params(self, yname=yname, xname=xname, alpha=.05,
-        #                       use_t=False)
-        #
-        #  diagn = summary_top(self, gleft=diagn_left, gright=diagn_right,
-        #                      yname=yname, xname=xname,
-        #                      title="Linear Model")
-        #
-        #  return summary_return([top, par, diagn], return_fmt=return_fmt)
-
     def summary2(self, yname=None, xname=None, title=None, alpha=.05,
                  float_format="%.4f"):
         """Experimental summary function to summarize the regression results
@@ -2528,9 +2517,7 @@ class RegressionResults(base.LikelihoodModelResults):
 
         See Also
         --------
-        statsmodels.iolib.summary.Summary : class to hold summary
-            results
-
+        statsmodels.iolib.summary2.Summary : class to hold summary results
         """
         # Diagnostics
         from statsmodels.stats.stattools import (jarque_bera,
@@ -2564,13 +2551,14 @@ class RegressionResults(base.LikelihoodModelResults):
 
         # Warnings
         if eigvals[-1] < 1e-10:
-            warn = "The smallest eigenvalue is %6.3g. This might indicate that\
-            there are strong multicollinearity problems or that the design\
-            matrix is singular." % eigvals[-1]
+            warn = ("The smallest eigenvalue is %6.3g. This might indicate "
+                    "that there are strong multicollinearity problems or "
+                    "that the design matrix is singular." % eigvals[-1])
             smry.add_text(warn)
         if condno > 1000:
-            warn = "* The condition number is large (%.g). This might indicate \
-            strong multicollinearity or other numerical problems." % condno
+            warn = ("* The condition number is large (%.g). This might "
+                    "indicate strong multicollinearity or other numerical "
+                    "problems." % condno)
             smry.add_text(warn)
 
         return smry
@@ -2612,7 +2600,7 @@ class OLSResults(RegressionResults):
         return OLSInfluence(self)
 
     def outlier_test(self, method='bonf', alpha=.05, labels=None,
-                 order=False, cutoff=None):
+                     order=False, cutoff=None):
         """
         Test observations for outliers according to method
 
@@ -2637,11 +2625,13 @@ class OLSResults(RegressionResults):
             returned pandas DataFrame. See also Returns below
         order : bool
             Whether or not to order the results by the absolute value of the
-            studentized residuals. If labels are provided they will also be sorted.
+            studentized residuals. If labels are provided they will also be
+            sorted.
         cutoff : None or float in [0, 1]
-            If cutoff is not None, then the return only includes observations with
-            multiple testing corrected p-values strictly below the cutoff. The
-            returned array or dataframe can be empty if t
+            If cutoff is not None, then the return only includes observations
+            with multiple testing corrected p-values strictly below the cutoff.
+            The returned array or dataframe can be empty if
+            [TODO: Finish this sentence]
 
         Returns
         -------
@@ -2788,13 +2778,11 @@ class OLSResults(RegressionResults):
 
         Returns
         -------
-
         ci : tuple
             The confidence interval
 
         See Also
         --------
-
         el_test
 
         Notes
@@ -2828,9 +2816,12 @@ class OLSResults(RegressionResults):
             upper_bound = self.conf_int(.01)[param_num][1]
         if lower_bound is None:
             lower_bound = self.conf_int(.01)[param_num][0]
-        f = lambda b0: self.el_test(np.array([b0]), np.array([param_num]),
-                                    method=method,
-                                    stochastic_exog=stochastic_exog)[0]-r0
+
+        def f(b0):
+            return self.el_test(np.array([b0]), np.array([param_num]),
+                                method=method,
+                                stochastic_exog=stochastic_exog)[0]-r0
+
         lowerl = optimize.brenth(f, lower_bound,
                                  self.params[param_num])
         upperl = optimize.brenth(f, self.params[param_num],
@@ -2864,7 +2855,7 @@ class RegressionResultsWrapper(wrap.ResultsWrapper):
                         base.LikelihoodResultsWrapper._wrap_methods,
                         _methods)
 
-wrap.populate_wrapper(RegressionResultsWrapper,
+wrap.populate_wrapper(RegressionResultsWrapper,  # noqa:E305
                       RegressionResults)
 
 

--- a/statsmodels/regression/tests/test_regression.py
+++ b/statsmodels/regression/tests/test_regression.py
@@ -265,6 +265,7 @@ class TestRTO(CheckRegressionResults):
         res_qr = OLS(data.endog, data.exog).fit(method="qr")
         cls.res_qr = res_qr
 
+
 class TestFtest(object):
     """
     Tests f_test vs. RegressionResults
@@ -288,6 +289,7 @@ class TestFtest(object):
 
     def test_Df_num(self):
         assert_equal(self.Ftest.df_num, 6)
+
 
 class TestFTest2(object):
     """
@@ -315,7 +317,7 @@ class TestFTest2(object):
 
     def test_pvalue(self):
         assert_almost_equal(self.Ftest1.pvalue, 0.0056052885317493459,
-                DECIMAL_4)
+                            DECIMAL_4)
 
     def test_df_denom(self):
         assert_equal(self.Ftest1.df_denom, 9)
@@ -354,12 +356,12 @@ class TestFtestQ(object):
     def test_df_num(self):
         assert_equal(self.Ftest1.df_num, 5)
 
+
 class TestTtest(object):
     """
     Test individual t-tests.  Ie., are the coefficients significantly
     different than zero.
-
-        """
+    """
     @classmethod
     def setup_class(cls):
         data = longley.load(as_pandas=False)
@@ -380,8 +382,9 @@ class TestTtest(object):
         assert_almost_equal(self.Ttest.sd, self.res1.bse, DECIMAL_4)
 
     def test_pvalue(self):
-        assert_almost_equal(self.Ttest.pvalue, student_t.sf(
-            np.abs(self.res1.tvalues), self.res1.model.df_resid)*2,
+        expected = 2 * student_t.sf(np.abs(self.res1.tvalues),
+                                    self.res1.model.df_resid)
+        assert_almost_equal(self.Ttest.pvalue, expected,
                             DECIMAL_4)
 
     def test_df_denom(self):
@@ -389,6 +392,7 @@ class TestTtest(object):
 
     def test_effect(self):
         assert_almost_equal(self.Ttest.effect, self.res1.params)
+
 
 class TestTtest2(object):
     """
@@ -422,6 +426,7 @@ class TestTtest2(object):
 
     def test_effect(self):
         assert_almost_equal(self.Ttest1.effect, -1829.2025687186533, DECIMAL_4)
+
 
 class TestGLS(object):
     """
@@ -485,6 +490,7 @@ class TestGLS(object):
         assert_equal(mod.endog.shape[0], 13)
         assert_equal(mod.exog.shape[0], 13)
         assert_equal(mod.sigma.shape, (13, 13))
+
 
 class TestGLS_alt_sigma(CheckRegressionResults):
     """
@@ -594,7 +600,6 @@ class TestLM(object):
                                                     use_lr=True)
         LMstat2 = LMstat_OLS[0]
         assert_almost_equal(LMstat, LMstat2, DECIMAL_7)
-
 
     def test_LM_nonnested(self):
         assert_raises(ValueError, self.res2_restricted.compare_lm_test,
@@ -758,8 +763,7 @@ def test_wls_tss():
 class TestWLSScalarVsArray(CheckRegressionResults):
     @classmethod
     def setup_class(cls):
-        from statsmodels.datasets.longley import load
-        dta = load(as_pandas=False)
+        dta = longley.load(as_pandas=False)
         dta.exog = add_constant(dta.exog, prepend=True)
         wls_scalar = WLS(dta.endog, dta.exog, weights=1./3).fit()
         weights = [1/3.] * len(dta.endog)
@@ -881,7 +885,8 @@ class TestGLS_large_data(TestDataDimensions):
         cls.ols_res = OLS(y, X).fit()
 
     def test_large_equal_params(self):
-        assert_almost_equal(self.ols_res.params, self.gls_res.params, DECIMAL_7)
+        assert_almost_equal(self.ols_res.params, self.gls_res.params,
+                            DECIMAL_7)
 
     def test_large_equal_loglike(self):
         assert_almost_equal(self.ols_res.llf, self.gls_res.llf, DECIMAL_7)
@@ -999,7 +1004,7 @@ def test_summary():
 Warnings: \\newline
  [1] Standard Errors assume that the covariance matrix of the errors is correctly specified. \\newline
  [2] The condition number is large, 4.86e+09. This might indicate that there are \\newline
- strong multicollinearity or other numerical problems."""
+ strong multicollinearity or other numerical problems."""  # noqa:E501
     assert_equal(table, expected)
 
 
@@ -1139,8 +1144,6 @@ def test_fvalue_implicit_constant():
     x = ((x > 0) == [True, False]).astype(int)
     y = x.sum(1) + np.random.randn(nobs)
 
-    from statsmodels.regression.linear_model import OLS, WLS
-
     res = OLS(y, x).fit(cov_type='HC1')
     assert_(np.isnan(res.fvalue))
     assert_(np.isnan(res.f_pvalue))
@@ -1158,8 +1161,6 @@ def test_fvalue_only_constant():
     np.random.seed(2)
     x = np.ones(nobs)
     y = np.random.randn(nobs)
-
-    from statsmodels.regression.linear_model import OLS, WLS
 
     res = OLS(y, x).fit(cov_type='hac', cov_kwds={'maxlags': 3})
     assert_(np.isnan(res.fvalue))
@@ -1222,7 +1223,7 @@ def test_regularized_predict():
     yvec = xmat.sum(1) + np.random.normal(size=n)
     wgt = np.random.uniform(1, 2, n)
 
-    for klass in WLS, GLS:
+    for klass in [WLS, GLS]:
         model1 = klass(yvec, xmat,  weights=wgt)
         result1 = model1.fit_regularized(alpha=2., L1_wt=0.5, refit=True)
 
@@ -1234,6 +1235,7 @@ def test_regularized_predict():
 
         pr = result1.predict()
         assert_allclose(fittedvalues, pr)
+
 
 def test_regularized_options():
     n = 100
@@ -1276,3 +1278,18 @@ def test_burg_errors():
         burg(np.random.randn(100), 0)
     with pytest.raises(ValueError):
         burg(np.random.randn(100), 'apple')
+
+
+def test_str():
+    # check that str(RegressionResults) returns a string instead of just
+    # printing one.  GH#5026
+
+    # TODO: make a fixture for tests that just need any valid Results object
+    #   or possibly to provide such an object for each extant model class?
+    data = longley.load_pandas()
+    endog = data.endog
+    exog = add_constant(data.exog)
+
+    model = OLS(endog, exog)
+    result = model.fit()
+    assert str(result) is not None

--- a/statsmodels/regression/tests/test_regression.py
+++ b/statsmodels/regression/tests/test_regression.py
@@ -1282,7 +1282,7 @@ def test_burg_errors():
 
 def test_str():
     # check that str(RegressionResults) returns a string instead of just
-    # printing one.  GH#5026
+    # printing one.  GH#5026, GH#4618
 
     # TODO: make a fixture for tests that just need any valid Results object
     #   or possibly to provide such an object for each extant model class?


### PR DESCRIPTION
closes #4618

Assorted cleanups in the vicinity.  One thing in linear_model I'm not sure how to address is long docstring math lines like:

```
.. math:: -\\frac{n}{2}\\log\\left(Y-\\hat{Y}\\right)-\\frac{n}{2}\\left(1+\\log\\left(\\frac{2\\pi}{n}\\right)\\right)-\\frac{1}{2}log\\left(\\left|W\\right|\\right)
```

Is there a Correct way to wrap these?  We can make the linter ignore these, but if wrapping is an option I'd find them easier to read if I didn't have to scroll right.