### PR TITLE
BUG: Allow `summary` even if filter_results=None (e.g. after `save`, `load`)

### DIFF
--- a/statsmodels/tsa/statespace/mlemodel.py
+++ b/statsmodels/tsa/statespace/mlemodel.py
@@ -2755,7 +2755,8 @@ class MLEResults(tsbase.TimeSeriesModelResults):
             ('AIC', ["%#5.3f" % self.aic]),
             ('BIC', ["%#5.3f" % self.bic]),
             ('HQIC', ["%#5.3f" % self.hqic])]
-        if self.filter_results.filter_concentrated:
+        if (self.filter_results is not None and
+                self.filter_results.filter_concentrated):
             top_right.append(('Scale', ["%#5.3f" % self.scale]))
 
         if hasattr(self, 'cov_type'):


### PR DESCRIPTION
Since `filter_results` is deleted during `save`, the check for `self.filter_results.filter_concentrated` would fail if `summary` was called.