### PR TITLE
CLN: remove unused imports in tools, sm.tsa

### DIFF
--- a/statsmodels/tsa/api.py
+++ b/statsmodels/tsa/api.py
@@ -1,6 +1,7 @@
 __all__ = ["AR", "ARMA", "ARIMA",
            "var", "VAR", "VECM", "SVAR", "DynamicVAR",
            "filters",
+           "innovations",
            "tsatools",
            "add_trend", "detrend", "lagmat", "lagmat2ds", "add_lag",
            "interp",

--- a/statsmodels/tsa/api.py
+++ b/statsmodels/tsa/api.py
@@ -1,3 +1,23 @@
+__all__ = ["AR", "ARMA", "ARIMA",
+           "var", "VAR", "VECM", "SVAR", "DynamicVAR",
+           "filters",
+           "tsatools",
+           "add_trend", "detrend", "lagmat", "lagmat2ds", "add_lag",
+           "interp",
+           "stattools",
+           "acovf", "acf", "pacf", "pacf_yw", "pacf_ols", "ccovf", "ccf",
+           "periodogram", "q_stat", "coint", "arma_order_select_ic",
+           "adfuller", "kpss", "bds",
+           "datetools",
+           "seasonal_decompose",
+           "graphics",
+           "x13_arima_select_order", "x13_arima_analysis",
+           "statespace",
+           "SARIMAX", "UnobservedComponents", "VARMAX", "DynamicFactor",
+           "MarkovRegression", "MarkovAutoregression",
+           "ExponentialSmoothing", "SimpleExpSmoothing", "Holt",
+           "arma_generate_sample", "ArmaProcess"]
+
 from .ar_model import AR
 from .arima_model import ARMA, ARIMA
 from . import vector_ar as var

--- a/statsmodels/tsa/ar_model.py
+++ b/statsmodels/tsa/ar_model.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import division
-from statsmodels.compat.python import iteritems, range, string_types, lmap, long
+from statsmodels.compat.python import iteritems, range, lmap
 
 import numpy as np
 from numpy import dot, identity

--- a/statsmodels/tsa/filters/api.py
+++ b/statsmodels/tsa/filters/api.py
@@ -1,3 +1,5 @@
+__all__ = ["bkfilter", "hpfilter", "cffilter", "miso_lfilter",
+           "convolution_filter", "recursive_filter"]
 from .bk_filter import bkfilter
 from .hp_filter import hpfilter
 from .cf_filter import cffilter

--- a/statsmodels/tsa/interp/__init__.py
+++ b/statsmodels/tsa/interp/__init__.py
@@ -1,1 +1,2 @@
+__all__ = ["dentonm"]
 from .denton import dentonm

--- a/statsmodels/tsa/tests/test_arima.py
+++ b/statsmodels/tsa/tests/test_arima.py
@@ -1852,7 +1852,6 @@ def test_bad_start_params():
 
 def test_arima_small_data_bug():
     # Issue 1038, too few observations with given order
-    from datetime import datetime
     import statsmodels.api as sm
 
     vals = [96.2, 98.3, 99.1, 95.5, 94.0, 87.1, 87.9, 86.7402777504474]
@@ -1866,7 +1865,6 @@ def test_arima_small_data_bug():
 
 def test_arima_dataframe_integer_name():
     # Smoke Test for Issue 1038
-    from datetime import datetime
     import statsmodels.api as sm
 
     vals = [96.2, 98.3, 99.1, 95.5, 94.0, 87.1, 87.9, 86.7402777504474,

--- a/statsmodels/tsa/tests/test_arima_process.py
+++ b/statsmodels/tsa/tests/test_arima_process.py
@@ -1,11 +1,8 @@
 from statsmodels.compat.python import range
 
-from distutils.version import LooseVersion
-
 from statsmodels.tsa.arima_model import ARMA
 from unittest import TestCase
 
-import pytest
 import numpy as np
 from numpy.testing import (assert_array_almost_equal, assert_almost_equal,
                            assert_allclose,

--- a/statsmodels/tsa/vector_ar/api.py
+++ b/statsmodels/tsa/vector_ar/api.py
@@ -1,5 +1,5 @@
 # pylint: disable=W0611
-
+__all__ = ["VAR", "SVAR", "DynamicVAR"]
 from .var_model import VAR
 from .svar_model import SVAR
 from .dynamic import DynamicVAR

--- a/statsmodels/tsa/vector_ar/irf.py
+++ b/statsmodels/tsa/vector_ar/irf.py
@@ -9,7 +9,6 @@ import numpy as np
 import numpy.linalg as la
 import scipy.linalg as L
 
-from scipy import stats
 
 from statsmodels.tools.decorators import cache_readonly
 from statsmodels.tools.tools import chain_dot

--- a/statsmodels/tsa/vector_ar/output.py
+++ b/statsmodels/tsa/vector_ar/output.py
@@ -1,9 +1,8 @@
 from __future__ import print_function
-from statsmodels.compat.python import cStringIO, lzip, lrange, StringIO, range
+from statsmodels.compat.python import lzip, StringIO, range
 import numpy as np
 
 from statsmodels.iolib import SimpleTable
-import statsmodels.tsa.vector_ar.util as util
 
 mat = np.array
 

--- a/statsmodels/tsa/vector_ar/tests/results/results_svar.py
+++ b/statsmodels/tsa/vector_ar/tests/results/results_svar.py
@@ -2,8 +2,6 @@
 Test Results for the SVAR model. Obtained from R using svartest.R
 """
 
-import numpy as np
-
 
 class SVARdataResults(object):
     def __init__(self):

--- a/statsmodels/tsa/vector_ar/tests/test_svar.py
+++ b/statsmodels/tsa/vector_ar/tests/test_svar.py
@@ -4,10 +4,8 @@ Test SVAR estimation
 
 import statsmodels.api as sm
 from statsmodels.tsa.vector_ar.svar_model import SVAR
-from numpy.testing import assert_almost_equal, assert_equal, assert_allclose
-from .results import results_svar
+from numpy.testing import assert_almost_equal, assert_allclose
 import numpy as np
-import numpy.testing as npt
 
 DECIMAL_6 = 6
 DECIMAL_5 = 5

--- a/statsmodels/tsa/vector_ar/util.py
+++ b/statsmodels/tsa/vector_ar/util.py
@@ -124,7 +124,6 @@ def parse_lutkepohl_data(path): # pragma: no cover
 
     from collections import deque
     from datetime import datetime
-    import pandas
     import re
 
     regex = re.compile(asbytes(r'<(.*) (\w)([\d]+)>.*'))

--- a/tools/code_maintenance.py
+++ b/tools/code_maintenance.py
@@ -3,7 +3,6 @@
 Code maintenance script modified from PyMC
 """
 
-import sys
 import os
 
 # This is a function, not a test case, because it has to be run from inside

--- a/tools/examples_rst.py
+++ b/tools/examples_rst.py
@@ -140,7 +140,6 @@ def restify(example_file, filehash, fname):
 
 if __name__ == "__main__":
     sys.path.insert(0, example_dir)
-    from run_all import filelist
     sys.path.remove(example_dir)
 
     if not os.path.exists(docs_rst_dir):

--- a/tools/github_stats.py
+++ b/tools/github_stats.py
@@ -10,8 +10,6 @@ https://github.com/ipython/ipython/blob/master/tools/github_stats.py
 
 from __future__ import print_function
 
-import json
-import re
 import sys
 
 from datetime import datetime, timedelta


### PR DESCRIPTION
Avoids results files that _might_ be auto-generated pending longer-term solution.

Avoids statespace which has other outstanding PRs.

Avoids a couple other files that need more in-depth excavation.