### PR TITLE
TST: Allow network failure in web tests

### DIFF
--- a/lint.sh
+++ b/lint.sh
@@ -20,6 +20,7 @@ if [ "$LINT" == true ]; then
         statsmodels/resampling/ \
         statsmodels/interface/ \
         statsmodels/compat/ \
+        statsmodels/datasets/tests/
         statsmodels/duration/__init__.py \
         statsmodels/formula/ \
         statsmodels/gam/ \


### PR DESCRIPTION
Allow passing when network fails on tests that read files on the internet

- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html#writing-the-commit-message). 
