### PR TITLE
ENH: Add R-squared and Adj. R_squared to summary_col

### DIFF
--- a/statsmodels/iolib/summary2.py
+++ b/statsmodels/iolib/summary2.py
@@ -1,7 +1,6 @@
 from statsmodels.compat.python import (lrange, iterkeys, iteritems, lzip,
                                        itervalues)
 
-
 from collections import OrderedDict
 import datetime
 from functools import reduce
@@ -394,6 +393,22 @@ def _col_params(result, float_format='%.4f', stars=True):
         res.loc[idx, res.columns[0]] = res.loc[idx, res.columns[0]] + '*'
     # Stack Coefs and Std.Errors
     res = res.iloc[:, :2]
+    res = res.iloc[:, :2]
+    rsquared = rsquared_adj = np.nan
+    if hasattr(result, 'rsquared'):
+        rsquared = result.rsquared
+    if hasattr(result, 'rsquared_adj'):
+        rsquared_adj = result.rsquared_adj
+    r_result = pd.DataFrame({'Basic': [rsquared], 'Adj.': [rsquared_adj]},
+                            index=['R-squared'])
+    if not np.all(np.isnan(np.asarray(r_result))):
+        for col in r_result:
+            r_result[col] = r_result[col].apply(lambda x: float_format % x)
+        try:
+            res = pd.DataFrame(res).append(r_result, sort=True)
+        except TypeError:
+            # TODO: Remove when min pandas >= 0.23
+            res = pd.DataFrame(res).append(r_result)
     res = res.stack()
     res = pd.DataFrame(res)
     res.columns = [str(result.model.endog_names)]

--- a/statsmodels/iolib/tests/test_summary2.py
+++ b/statsmodels/iolib/tests/test_summary2.py
@@ -19,12 +19,14 @@ class TestSummaryLatex(object):
 \begin{center}
 \begin{tabular}{lcc}
 \hline
-      &   y I    &   y II    \\
+          &   y I    &   y II    \\
 \midrule
-const & 7.7500   & 12.4231   \\
-      & (1.1058) & (3.1872)  \\
-x1    & -0.7500  & -1.5769   \\
-      & (0.2368) & (0.6826)  \\
+const     & 7.7500   & 12.4231   \\
+          & (1.1058) & (3.1872)  \\
+x1        & -0.7500  & -1.5769   \\
+          & (0.2368) & (0.6826)  \\
+R-squared & 0.6930   & 0.5202    \\
+          & 0.7697   & 0.6401    \\
 \hline
 \end{tabular}
 \end{center}
@@ -43,16 +45,18 @@ x1    & -0.7500  & -1.5769   \\
     def test_summarycol_float_format(self):
         # Test for latex output of summary_col object
         desired = r"""
-=================
-       y I   y II
------------------
-const 7.7   12.4 
-      (1.1) (3.2)
-x1    -0.7  -1.6 
-      (0.2) (0.7)
-=================
-Standard errors
-in parentheses.
+=====================
+           y I   y II
+---------------------
+const     7.7   12.4 
+          (1.1) (3.2)
+x1        -0.7  -1.6 
+          (0.2) (0.7)
+R-squared 0.7   0.5  
+          0.8   0.6  
+=====================
+Standard errors in
+parentheses.
 """  # noqa:W291
         x = [1, 5, 7, 3, 5]
         x = add_constant(x)


### PR DESCRIPTION
- [X] closes #5820
- [X] tests added / passed. 
- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
