### PR TITLE
Add "(uncentered)" after rsquared label in .summary, .summary2 when appropriate

### DIFF
--- a/statsmodels/iolib/summary2.py
+++ b/statsmodels/iolib/summary2.py
@@ -287,8 +287,10 @@ def summary_model(results):
     info['Norm:'] = lambda x: x.fit_options['norm']
     info['Scale Est.:'] = lambda x: x.fit_options['scale_est']
     info['Cov. Type:'] = lambda x: x.fit_options['cov']
-    info['R-squared:'] = lambda x: "%#8.3f" % x.rsquared
-    info['Adj. R-squared:'] = lambda x: "%#8.3f" % x.rsquared_adj
+
+    rsquared_type = '' if results.k_constant else ' (uncentered)'
+    info['R-squared' + rsquared_type + ':'] = lambda x: "%#8.3f" % x.rsquared
+    info['Adj. R-squared' + rsquared_type + ':'] = lambda x: "%#8.3f" % x.rsquared_adj
     info['Pseudo R-squared:'] = lambda x: "%#8.3f" % x.prsquared
     info['AIC:'] = lambda x: "%8.4f" % x.aic
     info['BIC:'] = lambda x: "%8.4f" % x.bic

--- a/statsmodels/iolib/tests/test_summary2.py
+++ b/statsmodels/iolib/tests/test_summary2.py
@@ -94,3 +94,18 @@ x1    & -0.7500  & -1.5769   \\
 \begin{tabular}'''
         result = string_to_find in actual
         assert(result is True)
+
+
+class TestSummaryLabels(object):
+
+    def test_OLSsummary_rsquared_label(self):
+        # Check that the "uncentered" label is correctly added after rsquared
+        x = [1, 5, 7, 3, 5, 2, 5, 3]
+        y = [6, 4, 2, 7, 4, 9, 10, 2]
+        reg_with_constant = OLS(y, x, hasconst=True).fit()
+        assert 'R-squared:' in str(reg_with_constant.summary2())
+        assert 'R-squared:' in str(reg_with_constant.summary())
+
+        reg_without_constant = OLS(y, x, hasconst=False).fit()
+        assert 'R-squared (uncentered):' in str(reg_without_constant.summary2())
+        assert 'R-squared (uncentered):' in str(reg_without_constant.summary())

--- a/statsmodels/regression/linear_model.py
+++ b/statsmodels/regression/linear_model.py
@@ -2375,8 +2375,9 @@ class RegressionResults(base.LikelihoodModelResults):
         if hasattr(self, 'cov_type'):
             top_left.append(('Covariance Type:', [self.cov_type]))
 
-        top_right = [('R-squared:', ["%#8.3f" % self.rsquared]),
-                     ('Adj. R-squared:', ["%#8.3f" % self.rsquared_adj]),
+        rsquared_type = '' if self.k_constant else ' (uncentered)'
+        top_right = [('R-squared' + rsquared_type + ':', ["%#8.3f" % self.rsquared]),
+                     ('Adj. R-squared' + rsquared_type + ':', ["%#8.3f" % self.rsquared_adj]),
                      ('F-statistic:', ["%#8.4g" % self.fvalue]),
                      ('Prob (F-statistic):', ["%#6.3g" % self.f_pvalue]),
                      ('Log-Likelihood:', None),  # ["%#6.4g" % self.llf]),


### PR DESCRIPTION
Add "(uncentered)" after rsquared label in .summary, .summary2 when appropriate

Related to https://github.com/statsmodels/statsmodels/issues/5078 

I didn't find any Unit Test related to the formatting/labeling of the .summary{2} functions.  

The following script
```
import statsmodels.formula.api as smf
import statsmodels.api as sm

dat = sm.datasets.get_rdataset("Guerry", "HistData").data

results = smf.ols('Lottery ~ Literacy + Pop1831', data=dat).fit()
print('#################################################')
print('#########   CENTERED      #######################')
print('#################################################')
print('')
print(results.summary())
print(results.summary2())



print('#################################################')
print('#########   UNCENTERED      #####################')
print('#################################################')
print('')
results = smf.ols('Lottery ~ Literacy + Pop1831 -1', data=dat).fit()
print(results.summary())
print(results.summary2())
```
leads to the following outputs:

```
#################################################
#########   CENTERED      #######################
#################################################

                            OLS Regression Results                            
==============================================================================
Dep. Variable:                Lottery   R-squared:                       0.325
Model:                            OLS   Adj. R-squared:                  0.308
Method:                 Least Squares   F-statistic:                     19.95
Date:                Sat, 01 Sep 2018   Prob (F-statistic):           8.40e-08
Time:                        21:25:42   Log-Likelihood:                -381.36
No. Observations:                  86   AIC:                             768.7
Df Residuals:                      83   BIC:                             776.1
Df Model:                           2                                         
Covariance Type:            nonrobust                                         
==============================================================================
                 coef    std err          t      P>|t|      [0.025      0.975]
------------------------------------------------------------------------------
Intercept     89.8137      7.683     11.690      0.000      74.532     105.095
Literacy      -0.4683      0.130     -3.596      0.001      -0.727      -0.209
Pop1831       -0.0738      0.015     -4.854      0.000      -0.104      -0.044
==============================================================================
Omnibus:                        3.172   Durbin-Watson:                   1.981
Prob(Omnibus):                  0.205   Jarque-Bera (JB):                2.810
Skew:                          -0.350   Prob(JB):                        0.245
Kurtosis:                       2.456   Cond. No.                     1.40e+03
==============================================================================

Warnings:
[1] Standard Errors assume that the covariance matrix of the errors is correctly specified.
[2] The condition number is large, 1.4e+03. This might indicate that there are
strong multicollinearity or other numerical problems.
                 Results: Ordinary least squares
=================================================================
Model:              OLS              Adj. R-squared:     0.308   
Dependent Variable: Lottery          AIC:                768.7289
Date:               2018-09-01 21:25 BIC:                776.0919
No. Observations:   86               Log-Likelihood:     -381.36 
Df Model:           2                F-statistic:        19.95   
Df Residuals:       83               Prob (F-statistic): 8.40e-08
R-squared:          0.325            Scale:              431.20  
------------------------------------------------------------------
              Coef.   Std.Err.     t     P>|t|    [0.025   0.975] 
------------------------------------------------------------------
Intercept    89.8137    7.6833  11.6895  0.0000  74.5320  105.0954
Literacy     -0.4683    0.1302  -3.5958  0.0005  -0.7273   -0.2093
Pop1831      -0.0738    0.0152  -4.8535  0.0000  -0.1040   -0.0435
-----------------------------------------------------------------
Omnibus:               3.172        Durbin-Watson:          1.981
Prob(Omnibus):         0.205        Jarque-Bera (JB):       2.810
Skew:                  -0.350       Prob(JB):               0.245
Kurtosis:              2.456        Condition No.:          1401 
=================================================================
* The condition number is large (1e+03). This might indicate
strong multicollinearity or other numerical problems.
#################################################
#########   UNCENTERED      #####################
#################################################

                                 OLS Regression Results                                
=======================================================================================
Dep. Variable:                Lottery   R-squared (uncentered):                   0.561
Model:                            OLS   Adj. R-squared (uncentered):              0.551
Method:                 Least Squares   F-statistic:                              53.67
Date:                Sat, 01 Sep 2018   Prob (F-statistic):                    9.65e-16
Time:                        21:25:42   Log-Likelihood:                         -423.21
No. Observations:                  86   AIC:                                      850.4
Df Residuals:                      84   BIC:                                      855.3
Df Model:                           2                                                  
Covariance Type:            nonrobust                                                  
==============================================================================
                 coef    std err          t      P>|t|      [0.025      0.975]
------------------------------------------------------------------------------
Literacy       0.4432      0.169      2.628      0.010       0.108       0.779
Pop1831        0.0488      0.018      2.742      0.007       0.013       0.084
==============================================================================
Omnibus:                        4.076   Durbin-Watson:                   1.845
Prob(Omnibus):                  0.130   Jarque-Bera (JB):                2.348
Skew:                          -0.161   Prob(JB):                        0.309
Kurtosis:                       2.258   Cond. No.                         19.1
==============================================================================

Warnings:
[1] Standard Errors assume that the covariance matrix of the errors is correctly specified.
                       Results: Ordinary least squares
==============================================================================
Model:                  OLS              Adj. R-squared (uncentered): 0.551   
Dependent Variable:     Lottery          AIC:                         850.4216
Date:                   2018-09-01 21:25 BIC:                         855.3303
No. Observations:       86               Log-Likelihood:              -423.21 
Df Model:               2                F-statistic:                 53.67   
Df Residuals:           84               Prob (F-statistic):          9.65e-16
R-squared (uncentered): 0.561            Scale:                       1127.5  
-----------------------------------------------------------------------------------
               Coef.       Std.Err.        t         P>|t|       [0.025      0.975]
-----------------------------------------------------------------------------------
Literacy       0.4432        0.1687      2.6276      0.0102      0.1078      0.7786
Pop1831        0.0488        0.0178      2.7421      0.0075      0.0134      0.0842
------------------------------------------------------------------------------
Omnibus:                  4.076             Durbin-Watson:               1.845
Prob(Omnibus):            0.130             Jarque-Bera (JB):            2.348
Skew:                     -0.161            Prob(JB):                    0.309
Kurtosis:                 2.258             Condition No.:               19   
==============================================================================

```
