### PR TITLE
MAINT: avoid pandas FutureWarning by checking specific condition

### DIFF
--- a/statsmodels/iolib/table.py
+++ b/statsmodels/iolib/table.py
@@ -635,11 +635,12 @@ class Cell(object):
     A cell can belong to a Row, but does not have to.
     """
     def __init__(self, data='', datatype=None, row=None, **fmt_dict):
-        try:  # might have passed a Cell instance
+        if isinstance(data, Cell):
+            # might have passed a Cell instance
             self.data = data.data
             self._datatype = data.datatype
             self._fmt = data._fmt
-        except (AttributeError, TypeError):  # passed ordinary data
+        else:
             self.data = data
             self._datatype = datatype
             self._fmt = dict()


### PR DESCRIPTION
Noticed in test logs:

```
iolib/table.py:639: FutureWarning: Index.data is deprecated and will be removed in a future version
  self.data = data.data
iolib/table.py:639: FutureWarning: Float64Index.data is deprecated and will be removed in a future version
  self.data = data.data
```

`Cell.__init__` currently uses a try/except to duck-type the check for another `Cell` object being passed as `data`.  In the case where a pandas Index is passed, the try/except works correctly, but not before issuing a warning.

This PR changes the try/except check to a specific check for the relevant case, avoiding the FutureWarning.