### PR TITLE
BUG: unused param in het_white, docstring wrong

### DIFF
--- a/statsmodels/sandbox/stats/diagnostic.py
+++ b/statsmodels/sandbox/stats/diagnostic.py
@@ -603,65 +603,6 @@ def het_breuschpagan(resid, exog_het):
     return lm, stats.chi2.sf(lm, nvars-1), fval, fpval
 
 
-def het_white(resid, exog, retres=False):
-    '''White's Lagrange Multiplier Test for Heteroscedasticity
-
-    Parameters
-    ----------
-    resid : array_like
-        residuals, square of it is used as endogenous variable
-    exog : array_like
-        possible explanatory variables for variance, squares and interaction
-        terms are included in the auxilliary regression.
-    resstore : instance (optional)
-        a class instance that holds intermediate results. Only returned if
-        store=True
-
-    Returns
-    -------
-    lm : float
-        lagrange multiplier statistic
-    lm_pvalue :float
-        p-value of lagrange multiplier test
-    fvalue : float
-        f-statistic of the hypothesis that the error variance does not depend
-        on x. This is an alternative test variant not the original LM test.
-    f_pvalue : float
-        p-value for the f-statistic
-
-    Notes
-    -----
-    assumes x contains constant (for counting dof)
-
-    question: does f-statistic make sense? constant ?
-
-    References
-    ----------
-    Greene section 11.4.1 5th edition p. 222
-    now test statistic reproduces Greene 5th, example 11.3
-
-    '''
-    x = np.asarray(exog)
-    y = np.asarray(resid)
-    if x.ndim == 1:
-        raise ValueError('x should have constant and at least one more variable')
-    nobs, nvars0 = x.shape
-    i0,i1 = np.triu_indices(nvars0)
-    exog = x[:,i0]*x[:,i1]
-    nobs, nvars = exog.shape
-    assert nvars == nvars0*(nvars0-1)/2. + nvars0
-    resols = OLS(y**2, exog).fit()
-    fval = resols.fvalue
-    fpval = resols.f_pvalue
-    lm = nobs * resols.rsquared
-    # Note: degrees of freedom for LM test is nvars minus constant
-    #degrees of freedom take possible reduced rank in exog into account
-    #df_model checks the rank to determine df
-    #extra calculation that can be removed:
-    assert resols.df_model == np.linalg.matrix_rank(exog) - 1
-    lmpval = stats.chi2.sf(lm, resols.df_model)
-    return lm, lmpval, fval, fpval
-
 def _het_goldfeldquandt2_old(y, x, idx, split=None, retres=False):
     '''test whether variance is the same in 2 subsamples
 
@@ -1673,7 +1614,6 @@ if __name__ == '__main__':
     print(het_goldfeldquandt(y,x, 1))
 
     print(het_breuschpagan(y,x))
-    print(het_white(y,x))
 
     f, fp, fo = het_goldfeldquandt(y,x, 1)
     print(f, fp)

--- a/statsmodels/stats/diagnostic.py
+++ b/statsmodels/stats/diagnostic.py
@@ -1,12 +1,100 @@
+# -*- coding: utf-8 -*-
+
+import numpy as np
+from scipy import stats
+
 # collect some imports of verified (at least one example) functions
 from statsmodels.sandbox.stats.diagnostic import (
     acorr_ljungbox, breaks_cusumolsresid, breaks_hansen, CompareCox, CompareJ,
     compare_cox, compare_j, het_breuschpagan, HetGoldfeldQuandt,
     het_goldfeldquandt, het_arch,
-    het_white, recursive_olsresiduals, acorr_breusch_godfrey,
+    recursive_olsresiduals, acorr_breusch_godfrey,
     linear_harvey_collier, linear_rainbow, linear_lm,
     spec_white, unitroot_adf)
 
-from ._lilliefors import (kstest_fit, lilliefors, kstest_normal,
-                          kstest_exponential)
-from ._adnorm import normal_ad
+from ._lilliefors import (  # noqa:F401
+    kstest_fit, lilliefors, kstest_normal, kstest_exponential)
+from ._adnorm import normal_ad  # noqa:F401
+
+
+# -----------------------------------------------------------------
+# Misc Helpers
+
+class ResultsStore(object):
+    # TODO: implement in something like tools.tools?
+    def __str__(self):
+        return self._str
+
+
+# -----------------------------------------------------------------
+# Tests for Heteroscedasticity
+
+def het_white(resid, exog):
+    """
+    White's Lagrange Multiplier Test for Heteroscedasticity
+
+    Parameters
+    ----------
+    resid : array_like
+        residuals, square of it is used as endogenous variable
+    exog : array_like
+        possible explanatory variables for variance, squares and interaction
+        terms are included in the auxilliary regression.
+
+    Returns
+    -------
+    lm : float
+        lagrange multiplier statistic
+    lm_pvalue :float
+        p-value of lagrange multiplier test
+    fvalue : float
+        f-statistic of the hypothesis that the error variance does not depend
+        on x. This is an alternative test variant not the original LM test.
+    f_pvalue : float
+        p-value for the f-statistic
+
+    Notes
+    -----
+    Assumes x contains constant (for counting degrees of freedom)
+
+    TODO: does f-statistic make sense? constant ?
+
+    References
+    ----------
+    Greene section 11.4.1 5th edition p. 222
+        now test statistic reproduces Greene 5th, example 11.3
+    """
+    x = np.asarray(exog)
+    y = np.asarray(resid)
+    if x.ndim == 1:
+        raise ValueError('x should have constant and at least one '
+                         'more variable')
+
+    nobs, nvars0 = x.shape
+    i0, i1 = np.triu_indices(nvars0)
+    exog = x[:, i0] * x[:, i1]
+    nobs, nvars = exog.shape
+    assert nvars == nvars0 * (nvars0 - 1) / 2. + nvars0
+
+    from statsmodels.api import OLS
+    resols = OLS(y**2, exog).fit()
+    fval = resols.fvalue
+    fpval = resols.f_pvalue
+    lm = nobs * resols.rsquared
+    # Note: degrees of freedom for LM test is nvars minus constant
+    #   degrees of freedom take possible reduced rank in exog into account
+    #   df_model checks the rank to determine df
+    lmpval = stats.chi2.sf(lm, resols.df_model)
+    return lm, lmpval, fval, fpval
+
+
+# -----------------------------------------------------------------
+# Tests for Autocorrelation
+
+
+# -----------------------------------------------------------------
+# Tests for Structural Breaks
+
+
+# -----------------------------------------------------------------
+# Tests for Functional Form

--- a/statsmodels/stats/tests/test_diagnostic.py
+++ b/statsmodels/stats/tests/test_diagnostic.py
@@ -61,8 +61,8 @@ def notyet_atst():
     res_ols = OLS(endogg, exogg).fit()
     res_ols2 = OLS(endogg, exogg2).fit()
 
-    #the following were done accidentally with res_ols1 in R,
-    #with original Greene data
+    # the following were done accidentally with res_ols1 in R,
+    #   with original Greene data
 
     params = np.array([-272.3986041341653, 0.1779455206941112,
                        0.2149432424658157])
@@ -75,21 +75,20 @@ def notyet_atst():
         -0.01268990195095196, 54.81079621448564, -0.01268990195095195,
         22.92512402151113]).reshape(3,3, order='F')
 
-    #goldfeld-quandt
+    # goldfeld-quandt
     het_gq_greater = dict(statistic=13.20512768685082, df1=99, df2=98,
                           pvalue=1.246141976112324e-30, distr='f')
     het_gq_less = dict(statistic=13.20512768685082, df1=99, df2=98, pvalue=1.)
     het_gq_2sided = dict(statistic=13.20512768685082, df1=99, df2=98,
                           pvalue=1.246141976112324e-30, distr='f')
 
-    #goldfeld-quandt, fraction = 0.5
+    # goldfeld-quandt, fraction = 0.5
     het_gq_greater_2 = dict(statistic=87.1328934692124, df1=48, df2=47,
                           pvalue=2.154956842194898e-33, distr='f')
 
     gq = smsdia.het_goldfeldquandt(endog, exog, split=0.5)
     compare_t_est(gq, het_gq_greater, decimal=(13, 14))
     assert_equal(gq[-1], 'increasing')
-
 
     harvey_collier = dict(stat=2.28042114041313, df=199,
                           pvalue=0.02364236161988260, distr='t')
@@ -98,17 +97,12 @@ def notyet_atst():
                           pvalue=0.4531244858006127, distr='t')
 
 
-
-    ##################################
-
-
-
 class TestDiagnosticG(object):
 
     @classmethod
     def setup_class(cls):
         d = macrodata.load_pandas().data
-        #growth rates
+        # growth rates
         gs_l_realinv = 400 * np.diff(np.log(d['realinv'].values))
         gs_l_realgdp = 400 * np.diff(np.log(d['realgdp'].values))
         lint = d['realint'][:-1].values
@@ -131,8 +125,8 @@ class TestDiagnosticG(object):
         cls.exog = cls.res.model.exog
 
     def test_basic(self):
-        #mainly to check I got the right regression
-        #> mkarray(fm$coefficients, "params")
+        # mainly to check I got the right regression
+        # > mkarray(fm$coefficients, "params")
         params = np.array([-9.48167277465485, 4.3742216647032,
                            -0.613996969478989])
 
@@ -140,16 +134,16 @@ class TestDiagnosticG(object):
 
     def test_hac(self):
         res = self.res
-        #> nw = NeweyWest(fm, lag = 4, prewhite = FALSE, verbose=TRUE)
-        #> nw2 = NeweyWest(fm, lag=10, prewhite = FALSE, verbose=TRUE)
+        # > nw = NeweyWest(fm, lag = 4, prewhite = FALSE, verbose=TRUE)
+        # > nw2 = NeweyWest(fm, lag=10, prewhite = FALSE, verbose=TRUE)
 
-        #> mkarray(nw, "cov_hac_4")
+        # > mkarray(nw, "cov_hac_4")
         cov_hac_4 = np.array([1.385551290884014, -0.3133096102522685,
             -0.0597207976835705, -0.3133096102522685, 0.1081011690351306,
             0.000389440793564336, -0.0597207976835705, 0.000389440793564339,
             0.0862118527405036]).reshape(3,3, order='F')
 
-        #> mkarray(nw2, "cov_hac_10")
+        # > mkarray(nw2, "cov_hac_10")
         cov_hac_10 = np.array([1.257386180080192, -0.2871560199899846,
             -0.03958300024627573, -0.2871560199899845, 0.1049107028987101,
             0.0003896205316866944, -0.03958300024627578, 0.0003896205316866961,
@@ -165,43 +159,42 @@ class TestDiagnosticG(object):
         assert_almost_equal(cov, cov_hac_10, decimal=14)
         assert_almost_equal(bse_hac, np.sqrt(np.diag(cov)), decimal=14)
 
-
     def test_het_goldfeldquandt(self):
-        #TODO: test options missing
+        # TODO: test options missing
 
-        #> gq = gqtest(fm, alternative='greater')
-        #> mkhtest_f(gq, 'het_gq_greater', 'f')
+        # > gq = gqtest(fm, alternative='greater')
+        # > mkhtest_f(gq, 'het_gq_greater', 'f')
         het_gq_greater = dict(statistic=0.5313259064778423,
                               pvalue=0.9990217851193723,
                               parameters=(98, 98), distr='f')
 
-        #> gq = gqtest(fm, alternative='less')
-        #> mkhtest_f(gq, 'het_gq_less', 'f')
+        # > gq = gqtest(fm, alternative='less')
+        # > mkhtest_f(gq, 'het_gq_less', 'f')
         het_gq_less = dict(statistic=0.5313259064778423,
                            pvalue=0.000978214880627621,
                            parameters=(98, 98), distr='f')
 
-        #> gq = gqtest(fm, alternative='two.sided')
-        #> mkhtest_f(gq, 'het_gq_two_sided', 'f')
+        # > gq = gqtest(fm, alternative='two.sided')
+        # > mkhtest_f(gq, 'het_gq_two_sided', 'f')
         het_gq_two_sided = dict(statistic=0.5313259064778423,
                                 pvalue=0.001956429761255241,
                                 parameters=(98, 98), distr='f')
 
 
-        #> gq = gqtest(fm, fraction=0.1, alternative='two.sided')
-        #> mkhtest_f(gq, 'het_gq_two_sided_01', 'f')
+        # > gq = gqtest(fm, fraction=0.1, alternative='two.sided')
+        # > mkhtest_f(gq, 'het_gq_two_sided_01', 'f')
         het_gq_two_sided_01 = dict(statistic=0.5006976835928314,
                                    pvalue=0.001387126702579789,
                                    parameters=(88, 87), distr='f')
 
-        #> gq = gqtest(fm, fraction=0.5, alternative='two.sided')
-        #> mkhtest_f(gq, 'het_gq_two_sided_05', 'f')
+        # > gq = gqtest(fm, fraction=0.5, alternative='two.sided')
+        # > mkhtest_f(gq, 'het_gq_two_sided_05', 'f')
         het_gq_two_sided_05 = dict(statistic=0.434815645134117,
                                    pvalue=0.004799321242905568,
                                    parameters=(48, 47), distr='f')
 
         endogg, exogg = self.endog, self.exog
-        #tests
+
         gq = smsdia.het_goldfeldquandt(endogg, exogg, split=0.5)
         compare_t_est(gq, het_gq_greater, decimal=(14, 14))
         assert_equal(gq[-1], 'increasing')
@@ -216,12 +209,12 @@ class TestDiagnosticG(object):
         compare_t_est(gq, het_gq_two_sided, decimal=(14, 14))
         assert_equal(gq[-1], 'two-sided')
 
-        #TODO: forcing the same split as R 202-90-90-1=21
+        # TODO: forcing the same split as R 202-90-90-1=21
         gq = smsdia.het_goldfeldquandt(endogg, exogg, split=90, drop=21,
                                        alternative='two-sided')
         compare_t_est(gq, het_gq_two_sided_01, decimal=(14, 14))
         assert_equal(gq[-1], 'two-sided')
-        #TODO other options ???
+        # TODO: other options ???
 
     def test_het_breusch_pagan(self):
         res = self.res
@@ -232,28 +225,26 @@ class TestDiagnosticG(object):
         bp = smsdia.het_breuschpagan(res.resid, res.model.exog)
         compare_t_est(bp, bptest, decimal=(12, 12))
 
-
-
     def test_het_white(self):
         res = self.res
 
-        #TODO: regressiontest, compare with Greene or Gretl or Stata
+        # TODO: regressiontest, compare with Greene or Gretl or Stata
         hw = smsdia.het_white(res.resid, res.model.exog)
         hw_values = (33.503722896538441, 2.9887960597830259e-06,
                      7.7945101228430946, 1.0354575277704231e-06)
         assert_almost_equal(hw, hw_values)
 
     def test_het_arch(self):
-        #test het_arch and indirectly het_lm against R
-        #> library(FinTS)
-        #> at = ArchTest(residuals(fm), lags=4)
-        #> mkhtest(at, 'archtest_4', 'chi2')
+        # test het_arch and indirectly het_lm against R
+        # > library(FinTS)
+        # > at = ArchTest(residuals(fm), lags=4)
+        # > mkhtest(at, 'archtest_4', 'chi2')
         archtest_4 = dict(statistic=3.43473400836259,
                           pvalue=0.487871315392619, parameters=(4,),
                           distr='chi2')
 
-        #> at = ArchTest(residuals(fm), lags=12)
-        #> mkhtest(at, 'archtest_12', 'chi2')
+        # > at = ArchTest(residuals(fm), lags=12)
+        # > mkhtest(at, 'archtest_12', 'chi2')
         archtest_12 = dict(statistic=8.648320999014171,
                            pvalue=0.732638635007718, parameters=(12,),
                            distr='chi2')
@@ -264,8 +255,8 @@ class TestDiagnosticG(object):
         compare_t_est(at12[:2], archtest_12, decimal=(12, 13))
 
     def test_het_arch2(self):
-        #test autolag options, this also test het_lm
-        #unfortunately optimal lag=1 for this data
+        # test autolag options, this also test het_lm
+        # unfortunately optimal lag=1 for this data
         resid = self.res.resid
 
         res1 = smsdia.het_arch(resid, maxlag=1, autolag=None, store=True)
@@ -277,23 +268,23 @@ class TestDiagnosticG(object):
         assert_almost_equal(rs2.resols.params, rs1.resols.params, decimal=13)
         assert_almost_equal(res2[:4], res1[:4], decimal=13)
 
-        #test that smallest lag, maxlag=1 works
+        # test that smallest lag, maxlag=1 works
         res3 = smsdia.het_arch(resid, maxlag=1, autolag='aic')
         assert_almost_equal(res3[:4], res1[:4], decimal=13)
 
     def test_acorr_breusch_godfrey(self):
         res = self.res
 
-        #bgf = bgtest(fm, order = 4, type="F")
+        # bgf = bgtest(fm, order = 4, type="F")
         breuschgodfrey_f = dict(statistic=1.179280833676792,
-                               pvalue=0.321197487261203,
-                               parameters=(4,195,), distr='f')
+                                pvalue=0.321197487261203,
+                                parameters=(4,195,), distr='f')
 
-        #> bgc = bgtest(fm, order = 4, type="Chisq")
-        #> mkhtest(bgc, "breuschpagan_c", "chi2")
+        # > bgc = bgtest(fm, order = 4, type="Chisq")
+        # > mkhtest(bgc, "breuschpagan_c", "chi2")
         breuschgodfrey_c = dict(statistic=4.771042651230007,
-                               pvalue=0.3116067133066697,
-                               parameters=(4,), distr='chi2')
+                                pvalue=0.3116067133066697,
+                                parameters=(4,), distr='chi2')
 
         bg = smsdia.acorr_breusch_godfrey(res, nlags=4)
         bg_r = [breuschgodfrey_c['statistic'], breuschgodfrey_c['pvalue'],
@@ -321,18 +312,17 @@ class TestDiagnosticG(object):
         #                          pvalue=0.0771260128929921,
         #                          parameters=(2,), distr='chi2')
 
-
         res = self.res
 
         #general test
 
-        #> bt = Box.test(residuals(fm), lag=4, type = "Ljung-Box")
-        #> mkhtest(bt, "ljung_box_4", "chi2")
+        # > bt = Box.test(residuals(fm), lag=4, type = "Ljung-Box")
+        # > mkhtest(bt, "ljung_box_4", "chi2")
         ljung_box_4 = dict(statistic=5.23587172795227, pvalue=0.263940335284713,
                            parameters=(4,), distr='chi2')
 
-        #> bt = Box.test(residuals(fm), lag=4, type = "Box-Pierce")
-        #> mkhtest(bt, "ljung_box_bp_4", "chi2")
+        # > bt = Box.test(residuals(fm), lag=4, type = "Box-Pierce")
+        # > mkhtest(bt, "ljung_box_bp_4", "chi2")
         ljung_box_bp_4 = dict(statistic=5.12462932741681,
                               pvalue=0.2747471266820692,
                               parameters=(4,), distr='chi2')
@@ -345,52 +335,59 @@ class TestDiagnosticG(object):
 
     def test_acorr_ljung_box_big_default(self):
         res = self.res
-        #test with big dataset and default lag
+        # test with big dataset and default lag
 
-        #> bt = Box.test(residuals(fm), type = "Ljung-Box")
-        #> mkhtest(bt, "ljung_box_none", "chi2")
-        ljung_box_none = dict(statistic=51.03724531797195, pvalue=0.11334744923390,
+        # > bt = Box.test(residuals(fm), type = "Ljung-Box")
+        # > mkhtest(bt, "ljung_box_none", "chi2")
+        ljung_box_none = dict(statistic=51.03724531797195,
+                              pvalue=0.11334744923390,
                               distr='chi2')
 
-        #> bt = Box.test(residuals(fm), type = "Box-Pierce")
-        #> mkhtest(bt, "ljung_box_bp_none", "chi2")
+        # > bt = Box.test(residuals(fm), type = "Box-Pierce")
+        # > mkhtest(bt, "ljung_box_bp_none", "chi2")
         ljung_box_bp_none = dict(statistic=45.12238537034000,
-                              pvalue=0.26638168491464,
-                              distr='chi2')
-        lb, lbpval, bp, bppval = smsdia.acorr_ljungbox(res.resid, boxpierce=True)
-        compare_t_est([lb[-1], lbpval[-1]], ljung_box_none, decimal=(13, 13))
-        compare_t_est([bp[-1], bppval[-1]], ljung_box_bp_none, decimal=(13, 13))
+                                 pvalue=0.26638168491464,
+                                 distr='chi2')
+        lb, lbpval, bp, bppval = smsdia.acorr_ljungbox(res.resid,
+                                                       boxpierce=True)
+        compare_t_est([lb[-1], lbpval[-1]], ljung_box_none,
+                      decimal=(13, 13))
+        compare_t_est([bp[-1], bppval[-1]], ljung_box_bp_none,
+                      decimal=(13, 13))
 
     def test_acorr_ljung_box_small_default(self):
         res = self.res
-        #test with small dataset and default lag
+        # test with small dataset and default lag
 
-        #> bt = Box.test(residuals(fm), type = "Ljung-Box")
-        #> mkhtest(bt, "ljung_box_small", "chi2")
-        ljung_box_small = dict(statistic=9.61503968281915, pvalue=0.72507000996945,
-                           parameters=(0,), distr='chi2')
+        # > bt = Box.test(residuals(fm), type = "Ljung-Box")
+        # > mkhtest(bt, "ljung_box_small", "chi2")
+        ljung_box_small = dict(statistic=9.61503968281915,
+                               pvalue=0.72507000996945,
+                               parameters=(0,), distr='chi2')
 
-        #> bt = Box.test(residuals(fm), type = "Box-Pierce")
-        #> mkhtest(bt, "ljung_box_bp_small", "chi2")
+        # > bt = Box.test(residuals(fm), type = "Box-Pierce")
+        # > mkhtest(bt, "ljung_box_bp_small", "chi2")
         ljung_box_bp_small = dict(statistic=7.41692150864936,
-                              pvalue=0.87940785887006,
-                              parameters=(0,), distr='chi2')
+                                  pvalue=0.87940785887006,
+                                  parameters=(0,), distr='chi2')
 
-        lb, lbpval, bp, bppval = smsdia.acorr_ljungbox(res.resid[:30], boxpierce=True)
-        compare_t_est([lb[-1], lbpval[-1]], ljung_box_small, decimal=(13, 13))
-        compare_t_est([bp[-1], bppval[-1]], ljung_box_bp_small, decimal=(13, 13))
-
+        lb, lbpval, bp, bppval = smsdia.acorr_ljungbox(res.resid[:30],
+                                                       boxpierce=True)
+        compare_t_est([lb[-1], lbpval[-1]], ljung_box_small,
+                      decimal=(13, 13))
+        compare_t_est([bp[-1], bppval[-1]], ljung_box_bp_small,
+                      decimal=(13, 13))
 
     def test_harvey_collier(self):
 
-        #> hc = harvtest(fm, order.by = NULL, data = list())
-        #> mkhtest_f(hc, 'harvey_collier', 't')
+        # > hc = harvtest(fm, order.by = NULL, data = list())
+        # > mkhtest_f(hc, 'harvey_collier', 't')
         harvey_collier = dict(statistic=0.494432160939874,
                               pvalue=0.6215491310408242,
                               parameters=(198), distr='t')
 
-        #> hc2 = harvtest(fm, order.by=ggdp , data = list())
-        #> mkhtest_f(hc2, 'harvey_collier_2', 't')
+        # > hc2 = harvtest(fm, order.by=ggdp , data = list())
+        # > mkhtest_f(hc2, 'harvey_collier_2', 't')
         harvey_collier_2 = dict(statistic=1.42104628340473,
                                 pvalue=0.1568762892441689,
                                 parameters=(198), distr='t')
@@ -398,31 +395,30 @@ class TestDiagnosticG(object):
         hc = smsdia.linear_harvey_collier(self.res)
         compare_t_est(hc, harvey_collier, decimal=(12, 12))
 
-
     def test_rainbow(self):
-        #rainbow test
-        #> rt = raintest(fm)
-        #> mkhtest_f(rt, 'raintest', 'f')
-        raintest = dict(statistic=0.6809600116739604, pvalue=0.971832843583418,
+        # > rt = raintest(fm)
+        # > mkhtest_f(rt, 'raintest', 'f')
+        raintest = dict(statistic=0.6809600116739604,
+                        pvalue=0.971832843583418,
                         parameters=(101, 98), distr='f')
 
-        #> rt = raintest(fm, center=0.4)
-        #> mkhtest_f(rt, 'raintest_center_04', 'f')
+        # > rt = raintest(fm, center=0.4)
+        # > mkhtest_f(rt, 'raintest_center_04', 'f')
         raintest_center_04 = dict(statistic=0.682635074191527,
                                   pvalue=0.971040230422121,
                                   parameters=(101, 98), distr='f')
 
-        #> rt = raintest(fm, fraction=0.4)
-        #> mkhtest_f(rt, 'raintest_fraction_04', 'f')
+        # > rt = raintest(fm, fraction=0.4)
+        # > mkhtest_f(rt, 'raintest_fraction_04', 'f')
         raintest_fraction_04 = dict(statistic=0.565551237772662,
                                     pvalue=0.997592305968473,
                                     parameters=(122, 77), distr='f')
 
-        #> rt = raintest(fm, order.by=ggdp)
-        #Warning message:
-        #In if (order.by == "mahalanobis") { :
+        # > rt = raintest(fm, order.by=ggdp)
+        # Warning message:
+        # In if (order.by == "mahalanobis") { :
         #  the condition has length > 1 and only the first element will be used
-        #> mkhtest_f(rt, 'raintest_order_gdp', 'f')
+        # > mkhtest_f(rt, 'raintest_order_gdp', 'f')
         raintest_order_gdp = dict(statistic=1.749346160513353,
                                   pvalue=0.002896131042494884,
                                   parameters=(101, 98), distr='f')
@@ -432,14 +428,13 @@ class TestDiagnosticG(object):
         rb = smsdia.linear_rainbow(self.res, frac=0.4)
         compare_t_est(rb, raintest_fraction_04, decimal=(13, 14))
 
-
     def test_compare_lr(self):
         res = self.res
-        res3 = self.res3 #nested within res
-        #lrtest
-        #lrt = lrtest(fm, fm2)
-        #Model 1: ginv ~ ggdp + lint
-        #Model 2: ginv ~ ggdp
+        res3 = self.res3  # nested within res
+        # lrtest
+        # lrt = lrtest(fm, fm2)
+        # Model 1: ginv ~ ggdp + lint
+        # Model 2: ginv ~ ggdp
 
         lrtest = dict(loglike1=-763.9752181602237, loglike2=-766.3091902020184,
                       chi2value=4.66794408358942, pvalue=0.03073069384028677,
@@ -455,12 +450,11 @@ class TestDiagnosticG(object):
         assert_almost_equal(wt[0], waldtest['fvalue'], decimal=11)
         assert_almost_equal(wt[1], waldtest['pvalue'], decimal=11)
 
-
     def test_compare_nonnested(self):
         res = self.res
         res2 = self.res2
-        #jt = jtest(fm, lm(ginv ~ ggdp + tbilrate))
-        #Estimate         Std. Error  t value Pr(>|t|)
+        # jt = jtest(fm, lm(ginv ~ ggdp + tbilrate))
+        # Estimate         Std. Error  t value Pr(>|t|)
         jtest = [('M1 + fitted(M2)', 1.591505670785873, 0.7384552861695823,
                   2.155182176352370, 0.032354572525314450, '*'),
                  ('M2 + fitted(M1)', 1.305687653016899, 0.4808385176653064,
@@ -472,7 +466,7 @@ class TestDiagnosticG(object):
         jt2 = smsdia.compare_j(res, res2)
         assert_almost_equal(jt2, jtest[1][3:5], decimal=14)
 
-        #Estimate        Std. Error  z value   Pr(>|z|)
+        # Estimate        Std. Error  z value   Pr(>|z|)
         coxtest = [('fitted(M1) ~ M2', -0.782030488930356, 0.599696502782265,
                     -1.304043770977755, 1.922186587840554e-01, ' '),
                    ('fitted(M2) ~ M1', -2.248817107408537, 0.392656854330139,
@@ -483,7 +477,7 @@ class TestDiagnosticG(object):
 
         ct2 = smsdia.compare_cox(res2, res)
         assert_almost_equal(ct2, coxtest[1][3:5], decimal=12)
-        #TODO should be approx
+        # TODO: should be approx
 
         #     Res.Df Df       F    Pr(>F)
         encomptest = [('M1 vs. ME',    198, -1, 4.644810213266983,
@@ -499,19 +493,20 @@ class TestDiagnosticG(object):
 
 
     def test_cusum_ols(self):
-        #R library(strucchange)
-        #> sc = sctest(ginv ~ ggdp + lint, type="OLS-CUSUM")
-        #> mkhtest(sc, 'cusum_ols', 'BB')
-        cusum_ols = dict(statistic=1.055750610401214, pvalue=0.2149567397376543,
-                         parameters=(), distr='BB') #Brownian Bridge
+        # R library(strucchange)
+        # > sc = sctest(ginv ~ ggdp + lint, type="OLS-CUSUM")
+        # > mkhtest(sc, 'cusum_ols', 'BB')
+        cusum_ols = dict(statistic=1.055750610401214,
+                         pvalue=0.2149567397376543,
+                         parameters=(), distr='BB')  # BB --> Brownian Bridge
 
-        k_vars=3
-        cs_ols = smsdia.breaks_cusumolsresid(self.res.resid, ddof=k_vars) #
+        k_vars = 3
+        cs_ols = smsdia.breaks_cusumolsresid(self.res.resid, ddof=k_vars)
         compare_t_est(cs_ols, cusum_ols, decimal=(12, 12))
 
     def test_breaks_hansen(self):
-        #> sc = sctest(ginv ~ ggdp + lint, type="Nyblom-Hansen")
-        #> mkhtest(sc, 'breaks_nyblom_hansen', 'BB')
+        # > sc = sctest(ginv ~ ggdp + lint, type="Nyblom-Hansen")
+        # > mkhtest(sc, 'breaks_nyblom_hansen', 'BB')
         breaks_nyblom_hansen = dict(statistic=1.0300792740544484,
                                     pvalue=0.1136087530212015,
                                     parameters=(), distr='BB')
@@ -519,7 +514,7 @@ class TestDiagnosticG(object):
         bh = smsdia.breaks_hansen(self.res)
         assert_almost_equal(bh[0], breaks_nyblom_hansen['statistic'],
                             decimal=13)
-        #TODO: breaks_hansen doesn't return pvalues
+        # TODO: breaks_hansen doesn't return pvalues
 
 
     def test_recursive_residuals(self):
@@ -549,15 +544,15 @@ class TestDiagnosticG(object):
         6.636, 6.975])
 
         rr = smsdia.recursive_olsresiduals(self.res, skip=3, alpha=0.95)
-        assert_equal(np.round(rr[5][1:], 3), reccumres_standardize) #extra zero in front
+        assert_equal(np.round(rr[5][1:], 3), reccumres_standardize)  # extra zero in front
         #assert_equal(np.round(rr[3][4:], 3), np.diff(reccumres_standardize))
         assert_almost_equal(rr[3][4:], np.diff(reccumres_standardize),3)
         assert_almost_equal(rr[4][3:].std(ddof=1), 10.7242, decimal=4)
 
-        #regression number, visually checked with graph from gretl
-        ub0 = np.array([ 13.37318571,  13.50758959,  13.64199346,  13.77639734,
+        # regression number, visually checked with graph from gretl
+        ub0 = np.array([13.37318571,  13.50758959,  13.64199346,  13.77639734,
                         13.91080121])
-        ub1 = np.array([ 39.44753774,  39.58194162,  39.7163455 ,  39.85074937,
+        ub1 = np.array([39.44753774,  39.58194162,  39.7163455 ,  39.85074937,
                         39.98515325])
         lb, ub = rr[6]
         assert_almost_equal(ub[:5], ub0, decimal=7)
@@ -565,7 +560,7 @@ class TestDiagnosticG(object):
         assert_almost_equal(ub[-5:], ub1, decimal=7)
         assert_almost_equal(lb[-5:], -ub1, decimal=7)
 
-        #test a few values with explicit OLS
+        # test a few values with explicit OLS
         endog = self.res.model.endog
         exog = self.res.model.exog
         params = []
@@ -574,6 +569,7 @@ class TestDiagnosticG(object):
             resi = OLS(endog[:i], exog[:i]).fit()
             ypred.append(resi.model.predict(resi.params, exog[i]))
             params.append(resi.params)
+
         assert_almost_equal(rr[2][3:10], ypred, decimal=12)
         assert_almost_equal(rr[0][3:10], endog[3:10] - ypred, decimal=12)
         assert_almost_equal(rr[1][2:9], params, decimal=12)
@@ -581,22 +577,23 @@ class TestDiagnosticG(object):
     def test_normality(self):
         res = self.res
 
-        #> library(nortest) #Lilliefors (Kolmogorov-Smirnov) normality test
-        #> lt = lillie.test(residuals(fm))
-        #> mkhtest(lt, "lilliefors", "-")
+        # > library(nortest) #Lilliefors (Kolmogorov-Smirnov) normality test
+        # > lt = lillie.test(residuals(fm))
+        # > mkhtest(lt, "lilliefors", "-")
         lilliefors1 = dict(statistic=0.0723390908786589,
-                          pvalue=0.01204113540102896, parameters=(), distr='-')
+                           pvalue=0.01204113540102896,
+                           parameters=(), distr='-')
 
-        #> lt = lillie.test(residuals(fm)**2)
-        #> mkhtest(lt, "lilliefors", "-")
+        # > lt = lillie.test(residuals(fm)**2)
+        # > mkhtest(lt, "lilliefors", "-")
         lilliefors2 = dict(statistic=0.301311621898024,
-                          pvalue=1.004305736618051e-51,
-                          parameters=(), distr='-')
+                           pvalue=1.004305736618051e-51,
+                           parameters=(), distr='-')
 
-        #> lt = lillie.test(residuals(fm)[1:20])
-        #> mkhtest(lt, "lilliefors", "-")
+        # > lt = lillie.test(residuals(fm)[1:20])
+        # > mkhtest(lt, "lilliefors", "-")
         lilliefors3 = dict(statistic=0.1333956004203103,
-                          pvalue=0.20, parameters=(), distr='-')
+                           pvalue=0.20, parameters=(), distr='-')
 
         lf1 = smsdia.lilliefors(res.resid)
         lf2 = smsdia.lilliefors(res.resid**2)
@@ -608,17 +605,18 @@ class TestDiagnosticG(object):
         compare_t_est(lf3, lilliefors3, decimal=(14, 1))
         # R uses different approximation for pvalue in last case
 
-        #> ad = ad.test(residuals(fm))
-        #> mkhtest(ad, "ad3", "-")
-        adr1 = dict(statistic=1.602209621518313, pvalue=0.0003937979149362316,
+        # > ad = ad.test(residuals(fm))
+        # > mkhtest(ad, "ad3", "-")
+        adr1 = dict(statistic=1.602209621518313,
+                    pvalue=0.0003937979149362316,
                     parameters=(), distr='-')
 
-        #> ad = ad.test(residuals(fm)**2)
-        #> mkhtest(ad, "ad3", "-")
+        # > ad = ad.test(residuals(fm)**2)
+        # > mkhtest(ad, "ad3", "-")
         adr2 = dict(statistic=np.inf, pvalue=np.nan, parameters=(), distr='-')
 
-        #> ad = ad.test(residuals(fm)[1:20])
-        #> mkhtest(ad, "ad3", "-")
+        # > ad = ad.test(residuals(fm)[1:20])
+        # > mkhtest(ad, "ad3", "-")
         adr3 = dict(statistic=0.3017073732210775, pvalue=0.5443499281265933,
                     parameters=(), distr='-')
 
@@ -628,7 +626,6 @@ class TestDiagnosticG(object):
         assert_(np.isinf(ad2[0]))
         ad3 = smsdia.normal_ad(res.resid[:20])
         compare_t_est(ad3, adr3, decimal=(11, 12))
-
 
     def test_influence(self):
         res = self.res
@@ -661,14 +658,13 @@ class TestDiagnosticG(object):
         assert_almost_equal(infl.resid_studentized_external,
                             lsdiag['stud.res'], decimal=14)
 
-        import pandas
-        fn = os.path.join(cur_dir,"results/influence_measures_R.csv")
-        infl_r = pandas.read_csv(fn, index_col=0)
-        conv = lambda s: 1 if s=='TRUE' else 0
-        fn = os.path.join(cur_dir,"results/influence_measures_bool_R.csv")
+        fn = os.path.join(cur_dir, "results", "influence_measures_R.csv")
+        infl_r = pd.read_csv(fn, index_col=0)
+        conv = lambda s: 1 if s == 'TRUE' else 0
+        fn = os.path.join(cur_dir, "results", "influence_measures_bool_R.csv")
         #not used yet:
-        #infl_bool_r  = pandas.read_csv(fn, index_col=0,
-        #                                converters=dict(zip(lrange(7),[conv]*7)))
+        #infl_bool_r  = pd.read_csv(fn, index_col=0,
+        #                           converters=dict(zip(lrange(7),[conv]*7)))
         infl_r2 = np.asarray(infl_r)
         assert_almost_equal(infl.dfbetas, infl_r2[:,:3], decimal=13)
         assert_almost_equal(infl.cov_ratio, infl_r2[:,4], decimal=14)
@@ -677,8 +673,8 @@ class TestDiagnosticG(object):
         assert_almost_equal(c0, infl_r2[:,5], decimal=14)
         assert_almost_equal(infl.hat_matrix_diag, infl_r2[:,6], decimal=14)
 
-        #Note: for dffits, R uses a threshold around 0.36, mine: dffits[1]=0.24373
-        #TODO: finish and check thresholds and pvalues
+        # Note: for dffits, R uses a threshold around 0.36, mine: dffits[1]=0.24373
+        # TODO: finish and check thresholds and pvalues
         '''
         R has
         >>> np.nonzero(np.asarray(infl_bool_r["dffit"]))[0]
