### PR TITLE
CLN: simplify lint configuration, fix some invalid escapes

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -33,14 +33,8 @@ parentdir_prefix = statsmodels-
 
 
 [flake8]
-exclude=.git,build,docs
+exclude=.git,build,docs,versioneer.py
 select=
-    E271,
-    # E271: multiple spaces after keyword
-    E901,
-    # E901: SyntaxError or IndentationError
-    E999,
-    # E999: Syntax Error
     E101,
     # E101: indentation contains mixed spaces and tabs
     W191,
@@ -85,20 +79,12 @@ select=
     # E224: tab after operator
     E242,
     # E242: tab after ','
-    E273,
-    # E273: tab after keyword
-    E274,
-    # E274: tab before keyword
-    E275,
-    # E275: missing whitespace after keyword
     E304,
     # E304: blank lines found after function decorator
     E742,
     # E742: do not define classes named 'l', 'O', or 'I'
     E743,
     # E743: do not define functions named 'l', 'O', or 'I'
-    E902,
-    # E902: IOError
     W602,
     # W602: deprecated form of raising exception
     W603,
@@ -115,45 +101,51 @@ select=
     # F406: 'from module import *' only allowed at module level
     F407,
     # F407: an undefined __future__ feature name was imported
-    F601,
-    # F601: dictionary key name repeated with different values
-    F602,
-    # F602: dictionary key variable name repeated with different values
-    F621,
-    # F621: too many expressions in an assignment with star-unpacking
-    F622,
-    # F622: two or more starred expressions in an assignment (a, *b, *c = d)
-    F631,
-    # F631: assertion test is a tuple, which are always True
-    F701,
-    # F701: a break statement outside of a while or for loop
-    F702,
-    # F702: a continue statement outside of a while or for loop
-    F703,
-    # F703: a continue statement in a finally block in a loop
-    F704,
-    # F704: a yield or yield from statement outside of a function
-    F705,
-    # F705: a return statement with arguments inside a generator
-    F706,
-    # F706: a return statement outside of a function/method
-    F707,
-    # F707: an except: block as not the last exception handler
-    F721,
-    # F721: doctest syntax error
-    F722,
-    # F722: syntax error in forward type annotation
     F831,
     # F831: duplicate argument name in function definition
-    F901,
-    # F901: raise NotImplemented should be raise NotImplementedError
     E306,
     # E306: expected 1 blank line before a nested definition, found 0
 
     W292,
     # W292: no newline at end of file
+    W293,
+    # W293: blank line contains whitespace
 
-    E272,
-    # E272: multiple spaces before keyword
-    E721
+    E713,
+    # E713: test for membership should be 'not in'
+    E721,
     # E721: do not compare types, use 'isinstance()'
+
+    F6,
+    # F601: dictionary key name repeated with different values
+    # F602: dictionary key variable name repeated with different values
+    # F621: too many expressions in an assignment with star-unpacking
+    # F622: two or more starred expressions in an assignment (a, *b, *c = d)
+    # F631: assertion test is a tuple, which are always True
+    # F632: use ==/!= to compare str, bytes, and int literals
+
+    F7,
+    # F701: a break statement outside of a while or for loop
+    # F702: a continue statement outside of a while or for loop
+    # F703: a continue statement in a finally block in a loop
+    # F704: a yield or yield from statement outside of a function
+    # F705: a return statement with arguments inside a generator
+    # F706: a return statement outside of a function/method
+    # F707: an except: block as not the last exception handler
+    # F721: doctest syntax error
+    # F722: syntax error in forward type annotation
+
+    F9,
+    # F901: raise NotImplemented should be raise NotImplementedError
+
+    E27,
+    # E271: multiple spaces after keyword
+    # E272: multiple spaces before keyword
+    # E273: tab after keyword
+    # E274: tab before keyword
+    # E275: missing whitespace after keyword
+
+    E9,
+    # E901: SyntaxError or IndentationError
+    # E902: IOError
+    # E999: Syntax Error

--- a/statsmodels/examples/example_enhanced_boxplots.py
+++ b/statsmodels/examples/example_enhanced_boxplots.py
@@ -80,13 +80,13 @@ ax = fig.add_subplot(111)
 plot_opts['violin_fc'] = (0.5, 0.5, 0.5)
 plot_opts['bean_show_mean'] = False
 plot_opts['bean_show_median'] = False
-plot_opts['bean_legend_text'] = 'Income < \$30k'
+plot_opts['bean_legend_text'] = r'Income < \$30k'
 plot_opts['cutoff_val'] = 10
 sm.graphics.beanplot(age_lower_income, ax=ax, labels=labels, side='left',
                      jitter=True, plot_opts=plot_opts)
 plot_opts['violin_fc'] = (0.7, 0.7, 0.7)
 plot_opts['bean_color'] = '#009D91'
-plot_opts['bean_legend_text'] = 'Income > \$50k'
+plot_opts['bean_legend_text'] = r'Income > \$50k'
 sm.graphics.beanplot(age_higher_income, ax=ax, labels=labels, side='right',
                      jitter=True, plot_opts=plot_opts)
 

--- a/statsmodels/iolib/foreign.py
+++ b/statsmodels/iolib/foreign.py
@@ -166,7 +166,7 @@ class _StataMissingValue(object):
     def __init__(self, offset, value):
         self._value = value
         if isinstance(value, (int, long)):
