### PR TITLE
MAINT: fix generated double whitespace

### DIFF
--- a/statsmodels/discrete/tests/results/results_count_margins.py
+++ b/statsmodels/discrete/tests/results/results_count_margins.py
@@ -78,7 +78,7 @@ margins_cov_rownames = 'sincome sperpoverty sperblack LN_VC100k96 south sdegree 
 class Bunch(dict):
     def __init__(self, **kw):
         dict.__init__(self, kw)
-        self.__dict__  = self
+        self.__dict__ = self
 
         for i,att in enumerate(['params', 'bse', 'tvalues', 'pvalues']):
             self[att] = self.margins_table[:,i]

--- a/statsmodels/discrete/tests/results/results_count_robust_cluster.py
+++ b/statsmodels/discrete/tests/results/results_count_robust_cluster.py
@@ -64,7 +64,7 @@ cov_rownames = 'yr_con op_75_79 _cons'.split()
 class Bunch(dict):
     def __init__(self, **kw):
         dict.__init__(self, kw)
-        self.__dict__  = self
+        self.__dict__ = self
 
         for i,att in enumerate(['params', 'bse', 'tvalues', 'pvalues']):
             self[att] = self.params_table[:,i]

--- a/statsmodels/discrete/tests/results/results_glm_logit_constrained.py
+++ b/statsmodels/discrete/tests/results/results_glm_logit_constrained.py
@@ -100,7 +100,7 @@ infocrit_rownames = '.'.split()
 class Bunch(dict):
     def __init__(self, **kw):
         dict.__init__(self, kw)
-        self.__dict__  = self
+        self.__dict__ = self
 
         for i,att in enumerate(['params', 'bse', 'tvalues', 'pvalues']):
             self[att] = self.params_table[:,i]

--- a/statsmodels/discrete/tests/results/results_poisson_constrained.py
+++ b/statsmodels/discrete/tests/results/results_poisson_constrained.py
@@ -3,7 +3,7 @@ import numpy as np
 class Bunch(dict):
     def __init__(self, **kw):
         dict.__init__(self, kw)
-        self.__dict__  = self
+        self.__dict__ = self
 
         for i,att in enumerate(['params', 'bse', 'tvalues', 'pvalues']):
             self[att] = self.params_table[:,i]

--- a/statsmodels/genmod/tests/results/res_R_var_weight.py
+++ b/statsmodels/genmod/tests/results/res_R_var_weight.py
@@ -10,7 +10,7 @@ dir_path = os.path.dirname(path)
 class Bunch(dict):
     def __init__(self, **kw):
         dict.__init__(self, kw)
