### PR TITLE
BUG: Replace midrule with hline

### DIFF
--- a/statsmodels/base/tests/test_penalized.py
+++ b/statsmodels/base/tests/test_penalized.py
@@ -94,7 +94,10 @@ class CheckPenalizedPoisson(object):
 
     @pytest.mark.smoke
     def test_summary2(self):
-        self.res1.summary2()
+        summ = self.res1.summary2()
+        assert isinstance(summ.as_latex(), str)
+        assert isinstance(summ.as_html(), str)
+        assert isinstance(summ.as_text(), str)
 
     def test_numdiff(self):
         res1 = self.res1

--- a/statsmodels/iolib/summary2.py
+++ b/statsmodels/iolib/summary2.py
@@ -221,7 +221,7 @@ class Summary(object):
 
         if self._merge_latex:
             # create single tabular object for summary_col
-            tab = re.sub(to_replace,r'\\midrule\n\\midrule\n', tab)
+            tab = re.sub(to_replace,r'\\midrule\n', tab)
 
         out = '\\begin{table}', title, tab, '\\end{table}'
         out = '\n'.join(out)

--- a/statsmodels/iolib/tests/test_summary2.py
+++ b/statsmodels/iolib/tests/test_summary2.py
@@ -21,7 +21,6 @@ class TestSummaryLatex(object):
 \hline
       &   y I    &   y II    \\
 \midrule
-\midrule
 const & 7.7500   & 12.4231   \\
       & (1.1058) & (3.1872)  \\
 x1    & -0.7500  & -1.5769   \\


### PR DESCRIPTION
midrule is placed twice in a row which is incorrect

closes #5454

- [X] closes #5454
- [X] tests added / passed. 
- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html#writing-the-commit-message). 
