### PR TITLE
TST: Adjust tol and reset random state

### DIFF
--- a/statsmodels/tsa/tests/test_ar.py
+++ b/statsmodels/tsa/tests/test_ar.py
@@ -287,7 +287,7 @@ def test_ar_dates():
     assert_equal(pred.index, predict_dates)
 
 
-def test_ar_named_series():
+def test_ar_named_series(reset_randomstate):
     dates = period_range(start="2011-1", periods=72, freq='M')
     y = Series(np.random.randn(72), name="foobar", index=dates)
     results = sm.tsa.AR(y).fit(2)

--- a/statsmodels/tsa/tests/test_seasonal.py
+++ b/statsmodels/tsa/tests/test_seasonal.py
@@ -135,13 +135,15 @@ class TestDecompose:
         assert_almost_equal(res_mult.seasonal.values.squeeze(), seasonal, 4)
         assert_almost_equal(res_mult.trend.values.squeeze(), trend, 2)
         assert_almost_equal(res_mult.resid.values.squeeze(), random, 4)
-        assert_almost_equal(res_mult_override.seasonal.values.squeeze(), seasonal, 4)
+        assert_almost_equal(res_mult_override.seasonal.values.squeeze(),
+                            seasonal, 4)
         assert_almost_equal(res_mult_override.trend.values.squeeze(), trend, 2)
-        assert_almost_equal(res_mult_override.resid.values.squeeze(), random, 4)
+        assert_almost_equal(res_mult_override.resid.values.squeeze(), random,
+                            4)
         assert_equal(res_mult.seasonal.index.values.squeeze(),
-                            self.data.index.values)
+                     self.data.index.values)
 
-    def test_pandas_nofreq(self):
+    def test_pandas_nofreq(self, reset_randomstate):
         # issue #3503
         nobs = 100
         dta = pd.Series([x % 3 for x in range(nobs)] + np.random.randn(nobs))

--- a/statsmodels/tsa/tests/test_tsa_tools.py
+++ b/statsmodels/tsa/tests/test_tsa_tools.py
@@ -64,28 +64,29 @@ def test_ywcoef():
                                                          method='mle')[0], 8)
 
 
+@pytest.mark.smoke
 def test_yule_walker_inter():
     # see 1869
     x = np.array([1, -1, 2, 2, 0, -2, 1, 0, -3, 0, 0])
     # it works
-    result = sm.regression.yule_walker(x, 3)
+    sm.regression.yule_walker(x, 3)
 
 
-def test_duplication_matrix():
+def test_duplication_matrix(reset_randomstate):
     for k in range(2, 10):
         m = tools.unvech(np.random.randn(k * (k + 1) // 2))
         Dk = tools.duplication_matrix(k)
         assert (np.array_equal(vec(m), np.dot(Dk, vech(m))))
 
 
-def test_elimination_matrix():
+def test_elimination_matrix(reset_randomstate):
     for k in range(2, 10):
         m = np.random.randn(k, k)
         Lk = tools.elimination_matrix(k)
         assert (np.array_equal(vech(m), np.dot(Lk, vec(m))))
 
 
-def test_commutation_matrix():
+def test_commutation_matrix(reset_randomstate):
     m = np.random.randn(4, 3)
     K = tools.commutation_matrix(4, 3)
     assert (np.array_equal(vec(m.T), np.dot(K, vec(m))))
@@ -117,9 +118,8 @@ class TestLagmat(object):
         cols = list(cls.macro_df.columns)
         cls.realgdp_loc = cols.index('realgdp')
         cls.cpi_loc = cols.index('cpi')
+        np.random.seed(12345)
         cls.random_data = np.random.randn(100)
-        year = cls.macro_df['year'].values
-        quarter = cls.macro_df['quarter'].values
 
         index = [str(int(yr)) + '-Q' + str(int(qu))
                  for yr, qu in zip(cls.macro_df.year, cls.macro_df.quarter)]
@@ -563,6 +563,7 @@ class TestLagmat2DS(object):
     def setup_class(cls):
         data = sm.datasets.macrodata.load_pandas()
         cls.macro_df = data.data[['year', 'quarter', 'realgdp', 'cpi']]
+        np.random.seed(12345)
         cls.random_data = np.random.randn(100)
         index = [str(int(yr)) + '-Q' + str(int(qu))
                  for yr, qu in zip(cls.macro_df.year, cls.macro_df.quarter)]


### PR DESCRIPTION
Adjust tolerance on test that randomly fails on Windows
Reset randomstate to ensure that the test is identical in repeated runs

- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html#writing-the-commit-message). 
