### PR TITLE
BUG: Add check for xnames length

### DIFF
--- a/statsmodels/iolib/summary.py
+++ b/statsmodels/iolib/summary.py
@@ -110,6 +110,12 @@ def summary(self, yname=None, xname=None, title=0, alpha=.05,
     if title == 0:
         title = _model_types[self.model.__class__.__name__]
 
+    if xname is not None and len(xname) != len(self.params):
+        # GH 2298
+        raise ValueError('User supplied xnames must have the same number of '
+                         'entries as the number of model parameters '
+                         '({0})'.format(len(self.params)))
+
     yname, xname = _getnames(self, yname, xname)
 
     time_now = time.localtime()

--- a/statsmodels/iolib/tests/test_summary.py
+++ b/statsmodels/iolib/tests/test_summary.py
@@ -5,6 +5,7 @@
 from __future__ import print_function
 
 import numpy as np  # noqa: F401
+import pytest
 
 from statsmodels.datasets import macrodata
 from statsmodels.regression.linear_model import OLS
@@ -19,6 +20,16 @@ def test_escaped_variable_name():
     res = mod.fit()
     assert 'CPI\\_' in res.summary().as_latex()
     assert 'CPI_' in res.summary().as_text()
+
+
+def test_wrong_len_xname(reset_randomstate):
+    y = np.random.randn(100)
+    x = np.random.randn(100, 2)
+    res = OLS(y, x).fit()
+    with pytest.raises(ValueError):
+        res.summary(xname=['x1'])
+    with pytest.raises(ValueError):
+        res.summary(xname=['x1', 'x2', 'x3'])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Verify that xnames has the same number of elements as parameters

- [X] closes #2298
- [X] tests added / passed. 
- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html#writing-the-commit-message). 
