### PR TITLE
CLN: Use cache_readonly instead of OneTimeProperty

### DIFF
--- a/statsmodels/sandbox/archive/linalg_covmat.py
+++ b/statsmodels/sandbox/archive/linalg_covmat.py
@@ -75,7 +75,7 @@ class AffineTransform(object):
         return - self.logabsdet + self.dist.logpdf(self.invtransform(x))
 
 
-from .linalg_decomp_1 import SvdArray, OneTimeProperty
+from .linalg_decomp_1 import SvdArray
 
 
 class MultivariateNormalChol(object):

--- a/statsmodels/sandbox/archive/linalg_decomp_1.py
+++ b/statsmodels/sandbox/archive/linalg_decomp_1.py
@@ -26,7 +26,7 @@ from __future__ import print_function
 import numpy as np
 from scipy import linalg
 
-from statsmodels.tools.decorators import OneTimeProperty
+from statsmodels.tools.decorators import cache_readonly
 
 
 class PlainMatrixArray(object):
@@ -52,22 +52,21 @@ class PlainMatrixArray(object):
         else:
             raise ValueError('either data or sym need to be given')
 
-    @OneTimeProperty
+    @cache_readonly
     def minv(self):
         return np.linalg.inv(self.m)
 
-    @OneTimeProperty
     def m_y(self, y):
         return np.dot(self.m, y)
 
     def minv_y(self, y):
         return np.dot(self.minv, y)
 
-    @OneTimeProperty
+    @cache_readonly
     def mpinv(self):
         return linalg.pinv(self.m)
 
-    @OneTimeProperty
+    @cache_readonly
     def xpinv(self):
         return linalg.pinv(self.x)
 
@@ -84,28 +83,28 @@ class PlainMatrixArray(object):
     def y_minv_yt(self, y):
         return np.dot(y, np.dot(self.minv, y.T))
 
-    @OneTimeProperty
+    @cache_readonly
     def mdet(self):
         return linalg.det(self.m)
 
-    @OneTimeProperty
+    @cache_readonly
     def mlogdet(self):
         return np.log(linalg.det(self.m))
 
-    @OneTimeProperty
+    @cache_readonly
     def meigh(self):
         evals, evecs = linalg.eigh(self.m)
         sortind = np.argsort(evals)[::-1]
         return evals[sortind], evecs[:,sortind]
 
-    @OneTimeProperty
+    @cache_readonly
     def mhalf(self):
         evals, evecs = self.meigh
         return np.dot(np.diag(evals**0.5), evecs.T)
         #return np.dot(evecs, np.dot(np.diag(evals**0.5), evecs.T))
         #return np.dot(evecs, 1./np.sqrt(evals) * evecs.T))
 
-    @OneTimeProperty
+    @cache_readonly
     def minvhalf(self):
         evals, evecs = self.meigh
         return np.dot(evecs, 1./np.sqrt(evals) * evecs.T)
@@ -132,35 +131,34 @@ class SvdArray(PlainMatrixArray):
     def _sdiagpow(self, p):
         return linalg.diagsvd(np.power(self.s, p), *x.shape)
 
-    @OneTimeProperty
+    @cache_readonly
     def minv(self):
         sinvv = np.dot(self.sinvdiag, self.v)
         return np.dot(sinvv.T, sinvv)
 
-
-    @OneTimeProperty
+    @cache_readonly
     def meigh(self):
         evecs = self.v.T
         evals = self.s**2
         return evals, evecs
 
-    @OneTimeProperty
+    @cache_readonly
     def mdet(self):
         return self.meigh[0].prod()
 
-    @OneTimeProperty
+    @cache_readonly
     def mlogdet(self):
         return np.log(self.meigh[0]).sum()
 
-    @OneTimeProperty
+    @cache_readonly
     def mhalf(self):
         return np.dot(np.diag(self.s), self.v)
 
-    @OneTimeProperty
+    @cache_readonly
     def xxthalf(self):
         return np.dot(self.u, self.sdiag)
 
-    @OneTimeProperty
+    @cache_readonly
     def xxtinvhalf(self):
         return np.dot(self.u, self.sinvdiag)
 

--- a/statsmodels/sandbox/tsa/fftarma.py
+++ b/statsmodels/sandbox/tsa/fftarma.py
@@ -35,7 +35,6 @@ import numpy.fft as fft
 #import scipy.fftpack as fft
 from scipy import signal
 #from try_var_convolve import maxabs
-from statsmodels.sandbox.archive.linalg_decomp_1 import OneTimeProperty
 from statsmodels.tsa.arima_process import ArmaProcess
 
 
@@ -165,7 +164,6 @@ class ArmaFft(ArmaProcess):
             n = len(self.ar)
         return fft.fft(self.padarr(self.ma, n))
 
