### PR TITLE
CI: Implement azure-pipelines with multi-platform support

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,9 +10,7 @@ environment:
     # Pip builds
     - PYTHON: C:\Python27
       PYTEST_DIRECTIVES:
-    - PYTHON: C:\Python27-x64
     - PYTHON: C:\Python36
-    - PYTHON: C:\Python36-x64
       PYTEST_DIRECTIVES:
     # Conda builds
     - PY_MAJOR_VER: 2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,58 @@
+# Python package
+# Create and test a Python package on multiple Python versions.
+# Add steps that analyze code, save the dist with the build record, publish to a PyPI-compatible index, and more:
+# https://docs.microsoft.com/azure/devops/pipelines/languages/python
+
+trigger:
+- master
+
+jobs:
+
+- job: 'Test'
+  pool:
+    vmImage: 'Ubuntu-16.04'
+  strategy:
+    matrix:
+      Python27:
+        python.version: '2.7'
+      Python35:
+        python.version: '3.5'
+      Python36:
+        python.version: '3.6'
+      Python37:
+        python.version: '3.7'
+    maxParallel: 4
+
+  steps:
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: '$(python.version)'
+      architecture: 'x64'
+
+  - script: python -m pip install --upgrade pip && pip install -r requirements.txt
+    displayName: 'Install dependencies'
+
+  - script: |
+      pip install pytest
+      pytest tests --doctest-modules --junitxml=junit/test-results.xml
+    displayName: 'pytest'
+
+  - task: PublishTestResults@2
+    inputs:
+      testResultsFiles: '**/test-results.xml'
+      testRunTitle: 'Python $(python.version)'
+    condition: succeededOrFailed()
+
+- job: 'Publish'
+  dependsOn: 'Test'
+  pool:
+    vmImage: 'Ubuntu-16.04'
+
+  steps:
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: '3.x'
+      architecture: 'x64'
+
+  - script: python setup.py sdist
+    displayName: 'Build sdist'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,12 +29,18 @@ jobs:
       versionSpec: '$(python.version)'
       architecture: 'x64'
 
-  - script: python -m pip install --upgrade pip && pip install -r requirements.txt
+  - script: |
+      python -m pip install --upgrade pip
+      pip install -r requirements.txt
+      pip install -r requirements-dev.txt
     displayName: 'Install dependencies'
 
   - script: |
-      pip install pytest
-      pytest tests --doctest-modules --junitxml=junit/test-results.xml
+      python setup.py build_ext --inplace -q
+    displayName: 'Build Cython Extensions'
+
+  - script: |
+      pytest statsmodels --junitxml=junit/test-results.xml --skip-examples
     displayName: 'pytest'
 
   - task: PublishTestResults@2
@@ -53,6 +59,3 @@ jobs:
     inputs:
       versionSpec: '3.x'
       architecture: 'x64'
-
-  - script: python setup.py sdist
-    displayName: 'Build sdist'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,61 +1,23 @@
-# Python package
-# Create and test a Python package on multiple Python versions.
-# Add steps that analyze code, save the dist with the build record, publish to a PyPI-compatible index, and more:
-# https://docs.microsoft.com/azure/devops/pipelines/languages/python
+# https://docs.microsoft.com/en-us/azure/devops/pipelines/process/templates?view=azure-devops#passing-parameters
 
 trigger:
 - master
 
+
 jobs:
+- template: tools/ci/azure_template.yml
+  parameters:
+    name: Linux
+    vmImage: 'ubuntu-16.04'
 
-- job: 'Test'
-  pool:
-    vmImage: 'Ubuntu-16.04'
-  strategy:
-    matrix:
-      Python27:
-        python.version: '2.7'
-      Python35:
-        python.version: '3.5'
-      Python36:
-        python.version: '3.6'
-      Python37:
-        python.version: '3.7'
-    maxParallel: 4
+# TODO: Enable these; they are currently disabled because
+#  test_lme.TestMixedLM.test_compare_numdiff fails on OSX
+# - template: tools/ci/azure_template.yml
+#  parameters:
+#    name: macOS
+#    vmImage: 'macOS-10.13'
 
