### PR TITLE
MAINT: Remove future and Python 2.7

### DIFF
--- a/statsmodels/base/_penalties.py
+++ b/statsmodels/base/_penalties.py
@@ -19,8 +19,6 @@ The penaties should be smooth so that they can be subtracted from log
 likelihood functions and optimized using standard methods (i.e. L1
 penalties do not belong here).
 """
-from __future__ import division
-
 import numpy as np
 
 

--- a/statsmodels/base/l1_solvers_common.py
+++ b/statsmodels/base/l1_solvers_common.py
@@ -1,7 +1,6 @@
 """
 Holds common functions for l1 solvers.
 """
-from __future__ import print_function
 
 import numpy as np
 

--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 from statsmodels.compat.python import lzip, range, reduce
 import numpy as np
 from scipy import stats

--- a/statsmodels/base/optimizer.py
+++ b/statsmodels/base/optimizer.py
@@ -2,7 +2,6 @@
 Functions that are general enough to use for any model fitting. The idea is
 to untie these from LikelihoodModel so that they may be re-used generally.
 """
-from __future__ import print_function
 
 import numpy as np
 from scipy import optimize

--- a/statsmodels/base/tests/test_shrink_pickle.py
+++ b/statsmodels/base/tests/test_shrink_pickle.py
@@ -5,7 +5,6 @@ Created on Fri Mar 09 16:00:27 2012
 
 Author: Josef Perktold
 """
-from __future__ import print_function
 from statsmodels.compat.python import iterkeys, cPickle, BytesIO
 
 import warnings

--- a/statsmodels/base/wrapper.py
+++ b/statsmodels/base/wrapper.py
@@ -1,7 +1,7 @@
 import inspect
 import functools
 
-from statsmodels.compat.python import iteritems, getargspec
+from statsmodels.compat.python import iteritems
 
 
 class ResultsWrapper(object):
@@ -95,15 +95,8 @@ def make_wrapper(func, how):
             obj = data.wrap_output(func(results, *args, **kwargs), how)
         return obj
 
-    try:  # Python 3.3+
-        sig = inspect.signature(func)
-        formatted = str(sig)
-    except AttributeError:
-        # TODO: Remove when Python 2.7 is dropped
-        argspec = getargspec(func)
-        formatted = inspect.formatargspec(argspec[0],
-                                          varargs=argspec[1],
-                                          defaults=argspec[3])
+    sig = inspect.signature(func)
+    formatted = str(sig)
 
     wrapper.__doc__ = "%s%s\n%s" % (func.__name__, formatted, wrapper.__doc__)
 

--- a/statsmodels/compat/numpy.py
+++ b/statsmodels/compat/numpy.py
@@ -39,7 +39,6 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 
-from __future__ import absolute_import
 from distutils.version import LooseVersion
 
 import numpy as np

--- a/statsmodels/compat/pandas.py
+++ b/statsmodels/compat/pandas.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 
 from distutils.version import LooseVersion
 

--- a/statsmodels/compat/scipy.py
+++ b/statsmodels/compat/scipy.py
@@ -1,11 +1,4 @@
-from __future__ import absolute_import
-from distutils.version import LooseVersion
-
 import numpy as np
-import scipy
-
-SP_GTE_019 = LooseVersion(scipy.__version__) >= LooseVersion('0.19')
-NumpyVersion = np.lib.NumpyVersion
 
 
 def _next_regular(target):
@@ -97,25 +90,3 @@ def _lazywhere(cond, arrays, f, fillvalue=None, f2=None):
         np.place(out, ~cond, f2(*temp))
 
     return out
-
-
-# Work around for complex chnges in gammaln in 1.0.0.
-#   loggamma introduced in 0.18.
-try:
-    from scipy.special import loggamma  # noqa:F401
-except ImportError:
-    from scipy.special import gammaln  # noqa:F401
-    loggamma = gammaln
-
-# Work around for factorial changes in 1.0.0
-
-try:
-    from scipy.special import factorial, factorial2  # noqa:F401
-except ImportError:
-    from scipy.misc import factorial, factorial2  # noqa:F401
-
-# Moved in 1.0 to special
-try:
-    from scipy.special import logsumexp  # noqa:F401
-except ImportError:
-    from scipy.misc import logsumexp  # noqa:F401

--- a/statsmodels/discrete/_diagnostics_count.py
+++ b/statsmodels/discrete/_diagnostics_count.py
@@ -5,8 +5,6 @@ Created on Fri Sep 15 12:53:45 2017
 Author: Josef Perktold
 """
 
-from __future__ import division
-
 import numpy as np
 from scipy import stats
 

--- a/statsmodels/discrete/count_model.py
+++ b/statsmodels/discrete/count_model.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 __all__ = ["ZeroInflatedPoisson", "ZeroInflatedGeneralizedPoisson",
            "ZeroInflatedNegativeBinomialP"]
 

--- a/statsmodels/discrete/discrete_model.py
+++ b/statsmodels/discrete/discrete_model.py
@@ -15,13 +15,11 @@ G.S. Madalla. `Limited-Dependent and Qualitative Variables in Econometrics`.
 
 W. Greene. `Econometric Analysis`. Prentice Hall, 5th. edition. 2003.
 """
-from __future__ import division
-
 __all__ = ["Poisson", "Logit", "Probit", "MNLogit", "NegativeBinomial",
            "GeneralizedPoisson", "NegativeBinomialP"]
 
 from statsmodels.compat.python import range
-from statsmodels.compat.scipy import loggamma
+from scipy.special import loggamma
 
 import numpy as np
 from pandas import get_dummies

--- a/statsmodels/discrete/tests/test_constrained.py
+++ b/statsmodels/discrete/tests/test_constrained.py
@@ -6,8 +6,6 @@ Author: Josef Perktold
 License: BSD-3
 
 """
-from __future__ import division
-
 from statsmodels.compat.python import StringIO
 
 import numpy as np

--- a/statsmodels/discrete/tests/test_count_model.py
+++ b/statsmodels/discrete/tests/test_count_model.py
@@ -1,6 +1,3 @@
-from __future__ import division
-from statsmodels.compat.scipy import SP_GTE_019
-
 import numpy as np
 from numpy.testing import (assert_,
                            assert_equal, assert_array_equal, assert_allclose)
@@ -295,7 +292,7 @@ class TestZeroInflatedGeneralizedPoisson(CheckGeneric):
 
         # Ser random_state here to improve reproducibility
         random_state = np.random.RandomState(1)
-        seed = {'seed': random_state} if SP_GTE_019 else {}
+        seed = {'seed': random_state}
         res_bh = model.fit(start_params=start_params,
                            method='basinhopping', niter=500, stepsize=0.1,
                            niter_success=None, disp=0, interval=1, **seed)

--- a/statsmodels/discrete/tests/test_diagnostic.py
+++ b/statsmodels/discrete/tests/test_diagnostic.py
@@ -5,8 +5,6 @@ Created on Fri Sep 15 13:38:13 2017
 Author: Josef Perktold
 """
 
-from __future__ import division
-
 import numpy as np
 from numpy.testing import assert_allclose
 import pytest

--- a/statsmodels/distributions/edgeworth.py
+++ b/statsmodels/distributions/edgeworth.py
@@ -1,10 +1,9 @@
-from __future__ import division, print_function, absolute_import
 
 import warnings
 
 import numpy as np
 from numpy.polynomial.hermite_e import HermiteE
-from statsmodels.compat.scipy import factorial
+from scipy.special import factorial
 from scipy.stats import rv_continuous
 import scipy.special as special
 

--- a/statsmodels/distributions/tests/test_edgeworth.py
+++ b/statsmodels/distributions/tests/test_edgeworth.py
@@ -1,4 +1,3 @@
-from __future__ import division, print_function, absolute_import
 
 import warnings
 
@@ -7,8 +6,7 @@ from numpy.testing import (assert_equal, assert_raises,
                            assert_allclose)
 import numpy.testing as npt
 
-from statsmodels.compat.scipy import factorial, factorial2
-from scipy.special import gamma
+from scipy.special import gamma, factorial, factorial2
 import scipy.stats as stats
 
 from statsmodels.distributions.edgeworth import (_faa_di_bruno_partitions,

--- a/statsmodels/emplike/aft_el.py
+++ b/statsmodels/emplike/aft_el.py
@@ -27,8 +27,6 @@ Statistics. 14:3, 643-656.
 
 
 """
-from __future__ import division
-
 import numpy as np
 from statsmodels.regression.linear_model import OLS, WLS
 from statsmodels.tools import add_constant

--- a/statsmodels/emplike/descriptive.py
+++ b/statsmodels/emplike/descriptive.py
@@ -15,8 +15,6 @@ General References:
 Owen, A. (2001). "Empirical Likelihood." Chapman and Hall
 
 """
-from __future__ import division
-
 import numpy as np
 from scipy import optimize
 from scipy.stats import chi2, skew, kurtosis

--- a/statsmodels/emplike/elanova.py
+++ b/statsmodels/emplike/elanova.py
@@ -9,8 +9,6 @@ General References
 
 Owen, A. B. (2001). Empirical Likelihood. Chapman and Hall.
 """
-from __future__ import division
-
 from statsmodels.compat.python import range
 import numpy as np
 from .descriptive import _OptFuncts

--- a/statsmodels/emplike/elregress.py
+++ b/statsmodels/emplike/elregress.py
@@ -12,8 +12,6 @@ General References
 Owen, A.B.(2001). Empirical Likelihood. Chapman and Hall
 
 """
-from __future__ import division
-
 import numpy as np
 from statsmodels.emplike.descriptive import _OptFuncts
 

--- a/statsmodels/emplike/originregress.py
+++ b/statsmodels/emplike/originregress.py
@@ -16,8 +16,6 @@ General References
 Owen, A.B. (2001). Empirical Likelihood.  Chapman and Hall. p. 82.
 
 """
-from __future__ import division
-
 import numpy as np
 from scipy.stats import chi2
 from scipy import optimize

--- a/statsmodels/emplike/tests/test_aft.py
+++ b/statsmodels/emplike/tests/test_aft.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 import numpy as np
 from numpy.testing import assert_almost_equal
 import pytest

--- a/statsmodels/emplike/tests/test_anova.py
+++ b/statsmodels/emplike/tests/test_anova.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 from numpy.testing import assert_almost_equal
 from statsmodels.datasets import star98
 from statsmodels.emplike.elanova import ANOVA

--- a/statsmodels/emplike/tests/test_descriptive.py
+++ b/statsmodels/emplike/tests/test_descriptive.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 import numpy as np
 from numpy.testing import assert_almost_equal
 from statsmodels.datasets import star98

--- a/statsmodels/emplike/tests/test_origin.py
+++ b/statsmodels/emplike/tests/test_origin.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 from numpy.testing import assert_almost_equal
 from statsmodels.emplike.originregress import ELOriginRegress
 from statsmodels.datasets import cancer

--- a/statsmodels/emplike/tests/test_regression.py
+++ b/statsmodels/emplike/tests/test_regression.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 from numpy.testing import assert_almost_equal
 
 import pytest

--- a/statsmodels/examples/es_misc_poisson2.py
+++ b/statsmodels/examples/es_misc_poisson2.py
@@ -1,5 +1,4 @@
 
-from __future__ import print_function
 import numpy as np
 
 import statsmodels.api as sm

--- a/statsmodels/examples/ex_arch_canada.py
+++ b/statsmodels/examples/ex_arch_canada.py
@@ -6,7 +6,6 @@ Created on Sat Dec 24 07:31:47 2011
 Author: Josef Perktold
 """
 
-from __future__ import print_function
 import numpy as np
 import statsmodels.sandbox.stats.diagnostic as dia
 

--- a/statsmodels/examples/ex_emplike_1.py
+++ b/statsmodels/examples/ex_emplike_1.py
@@ -5,7 +5,6 @@ it also generates plots.
 
 """
 
-from __future__ import print_function
 import numpy as np
 import statsmodels.api as sm
 print('Welcome to El')

--- a/statsmodels/examples/ex_emplike_2.py
+++ b/statsmodels/examples/ex_emplike_2.py
@@ -3,7 +3,6 @@ This script is a basic tutorial on how to conduct empirical
 likelihood estimation and inference in linear regression models.
 """
 
-from __future__ import print_function
 import numpy as np
 import statsmodels.api as sm
 

--- a/statsmodels/examples/ex_emplike_3.py
+++ b/statsmodels/examples/ex_emplike_3.py
@@ -6,7 +6,6 @@ We will be using the Stanford Heart Transplant data
 
 """
 
