### PR TITLE
BUG: Escape strings for latex output

### DIFF
--- a/statsmodels/iolib/table.py
+++ b/statsmodels/iolib/table.py
@@ -691,6 +691,16 @@ class Cell(object):
             raise ValueError('Unknown cell datatype: %s' % datatype)
         return align
 
+    @staticmethod
+    def _latex_escape(data, fmt, output_format):
+        if output_format != 'latex':
+            return data
+        if "replacements" in fmt:
+            if isinstance(data, str):
+                for repl in sorted(fmt["replacements"]):
+                    data = data.replace(repl, fmt["replacements"][repl])
+        return data
+
     def format(self, width, output_format='txt', **fmt_dict):
         """Return string.
         This is the default formatter for cells.
@@ -715,11 +725,10 @@ class Cell(object):
         if isinstance(datatype, (int, long)):
             datatype = datatype % len(data_fmts)  # constrain to indexes
             content = data_fmts[datatype] % (data,)
+            if datatype == 0:
+                content = self._latex_escape(content, fmt, output_format)
         elif datatype in fmt:
-            if "replacements" in fmt:
-                if isinstance(data, str):
-                    for repl in sorted(fmt["replacements"]):
-                        data = data.replace(repl, fmt["replacements"][repl])
+            data = self._latex_escape(data, fmt, output_format)
 
             dfmt = fmt.get(datatype)
             try:

--- a/statsmodels/iolib/tests/test_summary.py
+++ b/statsmodels/iolib/tests/test_summary.py
@@ -3,6 +3,24 @@
 
 '''
 from __future__ import print_function
+
+import numpy as np  # noqa: F401
+
+from statsmodels.datasets import macrodata
+from statsmodels.regression.linear_model import OLS
+
+
+def test_escaped_variable_name():
+    # Rename 'cpi' column to 'CPI_'
+    data = macrodata.load(True).data
+    data.rename(columns={'cpi': 'CPI_'}, inplace=True)
+
+    mod = OLS.from_formula('CPI_ ~ 1 + np.log(realgdp)', data=data)
+    res = mod.fit()
+    assert 'CPI\\_' in res.summary().as_latex()
+    assert 'CPI_' in res.summary().as_text()
+
+
 if __name__ == '__main__':
 
     from statsmodels.regression.tests.test_regression import TestOLS


### PR DESCRIPTION
Escale string when output is LaTeX

closes #5297

- [X] closes #5297
- [X] tests added / passed. 
- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html#writing-the-commit-message). 
