### PR TITLE
CLN: invalid escapes in linear_model

### DIFF
--- a/statsmodels/regression/linear_model.py
+++ b/statsmodels/regression/linear_model.py
@@ -1719,14 +1719,14 @@ class RegressionResults(base.LikelihoodModelResults):
 
     @cache_readonly
     def aic(self):
-        """Akaike's information criteria. For a model with a constant
+        r"""Akaike's information criteria. For a model with a constant
         :math:`-2llf + 2(df\_model + 1)`. For a model without a constant
         :math:`-2llf + 2(df\_model)`."""
         return -2 * self.llf + 2 * (self.df_model + self.k_constant)
 
     @cache_readonly
     def bic(self):
-        """Bayes' information criteria. For a model with a constant
+        r"""Bayes' information criteria. For a model with a constant
         :math:`-2llf + \log(n)(df\_model+1)`. For a model without a constant
         :math:`-2llf + \log(n)(df\_model)`"""
         return (-2 * self.llf + np.log(self.nobs) * (self.df_model +


### PR DESCRIPTION
These must have been introduced recently, since at the time #5692 was made that fixed all remaining invalid escapes.  These will keep slipping through the cracks.