### PR TITLE
REF: Use ArmaProcess.generate_sample instead of ArmaFft

### DIFF
--- a/lint.sh
+++ b/lint.sh
@@ -51,6 +51,7 @@ if [ "$LINT" == true ]; then
         statsmodels/sandbox/regression/tests/results_gmm_griliches_iter.py \
         statsmodels/sandbox/regression/tests/results_gmm_poisson.py \
         statsmodels/sandbox/regression/tests/results_ivreg2_griliches.py \
+        statsmodels/sandbox/tsa/tests/ \
         statsmodels/stats/__init__.py \
         statsmodels/stats/_knockoff.py \
         statsmodels/stats/base.py \

--- a/statsmodels/examples/tsa/arma_plots.py
+++ b/statsmodels/examples/tsa/arma_plots.py
@@ -27,10 +27,6 @@ for arcoef in arcoefs[:-1]:
         ar = np.r_[1., -arcoef]
         ma = np.r_[1.,  macoef]
 
-        #from statsmodels.sandbox.tsa.fftarma import ArmaFft as FftArmaProcess
-        #y = tsp.arma_generate_sample(ar,ma,nsample, sig, burnin)
-        #armaprocess = FftArmaProcess(ar, ma, nsample) #TODO: make n optional
-        #armaprocess.plot4()
         armaprocess = tsp.ArmaProcess(ar, ma)
         acf = armaprocess.acf(20)[:20]
         pacf = armaprocess.pacf(20)[:20]

--- a/statsmodels/examples/tsa/ex_arma_all.py
+++ b/statsmodels/examples/tsa/ex_arma_all.py
@@ -4,11 +4,12 @@ from __future__ import print_function
 import numpy as np
 from numpy.testing import assert_almost_equal
 import matplotlib.pyplot as plt
-import statsmodels.sandbox.tsa.fftarma as fa
+
+from statsmodels.tsa.arima_process import ArmaProcess
 from statsmodels.tsa.descriptivestats import TsaDescriptive
 from statsmodels.tsa.arma_mle import Arma
 
-x = fa.ArmaFft([1, -0.5], [1., 0.4], 40).generate_sample(size=200, burnin=1000)
+x = ArmaProcess([1, -0.5], [1., 0.4], 40).generate_sample(size=200, burnin=1000)
 d = TsaDescriptive(x)
 d.plot4()
 

--- a/statsmodels/sandbox/tsa/tests/test_armafft.py
+++ b/statsmodels/sandbox/tsa/tests/test_armafft.py
@@ -1,0 +1,53 @@
+import numpy as np
+from numpy.testing import (assert_almost_equal,
+                           assert_allclose,
+                           assert_equal)
+
+import pytest
+
+from statsmodels.sandbox.tsa.fftarma import ArmaFft
+
+
+arlist = [
+    [1.],
+    [1, -0.9],  # ma representation will need many terms to get high precision
+    [1, 0.9],
+    [1, -0.9, 0.3]
+]
+
+malist = [
+    [1.],
+    [1, 0.9],
+    [1, -0.9],
+    [1, 0.9, -0.3]
+]
+
+
+@pytest.mark.parametrize('ar', arlist)
+@pytest.mark.parametrize('ma', malist)
+def test_spectrum(ar, ma):
+    nfreq = 20
+    w = np.linspace(0, np.pi, nfreq, endpoint=False)
+
+    arma = ArmaFft(ar, ma, 20)
+    spdr, wr = arma.spdroots(w)
+    spdp, wp = arma.spdpoly(w, 200)
+    spdd, wd = arma.spddirect(nfreq * 2)
+    assert_equal(w, wr)
+    assert_equal(w, wp)
+    assert_almost_equal(w, wd[:nfreq], decimal=14)
+    assert_almost_equal(spdr, spdd[:nfreq], decimal=7,
+                        err_msg='spdr spdd not equal for %s, %s' % (ar, ma))
+    assert_almost_equal(spdr, spdp, decimal=7,
+                        err_msg='spdr spdp not equal for %s, %s' % (ar, ma))
+
+
+@pytest.mark.parametrize('ar', arlist)
+@pytest.mark.parametrize('ma', malist)
+def test_armafft(ar, ma):
+    # test other methods
+    arma = ArmaFft(ar, ma, 20)
+    ac1 = arma.invpowerspd(1024)[:10]
+    ac2 = arma.acovf(10)[:10]
+    assert_allclose(ac1, ac2, atol=1e-15,
+                    err_msg='acovf not equal for %s, %s' % (ar, ma))

