### PR TITLE
CLN: trim whitespace in ipynb/py files in parallel

### DIFF
--- a/examples/notebooks/discrete_choice_example.ipynb
+++ b/examples/notebooks/discrete_choice_example.ipynb
@@ -104,7 +104,7 @@
    },
    "outputs": [],
    "source": [
-    "affair_mod = logit(\"affair ~ occupation + educ + occupation_husb\" \n",
+    "affair_mod = logit(\"affair ~ occupation + educ + occupation_husb\"\n",
     "                   \"+ rate_marriage + age + yrs_married + children\"\n",
     "                   \" + religious\", dta).fit()"
    ]
@@ -177,9 +177,9 @@
    },
    "outputs": [],
    "source": [
-    "resp = dict(zip(range(1,9), respondent1000[[\"occupation\", \"educ\", \n",
-    "                                            \"occupation_husb\", \"rate_marriage\", \n",
-    "                                            \"age\", \"yrs_married\", \"children\", \n",
+    "resp = dict(zip(range(1,9), respondent1000[[\"occupation\", \"educ\",\n",
+    "                                            \"occupation_husb\", \"rate_marriage\",\n",
+    "                                            \"age\", \"yrs_married\", \"children\",\n",
     "                                            \"religious\"]].tolist()))\n",
     "resp.update({0 : 1})\n",
     "print(resp)"
@@ -265,7 +265,7 @@
     "support = np.linspace(-6, 6, 1000)\n",
     "ax.plot(support, stats.logistic.cdf(support), 'r-', label='Logistic')\n",
     "ax.plot(support, stats.norm.cdf(support), label='Probit')\n",
-    "ax.legend();"
+    "ax.legend()"
    ]
   },
   {
@@ -281,7 +281,7 @@
     "support = np.linspace(-6, 6, 1000)\n",
     "ax.plot(support, stats.logistic.pdf(support), 'r-', label='Logistic')\n",
     "ax.plot(support, stats.norm.pdf(support), label='Probit')\n",
-    "ax.legend();"
+    "ax.legend()"
    ]
   },
   {
@@ -295,7 +295,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Genarlized Linear Model Example"
+    "### Generalized Linear Model Example"
    ]
   },
   {
@@ -441,7 +441,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The number of trials "
+    "The number of trials"
    ]
   },
   {
@@ -600,7 +600,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Pearson residuals are defined to be \n",
+    "Pearson residuals are defined to be\n",
     "\n",
     "$$\\frac{(y - \\mu)}{\\sqrt{(var(\\mu))}}$$\n",
     "\n",
@@ -620,7 +620,7 @@
     "                          ylabel='Pearson Residuals')\n",
     "ax.scatter(yhat, stats.zscore(glm_mod.resid_pearson))\n",
     "ax.axis('tight')\n",
-    "ax.plot([0.0, 1.0],[0.0, 0.0], 'k-');"
+    "ax.plot([0.0, 1.0],[0.0, 0.0], 'k-')"
    ]
   },
   {
@@ -634,7 +634,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The definition of the deviance residuals depends on the family. For the Binomial distribution this is \n",
+    "The definition of the deviance residuals depends on the family. For the Binomial distribution this is\n",
     "\n",
     "$$r_{dev} = sign\\left(Y-\\mu\\right)*\\sqrt{2n(Y\\log\\frac{Y}{\\mu}+(1-Y)\\log\\frac{(1-Y)}{(1-\\mu)}}$$\n",
     "\n",
@@ -650,7 +650,7 @@
    "outputs": [],
    "source": [
     "resid = glm_mod.resid_deviance\n",
-    "resid_std = stats.zscore(resid) \n",
+    "resid_std = stats.zscore(resid)\n",
     "kde_resid = sm.nonparametric.KDEUnivariate(resid_std)\n",
     "kde_resid.fit()"
    ]
@@ -665,8 +665,8 @@
    "source": [
     "fig = plt.figure(figsize=(12,8))\n",
     "ax = fig.add_subplot(111, title=\"Standardized Deviance Residuals\")\n",
-    "ax.hist(resid_std, bins=25, normed=True);\n",
-    "ax.plot(kde_resid.support, kde_resid.density, 'r');"
+    "ax.hist(resid_std, bins=25, normed=True)\n",
+    "ax.plot(kde_resid.support, kde_resid.density, 'r')"
    ]
   },
   {

--- a/examples/notebooks/discrete_choice_overview.ipynb
+++ b/examples/notebooks/discrete_choice_overview.ipynb
@@ -141,7 +141,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Probit Model "
+    "## Probit Model"
    ]
   },
   {
@@ -232,7 +232,7 @@
    "source": [
     "## Poisson\n",
     "\n",
-    "Load the Rand data. Note that this example is similar to Cameron and Trivedi's `Microeconometrics` Table 20.5, but it is slightly different because of minor changes in the data. "
+    "Load the Rand data. Note that this example is similar to Cameron and Trivedi's `Microeconometrics` Table 20.5, but it is slightly different because of minor changes in the data."
    ]
   },
   {
@@ -252,7 +252,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Fit Poisson model: "
+    "Fit Poisson model:"
    ]
   },
   {
@@ -274,7 +274,7 @@
    "source": [
     "## Negative Binomial\n",
     "\n",
-    "The negative binomial model gives slightly different results. "
+    "The negative binomial model gives slightly different results."
    ]
   },
   {
@@ -296,7 +296,7 @@
    "source": [
     "## Alternative solvers\n",
     "\n",
-    "The default method for fitting discrete data MLE models is Newton-Raphson. You can use other solvers by using the ``method`` argument: "
+    "The default method for fitting discrete data MLE models is Newton-Raphson. You can use other solvers by using the ``method`` argument:"
    ]
   },
   {

--- a/examples/notebooks/generic_mle.ipynb
+++ b/examples/notebooks/generic_mle.ipynb
@@ -184,13 +184,13 @@
     "log-likelihood (type NB-2) function expressed as:\n",
     "\n",
     "$$\n",
-    "    \\mathcal{L}(\\beta_j; y, \\alpha) = \\sum_{i=1}^n y_i ln \n",
+    "    \\mathcal{L}(\\beta_j; y, \\alpha) = \\sum_{i=1}^n y_i ln\n",
     "    \\left ( \\frac{\\alpha exp(X_i'\\beta)}{1+\\alpha exp(X_i'\\beta)} \\right ) -\n",
     "    \\frac{1}{\\alpha} ln(1+\\alpha exp(X_i'\\beta)) + ln \\Gamma (y_i + 1/\\alpha) - ln \\Gamma (y_i+1) - ln \\Gamma (1/\\alpha)\n",
     "$$\n",
     "\n",
     "with a matrix of regressors $X$, a vector of coefficients $\\beta$,\n",
-    "and the negative binomial heterogeneity parameter $\\alpha$. \n",
+    "and the negative binomial heterogeneity parameter $\\alpha$.\n",
     "\n",
     "Using the ``nbinom`` distribution from ``scipy``, we can write this likelihood\n",
     "simply as:\n"
@@ -255,13 +255,13 @@
     "class NBin(GenericLikelihoodModel):\n",
     "    def __init__(self, endog, exog, **kwds):\n",
     "        super(NBin, self).__init__(endog, exog, **kwds)\n",
-    "        \n",
+    "\n",
     "    def nloglikeobs(self, params):\n",
     "        alph = params[-1]\n",
     "        beta = params[:-1]\n",
     "        ll = _ll_nb2(self.endog, self.exog, beta, alph)\n",
-    "        return -ll \n",
-    "    \n",
+    "        return -ll\n",
+    "\n",
     "    def fit(self, start_params=None, maxiter=10000, maxfun=5000, **kwds):\n",
     "        # we have one additional parameter and we need to add it for summary\n",
     "        self.exog_names.append('alpha')\n",
@@ -270,18 +270,18 @@
     "            start_params = np.append(np.zeros(self.exog.shape[1]), .5)\n",
     "            # intercept\n",
     "            start_params[-2] = np.log(self.endog.mean())\n",
-    "        return super(NBin, self).fit(start_params=start_params, \n",
-    "                                     maxiter=maxiter, maxfun=maxfun, \n",
-    "                                     **kwds) "
+    "        return super(NBin, self).fit(start_params=start_params,\n",
+    "                                     maxiter=maxiter, maxfun=maxfun,\n",
+    "                                     **kwds)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Two important things to notice: \n",
+    "Two important things to notice:\n",
     "\n",
-    "+ ``nloglikeobs``: This function should return one evaluation of the negative log-likelihood function per observation in your dataset (i.e. rows of the endog/X matrix). \n",
+    "+ ``nloglikeobs``: This function should return one evaluation of the negative log-likelihood function per observation in your dataset (i.e. rows of the endog/X matrix).\n",
     "+ ``start_params``: A one-dimensional array of starting values needs to be provided. The size of this array determines the number of parameters that will be used in optimization.\n",
     "   \n",
     "That's it! You're done!\n",
@@ -291,7 +291,7 @@
     "The [Medpar](https://raw.githubusercontent.com/vincentarelbundock/Rdatasets/doc/COUNT/medpar.html)\n",
     "dataset is hosted in CSV format at the [Rdatasets repository](https://raw.githubusercontent.com/vincentarelbundock/Rdatasets). We use the ``read_csv``\n",
     "function from the [Pandas library](http://pandas.pydata.org) to load the data\n",
-    "in memory. We then print the first few columns: \n"
+    "in memory. We then print the first few columns:\n"
    ]
   },
   {
@@ -459,7 +459,7 @@
     "    url = 'https://raw.githubusercontent.com/vincentarelbundock/Rdatasets/csv/COUNT/medpar.csv'\n",
     "    medpar = read.csv(url)\n",
     "    f = los~factor(type)+hmo+white\n",
-    "    \n",
+    "\n",
     "    library(MASS)\n",
     "    mod = glm.nb(f, medpar)\n",
     "    coef(summary(mod))\n",
@@ -470,7 +470,7 @@
     "    hmo           -0.06795522 0.05321375 -1.277024  2.015939e-01\n",
     "    white         -0.12906544 0.06836272 -1.887951  5.903257e-02\n",
     "\n",
-    "### Numerical precision \n",
+    "### Numerical precision\n",
     "\n",
     "The ``statsmodels`` generic MLE and ``R`` parameter estimates agree up to the fourth decimal. The standard errors, however, agree only up to the second decimal. This discrepancy is the result of imprecision in our Hessian numerical estimates. In the current context, the difference between ``MASS`` and ``statsmodels`` standard error estimates is substantively irrelevant, but it highlights the fact that users who need very precise estimates may not always want to rely on default settings when using numerical derivatives. In such cases, it is better to use analytical derivatives with the ``LikelihoodModel`` class."
    ]

