### PR TITLE
ENH: KPSS - detailed error message when lags > nobs

### DIFF
--- a/statsmodels/tsa/stattools.py
+++ b/statsmodels/tsa/stattools.py
@@ -1671,8 +1671,7 @@ def kpss(x, regression='c', lags=None, store=False):
               'same as lags=\'auto\' which uses an automatic lag length ' \
               'selection method. To silence this warning, either use ' \
               '\'auto\' or \'legacy\''
-        import warnings
-        warnings.warn(msg, DeprecationWarning)
+        warn(msg, DeprecationWarning)
     if lags == 'legacy':
         lags = int(np.ceil(12. * np.power(nobs / 100., 1 / 4.)))
     elif lags == 'auto':
@@ -1680,6 +1679,9 @@ def kpss(x, regression='c', lags=None, store=False):
         lags = _kpss_autolag(resids, nobs)
     else:
         lags = int(lags)
+
+    if lags > nobs:
+        raise ValueError("lags ({}) must be <= number of observations ({})".format(lags, nobs))
 
     pvals = [0.10, 0.05, 0.025, 0.01]
 

--- a/statsmodels/tsa/tests/test_stattools.py
+++ b/statsmodels/tsa/tests/test_stattools.py
@@ -535,6 +535,12 @@ class TestKPSS(SetupKPSS):
             lags = kpss(modechoice.load().data['invt'], 'ct', lags='auto')[2]
         assert_equal(lags, 18)
 
+    def test_kpss_fails_on_nobs_check(self):
+        # Test that if lags exceeds number of observations KPSS raises a clear error
+        nobs = len(self.x)
+        with pytest.raises(ValueError, match="lags \({}\) must be <= number of observations \({}\)".format(nobs+1, nobs)):
+            kpss(self.x, 'c', lags=nobs+1)
+
     def test_legacy_lags(self):
         # Test legacy lags are the same
         with warnings.catch_warnings(record=True):


### PR DESCRIPTION
I don't believe there are open issues for this, but the enhancement is related to #5432 & #3330, only for the KPSS test. Adds a clear error message when the lags parameter exceeds the number of observations.

- [ ] closes #xxxx
- [x] tests added / passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html#writing-the-commit-message). 