### PR TITLE
ENH Score test enhancements for GEE

### DIFF
--- a/statsmodels/genmod/generalized_estimating_equations.py
+++ b/statsmodels/genmod/generalized_estimating_equations.py
@@ -29,6 +29,7 @@ import numpy as np
 from scipy import stats
 import pandas as pd
 import patsy
+from numpy.testing import assert_array_equal
 
 from statsmodels.tools.decorators import (cache_readonly,
                                           resettable_cache)
@@ -784,7 +785,7 @@ class GEE(base.Model):
         if not isinstance(self.cov_struct, type(submod.cov_struct)):
             msg = "Model and submodel have different covariance structures."
             warnings.warn(msg)
-        if np.any(self.weights != submod.weights):
+        if not np.equal(self.weights, submod.weights).all():
             msg = "Model and submodel should have the same weights."
             warnings.warn(msg)
 

--- a/statsmodels/genmod/generalized_estimating_equations.py
+++ b/statsmodels/genmod/generalized_estimating_equations.py
@@ -2409,7 +2409,7 @@ def _score_test_submodel(par, sub):
     u, s, vt = np.linalg.svd(x1, 0)
 
     # Get the orthogonal complement of col(x2) in col(x1).
-    a, b, ct = np.linalg.svd(x2, 0)
+    a, _, _ = np.linalg.svd(x2, 0)
     a = u - np.dot(a, np.dot(a.T, u))
     x2c, sb, _ = np.linalg.svd(a, 0)
     x2c = x2c[:, sb > 1e-12]

--- a/statsmodels/genmod/generalized_estimating_equations.py
+++ b/statsmodels/genmod/generalized_estimating_equations.py
@@ -782,10 +782,10 @@ class GEE(base.Model):
         if self.exog.shape[0] != submod.exog.shape[0]:
             msg = "Model and submodel have different numbers of cases."
             warnings.warn(msg)
-        if type(self.family) is not type(submod.family):
+        if not isinstance(self.family, type(submod.family)):
             msg = "Model and submodel have different families."
             warnings.warn(msg)
-        if type(self.cov_struct) is not type(submod.cov_struct):
+        if not isinstance(self.cov_struct, type(submod.cov_struct)):
             msg = "Model and submodel have different covariance structures."
             warnings.warn(msg)
         if hasattr(self, "weights") != hasattr(submod, "weights"):

--- a/statsmodels/genmod/generalized_estimating_equations.py
+++ b/statsmodels/genmod/generalized_estimating_equations.py
@@ -743,15 +743,14 @@ class GEE(base.Model):
         submodel : GEEResults instance
             A fitted GEE model that is a submodel of this model.
         tol : float
-            A tolerance parameter used when assessing whether
-            the submodel is actually a submodel of this model.
+            A tolerance parameter used to match columns of the
+            submodel and the parent model.
 
         Returns
         -------
-        A dictionary with keys "statistic", "p-value", and
-        "df", containing the score test statistic, its chi^2
-        p-value, and the degrees of freedom used to compute the
-        p-value.
+        A dictionary with keys "statistic", "p-value", and "df",
+        containing the score test statistic, its chi^2 p-value,
+        and the degrees of freedom used to compute the p-value.
 
         Notes
         -----
@@ -760,14 +759,11 @@ class GEE(base.Model):
         fitted GEE.
 
         This method performs the same score test as can be obtained by
-        fitting the GEE with a linear constraint.  The interface for this
-        method is easier to use when testing a submodel whose design
-        matrix is a submatrix of the parent model.  This method is also
-        more convenient to use when the models have been fit using formulas.
-        On the other hand, the approach using constraints may be a better
-        option when the submodel is obtained by imposing linear equality
-        constraints that are not simply equating a subset of the parameters
-        to zero.
+        fitting the GEE with a linear constraint and calling `score_test`
+        on the results.  The interface for this method is easier to use
+        when testing a submodel whose design matrix is a submatrix of the
+        parent model.  This method is also more convenient to use when the
+        models have been fit using formulas.
 
         References
         ----------
@@ -781,14 +777,14 @@ class GEE(base.Model):
         submod = submodel.model
         if self.exog.shape[0] != submod.exog.shape[0]:
             msg = "Model and submodel have different numbers of cases."
-            warnings.warn(msg)
+            raise ValueError(msg)
         if not isinstance(self.family, type(submod.family)):
             msg = "Model and submodel have different families."
             warnings.warn(msg)
         if not isinstance(self.cov_struct, type(submod.cov_struct)):
             msg = "Model and submodel have different covariance structures."
             warnings.warn(msg)
-        if hasattr(self, "weights") != hasattr(submod, "weights"):
+        if np.any(self.weights != submod.weights):
             msg = "Model and submodel should have the same weights."
             warnings.warn(msg)
 
@@ -1679,9 +1675,11 @@ class GEEResults(base.LikelihoodModelResults):
 
         Notes
         -----
