### PR TITLE
MAINT: use correct key name to check cov params presence

### DIFF
--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -611,8 +611,8 @@ class LikelihoodModel(Model):
             res._results.mle_settings = res_constr.mle_settings
 
         res._results.params = params_full
-        if (not hasattr(res._results, 'normalized_cov_param') or
-                res._results.normalized_cov_param is None):
+        if (not hasattr(res._results, 'normalized_cov_params') or
+                res._results.normalized_cov_params is None):
             res._results.normalized_cov_params = np.zeros((k_params, k_params))
         else:
             res._results.normalized_cov_params[...] = 0


### PR DESCRIPTION
- [x] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html#writing-the-commit-message).

----
This was a typo: `'normalized_cov_param'` does not appear anywhere else in the repo. Only difference this should make is no longer unnecessarily re-allocating the params matrix. 