### PR TITLE
REF: Implement get_start_params_l1

### DIFF
--- a/statsmodels/discrete/count_model.py
+++ b/statsmodels/discrete/count_model.py
@@ -196,7 +196,13 @@ class GenericZeroInflated(CountModel):
             maxiter='defined_by_method', full_output=1, callback=None,
             alpha=0, trim_mode='auto', auto_trim_tol=0.01, size_trim_tol=1e-4,
             qc_tol=0.03, **kwargs):
+        """
+        If no `start_params` are given by the user, find reasonable defaults.
 
+        Returns
+        -------
+        start_params : ndarray
+        """
         alpha_p = alpha
         if self.k_extra and np.size(alpha) > 1:
             extra = self.k_extra - self.k_inflate

--- a/statsmodels/discrete/discrete_model.py
+++ b/statsmodels/discrete/discrete_model.py
@@ -649,6 +649,13 @@ class MultinomialModel(BinaryModel):
         return MultinomialResultsWrapper(mnfit)
 
     def _get_start_params_l1(self, **kwargs):
+        """
+        If no `start_params` are given by the user, find reasonable defaults.
+
+        Returns
+        -------
+        start_params : ndarray
+        """
         return np.zeros((self.K * (self.J - 1)))
 
     @Appender(DiscreteModel.fit_regularized.__doc__)
@@ -1545,6 +1552,13 @@ class GeneralizedPoisson(CountModel):
             maxiter='defined_by_method', full_output=1, callback=None,
             alpha=0, trim_mode='auto', auto_trim_tol=0.01, size_trim_tol=1e-4,
             qc_tol=0.03, **kwargs):
+        """
+        If no `start_params` are given by the user, find reasonable defaults.
+
+        Returns
+        -------
+        start_params : ndarray
+        """
 
         alpha_p = alpha
         if self.k_extra and np.size(alpha) > 1:
@@ -2982,6 +2996,13 @@ class NegativeBinomial(CountModel):
             maxiter='defined_by_method', full_output=1, callback=None,
             alpha=0, trim_mode='auto', auto_trim_tol=0.01, size_trim_tol=1e-4,
             qc_tol=0.03, **kwargs):
+        """
+        If no `start_params` are given by the user, find reasonable defaults.
+
+        Returns
+        -------
+        start_params : ndarray
+        """
 
         # Use poisson fit as first guess.
         # TODO, Warning: this assumes exposure is logged
@@ -3373,6 +3394,13 @@ class NegativeBinomialP(CountModel):
             maxiter='defined_by_method', full_output=1, callback=None,
             alpha=0, trim_mode='auto', auto_trim_tol=0.01, size_trim_tol=1e-4,
             qc_tol=0.03, **kwargs):
+        """
+        If no `start_params` are given by the user, find reasonable defaults.
+
+        Returns
+        -------
+        start_params : ndarray
+        """
 
         alpha_p = alpha
         if self.k_extra and np.size(alpha) > 1:


### PR DESCRIPTION
`fit_regularized` analogue to #5205.  Clarifies what parts of the namespace are needed where.

With a little more work, subclasses can override `_get_start_params_l1` and not need to override the `DiscreteModel` implementation of fit_regularized.

Also, the `_get_start_params_l1` implementations have some duplicated code that may be shareable.

Still needs docstrings.