### PR TITLE
BUG: variance_inflation_factor: resolve exog without constants

### DIFF
--- a/statsmodels/stats/outliers_influence.py
+++ b/statsmodels/stats/outliers_influence.py
@@ -146,7 +146,7 @@ def reset_ramsey(res, degree=5):
     return res_aux.f_test(r_matrix)  # , r_matrix, res_aux
 
 
-def variance_inflation_factor(exog, exog_idx):
+def variance_inflation_factor(exog, exog_idx, hasconst=None):
     """variance inflation factor, VIF, for one exogenous variable
 
     The variance inflation factor is a measure for the increase of the
@@ -166,7 +166,12 @@ def variance_inflation_factor(exog, exog_idx):
         regression
     exog_idx : int
         index of the exogenous variable in the columns of exog
-
+    hasconst : None or bool
+        indicates whether the exog includes a user-supplied constant. If True,
+        a constant is not checked for and k_constant is set to 1 and all result
+        statistics are calculated as if a constant is present. If False, a
+        constant is not checked for and k_constant is set to 0.
+    
     Returns
     -------
     vif : float
@@ -189,7 +194,7 @@ def variance_inflation_factor(exog, exog_idx):
     x_i = exog[:, exog_idx]
     mask = np.arange(k_vars) != exog_idx
     x_noti = exog[:, mask]
-    r_squared_i = OLS(x_i, x_noti).fit().rsquared
+    r_squared_i = OLS(x_i, x_noti, hasconst=hasconst).fit().rsquared
     vif = 1. / (1. - r_squared_i)
     return vif
 

--- a/statsmodels/stats/outliers_influence.py
+++ b/statsmodels/stats/outliers_influence.py
@@ -171,7 +171,7 @@ def variance_inflation_factor(exog, exog_idx, hasconst=None):
         a constant is not checked for and k_constant is set to 1 and all result
         statistics are calculated as if a constant is present. If False, a
         constant is not checked for and k_constant is set to 0.
-    
+
     Returns
     -------
     vif : float


### PR DESCRIPTION
Variance inflation factor (VIF) is used for testing collinearly of multiple features in a linear model, while the linear model may or may not have a constant term.

When the linear model does not have a constant term, users generally do not add constant to `exog`, which provides a misleading R^2 value, and this R^2 value has nothing to do with the collinearly of components in `exog`. In `OLS`, the parameter `hasconstant` resolves this and provide an alternative way to calculate R^2 in that case. Explicitly speaking, if we defined the R^2 in the form of R^2=1-SSE/SST, when there is a constant term, SST should be the sum of (y - mean)^2; when there are no constant term, SST should be the sum of y^2. The R^2 obtained by y^2 is what VIF actually wants. Therefore, it is necessary to provide the `hasconstant` parameter so users can obtain meaningful VIF result at that case.

When the linear model has a constant term, users are responsible for `add_constant`-ing to the `exog`, and everything works well. Explicityly listing out the `hasconstant` reminds the users of their responsibility.

Cf
https://github.com/statsmodels/statsmodels/issues/27
https://github.com/statsmodels/statsmodels/issues/423
https://github.com/statsmodels/statsmodels/pull/499

- [ ] closes #xxxx
- [ ] tests added / passed. 
- [ ] code/documentation is well formatted.  
- [ ] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
