### PR TITLE
Add check for convergence

### DIFF
--- a/statsmodels/robust/robust_linear_model.py
+++ b/statsmodels/robust/robust_linear_model.py
@@ -272,7 +272,7 @@ class RLM(base.LikelihoodModel):
         # done one iteration so update
         history = self._update_history(wls_results, history, conv)
         iteration = 1
-        converged = 0
+        converged = _check_convergence(criterion, iteration, tol, maxiter)
         while not converged:
             self.weights = self.M.weights(wls_results.resid/self.scale)
             wls_results = reg_tools._MinimalWLS(self.endog, self.exog,


### PR DESCRIPTION
Currently in robust_linear_model, we do one iteration, rescale, and then enter the iterations loop.

This can be a problem if the first iteration is a perfect fit or nearly a perfect fit. When dividing by scale, we get either NaN or an ill-conditioned problem.