### PR TITLE
BLD: Include pyx.in in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-global-include *.csv *.py *.txt *.pyx *.pxd *.pxi *.c *.h
+global-include *.csv *.py *.txt *.pyx *.pxd *.pxi *.pyx.in *.c *.h
 include MANIFEST.in
 include README.rst
 


### PR DESCRIPTION
Ensure cython files are included to avoid issue when Cython is availble
Defers choice of recompileing Cython or using C to Cython