### PR TITLE
MAINT: use flake8-per-file-ignores

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -117,7 +117,7 @@ before_install:
         export COVERAGE_OPTS=""
     fi
   - if [ ${DOCBUILD} = true ]; then source tools/ci/docbuild_install.sh; fi;
-  - pip install flake8
+  - pip install flake8 flake8-per-file-ignores
   - export SRCDIR=$PWD
 
 # Install packages

--- a/setup.cfg
+++ b/setup.cfg
@@ -111,7 +111,22 @@ select=
     # F901: raise NotImplemented should be raise NotImplementedError
     E306,
     # E306: expected 1 blank line before a nested definition, found 0
-
-
+    W291,
+    # W291: trailing whitespace
     E272
     # E272: multiple spaces before keyword
+
+per-file-ignores =
+    # See discussion in GH#5039
+    statsmodels/tsa/tests/results/arima111_results.py: W291
+    statsmodels/tsa/tests/results/arima111_css_results.py: W291
+    statsmodels/tsa/tests/results/arima111nc_results.py: W291
+    statsmodels/tsa/tests/results/arima111nc_css_results.py: W291
+    statsmodels/tsa/tests/results/arima112_css_results.py: W291
+    statsmodels/tsa/tests/results/arima112_results.py: W291
+    statsmodels/tsa/tests/results/arima112nc_results.py: W291
+    statsmodels/tsa/tests/results/arima112nc_css_results.py: W291
+    statsmodels/tsa/tests/results/arima211_css_results.py: W291
+    statsmodels/tsa/tests/results/arima211_results.py: W291
+    statsmodels/tsa/tests/results/arima211nc_results.py: W291
+    statsmodels/tsa/tests/results/arima211nc_css_results.py: W291

--- a/statsmodels/tsa/tests/results/arima111_css_results.py
+++ b/statsmodels/tsa/tests/results/arima111_css_results.py
@@ -1,3 +1,4 @@
+# pylint: disable=trailing-whitespace
 import numpy as np
 
 llf = np.array([-242.06033399744])

--- a/statsmodels/tsa/tests/results/arima111_results.py
+++ b/statsmodels/tsa/tests/results/arima111_results.py
@@ -1,3 +1,4 @@
+# pylint: disable=trailing-whitespace
 import numpy as np
 
 llf = np.array([-241.75576160303])

--- a/statsmodels/tsa/tests/results/arima111nc_css_results.py
+++ b/statsmodels/tsa/tests/results/arima111nc_css_results.py
@@ -1,3 +1,4 @@
+# pylint: disable=trailing-whitespace
 import numpy as np
 
 llf = np.array([-242.89663276735])

--- a/statsmodels/tsa/tests/results/arima111nc_results.py
+++ b/statsmodels/tsa/tests/results/arima111nc_results.py
@@ -1,3 +1,4 @@
+# pylint: disable=trailing-whitespace
 import numpy as np
 
 llf = np.array([-243.77512585356])

--- a/statsmodels/tsa/tests/results/arima112_css_results.py
+++ b/statsmodels/tsa/tests/results/arima112_css_results.py
@@ -1,3 +1,4 @@
+# pylint: disable=trailing-whitespace
 import numpy as np
 
 llf = np.array([ -244.3852892951])

--- a/statsmodels/tsa/tests/results/arima112_results.py
+++ b/statsmodels/tsa/tests/results/arima112_results.py
@@ -1,3 +1,4 @@
+# pylint: disable=trailing-whitespace
 import numpy as np
 
 llf = np.array([-245.40783909604])

--- a/statsmodels/tsa/tests/results/arima112nc_css_results.py
+++ b/statsmodels/tsa/tests/results/arima112nc_css_results.py
@@ -1,3 +1,4 @@
+# pylint: disable=trailing-whitespace
 import numpy as np
 
 llf = np.array([-239.75290561974])

--- a/statsmodels/tsa/tests/results/arima112nc_results.py
+++ b/statsmodels/tsa/tests/results/arima112nc_results.py
@@ -1,3 +1,4 @@
+# pylint: disable=trailing-whitespace
 import numpy as np
 
 llf = np.array([-240.79351748413])

--- a/statsmodels/tsa/tests/results/arima211_css_results.py
+++ b/statsmodels/tsa/tests/results/arima211_css_results.py
@@ -1,3 +1,4 @@
+# pylint: disable=trailing-whitespace
 import numpy as np
 
 llf = np.array([-240.29558272688])

--- a/statsmodels/tsa/tests/results/arima211_results.py
+++ b/statsmodels/tsa/tests/results/arima211_results.py
@@ -1,3 +1,4 @@
+# pylint: disable=trailing-whitespace
 import numpy as np
 
 llf = np.array([-239.91961140777])

--- a/statsmodels/tsa/tests/results/arima211nc_css_results.py
+++ b/statsmodels/tsa/tests/results/arima211nc_css_results.py
@@ -1,3 +1,4 @@
+# pylint: disable=trailing-whitespace
 import numpy as np
 
 llf = np.array([-240.21658671417])

--- a/statsmodels/tsa/tests/results/arima211nc_results.py
+++ b/statsmodels/tsa/tests/results/arima211nc_results.py
@@ -1,3 +1,4 @@
+# pylint: disable=trailing-whitespace
 import numpy as np
 
 llf = np.array([-241.25977940638])


### PR DESCRIPTION
Alternative to #5039.

Also should quiet the complaints about trailing whitespace in these files on codacy.

NB: this will NOT pass linting at the moment because it enables W291 for all files _other_ than those excluded here.  That leaves 179 occurrences, most of which are in examples files.  To make this go away forever, I'd like the go-ahead to fix these in one swoop.