### PR TITLE
MAINT: eliminate some pytest warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -125,9 +125,9 @@ before_install:
     if [ ${COVERAGE} = true ]; then
         pip install codecov coverage coveralls pytest-cov
         if [ -z ${SM_CYTHON_COVERAGE} ] || [ ${SM_CYTHON_COVERAGE} = false ]; then
-          export COVERAGE_OPTS="--cov-config=tools/coveragerc/.coveragerc_travis --cov=statsmodels"
+          export COVERAGE_OPTS="--cov-config=tools/coveragerc/.coveragerc_travis --cov=statsmodels --cov-report="
         else
-          export COVERAGE_OPTS="--cov-config=tools/coveragerc/.coveragerc_cython --cov=statsmodels"
+          export COVERAGE_OPTS="--cov-config=tools/coveragerc/.coveragerc_cython --cov=statsmodels --cov-report="
         fi
         echo "Cython coverage:" ${SM_CYTHON_COVERAGE}
     else

--- a/lint.sh
+++ b/lint.sh
@@ -21,26 +21,16 @@ if [ "$LINT" == true ]; then
         statsmodels/interface/ \
         statsmodels/duration/__init__.py \
         statsmodels/graphics/tsaplots.py \
-        statsmodels/graphics/functional.py \
-        statsmodels/graphics/tests/test_functional.py \
         statsmodels/examples/tests/ \
         statsmodels/iolib/smpickle.py \
-        statsmodels/iolib/tests/test_pickle.py \
-        statsmodels/regression/mixed_linear_model.py \
-        statsmodels/regression/recursive_ls.py \
         statsmodels/regression/tests/test_lme.py \
-        statsmodels/tools/linalg.py \
         statsmodels/tools/web.py \
         statsmodels/tools/tests/test_linalg.py \
         statsmodels/tools/decorators.py \
         statsmodels/tools/tests/test_decorators.py \
         statsmodels/tsa/base/tests/test_datetools.py \
-        statsmodels/tsa/kalmanf/ \
-        statsmodels/tsa/regime_switching \
         statsmodels/tsa/vector_ar/dynamic.py \
