### PR TITLE
DOC: Remove redundant attributes in GLM

### DIFF
--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -129,7 +129,7 @@ class Model(object):
         model : Model instance
 
         Notes
-        ------
+        -----
         data must define __getitem__ with the keys in the formula terms
         args and kwargs are passed on to the model instantiation. E.g.,
         a numpy structured or rec array, a dictionary, or a pandas DataFrame.
@@ -1039,7 +1039,7 @@ class LikelihoodModelResults(Results):
     Class to contain results from likelihood models
 
     Parameters
-    -----------
+    ----------
     model : LikelihoodModel instance or subclass instance
         LikelihoodModelResults holds a reference to the model that is fit.
     params : 1d array_like
@@ -1458,7 +1458,7 @@ class LikelihoodModelResults(Results):
         ==============================================================================
 
         See Also
-        ---------
+        --------
         tvalues : individual t statistics
         f_test : for F tests
         patsy.DesignInfo.linear_constraint
@@ -1968,7 +1968,7 @@ class LikelihoodModelResults(Results):
 
 
         Returns
-        --------
+        -------
         conf_int : array
             Each row contains [lower, upper] limits of the confidence interval
             for the corresponding parameter. The first column contains all
@@ -2362,7 +2362,7 @@ class GenericLikelihoodModelResults(LikelihoodModelResults, ResultMixin):
         """Summarize the Regression Results
 
         Parameters
-        -----------
+        ----------
         yname : string, optional
             Default is `y`
         xname : list of strings, optional

--- a/statsmodels/datasets/committee/data.py
+++ b/statsmodels/datasets/committee/data.py
@@ -62,7 +62,7 @@ def load(as_pandas=None):
         or numpy recarrays and arrays.  If True, returns pandas.
 
     Returns
-    --------
+    -------
     Dataset instance:
         See DATASET_PROPOSAL.txt for more information.
     """

--- a/statsmodels/datasets/copper/data.py
+++ b/statsmodels/datasets/copper/data.py
@@ -52,7 +52,7 @@ def load_pandas():
     Load the copper data and returns a Dataset class.
 
     Returns
-    --------
+    -------
     Dataset instance:
         See DATASET_PROPOSAL.txt for more information.
     """
@@ -71,7 +71,7 @@ def load(as_pandas=None):
         or numpy recarrays and arrays.  If True, returns pandas.
 
     Returns
-    --------
+    -------
     Dataset instance:
         See DATASET_PROPOSAL.txt for more information.
     """

--- a/statsmodels/datasets/stackloss/data.py
+++ b/statsmodels/datasets/stackloss/data.py
@@ -43,7 +43,7 @@ def load(as_pandas=None):
         or numpy recarrays and arrays.  If True, returns pandas.
 
     Returns
-    --------
+    -------
     Dataset instance:
         See DATASET_PROPOSAL.txt for more information.
     """
@@ -54,7 +54,7 @@ def load_pandas():
     Load the stack loss data and returns a Dataset class instance.
 
     Returns
-    --------
+    -------
     Dataset instance:
         See DATASET_PROPOSAL.txt for more information.
     """

--- a/statsmodels/datasets/sunspots/data.py
+++ b/statsmodels/datasets/sunspots/data.py
@@ -49,7 +49,7 @@ def load(as_pandas=None):
         or numpy recarrays and arrays.  If True, returns pandas.
 
     Returns
-    --------
+    -------
     Dataset instance:
         See DATASET_PROPOSAL.txt for more information.
 

--- a/statsmodels/datasets/template_data.py
+++ b/statsmodels/datasets/template_data.py
@@ -38,7 +38,7 @@ def load(as_pandas=None):
         or numpy recarrays and arrays.  If True, returns pandas.
 
     Returns
-    --------
+    -------
     Dataset instance:
         See DATASET_PROPOSAL.txt for more information.
 

--- a/statsmodels/discrete/conditional_models.py
+++ b/statsmodels/discrete/conditional_models.py
@@ -436,7 +436,7 @@ class ConditionalResults(base.LikelihoodModelResults):
         Summarize the fitted model.
 
         Parameters
-        -----------
+        ----------
         yname : string, optional
             Default is `y`
         xname : list of strings, optional

--- a/statsmodels/discrete/count_model.py
+++ b/statsmodels/discrete/count_model.py
@@ -44,7 +44,7 @@ class GenericZeroInflated(CountModel):
     %(extra_params)s
 
     Attributes
-    -----------
+    ----------
     endog : array
         A reference to the endogenous response variable
     exog : array
@@ -467,7 +467,7 @@ class ZeroInflatedPoisson(GenericZeroInflated):
     %(extra_params)s
 
     Attributes
-    -----------
+    ----------
     endog : array
         A reference to the endogenous response variable
     exog : array
@@ -633,7 +633,7 @@ class ZeroInflatedNegativeBinomialP(GenericZeroInflated):
     %(extra_params)s
 
     Attributes
-    -----------
+    ----------
     endog : array
         A reference to the endogenous response variable
     exog : array

--- a/statsmodels/discrete/discrete_model.py
+++ b/statsmodels/discrete/discrete_model.py
@@ -909,7 +909,7 @@ class Poisson(CountModel):
     %(extra_params)s
 
     Attributes
-    -----------
+    ----------
     endog : array
         A reference to the endogenous response variable
     exog : array
@@ -934,7 +934,7 @@ class Poisson(CountModel):
         Poisson model cumulative distribution function
 
         Parameters
-        -----------
+        ----------
         X : array-like
             `X` is the linear predictor of the model.  See notes.
 
@@ -962,7 +962,7 @@ class Poisson(CountModel):
         Poisson model probability mass function
 
         Parameters
-        -----------
+        ----------
         X : array-like
             `X` is the linear predictor of the model.  See notes.
 
@@ -1319,7 +1319,7 @@ class GeneralizedPoisson(CountModel):
     %(extra_params)s
 
     Attributes
-    -----------
+    ----------
     endog : array
         A reference to the endogenous response variable
     exog : array
@@ -1724,7 +1724,7 @@ class Logit(BinaryModel):
     %(extra_params)s
 
     Attributes
-    -----------
+    ----------
     endog : array
         A reference to the endogenous response variable
     exog : array
@@ -1746,10 +1746,13 @@ class Logit(BinaryModel):
         1/(1 + exp(-X))
 
         Notes
-        ------
+        -----
         In the logit model,
 
