### PR TITLE
MAINT: fix typos in pca, wrap long lines

### DIFF
--- a/lint.sh
+++ b/lint.sh
@@ -23,7 +23,12 @@ if [ "$LINT" == true ]; then
         statsmodels/graphics/tsaplots.py \
         statsmodels/examples/tests/ \
         statsmodels/iolib/smpickle.py \
+        statsmodels/iolib/tests/test_pickle.py \
+        statsmodels/multivariate/pca.py \
+        statsmodels/regression/mixed_linear_model.py \
+        statsmodels/regression/recursive_ls.py \
         statsmodels/regression/tests/test_lme.py \
+        statsmodels/tools/linalg.py \
         statsmodels/tools/web.py \
         statsmodels/tools/tests/test_linalg.py \
         statsmodels/tools/decorators.py \

--- a/statsmodels/multivariate/pca.py
+++ b/statsmodels/multivariate/pca.py
@@ -12,6 +12,7 @@ from statsmodels.compat.python import range
 from statsmodels.tools.sm_exceptions import (ValueWarning,
                                              EstimationWarning)
 
+
 def _norm(x):
     return np.sqrt(np.sum(x * x))
 
@@ -136,8 +137,8 @@ class PCA(object):
     Notes
     -----
     The default options perform principal component analysis on the
-    demeanded, unit variance version of data.  Setting standardize to False will
-    instead onle demean, and setting both standardized and
+    demeaned, unit variance version of data.  Setting standardize to False
+    will instead only demean, and setting both standardized and
     demean to False will not alter the data.
 
     Once the data have been transformed, the following relationships hold when
@@ -326,7 +327,8 @@ class PCA(object):
 
         # Check adjusted data size
         if self._adjusted_data.size == 0:
-            raise ValueError('Removal of missing values has eliminated all data.')
+            raise ValueError('Removal of missing values has eliminated '
+                             'all data.')
 
     def _compute_gls_weights(self):
         """
@@ -433,7 +435,8 @@ class PCA(object):
 
     def _compute_using_nipals(self):
         """
-        NIPALS implementation to compute small number of eigenvalues and eigenvectors
+        NIPALS implementation to compute small number of eigenvalues
+        and eigenvectors
         """
         x = self.transformed_data
         if self._ncomp > 1:
@@ -505,7 +508,8 @@ class PCA(object):
             self._compute_eig()
             # Call function to compute factors and projection
             self._compute_pca_from_eig()
-            projection = np.asarray(self.project(transform=False, unweight=False))
+            projection = np.asarray(self.project(transform=False,
+                                                 unweight=False))
             projection_masked = projection[mask]
             data[mask] = projection_masked
             delta = last_projection_masked - projection_masked
@@ -534,9 +538,10 @@ class PCA(object):
             if num_good < self._ncomp:
                 import warnings
 
-                warn = 'Only {num:d} eigenvalues are positive.  The is the ' \
-                       'maximum number of components that can be extracted.'
-                warnings.warn(warn.format(num=num_good), EstimationWarning)
+                warnings.warn('Only {num:d} eigenvalues are positive.  '
+                              'This is the maximum number of components '
+                              'that can be extracted.'.format(num=num_good),
+                              EstimationWarning)
 
                 self._ncomp = num_good
                 vals[num_good:] = np.finfo(np.float64).tiny
@@ -558,7 +563,8 @@ class PCA(object):
         Final statistics to compute
         """
         # TSS and related calculations
-        # TODO: This needs careful testing, with and without weights, gls, standardized and demean
+        # TODO: This needs careful testing, with and without weights,
+        #   gls, standardized and demean
         weights = self.weights
         ss_data = self.transformed_data * np.sqrt(weights)
         self._tss_indiv = np.sum(ss_data ** 2, 0)
@@ -680,7 +686,8 @@ class PCA(object):
         self.ic = pd.DataFrame(self.ic, columns=['IC_p1', 'IC_p2', 'IC_p3'])
         self.ic.index.name = 'ncomp'
 
-    def plot_scree(self, ncomp=None, log_scale=True, cumulative=False, ax=None):
+    def plot_scree(self, ncomp=None, log_scale=True,
+                   cumulative=False, ax=None):
         """
         Plot of the ordered eigenvalues
 
@@ -834,8 +841,8 @@ def pca(data, ncomp=None, standardize=True, demean=True, normalize=True,
 
     Notes
     -----
-    This is a simple function wrapper around the PCA class. See PCA for more information
-    and additional methods.
+    This is a simple function wrapper around the PCA class. See PCA for
+    more information and additional methods.
     """
     pc = PCA(data, ncomp=ncomp, standardize=standardize, demean=demean,
              normalize=normalize, gls=gls, weights=weights, method=method)


### PR DESCRIPTION
Couple of typos in a docstring and in a warning.  After that, the file is only a few long-lines away from being fully-lintable, so went for it.