### PR TITLE
ENH/BUG: Allow ARMA predict to swallow typ

### DIFF
--- a/statsmodels/tsa/arima_model.py
+++ b/statsmodels/tsa/arima_model.py
@@ -698,9 +698,12 @@ class ARMA(tsbase.TimeSeriesModel):
             errors = e[0][k_ar:]
         return errors.squeeze()
 
-    def predict(self, params, start=None, end=None, exog=None, dynamic=False):
+    def predict(self, params, start=None, end=None, exog=None, dynamic=False,
+                **kwargs):
+        if kwargs and 'typ' not in kwargs:
+            raise TypeError('Unkown extra arguments')
         method = getattr(self, 'method', 'mle')  # do not assume fit
-        #params = np.asarray(params)
+        # params = np.asarray(params)
 
         # will return an index of a date
         start, end, out_of_sample, _ = (
@@ -1483,8 +1486,10 @@ class ARMAResults(tsbase.TimeSeriesModelResults):
         df_resid = self.df_resid
         return t.sf(np.abs(self.tvalues), df_resid) * 2
 
-    def predict(self, start=None, end=None, exog=None, dynamic=False):
-        return self.model.predict(self.params, start, end, exog, dynamic)
+    def predict(self, start=None, end=None, exog=None, dynamic=False,
+                **kwargs):
+        return self.model.predict(self.params, start, end, exog, dynamic,
+                                  **kwargs)
     predict.__doc__ = _arma_results_predict
 
     def _forecast_error(self, steps):

--- a/statsmodels/tsa/tests/test_arima.py
+++ b/statsmodels/tsa/tests/test_arima.py
@@ -2503,3 +2503,17 @@ def test_constant_column_trend():
         model.fit(trend="c")
 
     # FIXME: calling model.fit(trend="nc") raises for orthogonal reasons
+
+
+def test_arima_d0_forecast(reset_randomstate):
+    arparams = np.array([1, -.75])
+    maparams = np.array([1, .65])
+    y = arma_generate_sample(arparams, maparams, 250)
+    mod = ARIMA(y, (1, 0, 1))
+    assert isinstance(mod, ARMA)
+    res = mod.fit(disp=-1)
+    pred = res.predict(start=200, end=300)
+    pred_typ = res.predict(start=200, end=300, typ='linear')
+    assert_allclose(pred, pred_typ)
+    pred_mod = mod.predict(res.params, start=200, end=300, typ='linear')
+    assert_allclose(pred, pred_mod)


### PR DESCRIPTION
Allow predict to swallow argument that is used in ARIMA forecasting
Needed since ARIMA can return ARMA when d=0

closes #2741

- [x] closes #2741
- [x] tests added / passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
