### PR TITLE
MAINT: Adjust tolerance for random fail on OSX

### DIFF
--- a/statsmodels/emplike/tests/test_regression.py
+++ b/statsmodels/emplike/tests/test_regression.py
@@ -63,22 +63,26 @@ class TestRegressionPowell(GenRes):
         assert_almost_equal(beta3res[2], self.res2.test_beta3[2], 4)
 
     # Confidence interval results obtained through hypothesis testing in Matlab
+    @pytest.mark.slow
     def test_ci_beta0(self):
         beta0ci = self.res1.conf_int_el(0, lower_bound=-52.9,
                                         upper_bound=-24.1, method='powell')
         assert_almost_equal(beta0ci, self.res2.test_ci_beta0, 3)
         #  Slightly lower precision.  CI was obtained from nm method.
 
+    @pytest.mark.slow
     def test_ci_beta1(self):
         beta1ci = self.res1.conf_int_el(1, lower_bound=.418, upper_bound=.986,
                                         method='powell')
         assert_almost_equal(beta1ci, self.res2.test_ci_beta1, 4)
 
+    @pytest.mark.slow
     def test_ci_beta2(self):
         beta2ci = self.res1.conf_int_el(2, lower_bound=.59,
                                         upper_bound=2.2, method='powell')
         assert_almost_equal(beta2ci, self.res2.test_ci_beta2, 5)
 
+    @pytest.mark.slow
     def test_ci_beta3(self):
         beta3ci = self.res1.conf_int_el(3, lower_bound=-.39, upper_bound=.01,
                                         method='powell')

--- a/statsmodels/examples/tests/test_notebooks.py
+++ b/statsmodels/examples/tests/test_notebooks.py
@@ -48,6 +48,7 @@ if not nbs:
     pytestmark = pytest.mark.skip(reason='No notebooks found so not tests run')
 
 
+@pytest.mark.slow
 @pytest.mark.example
 def test_notebook(notebook):
     fullfile = os.path.abspath(notebook)

--- a/statsmodels/graphics/tests/test_functional.py
+++ b/statsmodels/graphics/tests/test_functional.py
@@ -60,6 +60,7 @@ def test_hdr_basic(close_figures):
     assert_equal(labels[hdr.outliers_idx], outliers)
 
 
+@pytest.mark.slow
 @pytest.mark.matplotlib
 def test_hdr_basic_brute(close_figures, reset_randomstate):
     try:
@@ -75,6 +76,7 @@ def test_hdr_basic_brute(close_figures, reset_randomstate):
     assert_almost_equal(hdr.median, median_t, decimal=2)
 
 
+@pytest.mark.slow
 @pytest.mark.matplotlib
 def test_hdr_plot(close_figures):
     fig = plt.figure()

--- a/statsmodels/imputation/tests/test_mice.py
+++ b/statsmodels/imputation/tests/test_mice.py
@@ -352,7 +352,7 @@ class TestMICE(object):
             assert(isinstance(x, GLMResultsWrapper))
             assert(isinstance(x.family, sm.families.Binomial))
 
-
+    @pytest.mark.slow
     def test_combine(self):
 
         np.random.seed(3897)

--- a/statsmodels/multivariate/tests/test_pca.py
+++ b/statsmodels/multivariate/tests/test_pca.py
@@ -219,6 +219,7 @@ class TestPCA(object):
         assert_allclose(weights, pc_weights.weights)
         assert_allclose(np.abs(pc_weights.factors), np.abs(pc_gls.factors))
 
+    @pytest.mark.slow
     def test_wide(self):
         pc = PCA(self.x_wide)
         assert_equal(pc.factors.shape[1], self.x_wide.shape[0])
@@ -371,6 +372,7 @@ class TestPCA(object):
             rsquare[i] = 1.0 - np.sum(errors ** 2) / tss
         assert_allclose(rsquare, pc.rsquare)
 
+    @pytest.mark.slow
     def test_missing_dataframe(self):
         x = self.x.copy()
         x[::5, ::7] = np.nan

--- a/statsmodels/nonparametric/tests/test_kernel_density.py
+++ b/statsmodels/nonparametric/tests/test_kernel_density.py
@@ -126,17 +126,18 @@ class TestKDEMultivariate(KDETestBase):
 
         # Matches R to 3 decimals; results seem more stable than with R.
         # Can be checked with following code:
-        ## import rpy2.robjects as robjects
-        ## from rpy2.robjects.packages import importr
-        ## NP = importr('np')
-        ## r = robjects.r
-        ## D = {"S1": robjects.FloatVector(c1), "S2":robjects.FloatVector(c2),
-        ##      "S3":robjects.FloatVector(c3), "S4":robjects.FactorVector(o),
-        ##      "S5":robjects.FactorVector(o2)}
-        ## df = robjects.DataFrame(D)
-        ## formula = r('~S1+ordered(S4)+ordered(S5)')
-        ## r_bw = NP.npudensbw(formula, data=df, bwmethod='cv.ls')
+        # import rpy2.robjects as robjects
+        # from rpy2.robjects.packages import importr
+        # NP = importr('np')
+        # r = robjects.r
+        # D = {"S1": robjects.FloatVector(c1), "S2":robjects.FloatVector(c2),
+        #      "S3":robjects.FloatVector(c3), "S4":robjects.FactorVector(o),
+        #      "S5":robjects.FactorVector(o2)}
+        # df = robjects.DataFrame(D)
+        # formula = r('~S1+ordered(S4)+ordered(S5)')
+        # r_bw = NP.npudensbw(formula, data=df, bwmethod='cv.ls')
 
