### PR TITLE
TST: Remove __main__ sections in tests

### DIFF
--- a/statsmodels/base/tests/test_data.py
+++ b/statsmodels/base/tests/test_data.py
@@ -910,8 +910,3 @@ def test_raise_nonfinite_exog():
     assert_raises(MissingDataError, OLS, y, x)
     x[1, 1] = np.nan
     assert_raises(MissingDataError, OLS, y, x)
-
-
-if __name__ == "__main__":
-    import pytest
-    pytest.main([__file__, '-vvs', '-x', '--pdb'])

--- a/statsmodels/base/tests/test_shrink_pickle.py
+++ b/statsmodels/base/tests/test_shrink_pickle.py
@@ -284,19 +284,3 @@ class TestRemoveDataPicklePoissonRegularized(RemoveDataPickle):
         y_count = np.random.poisson(np.exp(x.sum(1) - x.mean()))
         model = sm.Poisson(y_count, x)
         self.results = model.fit_regularized(method='l1', disp=0, alpha=10)
-
-
-if __name__ == '__main__':
-    for cls in [TestRemoveDataPickleOLS, TestRemoveDataPickleWLS,
-                TestRemoveDataPicklePoisson,
-                TestRemoveDataPicklePoissonRegularized,
-                TestRemoveDataPickleNegativeBinomial,
-                TestRemoveDataPickleLogit, TestRemoveDataPickleRLM,
-                TestRemoveDataPickleGLM]:
-        print(cls)
-        cls.setup_class()
-        tt = cls()
-        tt.setup()
-        tt.test_remove_data_pickle()
-        tt.test_remove_data_docstring()
-        tt.test_pickle_wrapper()

--- a/statsmodels/compat/tests/test_itercompat.py
+++ b/statsmodels/compat/tests/test_itercompat.py
@@ -34,10 +34,3 @@ def test_combinations():
     actual = list(combinations(lrange(4), 3))
     desired = [(0, 1, 2), (0, 1, 3), (0, 2, 3), (1, 2, 3)]
     assert_(actual == desired, '%r not equal %r' % (actual, desired))
-
-
-
-
-if __name__ == '__main__':
-    test_zip_longest()
-    test_combinations()

--- a/statsmodels/discrete/tests/test_discrete.py
+++ b/statsmodels/discrete/tests/test_discrete.py
@@ -2376,8 +2376,3 @@ def test_unchanging_degrees_of_freedom():
     # Test that the call to `fit_regularized` didn't modify model.df_model inplace.
     assert_equal(res3.df_model, res1.df_model)
     assert_equal(res3.df_resid, res1.df_resid)
-
-
-if __name__ == "__main__":
-    import pytest
-    pytest.main([__file__, '-vvs', '-x', '--pdb'])

--- a/statsmodels/discrete/tests/test_sandwich_cov.py
+++ b/statsmodels/discrete/tests/test_sandwich_cov.py
@@ -722,13 +722,3 @@ class TestGLMGaussHACGroupsum(CheckDiscreteGLM):
     def test_kwd(self):
         # test corrected keyword name
         assert_allclose(self.res1b.bse, self.res1.bse, rtol=1e-12)
-
-
-
-if __name__ == '__main__':
-    tt = TestPoissonClu()
-    tt.setup_class()
-    tt.test_basic()
-    tt = TestNegbinClu()
-    tt.setup_class()
-    tt.test_basic()

--- a/statsmodels/distributions/tests/test_discrete.py
+++ b/statsmodels/distributions/tests/test_discrete.py
@@ -109,7 +109,3 @@ class TestZiNBP(object):
         nb_logpmf = nbinom.logpmf(2, n, p)
         tnb_logpmf = sm.distributions.zinegbin.logpmf(2, 5, 1, 1, 0.005)
         assert_allclose(nb_logpmf, tnb_logpmf, rtol=1e-2, atol=1e-2)
-
-if __name__ == "__main__":
-    import pytest
-    pytest.main([__file__, '-vvs', '-x', '--pdb'])

--- a/statsmodels/distributions/tests/test_edgeworth.py
+++ b/statsmodels/distributions/tests/test_edgeworth.py
@@ -4,7 +4,7 @@ import warnings
 
 import numpy as np
 from numpy.polynomial.hermite_e import HermiteE
-from numpy.testing import (run_module_suite, assert_equal, assert_raises,
+from numpy.testing import (assert_equal, assert_raises,
                            assert_allclose)
 import numpy.testing as npt
 
@@ -188,7 +188,3 @@ def check_distribution_rvs(distfn, args, alpha, rvs):
         D,pval = stats.kstest(distfn.rvs, distfn.cdf, args=args, N=1000)
         npt.assert_(pval > alpha, "D = " + str(D) + "; pval = " + str(pval) +
                "; alpha = " + str(alpha) + "\nargs = " + str(args))
-
-
-if __name__ == "__main__":
-    run_module_suite()

--- a/statsmodels/distributions/tests/test_mixture.py
+++ b/statsmodels/distributions/tests/test_mixture.py
@@ -103,8 +103,3 @@ class TestMixtureDistributions(object):
                        [ 3.60521933,  1.57316531,  0.82784584],
                        [ 3.86102275,  0.6211812 ,  1.33016426],
                        [ 3.91074761,  2.037155  ,  2.22247051]]))
