### PR TITLE
BUG: Replace $$ in generated LaTeX

### DIFF
--- a/statsmodels/iolib/table.py
+++ b/statsmodels/iolib/table.py
@@ -450,7 +450,8 @@ class SimpleTable(list):
         if center:
             formatted_rows.append(r'\end{center}')
 
-        return '\n'.join(formatted_rows)
+        # Replace $$ due to bug in GH 5444
+        return '\n'.join(formatted_rows).replace('$$', ' ')
 
 
     def extend_right(self, table):

--- a/statsmodels/regression/tests/test_regression.py
+++ b/statsmodels/regression/tests/test_regression.py
@@ -979,7 +979,7 @@ def test_summary_as_latex():
 \\bottomrule
 \\end{tabular}
 \\begin{tabular}{lcccccc}
-                  & \\textbf{coef} & \\textbf{std err} & \\textbf{t} & \\textbf{P$>$$|$t$|$} & \\textbf{[0.025} & \\textbf{0.975]}  \\\\
+                  & \\textbf{coef} & \\textbf{std err} & \\textbf{t} & \\textbf{P$> |$t$|$} & \\textbf{[0.025} & \\textbf{0.975]}  \\\\
 \\midrule
 \\textbf{GNPDEFL}  &      15.0619  &       84.915     &     0.177  &         0.863        &     -177.029    &      207.153     \\\\
 \\textbf{GNP}      &      -0.0358  &        0.033     &    -1.070  &         0.313        &       -0.112    &        0.040     \\\\


### PR DESCRIPTION
Replace $$ with a space to avoid compilation errors, and to
prevent munging of latex words during math mode

- [x] partially fixes  #5444
- [X] tests added / passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message. See [NumPy's guide](https://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html#writing-the-commit-message). 
