### PR TITLE
CLN: Fix invalid escapes where possible

### DIFF
--- a/statsmodels/examples/ex_generic_mle.py
+++ b/statsmodels/examples/ex_generic_mle.py
@@ -166,9 +166,6 @@ print("bse diff in percent")
 print((res_norm3.bse[:-1] / res2.bse)*100. - 100)
 
 '''
-C:\Programs\Python25\lib\site-packages\matplotlib-0.99.1-py2.5-win32.egg\matplotlib\rcsetup.py:117: UserWarning: rcParams key "numerix" is obsolete and has no effect;
- please delete it from your matplotlibrc file
-  warnings.warn('rcParams key "numerix" is obsolete and has no effect;\n'
 Optimization terminated successfully.
          Current function value: 12.818804
          Iterations 6

--- a/statsmodels/examples/ex_generic_mle_t.py
+++ b/statsmodels/examples/ex_generic_mle_t.py
@@ -129,9 +129,6 @@ NameError: name 'beta' is not defined
 '''
 
 '''
-C:\Programs\Python25\lib\site-packages\matplotlib-0.99.1-py2.5-win32.egg\matplotlib\rcsetup.py:117: UserWarning: rcParams key "numerix" is obsolete and has no effect;
- please delete it from your matplotlibrc file
-  warnings.warn('rcParams key "numerix" is obsolete and has no effect;\n'
 repr(start_params) array([ 1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.])
 Optimization terminated successfully.
          Current function value: 91.897859

--- a/statsmodels/examples/ex_generic_mle_tdist.py
+++ b/statsmodels/examples/ex_generic_mle_tdist.py
@@ -335,9 +335,6 @@ print(res5.summary())
 print(res5.t_test([[1,0]]))
 
 '''