-  steps:
-  - task: UsePythonVersion@0
-    inputs:
-      versionSpec: '$(python.version)'
-      architecture: 'x64'
-
-  - script: |
-      python -m pip install --upgrade pip
-      pip install -r requirements.txt
-      pip install -r requirements-dev.txt
-    displayName: 'Install dependencies'
-
-  - script: |
-      python setup.py build_ext --inplace -q
-    displayName: 'Build Cython Extensions'
-
-  - script: |
-      pytest statsmodels --junitxml=junit/test-results.xml --skip-examples
-    displayName: 'pytest'
-
-  - task: PublishTestResults@2
-    inputs:
-      testResultsFiles: '**/test-results.xml'
-      testRunTitle: 'Python $(python.version)'
-    condition: succeededOrFailed()
-
-- job: 'Publish'
-  dependsOn: 'Test'
-  pool:
-    vmImage: 'Ubuntu-16.04'
-
-  steps:
-  - task: UsePythonVersion@0
-    inputs:
-      versionSpec: '3.x'
-      architecture: 'x64'
+- template: tools/ci/azure_template.yml
+  parameters:
+    name: Windows
+    vmImage: 'vs2017-win2016'

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,11 @@
+# build
+cython
+
+# run
+matplotlib
+cvxopt
+
+# test
+pytest
+pytest-randomly
+flake8

--- a/tools/ci/azure_template.yml
+++ b/tools/ci/azure_template.yml
@@ -1,0 +1,71 @@
+# Python package
+# Create and test a Python package on multiple Python versions.
+# Add steps that analyze code, save the dist with the build record, publish to a PyPI-compatible index, and more:
+# https://docs.microsoft.com/azure/devops/pipelines/languages/python
+
+parameters:
+  # defaults for any parameters that aren't specified
+  name: ''
+  vmImage: ''
+
+
+jobs:
+
+- job: ${{ parameters.name }}Test
+  pool:
+    vmImage: ${{ parameters.vmImage }}
+  strategy:
+    matrix:
+      Python27:
+        python.version: '2.7'
+      Python35:
+        python.version: '3.5'
+      Python36:
+        python.version: '3.6'
+      Python37:
+        python.version: '3.7'
+    maxParallel: 4
+
+  steps:
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: '$(python.version)'
+      architecture: 'x64'
+
+  - ${{ if eq(parameters.name, 'Windows') }}:
+    # We need to install a C compiler, see
+    #  https://github.com/Microsoft/azure-pipelines-tasks/issues/9674
+    # TODO(py27): This is only necessary for the py27 build, can be removed
+    #  once py27 is dropped
+    - script: choco install vcpython27
+
+  - script: |
+      python -m pip install --upgrade pip
+      pip install -r requirements.txt
+      pip install -r requirements-dev.txt
+    displayName: 'Install dependencies'
+
+  - script: |
+      python setup.py build_ext --inplace -q
+    displayName: 'Build Cython Extensions'
+
+  - script: |
+      pytest statsmodels --junitxml=junit/test-results.xml --skip-examples
+    displayName: 'pytest'
+
+  - task: PublishTestResults@2
+    inputs:
+      testResultsFiles: '**/test-results.xml'
+      testRunTitle: 'Python $(python.version)'
+    condition: succeededOrFailed()
+
+- job: ${{ parameters.name }}Publish
+  dependsOn: ${{ parameters.name }}Test
+  pool:
+    vmImage: ${{ parameters.vmImage }}
+
+  steps:
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: '3.x'
+      architecture: 'x64'


### PR DESCRIPTION
Alternative to (builds on) #5609 enabling Windows builds in addition to Linux builds.  Mac builds are easy to enable, but are currently failing.