### PR TITLE
BUG: Flatten pandas MultiIndexes

### DIFF
--- a/statsmodels/base/data.py
+++ b/statsmodels/base/data.py
@@ -5,7 +5,7 @@ results, and doing data cleaning
 from statsmodels.compat.python import reduce, iteritems, lmap, zip, range
 from statsmodels.compat.numpy import np_matrix_rank
 import numpy as np
-from pandas import DataFrame, Series, isnull
+from pandas import DataFrame, Series, isnull, MultiIndex
 from statsmodels.tools.decorators import (resettable_cache, cache_readonly,
                                           cache_writable)
 import statsmodels.tools.data as data_util
@@ -367,7 +367,11 @@ class ModelData(object):
 
     def _get_names(self, arr):
         if isinstance(arr, DataFrame):
-            return list(arr.columns)
+            if isinstance(arr.columns, MultiIndex):
+                # Flatten MultiIndexes into "simple" column names
+                return [".".join((level for level in c if level)) for c in arr.columns]
+            else:
+                return list(arr.columns)
         elif isinstance(arr, Series):
             if arr.name:
                 return [arr.name]

--- a/statsmodels/base/tests/test_data.py
+++ b/statsmodels/base/tests/test_data.py
@@ -142,6 +142,32 @@ class TestDataFrames(TestArrays):
         ptesting.assert_frame_equal(data.wrap_output(self.cov_input, 'cov'),
                                 self.cov_result)
 
+class TestDataFramesWithMultiIndex(TestDataFrames):
+    @classmethod
+    def setup_class(cls):
+        cls.endog = pandas.DataFrame(np.random.random(10), columns=['y_1'])
+        exog = pandas.DataFrame(np.random.random((10,2)),
+                                 columns=pandas.MultiIndex.from_product([['x'], ['1', '2']]))
+        exog_flattened_idx = pandas.Index(['const', 'x.1', 'x.2'])
+        exog.insert(0, 'const', 1)
+        cls.exog = exog
+        cls.data = sm_data.handle_data(cls.endog, cls.exog)
+        nrows = 10
+        nvars = 3
+        cls.col_input = np.random.random(nvars)
+        cls.col_result = pandas.Series(cls.col_input,
+                                          index=exog_flattened_idx)
+        cls.row_input = np.random.random(nrows)
+        cls.row_result = pandas.Series(cls.row_input,
+                                          index=exog.index)
+        cls.cov_input = np.random.random((nvars, nvars))
+        cls.cov_result = pandas.DataFrame(cls.cov_input,
+                                           index = exog_flattened_idx,
+                                           columns = exog_flattened_idx)
+        cls.xnames = ['const', 'x.1', 'x.2']
+        cls.ynames = 'y_1'
+        cls.row_labels = cls.exog.index
+
 
 class TestLists(TestArrays):
     @classmethod


### PR DESCRIPTION
Flatten pandas MultiIndexes when extracting column names in the
data module. Prior to this commit, the MultiIndexes would be
exposed as a list of tuples, which would then result in the
DataFrame being treated as having more than 2 dimensions.

closes #5414