### PR TITLE
DOC: Describe binomial endog formats

### DIFF
--- a/statsmodels/genmod/families/family.py
+++ b/statsmodels/genmod/families/family.py
@@ -796,7 +796,15 @@ class Binomial(Family):
 
     Notes
     -----
-    endog for Binomial can be specified in one of three ways.
+    endog for Binomial can be specified in one of three ways:
+    A 1d array of 0 or 1 values, indicating failure or success 
+    respectively.
+    A 2d array, with two columns. The first column represents the 
+    success count and the second column represents the failure 
+    count.
+    A 1d array of proportions, indicating the proportion of 
+    successes, with parameter `var_weights` containing the 
+    number of trials for each row.
     """
 
     links = [L.logit, L.probit, L.cauchy, L.log, L.cloglog, L.identity]


### PR DESCRIPTION
A simple documentation update, adding additional information about the valid formats for specifying endogenous values for the binomial GLM. 

Thanks to @josef-pkt for guidance on the three ways of passing in endogenous variables. 

Closes #5519.