-from __future__ import print_function
 import statsmodels.api as sm
 import numpy as np
 

--- a/statsmodels/examples/ex_feasible_gls_het.py
+++ b/statsmodels/examples/ex_feasible_gls_het.py
@@ -21,7 +21,6 @@ regressors as in the main equation.
 
 """
 
-from __future__ import print_function
 import numpy as np
 from numpy.testing import assert_almost_equal
 

--- a/statsmodels/examples/ex_feasible_gls_het_0.py
+++ b/statsmodels/examples/ex_feasible_gls_het_0.py
@@ -16,7 +16,6 @@ Author: Josef Perktold
 
 """
 
-from __future__ import print_function
 import numpy as np
 from numpy.testing import assert_almost_equal
 

--- a/statsmodels/examples/ex_generic_mle.py
+++ b/statsmodels/examples/ex_generic_mle.py
@@ -1,5 +1,4 @@
 
-from __future__ import print_function
 from functools import partial
 
 import numpy as np

--- a/statsmodels/examples/ex_generic_mle_t.py
+++ b/statsmodels/examples/ex_generic_mle_t.py
@@ -6,7 +6,6 @@ Author: josef-pktd
 """
 
 
-from __future__ import print_function
 import numpy as np
 
 from scipy import special

--- a/statsmodels/examples/ex_generic_mle_tdist.py
+++ b/statsmodels/examples/ex_generic_mle_tdist.py
@@ -6,7 +6,6 @@ Author: josef-pktd
 """
 
 
-from __future__ import print_function
 from statsmodels.compat.python import zip
 import numpy as np
 

--- a/statsmodels/examples/ex_grangercausality.py
+++ b/statsmodels/examples/ex_grangercausality.py
@@ -6,7 +6,6 @@ Created on Sat Jul 06 15:44:57 2013
 Author: Josef Perktold
 """
 
-from __future__ import print_function
 from statsmodels.compat.python import iteritems
 import numpy as np
 from numpy.testing import assert_almost_equal

--- a/statsmodels/examples/ex_inter_rater.py
+++ b/statsmodels/examples/ex_inter_rater.py
@@ -6,7 +6,6 @@ Created on Mon Dec 10 08:54:02 2012
 Author: Josef Perktold
 """
 
-from __future__ import print_function
 import numpy as np
 
 from statsmodels.stats.inter_rater import fleiss_kappa, cohens_kappa

--- a/statsmodels/examples/ex_kde_confint.py
+++ b/statsmodels/examples/ex_kde_confint.py
@@ -6,7 +6,6 @@ Created on Mon Dec 16 11:02:59 2013
 Author: Josef Perktold
 """
 
-from __future__ import print_function
 import numpy as np
 from scipy import stats
 import matplotlib.pyplot as plt

--- a/statsmodels/examples/ex_kde_normalreference.py
+++ b/statsmodels/examples/ex_kde_normalreference.py
@@ -7,7 +7,6 @@ from a mixture of gaussians. Distribution has been chosen to be reasoanbly close
 to normal.
 """
 
-from __future__ import print_function
 import numpy as np
 from scipy import stats
 import matplotlib.pyplot as plt

--- a/statsmodels/examples/ex_kernel_regression.py
+++ b/statsmodels/examples/ex_kernel_regression.py
@@ -6,7 +6,6 @@ Created on Wed Jan 02 09:17:40 2013
 Author: Josef Perktold based on test file by George Panterov
 """
 
-from __future__ import print_function
 import numpy as np
 import numpy.testing as npt
 import matplotlib.pyplot as plt

--- a/statsmodels/examples/ex_kernel_regression2.py
+++ b/statsmodels/examples/ex_kernel_regression2.py
@@ -6,7 +6,6 @@ Created on Wed Jan 02 13:43:44 2013
 Author: Josef Perktold
 """
 
-from __future__ import print_function
 import numpy as np
 import statsmodels.nonparametric.api as nparam
 

--- a/statsmodels/examples/ex_kernel_regression3.py
+++ b/statsmodels/examples/ex_kernel_regression3.py
@@ -6,7 +6,6 @@ Created on Wed Jan 02 13:43:44 2013
 Author: Josef Perktold
 """
 
-from __future__ import print_function
 import numpy as np
 import statsmodels.nonparametric.api as nparam
 

--- a/statsmodels/examples/ex_kernel_regression_censored2.py
+++ b/statsmodels/examples/ex_kernel_regression_censored2.py
@@ -6,7 +6,6 @@ Created on Thu Jan 03 20:20:47 2013
 Author: Josef Perktold
 """
 
-from __future__ import print_function
 import numpy as np
 import statsmodels.nonparametric.api as nparam
 

--- a/statsmodels/examples/ex_kernel_regression_dgp.py
+++ b/statsmodels/examples/ex_kernel_regression_dgp.py
@@ -6,7 +6,6 @@ Created on Sun Jan 06 09:50:54 2013
 Author: Josef Perktold
 """
 
-from __future__ import print_function
 
 if __name__ == '__main__':
 

--- a/statsmodels/examples/ex_kernel_regression_sigtest.py
+++ b/statsmodels/examples/ex_kernel_regression_sigtest.py
@@ -33,7 +33,6 @@ times: 8.34599995613 20.6909999847 666.373999834
 
 """
 
-from __future__ import print_function
 import time
 
 import numpy as np

--- a/statsmodels/examples/ex_kernel_semilinear_dgp.py
+++ b/statsmodels/examples/ex_kernel_semilinear_dgp.py
@@ -6,7 +6,6 @@ Created on Sun Jan 06 09:50:54 2013
 Author: Josef Perktold
 """
 
-from __future__ import print_function
 
 
 if __name__ == '__main__':

--- a/statsmodels/examples/ex_kernel_singleindex_dgp.py
+++ b/statsmodels/examples/ex_kernel_singleindex_dgp.py
@@ -6,7 +6,6 @@ Created on Sun Jan 06 09:50:54 2013
 Author: Josef Perktold
 """
 
-from __future__ import print_function
 
 
 if __name__ == '__main__':

--- a/statsmodels/examples/ex_kernel_test_functional.py
+++ b/statsmodels/examples/ex_kernel_test_functional.py
@@ -6,7 +6,6 @@ Created on Tue Jan 08 19:03:20 2013
 Author: Josef Perktold
 """
 
-from __future__ import print_function
 
 
 if __name__ == '__main__':

--- a/statsmodels/examples/ex_kernel_test_functional_li_wang.py
+++ b/statsmodels/examples/ex_kernel_test_functional_li_wang.py
@@ -59,7 +59,6 @@ aymp.normal p-value (upper) 0.306629578855
 
 """
 
-from __future__ import print_function
 
 
 if __name__ == '__main__':

--- a/statsmodels/examples/ex_lowess.py
+++ b/statsmodels/examples/ex_lowess.py
@@ -7,7 +7,6 @@ Author: Chris Jordan Squire
 extracted from test suite by josef-pktd
 """
 
-from __future__ import print_function
 import os
 
 import numpy as np

--- a/statsmodels/examples/ex_misc_tarma.py
+++ b/statsmodels/examples/ex_misc_tarma.py
@@ -6,7 +6,6 @@ Created on Wed Jul 03 23:01:44 2013
 Author: Josef Perktold
 """
 
-from __future__ import print_function
 import numpy as np
 import matplotlib.pyplot as plt
 

--- a/statsmodels/examples/ex_misc_tmodel.py
+++ b/statsmodels/examples/ex_misc_tmodel.py
@@ -1,5 +1,4 @@
 
-from __future__ import print_function
 import numpy as np
 
 from scipy import stats

--- a/statsmodels/examples/ex_multivar_kde.py
+++ b/statsmodels/examples/ex_multivar_kde.py
@@ -5,7 +5,6 @@ distributions.
 
 author: George Panterov
 """
-from __future__ import print_function
 import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib import cm

--- a/statsmodels/examples/ex_nearest_corr.py
+++ b/statsmodels/examples/ex_nearest_corr.py
@@ -16,7 +16,6 @@ the sum of squared differences (Frobenious norm without taking the square root)
 
 """
 
-from __future__ import print_function
 import numpy as np
 from statsmodels.stats.correlation_tools import (
                  corr_nearest, corr_clipped)

--- a/statsmodels/examples/ex_ols_robustcov.py
+++ b/statsmodels/examples/ex_ols_robustcov.py
@@ -1,5 +1,4 @@
 
-from __future__ import print_function
 import numpy as np
 from statsmodels.regression.linear_model import OLS
 from statsmodels.tools.tools import add_constant

--- a/statsmodels/examples/ex_outliers_influence.py
+++ b/statsmodels/examples/ex_outliers_influence.py
@@ -39,7 +39,7 @@ if __name__ == '__main__':
 
     res = res_ols #alias
 
-    #https://en.wikipedia.org/wiki/PRESS_statistic
+    #http://en.wikipedia.org/wiki/PRESS_statistic
     #predicted residuals, leave one out predicted residuals
     resid_press = res.resid / (1-hh)
     ess_press = np.dot(resid_press, resid_press)
@@ -47,7 +47,7 @@ if __name__ == '__main__':
     sigma2_est = np.sqrt(res.mse_resid) #can be replace by different estimators of sigma
     sigma_est = np.sqrt(sigma2_est)
     resid_studentized = res.resid / sigma_est / np.sqrt(1 - hh)
-    #https://en.wikipedia.org/wiki/DFFITS:
+    #http://en.wikipedia.org/wiki/DFFITS:
     dffits = resid_studentized * np.sqrt(hh / (1 - hh))
 
     nobs, k_vars = res.model.exog.shape
@@ -56,7 +56,7 @@ if __name__ == '__main__':
 
     res_ols.df_modelwc = res_ols.df_model + 1
     n_params = res.model.exog.shape[1]
-    #https://en.wikipedia.org/wiki/Cook%27s_distance
+    #http://en.wikipedia.org/wiki/Cook%27s_distance
     cooks_d = res.resid**2 / sigma2_est / res_ols.df_modelwc * hh / (1 - hh)**2
     #or
     #Eubank p.93, 94

--- a/statsmodels/examples/ex_pandas.py
+++ b/statsmodels/examples/ex_pandas.py
@@ -4,7 +4,6 @@
 """
 
 
-from __future__ import print_function
 from statsmodels.compat.pandas import frequencies
 from statsmodels.compat.python import zip
 from datetime import datetime

--- a/statsmodels/examples/ex_pareto_plot.py
+++ b/statsmodels/examples/ex_pareto_plot.py
@@ -6,7 +6,6 @@ Author: josef-pktd
 """
 
 
-from __future__ import print_function
 import numpy as np
 from scipy import stats
 import matplotlib.pyplot as plt

--- a/statsmodels/examples/ex_proportion.py
+++ b/statsmodels/examples/ex_proportion.py
@@ -6,7 +6,6 @@ Created on Sun Apr 21 07:59:26 2013
 Author: Josef Perktold
 """
 
-from __future__ import print_function
 from statsmodels.compat.python import lmap
 import numpy as np
 import matplotlib.pyplot as plt

--- a/statsmodels/examples/ex_regressionplots.py
+++ b/statsmodels/examples/ex_regressionplots.py
@@ -5,7 +5,6 @@ Author: Josef Perktold
 
 """
 
-from __future__ import print_function
 import numpy as np
 import statsmodels.api as sm
 import matplotlib.pyplot as plt

--- a/statsmodels/examples/ex_rootfinding.py
+++ b/statsmodels/examples/ex_rootfinding.py
@@ -5,7 +5,6 @@ Created on Sat Mar 23 13:35:51 2013
 
 Author: Josef Perktold
 """
-from __future__ import print_function
 import numpy as np
 from statsmodels.tools.rootfinding import brentq_expanding
 

--- a/statsmodels/examples/ex_univar_kde.py
+++ b/statsmodels/examples/ex_univar_kde.py
@@ -14,7 +14,6 @@ Produces six different plots for each distribution
 """
 
 
-from __future__ import print_function
 import numpy as np
 import scipy.stats as stats
 import matplotlib.pyplot as plt

--- a/statsmodels/examples/example_discrete_mnl.py
+++ b/statsmodels/examples/example_discrete_mnl.py
@@ -1,7 +1,6 @@
 """Example: statsmodels.discretemod
 """
 
