### PR TITLE
MAINT: Use pytest.raises to check error message

### DIFF
--- a/lint.sh
+++ b/lint.sh
@@ -51,6 +51,7 @@ if [ "$LINT" == true ]; then
         statsmodels/regression/tests/test_lme.py \
         statsmodels/regression/tests/test_processreg.py \
         statsmodels/regression/tests/test_quantile_regression.py \
+        statsmodels/regression/tests/test_tools.py \
         statsmodels/regression/tests/results/ \
         statsmodels/robust/tests/ \
         statsmodels/sandbox/distributions/try_pot.py \

--- a/statsmodels/regression/tests/test_tools.py
+++ b/statsmodels/regression/tests/test_tools.py
@@ -45,18 +45,18 @@ class TestMinimalWLS(object):
 
     @pytest.mark.parametrize('bad_value', [np.nan, np.inf])
     def test_inf_nan(self, bad_value):
-        with pytest.raises(ValueError) as err:
+        with pytest.raises(
+                ValueError,
+                match=r'detected in endog, estimation infeasible'):
             endog = self.endog1.copy()
             endog[0] = bad_value
             _MinimalWLS(endog, self.exog1, self.weights1,
                         check_endog=True, check_weights=True).fit()
-        assert err.type is ValueError
-        assert 'endog' in str(err)
 
-        with pytest.raises(ValueError) as err:
+        with pytest.raises(
+                ValueError,
+                match=r'detected in weights, estimation infeasible'):
             weights = self.weights1.copy()
             weights[-1] = bad_value
             _MinimalWLS(self.endog1, self.exog1, weights,
                         check_endog=True, check_weights=True).fit()
-        assert err.type is ValueError
-        assert 'weights' in str(err)


### PR DESCRIPTION
- [X] tests added / passed. 
- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>

It looks like pytest 5 changed the way some errors are reported. Small syntax change and I think this should fix most of the failing tests.
</details>
