### PR TITLE
ENH: Tweedie log-likelihood (+ridge regression by gradient for all GLM)

### DIFF
--- a/statsmodels/genmod/families/family.py
+++ b/statsmodels/genmod/families/family.py
@@ -1472,7 +1472,7 @@ class Tweedie(Family):
         llf *= -1 / 2
 
         u = endog ** (2 - p) - (2 - p) * endog * mu ** (1 - p) + (1 - p) * mu ** (2 - p)
-        u *= var_weights / (scale * (1 - p)**2)
+        u *= var_weights / (scale * (1 - p) * (2 - p))
         llf += u
 
         return llf

--- a/statsmodels/genmod/families/family.py
+++ b/statsmodels/genmod/families/family.py
@@ -1332,6 +1332,7 @@ class Tweedie(Family):
     eql : bool
         If True, the Extended Quasi-Likelihood is used, else the
         likelihood is used (however the latter is not implemented).
+        If eql is True, var_power must be between 1 and 2.
 
     Attributes
     ----------
@@ -1361,6 +1362,9 @@ class Tweedie(Family):
     def __init__(self, link=None, var_power=1., eql=False):
         self.var_power = var_power
         self.eql = eql
+        if eql and (var_power < 1 or var_power > 2):
+            msg = "Tweedie: if EQL=True then var_power must fall between 1 and 2"
+            raise ValueError(msg)
         if link is None:
             link = L.log()
         super(Tweedie, self).__init__(
@@ -1463,7 +1467,7 @@ class Tweedie(Family):
         ----------
         http://support.sas.com/documentation/cdl/en/stathpug/67524/HTML/default/viewer.htm#stathpug_hpgenselect_details16.htm
         """
-        if self.eql == False:
+        if not self.eql:
             # We have not yet implemented the actual likelihood
             return np.nan
 

--- a/statsmodels/genmod/generalized_linear_model.py
+++ b/statsmodels/genmod/generalized_linear_model.py
@@ -1316,7 +1316,7 @@ class GLM(base.LikelihoodModel):
 
         return result
 
-    def _fit_ridge(self, alpha, start_params):
+    def _fit_ridge(self, alpha, start_params, method="newton-cg"):
 
         if start_params is None:
             start_params = np.zeros(self.exog.shape[1])
@@ -1331,8 +1331,14 @@ class GLM(base.LikelihoodModel):
         from statsmodels.base.elastic_net import (RegularizedResults,
             RegularizedResultsWrapper)
 
-        mr = minimize(fun, start_params, jac=grad)
+        mr = minimize(fun, start_params, jac=grad, method=method)
         params = mr.x
+
+        if not mr.success:
+            import warnings
+            ngrad = np.sqrt(np.sum(mr.jac**2))
+            msg = "GLM ridge optimization may have failed, |grad|=%f" % ngrad
+            warnings.warn(msg)
 
         results = RegularizedResults(self, params)
         results = RegularizedResultsWrapper(results)

--- a/statsmodels/genmod/generalized_linear_model.py
+++ b/statsmodels/genmod/generalized_linear_model.py
@@ -1292,6 +1292,10 @@ class GLM(base.LikelihoodModel):
         zero_tol : float
             Coefficients below this threshold are treated as zero.
         """
+
+        if kwargs.get("L1_wt", 1) == 0:
+            return self._fit_ridge(alpha, start_params)
+
         from statsmodels.base.elastic_net import fit_elasticnet
 
         if method != "elastic_net":
@@ -1311,6 +1315,29 @@ class GLM(base.LikelihoodModel):
         self.scale = self.estimate_scale(self.mu)
 
         return result
+
+    def _fit_ridge(self, alpha, start_params):
+
+        if start_params is None:
+            start_params = np.zeros(self.exog.shape[1])
+
+        def fun(x):
+            return -(self.loglike(x) / self.nobs - alpha * np.sum(x**2) / 2)
+
+        def grad(x):
+            return -(self.score(x) / self.nobs - alpha * x)
+
+        from scipy.optimize import minimize
+        from statsmodels.base.elastic_net import (RegularizedResults,
+            RegularizedResultsWrapper)
+
+        mr = minimize(fun, start_params, jac=grad)
+        params = mr.x
+
+        results = RegularizedResults(self, params)
+        results = RegularizedResultsWrapper(results)
+
+        return results
 
     def fit_constrained(self, constraints, start_params=None, **fit_kwds):
         """fit the model subject to linear equality constraints

--- a/statsmodels/genmod/tests/test_glm.py
+++ b/statsmodels/genmod/tests/test_glm.py
@@ -1904,8 +1904,10 @@ class TestTweedieSpecialLog3(CheckTweedieSpecial):
                            exog=cls.data.exog[['INCOME', 'SOUTH']],
                            family=family2).fit()
 
+@pytest.mark.filterwarnings("ignore:GLM ridge optimization")
 def test_tweedie_EQL():
-    # All tests below are regression tests
+    # All tests below are regression tests, but the results
+    # are very close to the population values.
 
     np.random.seed(3242)
     n = 500

--- a/statsmodels/genmod/tests/test_glm.py
+++ b/statsmodels/genmod/tests/test_glm.py
@@ -1935,18 +1935,17 @@ def test_tweedie_EQL():
     model2 = sm.GLM(y, x, family=fam)
     result2 = model2.fit_regularized(L1_wt=1, alpha=0.07)
     assert_allclose(result2.params,
-        np.array([1.00399431, -0.99124397,  0., 0.5044154]),
+        np.array([1.01059123, -1.00378706,  0., 0.50834694]),
         rtol=1e-5, atol=1e-5)
 
     # Series of ridge fits using gradients
-    ev = (np.array([1.00177988, -0.99388262, 0.007971, 0.50618676]),
-          np.array([0.9854501, -0.96991095, 0.0073212, 0.49744815]),
+    ev = (np.array([1.00724238, -0.99017577, 0.0057054, 0.50892953]),
+          np.array([0.98619792, -0.97033874, 0.00604844, 0.4981513]),
           np.array([0.20643362, -0.16456528, 0.00023651, 0.10249308]))
     for j, alpha in enumerate([0.05, 0.5, 0.7]):
         model3 = sm.GLM(y, x, family=fam)
         result3 = model3.fit_regularized(L1_wt=0, alpha=alpha)
         assert_allclose(result3.params, ev[j], rtol=1e-5, atol=1e-5)
-
 
 def testTweediePowerEstimate():
     # Test the Pearson estimate of the Tweedie variance and scale parameters.

--- a/statsmodels/genmod/tests/test_glm.py
+++ b/statsmodels/genmod/tests/test_glm.py
@@ -1940,8 +1940,8 @@ def test_tweedie_EQL():
 
     # Series of ridge fits using gradients
     ev = (np.array([1.00177988, -0.99388262, 0.007971, 0.50618676]),
-          np.array([0.98586638, -0.96953481, 0.00749983, 0.4975267]),
-          np.array([0.20642861, -0.16454719, 0.00023485, 0.1024888]))
+          np.array([0.9854501, -0.96991095, 0.0073212, 0.49744815]),
+          np.array([0.20643362, -0.16456528, 0.00023651, 0.10249308]))
     for j, alpha in enumerate([0.05, 0.5, 0.7]):
         model3 = sm.GLM(y, x, family=fam)
         result3 = model3.fit_regularized(L1_wt=0, alpha=alpha)


### PR DESCRIPTION
The quasi-likelihood allows fit_regularized to be used with Tweedie family GLM's.

Also bypasses coordinate-descent when calling fit_regularized on a GLM with L1_wt=0.  This is ridge regression and can be fit more efficiently and accurately using gradients optimization.

#3670 