-        .. math:: \\Lambda\\left(x^{\\prime}\\beta\\right)=\\text{Prob}\\left(Y=1|x\\right)=\\frac{e^{x^{\\prime}\\beta}}{1+e^{x^{\\prime}\\beta}}
+        .. math:: \\Lambda\\left(x^{\\prime}\\beta\\right)=
+                  \\text{Prob}\\left(Y=1|x\\right)=
+                  \\frac{e^{x^{\\prime}\\beta}}{1+e^{x^{\\prime}\\beta}}
+
         """
         X = np.asarray(X)
         return 1/(1+np.exp(-X))
@@ -1759,7 +1762,7 @@ class Logit(BinaryModel):
         The logistic probability density function
 
         Parameters
-        -----------
+        ----------
         X : array-like
             `X` is the linear predictor of the logit model.  See notes.
 
@@ -1783,7 +1786,7 @@ class Logit(BinaryModel):
         Log-likelihood of logit model.
 
         Parameters
-        -----------
+        ----------
         params : array-like
             The parameters of the logit model.
 
@@ -1794,8 +1797,11 @@ class Logit(BinaryModel):
             See notes.
 
         Notes
-        ------
-        .. math:: \\ln L=\\sum_{i}\\ln\\Lambda\\left(q_{i}x_{i}^{\\prime}\\beta\\right)
+        -----
+        .. math::
+
+           \\ln L=\\sum_{i}\\ln\\Lambda
+           \\left(q_{i}x_{i}^{\\prime}\\beta\\right)
 
         Where :math:`q=2y-1`. This simplification comes from the fact that the
         logistic distribution is symmetric.
@@ -1809,7 +1815,7 @@ class Logit(BinaryModel):
         Log-likelihood of logit model for each observation.
 
         Parameters
-        -----------
+        ----------
         params : array-like
             The parameters of the logit model.
 
@@ -1820,8 +1826,11 @@ class Logit(BinaryModel):
             at `params`. See Notes
 
         Notes
-        ------
-        .. math:: \\ln L=\\sum_{i}\\ln\\Lambda\\left(q_{i}x_{i}^{\\prime}\\beta\\right)
+        -----
+        .. math::
+
+           \\ln L=\\sum_{i}\\ln\\Lambda
+           \\left(q_{i}x_{i}^{\\prime}\\beta\\right)
 
         for observations :math:`i=1,...,n`
 
@@ -1926,7 +1935,7 @@ class Probit(BinaryModel):
     %(extra_params)s
 
     Attributes
-    -----------
+    ----------
     endog : array
         A reference to the endogenous response variable
     exog : array
@@ -1944,7 +1953,7 @@ class Probit(BinaryModel):
             The linear predictor of the model (XB).
 
         Returns
-        --------
+        -------
         cdf : ndarray
             The cdf evaluated at `X`.
 
@@ -1964,7 +1973,7 @@ class Probit(BinaryModel):
             The linear predictor of the model (XB).
 
         Returns
-        --------
+        -------
         pdf : ndarray
             The value of the normal density function for each point of X.
 
@@ -2196,7 +2205,7 @@ class MNLogit(MultinomialModel):
             The linear predictor of the model XB.
 
         Returns
-        --------
+        -------
         cdf : ndarray
             The cdf evaluated at `X`.
 
@@ -2224,8 +2233,13 @@ class MNLogit(MultinomialModel):
             See notes.
 
         Notes
-        ------
-        .. math:: \\ln L=\\sum_{i=1}^{n}\\sum_{j=0}^{J}d_{ij}\\ln\\left(\\frac{\\exp\\left(\\beta_{j}^{\\prime}x_{i}\\right)}{\\sum_{k=0}^{J}\\exp\\left(\\beta_{k}^{\\prime}x_{i}\\right)}\\right)
+        -----
+        .. math::
+
+           \\ln L=\\sum_{i=1}^{n}\\sum_{j=0}^{J}d_{ij}\\ln
+           \\left(\\frac{\\exp\\left(\\beta_{j}^{\\prime}x_{i}\\right)}
+           {\\sum_{k=0}^{J}
+           \\exp\\left(\\beta_{k}^{\\prime}x_{i}\\right)}\\right)
 
         where :math:`d_{ij}=1` if individual `i` chose alternative `j` and 0
         if not.
@@ -2251,8 +2265,13 @@ class MNLogit(MultinomialModel):
             at `params`. See Notes
 
         Notes
-        ------
-        .. math:: \\ln L_{i}=\\sum_{j=0}^{J}d_{ij}\\ln\\left(\\frac{\\exp\\left(\\beta_{j}^{\\prime}x_{i}\\right)}{\\sum_{k=0}^{J}\\exp\\left(\\beta_{k}^{\\prime}x_{i}\\right)}\\right)
+        -----
+        .. math::
+
+           \\ln L_{i}=\\sum_{j=0}^{J}d_{ij}\\ln
+           \\left(\\frac{\\exp\\left(\\beta_{j}^{\\prime}x_{i}\\right)}
+           {\\sum_{k=0}^{J}
+           \\exp\\left(\\beta_{k}^{\\prime}x_{i}\\right)}\\right)
 
         for observations :math:`i=1,...,n`
 
@@ -2274,7 +2293,7 @@ class MNLogit(MultinomialModel):
             The parameters of the multinomial logit model.
 
         Returns
-        --------
+        -------
         score : ndarray, (K * (J-1),)
             The 2-d score vector, i.e. the first derivative of the
             loglikelihood function, of the multinomial logit model evaluated at
@@ -2320,7 +2339,7 @@ class MNLogit(MultinomialModel):
             The parameters of the multinomial logit model.
 
         Returns
-        --------
+        -------
         jac : array-like
             The derivative of the loglikelihood for each observation evaluated
             at `params` .
@@ -2346,7 +2365,7 @@ class MNLogit(MultinomialModel):
         Multinomial logit Hessian matrix of the log-likelihood
 
         Parameters
-        -----------
+        ----------
         params : array-like
             The parameters of the model
 
@@ -2457,7 +2476,7 @@ class NegativeBinomial(CountModel):
     %(extra_params)s
 
     Attributes
-    -----------
+    ----------
     endog : array
         A reference to the endogenous response variable
     exog : array
@@ -2921,7 +2940,7 @@ class NegativeBinomialP(CountModel):
     %(params)s
     %(extra_params)s
     Attributes
-    -----------
+    ----------
     endog : array
         A reference to the endogenous response variable
     exog : array
@@ -3577,7 +3596,7 @@ class DiscreteResults(base.LikelihoodModelResults):
         """Summarize the Regression Results
 
         Parameters
-        -----------
+        ----------
         yname : string, optional
             Default is `y`
         xname : list of strings, optional
@@ -3646,7 +3665,7 @@ class DiscreteResults(base.LikelihoodModelResults):
         """Experimental function to summarize regression results
 
         Parameters
-        -----------
+        ----------
         xname : List of strings of length equal to the number of parameters
             Names of the independent variables (optional)
         yname : string
@@ -3837,7 +3856,7 @@ class BinaryResults(DiscreteResults):
             considered 1 and below which a prediction is considered 0.
 
         Notes
-        ------
+        -----
         pred_table[i,j] refers to the number of times "i" was observed and
         the model predicted "j". Correct predictions are along the diagonal.
         """
@@ -4111,7 +4130,7 @@ class MultinomialResults(DiscreteResults):
         """Experimental function to summarize regression results
 
         Parameters
-        -----------
+        ----------
         alpha : float
             significance level for the confidence intervals
         float_format: string

--- a/statsmodels/duration/hazard_regression.py
+++ b/statsmodels/duration/hazard_regression.py
@@ -1551,7 +1551,7 @@ class PHRegResults(base.LikelihoodModelResults):
         Summarize the proportional hazards regression results.
 
         Parameters
-        -----------
+        ----------
         yname : string, optional
             Default is `y`
         xname : list of strings, optional

--- a/statsmodels/duration/survfunc.py
+++ b/statsmodels/duration/survfunc.py
@@ -596,7 +596,7 @@ def survdiff(time, status, group, weight_type=None, strata=None,
         the risk set on or before the entry time.
 
     Returns
-    --------
+    -------
     chisq : The chi-square (1 degree of freedom) distributed test
             statistic value
     pvalue : The p-value for the chi^2 test

--- a/statsmodels/emplike/aft_el.py
+++ b/statsmodels/emplike/aft_el.py
@@ -97,7 +97,7 @@ class OptAFT(_OptFuncts):
         Uses EM algorithm to compute the maximum likelihood of a test
 
         Parameters
-        ---------
+        ----------
 
         Nuisance Params: array
             Vector of values to be used as nuisance params.
@@ -161,7 +161,7 @@ class OptAFT(_OptFuncts):
         parameter and some critical value.
 
         Parameters
-        ---------
+        ----------
         b0: float
             Value of a regression parameter
 
@@ -177,7 +177,7 @@ class emplikeAFT(object):
     Class for estimating and conducting inference in an AFT model.
 
     Parameters
-    ---------
+    ----------
 
     endog: nx1 array
         Response variables that are subject to random censoring
@@ -347,7 +347,7 @@ class emplikeAFT(object):
         Fits an AFT model and returns results instance
 
         Parameters
-        ---------
+        ----------
         None
 
 
@@ -377,7 +377,7 @@ class AFTResults(OptAFT):
         Fits an AFT model and returns parameters.
 
         Parameters
-        ---------
+        ----------
         None
 
 
@@ -428,7 +428,7 @@ class AFTResults(OptAFT):
             The log-likelihood and p-pvalue of the test.
 
         Notes
-        ----
+        -----
 
         The function will warn if the EM reaches the maxiter.  However, when
         optimizing over nuisance parameters, it is possible to reach a
@@ -439,7 +439,7 @@ class AFTResults(OptAFT):
         infinity.
 
         Examples
-        -------
+        --------
 
         >>> import statsmodels.api as sm
         >>> import numpy as np
@@ -513,7 +513,7 @@ class AFTResults(OptAFT):
         parameter in the AFT model.
 
         Parameters
-        ---------
+        ----------
 
         param_num: int
             Parameter number of interest
@@ -528,7 +528,7 @@ class AFTResults(OptAFT):
             Significance level.  Default is .05
 
         Notes
-        ----
+        -----
         If the function returns f(a) and f(b) must have different signs,
         consider widening the search area by adjusting beta_low and
         beta_high.

--- a/statsmodels/emplike/descriptive.py
+++ b/statsmodels/emplike/descriptive.py
@@ -377,7 +377,7 @@ class _OptFuncts(object):
         nuisance parameters mu and sigma
 
         Parameters
-        -----------
+        ----------
         nuis_params : 1darray
             An array with a nuisance mean and variance parameter
 
@@ -424,7 +424,7 @@ class _OptFuncts(object):
     def _ci_limits_kurt(self, kurt):
         """
         Parameters
