### PR TITLE
BLD: Check if docbuild succeeded before doctr

### DIFF
--- a/tools/ci/docbuild.sh
+++ b/tools/ci/docbuild.sh
@@ -32,6 +32,15 @@ echo '=          Broken Behavior (Errors and Warnings to be Fixed)           ='
 echo '========================================================================'
 grep -E '(SEVERE|ERROR|WARNING)' doc_build.log | grep -Ev '(noindex|toctree)'
 
+# Check that docbuild succeeded. Exit 1 if not.
+echo "Checking if index.html exists"
+if [ -f "build/html/index.html" ]; then
+  echo "docbuild succeeded.";
+else
+  echo "docbuild failed. Aborting doctr.";
+  exit 1;
+fi;
+
 # Deploy with doctr
 cd "$SRCDIR"
 if [[ -z "$TRAVIS_TAG" ]]; then


### PR DESCRIPTION
- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html#writing-the-commit-message). 

I've noticed that we get occasional fails of the docbuild for random reasons on commits to master. The result is that doctr pushes an empty devel doc. Here's an example commit to master today where that happened:

https://travis-ci.org/statsmodels/statsmodels/jobs/538617713

This checks if `index.html` was created, which basically means the docbuild succeeded. If so, it aborts the commit. 

https://travis-ci.org/thequackdaddy/statsmodels/jobs/539032795