### PR TITLE
TST: parametrize tests instead of using for loops

### DIFF
--- a/statsmodels/stats/tests/test_corrpsd.py
+++ b/statsmodels/stats/tests/test_corrpsd.py
@@ -6,11 +6,11 @@ Created on Mon May 27 12:07:02 2013
 Author: Josef Perktold
 """
 
+import pytest
 import numpy as np
 import pytest
 import scipy.sparse as sparse
-from numpy.testing import (assert_almost_equal, assert_allclose,
-                           assert_equal)
+from numpy.testing import assert_almost_equal, assert_allclose
 from statsmodels.stats.correlation_tools import (
     corr_nearest, corr_clipped, cov_nearest,
     _project_correlation_factors, corr_nearest_factor, _spg_optim,
@@ -300,7 +300,8 @@ class Test_Factor(object):
         err_msg = 'rank=%d, niter=%d' % (dm, len(rslt.objective_values))
         assert_allclose(rslt.objective_values[:5], objvals[dm - 1],
                         rtol=0.5, err_msg=err_msg)
-        assert_equal(rslt.Converged, True, err_msg=err_msg)
+        assert rslt.Converged
+
         mat1 = rslt.corr.to_matrix()
         assert_allclose(mat, mat1, rtol=0.25, atol=1e-3, err_msg=err_msg)
 
@@ -357,7 +358,7 @@ class Test_Factor(object):
         x = np.random.normal(size=dm)
         rslt = _spg_optim(obj, grad, x, project)
         xnew = rslt.params
-        assert_equal(rslt.Converged, True)
+        assert rslt.Converged is True
         assert_almost_equal(obj(xnew), 0, decimal=3)
 
     def test_decorrelate(self, reset_randomstate):
@@ -409,10 +410,10 @@ class Test_Factor(object):
         d = 100
 
         # Construct a test matrix with exact factor structure
-        X = np.zeros((d,dm), dtype=np.float64)
+        X = np.zeros((d, dm), dtype=np.float64)
         x = np.linspace(0, 2*np.pi, d)
         for j in range(dm):
-            X[:,j] = np.sin(x*(j+1))
+            X[:, j] = np.sin(x*(j+1))
         mat = np.dot(X, X.T)
         np.fill_diagonal(mat, np.diag(mat) + 3.1)
 
@@ -429,10 +430,10 @@ class Test_Factor(object):
         d = 100
 
         # Construct a test matrix with exact factor structure
-        X = np.zeros((d,dm), dtype=np.float64)
+        X = np.zeros((d, dm), dtype=np.float64)
         x = np.linspace(0, 2*np.pi, d)
         for j in range(dm):
-            X[:,j] = np.sin(x*(j+1))
+            X[:, j] = np.sin(x*(j+1))
         mat = np.dot(X, X.T)
         np.fill_diagonal(mat, np.diag(mat) + 3.1)
 

--- a/statsmodels/stats/tests/test_moment_helpers.py
+++ b/statsmodels/stats/tests/test_moment_helpers.py
@@ -4,6 +4,7 @@ Created on Sun Oct 16 17:33:56 2011
 
 Author: Josef Perktold
 """
