### PR TITLE
ENH: Improve numerical stability of _ar_transparams, _ar_invtransparams

### DIFF
--- a/statsmodels/tsa/tests/test_tsa_tools.py
+++ b/statsmodels/tsa/tests/test_tsa_tools.py
@@ -104,6 +104,11 @@ def test_vech():
     assert (np.array_equal(vech(arr), [1, 4, 7, 5, 8, 9]))
 
 
+def test_ar_transparams():
+    arr = np.array([-1000.0, -100.0, -10.0, 1.0, 0.0, 1.0, 10.0, 100.0, 1000.0])
+    assert (not np.isnan(tools._ar_transparams(arr)).any())
+
+
 class TestLagmat(object):
     @classmethod
     def setup_class(cls):

--- a/statsmodels/tsa/tsatools.py
+++ b/statsmodels/tsa/tsatools.py
@@ -609,17 +609,15 @@ def _ar_transparams(params):
 
     Parameters
     ----------
-    params : array
+    params : array_like
         The AR coefficients
 
     Reference
     ---------
     Jones(1980)
     """
-    newparams = ((1-np.exp(-params))/
-                (1+np.exp(-params))).copy()
-    tmp = ((1-np.exp(-params))/
-               (1+np.exp(-params))).copy()
+    newparams = np.tanh(params/2)
+    tmp = np.tanh(params/2)
     for j in range(1,len(params)):
         a = newparams[j]
         for kiter in range(j):

--- a/statsmodels/tsa/tsatools.py
+++ b/statsmodels/tsa/tsatools.py
@@ -632,10 +632,10 @@ def _ar_invtransparams(params):
 
     Parameters
     ----------
-    params : array
+    params : array_like
         The transformed AR coefficients
     """
-    # AR coeffs
+    params = params.copy()
     tmp = params.copy()
     for j in range(len(params)-1,0,-1):
         a = params[j]
@@ -643,7 +643,7 @@ def _ar_invtransparams(params):
             tmp[kiter] = (params[kiter] + a * params[j-kiter-1])/\
                     (1-a**2)
         params[:j] = tmp[:j]
-    invarcoefs = -np.log((1-params)/(1+params))
+    invarcoefs = 2*np.arctanh(params)
     return invarcoefs
 
 


### PR DESCRIPTION
(1 - e^-x)/(1 + e^-x) = tanh(x/2) 

I modified the code to use numpy's tanh since it doesn't have the issue with large scale numbers.