### PR TITLE
TST: Allow corr test to fail on Win32

### DIFF
--- a/statsmodels/stats/tests/test_corrpsd.py
+++ b/statsmodels/stats/tests/test_corrpsd.py
@@ -5,6 +5,7 @@ Created on Mon May 27 12:07:02 2013
 
 Author: Josef Perktold
 """
+from statsmodels.compat.platform import PLATFORM_WIN32
 
 import pytest
 import numpy as np
@@ -327,15 +328,20 @@ class Test_Factor(object):
         mat *= (np.abs(mat) >= 0.35)
         smat = sparse.csr_matrix(mat)
 
-        rslt = corr_nearest_factor(mat, dm, maxiter=10000)
-        assert rslt.Converged is True
-        mat_dense = rslt.corr.to_matrix()
+        try:
+            rslt = corr_nearest_factor(mat, dm, maxiter=10000)
+            assert rslt.Converged is True
+            mat_dense = rslt.corr.to_matrix()
 
-        rslt = corr_nearest_factor(smat, dm, maxiter=10000)
-        assert rslt.Converged is True
-        mat_sparse = rslt.corr.to_matrix()
+            rslt = corr_nearest_factor(smat, dm, maxiter=10000)
+            assert rslt.Converged is True
+            mat_sparse = rslt.corr.to_matrix()
 
-        assert_allclose(mat_dense, mat_sparse, rtol=.25, atol=1e-3)
+            assert_allclose(mat_dense, mat_sparse, rtol=.25, atol=1e-3)
+        except AssertionError as err:
+            if PLATFORM_WIN32:
+                pytest.xfail('Known to randomly fail on Win32')
+            raise err
 
     # Test on a quadratic function.
     def test_spg_optim(self, reset_randomstate):


### PR DESCRIPTION
Corr test fails to converge on Win32 occasionally

closes #4093

- [X] closes #4093
- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html#writing-the-commit-message). 