--- a/examples/notebooks/gls.ipynb
+++ b/examples/notebooks/gls.ipynb
@@ -25,7 +25,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The Longley dataset is a time series dataset: "
+    "The Longley dataset is a time series dataset:"
    ]
   },
   {
@@ -73,7 +73,7 @@
     "$\\epsilon_i = \\beta_0 + \\rho\\epsilon_{i-1} + \\eta_i$\n",
     "\n",
     "where $\\eta \\sim N(0,\\Sigma^2)$\n",
-    " \n",
+    "\n",
     "and that $\\rho$ is simply the correlation of the residual a consistent estimator for rho is to regress the residuals on the lagged residuals"
    ]
   },
@@ -166,7 +166,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Of course, the exact rho in this instance is not known so it it might make more sense to use feasible gls, which currently only has experimental support. \n",
+    "Of course, the exact rho in this instance is not known so it it might make more sense to use feasible gls, which currently only has experimental support.\n",
     "\n",
     "We can use the GLSAR model with one lag, to get to a similar result:"
    ]

--- a/examples/notebooks/ols.ipynb
+++ b/examples/notebooks/ols.ipynb
@@ -93,7 +93,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Quantities of interest can be extracted directly from the fitted model. Type ``dir(results)`` for a full list. Here are some examples:  "
+    "Quantities of interest can be extracted directly from the fitted model. Type ``dir(results)`` for a full list. Here are some examples:"
    ]
   },
   {
@@ -198,7 +198,7 @@
     "ax.plot(x, res.fittedvalues, 'r--.', label=\"OLS\")\n",
     "ax.plot(x, iv_u, 'r--')\n",
     "ax.plot(x, iv_l, 'r--')\n",
-    "ax.legend(loc='best');"
+    "ax.legend(loc='best')"
    ]
   },
   {
@@ -351,7 +351,7 @@
    "source": [
     "### Small group effects\n",
     "\n",
-    "If we generate artificial data with smaller group effects, the T test can no longer reject the Null hypothesis: "
+    "If we generate artificial data with smaller group effects, the T test can no longer reject the Null hypothesis:"
    ]
   },
   {
@@ -397,7 +397,7 @@
    "source": [
     "### Multicollinearity\n",
     "\n",
-    "The Longley dataset is well known to have high multicollinearity. That is, the exogenous predictors are highly correlated. This is problematic because it can affect the stability of our coefficient estimates as we make minor changes to model specification. "
+    "The Longley dataset is well known to have high multicollinearity. That is, the exogenous predictors are highly correlated. This is problematic because it can affect the stability of our coefficient estimates as we make minor changes to model specification."
    ]
   },
   {
@@ -440,7 +440,7 @@
    "source": [
     "#### Condition number\n",
     "\n",
-    "One way to assess multicollinearity is to compute the condition number. Values over 20 are worrisome (see Greene 4.9). The first step is to normalize the independent variables to have unit length: "
+    "One way to assess multicollinearity is to compute the condition number. Values over 20 are worrisome (see Greene 4.9). The first step is to normalize the independent variables to have unit length:"
    ]
   },
   {
@@ -463,7 +463,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Then, we take the square root of the ratio of the biggest to the smallest eigen values. "
+    "Then, we take the square root of the ratio of the biggest to the smallest eigenvalues."
    ]
   },
   {
@@ -485,7 +485,7 @@
    "source": [
     "#### Dropping an observation\n",
     "\n",
-    "Greene also points out that dropping a single observation can have a dramatic effect on the coefficient estimates: "
+    "Greene also points out that dropping a single observation can have a dramatic effect on the coefficient estimates:"
    ]
   },
   {

--- a/examples/notebooks/predict.ipynb
+++ b/examples/notebooks/predict.ipynb
@@ -51,7 +51,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Estimation "
+    "## Estimation"
    ]
   },
   {
@@ -129,7 +129,7 @@
     "ax.plot(x1, y, 'o', label=\"Data\")\n",
     "ax.plot(x1, y_true, 'b-', label=\"True\")\n",
     "ax.plot(np.hstack((x1, x1n)), np.hstack((ypred, ynewpred)), 'r', label=\"OLS prediction\")\n",
-    "ax.legend(loc=\"best\");"
+    "ax.legend(loc=\"best\")"
    ]
   },
   {

--- a/examples/notebooks/quantile_regression.ipynb
+++ b/examples/notebooks/quantile_regression.ipynb
@@ -143,7 +143,7 @@
     "for i in range(models.shape[0]):\n",
     "    y = get_y(models.a[i], models.b[i])\n",
     "    ax.plot(x, y, linestyle='dotted', color='grey')\n",
-    "    \n",
+    "\n",
     "y = get_y(ols['a'], ols['b'])\n",
     "\n",
     "ax.plot(x, y, color='red', label='OLS')\n",

--- a/examples/notebooks/regression_diagnostics.ipynb
+++ b/examples/notebooks/regression_diagnostics.ipynb
@@ -33,7 +33,6 @@
     "\n",
     "from __future__ import print_function\n",
     "from statsmodels.compat import lzip\n",
-    "import statsmodels\n",
     "import numpy as np\n",
     "import pandas as pd\n",
     "import statsmodels.formula.api as smf\n",
@@ -174,7 +173,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "name = ['Lagrange multiplier statistic', 'p-value', \n",
+    "name = ['Lagrange multiplier statistic', 'p-value',\n",
     "        'f-value', 'f p-value']\n",
     "test = sms.het_breushpagan(results.resid, results.model.exog)\n",
     "lzip(name, test)"

--- a/examples/notebooks/robust_models_0.ipynb
+++ b/examples/notebooks/robust_models_0.ipynb
@@ -144,7 +144,7 @@
    "source": [
     "### Example 1: quadratic function with linear truth\n",
     "\n",
-    "Note that the quadratic term in OLS regression will capture outlier effects. "
+    "Note that the quadratic term in OLS regression will capture outlier effects."
    ]
   },
   {
@@ -225,7 +225,7 @@
    },
    "outputs": [],
    "source": [
-    "X2 = X[:,[0,1]] \n",
+    "X2 = X[:, [0, 1]]\n",
     "res2 = sm.OLS(y2, X2).fit()\n",
     "print(res2.params)\n",
     "print(res2.bse)"

--- a/examples/notebooks/robust_models_1.ipynb
+++ b/examples/notebooks/robust_models_1.ipynb
@@ -28,14 +28,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "* An M-estimator minimizes the function \n",
+    "* An M-estimator minimizes the function\n",
     "\n",
     "$$Q(e_i, \\rho) = \\sum_i~\\rho \\left (\\frac{e_i}{s}\\right )$$\n",
     "\n",
-    "where $\\rho$ is a symmetric function of the residuals \n",
+    "where $\\rho$ is a symmetric function of the residuals\n",
     "\n",
     "* The effect of $\\rho$ is to reduce the influence of outliers\n",
-    "* $s$ is an estimate of scale. \n",
+    "* $s$ is an estimate of scale.\n",
     "* The robust estimates $\\hat{\\beta}$ are computed by the iteratively re-weighted least squares algorithm"
    ]
   },
