### PR TITLE
MAINT: simplify discrete calls to get_robustcov_results

### DIFF
--- a/statsmodels/discrete/discrete_model.py
+++ b/statsmodels/discrete/discrete_model.py
@@ -1515,6 +1515,9 @@ class GeneralizedPoisson(CountModel):
                              disp=disp,
                              full_output=full_output,
                              callback=callback,
+                             cov_type=cov_type,
+                             use_t=use_t,
+                             cov_kwds=cov_kwds,
                              **kwargs)
 
         if use_transparams and method not in ["newton", "ncg"]:

--- a/statsmodels/discrete/discrete_model.py
+++ b/statsmodels/discrete/discrete_model.py
@@ -3300,13 +3300,18 @@ class NegativeBinomialP(CountModel):
         mlefit = super(NegativeBinomialP, self).fit(start_params=start_params,
                         maxiter=maxiter, method=method, disp=disp,
                         full_output=full_output, callback=callback,
+                        cov_type=cov_type, use_t=use_t, cov_kwds=cov_kwds,
                         **kwargs)
 
         if use_transparams and method not in ["newton", "ncg"]:
             self._transparams = False
             mlefit._results.params[-1] = np.exp(mlefit._results.params[-1])
+            # ensure cov_params are re-evaluated with updated params
+            delattr(mlefit._results, "cov_type")
 
-        nbinfit = NegativeBinomialResults(self, mlefit._results)
+        nbinfit = NegativeBinomialResults(self, mlefit._results,
+                                          cov_type=cov_type, use_t=use_t,
+                                          cov_kwds=cov_kwds)
         result = NegativeBinomialResultsWrapper(nbinfit)
         return result
 

--- a/statsmodels/discrete/tests/test_discrete.py
+++ b/statsmodels/discrete/tests/test_discrete.py
@@ -2410,9 +2410,10 @@ def test_t_test():
 @pytest.mark.parametrize('cov_type', ['nonrobust', 'HC0', 'HC1', 'HC2', 'HC3'])
 @pytest.mark.parametrize('use_t', [True, False])
 @pytest.mark.parametrize('use_transparams', [True, False])
-def test_negbinp_cov_types(use_transparams, use_t, cov_type, method):
+@pytest.mark.parametrize('mod_cls', [sm.NegativeBinomialP, GeneralizedPoisson])
+def test_cov_types_attached(mod_cls, use_transparams, use_t, cov_type, method):
     # GH#5234 Test that cov_type and use_t are correctly attached to the
-    # results of NegativeBinomialP.fit
+    # results of NegativeBinomialP.fit and GeneralizedPoisson.fit
 
     # avoid runtime warning in cases where use_transparams is ignored
     use_transparams = use_transparams and method not in ['newton', 'ncg']
@@ -2425,7 +2426,8 @@ def test_negbinp_cov_types(use_transparams, use_t, cov_type, method):
     rand_exog_st = (rand_exog - rand_exog.mean(0)) / rand_exog.std(0)
     rand_exog = sm.add_constant(rand_exog_st, prepend=True)
 
-    model = sm.NegativeBinomialP(rand_data.endog, rand_exog)
+    # Use only first 500 observations to trim runtime
+    model = mod_cls(rand_data.endog[:500], rand_exog[:500])
     result = model.fit(method=method, cov_type=cov_type, use_t=use_t,
                        use_transparams=use_transparams,
                        disp=False)

--- a/statsmodels/discrete/tests/test_discrete.py
+++ b/statsmodels/discrete/tests/test_discrete.py
@@ -2410,10 +2410,12 @@ def test_t_test():
 @pytest.mark.parametrize('cov_type', ['nonrobust', 'HC0', 'HC1', 'HC2', 'HC3'])
 @pytest.mark.parametrize('use_t', [True, False])
 @pytest.mark.parametrize('use_transparams', [True, False])
-@pytest.mark.parametrize('mod_cls', [sm.NegativeBinomialP, GeneralizedPoisson])
+@pytest.mark.parametrize('mod_cls', [NegativeBinomialP,
+                                     GeneralizedPoisson,
+                                     Poisson])
 def test_cov_types_attached(mod_cls, use_transparams, use_t, cov_type, method):
     # GH#5234 Test that cov_type and use_t are correctly attached to the
-    # results of NegativeBinomialP.fit and GeneralizedPoisson.fit
+    # results of `model.fit`
 
     # avoid runtime warning in cases where use_transparams is ignored
     use_transparams = use_transparams and method not in ['newton', 'ncg']


### PR DESCRIPTION
`get_robustcov_results` is called in `LikelihoodModelResults.__init__`.  Avoid re-calling it to make things less-stateful.