### PR TITLE
TST: Explicitly set seed in basinhopping

### DIFF
--- a/statsmodels/base/tests/test_optimize.py
+++ b/statsmodels/base/tests/test_optimize.py
@@ -4,7 +4,6 @@ from statsmodels.base.optimizer import (_fit_newton, _fit_nm,
                                         _fit_bfgs, _fit_cg,
                                         _fit_ncg, _fit_powell,
                                         _fit_lbfgs, _fit_basinhopping)
-
 fit_funcs = {
     'newton': _fit_newton,
     'nm': _fit_nm,  # Nelder-Mead
@@ -29,7 +28,7 @@ def dummy_hess(x):
     return [[2.]]
 
 
-def test_full_output_false():
+def test_full_output_false(reset_randomstate):
     # just a smoke test
 
     # newton needs f, score, start, fargs, kwargs
@@ -56,7 +55,7 @@ def test_full_output_false():
             assert_(len(xopt) == 1)
 
 
-def test_full_output():
+def test_full_output(reset_randomstate):
     for method in fit_funcs:
         func = fit_funcs[method]
         if method == "newton":

--- a/statsmodels/compat/scipy.py
+++ b/statsmodels/compat/scipy.py
@@ -1,6 +1,10 @@
 from __future__ import absolute_import
-import numpy as np
+from distutils.version import LooseVersion
 
+import numpy as np
+import scipy
+
+SP_GTE_019 = LooseVersion(scipy.__version__) >= LooseVersion('0.19')
 NumpyVersion = np.lib.NumpyVersion
 
 

--- a/statsmodels/discrete/tests/test_count_model.py
+++ b/statsmodels/discrete/tests/test_count_model.py
@@ -1,4 +1,5 @@
 from __future__ import division
+from statsmodels.compat.scipy import SP_GTE_019
 
 import numpy as np
 from numpy.testing import (assert_,
@@ -295,9 +296,12 @@ class TestZeroInflatedGeneralizedPoisson(CheckGeneric):
                         atol=1e-3, rtol=0.6)
         assert_(res_dog.mle_retvals['converged'] is True)
 
+        # Ser random_state here to improve reproducibility
+        random_state = np.random.RandomState(1)
+        seed = {'seed': random_state} if SP_GTE_019 else {}
         res_bh = model.fit(start_params=start_params,
-                           method='basinhopping', maxiter=500,
-                           niter_success=3, disp=0)
+                           method='basinhopping', niter=500, stepsize=0.1,
+                           niter_success=None, disp=0, interval=1, **seed)
 
         assert_allclose(res_bh.params, self.res2.params,
                         atol=1e-4, rtol=3e-5)


### PR DESCRIPTION
Set seed in basinhopping optimizers to improve reproducibility

- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html#writing-the-commit-message). 