-from __future__ import print_function
 from statsmodels.compat.python import lrange
 import numpy as np
 import statsmodels.api as sm

--- a/statsmodels/examples/example_enhanced_boxplots.py
+++ b/statsmodels/examples/example_enhanced_boxplots.py
@@ -1,5 +1,4 @@
 
-from __future__ import print_function
 import numpy as np
 import matplotlib.pyplot as plt
 

--- a/statsmodels/examples/example_functional_plots.py
+++ b/statsmodels/examples/example_functional_plots.py
@@ -7,7 +7,6 @@ Author: Ralf Gommers
 
 '''
 
-from __future__ import print_function
 import numpy as np
 import matplotlib.pyplot as plt
 import statsmodels.api as sm

--- a/statsmodels/examples/example_kde.py
+++ b/statsmodels/examples/example_kde.py
@@ -1,5 +1,4 @@
 
-from __future__ import print_function
 import numpy as np
 from scipy import stats
 from statsmodels.distributions.mixture_rvs import mixture_rvs

--- a/statsmodels/examples/example_ols_minimal_comp.py
+++ b/statsmodels/examples/example_ols_minimal_comp.py
@@ -4,7 +4,6 @@ add example for new compare methods
 
 """
 
-from __future__ import print_function
 import numpy as np
 import statsmodels.api as sm
 

--- a/statsmodels/examples/example_rpy.py
+++ b/statsmodels/examples/example_rpy.py
@@ -17,7 +17,6 @@ There are also R scripts included with most of the datasets to run
 some basic models for comparisons of results to statsmodels.
 '''
 
-from __future__ import print_function
 from statsmodels.compat.python import iterkeys
 from rpy import r
 import statsmodels.api as sm

--- a/statsmodels/examples/l1_demo/demo.py
+++ b/statsmodels/examples/l1_demo/demo.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 from statsmodels.compat.python import range
 from optparse import OptionParser
 import statsmodels.api as sm

--- a/statsmodels/examples/l1_demo/short_demo.py
+++ b/statsmodels/examples/l1_demo/short_demo.py
@@ -17,7 +17,6 @@ The standard l1 solver is fmin_slsqp and is included with scipy.  It
 The l1_cvxopt_cp solver is part of CVXOPT and this package needs to be
     installed separately.  It works well even for larger data sizes.
 """
-from __future__ import print_function
 from statsmodels.compat.python import range
 import statsmodels.api as sm
 import matplotlib.pyplot as plt

--- a/statsmodels/examples/l1_demo/sklearn_compare.py
+++ b/statsmodels/examples/l1_demo/sklearn_compare.py
@@ -16,7 +16,6 @@ The results "prove" that the regularization paths are the same.  Note that
     finding the reparameterization is non-trivial since the coefficient paths
     are NOT monotonic.  As a result, the paths don't match up perfectly.
 """
-from __future__ import print_function
 from statsmodels.compat.python import range, lrange
 from sklearn import linear_model
 import statsmodels.api as sm

--- a/statsmodels/examples/run_all.py
+++ b/statsmodels/examples/run_all.py
@@ -7,7 +7,6 @@ manually, at least in my setup.
 uncomment plt.show() to show all plot windows
 
 '''
-from __future__ import print_function
 from statsmodels.compat.python import lzip, input
 import matplotlib.pyplot as plt #matplotlib is required for many examples
 

--- a/statsmodels/examples/try_2regress.py
+++ b/statsmodels/examples/try_2regress.py
@@ -7,7 +7,6 @@ Created on Thu Mar 25 22:56:45 2010
 Author: josef-pktd
 """
 
-from __future__ import print_function
 import numpy as np
 from numpy.testing import assert_almost_equal
 import statsmodels.api as sm

--- a/statsmodels/examples/try_gee.py
+++ b/statsmodels/examples/try_gee.py
@@ -6,7 +6,6 @@ Created on Thu Jul 18 14:57:46 2013
 Author: Josef Perktold
 """
 
-from __future__ import print_function
 import numpy as np
 
 from statsmodels.genmod.generalized_estimating_equations import GEE, GEEMargins

--- a/statsmodels/examples/try_gof_chisquare.py
+++ b/statsmodels/examples/try_gof_chisquare.py
@@ -6,7 +6,6 @@ Created on Thu Feb 28 15:37:53 2013
 Author: Josef Perktold
 """
 
-from __future__ import print_function
 import numpy as np
 from scipy import stats
 from statsmodels.stats.gof import (chisquare, chisquare_power,

--- a/statsmodels/examples/try_polytrend.py
+++ b/statsmodels/examples/try_polytrend.py
@@ -1,6 +1,5 @@
 
 
-from __future__ import print_function
 import numpy as np
 import matplotlib.pyplot as plt
 #import statsmodels.linear_model.regression as smreg

--- a/statsmodels/examples/try_power.py
+++ b/statsmodels/examples/try_power.py
@@ -6,7 +6,6 @@ Created on Sat Mar 02 14:38:17 2013
 Author: Josef Perktold
 """
 
-from __future__ import print_function
 
 import statsmodels.stats.power as smp
 

--- a/statsmodels/examples/try_power2.py
+++ b/statsmodels/examples/try_power2.py
@@ -6,7 +6,6 @@ Created on Wed Mar 13 13:06:14 2013
 Author: Josef Perktold
 """
 
-from __future__ import print_function
 from statsmodels.stats.power import TTestPower, TTestIndPower, tt_solve_power
 
 if __name__ == '__main__':

--- a/statsmodels/examples/try_tukey_hsd.py
+++ b/statsmodels/examples/try_tukey_hsd.py
@@ -6,7 +6,6 @@ Created on Wed Mar 28 15:34:18 2012
 Author: Josef Perktold
 """
 
-from __future__ import print_function
 from statsmodels.compat.python import StringIO
 import numpy as np
 from numpy.testing import assert_almost_equal, assert_equal

--- a/statsmodels/examples/tsa/ar1cholesky.py
+++ b/statsmodels/examples/tsa/ar1cholesky.py
@@ -5,7 +5,6 @@ Created on Thu Oct 21 15:42:18 2010
 Author: josef-pktd
 """
 
-from __future__ import print_function
 import numpy as np
 from scipy import linalg
 

--- a/statsmodels/examples/tsa/arma_plots.py
+++ b/statsmodels/examples/tsa/arma_plots.py
@@ -3,7 +3,6 @@
 '''
 
 
-from __future__ import print_function
 import numpy as np
 import matplotlib.pyplot as plt
 import matplotlib.ticker as mticker

--- a/statsmodels/examples/tsa/compare_arma.py
+++ b/statsmodels/examples/tsa/compare_arma.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 from time import time
 from statsmodels.tsa.arma_mle import Arma
 from statsmodels.tsa.api import ARMA

--- a/statsmodels/examples/tsa/ex_arma.py
+++ b/statsmodels/examples/tsa/ex_arma.py
@@ -4,7 +4,6 @@ doesn't seem to work so well anymore even with nobs=1000 ???
 works ok if noise variance is large
 '''
 
-from __future__ import print_function
 import numpy as np
 import statsmodels.api as sm
 from statsmodels.tsa.arima_process import arma_generate_sample

--- a/statsmodels/examples/tsa/ex_arma_all.py
+++ b/statsmodels/examples/tsa/ex_arma_all.py
@@ -1,6 +1,5 @@
 
 
-from __future__ import print_function
 import numpy as np
 from numpy.testing import assert_almost_equal
 import matplotlib.pyplot as plt

--- a/statsmodels/examples/tsa/ex_coint.py
+++ b/statsmodels/examples/tsa/ex_coint.py
@@ -1,5 +1,4 @@
 
-from __future__ import print_function
 from statsmodels.tsa.tests.test_stattools import TestCoint_t
 
 

--- a/statsmodels/examples/tsa/ex_var.py
+++ b/statsmodels/examples/tsa/ex_var.py
@@ -1,5 +1,4 @@
 
-from __future__ import print_function
 import numpy as np
 import statsmodels.api as sm
 from statsmodels.tsa.api import VAR

--- a/statsmodels/examples/tsa/ex_var_reorder.py
+++ b/statsmodels/examples/tsa/ex_var_reorder.py
@@ -1,5 +1,4 @@
 
-from __future__ import print_function
 from statsmodels.tsa.vector_ar.tests.test_var import TestVARResults
 
 test_VAR = TestVARResults()

--- a/statsmodels/examples/tsa/lagpolynomial.py
+++ b/statsmodels/examples/tsa/lagpolynomial.py
@@ -6,7 +6,6 @@ Author: josef-pktd
 License: BSD (3-clause)
 """
 
-from __future__ import print_function
 import numpy as np
 from numpy import polynomial as npp
 

--- a/statsmodels/examples/tsa/try_ar.py
+++ b/statsmodels/examples/tsa/try_ar.py
@@ -5,7 +5,6 @@ Created on Thu Oct 21 21:45:24 2010
 Author: josef-pktd
 """
 
-from __future__ import print_function
 import numpy as np
 from scipy import signal
 

--- a/statsmodels/examples/tut_ols_ancova.py
+++ b/statsmodels/examples/tut_ols_ancova.py
@@ -33,7 +33,6 @@ strongly rejected because differences in intercept are very large
 
 '''
 
-from __future__ import print_function
 import numpy as np
 import statsmodels.api as sm
 import matplotlib.pyplot as plt

