### PR TITLE
MAINT: remove no-longer-needed HC_se lookups

### DIFF
--- a/statsmodels/regression/linear_model.py
+++ b/statsmodels/regression/linear_model.py
@@ -2295,8 +2295,6 @@ class RegressionResults(base.LikelihoodModelResults):
                 raise ValueError('heteroscedasticity robust covariance '
                                  'does not use keywords')
             res.cov_kwds['description'] = descriptions[cov_type.upper()]
-            # TODO cannot access cov without calling se first
-            getattr(self, cov_type.upper() + '_se')
             res.cov_params_default = getattr(self, 'cov_' + cov_type.upper())
         elif cov_type.lower() == 'hac':
             maxlags = kwds['maxlags']   # required?, default in cov_hac_simple

--- a/statsmodels/regression/tests/test_cov.py
+++ b/statsmodels/regression/tests/test_cov.py
@@ -3,9 +3,10 @@
 """
 
 import numpy as np
+from numpy.testing import assert_almost_equal, assert_allclose
+
 import statsmodels.api as sm
 
-from numpy.testing import assert_almost_equal, assert_allclose
 
 def test_HC_use():
     np.random.seed(0)
@@ -17,12 +18,10 @@ def test_HC_use():
 
     results = sm.OLS(y, X).fit()
 
-    #test cov_params
-    idx = np.array([1,2])
-    #need to call HC0_se to have cov_HC0 available
-    results.HC0_se
-    cov12 = results.cov_params(column=[1,2], cov_p=results.cov_HC0)
-    assert_almost_equal(cov12, results.cov_HC0[idx[:,None], idx], decimal=15)
+    # test cov_params
+    idx = np.array([1, 2])
+    cov12 = results.cov_params(column=[1, 2], cov_p=results.cov_HC0)
+    assert_almost_equal(cov12, results.cov_HC0[idx[:, None], idx], decimal=15)
 
     #test t_test
     tvals = results.params/results.HC0_se

--- a/statsmodels/sandbox/regression/penalized.py
+++ b/statsmodels/sandbox/regression/penalized.py
@@ -36,15 +36,10 @@ problem with definition of df_model, it has 1 subtracted for constant
 from __future__ import print_function
 from statsmodels.compat.python import lrange
 import numpy as np
+
 from statsmodels.tools.decorators import cache_readonly
 from statsmodels.regression.linear_model import OLS, GLS, RegressionResults
-
-
-def atleast_2dcols(x):
-    x = np.asarray(x)
-    if x.ndim == 1:
-        x = x[:, None]
-    return x
+from statsmodels.regression.feasible_gls import atleast_2dcols
 
 
 class TheilGLS(GLS):

--- a/statsmodels/stats/anova.py
+++ b/statsmodels/stats/anova.py
@@ -10,25 +10,23 @@ from statsmodels.formula.formulatools import (_remove_intercept_patsy,
                                     _has_intercept, _intercept_idx)
 from statsmodels.iolib import summary2
 
+
 def _get_covariance(model, robust):
     if robust is None:
         return model.cov_params()
     elif robust == "hc0":
-        se = model.HC0_se
         return model.cov_HC0
     elif robust == "hc1":
-        se = model.HC1_se
         return model.cov_HC1
     elif robust == "hc2":
-        se = model.HC2_se
         return model.cov_HC2
     elif robust == "hc3":
-        se = model.HC3_se
         return model.cov_HC3
-    else: # pragma: no cover
+    else:  # pragma: no cover
         raise ValueError("robust options %s not understood" % robust)
 
-#NOTE: these need to take into account weights !
+
+# NOTE: these need to take into account weights !
 
 def anova_single(model, **kwargs):
     """


### PR DESCRIPTION
This had already been done in the version of get_robustcov_results in base.covtype, which drifted away from the near-identical version in RegressionResults.get_robustcov_results.  Confusion over "is this still needed/intentional" can be avoided by avoiding duplicated code.