### PR TITLE
MAINT: Update import of URLError

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -45,6 +45,7 @@ exclude_lines =
     raise AssertionError
     raise NotImplementedError
     except NotImplementedError
+    except (HTTPError, URLError)
     # Ignore pass
     pass
 

--- a/statsmodels/compat/python.py
+++ b/statsmodels/compat/python.py
@@ -20,7 +20,7 @@ if PY3:
     pickle = cPickle
     import urllib.request
     import urllib.parse
-    from urllib.request import HTTPError, URLError
+    from urllib.error import HTTPError, URLError
     bytes = bytes
     str = str
     unicode = str

--- a/statsmodels/datasets/tests/test_utils.py
+++ b/statsmodels/datasets/tests/test_utils.py
@@ -57,8 +57,8 @@ def test_webuse():
         pytest.skip('Unable to retrieve file - skipping test')
     try:
         res1 = webuse('macrodata', baseurl=base_gh, as_df=False)
-    except HTTPError:
-        pytest.skip('Failed with HTTP Error, these are random')
+    except (HTTPError, URLError):
+        pytest.skip('Failed with HTTPError or URLError, these are random')
     assert_array_equal(res1, res2)
 
 
@@ -74,7 +74,7 @@ def test_webuse_pandas():
         pytest.skip('Unable to retrieve file - skipping test')
     try:
         res1 = webuse('macrodata', baseurl=base_gh)
-    except HTTPError:
+    except (HTTPError, URLError):
         pytest.skip('Failed with HTTP Error, these are random')
     res1 = res1.astype(float)
     assert_frame_equal(res1, dta.astype(float))


### PR DESCRIPTION
Change location of import to reflect actual error
Broaden acepted errors types for network access

- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html#writing-the-commit-message). 
