### PR TITLE
keep index of series when recoding a series

### DIFF
--- a/statsmodels/graphics/factorplots.py
+++ b/statsmodels/graphics/factorplots.py
@@ -172,9 +172,11 @@ def _recode(x, levels):
     """
     from pandas import Series
     name = None
+    index = None
 
     if isinstance(x, Series):
         name = x.name
+        index = x.index
         x = x.values
 
     if x.dtype.type not in [np.str_, np.object_]:
@@ -194,7 +196,6 @@ def _recode(x, levels):
             out[x == level] = coding
 
         if name:
-            out = Series(out)
-            out.name = name
+            out = Series(out, name=name, index=index)
 
         return out

--- a/statsmodels/graphics/tests/test_factorplots.py
+++ b/statsmodels/graphics/tests/test_factorplots.py
@@ -3,7 +3,7 @@ from numpy.testing import assert_raises, assert_equal
 from pandas import Series
 import pytest
 
-from statsmodels.graphics.factorplots import interaction_plot
+from statsmodels.graphics.factorplots import interaction_plot, _recode
 
 try:
     import matplotlib.pyplot as plt
@@ -62,3 +62,10 @@ class TestInteractionPlot(object):
         fig = interaction_plot(self.weight, self.duration, self.days, plottype='scatter')
         assert_equal(isinstance(fig, plt.Figure), True)
         assert_raises(ValueError, interaction_plot, self.weight, self.duration, self.days, plottype='unknown')
+
+    def test_recode_series(self):
+        series = Series(['a', 'b'] * 10, index=np.arange(0, 40, 2),
+                        name='index_test')
+        series_ = _recode(series, {'a': 0, 'b': 1})
+        assert_equal(series_.index.values, series.index.values,
+                     err_msg='_recode changed the index')


### PR DESCRIPTION
`interaction_plot` tries to recode a 'list' of string to 'list' of integers: https://github.com/statsmodels/statsmodels/blob/0c3f6ce6096f88a23d78e90eec68a89d4afa2412/statsmodels/graphics/factorplots.py#L106
This causes problems when the input is a pandas Series which has indices which are not `range(length)` (in my case the series had not contiguous indices). After recording, `interaction_plot` tries to combine the two independent variables and dependent variable with pandas:
https://github.com/statsmodels/statsmodels/blob/0c3f6ce6096f88a23d78e90eec68a89d4afa2412/statsmodels/graphics/factorplots.py#L108
 Pandas notices it should create a DataFrame from several Series which have (through the recoding) potentially different indices, so it adds NAN for the non-overlapping values. This leads to a wrong interaction plot.

I fixed this behavior in `_recode` by keeping the original index of the series. 