### PR TITLE
CLN: remove identical functions

### DIFF
--- a/statsmodels/sandbox/tsa/garch.py
+++ b/statsmodels/sandbox/tsa/garch.py
@@ -84,6 +84,7 @@ import matplotlib.pyplot as plt
 import numdifftools as ndt
 
 from statsmodels.base.model import Model, LikelihoodModelResults
+from statsmodels.tsa.filters.filtertools import miso_lfilter
 from statsmodels.sandbox import tsa
 
 
@@ -1027,70 +1028,6 @@ def loglike_GARCH11(params, y):
 
     llvalues = -0.5*np.log(2*np.pi) - np.log(sqrtht) - 0.5*(x**2);
     return llvalues.sum(), llvalues, ht
-
-from statsmodels.tsa.filters.filtertools import miso_lfilter
-#copied to statsmodels.tsa.filters.filtertools
-def miso_lfilter_old(ar, ma, x, useic=False): #[0.1,0.1]):
-    '''
-    use nd convolution to merge inputs,
-    then use lfilter to produce output
-
-    arguments for column variables
-    return currently 1d
-
-    Parameters
-    ----------
-    ar : array_like, 1d, float
-        autoregressive lag polynomial including lag zero, ar(L)y_t
-    ma : array_like, same ndim as x, currently 2d
-        moving average lag polynomial ma(L)x_t
-    x : array_like, 2d
-        input data series, time in rows, variables in columns
-
-    Returns
-    -------
-    y : array, 1d
-        filtered output series
-    inp : array, 1d
-        combined input series
-
-    Notes
-    -----
-    currently for 2d inputs only, no choice of axis
-    Use of signal.lfilter requires that ar lag polynomial contains
-    floating point numbers
-    does not cut off invalid starting and final values
-
-    miso_lfilter find array y such that::
-
-            ar(L)y_t = ma(L)x_t
-
-    with shapes y (nobs,), x (nobs,nvars), ar (narlags,), ma (narlags,nvars)
-
-    '''
-    ma = np.asarray(ma)
-    ar = np.asarray(ar)
-    #inp = signal.convolve(x, ma, mode='valid')
-    #inp = signal.convolve(x, ma)[:, (x.shape[1]+1)//2]
-    #Note: convolve mixes up the variable left-right flip
-    #I only want the flip in time direction
-    #this might also be a mistake or problem in other code where I
-    #switched from correlate to convolve
-    # correct convolve version, for use with fftconvolve in other cases
-    inp2 = signal.convolve(x, ma[:,::-1])[:, (x.shape[1]+1)//2]
-    inp = signal.correlate(x, ma[::-1,:])[:, (x.shape[1]+1)//2]
-    assert_almost_equal(inp2, inp)
-    nobs = x.shape[0]
-    # cut of extra values at end
-
-    #todo initialize also x for correlate
-    if useic:
-        return signal.lfilter([1], ar, inp,
-                #zi=signal.lfilter_ic(np.array([1.,0.]),ar, ic))[0][:nobs], inp[:nobs]
-                zi=signal.lfiltic(np.array([1.,0.]),ar, useic))[0][:nobs], inp[:nobs]
-    else:
-        return signal.lfilter([1], ar, inp)[:nobs], inp[:nobs]
-    #return signal.lfilter([1], ar, inp), inp
 
 
 def test_misofilter():

--- a/statsmodels/sandbox/tsa/try_var_convolve.py
+++ b/statsmodels/sandbox/tsa/try_var_convolve.py
@@ -18,7 +18,8 @@ import numpy as np
 from numpy.testing import assert_equal
 from scipy import signal
 from scipy.signal.signaltools import _centered as trim_centered
-_centered = trim_centered
+
+from statsmodels.tsa.filters.filtertools import fftconvolveinv as fftconvolve
 
 
 x = np.arange(40).reshape((2,20)).T
@@ -45,9 +46,8 @@ print(trim_centered(y, x.shape))
 assert_equal(yvalid[:,0], y0.ravel())
 assert_equal(yvalid[:,1], y1.ravel())
 
-from statsmodels.tsa.filters import arfilter
-#copied/moved to statsmodels.tsa.filters
-def arfilter_old(x, a):
+
+def arfilter(x, a):
     '''apply an autoregressive filter to a series x
 
     x can be 2d, a can be 1d, 2d, or 3d
@@ -148,49 +148,6 @@ from scipy.fftpack import fft, ifft, ifftshift, fft2, ifft2, fftn, \
      ifftn, fftfreq
 from numpy import product,array
 
-from statsmodels.tsa.filters.filtertools import fftconvolveinv as fftconvolve
-#copied/moved to statsmodels.tsa.filters
-def fftconvolve_old(in1, in2, in3=None, mode="full"):
-    """Convolve two N-dimensional arrays using FFT. See convolve.
-
-    copied from scipy.signal.signaltools, but here used to try out inverse filter
-    doesn't work or I can't get it to work
-
-     2010-10-23:
-    looks ok to me for 1d,
-    from results below with padded data array (fftp)
-    but it doesn't work for multidimensional inverse filter (fftn)
-    original signal.fftconvolve also uses fftn
-
-    """
-    s1 = array(in1.shape)
-    s2 = array(in2.shape)
-    complex_result = (np.issubdtype(in1.dtype, np.complex) or
-                      np.issubdtype(in2.dtype, np.complex))
-    size = s1+s2-1
-
-    # Always use 2**n-sized FFT
-    fsize = 2**np.ceil(np.log2(size))
-    IN1 = fftn(in1,fsize)
-    #IN1 *= fftn(in2,fsize) #JP: this looks like the only change I made
-    IN1 /= fftn(in2,fsize)  # use inverse filter
-    # note the inverse is elementwise not matrix inverse
-    # is this correct, NO  doesn't seem to work for VARMA
-    fslice = tuple([slice(0, int(sz)) for sz in size])
-    ret = ifftn(IN1)[fslice].copy()
-    del IN1
-    if not complex_result:
-        ret = ret.real
-    if mode == "full":
-        return ret
-    elif mode == "same":
-        if product(s1,axis=0) > product(s2,axis=0):
-            osize = s1
-        else:
-            osize = s2
-        return _centered(ret,osize)
-    elif mode == "valid":
-        return _centered(ret,abs(s2-s1)+1)
 
 yff = fftconvolve(x.astype(float)[:,:,None],a3f)
 

--- a/statsmodels/tsa/filters/filtertools.py
+++ b/statsmodels/tsa/filters/filtertools.py
@@ -308,8 +308,7 @@ def convolution_filter(x, filt, nsides=2):
     return result
 
 
-#copied from sandbox.tsa.garch
-def miso_lfilter(ar, ma, x, useic=False): #[0.1,0.1]):
+def miso_lfilter(ar, ma, x, useic=False):
     '''
     use nd convolution to merge inputs,
     then use lfilter to produce output


### PR DESCRIPTION
garch.miso_lfilter_old is identical - up to 3 lines being commented-out in the non-sandbox version (which needs cleanup, but not today) - with filtertools.miso_lfilter.  Keeping it around makes it harder to salvage useful code.

garch.test_misofilter is a promising candidate to become useful (at the moment there appear to be no tests for miso_lfilter in filters.tests).  The test fails at the moment, looks like conventions about open/closed endpoints may have changed.  Once this goes through I'll try to salvage the test.

try_var_convolve. fftconvolve_old is identical to filtertools. fftconvolveinv, serves no positive purpose.