### PR TITLE
MAINT: Bump dependencies.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,26 +37,26 @@ matrix:
     - python: 2.7
       env:
         - PYTHON=2.7
-        - NUMPY=1.13
+        - NUMPY=1.15
         - MATPLOTLIB=2.0
         - COVERAGE=true
       # Python 2.7 + baseline packages
     - python: 2.7
       env:
         - PYTHON=2.7
-        - NUMPY=1.12
+        - NUMPY=1.14
         - BLAS= # Do not specify blas in this config due to conflict
-        - SCIPY=0.19
-        - PANDAS=0.20
+        - SCIPY=1.0
+        - PANDAS=0.21
         - USEMPL=false
         - LINT=true
-    # Python 3.4 + baseline packages
-    - python: 3.4
+    # Python 3.5 + baseline packages
+    - python: 3.5
       env:
-        - PYTHON=3.4
-        - NUMPY=1.11
-        - SCIPY=0.18
-        - PANDAS=0.19
+        - PYTHON=3.5
+        - NUMPY=1.14
+        - SCIPY=1.0
+        - PANDAS=0.21
         - MATPLOTLIB=1.5
     # Python 3.7 + cutting edge packages
     - python: 3.7
@@ -78,8 +78,8 @@ matrix:
     - python: 3.5
       env:
         - PYTHON=3.5
-        - NUMPY=1.13
-        - SCIPY=1.0
+        - NUMPY=1.15
+        - SCIPY=1.1
         - PANDAS=0.22
         - MATPLOTLIB=2.0
         - LINT=true
@@ -92,7 +92,7 @@ matrix:
       language: generic
       env:
         - PYTHON=3.6.6
-        - NUMPY=1.14
+        - NUMPY=1.15
         - BUILD_INIT=tools/ci/travis_pip.sh
     - os: osx
       language: generic
@@ -109,7 +109,7 @@ matrix:
       language: generic
       env:
         - PYTHON=3.6.6
-        - NUMPY=1.14
+        - NUMPY=1.15
         - BUILD_INIT=tools/ci/travis_pip.sh
     - os: osx
       language: generic

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,8 +17,8 @@ environment:
       PYTHON_ARCH: "x86"
     - PY_MAJOR_VER: 2
       PYTHON_ARCH: "x86_64"
-      SCIPY: "0.18"
-      NUMPY: "1.11"
+      SCIPY: "1.0"
+      NUMPY: "1.14"
     - PY_MAJOR_VER: 3
       PYTHON_ARCH: "x86_64"
       TEST_INSTALL: "true"

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -103,20 +103,18 @@ Dependencies
 
 The current minimum dependencies are:
 
-* `Python <https://www.python.org>`__ >= 2.7, including Python 3.4+
-* `NumPy <http://www.scipy.org/>`__ >= 1.11
-* `SciPy <http://www.scipy.org/>`__ >= 0.18
-* `Pandas <http://pandas.pydata.org/>`__ >= 0.19
-* `Patsy <https://patsy.readthedocs.io/en/latest/>`__ >= 0.4.0
-* `Cython <http://cython.org/>`__ >= 0.24 is required to build the code from
+* `Python <https://www.python.org>`__ >= 2.7, including Python 3.5+
+* `NumPy <http://www.scipy.org/>`__ >= 1.14
+* `SciPy <http://www.scipy.org/>`__ >= 1.0
+* `Pandas <http://pandas.pydata.org/>`__ >= 0.21
+* `Patsy <https://patsy.readthedocs.io/en/latest/>`__ >= 0.5.0
+* `Cython <http://cython.org/>`__ >= 0.27 is required to build the code from
   github but not from a source distribution.
 
 Given the long release cycle, Statsmodels follows a loose time-based policy for
 dependencies: minimal dependencies are lagged about one and a half to two
-years. Our next planned update of minimum versions in `setup.py` is expected in
-September 2018, when we will update to reflect Numpy >= 1.12 (released January
-2017), Scipy >= 0.19 (released March 2017) and Pandas >= 0.20 (released May
-2017).
+years. Our next planned update of minimum versions is expected in the first
+half of 2020.
 
 Optional Dependencies
 ---------------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy>=1.11
-scipy>=0.18
-pandas>=0.19
-patsy>=0.4
+numpy>=1.14
+scipy>=1.0
+pandas>=0.21
+patsy>=0.5

--- a/setup.py
+++ b/setup.py
@@ -36,8 +36,8 @@ import versioneer
 ###############################################################################
 # Key Values that Change Each Release
 ###############################################################################
-SETUP_REQUIREMENTS = {'numpy': '1.11',  # released March 2016
-                      'scipy': '0.18',  # released July 2016
+SETUP_REQUIREMENTS = {'numpy': '1.14',  # released January 2018
+                      'scipy': '1.0',  # released October 2017
                       }
 
 REQ_NOT_MET_MSG = """
@@ -59,11 +59,11 @@ for key in SETUP_REQUIREMENTS:
         raise RuntimeError(REQ_NOT_MET_MSG.format(key, ver, req_ver))
 
 INSTALL_REQUIREMENTS = SETUP_REQUIREMENTS.copy()
-INSTALL_REQUIREMENTS.update({'pandas': '0.19',  # released October 2016
-                             'patsy': '0.4.0',  # released July 2015
+INSTALL_REQUIREMENTS.update({'pandas': '0.21',  # released October 2017
+                             'patsy': '0.5',  # released January 2018
                              })
 
-CYTHON_MIN_VER = '0.24'  # released Apr 2016
+CYTHON_MIN_VER = '0.27'  # released September 2017
 
 SETUP_REQUIRES = [k + '>=' + v for k, v in SETUP_REQUIREMENTS.items()]
 INSTALL_REQUIRES = [k + '>=' + v for k, v in INSTALL_REQUIREMENTS.items()]
@@ -98,7 +98,6 @@ CLASSIFIERS = ['Development Status :: 4 - Beta',
                'Environment :: Console',
                'Programming Language :: Cython',
                'Programming Language :: Python :: 2.7',
-               'Programming Language :: Python :: 3.4',
                'Programming Language :: Python :: 3.5',
                'Programming Language :: Python :: 3.6',
                'Programming Language :: Python :: 3.7',


### PR DESCRIPTION
Closes #5839 

(Note: still happy to change these if there are objections / concerns)

Drops support for Python 3.4 and updates dependencies to:

- Numpy >= 1.14 (January 2018)
- Scipy >= 1.0.0 (October 2017)
- Pandas >= 0.21 (October 2017)
- Cython >= 0.27 (September 2017)
- Patsy >= 0.5 (January 2018)

I think I updated all the relevant files, and I bumped some of the versions in Travis that we above the previous minimums to be above these new minimums too. Hope I didn't mess anything up.