### PR TITLE
BUG: Refactor method used to name variables

### DIFF
--- a/statsmodels/tsa/arima_model.py
+++ b/statsmodels/tsa/arima_model.py
@@ -385,17 +385,6 @@ def _make_arma_names(data, k_trend, order, exog_names):
     ma_lag_names = [''.join(('ma.', i)) for i in ma_lag_names]
     trend_name = util.make_lag_names('', 0, k_trend)
 
-    # ensure exog_names stays unchanged when the `fit` method
-    # is called multiple times.
-    if k_ma ==0 and k_ar ==0:
-        if len(exog_names) != 0:
-            return exog_names
-    elif (exog_names[-k_ma:] == ma_lag_names and
-          exog_names[-(k_ar+k_ma):-k_ma] == ar_lag_names and
-          (not exog_names or not trend_name
-           or trend_name[0] == exog_names[0])):
-        return exog_names
-
     exog_names = trend_name + exog_names + ar_lag_names + ma_lag_names
     return exog_names
 
@@ -447,6 +436,7 @@ class ARMA(tsbase.TimeSeriesModel):
         else:
             k_exog = 0
         self.k_exog = k_exog
+        self._orig_exog_names = self.exog_names
 
     def _fit_start_params_hr(self, order, start_ar_lags=None):
         """
@@ -926,8 +916,8 @@ class ARMA(tsbase.TimeSeriesModel):
         self.exog = exog    # overwrites original exog from __init__
 
         # (re)set names for this model
-        self.exog_names = _make_arma_names(self.data, k_trend, (k_ar, k_ma),
-                                           self.exog_names)
+        self.exog_names = _make_arma_names(self.data, k_trend,
+                                           (k_ar, k_ma), self._orig_exog_names)
         k = k_trend + k_exog
 
         # choose objective function

--- a/statsmodels/tsa/tests/test_arima.py
+++ b/statsmodels/tsa/tests/test_arima.py
@@ -2465,3 +2465,14 @@ def test_arima_no_full_output():
     mod = ARIMA(endog, (1, 0, 1))
     res = mod.fit(trend="c", disp=-1, full_output=False)
     assert res.mle_retvals is None
+
+
+def test_arima_summary_no_lags(reset_randomstate):
+    y_train = pd.Series(np.random.randn(1000), name='y_train')
+    x_train = pd.DataFrame(np.random.randn(1000, 2), columns=['x1', 'x2'])
+    res = ARIMA(endog=y_train.values, exog=x_train,
+                order=(0, 1, 0)).fit(disp=-1)
+    summ = res.summary().as_text()
+    assert 'const ' in summ
+    assert 'x1 ' in summ
+    assert 'x2 ' in summ


### PR DESCRIPTION
Refactor method used when generating variable names across multiple calls

closes #4870

- [X] closes #4870
- [X] tests added / passed. 
- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide]