### PR TITLE
BUG: Ensure exponential smoothers has continuous double data

### DIFF
--- a/statsmodels/tsa/holtwinters.py
+++ b/statsmodels/tsa/holtwinters.py
@@ -484,6 +484,7 @@ class ExponentialSmoothing(TimeSeriesModel):
                  seasonal_periods=None, dates=None, freq=None, missing='none'):
         super(ExponentialSmoothing, self).__init__(endog, None, dates,
                                                    freq, missing=missing)
+        self.endog = self.endog.astype(np.double)
         if trend in ['additive', 'multiplicative']:
             trend = {'additive': 'add', 'multiplicative': 'mul'}[trend]
         self.trend = trend
@@ -633,7 +634,7 @@ class ExponentialSmoothing(TimeSeriesModel):
             y = data.squeeze()
         if np.ndim(y) != 1:
             raise ValueError('Only 1 dimensional data supported')
-        self._y = y
+        self._y = y = np.ascontiguousarray(y, dtype=np.double)
         lvls = np.zeros(self.nobs)
         b = np.zeros(self.nobs)
         s = np.zeros(self.nobs + m - 1)

--- a/statsmodels/tsa/tests/test_holtwinters.py
+++ b/statsmodels/tsa/tests/test_holtwinters.py
@@ -505,3 +505,13 @@ def test_direct_holt_add():
     assert_allclose(b, res.slope)
     assert_allclose(f, res.level.iloc[-1] + res.slope.iloc[-1] * np.array([1, 2, 3, 4, 5]))
     assert_allclose(f, res.forecast(5))
+
+
+def test_integer_array(reset_randomstate):
+    rs = np.random.RandomState(12345)
+    e = 10*rs.standard_normal((1000,2))
+    y_star = np.cumsum(e[:,0])
+    y = y_star + e[:,1]
+    y = y.astype(np.long)
+    res = ExponentialSmoothing(y,trend='add').fit()
+    assert res.params['smoothing_level'] != 0.0


### PR DESCRIPTION
Ensure data is always C contiguous and double

- [X] closes #5920
- [X] tests added / passed. 
- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html#writing-the-commit-message). 
