### PR TITLE
TST: Alter test condition due to parameter scale

### DIFF
--- a/statsmodels/tsa/statespace/tests/test_sarimax.py
+++ b/statsmodels/tsa/statespace/tests/test_sarimax.py
@@ -659,10 +659,9 @@ class TestFriedmanMLERegression(Friedman):
 
     def test_mle(self):
         result = self.model.fit(disp=-1)
-        assert_allclose(
-            result.params, self.result.params,
-            atol=1e-2, rtol=1e-3
-        )
+        # Use ratio to make atol more meaningful parameter scale differs
+        ratio = result.params / self.result.params
+        assert_allclose(ratio, np.ones(5), atol=1e-2, rtol=1e-3)
 
     def test_bse(self):
         # test defaults


### PR DESCRIPTION
Atol isn't meaningful when scale differs substantially.  Use ratio
to avoid issue

xref #5197