### PR TITLE
ENH: Allow dep_data to be specified using formula or names

### DIFF
--- a/statsmodels/genmod/cov_struct.py
+++ b/statsmodels/genmod/cov_struct.py
@@ -345,7 +345,7 @@ class Nested(CovStruct):
 
     The variance components are estimated using least squares
     regression of the products r*r', for standardized residuals r and
-    r' in the same group, on a vector of indicators defining which
+    r' in the same group, on a matrix of indicators defining which
     variance components are shared by r and r'.
     """
 
@@ -481,12 +481,21 @@ class Nested(CovStruct):
         dependence structure.
         """
 
-        msg = "Variance estimates\n------------------\n"
-        for k in range(len(self.vcomp_coeff)):
-            msg += "Component %d: %.3f\n" % (k + 1, self.vcomp_coeff[k])
-        msg += "Residual: %.3f\n" % (self.scale -
-                                     np.sum(self.vcomp_coeff))
-        return msg
+        dep_names = ["Groups"]
+        if hasattr(self.model, "_dep_data_names"):
+            dep_names.extend(self.model._dep_data_names)
+        else:
+            dep_names.extend(["Component %d:" % (k + 1) for k in range(len(self.vcomp_coeff) - 1)])
+        if hasattr(self.model, "_groups_name"):
+            dep_names[0] = self.model._groups_name
+        dep_names.append("Residual")
+
+        vc = self.vcomp_coeff.tolist()
+        vc.append(self.scale - np.sum(vc))
+
+        smry = pd.DataFrame({"Variance": vc}, index=dep_names)
+
+        return smry
 
 
 class Stationary(CovStruct):

--- a/statsmodels/genmod/generalized_estimating_equations.py
+++ b/statsmodels/genmod/generalized_estimating_equations.py
@@ -679,23 +679,23 @@ class GEE(base.Model):
         """ % {'missing_param_doc': base._missing_param_doc}
 
         groups_name = "Groups"
-        if type(groups) == str:
+        if isinstance(groups, str):
             groups_name = groups
             groups = data[groups]
 
-        if type(time) == str:
+        if isinstance(time, str):
             time = data[time]
 
-        if type(offset) == str:
+        if isinstance(offset, str):
             offset = data[offset]
 
-        if type(exposure) == str:
+        if isinstance(exposure, str):
             exposure = data[exposure]
 
         dep_data = kwargs.get("dep_data")
         dep_data_names = None
         if dep_data is not None:
-            if type(dep_data) is str:
+            if isinstance(dep_data, str):
                 dep_data = patsy.dmatrix(dep_data, data, return_type='dataframe')
                 dep_data_names = dep_data.columns.tolist()
             else:
@@ -2320,7 +2320,7 @@ class NominalGEE(GEE):
                 jrow += 1
 
         # exog names
-        if type(self.exog_orig) == pd.DataFrame:
+        if isinstance(self.exog_orig, pd.DataFrame):
             xnames_in = self.exog_orig.columns
         else:
             xnames_in = ["x%d" % k for k in range(1, exog.shape[1] + 1)]
@@ -2331,7 +2331,7 @@ class NominalGEE(GEE):
         exog_out = pd.DataFrame(exog_out, columns=xnames)
 
         # Preserve endog name if there is one
-        if type(self.endog_orig) == pd.Series:
+        if isinstance(self.endog_orig, pd.Series):
             endog_out = pd.Series(endog_out, name=self.endog_orig.name)
 
         return endog_out, exog_out, groups_out, time_out, offset_out


### PR DESCRIPTION
Better formula support for `dep_data`.

This is mainly to make it easier to use `cov_struct.Nested`, but could help with other cov_structs as well.