### PR TITLE
BUG: Stop hardcoding parameters in results

### DIFF
--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -2377,6 +2377,6 @@ class GenericLikelihoodModelResults(LikelihoodModelResults, ResultMixin):
         smry.add_table_2cols(self, gleft=top_left, gright=top_right,
                              yname=yname, xname=xname, title=title)
         smry.add_table_params(self, yname=yname, xname=xname, alpha=alpha,
-                              use_t=False)
+                              use_t=self.use_t)
 
         return smry

--- a/statsmodels/graphics/_regressionplots_doc.py
+++ b/statsmodels/graphics/_regressionplots_doc.py
@@ -212,4 +212,3 @@ _plot_leverage_resid2_doc = """\
 
     .. plot:: plots/graphics_regression_leverage_resid2.py
     """
-

--- a/statsmodels/iolib/summary.py
+++ b/statsmodels/iolib/summary.py
@@ -882,8 +882,6 @@ class Summary(object):
             table = summary_params(res, yname=yname, xname=xname, alpha=alpha,
                                    use_t=use_t)
         elif res.params.ndim == 2:
-#            _, table = summary_params_2dflat(res, yname=yname, xname=xname,
-#                                             alpha=alpha, use_t=use_t)
             _, table = summary_params_2dflat(res, endog_names=yname,
                                              exog_names=xname,
                                              alpha=alpha, use_t=use_t)

--- a/statsmodels/miscmodels/tests/test_generic_mle.py
+++ b/statsmodels/miscmodels/tests/test_generic_mle.py
@@ -60,12 +60,19 @@ class MyPareto(GenericLikelihoodModel):
 
 
 class CheckGenericMixin(object):
-    #mostly smoke tests for now
-
+    # mostly smoke tests for now
 
     def test_summary(self):
-        self.res1.summary()
-        #print self.res1.summary()
+        summ = self.res1.summary()
+        check_str = 'P>|t|' if self.res1.use_t else 'P>|z|'
+        assert check_str in str(summ)
+
+    def test_use_t_summary(self):
+        orig_val = self.res1.use_t
+        self.res1.use_t = True
+        summ = self.res1.summary()
+        assert 'P>|t|' in str(summ)
+        self.res1.use_t = orig_val
 
     def test_ttest(self):
         self.res1.t_test(np.eye(len(self.res1.params)))

--- a/statsmodels/regression/quantile_regression.py
+++ b/statsmodels/regression/quantile_regression.py
@@ -413,9 +413,9 @@ class QuantRegResults(RegressionResults):
         from statsmodels.iolib.summary import Summary
         smry = Summary()
         smry.add_table_2cols(self, gleft=top_left, gright=top_right,
-                          yname=yname, xname=xname, title=title)
-        smry.add_table_params(self, yname=yname, xname=xname, alpha=.05,
-                             use_t=True)
+                             yname=yname, xname=xname, title=title)
+        smry.add_table_params(self, yname=yname, xname=xname, alpha=alpha,
+                              use_t=self.use_t)
 
 #        smry.add_table_2cols(self, gleft=diagn_left, gright=diagn_right,
 #                          yname=yname, xname=xname,

--- a/statsmodels/regression/tests/test_quantile_regression.py
+++ b/statsmodels/regression/tests/test_quantile_regression.py
@@ -249,6 +249,28 @@ def test_zero_resid():
 
     assert_allclose(res.params, np.array([9.99982796e-08, 9.67741630e-01]),
                     rtol=1e-4, atol=1e-20)
-    assert_allclose(res.bse, np.array([0.04455029, 0.01155251]), rtol=1e-4, atol=1e-20)
+    assert_allclose(res.bse, np.array([0.04455029, 0.01155251]), rtol=1e-4,
+                    atol=1e-20)
     assert_allclose(res.resid, np.array([-9.99982796e-08, 3.22583598e-02,
-                                         -3.22574234e-02, 9.46361860e-07]), rtol=1e-4, atol=1e-20)
+                                         -3.22574234e-02, 9.46361860e-07]),
+                    rtol=1e-4, atol=1e-20)
+
+
+def test_use_t_summary():
+    X = np.array([[1, 0], [0, 1], [0, 2.1], [0, 3.1]], dtype=np.float64)
+    y = np.array([0, 1, 2, 3], dtype=np.float64)
+
+    res = QuantReg(y, X).fit(0.5, bandwidth='chamberlain', use_t=True)
+    summ = res.summary()
+    assert 'P>|t|' in str(summ)
+    assert 'P>|z|' not in str(summ)
+
+
+def test_alpha_summary():
+    X = np.array([[1, 0], [0, 1], [0, 2.1], [0, 3.1]], dtype=np.float64)
+    y = np.array([0, 1, 2, 3], dtype=np.float64)
+
+    res = QuantReg(y, X).fit(0.5, bandwidth='chamberlain', use_t=True)
+    summ_20 = res.summary(alpha=.2)
+    assert '[0.025      0.975]' not in str(summ_20)
+    assert '[0.1        0.9]' in str(summ_20)

--- a/statsmodels/sandbox/regression/gmm.py
+++ b/statsmodels/sandbox/regression/gmm.py
@@ -1287,7 +1287,6 @@ class GMMResults(LikelihoodModelResults):
             jdiff = - jdiff
         return jdiff, stats.chi2.sf(jdiff, df), df
 
-
     def summary(self, yname=None, xname=None, title=None, alpha=.05):
         """Summarize the Regression Results
 
@@ -1343,13 +1342,13 @@ class GMMResults(LikelihoodModelResults):
         if title is None:
             title = self.model.__class__.__name__ + ' ' + "Results"
 
-        #create summary table instance
+        # create summary table instance
         from statsmodels.iolib.summary import Summary
         smry = Summary()
         smry.add_table_2cols(self, gleft=top_left, gright=top_right,
-                          yname=yname, xname=xname, title=title)
+                             yname=yname, xname=xname, title=title)
         smry.add_table_params(self, yname=yname, xname=xname, alpha=alpha,
-                             use_t=False)
+                              use_t=self.use_t)
 
         return smry
 

--- a/statsmodels/sandbox/regression/tests/test_gmm.py
+++ b/statsmodels/sandbox/regression/tests/test_gmm.py
@@ -8,6 +8,8 @@ Author: Josef Perktold
 from __future__ import print_function
 from statsmodels.compat.python import lrange, lmap
 
+import copy
+
 import numpy as np
 from numpy.testing import assert_allclose, assert_equal
 import pandas as pd
@@ -242,6 +244,14 @@ class CheckGMM(object):
         summ = res1.summary()
         # len + 1 is for header line
         assert_equal(len(summ.tables[1]), len(res1.params) + 1)
+
+    def test_use_t(self):
+        # Copy to avoid cache
+        res1 = copy.deepcopy(self.res1)
+        res1.use_t = True
+        summ = res1.summary()
+        assert 'P>|t|' in str(summ)
+        assert 'P>|z|' not in str(summ)
 
 
 class TestGMMSt1(CheckGMM):


### PR DESCRIPTION
Remove hardcoded alpha and use_t

closes #5270

- [X] closes #5270
- [x] tests added / passed. 
- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html#writing-the-commit-message). 
