### PR TITLE
MAINT: Fix make.bat [skip ci]

### DIFF
--- a/docs/make.bat
+++ b/docs/make.bat
@@ -47,8 +47,8 @@ echo %SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS%
 if errorlevel 1 exit /b 1
 
 if "%1" == "html" (
-    echo xcopy /s /y source\examples\notebooks\generated\*.html %BUILDDIR%\html\examples\notebooks\generated
-    xcopy /s /y source\examples\notebooks\generated\*.html %BUILDDIR%\html\examples\notebooks\generated
+    echo xcopy /s /y source\examples\notebooks\generated\*.html %BUILDDIR%\html\examples\notebooks\generated\*.html
+    xcopy /s /y source\examples\notebooks\generated\*.html %BUILDDIR%\html\examples\notebooks\generated\*.html
 	echo python %TOOLSPATH%/%FOLDTOC% %BUILDDIR%/html/index.html
 	python %TOOLSPATH%/%FOLDTOC% %BUILDDIR%/html/index.html
 	echo python %TOOLSPATH%/%FOLDTOC% %BUILDDIR%/html/examples/index.html ../_static


### PR DESCRIPTION
Fix xopy on make.bat to run without prompt

- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html#writing-the-commit-message). 
