### PR TITLE
Fixes issue #2129: Fail more gracefully on bad exog for ARMAX

### DIFF
--- a/statsmodels/tsa/arima_model.py
+++ b/statsmodels/tsa/arima_model.py
@@ -912,7 +912,7 @@ class ARMA(tsbase.TimeSeriesModel):
 
         # (re)set trend and handle exogenous variables
         # always pass original exog
-        k_trend, exog = _make_arma_exog(endog, self.exog, trend)
+        k_trend, exog = _make_arma_exog(endog, self.data.orig_exog, trend)
 
         # Check has something to estimate
         if k_ar == 0 and k_ma == 0 and k_trend == 0 and k_exog == 0:

--- a/statsmodels/tsa/arima_model.py
+++ b/statsmodels/tsa/arima_model.py
@@ -405,7 +405,12 @@ def _make_arma_exog(endog, exog, trend):
     if exog is None and trend == 'c':   # constant only
         exog = np.ones((len(endog), 1))
     elif exog is not None and trend == 'c':  # constant plus exogenous
-        exog = add_trend(exog, trend='c', prepend=True)
+        if len(exog.var(axis=0)) > np.count_nonzero(exog.var(axis=0)): # if true, it means there is at least a constant
+            # column in the exog.
+            raise ValueError("Exog should not contain a constant or trend. These should be added in the fit method."
+                             "See: https://www.statsmodels.org/dev/generated/statsmodels.tsa.arima_model.ARMA.html")
+        else:
+            exog = add_trend(exog, trend='c', prepend=True, has_constant='skip')
     elif exog is not None and trend == 'nc':
         # make sure it's not holding constant from last run
         if exog.var() == 0:

--- a/statsmodels/tsa/tests/test_arima.py
+++ b/statsmodels/tsa/tests/test_arima.py
@@ -2432,3 +2432,13 @@ def test_endog_int():
     resf = ARIMA(yf.cumsum(), order=(1, 1, 1)).fit(disp=0)
     assert_allclose(res.params, resf.params, rtol=1e-6, atol=1e-5)
     assert_allclose(res.bse, resf.bse, rtol=1e-6, atol=1e-5)
+
+
+def test_constant_exog_raises_proper_error():
+    # issue 2129
+    with pytest.raises(ValueError) as excinfo:
+        np.random.seed(13)
+        y = np.random.randn(100)
+        u = np.ones((100, 2))
+        ARMA(y, order=(1, 1), exog=u).fit()
+    assert "Exog should not contain a constant or trend" in str(excinfo.value)

--- a/statsmodels/tsa/tests/test_arima.py
+++ b/statsmodels/tsa/tests/test_arima.py
@@ -2327,7 +2327,7 @@ def test_arima_exog_predict():
         res_002.forecast(steps=h, exog=np.empty(20))
 
 
-def test_arima_fit_mutliple_calls():
+def test_arima_fit_multiple_calls():
     y = [-1214.360173, -1848.209905, -2100.918158, -3647.483678, -4711.186773]
     mod = ARIMA(y, (1, 0, 2))
     # Make multiple calls to fit


### PR DESCRIPTION
Fixes issue #2129 

Hello, this is my first time contributing to an open source project, so I apologize in advance if this pull request is not up to standards.

I have been trying to work on a solution (with the help of @Juanlu001) to better explain the error in the following [example](https://stackoverflow.com/questions/27057445/how-to-fit-an-armax-model-using-statsmodels/). The statsmodels version I am using is: 'v0.10.0.dev0+1066.gdfc0b24c4'

I added an extra-condition(starting from line 408) that checks whether there is at least a constant in exog, in which case, the code raises a (hopefully) clearer error. I think this is the best place where to raise the error (and also the least invasive), because it is the part of the code that adds the trend to exog and as it is it adds one, whether exog has already a constant or not, which later leads to the current error as in the above example.

I would be grateful for any feedback you can give me on how to improve this solution.