@@ -696,7 +692,7 @@ class TestDiagnosticGPandas(TestDiagnosticG):
     @classmethod
     def setup_class(cls):
         d = macrodata.load_pandas().data
-        #growth rates
+        # growth rates
         d['gs_l_realinv'] = 400 * np.log(d['realinv']).diff()
         d['gs_l_realgdp'] = 400 * np.log(d['realgdp']).diff()
         d['lint'] = d['realint'].shift(1)
@@ -748,13 +744,14 @@ def test_spec_white():
             assert_almost_equal(wsres, [8.462, 0.671, 11], decimal=3)
 
 
+# FIXME: This should actually _test_ something
 def grangertest():
-    #> gt = grangertest(ginv, ggdp, order=4)
-    #> gt
-    #Granger causality test
+    # > gt = grangertest(ginv, ggdp, order=4)
+    # > gt
+    # Granger causality test
     #
-    #Model 1: ggdp ~ Lags(ggdp, 1:4) + Lags(ginv, 1:4)
-    #Model 2: ggdp ~ Lags(ggdp, 1:4)
+    # Model 1: ggdp ~ Lags(ggdp, 1:4) + Lags(ginv, 1:4)
+    # Model 2: ggdp ~ Lags(ggdp, 1:4)
 
     grangertest = dict(fvalue=1.589672703015157, pvalue=0.178717196987075,
                        df=(198,193))
