### PR TITLE
DOC: Clarify that predict expects arrays in dicts [skip ci]

### DIFF
--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -962,7 +962,7 @@ class Results(object):
         If a formula was used, then exog is processed in the same way as
         the original data. This transformation needs to have key access to the
         same variable names, and can be a pandas DataFrame or a dict like
-        object.
+        object that contains numpy arrays.
 
         If no formula was used, then the provided exog needs to have the
         same number of columns as the original exog in the model. No


### PR DESCRIPTION
Clarify docs so that predict gets dicts that return arrays, not lists.

closes #5557

- [X] closes #5557
- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html#writing-the-commit-message). 

