### PR TITLE
MAINT: Ensure no warnings are produced by foreign

### DIFF
--- a/statsmodels/iolib/foreign.py
+++ b/statsmodels/iolib/foreign.py
@@ -920,6 +920,8 @@ class StataWriter(object):
                     self._write(var)
                 else:
                     try:
+                        if typ in _type_converters:
+                            var = _type_converters[typ](var)
                         self._write(pack(byteorder+TYPE_MAP[typ], var))
                     except struct_error:
                         # have to be strict about type pack won't do any

--- a/statsmodels/iolib/tests/test_foreign.py
+++ b/statsmodels/iolib/tests/test_foreign.py
@@ -98,7 +98,9 @@ def test_stata_writer_pandas():
         dta4[col] = dta4[col].astype(np.int32)
     # dta is int64 'i8'  given to Stata writer
     writer = StataWriter(buf, dta)
-    writer.write_file()
+    with warnings.catch_warnings(record=True) as w:
+        writer.write_file()
+        assert len(w) == 0
     buf.seek(0)
     dta2 = genfromdta(buf)
     dta5 = DataFrame.from_records(dta2)


### PR DESCRIPTION
Cast before packing when required

- [X] tests added / passed. 
- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html#writing-the-commit-message). 