@@ -778,11 +775,8 @@ def test_outlier_influence_funcs(reset_randomstate):
 
 
 def test_influence_wrapped():
-    from pandas import DataFrame
-    from pandas.util.testing import assert_series_equal
-
     d = macrodata.load_pandas().data
-    #growth rates
+    # growth rates
     gs_l_realinv = 400 * np.log(d['realinv']).diff().dropna()
     gs_l_realgdp = 400 * np.log(d['realgdp']).diff().dropna()
     lint = d['realint'][:-1]
@@ -792,8 +786,8 @@ def test_influence_wrapped():
     gs_l_realinv.index = lint.index
 
     data = dict(const=np.ones_like(lint), lint=lint, lrealgdp=gs_l_realgdp)
-    #order is important
-    exog = DataFrame(data, columns=['const','lrealgdp','lint'])
+    # order is important
+    exog = pd.DataFrame(data, columns=['const', 'lrealgdp', 'lint'])
 
     res = OLS(gs_l_realinv, exog).fit()
 
@@ -808,17 +802,16 @@ def test_influence_wrapped():
 
     # smoke test just to make sure it works, results separately tested
     df = infl.summary_frame()
-    assert_(isinstance(df, DataFrame))
+    assert_(isinstance(df, pd.DataFrame))
 
     #this test is slow
     path = os.path.join(cur_dir, "results", "influence_lsdiag_R.json")
     with open(path, "r") as fp:
         lsdiag = json.load(fp)
 