--- a/statsmodels/examples/tut_ols_rlm_short.py
+++ b/statsmodels/examples/tut_ols_rlm_short.py
@@ -8,7 +8,6 @@ closer to true slope and not tilted like OLS.
 Note: uncomment plt.show() to display graphs
 '''
 
-from __future__ import print_function
 import numpy as np
 #from scipy import stats
 import statsmodels.api as sm

--- a/statsmodels/gam/gam_cross_validation/cross_validators.py
+++ b/statsmodels/gam/gam_cross_validation/cross_validators.py
@@ -6,8 +6,6 @@ Author: Luca Puggini
 
 """
 
-from __future__ import division
-
 from abc import ABCMeta, abstractmethod
 from statsmodels.compat.python import with_metaclass
 import numpy as np

--- a/statsmodels/gam/gam_cross_validation/gam_cross_validation.py
+++ b/statsmodels/gam/gam_cross_validation/gam_cross_validation.py
@@ -6,7 +6,6 @@ Author: Luca Puggini
 
 """
 
-from __future__ import division
 from abc import ABCMeta, abstractmethod
 from statsmodels.compat.python import with_metaclass
 import itertools

--- a/statsmodels/gam/generalized_additive_model.py
+++ b/statsmodels/gam/generalized_additive_model.py
@@ -8,11 +8,7 @@ Author: Josef Perktold
 created on 08/07/2015
 """
 
-from __future__ import division
-try:
-    from collections.abc import Iterable
-except ImportError:  # Python 2.7
-    from collections import Iterable
+from collections.abc import Iterable
 import copy  # check if needed when dropping python 2.7
 
 import numpy as np

--- a/statsmodels/gam/smooth_basis.py
+++ b/statsmodels/gam/smooth_basis.py
@@ -8,7 +8,6 @@ Author: Josef Perktold
 Created on Fri Jun  5 16:32:00 2015
 """
 
-from __future__ import division
 # import useful only for development
 from abc import ABCMeta, abstractmethod
 from statsmodels.compat.python import with_metaclass

--- a/statsmodels/gam/tests/test_gam.py
+++ b/statsmodels/gam/tests/test_gam.py
@@ -7,7 +7,6 @@ Author: Luca Puggini
 Created on 08/07/2015
 """
 
-from __future__ import division
 import os
 import numpy as np
 from numpy.testing import assert_allclose

--- a/statsmodels/genmod/bayes_mixed_glm.py
+++ b/statsmodels/genmod/bayes_mixed_glm.py
@@ -46,7 +46,6 @@ within and between values of the `ident` array).  The model
 :math:`p(y | vc, fep)` depends on the specific GLM being fit.
 """
 
-from __future__ import division
 import numpy as np
 from scipy.optimize import minimize
 from scipy import sparse

--- a/statsmodels/genmod/generalized_estimating_equations.py
+++ b/statsmodels/genmod/generalized_estimating_equations.py
@@ -22,7 +22,6 @@ http://www.sph.umn.edu/faculty1/wp-content/uploads/2012/11/rr2002-013.pdf
 LA Mancl LA, TA DeRouen (2001). A covariance estimator for GEE with
 improved small-sample properties.  Biometrics. 2001 Mar;57(1):126-34.
 """
-from __future__ import division
 from statsmodels.compat.python import range, lzip, zip
 
 import numpy as np

--- a/statsmodels/genmod/tests/gee_poisson_simulation_check.py
+++ b/statsmodels/genmod/tests/gee_poisson_simulation_check.py
@@ -6,7 +6,6 @@ This script checks Poisson models.
 See the generated file "gee_poisson_simulation_check.txt" for results.
 """
 
-from __future__ import print_function
 import numpy as np
 from statsmodels.genmod.families import Poisson
 from .gee_gaussian_simulation_check import GEE_simulator

--- a/statsmodels/genmod/tests/test_glm.py
+++ b/statsmodels/genmod/tests/test_glm.py
@@ -1,7 +1,6 @@
 """
 Test functions for models.GLM
 """
-from __future__ import division
 from statsmodels.compat import range
 
 import warnings

--- a/statsmodels/genmod/tests/test_glm_weights.py
+++ b/statsmodels/genmod/tests/test_glm_weights.py
@@ -777,15 +777,13 @@ def test_warnings_raised():
 
     cov_kwds = {'groups': gid, 'use_correction': False}
 
-    # Work around for buggy pytest repeated warning capture on Python 2.7
-    warning_type = SpecificationWarning
-    with pytest.warns(warning_type):
+    with pytest.warns(SpecificationWarning):
         res1 = GLM(cpunish_data.endog, cpunish_data.exog,
                    family=sm.families.Poisson(), freq_weights=weights
                    ).fit(cov_type='cluster', cov_kwds=cov_kwds)
         res1.summary()
 
-    with pytest.warns(warning_type):
+    with pytest.warns(SpecificationWarning):
         res1 = GLM(cpunish_data.endog, cpunish_data.exog,
                    family=sm.families.Poisson(), var_weights=weights
                    ).fit(cov_type='cluster', cov_kwds=cov_kwds)

--- a/statsmodels/graphics/functional.py
+++ b/statsmodels/graphics/functional.py
@@ -1,7 +1,7 @@
 """Module for functional boxplots."""
 from statsmodels.compat.python import range, zip
-from statsmodels.compat.scipy import factorial
 
+from scipy.special import factorial
 from statsmodels.multivariate.pca import PCA
 from statsmodels.nonparametric.kernel_density import KDEMultivariate
 from statsmodels.graphics.utils import _import_mpl

--- a/statsmodels/graphics/mosaicplot.py
+++ b/statsmodels/graphics/mosaicplot.py
@@ -7,7 +7,6 @@ see the docstring of the mosaic function for more informations.
 """
 # Author: Enrico Giampieri - 21 Jan 2013
 
-from __future__ import division
 from statsmodels.compat.python import (iteritems, iterkeys, lrange, string_types, lzip,
                                 itervalues, zip, range)
 import numpy as np

--- a/statsmodels/graphics/tests/test_mosaicplot.py
+++ b/statsmodels/graphics/tests/test_mosaicplot.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 from statsmodels.compat.python import iterkeys, zip, lrange, iteritems, range
 
 from collections import OrderedDict

--- a/statsmodels/imputation/ros.py
+++ b/statsmodels/imputation/ros.py
@@ -12,7 +12,6 @@ Date: 2016-06-14
 
 """
 
-from __future__ import division
 import warnings
 
 import numpy

--- a/statsmodels/imputation/tests/test_ros.py
+++ b/statsmodels/imputation/tests/test_ros.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 from textwrap import dedent
 
 import numpy.testing as npt

--- a/statsmodels/iolib/table.py
+++ b/statsmodels/iolib/table.py
@@ -67,7 +67,6 @@ Potential problems for Python 3
 - Calls ``next`` instead of ``__next__``.
   The 2to3 tool should handle that no problem.
   (We will switch to the `next` function if 2.5 support is ever dropped.)
-- from __future__ import division
 - Let me know if you find other problems.
 
 :contact: alan dot isaac at gmail dot com
@@ -83,7 +82,6 @@ Potential problems for Python 3
 :change: 2010-05-06 add `label_cells` to `SimpleTable`
 """
 
-from __future__ import division
 from statsmodels.compat.python import (lmap, lrange, zip, next, iteritems,
                                        zip_longest, range, long)
 

--- a/statsmodels/iolib/tests/test_summary.py
+++ b/statsmodels/iolib/tests/test_summary.py
@@ -2,7 +2,6 @@
 
 
 '''
-from __future__ import print_function
 
 import numpy as np  # noqa: F401
 import pytest

--- a/statsmodels/iolib/tests/test_table_econpy.py
+++ b/statsmodels/iolib/tests/test_table_econpy.py
@@ -5,7 +5,6 @@ Unit tests table.py.
 :see: http://agiletesting.blogspot.com/2005/01/python-unit-testing-part-1-unittest.html
 :see: http://aspn.activestate.com/ASPN/Cookbook/Python/Recipe/305292
 '''
-from __future__ import absolute_import
 from statsmodels.compat.python import zip
 
 import numpy as np

--- a/statsmodels/miscmodels/count.py
+++ b/statsmodels/miscmodels/count.py
@@ -28,10 +28,9 @@ Issues
 
 
 """
-from __future__ import print_function
 import numpy as np
 from scipy import stats
-from statsmodels.compat.scipy import factorial
+from scipy.special import factorial
 from statsmodels.base.model import GenericLikelihoodModel
 
 

--- a/statsmodels/miscmodels/try_mlecov.py
+++ b/statsmodels/miscmodels/try_mlecov.py
@@ -5,7 +5,6 @@ toeplitz structure is not exploited, need cholesky or inv for toeplitz
 Author: josef-pktd
 '''
 
-from __future__ import print_function
 import numpy as np
 from scipy import linalg
 from scipy.linalg import toeplitz

--- a/statsmodels/multivariate/cancorr.py
+++ b/statsmodels/multivariate/cancorr.py
@@ -4,8 +4,6 @@
 
 author: Yichuan Liu
 """
-from __future__ import division
-
 import numpy as np
 from numpy.linalg import svd
 import scipy

--- a/statsmodels/multivariate/factor.py
+++ b/statsmodels/multivariate/factor.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import division
 import warnings
 
 import numpy as np

--- a/statsmodels/multivariate/factor_rotation/_analytic_rotation.py
+++ b/statsmodels/multivariate/factor_rotation/_analytic_rotation.py
@@ -3,9 +3,6 @@
 This file contains analytic implementations of rotation methods.
 """
 
-from __future__ import division
-from __future__ import print_function
-
 import numpy as np
 import scipy as sp
 

--- a/statsmodels/multivariate/factor_rotation/_gpa_rotation.py
+++ b/statsmodels/multivariate/factor_rotation/_gpa_rotation.py
@@ -22,7 +22,6 @@ Psychometrika, 67, 7-19.
 [5] http://www.stat.ucla.edu/research/gpa/GPderfree.txt
 """
 
-from __future__ import division
 import numpy as np
 
 

--- a/statsmodels/multivariate/factor_rotation/_wrappers.py
+++ b/statsmodels/multivariate/factor_rotation/_wrappers.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import division, print_function
 
 from ._analytic_rotation import target_rotation
 from ._gpa_rotation import oblimin_objective, orthomax_objective, CF_objective

--- a/statsmodels/multivariate/factor_rotation/tests/test_rotation.py
+++ b/statsmodels/multivariate/factor_rotation/tests/test_rotation.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 import unittest
 import numpy as np
 

--- a/statsmodels/multivariate/manova.py
+++ b/statsmodels/multivariate/manova.py
@@ -4,8 +4,6 @@
 
 author: Yichuan Liu
 """
-from __future__ import division
-
 import numpy as np
 
 from statsmodels.base.model import Model

--- a/statsmodels/multivariate/multivariate_ols.py
+++ b/statsmodels/multivariate/multivariate_ols.py
@@ -4,8 +4,6 @@
 
 author: Yichuan Liu
 """
-from __future__ import division
-
 import numpy as np
 from numpy.linalg import eigvals, inv, solve, matrix_rank, pinv, svd
 from scipy import stats

--- a/statsmodels/multivariate/pca.py
+++ b/statsmodels/multivariate/pca.py
@@ -3,7 +3,6 @@
 Author: josef-pktd
 Modified by Kevin Sheppard
 """
-from __future__ import print_function, division
 
 import numpy as np
 import pandas as pd

--- a/statsmodels/multivariate/tests/test_pca.py
+++ b/statsmodels/multivariate/tests/test_pca.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, division
 
 from statsmodels.compat.platform import PLATFORM_WIN32
 

--- a/statsmodels/nonparametric/bandwidths.py
+++ b/statsmodels/nonparametric/bandwidths.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 import numpy as np
 from scipy.stats import scoreatpercentile as sap
 from statsmodels.sandbox.nonparametric import kernels

--- a/statsmodels/nonparametric/kde.py
+++ b/statsmodels/nonparametric/kde.py
@@ -11,7 +11,6 @@ https://en.wikipedia.org/wiki/Kernel_%28statistics%29
 
 Silverman, B.W.  Density Estimation for Statistics and Data Analysis.
 """
-from __future__ import absolute_import, print_function, division
 from statsmodels.compat.python import range
 import numpy as np
 from scipy import integrate, stats

--- a/statsmodels/nonparametric/kdetools.py
+++ b/statsmodels/nonparametric/kdetools.py
@@ -1,5 +1,4 @@
 #### Convenience Functions to be moved to kerneltools ####
-from __future__ import division
 from statsmodels.compat.python import range
 import numpy as np
 

--- a/statsmodels/nonparametric/kernel_density.py
+++ b/statsmodels/nonparametric/kernel_density.py
@@ -27,7 +27,6 @@ References
         Models", 2006, Econometric Reviews 25, 523-544
 
 """
-from __future__ import division
 # TODO: make default behavior efficient=True above a certain n_obs
 
 from statsmodels.compat.python import range, next

--- a/statsmodels/nonparametric/kernel_regression.py
+++ b/statsmodels/nonparametric/kernel_regression.py
@@ -28,7 +28,6 @@ References
 
 """
 
-from __future__ import division
 # TODO: make default behavior efficient=True above a certain n_obs
 
 from statsmodels.compat.python import range, string_types, next

--- a/statsmodels/nonparametric/kernels.py
+++ b/statsmodels/nonparametric/kernels.py
@@ -11,8 +11,6 @@ kernel density estimation much easier.
 NOTE: As it is, this module does not interact with the existing API
 """
 
-from __future__ import division
-
 import numpy as np
 from scipy.special import erf
 

--- a/statsmodels/nonparametric/tests/test_kernels.py
+++ b/statsmodels/nonparametric/tests/test_kernels.py
@@ -5,7 +5,6 @@ Created on Sat Dec 14 17:23:25 2013
 
 Author: Josef Perktold
 """
-from __future__ import print_function
 import os
 import numpy as np
 from numpy.testing import assert_allclose, assert_array_less

--- a/statsmodels/regression/linear_model.py
+++ b/statsmodels/regression/linear_model.py
@@ -31,7 +31,6 @@ R. Davidson and J.G. MacKinnon.  "Econometric Theory and Methods," Oxford,
 W. Green.  "Econometric Analysis," 5th ed., Pearson, 2003.
 """
 
-from __future__ import print_function
 
 from statsmodels.compat.python import lrange, lzip, range
 

--- a/statsmodels/regression/recursive_ls.py
+++ b/statsmodels/regression/recursive_ls.py
@@ -4,7 +4,6 @@ Recursive least squares model
 Author: Chad Fulton
 License: Simplified-BSD
 """
-from __future__ import division, absolute_import, print_function
 
 import numpy as np
 import pandas as pd

--- a/statsmodels/regression/tests/test_recursive_ls.py
+++ b/statsmodels/regression/tests/test_recursive_ls.py
@@ -4,7 +4,6 @@ Tests for recursive least squares models
 Author: Chad Fulton
 License: Simplified-BSD
 """
-from __future__ import division, absolute_import, print_function
 
 import numpy as np
 import pandas as pd

--- a/statsmodels/sandbox/archive/linalg_covmat.py
+++ b/statsmodels/sandbox/archive/linalg_covmat.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import math
 import numpy as np
 from scipy import linalg, stats, special

