### PR TITLE
BUG/TST: Fix innovations_filter, add test vs Kalman filter

### DIFF
--- a/statsmodels/tsa/stattools.py
+++ b/statsmodels/tsa/stattools.py
@@ -1093,7 +1093,7 @@ def innovations_filter(endog, theta):
             hat = (theta[i, :i] * u[:i][::-1]).sum()
         else:
             hat = (theta[i] * u[i - k:i][::-1]).sum()
-        u[i] = endog[i] + hat
+        u[i] = endog[i] - hat
     if is_pandas:
         u = pd.Series(u, index=orig_endog.index.copy())
     return u

--- a/statsmodels/tsa/stattools.py
+++ b/statsmodels/tsa/stattools.py
@@ -1005,9 +1005,9 @@ def innovations_algo(acov, nobs=None, rtol=None):
     rtol = 0.0 if rtol is None else rtol
     if not isinstance(rtol, float):
         raise ValueError('rtol must be a non-negative float or None.')
-    n = acov.shape[0] if nobs is None else int(nobs)
-    if n != nobs or nobs < 1:
+    if nobs is not None and (nobs != int(nobs) or nobs < 1):
         raise ValueError('nobs must be a positive integer')
+    n = acov.shape[0] if nobs is None else int(nobs)
     max_lag = int(np.max(np.argwhere(acov != 0)))
 
     v = np.zeros(n + 1)

--- a/statsmodels/tsa/stattools.py
+++ b/statsmodels/tsa/stattools.py
@@ -1020,7 +1020,7 @@ def innovations_algo(acov, nobs=None, rtol=None):
             for j in range(max(i - max_lag, 0), k):
                 sub += theta[k, k - j] * theta[i, i - j] * v[j]
             theta[i, i - k] = 1. / v[k] * (acov[i - k] - sub)
-            v[i] = acov[0]
+        v[i] = acov[0]
         for j in range(max(i - max_lag, 0), i):
             v[i] -= theta[i, i - j] ** 2 * v[j]
         # Break if v has converged

--- a/statsmodels/tsa/tests/test_stattools.py
+++ b/statsmodels/tsa/tests/test_stattools.py
@@ -759,7 +759,7 @@ def test_innovations_filter_brockwell_davis():
     resid = innovations_filter(endog, theta)
     expected = [endog[0]]
     for i in range(1, 4):
-        expected.append(endog[i] + theta[i, 0] * expected[-1])
+        expected.append(endog[i] - theta[i, 0] * expected[-1])
     expected = np.array(expected)
     assert_allclose(resid, expected)
 

--- a/statsmodels/tsa/tests/test_stattools.py
+++ b/statsmodels/tsa/tests/test_stattools.py
@@ -20,6 +20,8 @@ from statsmodels.tsa.stattools import (adfuller, acf, pacf_yw,
                                        arma_order_select_ic, levinson_durbin,
                                        levinson_durbin_pacf, pacf_burg,
                                        innovations_algo, innovations_filter)
+from statsmodels.tsa.arima_process import arma_acovf
+from statsmodels.tsa.statespace.sarimax import SARIMAX
 
 DECIMAL_8 = 8
 DECIMAL_6 = 6
@@ -787,3 +789,33 @@ def test_innovations_filter_errors():
         innovations_filter(np.empty(4), theta[:-1])
     with pytest.raises(ValueError):
         innovations_filter(pd.DataFrame(np.empty((1, 4))), theta)
+
+
+def test_innovations_algo_filter_kalman_filter():
+    # Test the innovations algorithm and filter against the Kalman filter
+    # for exact likelihood evaluation of an ARMA process
+    ar_params = np.array([0.5])
+    ma_params = np.array([0.2])
+    # TODO could generalize to sigma2 != 1, if desired, after #5324 is merged
+    # and there is a sigma2 argument to arma_acovf
+    # (but maybe this is not really necessary for the point of this test)
+    sigma2 = 1
+
+    endog = np.random.normal(size=10)
+
+    # Innovations algorithm approach
+    acovf = arma_acovf(np.r_[1, -ar_params], np.r_[1, ma_params],
+                       nobs=len(endog))
+
+    theta, v = innovations_algo(acovf)
+    u = innovations_filter(endog, theta)
+    llf_obs = -0.5 * u**2 / (sigma2 * v) - 0.5 * np.log(2 * np.pi * v)
+
+    # Kalman filter apparoach
+    mod = SARIMAX(endog, order=(len(ar_params), 0, len(ma_params)))
+    res = mod.filter(np.r_[ar_params, ma_params, sigma2])
+
+    # Test that the two approaches are identical
+    assert_allclose(u, res.forecasts_error[0])
+    assert_allclose(theta[1:, 0], res.filter_results.kalman_gain[0, 0, :-1])
+    assert_allclose(llf_obs, res.llf_obs)


### PR DESCRIPTION
This fixes two bugs in `tsa.stattools.innovation_filter` and adds a more comprehensive unit test versus Kalman filter output.

@bashtage would be happy for your thoughts.