-        ---------
+        ----------
         skew0 : float
             Hypothesized value of kurtosis
 
@@ -617,7 +617,7 @@ class DescStatUV(_OptFuncts):
             likelihood of observing sig2_0. Default is False
 
         Returns
-        --------
+        -------
         test_results : tuple
             The  log-likelihood ratio and the p_value  of sig2_0
 
@@ -662,7 +662,7 @@ class DescStatUV(_OptFuncts):
             The significance level. Default is .05
 
         Returns
-        --------
+        -------
         Interval : tuple
             Confidence interval for the variance
 
@@ -760,7 +760,7 @@ class DescStatUV(_OptFuncts):
             maximize the likelihood ratio. Default is False.
 
         Returns
-        --------
+        -------
         test_results : tuple
             The log-likelihood ratio and p_value of skew0
         """
@@ -901,7 +901,7 @@ class DescStatUV(_OptFuncts):
             Default is .99 confidence limit assuming normality.
 
         Returns
-        --------
+        -------
         Interval : tuple
             Lower and upper confidence limit
 

--- a/statsmodels/gam/gam_penalties.py
+++ b/statsmodels/gam/gam_penalties.py
@@ -17,7 +17,7 @@ class UnivariateGamPenalty(Penalty):
     Penalty for smooth term in Generalized Additive Models
 
     Parameters
-    -----------
+    ----------
     univariate_smoother : instance
         instance of univariate smoother or spline class
     alpha : float
@@ -26,7 +26,7 @@ class UnivariateGamPenalty(Penalty):
         TODO: not used and verified, might be removed
 
     Attributes
-    -----------
+    ----------
     Parameters are stored, additionally
     nob s: The number of samples used during the estimation
     n_columns : number of columns in smoother basis
@@ -132,7 +132,7 @@ class MultivariateGamPenalty(Penalty):
     Penalty for Generalized Additive Models
 
     Parameters
-    -----------
+    ----------
     multivariate_smoother : instance
         instance of additive smoother or spline class
     alpha : list of float
@@ -149,7 +149,7 @@ class MultivariateGamPenalty(Penalty):
         start at ``start_index``.
 
     Attributes
-    -----------
+    ----------
     Parameters are stored, additionally
     nob s: The number of samples used during the estimation
 

--- a/statsmodels/gam/generalized_additive_model.py
+++ b/statsmodels/gam/generalized_additive_model.py
@@ -595,7 +595,7 @@ class GLMGam(PenalizedMixin, GLM):
             penalization weight
 
         Returns
-        ----------
+        -------
         alpha : list
             penalization weight, list with length equal to the number of
             smooth terms

--- a/statsmodels/genmod/families/family.py
+++ b/statsmodels/genmod/families/family.py
@@ -218,13 +218,13 @@ class Family(object):
         Fitted values based on linear predictors lin_pred.
 
         Parameters
-        -----------
+        ----------
         lin_pred : array
             Values of the linear predictor of the model.
             :math:`X \cdot \beta` in a classical linear model.
 
         Returns
-        --------
+        -------
         mu : array
             The mean response variables given by the inverse of the link
             function.
@@ -844,7 +844,7 @@ class Binomial(Family):
             1d array of frequency weights
 
         Returns
-        --------
+        -------
         If `endog` is binary, returns `endog`
 
         If `endog` is a 2d array, then the input is assumed to be in the format

--- a/statsmodels/genmod/families/links.py
+++ b/statsmodels/genmod/families/links.py
@@ -113,12 +113,12 @@ class Logit(Link):
         Clip logistic values to range (eps, 1-eps)
 
         Parameters
-        -----------
+        ----------
         p : array-like
             Probabilities
 
         Returns
-        --------
+        -------
         pclip : array
             Clipped probabilities
         """
@@ -309,7 +309,7 @@ class Power(Link):
             Mean parameters
 
         Returns
-        --------
+        -------
         g'(p) : array
             Derivative of power transform of `p`
 
@@ -332,7 +332,7 @@ class Power(Link):
             Mean parameters
 
         Returns
-        --------
+        -------
         g''(p) : array
             Second derivative of the power transform of `p`
 
@@ -873,7 +873,7 @@ class NegativeBinomial(Link):
         Inverse of the negative binomial transform
 
         Parameters
-        -----------
+        ----------
         z : array-like
             The value of the inverse of the negative binomial link at `p`.
 
@@ -936,7 +936,7 @@ class NegativeBinomial(Link):
         Derivative of the inverse of the negative binomial transform
 
         Parameters
-        -----------
+        ----------
         z : array-like
             Usually the linear predictor for a GLM or GEE model
 

--- a/statsmodels/genmod/families/varfuncs.py
+++ b/statsmodels/genmod/families/varfuncs.py
@@ -20,7 +20,7 @@ class VarianceFunction(object):
     Alias for VarianceFunction:
     constant = VarianceFunction()
 
