### PR TITLE
BUG: Always set mle_retvals

### DIFF
--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -498,8 +498,8 @@ class LikelihoodModel(Model):
         mlefit = LikelihoodModelResults(self, xopt, Hinv, scale=1., **kwds)
 
         # TODO: hardcode scale?
+        mlefit.mle_retvals = retvals
         if isinstance(retvals, dict):
-            mlefit.mle_retvals = retvals
             if warn_convergence and not retvals['converged']:
                 from warnings import warn
                 from statsmodels.tools.sm_exceptions import ConvergenceWarning

--- a/statsmodels/tsa/tests/test_arima.py
+++ b/statsmodels/tsa/tests/test_arima.py
@@ -2450,3 +2450,11 @@ def test_multidim_endog(reset_randomstate):
     y = np.random.randn(1000, 1, 1)
     with pytest.raises(ValueError):
         ARMA(y, order=(1, 1))
+
+
+def test_arima_no_full_output():
+    # GH 2752
+    endog = y_arma[:, 6]
+    mod = ARIMA(endog, (1, 0, 1))
+    res = mod.fit(trend="c", disp=-1, full_output=False)
+    assert res.mle_retvals is None


### PR DESCRIPTION
Ensure this is always set, even if it could be none

closes #2752

- [X] closes #2752
- [X] tests added / passed. 
- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html#writing-the-commit-message). 
