### PR TITLE
BUG: Allow NumPy ints

### DIFF
--- a/statsmodels/tsa/statespace/initialization.py
+++ b/statsmodels/tsa/statespace/initialization.py
@@ -279,7 +279,8 @@ class Initialization(object):
         # Construct the index, using a slice object as an intermediate step
         # to enforce regularity
         if not isinstance(index, slice):
-            if isinstance(index, int):
+            if isinstance(index, (int, np.integer)):
+                index = int(index)
                 if index < 0 or index >= self.k_states:
                     raise ValueError('Invalid index.')
                 index = (index, index + 1)
@@ -422,7 +423,8 @@ class Initialization(object):
         initialization. To unset all initializations (including both global and
         block level), use the `clear` method.
         """
-        if isinstance(index, int):
+        if isinstance(index, (int, np.integer)):
+            index = int(index)
             if index < 0 or index > self.k_states:
                 raise ValueError('Invalid index.')
             index = (index, index + 1)

--- a/statsmodels/tsa/statespace/tests/test_tools.py
+++ b/statsmodels/tsa/statespace/tests/test_tools.py
@@ -30,7 +30,9 @@ class TestCompanionMatrix(object):
          np.array([[1, 2, 5, 6],
                    [3, 4, 7, 8],
                    [1, 0, 0, 0],
-                   [0, 1, 0, 0]]).T)
+                   [0, 1, 0, 0]]).T),
+        # GH 5570
+        (np.int64(2), np.array([[0, 1], [0, 0]]))
     ]
 
     def test_cases(self):

--- a/statsmodels/tsa/statespace/tools.py
+++ b/statsmodels/tsa/statespace/tools.py
@@ -178,8 +178,9 @@ def companion_matrix(polynomial):
 
     """
     identity_matrix = False
-    if isinstance(polynomial, int):
-        n = polynomial
+    if isinstance(polynomial, (int, np.integer)):
+        # GH 5570, allow numpy integer types, but coerce to python int
+        n = int(polynomial)
         m = 1
         polynomial = None
     else:


### PR DESCRIPTION
Allow NumPy ints in companion matrix and other tsa functions

closes #5570

- [X] closes #5570
- [X] tests added / passed. 
- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html#writing-the-commit-message). 
