### PR TITLE
MAINT: Avoid/Fix FutureWarnings

### DIFF
--- a/statsmodels/regression/_prediction.py
+++ b/statsmodels/regression/_prediction.py
@@ -42,7 +42,8 @@ class PredictionResults(object):
 
     def conf_int(self, obs=False, alpha=0.05):
         """
-        Returns the confidence interval of the value, `effect` of the constraint.
+        Returns the confidence interval of the value, `effect` of the
+        constraint.
 
         This is currently only available for t and z tests.
 


### PR DESCRIPTION
Broken off from #5132.

The part remaining over there is internal use of apparently-deprecated statsmodels API.  First pass at updating that usage broke a bunch of tests.  This part should be pretty easy.