### PR TITLE
multivariate - Return E and H matrices in dict

### DIFF
--- a/statsmodels/multivariate/multivariate_ols.py
+++ b/statsmodels/multivariate/multivariate_ols.py
@@ -276,7 +276,9 @@ def _multivariate_test(hypotheses, exog_names, endog_names, fn):
         T = L*inv(X'X)*L'
         H = M'B'L'*inv(T)*LBM
         E =  M'(Y'Y - B'X'XB)M
-    And then finding the eigenvalues of inv(H + E)*H
+    where H and E correspond to the numerator and denominator of a univariate F test.
+    Then find the eigenvalues of inv(H + E)*H from which the multivariate test
+    statistics are calculated.
 
     .. [*] https://support.sas.com/documentation/cdl/en/statug/63033/HTML/default/viewer.htm#statug_introreg_sect012.htm
 
@@ -480,6 +482,16 @@ class MultivariateTestResults(object):
            results[key]['contrast_L'] contains the contrast_L matrix
            results[key]['transform_M'] contains the transform_M matrix
            results[key]['constant_C'] contains the constant_C matrix
+           results[key]['H'] contains an intermediate Hypothesis matrix,
+            or the between groups sums of squares and cross-products matrix,
+            corresponding to the numerator of the univariate F test.
+           results[key]['E'] contains an intermediate Error matrix,
+            corresponding to the denominator of the univariate F test.
+            The Hypotheses and Error matrices can be used to calculate
+            the same test statistics in 'stat', as well as to calculate
+            the discriminant function (canonical correlates) from the
+            eigenvectors of inv(E)H.
+
     endog_names : str
     exog_names : str
     summary_frame : multiindex dataframe

--- a/statsmodels/multivariate/multivariate_ols.py
+++ b/statsmodels/multivariate/multivariate_ols.py
@@ -355,8 +355,9 @@ def _multivariate_test(hypotheses, exog_names, endog_names, fn):
         eigv2 = np.sort(eigvals(solve(EH, H)))
         stat_table = multivariate_stats(eigv2, p, q, df_resid)
 
-        results[name] = {'stat':stat_table, 'contrast_L':L,
-                         'transform_M':M, 'constant_C':C}
+        results[name] = {'stat': stat_table, 'contrast_L': L,
+                         'transform_M': M, 'constant_C': C,
+                         'E': E, 'H': H}
     return results
 
 


### PR DESCRIPTION
Following discussion in #5487 , this adds `E` and `H` matrices to the `multivariate_ols._multivariate_test` return dictionary. This dictionary makes its way into the `MultivariateTestResults` returned by `MANOVA.mv_test()` so these matrices are made available to the user who can use them to calculate the discriminant function coefficients.