### PR TITLE
MAINT: De-duplicate code in iolib.summary

### DIFF
--- a/statsmodels/iolib/summary.py
+++ b/statsmodels/iolib/summary.py
@@ -108,19 +108,13 @@ def summary(self, yname=None, xname=None, title=0, alpha=.05,
     """
 
     # TODO: Make sure all self.model.__class__.__name__ are listed
-    model_types = {'OLS' : 'Ordinary least squares',
-                   'GLS' : 'Generalized least squares',
-                   'GLSAR' : 'Generalized least squares with AR(p)',
-                   'WLS' : 'Weighted least squares',
-                   'RLM' : 'Robust linear model',
-                   'GLM' : 'Generalized linear model'
+    model_types = {'OLS': 'Ordinary least squares',
+                   'GLS': 'Generalized least squares',
+                   'GLSAR': 'Generalized least squares with AR(p)',
+                   'WLS': 'Weighted least squares',
+                   'RLM': 'Robust linear model',
+                   'GLM': 'Generalized linear model'
                    }
-    model_methods = {'OLS' : 'Least Squares',
-                   'GLS' : 'Least Squares',
-                   'GLSAR' : 'Least Squares',
-                   'WLS' : 'Least Squares',
-                   'RLM' : '?',
-                   'GLM' : '?'}
     if title == 0:
         title = model_types[self.model.__class__.__name__]
 
@@ -139,11 +133,11 @@ def summary(self, yname=None, xname=None, title=0, alpha=.05,
     # TODO: define this generically, overwrite in model classes
     #replace definition of stubs data by single list
     #e.g.
-    gen_left =   [('Model type:', [modeltype]),
-                  ('Date:', [date]),
-                  ('Dependent Variable:', yname), #What happens with multiple names?
-                  ('df model', [df_model])
-                  ]
+    gen_left = [('Model type:', [modeltype]),
+                ('Date:', [date]),
+                ('Dependent Variable:', yname),  # TODO: What happens with multiple names?
+                ('df model', [df_model])
+                ]
     gen_stubs_left, gen_data_left = zip_longest(*gen_left) #transpose row col
 
     gen_title = title
@@ -167,8 +161,9 @@ def summary(self, yname=None, xname=None, title=0, alpha=.05,
     gen_table_right = SimpleTable(gen_data_right,
                                   gen_header,
                                   gen_stubs_right,
-                                  title = gen_title,
-                                  txt_fmt = gen_fmt)
+                                  title=gen_title,
+                                  txt_fmt=gen_fmt
+                                  )
     gen_table_left.extend_right(gen_table_right)
     general_table = gen_table_left
 
@@ -238,18 +233,11 @@ def summary(self, yname=None, xname=None, title=0, alpha=.05,
         table = str(general_table)+'\n'+str(parameter_table)
         return table
 
-    def ols_to_csv():
-        """
-        exports ols summary data to csv
-        """
-        pass
-
     def glm_printer():
         table = str(general_table)+'\n'+str(parameter_table)
         return table
 
-    printers  = {'OLS': ols_printer,
-                 'GLM': glm_printer}
+    printers = {'OLS': ols_printer, 'GLM': glm_printer}
 
     if returns == 'print':
         try:
@@ -262,21 +250,18 @@ def _getnames(self, yname=None, xname=None):
     '''extract names from model or construct names
     '''
     if yname is None:
-        if hasattr(self.model, 'endog_names') and (
-                self.model.endog_names is not None):
+        if getattr(self.model, 'endog_names', None) is not None:
             yname = self.model.endog_names
         else:
             yname = 'y'
 
     if xname is None:
-        if hasattr(self.model, 'exog_names') and (
-                self.model.exog_names is not None):
+        if getattr(self.model, 'exog_names', None) is not None:
             xname = self.model.exog_names
         else:
             xname = ['var_%d' % i for i in range(len(self.params))]
 
     return yname, xname
-
 
 
 def summary_top(results, title=None, gleft=None, gright=None, yname=None, xname=None):
@@ -325,13 +310,12 @@ def summary_top(results, title=None, gleft=None, gright=None, yname=None, xname=
                     ('Df resid:', None)]
 
         try:
-            llf = results.llf
+            llf = results.llf  # noqa: F841
             gen_left.append(('Log-Likelihood', None))
         except: # AttributeError, NotImplementedError
             pass
 
         gen_right = []
-
 
     gen_title = title
     gen_header = None
@@ -352,7 +336,7 @@ def summary_top(results, title=None, gleft=None, gright=None, yname=None, xname=
             gen_right_.append((item, value))
         gen_right = gen_right_
 
-    #check
+    # check nothing was missed
     missing_values = [k for k,v in gen_left + gen_right if v is None]
     assert missing_values == [], missing_values
 
@@ -362,12 +346,12 @@ def summary_top(results, title=None, gleft=None, gright=None, yname=None, xname=
             # fill up with blank lines to same length
             gen_right += [(' ', ' ')] * (len(gen_left) - len(gen_right))
         elif len(gen_right) > len(gen_left):
-            #f ill up with blank lines to same length, just to keep it symmetric
+            # fill up with blank lines to same length, just to keep it symmetric
             gen_left += [(' ', ' ')] * (len(gen_right) - len(gen_left))
 
         # padding in SimpleTable doesn't work like I want
         #force extra spacing and exact string length in right table
-        g en_right = [('%-21s' % ('  '+k), v) for k,v in gen_right]
+        gen_right = [('%-21s' % ('  '+k), v) for k,v in gen_right]
         gen_stubs_right, gen_data_right = zip_longest(*gen_right) #transpose row col
         gen_table_right = SimpleTable(gen_data_right,
                                       gen_header,
@@ -377,7 +361,6 @@ def summary_top(results, title=None, gleft=None, gright=None, yname=None, xname=
                                       )
     else:
         gen_table_right = []  #because .extend_right seems works with []
-
 
     #moved below so that we can pad if needed to match length of gen_right
     #transpose rows and columns, `unzip`
@@ -394,7 +377,6 @@ def summary_top(results, title=None, gleft=None, gright=None, yname=None, xname=
     general_table = gen_table_left
 
     return general_table
-
 
 
 def summary_params(results, yname=None, xname=None, alpha=.05, use_t=True,
@@ -440,7 +422,6 @@ def summary_params(results, yname=None, xname=None, alpha=.05, use_t=True,
         tvalues = results.tvalues  #is this sometimes called zvalues
         pvalues = results.pvalues
         conf_int = results.conf_int(alpha)
-
 
     # Dictionary to store the header names for the parameter part of the
     # summary table. look up by modeltype
@@ -571,9 +552,9 @@ def summary_params_2d(result, extras=None, endog_names=None, exog_names=None,
     if endog_names is None:
         # TODO: note the [1:] is specific to current MNLogit
         endog_names = ['endog_%d' % i for i in
-                            np.unique(result.model.endog)[1:]]
+                       np.unique(result.model.endog)[1:]]
     if exog_names is None:
-        exog_names = ['var%d' %i for i in range(len(result.params))]
+        exog_names = ['var%d' % i for i in range(len(result.params))]
 
     # TODO: check formatting options with different values
     res_params = [[forg(item, prec=4) for item in row] for row in result.params]
@@ -592,7 +573,8 @@ def summary_params_2d(result, extras=None, endog_names=None, exog_names=None,
         stubs = endog_names
 
     txt_fmt = copy.deepcopy(fmt_params)
-    txt_fmt.update(dict(data_fmts = ["%s"]*result.params.shape[1]))
+    txt_fmt["data_fmts"] = ["%s"]*result.params.shape[1]
+
     return SimpleTable(data, headers=exog_names,
                              stubs=stubs,
                              title=title,

--- a/statsmodels/iolib/summary.py
+++ b/statsmodels/iolib/summary.py
@@ -1,8 +1,11 @@
+import copy
+import time
+
 from statsmodels.compat.python import range, lrange, lmap, lzip, zip_longest
 import numpy as np
 from statsmodels.iolib.table import SimpleTable
 from statsmodels.iolib.tableformatting import (gen_fmt, fmt_2,
-                                                fmt_params, fmt_base, fmt_2cols)
+                                               fmt_params, fmt_2cols)
 
 
 def forg(x, prec=3):
@@ -103,9 +106,8 @@ def summary(self, yname=None, xname=None, title=0, alpha=.05,
     -----
     conf_int calculated from normal dist.
     """
-    import time as time
 
-    #TODO Make sure all self.model.__class__.__name__ are listed
+    # TODO: Make sure all self.model.__class__.__name__ are listed
     model_types = {'OLS' : 'Ordinary least squares',
                    'GLS' : 'Generalized least squares',
                    'GLSAR' : 'Generalized least squares with AR(p)',
@@ -134,7 +136,7 @@ def summary(self, yname=None, xname=None, title=0, alpha=.05,
 
     #General part of the summary table, Applicable to all? models
     #------------------------------------------------------------
-    #TODO: define this generically, overwrite in model classes
+    # TODO: define this generically, overwrite in model classes
     #replace definition of stubs data by single list
     #e.g.
     gen_left =   [('Model type:', [modeltype]),
@@ -149,8 +151,8 @@ def summary(self, yname=None, xname=None, title=0, alpha=.05,
     gen_table_left = SimpleTable(gen_data_left,
                                  gen_header,
                                  gen_stubs_left,
-                                 title = gen_title,
-                                 txt_fmt = gen_fmt
+                                 title=gen_title,
+                                 txt_fmt=gen_fmt
                                  )
 
     gen_stubs_right = ('Method:',
@@ -170,24 +172,25 @@ def summary(self, yname=None, xname=None, title=0, alpha=.05,
     gen_table_left.extend_right(gen_table_right)
     general_table = gen_table_left
 
-    #Parameters part of the summary table
-    #------------------------------------
-    #Note: this is not necessary since we standardized names, only t versus normal
-    tstats = {'OLS' : self.t(),
-            'GLS' : self.t(),
-            'GLSAR' : self.t(),
-            'WLS' : self.t(),
-            'RLM' : self.t(),
-            'GLM' : self.t()}
-    prob_stats = {'OLS' : self.pvalues,
-                  'GLS' : self.pvalues,
-                  'GLSAR' : self.pvalues,
-                  'WLS' : self.pvalues,
-                  'RLM' : self.pvalues,
-                  'GLM' : self.pvalues
+    # Parameters part of the summary table
+    # ------------------------------------
+    # Note: this is not necessary since we standardized names,
+    #  only t versus normal
+    tstats = {'OLS': self.t(),
+              'GLS': self.t(),
+              'GLSAR': self.t(),
+              'WLS': self.t(),
+              'RLM': self.t(),
+              'GLM': self.t()}
+    prob_stats = {'OLS': self.pvalues,
+                  'GLS': self.pvalues,
+                  'GLSAR': self.pvalues,
+                  'WLS': self.pvalues,
+                  'RLM': self.pvalues,
+                  'GLM': self.pvalues
                   }
-    #Dictionary to store the header names for the parameter part of the
-    #summary table. look up by modeltype
+    # Dictionary to store the header names for the parameter part of the
+    # summary table. look up by modeltype
     alp = str((1-alpha)*100)+'%'
     param_header = {
          'OLS'   : ['coef', 'std err', 't', 'P>|t|', alp + ' Conf. Interval'],
@@ -214,8 +217,8 @@ def summary(self, yname=None, xname=None, title=0, alpha=.05,
     parameter_table = SimpleTable(params_data,
                                   param_header[modeltype],
                                   params_stubs,
-                                  title = None,
-                                  txt_fmt = fmt_2
+                                  title=None,
+                                  txt_fmt=fmt_2
                                   )
 
     #special table
@@ -240,15 +243,15 @@ def summary(self, yname=None, xname=None, title=0, alpha=.05,
         exports ols summary data to csv
         """
         pass
+
     def glm_printer():
         table = str(general_table)+'\n'+str(parameter_table)
         return table
-        pass
 
     printers  = {'OLS': ols_printer,
                  'GLM': glm_printer}
 
-    if returns=='print':
+    if returns == 'print':
         try:
             return printers[modeltype]()
         except KeyError:
@@ -288,7 +291,6 @@ def summary_top(results, title=None, gleft=None, gright=None, yname=None, xname=
     gen_left, gen_right = gleft, gright
 
     # time and names are always included
-    import time
     time_now = time.localtime()
     time_of_day = [time.strftime("%H:%M:%S", time_now)]
     date = time.strftime("%a, %d %b %Y", time_now)
@@ -354,24 +356,24 @@ def summary_top(results, title=None, gleft=None, gright=None, yname=None, xname=
     missing_values = [k for k,v in gen_left + gen_right if v is None]
     assert missing_values == [], missing_values
 
-    #pad both tables to equal number of rows
+    # pad both tables to equal number of rows
     if gen_right:
         if len(gen_right) < len(gen_left):
-            #fill up with blank lines to same length
+            # fill up with blank lines to same length
             gen_right += [(' ', ' ')] * (len(gen_left) - len(gen_right))
         elif len(gen_right) > len(gen_left):
-            #fill up with blank lines to same length, just to keep it symmetric
+            #f ill up with blank lines to same length, just to keep it symmetric
             gen_left += [(' ', ' ')] * (len(gen_right) - len(gen_left))
 
-        #padding in SimpleTable doesn't work like I want
+        # padding in SimpleTable doesn't work like I want
         #force extra spacing and exact string length in right table
-        gen_right = [('%-21s' % ('  '+k), v) for k,v in gen_right]
+        g en_right = [('%-21s' % ('  '+k), v) for k,v in gen_right]
         gen_stubs_right, gen_data_right = zip_longest(*gen_right) #transpose row col
         gen_table_right = SimpleTable(gen_data_right,
                                       gen_header,
                                       gen_stubs_right,
-                                      title = gen_title,
-                                      txt_fmt = fmt_2cols #gen_fmt
+                                      title=gen_title,
+                                      txt_fmt=fmt_2cols
                                       )
     else:
         gen_table_right = []  #because .extend_right seems works with []
@@ -384,8 +386,8 @@ def summary_top(results, title=None, gleft=None, gright=None, yname=None, xname=
     gen_table_left = SimpleTable(gen_data_left,
                                  gen_header,
                                  gen_stubs_left,
-                                 title = gen_title,
-                                 txt_fmt = fmt_2cols
+                                 title=gen_title,
+                                 txt_fmt=fmt_2cols
                                  )
 
     gen_table_left.extend_right(gen_table_right)
@@ -422,13 +424,14 @@ def summary_params(results, yname=None, xname=None, alpha=.05, use_t=True,
     params_table : SimpleTable instance
     '''
 
-    #Parameters part of the summary table
-    #------------------------------------
-    #Note: this is not necessary since we standardized names, only t versus normal
+    # Parameters part of the summary table
+    # ------------------------------------
+    # Note: this is not necessary since we standardized names,
+    #   only t versus normal
 
     if isinstance(results, tuple):
-        #for multivariate endog
-        #TODO: check whether I don't want to refactor this
+        # for multivariate endog
+        # TODO: check whether I don't want to refactor this
         #we need to give parameter alpha to conf_int
         results, params, std_err, tvalues, pvalues, conf_int = results
     else:
@@ -439,8 +442,8 @@ def summary_params(results, yname=None, xname=None, alpha=.05, use_t=True,
         conf_int = results.conf_int(alpha)
 
 
-    #Dictionary to store the header names for the parameter part of the
-    #summary table. look up by modeltype
+    # Dictionary to store the header names for the parameter part of the
+    # summary table. look up by modeltype
     if use_t:
         param_header = ['coef', 'std err', 't', 'P>|t|',
                         '[' + str(alpha/2), str(1-alpha/2) + ']']
@@ -450,7 +453,6 @@ def summary_params(results, yname=None, xname=None, alpha=.05, use_t=True,
 
     if skip_header:
         param_header = None
-
 
     _, xname = _getnames(results, yname=yname, xname=xname)
 
@@ -504,13 +506,14 @@ def summary_params_frame(results, yname=None, xname=None, alpha=.05,
     params_table : SimpleTable instance
     '''
 
-    #Parameters part of the summary table
-    #------------------------------------
-    #Note: this is not necessary since we standardized names, only t versus normal
+    # Parameters part of the summary table
+    # ------------------------------------
+    # Note: this is not necessary since we standardized names,
+    #   only t versus normal
 
     if isinstance(results, tuple):
-        #for multivariate endog
-        #TODO: check whether I don't want to refactor this
+        # for multivariate endog
+        # TODO: check whether I don't want to refactor this
         #we need to give parameter alpha to conf_int
         results, params, std_err, tvalues, pvalues, conf_int = results
     else:
@@ -520,10 +523,8 @@ def summary_params_frame(results, yname=None, xname=None, alpha=.05,
         pvalues = results.pvalues
         conf_int = results.conf_int(alpha)
 
-
-    #Dictionary to store the header names for the parameter part of the
-    #summary table. look up by modeltype
-    alp = str((1-alpha)*100)+'%'
+    # Dictionary to store the header names for the parameter part of the
+    # summary table. look up by modeltype
     if use_t:
         param_header = ['coef', 'std err', 't', 'P>|t|',
                         'Conf. Int. Low', 'Conf. Int. Upp.']
@@ -568,20 +569,20 @@ def summary_params_2d(result, extras=None, endog_names=None, exog_names=None,
 
     '''
     if endog_names is None:
-        #TODO: note the [1:] is specific to current MNLogit
+        # TODO: note the [1:] is specific to current MNLogit
         endog_names = ['endog_%d' % i for i in
                             np.unique(result.model.endog)[1:]]
     if exog_names is None:
         exog_names = ['var%d' %i for i in range(len(result.params))]
 
-    #TODO: check formatting options with different values
+    # TODO: check formatting options with different values
     res_params = [[forg(item, prec=4) for item in row] for row in result.params]
-    if extras: #not None or non-empty
-        #maybe this should be a simple triple loop instead of list comprehension?
+    if extras:
         extras_list = [[['%10s' % ('(' + forg(v, prec=3).strip() + ')')
-                                for v in col]
-                                for col in getattr(result, what)]
-                                for what in extras]
+                         for v in col]
+                        for col in getattr(result, what)]
+                       for what in extras
+                       ]
         data = lzip(res_params, *extras_list)
         data = [i for j in data for i in j]  #flatten
         stubs = lzip(endog_names, *[['']*len(endog_names)]*len(extras))
@@ -590,13 +591,12 @@ def summary_params_2d(result, extras=None, endog_names=None, exog_names=None,
         data = res_params
         stubs = endog_names
 
-    import copy
     txt_fmt = copy.deepcopy(fmt_params)
     txt_fmt.update(dict(data_fmts = ["%s"]*result.params.shape[1]))
     return SimpleTable(data, headers=exog_names,
                              stubs=stubs,
                              title=title,
-                             txt_fmt = txt_fmt)
+                             txt_fmt=txt_fmt)
 
 
 def summary_params_2dflat(result, endog_names=None, exog_names=None, alpha=0.05,
@@ -636,28 +636,27 @@ def summary_params_2dflat(result, endog_names=None, exog_names=None, alpha=0.05,
 
     res = result
     params = res.params
-    if params.ndim == 2: # we've got multiple equations
+    if params.ndim == 2:  # we've got multiple equations
         n_equ = params.shape[1]
-        if not len(endog_names) == params.shape[1]:
+        if len(endog_names) != params.shape[1]:
             raise ValueError('endog_names has wrong length')
     else:
-        if not len(endog_names) == len(params):
+        if len(endog_names) != len(params):
             raise ValueError('endog_names has wrong length')
         n_equ = 1
 
     #VAR doesn't have conf_int
     #params = res.params.T # this is a convention for multi-eq models
 
+    # check that we have the right length of names
     if not isinstance(endog_names, list):
-        #this might be specific to multinomial logit type, move?
+        # TODO: this might be specific to multinomial logit type, move?
         if endog_names is None:
             endog_basename = 'endog'
         else:
             endog_basename = endog_names
-        #TODO: note, the [1:] is specific to current MNLogit
+        # TODO: note, the [1:] is specific to current MNLogit
         endog_names = res.model.endog_names[1:]
-
-    #check if we have the right length of names
 
     tables = []
     for eq in range(n_equ):
@@ -671,7 +670,7 @@ def summary_params_2dflat(result, endog_names=None, exog_names=None, alpha=0.05,
 
         tables.append(tble)
 
-    #add titles, they will be moved to header lines in table_extend
+    # add titles, they will be moved to header lines in table_extend
     for i in range(len(endog_names)):
         tables[i].title = endog_names[i]
 
@@ -704,7 +703,7 @@ def table_extend(tables, keep_headers=True):
         t = deepcopy(t)
 
         #move title to first cell of header
-        #TODO: check if we have multiline headers
+        # TODO: check if we have multiline headers
         if t[0].datatype == 'header':
             t[0][0].data = t.title
             t[0][0]._datatype = None
@@ -713,7 +712,7 @@ def table_extend(tables, keep_headers=True):
                 for c in t[0][1:]:
                     c.data = ''
 
-        #add separating line and extend tables
+        # add separating line and extend tables
         if ii == 0:
             table_all = t
         else:
@@ -737,7 +736,6 @@ def summary_return(tables, return_fmt='text'):
         return '\n'.join(x.as_csv() for x in tables)
     elif return_fmt == 'latex':
         # TODO: insert \hline after updating SimpleTable
-        import copy
         table = copy.deepcopy(tables[0])
         del table[-1]
         for part in tables[1:]:

--- a/statsmodels/iolib/summary.py
+++ b/statsmodels/iolib/summary.py
@@ -128,7 +128,6 @@ def summary(self, yname=None, xname=None, title=0, alpha=.05,
     time_of_day = [time.strftime("%H:%M:%S", time_now)]
     date = time.strftime("%a, %d %b %Y", time_now)
     modeltype = self.model.__class__.__name__
-    #dist_family = self.model.family.__class__.__name__
     nobs = self.nobs
     df_model = self.df_model
     df_resid = self.df_resid
@@ -147,16 +146,6 @@ def summary(self, yname=None, xname=None, title=0, alpha=.05,
 
     gen_title = title
     gen_header = None
-##    gen_stubs_left = ('Model type:',
-##                      'Date:',
-##                      'Dependent Variable:',
-##                      'df model'
-##                  )
-##    gen_data_left = [[modeltype],
-##                     [date],
-##                     yname, #What happens with multiple names?
-##                     [df_model]
-##                     ]
     gen_table_left = SimpleTable(gen_data_left,
                                  gen_header,
                                  gen_stubs_left,
@@ -226,7 +215,7 @@ def summary(self, yname=None, xname=None, title=0, alpha=.05,
                                   param_header[modeltype],
                                   params_stubs,
                                   title = None,
-                                  txt_fmt = fmt_2, #gen_fmt,
+                                  txt_fmt = fmt_2
                                   )
 
     #special table
@@ -312,7 +301,6 @@ def summary_top(results, title=None, gleft=None, gright=None, yname=None, xname=
           ('Dependent Variable:', lambda: [yname]),
           ('Dep. Variable:', lambda: [yname]),
           ('Model:', lambda: [results.model.__class__.__name__]),
-          # ('Model type:', lambda: [results.model.__class__.__name__]),
           ('Date:', lambda: [date]),
           ('Time:', lambda: time_of_day),
           ('Number of Obs:', lambda: [results.nobs]),
@@ -320,7 +308,6 @@ def summary_top(results, title=None, gleft=None, gright=None, yname=None, xname=
           ('Df Model:', lambda: [d_or_f(results.df_model)]),
           ('Df Residuals:', lambda: [d_or_f(results.df_resid)]),
           ('Log-Likelihood:', lambda: ["%#8.5g" % results.llf])  # doesn't exist for RLM - exception
-          # ('Method:', lambda: [???]), # no default for this
     ])
 
     if title is None:
@@ -347,12 +334,11 @@ def summary_top(results, title=None, gleft=None, gright=None, yname=None, xname=
     gen_title = title
     gen_header = None
 
-    #needed_values = [k for k,v in gleft + gright if v is None] #not used anymore
-    #replace missing (None) values with default values
+    # replace missing (None) values with default values
     gen_left_ = []
     for item, value in gen_left:
         if value is None:
-            value = default_items[item]()  #let KeyErrors raise exception
+            value = default_items[item]()  # let KeyErrors raise exception
         gen_left_.append((item, value))
     gen_left = gen_left_
 
@@ -360,7 +346,7 @@ def summary_top(results, title=None, gleft=None, gright=None, yname=None, xname=
         gen_right_ = []
         for item, value in gen_right:
             if value is None:
-                value = default_items[item]()  #let KeyErrors raise exception
+                value = default_items[item]()  # let KeyErrors raise exception
             gen_right_.append((item, value))
         gen_right = gen_right_
 
@@ -405,7 +391,7 @@ def summary_top(results, title=None, gleft=None, gright=None, yname=None, xname=
     gen_table_left.extend_right(gen_table_right)
     general_table = gen_table_left
 
-    return general_table #, gen_table_left, gen_table_right
+    return general_table
 
 
 
@@ -484,8 +470,8 @@ def summary_params(results, yname=None, xname=None, alpha=.05, use_t=True,
     parameter_table = SimpleTable(params_data,
                                   param_header,
                                   params_stubs,
-                                  title = title,
-                                  txt_fmt = fmt_params #gen_fmt #fmt_2, #gen_fmt,
+                                  title=title,
+                                  txt_fmt=fmt_params
                                   )
 
     return parameter_table
@@ -547,9 +533,6 @@ def summary_params_frame(results, yname=None, xname=None, alpha=.05,
 
     _, xname = _getnames(results, yname=yname, xname=xname)
 
-
-    #------------------
-
     from pandas import DataFrame
     table = np.column_stack((params, std_err, tvalues, pvalues, conf_int))
     return DataFrame(table, columns=param_header, index=xname)
@@ -592,11 +575,9 @@ def summary_params_2d(result, extras=None, endog_names=None, exog_names=None,
         exog_names = ['var%d' %i for i in range(len(result.params))]
 
     #TODO: check formatting options with different values
-    #res_params = [['%10.4f'%item for item in row] for row in result.params]
     res_params = [[forg(item, prec=4) for item in row] for row in result.params]
     if extras: #not None or non-empty
         #maybe this should be a simple triple loop instead of list comprehension?
-        #below_list = [[['%10s' % ('('+('%10.3f'%v).strip()+')')
         extras_list = [[['%10s' % ('(' + forg(v, prec=3).strip() + ')')
                                 for v in col]
                                 for col in getattr(result, what)]
@@ -605,12 +586,9 @@ def summary_params_2d(result, extras=None, endog_names=None, exog_names=None,
         data = [i for j in data for i in j]  #flatten
         stubs = lzip(endog_names, *[['']*len(endog_names)]*len(extras))
         stubs = [i for j in stubs for i in j] #flatten
-        #return SimpleTable(data, headers=exog_names, stubs=stubs)
     else:
         data = res_params
         stubs = endog_names
-#        return SimpleTable(data, headers=exog_names, stubs=stubs,
-#                       data_fmts=['%10.4f'])
 
     import copy
     txt_fmt = copy.deepcopy(fmt_params)
@@ -618,12 +596,11 @@ def summary_params_2d(result, extras=None, endog_names=None, exog_names=None,
     return SimpleTable(data, headers=exog_names,
                              stubs=stubs,
                              title=title,
-#                             data_fmts = ["%s"]),
                              txt_fmt = txt_fmt)
 
 
 def summary_params_2dflat(result, endog_names=None, exog_names=None, alpha=0.05,
-                          use_t=True, keep_headers=True, endog_cols=False): #skip_headers2=True):
+                          use_t=True, keep_headers=True, endog_cols=False):
     '''summary table for parameters that are 2d, e.g. multi-equation models
 
     Parameters
@@ -687,11 +664,6 @@ def summary_params_2dflat(result, endog_names=None, exog_names=None, alpha=0.05,
         restup = (res, res.params[:,eq], res.bse[:,eq], res.tvalues[:,eq],
                   res.pvalues[:,eq], res.conf_int(alpha)[eq])
 
-        #not used anymore in current version
-#        if skip_headers2:
-#            skiph = (row != 0)
-#        else:
-#            skiph = False
         skiph = False
         tble = summary_params(restup, yname=endog_names[eq],
                               xname=exog_names, alpha=alpha, use_t=use_t,
@@ -754,18 +726,17 @@ def table_extend(tables, keep_headers=True):
 
 
 def summary_return(tables, return_fmt='text'):
-    ########  Return Summary Tables ########
-        # join table parts then print
+    # join table parts then print
     if return_fmt == 'text':
         strdrop = lambda x: str(x).rsplit('\n',1)[0]
-        #convert to string drop last line
+        # convert to string drop last line
         return '\n'.join(lmap(strdrop, tables[:-1]) + [str(tables[-1])])
     elif return_fmt == 'tables':
         return tables
     elif return_fmt == 'csv':
-        return '\n'.join(map(lambda x: x.as_csv(), tables))
+        return '\n'.join(x.as_csv() for x in tables)
     elif return_fmt == 'latex':
-        #TODO: insert \hline after updating SimpleTable
+        # TODO: insert \hline after updating SimpleTable
         import copy
         table = copy.deepcopy(tables[0])
         del table[-1]
@@ -787,9 +758,11 @@ class Summary(object):
     Attributes
     ----------
     tables : list of tables
-        Contains the list of SimpleTable instances, horizontally concatenated tables are not saved separately.
+        Contains the list of SimpleTable instances, horizontally concatenated
+        tables are not saved separately.
     extra_txt : string
-        extra lines that are added to the text output, used for warnings and explanations.
+        extra lines that are added to the text output, used for warnings
+        and explanations.
     '''
     def __init__(self):
         self.tables = []
@@ -799,7 +772,6 @@ class Summary(object):
         return self.as_text()
 
     def __repr__(self):
-        #return '<' + str(type(self)) + '>\n"""\n' + self.__str__() + '\n"""'
         return str(type(self)) + '\n"""\n' + self.__str__() + '\n"""'
 
     def _repr_html_(self):
@@ -807,7 +779,7 @@ class Summary(object):
         return self.as_html()
 
     def add_table_2cols(self, res,  title=None, gleft=None, gright=None,
-                            yname=None, xname=None):
+                        yname=None, xname=None):
         '''add a double table, 2 tables with one column merged horizontally
 
         Parameters
@@ -944,11 +916,3 @@ class Summary(object):
         if self.extra_txt is not None:
             html = html + '<br/><br/>' + self.extra_txt.replace('\n', '<br/>')
         return html
-
-
-if __name__ == "__main__":
-    import statsmodels.api as sm
-    data = sm.datasets.longley.load(as_pandas=False)
-    data.exog = sm.add_constant(data.exog)
-    res = sm.OLS(data.endog, data.exog).fit()
-    #summary(

--- a/statsmodels/iolib/summary.py
+++ b/statsmodels/iolib/summary.py
@@ -105,8 +105,6 @@ def summary(self, yname=None, xname=None, title=0, alpha=.05,
     """
     import time as time
 
-
-
     #TODO Make sure all self.model.__class__.__name__ are listed
     model_types = {'OLS' : 'Ordinary least squares',
                    'GLS' : 'Generalized least squares',
@@ -121,18 +119,11 @@ def summary(self, yname=None, xname=None, title=0, alpha=.05,
                    'WLS' : 'Least Squares',
                    'RLM' : '?',
                    'GLM' : '?'}
-    if title==0:
+    if title == 0:
         title = model_types[self.model.__class__.__name__]
-    if yname is None:
-        try:
-            yname = self.model.endog_names
-        except AttributeError:
-            yname = 'y'
-    if xname is None:
-        try:
-            xname = self.model.exog_names
-        except AttributeError:
-            xname = ['var_%d' % i for i in range(len(self.params))]
+
+    yname, xname = _getnames(self, yname, xname)
+
     time_now = time.localtime()
     time_of_day = [time.strftime("%H:%M:%S", time_now)]
     date = time.strftime("%a, %d %b %Y", time_now)
@@ -273,6 +264,7 @@ def summary(self, yname=None, xname=None, title=0, alpha=.05,
             return printers[modeltype]()
         except KeyError:
             return printers['OLS']()
+
 
 def _getnames(self, yname=None, xname=None):
     '''extract names from model or construct names

--- a/statsmodels/iolib/summary.py
+++ b/statsmodels/iolib/summary.py
@@ -221,7 +221,6 @@ def summary(self, yname=None, xname=None, title=0, alpha=.05,
     #TODO: exists in linear_model, what about other models
     #residual diagnostics
 
-
     #output options
     #--------------
     #TODO: JP the rest needs to be fixed, similar to summary in linear_model


### PR DESCRIPTION
Remove a bunch of commented-out code in cases where a superior alternative was implemented adjacent to the commented-out version.

Subsequent cleanups of comments in cases where the meaning of comments is clear.  Comments that need maintainer attention are left "messy".