### PR TITLE
BUG: Fix t-test and f-test for multidim params

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,10 +29,16 @@ env:
     - # Doctr deploy key for statsmodels/statsmodels.github.io
     - secure: "AzwB23FWdilHKVcEJnj57AsoY5yKTWT8cQKzsH2ih9i08wIXvZXP/Ui8XRDygV9tDKfqGVltC7HpBBDE3C4ngeMlis4uuKWlkp0O1757YQe+OdDnimuDZhrh3ILEk7xW3ab5YizjLeyv3iiBW7cNS5z8W3Yu8HeJPkr6Ck30gAA="
     - SM_CYTHON_COVERAGE=false # Run takes > 1 hour and so not feasible
+    - PYTEST_OPTIONS=--skip-slow  # skip slow on travis since tested on azure
 
 matrix:
   fast_finish: true
   include:
+    # Documentation build (on Python 3.7 + cutting edge packages). Slowest build
+    - python: 3.7
+      env:
+        - PYTHON=3.7
+        - DOCBUILD=true
     # Python 3.7 + fixed pandas
     - python: 3.7
       env:
@@ -40,11 +46,7 @@ matrix:
         - PANDAS=0.24
         - LINT=true
         - COVERAGE=true
-    # Documentation build (on Python 3.7 + cutting edge packages)
-    - python: 3.7
-      env:
-        - PYTHON=3.7
-        - DOCBUILD=true
+        - PYTEST_OPTIONS=
     # Python 3.6 + legacy blas + older pandas
     - python: 3.6
       env:
@@ -54,6 +56,7 @@ matrix:
         - SCIPY=1.1
         - BLAS="nomkl blas=*=openblas"
         - COVERAGE=true
+        - PYTEST_OPTIONS=
     # Python 3.5 + oldest packages
     - python: 3.5
       env:
@@ -133,8 +136,8 @@ script:
     else
         export XDIST_OPTS=""
     fi
-  - echo pytest -r a ${COVERAGE_OPTS} statsmodels --skip-examples ${XDIST_OPTS}
-  - pytest -r a ${COVERAGE_OPTS} statsmodels --skip-examples ${XDIST_OPTS}
+  - echo pytest -r a ${COVERAGE_OPTS} statsmodels --skip-examples ${XDIST_OPTS} ${PYTEST_OPTIONS}
+  - pytest -r a ${COVERAGE_OPTS} statsmodels --skip-examples ${XDIST_OPTS} ${PYTEST_OPTIONS}
   - ./lint.sh
 
 after_success:

--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -1498,7 +1498,7 @@ class LikelihoodModelResults(Results):
                           DeprecationWarning)
 
         from patsy import DesignInfo
-        names = self.model.data.param_names
+        names = self.model.data.cov_names
         LC = DesignInfo(names).linear_constraint(r_matrix)
         r_matrix, q_matrix = LC.coefs, LC.constants
         num_ttests = r_matrix.shape[0]
@@ -1508,7 +1508,8 @@ class LikelihoodModelResults(Results):
                 not hasattr(self, 'cov_params_default')):
             raise ValueError('Need covariance of parameters for computing '
                              'T statistics')
-        if num_params != self.params.shape[0]:
+        params = self.params.ravel()
+        if num_params != params.shape[0]:
             raise ValueError('r_matrix and params are not aligned')
         if q_matrix is None:
             q_matrix = np.zeros(num_ttests)
@@ -1524,10 +1525,7 @@ class LikelihoodModelResults(Results):
             # switch to use_t false if undefined
             use_t = (hasattr(self, 'use_t') and self.use_t)
 
-        _t = _sd = None
-
-        _effect = np.dot(r_matrix, self.params)
-        # nan_dot multiplies with the convention nan * 0 = 0
+        _effect = np.dot(r_matrix, params)
 
         # Perform the test
         if num_ttests > 1:
@@ -1718,7 +1716,8 @@ class LikelihoodModelResults(Results):
             use_f = (hasattr(self, 'use_t') and self.use_t)
 
         from patsy import DesignInfo
-        names = self.model.data.param_names
+        names = self.model.data.cov_names
+        params = self.params.ravel()
         LC = DesignInfo(names).linear_constraint(r_matrix)
         r_matrix, q_matrix = LC.coefs, LC.constants
 
@@ -1727,7 +1726,7 @@ class LikelihoodModelResults(Results):
             raise ValueError('need covariance of parameters for computing '
                              'F statistics')
 
-        cparams = np.dot(r_matrix, self.params[:, None])
+        cparams = np.dot(r_matrix, params[:, None])
         J = float(r_matrix.shape[0])  # number of restrictions
 
         if q_matrix is None:


### PR DESCRIPTION
Fix t-test and f-test to also work with multidimensional parameters
as in MNLogit or VAR

- [X] closes #669 
- [X] closes #457 
- [X] tests added / passed. 
- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