-            self._str = value-offset is 1 and \
+            self._str = value-offset == 1 and \
                     '.' or ('.' + chr(value-offset+96))
         else:
             self._str = '.'

--- a/statsmodels/iolib/table.py
+++ b/statsmodels/iolib/table.py
@@ -312,7 +312,7 @@ class SimpleTable(list):
         fmt.update(fmt_dict)
         ncols = max(len(row) for row in self)
         request = fmt.get('colwidths')
-        if request is 0:  # assume no extra space desired (e.g, CSV)
+        if request == 0:  # assume no extra space desired (e.g, CSV)
             return [0] * ncols
         elif request is None:  # assume no extra space desired (e.g, CSV)
             request = [0] * ncols

--- a/statsmodels/multivariate/cancorr.py
+++ b/statsmodels/multivariate/cancorr.py
@@ -25,7 +25,7 @@ class CanCorr(Model):
 
         x1 = x * x_cancoef, x1' * x1 is identity matrix
         y1 = y * y_cancoef, y1' * y1 is identity matrix
-    
+
     and the correlation between x1 and y1 is maximized.
 
     Attributes

--- a/statsmodels/sandbox/contrast_old.py
+++ b/statsmodels/sandbox/contrast_old.py
@@ -65,7 +65,7 @@ class Contrast(object):
     def __init__(self, term, formula, name=''):
         self.term = term
         self.formula = formula
-        if name is '':
+        if name == '':
             self.name = str(term)
         else:
             self.name = name

--- a/statsmodels/sandbox/formula.py
+++ b/statsmodels/sandbox/formula.py
@@ -120,9 +120,9 @@ class Term(object):
         Formula(self) * Formula(other)
         """
 
-        if isinstance(other, Term) and other.name is 'intercept':
+        if isinstance(other, Term) and other.name == 'intercept':
             f = Formula(self, namespace=self.namespace)
-        elif self.name is 'intercept':
+        elif self.name == 'intercept':
             f = Formula(other, namespace=other.namespace)
         else:
             other = Formula(other, namespace=other.namespace)
@@ -252,7 +252,7 @@ class Factor(Term):
 
         """
 
-        if isinstance(other, Term) and other.name is 'intercept':
+        if isinstance(other, Term) and other.name == 'intercept':
             return Formula(self, namespace=self.namespace)
         else:
             return Term.__add__(self, other)
@@ -565,10 +565,10 @@ class Formula(object):
                 selfnames = self.terms[i].names()
                 othernames = other.terms[j].names()
 
-                if self.terms[i].name is 'intercept':
+                if self.terms[i].name == 'intercept':
                     _term = other.terms[j]
                     _term.namespace = other.namespace
-                elif other.terms[j].name is 'intercept':
+                elif other.terms[j].name == 'intercept':
                     _term = self.terms[i]
                     _term.namespace = self.namespace
                 else:

--- a/statsmodels/sandbox/tsa/diffusion.py
+++ b/statsmodels/sandbox/tsa/diffusion.py
@@ -233,7 +233,7 @@ class GeometricBrownian(AffineDiffusion):
 
     $x_t $ stochastic process of Geometric Brownian motion,
     $\mu $ is the drift,
-    $\sigma $ is the Volatility,
+    $\\sigma $ is the Volatility,
     $W$ is the Wiener process (Brownian motion).
 
     '''

--- a/statsmodels/stats/contrast.py
+++ b/statsmodels/stats/contrast.py
@@ -51,7 +51,7 @@ class ContrastResults(object):
             self.sd = sd
             self.dist = getattr(stats, self.distribution)
             self.dist_args = kwds.get('dist_args', ())
-            if self.distribution is 'chi2':
+            if self.distribution == 'chi2':
                 self.pvalue = self.dist.sf(self.statistic, df_denom)
                 self.df_denom = df_denom
             else:
@@ -375,11 +375,11 @@ class WaldTestResults(object):
                 self.df_denom = table['df_denom'].values
 
         else:
-            if self.distribution is 'chi2':
+            if self.distribution == 'chi2':
                 self.dist = stats.chi2
                 self.df_constraints = self.dist_args[0]  # assumes tuple
                 # using dist_args[0] is a bit dangerous,
-            elif self.distribution is 'F':
+            elif self.distribution == 'F':
                 self.dist = stats.f
                 self.df_constraints, self.df_denom = self.dist_args
 

--- a/statsmodels/tsa/vector_ar/svar_model.py
+++ b/statsmodels/tsa/vector_ar/svar_model.py
@@ -407,13 +407,13 @@ class SVAR(tsbase.TimeSeriesModel):
 
         j = 0
         j_d = 0
-        if len(A_solve[A_mask]) is not 0:
+        if len(A_solve[A_mask]) != 0:
             A_vec = np.ravel(A_mask, order='F')
             for k in range(neqs**2):
                 if A_vec[k] == True:
                     S_B[k,j] = -1
                     j += 1
-        if len(B_solve[B_mask]) is not 0:
+        if len(B_solve[B_mask]) != 0:
             B_vec = np.ravel(B_mask, order='F')
             for k in range(neqs**2):
                 if B_vec[k] == True:


### PR DESCRIPTION
Adds a couple of lint checks that are passing but not currently specified.

Collects lint checks to be less verbose.

AFAICT the vast majority of remaining invalid escapes are caused by windows paths in docstring'd-out code (usually tracebacks) that needs to be either made into documentation or removed.