### PR TITLE
Update _smoothers_lowess.pyx

### DIFF
--- a/statsmodels/nonparametric/_smoothers_lowess.pyx
+++ b/statsmodels/nonparametric/_smoothers_lowess.pyx
@@ -138,6 +138,9 @@ def lowess(np.ndarray[DTYPE_t, ndim = 1] endog,
 
     y = endog   # now just alias
     x = exog
+           
+    if not 0<=frac<=1:
+           raise ValueError("Lowess `frac` must be in the range [0,1]!")
 
     n = x.shape[0]
 


### PR DESCRIPTION
The user is supposed to supply a value in the range [0,1] to the argument frac in the Lowess smoother, but this is not enforced! As a result, if the user mistakenly supplies a value such as frac=40 (for 40%) the software silently defaults to frac=1. Instead, the user should be alerted to this mistake.