-C:\Programs\Python25\lib\site-packages\matplotlib-0.99.1-py2.5-win32.egg\matplotlib\rcsetup.py:117: UserWarning: rcParams key "numerix" is obsolete and has no effect;
- please delete it from your matplotlibrc file
-  warnings.warn('rcParams key "numerix" is obsolete and has no effect;\n'
 0.0686702747648
 0.0164150896481
 0.128121386381
@@ -438,9 +435,6 @@ NameError: name 'mod_para' is not defined
 
 
 #'''
-#C:\Programs\Python25\lib\site-packages\matplotlib-0.99.1-py2.5-win32.egg\matplotlib\rcsetup.py:117: UserWarning: rcParams key "numerix" is obsolete and has no effect;
-# please delete it from your matplotlibrc file
-#  warnings.warn('rcParams key "numerix" is obsolete and has no effect;\n'
 #0.0686702747648
 #0.0164150896481
 #0.128121386381
@@ -1047,10 +1041,6 @@ Traceback (most recent call last):
   File "C:\Josef\eclipsegworkspace\statsmodels-josef-experimental-gsoc\scikits\statsmodels\examples\ex_generic_mle_tdist.py", line 184, in nloglikeobs
     scale = params[2]
 IndexError: index out of bounds
->>> hasattr(self, 'start_params')
-Traceback (most recent call last):
-  File "<stdin>", line 1, in <module>
-NameError: name 'self' is not defined
 
 >>> hasattr(mod_par, 'start_params')
 True
@@ -1064,12 +1054,6 @@ array([ 1.,  2.])
 (array(1.#INF), array(1.#INF), array(1.#QNAN), array(1.#QNAN))
 >>> stats.pareto.stats(1., moments='mvsk')
 (array(1.#INF), array(1.#INF), array(1.#QNAN), array(1.#QNAN))
->>> stats.pareto.stats(0.5., moments='mvsk')
-  File "<stdin>", line 1
-    stats.pareto.stats(0.5., moments='mvsk')
-                           ^
-SyntaxError: invalid syntax
-
 >>> stats.pareto.stats(0.5, moments='mvsk')
 (array(1.#INF), array(1.#INF), array(1.#QNAN), array(1.#QNAN))
 >>> stats.pareto.stats(2, moments='mvsk')
@@ -1080,10 +1064,6 @@ SyntaxError: invalid syntax
 array([ 1.07716265,  1.18977526,  1.07093   ,  1.05157081,  1.15991232,
         1.31015589,  1.06675107,  1.08082475,  1.19501243,  1.34967158])
 >>> r = stats.pareto.rvs(10, size=1000)
->>> plt
-Traceback (most recent call last):
-  File "<stdin>", line 1, in <module>
-NameError: name 'plt' is not defined
 
 >>> import matplotlib.pyplot as plt
 >>> plt.hist(r)

--- a/statsmodels/examples/try_gee.py
+++ b/statsmodels/examples/try_gee.py
@@ -44,17 +44,6 @@ tt2 = mdf2.t_test(np.eye(len(mdf2.params)))
 # need master to get wald_test
 #print mdf2.wald_test(np.eye(len(mdf2.params))[1:])
 
-'''
->>> mdf2.predict(da.exog.mean(0))
-Traceback (most recent call last):
-  File "<pyshell#11>", line 1, in <module>
-    mdf2.predict(da.exog.mean(0))
-  File "e:\josef\eclipsegworkspace\statsmodels-git\statsmodels-all-new2_py27\statsmodels\statsmodels\base\model.py", line 963, in predict
-    return self.model.predict(self.params, exog, *args, **kwargs)
-  File "e:\josef\eclipsegworkspace\statsmodels-git\statsmodels-all-new2_py27\statsmodels\statsmodels\genmod\generalized_estimating_equations.py", line 621, in predict
-    fitted = offset + np.dot(exog, params)
-TypeError: unsupported operand type(s) for +: 'NoneType' and 'numpy.float64'
-'''
 mdf2.predict(da.exog.mean(0), offset=0)
 # -0.10867809062890971
 

--- a/statsmodels/sandbox/distributions/genpareto.py
+++ b/statsmodels/sandbox/distributions/genpareto.py
@@ -160,9 +160,6 @@ print(rvs.mean(), rvs[rvs>-0.5].mean(), rvs[rvs>0].mean(), rvs[rvs>0.5].mean())
 
 
 '''
-C:\Programs\Python25\lib\site-packages\matplotlib-0.99.1-py2.5-win32.egg\matplotlib\rcsetup.py:117: UserWarning: rcParams key "numerix" is obsolete and has no effect;
- please delete it from your matplotlibrc file
-  warnings.warn('rcParams key "numerix" is obsolete and has no effect;\n'
 [ 1.   0.5  0.   0.   0. ]
 [ 1.   0.5  0.   0.   0. ]
 [ 0.    0.75  1.    1.    1.  ]

--- a/statsmodels/sandbox/regression/onewaygls.py
+++ b/statsmodels/sandbox/regression/onewaygls.py
@@ -355,16 +355,18 @@ standard dev', np.sqrt(res.sigmabygroup)
 
         return templ % resvals
 
-
-
     # a variation of this has been added to RegressionResults as compare_lr
     def lr_test(self):
-        '''generic likelihood ration test between nested models
+        r'''
+        generic likelihood ratio test between nested models
 
-            \begin{align} D & = -2(\ln(\text{likelihood for null model}) - \ln(\text{likelihood for alternative model})) \\ & = -2\ln\left( \frac{\text{likelihood for null model}}{\text{likelihood for alternative model}} \right). \end{align}
+            \begin{align}
+            D & = -2(\ln(\text{likelihood for null model}) - \ln(\text{likelihood for alternative model})) \\
+            & = -2\ln\left( \frac{\text{likelihood for null model}}{\text{likelihood for alternative model}} \right).
+            \end{align}
 
-            is distributed as chisquare with df equal to difference in number of parameters or equivalently
-            difference in residual degrees of freedom  (sign?)
+        is distributed as chisquare with df equal to difference in number of parameters or equivalently
+        difference in residual degrees of freedom  (sign?)
 
         TODO: put into separate function
         '''

--- a/statsmodels/sandbox/tsa/diffusion.py
+++ b/statsmodels/sandbox/tsa/diffusion.py
@@ -232,7 +232,7 @@ class GeometricBrownian(AffineDiffusion):
     dx_t &= \\mu x_t dt + \\sigma x_t dW_t
 
     $x_t $ stochastic process of Geometric Brownian motion,
-    $\mu $ is the drift,
+    $\\mu $ is the drift,
     $\\sigma $ is the Volatility,
     $W$ is the Wiener process (Brownian motion).
 

--- a/statsmodels/sandbox/tsa/diffusion2.py
+++ b/statsmodels/sandbox/tsa/diffusion2.py
@@ -71,9 +71,9 @@ TODO:
 
 
 random bug (showed up only once, need fuzz-testing to replicate)
-  File "...\diffusion2.py", line 375, in <module>
+  File "../diffusion2.py", line 375, in <module>
     x = jd.simulate(mu,sigma,lambd,a,D,ts,nrepl)
-  File "...\diffusion2.py", line 129, in simulate
+  File "../diffusion2.py", line 129, in simulate
     jumps_ts[n] = CumS[Events]
 IndexError: index out of bounds
 


### PR DESCRIPTION
One case is TeX that can be fixed with another backslash.  One case is fixed by updating the reference to the no-longer-existent pd.examples.finance.

Several cases are fixed by removing warning output from the py25 era.

The cases in try_gee are removed because the docstring'd-out code no longer raises.

The remaining cases _not_ addressed by this PR are in sandbox formula examples (#5692) or in other example files that no longer behave the way they did at the time of the docstring'd-out code (#5690), need input from @josef-pkt.

cc @bashtage 