### PR TITLE
MAINT: matplotlib normed -> density

### DIFF
--- a/statsmodels/examples/ex_kde_confint.py
+++ b/statsmodels/examples/ex_kde_confint.py
@@ -27,7 +27,13 @@ ci = kde.kernel.density_confint(kde.density, len(x))
 
 fig = plt.figure()
 ax = fig.add_subplot(1, 1, 1)
-ax.hist(x, bins=15, normed=True, alpha=0.25)
+
+# gh5792. Remove except after matplotlib>2.1 required
+try:
+    ax.hist(x, bins=15, density=True, alpha=0.25)
+except AttributeError:
+    ax.hist(x, bins=15, normed=True, alpha=0.25)
+
 ax.plot(kde.support, kde.density, lw=2, color='red')
 ax.fill_between(kde.support, ci[:,0], ci[:,1],
                     color='grey', alpha='0.7')
@@ -46,7 +52,13 @@ kernel_names = ['Biweight', 'Cosine', 'Epanechnikov', 'Gaussian',
 fig = plt.figure()
 for ii, kn in enumerate(kernel_names):
     ax = fig.add_subplot(2, 3, ii+1)   # without uniform
-    ax.hist(x, bins=10, normed=True, alpha=0.25)
+
+    # gh5792. Remove except after matplotlib>2.1 required
+    try:
+        ax.hist(x, bins=10, density=True, alpha=0.25)
+    except AttributeError:
+        ax.hist(x, bins=10, normed=True, alpha=0.25)
+
     #reduce bandwidth for Gaussian and Uniform which are to large in example
     if kn in ['Gaussian', 'Uniform']:
         args = (0.5,)

--- a/statsmodels/examples/ex_kde_normalreference.py
+++ b/statsmodels/examples/ex_kde_normalreference.py
@@ -40,7 +40,12 @@ fig = plt.figure()
 for ii, kn in enumerate(kernel_switch):
 
     ax = fig.add_subplot(2, 3, ii + 1)   # without uniform
-    ax.hist(x, bins=20, normed=True, alpha=0.25)
+
+    # gh5792. Remove except after matplotlib>2.1 required
+    try:
+        ax.hist(x, bins=20, density=True, alpha=0.25)
+    except AttributeError:
+        ax.hist(x, bins=20, normed=True, alpha=0.25)
 
     kde.fit(kernel=kn, bw='silverman', fft=False)
     ax.plot(kde.support, kde.density)

--- a/statsmodels/tsa/statespace/mlemodel.py
+++ b/statsmodels/tsa/statespace/mlemodel.py
@@ -2633,9 +2633,11 @@ class MLEResults(tsbase.TimeSeriesModelResults):
         # elements
         resid_nonmissing = resid[~(np.isnan(resid))]
         ax = fig.add_subplot(222)
-        # temporarily disable Deprecation warning, normed -> density
-        # hist needs to use `density` in future when minimum matplotlib has it
-        with warnings.catch_warnings(record=True):
+
+        # gh5792: Remove  except after support for matplotlib>2.1 required
+        try:
+            ax.hist(resid_nonmissing, density=True, label='Hist')
+        except AttributeError:
             ax.hist(resid_nonmissing, normed=True, label='Hist')
 
         from scipy.stats import gaussian_kde, norm


### PR DESCRIPTION
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html#writing-the-commit-message). 

Looks like matplotlib has changed the kwarg from `normed` to `density`. 

This is causing a fail in the pip_pre travis, and will likely cause fails elsewhere as time passes.