### PR TITLE
DOC: Move magic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 # versions.  Allows substantial flexibility for choosing versions of
 # required packages and is simpler to use to test up-to-date scientific Python
 # stack
-dist: trusty
+dist: xenial
 sudo: required
 language: python
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -155,13 +155,15 @@ before_install:
     else
         export COVERAGE_OPTS=""
     fi
-  - if [ ${DOCBUILD} = true ]; then source tools/ci/docbuild_install.sh; fi;
   - pip install flake8
   - export SRCDIR=$PWD
 
 # Install packages
 install:
   - python setup.py develop
+
+before_script:
+  - if [ ${DOCBUILD} = true ]; then source tools/ci/docbuild_install.sh; fi;
 
 script:
   # Show versions

--- a/docs/source/contrasts.rst
+++ b/docs/source/contrasts.rst
@@ -183,9 +183,9 @@ The coefficients taken on by polynomial coding for `k=4` levels are the linear, 
 
    _, bins = np.histogram(hsb2.read, 3)
    try: # requires numpy master
-      readcat = np.digitize(hsb2.read, bins, True)
+       readcat = np.digitize(hsb2.read, bins, True)
    except:
-      readcat = np.digitize(hsb2.read, bins)
+       readcat = np.digitize(hsb2.read, bins)
    hsb2['readcat'] = readcat
    hsb2.groupby('readcat').mean()['write']
 

--- a/docs/source/contrasts.rst
+++ b/docs/source/contrasts.rst
@@ -5,7 +5,7 @@ Patsy: Contrast Coding Systems for categorical variables
 
 .. note:: This document is based heavily on `this excellent resource from UCLA <http://www.ats.ucla.edu/stat/r/library/contrast_coding.htm>`__.
 
-A categorical variable of K categories, or levels, usually enters a regression as a sequence of K-1 dummy variables. This amounts to a linear hypothesis on the level means. That is, each test statistic for these variables amounts to testing whether the mean for that level is statistically significantly different from the mean of the base category. This dummy coding is called Treatment coding in R parlance, and we will follow this convention. There are, however, different coding methods that amount to different sets of linear hypotheses. 
+A categorical variable of K categories, or levels, usually enters a regression as a sequence of K-1 dummy variables. This amounts to a linear hypothesis on the level means. That is, each test statistic for these variables amounts to testing whether the mean for that level is statistically significantly different from the mean of the base category. This dummy coding is called Treatment coding in R parlance, and we will follow this convention. There are, however, different coding methods that amount to different sets of linear hypotheses.
 
 In fact, the dummy coding is not technically a contrast coding. This is because the dummy variables add to one and are not functionally independent of the model's intercept. On the other hand, a set of *contrasts* for a categorical variable with `k` levels is a set of `k-1` functionally independent linear combinations of the factor level means that are also independent of the sum of the dummy variables. The dummy coding isn't wrong *per se*. It captures all of the coefficients, but it complicates matters when the model assumes independence of the coefficients such as in ANOVA. Linear regression models do not assume independence of the coefficients and thus dummy coding is often the only coding that is taught in this context.
 
@@ -48,7 +48,7 @@ Example Data
 
 It will be instructive to look at the mean of the dependent variable, write, for each level of race ((1 = Hispanic, 2 = Asian, 3 = African American and 4 = Caucasian)).
 
-.. ipython::
+.. ipython:: python
 
    hsb2.groupby('race')['write'].mean()
 
@@ -171,7 +171,7 @@ As you can see, these are only equal up to a constant. Other versions of the Hel
    k = 3
    1./k * (grouped.mean()["write"][k] - grouped.mean()["write"][:k-1].mean())
 
-   
+
 Orthogonal Polynomial Coding
 ----------------------------
 

--- a/docs/source/contrasts.rst
+++ b/docs/source/contrasts.rst
@@ -14,25 +14,25 @@ To have a look at the contrast matrices in Patsy, we will use data from UCLA ATS
 .. ipython:: python
    :suppress:
 
-   import numpy as np
-   np.set_printoptions(precision=4, suppress=True)
+    import numpy as np
+    np.set_printoptions(precision=4, suppress=True)
 
-   from patsy.contrasts import ContrastMatrix
+    from patsy.contrasts import ContrastMatrix
 
-   def _name_levels(prefix, levels):
+    def _name_levels(prefix, levels):
        return ["[%s%s]" % (prefix, level) for level in levels]
 
-   class Simple(object):
-       def _simple_contrast(self, levels):
+    class Simple(object):
+        def _simple_contrast(self, levels):
            nlevels = len(levels)
            contr = -1./nlevels * np.ones((nlevels, nlevels-1))
            contr[1:][np.diag_indices(nlevels-1)] = (nlevels-1.)/nlevels
            return contr
-       def code_with_intercept(self, levels):
+        def code_with_intercept(self, levels):
            contrast = np.column_stack((np.ones(len(levels)),
                                        self._simple_contrast(levels)))
            return ContrastMatrix(contrast, _name_levels("Simp.", levels))
-       def code_without_intercept(self, levels):
+        def code_without_intercept(self, levels):
            contrast = self._simple_contrast(levels)
            return ContrastMatrix(contrast, _name_levels("Simp.", levels[:-1]))
 
@@ -42,15 +42,15 @@ Example Data
 
 .. ipython:: python
 
-   import pandas
-   url = 'https://stats.idre.ucla.edu/stat/data/hsb2.csv'
-   hsb2 = pandas.read_csv(url)
+    import pandas
+    url = 'https://stats.idre.ucla.edu/stat/data/hsb2.csv'
+    hsb2 = pandas.read_csv(url)
 
 It will be instructive to look at the mean of the dependent variable, write, for each level of race ((1 = Hispanic, 2 = Asian, 3 = African American and 4 = Caucasian)).
 
 .. ipython:: python
 
-   hsb2.groupby('race')['write'].mean()
+    hsb2.groupby('race')['write'].mean()
 
 Treatment (Dummy) Coding
 ------------------------
@@ -59,25 +59,25 @@ Dummy coding is likely the most well known coding scheme. It compares each level
 
 .. ipython:: python
 
-   from patsy.contrasts import Treatment
-   levels = [1,2,3,4]
-   contrast = Treatment(reference=0).code_without_intercept(levels)
-   print(contrast.matrix)
+    from patsy.contrasts import Treatment
+    levels = [1,2,3,4]
+    contrast = Treatment(reference=0).code_without_intercept(levels)
+    print(contrast.matrix)
 
 Here we used `reference=0`, which implies that the first level, Hispanic, is the reference category against which the other level effects are measured. As mentioned above, the columns do not sum to zero and are thus not independent of the intercept. To be explicit, let's look at how this would encode the `race` variable.
 
 .. ipython:: python
 
-   contrast.matrix[hsb2.race-1, :][:20]
+    contrast.matrix[hsb2.race-1, :][:20]
 
 This is a bit of a trick, as the `race` category conveniently maps to zero-based indices. If it does not, this conversion happens under the hood, so this won't work in general but nonetheless is a useful exercise to fix ideas. The below illustrates the output using the three contrasts above
 
 .. ipython:: python
 
-   from statsmodels.formula.api import ols
-   mod = ols("write ~ C(race, Treatment)", data=hsb2)
-   res = mod.fit()
-   print(res.summary())
+    from statsmodels.formula.api import ols
+    mod = ols("write ~ C(race, Treatment)", data=hsb2)
+    res = mod.fit()
+    print(res.summary())
 
 We explicitly gave the contrast for race; however, since Treatment is the default, we could have omitted this.
 
@@ -89,12 +89,12 @@ Like Treatment Coding, Simple Coding compares each level to a fixed reference le
 
 .. ipython:: python
 
-   contrast = Simple().code_without_intercept(levels)
-   print(contrast.matrix)
+    contrast = Simple().code_without_intercept(levels)
+    print(contrast.matrix)
 
-   mod = ols("write ~ C(race, Simple)", data=hsb2)
-   res = mod.fit()
-   print(res.summary())
+    mod = ols("write ~ C(race, Simple)", data=hsb2)
+    res = mod.fit()
+    print(res.summary())
 
 Sum (Deviation) Coding
 ----------------------
@@ -103,19 +103,19 @@ Sum coding compares the mean of the dependent variable for a given level to the 
 
 .. ipython:: python
 
-   from patsy.contrasts import Sum
-   contrast = Sum().code_without_intercept(levels)
-   print(contrast.matrix)
+    from patsy.contrasts import Sum
+    contrast = Sum().code_without_intercept(levels)
+    print(contrast.matrix)
 
-   mod = ols("write ~ C(race, Sum)", data=hsb2)
-   res = mod.fit()
-   print(res.summary())
+    mod = ols("write ~ C(race, Sum)", data=hsb2)
+    res = mod.fit()
+    print(res.summary())
 
 This correspons to a parameterization that forces all the coefficients to sum to zero. Notice that the intercept here is the grand mean where the grand mean is the mean of means of the dependent variable by each level.
 
 .. ipython:: python
 
-   hsb2.groupby('race')['write'].mean().mean()
+    hsb2.groupby('race')['write'].mean().mean()
 
 Backward Difference Coding
 --------------------------
@@ -124,20 +124,20 @@ In backward difference coding, the mean of the dependent variable for a level is
 
 .. ipython:: python
 