+import pytest
 
 from statsmodels.stats import moment_helpers
 from statsmodels.stats.moment_helpers import (cov2corr,
@@ -40,65 +41,63 @@ def test_cov2corr():
     assert_equal(corr_ma2.mask, cov_ma2.mask)
 
 
-def test_moment_conversion():
-    #this was initially written for an old version of moment_helpers
-    #I'm not sure whether there are not redundant cases after moving functions
-    ms  = [( [0.0, 1, 0, 3], [0.0, 1.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0] ),
-           ( [1.0, 1, 0, 3], [1.0, 1.0, 0.0, 0.0], [1.0, 0.0, -1.0, 6.0] ),
-           ( [0.0, 1, 1, 3], [0.0, 1.0, 1.0, 0.0], [0.0, 1.0, 1.0, 0.0] ),
-           ( [1.0, 1, 1, 3], [1.0, 1.0, 1.0, 0.0], [1.0, 0.0, 0.0, 2.0] ),
-           ( [1.0, 1, 1, 4], [1.0, 1.0, 1.0, 1.0], [1.0, 0.0, 0.0, 3.0] ),
-           ( [1.0, 2, 0, 3], [1.0, 2.0, 0.0, -9.0], [1.0, 1.0, -4.0, 9.0] ),
-           ( [0.0, 2, 1, 3], [0.0, 2.0, 1.0, -9.0], [0.0, 2.0, 1.0, -9.0] ),
-           ( [1.0, 0.5, 0, 3], [1.0, 0.5, 0.0, 2.25], [1.0, -0.5, 0.5, 2.25] ), #neg.variance if mnc2<mnc1
-           ( [0.0, 0.5, 1, 3], [0.0, 0.5, 1.0, 2.25], [0.0, 0.5, 1.0, 2.25] ),
-           ( [0.0, 1, 0, 3, 0], [0.0, 1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0, 0.0] ),
-           ( [1.0, 1, 0, 3, 1], [1.0, 1.0, 0.0, 0.0, 1.0], [1.0, 0.0, -1.0, 6.0, -20.0] )]
-
-    for mom in ms:
-        # test moment -> cumulant
-        assert_equal(mnc2cum(mc2mnc(mom[0])),mom[1])
-        assert_equal(mnc2cum(mom[0]),mom[2])
-        if len(mom) <= 4:
-            assert_equal(mc2cum(mom[0]),mom[1])
-
-    for mom in ms:
-        # test   cumulant -> moment
-        assert_equal(cum2mc(mom[1]),mom[0])
-        assert_equal(mc2mnc(cum2mc(mom[2])),mom[0])
-        if len(mom) <= 4:
-            assert_equal(cum2mc(mom[1]),mom[0])
-
-    for mom in ms:
-        #round trip: mnc -> cum -> mc == mnc -> mc,
-        assert_equal(cum2mc(mnc2cum(mom[0])),mnc2mc(mom[0]))
+ms = [([0.0, 1, 0, 3], [0.0, 1.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]),
+      ([1.0, 1, 0, 3], [1.0, 1.0, 0.0, 0.0], [1.0, 0.0, -1.0, 6.0]),
+      ([0.0, 1, 1, 3], [0.0, 1.0, 1.0, 0.0], [0.0, 1.0, 1.0, 0.0]),
+      ([1.0, 1, 1, 3], [1.0, 1.0, 1.0, 0.0], [1.0, 0.0, 0.0, 2.0]),
+      ([1.0, 1, 1, 4], [1.0, 1.0, 1.0, 1.0], [1.0, 0.0, 0.0, 3.0]),
+      ([1.0, 2, 0, 3], [1.0, 2.0, 0.0, -9.0], [1.0, 1.0, -4.0, 9.0]),
+      ([0.0, 2, 1, 3], [0.0, 2.0, 1.0, -9.0], [0.0, 2.0, 1.0, -9.0]),
+      ([1.0, 0.5, 0, 3], [1.0, 0.5, 0.0, 2.25], [1.0, -0.5, 0.5, 2.25]),  # neg.variance if mnc2<mnc1  # noqa:E501
+      ([0.0, 0.5, 1, 3], [0.0, 0.5, 1.0, 2.25], [0.0, 0.5, 1.0, 2.25]),
+      ([0.0, 1, 0, 3, 0], [0.0, 1.0, 0.0, 0.0, 0.0], [0., 1., 0., 0., 0.]),
+      ([1.0, 1, 0, 3, 1], [1.0, 1.0, 0.0, 0.0, 1.0], [1., 0., -1., 6., -20.])]
 
 
-    for mom in ms:
-        #round trip: mc -> mnc -> mc ==  mc,
-        assert_equal(mc2mnc(mnc2mc(mom[0])), mom[0])
+@pytest.mark.parametrize('mom', ms)
+def test_moment_conversion(mom):
+    # this was initially written for an old version of moment_helpers
+    # I'm not sure whether there are not redundant cases after moving functions
 
-    for mom in (m for m in ms if len(m[0]) == 4):
-        #print "testing", mom
-        #round trip: mc -> mvsk -> mc ==  mc
+    # test moment -> cumulant
+    assert_equal(mnc2cum(mc2mnc(mom[0])), mom[1])
+    assert_equal(mnc2cum(mom[0]), mom[2])
+    if len(mom) <= 4:
+        assert_equal(mc2cum(mom[0]), mom[1])
+
+    # test   cumulant -> moment
+    assert_equal(cum2mc(mom[1]), mom[0])
+    assert_equal(mc2mnc(cum2mc(mom[2])), mom[0])
+    if len(mom) <= 4:
+        assert_equal(cum2mc(mom[1]), mom[0])
+
+    # round trip: mnc -> cum -> mc == mnc -> mc,
+    assert_equal(cum2mc(mnc2cum(mom[0])), mnc2mc(mom[0]))
+
+    # round trip: mc -> mnc -> mc ==  mc,
+    assert_equal(mc2mnc(mnc2mc(mom[0])), mom[0])
+
+    if len(mom[0]) == 4:
+        # round trip: mc -> mvsk -> mc ==  mc
         assert_equal(mvsk2mc(mc2mvsk(mom[0])), mom[0])
-        #round trip: mc -> mvsk -> mnc ==  mc -> mnc
-        #TODO: mvsk2mnc not defined
-        #assert_equal(mvsk2mnc(mc2mvsk(mom[0])), mc2mnc(mom[0]))
+
+        # round trip: mc -> mvsk -> mnc ==  mc -> mnc
+        # TODO: mvsk2mnc not defined
+        # assert_equal(mvsk2mnc(mc2mvsk(mom[0])), mc2mnc(mom[0]))
 
 
-def test_moment_conversion_types():
+@pytest.mark.parametrize('func_name', ['cum2mc', 'cum2mc', 'mc2cum', 'mc2mnc',
+                                       'mc2mvsk', 'mnc2cum', 'mnc2mc',
+                                       'mnc2mc', 'mvsk2mc', 'mvsk2mnc'])
+def test_moment_conversion_types(func_name):
     # written in 2009
-    #why did I use list as return type
-    all_f = ['cum2mc', 'cum2mc', 'mc2cum', 'mc2mnc',
-           'mc2mvsk', 'mnc2cum', 'mnc2mc', 'mnc2mc',
-           'mvsk2mc', 'mvsk2mnc']
-    assert np.all([isinstance(getattr(moment_helpers,f)([1.0, 1, 0, 3]),list) or
-            isinstance(getattr(moment_helpers,f)(np.array([1.0, 1, 0, 3])),tuple)
-            for f in all_f])
-    assert np.all([isinstance(getattr(moment_helpers,f)(np.array([1.0, 1, 0, 3])),list) or
-            isinstance(getattr(moment_helpers,f)(np.array([1.0, 1, 0, 3])),tuple)
-            for f in all_f])
-    assert np.all([isinstance(getattr(moment_helpers,f)(tuple([1.0, 1, 0, 3])),list) or
-            isinstance(getattr(moment_helpers,f)(np.array([1.0, 1, 0, 3])),tuple)
-            for f in all_f])
+    # TODO: why did I use list as return type?
+    func = getattr(moment_helpers, func_name)
+    assert (isinstance(func([1.0, 1, 0, 3]), list) or
+            isinstance(func(np.array([1.0, 1, 0, 3])), tuple))
+
+    assert (isinstance(func(np.array([1.0, 1, 0, 3])), list) or
+            isinstance(func(np.array([1.0, 1, 0, 3])), tuple))
+
+    assert (isinstance(func(tuple([1.0, 1, 0, 3])), list) or
+            isinstance(func(np.array([1.0, 1, 0, 3])), tuple))

--- a/statsmodels/stats/tests/test_proportion.py
+++ b/statsmodels/stats/tests/test_proportion.py
@@ -7,6 +7,7 @@ Author: Josef Perktold
 """
 import warnings
 
+import pytest
 import numpy as np
 import pandas as pd
 import pytest
@@ -55,7 +56,8 @@ def test_confint_proportion():
                                 err_msg=repr(case) + method)
 
 
-def test_confint_proportion_ndim():
+@pytest.mark.parametrize('method', probci_methods)
+def test_confint_proportion_ndim(method):
     # check that it works with 1-D, 2-D and pandas
 
     count = np.arange(6).reshape(2, 3)
@@ -64,33 +66,32 @@ def test_confint_proportion_ndim():
     count_pd = pd.DataFrame(count)
     nobs_pd =  pd.DataFrame(nobs)
 
-    for method in probci_methods:
-        ci_arr = proportion_confint(count, nobs, alpha=0.05, method=method)
-        ci_pd = proportion_confint(count_pd, nobs_pd, alpha=0.05,
-                                   method=method)
-        assert_allclose(ci_arr, (ci_pd[0].values, ci_pd[1].values), rtol=1e-13)
-        # spot checking one value
-        ci12 = proportion_confint(count[1, 2], nobs[1, 2], alpha=0.05,
-                                  method=method)
-        assert_allclose((ci_pd[0].values[1, 2], ci_pd[1].values[1, 2]), ci12,
-                        rtol=1e-13)
-        assert_allclose((ci_arr[0][1, 2], ci_arr[1][1, 2]), ci12, rtol=1e-13)
+    ci_arr = proportion_confint(count, nobs, alpha=0.05, method=method)
+    ci_pd = proportion_confint(count_pd, nobs_pd, alpha=0.05,
+                               method=method)
+    assert_allclose(ci_arr, (ci_pd[0].values, ci_pd[1].values), rtol=1e-13)
+    # spot checking one value
+    ci12 = proportion_confint(count[1, 2], nobs[1, 2], alpha=0.05,
+                              method=method)
+    assert_allclose((ci_pd[0].values[1, 2], ci_pd[1].values[1, 2]), ci12,
+                    rtol=1e-13)
+    assert_allclose((ci_arr[0][1, 2], ci_arr[1][1, 2]), ci12, rtol=1e-13)
 
-        # check that lists work as input
-        ci_li = proportion_confint(count.tolist(), nobs.tolist(), alpha=0.05,
-                                   method=method)
-        assert_allclose(ci_arr, (ci_li[0], ci_li[1]), rtol=1e-13)
+    # check that lists work as input
+    ci_li = proportion_confint(count.tolist(), nobs.tolist(), alpha=0.05,
+                               method=method)
+    assert_allclose(ci_arr, (ci_li[0], ci_li[1]), rtol=1e-13)
 
-        # check pandas Series, 1-D
-        ci_pds = proportion_confint(count_pd.iloc[0], nobs_pd.iloc[0],
-                                    alpha=0.05, method=method)
-        assert_allclose((ci_pds[0].values, ci_pds[1].values),
-                        (ci_pd[0].values[0], ci_pd[1].values[0]), rtol=1e-13)
+    # check pandas Series, 1-D
+    ci_pds = proportion_confint(count_pd.iloc[0], nobs_pd.iloc[0],
+                                alpha=0.05, method=method)
+    assert_allclose((ci_pds[0].values, ci_pds[1].values),
+                    (ci_pd[0].values[0], ci_pd[1].values[0]), rtol=1e-13)
 
-        # check scalar nobs, verifying one value
-        ci_arr2 = proportion_confint(count, nobs[1, 2], alpha=0.05,
-                                     method=method)
-        assert_allclose((ci_arr2[0][1, 2], ci_arr[1][1, 2]), ci12, rtol=1e-13)
+    # check scalar nobs, verifying one value
+    ci_arr2 = proportion_confint(count, nobs[1, 2], alpha=0.05,
+                                 method=method)
+    assert_allclose((ci_arr2[0][1, 2], ci_arr[1][1, 2]), ci12, rtol=1e-13)
 
 
 def test_samplesize_confidenceinterval_prop():

--- a/statsmodels/stats/tests/test_qsturng.py
+++ b/statsmodels/stats/tests/test_qsturng.py
@@ -6,6 +6,7 @@ Created on Wed Mar 28 13:49:11 2012
 Author: Josef Perktold
 """
 
+import pytest
 import numpy as np
 from numpy.testing import assert_almost_equal
 
@@ -13,17 +14,16 @@ from statsmodels.stats.libqsturng import qsturng, psturng
 from statsmodels.sandbox.stats.multicomp import get_tukeyQcrit
 
 
-def test_qstrung():
+@pytest.mark.parametrize('alpha', [0.01, 0.05])
+@pytest.mark.parametrize('k', np.arange(2, 11))
+def test_qstrung(alpha, k):
     rows = [5,    6,    7,    8,    9,   10,   11,   12,   13,   14,   15,
             16,   17,   18,   19,   20,   24,   30,   40,   60,  120, 9999]
-    cols = np.arange(2, 11)
 
-    for alpha in [0.01, 0.05]:
-        for k in cols:
-            c1 = get_tukeyQcrit(k, rows, alpha=alpha)
-            c2 = qsturng(1-alpha, k, rows)
-            assert_almost_equal(c1, c2, decimal=2)
-            # roundtrip
-            assert_almost_equal(psturng(qsturng(1-alpha, k, rows), k, rows),
-                                alpha,
-                                5)
+    c1 = get_tukeyQcrit(k, rows, alpha=alpha)
+    c2 = qsturng(1 - alpha, k, rows)
+    assert_almost_equal(c1, c2, decimal=2)
+    # roundtrip
+    assert_almost_equal(psturng(qsturng(1 - alpha, k, rows), k, rows),
+                        alpha,
+                        5)

--- a/statsmodels/tools/tests/test_eval_measures.py
+++ b/statsmodels/tools/tests/test_eval_measures.py
@@ -4,10 +4,11 @@ Created on Tue Nov 08 22:28:48 2011
 
 @author: josef
 """
+import pytest
 
 from statsmodels.compat.python import zip
 import numpy as np
-from numpy.testing import assert_equal, assert_almost_equal, assert_
+from numpy.testing import assert_equal, assert_almost_equal
 
 from statsmodels.tools.eval_measures import (
     maxabs, meanabs, medianabs, medianbias, mse, rmse, stde, vare,
@@ -68,27 +69,33 @@ def test_eval_measures():
     assert_equal(vare(x, y, axis=1),
                  np.array([ 2.,  2.,  2.,  2.]))
 
-def test_ic():
-    # test information criteria
+
+ics = [aic, aicc, bic, hqic]
+ics_sig = [aic_sigma, aicc_sigma, bic_sigma, hqic_sigma]
+
+
+@pytest.mark.parametrize('ic,ic_sig', zip(ics, ics_sig))
+def test_ic_equivalence(ic, ic_sig):
     # consistency check
 
-    ics = [aic, aicc, bic, hqic]
-    ics_sig = [aic_sigma, aicc_sigma, bic_sigma, hqic_sigma]
+    assert ic(np.array(2), 10, 2).dtype == np.float
+    assert ic_sig(np.array(2), 10, 2).dtype == np.float
 
-    for ic, ic_sig in zip(ics, ics_sig):
-        assert_(ic(np.array(2),10,2).dtype == np.float, msg=repr(ic))
-        assert_(ic_sig(np.array(2),10,2).dtype == np.float, msg=repr(ic_sig) )
+    assert_almost_equal(ic(-10./2.*np.log(2.), 10, 2)/10,
+                        ic_sig(2, 10, 2),
+                        decimal=14)
 
-        assert_almost_equal(ic(-10./2.*np.log(2.),10,2)/10,
-                            ic_sig(2, 10, 2),
-                            decimal=14)
+    assert_almost_equal(ic_sig(np.log(2.), 10, 2, islog=True),
+                        ic_sig(2, 10, 2),
+                        decimal=14)
 
-        assert_almost_equal(ic_sig(np.log(2.),10,2, islog=True),
-                            ic_sig(2, 10, 2),
-                            decimal=14)
+
+def test_ic():
+    # test information criteria
 
     # examples penalty directly from formula
-    n, k = 10, 2
+    n = 10
+    k = 2
     assert_almost_equal(aic(0, 10, 2), 2*k, decimal=14)
     # next see Wikipedia
     assert_almost_equal(aicc(0, 10, 2),

--- a/statsmodels/tsa/tests/test_arima_process.py
+++ b/statsmodels/tsa/tests/test_arima_process.py
@@ -7,6 +7,7 @@ import numpy as np
 from numpy.testing import (assert_array_almost_equal, assert_almost_equal,
                            assert_allclose,
                            assert_equal, assert_raises, assert_)
+import pytest
 
 from statsmodels.tsa.arima_process import (arma_generate_sample, arma_acovf,
                                            arma_acf, arma_impulse_response, lpol_fiar, lpol_fima,
@@ -139,24 +140,24 @@ def _manual_arma_generate_sample(ar, ma, eta):
     return np.array(rep2[max(p, q):])
 
 
-def test_arma_generate_sample():
+@pytest.mark.parametrize('ar', arlist)
+@pytest.mark.parametrize('ma', malist)
+@pytest.mark.parametrize('dist', [np.random.randn])
+def test_arma_generate_sample(dist, ar, ma):
     # Test that this generates a true ARMA process
     # (amounts to just a test that scipy.signal.lfilter does what we want)
     T = 100
-    dists = [np.random.randn]
-    for dist in dists:
-        np.random.seed(1234)
-        eta = dist(T)
-        for ar in arlist:
-            for ma in malist:
-                # rep1: from module function
-                np.random.seed(1234)
-                rep1 = arma_generate_sample(ar, ma, T, distrvs=dist)
-                # rep2: "manually" create the ARMA process
-                ar_params = -1 * np.array(ar[1:])
-                ma_params = np.array(ma[1:])
-                rep2 = _manual_arma_generate_sample(ar_params, ma_params, eta)
-                assert_array_almost_equal(rep1, rep2, 13)
+    np.random.seed(1234)
+    eta = dist(T)
+
+    # rep1: from module function
+    np.random.seed(1234)
+    rep1 = arma_generate_sample(ar, ma, T, distrvs=dist)
+    # rep2: "manually" create the ARMA process
+    ar_params = -1 * np.array(ar[1:])
+    ma_params = np.array(ma[1:])
+    rep2 = _manual_arma_generate_sample(ar_params, ma_params, eta)
+    assert_array_almost_equal(rep1, rep2, 13)
 
 
 def test_fi():
@@ -174,35 +175,37 @@ def test_arma_impulse_response():
     assert_array_almost_equal(-armarep.arrep.ravel(), arrep, 14)
 
 
-def test_spectrum():
+@pytest.mark.parametrize('ar', arlist)
+@pytest.mark.parametrize('ma', malist)
+def test_spectrum(ar, ma):
     nfreq = 20
     w = np.linspace(0, np.pi, nfreq, endpoint=False)
-    for ar in arlist:
-        for ma in malist:
-            arma = ArmaFft(ar, ma, 20)
-            spdr, wr = arma.spdroots(w)
-            spdp, wp = arma.spdpoly(w, 200)
-            spdd, wd = arma.spddirect(nfreq * 2)
-            assert_equal(w, wr)
-            assert_equal(w, wp)
-            assert_almost_equal(w, wd[:nfreq], decimal=14)
-            assert_almost_equal(spdr, spdd[:nfreq], decimal=7,
-                                err_msg='spdr spdd not equal for %s, %s' % (ar, ma))
-            assert_almost_equal(spdr, spdp, decimal=7,
-                                err_msg='spdr spdp not equal for %s, %s' % (ar, ma))
+
+    arma = ArmaFft(ar, ma, 20)
+    spdr, wr = arma.spdroots(w)
+    spdp, wp = arma.spdpoly(w, 200)
+    spdd, wd = arma.spddirect(nfreq * 2)
+    assert_equal(w, wr)
+    assert_equal(w, wp)
+    assert_almost_equal(w, wd[:nfreq], decimal=14)
+    assert_almost_equal(spdr, spdd[:nfreq], decimal=7,
+                        err_msg='spdr spdd not equal for %s, %s' % (ar, ma))
+    assert_almost_equal(spdr, spdp, decimal=7,
+                        err_msg='spdr spdp not equal for %s, %s' % (ar, ma))
 
 
-def test_armafft():
+@pytest.mark.parametrize('ar', arlist)
+@pytest.mark.parametrize('ma', malist)
+def test_armafft(ar, ma):
     # test other methods
     nfreq = 20
     w = np.linspace(0, np.pi, nfreq, endpoint=False)
-    for ar in arlist:
-        for ma in malist:
-            arma = ArmaFft(ar, ma, 20)
-            ac1 = arma.invpowerspd(1024)[:10]
-            ac2 = arma.acovf(10)[:10]
-            assert_allclose(ac1, ac2, atol=1e-15,
-                            err_msg='acovf not equal for %s, %s' % (ar, ma))
+
+    arma = ArmaFft(ar, ma, 20)
+    ac1 = arma.invpowerspd(1024)[:10]
+    ac2 = arma.acovf(10)[:10]
+    assert_allclose(ac1, ac2, atol=1e-15,
+                    err_msg='acovf not equal for %s, %s' % (ar, ma))
 
 
 def test_lpol2index_index2lpol():

--- a/statsmodels/tsa/tests/test_stattools.py
+++ b/statsmodels/tsa/tests/test_stattools.py
@@ -529,15 +529,15 @@ def test_acovf2d():
         acovf(x, fft=False)
 
 
-def test_acovf_fft_vs_convolution():
+@pytest.mark.parametrize('demean', [True, False])
+@pytest.mark.parametrize('unbiased', [True, False])
+def test_acovf_fft_vs_convolution(demean, unbiased):
     np.random.seed(1)
     q = np.random.normal(size=100)
 
-    for demean in [True, False]:
-        for unbiased in [True, False]:
-            F1 = acovf(q, demean=demean, unbiased=unbiased, fft=True)
-            F2 = acovf(q, demean=demean, unbiased=unbiased, fft=False)
-            assert_almost_equal(F1, F2, decimal=7)
+    F1 = acovf(q, demean=demean, unbiased=unbiased, fft=True)
+    F2 = acovf(q, demean=demean, unbiased=unbiased, fft=False)
+    assert_almost_equal(F1, F2, decimal=7)
 
 
 @pytest.mark.smoke


### PR DESCRIPTION
For any skeptics, recall the advantage of parametrizing is that if a particular case fails, a) the parameter value that fails is included in the test output and b) subsequent tests are still run, so we get information on all failing cases.