### PR TITLE
BLD: Remove redundant travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -84,10 +84,6 @@ matrix:
         - PANDAS=0.22
         - MATPLOTLIB=2.0
         - LINT=true
-    # Standard pip install
-    - python: 3.6
-      env:
-        - BUILD_INIT=tools/ci/travis_pip.sh
     # Latest pre-release packages
     - python: 3.7
       env:


### PR DESCRIPTION
Remove one redundant travis build

- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html#writing-the-commit-message). 
