### PR TITLE
TST: Adjust test_irf atol

### DIFF
--- a/statsmodels/tsa/vector_ar/tests/test_svar.py
+++ b/statsmodels/tsa/vector_ar/tests/test_svar.py
@@ -68,4 +68,5 @@ class TestSVAR(object):
         irf = res1.irf()
         errband2 = irf.errband_mc(orth=False, svar=True, repl=50,
                                   signif=0.05, seed=987123, burn=100)
-        assert_allclose(errband1, errband2, rtol=1e-8, atol=1e-20)
+        # Windows precision limits require non-zero atol
+        assert_allclose(errband1, errband2, rtol=1e-8, atol=1e-8)


### PR DESCRIPTION
Adjust atol to allow Windows to pass

- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html#writing-the-commit-message). 
