### PR TITLE
BUG: Fix medcouple with ties

### DIFF
--- a/statsmodels/stats/stattools.py
+++ b/statsmodels/stats/stattools.py
@@ -415,7 +415,20 @@ def _medcouple_1d(y):
     is_zero = np.logical_and(lower == 0.0, upper == 0.0)
     standardization[is_zero] = np.inf
     spread = upper + lower
-    return np.median(spread / standardization)
+    h = spread / standardization
+    # GH5395
+    num_ties = np.sum(lower == 0.0)
+    if num_ties:
+        # Replacements has -1 above the anti-diagonal, 0 on the anti-diagonal,
+        # and 1 below the anti-diagonal
+        replacements = np.ones((num_ties, num_ties)) - np.eye(num_ties)
+        replacements -= 2 * np.triu(replacements)
+        # Convert diagonal to anti-diagonal
+        replacements = np.fliplr(replacements)
+        # Always replace upper right block
+        h[:num_ties, -num_ties:] = replacements
+
+    return np.median(h)
 
 
 def medcouple(y, axis=0):

--- a/statsmodels/stats/tests/test_statstools.py
+++ b/statsmodels/stats/tests/test_statstools.py
@@ -208,11 +208,15 @@ class TestStattools(object):
         mcn = medcouple(-x)
         assert_almost_equal(mcp + mcn, 0)
 
+    def test_medcouple_ties(self, reset_randomstate):
+        x = np.array([1, 2, 2, 3, 4])
+        mc = medcouple(x)
+        assert_almost_equal(mc, 1.0 / 6.0)
+
     def test_durbin_watson(self, reset_randomstate):
         x = np.random.standard_normal(100)
         dw = sum(np.diff(x)**2.0) / np.dot(x, x)
         assert_almost_equal(dw, durbin_watson(x))
-
 
     def test_durbin_watson_2d(self, reset_randomstate):
         shape = (1, 10)


### PR DESCRIPTION
Fix medcouple behaviour when there is an even number of ties

closes #5395