### PR TITLE
DEPR: Remove items deprecated in previous versions

### DIFF
--- a/examples/notebooks/regression_diagnostics.ipynb
+++ b/examples/notebooks/regression_diagnostics.ipynb
@@ -174,9 +174,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "name = ['Lagrange multiplier statistic', 'p-value', \n",
+    "name = ['Lagrange multiplier statistic', 'p-value',\n",
     "        'f-value', 'f p-value']\n",
-    "test = sms.het_breushpagan(results.resid, results.model.exog)\n",
+    "test = sms.het_breuschpagan(results.resid, results.model.exog)\n",
     "lzip(name, test)"
    ]
   },

--- a/examples/python/regression_diagnostics.py
+++ b/examples/python/regression_diagnostics.py
@@ -72,9 +72,9 @@ np.linalg.cond(results.model.exog)
 # 
 # Breush-Pagan test:
 
-name = ['Lagrange multiplier statistic', 'p-value', 
+name = ['Lagrange multiplier statistic', 'p-value',
         'f-value', 'f p-value']
-test = sms.het_breushpagan(results.resid, results.model.exog)
+test = sms.het_breuschpagan(results.resid, results.model.exog)
 lzip(name, test)
 
 

--- a/statsmodels/base/data.py
+++ b/statsmodels/base/data.py
@@ -3,7 +3,6 @@ Base tools for handling various kinds of data structures, attaching metadata to
 results, and doing data cleaning
 """
 from statsmodels.compat.python import reduce, iteritems, lmap, zip, range
-from statsmodels.compat.numpy import np_matrix_rank
 import numpy as np
 from pandas import DataFrame, Series, isnull
 from statsmodels.tools.decorators import (resettable_cache, cache_readonly,
@@ -171,8 +170,8 @@ class ModelData(object):
                 # Compute rank of augmented matrix
                 augmented_exog = np.column_stack(
                             (np.ones(self.exog.shape[0]), self.exog))
-                rank_augm = np_matrix_rank(augmented_exog)
-                rank_orig = np_matrix_rank(self.exog)
+                rank_augm = np.linalg.matrix_rank(augmented_exog)
+                rank_orig = np.linalg.matrix_rank(self.exog)
                 self.k_constant = int(rank_orig == rank_augm)
                 self.const_idx = None
 

--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -13,7 +13,6 @@ from statsmodels.tools.numdiff import approx_fprime
 from statsmodels.tools.sm_exceptions import ValueWarning, \
     HessianInversionWarning
 from statsmodels.formula import handle_formula_data
-from statsmodels.compat.numpy import np_matrix_rank
 from statsmodels.base.optimizer import Optimizer
 
 
@@ -772,7 +771,7 @@ class GenericLikelihoodModel(LikelihoodModel):
         # and should contain any preprocessing that needs to be done for a model
         if self.exog is not None:
             # assume constant
-            er = np_matrix_rank(self.exog)
+            er = np.linalg.matrix_rank(self.exog)
             self.df_model = float(er - 1)
             self.df_resid = float(self.exog.shape[0] - er)
         else:

--- a/statsmodels/discrete/discrete_model.py
+++ b/statsmodels/discrete/discrete_model.py
@@ -39,7 +39,6 @@ import statsmodels.base.model as base
 from statsmodels.base.data import handle_data  # for mnlogit
 import statsmodels.regression.linear_model as lm
 import statsmodels.base.wrapper as wrap
-from statsmodels.compat.numpy import np_matrix_rank
 
 from statsmodels.base.l1_slsqp import fit_l1_slsqp
 from statsmodels.distributions import genpoisson_p
@@ -178,7 +177,7 @@ class DiscreteModel(base.LikelihoodModel):
         and should contain any preprocessing that needs to be done for a model.
         """
         # assumes constant
-        rank = np_matrix_rank(self.exog)
+        rank = np.linalg.matrix_rank(self.exog)
         self.df_model = float(rank - 1)
         self.df_resid = float(self.exog.shape[0] - rank)
 

--- a/statsmodels/duration/hazard_regression.py
+++ b/statsmodels/duration/hazard_regression.py
@@ -3,7 +3,6 @@ from statsmodels.base import model
 import statsmodels.base.model as base
 from statsmodels.tools.decorators import cache_readonly
 from scipy.optimize import brent
-from statsmodels.compat.numpy import np_matrix_rank
 
 """
 Implementation of proportional hazards regression models for duration
@@ -333,8 +332,8 @@ class PHReg(model.LikelihoodModel):
         self.missing = missing
 
         self.df_resid = (np.float(self.exog.shape[0] -
-                                  np_matrix_rank(self.exog)))
-        self.df_model = np.float(np_matrix_rank(self.exog))
+                                  np.linalg.matrix_rank(self.exog)))
+        self.df_model = np.float(np.linalg.matrix_rank(self.exog))
 
         ties = ties.lower()
         if ties not in ("efron", "breslow"):

--- a/statsmodels/genmod/generalized_linear_model.py
+++ b/statsmodels/genmod/generalized_linear_model.py
@@ -17,8 +17,6 @@ Hardin, J.W. and Hilbe, J.M. 2007.  "Generalized Linear Models and
 McCullagh, P. and Nelder, J.A.  1989.  "Generalized Linear Models." 2nd ed.
     Chapman & Hall, Boca Rotan.
 """
-from statsmodels.compat.numpy import np_matrix_rank
-
 import numpy as np
 from . import families
 from statsmodels.tools.decorators import cache_readonly, resettable_cache
@@ -358,7 +356,7 @@ class GLM(base.LikelihoodModel):
                         'params': [np.inf],
                         'deviance': [np.inf]}
 