-    #@OneTimeProperty  # not while still debugging things
     def fftarma(self, n=None):
         '''Fourier transform of ARMA polynomial, zero-padded at end to n
 

--- a/statsmodels/stats/weightstats.py
+++ b/statsmodels/stats/weightstats.py
@@ -36,7 +36,7 @@ compared yet.
 import numpy as np
 from scipy import stats
 
-from statsmodels.tools.decorators import OneTimeProperty
+from statsmodels.tools.decorators import cache_readonly
 
 
 class DescrStatsW(object):
@@ -106,37 +106,37 @@ class DescrStatsW(object):
         if weights is None:
             self.weights = np.ones(self.data.shape[0])
         else:
-            #why squeeze?
+            # TODO: why squeeze?
             self.weights = np.asarray(weights).squeeze().astype(float)
         self.ddof = ddof
 
 
-    @OneTimeProperty
+    @cache_readonly
     def sum_weights(self):
         return self.weights.sum(0)
 
-    @OneTimeProperty
+    @cache_readonly
     def nobs(self):
         '''alias for number of observations/cases, equal to sum of weights
         '''
         return self.sum_weights
 
-    @OneTimeProperty
+    @cache_readonly
     def sum(self):
         '''weighted sum of data'''
         return np.dot(self.data.T, self.weights)
 
-    @OneTimeProperty
+    @cache_readonly
     def mean(self):
         '''weighted mean of data'''
         return self.sum / self.sum_weights
 
-    @OneTimeProperty
+    @cache_readonly
     def demeaned(self):
         '''data with weighted mean subtracted'''
         return self.data - self.mean
 
-    @OneTimeProperty
+    @cache_readonly
     def sumsquares(self):
         '''weighted sum of squares of demeaned data'''
         return np.dot((self.demeaned**2).T, self.weights)
@@ -172,13 +172,13 @@ class DescrStatsW(object):
         '''
         return np.sqrt(self.var_ddof(ddof=ddof))
 
-    @OneTimeProperty
+    @cache_readonly
     def var(self):
         '''variance with default degrees of freedom correction
         '''
         return self.sumsquares / (self.sum_weights - self.ddof)
 
-    @OneTimeProperty
+    @cache_readonly
     def _var(self):
         '''variance without degrees of freedom correction
 
@@ -186,13 +186,13 @@ class DescrStatsW(object):
         '''
         return self.sumsquares / self.sum_weights
 
-    @OneTimeProperty
+    @cache_readonly
     def std(self):
         '''standard deviation with default degrees of freedom correction
         '''
         return np.sqrt(self.var)
 
-    @OneTimeProperty
+    @cache_readonly
     def cov(self):
         '''weighted covariance of data if data is 2 dimensional
 
@@ -203,7 +203,7 @@ class DescrStatsW(object):
         cov_ /= (self.sum_weights - self.ddof)
         return cov_
 
-    @OneTimeProperty
+    @cache_readonly
     def corrcoef(self):
         '''weighted correlation with default ddof
 
@@ -211,7 +211,7 @@ class DescrStatsW(object):
         '''
         return self.cov / self.std / self.std[:,None]
 
-    @OneTimeProperty
+    @cache_readonly
     def std_mean(self):
         '''standard deviation of weighted mean
         '''
@@ -814,14 +814,14 @@ class CompareMeans(object):
                 alpha=alpha, use_t=use_t, yname=yname, xname=xname,
                 title=title)
 
-    @OneTimeProperty
+    @cache_readonly
     def std_meandiff_separatevar(self):
         #this uses ``_var`` to use ddof=0 for formula
         d1 = self.d1
         d2 = self.d2
         return np.sqrt(d1._var / (d1.nobs-1) + d2._var / (d2.nobs-1))
 
-    @OneTimeProperty
+    @cache_readonly
     def std_meandiff_pooledvar(self):
         '''variance assuming equal variance in both data sets
 

--- a/statsmodels/tools/decorators.py
+++ b/statsmodels/tools/decorators.py
@@ -146,48 +146,6 @@ class cache_writable(_cache_readonly):
                                        resetlist=self.resetlist)
 
 
-# this has been copied from nitime a long time ago
-# TODO: ceck whether class has change in nitime
-class OneTimeProperty(object):
-    """
-    A descriptor to make special properties that become normal attributes.
-
-    This is meant to be used mostly by the auto_attr decorator in this module.
-    Author: Fernando Perez, copied from nitime
-    """
-    def __init__(self, func):
-
-        """Create a OneTimeProperty instance.
-
-         Parameters
-         ----------
-           func : method
-
-             The method that will be called the first time to compute a value.
-             Afterwards, the method's name will be a standard attribute holding
-             the value of this computation.
-             """
-        self.getter = func
-        self.name = func.__name__
-
-    def __get__(self, obj, type=None):
-        """
-        This will be called on attribute access on the class or instance.
-        """
-
-        if obj is None:
-            # Being called on the class, return the original function.
-            # This way, introspection works on the class.
-            # return func
-            # print('class access')
-            return self.getter
-
-        val = self.getter(obj)
-        # print("** auto_attr - loading '%s'" % self.name  # dbg)
-        setattr(obj, self.name, val)
-        return val
-
-
 def nottest(fn):
     fn.__test__ = False
     return fn


### PR DESCRIPTION
fix usage of OneTimeProperty that would be incorrect, specifically one that had more than just `self` as an argument.