### PR TITLE
TST: Add a test for variance_inflation_factor

### DIFF
--- a/statsmodels/stats/tests/test_outliers_influence.py
+++ b/statsmodels/stats/tests/test_outliers_influence.py
@@ -18,9 +18,21 @@ def test_reset_stata():
     assert_almost_equal(stat.pvalue, 0.2221, decimal=4)
 
 
-def test_variance_inflation_factor():
+def test_variance_inflation_factor():    
     # Test Case: perfect collinear with constant component
-    exog = np.stack([np.arange(8), 10. - np.arange(8)]).T
+    exog = np.array([[0, 1, 2, 3, 4, 5, 6, 7], [1, 2, 3, 4, 5, 6, 7, 8]]).T
     exog = add_constant(exog)
-    vif = variance_inflation_factor(exog, 0)
-    assert_almost_equal(vif, 0., decimal=4)
+    vif = variance_inflation_factor(exog, 1)
+    assert_almost_equal(vif, float('+inf'), decimal=4)
+
+    # Test Case: partial collinear with constant component
+    exog = np.array([[0, 0, 1, 1, 2, 2, 3, 3], [0, 0, 0, 0, 1, 1, 1, 1]]).T
+    exog = add_constant(exog)
+    vif = variance_inflation_factor(exog, 1)
+    assert_almost_equal(vif, 5., decimal=4)
+
+    # Test Case: no collinear with constant component
+    exog = np.array([[0, 0, 0, 0, 2, 2, 2, 2], [0, 2, 0, 2, 0, 2, 0, 2]]).T
+    exog = add_constant(exog)
+    vif = variance_inflation_factor(exog, 1)
+    assert_almost_equal(vif, 1., decimal=4)

--- a/statsmodels/stats/tests/test_outliers_influence.py
+++ b/statsmodels/stats/tests/test_outliers_influence.py
@@ -18,7 +18,7 @@ def test_reset_stata():
     assert_almost_equal(stat.pvalue, 0.2221, decimal=4)
 
 
-def test_variance_inflation_factor():    
+def test_variance_inflation_factor():
     # Test Case: perfect collinear with constant component
     exog = np.array([[0, 1, 2, 3, 4, 5, 6, 7], [1, 2, 3, 4, 5, 6, 7, 8]]).T
     exog = add_constant(exog)

--- a/statsmodels/stats/tests/test_outliers_influence.py
+++ b/statsmodels/stats/tests/test_outliers_influence.py
@@ -1,8 +1,10 @@
+import numpy as np
 from numpy.testing import assert_almost_equal
 
 from statsmodels.datasets import statecrime
 from statsmodels.regression.linear_model import OLS
 from statsmodels.stats.outliers_influence import reset_ramsey
+from statsmodels.stats.outliers_influence import variance_inflation_factor
 from statsmodels.tools import add_constant
 
 data = statecrime.load_pandas().data
@@ -14,3 +16,11 @@ def test_reset_stata():
     stat = reset_ramsey(res, degree=4)
     assert_almost_equal(stat.fvalue[0, 0], 1.52, decimal=2)
     assert_almost_equal(stat.pvalue, 0.2221, decimal=4)
+
+
+def test_variance_inflation_factor():
+    # Test Case: perfect collinear with constant component
+    exog = np.stack([np.arange(8), 10. - np.arange(8)]).T
+    exog = add_constant(exog)
+    vif = variance_inflation_factor(exog, 0)
+    assert_almost_equal(vif, 0., decimal=4)

--- a/statsmodels/stats/tests/test_outliers_influence.py
+++ b/statsmodels/stats/tests/test_outliers_influence.py
@@ -23,7 +23,7 @@ def test_variance_inflation_factor():
     exog = np.array([[0, 1, 2, 3, 4, 5, 6, 7], [1, 2, 3, 4, 5, 6, 7, 8]]).T
     exog = add_constant(exog)
     vif = variance_inflation_factor(exog, 1)
-    assert_almost_equal(vif, float('+inf'), decimal=4)
+    assert_almost_equal(vif, np.inf, decimal=4)
 
     # Test Case: partial collinear with constant component
     exog = np.array([[0, 0, 1, 1, 2, 2, 3, 3], [0, 0, 0, 0, 1, 1, 1, 1]]).T


### PR DESCRIPTION
Add tests to protect the existing (and released) functionality of `test_variance_inflation_factor`.
including the cases of perfect collinear, partial collinear, and no collinear.

Test case of perfect collinearly:
endog of OLS: [0, 1, 2, 3, 4, 5, 6, 7]
exog of OLS: [1, 2, 3, 4, 5, 6, 7, 8]
R^2 = 1
VIF = inf

Test case of partial collinearly:
endog of OLS: [0, 0, 1, 1, 2, 2, 3, 3]
exog of OLS: [0, 0, 0, 0, 1, 1, 1, 1]
R^2 = 0.8
VIF = 5

Test case of no collinearly:
endog of OLS: [0, 0, 0, 0, 2, 2, 2, 2]
exog of OLS: [0, 2, 0, 2, 0, 2, 0, 2]
R^2 = 0
VIF = 1


- [ ] closes #xxxx
- [ ] tests added / passed. 
- [ ] code/documentation is well formatted.  
- [ ] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