-    c0, c1 = infl.cooks_distance #TODO: what's c1, it's pvalues? -ss
+    c0, c1 = infl.cooks_distance  # TODO: what's c1, it's pvalues? -ss
 
-
-    #NOTE: we get a hard-cored 5 decimals with pandas testing
+    # NOTE: we get a hard-cored 5 decimals with pandas testing
     assert_almost_equal(c0, lsdiag['cooks'], 14)
     assert_almost_equal(infl.hat_matrix_diag, (lsdiag['hat']), 14)
     assert_almost_equal(infl.resid_studentized_internal,
@@ -830,16 +823,15 @@ def test_influence_wrapped():
     assert_almost_equal(infl.resid_studentized_external,
                         lsdiag['stud.res'], 14)
 
-    import pandas
-    fn = os.path.join(cur_dir,"results/influence_measures_R.csv")
-    infl_r = pandas.read_csv(fn, index_col=0)
-    conv = lambda s: 1 if s=='TRUE' else 0
-    fn = os.path.join(cur_dir,"results/influence_measures_bool_R.csv")
+    fn = os.path.join(cur_dir, "results", "influence_measures_R.csv")
+    infl_r = pd.read_csv(fn, index_col=0)
+    conv = lambda s: 1 if s == 'TRUE' else 0
+    fn = os.path.join(cur_dir, "results", "influence_measures_bool_R.csv")
     #not used yet:
-    #infl_bool_r  = pandas.read_csv(fn, index_col=0,
-    #                                converters=dict(zip(lrange(7),[conv]*7)))
+    #infl_bool_r  = pd.read_csv(fn, index_col=0,
+    #                           converters=dict(zip(lrange(7),[conv]*7)))
     infl_r2 = np.asarray(infl_r)
-    #TODO: finish wrapping this stuff
+    # TODO: finish wrapping this stuff
     assert_almost_equal(infl.dfbetas, infl_r2[:,:3], decimal=13)
     assert_almost_equal(infl.cov_ratio, infl_r2[:,4], decimal=14)
 
@@ -981,21 +973,6 @@ def test_outlier_test():
 if __name__ == '__main__':
     import pytest
     pytest.main([__file__, '-vvs', '-x', '--pdb'])
-
-    #t = TestDiagnosticG()
-    #t.test_basic()
-    #t.test_hac()
-    #t.test_acorr_breusch_godfrey()
-    #t.test_acorr_ljung_box()
-    #t.test_het_goldfeldquandt()
-    #t.test_het_breusch_pagan()
-    #t.test_het_white()
-    #t.test_compare_lr()
-    #t.test_compare_nonnested()
-    #t.test_influence()
-
-
-    ##################################################
 
     '''
     J test

--- a/statsmodels/stats/tests/test_diagnostic.py
+++ b/statsmodels/stats/tests/test_diagnostic.py
@@ -757,7 +757,6 @@ def grangertest():
                        df=(198,193))
 
 
-@pytest.mark.smoke
 def test_outlier_influence_funcs(reset_randomstate):
     x = add_constant(np.random.randn(10, 2))
     y = x.sum(1) + np.random.randn(10)


### PR DESCRIPTION
This starts the process of, one-by-one, taking functions in sandbox.stats.diagnostic, ensuring they are tested, and moving them to stats.diagnostic.  non-sandbox should not be importing from sandbox.

Also sandbox.stats.diagnostic has a bunch of stuff labelled as "will be removed in 0.9" which can go as part of this sequence of PRs.