### PR TITLE
MAINT: Import instead of copy/pasting utils

### DIFF
--- a/statsmodels/sandbox/utils_old.py
+++ b/statsmodels/sandbox/utils_old.py
@@ -3,36 +3,11 @@ import numpy.linalg as L
 import scipy.interpolate
 import scipy.linalg
 
+from statsmodels.tools.tools import recipr, recipr0, clean0  # noqa:F401
 from statsmodels.robust.scale import mad  # noqa:F401
 
 __docformat__ = 'restructuredtext'
 
-def recipr(X):
-    """
-    Return the reciprocal of an array, setting all entries less than or
-    equal to 0 to 0. Therefore, it presumes that X should be positive in
-    general.
-    """
-    x = np.maximum(np.asarray(X).astype(np.float64), 0)
-    return np.greater(x, 0.) / (x + np.less_equal(x, 0.))
-
-
-def recipr0(X):
-    """
-    Return the reciprocal of an array, setting all entries equal to 0
-    as 0. It does not assume that X should be positive in
-    general.
-    """
-    test = np.equal(np.asarray(X), 0)
-    return np.where(test, 0, 1. / X)
-
-def clean0(matrix):
-    """
-    Erase columns of zeros: can save some time in pseudoinverse.
-    """
-    colsum = np.add.reduce(matrix**2, 0)
-    val = [matrix[:,i] for i in np.flatnonzero(colsum)]
-    return np.array(np.transpose(val))
 
 def rank(X, cond=1.0e-12):
     """

--- a/statsmodels/sandbox/utils_old.py
+++ b/statsmodels/sandbox/utils_old.py
@@ -1,10 +1,10 @@
 import numpy as np
-import numpy.linalg as L
-import scipy.interpolate
 import scipy.linalg
 
 from statsmodels.tools.tools import recipr, recipr0, clean0  # noqa:F401
 from statsmodels.robust.scale import mad  # noqa:F401
+from statsmodels.distributions.empirical_distribution import (  # noqa:F401
+    StepFunction, monotone_fn_inverter)
 
 __docformat__ = 'restructuredtext'
 
@@ -21,6 +21,7 @@ def rank(X, cond=1.0e-12):
     else:
         return int(not np.alltrue(np.equal(X, 0.)))
 
+
 def fullrank(X, r=None):
     """
     Return a matrix whose column span is the same as X.
@@ -33,7 +34,7 @@ def fullrank(X, r=None):
     if r is None:
         r = rank(X)
 
-    V, D, U = L.svd(X, full_matrices=0)
+    V, D, U = np.linalg.svd(X, full_matrices=0)
     order = np.argsort(D)
     order = order[::-1]
     value = []
@@ -41,52 +42,6 @@ def fullrank(X, r=None):
         value.append(V[:,order[i]])
     return np.asarray(np.transpose(value)).astype(np.float64)
 
-class StepFunction(object):
-    """
-    A basic step function: values at the ends are handled in the simplest
-    way possible: everything to the left of x[0] is set to ival; everything
-    to the right of x[-1] is set to y[-1].
-
-    Examples
-    --------
-    >>> from numpy import arange
-    >>> from statsmodels.sandbox.utils_old import StepFunction
-    >>>
-    >>> x = arange(20)
-    >>> y = arange(20)
-    >>> f = StepFunction(x, y)
-    >>>
-    >>> print f(3.2)
-    3.0
-    >>> print f([[3.2,4.5],[24,-3.1]])
-    [[  3.   4.]
-     [ 19.   0.]]
-    """
-
-    def __init__(self, x, y, ival=0., sorted=False):
-
-        _x = np.asarray(x)
-        _y = np.asarray(y)
-
-        if _x.shape != _y.shape:
-            raise ValueError('in StepFunction: x and y do not have the same shape')
-        if len(_x.shape) != 1:
-            raise ValueError('in StepFunction: x and y must be 1-dimensional')
-
-        self.x = np.hstack([[-np.inf], _x])
-        self.y = np.hstack([[ival], _y])
-
-        if not sorted:
-            asort = np.argsort(self.x)
-            self.x = np.take(self.x, asort, 0)
-            self.y = np.take(self.y, asort, 0)
-        self.n = self.x.shape[0]
-
-    def __call__(self, time):
-
-        tind = np.searchsorted(self.x, time) - 1
-        _shape = tind.shape
-        return self.y[tind]
 
 def ECDF(values):
     """
@@ -98,22 +53,3 @@ def ECDF(values):
     n = x.shape[0]
     y = (np.arange(n) + 1.) / n
     return StepFunction(x, y)
-
-def monotone_fn_inverter(fn, x, vectorized=True, **keywords):
-    """
-    Given a monotone function fn (no checking is done to verify monotonicity)
-    and a set of x values, return an linearly interpolated approximation
-    to its inverse from its values on x.
-    """
-
-    if vectorized:
-        y = fn(x, **keywords)
-    else:
-        y = []
-        for _x in x:
-            y.append(fn(_x, **keywords))
-        y = np.array(y)
-
-    a = np.argsort(y)
-
-    return scipy.interpolate.interp1d(y[a], x[a])

--- a/statsmodels/sandbox/utils_old.py
+++ b/statsmodels/sandbox/utils_old.py
@@ -3,6 +3,8 @@ import numpy.linalg as L
 import scipy.interpolate
 import scipy.linalg
 
+from statsmodels.robust.scale import mad  # noqa:F401
+
 __docformat__ = 'restructuredtext'
 
 def recipr(X):
@@ -14,19 +16,6 @@ def recipr(X):
     x = np.maximum(np.asarray(X).astype(np.float64), 0)
     return np.greater(x, 0.) / (x + np.less_equal(x, 0.))
 
-def mad(a, c=0.6745, axis=0):
-    """
-    Median Absolute Deviation:
-
-    median(abs(a - median(a))) / c
-
-    """
-
-    _shape = a.shape
-    a.shape = np.product(a.shape,axis=0)
-    m = np.median(np.fabs(a - np.median(a))) / c
-    a.shape = _shape
-    return m
 
 def recipr0(X):
     """


### PR DESCRIPTION
Particularly the tools.tools functions are strictly better maintained in the non-sandbox versions.

Of the three remaining functions, `rank`, `fullrank`, `ECDF`, there are _almost_ identical non-sandbox versions, and I think it very likely that the differences are unintentional.  But until that is confirmed, leaving those in place.