-   from patsy.contrasts import Diff
-   contrast = Diff().code_without_intercept(levels)
-   print(contrast.matrix)
+    from patsy.contrasts import Diff
+    contrast = Diff().code_without_intercept(levels)
+    print(contrast.matrix)
 
-   mod = ols("write ~ C(race, Diff)", data=hsb2)
-   res = mod.fit()
-   print(res.summary())
+    mod = ols("write ~ C(race, Diff)", data=hsb2)
+    res = mod.fit()
+    print(res.summary())
 
 For example, here the coefficient on level 1 is the mean of `write` at level 2 compared with the mean at level 1. Ie.,
 
 .. ipython:: python
 
-   res.params["C(race, Diff)[D.1]"]
-   hsb2.groupby('race').mean()["write"][2] - \
+    res.params["C(race, Diff)[D.1]"]
+    hsb2.groupby('race').mean()["write"][2] - \
         hsb2.groupby('race').mean()["write"][1]
 
 Helmert Coding
@@ -147,29 +147,29 @@ Our version of Helmert coding is sometimes referred to as Reverse Helmert Coding
 
 .. ipython:: python
 
-   from patsy.contrasts import Helmert
-   contrast = Helmert().code_without_intercept(levels)
-   print(contrast.matrix)
+    from patsy.contrasts import Helmert
+    contrast = Helmert().code_without_intercept(levels)
+    print(contrast.matrix)
 
-   mod = ols("write ~ C(race, Helmert)", data=hsb2)
-   res = mod.fit()
-   print(res.summary())
+    mod = ols("write ~ C(race, Helmert)", data=hsb2)
+    res = mod.fit()
+    print(res.summary())
 
 To illustrate, the comparison on level 4 is the mean of the dependent variable at the previous three levels taken from the mean at level 4
 
 .. ipython:: python
 
-   grouped = hsb2.groupby('race')
-   grouped.mean()["write"][4] - grouped.mean()["write"][:3].mean()
+    grouped = hsb2.groupby('race')
+    grouped.mean()["write"][4] - grouped.mean()["write"][:3].mean()
 
 As you can see, these are only equal up to a constant. Other versions of the Helmert contrast give the actual difference in means. Regardless, the hypothesis tests are the same.
 
 .. ipython:: python
 
-   k = 4
-   1./k * (grouped.mean()["write"][k] - grouped.mean()["write"][:k-1].mean())
-   k = 3
-   1./k * (grouped.mean()["write"][k] - grouped.mean()["write"][:k-1].mean())
+    k = 4
+    1./k * (grouped.mean()["write"][k] - grouped.mean()["write"][:k-1].mean())
+    k = 3
+    1./k * (grouped.mean()["write"][k] - grouped.mean()["write"][:k-1].mean())
 
 
 Orthogonal Polynomial Coding
@@ -179,24 +179,24 @@ The coefficients taken on by polynomial coding for `k=4` levels are the linear, 
 
 .. ipython:: python
 
-   _, bins = np.histogram(hsb2.read, 3)
-   try: # requires numpy master
+    _, bins = np.histogram(hsb2.read, 3)
+    try: # requires numpy master
        readcat = np.digitize(hsb2.read, bins, True)
-   except:
+    except:
        readcat = np.digitize(hsb2.read, bins)
-   hsb2['readcat'] = readcat
-   hsb2.groupby('readcat').mean()['write']
+    hsb2['readcat'] = readcat
+    hsb2.groupby('readcat').mean()['write']
 
 .. ipython:: python
 
-   from patsy.contrasts import Poly
-   levels = hsb2.readcat.unique().tolist()
-   contrast = Poly().code_without_intercept(levels)
-   print(contrast.matrix)
+    from patsy.contrasts import Poly
+    levels = hsb2.readcat.unique().tolist()
+    contrast = Poly().code_without_intercept(levels)
+    print(contrast.matrix)
 
-   mod = ols("write ~ C(readcat, Poly)", data=hsb2)
-   res = mod.fit()
-   print(res.summary())
+    mod = ols("write ~ C(readcat, Poly)", data=hsb2)
+    res = mod.fit()
+    print(res.summary())
 
 As you can see, readcat has a significant linear effect on the dependent variable `write` but not a significant quadratic or cubic effect.
 
@@ -209,26 +209,27 @@ If you want to use your own coding, you must do so by writing a coding class tha
 
 .. ipython:: python
 
-   from patsy.contrasts import ContrastMatrix
+    from patsy.contrasts import ContrastMatrix
 
-   def _name_levels(prefix, levels):
-       return ["[%s%s]" % (prefix, level) for level in levels]
+    def _name_levels(prefix, levels):
+        return ["[%s%s]" % (prefix, level) for level in levels]
 
-   class Simple(object):
-       def _simple_contrast(self, levels):
+    class Simple(object):
+        def _simple_contrast(self, levels):
            nlevels = len(levels)
            contr = -1./nlevels * np.ones((nlevels, nlevels-1))
            contr[1:][np.diag_indices(nlevels-1)] = (nlevels-1.)/nlevels
            return contr
 
-       def code_with_intercept(self, levels):
+        def code_with_intercept(self, levels):
            contrast = np.column_stack((np.ones(len(levels)),
                                        self._simple_contrast(levels)))
            return ContrastMatrix(contrast, _name_levels("Simp.", levels))
 
-       def code_without_intercept(self, levels):
+        def code_without_intercept(self, levels):
            contrast = self._simple_contrast(levels)
            return ContrastMatrix(contrast, _name_levels("Simp.", levels[:-1]))
 
-   mod = ols("write ~ C(race, Simple)", data=hsb2)
-   res = mod.fit()
+    mod = ols("write ~ C(race, Simple)", data=hsb2)
+    res = mod.fit()
+    print(res.summary())

--- a/docs/source/datasets/index.rst
+++ b/docs/source/datasets/index.rst
@@ -125,7 +125,8 @@ The full DataFrame is available in the ``data`` attribute of the Dataset object
 With pandas integration in the estimation classes, the metadata will be attached
 to model results:
 
-.. ipython:: python,okwarning
+.. ipython:: python
+   :okwarning:
 
    y, x = data.endog, data.exog
    res = sm.OLS(y, x).fit()

--- a/docs/source/vector_ar.rst
+++ b/docs/source/vector_ar.rst
@@ -51,36 +51,36 @@ class will use the passed variable names. Otherwise they can be passed
 explicitly:
 
 .. ipython:: python
-    :suppress:
+   :suppress:
 
-    import pandas as pd
-    pd.options.display.max_rows = 10
-    import matplotlib
-    import matplotlib.pyplot as plt
-    matplotlib.style.use('ggplot')
+   import pandas as pd
+   pd.options.display.max_rows = 10
+   import matplotlib
+   import matplotlib.pyplot as plt
+   matplotlib.style.use('ggplot')
 
 .. ipython:: python
    :okwarning:
 
-    # some example data
-    import numpy as np
-    import pandas
-    import statsmodels.api as sm
-    from statsmodels.tsa.api import VAR, DynamicVAR
-    mdata = sm.datasets.macrodata.load_pandas().data
+   # some example data
+   import numpy as np
+   import pandas
+   import statsmodels.api as sm
+   from statsmodels.tsa.api import VAR, DynamicVAR
+   mdata = sm.datasets.macrodata.load_pandas().data
 
-    # prepare the dates index
-    dates = mdata[['year', 'quarter']].astype(int).astype(str)
-    quarterly = dates["year"] + "Q" + dates["quarter"]
-    from statsmodels.tsa.base.datetools import dates_from_str
-    quarterly = dates_from_str(quarterly)
+   # prepare the dates index
+   dates = mdata[['year', 'quarter']].astype(int).astype(str)
+   quarterly = dates["year"] + "Q" + dates["quarter"]
+   from statsmodels.tsa.base.datetools import dates_from_str
+   quarterly = dates_from_str(quarterly)
 
-    mdata = mdata[['realgdp','realcons','realinv']]
-    mdata.index = pandas.DatetimeIndex(quarterly)
-    data = np.log(mdata).diff().dropna()
+   mdata = mdata[['realgdp','realcons','realinv']]
+   mdata.index = pandas.DatetimeIndex(quarterly)
+   data = np.log(mdata).diff().dropna()
 
-    # make a VAR model
-    model = VAR(data)
+   # make a VAR model
+   model = VAR(data)
 
 .. note::
 
@@ -95,11 +95,10 @@ order. Or you can have the model select a lag order based on a standard
 information criterion (see below):
 
 .. ipython:: python
+   :okwarning:
 
-    results = model.fit(2)
-
-    results.summary()
-
+   results = model.fit(2)
+   results.summary()
 
 Several ways to visualize the data using `matplotlib` are available.
 
@@ -107,16 +106,16 @@ Plotting input time series:
 
 .. ipython:: python
 
-    @savefig var_plot_input.png
-    results.plot()
+   @savefig var_plot_input.png
+   results.plot()
 
 
 Plotting time series autocorrelation function:
 
 .. ipython:: python
 
-    @savefig var_plot_acorr.png
-    results.plot_acorr()
+   @savefig var_plot_acorr.png
+   results.plot_acorr()
 
 
 Lag order selection
@@ -128,14 +127,14 @@ implemented the latter, accessible through the :class:`VAR` class:
 
 .. ipython:: python
 
