### PR TITLE
BUG: Ensure coint_johansen runs with 0 lags

### DIFF
--- a/statsmodels/tsa/vector_ar/tests/test_coint.py
+++ b/statsmodels/tsa/vector_ar/tests/test_coint.py
@@ -10,6 +10,8 @@ import warnings
 
 import numpy as np
 from numpy.testing import assert_almost_equal, assert_equal
+import pandas as pd
+import pytest
 
 from statsmodels.tsa.vector_ar.vecm import coint_johansen
 from statsmodels.tools.sm_exceptions import HypothesisTestWarning
@@ -120,8 +122,32 @@ class TestCointJoh25(CheckCointJoh):
             cls.res = coint_johansen(dta, 2, 5)
         cls.nobs_r = 173 - 1 - 5
 
-        #Note: critical values not available if trend>1
-        cls.res1_m = np.array([270.1887263915158,  171.6870096307863,  107.8613367358704,  70.82424032233558,  44.62551818267534,  25.74352073857572,  14.17882426926978,  4.288656185006764,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,  0])
+        # Note: critical values not available if trend>1
+        cls.res1_m = np.array([270.1887263915158, 171.6870096307863,
+                               107.8613367358704, 70.82424032233558,
+                               44.62551818267534, 25.74352073857572,
+                               14.17882426926978, 4.288656185006764,
+                               0, 0, 0, 0, 0, 0, 0, 0, 0,
+                               0, 0, 0, 0, 0, 0, 0, 0, 0,
+                               0, 0, 0, 0, 0, 0])
         cls.res1_m[cls.res1_m == 0] = np.nan
-        cls.res2_m = np.array([98.50171676072955,  63.82567289491584,  37.03709641353485,  26.19872213966024,  18.88199744409963,  11.56469646930594,  9.890168084263012,  4.288656185006764,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,  0])
+        cls.res2_m = np.array([98.50171676072955, 63.82567289491584,
+                               37.03709641353485, 26.19872213966024,
+                               18.88199744409963, 11.56469646930594,
+                               9.890168084263012, 4.288656185006764,
+                               0, 0, 0, 0, 0, 0, 0, 0,
+                               0, 0, 0, 0, 0, 0, 0, 0,
+                               0, 0, 0, 0, 0, 0, 0, 0])
         cls.res2_m[cls.res2_m == 0] = np.nan
+
+
+@pytest.mark.smoke
+def test_coint_johansen_0lag(reset_randomstate):
+    # GH 5731
+    x_diff = np.random.normal(0, 1, 1000)
+    x = pd.Series(np.cumsum(x_diff))
+    e1 = np.random.normal(0, 1, 1000)
+    y = x + 5 + e1
+    data = pd.concat([x, y], axis=1)
+    result = coint_johansen(data, det_order=-1, k_ar_diff=0)
+    assert result.eig.shape == (2,)

--- a/statsmodels/tsa/vector_ar/vecm.py
+++ b/statsmodels/tsa/vector_ar/vecm.py
@@ -623,6 +623,7 @@ def coint_johansen(endog, det_order, k_ar_diff):
         r = y - np.dot(x, np.dot(np.linalg.pinv(x), y))
         return r
 
+    endog = np.asarray(endog)
     nobs, neqs = endog.shape
 
     # why this?  f is detrend transformed series, det_order is detrend data
@@ -641,11 +642,14 @@ def coint_johansen(endog, det_order, k_ar_diff):
 
     dx = detrend(dx, f)
     r0t = resid(dx, z)
-    lx = endog[:-k_ar_diff]
+    # GH 5731, [:-0] does not work, need [:t-0]
+    lx = endog[:(endog.shape[0]-k_ar_diff)]
     lx = lx[1:]
     dx = detrend(lx, f)
     rkt = resid(dx, z)  # level on lagged diffs
+    # Level covariance after filtering k_ar_diff
     skk = np.dot(rkt.T, rkt) / rkt.shape[0]
+    # Covariacne between filtered and unfiltered
     sk0 = np.dot(rkt.T, r0t) / rkt.shape[0]
     s00 = np.dot(r0t.T, r0t) / r0t.shape[0]
     sig = np.dot(sk0, np.dot(inv(s00), sk0.T))


### PR DESCRIPTION
Fix bug created using [:-0]

closes #5731

- [X] closes #5731
- [X] tests added / passed. 
- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html#writing-the-commit-message). 

