### PR TITLE
ENH: expose innovations computation method to API.

### DIFF
--- a/statsmodels/tsa/innovations/_arma_innovations.pyx.in
+++ b/statsmodels/tsa/innovations/_arma_innovations.pyx.in
@@ -89,9 +89,9 @@ cdef {{prefix}}toeplitz(int n, int offset0, int offset1,
               out_matrix[offset0 + j, offset1 + i] = in_column[i - j]
 
 
-def {{prefix}}arma_transformed_acovf_fast({{cython_type}} [:] ar,
-                                         {{cython_type}} [:] ma,
-                                         {{cython_type}} [:] arma_acovf):
+cpdef {{prefix}}arma_transformed_acovf_fast({{cython_type}} [:] ar,
+                                            {{cython_type}} [:] ma,
+                                            {{cython_type}} [:] arma_acovf):
     """
     arma_transformed_acovf_fast({{cython_type}} [:] ar, {{cython_type}} [:] ma, {{cython_type}} [:] arma_acovf)
     
@@ -196,11 +196,11 @@ def {{prefix}}arma_transformed_acovf_fast({{cython_type}} [:] ar,
     return acovf[:n, :n], acovf2
 
 
-def {{prefix}}arma_innovations_algo_fast(int nobs,
-                                         {{cython_type}} [:] ar_params,
-                                         {{cython_type}} [:] ma_params,
-                                         {{cython_type}} [:, :] acovf,
-                                         {{cython_type}} [:] acovf2):
+cpdef {{prefix}}arma_innovations_algo_fast(int nobs,
+                                           {{cython_type}} [:] ar_params,
+                                           {{cython_type}} [:] ma_params,
+                                           {{cython_type}} [:, :] acovf,
+                                           {{cython_type}} [:] acovf2):
     """
     arma_innovations_algo_fast(int nobs, {{cython_type}} [:] ar_params, {{cython_type}} [:] ma_params, {{cython_type}} [:, :] acovf, {{cython_type}} [:] acovf2)
     
@@ -301,10 +301,10 @@ def {{prefix}}arma_innovations_algo_fast(int nobs,
     return theta, v
 
 
-def {{prefix}}arma_innovations_filter({{cython_type}} [:] endog,
-                                      {{cython_type}} [:] ar_params,
-                                      {{cython_type}} [:] ma_params,
-                                      {{cython_type}} [:, :] theta):
+cpdef {{prefix}}arma_innovations_filter({{cython_type}} [:] endog,
+                                        {{cython_type}} [:] ar_params,
+                                        {{cython_type}} [:] ma_params,
+                                        {{cython_type}} [:, :] theta):
     """
     arma_innovations_filter({{cython_type}} [:] endog, {{cython_type}} [:] ar_params, {{cython_type}} [:] ma_params, {{cython_type}} [:, :] theta):
     
@@ -373,6 +373,70 @@ def {{prefix}}arma_innovations_filter({{cython_type}} [:] endog,
     return u
 
 
+cpdef {{prefix}}arma_innovations({{cython_type}} [:] endog,
+                                      {{cython_type}} [:] ar_params,
+                                      {{cython_type}} [:] ma_params,
+                                      {{cython_type}} sigma2):
+    """
+    arma_innovations({{cython_type}} [:] endog, {{cython_type}} [:] ar_params, {{cython_type}} [:] ma_params):
+    
+    Compute innovations and variances based on an ARMA process.
+
+    Parameters
+    ----------
+    endog : ndarray
+        The observed time-series process.
+    ar_params : ndarray
+        Autoregressive parameters.
+    ma_params : ndarray
+        Moving average parameters.
+    sigma2 : ndarray
+        The ARMA innovation variance.
+
+    Returns
+    -------
+    u : ndarray
+        The vector of innovations: the one-step-ahead prediction errors from
+        applying the innovations algorithm.
+    v : ndarray
+        The vector of innovation variances.
+
+    Notes
+    -----
+    The innovations algorithm is presented in _[1], section 2.5.2.
+
+    References
+    ----------
+    .. [1] Brockwell, Peter J., and Richard A. Davis. 2009.
+       Time Series: Theory and Methods. 2nd ed. 1991.
+       New York, NY: Springer.
+
+    """
+    cdef Py_ssize_t nobs = len(endog), i
+    cdef {{cython_type}} const
+    cdef {{cython_type}} [:] ar, ma, arma_acovf, llf_obs, acovf2, u, v
+    cdef {{cython_type}} [:, :] acovf
+    cdef cnp.npy_intp dim1[1]
+
+    dim1[0] = len(ar_params) + 1;
+    ar = cnp.PyArray_ZEROS(1, dim1, {{typenum}}, C)
+    dim1[0] = len(ma_params) + 1;
+    ma = cnp.PyArray_ZEROS(1, dim1, {{typenum}}, C)
+
+    ar[0] = 1
+    for i in range(1, len(ar_params) + 1):
+        ar[i] = -1 * ar_params[i - 1]
+    ma[0] = 1
+    ma[1:] = ma_params
+
+    arma_acovf = arima_process.arma_acovf(ar, ma, nobs, sigma2, dtype={{dtype}}) / sigma2
+    acovf, acovf2 = {{prefix}}arma_transformed_acovf_fast(ar, ma, arma_acovf)
+    theta, v = {{prefix}}arma_innovations_algo_fast(nobs, ar_params, ma_params, acovf, acovf2)
+    u = {{prefix}}arma_innovations_filter(endog, ar_params, ma_params, theta)
+
+    return u, v
+
+
 cpdef {{prefix}}arma_loglikeobs_fast({{cython_type}} [:] endog,
                                      {{cython_type}} [:] ar_params,
                                      {{cython_type}} [:] ma_params,
@@ -413,25 +477,10 @@ cpdef {{prefix}}arma_loglikeobs_fast({{cython_type}} [:] endog,
 
     cdef Py_ssize_t nobs = len(endog), i
     cdef {{cython_type}} const
-    cdef {{cython_type}} [:] ar, ma, arma_acovf, llf_obs, acovf2
-    cdef {{cython_type}} [:, :] acovf
+    cdef {{cython_type}} [:] llf_obs, u, v
     cdef cnp.npy_intp dim1[1]
 
-    dim1[0] = len(ar_params) + 1;
-    ar = cnp.PyArray_ZEROS(1, dim1, {{typenum}}, C)
-    dim1[0] = len(ma_params) + 1;
-    ma = cnp.PyArray_ZEROS(1, dim1, {{typenum}}, C)
-
-    ar[0] = 1
-    for i in range(1, len(ar_params) + 1):
-        ar[i] = -1 * ar_params[i - 1]
-    ma[0] = 1
-    ma[1:] = ma_params
-
-    arma_acovf = arima_process.arma_acovf(ar, ma, nobs, sigma2, dtype={{dtype}}) / sigma2
-    acovf, acovf2 = {{prefix}}arma_transformed_acovf_fast(ar, ma, arma_acovf)
-    theta, v = {{prefix}}arma_innovations_algo_fast(nobs, ar_params, ma_params, acovf, acovf2)
-    u = {{prefix}}arma_innovations_filter(endog, ar_params, ma_params, theta)
+    u, v = {{prefix}}arma_innovations(endog, ar_params, ma_params, sigma2)
 
     dim1[0] = nobs;
     llf_obs = cnp.PyArray_ZEROS(1, dim1, {{typenum}}, C)

--- a/statsmodels/tsa/innovations/api.py
+++ b/statsmodels/tsa/innovations/api.py
@@ -1,2 +1,2 @@
 from .arma_innovations import (  # noqa: F401
-    arma_loglike, arma_loglikeobs, arma_score, arma_scoreobs)
+    arma_innovations, arma_loglike, arma_loglikeobs, arma_score, arma_scoreobs)

--- a/statsmodels/tsa/innovations/arma_innovations.py
+++ b/statsmodels/tsa/innovations/arma_innovations.py
@@ -1,9 +1,101 @@
 import numpy as np
 
+from statsmodels.tsa import arima_process
 from statsmodels.tsa.statespace.tools import prefix_dtype_map
 from statsmodels.tools.numdiff import _get_epsilon, approx_fprime_cs
 from scipy.linalg.blas import find_best_blas_type
 from . import _arma_innovations
+
+
+def arma_innovations(endog, ar_params=None, ma_params=None, sigma2=1,
+                     normalize=False, prefix=None):
+    """
+    Compute innovations using a given ARMA process
+
+    Parameters
+    ----------
+    endog : ndarray
+        The observed time-series process, may be univariate or multivariate.
+    ar_params : ndarray, optional
+        Autoregressive parameters.
+    ma_params : ndarray, optional
+        Moving average parameters.
+    sigma2 : ndarray, optional
+        The ARMA innovation variance. Default is 1.
+    normalize : boolean, optional
+        Whether or not to normalize the returned innovations. Default is False.
+    prefix : str, optional
+        The BLAS prefix associated with the datatype. Default is to find the
+        best datatype based on given input. This argument is typically only
+        used internally.
+
+    Returns
+    -------
+    innovations : ndarray
+        Innovations (one-step-ahead prediction errors) for the given `endog`
+        series with predictions based on the given ARMA process. If
+        `normalize=True`, then the returned innovations have been "whitened" by
+        dividing through by the square root of the mean square error.
+    innovations_mse : ndarray
+        Mean square error for the innovations.
+
+    """
+    # Parameters
+    endog = np.array(endog)
+    squeezed = endog.ndim == 1
+    if squeezed:
+        endog = endog[:, None]
+
+    ar_params = np.atleast_1d([] if ar_params is None else ar_params)
+    ma_params = np.atleast_1d([] if ma_params is None else ma_params)
+
+    nobs, k_endog = endog.shape
+    ar = np.r_[1, -ar_params]
+    ma = np.r_[1, ma_params]
+
+    # Get BLAS prefix
+    if prefix is None:
+        prefix, dtype, _ = find_best_blas_type(
+            [endog, ar_params, ma_params, np.array(sigma2)])
+    dtype = prefix_dtype_map[prefix]
+
+    # Make arrays contiguous for BLAS calls
+    endog = np.asfortranarray(endog, dtype=dtype)
+    ar_params = np.asfortranarray(ar_params, dtype=dtype)
+    ma_params = np.asfortranarray(ma_params, dtype=dtype)
+    sigma2 = dtype(sigma2).item()
+
+    # Get the appropriate functions
+    arma_transformed_acovf_fast = getattr(
+        _arma_innovations, prefix + 'arma_transformed_acovf_fast')
+    arma_innovations_algo_fast = getattr(
+        _arma_innovations, prefix + 'arma_innovations_algo_fast')
+    arma_innovations_filter = getattr(
+        _arma_innovations, prefix + 'arma_innovations_filter')
+
+    # Run the innovations algorithm for ARMA coefficients
+    arma_acovf = arima_process.arma_acovf(ar, ma,
+                                          sigma2=sigma2, nobs=nobs) / sigma2
+    acovf, acovf2 = arma_transformed_acovf_fast(ar, ma, arma_acovf)
+    theta, v = arma_innovations_algo_fast(nobs, ar_params, ma_params,
+                                          acovf, acovf2)
+    v = np.array(v)
+    if normalize:
+        v05 = v**0.5
+
+    # Run the innovations filter across each series
+    u = []
+    for i in range(k_endog):
+        u_i = np.array(arma_innovations_filter(endog[:, i], ar_params,
+                                               ma_params, theta))
+        u.append(u_i / v05 if normalize else u_i)
+    u = np.vstack(u).T
+
+    # Post-processing
+    if squeezed:
+        u = u.squeeze()
+
+    return u, v
 
 
 def arma_loglike(endog, ar_params=None, ma_params=None, sigma2=1, prefix=None):


### PR DESCRIPTION
- [x] tests added / passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message.

This exposes the "innovations filter", which is used for computing the one-step-ahead prediction errors for one more multiple series, assuming a given ARMA process, via the innovations algorithm.

In particular, this can be useful for generalized least squares estimation of regression with ARMA errors, since it can compute the transformed variables on which regression can be run (like the Prais–Winsten approach but for arbitrary ARMA processes).