### PR TITLE
DOC: Update version dropdown javascript

### DIFF
--- a/docs/themes/statsmodels/layout.html
+++ b/docs/themes/statsmodels/layout.html
@@ -19,15 +19,30 @@ $.facebox.settings.loadingImage = "{{ pathto('_static/loading.gif', 1) }}"
 
 <script>
 $(document).ready(function() {
-  $.getJSON("{{ pathto('../versions.json', 1) }}", function(data) {
-    $(".header").prepend(`
-    <div class="dropdown">
-      <button class="dropbtn">Other Versions</button>
-      <div class="dropdown-content">
-      </div>
-    </div>`)
-    for (var i = 0; i < data.length; i++) {
-      $(".dropdown-content").append("<a href=\"{{ pathto('../', 1) }}" + data[i] + "/index.html\">" + data[i] + "</a>")
+  $.getJSON("{{ pathto('../versions.json', 1) }}", function(versions) {
+    var dropdown = document.createElement("div");
+    dropdown.className = "dropdown";
+    var button = document.createElement("button");
+    button.className = "dropbtn";
+    button.innerHTML = "Other Versions";
+    var content = document.createElement("div");
+    content.className = "dropdown-content";
+    dropdown.appendChild(button);
+    dropdown.appendChild(content);
+    $(".header").prepend(dropdown);
+    for (var i = 0; i < versions.length; i++) {
+      if (versions[i].substring(0, 1) == "v") {
+        versions[i] = [versions[i], versions[i].substring(1)];
+      } else {
+        versions[i] = [versions[i], versions[i]];
+      };
+    };
+    for (var i = 0; i < versions.length; i++) {
+      var a = document.createElement("a");
+      a.innerHTML = versions[i][1];
+      a.href = "{{ pathto('../', 1) }}" + versions[i][0] + "/index.html";
+      a.title = versions[i][1];
+      $(".dropdown-content").append(a);
     };
   });
 });


### PR DESCRIPTION
- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html#writing-the-commit-message). 

So doctr by default prepends a "v" to the version number of the folders. Historically, we've  not had the "v" prefix. This changes the javascript that we use to handle drop the prefix.

See the finished product here...

https://thequackdaddy.github.io/statsmodels.github.io/devel/index.html

Before:
<img width="193" alt="Screen Shot 2019-06-23 at 1 59 55 PM" src="https://user-images.githubusercontent.com/8186432/59980718-4dea3e80-95bf-11e9-96b8-5f50a5b5bdff.png">


After:
<img width="200" alt="Screen Shot 2019-06-23 at 1 59 11 PM" src="https://user-images.githubusercontent.com/8186432/59980712-4165e600-95bf-11e9-80c2-a5fd2bcfa028.png">


