### PR TITLE
REF: raise early on invalid method

### DIFF
--- a/statsmodels/discrete/count_model.py
+++ b/statsmodels/discrete/count_model.py
@@ -12,6 +12,7 @@ from statsmodels.discrete.discrete_model import (DiscreteModel, CountModel,
                                                  Poisson, Logit, CountResults,
                                                  L1CountResults, Probit,
                                                  _discrete_results_docs,
+                                                 _validate_l1_method,
                                                  GeneralizedPoisson,
                                                  NegativeBinomialP)
 from statsmodels.distributions import zipoisson, zigenpoisson, zinegbin
@@ -201,6 +202,8 @@ class GenericZeroInflated(CountModel):
             alpha=0, trim_mode='auto', auto_trim_tol=0.01, size_trim_tol=1e-4,
             qc_tol=0.03, **kwargs):
 
+        _validate_l1_method(method)
+
         if np.size(alpha) == 1 and alpha != 0:
             k_params = self.k_exog + self.k_inflate
             alpha = alpha * np.ones(k_params)
@@ -224,12 +227,7 @@ class GenericZeroInflated(CountModel):
                 alpha=alpha, trim_mode=trim_mode, auto_trim_tol=auto_trim_tol,
                 size_trim_tol=size_trim_tol, qc_tol=qc_tol, **kwargs)
 
-        if method in ['l1', 'l1_cvxopt_cp']:
-            discretefit = self.result_class_reg(self, cntfit)
-        else:
-            raise ValueError(
-                    "argument method == %s, which is not handled" % method)
-
+        discretefit = self.result_class_reg(self, cntfit)
         return self.result_class_reg_wrapper(discretefit)
 
     fit_regularized.__doc__ = DiscreteModel.fit_regularized.__doc__

--- a/statsmodels/discrete/tests/test_count_model.py
+++ b/statsmodels/discrete/tests/test_count_model.py
@@ -7,9 +7,10 @@ import pytest
 
 import statsmodels.api as sm
 from .results.results_discrete import RandHIE
+from .test_discrete import CheckModelMixin
 
 
-class CheckGeneric(object):
+class CheckGeneric(CheckModelMixin):
     def test_params(self):
         assert_allclose(self.res1.params, self.res2.params, atol=1e-5, rtol=1e-5)
 
@@ -45,7 +46,6 @@ class CheckGeneric(object):
 
     def test_init_keys(self):
         init_kwds = self.res1.model._get_init_kwds()
-        #assert_equal(sorted(list(init_kwds.keys())), self.init_keys)
         assert_equal(set(init_kwds.keys()), set(self.init_keys))
         for key, value in self.init_kwds.items():
             assert_equal(init_kwds[key], value)

--- a/statsmodels/discrete/tests/test_discrete.py
+++ b/statsmodels/discrete/tests/test_discrete.py
@@ -48,7 +48,21 @@ DECIMAL_2 = 2
 DECIMAL_1 = 1
 DECIMAL_0 = 0
 
-class CheckModelResults(object):
+
+class CheckModelMixin(object):
+    # Assertions about the Model object, as opposed to the Results
+    # Assumes that mixed-in class implements:
+    #   res1
+
+    def test_fit_regularized_invalid_method(self):
+        # GH#5224 check we get ValueError when passing invalid "method" arg
+        model = self.res1.model
+
+        with pytest.raises(ValueError, match=r'is not supported, use either'):
+            model.fit_regularized(method="foo")
+
+
+class CheckModelResults(CheckModelMixin):
     """
     res2 should be the test results from RModelWrap
     or the results as defined in model_results_data


### PR DESCRIPTION
Check for a valid "method" argument before doing anything else, avoiding potentially-expensive calls.

Flesh out a more helpful error message.