### PR TITLE
CI: Setup Azure-Pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,58 @@
+# Python package
+# Create and test a Python package on multiple Python versions.
+# Add steps that analyze code, save the dist with the build record, publish to a PyPI-compatible index, and more:
+# https://docs.microsoft.com/azure/devops/pipelines/languages/python
+
+trigger:
+- master
+
+jobs:
+
+- job: 'Test'
+  pool:
+    vmImage: 'Ubuntu-16.04'
+  strategy:
+    matrix:
+      Python27:
+        python.version: '2.7'
+      Python35:
+        python.version: '3.5'
+      Python36:
+        python.version: '3.6'
+      Python37:
+        python.version: '3.7'
+    maxParallel: 4
+
+  steps:
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: '$(python.version)'
+      architecture: 'x64'
+
+  - script: python -m pip install --upgrade pip && pip install -r requirements.txt
+    displayName: 'Install dependencies'
+
+  - script: |
+      pip install pytest
+      pytest tests --doctest-modules --junitxml=junit/test-results.xml
+    displayName: 'pytest'
+
+  - task: PublishTestResults@2
+    inputs:
+      testResultsFiles: '**/test-results.xml'
+      testRunTitle: 'Python $(python.version)'
+    condition: succeededOrFailed()
+
+- job: 'Publish'
+  dependsOn: 'Test'
+  pool:
+    vmImage: 'Ubuntu-16.04'
+
+  steps:
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: '3.x'
+      architecture: 'x64'
+
+  - script: python setup.py sdist
+    displayName: 'Build sdist'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,12 +29,18 @@ jobs:
       versionSpec: '$(python.version)'
       architecture: 'x64'
 
-  - script: python -m pip install --upgrade pip && pip install -r requirements.txt
+  - script: |
+      python -m pip install --upgrade pip
+      pip install -r requirements.txt
+      pip install -r requirements-dev.txt
     displayName: 'Install dependencies'
 
   - script: |
-      pip install pytest
-      pytest tests --doctest-modules --junitxml=junit/test-results.xml
+      python setup.py build_ext --inplace -q
+    displayName: 'Build Cython Extensions'
+
+  - script: |
+      pytest statsmodels --junitxml=junit/test-results.xml --skip-examples
     displayName: 'pytest'
 
   - task: PublishTestResults@2
@@ -53,6 +59,3 @@ jobs:
     inputs:
       versionSpec: '3.x'
       architecture: 'x64'
-
-  - script: python setup.py sdist
-    displayName: 'Build sdist'

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,11 @@
+# build
+cython
+
+# run
+matplotlib
+cvxopt
+
+# test
+pytest
+pytest-randomly
+flake8


### PR DESCRIPTION
Closes #5423 
Makes progress towards closing #5231.

This implementation is pretty bare-bones, just takes the default template Azure provides and tweaks it enough for the tests to run as expected.  In follow-ups we can configure Windows and MacOS builds.

4 builds run in parallel, 3 of them taking about 21 minutes.  The py27 build is taking another 8 minutes because it apparently is building pandas instead of getting a wheel.  Will look into whats causing this.

cc: @datapythonista if you have any ideas on how to implement this more effectively/gracefully.
