### PR TITLE
BUG/ENH: Improve RLM in the case of perfect fit

### DIFF
--- a/statsmodels/robust/tests/test_rlm.py
+++ b/statsmodels/robust/tests/test_rlm.py
@@ -107,6 +107,7 @@ class TestRlm(CheckRlmResultsMixin):
         cls.decimal_scale = DECIMAL_3
 
         model = RLM(cls.data.endog, cls.data.exog, M=norms.HuberT())
+        cls.model = model
         results = model.fit()
         h2 = model.fit(cov="H2").bcov_scaled
         h3 = model.fit(cov="H3").bcov_scaled
@@ -121,6 +122,18 @@ class TestRlm(CheckRlmResultsMixin):
     @pytest.mark.smoke
     def test_summary(self):
         self.res1.summary()
+
+    @pytest.mark.smoke
+    def test_summary2(self):
+        self.res1.summary2()
+
+    @pytest.mark.smoke
+    def test_chisq(self):
+        assert isinstance(self.res1.chisq, np.ndarray)
+
+    @pytest.mark.smoke
+    def test_predict(self):
+        assert isinstance(self.model.predict(self.res1.params), np.ndarray)
 
 
 class TestHampel(TestRlm):
@@ -314,3 +327,48 @@ def test_rlm_start_values_errors():
     start_params = np.array([start_params, start_params]).T
     with pytest.raises(ValueError):
         model.fit(start_params=start_params)
+
+
+@pytest.fixture(scope='module',
+                params=[norms.AndrewWave, norms.LeastSquares, norms.HuberT,
+                        norms.TrimmedMean, norms.TukeyBiweight, norms.Hampel,
+                        norms.RamsayE])
+def norm(request):
+    return request.param()
+
+
+@pytest.fixture(scope='module')
+def perfect_fit_data(request):
+    from statsmodels.tools.tools import Bunch
+    rs = np.random.RandomState(1249328932)
+    exog = rs.standard_normal((1000, 1))
+    endog = exog + exog ** 2
+    exog = sm.add_constant(np.c_[exog, exog ** 2])
+    return Bunch(endog=endog, exog=exog, const=(3.2 * np.ones_like(endog)))
+
+
+def test_perfect_fit(perfect_fit_data, norm):
+    res = RLM(perfect_fit_data.endog, perfect_fit_data.exog, M=norm).fit()
+    assert_allclose(res.params, np.array([0, 1, 1]), atol=1e-8)
+
+
+def test_perfect_const(perfect_fit_data, norm):
+    res = RLM(perfect_fit_data.const, perfect_fit_data.exog, M=norm).fit()
+    assert_allclose(res.params, np.array([3.2, 0, 0]), atol=1e-8)
+
+
+@pytest.mark.parametrize('conv', ('weights', 'coefs', 'sresid'))
+def test_alt_criterion(conv):
+    data = sm.datasets.stackloss.load(as_pandas=True)
+    data.exog = sm.add_constant(data.exog, prepend=False)
+    base = RLM(data.endog, data.exog, M=norms.HuberT()).fit()
+    alt = RLM(data.endog, data.exog, M=norms.HuberT()).fit(conv=conv)
+    assert_allclose(base.params, alt.params)
+
+
+def test_bad_criterion():
+    data = sm.datasets.stackloss.load(as_pandas=True)
+    data.exog = sm.add_constant(data.exog, prepend=False)
+    mod = RLM(data.endog, data.exog, M=norms.HuberT())
+    with pytest.raises(ValueError, match='Convergence argument unknown'):
+        mod.fit(conv='unknown')


### PR DESCRIPTION
Ensure RLM doesn't crash if perfect fit
Clean norms so that they don't crash either
Avoid calculations the load to nan
Improve testing of RLM
Replace fabs with abs

xref #55

- [X] closes #5585
- [X] closes #1341
- [X] closes #5878
- [X] closes #5356
- [X] closes #3319
- [X] tests added / passed. 
- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