--- a/statsmodels/tsa/tests/test_arima.py
+++ b/statsmodels/tsa/tests/test_arima.py
@@ -12,13 +12,12 @@ from pandas import DatetimeIndex, date_range, period_range
 import pytest
 
 from statsmodels.datasets.macrodata import load_pandas as load_macrodata_pandas
-import statsmodels.sandbox.tsa.fftarma as fa
 from statsmodels.tools.testing import assert_equal
 from statsmodels.tsa.arma_mle import Arma
 from statsmodels.tsa.arima_model import AR, ARMA, ARIMA
 from statsmodels.regression.linear_model import OLS
 from statsmodels.tsa.tests.results import results_arma, results_arima
-from statsmodels.tsa.arima_process import arma_generate_sample
+from statsmodels.tsa.arima_process import arma_generate_sample, ArmaProcess
 
 DECIMAL_4 = 4
 DECIMAL_3 = 3
@@ -42,8 +41,8 @@ def test_compare_arma():
     #for now without random.seed
 
     np.random.seed(9876565)
-    x = fa.ArmaFft([1, -0.5], [1., 0.4], 40).generate_sample(nsample=200,
-            burnin=1000)
+    x = ArmaProcess([1, -0.5], [1., 0.4], 40).generate_sample(nsample=200,
+                                                              burnin=1000)
 
     # this used kalman filter through descriptive
     #d = ARMA(x)
@@ -2379,8 +2378,8 @@ def test_long_ar_start_params():
 
 def test_arma_pickle():
     np.random.seed(9876565)
-    x = fa.ArmaFft([1, -0.5], [1., 0.4], 40).generate_sample(nsample=200,
-                                                             burnin=1000)
+    x = ArmaProcess([1, -0.5], [1., 0.4], 40).generate_sample(nsample=200,
+                                                              burnin=1000)
     mod = ARMA(x, (1, 1))
     pkl_mod = cPickle.loads(cPickle.dumps(mod))
 

--- a/statsmodels/tsa/tests/test_arima_process.py
+++ b/statsmodels/tsa/tests/test_arima_process.py
@@ -12,7 +12,6 @@ import pytest
 from statsmodels.tsa.arima_process import (arma_generate_sample, arma_acovf,
                                            arma_acf, arma_impulse_response, lpol_fiar, lpol_fima,
                                            ArmaProcess, lpol2index, index2lpol)
-from statsmodels.sandbox.tsa.fftarma import ArmaFft
 
 from statsmodels.tsa.tests.results.results_process import armarep  # benchmarkdata
 from statsmodels.tsa.tests.results import results_arma_acf
@@ -173,39 +172,6 @@ def test_arma_impulse_response():
     assert_array_almost_equal(armarep.marep.ravel(), marep, 14)
     # difference in sign convention to matlab for AR term
     assert_array_almost_equal(-armarep.arrep.ravel(), arrep, 14)
-
-
-@pytest.mark.parametrize('ar', arlist)
-@pytest.mark.parametrize('ma', malist)
-def test_spectrum(ar, ma):
-    nfreq = 20
-    w = np.linspace(0, np.pi, nfreq, endpoint=False)
-
-    arma = ArmaFft(ar, ma, 20)
-    spdr, wr = arma.spdroots(w)
-    spdp, wp = arma.spdpoly(w, 200)
-    spdd, wd = arma.spddirect(nfreq * 2)
-    assert_equal(w, wr)
-    assert_equal(w, wp)
-    assert_almost_equal(w, wd[:nfreq], decimal=14)
-    assert_almost_equal(spdr, spdd[:nfreq], decimal=7,
-                        err_msg='spdr spdd not equal for %s, %s' % (ar, ma))
-    assert_almost_equal(spdr, spdp, decimal=7,
-                        err_msg='spdr spdp not equal for %s, %s' % (ar, ma))
-
-
-@pytest.mark.parametrize('ar', arlist)
-@pytest.mark.parametrize('ma', malist)
-def test_armafft(ar, ma):
-    # test other methods
-    nfreq = 20
-    w = np.linspace(0, np.pi, nfreq, endpoint=False)
-
-    arma = ArmaFft(ar, ma, 20)
-    ac1 = arma.invpowerspd(1024)[:10]
-    ac2 = arma.acovf(10)[:10]
-    assert_allclose(ac1, ac2, atol=1e-15,
-                    err_msg='acovf not equal for %s, %s' % (ar, ma))
 
 
 def test_lpol2index_index2lpol():


### PR DESCRIPTION
Move armafft-specific test to an armafft-specific test file.  After this, non-sandbox does not import armafft
