### PR TITLE
MAINT: raise specific exceptions instead of just Exception

### DIFF
--- a/statsmodels/base/l1_solvers_common.py
+++ b/statsmodels/base/l1_solvers_common.py
@@ -152,7 +152,7 @@ def do_trim_params(params, k_params, alpha, score, passed, trim_mode,
                     params[i] = 0.0
                     trimmed[i] = True
     else:
-        raise Exception(
+        raise ValueError(
             "trim_mode == %s, which is not recognized" % (trim_mode))
 
     return params, np.asarray(trimmed)

--- a/statsmodels/discrete/discrete_margins.py
+++ b/statsmodels/discrete/discrete_margins.py
@@ -345,11 +345,13 @@ def margeff_cov_with_se(model, params, exog, cov_params, at, derivative,
 def margeff():
     pass
 
+
 def _check_at_is_all(method):
     if method['at'] == 'all':
-        raise NotImplementedError("Only margeff are available when `at` is "
-                    "all. Please input specific points if you would like to "
-                    "do inference.")
+        raise ValueError("Only margeff are available when `at` is "
+                         "'all'. Please input specific points if you would "
+                         "like to do inference.")
+
 
 _transform_names = dict(dydx='dy/dx',
                         eyex='d(lny)/d(lnx)',

--- a/statsmodels/discrete/discrete_model.py
+++ b/statsmodels/discrete/discrete_model.py
@@ -325,7 +325,7 @@ class DiscreteModel(base.LikelihoodModel):
         if method in ['l1', 'l1_cvxopt_cp']:
             cov_params_func = self.cov_params_func_l1
         else:
-            raise Exception("argument method == %s, which is not handled"
+            raise ValueError("argument method == %s, which is not handled"
                             % method)
 
         ### Bundle up extra kwargs for the dictionary kwargs.  These are
@@ -460,7 +460,7 @@ class BinaryModel(DiscreteModel):
         if method in ['l1', 'l1_cvxopt_cp']:
             discretefit = L1BinaryResults(self, bnryfit)
         else:
-            raise Exception(
+            raise ValueError(
                     "argument method == %s, which is not handled" % method)
         return L1BinaryResultsWrapper(discretefit)
     fit_regularized.__doc__ = DiscreteModel.fit_regularized.__doc__
@@ -871,7 +871,7 @@ class CountModel(DiscreteModel):
         if method in ['l1', 'l1_cvxopt_cp']:
             discretefit = L1CountResults(self, cntfit)
         else:
-            raise Exception(
+            raise ValueError(
                     "argument method == %s, which is not handled" % method)
         return L1CountResultsWrapper(discretefit)
     fit_regularized.__doc__ = DiscreteModel.fit_regularized.__doc__
@@ -1064,7 +1064,7 @@ class Poisson(CountModel):
         if method in ['l1', 'l1_cvxopt_cp']:
             discretefit = L1PoissonResults(self, cntfit)
         else:
-            raise Exception(
+            raise ValueError(
                     "argument method == %s, which is not handled" % method)
         return L1PoissonResultsWrapper(discretefit)
 
@@ -1513,7 +1513,7 @@ class GeneralizedPoisson(CountModel):
         if method in ['l1', 'l1_cvxopt_cp']:
             discretefit = L1GeneralizedPoissonResults(self, cntfit)
         else:
-            raise Exception(
+            raise ValueError(
                     "argument method == %s, which is not handled" % method)
 
         return L1GeneralizedPoissonResultsWrapper(discretefit)
@@ -2903,7 +2903,7 @@ class NegativeBinomial(CountModel):
         if method in ['l1', 'l1_cvxopt_cp']:
             discretefit = L1NegativeBinomialResults(self, cntfit)
         else:
-            raise Exception(
+            raise ValueError(
                     "argument method == %s, which is not handled" % method)
 
         return L1NegativeBinomialResultsWrapper(discretefit)

--- a/statsmodels/emplike/descriptive.py
+++ b/statsmodels/emplike/descriptive.py
@@ -984,8 +984,8 @@ class DescStatMV(_OptFuncts):
         endog = self.endog
         nobs = self.nobs
         if len(mu_array) != endog.shape[1]:
-            raise Exception('mu_array must have the same number of \
-                           elements as the columns of the data.')
+            raise ValueError('mu_array must have the same number of '
+                             'elements as the columns of the data.')
         mu_array = mu_array.reshape(1, endog.shape[1])
         means = np.ones((endog.shape[0], endog.shape[1]))
         means = mu_array * means
@@ -1050,7 +1050,7 @@ class DescStatMV(_OptFuncts):
         >>> contourp.show()
         """
         if self.endog.shape[1] != 2:
-            raise Exception('Data must contain exactly two variables')
+            raise ValueError('Data must contain exactly two variables')
         fig, ax = utils.create_mpl_ax()
         if var2_name is None:
             ax.set_ylabel('Variable 2')
@@ -1091,7 +1091,7 @@ class DescStatMV(_OptFuncts):
         nobs = self.nobs
         endog = self.endog
         if endog.shape[1] != 2:
-            raise Exception('Correlation matrix not yet implemented')
+            raise NotImplementedError('Correlation matrix not yet implemented')
         nuis0 = np.array([endog[:, 0].mean(),
                               endog[:, 0].var(),
                               endog[:, 1].mean(),

--- a/statsmodels/graphics/mosaicplot.py
+++ b/statsmodels/graphics/mosaicplot.py
@@ -392,9 +392,9 @@ def _create_labels(rects, horizontal, ax, rotation):
     """
     categories = _categories_level(list(iterkeys(rects)))
     if len(categories) > 4:
-        msg = ("maximum of 4 level supported for axes labeling..and 4"
-               "is alreay a lot of level, are you sure you need them all?")
-        raise NotImplementedError(msg)
+        msg = ("maximum of 4 level supported for axes labeling... and 4"
+               "is already a lot of levels, are you sure you need them all?")
+        raise ValueError(msg)
     labels = {}
     #keep it fixed as will be used a lot of times
     items = list(iteritems(rects))

--- a/statsmodels/iolib/summary.py
+++ b/statsmodels/iolib/summary.py
@@ -3,12 +3,11 @@ import numpy as np
 from statsmodels.iolib.table import SimpleTable
 from statsmodels.iolib.tableformatting import (gen_fmt, fmt_2,
                                                 fmt_params, fmt_base, fmt_2cols)
-#from statsmodels.iolib.summary2d import summary_params_2dflat
-#from summary2d import summary_params_2dflat
+
 
 def forg(x, prec=3):
     if prec == 3:
-    #for 3 decimals
+        # for 3 decimals
         if (abs(x) >= 1e4) or (abs(x) < 1e-4):
             return '%9.3g' % x
         else:
@@ -19,7 +18,8 @@ def forg(x, prec=3):
         else:
             return '%10.4f' % x
     else:
-        raise NotImplementedError
+        raise ValueError("`prec` argument must be either 3 or 4, not {prec}"
+                         .format(prec=prec))
 
 
 def summary(self, yname=None, xname=None, title=0, alpha=.05,

--- a/statsmodels/tools/data.py
+++ b/statsmodels/tools/data.py
@@ -65,7 +65,8 @@ def interpret_data(data, colnames=None, rownames=None):
         colnames = data.columns
         rownames = data.index
     else:  # pragma: no cover
-        raise Exception('cannot handle other input types at the moment')
+        raise TypeError('Cannot handle input type {typ}'
+                        .format(typ=type(data).__name__))
 
     if not isinstance(colnames, list):
         colnames = list(colnames)

--- a/statsmodels/tsa/vector_ar/dynamic.py
+++ b/statsmodels/tsa/vector_ar/dynamic.py
@@ -137,7 +137,7 @@ def _get_window_type(window_type):
         elif window_type_up == 'EXPANDING':
             return EXPANDING
 
-    raise Exception('Unrecognized window type: %s' % window_type)
+    raise ValueError('Unrecognized window type: %s' % window_type)
 
 
 class DynamicVAR(object):

--- a/statsmodels/tsa/vector_ar/svar_model.py
+++ b/statsmodels/tsa/vector_ar/svar_model.py
@@ -168,8 +168,8 @@ class SVAR(tsbase.TimeSeriesModel):
         if ic is not None:
             selections = self.select_order(maxlags=maxlags, verbose=verbose)
             if ic not in selections:
-                raise Exception("%s not recognized, must be among %s"
-                                % (ic, sorted(selections)))
+                raise ValueError("%s not recognized, must be among %s"
+                                 % (ic, sorted(selections)))
             lags = selections[ic]
             if verbose:
                 print('Using %d based on %s criterion' %  (lags, ic))

--- a/statsmodels/tsa/vector_ar/var_model.py
+++ b/statsmodels/tsa/vector_ar/var_model.py
@@ -617,8 +617,8 @@ class VAR(tsbase.TimeSeriesModel):
         if ic is not None:
             selections = self.select_order(maxlags=maxlags)
             if not hasattr(selections, ic):
-                raise Exception("%s not recognized, must be among %s"
-                                % (ic, sorted(selections)))
+                raise ValueError("%s not recognized, must be among %s"
+                                 % (ic, sorted(selections)))
             lags = getattr(selections, ic)
             if verbose:
                 print(selections)
@@ -1792,7 +1792,7 @@ class VARResults(VARProcess):
             df = (num_restr, k * self.df_resid)
             dist = stats.f(*df)
         else:
-            raise Exception('kind %s not recognized' % kind)
+            raise ValueError('kind %s not recognized' % kind)
 
         pvalue = dist.sf(statistic)
         crit_value = dist.ppf(1 - signif)


### PR DESCRIPTION
Side-note: There are a bunch of places that raise `NotImplementedError("Only options [foo, bar] are implemented")` that arguably should be `ValueError`s.  May need discussion.