### PR TITLE
MAINT: Fix pandas imports

### DIFF
--- a/statsmodels/compat/pandas.py
+++ b/statsmodels/compat/pandas.py
@@ -4,35 +4,25 @@ from distutils.version import LooseVersion
 
 import pandas
 
+__all__ = ['assert_frame_equal', 'assert_index_equal', 'assert_series_equal',
+           'data_klasses', 'frequencies', 'is_numeric_dtype', 'testing']
 
 version = LooseVersion(pandas.__version__)
-pandas_lte_0_19_2 = version <= LooseVersion('0.19.2')
-pandas_gt_0_19_2 = version > LooseVersion('0.19.2')
-pandas_ge_20_0 = version >= LooseVersion('0.20.0')
-pandas_ge_25_0 = version >= LooseVersion('0.25.0')
+pandas_lt_25_0 = version < LooseVersion('0.25.0')
 
 try:
-    from pandas.api.types import is_numeric_dtype  # noqa:F401
+    from pandas.api.types import is_numeric_dtype
 except ImportError:
-    from pandas.core.common import is_numeric_dtype  # noqa:F401
+    from pandas.core.common import is_numeric_dtype
 
-if pandas_ge_25_0:
-    from pandas.tseries import frequencies  # noqa:F401
-    data_klasses = (pandas.Series, pandas.DataFrame)
-elif pandas_ge_20_0:
-    try:
-        from pandas.tseries import offsets as frequencies
-    except ImportError:
-        from pandas.tseries import frequencies
-    data_klasses = (pandas.Series, pandas.DataFrame, pandas.Panel)
-else:
-    try:
-        import pandas.tseries.frequencies as frequencies
-    except ImportError:
-        from pandas.core import datetools as frequencies  # noqa
+try:
+    from pandas.tseries import offsets as frequencies
+except ImportError:
+    from pandas.tseries import frequencies
 
-    data_klasses = (pandas.Series, pandas.DataFrame, pandas.Panel,
-                    pandas.WidePanel)
+data_klasses = (pandas.Series, pandas.DataFrame)
+if pandas_lt_25_0:
+    data_klasses += (pandas.Panel,)
 
 try:
     import pandas.testing as testing

--- a/statsmodels/graphics/tests/test_tsaplots.py
+++ b/statsmodels/graphics/tests/test_tsaplots.py
@@ -6,7 +6,6 @@ from numpy.testing import assert_equal, assert_
 import pytest
 
 import statsmodels.api as sm
-from statsmodels.compat.pandas import pandas_lte_0_19_2
 from statsmodels.graphics.tsaplots import (plot_acf, plot_pacf, month_plot,
                                            quarter_plot, seasonal_plot)
 import statsmodels.tsa.arima_process as tsp
@@ -153,7 +152,6 @@ def test_plot_pacf_irregular(close_figures):
     plot_pacf(pacf, ax=ax, alpha=None, zero=False)
 
 
-@pytest.mark.skipif(pandas_lte_0_19_2, reason='pandas too old')
 @pytest.mark.matplotlib
 def test_plot_month(close_figures):
     dta = sm.datasets.elnino.load_pandas().data
@@ -177,7 +175,6 @@ def test_plot_month(close_figures):
     fig = month_plot(dta)
 
 
-@pytest.mark.skipif(pandas_lte_0_19_2, reason='pandas too old')
 @pytest.mark.matplotlib
 def test_plot_quarter(close_figures):
     dta = sm.datasets.macrodata.load_pandas().data

--- a/statsmodels/tsa/vector_ar/tests/test_dynamic.py
+++ b/statsmodels/tsa/vector_ar/tests/test_dynamic.py
@@ -1,14 +1,11 @@
-
 import numpy as np
 import pandas as pd
 import pytest
 from numpy.testing import assert_allclose
 from pandas.util.testing import assert_frame_equal, assert_series_equal
 
-from statsmodels.compat.pandas import pandas_gt_0_19_2
-
-pytestmark = pytest.mark.skipif(pandas_gt_0_19_2,
-                                reason='Requires pandas <= 0.19.2')
+pytestmark = pytest.mark.skip('Deprecated, pending removal. Reuqires pandas'
+                              '< 0.19.2, which are unsupported.')
 
 from statsmodels.tsa.vector_ar.dynamic import _window_ols  # noqa:E402
 


### PR DESCRIPTION
Modernize pandas compat imports to reflect min version

- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
