### PR TITLE
TST/CLN: Tighten tol to reduce spurious test failure

### DIFF
--- a/statsmodels/sandbox/distributions/multivariate.py
+++ b/statsmodels/sandbox/distributions/multivariate.py
@@ -65,7 +65,8 @@ def bghfactor(df):
 
 
 def mvstdtprob(a, b, R, df, ieps=1e-5, quadkwds=None, mvstkwds=None):
-    '''probability of rectangular area of standard t distribution
+    """
+    Probability of rectangular area of standard t distribution
 
     assumes mean is zero and R is correlation matrix
 
@@ -74,14 +75,12 @@ def mvstdtprob(a, b, R, df, ieps=1e-5, quadkwds=None, mvstkwds=None):
     This function does not calculate the estimate of the combined error
     between the underlying multivariate normal probability calculations
     and the integration.
-
-    '''
-    kwds = dict(args=(a,b,R,df), epsabs=1e-4, epsrel=1e-2, limit=150)
+    """
+    kwds = dict(args=(a, b, R, df), epsabs=1e-4, epsrel=1e-2, limit=150)
     if not quadkwds is None:
         kwds.update(quadkwds)
-    #print kwds
-    res, err = integrate.quad(funbgh2, *chi.ppf([ieps,1-ieps], df),
-                          **kwds)
+    lower, upper = chi.ppf([ieps, 1 - ieps], df)
+    res, err = integrate.quad(funbgh2, lower, upper, **kwds)
     prob = res * bghfactor(df)
     return prob
 

--- a/statsmodels/sandbox/distributions/tests/test_multivariate.py
+++ b/statsmodels/sandbox/distributions/tests/test_multivariate.py
@@ -63,15 +63,17 @@ class Test_MVN_MVT_prob(object):
         df = self.df
         corr2 = self.corr2
 
-        #from -inf
-        #print 'from -inf'
         a2 = a.copy()
         a2[:] = -np.inf
-        probmvn_R = 0.9961141 #using higher precision in R, error approx. 6.866163e-07
-        probmvt_R = 0.9522146 #using higher precision in R, error approx. 1.6e-07
-        assert_almost_equal(probmvt_R, mvstdtprob(a2, b, corr2, df), 4)
-        assert_almost_equal(probmvn_R, mvstdnormcdf(a2, b, corr2, maxpts=100000,
-                                                    abseps=1e-5), 4)
+        # using higher precision in R, error approx. 6.866163e-07
+        probmvn_R = 0.9961141
+        # using higher precision in R, error approx. 1.6e-07
+        probmvt_R = 0.9522146
+        quadkwds = {'epsabs': 1e-08}
+        probmvt = mvstdtprob(a2, b, corr2, df, quadkwds=quadkwds)
+        assert_almost_equal(probmvt_R, probmvt, 4)
+        probmvn = mvstdnormcdf(a2, b, corr2, maxpts=100000, abseps=1e-5)
+        assert_almost_equal(probmvn_R, probmvn, 4)
 
     def test_mvn_mvt_4(self):
         a, bl = self.a, self.b


### PR DESCRIPTION
Tighten integration tol to avoid spurious fail on Win32
Clean up related functions

xref #5197 

See https://ci.appveyor.com/project/bashtage/statsmodels/build/1.0.1019/job/gbmi5g4cwbfbqclp