### PR TITLE
ENH: add score_factor, hessian_factor to discrete rebased

### DIFF
--- a/statsmodels/base/_parameter_inference.py
+++ b/statsmodels/base/_parameter_inference.py
@@ -5,17 +5,11 @@ Created on Wed May 30 15:11:09 2018
 @author: josef
 """
 
-import time
 import numpy as np
 from scipy import stats
 
-from statsmodels.regression.linear_model import OLS
-from statsmodels.genmod.generalized_linear_model import GLM
-from statsmodels.genmod import families
-import statsmodels.stats._diagnostic_other as diao
 
-
-# this is a copy from stats._diagnostic_other
+# this is a copy from stats._diagnostic_other to avoid circular imports
 def _lm_robust(score, constraint_matrix, score_deriv_inv, cov_score,
                cov_params=None):
     '''general formula for score/LM test
@@ -220,7 +214,11 @@ def score_test(self, exog_extra=None, params_constrained=None,
         score = score_obs.sum(0)
         hessian_factor = model.hessian_factor(params_constrained,
                                               **hess_kwd)
-        hessian = -np.dot(ex.T * hessian_factor, ex)
+        # see #4714
+        from statsmodels.genmod.generalized_linear_model import GLM
+        if isinstance(model, GLM):
+            hessian_factor *= -1
+        hessian = np.dot(ex.T * hessian_factor, ex)
 
     if cov_type == 'nonrobust':
         cov_score_test = -hessian

--- a/statsmodels/discrete/discrete_model.py
+++ b/statsmodels/discrete/discrete_model.py
@@ -38,6 +38,7 @@ from statsmodels.tools.numdiff import approx_fprime_cs
 import statsmodels.base.model as base
 from statsmodels.base.data import handle_data  # for mnlogit
 from statsmodels.base._constraints import fit_constrained_wrap
+import statsmodels.base._parameter_inference as infer
 import statsmodels.regression.linear_model as lm
 import statsmodels.base.wrapper as wrap
 
@@ -3874,6 +3875,22 @@ class DiscreteResults(base.LikelihoodModelResults):
     @cache_readonly
     def bic(self):
         return -2*self.llf + np.log(self.nobs)*(self.df_model+1)
+
+
+    def score_test(self, exog_extra=None, params_constrained=None,
+                   hypothesis='joint', cov_type=None, cov_kwds=None,
+                   k_constraints=None, observed=True):
+
+        res = infer.score_test(self, exog_extra=exog_extra,
+                               params_constrained=params_constrained,
+                               hypothesis=hypothesis,
+                               cov_type=cov_type, cov_kwds=cov_kwds,
+                               k_constraints=k_constraints,
+                               observed=observed)
+        return res
+
+    score_test.__doc__ = infer.score_test.__doc__
+
 
     def _get_endog_name(self, yname, yname_list):
         if yname is None:

--- a/statsmodels/discrete/discrete_model.py
+++ b/statsmodels/discrete/discrete_model.py
@@ -37,11 +37,14 @@ from statsmodels.tools.sm_exceptions import PerfectSeparationError
 from statsmodels.tools.numdiff import approx_fprime_cs
 import statsmodels.base.model as base
 from statsmodels.base.data import handle_data  # for mnlogit
+from statsmodels.base._constraints import fit_constrained_wrap
 import statsmodels.regression.linear_model as lm
 import statsmodels.base.wrapper as wrap
 
 from statsmodels.base.l1_slsqp import fit_l1_slsqp
+
 from statsmodels.distributions import genpoisson_p
+
 
 try:
     import cvxopt  # noqa:F401
@@ -507,6 +510,14 @@ class BinaryModel(DiscreteModel):
         discretefit = L1BinaryResults(self, bnryfit)
         return L1BinaryResultsWrapper(discretefit)
     fit_regularized.__doc__ = DiscreteModel.fit_regularized.__doc__
+
+    def fit_constrained(self, constraints, start_params=None, **fit_kwds):
+
+        res = fit_constrained_wrap(self, constraints, start_params=None,
+                                   **fit_kwds)
+        return res
+
+    fit_constrained.__doc__ = fit_constrained_wrap.__doc__
 
     def _derivative_predict(self, params, exog=None, transform='dydx',
                             offset=None):

--- a/statsmodels/discrete/tests/test_constrained.py
+++ b/statsmodels/discrete/tests/test_constrained.py
@@ -449,6 +449,31 @@ class TestGLMLogitConstrained1(CheckGLMConstrainedMixin):
         cls.res1 = fit_constrained(mod1, R, q)
 
 
+class TestLogitConstrained1(CheckGLMConstrainedMixin):
+
+    @classmethod
+    def setup_class(cls):
+        cls.idx = slice(None)
+        # params sequence same as Stata, but Stata reports param = nan
+        # and we have param = value = 0
+
+        #res1ul = Logit(data.endog, data.exog).fit(method="newton", disp=0)
+        cls.res2 = reslogit.results_constraint1
+
+        mod1 = Logit(spector_data.endog, spector_data.exog)
+
+        constr = 'x1 = 2.8'
+        # newton doesn't work, raises hessian singular
+        cls.res1m = mod1.fit_constrained(constr, method='bfgs')
+
+        R, q = cls.res1m.constraints.coefs, cls.res1m.constraints.constants
+        cls.res1 = fit_constrained(mod1, R, q, fit_kwds={'method': 'bfgs'})
+
+    @pytest.mark.skip(reason='not a GLM')
+    def test_glm(self):
+        return
+
+
 class TestGLMLogitConstrained2(CheckGLMConstrainedMixin):
 
     @classmethod
@@ -526,6 +551,38 @@ class TestGLMLogitConstrained2HC(CheckGLMConstrainedMixin):
                                                          'cov_type': cov_type,
                                                          'cov_kwds': cov_kwds})
         cls.constraints_rq = (R, q)
+
+
+class TestLogitConstrained2HC(CheckGLMConstrainedMixin):
+
+    @classmethod
+    def setup_class(cls):
+        cls.idx = slice(None)  # params sequence same as Stata
+        #res1ul = Logit(data.endog, data.exog).fit(method="newton", disp=0)
+        cls.res2 = reslogit.results_constraint2_robust
+
+        mod1 = Logit(spector_data.endog, spector_data.exog)
+
+        # not used to match Stata for HC
+        # nobs, k_params = mod1.exog.shape
+        # k_params -= 1   # one constraint
+        cov_type = 'HC0'
+        cov_kwds = {'scaling_factor': 32/31}
+        # looks like nobs / (nobs - 1) and not (nobs - 1.) / (nobs - k_params)}
+        constr = 'x1 - x3 = 0'
+        cls.res1m = mod1.fit_constrained(constr, cov_type=cov_type,
+                                         cov_kwds=cov_kwds, atol=1e-10,
+                                         )
+
+        R, q = cls.res1m.constraints.coefs, cls.res1m.constraints.constants
+        cls.res1 = fit_constrained(mod1, R, q, fit_kwds={'atol': 1e-10,
+                                                         'cov_type': cov_type,
+                                                         'cov_kwds': cov_kwds})
+        cls.constraints_rq = (R, q)
+
+    @pytest.mark.skip(reason='not a GLM')
+    def test_glm(self):
+        return
 
 
 def junk():

--- a/statsmodels/discrete/tests/test_discrete.py
+++ b/statsmodels/discrete/tests/test_discrete.py
@@ -49,6 +49,45 @@ DECIMAL_1 = 1
 DECIMAL_0 = 0
 
 
+def check_jac(self):
+    # moved from CheckModelResults
+    res1 = self.res1
+    exog = self.res1.model.exog
+    #basic cross check
+    jacsum = self.res1.model.score_obs(self.res1.params).sum(0)
+    score = self.res1.model.score(self.res1.params)
+    assert_almost_equal(jacsum, score, DECIMAL_9) #Poisson has low precision ?
+
+    if isinstance(res1.model, (NegativeBinomial, MNLogit)):
+        # skip the rest
+        return
+
+    # check score_factor
+    # TODO: change when score_obs uses score_factor for DRYing
+    s1 = res1.model.score_obs(res1.params)
+    sf = res1.model.score_factor(res1.params)
+    if sf.ndim == 1:
+        s2 = sf[:, None] * exog
+    elif sf.ndim == 2:
+        s2 = np.column_stack((sf[:, :1] * exog, sf[:, 1:]))
+
+    assert_allclose(s2, s1, rtol=1e-10)
+
+    # check hessian_factor
+    h1 = res1.model.hessian(res1.params)
+    hf = res1.model.hessian_factor(res1.params)
+    if sf.ndim == 1:
+        h2 = (hf * exog.T).dot(exog)
+    elif sf.ndim == 2:
+        h00 = (hf[:, 0] * exog.T).dot(exog)
+        h10 = np.atleast_2d(hf[:, 1].T.dot(exog))
+        h11 = np.atleast_2d(hf[:, 2].sum(0))
+        h2 = np.vstack((np.column_stack((h00, h10.T)),
+                        np.column_stack((h10, h11))))
+
+    assert_allclose(h2, h1, rtol=1e-10)
+
+
 class CheckModelMixin(object):
     # Assertions about the Model object, as opposed to the Results
     # Assumes that mixed-in class implements:
@@ -135,10 +174,7 @@ class CheckModelResults(CheckModelMixin):
         assert_almost_equal(llobssum, self.res1.llf, DECIMAL_14)
 
     def test_jac(self):
-        #basic cross check
-        jacsum = self.res1.model.score_obs(self.res1.params).sum(0)
-        score = self.res1.model.score(self.res1.params)
-        assert_almost_equal(jacsum, score, DECIMAL_9) #Poisson has low precision ?
+        check_jac(self)
 
 
 class CheckBinaryResults(CheckModelResults):
@@ -1837,6 +1873,10 @@ class TestGeneralizedPoisson_underdispersion(object):
         chi2 = stats.chisquare(freq, pr.sum(0))
         assert_allclose(chi2[:], (0.64628806058715882, 0.98578597726324468),
                         rtol=0.01)
+
+    def test_jac(self):
+        self.res1 = self.res
+        check_jac(self)
 
 
 class TestNegativeBinomialPNB2Newton(CheckNegBinMixin, CheckModelResults):

--- a/statsmodels/discrete/tests/test_sandwich_cov.py
+++ b/statsmodels/discrete/tests/test_sandwich_cov.py
@@ -516,6 +516,20 @@ class TestGLMLogit(CheckDiscreteGLM):
         cls.res2 = mod1.fit(cov_type='cluster', cov_kwds=dict(groups=group))
 
 
+class TestGLMLogitOffset(CheckDiscreteGLM):
+
+    @classmethod
+    def setup_class(cls):
+        endog_bin = (endog > endog.mean()).astype(int)
+        cls.cov_type = 'cluster'
+        offset = np.ones(endog_bin.shape[0])
+
+        mod1 = GLM(endog_bin, exog, family=families.Binomial(), offset=offset)
+        cls.res1 = mod1.fit(cov_type='cluster', cov_kwds=dict(groups=group))
+
+        mod1 = smd.Logit(endog_bin, exog, offset=offset)
+        cls.res2 = mod1.fit(cov_type='cluster', cov_kwds=dict(groups=group))
+
 class TestGLMProbit(CheckDiscreteGLM):
 
     @classmethod
@@ -542,6 +556,25 @@ class TestGLMProbit(CheckDiscreteGLM):
         hess1 = res1.model.hessian(res1.params)
         hess2 = res2.model.hessian(res1.params)
         assert_allclose(hess1, hess2, rtol=1e-10)
+
+
+class TestGLMProbitOffset(CheckDiscreteGLM):
+
+    @classmethod
+    def setup_class(cls):
+        endog_bin = (endog > endog.mean()).astype(int)
+        cls.cov_type = 'cluster'
+        offset = np.ones(endog_bin.shape[0])
+
+        mod1 = GLM(endog_bin, exog,
+                   family=families.Binomial(link=links.probit()),
+                   offset=offset)
+        cls.res1 = mod1.fit(method='newton',
+                            cov_type='cluster', cov_kwds=dict(groups=group))
+
+        mod1 = smd.Probit(endog_bin, exog, offset=offset)
+        cls.res2 = mod1.fit(cov_type='cluster', cov_kwds=dict(groups=group))
+        cls.rtol = 1e-6
 
 
 class TestGLMGaussNonRobust(CheckDiscreteGLM):

--- a/statsmodels/discrete/tests/test_sandwich_cov.py
+++ b/statsmodels/discrete/tests/test_sandwich_cov.py
@@ -485,6 +485,20 @@ class CheckDiscreteGLM(object):
         hessf2 = res2.model.hessian_factor(res1.params, **kwds)
         assert_allclose(sgn * hessf1, hessf2, rtol=1e-10)
 
+    def test_score_test(self):
+        res1 = self.res1
+        res2 = self.res2
+
+        if isinstance(res2.model, OLS):
+            # skip
+            return
+
+        fitted = self.res1.fittedvalues
+        exog_extra = np.column_stack((fitted**2, fitted**3))
+        res_lm1 = res1.score_test(exog_extra, cov_type='nonrobust')
+        res_lm2 = res2.score_test(exog_extra, cov_type='nonrobust')
+        assert_allclose(np.hstack(res_lm1), np.hstack(res_lm2), rtol=5e-7)
+
 
 class TestGLMPoisson(CheckDiscreteGLM):
 

--- a/statsmodels/discrete/tests/test_sandwich_cov.py
+++ b/statsmodels/discrete/tests/test_sandwich_cov.py
@@ -441,8 +441,8 @@ class CheckDiscreteGLM(object):
     # compare GLM with other models, no verified reference results
 
     def test_basic(self):
-        res1 = self.res1
-        res2 = self.res2
+        res1 = self.res1  # GLM model
+        res2 = self.res2  # comparison model, discrete or OLS
 
         assert_equal(res1.cov_type, self.cov_type)
         assert_equal(res2.cov_type, self.cov_type)
@@ -450,6 +450,56 @@ class CheckDiscreteGLM(object):
         rtol = getattr(res1, 'rtol', 1e-13)
         assert_allclose(res1.params, res2.params, rtol=rtol)
         assert_allclose(res1.bse, res2.bse, rtol=1e-10)
+
+    def test_score_hessian(self):
+        res1 = self.res1
+        res2 = self.res2
+
+        # We need to fix scale in GLM and OLS,
+        # discrete MLE have it always fixed
+        if isinstance(res2.model, OLS):
+            kwds = {'scale': res2.scale}
+        else:
+            kwds = {}
+        if isinstance(res2.model, OLS):
+            sgn = + 1
+        else:
+            sgn = -1  # see #4714
+
+        score1 = res1.model.score(res1.params * 0.98, scale=res1.scale)
+        score2 = res2.model.score(res1.params * 0.98, **kwds)
+        assert_allclose(score1, score2, rtol=1e-13)
+
+        hess1 = res1.model.hessian(res1.params, scale=res1.scale)
+        hess2 = res2.model.hessian(res1.params, **kwds)
+        assert_allclose(hess1, hess2, rtol=1e-10)
+
+        if isinstance(res2.model, OLS):
+            # skip the rest
+            return
+        scoref1 = res1.model.score_factor(res1.params, scale=res1.scale)
+        scoref2 = res2.model.score_factor(res1.params, **kwds)
+        assert_allclose(scoref1, scoref2, rtol=1e-10)
+
+        hessf1 = res1.model.hessian_factor(res1.params, scale=res1.scale)
+        hessf2 = res2.model.hessian_factor(res1.params, **kwds)
+        assert_allclose(sgn * hessf1, hessf2, rtol=1e-10)
+
+
+class TestGLMPoisson(CheckDiscreteGLM):
+
+    @classmethod
+    def setup_class(cls):
+        endog_count = np.random.poisson(endog)
+        cls.cov_type = 'HC0'
+
+        mod1 = GLM(endog_count, exog, family=families.Poisson())
+        cls.res1 = mod1.fit(cov_type='HC0')
+
+        mod1 = smd.Poisson(endog_count, exog)
+        cls.res2 = mod1.fit(cov_type='HC0')
+
+        cls.res1.rtol = 1e-11
 
 
 class TestGLMLogit(CheckDiscreteGLM):

--- a/statsmodels/genmod/generalized_linear_model.py
+++ b/statsmodels/genmod/generalized_linear_model.py
@@ -24,6 +24,7 @@ from statsmodels.tools.decorators import cache_readonly
 import statsmodels.base.model as base
 import statsmodels.regression.linear_model as lm
 import statsmodels.base.wrapper as wrap
+import statsmodels.base._parameter_inference as infer
 import statsmodels.regression._tools as reg_tools
 
 from statsmodels.graphics._regressionplots_doc import (
@@ -1708,6 +1709,20 @@ class GLMResults(base.LikelihoodModelResults):
         return res
 
     get_prediction.__doc__ = pred.get_prediction_glm.__doc__
+
+    def score_test(self, exog_extra=None, params_constrained=None,
+                   hypothesis='joint', cov_type=None, cov_kwds=None,
+                   k_constraints=None, observed=True):
+
+        res = infer.score_test(self, exog_extra=exog_extra,
+                               params_constrained=params_constrained,
+                               hypothesis=hypothesis,
+                               cov_type=cov_type, cov_kwds=cov_kwds,
+                               k_constraints=k_constraints,
+                               observed=observed)
+        return res
+
+    score_test.__doc__ = infer.score_test.__doc__
 
     def get_hat_matrix_diag(self, observed=True):
         """


