### PR TITLE
CLN: Fix/lint for dangerious redefinitions and comparisons

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -43,6 +43,8 @@ select=
     # E124: closing bracket does not match visual indentation
     F811,
     # F811: redefinition of unused 'pytest' from line 10
+    F812,
+    # F821: list comprehension redefines 'x' from line 199
     F822,
     # F882: undefined name name in __all__
     F823,

--- a/setup.cfg
+++ b/setup.cfg
@@ -109,6 +109,8 @@ select=
     # W292: no newline at end of file
     # W293: blank line contains whitespace
 
+    E711,
+    # E711: comparison to None should be 'if cond is None:'
     E713,
     # E713: test for membership should be 'not in'
     E721,

--- a/setup.cfg
+++ b/setup.cfg
@@ -111,6 +111,8 @@ select=
 
     E711,
     # E711: comparison to None should be 'if cond is None:'
+    E712,
+    # E712: comparison to True should be 'if cond is True:' or 'if cond:'
     E713,
     # E713: test for membership should be 'not in'
     E721,

--- a/statsmodels/base/l1_solvers_common.py
+++ b/statsmodels/base/l1_solvers_common.py
@@ -58,7 +58,7 @@ def qc_results(params, alpha, score, qc_tol, qc_verbose=False):
         fprime=fprime, alpha=alpha, params=params, passed_array=passed_array)
     passed = passed_array.min()
     if not passed:
-        num_failed = (passed_array == False).sum()
+        num_failed = (~passed_array).sum()
         message = 'QC check did not pass for %d out of %d parameters' % (
             num_failed, k_params)
         message += '\nTry increasing solver accuracy or number of iterations'\

--- a/statsmodels/discrete/discrete_model.py
+++ b/statsmodels/discrete/discrete_model.py
@@ -400,8 +400,8 @@ class DiscreteModel(base.LikelihoodModel):
         """
         H = likelihood_model.hessian(xopt)
         trimmed = retvals['trimmed']
-        nz_idx = np.nonzero(trimmed == False)[0]
-        nnz_params = (trimmed == False).sum()
+        nz_idx = np.nonzero(~trimmed)[0]
+        nnz_params = (~trimmed).sum()
         if nnz_params > 0:
             H_restricted = H[nz_idx[:, None], nz_idx]
             # Covariance estimate for the nonzero params
@@ -3767,7 +3767,7 @@ class L1CountResults(DiscreteResults):
         # self.trimmed is a boolean array with T/F telling whether or not that
         # entry in params has been set zero'd out.
         self.trimmed = cntfit.mle_retvals['trimmed']
-        self.nnz_params = (self.trimmed == False).sum()
+        self.nnz_params = (~self.trimmed).sum()
 
         # Set degrees of freedom.  In doing so,
         # adjust for extra parameter in NegativeBinomial nb1 and nb2
@@ -4024,7 +4024,7 @@ class L1BinaryResults(BinaryResults):
         # self.trimmed is a boolean array with T/F telling whether or not that
         # entry in params has been set zero'd out.
         self.trimmed = bnryfit.mle_retvals['trimmed']
-        self.nnz_params = (self.trimmed == False).sum()
+        self.nnz_params = (~self.trimmed).sum()
         self.df_model = self.nnz_params - 1
         self.df_resid = float(self.model.endog.shape[0] - self.nnz_params)
 
@@ -4179,7 +4179,7 @@ class L1MultinomialResults(MultinomialResults):
         # self.trimmed is a boolean array with T/F telling whether or not that
         # entry in params has been set zero'd out.
         self.trimmed = mlefit.mle_retvals['trimmed']
-        self.nnz_params = (self.trimmed == False).sum()
+        self.nnz_params = (~self.trimmed).sum()
 
         # Note: J-1 constants
         self.df_model = self.nnz_params - (self.model.J - 1)

--- a/statsmodels/duration/hazard_regression.py
+++ b/statsmodels/duration/hazard_regression.py
@@ -1607,7 +1607,7 @@ class PHRegResults(base.LikelihoodModelResults):
         param.loc[:, a] = np.exp(param.loc[:, a])
         a = "%.3f]" % (1 - alpha / 2)
         param.loc[:, a] = np.exp(param.loc[:, a])
-        if xname != None:
+        if xname is not None:
             param.index = xname
         smry.add_df(param, float_format=float_format)
         smry.add_title(title=title, results=self)

--- a/statsmodels/graphics/dotplots.py
+++ b/statsmodels/graphics/dotplots.py
@@ -155,10 +155,10 @@ def dot_plot(points, intervals=None, lines=None, sections=None,
         nsect = len(set(section_order))
 
     # The number of section titles
-    if show_section_titles == False:
+    if show_section_titles is False:
         draw_section_titles = False
         nsect_title = 0
-    elif show_section_titles == True:
+    elif show_section_titles is True:
         draw_section_titles = True
         nsect_title = nsect
     else:

--- a/statsmodels/graphics/utils.py
+++ b/statsmodels/graphics/utils.py
@@ -127,7 +127,7 @@ def get_data_names(series_or_dataframe):
     if not names:
         shape = getattr(series_or_dataframe, 'shape', [1])
         nvars = 1 if len(shape) == 1 else series_or_dataframe.shape[1]
-        names = ["X%d" for names in range(nvars)]
+        names = ["X%d" for _ in range(nvars)]
         if nvars == 1:
             names = names[0]
     else:

--- a/statsmodels/imputation/ros.py
+++ b/statsmodels/imputation/ros.py
@@ -114,7 +114,7 @@ def cohn_numbers(df, observations, censorship):
         below = df[observations] < row['upper_dl']
 
         # index of non-detect observations
-        detect = df[censorship] == False
+        detect = ~df[censorship]
 
         # return the number of observations where all conditions are True
         return df[above & below & detect].shape[0]
@@ -131,8 +131,8 @@ def cohn_numbers(df, observations, censorship):
         less_thanequal = df[observations] <= row['lower_dl']
 
         # index of detects, non-detects
-        uncensored = df[censorship] == False
-        censored = df[censorship] == True
+        uncensored = ~df[censorship]
+        censored = df[censorship]
 
         # number observations less than or equal to lower_dl DL and non-detect
         LTE_censored = df[less_thanequal & censored].shape[0]
@@ -411,8 +411,8 @@ def _impute(df, observations, censorship, transform_in, transform_out):
     """
 
     # detect/non-detect selectors
