### PR TITLE
Set python3 as interpreter for doc tools

### DIFF
--- a/tools/dataset_rst.py
+++ b/tools/dataset_rst.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 Run this script to convert dataset documentation to ReST files. Relies
 on the meta-information from the datasets of the currently installed version.

--- a/tools/examples_rst.py
+++ b/tools/examples_rst.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 import sys

--- a/tools/fold_toc.py
+++ b/tools/fold_toc.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 import sys
 import re

--- a/tools/nbgenerate.py
+++ b/tools/nbgenerate.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 import argparse
 import io


### PR DESCRIPTION
The scripts require python3 so the interpreter should use that.
python does not point to python3 on most distributions.