### PR TITLE
DOC: Improve bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -13,15 +13,21 @@ assignees: ''
 
 #### Code Sample, a copy-pastable example if possible
 
-```python
-# Your code here
 
+```python
+# Your code here that produces the bug
+# This example should be self-contained, and so not rely on external data.
+# It should run in a fresh ipython session, and so include all relevant imports.
 ```
+<details>
+
 **Note**: As you can see, there are many issues on our GitHub tracker, so it is very possible that your issue has been posted before. Please check first before submitting so that we do not have to handle and close duplicates.
 
 **Note**: Please be sure you are using the latest released version of `statsmodels`, or a recent build of `master`. If your problem has been fixed in an unreleased version, you might be able to use `master` until a new release occurs. 
 
 **Note**: If you are using a released version, have you verified that the bug exists in the master branch of this repository? It helps the limited resources if we know problems exist in the current master so that they do not need to check whether the code sample produces a bug in the next release.
+
+</details>
 
 
 If the issue has not been resolved, please file it in the issue tracker.
@@ -34,6 +40,6 @@ A clear and concise description of what you expected to happen.
 
 <details>
 
-[paste the output of ``sm.show_versions()`` here below this line]
+[paste the output of ``import statsmodels.api as sm; sm.show_versions()`` here below this line]
 
 </details>

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,6 +4,9 @@
 - [ ] properly formatted commit message. See 
       [NumPy's guide](https://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html#writing-the-commit-message). 
 
+<details>
+
+
 **Notes**:
 
 * It is essential that you add a test when making code changes. Tests are not 
@@ -21,3 +24,5 @@
   local Linux environment. While passing this test is not required, it is good practice and it help 
   improve code quality in `statsmodels`.
 * Docstring additions must render correctly, including escapes and LaTeX.
+
+</details>


### PR DESCRIPTION
[skip ci]
Improve template to help users report better bugs

- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html#writing-the-commit-message). 
