### PR TITLE
BUG: Fix mosaic plot with missing category

### DIFF
--- a/statsmodels/graphics/mosaicplot.py
+++ b/statsmodels/graphics/mosaicplot.py
@@ -330,6 +330,8 @@ def _normalize_dataframe(dataframe, index):
     grouped = data.groupby(index, sort=False)
     counted = grouped[index].count()
     averaged = counted.mean(axis=1)
+    # Fill empty missing with 0, see GH5639
+    averaged = averaged.fillna(0.0)
     return averaged
 
 

--- a/statsmodels/graphics/tests/test_mosaicplot.py
+++ b/statsmodels/graphics/tests/test_mosaicplot.py
@@ -1,17 +1,19 @@
 from __future__ import division
+
 from statsmodels.compat.python import iterkeys, zip, lrange, iteritems, range
 
-from numpy.testing import assert_, assert_raises
-import pandas as pd
-import pytest
-
-# utilities for the tests
-
 from collections import OrderedDict
-from statsmodels.api import datasets
+from io import BytesIO
+from itertools import product
 
 import numpy as np
-from itertools import product
+import pandas as pd
+import pytest
+from numpy.testing import assert_, assert_raises
+
+from statsmodels.api import datasets
+
+# utilities for the tests
 
 try:
     import matplotlib.pyplot as plt  # noqa:F401
@@ -428,3 +430,18 @@ def test_default_arg_index(close_figures):
                        'length' : ['long', 'short', 'short', 'long', 'long',
                                    'short']})
     assert_raises(ValueError, mosaic, data=df, title='foobar')
+
+
+def test_missing_category(close_figures):
+    # GH5639
+    animal = ['dog', 'dog', 'dog', 'cat', 'dog', 'cat', 'cat',
+              'dog', 'dog', 'cat']
+    size = ['medium', 'large', 'medium', 'medium', 'medium', 'medium',
+            'large', 'large', 'large', 'small']
+    testdata = pd.DataFrame({'animal': animal, 'size': size})
+    testdata['size'] = pd.Categorical(testdata['size'],
+                                      categories=['small', 'medium', 'large'])
+    testdata = testdata.sort_values('size')
+    fig, _ = mosaic(testdata, ['animal', 'size'])
+    bio = BytesIO()
+    fig.savefig(bio, format='png')


### PR DESCRIPTION
Fix plot so that it work with dataframes that are missing categories

closes #5639

- [X] closes #5639
- [X] tests added / passed. 
- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