+    @pytest.mark.slow
     def test_pdf_mixeddata_LS_vs_ML(self):
         dens_ls = nparam.KDEMultivariate(data=[self.c1, self.o, self.o2],
                                          var_type='coo', bw='cv_ls')

--- a/statsmodels/nonparametric/tests/test_kernel_regression.py
+++ b/statsmodels/nonparametric/tests/test_kernel_regression.py
@@ -170,9 +170,11 @@ class TestKernelReg(KernelRegressionTestBase):
         model = nparam.KernelReg(endog=[Y], exog=[C1, C2, ovals],
                                  reg_type='ll', var_type='cco', bw=bw_cv_ls)
         sm_mean, sm_mfx = model.fit()
-        sm_R2 = model.r_squared()  # TODO: add expected result
-        npt.assert_allclose(sm_mfx[0,:], [b1,b2,b3], rtol=2e-1)
+        # TODO: add expected result
+        sm_R2 = model.r_squared()  # noqa: F841
+        npt.assert_allclose(sm_mfx[0, :], [b1, b2, b3], rtol=2e-1)
 
+    @pytest.mark.slow
     @pytest.mark.xfail(reason="Test doesn't make much sense - always passes "
                               "with very small bw.")
     def test_mfx_nonlinear_ll_cvls(self, file_name='RegData.csv'):

--- a/statsmodels/regression/tests/test_lme.py
+++ b/statsmodels/regression/tests/test_lme.py
@@ -194,6 +194,7 @@ class TestMixedLM(object):
         rslt = mod.fit(full_output=True)
         assert_equal(hasattr(rslt, "hist"), True)
 
+    @pytest.mark.slow
     @pytest.mark.smoke
     def test_profile_inference(self):
         np.random.seed(9814)
@@ -601,6 +602,7 @@ class TestMixedLM(object):
         # BIC(r)
         assert_allclose(result.bic, 264.3718, rtol=1e-3)
 
+    @pytest.mark.slow
     def test_vcomp_formula(self):
 
         np.random.seed(6241)
@@ -712,6 +714,7 @@ class TestMixedLM(object):
             rslt5 = mod5.fit()
         assert_almost_equal(rslt4.params, rslt5.params)
 
+    @pytest.mark.slow
     def test_regularized(self):
 
         np.random.seed(3453)
@@ -969,6 +972,7 @@ def test_random_effects():
     assert_(len(re[0]) == 2)
 
 
+@pytest.mark.slow
 def test_handle_missing():
 
     np.random.seed(23423)

--- a/statsmodels/regression/tests/test_processreg.py
+++ b/statsmodels/regression/tests/test_processreg.py
@@ -1,9 +1,12 @@
 # -*- coding: utf-8 -*-
+from statsmodels.compat.platform import PLATFORM_OSX
 
 from statsmodels.regression.process_regression import (
        ProcessMLE, GaussianCovariance)
 import numpy as np
 import pandas as pd
+import pytest
+
 import collections
 import statsmodels.tools.numdiff as nd
 from numpy.testing import assert_allclose, assert_equal
@@ -70,6 +73,7 @@ def run_arrays(n, get_model):
     return preg.fit()
 
 
+@pytest.mark.slow
 def test_arrays():
 
     np.random.seed(8234)
@@ -139,6 +143,7 @@ def run_formula(n, get_model):
     return f, df
 
 
+@pytest.mark.slow
 def test_formulas():
 
     np.random.seed(8789)
@@ -188,9 +193,10 @@ def test_score_numdiff():
 
     np.random.seed(342)
 
+    atol = 2e-3 if PLATFORM_OSX else 1e-2
     for _ in range(5):
         par0 = preg._get_start()
         par = par0 + 0.1 * np.random.normal(size=q)
         score = preg.score(par)
         score_nd = nd.approx_fprime(par, loglike, epsilon=1e-7)
-        assert_allclose(score, score_nd, atol=1e-3, rtol=1e-4)
+        assert_allclose(score, score_nd, atol=atol, rtol=1e-4)

--- a/statsmodels/stats/tests/test_mediation.py
+++ b/statsmodels/stats/tests/test_mediation.py
@@ -51,6 +51,7 @@ df = [['index', 'Estimate', 'Lower CI bound', 'Upper CI bound', 'P-value'],
 framing_moderated_4231 = pd.DataFrame(df[1:], columns=df[0]).set_index('index')
 
 
+@pytest.mark.slow
 def test_framing_example():
 
     cur_dir = os.path.dirname(os.path.abspath(__file__))
@@ -144,6 +145,7 @@ def test_framing_example_formula():
     assert_allclose(diff, 0, atol=1e-6)
 
 
+@pytest.mark.slow
 def test_framing_example_moderator_formula():
 
     cur_dir = os.path.dirname(os.path.abspath(__file__))


### PR DESCRIPTION
Adjust test tolerance after seeing a random OSX fail
Update slow markers

- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html#writing-the-commit-message). 
