### PR TITLE
BUG: Sequential simulation in models with state_intercept

### DIFF
--- a/statsmodels/tsa/statespace/simulation_smoother.py
+++ b/statsmodels/tsa/statespace/simulation_smoother.py
@@ -131,19 +131,16 @@ class SimulationSmoother(KalmanSmoother):
 
     def _simulate(self, nsimulations, measurement_shocks, state_shocks,
                   initial_state):
+        # Initialize the filter and representation
+        prefix, dtype, create_smoother, create_filter, create_statespace = (
+            self._initialize_smoother())
 
-        prefix = self.prefix
+        # Initialize the state
+        self._initialize_state(prefix=prefix)
 
         # Create the simulator if necessary
         if (prefix not in self._simulators or
                 not nsimulations == self._simulators[prefix].nobs):
-
-            # Make sure we have the required Statespace representation
-            prefix, dtype, create_statespace = (
-                self._initialize_representation())
-
-            # Initialize the state
-            self._initialize_state(prefix=self.prefix)
 
             simulation_output = 0
             # Kalman smoother parameters
@@ -228,11 +225,8 @@ class SimulationSmoother(KalmanSmoother):
             raise ValueError('Invalid results class provided.')
 
         # Make sure we have the required Statespace representation
-        if prefix is None:
-            prefix = self.prefix
-        prefix, dtype, create_statespace = (
-            self._initialize_representation(prefix)
-        )
+        prefix, dtype, create_smoother, create_filter, create_statespace = (
+            self._initialize_smoother())
 
         # Simulation smoother parameters
         simulation_output = self.get_simulation_output(simulation_output,
@@ -555,10 +549,11 @@ class SimulationSmoothResults(object):
         self._simulated_state_disturbance = None
 
         # Re-initialize the _statespace representation
-        self.model._initialize_representation(prefix=self.prefix)
+        prefix, dtype, create_smoother, create_filter, create_statespace = (
+            self.model._initialize_smoother())
 
         # Initialize the state
-        self.model._initialize_state(prefix=self.prefix)
+        self.model._initialize_state(prefix=prefix)
 
         # Draw the (independent) random variates for disturbances in the
         # simulation

--- a/statsmodels/tsa/statespace/tests/test_simulate.py
+++ b/statsmodels/tsa/statespace/tests/test_simulate.py
@@ -539,3 +539,17 @@ def test_known_initialization():
                           state_shocks=eps1)
     tmp = 100 * 0.5**np.arange(nobs)
     assert_allclose(actual, np.c_[0.8 * tmp, 0.2 * tmp])
+
+
+def test_sequential_simulate():
+    # Test that we can perform simulation, change the system matrices, and then
+    # perform simulation again (i.e. check that everything updates correctly
+    # in the simulation smoother).
+    n_simulations = 100
+    mod = sarimax.SARIMAX([1], order=(0, 0, 0), trend='c')
+
+    actual = mod.simulate([1, 0], n_simulations)
+    assert_allclose(actual, np.ones(n_simulations))
+
+    actual = mod.simulate([10, 0], n_simulations)
+    assert_allclose(actual, np.ones(n_simulations) * 10)


### PR DESCRIPTION
`SimulationSmoother` objects store a Cython  `_{{prefix}}SimulationSmoother` object that is reused each time `simulate` is called.

Unfortunately, `simulate` wasn't properly updating the Cython objects' `state_intercept` in the case of multiple simulate calls, so for example the following:

```python
mod = sm.tsa.SARIMAX([1], order=(0, 0, 0), trend='c')
print(mod.simulate([1, 0], 5))
print(mod.simulate([10, 0], 5))
```

was giving:

```
[1. 1. 1. 1. 1.]
[10. 1. 1. 1. 1.]
```

instead of

```
[1. 1. 1. 1. 1.]
[10. 10. 10. 10. 10.]
```

This PR adds a unit test and corrects the issue.