### PR TITLE
TST: Set seed when using basin hopping

### DIFF
--- a/statsmodels/conftest.py
+++ b/statsmodels/conftest.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pytest
 
 
@@ -68,3 +69,24 @@ def close_figures():
 
     yield close
     close()
+
+
+@pytest.fixture()
+def reset_randomstate():
+    """
+    Fixture that set the global RandomState to the fixed seed 1
+
+    Notes
+    -----
+    Used by passing as an argument to the function that uses the global
+    RandomState
+
+    def test_some_plot(reset_randomstate):
+        <test code>
+
+    Returns the state after the test function exits
+    """
+    state = np.random.get_state()
+    np.random.seed(1)
+    yield
+    np.random.set_state(state)

--- a/statsmodels/discrete/tests/test_count_model.py
+++ b/statsmodels/discrete/tests/test_count_model.py
@@ -269,7 +269,7 @@ class TestZeroInflatedGeneralizedPoisson(CheckGeneric):
         t_test = self.res1.t_test(unit_matrix)
         assert_allclose(self.res1.tvalues, t_test.tvalue)
 
-    def test_minimize(self):
+    def test_minimize(self, reset_randomstate):
         # check additional optimizers using the `minimize` option
         model = self.res1.model
         # use the same start_params, but avoid recomputing
@@ -380,7 +380,7 @@ class TestZeroInflatedNegativeBinomialP(CheckGeneric):
             atol=1e-1, rtol=1e-1)
 
     # possibly slow, adds 25 seconds
-    def test_minimize(self):
+    def test_minimize(self, reset_randomstate):
         # check additional optimizers using the `minimize` option
         model = self.res1.model
         # use the same start_params, but avoid recomputing

--- a/statsmodels/discrete/tests/test_discrete.py
+++ b/statsmodels/discrete/tests/test_discrete.py
@@ -424,6 +424,7 @@ class TestProbitBasinhopping(CheckBinaryResults):
         res2.probit()
         cls.res2 = res2
         fit = Probit(data.endog, data.exog).fit
+        np.random.seed(1)
         cls.res1 = fit(method="basinhopping", disp=0, niter=5,
                         minimizer={'method' : 'L-BFGS-B', 'tol' : 1e-8})
 

--- a/statsmodels/tsa/tests/test_holtwinters.py
+++ b/statsmodels/tsa/tests/test_holtwinters.py
@@ -327,7 +327,7 @@ def test_invalid_start_param_length():
         mod.fit(start_params=np.array([0.5]))
 
 
-def test_basin_hopping():
+def test_basin_hopping(reset_randomstate):
     mod = ExponentialSmoothing(housing_data, trend='add')
     res = mod.fit()
     res2 = mod.fit(use_basinhopping=True)


### PR DESCRIPTION
Basin hopping uses the global RandomState by default.  Add a fixture
to set the global state to a fixed and then restore it to its original
value after the test has completed.

Fixes random failures in TestZeroInflatedGeneralizedPoisson.test_minimize

xref #4230