### PR TITLE
Misspelling in the documentation proportions_ztest

### DIFF
--- a/statsmodels/stats/proportion.py
+++ b/statsmodels/stats/proportion.py
@@ -795,7 +795,7 @@ def proportions_ztest(count, nobs, value=None, alternative='two-sided',
     >>> from statsmodels.stats.proportion import proportions_ztest
     >>> count = np.array([5, 12])
     >>> nobs = np.array([83, 99])
-    >>> stat, pval = proportions_ztest(counts, nobs)
+    >>> stat, pval = proportions_ztest(count, nobs)
     >>> print('{0:0.3f}'.format(pval))
     0.159
 


### PR DESCRIPTION
Simple fix to the documentation to render the correct variable name.
Not a big issue, more quality of life for documentation users.