--- a/statsmodels/sandbox/archive/linalg_decomp_1.py
+++ b/statsmodels/sandbox/archive/linalg_decomp_1.py
@@ -22,7 +22,6 @@ Author: josef-pktd
 Created on 2010-10-20
 '''
 
-from __future__ import print_function
 import numpy as np
 from scipy import linalg
 

--- a/statsmodels/sandbox/datarich/factormodels.py
+++ b/statsmodels/sandbox/datarich/factormodels.py
@@ -6,7 +6,6 @@ Author: josef-pktd
 License: BSD (3-clause)
 """
 
-from __future__ import print_function
 import numpy as np
 import statsmodels.api as sm
 from statsmodels.sandbox.tools import pca

--- a/statsmodels/sandbox/distributions/estimators.py
+++ b/statsmodels/sandbox/distributions/estimators.py
@@ -87,7 +87,6 @@ added Maximum Product-of-Spacings 2010-05-12
 
 '''
 
-from __future__ import print_function
 import numpy as np
 from scipy import stats, optimize, special
 

--- a/statsmodels/sandbox/distributions/examples/ex_fitfr.py
+++ b/statsmodels/sandbox/distributions/examples/ex_fitfr.py
@@ -7,7 +7,6 @@ methods.
 
 '''
 
-from __future__ import print_function
 import numpy as np
 from scipy import stats
 # Note the following import attaches methods to scipy.stats.distributions

--- a/statsmodels/sandbox/distributions/examples/ex_gof.py
+++ b/statsmodels/sandbox/distributions/examples/ex_gof.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 from scipy import stats
 from statsmodels.stats import gof
 

--- a/statsmodels/sandbox/distributions/examples/ex_mvelliptical.py
+++ b/statsmodels/sandbox/distributions/examples/ex_mvelliptical.py
@@ -10,7 +10,6 @@ Created on Fri Jun 03 16:00:26 2011
 for comparison I used R mvtnorm version 0.9-96
 
 """
-from __future__ import print_function
 import numpy as np
 from numpy.testing import assert_array_almost_equal
 import matplotlib.pyplot as plt

--- a/statsmodels/sandbox/distributions/examples/ex_transf2.py
+++ b/statsmodels/sandbox/distributions/examples/ex_transf2.py
@@ -4,7 +4,6 @@ Created on Sun May 09 22:23:22 2010
 Author: josef-pktd
 Licese: BSD
 """
-from __future__ import print_function
 import numpy as np
 
 from numpy.testing import assert_almost_equal

--- a/statsmodels/sandbox/distributions/examples/matchdist.py
+++ b/statsmodels/sandbox/distributions/examples/matchdist.py
@@ -15,7 +15,6 @@ TODO:
 *
 
 '''
-from __future__ import print_function
 from scipy import stats
 import numpy as np
 import matplotlib.pyplot as plt

--- a/statsmodels/sandbox/distributions/extras.py
+++ b/statsmodels/sandbox/distributions/extras.py
@@ -49,7 +49,6 @@ Author: josef-pktd
 License: BSD
 
 '''
-from __future__ import print_function
 
 import numpy as np
 from numpy import poly1d,sqrt, exp

--- a/statsmodels/sandbox/distributions/genpareto.py
+++ b/statsmodels/sandbox/distributions/genpareto.py
@@ -6,7 +6,6 @@ Warning: not tried out or tested yet, Done
 
 Author: josef-pktd
 """
-from __future__ import print_function
 import numpy as np
 from scipy import stats
 from scipy.special import comb

--- a/statsmodels/sandbox/distributions/gof_new.py
+++ b/statsmodels/sandbox/distributions/gof_new.py
@@ -17,7 +17,6 @@ References
 ----------
 
 '''
-from __future__ import print_function
 from statsmodels.compat.python import range, lmap, string_types
 import numpy as np
 

--- a/statsmodels/sandbox/distributions/multivariate.py
+++ b/statsmodels/sandbox/distributions/multivariate.py
@@ -14,7 +14,6 @@ Reference:
 Genz and Bretz for formula
 
 '''
-from __future__ import print_function
 import numpy as np
 from scipy import integrate, stats, special
 from scipy.stats import chi

--- a/statsmodels/sandbox/distributions/mv_normal.py
+++ b/statsmodels/sandbox/distributions/mv_normal.py
@@ -144,7 +144,6 @@ What's currently there?
 'standardize', 'standardized', 'std', 'std_sigma', 'whiten']
 
 """
-from __future__ import print_function
 import numpy as np
 from scipy import special
 

--- a/statsmodels/sandbox/distributions/otherdist.py
+++ b/statsmodels/sandbox/distributions/otherdist.py
@@ -21,7 +21,6 @@ existing distributions by transformation, mixing, compounding
 '''
 
 
-from __future__ import print_function
 import numpy as np
 from scipy import stats
 

--- a/statsmodels/sandbox/distributions/quantize.py
+++ b/statsmodels/sandbox/distributions/quantize.py
@@ -2,7 +2,6 @@
 
 Author: josef-pktd
 '''
-from __future__ import print_function
 from statsmodels.compat.python import range, lmap
 import numpy as np
 

--- a/statsmodels/sandbox/distributions/sppatch.py
+++ b/statsmodels/sandbox/distributions/sppatch.py
@@ -10,7 +10,6 @@ distribution fit, but these are neither general nor verified.
 Author: josef-pktd
 License: Simplified BSD
 '''
-from __future__ import print_function
 from statsmodels.compat.python import range, lmap
 import numpy as np
 from scipy import stats, optimize, integrate

--- a/statsmodels/sandbox/distributions/tests/test_transf.py
+++ b/statsmodels/sandbox/distributions/tests/test_transf.py
@@ -15,7 +15,6 @@ Warning: The algorithm does not converge.  Roundoff error is detected
   the best which can be obtained.
 array(2981.0032380193438)
 """
-from __future__ import print_function
 import warnings # for silencing, see above...
 import numpy as np
 from numpy.testing import assert_almost_equal

--- a/statsmodels/sandbox/distributions/transform_functions.py
+++ b/statsmodels/sandbox/distributions/transform_functions.py
@@ -7,7 +7,6 @@ Created on Sat Apr 16 16:06:11 2011
 Author: Josef Perktold
 License : BSD
 """
-from __future__ import print_function
 import numpy as np
 
 

--- a/statsmodels/sandbox/distributions/transformed.py
+++ b/statsmodels/sandbox/distributions/transformed.py
@@ -38,7 +38,6 @@ Author: josef-pktd
 License: BSD
 
 '''
-from __future__ import print_function
 from statsmodels.compat.python import iteritems
 
 from scipy import stats

--- a/statsmodels/sandbox/distributions/try_max.py
+++ b/statsmodels/sandbox/distributions/try_max.py
@@ -7,7 +7,6 @@ there might still be problems with loc and scale,
 '''
 
 
-from __future__ import division
 from scipy import stats
 __date__ = "2010-12-29 dec"
 

--- a/statsmodels/sandbox/distributions/try_pot.py
+++ b/statsmodels/sandbox/distributions/try_pot.py
@@ -4,7 +4,6 @@ Created on Wed May 04 06:09:18 2011
 
 @author: josef
 """
-from __future__ import print_function
 import numpy as np
 
 

--- a/statsmodels/sandbox/examples/ex_mixed_lls_0.py
+++ b/statsmodels/sandbox/examples/ex_mixed_lls_0.py
@@ -11,7 +11,6 @@ effects and random coefficients, and uses OneWayMixed to estimate it.
 
 
 """
-from __future__ import print_function
 import numpy as np
 
 from statsmodels.sandbox.panel.mixed import OneWayMixed, Unit

--- a/statsmodels/sandbox/mle.py
+++ b/statsmodels/sandbox/mle.py
@@ -3,7 +3,6 @@ Does not run because of missing mtx files, now included
 
 changes: JP corrections to imports so it runs, comment out print
 '''
-from __future__ import print_function
 import numpy as np
 from numpy import dot,  outer, random
 from scipy import io, linalg, optimize

--- a/statsmodels/sandbox/nonparametric/densityorthopoly.py
+++ b/statsmodels/sandbox/nonparametric/densityorthopoly.py
@@ -37,7 +37,6 @@ enhancements:
 
 
 '''
-from __future__ import print_function
 from statsmodels.compat.python import zip
 from scipy import stats, integrate, special
 

--- a/statsmodels/sandbox/nonparametric/kde2.py
+++ b/statsmodels/sandbox/nonparametric/kde2.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import print_function
 from statsmodels.compat.python import lzip, zip
 import numpy as np
 from . import kernels

--- a/statsmodels/sandbox/nonparametric/kernels.py
+++ b/statsmodels/sandbox/nonparametric/kernels.py
@@ -21,7 +21,7 @@ http://fedc.wiwi.hu-berlin.de/xplore/ebooks/html/anr/anrhtmlframe62.html
 from statsmodels.compat.python import lzip, lfilter, zip
 import numpy as np
 import scipy.integrate
-from statsmodels.compat.scipy import factorial
+from scipy.special import factorial
 from numpy import exp, multiply, square, divide, subtract, inf
 
 

--- a/statsmodels/sandbox/nonparametric/smoothers.py
+++ b/statsmodels/sandbox/nonparametric/smoothers.py
@@ -7,7 +7,6 @@ who generate a smooth fit of a set of (x,y) pairs.
 # pylint: disable-msg=W0142
 # pylint: disable-msg=E0611
 # pylint: disable-msg=E1101
-from __future__ import print_function
 from statsmodels.compat.python import long
 
 import numpy as np

--- a/statsmodels/sandbox/nonparametric/tests/ex_gam_am_new.py
+++ b/statsmodels/sandbox/nonparametric/tests/ex_gam_am_new.py
@@ -10,7 +10,6 @@ Created on Fri Nov 04 13:45:43 2011
 Author: Josef Perktold
 
 """
-from __future__ import print_function
 from statsmodels.compat.python import lrange, zip
 
 import numpy as np

--- a/statsmodels/sandbox/nonparametric/tests/ex_gam_new.py
+++ b/statsmodels/sandbox/nonparametric/tests/ex_gam_new.py
@@ -9,7 +9,6 @@ Created on Fri Nov 04 13:45:43 2011
 
 Author: Josef Perktold
 """
-from __future__ import print_function
 from statsmodels.compat.python import lrange, zip
 import time
 

--- a/statsmodels/sandbox/nonparametric/tests/ex_smoothers.py
+++ b/statsmodels/sandbox/nonparametric/tests/ex_smoothers.py
@@ -4,7 +4,6 @@ Created on Fri Nov 04 10:51:39 2011
 
 @author: josef
 """
-from __future__ import print_function
 import numpy as np
 
 from statsmodels.sandbox.nonparametric import smoothers

--- a/statsmodels/sandbox/panel/mixed.py
+++ b/statsmodels/sandbox/panel/mixed.py
@@ -17,7 +17,6 @@ With correctly specified model, convergence is fast, in 6 iterations in
 example.
 
 """
-from __future__ import print_function
 import numpy as np
 import numpy.linalg as L
 

--- a/statsmodels/sandbox/panel/panelmod.py
+++ b/statsmodels/sandbox/panel/panelmod.py
@@ -6,7 +6,6 @@ References
 
 Baltagi, Badi H. `Econometric Analysis of Panel Data.` 4th ed. Wiley, 2008.
 """
-from __future__ import print_function
 from statsmodels.compat.python import range, reduce
 from statsmodels.regression.linear_model import GLS
 import numpy as np

--- a/statsmodels/sandbox/regression/anova_nistcertified.py
+++ b/statsmodels/sandbox/regression/anova_nistcertified.py
@@ -2,7 +2,6 @@
 
 compares my implementations, stats.f_oneway and anova using statsmodels.OLS
 '''
-from __future__ import print_function
 from statsmodels.compat.python import lmap
 import os
 import numpy as np

--- a/statsmodels/sandbox/regression/ar_panel.py
+++ b/statsmodels/sandbox/regression/ar_panel.py
@@ -21,7 +21,6 @@ Could be extended to AR(p) errors, but then requires panel with larger T
 '''
 
 
-from __future__ import print_function
 import numpy as np
 from scipy import optimize
 

--- a/statsmodels/sandbox/regression/gmm.py
+++ b/statsmodels/sandbox/regression/gmm.py
@@ -48,7 +48,6 @@ License: BSD (3-clause)
 '''
 
 
-from __future__ import print_function
 from statsmodels.compat.python import lrange
 
 import numpy as np

--- a/statsmodels/sandbox/regression/ols_anova_original.py
+++ b/statsmodels/sandbox/regression/ols_anova_original.py
@@ -6,7 +6,6 @@ in ANOVA
 
 '''
 
-from __future__ import print_function
 import numpy as np
 import numpy.lib.recfunctions
 

--- a/statsmodels/sandbox/regression/penalized.py
+++ b/statsmodels/sandbox/regression/penalized.py
@@ -33,7 +33,6 @@ problem with definition of df_model, it has 1 subtracted for constant
 
 
 """
