### PR TITLE
Mad fun empty

### DIFF
--- a/statsmodels/robust/scale.py
+++ b/statsmodels/robust/scale.py
@@ -39,6 +39,8 @@ def mad(a, c=Gaussian.ppf(3/4.), axis=0, center=np.median):
     mad : float
         `mad` = median(abs(`a` - center))/`c`
     """
+    if a.size == 0:
+        return np.nan
     a = np.asarray(a)
     if callable(center):
         center = np.apply_over_axes(center, a, axis)

--- a/statsmodels/robust/scale.py
+++ b/statsmodels/robust/scale.py
@@ -40,7 +40,7 @@ def mad(a, c=Gaussian.ppf(3/4.), axis=0, center=np.median):
         `mad` = median(abs(`a` - center))/`c`
     """
     if a.size == 0:
-        return np.nan
+        return np.array([np.nan])
     a = np.asarray(a)
     if callable(center):
         center = np.apply_over_axes(center, a, axis)

--- a/statsmodels/robust/tests/test_scale.py
+++ b/statsmodels/robust/tests/test_scale.py
@@ -56,6 +56,10 @@ class TestMad(object):
         m = scale.mad(self.X)
         assert_equal(m.shape, (10,))
 
+    def test_mad_empty(self):
+        empty = np.asarray([])
+        assert_equal(np.isnan(scale.mad(empty),True)
+
     def test_mad_center(self):
         n = scale.mad(self.X, center=0)
         assert_equal(n.shape, (10,))

--- a/statsmodels/robust/tests/test_scale.py
+++ b/statsmodels/robust/tests/test_scale.py
@@ -58,7 +58,7 @@ class TestMad(object):
 
     def test_mad_empty(self):
         empty = np.asarray([])
-        assert_equal(np.isnan(scale.mad(empty),True)
+        assert_equal(np.isnan(scale.mad(empty)),True)
 
     def test_mad_center(self):
         n = scale.mad(self.X, center=0)

--- a/statsmodels/robust/tests/test_scale.py
+++ b/statsmodels/robust/tests/test_scale.py
@@ -58,7 +58,7 @@ class TestMad(object):
 
     def test_mad_empty(self):
         empty = np.asarray([])
-        assert_equal(np.isnan(scale.mad(empty)),True)
+        assert_equal(np.isnan(empty)[0],True)
 
     def test_mad_center(self):
         n = scale.mad(self.X, center=0)


### PR DESCRIPTION
While reviewing the scipy PR 9637 I started poking around at the behavior of `mad` for an empty array. 
PR in scipy is here:
https://github.com/scipy/scipy/pull/9637/files

It looks like the current behavior could throw a runtime warning in this case. 

This PR should make the `statsmodels.robust.mad` function return a `nan` if the input array is empty. 

