### PR TITLE
ENH: Add cov type to summary for discrete models

### DIFF
--- a/statsmodels/discrete/discrete_model.py
+++ b/statsmodels/discrete/discrete_model.py
@@ -3604,7 +3604,7 @@ class DiscreteResults(base.LikelihoodModelResults):
                      ('Method:', ['MLE']),
                      ('Date:', None),
                      ('Time:', None),
-                     ('converged:', ["%s" % self.mle_retvals['converged']])
+                     ('converged:', ["%s" % self.mle_retvals['converged']]),
                     ]
 
         top_right = [('No. Observations:', None),
@@ -3615,6 +3615,9 @@ class DiscreteResults(base.LikelihoodModelResults):
                      ('LL-Null:', ["%#8.5g" % self.llnull]),
                      ('LLR p-value:', ["%#6.4g" % self.llr_pvalue])
                      ]
+
+        if hasattr(self, 'cov_type'):
+            top_left.append(('Covariance Type:', [self.cov_type]))
 
         if title is None:
             title = self.model.__class__.__name__ + ' ' + "Regression Results"

--- a/statsmodels/discrete/tests/test_count_model.py
+++ b/statsmodels/discrete/tests/test_count_model.py
@@ -64,7 +64,9 @@ class CheckGeneric(CheckModelMixin):
 
     @pytest.mark.smoke
     def test_summary(self):
-        self.res1.summary()
+        summ = self.res1.summary()
+        # GH 4581
+        assert 'Covariance Type:' in str(summ)
 
 
 class TestZeroInflatedModel_logit(CheckGeneric):

--- a/statsmodels/genmod/generalized_linear_model.py
+++ b/statsmodels/genmod/generalized_linear_model.py
@@ -1869,7 +1869,7 @@ class GLMResults(base.LikelihoodModelResults):
                      ]
 
         if hasattr(self, 'cov_type'):
-            top_right.append(('Covariance Type:', [self.cov_type]))
+            top_left.append(('Covariance Type:', [self.cov_type]))
 
         if title is None:
             title = "Generalized Linear Model Regression Results"


### PR DESCRIPTION
Show cov type for discrete models

closes #4581

- [X] closes #4581
- [X] tests added / passed. 
- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html#writing-the-commit-message). 
