### PR TITLE
BUG: Fix default alignment for SimpleTable

### DIFF
--- a/statsmodels/iolib/table.py
+++ b/statsmodels/iolib/table.py
@@ -782,7 +782,7 @@ default_txt_fmt = dict(
     row_dec_below=None,
     colwidths=None,
     colsep=' ',
-    data_aligns="c",
+    data_aligns="r",  # GH 1477
     # data formats
     # data_fmt="%s",  #deprecated; use data_fmts
     data_fmts=["%s"],

--- a/statsmodels/iolib/tests/test_table.py
+++ b/statsmodels/iolib/tests/test_table.py
@@ -224,3 +224,20 @@ stub R2 C2  40.95038  40.65765
                    "y_amax         0.2432      0.035      "]
 
         assert_equal(sorted(desired), sorted(interesting_lines))
+
+    def test_default_alignment(self):
+        desired = '''
+=====================
+      header1 header2
+---------------------
+stub1 1.30312    2.73
+stub2 1.95038     2.6
+---------------------
+'''
+        test1data = [[1.30312, 2.73], [1.95038, 2.6]]
+        test1stubs = ('stub1', 'stub2')
+        test1header = ('header1', 'header2')
+        actual = SimpleTable(test1data, test1header, test1stubs,
+                             txt_fmt=default_txt_fmt)
+        actual = '\n%s\n' % actual.as_text()
+        assert_equal(desired, str(actual))


### PR DESCRIPTION
Switch to right for text align

closes #1477

- [X] closes #1477
- [X] tests added / passed. 
- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html#writing-the-commit-message). 
