### PR TITLE
TST: apply stacklevel to warning in Family.__init__

### DIFF
--- a/statsmodels/genmod/families/family.py
+++ b/statsmodels/genmod/families/family.py
@@ -78,7 +78,9 @@ class Family(object):
             warnmssg = "Calling Family(..) with a link class as argument "
             warnmssg += "is deprecated.\n"
             warnmssg += "Use an instance of a link class instead."
-            warnings.warn(warnmssg, category=DeprecationWarning)
+            lvl = 2 if type(self) is Family else 3
+            warnings.warn(warnmssg,
+                          category=DeprecationWarning, stacklevel=lvl)
             self.link = link()
         else:
             self.link = link

--- a/statsmodels/genmod/tests/results/results_glm.py
+++ b/statsmodels/genmod/tests/results/results_glm.py
@@ -1162,7 +1162,7 @@ class InvGauss(object):
 #        hyperbolic random variables seems to be the canonical ref
 #        Y = np.dot(X,params) + np.random.wald(mu, sigma, 1000)
 #        model = GLM(Y, X, family=models.family.InverseGaussian(link=\
-#            models.family.links.identity))
+#            models.family.links.identity()))
 
     def __init__(self):
         # set up data #

--- a/statsmodels/genmod/tests/test_gee_glm.py
+++ b/statsmodels/genmod/tests/test_gee_glm.py
@@ -115,7 +115,7 @@ class TestCompareGamma(CheckGEEGLM):
     def setup_class(cls):
         # adjusted for Gamma, not in test_gee.py
         vs = Independence()
-        family = families.Gamma(link=links.log)
+        family = families.Gamma(link=links.log())
         np.random.seed(987126)
         #Y = np.random.normal(size=100)**2
         Y = np.exp(0.1 + np.random.normal(size=100))   # log-normal


### PR DESCRIPTION
`Family.__init__` warns if the `link` given is a class instead of an instance.  That warning showed up in the CI, but did not have a useful line number attached to it to tell me where it came from.  To fix that going forward, this sets the appropriate `stacklevel` in the issued warning.

Then tracks down the couple of places where the tests used the deprecated call and updates them.

Then I went to de-duplicate an import of `cpunish` in the vicinity of that last fixup, which ended up touching a bunch of `test_glm`.  Here's hoping the fixes here earn enough leeway...
