### PR TITLE
WIP/MAINT: Identify defunct code in summary methods

### DIFF
--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -2378,9 +2378,7 @@ class GenericLikelihoodModelResults(LikelihoodModelResults, ResultMixin):
 
         See Also
         --------
-        statsmodels.iolib.summary.Summary : class to hold summary
-            results
-
+        statsmodels.iolib.summary.Summary : class to hold summary results
         """
 
         top_left = [('Dep. Variable:', None),
@@ -2389,15 +2387,11 @@ class GenericLikelihoodModelResults(LikelihoodModelResults, ResultMixin):
                     ('Date:', None),
                     ('Time:', None),
                     ('No. Observations:', None),
-                    ('Df Residuals:', None),  # [self.df_resid]),
-                    ('Df Model:', None),  # [self.df_model])
+                    ('Df Residuals:', None),
+                    ('Df Model:', None),
                     ]
 
-        top_right = [  # ('R-squared:', ["%#8.3f" % self.rsquared]),
-                       # ('Adj. R-squared:', ["%#8.3f" % self.rsquared_adj]),
-                       # ('F-statistic:', ["%#8.4g" % self.fvalue] ),
-                       # ('Prob (F-statistic):', ["%#6.3g" % self.f_pvalue]),
-                     ('Log-Likelihood:', None),  # ["%#6.4g" % self.llf]),
+        top_right = [('Log-Likelihood:', None),
                      ('AIC:', ["%#8.4g" % self.aic]),
                      ('BIC:', ["%#8.4g" % self.bic])
                      ]

--- a/statsmodels/discrete/discrete_margins.py
+++ b/statsmodels/discrete/discrete_margins.py
@@ -546,7 +546,7 @@ class DiscreteMargins(object):
         exog_names = model.exog_names[:] # copy
         smry = Summary()
 
-        # sigh, we really need to hold on to this in _data...
+        # TODO: sigh, we really need to hold on to this in _data...
         _, const_idx = _get_const_index(model.exog)
         if const_idx is not None:
             exog_names.pop(const_idx[0])
@@ -564,7 +564,7 @@ class DiscreteMargins(object):
         smry.add_table_2cols(self, gleft=top_left, gright=[],
                 yname=yname, xname=exog_names, title=title)
 
-        #NOTE: add_table_params is not general enough yet for margeff
+        # NOTE: add_table_params is not general enough yet for margeff
         # could use a refactor with getattr instead of hard-coded params
         # tvalues etc.
         table = []
@@ -585,7 +585,6 @@ class DiscreteMargins(object):
                 header = ['', _transform_names[method], 'std err', 'z',
                         'P>|z|', '[' + str(alpha/2), str(1-alpha/2) + ']']
                 tble.insert_header_row(0, header)
-                #from IPython.core.debugger import Pdb; Pdb().set_trace()
                 table.append(tble)
 
             table = table_extend(table, keep_headers=True)

--- a/statsmodels/discrete/discrete_model.py
+++ b/statsmodels/discrete/discrete_model.py
@@ -3595,9 +3595,7 @@ class DiscreteResults(base.LikelihoodModelResults):
 
         See Also
         --------
-        statsmodels.iolib.summary.Summary : class to hold summary
-            results
-
+        statsmodels.iolib.summary.Summary : class to hold summary results
         """
 
         top_left = [('Dep. Variable:', None),
@@ -3605,7 +3603,6 @@ class DiscreteResults(base.LikelihoodModelResults):
                      ('Method:', ['MLE']),
                      ('Date:', None),
                      ('Time:', None),
-                     #('No. iterations:', ["%d" % self.mle_retvals['iterations']]),
                      ('converged:', ["%s" % self.mle_retvals['converged']])
                     ]
 
@@ -3625,9 +3622,11 @@ class DiscreteResults(base.LikelihoodModelResults):
         from statsmodels.iolib.summary import Summary
         smry = Summary()
         yname, yname_list = self._get_endog_name(yname, yname_list)
+
         # for top of table
         smry.add_table_2cols(self, gleft=top_left, gright=top_right,
                              yname=yname, xname=xname, title=title)
+
         # for parameters, etc
         smry.add_table_params(self, yname=yname_list, xname=xname, alpha=alpha,
                               use_t=self.use_t)