-        self.df_model = np_matrix_rank(self.exog) - 1
+        self.df_model = np.linalg.matrix_rank(self.exog) - 1
 
         if (self.freq_weights is not None) and \
            (self.freq_weights.shape[0] == self.endog.shape[0]):

--- a/statsmodels/regression/linear_model.py
+++ b/statsmodels/regression/linear_model.py
@@ -40,7 +40,6 @@ from scipy.linalg import toeplitz
 from scipy import stats
 from scipy import optimize
 
-from statsmodels.compat.numpy import np_matrix_rank
 from statsmodels.tools.tools import add_constant, chain_dot, pinv_extended
 from statsmodels.tools.decorators import (resettable_cache,
                                           cache_readonly,
@@ -197,7 +196,7 @@ class RegressionModel(base.LikelihoodModel):
         """
         if self._df_model is None:
             if self.rank is None:
-                self.rank = np_matrix_rank(self.exog)
+                self.rank = np.linalg.matrix_rank(self.exog)
             self._df_model = float(self.rank - self.k_constant)
         return self._df_model
 
@@ -214,7 +213,7 @@ class RegressionModel(base.LikelihoodModel):
 
         if self._df_resid is None:
             if self.rank is None:
-                self.rank = np_matrix_rank(self.exog)
+                self.rank = np.linalg.matrix_rank(self.exog)
             self._df_resid = self.nobs - self.rank
         return self._df_resid
 
@@ -276,7 +275,7 @@ class RegressionModel(base.LikelihoodModel):
 
                 # Cache these singular values for use later.
                 self.wexog_singular_values = singular_values
-                self.rank = np_matrix_rank(np.diag(singular_values))
+                self.rank = np.linalg.matrix_rank(np.diag(singular_values))
 
             beta = np.dot(self.pinv_wexog, self.wendog)
 
@@ -291,7 +290,7 @@ class RegressionModel(base.LikelihoodModel):
 
                 # Cache singular values from R.
                 self.wexog_singular_values = np.linalg.svd(R, 0, 0)
-                self.rank = np_matrix_rank(R)
+                self.rank = np.linalg.matrix_rank(R)
             else:
                 Q, R = self.exog_Q, self.exog_R
 

--- a/statsmodels/regression/mixed_linear_model.py
+++ b/statsmodels/regression/mixed_linear_model.py
@@ -157,7 +157,6 @@ from statsmodels.compat import range
 import warnings
 from statsmodels.tools.sm_exceptions import ConvergenceWarning
 from statsmodels.base._penalties import Penalty
-from statsmodels.compat.numpy import np_matrix_rank
 
 
 def _dot(x, y):
@@ -2177,7 +2176,7 @@ class MixedLMResults(base.LikelihoodModelResults, base.ResultMixin):
         super(MixedLMResults, self).__init__(model, params,
                                              normalized_cov_params=cov_params)
         self.nobs = self.model.nobs
-        self.df_resid = self.nobs - np_matrix_rank(self.model.exog)
+        self.df_resid = self.nobs - np.linalg.matrix_rank(self.model.exog)
 
     @cache_readonly
     def fittedvalues(self):

--- a/statsmodels/regression/quantile_regression.py
+++ b/statsmodels/regression/quantile_regression.py
@@ -24,7 +24,6 @@ import scipy.stats as stats
 from scipy.linalg import pinv
 from scipy.stats import norm
 from statsmodels.tools.tools import chain_dot
-from statsmodels.compat.numpy import np_matrix_rank
 from statsmodels.tools.decorators import cache_readonly
 from statsmodels.regression.linear_model import (RegressionModel,
                                                  RegressionResults,
@@ -139,7 +138,7 @@ class QuantReg(RegressionModel):
         endog = self.endog
         exog = self.exog
         nobs = self.nobs
-        exog_rank = np_matrix_rank(self.exog)
+        exog_rank = np.linalg.matrix_rank(self.exog)
         self.rank = exog_rank
         self.df_model = float(self.rank - self.k_constant)
         self.df_resid = self.nobs - self.rank

--- a/statsmodels/regression/tests/test_regression.py
+++ b/statsmodels/regression/tests/test_regression.py
@@ -11,7 +11,6 @@ from numpy.testing import (assert_almost_equal, assert_approx_equal, assert_,
 import pytest
 from scipy.linalg import toeplitz
 from statsmodels.tools.tools import add_constant, categorical
-from statsmodels.compat.numpy import np_matrix_rank
 from statsmodels.regression.linear_model import (OLS, WLS, GLS, yule_walker,
                                                  burg)
 from statsmodels.datasets import longley
@@ -167,7 +166,7 @@ class TestOLS(CheckRegressionResults):
         Q, R = np.linalg.qr(data.exog)
         model_qr.exog_Q, model_qr.exog_R = Q, R
         model_qr.normalized_cov_params = np.linalg.inv(np.dot(R.T, R))
-        model_qr.rank = np_matrix_rank(R)
+        model_qr.rank = np.linalg.matrix_rank(R)
         res_qr2 = model_qr.fit(method="qr")
 
         cls.res_qr = res_qr

--- a/statsmodels/robust/robust_linear_model.py
+++ b/statsmodels/robust/robust_linear_model.py
@@ -16,21 +16,21 @@ R Venables, B Ripley. 'Modern Applied Statistics in S'  Springer, New York,
 import numpy as np
 import scipy.stats as stats
 
-from statsmodels.tools.decorators import (cache_readonly,
-                                                  resettable_cache)
+from statsmodels.tools.decorators import cache_readonly, resettable_cache
 import statsmodels.regression.linear_model as lm
 import statsmodels.regression._tools as reg_tools
 import statsmodels.robust.norms as norms
 import statsmodels.robust.scale as scale
 import statsmodels.base.model as base
 import statsmodels.base.wrapper as wrap
-from statsmodels.compat.numpy import np_matrix_rank
 
 __all__ = ['RLM']
+
 
 def _check_convergence(criterion, iteration, tol, maxiter):
     return not (np.any(np.fabs(criterion[iteration] -
                 criterion[iteration-1]) > tol) and iteration < maxiter)
+
 
 class RLM(base.LikelihoodModel):
     __doc__ = """
@@ -126,8 +126,8 @@ class RLM(base.LikelihoodModel):
         self.normalized_cov_params = np.dot(self.pinv_wexog,
                                         np.transpose(self.pinv_wexog))
         self.df_resid = (np.float(self.exog.shape[0] -
-                         np_matrix_rank(self.exog)))
-        self.df_model = np.float(np_matrix_rank(self.exog)-1)
+                         np.linalg.matrix_rank(self.exog)))
+        self.df_model = np.float(np.linalg.matrix_rank(self.exog)-1)
         self.nobs = float(self.endog.shape[0])
 
     def score(self, params):

