### PR TITLE
CLN: ellipses-out invalid escapes traceback

### DIFF
--- a/statsmodels/examples/ex_generic_mle_t.py
+++ b/statsmodels/examples/ex_generic_mle_t.py
@@ -110,10 +110,6 @@ print(tmp.shape)
 8
 >>> tmp.shape
 (100, 100)
->>> np.dot(modp.exog, beta).shape
-Traceback (most recent call last):
-  File "<stdin>", line 1, in <module>
-NameError: name 'beta' is not defined
 
 >>> params = modp.start_value
 >>> beta = params[:-2]
@@ -254,10 +250,7 @@ array([ 31.93524822,  22.0333515 ,          NaN,  29.90198792,
 >>> hb=-approx_hess(resp.params, modp.loglike, epsilon=-1e-8)
 >>> np.sqrt(np.diag(np.linalg.inv(hb)))
 Traceback (most recent call last):
-  File "<stdin>", line 1, in <module>
-  File "C:\Programs\Python25\lib\site-packages\numpy\linalg\linalg.py", line 423, in inv
-    return wrap(solve(a, identity(a.shape[0], dtype=a.dtype)))
-  File "C:\Programs\Python25\lib\site-packages\numpy\linalg\linalg.py", line 306, in solve
+  [...]
     raise LinAlgError, 'Singular matrix'
 numpy.linalg.linalg.LinAlgError: Singular matrix
 >>> resp.params


### PR DESCRIPTION
The docstring'd-out output there is apparently very out-of-date; the _shapes_ of several of the inspected outputs have changed.  I have no idea how the results on 106 and 112 would have been found.  (Re-running the code now, `tmp` produced on line 103 is a scalar, and tmp in line 111 has shape `(1000,)`)

Considered updating all the debugging output (the LinAlgError no longer occurs), but thats just trading one wall of text for another.