### PR TITLE
Mattwigway mice setting with copy warning

### DIFF
--- a/statsmodels/imputation/mice.py
+++ b/statsmodels/imputation/mice.py
@@ -395,7 +395,7 @@ class MICEData(object):
 
         ix = self.ix_miss[col]
         if len(ix) > 0:
-            self.data[col].iloc[ix] = np.atleast_1d(vals)
+            self.data.iloc[ix, self.data.columns.get_loc(col)] = np.atleast_1d(vals)
 
     def update_all(self, n_iter=1):
         """

--- a/statsmodels/imputation/tests/test_mice.py
+++ b/statsmodels/imputation/tests/test_mice.py
@@ -126,7 +126,7 @@ class TestMICEData(object):
                 # "DeprecationWarning('pandas.core.common.is_categorical_dtype is deprecated. import from the public API:
                 # pandas.api.types.is_categorical_dtype instead',)"
                 # ignore this warning, as this is not what is being tested in this test
-                assert ((len(ws) == 0) or all([w.category == DeprecationWarning for w in ws]))           
+                assert ((len(ws) == 0) or all([w.category == DeprecationWarning for w in ws]))
 
     def test_next_sample(self):
 

--- a/statsmodels/imputation/tests/test_mice.py
+++ b/statsmodels/imputation/tests/test_mice.py
@@ -3,7 +3,7 @@ import pandas as pd
 import pytest
 from statsmodels.imputation import mice
 import statsmodels.api as sm
-from numpy.testing import assert_equal, assert_allclose
+from numpy.testing import assert_equal, assert_allclose, assert_no_warnings
 
 try:
     import matplotlib.pyplot as plt
@@ -106,6 +106,21 @@ class TestMICEData(object):
         assert_equal(exog_obs.shape, [190, 6])
         assert_equal(exog_miss.shape, [10, 6])
 
+    def test_settingwithcopywarning(self):
+        # Test that MICEData does not throw a settingwithcopywarning when imputing.
+
+        df = gendat()
+        # There need to be some ints in here for the error to be thrown
+        df['intcol'] = np.arange(len(df))
+        df['intcol'] = df.intcol.astype('int32')
+        orig = df.copy()
+        mx = pd.notnull(df)
+
+        miceData = mice.MICEData(df)
+
+        with pd.option_context('mode.chained_assignment', 'warn'):
+            with assert_no_warnings():
+                miceData.update_all()
 
     def test_next_sample(self):
 

--- a/statsmodels/imputation/tests/test_mice.py
+++ b/statsmodels/imputation/tests/test_mice.py
@@ -113,8 +113,6 @@ class TestMICEData(object):
         # There need to be some ints in here for the error to be thrown
         df['intcol'] = np.arange(len(df))
         df['intcol'] = df.intcol.astype('int32')
-        orig = df.copy()
-        mx = pd.notnull(df)
 
         miceData = mice.MICEData(df)
 


### PR DESCRIPTION
- [x] closes #5431
- [x] tests added / passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html#writing-the-commit-message). 