@@ -96,7 +96,7 @@
     "a = 1.339\n",
     "support = np.linspace(-np.pi*a, np.pi*a, 100)\n",
     "andrew = norms.AndrewWave(a=a)\n",
-    "plot_weights(support, andrew.weights, ['$-\\pi*a$', '0', '$\\pi*a$'], [-np.pi*a, 0, np.pi*a]);"
+    "plot_weights(support, andrew.weights, ['$-\\pi*a$', '0', '$\\pi*a$'], [-np.pi*a, 0, np.pi*a])"
    ]
   },
   {
@@ -124,7 +124,7 @@
     "c = 8\n",
     "support = np.linspace(-3*c, 3*c, 1000)\n",
     "hampel = norms.Hampel(a=2., b=4., c=c)\n",
-    "plot_weights(support, hampel.weights, ['3*c', '0', '3*c'], [-3*c, 0, 3*c]);"
+    "plot_weights(support, hampel.weights, ['3*c', '0', '3*c'], [-3*c, 0, 3*c])"
    ]
   },
   {
@@ -152,7 +152,7 @@
     "t = 1.345\n",
     "support = np.linspace(-3*t, 3*t, 1000)\n",
     "huber = norms.HuberT(t=t)\n",
-    "plot_weights(support, huber.weights, ['-3*t', '0', '3*t'], [-3*t, 0, 3*t]);"
+    "plot_weights(support, huber.weights, ['-3*t', '0', '3*t'], [-3*t, 0, 3*t])"
    ]
   },
   {
@@ -179,7 +179,7 @@
    "source": [
     "support = np.linspace(-3, 3, 1000)\n",
     "lst_sq = norms.LeastSquares()\n",
-    "plot_weights(support, lst_sq.weights, ['-3', '0', '3'], [-3, 0, 3]);"
+    "plot_weights(support, lst_sq.weights, ['-3', '0', '3'], [-3, 0, 3])"
    ]
   },
   {
@@ -207,7 +207,7 @@
     "a = .3\n",
     "support = np.linspace(-3*a, 3*a, 1000)\n",
     "ramsay = norms.RamsayE(a=a)\n",
-    "plot_weights(support, ramsay.weights, ['-3*a', '0', '3*a'], [-3*a, 0, 3*a]);"
+    "plot_weights(support, ramsay.weights, ['-3*a', '0', '3*a'], [-3*a, 0, 3*a])"
    ]
   },
   {
@@ -235,7 +235,7 @@
     "c = 2\n",
     "support = np.linspace(-3*c, 3*c, 1000)\n",
     "trimmed = norms.TrimmedMean(c=c)\n",
-    "plot_weights(support, trimmed.weights, ['-3*c', '0', '3*c'], [-3*c, 0, 3*c]);"
+    "plot_weights(support, trimmed.weights, ['-3*c', '0', '3*c'], [-3*c, 0, 3*c])"
    ]
   },
   {
@@ -263,7 +263,7 @@
     "c = 4.685\n",
     "support = np.linspace(-3*c, 3*c, 1000)\n",
     "tukey = norms.TukeyBiweight(c=c)\n",
-    "plot_weights(support, tukey.weights, ['-3*c', '0', '3*c'], [-3*c, 0, 3*c]);"
+    "plot_weights(support, tukey.weights, ['-3*c', '0', '3*c'], [-3*c, 0, 3*c])"
    ]
   },
   {
@@ -424,7 +424,7 @@
     "kde.fit()\n",
     "fig = plt.figure(figsize=(12,8))\n",
     "ax = fig.add_subplot(111)\n",
-    "ax.plot(kde.support, kde.density);"
+    "ax.plot(kde.support, kde.density)"
    ]
   },
   {
@@ -540,7 +540,7 @@
     "ax1.annotate('Minister', xy_outlier, xy_outlier+1, fontsize=16)\n",
     "ax2 = fig.add_subplot(212, xlabel='Education',\n",
     "                           ylabel='Prestige')\n",
-    "ax2.scatter(prestige.education, prestige.prestige);"
+    "ax2.scatter(prestige.education, prestige.prestige)"
    ]
   },
   {
@@ -658,7 +658,7 @@
     "ax.scatter(*dta.values.T)\n",
     "# highlight outliers\n",
     "e = Ellipse((3.5, 6), .2, 1, alpha=.25, color='r')\n",
-    "ax.add_patch(e);\n",
+    "ax.add_patch(e)\n",
     "ax.annotate('Red giants', xy=(3.6, 6), xytext=(3.8, 6),\n",
     "            arrowprops=dict(facecolor='black', shrink=0.05, width=2),\n",
     "            horizontalalignment='left', verticalalignment='bottom',\n",
@@ -786,7 +786,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "* MM estimators are good for this type of problem, unfortunately, we don't yet have these yet. \n",
+    "* MM estimators are good for this type of problem, unfortunately, we don't yet have these yet.\n",
     "* It's being worked on, but it gives a good excuse to look at the R cell magics in the notebook."
    ]
   },

