### PR TITLE
MAINT: Chrome doesn't like having a secure link with an unsecure image

### DIFF
--- a/docs/themes/statsmodels/sidelinks.html
+++ b/docs/themes/statsmodels/sidelinks.html
@@ -1,2 +1,2 @@
-<p><a href="https://twitter.com/statsmodels"><img src="http://twitter-badges.s3.amazonaws.com/t_small-a.png" alt="Follow statsmodels on Twitter"/></a>
+<p><a href="https://twitter.com/statsmodels"><img src="https://twitter-badges.s3.amazonaws.com/t_small-a.png" alt="Follow statsmodels on Twitter"/></a>
 <a href="http://scipystats.blogspot.com/"><img src="{{ pathto('_static/blogger_sm.png', 1) }}" alt="Blog"></a></p>


### PR DESCRIPTION
When using chrome, you get a warning that the docs aren't secure because every link needs to be to a secure resource. This fixes that. 

Before:
![image](https://user-images.githubusercontent.com/8186432/44960045-b693ed80-aebd-11e8-982e-244e6da4a91a.png)

After:
![image](https://user-images.githubusercontent.com/8186432/44960049-c6133680-aebd-11e8-8f91-a20b3d6ad5dd.png)