-
-
-if __name__ == "__main__":
-    import pytest
-    pytest.main([__file__, '-vvs', '-x', '--pdb'])

--- a/statsmodels/duration/tests/test_phreg.py
+++ b/statsmodels/duration/tests/test_phreg.py
@@ -414,8 +414,3 @@ strata_f = (False, True)
                          list(itertools.product(fnames, ties, entry_f, strata_f)))
 def test_r(fname, ties, entry_f, strata_f):
     TestPHReg.do1(fname, ties, entry_f, strata_f)
-
-
-if __name__ == "__main__":
-    import pytest
-    pytest.main([__file__, '-vvs', '-x', '--pdb'])

--- a/statsmodels/genmod/families/tests/test_link.py
+++ b/statsmodels/genmod/families/tests/test_link.py
@@ -114,7 +114,3 @@ def test_invlogit_stability():
          812.2382651982667, 495.06449978924525]
     zinv = logit.inverse(z)
     assert_equal(zinv, np.ones_like(z))
-
-if __name__=="__main__":
-    import pytest
-    pytest.main([__file__, '-vvs', '-x', '--pdb'])

--- a/statsmodels/genmod/tests/test_glm.py
+++ b/statsmodels/genmod/tests/test_glm.py
@@ -2124,8 +2124,3 @@ def test_non_invertible_hessian_fails_summary():
         mod = sm.GLM(data.endog, data.exog, family=sm.families.Gamma())
         res = mod.fit(maxiter=1, method='bfgs', max_start_irls=0)
         res.summary()
-
-
-if __name__ == "__main__":
-    import pytest
-    pytest.main([__file__, '-vvs', '-x', '--pdb'])

--- a/statsmodels/graphics/tests/test_mosaicplot.py
+++ b/statsmodels/graphics/tests/test_mosaicplot.py
@@ -2,7 +2,6 @@ from __future__ import division
 from statsmodels.compat.python import iterkeys, zip, lrange, iteritems, range
 
 from numpy.testing import assert_, assert_raises
-from numpy.testing import run_module_suite
 import pytest
 
 # utilities for the tests
@@ -445,7 +444,3 @@ def test_default_arg_index(close_figures):
                                    'short']})
     assert_raises(ValueError, mosaic, data=df, title='foobar')
     pylab.close('all')
-
-
-if __name__ == '__main__':
-    run_module_suite()

--- a/statsmodels/graphics/tests/test_regressionplots.py
+++ b/statsmodels/graphics/tests/test_regressionplots.py
@@ -336,7 +336,3 @@ class TestCERESPlot(object):
                 ax.set_title(ti + "\nPoisson regression\n" +
                              effect_str)
                 close_or_save(pdf, fig)
-
-if __name__ == "__main__":
-    import pytest
-    pytest.main([__file__, '-vvs', '-x', '--pdb'])

--- a/statsmodels/imputation/tests/test_mice.py
+++ b/statsmodels/imputation/tests/test_mice.py
@@ -373,8 +373,3 @@ def test_micedata_miss1():
 
     for k in ix_miss:
         assert_equal(data_imp.ix_miss[k], ix_miss[k])
-
-
-if __name__=="__main__":
-    import pytest
-    pytest.main([__file__, '-vvs', '-x', '--pdb'])

--- a/statsmodels/iolib/tests/test_foreign.py
+++ b/statsmodels/iolib/tests/test_foreign.py
@@ -185,8 +185,3 @@ def test_datetime_roundtrip():
     buf.seek(0)
     dta2 = genfromdta(buf, pandas=True)
     ptesting.assert_frame_equal(dta, dta2.drop('index', axis=1))
-
-
-if __name__ == "__main__":
-    import pytest
-    pytest.main([__file__, '-vvs', '-x', '--pdb'])

--- a/statsmodels/nonparametric/tests/test_bandwidths.py
+++ b/statsmodels/nonparametric/tests/test_bandwidths.py
@@ -71,8 +71,3 @@ class TestTriweight(CheckNormalReferenceConstant):
 
     kern = kernels.Triweight()
     constant = 3.15
-
-
-if __name__ == "__main__":
-    import pytest
-    pytest.main([__file__, '-vvs', '-x', '--pdb'])