-    See also
+    See Also
     --------
     statsmodels.genmod.families.family
     """
@@ -30,7 +30,7 @@ class VarianceFunction(object):
         Default variance function
 
         Parameters
-        -----------
+        ----------
         mu : array-like
             mean parameters
 
@@ -179,7 +179,7 @@ class Binomial(object):
         Binomial variance function
 
         Parameters
-        -----------
+        ----------
         mu : array-like
             mean parameters
 

--- a/statsmodels/genmod/generalized_estimating_equations.py
+++ b/statsmodels/genmod/generalized_estimating_equations.py
@@ -672,7 +672,7 @@ class GEE(base.Model):
         model : GEE model instance
 
         Notes
-        ------
+        -----
         `data` must define __getitem__ with the keys in the formula
         terms args and kwargs are passed on to the model
         instantiation. E.g., a numpy structured or rec array, a
@@ -2015,7 +2015,7 @@ class GEEResults(base.LikelihoodModelResults):
         Summarize the GEE regression results
 
         Parameters
-        -----------
+        ----------
         yname : string, optional
             Default is `y`
         xname : list of strings, optional

--- a/statsmodels/genmod/generalized_linear_model.py
+++ b/statsmodels/genmod/generalized_linear_model.py
@@ -56,7 +56,7 @@ class GLM(base.LikelihoodModel):
     GLM inherits from statsmodels.base.model.LikelihoodModel
 
     Parameters
-    -----------
+    ----------
     endog : array-like
         1d array of endogenous response variable.  This array can be 1d or 2d.
         Binomial family models accept a 2d array with two columns. If
@@ -93,34 +93,67 @@ class GLM(base.LikelihoodModel):
     %(extra_params)s
 
     Attributes
-    -----------
+    ----------
     df_model : float
-        `p` - 1, where `p` is the number of regressors including the intercept.
+        Model degrees of freedom is equal to p - 1, where p is the number
+        of regressors.  Note that the intercept is not reported as a
+        degree of freedom.
     df_resid : float
-        The number of observation `n` minus the number of regressors `p`.
+        Residual degrees of freedom is equal to the number of observation n
+        minus the number of regressors p.
     endog : array
-        See Parameters.
+        See Notes.  Note that `endog` is a reference to the data so that if
+        data is already an array and it is changed, then `endog` changes
+        as well.
+    exposure : array-like
+        Include ln(exposure) in model with coefficient constrained to 1. Can
+        only be used if the link is the logarithm function.
     exog : array
-        See Parameters.
-    family : family class instance
-        A pointer to the distribution family of the model.
+        See Notes.  Note that `exog` is a reference to the data so that if
+        data is already an array and it is changed, then `exog` changes
+        as well.
     freq_weights : array
-        See Parameters.
+        See Notes. Note that `freq_weights` is a reference to the data so that
+        if data is already an array and it is changed, then `freq_weights`
+        changes as well.
     var_weights : array
-        See Parameters.
+        See Notes. Note that `var_weights` is a reference to the data so that
+        if data is already an array and it is changed, then `var_weights`
+        changes as well.
+    iteration : int
+        The number of iterations that fit has run.  Initialized at 0.
+    family : family class instance
+        The distribution family of the model. Can be any family in
+        statsmodels.families.  Default is Gaussian.
     mu : array
-        The estimated mean response of the transformed variable.
+        The mean response of the transformed variable.  `mu` is the value of
+        the inverse of the link function at lin_pred, where lin_pred is the
+        linear predicted value of the WLS fit of the transformed variable.
+        `mu` is only available after fit is called.  See
+        statsmodels.families.family.fitted of the distribution family for more
+        information.
     n_trials : array
-        See Parameters.
+        See Notes. Note that `n_trials` is a reference to the data so that if
+        data is already an array and it is changed, then `n_trials` changes
+        as well. `n_trials` is the number of binomial trials and only available
+        with that distribution. See statsmodels.families.Binomial for more
+        information.
     normalized_cov_params : array
-        `p` x `p` normalized covariance of the design / exogenous data.
+        The p x p normalized covariance of the design / exogenous data.
+        This is approximately equal to (X.T X)^(-1)
+    offset : array-like
+        Include offset in model with coefficient constrained to 1.
     scale : float
-        The estimate of the scale / dispersion.  Available after fit is called.
+        The estimate of the scale / dispersion of the model fit.  Only
+        available after fit is called.  See GLM.fit and GLM.estimate_scale
+        for more information.
     scaletype : str
-        The scaling used for fitting the model.  Available after fit is called.
+        The scaling used for fitting the model.  This is only available after
+        fit is called.  The default is None.  See GLM.fit for more information.
     weights : array
-        The value of the weights after the last iteration of fit.
-
+        The value of the weights after the last iteration of fit.  Only
+        available after fit is called.  See statsmodels.families.family for
+        the specific distribution weighting functions.
 
     Examples
     --------
@@ -146,7 +179,7 @@ class GLM(base.LikelihoodModel):
     >>> gamma_results.llf
     -83.017202161073527
 
-    See also
+    See Also
     --------
     statsmodels.genmod.families.family.Family
     :ref:`families`
@@ -223,69 +256,6 @@ class GLM(base.LikelihoodModel):
     and statistics based on it, such AIC or likelihood ratio tests, are not
     appropriate.
 
-    Attributes
-    ----------
-
-    df_model : float
-        Model degrees of freedom is equal to p - 1, where p is the number
-        of regressors.  Note that the intercept is not reported as a
-        degree of freedom.
-    df_resid : float
-        Residual degrees of freedom is equal to the number of observation n
-        minus the number of regressors p.
-    endog : array
-        See above.  Note that `endog` is a reference to the data so that if
-        data is already an array and it is changed, then `endog` changes
-        as well.
-    exposure : array-like
-        Include ln(exposure) in model with coefficient constrained to 1. Can
-        only be used if the link is the logarithm function.
-    exog : array
-        See above.  Note that `exog` is a reference to the data so that if
-        data is already an array and it is changed, then `exog` changes
-        as well.
-    freq_weights : array
-        See above. Note that `freq_weights` is a reference to the data so that
-        if data is already an array and it is changed, then `freq_weights`
-        changes as well.
-    var_weights : array
-        See above. Note that `var_weights` is a reference to the data so that
-        if data is already an array and it is changed, then `var_weights`
-        changes as well.
-    iteration : int
-        The number of iterations that fit has run.  Initialized at 0.
-    family : family class instance
-        The distribution family of the model. Can be any family in
-        statsmodels.families.  Default is Gaussian.
-    mu : array
-        The mean response of the transformed variable.  `mu` is the value of
-        the inverse of the link function at lin_pred, where lin_pred is the
-        linear predicted value of the WLS fit of the transformed variable.
-        `mu` is only available after fit is called.  See
-        statsmodels.families.family.fitted of the distribution family for more
-        information.
-    n_trials : array
-        See above. Note that `n_trials` is a reference to the data so that if
-        data is already an array and it is changed, then `n_trials` changes
-        as well. `n_trials` is the number of binomial trials and only available
-        with that distribution. See statsmodels.families.Binomial for more
-        information.
-    normalized_cov_params : array
-        The p x p normalized covariance of the design / exogenous data.
-        This is approximately equal to (X.T X)^(-1)
-    offset : array-like
-        Include offset in model with coefficient constrained to 1.
-    scale : float
-        The estimate of the scale / dispersion of the model fit.  Only
-        available after fit is called.  See GLM.fit and GLM.estimate_scale
-        for more information.
-    scaletype : str
-        The scaling used for fitting the model.  This is only available after
-        fit is called.  The default is None.  See GLM.fit for more information.
-    weights : array
-        The value of the weights after the last iteration of fit.  Only
-        available after fit is called.  See statsmodels.families.family for
-        the specific distribution weighting functions.
     """ % {'extra_params': base._missing_param_doc}
 
     def __init__(self, endog, exog, family=None, offset=None,
@@ -771,7 +741,7 @@ class GLM(base.LikelihoodModel):
         families is 1.  The default for the other families is Pearson's
         Chi-Square estimate.
 
-        See also
+        See Also
         --------
         statsmodels.genmod.generalized_linear_model.GLM.fit for more
         information
@@ -1749,7 +1719,7 @@ class GLMResults(base.LikelihoodModelResults):
             The instance has methods to calculate the main influence and
             outlier measures as attributes.
 
-        See also
+        See Also
         --------
         statsmodels.stats.outliers_influence.GLMInfluence
         """
@@ -1826,7 +1796,7 @@ class GLMResults(base.LikelihoodModelResults):
         Summarize the Regression Results
 
         Parameters
-        -----------
+        ----------
         yname : string, optional
             Default is `y`
         xname : list of strings, optional
@@ -1892,7 +1862,7 @@ class GLMResults(base.LikelihoodModelResults):
         """Experimental summary for regression Results
 
         Parameters
-        -----------
+        ----------
         yname : string
             Name of the dependent variable (optional)
         xname : List of strings of length equal to the number of parameters

--- a/statsmodels/graphics/gofplots.py
+++ b/statsmodels/graphics/gofplots.py
@@ -68,10 +68,11 @@ class ProbPlot(object):
 
     Examples
     --------
-    >>> import statsmodels.api as sm
-    >>> from matplotlib import pyplot as plt
+    The first example shows a Q-Q plot for regression residuals
 
     >>> # example 1
+    >>> import statsmodels.api as sm
+    >>> from matplotlib import pyplot as plt
     >>> data = sm.datasets.longley.load(as_pandas=False)
     >>> data.exog = sm.add_constant(data.exog)
     >>> model = sm.OLS(data.endog, data.exog)
@@ -109,7 +110,7 @@ class ProbPlot(object):
     >>> h = plt.title('Ex. 4 - qqplot - resids vs. quantiles of fitted t-dist')
     >>> plt.show()
 
-    A second `ProbPlot` object can be used to compare two seperate sample
+    A second `ProbPlot` object can be used to compare two separate sample
     sets by using the `other` kwarg in the `qqplot` and `ppplot` methods.
 
     >>> # example 5
@@ -127,27 +128,21 @@ class ProbPlot(object):
     size of the first by interpolation
 
     >>> # example 6
-    >>> import numpy as np
     >>> x = np.random.normal(loc=8.25, scale=2.75, size=37)
     >>> y = np.random.normal(loc=8.75, scale=3.25, size=57)
     >>> pp_x = sm.ProbPlot(x, fit=True)
     >>> pp_y = sm.ProbPlot(y, fit=True)
-    >>> fig = pp_y.qqplot(other=pp_x)
-    Traceback (most recent call last):
-        ...
-    ValueError: Sample size of `other` must be equal or larger than ...
     >>> fig = pp_x.qqplot(line='45', other=pp_y)
-    >>> title 'Ex. 6 - qqplot - compare two data sets with diff. sample size'
+    >>> title = 'Ex. 6 - qqplot - compare different sample sizes'
     >>> h = plt.title(title)
     >>> plt.show()
 
-   In ppplot, sample size of `other` and the first can be different. `other`
-   will be used to estimate an empirical cumulative distribution function
-   (ECDF). ECDF(x) will be plotted against p(x)=0.5/n, 1.5/n, ..., (n-0.5)/n
-   where x are sorted samples from the first.
+    In ppplot, sample size of `other` and the first can be different. `other`
+    will be used to estimate an empirical cumulative distribution function
+    (ECDF). ECDF(x) will be plotted against p(x)=0.5/n, 1.5/n, ..., (n-0.5)/n
+    where x are sorted samples from the first.
 
     >>> # example 7
-    >>> import numpy as np
     >>> x = np.random.normal(loc=8.25, scale=2.75, size=37)
     >>> y = np.random.normal(loc=8.75, scale=3.25, size=57)
     >>> pp_x = sm.ProbPlot(x, fit=True)
@@ -240,28 +235,31 @@ class ProbPlot(object):
 
         Parameters
         ----------
-        xlabel, ylabel : str or None, optional
-            User-provided lables for the x-axis and y-axis. If None (default),
+        xlabel : str or None, optional
+            User-provided lables for the x-axis. If None (default),
+            other values are used depending on the status of the kwarg `other`.
+        ylabel : str or None, optional
+            User-provided lables for the y-axis. If None (default),
             other values are used depending on the status of the kwarg `other`.
         line : str {'45', 's', 'r', q'} or None, optional
             Options for the reference line to which the data is compared:
 
-            - '45' - 45-degree line
-            - 's' - standardized line, the expected order statistics are scaled
-              by the standard deviation of the given sample and have the mean
-              added to them
-            - 'r' - A regression line is fit
-            - 'q' - A line is fit through the quartiles.
-            - None - by default no reference line is added to the plot.
+                - '45': 45-degree line
+                - 's': standardized line, the expected order statistics are
+                  scaled by the standard deviation of the given sample and have
+                  the mean added to them
+                - 'r': A regression line is fit
+                - 'q': A line is fit through the quartiles.
+                - None: by default no reference line is added to the plot.
 
-        other : `ProbPlot` instance, array-like, or None, optional
+        other : ProbPlot, array-like, or None, optional
             If provided, ECDF(x) will be plotted against p(x) where x are
-            sorted samples from `self`, ECDF is an empirical cumulative
+            sorted samples from `self`. ECDF is an empirical cumulative
             distribution function estimated from `other` and
-            p(x) = 0.5/n, 1.5/n, ..., [n-0.5]/n (n is the number of samples
-            in `self`). If an array-object is provided, it will be turned into
-            a `ProbPlot` instance default parameters. If not provided
-            (default), `self.dist`(x) will be plotted against p(x).
+            p(x) = 0.5/n, 1.5/n, ..., (n-0.5)/n where n is the number of
+            samples in `self`. If an array-object is provided, it will be
+            turned into a `ProbPlot` instance default parameters. If not
+            provided (default), `self.dist(x)` is be plotted against p(x).
 
         ax : Matplotlib AxesSubplot instance, optional
             If given, this subplot is used to plot in instead of a new figure
@@ -754,7 +752,7 @@ def plotting_pos(nobs, a):
     The plotting positions are given by (i - a)/(nobs - 2*a + 1) for i in
     range(0,nobs+1)
 
-    See also
+    See Also
     --------
     scipy.stats.mstats.plotting_positions
     """

--- a/statsmodels/graphics/mosaicplot.py
+++ b/statsmodels/graphics/mosaicplot.py
@@ -172,7 +172,7 @@ def _hierarchical_split(count_dict, horizontal=True, gap=0.05):
         it with exponentially decreasing gaps
 
     Returns
-    ----------
+    ---------
     base_rect : dict
         A dictionary containing the result of the split.
         To each key is associated a 4-tuple of coordinates
@@ -532,7 +532,7 @@ def mosaic(data, index=None, ax=None, horizontal=True, gap=0.005,
         each axis can have a different rotation
 
     Returns
-    ----------
+    ---------
     fig : matplotlib.Figure
         The generate figure
     rects : dict

--- a/statsmodels/imputation/bayes_mi.py
+++ b/statsmodels/imputation/bayes_mi.py
@@ -391,7 +391,7 @@ class MIResults(LikelihoodModelResults):
         Summarize the results of running multiple imputation.
 
         Parameters
-        -----------
+        ----------
         title : string, optional
             Title for the top table. If not None, then this replaces
             the default title

--- a/statsmodels/imputation/mice.py
+++ b/statsmodels/imputation/mice.py
@@ -1303,7 +1303,7 @@ class MICEResults(LikelihoodModelResults):
         Summarize the results of running MICE.
 
         Parameters
-        -----------
+        ----------
         title : string, optional
             Title for the top table. If not None, then this replaces
             the default title

--- a/statsmodels/imputation/ros.py
+++ b/statsmodels/imputation/ros.py
@@ -221,7 +221,7 @@ def _detection_limit_index(obs, cohn):
     det_limit_index : int
         The index of the corresponding detection limit in `cohn`
 
-    See also
+    See Also
     --------
     cohn_numbers
 
@@ -300,7 +300,7 @@ def _ros_plot_pos(row, censorship, cohn):
     -------
     plotting_position : float
 
-    See also
+    See Also
     --------
     cohn_numbers
 
@@ -360,7 +360,7 @@ def plotting_positions(df, censorship, cohn):
     -------
     plotting_position : array of float
 
-    See also
+    See Also
     --------
     cohn_numbers
 

--- a/statsmodels/iolib/foreign.py
+++ b/statsmodels/iolib/foreign.py
@@ -149,7 +149,7 @@ class _StataMissingValue(object):
     An observation's missing value.
 
     Parameters
-    -----------
+    ----------
     offset
     value
 
@@ -186,7 +186,7 @@ class _StataVariable(object):
     variable_data
 
     Attributes
-    -----------
+    ----------
     format : str
         Stata variable format.  See notes for more information.
     index : int
@@ -244,7 +244,7 @@ class StataReader(object):
         Used for Python 3 only. Encoding to use when reading the .dta file.
         Defaults to `locale.getpreferredencoding`
 
-    See also
+    See Also
     --------
     statsmodels.iolib.foreign.genfromdta
     pandas.read_stata

--- a/statsmodels/iolib/summary.py
+++ b/statsmodels/iolib/summary.py
@@ -56,7 +56,7 @@ def summary(self, yname=None, xname=None, title=0, alpha=.05,
             returns='text', model_info=None):
     """
     Parameters
-    -----------
+    ----------
     yname : string
             optional, Default is `Y`
     xname : list of strings

--- a/statsmodels/multivariate/cancorr.py
+++ b/statsmodels/multivariate/cancorr.py
@@ -29,7 +29,7 @@ class CanCorr(Model):
     and the correlation between x1 and y1 is maximized.
 
     Attributes
-    -----------
+    ----------
     endog : array
         See Parameters.
     exog : array
@@ -158,7 +158,7 @@ class CanCorrTestResults(object):
     Canonical correlation results class
 
     Attributes
-    -----------
+    ----------
     stats : DataFrame
         Contain statistical tests results for each canonical correlation
     stats_mv : DataFrame

--- a/statsmodels/multivariate/factor_rotation/_analytic_rotation.py
+++ b/statsmodels/multivariate/factor_rotation/_analytic_rotation.py
@@ -128,7 +128,7 @@ def promax(A, k=2):
     Then, oblique target rotation is performed towards the target.
 
     Parameters
-    ---------
+    ----------
     A : numpy matrix
         non rotated factors
     k : float

--- a/statsmodels/multivariate/factor_rotation/_wrappers.py
+++ b/statsmodels/multivariate/factor_rotation/_wrappers.py
@@ -214,7 +214,7 @@ def rotate_factors(A, method, *method_args, **algorithm_kwargs):
             matrix with weights, entries can either be one or zero
 
     Examples
-    -------
+    --------
     >>> A = np.random.randn(8,2)
     >>> L, T = rotate_factors(A,'varimax')
     >>> np.allclose(L,A.dot(T))

--- a/statsmodels/multivariate/multivariate_ols.py
+++ b/statsmodels/multivariate/multivariate_ols.py
@@ -383,7 +383,7 @@ class _MultivariateOLS(Model):
         default)
 
     Attributes
-    -----------
+    ----------
     endog : array
         See Parameters.
     exog : array
@@ -474,7 +474,7 @@ class MultivariateTestResults(object):
     Returned by `mv_test` method of `_MultivariateOLSResults` class
 
     Attributes
-    -----------
+    ----------
     results : dict
        For hypothesis name `key`:
            results[key]['stat'] contains the multivaraite test results

--- a/statsmodels/nonparametric/kernel_density.py
+++ b/statsmodels/nonparametric/kernel_density.py
@@ -382,7 +382,7 @@ class KDEMultivariateConditional(GenericKDE):
         The default values for the efficient bandwidth estimation
 
     Attributes
-    ---------
+    ----------
     bw: array_like
         The bandwidth parameters
 

--- a/statsmodels/nonparametric/kernel_regression.py
+++ b/statsmodels/nonparametric/kernel_regression.py
@@ -81,7 +81,7 @@ class KernelReg(GenericKDE):
         The default values for the efficient bandwidth estimation.
 
     Attributes
-    ---------
+    ----------
     bw: array_like
         The bandwidth parameters.
     """
@@ -483,7 +483,7 @@ class KernelCensoredReg(KernelReg):
         The default values for the efficient bandwidth estimation
 
     Attributes
-    ---------
+    ----------
     bw: array_like
         The bandwidth parameters
     """

--- a/statsmodels/regression/linear_model.py
+++ b/statsmodels/regression/linear_model.py
@@ -273,7 +273,7 @@ class RegressionModel(base.LikelihoodModel):
         A RegressionResults class instance.
 
         See Also
-        ---------
+        --------
         regression.linear_model.RegressionResults
         regression.linear_model.RegressionResults.get_robustcov_results
 
@@ -496,7 +496,7 @@ class GLS(RegressionModel):
         GLS whiten method.
 
         Parameters
-        -----------
+        ----------
         X : array-like
             Data to be whitened.
 
@@ -638,7 +638,7 @@ class WLS(RegressionModel):
     See regression.GLS
 
     Examples
-    ---------
+    --------
     >>> import numpy as np
     >>> import statsmodels.api as sm
     >>> Y = [1,3,4,5,2,3,4]
@@ -2432,7 +2432,7 @@ class RegressionResults(base.LikelihoodModelResults):
         """Summarize the Regression Results
 
         Parameters
-        -----------
+        ----------
         yname : string, optional
             Default is `y`
         xname : list of strings, optional
@@ -2562,7 +2562,7 @@ class RegressionResults(base.LikelihoodModelResults):
         """Experimental summary function to summarize the regression results
 
         Parameters
-        -----------
+        ----------
         xname : List of strings of length equal to the number of parameters
             Names of the independent variables (optional)
         yname : string
@@ -2658,7 +2658,7 @@ class OLSResults(RegressionResults):
             the instance has methods to calculate the main influence and
             outlier measures for the OLS regression
 
-        See also
+        See Also
         --------
         statsmodels.stats.outliers_influence.OLSInfluence
         """

--- a/statsmodels/regression/mixed_linear_model.py
+++ b/statsmodels/regression/mixed_linear_model.py
@@ -822,7 +822,7 @@ class MixedLM(base.LikelihoodModel):
         model : Model instance
 
         Notes
-        ------
+        -----
         `data` must define __getitem__ with the keys in the formula
         terms args and kwargs are passed on to the model
         instantiation. E.g., a numpy structured or rec array, a
@@ -2493,7 +2493,7 @@ class MixedLMResults(base.LikelihoodModelResults, base.ResultMixin):
         Summarize the mixed model regression results.
 
         Parameters
-        -----------
+        ----------
         yname : string, optional
             Default is `y`
         xname_fe : list of strings, optional

--- a/statsmodels/regression/quantile_regression.py
+++ b/statsmodels/regression/quantile_regression.py
@@ -341,7 +341,7 @@ class QuantRegResults(RegressionResults):
         """Summarize the Regression Results
 
         Parameters
-        -----------
+        ----------
         yname : string, optional
             Default is `y`
         xname : list of strings, optional

--- a/statsmodels/robust/norms.py
+++ b/statsmodels/robust/norms.py
@@ -90,7 +90,7 @@ class LeastSquares(RobustNorm):
     """
     Least squares rho for M-estimation and its derived functions.
 
-    See also
+    See Also
     --------
     statsmodels.robust.norms.RobustNorm for the methods.
     """
@@ -100,7 +100,7 @@ class LeastSquares(RobustNorm):
         The least squares estimator rho function
 
         Parameters
-        -----------
+        ----------
         z : array
             1d array
 
@@ -177,7 +177,7 @@ class HuberT(RobustNorm):
         The tuning constant for Huber's t function. The default value is
         1.345.
 
-    See also
+    See Also
     --------
     statsmodels.robust.norms.RobustNorm
     """
@@ -281,7 +281,7 @@ class RamsayE(RobustNorm):
         The tuning constant for Ramsay's Ea function.  The default value is
         0.3.
 
-    See also
+    See Also
     --------
     statsmodels.robust.norms.RobustNorm
     """
@@ -370,7 +370,7 @@ class AndrewWave(RobustNorm):
         The tuning constant for Andrew's Wave function.  The default value is
         1.339.
 
-    See also
+    See Also
     --------
     statsmodels.robust.norms.RobustNorm
     """
@@ -478,7 +478,7 @@ class TrimmedMean(RobustNorm):
         The tuning constant for Ramsay's Ea function.  The default value is
         2.0.
 
-    See also
+    See Also
     --------
     statsmodels.robust.norms.RobustNorm
     """
@@ -586,7 +586,7 @@ class Hampel(RobustNorm):
         The tuning constants for Hampel's function.  The default values are
         a,b,c = 2, 4, 8.
 
-    See also
+    See Also
     --------
     statsmodels.robust.norms.RobustNorm
     """
@@ -842,7 +842,7 @@ def estimate_location(a, scale, norm=None, axis=0, initial=None,
         Toleration for convergence.  The default is 1e-06.
 
     Returns
-    --------
+    -------
     mu : array
         Estimate of location
     """

--- a/statsmodels/robust/robust_linear_model.py
+++ b/statsmodels/robust/robust_linear_model.py
@@ -83,7 +83,7 @@ class RLM(base.LikelihoodModel):
 
 
     Examples
-    ---------
+    --------
     >>> import statsmodels.api as sm
     >>> data = sm.datasets.stackloss.load(as_pandas=False)
     >>> data.exog = sm.add_constant(data.exog)
@@ -378,7 +378,7 @@ class RLMResults(base.LikelihoodModelResults):
         The reported weights are determined by passing the scaled residuals
         from the last weighted least squares fit in the IRLS algortihm.
 
-    See also
+    See Also
     --------
     statsmodels.base.model.LikelihoodModelResults
     """

--- a/statsmodels/sandbox/descstats.py
+++ b/statsmodels/sandbox/descstats.py
@@ -18,7 +18,7 @@ def descstats(data, cols=None, axis=0):
     Prints descriptive statistics for one or multiple variables.
 
     Parameters
-    ------------
+    ----------
     data: numpy array
         `x` is the data
 

--- a/statsmodels/sandbox/distributions/mv_normal.py
+++ b/statsmodels/sandbox/distributions/mv_normal.py
@@ -506,7 +506,7 @@ class MVElliptical(object):
         whiten the data by linear transformation
 
         Parameters
-        -----------
+        ----------
         x : array-like, 1d or 2d
             Data to be whitened, if 2d then each row contains an independent
             sample of the multivariate random vector
@@ -549,7 +549,7 @@ class MVElliptical(object):
         '''standardize the random variable, i.e. subtract mean and whiten
 
         Parameters
-        -----------
+        ----------
         x : array-like, 1d or 2d
             Data to be whitened, if 2d then each row contains an independent
             sample of the multivariate random vector
@@ -582,7 +582,7 @@ class MVElliptical(object):
         The distribution will have zero mean and sigma equal to correlation
 
         Parameters
-        -----------
+        ----------
         x : array-like, 1d or 2d
             Data to be whitened, if 2d then each row contains an independent
             sample of the multivariate random vector
@@ -726,7 +726,7 @@ class MVNormal0(object):
         whiten the data by linear transformation
 
         Parameters
-        -----------
+        ----------
         X : array-like, 1d or 2d
             Data to be whitened, if 2d then each row contains an independent
             sample of the multivariate random vector

--- a/statsmodels/sandbox/infotheo.py
+++ b/statsmodels/sandbox/infotheo.py
@@ -160,7 +160,7 @@ def shannonentropy(px, logbase=2):
     This is Shannon's entropy
 
     Parameters
-    -----------
+    ----------
     logbase, int or np.e
         The base of the log
     px : 1d or 2d array_like

--- a/statsmodels/sandbox/panel/panelmod.py
+++ b/statsmodels/sandbox/panel/panelmod.py
@@ -88,7 +88,7 @@ class PanelModel(object):
     An abstract statistical model class for panel (longitudinal) datasets.
 
     Parameters
-    ---------
+    ----------
     endog : array-like or str
         If a pandas object is used then endog should be the name of the
         endogenous variable as a string.
@@ -252,7 +252,7 @@ class PanelModel(object):
 
 
         Notes
-        ------
+        -----
         This is unfinished.  None of the method arguments work yet.
         Only oneway effects should work.
         """

--- a/statsmodels/sandbox/regression/gmm.py
+++ b/statsmodels/sandbox/regression/gmm.py
@@ -254,7 +254,7 @@ class IVRegressionResults(RegressionResults):
         """Summarize the Regression Results
 
         Parameters
-        -----------
+        ----------
         yname : string, optional
             Default is `y`
         xname : list of strings, optional
@@ -1291,7 +1291,7 @@ class GMMResults(LikelihoodModelResults):
         """Summarize the Regression Results
 
         Parameters
-        -----------
+        ----------
         yname : string, optional
             Default is `y`
         xname : list of strings, optional

--- a/statsmodels/sandbox/regression/tools.py
+++ b/statsmodels/sandbox/regression/tools.py
@@ -241,7 +241,7 @@ def tstd_dlldy(y, df):
     '''derivative of log pdf of standardized t with respect to y
 
         Parameters
-    ----------
+        ----------
     y : array_like
         data points of random variable at which loglike is evaluated
     df : array_like

--- a/statsmodels/sandbox/sysreg.py
+++ b/statsmodels/sandbox/sysreg.py
@@ -187,7 +187,7 @@ exogenous variables.  Got length %s" % len(sys))
         SUR whiten method.
 
         Parameters
-        -----------
+        ----------
         X : list of arrays
             Data to be whitened.
 

--- a/statsmodels/sandbox/tools/tools_pca.py
+++ b/statsmodels/sandbox/tools/tools_pca.py
@@ -109,7 +109,7 @@ def pcasvd(data, keepdim=0, demean=True):
         eigenvectors, normalized if normalize is true
 
     See Also
-    -------
+    --------
     pca : principal component analysis using eigenvector decomposition
 
     Notes

--- a/statsmodels/stats/contingency_tables.py
+++ b/statsmodels/stats/contingency_tables.py
@@ -90,7 +90,7 @@ class Table(object):
     table_orig : array-like
         The original table is cached as `table_orig`.
 
-    See also
+    See Also
     --------
     statsmodels.graphics.mosaicplot.mosaic
     scipy.stats.chi2_contingency

--- a/statsmodels/stats/contrast.py
+++ b/statsmodels/stats/contrast.py
@@ -103,7 +103,7 @@ class ContrastResults(object):
         """Summarize the Results of the hypothesis test
 
         Parameters
-        -----------
+        ----------
 
         xname : list of strings, optional
             Default is `c_##` for ## in p the number of regressors

--- a/statsmodels/stats/descriptivestats.py
+++ b/statsmodels/stats/descriptivestats.py
@@ -39,7 +39,7 @@ _sign_test_doc = '''
         default, but it is common to set it to the median.
 
     Returns
-    ---------
+    --------
     M, p-value
 
     Notes
@@ -57,7 +57,7 @@ _sign_test_doc = '''
     equals N(+) + N(-).
 
     See Also
-    ---------
+    --------
     scipy.stats.wilcoxon
     '''
 
@@ -180,7 +180,7 @@ class Describe(object):
         Return a summary of descriptive statistics.
 
         Parameters
-        -----------
+        ----------
         stats: list or str
             The desired statistics, Accepts 'basic' or 'all' or a list.
                'basic' = ('obs', 'mean', 'std', 'min', 'max')

--- a/statsmodels/stats/stattools.py
+++ b/statsmodels/stats/stattools.py
@@ -17,11 +17,11 @@ def durbin_watson(resids, axis=0):
     Calculates the Durbin-Watson statistic
 
     Parameters
-    -----------
+    ----------
     resids : array-like
 
     Returns
-    --------
+    -------
     dw : float, array-like
         The Durbin-Watson statistic.
 
@@ -52,7 +52,7 @@ def omni_normtest(resids, axis=0):
     Omnibus test for normality
 
     Parameters
-    -----------
+    ----------
     resid : array-like
     axis : int, optional
         Default is 0
@@ -79,7 +79,7 @@ def jarque_bera(resids, axis=0):
     Calculates the Jarque-Bera test for normality
 
     Parameters
-    -----------
+    ----------
     data : array-like
         Data to test for normality
     axis : int, optional

--- a/statsmodels/tools/tools.py
+++ b/statsmodels/tools/tools.py
@@ -85,7 +85,7 @@ def categorical(data, col=None, dictnames=False, drop=False, ):
         Whether or not keep the categorical variable in the returned matrix.
 
     Returns
-    --------
+    -------
     dummy_matrix, [dictnames, optional]
         A matrix of dummy (indicator/binary) float variables for the
         categorical data.  If dictnames is True, then the dictionary

--- a/statsmodels/tsa/ar_model.py
+++ b/statsmodels/tsa/ar_model.py
@@ -514,7 +514,7 @@ class AR(tsbase.TimeSeriesModel):
             series with missing observations."  `Technometrics`.  22.3.
             389-95.
 
-        See also
+        See Also
         --------
         statsmodels.base.model.LikelihoodModel.fit
         """

--- a/statsmodels/tsa/arima_model.py
+++ b/statsmodels/tsa/arima_model.py
@@ -884,14 +884,14 @@ class ARMA(tsbase.TimeSeriesModel):
         -------
         statsmodels.tsa.arima_model.ARMAResults class
 
-        See also
+        See Also
         --------
         statsmodels.base.model.LikelihoodModel.fit : for more information
             on using the solvers.
         ARMAResults : results class returned by fit
 
         Notes
-        ------
+        -----
         If fit by 'mle', it is assumed for the Kalman Filter that the initial
         unknown state is zero, and that the initial variance is
         P = dot(inv(identity(m**2)-kron(T,T)),dot(R,R.T).ravel('F')).reshape(r,
@@ -1138,14 +1138,14 @@ class ARIMA(ARMA):
         -------
         `statsmodels.tsa.arima.ARIMAResults` class
 
-        See also
+        See Also
         --------
         statsmodels.base.model.LikelihoodModel.fit : for more information
             on using the solvers.
         ARIMAResults : results class returned by fit
 
         Notes
-        ------
+        -----
         If fit by 'mle', it is assumed for the Kalman Filter that the initial
         unknown state is zero, and that the initial variance is
         P = dot(inv(identity(m**2)-kron(T,T)),dot(R,R.T).ravel('F')).reshape(r,
@@ -1287,7 +1287,7 @@ class ARMAResults(tsbase.TimeSeriesModelResults):
         Optional argument to scale the variance covariance matrix.
 
     Returns
-    --------
+    -------
     **Attributes**
 
     aic : float
@@ -1685,7 +1685,7 @@ class ARMAResults(tsbase.TimeSeriesModelResults):
         """Experimental summary function for ARIMA Results
 
         Parameters
-        -----------
+        ----------
         title : string, optional
             Title for the top table. If not None, then this replaces the
             default title

--- a/statsmodels/tsa/filters/hp_filter.py
+++ b/statsmodels/tsa/filters/hp_filter.py
@@ -28,7 +28,7 @@ def hpfilter(X, lamb=1600):
         The estimated trend in the data given lamb.
 
     Examples
-    ---------
+    --------
     >>> import statsmodels.api as sm
     >>> import pandas as pd
     >>> dta = sm.datasets.macrodata.load_pandas().data

--- a/statsmodels/tsa/holtwinters.py
+++ b/statsmodels/tsa/holtwinters.py
@@ -992,7 +992,7 @@ class SimpleExpSmoothing(ExponentialSmoothing):
     :class:`ExponentialSmoothing`.
 
     See Also
-    ---------
+    --------
     ExponentialSmoothing
     Holt
 
@@ -1071,7 +1071,7 @@ class Holt(ExponentialSmoothing):
     per [1]. `Holt` is a restricted version of :class:`ExponentialSmoothing`.
 
     See Also
-    ---------
+    --------
     ExponentialSmoothing
     SimpleExpSmoothing
 

--- a/statsmodels/tsa/innovations/arma_innovations.py
+++ b/statsmodels/tsa/innovations/arma_innovations.py
@@ -197,7 +197,7 @@ def arma_score(endog, ar_params=None, ma_params=None, sigma2=1,
         used internally.
 
     Returns
-    ----------
+    ---------
     score : array
         Score, evaluated at the given parameters.
 
@@ -245,7 +245,7 @@ def arma_scoreobs(endog, ar_params=None, ma_params=None, sigma2=1,
         used internally.
 
     Returns
-    ----------
+    ---------
     scoreobs : array
         Score per observation, evaluated at the given parameters.
 

--- a/statsmodels/tsa/kalmanf/kalmanfilter.py
+++ b/statsmodels/tsa/kalmanf/kalmanfilter.py
@@ -20,7 +20,7 @@ Harvey uses Durbin and Koopman notation.
 # Anderson and Moore `Optimal Filtering` provides a more efficient algorithm
 # namely the information filter
 # if the number of series is much greater than the number of states
-# e.g., with a DSGE model.  See also
+# e.g., with a DSGE model.  See Also
 # http://www.federalreserve.gov/pubs/oss/oss4/aimindex.html
 # Harvey notes that the square root filter will keep P_t pos. def. but
 # is not strictly needed outside of the engineering (long series)

--- a/statsmodels/tsa/statespace/mlemodel.py
+++ b/statsmodels/tsa/statespace/mlemodel.py
@@ -433,7 +433,7 @@ class MLEModel(tsbase.TimeSeriesModel):
         -------
         MLEResults
 
-        See also
+        See Also
         --------
         statsmodels.base.model.LikelihoodModel.fit
         MLEResults
@@ -1109,7 +1109,7 @@ class MLEModel(tsbase.TimeSeriesModel):
             Additional arguments to the `loglike` method.
 
         Returns
-        ----------
+        -------
         score : array
             Score per observation, evaluated at `params`.
 

--- a/statsmodels/tsa/stattools.py
+++ b/statsmodels/tsa/stattools.py
@@ -460,7 +460,7 @@ def q_stat(x, nobs, type="ljungbox"):
         P-value of the Q statistic
 
     Notes
-    ------
+    -----
     Written to be used with acf.
     """
     x = np.asarray(x)
@@ -580,7 +580,7 @@ def pacf_yw(x, nlags=40, method='unbiased'):
     pacf : 1d array
         partial autocorrelations, maxlag+1 elements
 
-    See also
+    See Also
     --------
     statsmodels.tsa.stattools.pacf
     statsmodels.tsa.stattools.pacf_burg
@@ -618,7 +618,7 @@ def pacf_burg(x, nlags=None, demean=True):
         Residual variance estimates where the value in position m is the
         residual variance in an AR model that includes m lags
 
-    See also
+    See Also
     --------
     statsmodels.tsa.stattools.pacf
     statsmodels.tsa.stattools.pacf_yw
@@ -699,7 +699,7 @@ def pacf_ols(x, nlags=40, efficient=True, unbiased=False):
     OLS estimation of the pacf does not guarantee that all pacf values are
     between -1 and 1.
 
-    See also
+    See Also
     --------
     statsmodels.tsa.stattools.pacf
     statsmodels.tsa.stattools.pacf_yw
@@ -775,7 +775,7 @@ def pacf(x, nlags=40, method='ywunbiased', alpha=None):
     confint : array, optional
         Confidence intervals for the PACF. Returned if confint is not None.
 
-    See also
+    See Also
     --------
     statsmodels.tsa.stattools.acf
     statsmodels.tsa.stattools.pacf_yw
@@ -1070,7 +1070,7 @@ def innovations_algo(acov, nobs=None, rtol=None):
     >>> nobs = activity.shape[0]
     >>> theta, sigma2  = innovations_algo(acov[:4], nobs=nobs)
 
-    See also
+    See Also
     --------
     innovations_filter
 
@@ -1143,7 +1143,7 @@ def innovations_filter(endog, theta):
     >>> theta, sigma2  = innovations_algo(acov[:4], nobs=nobs)
     >>> resid = innovations_filter(rgdpg, theta)
 
-    See also
+    See Also
     --------
     innovations_algo
 

--- a/statsmodels/tsa/tsatools.py
+++ b/statsmodels/tsa/tsatools.py
@@ -46,7 +46,7 @@ def add_trend(x, trend="c", prepend=False, has_constant='skip'):
     Returns columns as ["ctt","ct","c"] whenever applicable. There is currently
     no checking for an existing trend.
 
-    See also
+    See Also
     --------
     statsmodels.tools.tools.add_constant
     """


### PR DESCRIPTION
Remove redundant attributed in GLM docs
Fix all incorrect under line lengths (------)
Fix recently introduced bugs in ProbPlot and ppplot

closes #4447

- [X] closes #4447
- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html#writing-the-commit-message). 
