### PR TITLE
DOC: minor fix on documentation on Durbin Watson test

### DIFF
--- a/statsmodels/stats/stattools.py
+++ b/statsmodels/stats/stattools.py
@@ -23,8 +23,7 @@ def durbin_watson(resids, axis=0):
     Returns
     --------
     dw : float, array-like
-
-    The Durbin-Watson statistic.
+        The Durbin-Watson statistic.
 
     Notes
     -----


### PR DESCRIPTION
Indentation error caused another bullet point in the return, when only dw statistic is returned.

![image](https://user-images.githubusercontent.com/14131823/46671488-d7daae80-cbcc-11e8-88d1-22e916d61404.png)