--- a/statsmodels/nonparametric/tests/test_kde.py
+++ b/statsmodels/nonparametric/tests/test_kde.py
@@ -328,7 +328,3 @@ class TestNormConstant():
         custom_gauss = kernels.CustomKernel(lambda x: np.exp(-x**2/2.0))
         gauss_true_const = 0.3989422804014327
         npt.assert_almost_equal(gauss_true_const, custom_gauss.norm_const)
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, '-vvs', '-x', '--pdb'])

--- a/statsmodels/nonparametric/tests/test_kernel_density.py
+++ b/statsmodels/nonparametric/tests/test_kernel_density.py
@@ -398,7 +398,3 @@ class TestKDEMultivariateConditional(KDETestBase):
                                                           randomize=False,
                                                           n_sub=100))
         npt.assert_equal(dens.bw, bw_user)
-
-if __name__ == "__main__":
-    import pytest
-    pytest.main([__file__, '-vvs', '-x', '--pdb'])

--- a/statsmodels/nonparametric/tests/test_kernel_regression.py
+++ b/statsmodels/nonparametric/tests/test_kernel_regression.py
@@ -336,8 +336,3 @@ def test_invalid_bw():
     y = x ** 2
     with pytest.raises(ValueError):
         nparam.KernelReg(x, y, 'c', bw=[12.5, 1.])
-
-
-if __name__ == "__main__":
-    import pytest
-    pytest.main([__file__, '-vvs', '-x', '--pdb'])

--- a/statsmodels/nonparametric/tests/test_kernels.py
+++ b/statsmodels/nonparametric/tests/test_kernels.py
@@ -143,12 +143,3 @@ class TestBiweight(CheckKernelMixin):
     kern = kernels.Biweight()
     se_n_diff = 9
     low_rtol = 0.3
-
-if __name__ == '__main__':
-    tt = TestEpan()
-    tt = TestGau()
-    tt = TestBiweight()
-    tt.test_smoothconf()
-    diff_rel = tt.fittedg / tt.res_fittedg - 1
-    diff_abs = tt.fittedg - tt.res_fittedg
-    mask = np.abs(tt.fittedg - tt.res_fittedg) > (0.3 + 0.1 * tt.res_fittedg)

--- a/statsmodels/nonparametric/tests/test_lowess.py
+++ b/statsmodels/nonparametric/tests/test_lowess.py
@@ -154,7 +154,3 @@ def test_returns_inputs():
     x = np.arange(20)
     result = lowess(y, x, frac=.4)
     assert_almost_equal(result, np.column_stack((x, y)))
-
-if __name__ == '__main__':
-    import pytest
-    pytest.main([__file__, '-vvs', '-x', '--pdb'])