-        See also GEE.score_test for an alternative way to perform a score
-        test based on a submodel.  The GEE.score_test approach is generally
-        easier to use, but slightly less general.
+        See also GEE.compare_score_test for an alternative way to perform
+        a score test.  GEEResults.score_test is more general, in that it
+        supports testing arbitrary linear equality constraints.   However
+        GEE.compare_score_test might be easier to use when comparing
+        two explicit models.
 
         References
         ----------

--- a/statsmodels/genmod/generalized_estimating_equations.py
+++ b/statsmodels/genmod/generalized_estimating_equations.py
@@ -1682,6 +1682,12 @@ class GEEResults(base.LikelihoodModelResults):
         See also GEE.score_test for an alternative way to perform a score
         test based on a submodel.  The GEE.score_test approach is generally
         easier to use, but slightly less general.
+
+        References
+        ----------
+        Xu Guo and Wei Pan (2002). "Small sample performance of the score
+        test in GEE".
+        http://www.sph.umn.edu/faculty1/wp-content/uploads/2012/11/rr2002-013.pdf
         """
 
         if not hasattr(self.model, "score_test_results"):

--- a/statsmodels/genmod/generalized_estimating_equations.py
+++ b/statsmodels/genmod/generalized_estimating_equations.py
@@ -29,7 +29,6 @@ import numpy as np
 from scipy import stats
 import pandas as pd
 import patsy
-from numpy.testing import assert_array_equal
 
 from statsmodels.tools.decorators import (cache_readonly,
                                           resettable_cache)

--- a/statsmodels/genmod/generalized_estimating_equations.py
+++ b/statsmodels/genmod/generalized_estimating_equations.py
@@ -734,7 +734,7 @@ class GEE(base.Model):
             return [np.array(array[self.group_indices[k], :])
                     for k in self.group_labels]
 
-    def score_test(self, submodel, tol=1e-6):
+    def compare_score_test(self, submodel, tol=1e-6):
         """
         Perform a score test for the given submodel against this model.
 

--- a/statsmodels/genmod/tests/test_gee.py
+++ b/statsmodels/genmod/tests/test_gee.py
@@ -597,10 +597,8 @@ class TestGEE(object):
         L = np.asarray([[0, 1, 0, 0], [0, 0, 1, 0]])
         R = np.zeros(2)
         mod_lr = GEE(endog, exog, group, constraint=(L, R), cov_struct=cov_struct())
-        res_lr = mod_lr.fit()
+        _ = mod_lr.fit()
 
-        family = Gaussian()
-        va = Independence()
         mod_sub = GEE(endog, exog_sub, group, cov_struct=cov_struct())
         res_sub = mod_sub.fit()
         mod = GEE(endog, exog, group, cov_struct=cov_struct())

--- a/statsmodels/genmod/tests/test_gee.py
+++ b/statsmodels/genmod/tests/test_gee.py
@@ -624,21 +624,21 @@ class TestGEE(object):
             mod_sub = GEE(endog, exog_sub, group, cov_struct=sm.cov_struct.Exchangeable())
             res_sub = mod_sub.fit()
             mod = GEE(endog, exog, group, cov_struct=sm.cov_struct.Independence())
-            score_results = mod.compare_score_test(res_sub)
+            _ = mod.compare_score_test(res_sub)
 
         # Mismatched family
         with assert_warns(UserWarning):
             mod_sub = GEE(endog, exog_sub, group, family=sm.families.Gaussian())
             res_sub = mod_sub.fit()
             mod = GEE(endog, exog, group, family=sm.families.Poisson())
-            score_results = mod.compare_score_test(res_sub)
+            _ = mod.compare_score_test(res_sub)
 
         # Mismatched size
         with assert_raises(Exception):
             mod_sub = GEE(endog, exog_sub, group)
             res_sub = mod_sub.fit()
             mod = GEE(endog[0:100], exog[:100, :], group[0:100])
-            score_results = mod.compare_score_test(res_sub)
+            _ = mod.compare_score_test(res_sub)
 
         # Mismatched weights
         with assert_warns(UserWarning):
@@ -646,7 +646,7 @@ class TestGEE(object):
             mod_sub = GEE(endog, exog_sub, group, weights=w)
             res_sub = mod_sub.fit()
             mod = GEE(endog, exog, group)
-            score_results = mod.compare_score_test(res_sub)
+            _ = mod.compare_score_test(res_sub)
 
     def test_constraint_covtype(self):
         # Test constraints with different cov types

--- a/statsmodels/genmod/tests/test_gee.py
+++ b/statsmodels/genmod/tests/test_gee.py
@@ -602,7 +602,7 @@ class TestGEE(object):
         mod_sub = GEE(endog, exog_sub, group, cov_struct=cov_struct())
         res_sub = mod_sub.fit()
         mod = GEE(endog, exog, group, cov_struct=cov_struct())
-        score_results = mod.score_test(res_sub)
+        score_results = mod.compare_score_test(res_sub)
         assert_almost_equal(score_results["statistic"],
             mod_lr.score_test_results["statistic"])
         assert_almost_equal(score_results["p-value"],


### PR DESCRIPTION
Allow the submodel to be provided as a fitted GEEResults object, instead of via a system of linear constraints.