@@ -3636,10 +3635,6 @@ class DiscreteResults(base.LikelihoodModelResults):
             smry.add_extra_txt(['Model has been estimated subject to linear '
                                 'equality constraints.'])
 
-        #diagnostic table not used yet
-        #smry.add_table_2cols(self, gleft=diagn_left, gright=diagn_right,
-        #                   yname=yname, xname=xname,
-        #                   title="")
         return smry
 
     def summary2(self, yname=None, xname=None, title=None, alpha=.05,
@@ -3849,19 +3844,18 @@ class BinaryResults(DiscreteResults):
         bins = np.array([0, 0.5, 1])
         return np.histogram2d(actual, pred, bins=bins)[0]
 
-
     def summary(self, yname=None, xname=None, title=None, alpha=.05,
                 yname_list=None):
         smry = super(BinaryResults, self).summary(yname, xname, title, alpha,
-                     yname_list)
+                                                  yname_list)
         fittedvalues = self.model.cdf(self.fittedvalues)
         absprederror = np.abs(self.model.endog - fittedvalues)
         predclose_sum = (absprederror < 1e-4).sum()
         predclose_frac = predclose_sum / len(fittedvalues)
 
-        #add warnings/notes
+        # add warnings/notes
         etext = []
-        if predclose_sum == len(fittedvalues): #nobs?
+        if predclose_sum == len(fittedvalues):  # TODO: nobs?
             wstr = "Complete Separation: The results show that there is"
             wstr += "complete separation.\n"
             wstr += "In this case the Maximum Likelihood Estimator does "
@@ -4122,9 +4116,7 @@ class MultinomialResults(DiscreteResults):
 
         See Also
         --------
-        statsmodels.iolib.summary2.Summary : class to hold summary
-            results
-
+        statsmodels.iolib.summary2.Summary : class to hold summary results
         """
 
         from statsmodels.iolib import summary2
@@ -4134,14 +4126,18 @@ class MultinomialResults(DiscreteResults):
         eqn = self.params.shape[1]
         confint = self.conf_int(alpha)
         for i in range(eqn):
-            coefs = summary2.summary_params((self, self.params[:,i],
-                    self.bse[:,i], self.tvalues[:,i], self.pvalues[:,i],
-                    confint[i]), alpha=alpha)
+            coefs = summary2.summary_params((self, self.params[:, i],
+                                             self.bse[:, i],
+                                             self.tvalues[:, i],
+                                             self.pvalues[:, i],
+                                             confint[i]),
+                                            alpha=alpha)
             # Header must show value of endog
             level_str =  self.model.endog_names + ' = ' + str(i)
             coefs[level_str] = coefs.index
-            coefs = coefs.iloc[:,[-1,0,1,2,3,4,5]]
-            smry.add_df(coefs, index=False, header=True, float_format=float_format)
+            coefs = coefs.iloc[:, [-1, 0, 1, 2, 3, 4, 5]]
+            smry.add_df(coefs, index=False, header=True,
+                        float_format=float_format)
             smry.add_title(results=self)
         return smry
 

--- a/statsmodels/duration/hazard_regression.py
+++ b/statsmodels/duration/hazard_regression.py
@@ -1570,8 +1570,7 @@ class PHRegResults(base.LikelihoodModelResults):
 
         See Also
         --------
-        statsmodels.iolib.summary.Summary : class to hold summary
-            results
+        statsmodels.iolib.summary2.Summary : class to hold summary results
         """
 
         from statsmodels.iolib import summary2
@@ -1639,6 +1638,7 @@ class PHRegResults(base.LikelihoodModelResults):
             smry.add_text("Standard errors do not account for the regularization")
 
         return smry