-        self.__dict__  = self
+        self.__dict__ = self
 
 res = dict() 
 res['params'] = np.array([0.74699331283637471213, -0.031592165334818442246, -0.021959412079720418837,

--- a/statsmodels/genmod/tests/results/results_glm_poisson_weights.py
+++ b/statsmodels/genmod/tests/results/results_glm_poisson_weights.py
@@ -165,7 +165,7 @@ resids_rownames = 'r1 r2 r3 r4 r5 r6 r7 r8 r9 r10 r11 r12 r13 r14 r15 r16 r17'.s
 class Bunch(dict):
     def __init__(self, **kw):
         dict.__init__(self, kw)
-        self.__dict__  = self
+        self.__dict__ = self
 
         for i,att in enumerate(['params', 'bse', 'tvalues', 'pvalues']):
             self[att] = self.params_table[:,i]

--- a/statsmodels/regression/tests/results/macro_gr_corc_stata.py
+++ b/statsmodels/regression/tests/results/macro_gr_corc_stata.py
@@ -494,7 +494,7 @@ fittedvalues_se_rownames = 'r1 r2 r3 r4 r5 r6 r7 r8 r9 r10 r11 r12 r13 r14 r15 r
 class Bunch(dict):
     def __init__(self, **kw):
         dict.__init__(self, kw)
-        self.__dict__  = self
+        self.__dict__ = self
 
         for i,att in enumerate(['params', 'bse', 'tvalues', 'pvalues']):
             self[att] = self.params_table[:,i]

--- a/statsmodels/regression/tests/results/results_grunfeld_ols_robust_cluster.py
+++ b/statsmodels/regression/tests/results/results_grunfeld_ols_robust_cluster.py
@@ -4,7 +4,7 @@ import numpy as np
 class Bunch(dict):
     def __init__(self, **kw):
         dict.__init__(self, kw)
-        self.__dict__  = self
+        self.__dict__ = self
 
         for i,att in enumerate(['params', 'bse', 'tvalues', 'pvalues']):
             self[att] = self.params_table[:,i]

--- a/statsmodels/regression/tests/results/results_macro_ols_robust.py
+++ b/statsmodels/regression/tests/results/results_macro_ols_robust.py
@@ -55,7 +55,7 @@ cov_rownames = 'g_realgdp L.realint _cons'.split()
 class Bunch(dict):
     def __init__(self, **kw):
         dict.__init__(self, kw)
-        self.__dict__  = self
+        self.__dict__ = self
 
         for i,att in enumerate(['params', 'bse', 'tvalues', 'pvalues']):
             self[att] = self.params_table[:,i]

--- a/statsmodels/regression/tests/results/results_theil_textile.py
+++ b/statsmodels/regression/tests/results/results_theil_textile.py
@@ -53,7 +53,7 @@ cov_prior_rownames = 'lincome lprice _cons'.split()
 class Bunch(dict):
     def __init__(self, **kw):
         dict.__init__(self, kw)
-        self.__dict__  = self
+        self.__dict__ = self
 
         for i,att in enumerate(['params', 'bse', 'tvalues', 'pvalues']):
             self[att] = self.params_table[:,i]

--- a/statsmodels/regression/tests/results_quantile_regression.py
+++ b/statsmodels/regression/tests/results_quantile_regression.py
@@ -2,7 +2,7 @@ import numpy as np
 class Bunch(dict):
     def __init__(self, **kw):
         dict.__init__(self, kw)
-        self.__dict__  = self
+        self.__dict__ = self
 
 epanechnikov_hsheather_q75 = Bunch()
 epanechnikov_hsheather_q75.table = np.array([

--- a/statsmodels/sandbox/regression/tests/results_gmm_griliches.py
+++ b/statsmodels/sandbox/regression/tests/results_gmm_griliches.py
@@ -130,7 +130,7 @@ cov_rownames = '_cons _cons _cons _cons _cons _cons _cons _cons _cons _cons _con
 class Bunch(dict):
     def __init__(self, **kw):
         dict.__init__(self, kw)
-        self.__dict__  = self
+        self.__dict__ = self
 
         for i,att in enumerate(['params', 'bse', 'tvalues', 'pvalues']):
             self[att] = self.params_table[:,i]

--- a/statsmodels/sandbox/regression/tests/results_gmm_griliches_iter.py
+++ b/statsmodels/sandbox/regression/tests/results_gmm_griliches_iter.py
@@ -124,7 +124,7 @@ cov_rownames = '_cons _cons _cons _cons _cons _cons _cons _cons _cons _cons _con
 class Bunch(dict):
     def __init__(self, **kw):
         dict.__init__(self, kw)
-        self.__dict__  = self
+        self.__dict__ = self
 
         for i,att in enumerate(['params', 'bse', 'tvalues', 'pvalues']):
             self[att] = self.params_table[:,i]

--- a/statsmodels/sandbox/regression/tests/results_gmm_poisson.py
+++ b/statsmodels/sandbox/regression/tests/results_gmm_poisson.py
@@ -86,7 +86,7 @@ cov_rownames = '_cons _cons _cons _cons _cons _cons _cons _cons'.split()
 class Bunch(dict):
     def __init__(self, **kw):
         dict.__init__(self, kw)
-        self.__dict__  = self
+        self.__dict__ = self
 
         for i,att in enumerate(['params', 'bse', 'tvalues', 'pvalues']):
             self[att] = self.params_table[:,i]

--- a/statsmodels/sandbox/regression/tests/results_ivreg2_griliches.py
+++ b/statsmodels/sandbox/regression/tests/results_ivreg2_griliches.py
@@ -145,7 +145,7 @@ cov_rownames = 's iq expr tenure rns smsa dyear_67 dyear_68 dyear_69 dyear_70 dy
 class Bunch(dict):
     def __init__(self, **kw):
         dict.__init__(self, kw)
-        self.__dict__  = self
+        self.__dict__ = self
 
         for i,att in enumerate(['params', 'bse', 'tvalues', 'pvalues']):
             self[att] = self.params_table[:,i]
@@ -307,7 +307,7 @@ cov_rownames = 's iq expr tenure rns smsa dyear_67 dyear_68 dyear_69 dyear_70 dy
 class Bunch(dict):
     def __init__(self, **kw):
         dict.__init__(self, kw)
-        self.__dict__  = self
+        self.__dict__ = self
 
         for i,att in enumerate(['params', 'bse', 'tvalues', 'pvalues']):
             self[att] = self.params_table[:,i]
@@ -472,7 +472,7 @@ cov_rownames = 's iq expr tenure rns smsa dyear_67 dyear_68 dyear_69 dyear_70 dy
 class Bunch(dict):
     def __init__(self, **kw):
         dict.__init__(self, kw)
-        self.__dict__  = self
+        self.__dict__ = self
 
         for i,att in enumerate(['params', 'bse', 'tvalues', 'pvalues']):
             self[att] = self.params_table[:,i]
@@ -649,7 +649,7 @@ cov_rownames = 's iq expr tenure rns smsa dyear_67 dyear_68 dyear_69 dyear_70 dy
 class Bunch(dict):
     def __init__(self, **kw):
         dict.__init__(self, kw)
-        self.__dict__  = self
+        self.__dict__ = self
 
         for i,att in enumerate(['params', 'bse', 'tvalues', 'pvalues']):
             self[att] = self.params_table[:,i]
@@ -811,7 +811,7 @@ cov_rownames = 's iq expr tenure rns smsa dyear_67 dyear_68 dyear_69 dyear_70 dy
 class Bunch(dict):
     def __init__(self, **kw):
         dict.__init__(self, kw)
-        self.__dict__  = self
+        self.__dict__ = self
 
         for i,att in enumerate(['params', 'bse', 'tvalues', 'pvalues']):
             self[att] = self.params_table[:,i]

--- a/statsmodels/stats/inter_rater.py
+++ b/statsmodels/stats/inter_rater.py
@@ -46,7 +46,7 @@ class ResultsBunch(dict):
 
     def __init__(self, **kwds):
         dict.__init__(self, kwds)
-        self.__dict__  = self
+        self.__dict__ = self
         self._initialize()
 
     def _initialize(self):

--- a/statsmodels/stats/tests/results/results_panelrobust.py
+++ b/statsmodels/stats/tests/results/results_panelrobust.py
@@ -73,7 +73,7 @@ cov_dk4_stata = np.array([ .00018052657317,
 class Bunch(dict):
     def __init__(self, **kw):
         dict.__init__(self, kw)
-        self.__dict__  = self
+        self.__dict__ = self
 
 
 results = Bunch(cov_clu_stata=cov_clu_stata, cov_pnw0_stata=cov_pnw0_stata, cov_pnw1_stata=cov_pnw1_stata, cov_pnw4_stata=cov_pnw4_stata, cov_dk0_stata=cov_dk0_stata, cov_dk1_stata=cov_dk1_stata, cov_dk4_stata=cov_dk4_stata, )

--- a/statsmodels/tsa/tests/results/arima111_css_results.py
+++ b/statsmodels/tsa/tests/results/arima111_css_results.py
@@ -1275,7 +1275,7 @@ icstats = np.array([             202,
 class Bunch(dict):
     def __init__(self, **kw):
         dict.__init__(self, kw)
-        self.__dict__  = self
+        self.__dict__ = self
 
 
 results = Bunch(llf=llf, nobs=nobs, k=k, k_exog=k_exog, sigma=sigma, chi2=chi2, df_model=df_model, k_ar=k_ar, k_ma=k_ma, params=params, cov_params=cov_params, xb=xb, y=y, resid=resid, yr=yr, mse=mse, stdp=stdp, icstats=icstats, )

--- a/statsmodels/tsa/tests/results/arima111_results.py
+++ b/statsmodels/tsa/tests/results/arima111_results.py
@@ -1275,7 +1275,7 @@ icstats = np.array([             202,
 class Bunch(dict):
     def __init__(self, **kw):
         dict.__init__(self, kw)
-        self.__dict__  = self
+        self.__dict__ = self
 
 
 results = Bunch(llf=llf, nobs=nobs, k=k, k_exog=k_exog, sigma=sigma, chi2=chi2, df_model=df_model, k_ar=k_ar, k_ma=k_ma, params=params, cov_params=cov_params, xb=xb, y=y, resid=resid, yr=yr, mse=mse, stdp=stdp, icstats=icstats, )

--- a/statsmodels/tsa/tests/results/arima111nc_css_results.py
+++ b/statsmodels/tsa/tests/results/arima111nc_css_results.py
@@ -1267,7 +1267,7 @@ icstats = np.array([             202,
 class Bunch(dict):
     def __init__(self, **kw):
         dict.__init__(self, kw)
-        self.__dict__  = self
+        self.__dict__ = self
 
 
 results = Bunch(llf=llf, nobs=nobs, k=k, k_exog=k_exog, sigma=sigma, chi2=chi2, df_model=df_model, k_ar=k_ar, k_ma=k_ma, params=params, cov_params=cov_params, xb=xb, y=y, resid=resid, yr=yr, mse=mse, stdp=stdp, icstats=icstats, )

--- a/statsmodels/tsa/tests/results/arima111nc_results.py
+++ b/statsmodels/tsa/tests/results/arima111nc_results.py
@@ -1267,7 +1267,7 @@ icstats = np.array([             202,
 class Bunch(dict):
     def __init__(self, **kw):
         dict.__init__(self, kw)
-        self.__dict__  = self
+        self.__dict__ = self
 
 
 results = Bunch(llf=llf, nobs=nobs, k=k, k_exog=k_exog, sigma=sigma, chi2=chi2, df_model=df_model, k_ar=k_ar, k_ma=k_ma, params=params, cov_params=cov_params, xb=xb, y=y, resid=resid, yr=yr, mse=mse, stdp=stdp, icstats=icstats, )

--- a/statsmodels/tsa/tests/results/arima112_css_results.py
+++ b/statsmodels/tsa/tests/results/arima112_css_results.py
@@ -1285,7 +1285,7 @@ icstats = np.array([             202,
 class Bunch(dict):
     def __init__(self, **kw):
         dict.__init__(self, kw)
-        self.__dict__  = self
+        self.__dict__ = self
 
 
 results = Bunch(llf=llf, nobs=nobs, k=k, k_exog=k_exog, sigma=sigma, chi2=chi2, df_model=df_model, k_ar=k_ar, k_ma=k_ma, params=params, cov_params=cov_params, xb=xb, y=y, resid=resid, yr=yr, mse=mse, stdp=stdp, icstats=icstats, )

--- a/statsmodels/tsa/tests/results/arima112_results.py
+++ b/statsmodels/tsa/tests/results/arima112_results.py
@@ -1285,7 +1285,7 @@ icstats = np.array([             202,
 class Bunch(dict):
     def __init__(self, **kw):
         dict.__init__(self, kw)
-        self.__dict__  = self
+        self.__dict__ = self
 
 
 results = Bunch(llf=llf, nobs=nobs, k=k, k_exog=k_exog, sigma=sigma, chi2=chi2, df_model=df_model, k_ar=k_ar, k_ma=k_ma, params=params, cov_params=cov_params, xb=xb, y=y, resid=resid, yr=yr, mse=mse, stdp=stdp, icstats=icstats, )

--- a/statsmodels/tsa/tests/results/arima112nc_css_results.py
+++ b/statsmodels/tsa/tests/results/arima112nc_css_results.py
@@ -1275,7 +1275,7 @@ icstats = np.array([             202,
 class Bunch(dict):
     def __init__(self, **kw):
         dict.__init__(self, kw)
-        self.__dict__  = self
+        self.__dict__ = self
 
 
 results = Bunch(llf=llf, nobs=nobs, k=k, k_exog=k_exog, sigma=sigma, chi2=chi2, df_model=df_model, k_ar=k_ar, k_ma=k_ma, params=params, cov_params=cov_params, xb=xb, y=y, resid=resid, yr=yr, mse=mse, stdp=stdp, icstats=icstats, )

--- a/statsmodels/tsa/tests/results/arima112nc_results.py
+++ b/statsmodels/tsa/tests/results/arima112nc_results.py
@@ -1071,7 +1071,7 @@ icstats = np.array([             202,
 class Bunch(dict):
     def __init__(self, **kw):
         dict.__init__(self, kw)
-        self.__dict__  = self
+        self.__dict__ = self
 
 
 results = Bunch(llf=llf, nobs=nobs, k=k, k_exog=k_exog, sigma=sigma, chi2=chi2, df_model=df_model, k_ar=k_ar, k_ma=k_ma, params=params, cov_params=cov_params, xb=xb, y=y, resid=resid, yr=yr, mse=mse, icstats=icstats, )

--- a/statsmodels/tsa/tests/results/arima211_css_results.py
+++ b/statsmodels/tsa/tests/results/arima211_css_results.py
@@ -1285,7 +1285,7 @@ icstats = np.array([             202,
 class Bunch(dict):
     def __init__(self, **kw):
         dict.__init__(self, kw)
-        self.__dict__  = self
+        self.__dict__ = self
 
 
 results = Bunch(llf=llf, nobs=nobs, k=k, k_exog=k_exog, sigma=sigma, chi2=chi2, df_model=df_model, k_ar=k_ar, k_ma=k_ma, params=params, cov_params=cov_params, xb=xb, y=y, resid=resid, yr=yr, mse=mse, stdp=stdp, icstats=icstats, )

--- a/statsmodels/tsa/tests/results/arima211_results.py
+++ b/statsmodels/tsa/tests/results/arima211_results.py
@@ -1285,7 +1285,7 @@ icstats = np.array([             202,
 class Bunch(dict):
     def __init__(self, **kw):
         dict.__init__(self, kw)
-        self.__dict__  = self
+        self.__dict__ = self
 
 
 results = Bunch(llf=llf, nobs=nobs, k=k, k_exog=k_exog, sigma=sigma, chi2=chi2, df_model=df_model, k_ar=k_ar, k_ma=k_ma, params=params, cov_params=cov_params, xb=xb, y=y, resid=resid, yr=yr, mse=mse, stdp=stdp, icstats=icstats, )

--- a/statsmodels/tsa/tests/results/arima211nc_css_results.py
+++ b/statsmodels/tsa/tests/results/arima211nc_css_results.py
@@ -1275,7 +1275,7 @@ icstats = np.array([             202,
 class Bunch(dict):
     def __init__(self, **kw):
         dict.__init__(self, kw)
-        self.__dict__  = self
+        self.__dict__ = self
 
 
 results = Bunch(llf=llf, nobs=nobs, k=k, k_exog=k_exog, sigma=sigma, chi2=chi2, df_model=df_model, k_ar=k_ar, k_ma=k_ma, params=params, cov_params=cov_params, xb=xb, y=y, resid=resid, yr=yr, mse=mse, stdp=stdp, icstats=icstats, )

--- a/statsmodels/tsa/tests/results/arima211nc_results.py
+++ b/statsmodels/tsa/tests/results/arima211nc_results.py
@@ -1071,7 +1071,7 @@ icstats = np.array([             202,
 class Bunch(dict):
     def __init__(self, **kw):
         dict.__init__(self, kw)
-        self.__dict__  = self
+        self.__dict__ = self
 
 
 results = Bunch(llf=llf, nobs=nobs, k=k, k_exog=k_exog, sigma=sigma, chi2=chi2, df_model=df_model, k_ar=k_ar, k_ma=k_ma, params=params, cov_params=cov_params, xb=xb, y=y, resid=resid, yr=yr, mse=mse, icstats=icstats, )

--- a/statsmodels/tsa/vector_ar/tests/results/results_svar_st.py
+++ b/statsmodels/tsa/vector_ar/tests/results/results_svar_st.py
@@ -4,7 +4,7 @@ import numpy as np
 class Bunch(dict):
     def __init__(self, **kw):
         dict.__init__(self, kw)
-        self.__dict__  = self
+        self.__dict__ = self
 
         for i,att in enumerate(['params', 'bse', 'tvalues', 'pvalues']):
             self[att] = self.params_table[:,i]

--- a/tools/R2nparray/R/R2nparray.R
+++ b/tools/R2nparray/R/R2nparray.R
@@ -189,7 +189,7 @@ import numpy as np
 class Bunch(dict):
     def __init__(self, **kw):
         dict.__init__(self, kw)
-        self.__dict__  = self
+        self.__dict__ = self
 
 "
 write_header = function(){

--- a/tools/estmat2nparray.ado
+++ b/tools/estmat2nparray.ado
@@ -53,7 +53,7 @@ program define estmat2nparray
     file write `myfile' "class Bunch(dict):" _n
     file write `myfile' "    def __init__(self, **kw):" _n
     file write `myfile' "        dict.__init__(self, kw)" _n
-    file write `myfile' "        self.__dict__  = self" _n _n
+    file write `myfile' "        self.__dict__ = self" _n _n
 
 	if "`noest'" == "" {
 		file write `myfile' "        for i,att in enumerate(['params', 'bse', 'tvalues', 'pvalues']):" _n


### PR DESCRIPTION
R2nparray.R and estmat2nparray.ado currently add an extra space before an `=`.  This removes that extra space in the generating files and all of the affected files.