### PR TITLE
ENH: Allow const idx to be found

### DIFF
--- a/statsmodels/base/data.py
+++ b/statsmodels/base/data.py
@@ -114,16 +114,9 @@ class ModelData(object):
         self.__dict__.update(d)
 
     def _handle_constant(self, hasconst):
-        if hasconst is not None:
-            if hasconst:
-                self.k_constant = 1
-                self.const_idx = None
-            else:
-                self.k_constant = 0
-                self.const_idx = None
-        elif self.exog is None:
-            self.const_idx = None
+        if hasconst is False or self.exog is None:
             self.k_constant = 0
+            self.const_idx = None
         else:
             # detect where the constant is
             check_implicit = False

--- a/statsmodels/base/tests/test_data.py
+++ b/statsmodels/base/tests/test_data.py
@@ -564,6 +564,7 @@ class TestMissingArray(object):
         data = sm_data.handle_data(self.y, self.X, 'none', hasconst=False)
         np.testing.assert_array_equal(data.endog, self.y)
         np.testing.assert_array_equal(data.exog, self.X)
+        assert data.k_constant == 0
 
     def test_endog_only_raise(self):
         np.testing.assert_raises(Exception, sm_data.handle_data,
@@ -635,6 +636,7 @@ class TestMissingPandas(object):
         data = sm_data.handle_data(self.y, self.X, 'none', hasconst=False)
         np.testing.assert_array_equal(data.endog, self.y.values)
         np.testing.assert_array_equal(data.exog, self.X.values)
+        assert data.k_constant == 0
 
     def test_endog_only_raise(self):
         np.testing.assert_raises(Exception, sm_data.handle_data,

--- a/statsmodels/iolib/tests/test_summary2.py
+++ b/statsmodels/iolib/tests/test_summary2.py
@@ -121,20 +121,20 @@ in parentheses.
         assert(result is True)
 
 
-class TestSummaryLabels(object):
+def test_ols_summary_rsquared_label():
+    # Check that the "uncentered" label is correctly added after rsquared
+    x = [1, 5, 7, 3, 5, 2, 5, 3]
+    y = [6, 4, 2, 7, 4, 9, 10, 2]
+    reg_with_constant = OLS(y, add_constant(x)).fit()
+    r2_str = 'R-squared:'
+    with pytest.warns(UserWarning):
+        assert r2_str in str(reg_with_constant.summary2())
+    with pytest.warns(UserWarning):
+        assert r2_str in str(reg_with_constant.summary())
 
-    def test_OLSsummary_rsquared_label(self):
-        # Check that the "uncentered" label is correctly added after rsquared
-        x = [1, 5, 7, 3, 5, 2, 5, 3]
-        y = [6, 4, 2, 7, 4, 9, 10, 2]
-        reg_with_constant = OLS(y, x, hasconst=True).fit()
-        with pytest.warns(UserWarning):
-            assert 'R-squared:' in str(reg_with_constant.summary2())
-        with pytest.warns(UserWarning):
-            assert 'R-squared:' in str(reg_with_constant.summary())
-
-        reg_without_constant = OLS(y, x, hasconst=False).fit()
-        with pytest.warns(UserWarning):
-            assert 'R-squared (uncentered):' in str(reg_without_constant.summary2())
-        with pytest.warns(UserWarning):
-            assert 'R-squared (uncentered):' in str(reg_without_constant.summary())
+    reg_without_constant = OLS(y, x, hasconst=False).fit()
+    r2_str = 'R-squared (uncentered):'
+    with pytest.warns(UserWarning):
+        assert r2_str in str(reg_without_constant.summary2())
+    with pytest.warns(UserWarning):
+        assert r2_str in str(reg_without_constant.summary())

--- a/statsmodels/regression/tests/test_regression.py
+++ b/statsmodels/regression/tests/test_regression.py
@@ -933,9 +933,21 @@ def test_const_indicator():
     X = np.random.randint(0, 3, size=30)
     X = categorical(X, drop=True)
     y = np.dot(X, [1., 2., 3.]) + np.random.normal(size=30)
-    modc = OLS(y, add_constant(X[:, 1:], prepend=True)).fit()
-    mod = OLS(y, X, hasconst=True).fit()
-    assert_almost_equal(modc.rsquared, mod.rsquared, 12)
+    resc = OLS(y, add_constant(X[:, 1:], prepend=True)).fit()
+    res = OLS(y, X, hasconst=True).fit()
+    assert_almost_equal(resc.rsquared, res.rsquared, 12)
+    assert res.model.data.k_constant == 1
+    assert resc.model.data.k_constant == 1
+
+
+def test_fvalue_const_only():
+    np.random.seed(12345)
+    x = np.random.randint(0, 3, size=30)
+    x = categorical(x, drop=True)
+    x[:, 0] = 1
+    y = np.dot(x, [1., 2., 3.]) + np.random.normal(size=30)
+    res = OLS(y, x, hasconst=True).fit(cov_type='HC1')
+    assert not np.isnan(res.fvalue)
 
 
 def test_conf_int_single_regressor():


### PR DESCRIPTION
Check const_idx when has_const is set to True

- [x] tests added / passed. 
- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html#writing-the-commit-message). 