-    model.select_order(15)
+   model.select_order(15)
 
 When calling the `fit` function, one can pass a maximum number of lags and the
 order criterion to use for order selection:
 
 .. ipython:: python
 
-    results = model.fit(maxlags=15, ic='aic')
+   results = model.fit(maxlags=15, ic='aic')
 
 Forecasting
 ~~~~~~~~~~~
@@ -152,8 +151,8 @@ to specify the "initial value" for the forecast:
 
 .. ipython:: python
 
-    lag_order = results.k_ar
-    results.forecast(data.values[-lag_order:], 5)
+   lag_order = results.k_ar
+   results.forecast(data.values[-lag_order:], 5)
 
 The `forecast_interval` function will produce the above forecast along with
 asymptotic standard errors. These can be visualized using the `plot_forecast`
@@ -210,8 +209,9 @@ We can perform an impulse response analysis by calling the `irf` function on a
 `VARResults` object:
 
 .. ipython:: python
+   :okwarning:
 
-    irf = results.irf(10)
+   irf = results.irf(10)
 
 These can be visualized using the `plot` function, in either orthogonalized or
 non-orthogonalized form. Asymptotic standard errors are plotted by default at
@@ -225,8 +225,8 @@ the 95% significance level, which can be modified by the user.
 
 .. ipython:: python
 
-    @savefig var_irf.png
-    irf.plot(orth=False)
+   @savefig var_irf.png
+   irf.plot(orth=False)
 
 
 Note the `plot` function is flexible and can plot only variables of interest if
@@ -234,16 +234,16 @@ so desired:
 
 .. ipython:: python
 
-    @savefig var_realgdp.png
-    irf.plot(impulse='realgdp')
+   @savefig var_realgdp.png
+   irf.plot(impulse='realgdp')
 
 The cumulative effects :math:`\Psi_n = \sum_{i=0}^n \Phi_i` can be plotted with
 the long run effects as follows:
 
 .. ipython:: python
 
-    @savefig var_irf_cum.png
-    irf.plot_cum_effects(orth=False)
+   @savefig var_irf_cum.png
+   irf.plot_cum_effects(orth=False)
 
 
 Reference
@@ -270,16 +270,15 @@ These are computed via the `fevd` function up through a total number of steps ah
 
 .. ipython:: python
 
-    fevd = results.fevd(5)
-
-    fevd.summary()
+   fevd = results.fevd(5)
+   fevd.summary()
 
 They can also be visualized through the returned :class:`FEVD` object:
 
 .. ipython:: python
 
-    @savefig var_fevd.png
-    results.fevd(20).plot()
+   @savefig var_fevd.png
+   results.fevd(20).plot()
 
 
 Reference
@@ -310,7 +309,7 @@ F-test.
 
 .. ipython:: python
 
-    results.test_causality('realgdp', ['realinv', 'realcons'], kind='f')
+   results.test_causality('realgdp', ['realinv', 'realcons'], kind='f')
 
 Normality
 ~~~~~~~~~
@@ -335,13 +334,13 @@ a VAR(p) model estimated at each point in time.
 
 .. ipython:: python
 
-    np.random.seed(1)
-    import pandas.util.testing as ptest
-    ptest.N = 500
-    data = ptest.makeTimeDataFrame().cumsum(0)
-    data
+   np.random.seed(1)
+   import pandas.util.testing as ptest
+   ptest.N = 500
+   data = ptest.makeTimeDataFrame().cumsum(0)
+   data
 
-    var = DynamicVAR(data, lag_order=2, window_type='expanding')
+   var = DynamicVAR(data, lag_order=2, window_type='expanding')
 
 The estimated coefficients for the dynamic model are returned as a
 :class:`pandas.Panel` object, which can allow you to easily examine, for
@@ -350,29 +349,30 @@ example, all of the model coefficients by equation or by date:
 .. ipython:: python
    :okwarning:
 
-    import datetime as dt
+   import datetime as dt
 
-    var.coefs
+   var.coefs
 
-    # all estimated coefficients for equation A
-    var.coefs.minor_xs('A').info()
+   # all estimated coefficients for equation A
+   var.coefs.minor_xs('A').info()
 
-    # coefficients on 11/30/2001
-    var.coefs.major_xs(dt.datetime(2001, 11, 30)).T
+   # coefficients on 11/30/2001
+   var.coefs.major_xs(dt.datetime(2001, 11, 30)).T
 
 Dynamic forecasts for a given number of steps ahead can be produced using the
 `forecast` function and return a :class:`pandas.DataMatrix` object:
 
 .. ipython:: python
+   :okwarning:
 
-    var.forecast(2)
+   var.forecast(2)
 
 The forecasts can be visualized using `plot_forecast`:
 
 .. ipython:: python
 
-    @savefig dvar_forecast.png
-    var.plot_forecast(2)
+   @savefig dvar_forecast.png
+   var.plot_forecast(2)
 
 Reference
 ~~~~~~~~~
@@ -398,14 +398,14 @@ specify and estimate these models.
 
 A VECM(:math:`k_{ar}-1`) has the following form
 
-.. math:: 
+.. math::
 
-    \Delta y_t = \Pi y_{t-1} + \Gamma_1 \Delta y_{t-1} + \ldots 
+    \Delta y_t = \Pi y_{t-1} + \Gamma_1 \Delta y_{t-1} + \ldots
                    + \Gamma_{k_{ar}-1} \Delta y_{t-k_{ar}+1} + u_t
 
 where
 
-.. math:: 
+.. math::
 
     \Pi = \alpha \beta'
 

--- a/docs/sphinxext/github.py
+++ b/docs/sphinxext/github.py
@@ -20,6 +20,7 @@ Authors
 from docutils import nodes, utils
 from docutils.parsers.rst.roles import set_classes
 
+
 def make_link_node(rawtext, app, type, slug, options):
     """Create a link to a github resource.
 
@@ -37,7 +38,8 @@ def make_link_node(rawtext, app, type, slug, options):
         if not base.endswith('/'):
             base += '/'
     except AttributeError as err:
-        raise ValueError('github_project_url configuration value is not set (%s)' % str(err))
+        raise ValueError('github_project_url configuration value is not set'
+                         ' (%s)' % str(err))
 
     ref = base + type + '/' + slug + '/'
     set_classes(options)
@@ -47,6 +49,7 @@ def make_link_node(rawtext, app, type, slug, options):
     node = nodes.reference(rawtext, prefix + utils.unescape(slug), refuri=ref,
                            **options)
     return node
+
 
 def ghissue_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
     """Link to a GitHub issue.
@@ -75,7 +78,7 @@ def ghissue_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
         prb = inliner.problematic(rawtext, rawtext, msg)
         return [prb], [msg]
     app = inliner.document.settings.env.app
-    #app.info('issue %r' % text)
+    # app.info('issue %r' % text)
     if 'pull' in name.lower():
         category = 'pull'
     elif 'issue' in name.lower():
@@ -88,6 +91,7 @@ def ghissue_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
         return [prb], [msg]
     node = make_link_node(rawtext, app, category, str(issue_num), options)
     return [node], []
+
 
 def ghuser_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
     """Link to a GitHub user.
@@ -104,11 +108,12 @@ def ghuser_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
     :param options: Directive options for customization.
     :param content: The directive content for customization.
     """
-    app = inliner.document.settings.env.app
-    #app.info('user link %r' % text)
+    # app = inliner.document.settings.env.app
+    # app.info('user link %r' % text)
     ref = 'https://www.github.com/' + text
     node = nodes.reference(rawtext, text, refuri=ref, **options)
     return [node], []
+
 
 def ghcommit_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
     """Link to a GitHub commit.
@@ -126,7 +131,7 @@ def ghcommit_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
     :param content: The directive content for customization.
     """
     app = inliner.document.settings.env.app
-    #app.info('user link %r' % text)
+    # app.info('user link %r' % text)
     try:
         base = app.config.github_project_url
         if not base:
@@ -134,7 +139,8 @@ def ghcommit_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
         if not base.endswith('/'):
             base += '/'
     except AttributeError as err:
-        raise ValueError('github_project_url configuration value is not set (%s)' % str(err))
+        raise ValueError('github_project_url configuration value is not '
+                         'set (%s)' % str(err))
 
     ref = base + text
     node = nodes.reference(rawtext, text[:6], refuri=ref, **options)
@@ -143,10 +149,12 @@ def ghcommit_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
 
 def setup(app):
     """Install the plugin.
-    
+
     :param app: Sphinx application context.
     """
-    app.info('Initializing GitHub plugin')
+    from sphinx.util import logging
+    logger = logging.getLogger(__name__)
+    logger.info('Initializing GitHub plugin')
     app.add_role('ghissue', ghissue_role)
     app.add_role('ghpull', ghissue_role)
     app.add_role('ghuser', ghuser_role)

