### PR TITLE
BUG/DOC: Description of k_posdef

### DIFF
--- a/statsmodels/tsa/statespace/kalman_filter.py
+++ b/statsmodels/tsa/statespace/kalman_filter.py
@@ -66,7 +66,7 @@ class KalmanFilter(Representation):
         The dimension of the unobserved state process.
     k_posdef : int, optional
         The dimension of a guaranteed positive definite covariance matrix
-        describing the shocks in the measurement equation. Must be less than
+        describing the shocks in the transition equation. Must be less than
         or equal to `k_states`. Default is `k_states`.
     loglikelihood_burn : int, optional
         The number of initial periods during which the loglikelihood is not


### PR DESCRIPTION
Closes #3610

Corrects documentation to note that k_posdef is the dimension of the state innovation.