### PR TITLE
ENH: Improve error when ARMA endog is not 1d

### DIFF
--- a/statsmodels/tsa/arima_model.py
+++ b/statsmodels/tsa/arima_model.py
@@ -430,6 +430,10 @@ class ARMA(tsbase.TimeSeriesModel):
     def __init__(self, endog, order, exog=None, dates=None, freq=None,
                  missing='none'):
         super(ARMA, self).__init__(endog, exog, dates, freq, missing=missing)
+        # GH 2575
+        _endog = endog if hasattr(endog, 'ndim') else np.asarray(endog)
+        if (_endog.ndim == 2 and _endog.shape[1] != 1) or _endog.ndim > 2:
+            raise ValueError('endog must be 1-d or 2-d with 1 column')
         exog = self.data.exog  # get it after it's gone through processing
         _check_estimable(len(self.endog), sum(order))
         self.k_ar = k_ar = order[0]

--- a/statsmodels/tsa/tests/test_arima.py
+++ b/statsmodels/tsa/tests/test_arima.py
@@ -2432,3 +2432,17 @@ def test_endog_int():
     resf = ARIMA(yf.cumsum(), order=(1, 1, 1)).fit(disp=0)
     assert_allclose(res.params, resf.params, rtol=1e-6, atol=1e-5)
     assert_allclose(res.bse, resf.bse, rtol=1e-6, atol=1e-5)
+
+
+def test_multidim_endog(reset_randomstate):
+    y = np.random.randn(1000, 2)
+    with pytest.raises(ValueError):
+        ARMA(y, order=(1, 1))
+
+    y = np.random.randn(1000, 1, 2)
+    with pytest.raises(ValueError):
+        ARMA(y, order=(1, 1))
+
+    y = np.random.randn(1000, 1, 1)
+    with pytest.raises(ValueError):
+        ARMA(y, order=(1, 1))


### PR DESCRIPTION
Improve explanation when passing an array that is not 1d or 1 column, 2d

closes #2575

- [X] closes #2575
- [X] tests added / passed. 
- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html#writing-the-commit-message). 
