### PR TITLE
WIP: TST: Sort dicts in test_multi

### DIFF
--- a/statsmodels/stats/tests/test_multi.py
+++ b/statsmodels/stats/tests/test_multi.py
@@ -182,7 +182,7 @@ res0_large = np.array([
 
 class CheckMultiTestsMixin(object):
 
-    @pytest.mark.parametrize('key,val', list(rmethods.items()))
+    @pytest.mark.parametrize('key,val', sorted(rmethods.items()))
     def test_multi_pvalcorrection_rmethods(self, key, val):
         # test against R package multtest mt.rawp2adjp
 
@@ -310,7 +310,7 @@ def test_fdr_bky():
     #print fdrcorrection_twostage(pvals, alpha=0.05, iter=True)
 
 
-@pytest.mark.parametrize('method', multitest_methods_names)
+@pytest.mark.parametrize('method', sorted(multitest_methods_names))
 def test_issorted(method):
     # test that is_sorted keyword works correctly
     # the fdrcorrection functions are tested indirectly


### PR DESCRIPTION
- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html#writing-the-commit-message). 

**Notes**:

See https://github.com/MacPython/statsmodels-wheels/pull/2

I think we just need to sort these. Seems like if this passing/failing is just luck if you are using xdist. 