-    uncensored_mask = df[censorship] == False
-    censored_mask = df[censorship] == True
+    uncensored_mask = ~df[censorship]
+    censored_mask = df[censorship]
 
     # fit a line to the logs of the detected data
     fit_params = stats.linregress(

--- a/statsmodels/imputation/tests/test_mice.py
+++ b/statsmodels/imputation/tests/test_mice.py
@@ -199,7 +199,7 @@ class TestMICEData(object):
             x = idata.next_sample()
             assert(isinstance(x, pd.DataFrame))
 
-        assert(all([x == (299, 4) for x in hist]))
+        assert(all([val == (299, 4) for val in hist]))
 
     def test_set_imputer(self):
         # Test with specified perturbation method.

--- a/statsmodels/iolib/foreign.py
+++ b/statsmodels/iolib/foreign.py
@@ -1011,8 +1011,8 @@ def genfromdta(fname, missing_flt=-999., encoding=None, pandas=False,
         # make the dtype for the datetime types
         cols = np.where(lmap(lambda x : x in _date_formats, fmtlist))[0]
         dtype = data.dtype.descr
-        dtype = [(dt[0], object) if i in cols else dt for i,dt in
-                 enumerate(dtype)]
+        dtype = [(sub_dtype[0], object) if i in cols else sub_dtype
+                  for i, sub_dtype in enumerate(dtype)]
         data = data.astype(dtype) # have to copy
         for col in cols:
             def convert(x):

--- a/statsmodels/iolib/foreign.py
+++ b/statsmodels/iolib/foreign.py
@@ -263,7 +263,7 @@ class StataReader(object):
             (-1.798e+308, +8.988e+307) }
 
     def __init__(self, fname, missing_values=False, encoding=None):
-        if encoding == None:
+        if encoding is None:
             import locale
             self._encoding = locale.getpreferredencoding()
         else:
@@ -477,7 +477,7 @@ class StataReader(object):
         if len(self._col_sizes) == 0:
             self._col_sizes = lmap(lambda x: self._calcsize(x),
                     self._header['typlist'])
-        if k == None:
+        if k is None:
             return self._col_sizes
         else:
             return self._col_sizes[k]

--- a/statsmodels/nonparametric/kde.py
+++ b/statsmodels/nonparametric/kde.py
@@ -319,7 +319,7 @@ def kdensity(X, kernel="gau", bw="normal_reference", weights=None, gridsize=None
 
     nobs = len(X) # after trim
 
-    if gridsize == None:
+    if gridsize is None:
         gridsize = max(nobs,50) # don't need to resize if no FFT
 
         # handle weights
@@ -459,7 +459,7 @@ def kdensityfft(X, kernel="gau", bw="normal_reference", weights=None, gridsize=N
     nobs = len(X) # after trim
 
     # 1 Make grid and discretize the data
-    if gridsize == None:
+    if gridsize is None:
         gridsize = np.max((nobs, 512.))
     gridsize = 2**np.ceil(np.log2(gridsize)) # round to next power of 2
 

--- a/statsmodels/sandbox/examples/ex_formula_factor.py
+++ b/statsmodels/sandbox/examples/ex_formula_factor.py
@@ -15,7 +15,7 @@ f = ['a']*4 + ['b']*3 + ['c']*4
 fac = formula.Factor('ff', f)
 fac.namespace = {'ff':f}
 list(fac.values())
-[f for f in dir(fac) if f[0] != '_']
+[x for x in dir(fac) if x[0] != '_']
 
 #create dummy variable
 

--- a/statsmodels/sandbox/examples/ex_mixed_lls_0.py
+++ b/statsmodels/sandbox/examples/ex_mixed_lls_0.py
@@ -61,9 +61,9 @@ if 'ex1' in examples:
         #effects covariance matrix changes - still need to check details.
         X = np.hstack((X,Z))
 
-        #create units and append to list
-        unit = Unit(Y, X, Z)
-        units.append(unit)
+        # create units and append to list
+        new_unit = Unit(Y, X, Z)
+        units.append(new_unit)
 
 
     m = OneWayMixed(units)

--- a/statsmodels/sandbox/examples/ex_mixed_lls_re.py
+++ b/statsmodels/sandbox/examples/ex_mixed_lls_re.py
@@ -64,9 +64,9 @@ if 'ex1' in examples:
         #effects covariance matrix changes - still need to check details.
         X = np.hstack((X,Z))
 
-        #create units and append to list
-        unit = Unit(Y, X, Z)
-        units.append(unit)
+        # create units and append to list
+        new_unit = Unit(Y, X, Z)
+        units.append(new_unit)
 
 
     m = OneWayMixed(units)

--- a/statsmodels/sandbox/examples/ex_mixed_lls_timecorr.py
+++ b/statsmodels/sandbox/examples/ex_mixed_lls_timecorr.py
@@ -109,9 +109,9 @@ if 'ex1' in examples:
         #X = np.hstack((X,Z))
         X = np.hstack((X, time_dummies))
 
-        #create units and append to list
-        unit = Unit(Y, X, Z)
-        units.append(unit)
+        # create units and append to list
+        new_unit = Unit(Y, X, Z)
+        units.append(new_unit)
 
 
     m = OneWayMixed(units)

--- a/statsmodels/sandbox/examples/example_gam_0.py
+++ b/statsmodels/sandbox/examples/example_gam_0.py
@@ -89,8 +89,8 @@ if example == 3:
     f = families.Poisson()
     #y = y/y.max() * 3
     yp = f.link.inverse(z)
-    #p = np.asarray([scipy.stats.poisson.rvs(p) for p in f.link.inverse(y)], float)
-    p = np.asarray([scipy.stats.poisson.rvs(p) for p in f.link.inverse(z)], float)
+    p = np.asarray([scipy.stats.poisson.rvs(val) for val in f.link.inverse(z)],
+                   float)
     p.shape = y.shape
     m = GAM(p, d, family=f)
     toc = time.time()

--- a/statsmodels/sandbox/examples/example_nbin.py
+++ b/statsmodels/sandbox/examples/example_nbin.py
@@ -162,7 +162,7 @@ class NBin(GenericLikelihoodModel):
             return -self.ll_func(self.endog, self.exog, beta, alph)
 
     def fit(self, start_params=None, maxiter=10000, maxfun=5000, **kwds):
-        if start_params==None:
+        if start_params is None:
             countfit = super(NBin, self).fit(start_params=self.start_params_default,
                                              maxiter=maxiter, maxfun=maxfun, **kwds)
         else:

--- a/statsmodels/sandbox/examples/thirdparty/ex_ratereturn.py
+++ b/statsmodels/sandbox/examples/thirdparty/ex_ratereturn.py
@@ -67,7 +67,7 @@ plot_corr(residcorr, xnames=ticksym, title='Correlation Residuals',
           normcolor=normcolor, ax=ax3)
 
 import matplotlib as mpl
-images = [c for ax in fig.axes for c in ax.get_children() if isinstance(c, mpl.image.AxesImage)]
+images = [c for fig_ax in fig.axes for c in fig_ax.get_children() if isinstance(c, mpl.image.AxesImage)]
 print(images)
 print(ax.get_children())
 #cax = fig.add_subplot(2,2,2)
@@ -117,7 +117,7 @@ if has_sklearn:
         plot_corr(c, xnames=None, title=titles[i],
               normcolor=normcolor, ax=ax)
 
-    images = [c for ax in fig.axes for c in ax.get_children() if isinstance(c, mpl.image.AxesImage)]
+    images = [c for fig_ax in fig.axes for c in fig_ax.get_children() if isinstance(c, mpl.image.AxesImage)]
     fig. subplots_adjust(bottom=0.1, right=0.9, top=0.9)
     cax = fig.add_axes([0.9, 0.1, 0.025, 0.8])
     fig.colorbar(images[0], cax=cax)

--- a/statsmodels/sandbox/infotheo.py
+++ b/statsmodels/sandbox/infotheo.py
@@ -104,7 +104,7 @@ def discretize(X, method="ef", nbins=None):
     --------
     """
     nobs = len(X)
-    if nbins == None:
+    if nbins is None:
         nbins = np.floor(np.sqrt(nobs))
     if method == "ef":
         discrete = np.ceil(nbins * stats.rankdata(X)/nobs)
@@ -234,9 +234,9 @@ def condentropy(px, py, pxpy=None, logbase=2):
     """
     if not _isproperdist(px) or not _isproperdist(py):
         raise ValueError("px or py is not a proper probability distribution")
-    if pxpy != None and not _isproperdist(pxpy):
+    if pxpy is not None and not _isproperdist(pxpy):
         raise ValueError("pxpy is not a proper joint distribtion")
-    if pxpy == None:
+    if pxpy is None:
         pxpy = np.outer(py,px)
     condent = np.sum(pxpy * np.nan_to_num(np.log2(py/pxpy)))
     if logbase == 2:
@@ -267,9 +267,9 @@ def mutualinfo(px,py,pxpy, logbase=2):
     """
     if not _isproperdist(px) or not _isproperdist(py):
         raise ValueError("px or py is not a proper probability distribution")
-    if pxpy != None and not _isproperdist(pxpy):
+    if pxpy is not None and not _isproperdist(pxpy):
         raise ValueError("pxpy is not a proper joint distribtion")
-    if pxpy == None:
+    if pxpy is None:
         pxpy = np.outer(py,px)
     return shannonentropy(px, logbase=logbase) - condentropy(px,py,pxpy,
             logbase=logbase)
@@ -306,9 +306,9 @@ def corrent(px,py,pxpy,logbase=2):
     """
     if not _isproperdist(px) or not _isproperdist(py):
         raise ValueError("px or py is not a proper probability distribution")
-    if pxpy != None and not _isproperdist(pxpy):
+    if pxpy is not None and not _isproperdist(pxpy):
         raise ValueError("pxpy is not a proper joint distribtion")
-    if pxpy == None:
+    if pxpy is None:
         pxpy = np.outer(py,px)
 
     return mutualinfo(px,py,pxpy,logbase=logbase)/shannonentropy(py,
@@ -347,9 +347,9 @@ def covent(px,py,pxpy,logbase=2):
     """
     if not _isproperdist(px) or not _isproperdist(py):
         raise ValueError("px or py is not a proper probability distribution")
-    if pxpy != None and not _isproperdist(pxpy):
+    if pxpy is not None and not _isproperdist(pxpy):
         raise ValueError("pxpy is not a proper joint distribtion")
-    if pxpy == None:
+    if pxpy is None:
         pxpy = np.outer(py,px)
 
     return condent(px,py,pxpy,logbase=logbase) + condent(py,px,pxpy,

--- a/statsmodels/sandbox/nonparametric/tests/ex_gam_new.py
+++ b/statsmodels/sandbox/nonparametric/tests/ex_gam_new.py
@@ -70,8 +70,8 @@ if example == 3:
     f = family.Poisson()
     #y = y/y.max() * 3
     yp = f.link.inverse(z)
-    #p = np.asarray([scipy.stats.poisson.rvs(p) for p in f.link.inverse(y)], float)
-    p = np.asarray([stats.poisson.rvs(p) for p in f.link.inverse(z)], float)
+    p = np.asarray([stats.poisson.rvs(val) for val in f.link.inverse(z)],
+                   float)
     p.shape = y.shape
     m = GAM(p, d, family=f)
     toc = time.time()

--- a/statsmodels/sandbox/panel/panelmod.py
+++ b/statsmodels/sandbox/panel/panelmod.py
@@ -103,7 +103,7 @@ class PanelModel(object):
     """
     def __init__(self, endog=None, exog=None, panel=None, time=None,
             xtnames=None, equation=None, panel_data=None):
-        if panel_data == None:
+        if panel_data is None:
 #            if endog == None and exog == None and panel == None and \
 #                    time == None:
 #                raise ValueError("If pandel_data is False then endog, exog, \
@@ -184,7 +184,7 @@ class PanelModel(object):
         self.panel_data = panel_data
         endog = panel_data[endog_name].values # does this create a copy?
         self.endog = np.squeeze(endog)
-        if exog_name == None:
+        if exog_name is None:
             exog_name = panel_data.columns.tolist()
             exog_name.remove(endog_name)
         self.exog = panel_data.filterItems(exog_name).values # copy?

--- a/statsmodels/sandbox/panel/panelmod.py
+++ b/statsmodels/sandbox/panel/panelmod.py
@@ -218,13 +218,13 @@ class PanelModel(object):
             mean = np.dot(dummy,X)/dummy.sum(1)[:,None]
         else:
             mean = np.dot(dummy,X)/dummy.sum(1)
-        if counts == False and dummies == False:
+        if counts is False and dummies is False:
             return mean
-        elif counts == True and dummies == False:
+        elif counts is True and dummies is False:
             return mean, dummy.sum(1)
-        elif counts == True and dummies == True:
+        elif counts is True and dummies is True:
             return mean, dummy.sum(1), dummy
-        elif counts == False and dummies == True:
+        elif counts is False and dummies is True:
             return mean, dummy
 
 #TODO: Use kwd arguments or have fit_method methods?

--- a/statsmodels/sandbox/pca.py
+++ b/statsmodels/sandbox/pca.py
@@ -39,7 +39,7 @@ class Pca(object):
         self._colors= np.tile(self._colors,int((p-1)/len(self._colors))+1)[:p]
         if names is not None and len(names) != p:
             raise ValueError('names must match data dimension')
-        self.names = None if names is None else tuple([str(n) for n in names])
+        self.names = None if names is None else tuple([str(x) for x in names])
 
 
     def getCovarianceMatrix(self):

--- a/statsmodels/sandbox/pca.py
+++ b/statsmodels/sandbox/pca.py
@@ -152,7 +152,7 @@ class Pca(object):
 
         returns n,p(>threshold) dimension array
         """
-        nonnones = sum([e != None for e in (enthresh,nPCs,cumen)])
+        nonnones = sum([e is not None for e in (enthresh, nPCs, cumen)])
         if nonnones == 0:
             m = slice(None)
         elif nonnones > 1:

--- a/statsmodels/sandbox/predict_functional.py
+++ b/statsmodels/sandbox/predict_functional.py
@@ -441,7 +441,7 @@ def _glm_basic_scr(result, exog, alpha):
     from scipy.optimize import brentq
 
     c, rslt = brentq(func, 1, 10, full_output=True)
-    if rslt.converged == False:
+    if not rslt.converged:
         raise ValueError("Root finding error in basic SCR")
 
     return sigma, c

--- a/statsmodels/sandbox/regression/try_catdata.py
+++ b/statsmodels/sandbox/regression/try_catdata.py
@@ -77,7 +77,7 @@ def convertlabels(ys, indices=None):
     '''convert labels based on multiple variables or string labels to unique
     index labels 0,1,2,...,nk-1 where nk is the number of distinct labels
     '''
-    if indices == None:
+    if indices is None:
         ylabel = ys
     else:
         idx = np.array(indices)

--- a/statsmodels/sandbox/stats/multicomp.py
+++ b/statsmodels/sandbox/stats/multicomp.py
@@ -1882,7 +1882,7 @@ if __name__ == '__main__':
         xli = [X[X[:,1]==k,0] for k in range(1,5)]
         xranks = stats.rankdata(X[:,0])
         xranksli = [xranks[X[:,1]==k] for k in range(1,5)]
-        xnobs = np.array([len(x) for x in xli])
+        xnobs = np.array([len(xval) for xval in xli])
         meanranks = [item.mean() for item in xranksli]
         sumranks = [item.sum() for item in xranksli]
         # equivalent function

--- a/statsmodels/sandbox/sysreg.py
+++ b/statsmodels/sandbox/sysreg.py
@@ -131,7 +131,7 @@ exogenous variables.  Got length %s" % len(sys))
 # Deal with sigma, check shape earlier if given
         if np.any(sigma):
             sigma = np.asarray(sigma) # check shape
-        elif sigma == None:
+        elif sigma is None:
             resids = []
             for i in range(M):
                 resids.append(GLS(endog[i],exog[:,

--- a/statsmodels/sandbox/tsa/garch.py
+++ b/statsmodels/sandbox/tsa/garch.py
@@ -804,7 +804,7 @@ class AR(LikelihoodModel):
                     maxiter=maxiter, tol=tol)
         else:
             bounds = [(-.999,.999)]   # assume stationarity
-            if start_params == None:
+            if start_params is None:
                 start_params = np.array([0]) #TODO: assumes AR(1)
             if method == 'bfgs-b':
                 retval = optimize.fmin_l_bfgs_b(minfunc, start_params,

--- a/statsmodels/sandbox/tsa/movstat.py
+++ b/statsmodels/sandbox/tsa/movstat.py
@@ -86,7 +86,7 @@ def movorder(x, order = 'med', windsize=3, lag='lagged'):
         lead = -windsize//2 +1
     else:
         raise ValueError
-    if np.isfinite(order) == True: #if np.isnumber(order):
+    if np.isfinite(order): #if np.isnumber(order):
         ord = order   # note: ord is a builtin function
     elif order == 'med':
         ord = (windsize - 1)/2

--- a/statsmodels/stats/descriptivestats.py
+++ b/statsmodels/stats/descriptivestats.py
@@ -166,12 +166,12 @@ class Describe(object):
             except (TypeError, ValueError):
                 return False
             return True
-        if number_like()==True and string_like()==False:
+        if number_like() and not string_like():
             return 'number'
-        elif number_like()==False and string_like()==True:
+        elif not number_like() and string_like():
             return 'string'
         else:
-            assert (number_like()==True or string_like()==True), '\
+            assert (number_like() or string_like()), '\
             Not sure of dtype'+str(self.dataset[col][0])
 
     #@property

--- a/statsmodels/stats/descriptivestats.py
+++ b/statsmodels/stats/descriptivestats.py
@@ -196,7 +196,7 @@ class Describe(object):
         # standard array: Specifiy column numbers (NEED TO TEST)
         # percentiles currently broken
         # mode requires mode_val and mode_bin separately
-        if self._arraytype == None:
+        if self._arraytype is None:
             self._array_typer()
 
         if stats == 'basic':

--- a/statsmodels/tools/sequences.py
+++ b/statsmodels/tools/sequences.py
@@ -206,7 +206,7 @@ def halton(dim, n_sample, bounds=None, start_index=0):
     base = n_primes(dim)
 
     # Generate a sample using a Van der Corput sequence per dimension.
-    sample = [van_der_corput(n_sample + 1, dim, start_index) for dim in base]
+    sample = [van_der_corput(n_sample + 1, bdim, start_index) for bdim in base]
     sample = np.array(sample).T[1:]
 
     # Sample scaling from unit hypercube to feature range

--- a/statsmodels/tsa/vector_ar/irf.py
+++ b/statsmodels/tsa/vector_ar/irf.py
@@ -342,7 +342,7 @@ class IRAnalysis(BaseIRAnalysis):
 
         W, eigva, k =self._eigval_decomp_SZ(irf_resim)
 
-        if component != None:
+        if component is not None:
             if np.shape(component) != (neqs,neqs):
                 raise ValueError("Component array must be " + str(neqs) + " x " + str(neqs))
             if np.argmax(component) >= neqs*periods:
@@ -398,7 +398,7 @@ class IRAnalysis(BaseIRAnalysis):
 
         W, eigva, k = self._eigval_decomp_SZ(irf_resim)
 
-        if component != None:
+        if component is not None:
             if np.shape(component) != (neqs,neqs):
                 raise ValueError("Component array must be " + str(neqs) + " x " + str(neqs))
             if np.argmax(component) >= neqs*periods:
@@ -471,7 +471,7 @@ class IRAnalysis(BaseIRAnalysis):
         eigva = np.zeros((neqs, periods*neqs))
         k = np.zeros((neqs))
 
-        if component != None:
+        if component is not None:
             if np.size(component) != (neqs):
                 raise ValueError("Component array must be of length " + str(neqs))
             if np.argmax(component) >= neqs*periods:

--- a/statsmodels/tsa/vector_ar/irf.py
+++ b/statsmodels/tsa/vector_ar/irf.py
@@ -140,7 +140,7 @@ class BaseIRAnalysis(object):
         else:
             title = 'Impulse responses'
 
-        if plot_stderr == False:
+        if plot_stderr is False:
             stderr = None
 
         elif stderr_type not in ['asym', 'mc', 'sz1', 'sz2','sz3']:
@@ -294,7 +294,7 @@ class IRAnalysis(BaseIRAnalysis):
         """
         model = self.model
         periods = self.periods
-        if svar == True:
+        if svar:
             return model.sirf_errband_mc(orth=orth, repl=repl, T=periods,
                                          signif=signif, seed=seed,
                                          burn=burn, cum=False)

--- a/statsmodels/tsa/vector_ar/svar_model.py
+++ b/statsmodels/tsa/vector_ar/svar_model.py
@@ -356,7 +356,7 @@ class SVAR(tsbase.TimeSeriesModel):
         A[A_mask] = start_params[:A_len]
         B[B_mask] = start_params[A_len:]
 
-        if override == False:
+        if not override:
             J = self._compute_J(A, B)
             self.check_order(J)
             self.check_rank(J)
@@ -413,13 +413,13 @@ class SVAR(tsbase.TimeSeriesModel):
         if len(A_solve[A_mask]) != 0:
             A_vec = np.ravel(A_mask, order='F')
             for k in range(neqs**2):
-                if A_vec[k] == True:
+                if A_vec[k]:
                     S_B[k,j] = -1
                     j += 1
         if len(B_solve[B_mask]) != 0:
             B_vec = np.ravel(B_mask, order='F')
             for k in range(neqs**2):
-                if B_vec[k] == True:
+                if B_vec[k]:
                     S_D[k,j_d] = 1
                     j_d +=1
 


### PR DESCRIPTION
F812, E711, and E712 are the three least-common remaining warnings.  E711 and E712 check for comparison operations with None, True, and False.  F812 checks for e.g.

```
x = 4
foo = [x**2 for x in range(10)]
```

which can be really easy to not notice and become a PITA to debug.

