### PR TITLE
BUG: Limit lags in KPSS

### DIFF
--- a/statsmodels/tsa/stattools.py
+++ b/statsmodels/tsa/stattools.py
@@ -1607,6 +1607,7 @@ def kpss(x, regression='c', lags=None, store=False):
     elif lags == 'auto':
         # autolag method of Hobijn et al. (1998)
         lags = _kpss_autolag(resids, nobs)
+        lags = min(lags, nobs - 1)
     else:
         lags = int(lags)
 
@@ -1672,5 +1673,5 @@ def _kpss_autolag(resids, nobs):
     s_hat = s1 / s0
     pwr = 1. / 3.
     gamma_hat = 1.1447 * np.power(s_hat * s_hat, pwr)
-    autolags = np.amin([nobs, int(gamma_hat * np.power(nobs, pwr))])
+    autolags = int(gamma_hat * np.power(nobs, pwr))
     return autolags

--- a/statsmodels/tsa/tests/test_stattools.py
+++ b/statsmodels/tsa/tests/test_stattools.py
@@ -553,6 +553,27 @@ class TestKPSS(SetupKPSS):
         with pytest.raises(ValueError, match=msg):
             kpss(self.x, 'c', lags=nobs)
 
+    def test_kpss_autolags_does_not_assign_lags_equal_to_nobs(self):
+        # Test that if *autolags* exceeds number of observations, we set suitable lags
+        # GH5925
+        data_which_breaks_autolag = np.array(
+            [0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 1, 1, 0,
+             0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 1, 1, 0, 0,
+             0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0,
+             0, 0, 1, 1, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0,
+             0, 1, 1, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0,
+             1, 1, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 1,
+             1, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 1, 1,
+             0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 1, 1, 0,
+             0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 1, 1, 0, 0,
+             0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0,
+             0, 0, 1, 1, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0,
+             0, 1, 1, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0,
+             1, 1, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 1,
+             1, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0]).astype(float)
+
+        kpss(data_which_breaks_autolag, lags="auto")
+
     def test_legacy_lags(self):
         # Test legacy lags are the same
         with pytest.warns(InterpolationWarning):


### PR DESCRIPTION
- [x] closes #5925 
- [x] tests added / passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message. 

Catches an issue with unusual datasets where autolags attempts to assign too high a lag-value.

Fix #5930 changed verification between `nobs` and `lags` to address this issue, but missed the matching min-value assignment logic at the end of `_kpss_autolag`. 
I've moved that min-value check to the main function so it's more obvious and matches the `lags="legacy"` behaviour.