### PR TITLE
BUG: Tweedie EQL quasi-likelihood

### DIFF
--- a/statsmodels/genmod/families/family.py
+++ b/statsmodels/genmod/families/family.py
@@ -1477,8 +1477,16 @@ class Tweedie(Family):
         llf = np.log(2 * np.pi * scale) + p * np.log(mu) - np.log(var_weights)
         llf /= -2
 
-        u = endog ** (2 - p) - (2 - p) * endog * mu ** (1 - p) + (1 - p) * mu ** (2 - p)
-        u *= var_weights / (scale * (1 - p) * (2 - p))
+        if p == 1:
+            u = endog * np.log(endog / mu) - (endog - mu)
+            u *= var_weights / scale
+        elif p == 2:
+            yr = endog / mu
+            u = yr - np.log(yr) - 1
+            u *= var_weights / scale
+        else:
+            u = endog ** (2 - p) - (2 - p) * endog * mu ** (1 - p) + (1 - p) * mu ** (2 - p)
+            u *= var_weights / (scale * (1 - p) * (2 - p))
         llf -= u
 
         return llf

--- a/statsmodels/genmod/families/family.py
+++ b/statsmodels/genmod/families/family.py
@@ -1465,19 +1465,21 @@ class Tweedie(Family):
 
         References
         ----------
-        http://support.sas.com/documentation/cdl/en/stathpug/67524/HTML/default/viewer.htm#stathpug_hpgenselect_details16.htm
+        JA Nelder, D Pregibon (1987).  An extended quasi-likelihood function.  Biometrika
+        74:2, pp 221-232.  https://www.jstor.org/stable/2336136
         """
         if not self.eql:
             # We have not yet implemented the actual likelihood
             return np.nan
 
+        # Equations 9-10 or Nelder and Pregibon
         p = self.var_power
-        llf = np.log(2 * np.pi * scale) + p * np.log(endog) - np.log(var_weights)
-        llf *= -1 / 2
+        llf = np.log(2 * np.pi * scale) + p * np.log(mu) - np.log(var_weights)
+        llf /= -2
 
         u = endog ** (2 - p) - (2 - p) * endog * mu ** (1 - p) + (1 - p) * mu ** (2 - p)
         u *= var_weights / (scale * (1 - p) * (2 - p))
-        llf += u
+        llf -= u
 
         return llf
 

--- a/statsmodels/genmod/tests/test_glm.py
+++ b/statsmodels/genmod/tests/test_glm.py
@@ -1933,7 +1933,7 @@ def test_tweedie_EQL():
        np.array([1.00350497, -0.99656954, 0.00802702, 0.50713209]),
        rtol=1e-5, atol=1e-5)
 
-    # Lasso fit using coordinatewise descent
+    # Lasso fit using coordinate-wise descent
     model2 = sm.GLM(y, x, family=fam)
     result2 = model2.fit_regularized(L1_wt=1, alpha=0.07)
     import sys
@@ -1943,12 +1943,12 @@ def test_tweedie_EQL():
     else:
         rtol, atol = 1e-2, 1e-2
     assert_allclose(result2.params,
-        np.array([1.01059123, -1.00378706,  0., 0.50834694]),
+        np.array([1.00281192, -0.99182638, 0., 0.50448516]),
         rtol=rtol, atol=atol)
 
     # Series of ridge fits using gradients
-    ev = (np.array([1.00724238, -0.99017577, 0.0057054, 0.50892953]),
-          np.array([0.98619792, -0.97033874, 0.00604844, 0.4981513]),
+    ev = (np.array([1.00186882, -0.99213087, 0.00717758, 0.50610942]),
+          np.array([0.98560143, -0.96976442,  0.00727526,  0.49749763]),
           np.array([0.20643362, -0.16456528, 0.00023651, 0.10249308]))
     for j, alpha in enumerate([0.05, 0.5, 0.7]):
         model3 = sm.GLM(y, x, family=fam)


### PR DESCRIPTION
@thequackdaddy , @ludviclaberge

The EQL formula from the SAS docs seems to have multiple issues (not just the 1-p factor in the denominator).  I believe that the correct formula is here:
 
https://www.jstor.org/stable/2336136?seq=4#metadata_info_tab_contents

This PR fixes these errors.  The results have changed, so what we were returning before was (presumably) wrong.