--- a/examples/notebooks/discrete_choice_example.ipynb
+++ b/examples/notebooks/discrete_choice_example.ipynb
@@ -25,12 +25,19 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": true
    },
    "outputs": [],
    "source": [
-    "%matplotlib inline\n",
-    "\n",
+    "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "from __future__ import print_function\n",
     "import numpy as np\n",
     "import pandas as pd\n",
@@ -43,9 +50,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "print(sm.datasets.fair.SOURCE)"
@@ -54,9 +59,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "print( sm.datasets.fair.NOTE)"
@@ -65,9 +68,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "dta = sm.datasets.fair.load_pandas().data"
@@ -76,9 +77,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "dta['affair'] = (dta['affairs'] > 0).astype(float)\n",
@@ -88,9 +87,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "print(dta.describe())"
@@ -99,12 +96,10 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "affair_mod = logit(\"affair ~ occupation + educ + occupation_husb\" \n",
+    "affair_mod = logit(\"affair ~ occupation + educ + occupation_husb\"\n",
     "                   \"+ rate_marriage + age + yrs_married + children\"\n",
     "                   \" + religious\", dta).fit()"
    ]
@@ -112,9 +107,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "print(affair_mod.summary())"
@@ -130,9 +123,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "affair_mod.pred_table()"
@@ -148,9 +139,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "mfx = affair_mod.get_margeff()\n",
@@ -160,9 +149,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "respondent1000 = dta.iloc[1000]\n",
@@ -172,9 +159,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "resp = dict(zip(range(1,9), respondent1000[[\"occupation\", \"educ\", \n",
@@ -188,9 +173,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "mfx = affair_mod.get_margeff(atexog=resp)\n",
@@ -207,9 +190,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "respondent1000 = dta.iloc[[1000]]\n",
@@ -219,9 +200,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "affair_mod.fittedvalues[1000]"
@@ -230,9 +209,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "affair_mod.model.cdf(affair_mod.fittedvalues[1000])"
@@ -255,9 +232,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "fig = plt.figure(figsize=(12,8))\n",
@@ -271,9 +246,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "fig = plt.figure(figsize=(12,8))\n",
@@ -301,9 +274,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "print(sm.datasets.star98.SOURCE)"
@@ -312,9 +283,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "print(sm.datasets.star98.DESCRLONG)"
@@ -323,9 +292,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "print(sm.datasets.star98.NOTE)"
@@ -334,9 +301,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "dta = sm.datasets.star98.load_pandas().data\n",
@@ -346,9 +311,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "print(dta[['NABOVE', 'NBELOW', 'LOWINC', 'PERASIAN', 'PERBLACK', 'PERHISP', 'PERMINTE']].head(10))"
@@ -357,9 +320,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "print(dta[['AVYRSEXP', 'AVSALK', 'PERSPENK', 'PTRATIO', 'PCTAF', 'PCTCHRT', 'PCTYRRND']].head(10))"
@@ -368,9 +329,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "formula = 'NABOVE + NBELOW ~ LOWINC + PERASIAN + PERBLACK + PERHISP + PCTCHRT '\n",
@@ -394,9 +353,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "stats.binom(5, 1./6).pmf(2)"
@@ -405,9 +362,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from scipy.misc import comb\n",
@@ -417,9 +372,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from statsmodels.formula.api import glm\n",
@@ -429,9 +382,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "print(glm_mod.summary())"
@@ -447,9 +398,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "glm_mod.model.data.orig_endog.sum(1)"
@@ -458,9 +407,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "glm_mod.fittedvalues * glm_mod.model.data.orig_endog.sum(1)"
@@ -477,9 +424,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "exog = glm_mod.model.data.orig_exog # get the dataframe"
@@ -488,9 +433,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "means25 = exog.mean()\n",
@@ -500,9 +443,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "means25['LOWINC'] = exog['LOWINC'].quantile(.25)\n",
@@ -512,9 +453,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "means75 = exog.mean()\n",
@@ -532,9 +471,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "resp25 = glm_mod.predict(pd.DataFrame(means25).T)\n",
@@ -552,9 +489,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "print(\"%2.4f%%\" % (diff[0]*100))"
@@ -563,9 +498,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "nobs = glm_mod.nobs\n",
@@ -576,9 +509,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from statsmodels.graphics.api import abline_plot\n",
@@ -610,9 +541,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "fig = plt.figure(figsize=(12,8))\n",
@@ -644,9 +573,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "resid = glm_mod.resid_deviance\n",
@@ -658,9 +585,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "fig = plt.figure(figsize=(12,8))\n",
@@ -679,9 +604,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "fig = plt.figure(figsize=(12,8))\n",
@@ -706,9 +629,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.3"
+   "version": "3.6.3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/examples/notebooks/glm.ipynb
+++ b/examples/notebooks/glm.ipynb
@@ -11,12 +11,19 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": true
    },
    "outputs": [],
    "source": [
-    "%matplotlib inline\n",
-    "\n",
+    "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "from __future__ import print_function\n",
     "import numpy as np\n",
     "import statsmodels.api as sm\n",
@@ -40,9 +47,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "print(sm.datasets.star98.NOTE)"
@@ -58,9 +63,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "data = sm.datasets.star98.load()\n",
@@ -77,9 +80,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "print(data.endog[:5,:])"
@@ -96,9 +97,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "print(data.exog[:2,:])"
@@ -114,9 +113,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "glm_binom = sm.GLM(data.endog, data.exog, family=sm.families.Binomial())\n",
@@ -134,9 +131,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "print('Total number of trials:',  data.endog[0].sum())\n",
@@ -154,9 +149,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "means = data.exog.mean(axis=0)\n",
@@ -179,9 +172,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "print(\"%2.4f%%\" % (diff*100))"
@@ -199,9 +190,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "nobs = res.nobs\n",
@@ -219,9 +208,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from statsmodels.graphics.api import abline_plot"
@@ -230,9 +217,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "fig, ax = plt.subplots()\n",
@@ -256,9 +241,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "fig, ax = plt.subplots()\n",
@@ -281,9 +264,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from scipy import stats\n",
@@ -306,9 +287,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from statsmodels import graphics\n",
@@ -331,9 +310,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "print(sm.datasets.scotland.DESCRLONG)"
@@ -349,9 +326,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "data2 = sm.datasets.scotland.load()\n",
@@ -370,9 +345,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "glm_gamma = sm.GLM(data2.endog, data2.exog, family=sm.families.Gamma())\n",
@@ -392,9 +365,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "nobs2 = 100\n",
@@ -415,9 +386,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "gauss_log = sm.GLM(lny, X, family=sm.families.Gaussian(sm.families.links.log))\n",
@@ -442,9 +411,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.4.3"
+   "version": "3.6.3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/examples/notebooks/interactions_anova.ipynb
+++ b/examples/notebooks/interactions_anova.ipynb
@@ -20,12 +20,19 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": true
    },
    "outputs": [],
    "source": [
-    "%matplotlib inline\n",
-    "\n",
+    "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "from __future__ import print_function\n",
     "from statsmodels.compat import urlopen\n",
     "import numpy as np\n",
@@ -62,9 +69,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "plt.figure(figsize=(6,6))\n",
@@ -89,9 +94,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "formula = 'S ~ C(E) + C(M) + X'\n",
@@ -109,9 +112,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "lm.model.exog[:5]"
@@ -127,9 +128,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "lm.model.data.orig_exog[:5]"
@@ -145,9 +144,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "lm.model.data.frame[:5]"
@@ -163,9 +160,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "infl = lm.get_influence()\n",
@@ -182,9 +177,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "df_infl = infl.summary_frame()"
@@ -193,9 +186,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "df_infl[:5]"
@@ -211,9 +202,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "resid = lm.resid\n",
@@ -238,9 +227,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "interX_lm = ols(\"S ~ C(E) * X + C(M)\", salary_table).fit()\n",
@@ -257,9 +244,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from statsmodels.stats.api import anova_lm\n",
@@ -284,9 +269,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "interM_lm.model.data.orig_exog[:5]"
@@ -302,9 +285,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "interM_lm.model.exog\n",
@@ -314,9 +295,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "infl = interM_lm.get_influence()\n",
@@ -341,9 +320,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "drop_idx = abs(resid).argmax()\n",
@@ -383,9 +360,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "try:\n",
@@ -413,9 +388,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "lm_final = ols('S ~ X + C(E)*C(M)', data = salary_table.drop([drop_idx])).fit()\n",
@@ -445,9 +418,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "U = S - X * interX_lm32.params['X']\n",
@@ -467,9 +438,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "try:\n",
@@ -493,9 +462,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "min_lm = ols('JPERF ~ TEST', data=jobtest_table).fit()\n",
@@ -505,9 +472,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "fig, ax = plt.subplots(figsize=(6,6));\n",
@@ -523,9 +488,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "min_lm2 = ols('JPERF ~ TEST + TEST:MINORITY',\n",
@@ -537,9 +500,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "fig, ax = plt.subplots(figsize=(6,6));\n",
@@ -557,9 +518,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "min_lm3 = ols('JPERF ~ TEST + MINORITY', data = jobtest_table).fit()\n",
@@ -569,9 +528,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "fig, ax = plt.subplots(figsize=(6,6));\n",
@@ -588,9 +545,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "min_lm4 = ols('JPERF ~ TEST * MINORITY', data = jobtest_table).fit()\n",
@@ -600,9 +555,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "fig, ax = plt.subplots(figsize=(8,6));\n",
@@ -620,9 +573,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# is there any effect of MINORITY on slope or intercept?\n",
@@ -633,9 +584,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# is there any effect of MINORITY on intercept\n",
@@ -646,9 +595,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# is there any effect of MINORITY on slope\n",
@@ -659,9 +606,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# is it just the slope or both?\n",
@@ -679,9 +624,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "try:\n",
@@ -698,9 +641,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "rehab_lm = ols('Time ~ C(Fitness)', data=rehab_table).fit()\n",
@@ -713,9 +654,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "print(rehab_lm.summary())"
@@ -731,9 +670,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "try:\n",
@@ -753,9 +690,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "kidney_table.head(10)"
@@ -771,9 +706,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "kt = kidney_table\n",
@@ -792,9 +725,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "kidney_lm = ols('np.log(Days+1) ~ C(Duration) * C(Weight)', data=kt).fit()\n",
@@ -829,9 +760,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "sum_lm = ols('np.log(Days+1) ~ C(Duration, Sum) * C(Weight, Sum)',\n",
@@ -845,9 +774,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "nosum_lm = ols('np.log(Days+1) ~ C(Duration, Treatment) * C(Weight, Treatment)',\n",
@@ -874,9 +801,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.6.3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/examples/notebooks/ols.ipynb
+++ b/examples/notebooks/ols.ipynb
@@ -11,12 +11,19 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": true
    },
    "outputs": [],
    "source": [
-    "%matplotlib inline\n",
-    "\n",
+    "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "from __future__ import print_function\n",
     "import numpy as np\n",
     "import statsmodels.api as sm\n",
@@ -38,9 +45,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "nsample = 100\n",
@@ -60,9 +65,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "X = sm.add_constant(X)\n",
@@ -79,9 +82,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "model = sm.OLS(y, X)\n",
@@ -99,9 +100,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "print('Parameters: ', results.params)\n",
@@ -120,9 +119,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "nsample = 50\n",
@@ -145,9 +142,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "res = sm.OLS(y, X).fit()\n",
@@ -164,9 +159,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "print('Parameters: ', res.params)\n",
@@ -184,9 +177,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "prstd, iv_l, iv_u = wls_prediction_std(res)\n",
@@ -213,9 +204,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "nsample = 50\n",
@@ -246,9 +235,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "print(X[:5,:])\n",
@@ -267,9 +254,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "res2 = sm.OLS(y, X).fit()\n",
@@ -286,9 +271,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "prstd, iv_l, iv_u = wls_prediction_std(res2)\n",
@@ -317,9 +300,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "R = [[0, 1, 0, 0], [0, 0, 1, 0]]\n",
@@ -337,9 +318,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "print(res2.f_test(\"x2 = x3 = 0\"))"
@@ -357,9 +336,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "beta = [1., 0.3, -0.0, 10]\n",
@@ -372,9 +349,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "print(res3.f_test(R))"
@@ -383,9 +358,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "print(res3.f_test(\"x2 = x3 = 0\"))"
@@ -403,9 +376,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from statsmodels.datasets.longley import load_pandas\n",
@@ -424,9 +395,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "ols_model = sm.OLS(y, X)\n",
@@ -446,9 +415,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "norm_x = X.values\n",
@@ -469,9 +436,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "eigs = np.linalg.eigvals(norm_xtx)\n",
@@ -491,9 +456,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "ols_results2 = sm.OLS(y.iloc[:14], X.iloc[:14]).fit()\n",
@@ -510,9 +473,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "infl = ols_results.get_influence()"
@@ -528,9 +489,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "2./len(X)**.5"
@@ -539,9 +498,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "print(infl.summary_frame().filter(regex=\"dfb\"))"
@@ -564,9 +521,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.3"
+   "version": "3.6.3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/examples/notebooks/plots_boxplots.ipynb
+++ b/examples/notebooks/plots_boxplots.ipynb
@@ -18,12 +18,19 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": true
    },
    "outputs": [],
    "source": [
-    "%matplotlib inline\n",
-    "\n",
+    "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
     "import statsmodels.api as sm"
@@ -50,9 +57,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "data = sm.datasets.anes96.load_pandas()\n",
@@ -72,9 +77,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "plt.rcParams['figure.subplot.bottom'] = 0.23  # keep labels visible\n",
@@ -95,9 +98,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def beanplot(data, plot_opts={}, jitter=False):\n",
@@ -118,9 +119,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "fig = beanplot(age, jitter=True)"
@@ -129,9 +128,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "fig = beanplot(age, plot_opts={'violin_width': 0.5, 'violin_fc':'#66c2a5'})"
@@ -140,9 +137,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "fig = beanplot(age, plot_opts={'violin_fc':'#66c2a5'})"
@@ -151,9 +146,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "fig = beanplot(age, plot_opts={'bean_size': 0.2, 'violin_width': 0.75, 'violin_fc':'#66c2a5'})"
@@ -162,9 +155,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "fig = beanplot(age, jitter=True, plot_opts={'violin_fc':'#66c2a5'})"
@@ -173,9 +164,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "fig = beanplot(age, jitter=True, plot_opts={'violin_width': 0.5, 'violin_fc':'#66c2a5'})"
@@ -184,9 +173,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": []
   },
