### PR TITLE
removed duplicates of commands done in 'update'

### DIFF
--- a/statsmodels/tsa/statespace/mlemodel.py
+++ b/statsmodels/tsa/statespace/mlemodel.py
@@ -541,11 +541,7 @@ class MLEModel(tsbase.TimeSeriesModel):
             Additional keyword arguments to pass to the Kalman filter. See
             `KalmanFilter.filter` for more details.
         """
-        params = np.array(params, ndmin=1)
-
-        if not transformed:
-            params = self.transform_params(params)
-        self.update(params, transformed=True, complex_step=complex_step)
+        self.update(params, transformed=transformed, complex_step=complex_step)
 
         # Save the parameter names
         self.data.param_names = self.param_names
@@ -587,11 +583,7 @@ class MLEModel(tsbase.TimeSeriesModel):
             Additional keyword arguments to pass to the Kalman filter. See
             `KalmanFilter.filter` for more details.
         """
-        params = np.array(params, ndmin=1)
-
-        if not transformed:
-            params = self.transform_params(params)
-        self.update(params, transformed=True, complex_step=complex_step)
+        self.update(params, transformed=transformed, complex_step=complex_step)
 
         # Save the parameter names
         self.data.param_names = self.param_names
@@ -645,10 +637,7 @@ class MLEModel(tsbase.TimeSeriesModel):
             MLEModel._loglike_param_names, MLEModel._loglike_param_defaults,
             *args, **kwargs)
 
-        if not transformed:
-            params = self.transform_params(params)
-
-        self.update(params, transformed=True, complex_step=complex_step)
+        self.update(params, transformed=transformed, complex_step=complex_step)
 
         if complex_step:
             kwargs['inversion_method'] = INVERT_UNIVARIATE | SOLVE_LU
@@ -691,15 +680,12 @@ class MLEModel(tsbase.TimeSeriesModel):
         --------
         update : modifies the internal state of the Model to reflect new params
         """
-        if not transformed:
-            params = self.transform_params(params)
-
         # If we're using complex-step differentiation, then we can't use
         # Cholesky factorization
         if complex_step:
             kwargs['inversion_method'] = INVERT_UNIVARIATE | SOLVE_LU
 
-        self.update(params, transformed=True, complex_step=complex_step)
+        self.update(params, transformed=transformed, complex_step=complex_step)
 
         return self.ssm.loglikeobs(complex_step=complex_step, **kwargs)
 
@@ -727,8 +713,6 @@ class MLEModel(tsbase.TimeSeriesModel):
                                              approx_complex_step=None,
                                              approx_centered=False,
                                              res=None, **kwargs):
-        params = np.array(params, ndmin=1)
-
         # We can't use complex-step differentiation with non-transformed
         # parameters
         if approx_complex_step is None:
@@ -848,8 +832,6 @@ class MLEModel(tsbase.TimeSeriesModel):
         Cambridge University Press.
 
         """
-        params = np.array(params, ndmin=1)
-
         # Setup
         n = len(params)
 
@@ -989,7 +971,6 @@ class MLEModel(tsbase.TimeSeriesModel):
         Cambridge University Press.
 
         """
-        params = np.array(params, ndmin=1)
         n = len(params)
 
         # Get values at the params themselves


### PR DESCRIPTION
The following is already done in 'update':
``` python
params = np.array(params, ndmin=1)
```
and
``` python
if not transformed:
    params = self.transform_params(params)
```
and so there is no need to do them twice.

The changes are very simple, but it would be nice to run whatever tests exists for the code (which I do not know how to run). I plan to create small and simple bite size pull requests, which are easy to create and easy to review.
