### PR TITLE
CLN: cython cleanups

### DIFF
--- a/statsmodels/nonparametric/_smoothers_lowess.pyx
+++ b/statsmodels/nonparametric/_smoothers_lowess.pyx
@@ -138,8 +138,8 @@ def lowess(np.ndarray[DTYPE_t, ndim = 1] endog,
 
     y = endog   # now just alias
     x = exog
-           
-    if not 0<=frac<=1:
+
+    if not 0 <= frac <= 1:
            raise ValueError("Lowess `frac` must be in the range [0,1]!")
 
     n = x.shape[0]

--- a/statsmodels/tsa/_exponential_smoothers.pyx
+++ b/statsmodels/tsa/_exponential_smoothers.pyx
@@ -6,6 +6,7 @@ cimport numpy as np
 
 np.import_array()
 
+
 cdef object _holt_init(double[::1] x, np.uint8_t[::1] xi, double[::1] p,
                        y, double[::1] l, double[::1] b):
     """Initialization for the Holt Models"""
@@ -30,10 +31,10 @@ cdef object _holt_init(double[::1] x, np.uint8_t[::1] xi, double[::1] p,
 
 cdef double[::1] ensure_1d(object x):
     """
-    This is a work aound function that ensures that X is a 1-d array.  It is needed since 
-    scipy.optimize.brute in version <= 1.0 calls squueze so that 1-d arrays are squeezed to 
+    This is a work aound function that ensures that X is a 1-d array.  It is needed since
+    scipy.optimize.brute in version <= 1.0 calls squueze so that 1-d arrays are squeezed to
     scalars.
-    
+
     Fixed in SciPy 1.1
     """
     if x.ndim == 0:
@@ -46,7 +47,7 @@ def _holt__(object x, np.uint8_t[::1] xi, double[::1] p, double[::1] y, double[:
             double[::1] b, double[::1] s, Py_ssize_t m, Py_ssize_t n, double max_seen):
     """
     Compute the sum of squared residuals for Simple Exponential Smoothing
-    
+
     Returns
     -------
     sse : float
@@ -105,7 +106,7 @@ def _holt_add_dam(object x, np.uint8_t[::1] xi, double[::1] p, double[::1] y, do
     cdef double alpha, beta, phi, betac, alphac, err, sse
     cdef double[::1] x_arr
     cdef Py_ssize_t i
-    
+
     x_arr = ensure_1d(x)
     alpha, beta, phi, alphac, betac = _holt_init(x_arr, xi, p, y, l, b)
     if alpha == 0.0:

--- a/statsmodels/tsa/_innovations.pyx
+++ b/statsmodels/tsa/_innovations.pyx
@@ -1,7 +1,6 @@
 #cython: language_level=3, wraparound=False, cdivision=True, boundscheck=False
 import numpy as np
 
-cimport numpy as np
 
 from statsmodels.tools.validation import (array_like, PandasWrapper,
                                           int_like, float_like)

--- a/statsmodels/tsa/_stl.pyx
+++ b/statsmodels/tsa/_stl.pyx
@@ -81,15 +81,14 @@ work    workspace of (n+2*np)*5 locations.
 """
 import pandas as pd
 import numpy as np
-cimport numpy as np 
 from libc.math cimport fabs, sqrt, isnan, NAN
 
 from statsmodels.tsa.tsatools import freq_to_period
 
-np.import_array()
 
 def _is_pos_int(x, odd):
-    valid = isinstance(x, (int, np.integer))
+    valid = (isinstance(x, (int, np.integer))
+             and not isinstance(x, np.timedelta64))
     valid = valid and not isinstance(x, (float, np.floating))
     try:
         valid = valid and x > 0

--- a/statsmodels/tsa/regime_switching/_hamilton_filter.pxd
+++ b/statsmodels/tsa/regime_switching/_hamilton_filter.pxd
@@ -4,7 +4,7 @@
 """
 Hamilton filter declarations
 
-Author: Chad Fulton  
+Author: Chad Fulton
 License: Simplified-BSD
 """
 

--- a/statsmodels/tsa/regime_switching/_kim_smoother.pxd
+++ b/statsmodels/tsa/regime_switching/_kim_smoother.pxd
@@ -11,33 +11,33 @@ License: Simplified-BSD
 cimport numpy as np
 
 cpdef skim_smoother_log(int nobs, int k_regimes, int order,
-                    np.float32_t [:,:,:] regime_transition,
-                    np.float32_t [:,:] predicted_joint_probabilities,
-                    np.float32_t [:,:] filtered_joint_probabilities,
-                    np.float32_t [:,:] smoothed_joint_probabilities)
+                    np.float32_t [:, :, :] regime_transition,
+                    np.float32_t [:, :] predicted_joint_probabilities,
+                    np.float32_t [:, :] filtered_joint_probabilities,
+                    np.float32_t [:, :] smoothed_joint_probabilities)
 
 cpdef dkim_smoother_log(int nobs, int k_regimes, int order,
-                    np.float64_t [:,:,:] regime_transition,
-                    np.float64_t [:,:] predicted_joint_probabilities,
-                    np.float64_t [:,:] filtered_joint_probabilities,
-                    np.float64_t [:,:] smoothed_joint_probabilities)
+                    np.float64_t [:, :, :] regime_transition,
+                    np.float64_t [:, :] predicted_joint_probabilities,
+                    np.float64_t [:, :] filtered_joint_probabilities,
+                    np.float64_t [:, :] smoothed_joint_probabilities)
 
 cpdef ckim_smoother_log(int nobs, int k_regimes, int order,
-                    np.complex64_t [:,:,:] regime_transition,
-                    np.complex64_t [:,:] predicted_joint_probabilities,
-                    np.complex64_t [:,:] filtered_joint_probabilities,
-                    np.complex64_t [:,:] smoothed_joint_probabilities)
+                    np.complex64_t [:, :, :] regime_transition,
+                    np.complex64_t [:, :] predicted_joint_probabilities,
+                    np.complex64_t [:, :] filtered_joint_probabilities,
+                    np.complex64_t [:, :] smoothed_joint_probabilities)
 
 cpdef zkim_smoother_log(int nobs, int k_regimes, int order,
-                    np.complex128_t [:,:,:] regime_transition,
-                    np.complex128_t [:,:] predicted_joint_probabilities,
-                    np.complex128_t [:,:] filtered_joint_probabilities,
-                    np.complex128_t [:,:] smoothed_joint_probabilities)
+                    np.complex128_t [:, :, :] regime_transition,
+                    np.complex128_t [:, :] predicted_joint_probabilities,
+                    np.complex128_t [:, :] filtered_joint_probabilities,
+                    np.complex128_t [:, :] smoothed_joint_probabilities)
 
 cdef void skim_smoother_log_iteration(int tt, int k_regimes, int order,
                     np.float32_t [:] tmp_joint_probabilities,
                     np.float32_t [:] tmp_probabilities_fraction,
-                    np.float32_t [:,:] regime_transition,
+                    np.float32_t [:, :] regime_transition,
                     np.float32_t [:] predicted_joint_probabilities,
                     np.float32_t [:] filtered_joint_probabilities,
                     np.float32_t [:] prev_smoothed_joint_probabilities,
@@ -46,7 +46,7 @@ cdef void skim_smoother_log_iteration(int tt, int k_regimes, int order,
 cdef void dkim_smoother_log_iteration(int tt, int k_regimes, int order,
                     np.float64_t [:] tmp_joint_probabilities,
                     np.float64_t [:] tmp_probabilities_fraction,
-                    np.float64_t [:,:] regime_transition,
+                    np.float64_t [:, :] regime_transition,
                     np.float64_t [:] predicted_joint_probabilities,
                     np.float64_t [:] filtered_joint_probabilities,
                     np.float64_t [:] prev_smoothed_joint_probabilities,
@@ -55,7 +55,7 @@ cdef void dkim_smoother_log_iteration(int tt, int k_regimes, int order,
 cdef void ckim_smoother_log_iteration(int tt, int k_regimes, int order,
                     np.complex64_t [:] tmp_joint_probabilities,
                     np.complex64_t [:] tmp_probabilities_fraction,
-                    np.complex64_t [:,:] regime_transition,
+                    np.complex64_t [:, :] regime_transition,
                     np.complex64_t [:] predicted_joint_probabilities,
                     np.complex64_t [:] filtered_joint_probabilities,
                     np.complex64_t [:] prev_smoothed_joint_probabilities,
@@ -64,7 +64,7 @@ cdef void ckim_smoother_log_iteration(int tt, int k_regimes, int order,
 cdef void zkim_smoother_log_iteration(int tt, int k_regimes, int order,
                     np.complex128_t [:] tmp_joint_probabilities,
                     np.complex128_t [:] tmp_probabilities_fraction,
-                    np.complex128_t [:,:] regime_transition,
+                    np.complex128_t [:, :] regime_transition,
                     np.complex128_t [:] predicted_joint_probabilities,
                     np.complex128_t [:] filtered_joint_probabilities,
                     np.complex128_t [:] prev_smoothed_joint_probabilities,

--- a/statsmodels/tsa/regime_switching/_kim_smoother.pyx.in
+++ b/statsmodels/tsa/regime_switching/_kim_smoother.pyx.in
@@ -44,10 +44,10 @@ if prefix == 's':
 
 
 cpdef {{prefix}}kim_smoother_log(int nobs, int k_regimes, int order,
-                             {{cython_type}} [:,:,:] regime_transition,
-                             {{cython_type}} [:,:] predicted_joint_probabilities,
-                             {{cython_type}} [:,:] filtered_joint_probabilities,
-                             {{cython_type}} [:,:] smoothed_joint_probabilities):
+                             {{cython_type}} [:, :, :] regime_transition,
+                             {{cython_type}} [:, :] predicted_joint_probabilities,
+                             {{cython_type}} [:, :] filtered_joint_probabilities,
+                             {{cython_type}} [:, :] smoothed_joint_probabilities):
     cdef int t, i, j, k, ix, regime_transition_t = 0, time_varying_regime_transition
     cdef:
         int k_regimes_order_m1 = k_regimes**(order - 1)
@@ -81,7 +81,7 @@ cpdef {{prefix}}kim_smoother_log(int nobs, int k_regimes, int order,
 cdef void {{prefix}}kim_smoother_log_iteration(int tt, int k_regimes, int order,
                              {{cython_type}} [:] tmp_joint_probabilities,
                              {{cython_type}} [:] tmp_probabilities_fraction,
-                             {{cython_type}} [:,:] regime_transition,
+                             {{cython_type}} [:, :] regime_transition,
                              {{cython_type}} [:] predicted_joint_probabilities,
                              {{cython_type}} [:] filtered_joint_probabilities,
                              {{cython_type}} [:] prev_smoothed_joint_probabilities,

--- a/statsmodels/tsa/statespace/_smoothers/_univariate_diffuse.pyx.in
+++ b/statsmodels/tsa/statespace/_smoothers/_univariate_diffuse.pyx.in
@@ -29,7 +29,7 @@ So, what we ought to have is:
 \hat \varepsilon_{t,i} = \sigma_{t,i}^2 F_{t,i}^{-1} (v_{t,i} - F_{t,i} K_{t,i}' r_{t,i})
 Var(\hat \varepsilon_{t,i}) = \sigma_{t,i}^2 - \sigma_{t,i}^4 F_{t,i}^{-2} (v_{t,i} - F_{t,i} K_{t,i}' r_{t,i})
 
-Author: Chad Fulton  
+Author: Chad Fulton
 License: Simplified-BSD
 """
 
@@ -100,8 +100,8 @@ cdef int {{prefix}}smoothed_estimators_measurement_univariate_diffuse({{prefix}}
         smoother.scaled_smoothed_diffuse1_estimator_cov[:, :, model.nobs-1] = 0
         smoother.scaled_smoothed_diffuse2_estimator_cov[:, :, model.nobs-1] = 0
 
-    # Smoothing error  
-    # (not used in the univariate approach)  
+    # Smoothing error
+    # (not used in the univariate approach)
 
     # Given r_{t,0}:
     # calculate r_{t-1,p}, ..., r_{t-1, 0} and N_{t-1,p}, ..., N_{t-1,0}
@@ -527,7 +527,7 @@ cdef int {{prefix}}smoothed_disturbances_univariate_diffuse({{prefix}}KalmanSmoo
 
     # Temporary arrays
 
-    # $\\#_0 = R_t Q_t$  
+    # $\\#_0 = R_t Q_t$
     # $(m \times r) = (m \times r) (r \times r)$
     blas.{{prefix}}gemm("N", "N", &model._k_states, &model._k_posdef, &model._k_posdef,
               &alpha, model._selection, &model._k_states,
@@ -539,9 +539,9 @@ cdef int {{prefix}}smoothed_disturbances_univariate_diffuse({{prefix}}KalmanSmoo
         forecast_error_diffuse_cov = kfilter._forecast_error_diffuse_cov[i + i*kfilter.k_endog]
         obs_cov = model._obs_cov[i + i*model._k_endog]
 
-        # Smoothed measurement disturbance  
+        # Smoothed measurement disturbance
         if smoother.smoother_output & SMOOTHER_DISTURBANCE:
-            if {{combined_prefix}}abs(forecast_error_diffuse_cov) > kfilter.tolerance_diffuse:  
+            if {{combined_prefix}}abs(forecast_error_diffuse_cov) > kfilter.tolerance_diffuse:
                 smoother._smoothed_measurement_disturbance[i] = -obs_cov * smoother._smoothed_measurement_disturbance[i]
             elif not forecast_error_cov == 0:
                 smoother._smoothed_measurement_disturbance[i] = obs_cov * (
@@ -549,9 +549,9 @@ cdef int {{prefix}}smoothed_disturbances_univariate_diffuse({{prefix}}KalmanSmoo
             else:
                 smoother._smoothed_measurement_disturbance[i] = 0
 
-        # Smoothed measurement disturbance covariance matrix  
+        # Smoothed measurement disturbance covariance matrix
         if smoother.smoother_output & SMOOTHER_DISTURBANCE_COV:
-            if {{combined_prefix}}abs(forecast_error_diffuse_cov) > kfilter.tolerance_diffuse:  
+            if {{combined_prefix}}abs(forecast_error_diffuse_cov) > kfilter.tolerance_diffuse:
                 smoother._smoothed_measurement_disturbance_cov[i + i*kfilter.k_endog] = (
                     obs_cov * (1 - obs_cov * smoother._smoothed_measurement_disturbance_cov[i + i*kfilter.k_endog]))
             elif not forecast_error_cov == 0:
@@ -560,14 +560,14 @@ cdef int {{prefix}}smoothed_disturbances_univariate_diffuse({{prefix}}KalmanSmoo
             else:
                 smoother._smoothed_measurement_disturbance_cov[i + i*kfilter.k_endog] = obs_cov
 
-    # Smoothed state disturbance  
+    # Smoothed state disturbance
     if smoother.smoother_output & SMOOTHER_DISTURBANCE:
         blas.{{prefix}}gemv("T", &model._k_states, &model._k_posdef,
                       &alpha, smoother._tmp0, &kfilter.k_states,
                               smoother._input_scaled_smoothed_estimator, &inc,
                       &beta, smoother._smoothed_state_disturbance, &inc)
 
-    # Smoothed state disturbance covariance matrix  
+    # Smoothed state disturbance covariance matrix
     if smoother.smoother_output & SMOOTHER_DISTURBANCE_COV:
         blas.{{prefix}}gemm("N", "N", &model._k_states, &model._k_posdef, &model._k_states,
                   &alpha, smoother._input_scaled_smoothed_estimator_cov, &kfilter.k_states,

--- a/statsmodels/tsa/statespace/_tools.pyx.in
+++ b/statsmodels/tsa/statespace/_tools.pyx.in
@@ -680,7 +680,7 @@ cdef int _{{prefix}}ldl({{cython_type}} * A, int n) except *:
     cdef:
         int info = 0
         int j, i, k
-        cdef np.npy_intp dim[1]
+        np.npy_intp dim[1]
         np.float64_t tol = 1e-15
         {{cython_type}} [:] v
 


### PR DESCRIPTION
trailing whitespace, `cimport numpy as cnp` instead of as `np` to disambiguate the namespaces