### PR TITLE
TST: Relax tolerance on OSX for OpenBlas issues

### DIFF
--- a/statsmodels/regression/tests/test_lme.py
+++ b/statsmodels/regression/tests/test_lme.py
@@ -1206,7 +1206,9 @@ def check_smw_logdet(p, q, r, s):
 
     _, bd = np.linalg.slogdet(B)
     d1 = _smw_logdet(s, A, AtA, Qi, di, bd)
-    assert_allclose(d1, d2)
+    # GH 5642, OSX OpenBlas tolerance increase
+    rtol = 1e-6 if PLATFORM_OSX else 1e-7
+    assert_allclose(d1, d2, rtol=rtol)
 
 
 class TestSMWLogdet(object):

--- a/statsmodels/tsa/tests/test_holtwinters.py
+++ b/statsmodels/tsa/tests/test_holtwinters.py
@@ -2,6 +2,8 @@
 Author: Terence L van Zyl
 Modified: Kevin Sheppard
 """
+from statsmodels.compat.platform import PLATFORM_OSX
+
 import os
 import warnings
 
@@ -331,7 +333,9 @@ def test_basin_hopping(reset_randomstate):
     mod = ExponentialSmoothing(housing_data, trend='add')
     res = mod.fit()
     res2 = mod.fit(use_basinhopping=True)
-    assert res2.sse <= res.sse
+    # GH 5642
+    tol = 1e-6 if PLATFORM_OSX else 0.0
+    assert res2.sse <= res.sse + tol
 
 
 def test_debiased():


### PR DESCRIPTION
OpenBlas produces larger errors than MKL on OSX

- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html#writing-the-commit-message). 