@@ -207,9 +194,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from __future__ import print_function\n",
@@ -235,9 +220,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Create a violin plot.\n",
@@ -257,9 +240,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Create a bean plot.\n",
@@ -279,9 +260,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Create a jitter plot.\n",
@@ -303,9 +282,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Create an asymmetrical jitter plot.\n",
@@ -361,9 +338,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.4.3"
+   "version": "3.6.3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/examples/notebooks/predict.ipynb
+++ b/examples/notebooks/predict.ipynb
@@ -11,12 +11,19 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": true
    },
    "outputs": [],
    "source": [
-    "%matplotlib inline\n",
-    "\n",
+    "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "from __future__ import print_function\n",
     "import numpy as np\n",
     "import statsmodels.api as sm"
@@ -32,9 +39,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "nsample = 50\n",
@@ -57,9 +62,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "olsmod = sm.OLS(y, X)\n",
@@ -77,9 +80,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "ypred = olsres.predict(X)\n",
@@ -96,9 +97,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "x1n = np.linspace(20.5,25, 10)\n",
@@ -118,9 +117,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import matplotlib.pyplot as plt\n",
@@ -149,9 +146,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from statsmodels.formula.api import ols\n",
@@ -171,9 +166,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "res.params"
@@ -189,9 +182,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "res.predict(exog=dict(x1=x1n))"
@@ -214,9 +205,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.4.3"
+   "version": "3.6.3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/examples/notebooks/quantile_regression.ipynb
+++ b/examples/notebooks/quantile_regression.ipynb
@@ -27,12 +27,19 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": true
    },
    "outputs": [],
    "source": [
-    "%matplotlib inline\n",
-    "\n",
+    "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "from __future__ import print_function\n",
     "import patsy\n",
     "import numpy as np\n",
@@ -58,9 +65,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "mod = smf.quantreg('foodexp ~ income', data)\n",
@@ -89,9 +94,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "quantiles = np.arange(.05, .96, .1)\n",
@@ -130,9 +133,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "x = np.arange(data.income.min(), data.income.max(), 50)\n",
@@ -169,9 +170,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "n = models.shape[0]\n",
@@ -204,9 +203,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.3"
+   "version": "3.6.3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/examples/notebooks/regression_diagnostics.ipynb
+++ b/examples/notebooks/regression_diagnostics.ipynb
@@ -26,11 +26,22 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
-    "%matplotlib inline\n",
-    "\n",
+    "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
     "from __future__ import print_function\n",
     "from statsmodels.compat import lzip\n",
     "import statsmodels\n",
@@ -68,7 +79,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "name = ['Jarque-Bera', 'Chi^2 two-tail prob.', 'Skew', 'Kurtosis']\n",
@@ -86,7 +99,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "name = ['Chi^2', 'Two-tail probability']\n",
@@ -106,7 +121,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "from statsmodels.stats.outliers_influence import OLSInfluence\n",
@@ -126,7 +143,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "from statsmodels.graphics.regressionplots import plot_leverage_resid2\n",
@@ -153,7 +172,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "np.linalg.cond(results.model.exog)"
@@ -171,7 +192,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "name = ['Lagrange multiplier statistic', 'p-value',\n",
@@ -190,7 +213,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "name = ['F statistic', 'p-value']\n",
@@ -210,7 +235,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "name = ['t value', 'p value']\n",
@@ -235,7 +262,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.6.3"
   }
  },
  "nbformat": 4,

--- a/examples/notebooks/regression_plots.ipynb
+++ b/examples/notebooks/regression_plots.ipynb
@@ -10,11 +10,22 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
-    "%matplotlib inline\n",
-    "\n",
+    "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
     "from __future__ import print_function\n",
     "from statsmodels.compat import lzip\n",
     "import numpy as np\n",