--- a/statsmodels/stats/libqsturng/tests/test_qsturng.py
+++ b/statsmodels/stats/libqsturng/tests/test_qsturng.py
@@ -7,14 +7,14 @@ extensively ensure the stability and accuracy of the functions"""
 
 from statsmodels.compat.python import iterkeys, lzip, lmap
 
-from numpy.testing import rand, assert_, assert_equal, \
-    assert_almost_equal, assert_array_almost_equal, assert_array_equal, \
-    assert_approx_equal, assert_raises, run_module_suite
+from numpy.testing import assert_, assert_equal, \
+    assert_almost_equal, assert_array_almost_equal, \
+    assert_raises
 
 import numpy as np
 import pytest
 
-from statsmodels.stats.libqsturng import qsturng, psturng,p_keys,v_keys
+from statsmodels.stats.libqsturng import qsturng, psturng, p_keys, v_keys
 
 
 def read_ch(fname):
@@ -197,6 +197,3 @@ class TestPsturng(object):
 
 ##     def test_more_exotic_stuff(self, level=3):
 ##         something_obscure_and_expensive()
-
-if __name__ == '__main__':
-    run_module_suite()

--- a/statsmodels/stats/tests/test_anova.py
+++ b/statsmodels/stats/tests/test_anova.py
@@ -515,7 +515,3 @@ class TestAnova3HC3(TestAnovaLM):
         #np.testing.assert_almost_equal(results['sum_sq'].values, Sum_Sq, 4)
         np.testing.assert_almost_equal(results['F'].values, F, 4)
         np.testing.assert_almost_equal(results['PR(>F)'].values, PrF)
-
-if __name__ == "__main__":
-    import pytest
-    pytest.main([__file__, '-vvs', '-x', '--pdb'])

--- a/statsmodels/stats/tests/test_groups_sw.py
+++ b/statsmodels/stats/tests/test_groups_sw.py
@@ -75,7 +75,3 @@ class TestUnBalanced(CheckPanelLagMixin):
             5 : np.array([[113, 114, 115, 116, 117]]),
             }
         cls.calculate()
-
-if __name__ == '__main__':
-    import pytest
-    pytest.main([__file__, '-vvs', '-x', '--pdb'])

--- a/statsmodels/stats/tests/test_moment_helpers.py
+++ b/statsmodels/stats/tests/test_moment_helpers.py
@@ -102,8 +102,3 @@ def test_moment_conversion_types():
     assert np.all([isinstance(getattr(moment_helpers,f)(tuple([1.0, 1, 0, 3])),list) or
             isinstance(getattr(moment_helpers,f)(np.array([1.0, 1, 0, 3])),tuple)
             for f in all_f])
-
-if __name__ == '__main__':
-    test_cov2corr()
-    test_moment_conversion()
-    test_moment_conversion_types()

--- a/statsmodels/stats/tests/test_power.py
+++ b/statsmodels/stats/tests/test_power.py
@@ -773,14 +773,3 @@ def test_power_solver_warn():
                               alternative='larger')
         assert_equal(nip.cache_fit_res[0], 0)
         assert_equal(len(nip.cache_fit_res), 3)
-
-
-
-if __name__ == '__main__':
-    test_normal_power_explicit()
-    nt = TestNormalIndPower1()
-    nt.test_power()
-    nt.test_roots()
-    nt = TestNormalIndPower_onesamp1()
-    nt.test_power()
-    nt.test_roots()

--- a/statsmodels/stats/tests/test_proportion.py
+++ b/statsmodels/stats/tests/test_proportion.py
@@ -569,6 +569,3 @@ def test_proportion_ztests():
     res2 = smprop.proportions_chisquare(np.asarray([15, 10]), np.asarray([20., 20]))
     # test only p-value
     assert_almost_equal(res1[1], res2[1], decimal=13)
-
-if __name__ == '__main__':
-    test_confint_proportion()

--- a/statsmodels/stats/tests/test_sandwich.py
+++ b/statsmodels/stats/tests/test_sandwich.py
@@ -88,7 +88,3 @@ def test_hac_simple():
     cov3 = sw.cov_hac_simple(res_olsg, use_correction=False)
     cov4 = sw.cov_hac_simple(res_olsg, nlags=4, use_correction=False)
     assert_almost_equal(cov3, cov4, decimal=14)
-
-if __name__ == '__main__':
-    import pytest
-    pytest.main([__file__, '-vvs', '-x', '--pdb'])

--- a/statsmodels/stats/tests/test_statstools.py
+++ b/statsmodels/stats/tests/test_statstools.py
@@ -298,8 +298,3 @@ class TestStattools(object):
         kurtosis = robust_kurtosis(self.kurtosis_x, dg=(delta,gamma), excess=False)
         q = np.percentile(x,[delta, 100.0-delta, gamma, 100.0-gamma])
         assert_almost_equal(kurtosis[3], (q[1] - q[0]) / (q[3] - q[2]))
-
-
-if __name__ == "__main__":
-    import pytest
-    pytest.main([__file__, '-vvs', '-x', '--pdb'])

--- a/statsmodels/stats/tests/test_tost.py
+++ b/statsmodels/stats/tests/test_tost.py
@@ -557,16 +557,3 @@ def tost_transform_paired():
     assert_almost_equal(res1[1:], res_sas[1:], 2)
     #result R tost
     assert_almost_equal(res1[0], tost_s_paired.p_value, 13)
-
-if __name__ == '__main__':
-    tt = TestTostp1()
-    tt.test_special()
-    for cls in [TestTostp1, TestTostp2, TestTosti1, TestTosti2,
-                TestTostip1, TestTostip2]:
-        #print cls
-        tt = cls()
-        tt.test_pval()
-
-    test_ttest()
-    tost_transform_paired()
-    test_tost_log()

--- a/statsmodels/tsa/filters/tests/test_filters.py
+++ b/statsmodels/tsa/filters/tests/test_filters.py
@@ -732,8 +732,3 @@ class TestFilters(object):
         np.testing.assert_almost_equal(res.values.squeeze(), expected, 4)
         np.testing.assert_(res.index[0] == start)
         np.testing.assert_(res.index[-1] == end)
-
-
-if __name__ == "__main__":
-    import pytest
-    pytest.main([__file__, '-vvs', '-x', '--pdb'])

--- a/statsmodels/tsa/tests/test_tsa_tools.py
+++ b/statsmodels/tsa/tests/test_tsa_tools.py
@@ -657,8 +657,3 @@ class TestLagmat2DS(object):
 
         data = np.zeros((100,2,2))
         assert_raises(TypeError, sm.tsa.lagmat2ds, data, 5)
-
-
-if __name__ == '__main__':
-    import pytest
-    pytest.main([__file__, '-vvs', '-x', '--pdb'])


### PR DESCRIPTION
There was in Issue recently about settling on ways to run the test suite, and IIRC one of the takeaways was that we don't want `__main__` sections in test files.

Addresses many of the checkboxes in #5128.