### PR TITLE
REF: put contrast_allpairs directly in contrast, avoiding sandbox imports

### DIFF
--- a/statsmodels/sandbox/stats/contrast_tools.py
+++ b/statsmodels/sandbox/stats/contrast_tools.py
@@ -26,29 +26,10 @@ from __future__ import print_function
 from statsmodels.compat.python import zip
 import numpy as np
 
-#next 3 functions copied from multicomp.py
+from statsmodels.stats.contrast import contrast_allpairs
 
-def contrast_allpairs(nm):
-    '''contrast or restriction matrix for all pairs of nm variables
 
-    Parameters
-    ----------
-    nm : int
-
-    Returns
-    -------
-    contr : ndarray, 2d, (nm*(nm-1)/2, nm)
-       contrast matrix for all pairwise comparisons
-
-    '''
-    contr = []
-    for i in range(nm):
-        for j in range(i+1, nm):
-            contr_row = np.zeros(nm)
-            contr_row[i] = 1
-            contr_row[j] = -1
-            contr.append(contr_row)
-    return np.array(contr)
+# next 2 functions moved from multicomp.py
 
 def contrast_all_one(nm):
     '''contrast or restriction matrix for all against first comparison

--- a/statsmodels/sandbox/stats/multicomp.py
+++ b/statsmodels/sandbox/stats/multicomp.py
@@ -90,6 +90,7 @@ from statsmodels.iolib.table import SimpleTable
 from numpy.testing import assert_almost_equal, assert_equal
 #temporary circular import
 from statsmodels.stats.multitest import multipletests, _ecdf as ecdf, fdrcorrection as fdrcorrection0, fdrcorrection_twostage
+from statsmodels.stats.contrast import contrast_allpairs
 from statsmodels.graphics import utils
 from statsmodels.tools.sm_exceptions import ValueWarning
 
@@ -1439,59 +1440,6 @@ def distance_st_range(mean_all, nobs_all, var_all, df=None, triu=False):
 
     return st_range, meandiffs, std_pairs, (idx1,idx2)  #return square arrays
 
-
-def contrast_allpairs(nm):
-    '''contrast or restriction matrix for all pairs of nm variables
-
-    Parameters
-    ----------
-    nm : int
-
-    Returns
-    -------
-    contr : ndarray, 2d, (nm*(nm-1)/2, nm)
-       contrast matrix for all pairwise comparisons
-
-    '''
-    contr = []
-    for i in range(nm):
-        for j in range(i+1, nm):
-            contr_row = np.zeros(nm)
-            contr_row[i] = 1
-            contr_row[j] = -1
-            contr.append(contr_row)
-    return np.array(contr)
-
-def contrast_all_one(nm):
-    '''contrast or restriction matrix for all against first comparison
-
-    Parameters
-    ----------
-    nm : int
-
-    Returns
-    -------
-    contr : ndarray, 2d, (nm-1, nm)
-       contrast matrix for all against first comparisons
-
-    '''
-    contr = np.column_stack((np.ones(nm-1), -np.eye(nm-1)))
-    return contr
-
-def contrast_diff_mean(nm):
-    '''contrast or restriction matrix for all against mean comparison
-
-    Parameters
-    ----------
-    nm : int
-
-    Returns
-    -------
-    contr : ndarray, 2d, (nm-1, nm)
-       contrast matrix for all against mean comparisons
-
-    '''
-    return np.eye(nm) - np.ones((nm,nm))/nm
 
 def tukey_pvalues(std_range, nm, df):
     #corrected but very slow with warnings about integration

--- a/statsmodels/stats/contrast.py
+++ b/statsmodels/stats/contrast.py
@@ -344,6 +344,30 @@ def contrastfromcols(L, D, pseudo=None):
     return np.squeeze(C)
 
 
+def contrast_allpairs(nm):
+    """
+    contrast or restriction matrix for all pairs of nm variables
+
+    Parameters
+    ----------
+    nm : int
+
+    Returns
+    -------
+    contr : ndarray, 2d, (nm*(nm-1)/2, nm)
+       contrast matrix for all pairwise comparisons
+
+    """
+    contr = []
+    for i in range(nm):
+        for j in range(i+1, nm):
+            contr_row = np.zeros(nm)
+            contr_row[i] = 1
+            contr_row[j] = -1
+            contr.append(contr_row)
+    return np.array(contr)
+
+
 # TODO: this is currently a minimal version, stub
 class WaldTestResults(object):
     # for F and chi2 tests of joint hypothesis, mainly for vectorized
@@ -580,9 +604,8 @@ def _constraints_factor(encoding_matrix, comparison='pairwise', k_params=None,
     cm = encoding_matrix
     k_level, k_p = cm.shape
 
-    import statsmodels.sandbox.stats.multicomp as mc
     if comparison in ['pairwise', 'pw', 'pairs']:
-        c_all = -mc.contrast_allpairs(k_level)
+        c_all = -contrast_allpairs(k_level)
     else:
         raise NotImplementedError('currentlyonly pairwise comparison')
 
@@ -665,8 +688,7 @@ def t_test_pairwise(result, term_name, method='hs', alpha=0.05,
     k_params = len(result.params)
     labels = _get_pairs_labels(k_level, cat)
 
-    import statsmodels.sandbox.stats.multicomp as mc
-    c_all_pairs = -mc.contrast_allpairs(k_level)
+    c_all_pairs = -contrast_allpairs(k_level)
     contrasts_sub = c_all_pairs.dot(cm)
     contrasts = _embed_constraints(contrasts_sub, k_params, idx_start)
     res_df = t_test_multi(result, contrasts, method=method, ci_method=None,

--- a/statsmodels/stats/tests/test_contrast.py
+++ b/statsmodels/stats/tests/test_contrast.py
@@ -1,7 +1,7 @@
 import numpy as np
 import numpy.random
 from numpy.testing import assert_almost_equal, assert_equal
-from statsmodels.stats.contrast import Contrast
+from statsmodels.stats.contrast import Contrast, contrast_allpairs
 import statsmodels.stats.contrast as smc
 
 
@@ -66,3 +66,28 @@ def test_constraints():
 
     c1 = smc._contrast_pairs(6, 4, 1)  # k_params, k_level, idx_start
     assert_equal(c1, cpairs2)
+
+
+def test_contrast_allpairs():
+    result = contrast_allpairs(1)
+    assert result.size == 0
+
+    result = contrast_allpairs(2)
+    expected = np.array([[1., -1.]])
+    assert_equal(result, expected)
+
+    result = contrast_allpairs(3)
+    expected = np.array([[1, -1, 0],
+                         [1, 0, -1],
+                         [0, 1, -1]])
+    assert_equal(result, expected)
+
+    for n in range(4, 15):
+        result = contrast_allpairs(n)
+
+        assert (result.sum(1) == 0).all()
+        assert result[:, 0].sum() == n - 1
+
+        rsum = result.sum(0)
+        expsum = range(n-1, -n, -2)
+        assert_equal(rsum, expsum)


### PR DESCRIPTION
It's straightforward to verify that it is in good shape.  It gets tested indirectly in the test suite, but this PR implements some specific tests just to be on the safe side.

Avoids both sandbox imports and duplication of this function in multicomp and contrast_tools.

Removes two other contrast_foo functions from multicomp that are available in contrast_tools and never used.