### PR TITLE
BUG: Restore ResettableCache

### DIFF
--- a/statsmodels/tools/decorators.py
+++ b/statsmodels/tools/decorators.py
@@ -2,7 +2,14 @@ from __future__ import print_function
 from statsmodels.tools.sm_exceptions import CacheWriteWarning
 import warnings
 
-__all__ = ['cache_readonly', 'cache_writable', 'deprecated_alias']
+__all__ = ['cache_readonly', 'cache_writable', 'deprecated_alias',
+           'ResettableCache']
+
+
+class ResettableCache(dict):
+    def __init__(self, *args, **kwargs):
+        super(ResettableCache, self).__init__(*args, **kwargs)
+        self.__dict__ = self
 
 
 def deprecated_alias(old_name, new_name, remove_version=None, msg=None,


### PR DESCRIPTION
Restore ResettableCache so that 0.9 pickles can loaded

closes #5899

- [X] closes #5899
- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html#writing-the-commit-message). 
