### PR TITLE
CLN: fix invalid escapes in test_stattools introduced in #5707

### DIFF
--- a/statsmodels/tsa/tests/test_stattools.py
+++ b/statsmodels/tsa/tests/test_stattools.py
@@ -538,7 +538,9 @@ class TestKPSS(SetupKPSS):
     def test_kpss_fails_on_nobs_check(self):
         # Test that if lags exceeds number of observations KPSS raises a clear error
         nobs = len(self.x)
-        with pytest.raises(ValueError, match="lags \({}\) must be <= number of observations \({}\)".format(nobs+1, nobs)):
+        msg = (r"lags \({}\) must be <= number of observations \({}\)"
+               .format(nobs+1, nobs))
+        with pytest.raises(ValueError, match=msg):
             kpss(self.x, 'c', lags=nobs+1)
 
     def test_legacy_lags(self):


### PR DESCRIPTION
We're close to having all the invalid escapes gone (at which point we can add them to lint.sh and never worry about them again).  This fixes a handful that were recently introduced; all remaining cases are in either examples or sandbox