### PR TITLE
Allow results to be stored for multiple imputation

### DIFF
--- a/statsmodels/imputation/bayes_mi.py
+++ b/statsmodels/imputation/bayes_mi.py
@@ -291,6 +291,7 @@ class MI(object):
 
         par = []
         cov = []
+        all_results = []
 
         for k in range(self.nrep):
 
@@ -311,6 +312,7 @@ class MI(object):
                           **self.model_kwds_fn(da))
 
             result = model.fit(*self.fit_args(da), **self.fit_kwds(da))
+            all_results.append(result)
 
             par.append(np.asarray(result.params.copy()))
             cov.append(np.asarray(result.cov_params().copy()))
@@ -319,6 +321,9 @@ class MI(object):
 
         r = MIResults(self, model, params, cov_params)
         r.fmi = fmi
+
+        r.results = all_results
+
         return r
 
     def _combine(self, par, cov):

--- a/statsmodels/imputation/bayes_mi.py
+++ b/statsmodels/imputation/bayes_mi.py
@@ -250,7 +250,7 @@ class MI(object):
 
         if model_args_fn is None:
             def f(x):
-                return (x,)
+                return []
             model_args_fn = f
         self.model_args_fn = model_args_fn
 
@@ -280,17 +280,24 @@ class MI(object):
         for k in range(burn):
             imp.update()
 
-    def fit(self):
+    def fit(self, results_cb=None):
         """
-        fit imputes datasets, fits models, and pools results.
+        Impute datasets, fit models, and pool results.
+
+        Parameters
+        ----------
+        results_cb : function, optional
+            If provided, each results instance r is passed through `results_cb`,
+            then appended to the `results` attribute of the MIResults object.
+            To save complete results, use `results_cb=lambda x: x`.  The default
+            behavior is to save no results.
 
         Returns
         -------
         A MIResults object.
         """
 
-        par = []
-        cov = []
+        par, cov = [], []
         all_results = []
 
         for k in range(self.nrep):
@@ -312,7 +319,9 @@ class MI(object):
                           **self.model_kwds_fn(da))
 
             result = model.fit(*self.fit_args(da), **self.fit_kwds(da))
-            all_results.append(result)
+
+            if results_cb is not None:
+                all_results.append(results_cb(result))
 
             par.append(np.asarray(result.params.copy()))
             cov.append(np.asarray(result.cov_params().copy()))


### PR DESCRIPTION
This PR allows optional storage of results generated during multiple imputation by passing each results instance through a callback function.  It needs to be optional and customizable since results contains a reference to the data, and there may not be room to store all imputed data in memory at once.

This also changes the default model_args_fn behavior since the existing approach did not work with models where the data parameter does not appear in the first position of the model initializer.  This is a new class from <6 months ago so minor compatibility break should be acceptable.