-        statsmodels/tsa/vector_ar/hypothesis_test_results.py \
-        statsmodels/tsa/statespace/*.py \
-        statsmodels/tsa/statespace/tests/results/ \
+        statsmodels/tsa/statespace/tests/results/results_var_R.py \
         statsmodels/tsa/statespace/tests/test_var.py \
         statsmodels/conftest.py \
         setup.py

--- a/setup.cfg
+++ b/setup.cfg
@@ -96,7 +96,7 @@ select=
     # W603: '<>' is deprecated, use '!='
     W604,
     # W604: backticks are deprecated, use 'repr()'
-    W605,
+    # W605,
     # W605: invalid escape sequence 'x'
     W606,
     # W606: 'async' and 'await' are reserved keywords starting with Python 3.7

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,6 +11,7 @@ filterwarnings =
     ignore:Using a non-tuple sequence:FutureWarning:mkl_fft
     ignore:Using a non-tuple:FutureWarning:scipy.signal
     ignore:Using a non-tuple:FutureWarning:scipy.stats.stats
+    ignore:the matrix subclass:PendingDeprecationWarning:numpy.matrixlib.defmatrix
 markers =
     example: mark a test that runs example code
     matplotlib: mark a test that requires matplotlib

--- a/statsmodels/base/data.py
+++ b/statsmodels/base/data.py
@@ -242,6 +242,7 @@ class ModelData(object):
                     raise ValueError("Shape mismatch between endog/exog "
                                      "and extra arrays given to model.")
                 # for going back and updated endog/exog
+                nan_mask = getattr(nan_mask, 'values', nan_mask)
                 updated_row_mask = combined_nans[~nan_mask]
                 nan_mask |= combined_nans  # for updating extra arrays only
             if combined_2d:

--- a/statsmodels/base/data.py
+++ b/statsmodels/base/data.py
@@ -242,7 +242,6 @@ class ModelData(object):
                     raise ValueError("Shape mismatch between endog/exog "
                                      "and extra arrays given to model.")
                 # for going back and updated endog/exog
-                nan_mask = getattr(nan_mask, 'values', nan_mask)
                 updated_row_mask = combined_nans[~nan_mask]
                 nan_mask |= combined_nans  # for updating extra arrays only
             if combined_2d:

--- a/statsmodels/sandbox/distributions/tests/test_multivariate.py
+++ b/statsmodels/sandbox/distributions/tests/test_multivariate.py
@@ -70,9 +70,9 @@ class Test_MVN_MVT_prob(object):
         probmvt_R = 0.9522146
         quadkwds = {'epsabs': 1e-08}
         probmvt = mvstdtprob(a2, b, corr2, df, quadkwds=quadkwds)
-        assert_allclose(probmvt_R, probmvt, atol=0.0005)
+        assert_allclose(probmvt_R, probmvt, atol=5e-4)
         probmvn = mvstdnormcdf(a2, b, corr2, maxpts=100000, abseps=1e-5)
-        assert_allclose(probmvn_R, probmvn, atol=0.0001)
+        assert_allclose(probmvn_R, probmvn, atol=1e-4)
 
     def test_mvn_mvt_4(self):
         a, bl = self.a, self.b

--- a/statsmodels/sandbox/distributions/tests/test_multivariate.py
+++ b/statsmodels/sandbox/distributions/tests/test_multivariate.py
@@ -3,13 +3,13 @@
 Created on Sat Apr 16 15:02:13 2011
 @author: Josef Perktold
 """
-
 import numpy as np
-from numpy.testing import assert_almost_equal, assert_array_almost_equal
-
+from numpy.testing import (assert_almost_equal, assert_array_almost_equal,
+                           assert_allclose)
 from statsmodels.sandbox.distributions.multivariate import (
                 mvstdtprob, mvstdnormcdf)
 from statsmodels.sandbox.distributions.mv_normal import MVT, MVNormal
+
 
 class Test_MVN_MVT_prob(object):
     #test for block integratal, cdf, of multivariate t and normal
@@ -25,7 +25,6 @@ class Test_MVN_MVT_prob(object):
         corr2 = cls.corr_equal.copy()
         corr2[2,1] = -0.5
         cls.corr2 = corr2
-
 
     def test_mvn_mvt_1(self):
         a, b = self.a, self.b
@@ -71,9 +70,9 @@ class Test_MVN_MVT_prob(object):
         probmvt_R = 0.9522146
         quadkwds = {'epsabs': 1e-08}
         probmvt = mvstdtprob(a2, b, corr2, df, quadkwds=quadkwds)
-        assert_almost_equal(probmvt_R, probmvt, 4)
+        assert_allclose(probmvt_R, probmvt, atol=0.0005)
         probmvn = mvstdnormcdf(a2, b, corr2, maxpts=100000, abseps=1e-5)
-        assert_almost_equal(probmvn_R, probmvn, 4)
+        assert_allclose(probmvn_R, probmvn, atol=0.0001)
 
     def test_mvn_mvt_4(self):
         a, bl = self.a, self.b

--- a/statsmodels/stats/_lilliefors.py
+++ b/statsmodels/stats/_lilliefors.py
@@ -164,9 +164,7 @@ def get_lilliefors_table(dist='norm'):
                                [ 37,  39,  41,  45,  52,  61],
                                [ 25,  26,  28,  30,  35,  42]])[:,::-1] / 1000.
 
-
         # also build a table for larger sample sizes
-
         def f(n):
             return np.array([0.736, 0.768, 0.805, 0.886, 1.031]) / np.sqrt(n)
 

--- a/statsmodels/stats/tests/test_corrpsd.py
+++ b/statsmodels/stats/tests/test_corrpsd.py
@@ -18,8 +18,6 @@ from statsmodels.stats.correlation_tools import (
 
 import warnings
 
-# ignore PendingDeprecationWarning due to matrix conversion in SciPy
-pytestmark = pytest.mark.filterwarnings('ignore:matrix subclass')
 
 def norm_f(x, y):
     '''Frobenious norm (squared sum) of difference between two arrays

--- a/tools/ci/travis_conda.sh
+++ b/tools/ci/travis_conda.sh
@@ -1,5 +1,5 @@
 # Source to configure conda CI builds
-wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
+wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh -nv
 chmod +x miniconda.sh
 ./miniconda.sh -b -p /home/travis/miniconda
 export PATH=/home/travis/miniconda/bin:$PATH

--- a/tools/ci/travis_pip.sh
+++ b/tools/ci/travis_pip.sh
@@ -16,7 +16,7 @@ if [ ${USEMPL} = true ]; then
         PKGS="${PKGS}==${MATPLOTLIB}"
     fi
 fi
-if [ ${PIP_PRE} = true ]; then
+if [ "${PIP_PRE}" = true ]; then
     EXTRA_PIP_FLAGS="--pre $EXTRA_PIP_FLAGS --find-links $PRE_WHEELS"
 fi
 # Install in our own virtualenv


### PR DESCRIPTION
Closes #5329

I also added a `-nv` option on the `wget miniconda.sh` because it shrinks the log file a bunch, and that should make it so that the docbuild will take under 10,000 lines, so you can see the entire log on travis without going to the raw log.