### PR TITLE
modify comments in stats.proportion.proportion_confint

### DIFF
--- a/statsmodels/stats/proportion.py
+++ b/statsmodels/stats/proportion.py
@@ -26,7 +26,7 @@ def proportion_confint(count, nobs, alpha=0.05, method='normal'):
         total number of trials
     alpha : float in (0, 1)
         significance level, default 0.05
-    method : string in ['normal']
+    method : string in ['normal', 'agresti_coull', 'beta', 'wilson', 'binom_test']
         method to use for confidence interval,
         currently available methods :
 

--- a/statsmodels/stats/proportion.py
+++ b/statsmodels/stats/proportion.py
@@ -26,7 +26,8 @@ def proportion_confint(count, nobs, alpha=0.05, method='normal'):
         total number of trials
     alpha : float in (0, 1)
         significance level, default 0.05
-    method : string in ['normal', 'agresti_coull', 'beta', 'wilson', 'binom_test']
+    method : {'normal', 'agresti_coull', 'beta', 'wilson', 'binom_test'}
+        default: 'normal'
         method to use for confidence interval,
         currently available methods :
 


### PR DESCRIPTION
methods in ['normal', 'agresti_coull', 'beta', 'wilson', 'binom_test'] are all available(in line 88~143), but the comments was not updated. This PR updates the comments. 