@@ -48,7 +59,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "prestige = sm.datasets.get_rdataset(\"Duncan\", \"carData\", cache=True).data"
@@ -57,7 +70,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "prestige.head()"
@@ -66,7 +81,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "prestige_model = ols(\"prestige ~ income + education\", data=prestige).fit()"
@@ -75,7 +92,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "print(prestige_model.summary())"
@@ -112,7 +131,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "fig, ax = plt.subplots(figsize=(12,8))\n",
@@ -158,7 +179,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "fig, ax = plt.subplots(figsize=(12,8))\n",
@@ -168,7 +191,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "fix, ax = plt.subplots(figsize=(12,14))\n",
@@ -185,7 +210,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "subset = ~prestige.index.isin([\"conductor\", \"RR.engineer\", \"minister\"])\n",
@@ -204,7 +231,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "fig = plt.figure(figsize=(12,8))\n",
@@ -235,7 +264,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "fig, ax = plt.subplots(figsize=(12, 8))\n",
@@ -252,7 +283,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "fig = plt.figure(figsize=(12, 8))\n",
@@ -276,7 +309,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "fig = plt.figure(figsize=(12,8))\n",
@@ -300,7 +335,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "fig, ax = plt.subplots(figsize=(12, 8))\n",
@@ -326,7 +363,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "#dta = pd.read_csv(\"http://www.stat.ufl.edu/~aa/social/csv_files/statewide-crime-2.csv\")\n",
@@ -346,7 +385,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "dta = sm.datasets.statecrime.load_pandas().data"
@@ -355,7 +396,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "crime_model = ols(\"murder ~ urban + poverty + hs_grad + single\", data=dta).fit()\n",
@@ -372,7 +415,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "fig = plt.figure(figsize=(12,8))\n",
@@ -382,7 +427,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "fig, ax = plt.subplots(figsize=(12,8))\n",
@@ -406,7 +453,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "fig, ax = plt.subplots(figsize=(8,6))\n",
@@ -423,7 +472,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "fig, ax = plt.subplots(figsize=(8,6))\n",
@@ -447,7 +498,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "from statsmodels.formula.api import rlm"
@@ -456,7 +509,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "rob_crime_model = rlm(\"murder ~ urban + poverty + hs_grad + single\", data=dta, \n",
@@ -467,7 +522,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "#rob_crime_model = rlm(\"murder ~ pctmetro + poverty + pcths + single\", data=dta, M=sm.robust.norms.TukeyBiweight()).fit(conv=\"weights\")\n",
@@ -484,7 +541,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "weights = rob_crime_model.weights\n",
@@ -503,7 +562,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "from statsmodels.graphics import utils\n",
@@ -538,7 +599,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.6"
+   "version": "3.6.3"
   }
  },
  "nbformat": 4,

--- a/examples/notebooks/robust_models_0.ipynb
+++ b/examples/notebooks/robust_models_0.ipynb
@@ -11,12 +11,19 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": true
    },
    "outputs": [],
    "source": [
-    "%matplotlib inline\n",
-    "\n",
+    "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "from __future__ import print_function\n",
     "import numpy as np\n",
     "import statsmodels.api as sm\n",
@@ -36,9 +43,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "data = sm.datasets.stackloss.load()\n",
@@ -55,9 +60,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "huber_t = sm.RLM(data.endog, data.exog, M=sm.robust.norms.HuberT())\n",
@@ -78,9 +81,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "hub_results2 = huber_t.fit(cov=\"H2\")\n",
@@ -98,9 +99,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "andrew_mod = sm.RLM(data.endog, data.exog, M=sm.robust.norms.AndrewWave())\n",
@@ -122,9 +121,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "nsample = 50\n",
@@ -150,9 +147,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "res = sm.OLS(y2, X).fit()\n",
@@ -171,9 +166,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "resrlm = sm.RLM(y2, X).fit()\n",
@@ -191,9 +184,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "fig = plt.figure(figsize=(12,8))\n",
@@ -220,9 +211,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "X2 = X[:,[0,1]] \n",
@@ -241,9 +230,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "resrlm2 = sm.RLM(y2, X2).fit()\n",
@@ -261,9 +248,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "prstd, iv_l, iv_u = wls_prediction_std(res2)\n",
@@ -295,9 +280,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.4.3"
+   "version": "3.6.3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/examples/notebooks/robust_models_1.ipynb
+++ b/examples/notebooks/robust_models_1.ipynb
@@ -10,11 +10,22 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
-    "%matplotlib inline\n",
-    "\n",
+    "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
     "from __future__ import print_function\n",
     "from statsmodels.compat import lmap\n",
     "import numpy as np\n",
@@ -49,7 +60,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "norms = sm.robust.norms"
@@ -58,7 +71,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "def plot_weights(support, weights_func, xlabels, xticks):\n",
@@ -81,7 +96,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "help(norms.AndrewWave.weights)"
@@ -90,7 +107,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "a = 1.339\n",
@@ -109,7 +128,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "help(norms.Hampel.weights)"
@@ -118,7 +139,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "c = 8\n",
@@ -137,7 +160,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "help(norms.HuberT.weights)"
@@ -146,7 +171,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "t = 1.345\n",
@@ -165,7 +192,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "help(norms.LeastSquares.weights)"
@@ -174,7 +203,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "support = np.linspace(-3, 3, 1000)\n",
@@ -192,7 +223,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "help(norms.RamsayE.weights)"
@@ -201,7 +234,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "a = .3\n",
@@ -220,7 +255,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "help(norms.TrimmedMean.weights)"
@@ -229,7 +266,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "c = 2\n",
@@ -248,7 +287,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "help(norms.TukeyBiweight.weights)"
@@ -257,7 +298,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "c = 4.685\n",
@@ -283,7 +326,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "x = np.array([1, 2, 3, 4, 500])"
@@ -299,7 +344,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "x.mean()"
@@ -315,7 +362,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "np.median(x)"
@@ -332,7 +381,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "x.std()"
@@ -363,7 +414,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "stats.norm.ppf(.75)"
@@ -372,7 +425,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "print(x)"
@@ -381,7 +436,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "sm.robust.scale.mad(x)"
@@ -390,7 +447,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "np.array([1,2,3,4,5.]).std()"
@@ -407,7 +466,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "np.random.seed(12345)\n",
@@ -417,7 +478,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "kde = sm.nonparametric.KDEUnivariate(fat_tails)\n",
@@ -430,7 +493,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "print(fat_tails.mean(), fat_tails.std())"
@@ -439,7 +504,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "print(stats.norm.fit(fat_tails))"
@@ -448,7 +515,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "print(stats.t.fit(fat_tails, f0=6))"
@@ -457,7 +526,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "huber = sm.robust.scale.Huber()\n",
@@ -468,7 +539,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "sm.robust.mad(fat_tails)"
@@ -477,7 +550,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "sm.robust.mad(fat_tails, c=stats.t(6).ppf(.75))"
@@ -486,7 +561,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "sm.robust.scale.mad(fat_tails)"
@@ -502,7 +579,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "from statsmodels.graphics.api import abline_plot\n",
@@ -512,7 +591,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "prestige = sm.datasets.get_rdataset(\"Duncan\", \"carData\", cache=True).data"
@@ -521,7 +602,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "print(prestige.head(10))"
@@ -530,7 +613,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "fig = plt.figure(figsize=(12,12))\n",
@@ -546,7 +631,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "ols_model = ols('prestige ~ income + education', prestige).fit()\n",
@@ -556,7 +643,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "infl = ols_model.get_influence()\n",
@@ -567,7 +656,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "print(student.loc[np.abs(student) > 2])"
@@ -576,7 +667,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "print(infl.summary_frame().loc['minister'])"
@@ -585,7 +678,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "sidak = ols_model.outlier_test('sidak')\n",
@@ -596,7 +691,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "fdr = ols_model.outlier_test('fdr_bh')\n",
@@ -607,7 +704,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "rlm_model = rlm('prestige ~ income + education', prestige).fit()\n",
@@ -617,7 +716,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "print(rlm_model.weights)"
@@ -640,7 +741,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "dta = sm.datasets.get_rdataset(\"starsCYG\", \"robustbase\", cache=True).data"
@@ -649,7 +752,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "from matplotlib.patches import Ellipse\n",
@@ -674,7 +779,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "from IPython.display import Image\n",
@@ -684,7 +791,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "y = dta['log.light']\n",
@@ -696,7 +805,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "rlm_mod = sm.RLM(y, X, sm.robust.norms.TrimmedMean(.5)).fit()\n",
@@ -713,7 +824,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "infl = ols_model.get_influence()"
@@ -722,7 +835,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "h_bar = 2*(ols_model.df_model + 1 )/ols_model.nobs\n",
@@ -733,7 +848,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "sidak2 = ols_model.outlier_test('sidak')\n",
@@ -744,7 +861,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "fdr2 = ols_model.outlier_test('fdr_bh')\n",
@@ -762,7 +881,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "l =  ax.lines[-1]\n",
@@ -773,7 +894,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "weights = np.ones(len(X))\n",
@@ -793,7 +916,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "yy = y.values[:,None]\n",
@@ -803,7 +928,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "%load_ext rpy2.ipython"
@@ -812,7 +939,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "%R library(robustbase)\n",
@@ -825,7 +954,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "%R print(mod)"
@@ -834,7 +965,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "print(params)"
@@ -843,7 +976,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "abline_plot(intercept=params[0], slope=params[1], ax=ax, color='red')"
@@ -859,7 +994,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "np.random.seed(12345)\n",
@@ -875,7 +1012,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "all_betas = []\n",
@@ -890,7 +1029,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "all_betas = np.asarray(all_betas)\n",
@@ -908,7 +1049,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "np.array(se_beta).mean()"
@@ -917,7 +1060,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "all_betas.mean(0)"
@@ -926,7 +1071,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "beta_true"
@@ -935,7 +1082,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "se_loss(all_betas.mean(0) - beta_true)"
@@ -958,7 +1107,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.6"
+   "version": "3.6.3"
   }
  },
  "nbformat": 4,

