### PR TITLE
REF: implement _get_start_params

### DIFF
--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -312,6 +312,33 @@ class LikelihoodModel(Model):
         """
         raise NotImplementedError
 
+    def _get_start_params(self, **kwargs):
+        """
+        Find reasonable starting points for parameter optimization.
+
+        Parameters
+        ----------
+        **kwargs : Keyword arguments passed to `fit`
+            Not used in base class implementation
+
+        Returns
+        -------
+        start_params : np.ndarray
+
+        Raises
+        ------
+        ValueError if start_params cannot be found.
+        """
+        if hasattr(self, 'start_params'):
+            start_params = self.start_params
+        elif self.exog is not None:
+            # fails for shape (K,)?
+            start_params = [0] * self.exog.shape[1]
+        else:  # pragma: no cover
+            raise ValueError("If exog is None, then start_params should "
+                             "be specified")
+        return start_params
+
     def fit(self, start_params=None, method='newton', maxiter=100,
             full_output=True, disp=True, fargs=(), callback=None, retall=False,
             skip_hessian=False, **kwargs):
@@ -481,14 +508,7 @@ class LikelihoodModel(Model):
         Hinv = None  # JP error if full_output=0, Hinv not defined
 
         if start_params is None:
-            if hasattr(self, 'start_params'):
-                start_params = self.start_params
-            elif self.exog is not None:
-                # fails for shape (K,)?
-                start_params = [0] * self.exog.shape[1]
-            else:
-                raise ValueError("If exog is None, then start_params should "
-                                 "be specified")
+            start_params = self._get_start_params()
 
         # TODO: separate args from nonarg taking score and hessian, ie.,
         # user-supplied and numerically evaluated estimate frprime does not take

--- a/statsmodels/discrete/count_model.py
+++ b/statsmodels/discrete/count_model.py
@@ -168,9 +168,6 @@ class GenericZeroInflated(CountModel):
             full_output=1, disp=1, callback=None,
             cov_type='nonrobust', cov_kwds=None, use_t=None, **kwargs):
         if start_params is None:
-            offset = getattr(self, "offset", 0) + getattr(self, "exposure", 0)
-            if np.size(offset) == 1 and offset == 0:
-                offset = None
             start_params = self._get_start_params()
 
         if callback is None:
@@ -208,9 +205,6 @@ class GenericZeroInflated(CountModel):
         alpha_p = alpha[:-(self.k_extra - extra)] if (self.k_extra
             and np.size(alpha) > 1) else alpha
         if start_params is None:
-            offset = getattr(self, "offset", 0) + getattr(self, "exposure", 0)
-            if np.size(offset) == 1 and offset == 0:
-                offset = None
             start_params = self.model_main.fit_regularized(
                 start_params=start_params, method=method, maxiter=maxiter,
                 full_output=full_output, disp=0, callback=callback,
@@ -535,10 +529,11 @@ class ZeroInflatedPoisson(GenericZeroInflated):
         result = self.distribution.pmf(counts, mu, w)
         return result[0] if transform else result
 
-    def _get_start_params(self):
+    def _get_start_params(self, **kwargs):
         start_params = self.model_main.fit(disp=0, method="nm").params
         start_params = np.append(np.ones(self.k_inflate) * 0.1, start_params)
         return start_params
+    _get_start_params.__doc__ = base.LikelihoodModel._get_start_params.__doc__
 
 
 class ZeroInflatedGeneralizedPoisson(GenericZeroInflated):
@@ -610,13 +605,14 @@ class ZeroInflatedGeneralizedPoisson(GenericZeroInflated):
         result = self.distribution.pmf(counts, mu, params_main[-1], p, w)
         return result[0] if transform else result
 
-    def _get_start_params(self):
+    def _get_start_params(self, **kwargs):
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", category=ConvergenceWarning)
             start_params = ZeroInflatedPoisson(self.endog, self.exog,
                 exog_infl=self.exog_infl).fit(disp=0).params
         start_params = np.append(start_params, 0.1)
         return start_params
+    _get_start_params.__doc__ = base.LikelihoodModel._get_start_params.__doc__
 
 
 class ZeroInflatedNegativeBinomialP(GenericZeroInflated):
@@ -689,12 +685,13 @@ class ZeroInflatedNegativeBinomialP(GenericZeroInflated):
         result = self.distribution.pmf(counts, mu, params_main[-1], p, w)
         return result[0] if transform else result
 
-    def _get_start_params(self):
+    def _get_start_params(self, **kwargs):
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", category=ConvergenceWarning)
             start_params = self.model_main.fit(disp=0, method='nm').params
         start_params = np.append(np.zeros(self.k_inflate), start_params)
         return start_params
+    _get_start_params.__doc__ = base.LikelihoodModel._get_start_params.__doc__
 
 
 class ZeroInflatedPoissonResults(CountResults):

--- a/statsmodels/discrete/discrete_model.py
+++ b/statsmodels/discrete/discrete_model.py
@@ -1577,15 +1577,23 @@ class GeneralizedPoisson(CountModel):
             offset = getattr(self, "offset", 0) + getattr(self, "exposure", 0)
             if np.size(offset) == 1 and offset == 0:
                 offset = None
+
+            # GH#5255 for TestGeneralizedPoisson_p1.test_fit_regularized we need
+            #  to have the non-optimized start_params passed to Poisson.fit
+            #  TODO: this either indicates a too-tight test precision or an
+            #  over-sensitivity of fit_regularized output to start_params.
+            poi_start = np.zeros(self.exog.shape[1])
             mod_poi = Poisson(self.endog, self.exog, offset=offset)
+
             with warnings.catch_warnings():
                 warnings.simplefilter("always")
                 start_params = mod_poi.fit_regularized(
-                    start_params=start_params, method=method, maxiter=maxiter,
+                    start_params=poi_start, method=method, maxiter=maxiter,
                     full_output=full_output, disp=0, callback=callback,
                     alpha=alpha_p, trim_mode=trim_mode,
                     auto_trim_tol=auto_trim_tol, size_trim_tol=size_trim_tol,
                     qc_tol=qc_tol, **kwargs).params
+
             start_params = np.append(start_params, 0.1)
 
         cntfit = super(CountModel, self).fit_regularized(


### PR DESCRIPTION
count_model implements a `_get_start_params` method that gets called at the top of `fit` if `start_params is None`.  This extends that pattern up to the base class.  This is done in such a way that subclass authors can completely ignore this if they want, nothing has to be changed for subclasses.

The big benefits of this:
- _get_start_params is a reasonable scope for a method, its purpose is completely intuitive
- many classes that currently override `fit` will in the future be able to override _just_ `_get_start_params`
- tighter scopes make it easier to see what is actually necessary where (e.g. the `offset` variables copy/pasted into count_model)