### PR TITLE
BUG: State space univariate smoothing w/ time-varying transition matrix: wrong transition matrix used

### DIFF
--- a/statsmodels/tsa/statespace/_smoothers/_univariate.pyx.in
+++ b/statsmodels/tsa/statespace/_smoothers/_univariate.pyx.in
@@ -231,16 +231,19 @@ cdef int {{prefix}}smoothed_estimators_time_univariate({{prefix}}KalmanSmoother 
         {{cython_type}} gamma = -1.0
         {{cython_type}} scalar
         int k_states = model._k_states
+        {{cython_type}} * _transition
 
     if smoother.t == 0:
         return 1
 
-    # TODO check that this is the right transition matrix to use in the case
-    # of time-varying matrices
     # r_{t-1,p} = T_{t-1}' r_{t,0}
+    if model.transition.shape[2] > 1:
+        _transition = &model.transition[0, 0, smoother.t-1]
+    else:
+        _transition = &model.transition[0, 0, 0]
     if smoother.smoother_output & (SMOOTHER_STATE | SMOOTHER_DISTURBANCE):
         blas.{{prefix}}gemv("T", &model._k_states, &model._k_states,
-                                 &alpha, model._transition, &model._k_states,
+                                 &alpha, _transition, &model._k_states,
                                          smoother._scaled_smoothed_estimator, &inc,
                                  &beta, &smoother.scaled_smoothed_estimator[0, smoother.t-1], &inc)
     # N_{t-1,p} = T_{t-1}' N_{t,0} T_{t-1}
@@ -248,12 +251,12 @@ cdef int {{prefix}}smoothed_estimators_time_univariate({{prefix}}KalmanSmoother 
         blas.{{prefix}}copy(&kfilter.k_states2, smoother._scaled_smoothed_estimator_cov, &inc,
                                                  &smoother.scaled_smoothed_estimator_cov[0, 0, smoother.t-1], &inc)
         blas.{{prefix}}gemm("T", "N", &model._k_states, &model._k_states, &model._k_states,
-                                      &alpha, model._transition, &model._k_states,
+                                      &alpha, _transition, &model._k_states,
                                               smoother._scaled_smoothed_estimator_cov, &kfilter.k_states,
                                       &beta, smoother._tmp0, &kfilter.k_states)
         blas.{{prefix}}gemm("N", "N", &model._k_states, &model._k_states, &model._k_states,
                                       &alpha, smoother._tmp0, &kfilter.k_states,
-                                              model._transition, &model._k_states,
+                                              _transition, &model._k_states,
                                       &beta, &smoother.scaled_smoothed_estimator_cov[0, 0, smoother.t-1], &kfilter.k_states)
 
 

--- a/statsmodels/tsa/statespace/tests/test_univariate.py
+++ b/statsmodels/tsa/statespace/tests/test_univariate.py
@@ -23,6 +23,7 @@ import pytest
 from statsmodels import datasets
 from statsmodels.tsa.statespace.mlemodel import MLEModel
 from statsmodels.tsa.statespace.tests.results import results_kalman_filter
+from statsmodels.tsa.statespace.sarimax import SARIMAX
 
 current_path = os.path.dirname(os.path.abspath(__file__))
 
@@ -682,3 +683,61 @@ class TestMultivariateVAR(object):
             self.conventional_sim.simulated_state_disturbance,
             self.univariate_sim.simulated_state_disturbance, 9
         )
+
+
+def test_time_varying_transition():
+    # Test for correct univariate filtering/smoothing when we have a
+    # time-varying transition matrix
+    endog = np.array([10, 5, 2.5, 1.25, 2.5, 5, 10])
+    transition = np.ones((1, 1, 7))
+    transition[..., :5] = 0.5
+    transition[..., 5:] = 2
+
+    # Conventional filter / smoother
+    mod1 = SARIMAX(endog, order=(1, 0, 0), measurement_error=True)
+    mod1.update([2., 1., 1.])
+    mod1.ssm['transition'] = transition
+    res1 = mod1.ssm.smooth()
+
+    # Univariate filter / smoother
+    mod2 = SARIMAX(endog, order=(1, 0, 0), measurement_error=True)
+    mod2.ssm.filter_univariate = True
+    mod2.update([2., 1., 1.])
+    mod2.ssm['transition'] = transition
+    res2 = mod2.ssm.smooth()
+
+    # Simulation smoothers
+    n_disturbance_variates = (mod1.k_endog + mod1.k_posdef) * mod1.nobs
+    sim1 = mod1.simulation_smoother(
+        disturbance_variates=np.zeros(n_disturbance_variates),
+        initial_state_variates=np.zeros(mod1.k_states))
+    sim2 = mod2.simulation_smoother(
+        disturbance_variates=np.zeros(n_disturbance_variates),
+        initial_state_variates=np.zeros(mod2.k_states))
+
+    # Test for correctness
+    assert_allclose(res1.forecasts[0, :], res2.forecasts[0, :])
+    assert_allclose(res1.forecasts_error[0, :], res2.forecasts_error[0, :])
+    assert_allclose(res1.forecasts_error_cov[0, 0, :],
+                    res2.forecasts_error_cov[0, 0, :])
+    assert_allclose(res1.filtered_state, res2.filtered_state)
+    assert_allclose(res1.filtered_state_cov, res2.filtered_state_cov)
+    assert_allclose(res1.predicted_state, res2.predicted_state)
+    assert_allclose(res1.predicted_state_cov, res2.predicted_state_cov)
+    assert_allclose(res1.llf_obs, res2.llf_obs)
+    assert_allclose(res1.smoothed_state, res2.smoothed_state)
+    assert_allclose(res1.smoothed_state_cov, res2.smoothed_state_cov)
+    assert_allclose(res1.smoothed_measurement_disturbance,
+                    res2.smoothed_measurement_disturbance)
+    assert_allclose(res1.smoothed_measurement_disturbance_cov.diagonal(),
+                    res2.smoothed_measurement_disturbance_cov.diagonal())
+    assert_allclose(res1.smoothed_state_disturbance,
+                    res2.smoothed_state_disturbance)
+    assert_allclose(res1.smoothed_state_disturbance_cov,
+                    res2.smoothed_state_disturbance_cov)
+
+    assert_allclose(sim1.simulated_state, sim2.simulated_state)
+    assert_allclose(sim1.simulated_measurement_disturbance,
+                    sim2.simulated_measurement_disturbance)
+    assert_allclose(sim1.simulated_state_disturbance,
+                    sim2.simulated_state_disturbance)


### PR DESCRIPTION
- [x] tests added / passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message.

In a particular place, smoothing algorithm should use T_{t-1} and I had been using T_{t}.

I had a helpful TODO suggesting that I check it, but then apparently did not check it :(

Should be merged in before 0.10 release.