### PR DESCRIPTION
This is a rebased version of #4716 

changes to order of import statements got lost in merge conflict resolution
otherwise unchanged

see #4716 for notes, notebook for application of score test https://gist.github.com/josef-pkt/f20abdbd360c2e549f73e98844f5d2c4

ENH:

- adds offset to binary models
  count models already have offset  
  MNLogit does not have offset
  ZeroInflated models don't have offset for the binary model, but have it already for the count submodel
- adds fit_constrained to binary models as application of offset
- adds score and hessian factor methods to several models
- adds score_test to GLM and DiscreteResults
  DiscreteResults.score_test will not work for all models that inherit from it.   
  Which models work currently? Which are unit tested?

Unit Tests:


- compare discrete and GLM `statsmodels/discrete/tests/test_sandwich_cov.py` `CheckDiscreteGLM`
  covered: score_test, score_factor, including binary models with offset
  models: Poisson, Logit, Probit, Gauss (is skipped in new assert because methods are not available in OLS)
- `statsmodels/discrete/tests/test_constrained.py` 
  new Logit subclasses for comparing with GLM `CheckGLMConstrainedMixin`  
  tests fit_constrained, and implicilty offset (I guess)
- `statsmodels/discrete/tests/test_discrete.py`
  compare score_factor,  hessian_factor with existing methods, 
  Warning: this will not test anything when the code duplication is removed.
  `CheckModelResults.test_jac` is inherited by test classes for most models.

NO new tests for verifying correctness of `score_test` 
(unit tests check only that GLM and discrete models produce the same results up to tolerance)
  
