### PR TITLE
TST: Fix incorrect assertion

### DIFF
--- a/lint.sh
+++ b/lint.sh
@@ -18,6 +18,8 @@ if [ "$LINT" == true ]; then
         statsmodels/info.py \
         statsmodels/resampling/ \
         statsmodels/interface/ \
+        statsmodels/iolib/smpickle.py \
+        statsmodels.iolib/tests/test_pickle.py \
         statsmodels/tsa/regime_switching \
         statsmodels/regression/mixed_linear_model.py \
         statsmodels/duration/__init__.py \

--- a/statsmodels/iolib/smpickle.py
+++ b/statsmodels/iolib/smpickle.py
@@ -1,6 +1,7 @@
-'''Helper files for pickling'''
+"""Helper files for pickling"""
 from statsmodels.compat.python import cPickle
 from statsmodels.iolib.openfile import get_file_obj
+
 
 def save_pickle(obj, fname):
     """

--- a/statsmodels/iolib/tests/test_pickle.py
+++ b/statsmodels/iolib/tests/test_pickle.py
@@ -1,16 +1,19 @@
+import tempfile
+
+from numpy.testing import assert_equal
+
 from statsmodels.compat.python import lrange, BytesIO
 from statsmodels.iolib.smpickle import save_pickle, load_pickle
 
+
 def test_pickle():
-    import tempfile
-    from numpy.testing import assert_equal
     tmpdir = tempfile.mkdtemp(prefix='pickle')
     a = lrange(10)
     save_pickle(a, tmpdir+'/res.pkl')
     b = load_pickle(tmpdir+'/res.pkl')
     assert_equal(a, b)
 
-    #cleanup, tested on Windows
+    # cleanup, tested on Windows
     try:
         import os
         os.remove(tmpdir+'/res.pkl')
@@ -19,10 +22,10 @@ def test_pickle():
         pass
     assert not os.path.exists(tmpdir)
 
-    #test with file handle
+    # test with file handle
     fh = BytesIO()
     save_pickle(a, fh)
-    fh.seek(0,0)
+    fh.seek(0, 0)
     c = load_pickle(fh)
     fh.close()
-    assert_equal(a,b)
+    assert_equal(a, c)


### PR DESCRIPTION
asserts `assert_equal(a,b)` twice, where the second assertion should be `assert_equal(a, c)`