-from __future__ import print_function
 from statsmodels.compat.python import lrange
 import numpy as np
 

--- a/statsmodels/sandbox/regression/runmnl.py
+++ b/statsmodels/sandbox/regression/runmnl.py
@@ -23,7 +23,6 @@ Author: josef-pktd
 License: BSD (simplified)
 '''
 
-from __future__ import print_function
 from statsmodels.compat.python import zip
 import numpy as np
 import numpy.lib.recfunctions as recf

--- a/statsmodels/sandbox/regression/sympy_diff.py
+++ b/statsmodels/sandbox/regression/sympy_diff.py
@@ -4,7 +4,6 @@ Created on Sat Mar 13 07:56:22 2010
 
 Author: josef-pktd
 """
-from __future__ import print_function
 import sympy as sy
 
 

--- a/statsmodels/sandbox/regression/tests/test_gmm.py
+++ b/statsmodels/sandbox/regression/tests/test_gmm.py
@@ -5,7 +5,6 @@ Created on Fri Oct 04 13:19:01 2013
 
 Author: Josef Perktold
 """
-from __future__ import print_function
 from statsmodels.compat.python import lrange, lmap
 
 import os

--- a/statsmodels/sandbox/regression/tools.py
+++ b/statsmodels/sandbox/regression/tools.py
@@ -19,7 +19,6 @@ A: josef-pktd
 
 '''
 
-from __future__ import print_function
 import numpy as np
 from scipy import special
 from scipy.special import gammaln

--- a/statsmodels/sandbox/regression/treewalkerclass.py
+++ b/statsmodels/sandbox/regression/treewalkerclass.py
@@ -101,7 +101,6 @@ still todo:
 Author: Josef Perktold
 License : BSD (3-clause)
 '''
-from __future__ import print_function
 from statsmodels.compat.python import iteritems, itervalues, lrange, zip
 import numpy as np
 from pprint import pprint

--- a/statsmodels/sandbox/regression/try_ols_anova.py
+++ b/statsmodels/sandbox/regression/try_ols_anova.py
@@ -12,7 +12,6 @@ TODO:
 
 '''
 
-from __future__ import print_function
 from statsmodels.compat.python import lmap
 import numpy as np
 #from scipy import stats

--- a/statsmodels/sandbox/regression/try_treewalker.py
+++ b/statsmodels/sandbox/regression/try_treewalker.py
@@ -5,7 +5,6 @@ sum is standing for likelihood calculations
 should collect and aggregate likelihood contributions bottom up
 
 '''
-from __future__ import print_function
 from statsmodels.compat.python import iteritems, itervalues, lrange, zip, long
 import numpy as np
 

--- a/statsmodels/sandbox/rls.py
+++ b/statsmodels/sandbox/rls.py
@@ -3,7 +3,6 @@
 from pandas
 License: Simplified BSD
 """
-from __future__ import print_function
 import numpy as np
 from statsmodels.regression.linear_model import GLS, RegressionResults
 

--- a/statsmodels/sandbox/stats/contrast_tools.py
+++ b/statsmodels/sandbox/stats/contrast_tools.py
@@ -22,7 +22,6 @@ Idea for second part
 
 
 
-from __future__ import print_function
 from numpy.testing import assert_equal
 
 from statsmodels.compat.python import zip

--- a/statsmodels/sandbox/stats/diagnostic.py
+++ b/statsmodels/sandbox/stats/diagnostic.py
@@ -28,7 +28,6 @@ missing:
 
 
 """
-from __future__ import print_function
 from statsmodels.compat.python import iteritems, map, long
 import numpy as np
 from scipy import stats

--- a/statsmodels/sandbox/stats/ex_newtests.py
+++ b/statsmodels/sandbox/stats/ex_newtests.py
@@ -1,5 +1,4 @@
 
-from __future__ import print_function
 from .diagnostic import unitroot_adf
 
 import statsmodels.datasets.macrodata.data as macro

--- a/statsmodels/sandbox/stats/multicomp.py
+++ b/statsmodels/sandbox/stats/multicomp.py
@@ -61,7 +61,6 @@ TODO
 
 
 '''
-from __future__ import print_function
 
 import copy
 import math

--- a/statsmodels/sandbox/stats/runs.py
+++ b/statsmodels/sandbox/stats/runs.py
@@ -19,7 +19,6 @@ TODO
 
 '''
 
-from __future__ import print_function
 import numpy as np
 from scipy import stats
 from scipy.special import comb

--- a/statsmodels/sandbox/stats/stats_dhuard.py
+++ b/statsmodels/sandbox/stats/stats_dhuard.py
@@ -80,7 +80,6 @@ Author: josef-pktd, parts based on David Huard
 License: BSD
 
 '''
-from __future__ import print_function
 import scipy.interpolate as interpolate
 import numpy as np
 

--- a/statsmodels/sandbox/stats/stats_mstats_short.py
+++ b/statsmodels/sandbox/stats/stats_mstats_short.py
@@ -21,7 +21,6 @@ weighted plotting_positions
 
 
 '''
-from __future__ import print_function
 import numpy as np
 from numpy import ma
 from scipy import stats

--- a/statsmodels/sandbox/tools/mctools.py
+++ b/statsmodels/sandbox/tools/mctools.py
@@ -23,7 +23,6 @@ I guess this is currently only for one sided test statistics, e.g. for
 two-sided tests basend on t or normal distribution use the absolute value.
 
 '''
-from __future__ import print_function
 from statsmodels.compat.python import lrange
 import numpy as np
 

--- a/statsmodels/sandbox/tsa/diffusion.py
+++ b/statsmodels/sandbox/tsa/diffusion.py
@@ -48,7 +48,6 @@ finance applications ? option pricing, interest rate models
 
 
 '''
-from __future__ import print_function
 import numpy as np
 from scipy import stats, signal
 import matplotlib.pyplot as plt

--- a/statsmodels/sandbox/tsa/example_arma.py
+++ b/statsmodels/sandbox/tsa/example_arma.py
@@ -4,7 +4,6 @@ explicit functions for autocovariance functions of ARIMA(1,1), MA(1), MA(2)
 plus 3 functions from nitime.utils
 
 '''
-from __future__ import print_function
 from statsmodels.compat.python import range
 import numpy as np
 from numpy.testing import assert_array_almost_equal

--- a/statsmodels/sandbox/tsa/examples/ex_mle_arma.py
+++ b/statsmodels/sandbox/tsa/examples/ex_mle_arma.py
@@ -7,7 +7,6 @@ Created on Thu Feb 11 23:41:53 2010
 Author: josef-pktd
 copyright: Simplified BSD see license.txt
 """
-from __future__ import print_function
 import numpy as np
 
 import numdifftools as ndt

--- a/statsmodels/sandbox/tsa/examples/ex_mle_garch.py
+++ b/statsmodels/sandbox/tsa/examples/ex_mle_garch.py
@@ -61,7 +61,6 @@ todo: add code and verify, check for longer lagpolys
 
 """
 
-from __future__ import print_function
 import numpy as np
 
 from scipy import optimize

--- a/statsmodels/sandbox/tsa/fftarma.py
+++ b/statsmodels/sandbox/tsa/fftarma.py
@@ -29,7 +29,6 @@ get function drop imag if close to zero from numpy/scipy source, where?
 
 """
 
-from __future__ import print_function
 import numpy as np
 import numpy.fft as fft
 #import scipy.fftpack as fft

--- a/statsmodels/sandbox/tsa/garch.py
+++ b/statsmodels/sandbox/tsa/garch.py
@@ -72,7 +72,6 @@ see notes_references.txt
 Created on Feb 6, 2010
 @author: "josef pktd"
 '''
-from __future__ import print_function
 from statsmodels.compat.python import zip
 import numpy as np
 from numpy.testing import assert_almost_equal

--- a/statsmodels/sandbox/tsa/movstat.py
+++ b/statsmodels/sandbox/tsa/movstat.py
@@ -42,7 +42,6 @@ update
 2009-09-06: cosmetic changes, rearrangements
 '''
 
-from __future__ import print_function
 import numpy as np
 from scipy import signal
 

--- a/statsmodels/sandbox/tsa/try_arma_more.py
+++ b/statsmodels/sandbox/tsa/try_arma_more.py
@@ -11,7 +11,6 @@ Created on Wed Oct 14 23:02:19 2009
 
 Author: josef-pktd
 """
-from __future__ import print_function
 import numpy as np
 from scipy import signal, ndimage
 import matplotlib.mlab as mlb

--- a/statsmodels/sandbox/tsa/try_fi.py
+++ b/statsmodels/sandbox/tsa/try_fi.py
@@ -8,7 +8,6 @@ second part in here is ar2arma
 only examples left
 
 '''
-from __future__ import print_function
 import numpy as np
 from scipy.special import gamma
 from scipy import signal

--- a/statsmodels/sandbox/tsa/try_var_convolve.py
+++ b/statsmodels/sandbox/tsa/try_var_convolve.py
@@ -13,7 +13,6 @@ update 2010-10-22
 what the results are.
 Runs now without raising exception
 """
-from __future__ import print_function
 import numpy as np
 from numpy.testing import assert_equal
 from scipy import signal, stats

--- a/statsmodels/sandbox/tsa/varma.py
+++ b/statsmodels/sandbox/tsa/varma.py
@@ -22,7 +22,6 @@ Author : josefpkt
 License : BSD
 '''
 
-from __future__ import print_function
 import numpy as np
 from scipy import signal
 

--- a/statsmodels/stats/_adnorm.py
+++ b/statsmodels/stats/_adnorm.py
@@ -5,7 +5,6 @@ Created on Sun Sep 25 21:23:38 2011
 Author: Josef Perktold and Scipy developers
 License : BSD-3
 """
-from __future__ import print_function
 from statsmodels.compat.python import range
 import numpy as np
 from scipy import stats

--- a/statsmodels/stats/contingency_tables.py
+++ b/statsmodels/stats/contingency_tables.py
@@ -25,7 +25,6 @@ sampled.  In general the observed units are independent and
 identically distributed.
 """
 
-from __future__ import division
 from statsmodels.tools.decorators import cache_readonly
 import numpy as np
 from scipy import stats

--- a/statsmodels/stats/inter_rater.py
+++ b/statsmodels/stats/inter_rater.py
@@ -35,7 +35,6 @@ convenience functions to create required data format from raw data
 
 """
 
-from __future__ import division
 import numpy as np
 from scipy import stats  #get rid of this? need only norm.sf
 

--- a/statsmodels/stats/libqsturng/qsturng_.py
+++ b/statsmodels/stats/libqsturng/qsturng_.py
@@ -22,7 +22,6 @@ see:
     Studentized range distribution.
     http://www.stata.com/stb/stb46/dm64/sturng.pdf
 """
-from __future__ import print_function
 from statsmodels.compat.python import lrange, map
 import math
 import scipy.stats

--- a/statsmodels/stats/power.py
+++ b/statsmodels/stats/power.py
@@ -30,7 +30,6 @@ refactoring
 
 
 """
-from __future__ import print_function
 from statsmodels.compat.python import iteritems
 import numpy as np
 from scipy import stats, optimize

--- a/statsmodels/stats/tabledist.py
+++ b/statsmodels/stats/tabledist.py
@@ -15,7 +15,6 @@ check: instead of bound checking I could use the fill-value of the interpolators
 
 
 """
-from __future__ import print_function
 from statsmodels.compat.python import range
 import numpy as np
 from scipy.interpolate import interp1d, interp2d, Rbf

--- a/statsmodels/tools/catadd.py
+++ b/statsmodels/tools/catadd.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import numpy as np
 
 