--- a/statsmodels/sandbox/regression/gmm.py
+++ b/statsmodels/sandbox/regression/gmm.py
@@ -50,7 +50,6 @@ License: BSD (3-clause)
 
 from __future__ import print_function
 from statsmodels.compat.python import lrange
-from statsmodels.compat.numpy import np_matrix_rank
 
 import numpy as np
 from scipy import optimize, stats
@@ -65,6 +64,7 @@ from statsmodels.tools.decorators import (resettable_cache, cache_readonly)
 from statsmodels.tools.tools import _ensure_2d
 
 DEBUG = 0
+
 
 def maxabs(x):
     '''just a shortcut to np.abs(x).max()
@@ -241,7 +241,7 @@ class IVRegressionResults(RegressionResults):
         #use linalg.lstsq or svd directly
         #cov_diff will very often be in-definite (singular)
         if not dof:
-            dof = np_matrix_rank(cov_diff)
+            dof = np.linalg.matrix_rank(cov_diff)
         cov_diffpinv = np.linalg.pinv(cov_diff)
         H = np.dot(params_diff, np.dot(cov_diffpinv, params_diff))/se2
         pval = stats.chi2.sf(H, dof)
@@ -1673,7 +1673,7 @@ def spec_hausman(params_e, params_i, cov_params_e, cov_params_i, dof=None):
     #use linalg.lstsq or svd directly
     #cov_diff will very often be in-definite (singular)
     if not dof:
-        dof = np_matrix_rank(cov_diff)
+        dof = np.linalg.matrix_rank(cov_diff)
     cov_diffpinv = np.linalg.pinv(cov_diff)
     H = np.dot(params_diff, np.dot(cov_diffpinv, params_diff))
     pval = stats.chi2.sf(H, dof)

--- a/statsmodels/sandbox/stats/diagnostic.py
+++ b/statsmodels/sandbox/stats/diagnostic.py
@@ -37,9 +37,9 @@ from statsmodels.regression.linear_model import OLS
 from statsmodels.tools.tools import add_constant
 from statsmodels.tsa.stattools import acf, adfuller
 from statsmodels.tsa.tsatools import lagmat
-from statsmodels.compat.numpy import np_matrix_rank
 
-#get the old signature back so the examples work
+
+# get the old signature back so the examples work
 def unitroot_adf(x, maxlag=None, trendorder=0, autolag='AIC', store=False):
     return adfuller(x, maxlag=maxlag, regression=trendorder, autolag=autolag,
                     store=store, regresults=False)
@@ -658,7 +658,7 @@ def het_white(resid, exog, retres=False):
     #degrees of freedom take possible reduced rank in exog into account
     #df_model checks the rank to determine df
     #extra calculation that can be removed:
-    assert resols.df_model == np_matrix_rank(exog) - 1
+    assert resols.df_model == np.linalg.matrix_rank(exog) - 1
     lmpval = stats.chi2.sf(lm, resols.df_model)
     return lm, lmpval, fval, fpval
 

--- a/statsmodels/sandbox/stats/diagnostic.py
+++ b/statsmodels/sandbox/stats/diagnostic.py
@@ -531,14 +531,6 @@ def acorr_breusch_godfrey(results, nlags=None, store=False):
         return lm, lmpval, fval, fpval
 
 
-msg = "Use acorr_breusch_godfrey, acorr_breush_godfrey will be removed " \
-      "in 0.9 \n (Note: misspelling missing 'c'),"
-
-acorr_breush_godfrey = np.deprecate(acorr_breusch_godfrey, 'acorr_breush_godfrey',
-                               'acorr_breusch_godfrey',
-                               msg)
-
-
 def het_breuschpagan(resid, exog_het):
     '''Breusch-Pagan Lagrange Multiplier test for heteroscedasticity
 
