### PR TITLE
TST: Add mac testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -93,6 +93,16 @@ matrix:
     env:
     - PIP_PRE=true
     - BUILD_INIT=tools/ci/travis_pip.sh
+  - os: osx
+    language: generic
+    env:
+      - PYTHON=3.6.6
+      - NUMPY=1.14
+      - BUILD_INIT=tools/ci/travis_pip.sh
+  - os: osx
+    language: generic
+    env:
+      - PYTHON=3.7
 
   allow_failures:
   # pre-testing is a little fragile. Make it an FYI.
@@ -100,6 +110,16 @@ matrix:
     env:
     - PIP_PRE=true
     - BUILD_INIT=tools/ci/travis_pip.sh
+  - os: osx
+    language: generic
+    env:
+      - PYTHON=3.6.6
+      - NUMPY=1.14
+      - BUILD_INIT=tools/ci/travis_pip.sh
+  - os: osx
+    language: generic
+    env:
+      - PYTHON=3.7
 
 notifications:
   email:
@@ -111,10 +131,12 @@ before_install:
   - if [[ $TRAVIS_PULL_REQUEST == false ]]; then COMMIT_MESSAGE=${TRAVIS_COMMIT_MESSAGE}; fi
   - if echo "$COMMIT_MESSAGE" | grep -E '\[(skip travis|travis skip)\]'; then exit 0 ; fi
   # Show information about CPU running job to understand BLAS issues
-  - sudo lshw -class processor
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo lshw -class processor; fi
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then sysctl -a | grep machdep.cpu; fi
   # Fix for headless TravisCI
   - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then ( sh -e /etc/init.d/xvfb start )& fi
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then ( sudo Xvfb :99 -ac -screen 0 1024x768x8; echo ok )& fi
   # Avoid noise from matplotlib
   - mkdir -p $HOME/.config/matplotlib
   - SRCDIR=$PWD

--- a/tools/ci/travis_conda.sh
+++ b/tools/ci/travis_conda.sh
@@ -1,8 +1,14 @@
 # Source to configure conda CI builds
-wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh -nv
+if [ "$TRAVIS_OS_NAME" = "linux" ]; then
+  CONDA_FILE="Miniconda3-latest-Linux-x86_64.sh";
+fi
+if [ "$TRAVIS_OS_NAME" = "osx" ]; then
+  CONDA_FILE="Miniconda3-latest-MacOSX-x86_64.sh";
+fi
+wget https://repo.continuum.io/miniconda/"$CONDA_FILE" -O miniconda.sh -nv
 chmod +x miniconda.sh
-./miniconda.sh -b -p /home/travis/miniconda
-export PATH=/home/travis/miniconda/bin:$PATH
+./miniconda.sh -b -p "$HOME"/miniconda
+export PATH="$HOME"/miniconda/bin:$PATH
 conda config --set always_yes yes
 conda update --quiet conda
 # Build package list to avoid empty package=versions; only needed for versioned packages

--- a/tools/ci/travis_pip.sh
+++ b/tools/ci/travis_pip.sh
@@ -19,6 +19,20 @@ fi
 if [ "${PIP_PRE}" = true ]; then
     EXTRA_PIP_FLAGS="--pre $EXTRA_PIP_FLAGS --find-links $PRE_WHEELS"
 fi
+
+# travis osx python support is limited. Use homebrew/pyenv to install python.
+if [ "$TRAVIS_OS_NAME" = "osx" ]; then
+
+  brew update && brew upgrade pyenv
+
+  eval "$(pyenv init -)"
+
+  pyenv install "$PYTHON"
+  pyenv local "$PYTHON"
+  pyenv global "$PYTHON"
+  pyenv shell "$PYTHON"
+fi
+
 # Install in our own virtualenv
 python -m pip install --upgrade pip
 pip install --upgrade virtualenv


### PR DESCRIPTION
Here's an attempt to get travis to run on Mac. 2 more scenarios, so even slower than before. 

There are 2 runs. The first will use pyenv to download/install python 3.6.6 and I basically just use our pip install with a few modifications. 

The second run uses python 3.7 and uses pretty much our conda install. 

xref #2069 
xref #5154 
