### PR TITLE
MAINT: fix non-working example ex_pandas

### DIFF
--- a/statsmodels/examples/ex_pandas.py
+++ b/statsmodels/examples/ex_pandas.py
@@ -90,7 +90,7 @@ plot_acf_multiple(log_difference.values)
 
 #Example TSA VAR
 
-model = tsa.VAR(log_difference, freq='D')
+model = tsa.VAR(log_difference, freq='BQ')
 print(model.select_order())
 
 res = model.fit(2)
@@ -103,21 +103,9 @@ irf.plot()
 fevd = res.fevd()
 fevd.plot()
 
-#print res.test_whiteness()
+print(res.test_whiteness())
 print(res.test_causality('m1', 'realgdp'))
-#print res.test_normality() # exception
-'''
-Traceback (most recent call last):
-  File "E:\Josef\eclipsegworkspace\statsmodels-git\statsmodels-josef\scikits\statsmodels\examples\ex_pandas.py", line 100, in <module>
-    print res.test_normality()
-  File "e:\josef\eclipsegworkspace\statsmodels-git\statsmodels-all\scikits\statsmodels\tsa\vector_ar\var_model.py", line 1456, in test_normality
-    summ = output.normality_summary(results)
-  File "e:\josef\eclipsegworkspace\statsmodels-git\statsmodels-all\scikits\statsmodels\tsa\vector_ar\output.py", line 182, in normality_summary
-    return hypothesis_test_table(results, title, null_hyp)
-  File "e:\josef\eclipsegworkspace\statsmodels-git\statsmodels-all\scikits\statsmodels\tsa\vector_ar\output.py", line 190, in hypothesis_test_table
-    results['crit_value'],
-KeyError: 'crit_value'
-'''
+print(res.test_normality())
 
 
 #Example TSA ARMA
@@ -140,13 +128,12 @@ y = arma_generate_sample(arparams, maparams, nobs)
 plt.figure()
 plt.plot(y)
 
-#Now, optionally, we can add some dates information. For this example,
+# Now, optionally, we can add some dates information. For this example,
 # we'll use a pandas time series.
 dates = sm.tsa.datetools.dates_from_range('1980m1', length=nobs)
 y = Series(y, index=dates)
-arma_mod = sm.tsa.ARMA(y, freq='M')
-#arma_res = arma_mod.fit(order=(2,2), trend='nc', disp=-1) #fails
-#old pandas 0.4.0: AttributeError: 'TimeSeries' object has no attribute 'name'
-#arma_res.params
+arma_mod = sm.tsa.ARMA(y, order=(2, 2), freq='M')
+arma_res = arma_mod.fit(trend='nc', disp=-1)
+print(arma_res.params)
 
 plt.show()


### PR DESCRIPTION
A couple of usages were out of date:

- an incorrect frequency passed to `VAR` raised, so this now passes the correct frequency.  
- `order` was passed to ARMA.fit instead of to the ARMA constructor, which raises, so this passes it in the up-to-date signature.

A couple of things were commented out, and one docstring'd-out traceback for things that used to fail or not exist.  These are now printed like everything else as they now work.