@@ -610,9 +602,6 @@ def het_breuschpagan(resid, exog_het):
     # Note: degrees of freedom for LM test is nvars minus constant
     return lm, stats.chi2.sf(lm, nvars-1), fval, fpval
 
-het_breushpagan = np.deprecate(het_breuschpagan, 'het_breushpagan', 'het_breuschpagan',
-                               "Use het_breuschpagan, het_breushpagan will be "
-                               "removed in 0.9 \n(Note: misspelling missing 'c')")
 
 def het_white(resid, exog, retres=False):
     '''White's Lagrange Multiplier Test for Heteroscedasticity

--- a/statsmodels/sandbox/sysreg.py
+++ b/statsmodels/sandbox/sysreg.py
@@ -3,11 +3,11 @@ from statsmodels.regression.linear_model import GLS
 import numpy as np
 from statsmodels.base.model import LikelihoodModelResults
 from scipy import sparse
-from statsmodels.compat.numpy import np_matrix_rank
 
-#http://www.irisa.fr/aladin/wg-statlin/WORKSHOPS/RENNES02/SLIDES/Foschi.pdf
+# http://www.irisa.fr/aladin/wg-statlin/WORKSHOPS/RENNES02/SLIDES/Foschi.pdf
 
 __all__ = ['SUR', 'Sem2SLS']
+
 
 #probably should have a SystemModel superclass
 # TODO: does it make sense of SUR equations to have
@@ -112,11 +112,11 @@ exogenous variables.  Got length %s" % len(sys))
         self.endog = endog
         self.nobs = float(self.endog[0].shape[0]) # assumes all the same length
 
-# Degrees of Freedom
+        # Degrees of Freedom
         df_resid = []
         df_model = []
-        [df_resid.append(self.nobs - np_matrix_rank(_)) for _ in sys[1::2]]
-        [df_model.append(np_matrix_rank(_) - 1) for _ in sys[1::2]]
+        [df_resid.append(self.nobs - np.linalg.matrix_rank(_)) for _ in sys[1::2]]
+        [df_model.append(np.linalg.matrix_rank(_) - 1) for _ in sys[1::2]]
         self.df_resid = np.asarray(df_resid)
         self.df_model = np.asarray(df_model)
 
@@ -290,7 +290,7 @@ exogenous variables.  Got length %s" % len(sys))
 # The lists are probably a bad idea
         self.endog = sys[::2]   # these are just list containers
         self.exog = sys[1::2]
-        self._K = [np_matrix_rank(_) for _ in sys[1::2]]
+        self._K = [np.linalg.matrix_rank(_) for _ in sys[1::2]]
 #        fullexog = np.column_stack((_ for _ in self.exog))
 
         self.instruments = instruments

--- a/statsmodels/stats/_lilliefors.py
+++ b/statsmodels/stats/_lilliefors.py
@@ -348,11 +348,7 @@ def kstest_fit(x, dist='norm', pvalmethod='approx'):
     return d_ks, pval
 
 
-
 lilliefors = kstest_fit
-lillifors = np.deprecate(lilliefors, 'lillifors', 'lilliefors',
-                               "Use lilliefors, lillifors will be "
-                               "removed in 0.9 \n(Note: misspelling missing 'e')")
 
 # namespace aliases
 from functools import partial

--- a/statsmodels/stats/api.py
+++ b/statsmodels/stats/api.py
@@ -1,17 +1,15 @@
 # pylint: disable=W0611
 from . import diagnostic
 from .diagnostic import (
-            acorr_ljungbox, acorr_breusch_godfrey,
-            CompareCox, compare_cox, CompareJ, compare_j,
-            HetGoldfeldQuandt, het_goldfeldquandt,
-            het_breuschpagan, het_white, het_arch,
-            linear_harvey_collier, linear_rainbow, linear_lm,
-            breaks_cusumolsresid, breaks_hansen, recursive_olsresiduals,
-            unitroot_adf,
-            normal_ad, lilliefors,
-             # deprecated because of misspelling:
-            lillifors, het_breushpagan, acorr_breush_godfrey
-            )
+    acorr_ljungbox, acorr_breusch_godfrey,
+    CompareCox, compare_cox, CompareJ, compare_j,
+    HetGoldfeldQuandt, het_goldfeldquandt,
+    het_breuschpagan, het_white, het_arch,
+    linear_harvey_collier, linear_rainbow, linear_lm,
+    breaks_cusumolsresid, breaks_hansen, recursive_olsresiduals,
+    unitroot_adf,
+    normal_ad, lilliefors
+)
 
 from . import multicomp
 from .multitest import (multipletests, fdrcorrection, fdrcorrection_twostage,
@@ -25,22 +23,23 @@ from .stattools import durbin_watson, omni_normtest, jarque_bera
 
 from . import sandwich_covariance
 from .sandwich_covariance import (
-            cov_cluster, cov_cluster_2groups, cov_nw_panel,
-            cov_hac, cov_white_simple,
-            cov_hc0, cov_hc1, cov_hc2, cov_hc3,
-            se_cov
-            )
+    cov_cluster, cov_cluster_2groups, cov_nw_panel,
+    cov_hac, cov_white_simple,
+    cov_hc0, cov_hc1, cov_hc2, cov_hc3,
+    se_cov
+)
 
 from .weightstats import (DescrStatsW, CompareMeans, ttest_ind, ttost_ind,
-                         ttost_paired, ztest, ztost, zconfint)
+                          ttost_paired, ztest, ztost, zconfint)
 
-from .proportion import (binom_test_reject_interval, binom_test,
-            binom_tost, binom_tost_reject_interval,
-            power_binom_tost, power_ztost_prop,
-            proportion_confint, proportion_effectsize,
-            proportions_chisquare, proportions_chisquare_allpairs,
-            proportions_chisquare_pairscontrol, proportions_ztest,
-            proportions_ztost, multinomial_proportions_confint)
+from .proportion import (
+    binom_test_reject_interval, binom_test,
+    binom_tost, binom_tost_reject_interval,
+    power_binom_tost, power_ztost_prop,
+    proportion_confint, proportion_effectsize,
+    proportions_chisquare, proportions_chisquare_allpairs,
+    proportions_chisquare_pairscontrol, proportions_ztest,
+    proportions_ztost, multinomial_proportions_confint)
 
 from .power import (TTestPower, TTestIndPower, GofChisquarePower,
                     NormalIndPower, FTestAnovaPower, FTestPower,
@@ -51,11 +50,12 @@ from .descriptivestats import Describe
 from .anova import anova_lm
 
 from . import moment_helpers
-from .correlation_tools import (corr_clipped, corr_nearest,
-            corr_nearest_factor, corr_thresholded, cov_nearest,
-            cov_nearest_factor_homog, FactoredPSDMatrix)
+from .correlation_tools import (
+    corr_clipped, corr_nearest,
+    corr_nearest_factor, corr_thresholded, cov_nearest,
+    cov_nearest_factor_homog, FactoredPSDMatrix)
 
-from statsmodels.sandbox.stats.runs import (Runs, runstest_1samp, runstest_2samp)
+from statsmodels.sandbox.stats.runs import Runs, runstest_1samp, runstest_2samp
 
 from statsmodels.stats.contingency_tables import (mcnemar, cochrans_q,
                                                   SquareTable,

--- a/statsmodels/stats/contrast.py
+++ b/statsmodels/stats/contrast.py
@@ -4,7 +4,6 @@ from scipy.stats import f as fdist
 from scipy.stats import t as student_t
 from scipy import stats
 from statsmodels.tools.tools import clean0, fullrank
-from statsmodels.compat.numpy import np_matrix_rank
 from statsmodels.stats.multitest import multipletests
 
 
@@ -345,7 +344,7 @@ def contrastfromcols(L, D, pseudo=None):
     if len(Lp.shape) == 1:
         Lp.shape = (n, 1)
 
-    if np_matrix_rank(Lp) != Lp.shape[1]:
+    if np.linalg.matrix_rank(Lp) != Lp.shape[1]:
         Lp = fullrank(Lp)
         C = np.dot(pseudo, Lp).T
 

--- a/statsmodels/stats/diagnostic.py
+++ b/statsmodels/stats/diagnostic.py
@@ -1,14 +1,13 @@
-#collect some imports of verified (at least one example) functions
+# collect some imports of verified (at least one example) functions
 from statsmodels.sandbox.stats.diagnostic import (
     acorr_ljungbox, breaks_cusumolsresid, breaks_hansen, CompareCox, CompareJ,
     compare_cox, compare_j, het_breuschpagan, HetGoldfeldQuandt,
     het_goldfeldquandt, het_arch,
     het_white, recursive_olsresiduals, acorr_breusch_godfrey,
     linear_harvey_collier, linear_rainbow, linear_lm,
-    unitroot_adf,
-    het_breushpagan, acorr_breush_godfrey  # deprecated because of misspelling
-    )
+    unitroot_adf
+)
 
-from ._lilliefors import (kstest_fit, lilliefors, lillifors, kstest_normal,
-                          kstest_exponential)  # lillifors is deprecated
+from ._lilliefors import (kstest_fit, lilliefors, kstest_normal,
+                          kstest_exponential)
 from ._adnorm import normal_ad

--- a/statsmodels/tools/catadd.py
+++ b/statsmodels/tools/catadd.py
@@ -1,24 +1,22 @@
 from __future__ import print_function
 import numpy as np
-from statsmodels.compat.numpy import np_matrix_rank
 
 
 def add_indep(x, varnames, dtype=None):
     '''
     construct array with independent columns
 