--- a/examples/notebooks/wls.ipynb
+++ b/examples/notebooks/wls.ipynb
@@ -33,7 +33,7 @@
    "source": [
     "## WLS Estimation\n",
     "\n",
-    "### Artificial data: Heteroscedasticity 2 groups \n",
+    "### Artificial data: Heteroscedasticity 2 groups\n",
     "\n",
     "Model assumptions:\n",
     "\n",
@@ -60,7 +60,7 @@
     "w[nsample * 6//10:] = 3\n",
     "y_true = np.dot(X, beta)\n",
     "e = np.random.normal(size=nsample)\n",
-    "y = y_true + sig * w * e \n",
+    "y = y_true + sig * w * e\n",
     "X = X[:,[0,1]]"
    ]
   },
@@ -92,7 +92,7 @@
    "source": [
     "## OLS vs. WLS\n",
     "\n",
-    "Estimate an OLS model for comparison: "
+    "Estimate an OLS model for comparison:"
    ]
   },
   {
@@ -123,7 +123,7 @@
    },
    "outputs": [],
    "source": [
-    "se = np.vstack([[res_wls.bse], [res_ols.bse], [res_ols.HC0_se], \n",
+    "se = np.vstack([[res_wls.bse], [res_ols.bse], [res_ols.HC0_se],\n",
     "                [res_ols.HC1_se], [res_ols.HC2_se], [res_ols.HC3_se]])\n",
     "se = np.round(se,4)\n",
     "colnames = ['x1', 'const']\n",
@@ -192,7 +192,7 @@
     "ax.plot(x, res_wls.fittedvalues, 'g--.')\n",
     "ax.plot(x, iv_u, 'g--', label=\"WLS\")\n",
     "ax.plot(x, iv_l, 'g--')\n",
-    "ax.legend(loc=\"best\");"
+    "ax.legend(loc=\"best\")"
    ]
   },
   {

--- a/examples/python/discrete_choice_example.py
+++ b/examples/python/discrete_choice_example.py
@@ -28,7 +28,7 @@ print(dta.head(10))
 print(dta.describe())
 
 
-affair_mod = logit("affair ~ occupation + educ + occupation_husb" 
+affair_mod = logit("affair ~ occupation + educ + occupation_husb"
                    "+ rate_marriage + age + yrs_married + children"
                    " + religious", dta).fit()
 
@@ -51,9 +51,9 @@ respondent1000 = dta.iloc[1000]
 print(respondent1000)
 
 
-resp = dict(zip(range(1,9), respondent1000[["occupation", "educ", 
-                                            "occupation_husb", "rate_marriage", 
-                                            "age", "yrs_married", "children", 
+resp = dict(zip(range(1,9), respondent1000[["occupation", "educ",
+                                            "occupation_husb", "rate_marriage",
+                                            "age", "yrs_married", "children",
                                             "religious"]].tolist()))
 resp.update({0 : 1})
 print(resp)
@@ -81,7 +81,7 @@ ax = fig.add_subplot(111)
 support = np.linspace(-6, 6, 1000)
 ax.plot(support, stats.logistic.cdf(support), 'r-', label='Logistic')
 ax.plot(support, stats.norm.cdf(support), label='Probit')
-ax.legend();
+ax.legend()
 
 
 fig = plt.figure(figsize=(12,8))
@@ -89,12 +89,12 @@ ax = fig.add_subplot(111)
 support = np.linspace(-6, 6, 1000)
 ax.plot(support, stats.logistic.pdf(support), 'r-', label='Logistic')
 ax.plot(support, stats.norm.pdf(support), label='Probit')
-ax.legend();
+ax.legend()
 
 
 # Compare the estimates of the Logit Fair model above to a Probit model. Does the prediction table look better? Much difference in marginal effects?
 
-#### Genarlized Linear Model Example
+#### Generalized Linear Model Example
 
 print(sm.datasets.star98.SOURCE)
 
@@ -137,7 +137,7 @@ glm_mod = glm(formula, dta, family=sm.families.Binomial()).fit()
 print(glm_mod.summary())
 
 
-# The number of trials 
+# The number of trials
 
 glm_mod.model.data.orig_endog.sum(1)
 
@@ -189,7 +189,7 @@ fig = abline_plot(model_results=y_vs_yhat, ax=ax)
 
 ##### Plot fitted values vs Pearson residuals
 
-# Pearson residuals are defined to be 
+# Pearson residuals are defined to be
 # 
 # $$\frac{(y - \mu)}{\sqrt{(var(\mu))}}$$
 # 
@@ -200,27 +200,27 @@ ax = fig.add_subplot(111, title='Residual Dependence Plot', xlabel='Fitted Value
                           ylabel='Pearson Residuals')
 ax.scatter(yhat, stats.zscore(glm_mod.resid_pearson))
 ax.axis('tight')
-ax.plot([0.0, 1.0],[0.0, 0.0], 'k-');
+ax.plot([0.0, 1.0],[0.0, 0.0], 'k-')
 
 
 ##### Histogram of standardized deviance residuals with Kernel Density Estimate overlayed
 
-# The definition of the deviance residuals depends on the family. For the Binomial distribution this is 
+# The definition of the deviance residuals depends on the family. For the Binomial distribution this is
 # 
 # $$r_{dev} = sign\(Y-\mu\)*\sqrt{2n(Y\log\frac{Y}{\mu}+(1-Y)\log\frac{(1-Y)}{(1-\mu)}}$$
 # 
 # They can be used to detect ill-fitting covariates
 
 resid = glm_mod.resid_deviance
-resid_std = stats.zscore(resid) 
+resid_std = stats.zscore(resid)
 kde_resid = sm.nonparametric.KDEUnivariate(resid_std)
 kde_resid.fit()
 
 
 fig = plt.figure(figsize=(12,8))
 ax = fig.add_subplot(111, title="Standardized Deviance Residuals")
-ax.hist(resid_std, bins=25, normed=True);
-ax.plot(kde_resid.support, kde_resid.density, 'r');
+ax.hist(resid_std, bins=25, normed=True)
+ax.plot(kde_resid.support, kde_resid.density, 'r')
 
 
 ##### QQ-plot of deviance residuals

--- a/examples/python/discrete_choice_overview.py
+++ b/examples/python/discrete_choice_overview.py
@@ -44,7 +44,7 @@ print(margeff.summary())
 print(logit_res.summary())
 
 
-# ## Probit Model 
+# ## Probit Model
 
 probit_mod = sm.Probit(spector_data.endog, spector_data.exog)
 probit_res = probit_mod.fit()
@@ -78,14 +78,14 @@ print(mlogit_res.params)
 
 # ## Poisson
 # 
-# Load the Rand data. Note that this example is similar to Cameron and Trivedi's `Microeconometrics` Table 20.5, but it is slightly different because of minor changes in the data. 
+# Load the Rand data. Note that this example is similar to Cameron and Trivedi's `Microeconometrics` Table 20.5, but it is slightly different because of minor changes in the data.
 
 rand_data = sm.datasets.randhie.load()
 rand_exog = rand_data.exog.view(float, type=np.ndarray).reshape(len(rand_data.exog), -1)
 rand_exog = sm.add_constant(rand_exog, prepend=False)
 
 
-# Fit Poisson model: 
+# Fit Poisson model:
 
 poisson_mod = sm.Poisson(rand_data.endog, rand_exog)
 poisson_res = poisson_mod.fit(method="newton")
@@ -94,7 +94,7 @@ print(poisson_res.summary())
 
 # ## Negative Binomial
 # 
-# The negative binomial model gives slightly different results. 
+# The negative binomial model gives slightly different results.
 
 mod_nbin = sm.NegativeBinomial(rand_data.endog, rand_exog)
 res_nbin = mod_nbin.fit(disp=False)
@@ -103,7 +103,7 @@ print(res_nbin.summary())
 
 # ## Alternative solvers
 # 
-# The default method for fitting discrete data MLE models is Newton-Raphson. You can use other solvers by using the ``method`` argument: 
+# The default method for fitting discrete data MLE models is Newton-Raphson. You can use other solvers by using the ``method`` argument:
 
 mlogit_res = mlogit_mod.fit(method='bfgs', maxiter=100)
 print(mlogit_res.summary())

--- a/examples/python/generic_mle.py
+++ b/examples/python/generic_mle.py
@@ -69,13 +69,13 @@ print(sm_probit_manual.cov_params())
 # log-likelihood (type NB-2) function expressed as:
 # 
 # $$
-#     \mathcal{L}(\beta_j; y, \alpha) = \sum_{i=1}^n y_i ln 
+#     \mathcal{L}(\beta_j; y, \alpha) = \sum_{i=1}^n y_i ln
 #     \left ( \frac{\alpha exp(X_i'\beta)}{1+\alpha exp(X_i'\beta)} \right ) -
 #     \frac{1}{\alpha} ln(1+\alpha exp(X_i'\beta)) + ln \Gamma (y_i + 1/\alpha) - ln \Gamma (y_i+1) - ln \Gamma (1/\alpha)
 # $$
 # 
 # with a matrix of regressors $X$, a vector of coefficients $\beta$,
-# and the negative binomial heterogeneity parameter $\alpha$. 
+# and the negative binomial heterogeneity parameter $\alpha$.
 # 
 # Using the ``nbinom`` distribution from ``scipy``, we can write this likelihood
 # simply as:
@@ -103,13 +103,13 @@ from statsmodels.base.model import GenericLikelihoodModel
 class NBin(GenericLikelihoodModel):
     def __init__(self, endog, exog, **kwds):
         super(NBin, self).__init__(endog, exog, **kwds)
-        
+
     def nloglikeobs(self, params):
         alph = params[-1]
         beta = params[:-1]
         ll = _ll_nb2(self.endog, self.exog, beta, alph)
-        return -ll 
-    
+        return -ll
+
     def fit(self, start_params=None, maxiter=10000, maxfun=5000, **kwds):
         # we have one additional parameter and we need to add it for summary
         self.exog_names.append('alpha')
@@ -118,16 +118,16 @@ class NBin(GenericLikelihoodModel):
             start_params = np.append(np.zeros(self.exog.shape[1]), .5)
             # intercept
             start_params[-2] = np.log(self.endog.mean())
-        return super(NBin, self).fit(start_params=start_params, 
-                                     maxiter=maxiter, maxfun=maxfun, 
-                                     **kwds) 
+        return super(NBin, self).fit(start_params=start_params,
+                                     maxiter=maxiter, maxfun=maxfun,
+                                     **kwds)
 
 
-# Two important things to notice: 
+# Two important things to notice:
 # 
-# + ``nloglikeobs``: This function should return one evaluation of the negative log-likelihood function per observation in your dataset (i.e. rows of the endog/X matrix). 
+# + ``nloglikeobs``: This function should return one evaluation of the negative log-likelihood function per observation in your dataset (i.e. rows of the endog/X matrix).
 # + ``start_params``: A one-dimensional array of starting values needs to be provided. The size of this array determines the number of parameters that will be used in optimization.
-#    
+# 
 # That's it! You're done!
 # 
 # ### Usage Example
@@ -135,7 +135,7 @@ class NBin(GenericLikelihoodModel):
 # The [Medpar](https://raw.githubusercontent.com/vincentarelbundock/Rdatasets/doc/COUNT/medpar.html)
 # dataset is hosted in CSV format at the [Rdatasets repository](https://raw.githubusercontent.com/vincentarelbundock/Rdatasets). We use the ``read_csv``
 # function from the [Pandas library](http://pandas.pydata.org) to load the data
-# in memory. We then print(the first few columns: 
+# in memory. We then print(the first few columns:
 # 
 
 import statsmodels.api as sm
@@ -157,7 +157,7 @@ X = medpar[["type2", "type3", "hmo", "white"]]
 X["constant"] = 1
 
 
-# Then, we fit the model and extract some information: 
+# Then, we fit the model and extract some information:
 
 mod = NBin(y, X)
 res = mod.fit()
@@ -197,7 +197,7 @@ print(res_nbin.bse)
 #     url = 'https://raw.githubusercontent.com/vincentarelbundock/Rdatasets/csv/COUNT/medpar.csv'
 #     medpar = read.csv(url)
 #     f = los~factor(type)+hmo+white
-#     
+# 
 #     library(MASS)
 #     mod = glm.nb(f, medpar)
 #     coef(summary(mod))
@@ -208,7 +208,7 @@ print(res_nbin.bse)
 #     hmo           -0.06795522 0.05321375 -1.277024  2.015939e-01
 #     white         -0.12906544 0.06836272 -1.887951  5.903257e-02
 # 
-# ### Numerical precision 
+# ### Numerical precision
 # 
 # The ``statsmodels`` generic MLE and ``R`` parameter estimates agree up to the fourth decimal. The standard errors, however, agree only up to the second decimal. This discrepancy is the result of imprecision in our Hessian numerical estimates. In the current context, the difference between ``MASS`` and ``statsmodels`` standard error estimates is substantively irrelevant, but it highlights the fact that users who need very precise estimates may not always want to rely on default settings when using numerical derivatives. In such cases, it is better to use analytical derivatives with the ``LikelihoodModel`` class.
 # 

--- a/examples/python/gls.py
+++ b/examples/python/gls.py
@@ -7,7 +7,7 @@ import numpy as np
 from statsmodels.iolib.table import (SimpleTable, default_txt_fmt)
 
 
-# The Longley dataset is a time series dataset: 
+# The Longley dataset is a time series dataset:
 
 data = sm.datasets.longley.load()
 data.exog = sm.add_constant(data.exog)
@@ -29,7 +29,7 @@ ols_resid = sm.OLS(data.endog, data.exog).fit().resid
 # $\epsilon_i = \beta_0 + \rho\epsilon_{i-1} + \eta_i$
 # 
 # where $\eta \sim N(0,\Sigma^2)$
-#  
+# 
 # and that $\rho$ is simply the correlation of the residual a consistent estimator for rho is to regress the residuals on the lagged residuals
 
 resid_fit = sm.OLS(ols_resid[1:], sm.add_constant(ols_resid[:-1])).fit()
@@ -62,7 +62,7 @@ gls_model = sm.GLS(data.endog, data.exog, sigma=sigma)
 gls_results = gls_model.fit()
 
 
-# Of course, the exact rho in this instance is not known so it it might make more sense to use feasible gls, which currently only has experimental support. 
+# Of course, the exact rho in this instance is not known so it it might make more sense to use feasible gls, which currently only has experimental support.
 # 
 # We can use the GLSAR model with one lag, to get to a similar result:
 

--- a/examples/python/ols.py
+++ b/examples/python/ols.py
@@ -40,7 +40,7 @@ results = model.fit()
 print(results.summary())
 
 
-# Quantities of interest can be extracted directly from the fitted model. Type ``dir(results)`` for a full list. Here are some examples:  
+# Quantities of interest can be extracted directly from the fitted model. Type ``dir(results)`` for a full list. Here are some examples:
 
 print('Parameters: ', results.params)
 print('R2: ', results.rsquared)
@@ -84,7 +84,7 @@ ax.plot(x, y_true, 'b-', label="True")
 ax.plot(x, res.fittedvalues, 'r--.', label="OLS")
 ax.plot(x, iv_u, 'r--')
 ax.plot(x, iv_l, 'r--')
-ax.legend(loc='best');
+ax.legend(loc='best')
 
 
 # ## OLS with dummy variables
@@ -155,7 +155,7 @@ print(res2.f_test("x2 = x3 = 0"))
 
 # ### Small group effects
 # 
-# If we generate artificial data with smaller group effects, the T test can no longer reject the Null hypothesis: 
+# If we generate artificial data with smaller group effects, the T test can no longer reject the Null hypothesis:
 
 beta = [1., 0.3, -0.0, 10]
 y_true = np.dot(X, beta)
@@ -172,7 +172,7 @@ print(res3.f_test("x2 = x3 = 0"))
 
 # ### Multicollinearity
 # 
-# The Longley dataset is well known to have high multicollinearity. That is, the exogenous predictors are highly correlated. This is problematic because it can affect the stability of our coefficient estimates as we make minor changes to model specification. 
+# The Longley dataset is well known to have high multicollinearity. That is, the exogenous predictors are highly correlated. This is problematic because it can affect the stability of our coefficient estimates as we make minor changes to model specification.
 
 from statsmodels.datasets.longley import load_pandas
 y = load_pandas().endog
@@ -189,7 +189,7 @@ print(ols_results.summary())
 
 # #### Condition number
 # 
-# One way to assess multicollinearity is to compute the condition number. Values over 20 are worrisome (see Greene 4.9). The first step is to normalize the independent variables to have unit length: 
+# One way to assess multicollinearity is to compute the condition number. Values over 20 are worrisome (see Greene 4.9). The first step is to normalize the independent variables to have unit length:
 
 for i, name in enumerate(X):
     if name == "const":
@@ -198,7 +198,7 @@ for i, name in enumerate(X):
 norm_xtx = np.dot(norm_x.T,norm_x)
 
 
-# Then, we take the square root of the ratio of the biggest to the smallest eigen values. 
+# Then, we take the square root of the ratio of the biggest to the smallest eigenvalues.
 
 eigs = np.linalg.eigvals(norm_xtx)
 condition_number = np.sqrt(eigs.max() / eigs.min())
@@ -207,7 +207,7 @@ print(condition_number)
 
 # #### Dropping an observation
 # 
-# Greene also points out that dropping a single observation can have a dramatic effect on the coefficient estimates: 
+# Greene also points out that dropping a single observation can have a dramatic effect on the coefficient estimates:
 
 ols_results2 = sm.OLS(y.iloc[:14], X.iloc[:14]).fit()
 print("Percentage change %4.2f%%\n"*7 % tuple([i for i in (ols_results2.params - ols_results.params)/ols_results.params*100]))

--- a/examples/python/predict.py
+++ b/examples/python/predict.py
@@ -18,7 +18,7 @@ y_true = np.dot(X, beta)
 y = y_true + sig * np.random.normal(size=nsample)
 
 
-# ## Estimation 
+# ## Estimation
 
 olsmod = sm.OLS(y, X)
 olsres = olsmod.fit()
@@ -48,7 +48,7 @@ fig, ax = plt.subplots()
 ax.plot(x1, y, 'o', label="Data")
 ax.plot(x1, y_true, 'b-', label="True")
 ax.plot(np.hstack((x1, x1n)), np.hstack((ypred, ynewpred)), 'r', label="OLS prediction")
-ax.legend(loc="best");
+ax.legend(loc="best")
 
 
 ### Predicting with Formulas

--- a/examples/python/quantile_regression.py
+++ b/examples/python/quantile_regression.py
@@ -78,7 +78,7 @@ get_y = lambda a, b: a + b * x
 for i in range(models.shape[0]):
     y = get_y(models.a[i], models.b[i])
     plt.plot(x, y, linestyle='dotted', color='grey')
-    
+
 y = get_y(ols['a'], ols['b'])
 plt.plot(x, y, color='red', label='OLS')
 

--- a/examples/python/regression_diagnostics.py
+++ b/examples/python/regression_diagnostics.py
@@ -9,7 +9,6 @@
 
 from __future__ import print_function
 from statsmodels.compat import lzip
-import statsmodels
 import numpy as np
 import pandas as pd
 import statsmodels.formula.api as smf
@@ -72,7 +71,7 @@ np.linalg.cond(results.model.exog)
 # 
 # Breush-Pagan test:
 
-name = ['Lagrange multiplier statistic', 'p-value', 
+name = ['Lagrange multiplier statistic', 'p-value',
         'f-value', 'f p-value']
 test = sms.het_breushpagan(results.resid, results.model.exog)
 lzip(name, test)

--- a/examples/python/robust_models_0.py
+++ b/examples/python/robust_models_0.py
@@ -59,7 +59,7 @@ y2[[39,41,43,45,48]] -= 5   # add some outliers (10% of nsample)
 
 # ### Example 1: quadratic function with linear truth
 # 
-# Note that the quadratic term in OLS regression will capture outlier effects. 
+# Note that the quadratic term in OLS regression will capture outlier effects.
 
 res = sm.OLS(y2, X).fit()
 print(res.params)
@@ -92,7 +92,7 @@ ax.legend(loc="best")
 # 
 # Fit a new OLS model using only the linear term and the constant:
 
-X2 = X[:,[0,1]] 
+X2 = X[:, [0, 1]]
 res2 = sm.OLS(y2, X2).fit()
 print(res2.params)
 print(res2.bse)

--- a/examples/python/robust_models_1.py
+++ b/examples/python/robust_models_1.py
@@ -7,17 +7,16 @@ from scipy import stats
 import matplotlib.pyplot as plt
 
 import statsmodels.api as sm
-from statsmodels.compat.pandas import sort_values
 
 
-# * An M-estimator minimizes the function 
+# * An M-estimator minimizes the function
 # 
 # $$Q(e_i, \rho) = \sum_i~\rho \left (\frac{e_i}{s}\right )$$
 # 
-# where $\rho$ is a symmetric function of the residuals 
+# where $\rho$ is a symmetric function of the residuals
 # 
 # * The effect of $\rho$ is to reduce the influence of outliers
-# * $s$ is an estimate of scale. 
+# * $s$ is an estimate of scale.
 # * The robust estimates $\hat{\beta}$ are computed by the iteratively re-weighted least squares algorithm
 
 # * We have several choices available for the weighting functions to be used
@@ -43,7 +42,7 @@ help(norms.AndrewWave.weights)
 a = 1.339
 support = np.linspace(-np.pi*a, np.pi*a, 100)
 andrew = norms.AndrewWave(a=a)
-plot_weights(support, andrew.weights, ['$-\pi*a$', '0', '$\pi*a$'], [-np.pi*a, 0, np.pi*a]);
+plot_weights(support, andrew.weights, ['$-\pi*a$', '0', '$\pi*a$'], [-np.pi*a, 0, np.pi*a])
 
 
 #### Hampel's 17A
@@ -54,7 +53,7 @@ help(norms.Hampel.weights)
 c = 8
 support = np.linspace(-3*c, 3*c, 1000)
 hampel = norms.Hampel(a=2., b=4., c=c)
-plot_weights(support, hampel.weights, ['3*c', '0', '3*c'], [-3*c, 0, 3*c]);
+plot_weights(support, hampel.weights, ['3*c', '0', '3*c'], [-3*c, 0, 3*c])
 
 
 #### Huber's t
@@ -65,7 +64,7 @@ help(norms.HuberT.weights)
 t = 1.345
 support = np.linspace(-3*t, 3*t, 1000)
 huber = norms.HuberT(t=t)
-plot_weights(support, huber.weights, ['-3*t', '0', '3*t'], [-3*t, 0, 3*t]);
+plot_weights(support, huber.weights, ['-3*t', '0', '3*t'], [-3*t, 0, 3*t])
 
 
 #### Least Squares
@@ -75,7 +74,7 @@ help(norms.LeastSquares.weights)
 
 support = np.linspace(-3, 3, 1000)
 lst_sq = norms.LeastSquares()
-plot_weights(support, lst_sq.weights, ['-3', '0', '3'], [-3, 0, 3]);
+plot_weights(support, lst_sq.weights, ['-3', '0', '3'], [-3, 0, 3])
 
 
 #### Ramsay's Ea
@@ -86,7 +85,7 @@ help(norms.RamsayE.weights)
 a = .3
 support = np.linspace(-3*a, 3*a, 1000)
 ramsay = norms.RamsayE(a=a)
-plot_weights(support, ramsay.weights, ['-3*a', '0', '3*a'], [-3*a, 0, 3*a]);
+plot_weights(support, ramsay.weights, ['-3*a', '0', '3*a'], [-3*a, 0, 3*a])
 
 
 #### Trimmed Mean
@@ -97,7 +96,7 @@ help(norms.TrimmedMean.weights)
 c = 2
 support = np.linspace(-3*c, 3*c, 1000)
 trimmed = norms.TrimmedMean(c=c)
-plot_weights(support, trimmed.weights, ['-3*c', '0', '3*c'], [-3*c, 0, 3*c]);
+plot_weights(support, trimmed.weights, ['-3*c', '0', '3*c'], [-3*c, 0, 3*c])
 
 
 #### Tukey's Biweight
@@ -108,7 +107,7 @@ help(norms.TukeyBiweight.weights)
 c = 4.685
 support = np.linspace(-3*c, 3*c, 1000)
 tukey = norms.TukeyBiweight(c=c)
-plot_weights(support, tukey.weights, ['-3*c', '0', '3*c'], [-3*c, 0, 3*c]);
+plot_weights(support, tukey.weights, ['-3*c', '0', '3*c'], [-3*c, 0, 3*c])
 
 
 #### Scale Estimators
@@ -169,7 +168,7 @@ kde = sm.nonparametric.KDE(fat_tails)
 kde.fit()
 fig = plt.figure(figsize=(12,8))
 ax = fig.add_subplot(111)
-ax.plot(kde.support, kde.density);
+ax.plot(kde.support, kde.density)
 
 
 print(fat_tails.mean(), fat_tails.std())
@@ -214,7 +213,7 @@ xy_outlier = prestige.loc['minister'][['income','prestige']]
 ax1.annotate('Minister', xy_outlier, xy_outlier+1, fontsize=16)
 ax2 = fig.add_subplot(212, xlabel='Education',
                            ylabel='Prestige')
-ax2.scatter(prestige.education, prestige.prestige);
+ax2.scatter(prestige.education, prestige.prestige)
 
 
 ols_model = ols('prestige ~ income + education', prestige).fit()
@@ -233,12 +232,12 @@ print(infl.summary_frame().loc['minister'])
 
 
 sidak = ols_model.outlier_test('sidak')
-sort_values(sidak, 'unadj_p', inplace=True)
+sidak.sort_values('unadj_p', inplace=True)
 print(sidak)
 
 
 fdr = ols_model.outlier_test('fdr_bh')
-sort_values(fdr, 'unadj_p', inplace=True)
+fdr.sort_values('unadj_p', inplace=True)
 print(fdr)
 
 
@@ -262,7 +261,7 @@ ax = fig.add_subplot(111, xlabel='log(Temp)', ylabel='log(Light)', title='Hertzs
 ax.scatter(*dta.values.T)
 # highlight outliers
 e = Ellipse((3.5, 6), .2, 1, alpha=.25, color='r')
-ax.add_patch(e);
+ax.add_patch(e)
 ax.annotate('Red giants', xy=(3.6, 6), xytext=(3.8, 6),
             arrowprops=dict(facecolor='black', shrink=0.05, width=2),
             horizontalalignment='left', verticalalignment='bottom',
@@ -300,12 +299,12 @@ hat_diag.loc[hat_diag > h_bar]
 
 
 sidak2 = ols_model.outlier_test('sidak')
-sort_values(sidak2, 'unadj_p', inplace=True)
+sidak2.sort_values('unadj_p', inplace=True)
 print(sidak2)
 
 
 fdr2 = ols_model.outlier_test('fdr_bh')
-sort_values(fdr2, 'unadj_p', inplace=True)
+fdr2.sort_values('unadj_p', inplace=True)
 print(fdr2)
 
 
@@ -320,7 +319,7 @@ wls_model = sm.WLS(y, X, weights=weights).fit()
 abline_plot(model_results=wls_model, ax=ax, color='green')
 
 
-# * MM estimators are good for this type of problem, unfortunately, we don't yet have these yet. 
+# * MM estimators are good for this type of problem, unfortunately, we don't yet have these yet.
 # * It's being worked on, but it gives a good excuse to look at the R cell magics in the notebook.
 
 yy = y.values[:,None]

--- a/examples/python/wls.py
+++ b/examples/python/wls.py
@@ -12,7 +12,7 @@ np.random.seed(1024)
 
 # ## WLS Estimation
 # 
-# ### Artificial data: Heteroscedasticity 2 groups 
+# ### Artificial data: Heteroscedasticity 2 groups
 # 
 # Model assumptions:
 # 
@@ -30,7 +30,7 @@ w = np.ones(nsample)
 w[nsample * 6/10:] = 3
 y_true = np.dot(X, beta)
 e = np.random.normal(size=nsample)
-y = y_true + sig * w * e 
+y = y_true + sig * w * e
 X = X[:,[0,1]]
 
 
@@ -43,7 +43,7 @@ print(res_wls.summary())
 
 # ## OLS vs. WLS
 # 
-# Estimate an OLS model for comparison: 
+# Estimate an OLS model for comparison:
 
 res_ols = sm.OLS(y, X).fit()
 print(res_ols.params)
@@ -52,7 +52,7 @@ print(res_wls.params)
 
 # Compare the WLS standard errors to  heteroscedasticity corrected OLS standard errors:
 
-se = np.vstack([[res_wls.bse], [res_ols.bse], [res_ols.HC0_se], 
+se = np.vstack([[res_wls.bse], [res_ols.bse], [res_ols.HC0_se],
                 [res_ols.HC1_se], [res_ols.HC2_se], [res_ols.HC3_se]])
 se = np.round(se,4)
 colnames = ['x1', 'const']
@@ -87,7 +87,7 @@ ax.plot(x, iv_l_ols, 'r--')
 ax.plot(x, res_wls.fittedvalues, 'g--.')
 ax.plot(x, iv_u, 'g--', label="WLS")
 ax.plot(x, iv_l, 'g--')
-ax.legend(loc="best");
+ax.legend(loc="best")
 
 
 # ## Feasible Weighted Least Squares (2-stage FWLS)


### PR DESCRIPTION
This gets the bits that can be gotten directly in the ipynb files.  For some of it I now need to look at nbgenerate.py and see where extraneous whitespace is getting added.

Also removed some unnecessary semicolons.

Longer-term I'm pretty sure the way to keep these in sync is to only generate the py files at test+release time.