### PR TITLE
BUG: exponential smoothing - damped trend gives incorrect param, predictions

### DIFF
--- a/statsmodels/tsa/holtwinters.py
+++ b/statsmodels/tsa/holtwinters.py
@@ -1135,4 +1135,4 @@ class Holt(ExponentialSmoothing):
         return super(Holt, self).fit(smoothing_level=smoothing_level,
                                      smoothing_slope=smoothing_slope, damping_slope=damping_slope,
                                      optimized=optimized, start_params=start_params,
-                                     initial_level=None, initial_slope=None, use_brute=use_brute)
+                                     initial_level=initial_level, initial_slope=initial_slope, use_brute=use_brute)

--- a/statsmodels/tsa/holtwinters.py
+++ b/statsmodels/tsa/holtwinters.py
@@ -930,14 +930,12 @@ class ExponentialSmoothing(TimeSeriesModel):
         resid = data - fitted[:-h - 1]
         if remove_bias:
             fitted += resid.mean()
-        if not damped:
-            phi = np.NaN
         self.params = {'smoothing_level': alpha,
                        'smoothing_slope': beta,
                        'smoothing_seasonal': gamma,
-                       'damping_slope': phi,
+                       'damping_slope': phi if damped else np.nan,
                        'initial_level': lvls[0],
-                       'initial_slope': b[0],
+                       'initial_slope': b[0] / phi,
                        'initial_seasons': s[:m],
                        'use_boxcox': use_boxcox,
                        'lamda': lamda,

--- a/statsmodels/tsa/tests/test_holtwinters.py
+++ b/statsmodels/tsa/tests/test_holtwinters.py
@@ -226,14 +226,14 @@ class TestHoltWinters(object):
         assert_almost_equal(fit4.params['smoothing_slope'], 0.00, 2)
         assert_almost_equal(fit4.params['damping_slope'], 0.98, 2)
         assert_almost_equal(fit4.params['initial_level'], 257.36, 2)
-        assert_almost_equal(fit4.params['initial_slope'], 6.51, 2)
+        assert_almost_equal(fit4.params['initial_slope'], 6.64, 2)
         assert_almost_equal(fit4.sse, 6036.56, 2)  # 6080.26
 
         assert_almost_equal(fit5.params['smoothing_level'], 0.97, 2)
         assert_almost_equal(fit5.params['smoothing_slope'], 0.00, 2)
         assert_almost_equal(fit5.params['damping_slope'], 0.98, 2)
         assert_almost_equal(fit5.params['initial_level'], 258.95, 2)
-        assert_almost_equal(fit5.params['initial_slope'], 1.02, 2)
+        assert_almost_equal(fit5.params['initial_slope'], 1.04, 2)
         assert_almost_equal(fit5.sse, 6082.00, 2)  # 6100.11
 
     def test_holt_damp_R(self):


### PR DESCRIPTION
Exponential smoothing with a damped trend gives the wrong result for `res.params['initial_slope']` and gives wrong predictions.

The problem is the initial trend is accidentally multiplied by the damping parameter before the results object is created. This means that when predictions are made later, they will be based on the wrong initial trend.

This PR also fixes the problem that `sm.tsa.Holt` silently ignores the `initial_level` and `initial_slope` arguments.