### PR TITLE
MAINT: Improve user-facing error message

### DIFF
--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -993,7 +993,15 @@ class Results(object):
                     exog = pd.DataFrame(exog).T
             orig_exog_len = len(exog)
             is_dict = isinstance(exog, dict)
-            exog = dmatrix(design_info, exog, return_type="dataframe")
+            try:
+                exog = dmatrix(design_info, exog, return_type="dataframe")
+            except Exception as exc:
+                msg = ('predict requires that you use a DataFrame when '
+                       'predicting from a model\nthat was created using the '
+                       'formula api.'
+                       '\n\nThe original error message returned by patsy is:\n'
+                       '{0}'.format(str(str(exc))))
+                raise exc.__class__(msg)
             if orig_exog_len > len(exog) and not is_dict:
                 import warnings
                 if exog_index is None:

--- a/statsmodels/formula/tests/test_formula.py
+++ b/statsmodels/formula/tests/test_formula.py
@@ -1,4 +1,4 @@
-from statsmodels.compat.python import iteritems, StringIO
+from statsmodels.compat.python import iteritems, StringIO, PY3
 import warnings
 
 from statsmodels.formula.api import ols
@@ -10,6 +10,8 @@ from statsmodels.datasets import cpunish
 import numpy.testing as npt
 from statsmodels.tools.testing import assert_equal
 import numpy as np
+import pandas as pd
+import patsy
 import pytest
 
 
@@ -210,3 +212,14 @@ def test_patsy_missing_data():
         assert 'nan values have been dropped' in repr(w[-1].message)
     # Frist record will be dropped in both cases
     assert_equal(res.fittedvalues, res2)
+
+
+def test_predict_nondataframe():
+    df = pd.DataFrame([[3, 0.030], [10, 0.060], [20, 0.120]],
+                      columns=['BSA', 'Absorbance'])
+
+    model = ols('Absorbance ~ BSA', data=df)
+    fit = model.fit()
+    error = patsy.PatsyError if PY3 else TypeError
+    with pytest.raises(error):
+        fit.predict([0.25])


### PR DESCRIPTION
Improve error message shown for incorrect use of predict after formula

closes #3987

- [x] closes #3987
- [x] tests added / passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html#writing-the-commit-message). 
