### PR TITLE
BLD: Ensure master is available when linting

### DIFF
--- a/lint.sh
+++ b/lint.sh
@@ -47,7 +47,10 @@ if [ "$LINT" == true ]; then
     fi
 
     # Tests any new python files
-    NEW_FILES=$(git diff master --name-status -u -- "*.py" | grep ^A | cut -c 3- | paste -sd " " -)
+    git fetch --unshallow --quiet
+    git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
+    git fetch origin --quiet
+    NEW_FILES=$(git diff origin/master --name-status -u -- "*.py" | grep ^A | cut -c 3- | paste -sd " " -)
     if [ -n "$NEW_FILES" ]; then
         echo "Linting newly added files with strict rules"
         flake8 --isolated $(eval echo $NEW_FILES)


### PR DESCRIPTION
Travis only clones a single branch by default. Manually clone master