### PR TITLE
TST: Verify categorical is supported for MNLogit

### DIFF
--- a/statsmodels/discrete/discrete_model.py
+++ b/statsmodels/discrete/discrete_model.py
@@ -2149,9 +2149,9 @@ class MNLogit(MultinomialModel):
     ----------
     endog : array_like
         `endog` is an 1-d vector of the endogenous response.  `endog` can
-        contain strings, ints, or floats.  Note that if it contains strings,
-        every distinct string will be a category.  No stripping of whitespace
-        is done.
+        contain strings, ints, or floats or may be a pandas Categorical Series.
+        Note that if it contains strings, every distinct string will be a
+        category.  No stripping of whitespace is done.
     exog : array_like
         A nobs x k array where `nobs` is the number of observations and `k`
         is the number of regressors. An intercept is not included by default

--- a/statsmodels/discrete/tests/test_discrete.py
+++ b/statsmodels/discrete/tests/test_discrete.py
@@ -1554,6 +1554,18 @@ def test_mnlogit_factor():
     assert_allclose(predicted_f, predicted, rtol=1e-10)
 
 
+def test_mnlogit_factor_categorical():
+    dta = sm.datasets.anes96.load_pandas()
+    dta['endog'] = dta.endog.replace(dict(zip(range(7), 'ABCDEFG')))
+    exog = sm.add_constant(dta.exog, prepend=True)
+    mod = sm.MNLogit(dta.endog, exog)
+    res = mod.fit(disp=0)
+    dta['endog'] = dta['endog'].astype('category')
+    mod = sm.MNLogit(dta.endog, exog)
+    res_cat = mod.fit(disp=0)
+    assert_allclose(res.params, res_cat.params)
+
+
 def test_formula_missing_exposure():
     # see 2083
     d = {'Foo': [1, 2, 10, 149], 'Bar': [1, 2, 3, np.nan],


### PR DESCRIPTION
Add test for categorical endog in MNLogit

closes #2601

- [X] closes #2601
- [X] tests added / passed. 
- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