--- a/statsmodels/tools/decorators.py
+++ b/statsmodels/tools/decorators.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 from statsmodels.tools.sm_exceptions import CacheWriteWarning
 from statsmodels.compat.pandas import cache_readonly as PandasCacheReadonly
 

--- a/statsmodels/tools/grouputils.py
+++ b/statsmodels/tools/grouputils.py
@@ -27,7 +27,6 @@ Not all methods and options have been tried out yet after refactoring
 
 need more efficient loop if groups are sorted -> see GroupSorted.group_iter
 """
-from __future__ import print_function
 from statsmodels.compat.python import lrange, lzip, range
 import numpy as np
 import pandas as pd

--- a/statsmodels/tools/linalg.py
+++ b/statsmodels/tools/linalg.py
@@ -1,7 +1,6 @@
 """
 Linear Algebra solvers and other helpers
 """
-from __future__ import print_function
 from statsmodels.compat.python import range
 import numpy as np
 from scipy.linalg import pinv, pinv2, lstsq  # noqa:F401

--- a/statsmodels/tools/numdiff.py
+++ b/statsmodels/tools/numdiff.py
@@ -43,7 +43,6 @@ without dependencies.
 #
 # in example: if J = d x*beta / d beta then J'J == X'X
 #    similar to https://en.wikipedia.org/wiki/Levenberg%E2%80%93Marquardt_algorithm
-from __future__ import print_function
 from statsmodels.compat.python import range
 import numpy as np
 

--- a/statsmodels/tools/parallel.py
+++ b/statsmodels/tools/parallel.py
@@ -9,7 +9,6 @@ changes for statsmodels (Josef Perktold)
 - try import from joblib directly, (doesn't import all of sklearn)
 
 """
-from __future__ import print_function
 
 from statsmodels.tools.sm_exceptions import (ModuleUnavailableWarning,
                                              module_unavailable_doc)

--- a/statsmodels/tools/print_version.py
+++ b/statsmodels/tools/print_version.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-from __future__ import print_function
 from statsmodels.compat.python import reduce
 import sys
 from os.path import dirname

--- a/statsmodels/tools/rootfinding.py
+++ b/statsmodels/tools/rootfinding.py
@@ -10,7 +10,6 @@ TODO:
   - rewrite core loop to use for...except instead of while.
 
 """
-from __future__ import print_function
 import numpy as np
 from scipy import optimize
 

--- a/statsmodels/tools/sequences.py
+++ b/statsmodels/tools/sequences.py
@@ -1,5 +1,4 @@
 """Low discrepancy sequence tools."""
-from __future__ import division
 import numpy as np
 
 

--- a/statsmodels/tools/tests/test_numdiff.py
+++ b/statsmodels/tools/tests/test_numdiff.py
@@ -6,7 +6,6 @@ finite difference Hessian has some problems that I didn't look at yet
 Should Hessian also work per observation, if fun returns 2d
 
 '''
-from __future__ import print_function
 import numpy as np
 from numpy.testing import assert_almost_equal, assert_allclose
 import statsmodels.api as sm

--- a/statsmodels/tsa/_bds.py
+++ b/statsmodels/tsa/_bds.py
@@ -17,7 +17,6 @@ LeBaron, Blake. 1997.
 Studies in Nonlinear Dynamics & Econometrics 2 (2) (January 1).
 """
 
-from __future__ import division
 import numpy as np
 from scipy import stats
 

--- a/statsmodels/tsa/ar_model.py
+++ b/statsmodels/tsa/ar_model.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import division
 from statsmodels.compat.python import iteritems, range, lmap
 
 import numpy as np

--- a/statsmodels/tsa/arima_model.py
+++ b/statsmodels/tsa/arima_model.py
@@ -4,7 +4,6 @@
 #       This code does not allow this, but it adds consistency with other
 #       packages such as gretl and X12-ARIMA
 
-from __future__ import absolute_import
 from statsmodels.compat.python import string_types, range, long
 # for 2to3 with extensions
 

--- a/statsmodels/tsa/base/tests/test_tsa_indexes.py
+++ b/statsmodels/tsa/base/tests/test_tsa_indexes.py
@@ -9,7 +9,6 @@ Test index support in time series models
 Author: Chad Fulton
 License: BSD-3
 """
-from __future__ import division, absolute_import, print_function
 
 import pytest
 import warnings

--- a/statsmodels/tsa/filters/bk_filter.py
+++ b/statsmodels/tsa/filters/bk_filter.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 
 import numpy as np
 from scipy.signal import fftconvolve

--- a/statsmodels/tsa/filters/hp_filter.py
+++ b/statsmodels/tsa/filters/hp_filter.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 
 import numpy as np
 from scipy import sparse

--- a/statsmodels/tsa/innovations/tests/test_arma_innovations.py
+++ b/statsmodels/tsa/innovations/tests/test_arma_innovations.py
@@ -1,7 +1,6 @@
 """
 Tests for ARMA innovations algorithm wrapper
 """
-from __future__ import division, absolute_import, print_function
 
 import numpy as np
 import pytest

--- a/statsmodels/tsa/innovations/tests/test_cython_arma_innovations_fast.py
+++ b/statsmodels/tsa/innovations/tests/test_cython_arma_innovations_fast.py
@@ -1,7 +1,6 @@
 """
 Tests for fast version of ARMA innovations algorithm
 """
-from __future__ import division, absolute_import, print_function
 
 import numpy as np
 import pytest

--- a/statsmodels/tsa/kalmanf/kalmanfilter.py
+++ b/statsmodels/tsa/kalmanf/kalmanfilter.py
@@ -24,7 +24,6 @@ Harvey uses Durbin and Koopman notation.
 # http://www.federalreserve.gov/pubs/oss/oss4/aimindex.html
 # Harvey notes that the square root filter will keep P_t pos. def. but
 # is not strictly needed outside of the engineering (long series)
-from __future__ import print_function
 import numpy as np
 
 from . import kalman_loglike

--- a/statsmodels/tsa/regime_switching/markov_autoregression.py
+++ b/statsmodels/tsa/regime_switching/markov_autoregression.py
@@ -5,7 +5,6 @@ Author: Chad Fulton
 License: BSD-3
 """
 
-from __future__ import division, absolute_import, print_function
 
 import numpy as np
 import statsmodels.base.wrapper as wrap

--- a/statsmodels/tsa/regime_switching/markov_regression.py
+++ b/statsmodels/tsa/regime_switching/markov_regression.py
@@ -5,7 +5,6 @@ Author: Chad Fulton
 License: BSD-3
 """
 
-from __future__ import division, absolute_import, print_function
 
 import numpy as np
 import statsmodels.base.wrapper as wrap

--- a/statsmodels/tsa/regime_switching/markov_switching.py
+++ b/statsmodels/tsa/regime_switching/markov_switching.py
@@ -4,14 +4,12 @@ Markov switching models
 Author: Chad Fulton
 License: BSD-3
 """
-from __future__ import division, absolute_import, print_function
-from statsmodels.compat.scipy import logsumexp
-
 import warnings
 from collections import OrderedDict
 
 import numpy as np
 import pandas as pd
+from scipy.special import logsumexp
 
 from statsmodels.tools.tools import Bunch
 from statsmodels.tools.numdiff import approx_fprime_cs, approx_hess_cs

--- a/statsmodels/tsa/regime_switching/tests/test_markov_autoregression.py
+++ b/statsmodels/tsa/regime_switching/tests/test_markov_autoregression.py
@@ -4,7 +4,6 @@ Tests for Markov Autoregression models
 Author: Chad Fulton
 License: BSD-3
 """
-from __future__ import division, absolute_import, print_function
 
 import warnings
 import os

--- a/statsmodels/tsa/regime_switching/tests/test_markov_regression.py
+++ b/statsmodels/tsa/regime_switching/tests/test_markov_regression.py
@@ -4,7 +4,6 @@ Tests for Markov Regression models
 Author: Chad Fulton
 License: BSD-3
 """
-from __future__ import division, absolute_import, print_function
 
 import os
 import warnings

--- a/statsmodels/tsa/regime_switching/tests/test_markov_switching.py
+++ b/statsmodels/tsa/regime_switching/tests/test_markov_switching.py
@@ -4,7 +4,6 @@ General tests for Markov switching models
 Author: Chad Fulton
 License: BSD-3
 """
-from __future__ import division, absolute_import, print_function
 
 import numpy as np
 from numpy.testing import assert_equal, assert_allclose, assert_raises

--- a/statsmodels/tsa/statespace/_pykalman_smoother.py
+++ b/statsmodels/tsa/statespace/_pykalman_smoother.py
@@ -4,7 +4,6 @@ Kalman Smoother
 Author: Chad Fulton
 License: Simplified-BSD
 """
-from __future__ import division, absolute_import, print_function
 
 import numpy as np
 

--- a/statsmodels/tsa/statespace/dynamic_factor.py
+++ b/statsmodels/tsa/statespace/dynamic_factor.py
@@ -5,7 +5,6 @@ Dynamic factor model
 Author: Chad Fulton
 License: Simplified-BSD
 """
-from __future__ import division, absolute_import, print_function
 
 from warnings import warn
 from collections import OrderedDict

--- a/statsmodels/tsa/statespace/kalman_filter.py
+++ b/statsmodels/tsa/statespace/kalman_filter.py
@@ -4,7 +4,6 @@ State Space Representation and Kalman Filter
 Author: Chad Fulton
 License: Simplified-BSD
 """
-from __future__ import division, absolute_import, print_function
 
 import contextlib
 from warnings import warn

--- a/statsmodels/tsa/statespace/kalman_smoother.py
+++ b/statsmodels/tsa/statespace/kalman_smoother.py
@@ -4,7 +4,6 @@ State Space Representation and Kalman Filter, Smoother
 Author: Chad Fulton
 License: Simplified-BSD
 """
-from __future__ import division, absolute_import, print_function
 
 import numpy as np
 

--- a/statsmodels/tsa/statespace/mlemodel.py
+++ b/statsmodels/tsa/statespace/mlemodel.py
@@ -5,7 +5,6 @@ State Space Model
 Author: Chad Fulton
 License: Simplified-BSD
 """
-from __future__ import division, absolute_import, print_function
 import warnings
 
 from collections import OrderedDict

--- a/statsmodels/tsa/statespace/representation.py
+++ b/statsmodels/tsa/statespace/representation.py
@@ -4,7 +4,6 @@ State Space Representation
 Author: Chad Fulton
 License: Simplified-BSD
 """
-from __future__ import division, absolute_import, print_function
 
 import numpy as np
 from .tools import (

--- a/statsmodels/tsa/statespace/sarimax.py
+++ b/statsmodels/tsa/statespace/sarimax.py
@@ -4,7 +4,6 @@ SARIMAX Model
 Author: Chad Fulton
 License: Simplified-BSD
 """
-from __future__ import division, absolute_import, print_function
 from warnings import warn
 
 import numpy as np

--- a/statsmodels/tsa/statespace/simulation_smoother.py
+++ b/statsmodels/tsa/statespace/simulation_smoother.py
@@ -4,7 +4,6 @@ State Space Representation, Kalman Filter, Smoother, and Simulation Smoother
 Author: Chad Fulton
 License: Simplified-BSD
 """
-from __future__ import division, absolute_import, print_function
 
 import numpy as np
 from .kalman_smoother import KalmanSmoother

--- a/statsmodels/tsa/statespace/structural.py
+++ b/statsmodels/tsa/statespace/structural.py
@@ -4,7 +4,6 @@ Univariate structural time series models
 Author: Chad Fulton
 License: Simplified-BSD
 """
-from __future__ import division, absolute_import, print_function
 
 from warnings import warn
 from collections import OrderedDict

--- a/statsmodels/tsa/statespace/tests/test_collapsed.py
+++ b/statsmodels/tsa/statespace/tests/test_collapsed.py
@@ -7,7 +7,6 @@ observations (2) is smaller than the number of states (6).
 Author: Chad Fulton
 License: Simplified-BSD
 """
-from __future__ import division, absolute_import, print_function
 
 import numpy as np
 import pandas as pd

--- a/statsmodels/tsa/statespace/tests/test_concentrated.py
+++ b/statsmodels/tsa/statespace/tests/test_concentrated.py
@@ -6,7 +6,6 @@ Note: the univariate cases is well tested in test_sarimax.py
 Author: Chad Fulton
 License: Simplified-BSD
 """
