### PR TITLE
MAINT: clean up docstring'd-out failure in __main__ block

### DIFF
--- a/lint.sh
+++ b/lint.sh
@@ -38,6 +38,7 @@ if [ "$LINT" == true ]; then
         statsmodels/regression/tests/results/generate_lasso.py \
         statsmodels/regression/tests/results/generate_lme.py \
         statsmodels/robust/tests/ \
+        statsmodels/sandbox/distributions/try_pot.py \
         statsmodels/sandbox/panel/correlation_structures.py \
         statsmodels/stats/__init__.py \
         statsmodels/stats/_knockoff.py \

--- a/statsmodels/sandbox/distributions/try_pot.py
+++ b/statsmodels/sandbox/distributions/try_pot.py
@@ -7,22 +7,27 @@ Created on Wed May 04 06:09:18 2011
 from __future__ import print_function
 import numpy as np
 
+
 def mean_residual_life(x, frac=None, alpha=0.05):
     '''emprirical mean residual life or expected shortfall
 
     Parameters
     ----------
+    x : 1-dimensional array-like
+    frac : list[float], optional
+        All entries must be between 0 and 1
+    alpha : float, default 0.05
+        FIXME: not actually used.
 
-
-    todo: check formula for std of mean
-    doesn't include case for all observations
-    last observations std is zero
-    vectorize loop using cumsum
-    frac doesn't work yet
-
+    TODO:
+        check formula for std of mean
+        doesn't include case for all observations
+        last observations std is zero
+        vectorize loop using cumsum
+        frac doesn't work yet
     '''
 
-    axis = 0  #searchsorted is 1d only
+    axis = 0  # searchsorted is 1d only
     x = np.asarray(x)
     nobs = x.shape[axis]
     xsorted = np.sort(x, axis=axis)
@@ -30,44 +35,33 @@ def mean_residual_life(x, frac=None, alpha=0.05):
         xthreshold = xsorted
     else:
         xthreshold = xsorted[np.floor(nobs * frac).astype(int)]
-    #use searchsorted instead of simple index in case of ties
+    # use searchsorted instead of simple index in case of ties
     xlargerindex = np.searchsorted(xsorted, xthreshold, side='right')
 
-    #replace loop with cumsum ?
+    # TODO:replace loop with cumsum ?
     result = []
     for i in range(len(xthreshold)-1):
         k_ind = xlargerindex[i]
         rmean = x[k_ind:].mean()
-        rstd = x[k_ind:].std()   #this doesn't work for last observations, nans
-        rmstd = rstd/np.sqrt(nobs-k_ind)    #std error of mean, check formula
+        rstd = x[k_ind:].std()  # this doesn't work for last observations, nans
+        rmstd = rstd/np.sqrt(nobs-k_ind)  # std error of mean, check formula
         result.append((k_ind, xthreshold[i], rmean, rmstd))
 
     res = np.array(result)
-    crit = 1.96  # todo: without loading stats, crit = -stats.t.ppf(0.05)
-    confint = res[:,1:2] + crit * res[:,-1:] * np.array([[-1,1]])
+    crit = 1.96  # TODO: without loading stats, crit = -stats.t.ppf(0.05)
+    confint = res[:, 1:2] + crit * res[:, -1:] * np.array([[-1, 1]])
     return np.column_stack((res, confint))
 
-expected_shortfall = mean_residual_life #alias
+
+expected_shortfall = mean_residual_life  # alias
 
 
 if __name__ == "__main__":
-    rvs = np.random.standard_t(5, size= 10)
+    rvs = np.random.standard_t(5, size=10)
     res = mean_residual_life(rvs)
     print(res)
     rmean = [rvs[i:].mean() for i in range(len(rvs))]
-    print(res[:,2] - rmean[1:])
+    print(res[:, 2] - rmean[1:])
 
-'''
->>> mean_residual_life(rvs, frac= 0.5)
-Traceback (most recent call last):
-  File "<stdin>", line 1, in <module>
-  File "E:\Josef\eclipsegworkspace\statsmodels-josef-experimental-030\scikits\statsmodels\sandbox\distributions\try_pot.py", line 35, in mean_residual_life
-    for i in range(len(xthreshold)-1):
-TypeError: object of type 'numpy.float64' has no len()
->>> mean_residual_life(rvs, frac= [0.5])
-array([[ 1.        , -1.16904459,  0.35165016,  0.41090978, -1.97442776,
-        -0.36366142],
-       [ 1.        , -1.16904459,  0.35165016,  0.41090978, -1.97442776,
-        -0.36366142],
-       [ 1.        , -1.1690445
-'''
+    res_frac = mean_residual_life(rvs, frac=[0.5])
+    print(res_frac)


### PR DESCRIPTION
`try_pot`'s `__main__` block has docstring'd-out code with a traceback that I expect was meant to work.  It contains two calls to `mean_residual_life` that pass a `frac` kwarg, one of which raises.

This updates the docstring for `mean_residual_life` to clarify that the non-raising usage is the correct one, making the traceback unnecessary.  Adds the non-raising call to the end of the `__main__` block.

Followed by whitespace fixups.