### PR TITLE
DOC: Clarify/fix docs on GLM scale estimation for negative binomial

### DIFF
--- a/statsmodels/genmod/generalized_estimating_equations.py
+++ b/statsmodels/genmod/generalized_estimating_equations.py
@@ -701,8 +701,11 @@ class GEE(base.Model):
 
     def estimate_scale(self):
         """
-        Returns an estimate of the scale parameter at the current
-        parameter value.
+        Estimate the dispersion/scale.
+
+        The scale parameter for binomial, Poisson, and multinomial
+        families is fixed at 1, otherwise it is estimated from
+        the data.
         """
 
         if isinstance(self.family, (families.Binomial, families.Poisson,

--- a/statsmodels/genmod/generalized_linear_model.py
+++ b/statsmodels/genmod/generalized_linear_model.py
@@ -768,8 +768,9 @@ class GLM(base.LikelihoodModel):
 
         Notes
         -----
-        The default scale for Binomial and Poisson families is 1.  The default
-        for the other families is Pearson's Chi-Square estimate.
+        The default scale for Binomial, Poisson and Negative Binomial
+        families is 1.  The default for the other families is Pearson's
+        Chi-Square estimate.
 
         See also
         --------


### PR DESCRIPTION
Scale parameter for negative binomial in GLM fitting is fixed at 1. 