--- a/examples/notebooks/tsa_arma_0.ipynb
+++ b/examples/notebooks/tsa_arma_0.ipynb
@@ -11,12 +11,19 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": true
    },
    "outputs": [],
    "source": [
-    "%matplotlib inline\n",
-    "\n",
+    "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "from __future__ import print_function\n",
     "import numpy as np\n",
     "from scipy import stats\n",
@@ -29,9 +36,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from statsmodels.graphics.api import qqplot"
@@ -47,9 +52,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "print(sm.datasets.sunspots.NOTE)"
@@ -58,9 +61,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "dta = sm.datasets.sunspots.load_pandas().data"
@@ -69,9 +70,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "dta.index = pd.Index(sm.tsa.datetools.dates_from_range('1700', '2008'))\n",
@@ -81,9 +80,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "dta.plot(figsize=(12,8));"
@@ -92,9 +89,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "fig = plt.figure(figsize=(12,8))\n",
@@ -107,9 +102,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "arma_mod20 = sm.tsa.ARMA(dta, (2,0)).fit(disp=False)\n",
@@ -119,9 +112,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "arma_mod30 = sm.tsa.ARMA(dta, (3,0)).fit(disp=False)"
@@ -130,9 +121,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "print(arma_mod20.aic, arma_mod20.bic, arma_mod20.hqic)"
@@ -141,9 +130,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "print(arma_mod30.params)"
@@ -152,9 +139,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "print(arma_mod30.aic, arma_mod30.bic, arma_mod30.hqic)"
@@ -170,9 +155,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "sm.stats.durbin_watson(arma_mod30.resid.values)"
@@ -181,9 +164,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "fig = plt.figure(figsize=(12,8))\n",
@@ -194,9 +175,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "resid = arma_mod30.resid"
@@ -205,9 +184,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "stats.normaltest(resid)"
@@ -216,9 +193,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "fig = plt.figure(figsize=(12,8))\n",
@@ -229,9 +204,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "fig = plt.figure(figsize=(12,8))\n",
@@ -244,9 +217,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "r,q,p = sm.tsa.acf(resid.values.squeeze(), qstat=True)\n",
@@ -272,9 +243,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "predict_sunspots = arma_mod30.predict('1990', '2012', dynamic=True)\n",
@@ -284,9 +253,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "fig, ax = plt.subplots(figsize=(12, 8))\n",
@@ -297,9 +264,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def mean_forecast_err(y, yhat):\n",
@@ -309,9 +274,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "mean_forecast_err(dta.SUNACTIVITY, predict_sunspots)"
@@ -334,9 +297,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from statsmodels.tsa.arima_process import arma_generate_sample, ArmaProcess"
@@ -345,9 +306,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "np.random.seed(1234)\n",
@@ -366,9 +325,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "arma_t = ArmaProcess(arparams, maparams)"
@@ -377,9 +334,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "arma_t.isinvertible"
@@ -388,9 +343,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "arma_t.isstationary"
@@ -406,9 +359,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "fig = plt.figure(figsize=(12,8))\n",
@@ -419,9 +370,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "arparams = np.array([1, .35, -.15, .55, .1])\n",
@@ -433,9 +382,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "arma_rvs = arma_t.generate_sample(nsample=500, burnin=250, scale=2.5)"
@@ -444,9 +391,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "fig = plt.figure(figsize=(12,8))\n",
@@ -467,9 +412,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "arma11 = sm.tsa.ARMA(arma_rvs, (1,1)).fit(disp=False)\n",
@@ -483,9 +426,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "arma41 = sm.tsa.ARMA(arma_rvs, (4,1)).fit(disp=False)\n",
@@ -506,9 +447,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "macrodta = sm.datasets.macrodata.load_pandas().data\n",
@@ -526,9 +465,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "fig = plt.figure(figsize=(12,8))\n",
@@ -547,9 +484,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "print(sm.tsa.adfuller(cpi)[1])"
@@ -572,9 +507,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.3"
+   "version": "3.6.3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/examples/notebooks/tsa_arma_1.ipynb
+++ b/examples/notebooks/tsa_arma_1.ipynb
@@ -11,12 +11,19 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": true
    },
    "outputs": [],
    "source": [
-    "%matplotlib inline\n",
-    "\n",
+    "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "from __future__ import print_function\n",
     "import numpy as np\n",
     "import statsmodels.api as sm\n",
@@ -35,9 +42,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "arparams = np.array([.75, -.25])\n",
@@ -54,9 +59,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "arparams = np.r_[1, -arparams]\n",
@@ -75,9 +78,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "dates = sm.tsa.datetools.dates_from_range('1980m1', length=nobs)\n",
@@ -89,9 +90,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "print(arma_res.summary())"
@@ -100,9 +99,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "y.tail()"
@@ -111,9 +108,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import matplotlib.pyplot as plt\n",
@@ -139,9 +134,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.6.3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/examples/notebooks/tsa_filters.ipynb
+++ b/examples/notebooks/tsa_filters.ipynb
@@ -11,12 +11,19 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": true
    },
    "outputs": [],
    "source": [
-    "%matplotlib inline\n",
-    "\n",
+    "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "from __future__ import print_function\n",
     "import pandas as pd\n",
     "import matplotlib.pyplot as plt\n",
@@ -27,9 +34,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "dta = sm.datasets.macrodata.load_pandas().data"
@@ -38,9 +43,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "index = pd.Index(sm.tsa.datetools.dates_from_range('1959Q1', '2009Q3'))\n",
@@ -50,9 +53,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "dta.index = index\n",
@@ -63,9 +64,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "print(sm.datasets.macrodata.NOTE)"
@@ -74,9 +73,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "print(dta.head(10))"
@@ -85,9 +82,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "fig = plt.figure(figsize=(12,8))\n",
@@ -120,9 +115,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "gdp_cycle, gdp_trend = sm.tsa.filters.hpfilter(dta.realgdp)"
@@ -131,9 +124,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "gdp_decomp = dta[['realgdp']].copy()\n",
@@ -144,9 +135,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "fig = plt.figure(figsize=(12,8))\n",
@@ -201,9 +190,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "bk_cycles = sm.tsa.filters.bkfilter(dta[[\"infl\",\"unemp\"]])"
@@ -219,9 +206,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "fig = plt.figure(figsize=(12,10))\n",
@@ -264,9 +249,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "print(sm.tsa.stattools.adfuller(dta['unemp'])[:3])"
@@ -275,9 +258,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "print(sm.tsa.stattools.adfuller(dta['infl'])[:3])"
@@ -286,9 +267,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "cf_cycles, cf_trend = sm.tsa.filters.cffilter(dta[[\"infl\",\"unemp\"]])\n",
@@ -298,9 +277,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "fig = plt.figure(figsize=(14,10))\n",
@@ -332,9 +309,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.4.3"
+   "version": "3.6.3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/examples/notebooks/wls.ipynb
+++ b/examples/notebooks/wls.ipynb
@@ -11,12 +11,19 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": true
    },
    "outputs": [],
    "source": [
-    "%matplotlib inline\n",
-    "\n",
+    "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "from __future__ import print_function\n",
     "import numpy as np\n",
     "from scipy import stats\n",
@@ -45,9 +52,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "nsample = 50\n",
@@ -76,9 +81,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "mod_wls = sm.WLS(y, X, weights=1./(w ** 2))\n",
@@ -98,9 +101,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "res_ols = sm.OLS(y, X).fit()\n",
@@ -118,9 +119,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "se = np.vstack([[res_wls.bse], [res_ols.bse], [res_ols.HC0_se], \n",
@@ -142,9 +141,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "covb = res_ols.cov_params()\n",
@@ -156,9 +153,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "prstd_ols, iv_l_ols, iv_u_ols = wls_prediction_std(res_ols)"
@@ -174,9 +169,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "prstd, iv_l, iv_u = wls_prediction_std(res_wls)\n",
@@ -207,9 +200,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "resid1 = res_ols.resid[w==1.]\n",
@@ -239,9 +230,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.4.3"
+   "version": "3.6.3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/statsmodels/regression/mixed_linear_model.py
+++ b/statsmodels/regression/mixed_linear_model.py
@@ -2174,8 +2174,8 @@ class _mixedlm_distribution(object):
         self.model = model
         self.exog = exog if exog is not None else model.exog
 
-        po = MixedLMParams.from_packed(params,
-                 model.k_fe, model.k_re, False, True)
+        po = MixedLMParams.from_packed(
+                params, model.k_fe, model.k_re, False, True)
 
         self.fe_params = po.fe_params
         self.cov_re = scale * po.cov_re
@@ -2219,6 +2219,7 @@ class _mixedlm_distribution(object):
         y += np.sqrt(self.scale) * np.random.normal(size=len(y))
 
         return y
+
 
 class MixedLMResults(base.LikelihoodModelResults, base.ResultMixin):
     '''

--- a/statsmodels/tools/linalg.py
+++ b/statsmodels/tools/linalg.py
@@ -4,7 +4,7 @@ Linear Algebra solvers and other helpers
 from __future__ import print_function
 from statsmodels.compat.python import range
 import numpy as np
-from scipy.linalg import pinv, pinv2, lstsq  # noqa:F421
+from scipy.linalg import pinv, pinv2, lstsq  # noqa:F401
 
 
 def logdet_symm(m, check_symm=False):
@@ -114,7 +114,8 @@ def transf_constraints(constraints):
     return transf
 
 
-def matrix_sqrt(mat, inverse=False, full=False, nullspace=False, threshold=1e-15):
+def matrix_sqrt(mat, inverse=False, full=False, nullspace=False,
+                threshold=1e-15):
     """matrix square root for symmetric matrices
 
     Usage is for decomposing a covariance function S into a square root R

--- a/statsmodels/tsa/innovations/tests/test_arma_innovations.py
+++ b/statsmodels/tsa/innovations/tests/test_arma_innovations.py
@@ -22,6 +22,7 @@ from statsmodels.tsa.statespace.sarimax import SARIMAX
 def test_innovations_algo_filter_kalman_filter(ar_params, ma_params, sigma2):
     # Test the innovations algorithm and filter against the Kalman filter
     # for exact likelihood evaluation of an ARMA process
+    np.random.seed(42)
     endog = np.random.normal(size=100)
 
     # Innovations algorithm approach

--- a/tools/ci/docbuild_install.sh
+++ b/tools/ci/docbuild_install.sh
@@ -4,8 +4,8 @@
 echo sudo apt-get install graphviz -qq
 sudo apt-get install graphviz -qq
 # Install required packages and R
-echo conda install --channel conda-forge/label/gcc7 sphinx ipython jupyter nbconvert numpydoc tzlocal r-robustbase r-lme4 r-geepack libiconv --yes --quiet
-conda install --channel conda-forge/label/gcc7 sphinx ipython jupyter nbconvert numpydoc tzlocal r-robustbase r-lme4 r-geepack libiconv --yes --quiet
+echo conda install --channel conda-forge/label/gcc7 sphinx ipython jupyter nbconvert numpydoc tzlocal r-robustbase r-lme4 r-geepack libiconv rpy2 --yes --quiet
+conda install --channel conda-forge/label/gcc7 sphinx ipython jupyter nbconvert numpydoc tzlocal r-robustbase r-lme4 r-geepack libiconv rpy2 --yes --quiet
 # doctr and pdr
-echo pip install colorama doctr pandas-datareader rpy2
-pip install colorama doctr pandas-datareader rpy2
+echo pip install colorama doctr pandas-datareader simplegeneric
+pip install colorama doctr pandas-datareader simplegeneric

--- a/tools/ci/docbuild_install.sh
+++ b/tools/ci/docbuild_install.sh
@@ -7,5 +7,5 @@ sudo apt-get install graphviz -qq
 echo conda install --channel conda-forge/label/gcc7 sphinx ipython jupyter nbconvert numpydoc tzlocal r-robustbase r-lme4 r-geepack libiconv rpy2 --yes --quiet
 conda install --channel conda-forge/label/gcc7 sphinx ipython jupyter nbconvert numpydoc tzlocal r-robustbase r-lme4 r-geepack libiconv rpy2 --yes --quiet
 # doctr and pdr
-echo pip install colorama doctr pandas-datareader simplegeneric
-pip install colorama doctr pandas-datareader simplegeneric
+echo pip install doctr pandas-datareader simplegeneric
+pip install doctr pandas-datareader simplegeneric

--- a/tools/ci/docbuild_install.sh
+++ b/tools/ci/docbuild_install.sh
@@ -4,11 +4,11 @@
 echo sudo apt-get install graphviz -qq
 sudo apt-get install graphviz -qq
 # Install required packages
-echo conda install sphinx "ipython<7.0" jupyter nbconvert numpydoc tzlocal "testpath<0.4.0" --yes --quiet
-conda install sphinx "ipython<7.0" jupyter nbconvert numpydoc tzlocal "testpath<0.4.0" --yes --quiet
+echo conda install sphinx ipython jupyter nbconvert numpydoc tzlocal --yes --quiet
+conda install sphinx ipython jupyter nbconvert numpydoc tzlocal --yes --quiet
 # doctr and pdr
-echo pip install colorama doctr pandas-datareader
-pip install colorama doctr pandas-datareader
+echo pip install colorama doctr pandas-datareader simplegeneric
+pip install colorama doctr pandas-datareader simplegeneric  # TODO: Remove simplegeneric after rpy2 updated
 # R and dependencies
 echo conda install --channel conda-forge/label/gcc7 rpy2 r-robustbase r-lme4 r-geepack libiconv --yes --quiet
 conda install --channel conda-forge/label/gcc7 rpy2 r-robustbase r-lme4 r-geepack libiconv --yes --quiet

--- a/tools/ci/docbuild_install.sh
+++ b/tools/ci/docbuild_install.sh
@@ -1,11 +1,14 @@
 # Additional installation requirements for travis docbuilds
 
 # Install system dependencies
-echo sudo apt-get install graphviz -qq
-sudo apt-get install graphviz -qq
+echo sudo apt-get update
+sudo apt-get update
+
+echo sudo apt-get install graphviz libgfortran3 -qq
+sudo apt-get install graphviz libgfortran3 -qq
 # Install required packages and R
-echo conda install --channel conda-forge/label/gcc7 sphinx jupyter nbconvert numpydoc "tornado<6" r-robustbase r-lme4 r-geepack libiconv rpy2 --yes --quiet
-conda install --channel conda-forge/label/gcc7 sphinx jupyter nbconvert numpydoc "tornado<6" r-robustbase r-lme4 r-geepack libiconv rpy2 --yes --quiet
+echo conda install --channel conda-forge sphinx jupyter nbconvert numpydoc r-robustbase r-lme4 r-geepack libiconv rpy2 --yes --quiet
+conda install --channel conda-forge sphinx jupyter nbconvert numpydoc r-robustbase r-lme4 r-geepack libiconv rpy2 --yes --quiet
 # doctr and pdr
 echo pip install doctr pandas-datareader simplegeneric
 pip install doctr pandas-datareader simplegeneric

--- a/tools/ci/docbuild_install.sh
+++ b/tools/ci/docbuild_install.sh
@@ -4,8 +4,8 @@
 echo sudo apt-get install graphviz -qq
 sudo apt-get install graphviz -qq
 # Install required packages and R
-echo conda install --channel conda-forge/label/gcc7 sphinx ipython jupyter nbconvert numpydoc tzlocal r-robustbase r-lme4 r-geepack libiconv rpy2 --yes --quiet
-conda install --channel conda-forge/label/gcc7 sphinx ipython jupyter nbconvert numpydoc tzlocal r-robustbase r-lme4 r-geepack libiconv rpy2 --yes --quiet
+echo conda install --channel conda-forge/label/gcc7 sphinx jupyter nbconvert numpydoc "tornado<6" r-robustbase r-lme4 r-geepack libiconv rpy2 --yes --quiet
+conda install --channel conda-forge/label/gcc7 sphinx jupyter nbconvert numpydoc "tornado<6" r-robustbase r-lme4 r-geepack libiconv rpy2 --yes --quiet
 # doctr and pdr
 echo pip install doctr pandas-datareader simplegeneric
 pip install doctr pandas-datareader simplegeneric

--- a/tools/ci/docbuild_install.sh
+++ b/tools/ci/docbuild_install.sh
@@ -3,12 +3,9 @@
 # Install system dependencies
 echo sudo apt-get install graphviz -qq
 sudo apt-get install graphviz -qq
-# Install required packages
-echo conda install sphinx ipython jupyter nbconvert numpydoc tzlocal --yes --quiet
-conda install sphinx ipython jupyter nbconvert numpydoc tzlocal --yes --quiet
+# Install required packages and R
+echo conda install --channel conda-forge/label/gcc7 sphinx ipython jupyter nbconvert numpydoc tzlocal r-robustbase r-lme4 r-geepack libiconv --yes --quiet
+conda install --channel conda-forge/label/gcc7 sphinx ipython jupyter nbconvert numpydoc tzlocal r-robustbase r-lme4 r-geepack libiconv --yes --quiet
 # doctr and pdr
-echo pip install colorama doctr pandas-datareader simplegeneric
-pip install colorama doctr pandas-datareader simplegeneric  # TODO: Remove simplegeneric after rpy2 updated
-# R and dependencies
-echo conda install --channel conda-forge/label/gcc7 rpy2 r-robustbase r-lme4 r-geepack libiconv --yes --quiet
-conda install --channel conda-forge/label/gcc7 rpy2 r-robustbase r-lme4 r-geepack libiconv --yes --quiet
+echo pip install colorama doctr pandas-datareader rpy2
+pip install colorama doctr pandas-datareader rpy2

--- a/tools/ci/travis_pip.sh
+++ b/tools/ci/travis_pip.sh
@@ -28,8 +28,6 @@ if [ "$TRAVIS_OS_NAME" = "osx" ]; then
   eval "$(pyenv init -)"
 
   pyenv install "$PYTHON"
-  pyenv local "$PYTHON"
-  pyenv global "$PYTHON"
   pyenv shell "$PYTHON"
 fi
 


### PR DESCRIPTION
I think we can revert #5306 now. However, the magic in the jupyter notebooks need to be moved to a separate cell because that now counts against `from __future__` being at the "top" of a file. 