+
 
 class rv_discrete_float(object):
     """

--- a/statsmodels/genmod/generalized_estimating_equations.py
+++ b/statsmodels/genmod/generalized_estimating_equations.py
@@ -2039,9 +2039,7 @@ class GEEResults(base.LikelihoodModelResults):
 
         See Also
         --------
-        statsmodels.iolib.summary.Summary : class to hold summary
-            results
-
+        statsmodels.iolib.summary.Summary : class to hold summary results
         """
 
         top_left = [('Dep. Variable:', None),

--- a/statsmodels/genmod/generalized_linear_model.py
+++ b/statsmodels/genmod/generalized_linear_model.py
@@ -1852,9 +1852,7 @@ class GLMResults(base.LikelihoodModelResults):
 
         See Also
         --------
-        statsmodels.iolib.summary.Summary : class to hold summary
-            results
-
+        statsmodels.iolib.summary.Summary : class to hold summary results
         """
 
         top_left = [('Dep. Variable:', None),
@@ -1886,7 +1884,7 @@ class GLMResults(base.LikelihoodModelResults):
         # create summary tables
         from statsmodels.iolib.summary import Summary
         smry = Summary()
-        smry.add_table_2cols(self, gleft=top_left, gright=top_right,  # [],
+        smry.add_table_2cols(self, gleft=top_left, gright=top_right,
                              yname=yname, xname=xname, title=title)
         smry.add_table_params(self, yname=yname, xname=xname, alpha=alpha,
                               use_t=self.use_t)
@@ -1894,17 +1892,10 @@ class GLMResults(base.LikelihoodModelResults):
         if hasattr(self, 'constraints'):
             smry.add_extra_txt(['Model has been estimated subject to linear '
                                 'equality constraints.'])
-
-        # diagnostic table is not used yet:
-        # smry.add_table_2cols(self, gleft=diagn_left, gright=diagn_right,
-        #                   yname=yname, xname=xname,
-        #                   title="")
-
         return smry
 
     def summary2(self, yname=None, xname=None, title=None, alpha=.05,
                  float_format="%.4f"):
-
         """Experimental summary for regression Results
 
         Parameters
@@ -1929,9 +1920,7 @@ class GLMResults(base.LikelihoodModelResults):
 
         See Also
         --------
-        statsmodels.iolib.summary2.Summary : class to hold summary
-            results
-
+        statsmodels.iolib.summary2.Summary : class to hold summary results
         """
         self.method = 'IRLS'
         from statsmodels.iolib import summary2

--- a/statsmodels/iolib/summary.py
+++ b/statsmodels/iolib/summary.py
@@ -6,6 +6,7 @@ import numpy as np
 from statsmodels.iolib.table import SimpleTable
 from statsmodels.iolib.tableformatting import (gen_fmt, fmt_2,
                                                fmt_params, fmt_2cols)
+from .summary2 import _model_types
 
 
 def forg(x, prec=3):
@@ -106,17 +107,8 @@ def summary(self, yname=None, xname=None, title=0, alpha=.05,
     -----
     conf_int calculated from normal dist.
     """
-
-    # TODO: Make sure all self.model.__class__.__name__ are listed
-    model_types = {'OLS': 'Ordinary least squares',
-                   'GLS': 'Generalized least squares',
-                   'GLSAR': 'Generalized least squares with AR(p)',
-                   'WLS': 'Weighted least squares',
-                   'RLM': 'Robust linear model',
-                   'GLM': 'Generalized linear model'
-                   }
     if title == 0:
-        title = model_types[self.model.__class__.__name__]
+        title = _model_types[self.model.__class__.__name__]
 
     yname, xname = _getnames(self, yname, xname)
 

--- a/statsmodels/iolib/summary2.py
+++ b/statsmodels/iolib/summary2.py
@@ -160,8 +160,6 @@ class Summary(object):
         pad_col, pad_index, widest = _measure_tables(tables, settings)
 
         rule_equal = widest * '='
-        #TODO: this isn't used anywhere?
-        rule_dash = widest * '-'
 
         simple_tables = _simple_tables(tables, settings, pad_col, pad_index)
         tab = [x.as_text() for x in simple_tables]
@@ -256,22 +254,24 @@ def _measure_tables(tables, settings):
 
 
 # Useful stuff
-_model_types = {'OLS' : 'Ordinary least squares',
-                'GLS' : 'Generalized least squares',
+_model_types = {'OLS': 'Ordinary least squares',
+                'GLS': 'Generalized least squares',
                 'GLSAR' : 'Generalized least squares with AR(p)',
-                'WLS' : 'Weighted least squares',
-                'RLM' : 'Robust linear model',
+                'WLS': 'Weighted least squares',
+                'RLM': 'Robust linear model',
                 'NBin': 'Negative binomial model',
-                'GLM' : 'Generalized linear model'
+                'GLM': 'Generalized linear model'
                 }
 
 
 def summary_model(results):
     '''Create a dict with information about the model
     '''
+
     def time_now(*args, **kwds):
         now = datetime.datetime.now()
         return now.strftime('%Y-%m-%d %H:%M')
+
     info = OrderedDict()
     info['Model:'] = lambda x: x.model.__class__.__name__
     info['Model Family:'] = lambda x: x.family.__class.__name__
@@ -306,8 +306,9 @@ def summary_model(results):
     for key, func in iteritems(info):
         try:
             out[key] = func(results)
-        # NOTE: some models don't have loglike defined (RLM), so that's NIE
         except (AttributeError, KeyError, NotImplementedError):
+            # NOTE: some models don't have loglike defined (RLM),
+            #   so raise NotImplementedError
             pass
     return out
 

--- a/statsmodels/regression/linear_model.py
+++ b/statsmodels/regression/linear_model.py
@@ -2451,20 +2451,18 @@ class RegressionResults(base.LikelihoodModelResults):
 
         See Also
         --------
-        statsmodels.iolib.summary.Summary : class to hold summary
-            results
-
+        statsmodels.iolib.summary.Summary : class to hold summary results
         """
-
-        # TODO: import where we need it (for now), add as cached attributes
         from statsmodels.stats.stattools import (
             jarque_bera, omni_normtest, durbin_watson)
+
         jb, jbpv, skew, kurtosis = jarque_bera(self.wresid)
         omni, omnipv = omni_normtest(self.wresid)
 
         eigvals = self.eigenvals
         condno = self.condition_number
 
+        # TODO: Avoid adding attributes in non-__init__
         self.diagn = dict(jb=jb, jbpv=jbpv, skew=skew, kurtosis=kurtosis,
                           omni=omni, omnipv=omnipv, condno=condno,
                           mineigval=eigvals[-1])
@@ -2474,7 +2472,7 @@ class RegressionResults(base.LikelihoodModelResults):
         # diagn_right_header = ['Residual stats']
 
         # TODO: requiring list/iterable is a bit annoying
-        # need more control over formatting
+        #   need more control over formatting
         # TODO: default don't work if it's not identically spelled
 
         top_left = [('Dep. Variable:', None),
@@ -2483,8 +2481,8 @@ class RegressionResults(base.LikelihoodModelResults):
                     ('Date:', None),
                     ('Time:', None),
                     ('No. Observations:', None),
-                    ('Df Residuals:', None),  # [self.df_resid]), TODO: spelling
-                    ('Df Model:', None),  # [self.df_model])
+                    ('Df Residuals:', None),
+                    ('Df Model:', None),
                     ]
 
         if hasattr(self, 'cov_type'):
@@ -2495,7 +2493,7 @@ class RegressionResults(base.LikelihoodModelResults):
                      ('Adj. R-squared' + rsquared_type + ':', ["%#8.3f" % self.rsquared_adj]),
                      ('F-statistic:', ["%#8.4g" % self.fvalue]),
                      ('Prob (F-statistic):', ["%#6.3g" % self.f_pvalue]),
-                     ('Log-Likelihood:', None),  # ["%#6.4g" % self.llf]),
+                     ('Log-Likelihood:', None),
                      ('AIC:', ["%#8.4g" % self.aic]),
                      ('BIC:', ["%#8.4g" % self.bic])
                      ]
@@ -2543,7 +2541,7 @@ class RegressionResults(base.LikelihoodModelResults):
             wstr += "matrix is singular."
             wstr = wstr % eigvals[-1]
             etext.append(wstr)
-        elif condno > 1000:  # TODO: what is recommended
+        elif condno > 1000:  # TODO: what is recommended?
             wstr = "The condition number is large, %6.3g. This might "
             wstr += "indicate that there are\n"
             wstr += "strong multicollinearity or other numerical "
@@ -2558,19 +2556,6 @@ class RegressionResults(base.LikelihoodModelResults):
             smry.add_extra_txt(etext)
 
         return smry
-
-        #  top = summary_top(self, gleft=topleft, gright=diagn_left, #[],
-        #                    yname=yname, xname=xname,
-        #                    title=self.model.__class__.__name__ + ' ' +
-        #                    "Regression Results")
-        #  par = summary_params(self, yname=yname, xname=xname, alpha=.05,
-        #                       use_t=False)
-        #
-        #  diagn = summary_top(self, gleft=diagn_left, gright=diagn_right,
-        #                      yname=yname, xname=xname,
-        #                      title="Linear Model")
-        #
-        #  return summary_return([top, par, diagn], return_fmt=return_fmt)
 
     def summary2(self, yname=None, xname=None, title=None, alpha=.05,
                  float_format="%.4f"):
@@ -2598,8 +2583,7 @@ class RegressionResults(base.LikelihoodModelResults):
 
         See Also
         --------
-        statsmodels.iolib.summary.Summary : class to hold summary
-            results
+        statsmodels.iolib.summary2.Summary : class to hold summary results
 
         """
         # Diagnostics

--- a/statsmodels/regression/mixed_linear_model.py
+++ b/statsmodels/regression/mixed_linear_model.py
@@ -2514,8 +2514,7 @@ class MixedLMResults(base.LikelihoodModelResults, base.ResultMixin):
 
         See Also
         --------
-        statsmodels.iolib.summary.Summary : class to hold summary
-            results
+        statsmodels.iolib.summary2.Summary : class to hold summary results
         """
 
         from statsmodels.iolib import summary2
@@ -2525,14 +2524,17 @@ class MixedLMResults(base.LikelihoodModelResults, base.ResultMixin):
         info["Model:"] = "MixedLM"
         if yname is None:
             yname = self.model.endog_names
+
         param_names = self.model.data.param_names[:]
         k_fe_params = len(self.fe_params)
         k_re_params = len(param_names) - len(self.fe_params)
+
         if xname_fe is not None:
             if len(xname_fe) != k_fe_params:
                 msg = "xname_fe should be a list of length %d" % k_fe_params
                 raise ValueError(msg)
             param_names[:k_fe_params] = xname_fe
+
         if xname_re is not None:
             if len(xname_re) != k_re_params:
                 msg = "xname_re should be a list of length %d" % k_re_params

--- a/statsmodels/regression/quantile_regression.py
+++ b/statsmodels/regression/quantile_regression.py
@@ -360,23 +360,10 @@ class QuantRegResults(RegressionResults):
 
         See Also
         --------
-        statsmodels.iolib.summary.Summary : class to hold summary
-            results
-
+        statsmodels.iolib.summary.Summary : class to hold summary results
         """
-
-        # #TODO: import where we need it (for now), add as cached attributes
-        # from statsmodels.stats.stattools import (jarque_bera,
-        #         omni_normtest, durbin_watson)
-        # jb, jbpv, skew, kurtosis = jarque_bera(self.wresid)
-        # omni, omnipv = omni_normtest(self.wresid)
-        #
         eigvals = self.eigenvals
         condno = self.condition_number
-        #
-        # self.diagn = dict(jb=jb, jbpv=jbpv, skew=skew, kurtosis=kurtosis,
-        #                   omni=omni, omnipv=omnipv, condno=condno,
-        #                   mineigval=eigvals[0])
 
         top_left = [('Dep. Variable:', None),
                     ('Model:', None),
@@ -389,27 +376,14 @@ class QuantRegResults(RegressionResults):
                      ('Bandwidth:', ["%#8.4g" % self.bandwidth]),
                      ('Sparsity:', ["%#8.4g" % self.sparsity]),
                      ('No. Observations:', None),
-                     ('Df Residuals:', None), #[self.df_resid]), #TODO: spelling
-                     ('Df Model:', None) #[self.df_model])
+                     ('Df Residuals:', None),
+                     ('Df Model:', None)
                      ]
-
-        # diagn_left = [('Omnibus:', ["%#6.3f" % omni]),
-        #               ('Prob(Omnibus):', ["%#6.3f" % omnipv]),
-        #               ('Skew:', ["%#6.3f" % skew]),
-        #               ('Kurtosis:', ["%#6.3f" % kurtosis])
-        #               ]
-        #
-        # diagn_right = [('Durbin-Watson:', ["%#8.3f" % durbin_watson(self.wresid)]),
-        #                ('Jarque-Bera (JB):', ["%#8.3f" % jb]),
-        #                ('Prob(JB):', ["%#8.3g" % jbpv]),
-        #                ('Cond. No.', ["%#8.3g" % condno])
-        #                ]
-
 
         if title is None:
             title = self.model.__class__.__name__ + ' ' + "Regression Results"
 
-        #create summary table instance
+        # create summary table instance
         from statsmodels.iolib.summary import Summary
         smry = Summary()
         smry.add_table_2cols(self, gleft=top_left, gright=top_right,
@@ -417,11 +391,7 @@ class QuantRegResults(RegressionResults):
         smry.add_table_params(self, yname=yname, xname=xname, alpha=alpha,
                               use_t=self.use_t)
 
-#        smry.add_table_2cols(self, gleft=diagn_left, gright=diagn_right,
-#                          yname=yname, xname=xname,
-#                          title="")
-
-        #add warnings/notes, added to text format only
+        # add warnings/notes, added to text format only
         etext = []
         if eigvals[-1] < 1e-10:
             wstr = "The smallest eigenvalue is %6.3g. This might indicate "
@@ -430,7 +400,7 @@ class QuantRegResults(RegressionResults):
             wstr += "matrix is singular."
             wstr = wstr % eigvals[-1]
             etext.append(wstr)
-        elif condno > 1000:  #TODO: what is recommended
+        elif condno > 1000:  # TODO: what is recommended
             wstr = "The condition number is large, %6.3g. This might "
             wstr += "indicate that there are\n"
             wstr += "strong multicollinearity or other numerical "

--- a/statsmodels/robust/robust_linear_model.py
+++ b/statsmodels/robust/robust_linear_model.py
@@ -460,29 +460,11 @@ class RLMResults(base.LikelihoodModelResults):
     def chisq(self):
         return (self.params/self.bse)**2
 
-    def remove_data(self):
-        super(self.__class__, self).remove_data()
-        #self.model.history['sresid'] = None
-        #self.model.history['weights'] = None
-
-    remove_data.__doc__ = base.LikelihoodModelResults.remove_data.__doc__
-
     def summary(self, yname=None, xname=None, title=0, alpha=.05,
                 return_fmt='text'):
         """
         This is for testing the new summary setup
         """
-
-##        left = [(i, None) for i in (
-##                        'Dependent Variable:',
-##                        'Model type:',
-##                        'Method:',
-##			'Date:',
-##                        'Time:',
-##                        'Number of Obs:',
-##                        'df resid',
-##		        'df model',
-##                         )]
         top_left = [('Dep. Variable:', None),
                     ('Model:', None),
                     ('Method:', ['IRLS']),
@@ -501,24 +483,20 @@ class RLMResults(base.LikelihoodModelResults):
         if title is not None:
             title = "Robust linear Model Regression Results"
 
-        #boiler plate
+        # boiler plate
         from statsmodels.iolib.summary import Summary
         smry = Summary()
-        smry.add_table_2cols(self, gleft=top_left, gright=top_right, #[],
-                          yname=yname, xname=xname, title=title)
+        smry.add_table_2cols(self, gleft=top_left, gright=top_right,
+                             yname=yname, xname=xname, title=title)
         smry.add_table_params(self, yname=yname, xname=xname, alpha=alpha,
-                             use_t=self.use_t)
+                              use_t=self.use_t)
 
-        #diagnostic table is not used yet
-#        smry.add_table_2cols(self, gleft=diagn_left, gright=diagn_right,
-#                          yname=yname, xname=xname,
-#                          title="")
-
-#add warnings/notes, added to text format only
-        etext =[]
-        wstr = \
-'''If the model instance has been used for another fit with different fit
-parameters, then the fit options might not be the correct ones anymore .'''
+        # add warnings/notes, added to text format only
+        etext = []
+        wstr = ("If the model instance has been used for another fit "
+                "with different fit\n"
+               "parameters, then the fit options might not be the correct "
+               "ones anymore .")
         etext.append(wstr)
 
         if etext:
@@ -526,13 +504,12 @@ parameters, then the fit options might not be the correct ones anymore .'''
 
         return smry
 
-
     def summary2(self, xname=None, yname=None, title=None, alpha=.05,
-                float_format="%.4f"):
+                 float_format="%.4f"):
         """Experimental summary function for regression results
 
         Parameters
-        -----------
+        ----------
         xname : List of strings of length equal to the number of parameters
             Names of the independent variables (optional)
         yname : string
@@ -553,22 +530,20 @@ parameters, then the fit options might not be the correct ones anymore .'''
 
         See Also
         --------
-        statsmodels.iolib.summary.Summary : class to hold summary
-            results
-
+        statsmodels.iolib.summary2.Summary : class to hold summary results
         """
-        # Summary
         from statsmodels.iolib import summary2
         smry = summary2.Summary()
         smry.add_base(results=self, alpha=alpha, float_format=float_format,
-                xname=xname, yname=yname, title=title)
+                      xname=xname, yname=yname, title=title)
 
         return smry
 
 
 class RLMResultsWrapper(lm.RegressionResultsWrapper):
     pass
-wrap.populate_wrapper(RLMResultsWrapper, RLMResults)
+wrap.populate_wrapper(RLMResultsWrapper, RLMResults)  # noqa:E305
+
 
 if __name__=="__main__":
 #NOTE: This is to be removed

--- a/statsmodels/stats/anova.py
+++ b/statsmodels/stats/anova.py
@@ -635,7 +635,7 @@ class AnovaResults(object):
 
         Returns
         -------
-        summary : Summary instance
+        summary : summary2.Summary instance
 
         """
         summ = summary2.Summary()
@@ -643,6 +643,7 @@ class AnovaResults(object):
         summ.add_df(self.anova_table)
 
         return summ
+
 
 if __name__ == "__main__":
     import pandas

--- a/statsmodels/stats/contingency_tables.py
+++ b/statsmodels/stats/contingency_tables.py
@@ -887,7 +887,7 @@ class Table2x2(SquareTable):
         """
 
         def fmt(x):
-            if type(x) is str:
+            if isinstance(x, str):
                 return x
             return float_format % x
 
@@ -1246,7 +1246,7 @@ class StratifiedTable(object):
         """
 
         def fmt(x):
-            if type(x) is str:
+            if isinstance(x, str):
                 return x
             return float_format % x
 

--- a/statsmodels/stats/mediation.py
+++ b/statsmodels/stats/mediation.py
@@ -374,15 +374,20 @@ class MediationResults(object):
         """
 
         columns = ["Estimate", "Lower CI bound", "Upper CI bound", "P-value"]
-        index = ["ACME (control)", "ACME (treated)", "ADE (control)", "ADE (treated)",
-                 "Total effect", "Prop. mediated (control)", "Prop. mediated (treated)",
-                 "ACME (average)", "ADE (average)", "Prop. mediated (average)"]
+        index = ["ACME (control)", "ACME (treated)",
+                 "ADE (control)", "ADE (treated)",
+                 "Total effect",
+                 "Prop. mediated (control)",
+                 "Prop. mediated (treated)",
+                 "ACME (average)", "ADE (average)",
+                 "Prop. mediated (average)"]
         smry = pd.DataFrame(columns=columns, index=index)
 
-        for i, vec in enumerate([self.ACME_ctrl, self.ACME_tx, self.ADE_ctrl, self.ADE_tx,
+        for i, vec in enumerate([self.ACME_ctrl, self.ACME_tx,
+                                 self.ADE_ctrl, self.ADE_tx,
                                  self.total_effect, self.prop_med_ctrl,
-                                 self.prop_med_tx, self.ACME_avg, self.ADE_avg,
-                                 self.prop_med_avg]):
+                                 self.prop_med_tx, self.ACME_avg,
+                                 self.ADE_avg, self.prop_med_avg]):
 
             if ((vec is self.prop_med_ctrl) or (vec is self.prop_med_tx) or
                     (vec is self.prop_med_avg)):


### PR DESCRIPTION
In a few cases this has unambiguous fixes, e.g. where a docstring incorrectly references summary.Summary instead of summary2.Summary.  In most cases there is just a ton of commented-out code in summary methods and I'd like to start the process of identifying what can be made useful and what should be removed.