### PR TITLE
BUG/REF: SVAR sirf_errband_mc use unicode, use seed

### DIFF
--- a/statsmodels/tsa/vector_ar/svar_model.py
+++ b/statsmodels/tsa/vector_ar/svar_model.py
@@ -674,8 +674,8 @@ class SVARResults(SVARProcess, VARResults):
         B = self.B
         A_mask = self.A_mask
         B_mask = self.B_mask
-        A_pass = np.zeros(A.shape, dtype='|S1')
-        B_pass = np.zeros(B.shape, dtype='|S1')
+        A_pass = np.zeros(A.shape, dtype='<U11')
+        B_pass = np.zeros(B.shape, dtype='<U11')
         A_pass[~A_mask] = A[~A_mask]
         B_pass[~B_mask] = B[~B_mask]
         A_pass[A_mask] = 'E'
@@ -690,8 +690,8 @@ class SVARResults(SVARProcess, VARResults):
 
         for i in range(repl):
             #discard first hundred to correct for starting bias
-            sim = util.varsim(coefs, intercept, sigma_u,
-                    steps=nobs+burn)
+            sim = util.varsim(coefs, intercept, sigma_u, seed=seed,
+                              steps=nobs + burn)
             sim = sim[burn:]
             if cum == True:
                 if i < 10:

--- a/statsmodels/tsa/vector_ar/svar_model.py
+++ b/statsmodels/tsa/vector_ar/svar_model.py
@@ -76,6 +76,9 @@ class SVAR(tsbase.TimeSeriesModel):
 
         svar_ckerr(svar_type, A, B)
 
+        self.A_original = A
+        self.B_original = B
+
         #initialize A, B as I if not given
         #Initialize SVAR masks
         if A is None:
@@ -674,18 +677,10 @@ class SVARResults(SVARProcess, VARResults):
         B = self.B
         A_mask = self.A_mask
         B_mask = self.B_mask
-        A_pass = np.zeros(A.shape, dtype='<U11')
-        B_pass = np.zeros(B.shape, dtype='<U11')
-        A_pass[~A_mask] = A[~A_mask]
-        B_pass[~B_mask] = B[~B_mask]
-        A_pass[A_mask] = 'E'
-        B_pass[B_mask] = 'E'
-        if A_mask.sum() == 0:
-            s_type = 'B'
-        elif B_mask.sum() == 0:
-            s_type = 'A'
-        else:
-            s_type = 'AB'
+        A_pass = self.model.A_original
+        B_pass = self.model.B_original
+        s_type = self.model.svar_type
+
         g_list = []
 
         for i in range(repl):
@@ -738,7 +733,8 @@ class SVARResults(SVARProcess, VARResults):
                                  svar_ma_rep(maxn=T)
 
         ma_sort = np.sort(ma_coll, axis=0) #sort to get quantiles
-        index = round(signif/2*repl)-1,round((1-signif/2)*repl)-1
+        index = (int(round(signif / 2 * repl) - 1),
+                 int(round((1 - signif / 2) * repl) - 1))
         lower = ma_sort[index[0],:, :, :]
         upper = ma_sort[index[1],:, :, :]
         return lower, upper

--- a/statsmodels/tsa/vector_ar/svar_model.py
+++ b/statsmodels/tsa/vector_ar/svar_model.py
@@ -696,7 +696,10 @@ class SVARResults(SVARProcess, VARResults):
             if cum == True:
                 if i < 10:
                     sol = SVAR(sim, svar_type=s_type, A=A_pass,
-                               B=B_pass).fit(maxlags=k_ar)
+                               B=B_pass).fit(maxlags=k_ar,
+                                             A_guess=A[A_mask],
+                                             B_guess=B[B_mask])
+
                     g_list.append(np.append(sol.A[sol.A_mask].\
                                             tolist(),
                                             sol.B[sol.B_mask].\
@@ -716,7 +719,10 @@ class SVARResults(SVARProcess, VARResults):
             elif cum == False:
                 if i < 10:
                     sol = SVAR(sim, svar_type=s_type, A=A_pass,
-                               B=B_pass).fit(maxlags=k_ar)
+                               B=B_pass).fit(maxlags=k_ar,
+                                             A_guess=A[A_mask],
+                                             B_guess=B[B_mask])
+
                     g_list.append(np.append(sol.A[A_mask].tolist(),
                                             sol.B[B_mask].tolist()))
                     ma_coll[i] = sol.svar_ma_rep(maxn=T)

--- a/statsmodels/tsa/vector_ar/tests/test_svar.py
+++ b/statsmodels/tsa/vector_ar/tests/test_svar.py
@@ -1,7 +1,7 @@
 """
 Test SVAR estimation
 """
-
+import pytest
 import statsmodels.api as sm
 from statsmodels.tsa.vector_ar.svar_model import SVAR
 from numpy.testing import assert_almost_equal, assert_equal, assert_allclose
@@ -57,3 +57,16 @@ class TestSVAR(object):
         assert_allclose(res1.aic - corr_const, res2.aic_var, atol=1e-12)
         assert_allclose(res1.bic - corr_const, res2.sbic_var, atol=1e-12)
         assert_allclose(res1.hqic - corr_const, res2.hqic_var, atol=1e-12)
+
+    # @pytest.mark.smoke
+    def test_irf(self):
+        # this only checks that the methods work and produce the same result
+        res1 = self.res1
+        errband1 = res1.sirf_errband_mc(orth=False, repl=50, T=10, signif=0.05,
+                                        seed=987123, burn=100, cum=False)
+
+        irf = res1.irf()
+        errband2 = irf.errband_mc(orth=False, svar=True, repl=50,
+                                  signif=0.05, seed=987123, burn=100)
+        # on my Windows environment those two are equal
+        assert_allclose(errband1, errband2, rtol=1e-10)

--- a/statsmodels/tsa/vector_ar/tests/test_svar.py
+++ b/statsmodels/tsa/vector_ar/tests/test_svar.py
@@ -1,7 +1,7 @@
 """
 Test SVAR estimation
 """
-import pytest
+
 import statsmodels.api as sm
 from statsmodels.tsa.vector_ar.svar_model import SVAR
 from numpy.testing import assert_almost_equal, assert_equal, assert_allclose
@@ -58,8 +58,8 @@ class TestSVAR(object):
         assert_allclose(res1.bic - corr_const, res2.sbic_var, atol=1e-12)
         assert_allclose(res1.hqic - corr_const, res2.hqic_var, atol=1e-12)
 
-    # @pytest.mark.smoke
     def test_irf(self):
+        # mostly SMOKE, API test
         # this only checks that the methods work and produce the same result
         res1 = self.res1
         errband1 = res1.sirf_errband_mc(orth=False, repl=50, T=10, signif=0.05,
@@ -69,4 +69,4 @@ class TestSVAR(object):
         errband2 = irf.errband_mc(orth=False, svar=True, repl=50,
                                   signif=0.05, seed=987123, burn=100)
         # on my Windows environment those two are equal
-        assert_allclose(errband1, errband2, rtol=1e-10)
+        assert_allclose(errband1, errband2, rtol=1e-8, atol=1e-20)


### PR DESCRIPTION
closes #5280 SVAR sirf_errband_mc raises exception, especially on py 3

this avoids recreating the original A and B, and choosing string/bytes versus unicode, py2 and py3 compatible

adds unit test that is mostly smoke test (but found a missing seed bug)
errband/confint values in plot look reasonable