-    x is either iterable (list, tuple) or instance of ndarray or a subclass of it.
-    If x is an ndarray, then each column is assumed to represent a variable with
-    observations in rows.
+    x is either iterable (list, tuple) or instance of ndarray or a subclass
+    of it.  If x is an ndarray, then each column is assumed to represent a
+    variable with observations in rows.
     '''
-    #TODO: this needs tests for subclasses
+    # TODO: this needs tests for subclasses
 
     if isinstance(x, np.ndarray) and x.ndim == 2:
         x = x.T
 
     nvars_orig = len(x)
     nobs = len(x[0])
-    #print('nobs, nvars_orig', nobs, nvars_orig)
     if not dtype:
         dtype = np.asarray(x[0]).dtype
     xout = np.zeros((nobs, nvars_orig), dtype=dtype)
@@ -28,10 +26,8 @@ def add_indep(x, varnames, dtype=None):
     varnames_dropped = []
     keepindx = []
     for (xi, ni) in zip(x, varnames):
-        #print(xi.shape, xout.shape)
-        xout[:,count] = xi
-        rank_new = np_matrix_rank(xout)
-        #print(rank_new)
+        xout[:, count] = xi
+        rank_new = np.linalg.matrix_rank(xout)
         if rank_new > rank_old:
             varnames_new.append(ni)
             rank_old = rank_new
@@ -39,7 +35,8 @@ def add_indep(x, varnames, dtype=None):
         else:
             varnames_dropped.append(ni)
 
-    return xout[:,:count], varnames_new
+    return xout[:, :count], varnames_new
+
 
 if __name__ == '__main__':
     x1 = np.array([0,0,0,0,0,1,1,1,2,2,2])

--- a/statsmodels/tools/tools.py
+++ b/statsmodels/tools/tools.py
@@ -10,7 +10,6 @@ import pandas as pd
 
 from statsmodels.datasets import webuse
 from statsmodels.tools.data import _is_using_pandas, _is_recarray
-from statsmodels.compat.numpy import np_matrix_rank
 
 
 def _make_dictnames(tmp_arr, offset=0):
@@ -325,7 +324,7 @@ def isestimable(C, D):
     if C.shape[1] != D.shape[1]:
         raise ValueError('Contrast should have %d columns' % D.shape[1])
     new = np.vstack([C, D])
-    if np_matrix_rank(new) != np_matrix_rank(D):
+    if np.linalg.matrix_rank(new) != np.linalg.matrix_rank(D):
         return False
     return True
 
@@ -406,7 +405,7 @@ def fullrank(X, r=None):
     """
 
     if r is None:
-        r = np_matrix_rank(X)
+        r = np.linalg.matrix_rank(X)
 
     V, D, U = L.svd(X, full_matrices=0)
     order = np.argsort(D)

--- a/statsmodels/tsa/vector_ar/svar_model.py
+++ b/statsmodels/tsa/vector_ar/svar_model.py
@@ -13,17 +13,12 @@ import numpy as np
 import numpy.linalg as npl
 from numpy.linalg import slogdet
 
-from statsmodels.tools.numdiff import (approx_hess, approx_fprime)
-from statsmodels.tools.decorators import cache_readonly
+from statsmodels.tools.numdiff import approx_hess, approx_fprime
 from statsmodels.tsa.vector_ar.irf import IRAnalysis
-from statsmodels.tsa.vector_ar.var_model import VARProcess, \
-                                                        VARResults
+from statsmodels.tsa.vector_ar.var_model import VARProcess, VARResults
 
 import statsmodels.tsa.vector_ar.util as util
 import statsmodels.tsa.base.tsa_model as tsbase
-from statsmodels.compat.numpy import np_matrix_rank
-
-mat = np.array
 
 
 def svar_ckerr(svar_type, A, B):
@@ -440,7 +435,7 @@ class SVAR(tsbase.TimeSeriesModel):
                              "solution may not be unique")
 
     def check_rank(self, J):
-        rank = np_matrix_rank(J)
+        rank = np.linalg.matrix_rank(J)
         if rank < np.size(J, axis=1):
             raise ValueError("Rank condition not met: "
                              "solution may not be unique.")
@@ -497,7 +492,7 @@ class SVARProcess(VARProcess):
             P = np.dot(npl.inv(A_solve), B_solve)
 
         ma_mats = self.ma_rep(maxn=maxn)
-        return mat([np.dot(coefs, P) for coefs in ma_mats])
+        return np.array([np.dot(coefs, P) for coefs in ma_mats])
 
 
 class SVARResults(SVARProcess, VARResults):

--- a/statsmodels/tsa/vector_ar/util.py
+++ b/statsmodels/tsa/vector_ar/util.py
@@ -172,18 +172,6 @@ def parse_lutkepohl_data(path): # pragma: no cover
     return data, date_range
 
 
-def get_logdet(m):
-    from statsmodels.tools.linalg import logdet_symm
-    return logdet_symm(m)
-
-
-get_logdet = np.deprecate(get_logdet,
-                          "statsmodels.tsa.vector_ar.util.get_logdet",
-                          "statsmodels.tools.linalg.logdet_symm",
-                          "get_logdet is deprecated and will be removed in "
-                          "0.8.0")
-
-
 def norm_signif_level(alpha=0.05):
     return stats.norm.ppf(1 - alpha / 2)
 


### PR DESCRIPTION
Ref #5092.

Also usages of `np_matrix_rank`, which is no longer necessary.