### PR TITLE
BUG: Limit lags in KPSS

### DIFF
--- a/statsmodels/tsa/stattools.py
+++ b/statsmodels/tsa/stattools.py
@@ -1682,17 +1682,18 @@ def kpss(x, regression='c', lags=None, store=False):
               'same as lags=\'auto\' which uses an automatic lag length ' \
               'selection method. To silence this warning, either use ' \
               '\'auto\' or \'legacy\''
-        warn(msg, DeprecationWarning)
+        warn(msg, FutureWarning)
     if lags == 'legacy':
         lags = int(np.ceil(12. * np.power(nobs / 100., 1 / 4.)))
+        lags = min(lags, nobs - 1)
     elif lags == 'auto':
         # autolag method of Hobijn et al. (1998)
         lags = _kpss_autolag(resids, nobs)
     else:
         lags = int(lags)
 
-    if lags > nobs:
-        raise ValueError("lags ({}) must be <= number of observations ({})"
+    if lags >= nobs:
+        raise ValueError("lags ({}) must be < number of observations ({})"
                          .format(lags, nobs))
 
     pvals = [0.10, 0.05, 0.025, 0.01]


### PR DESCRIPTION
Limit lags to nobs - 1 in KPSS

closes #5925

- [X] closes #5925
- [X] tests added / passed. 
- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html#writing-the-commit-message). 