-from __future__ import division, absolute_import, print_function
 
 import numpy as np
 import pandas as pd

--- a/statsmodels/tsa/statespace/tests/test_dynamic_factor.py
+++ b/statsmodels/tsa/statespace/tests/test_dynamic_factor.py
@@ -4,7 +4,6 @@ Tests for VARMAX models
 Author: Chad Fulton
 License: Simplified-BSD
 """
-from __future__ import division, absolute_import, print_function
 import os
 import re
 import warnings

--- a/statsmodels/tsa/statespace/tests/test_exact_diffuse_filtering.py
+++ b/statsmodels/tsa/statespace/tests/test_exact_diffuse_filtering.py
@@ -40,7 +40,6 @@ the diffuse observations.
 Author: Chad Fulton
 License: Simplified-BSD
 """
-from __future__ import division, absolute_import, print_function
 
 import numpy as np
 import pandas as pd

--- a/statsmodels/tsa/statespace/tests/test_impulse_responses.py
+++ b/statsmodels/tsa/statespace/tests/test_impulse_responses.py
@@ -4,8 +4,6 @@ Tests for impulse responses of time series
 Author: Chad Fulton
 License: Simplified-BSD
 """
-from __future__ import division, absolute_import, print_function
-
 import warnings
 
 import numpy as np

--- a/statsmodels/tsa/statespace/tests/test_initialization.py
+++ b/statsmodels/tsa/statespace/tests/test_initialization.py
@@ -5,7 +5,6 @@ Author: Chad Fulton
 License: Simplified-BSD
 """
 
-from __future__ import division, absolute_import, print_function
 
 import numpy as np
 from scipy.linalg import solve_discrete_lyapunov

--- a/statsmodels/tsa/statespace/tests/test_kalman.py
+++ b/statsmodels/tsa/statespace/tests/test_kalman.py
@@ -16,7 +16,6 @@ Hamilton, James D. 1994.
 Time Series Analysis.
 Princeton, N.J.: Princeton University Press.
 """
-from __future__ import division, absolute_import, print_function
 from statsmodels.compat import cPickle
 
 import copy

--- a/statsmodels/tsa/statespace/tests/test_mlemodel.py
+++ b/statsmodels/tsa/statespace/tests/test_mlemodel.py
@@ -4,7 +4,6 @@ Tests for the generic MLEModel
 Author: Chad Fulton
 License: Simplified-BSD
 """
-from __future__ import division, absolute_import, print_function
 
 import os
 import re

--- a/statsmodels/tsa/statespace/tests/test_models.py
+++ b/statsmodels/tsa/statespace/tests/test_models.py
@@ -4,7 +4,6 @@ Tests for miscellaneous models
 Author: Chad Fulton
 License: Simplified-BSD
 """
-from __future__ import division, absolute_import, print_function
 
 import numpy as np
 import pandas as pd

--- a/statsmodels/tsa/statespace/tests/test_options.py
+++ b/statsmodels/tsa/statespace/tests/test_options.py
@@ -7,7 +7,6 @@ option)
 Author: Chad Fulton
 License: Simplified-BSD
 """
-from __future__ import division, absolute_import, print_function
 
 import numpy as np
 from statsmodels.tsa.statespace.kalman_filter import (

--- a/statsmodels/tsa/statespace/tests/test_pickle.py
+++ b/statsmodels/tsa/statespace/tests/test_pickle.py
@@ -12,7 +12,6 @@ Kim, Chang-Jin, and Charles R. Nelson. 1999.
 Classical and Gibbs-Sampling Approaches with Applications".
 MIT Press Books. The MIT Press.
 """
-from __future__ import division, absolute_import, print_function
 
 import numpy as np
 import pandas as pd

--- a/statsmodels/tsa/statespace/tests/test_prediction.py
+++ b/statsmodels/tsa/statespace/tests/test_prediction.py
@@ -5,7 +5,6 @@ Author: Chad Fulton
 License: Simplified-BSD
 """
 
-from __future__ import division, absolute_import, print_function
 
 import numpy as np
 import pandas as pd

--- a/statsmodels/tsa/statespace/tests/test_representation.py
+++ b/statsmodels/tsa/statespace/tests/test_representation.py
@@ -12,7 +12,6 @@ Kim, Chang-Jin, and Charles R. Nelson. 1999.
 Classical and Gibbs-Sampling Approaches with Applications".
 MIT Press Books. The MIT Press.
 """
-from __future__ import division, absolute_import, print_function
 
 import os
 import warnings

--- a/statsmodels/tsa/statespace/tests/test_sarimax.py
+++ b/statsmodels/tsa/statespace/tests/test_sarimax.py
@@ -4,7 +4,6 @@ Tests for SARIMAX models
 Author: Chad Fulton
 License: Simplified-BSD
 """
-from __future__ import division, absolute_import, print_function
 
 import os
 import warnings

--- a/statsmodels/tsa/statespace/tests/test_save.py
+++ b/statsmodels/tsa/statespace/tests/test_save.py
@@ -2,7 +2,6 @@
 Tests of save / load / remove_data state space functionality.
 """
 
-from __future__ import division, absolute_import, print_function
 from statsmodels.compat import cPickle
 
 import tempfile

--- a/statsmodels/tsa/statespace/tests/test_simulate.py
+++ b/statsmodels/tsa/statespace/tests/test_simulate.py
@@ -4,7 +4,6 @@ Tests for simulation of time series
 Author: Chad Fulton
 License: Simplified-BSD
 """
-from __future__ import division, absolute_import, print_function
 
 import numpy as np
 from numpy.testing import assert_allclose

--- a/statsmodels/tsa/statespace/tests/test_simulation_smoothing.py
+++ b/statsmodels/tsa/statespace/tests/test_simulation_smoothing.py
@@ -4,7 +4,6 @@ Tests for simulation smoothing
 Author: Chad Fulton
 License: Simplified-BSD
 """
-from __future__ import division, absolute_import, print_function
 import os
 
 import numpy as np

--- a/statsmodels/tsa/statespace/tests/test_smoothing.py
+++ b/statsmodels/tsa/statespace/tests/test_smoothing.py
@@ -12,7 +12,6 @@ MATLAB (ssm toolbox)
 Author: Chad Fulton
 License: Simplified-BSD
 """
-from __future__ import division, absolute_import, print_function
 import os
 
 import numpy as np

--- a/statsmodels/tsa/statespace/tests/test_structural.py
+++ b/statsmodels/tsa/statespace/tests/test_structural.py
@@ -4,7 +4,6 @@ Tests for structural time series models
 Author: Chad Fulton
 License: Simplified-BSD
 """
-from __future__ import division, absolute_import, print_function
 
 import warnings
 

--- a/statsmodels/tsa/statespace/tests/test_tools.py
+++ b/statsmodels/tsa/statespace/tests/test_tools.py
@@ -4,7 +4,6 @@ Tests for tools
 Author: Chad Fulton
 License: Simplified-BSD
 """
-from __future__ import division, absolute_import, print_function
 
 import pytest
 import numpy as np

--- a/statsmodels/tsa/statespace/tests/test_univariate.py
+++ b/statsmodels/tsa/statespace/tests/test_univariate.py
@@ -12,7 +12,6 @@ univariate smoother must return a diagonal covariance matrix).
 Author: Chad Fulton
 License: Simplified-BSD
 """
-from __future__ import division, absolute_import, print_function
 import os
 
 import numpy as np

--- a/statsmodels/tsa/statespace/tests/test_var.py
+++ b/statsmodels/tsa/statespace/tests/test_var.py
@@ -10,7 +10,6 @@ CSS approach is the conditional loglikelihood.
 Author: Chad Fulton
 License: Simplified-BSD
 """
-from __future__ import division, absolute_import, print_function
 import os
 
 import numpy as np

--- a/statsmodels/tsa/statespace/tests/test_varmax.py
+++ b/statsmodels/tsa/statespace/tests/test_varmax.py
@@ -4,7 +4,6 @@ Tests for VARMAX models
 Author: Chad Fulton
 License: Simplified-BSD
 """
-from __future__ import division, absolute_import, print_function
 import os
 import re
 import warnings

--- a/statsmodels/tsa/statespace/tools.py
+++ b/statsmodels/tsa/statespace/tools.py
@@ -4,7 +4,6 @@ Statespace Tools
 Author: Chad Fulton
 License: Simplified-BSD
 """
-from __future__ import division, absolute_import, print_function
 import warnings
 
 import numpy as np

--- a/statsmodels/tsa/statespace/varmax.py
+++ b/statsmodels/tsa/statespace/varmax.py
@@ -5,7 +5,6 @@ Vector Autoregressive Moving Average with eXogenous regressors model
 Author: Chad Fulton
 License: Simplified-BSD
 """
-from __future__ import division, absolute_import, print_function
 
 from warnings import warn
 from collections import OrderedDict

--- a/statsmodels/tsa/stattools.py
+++ b/statsmodels/tsa/stattools.py
@@ -1,7 +1,6 @@
 """
 Statistical tools for time series analysis
 """
-from __future__ import division
 from statsmodels.compat.python import (iteritems, range, lrange, string_types,
                                        lzip, zip, long)
 from statsmodels.compat.numpy import lstsq

--- a/statsmodels/tsa/varma_process.py
+++ b/statsmodels/tsa/varma_process.py
@@ -28,7 +28,6 @@ Extensions
 see also VAR section in Notes.txt
 
 """
-from __future__ import print_function
 import numpy as np
 from scipy import signal
 

--- a/statsmodels/tsa/vector_ar/irf.py
+++ b/statsmodels/tsa/vector_ar/irf.py
@@ -3,8 +3,6 @@
 Impulse reponse-related code
 """
 
-from __future__ import division
-
 import numpy as np
 import numpy.linalg as la
 import scipy.linalg as L

--- a/statsmodels/tsa/vector_ar/output.py
+++ b/statsmodels/tsa/vector_ar/output.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 from statsmodels.compat.python import lzip, StringIO, range
 import numpy as np
 

--- a/statsmodels/tsa/vector_ar/svar_model.py
+++ b/statsmodels/tsa/vector_ar/svar_model.py
@@ -6,7 +6,6 @@ References
 ----------
 Lütkepohl (2005) New Introduction to Multiple Time Series Analysis
 """
-from __future__ import print_function, division
 
 import numpy as np
 import numpy.linalg as npl

--- a/statsmodels/tsa/vector_ar/tests/test_var_jmulti.py
+++ b/statsmodels/tsa/vector_ar/tests/test_var_jmulti.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, print_function
 
 import numpy as np
 from numpy.testing import assert_, assert_allclose, assert_raises

--- a/statsmodels/tsa/vector_ar/tests/test_vecm.py
+++ b/statsmodels/tsa/vector_ar/tests/test_vecm.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, print_function
 
 import numpy as np
 from numpy.testing import (assert_, assert_allclose, assert_raises,

--- a/statsmodels/tsa/vector_ar/util.py
+++ b/statsmodels/tsa/vector_ar/util.py
@@ -2,8 +2,6 @@
 """
 Miscellaneous utility code for VAR estimation
 """
-from __future__ import division
-
 from statsmodels.compat.python import range, string_types, asbytes, long
 from statsmodels.compat.pandas import frequencies
 import numpy as np

--- a/statsmodels/tsa/vector_ar/var_model.py
+++ b/statsmodels/tsa/vector_ar/var_model.py
@@ -7,7 +7,6 @@ References
 Lütkepohl (2005) New Introduction to Multiple Time Series Analysis
 """
 
-from __future__ import division, print_function
 from statsmodels.compat.python import (range, lrange, string_types,
                                        StringIO, iteritems)
 from statsmodels.compat.pandas import deprecate_kwarg

--- a/statsmodels/tsa/vector_ar/vecm.py
+++ b/statsmodels/tsa/vector_ar/vecm.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import division, print_function
 
 from collections import defaultdict
 import numpy as np

--- a/statsmodels/tsa/x13.py
+++ b/statsmodels/tsa/x13.py
@@ -7,7 +7,6 @@ Notes
 Many of the functions are called x12. However, they are also intended to work
 for x13. If this is not the case, it's a bug.
 """
-from __future__ import print_function
 import os
 import subprocess
 import tempfile


### PR DESCRIPTION
Remove future and Python 2.7 references
Remvoe old scipy code

- [x] code/documentation is well formatted.  
- [x] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
