### PR TITLE
ENH: Set limit for number of endog variables when using formulas

### DIFF
--- a/.pep8speaks.yml
+++ b/.pep8speaks.yml
@@ -1,0 +1,3 @@
+pycodestyle:
+    ignore:  # Errors and warnings to ignore
+        - W504  # line break after binary operator

--- a/statsmodels/genmod/families/family.py
+++ b/statsmodels/genmod/families/family.py
@@ -855,7 +855,11 @@ class Binomial(Family):
         '''
         # if not np.all(np.asarray(freq_weights) == 1):
         #     self.variance = V.Binomial(n=freq_weights)
-        if (endog.ndim > 1 and endog.shape[1] > 1):
+        if endog.ndim > 1 and endog.shape[1] > 2:
+            raise ValueError('endog has more than 2 columns. The Binomial '
+                             'link supports either a single response variable '
+                             'or a paired response variable.')
+        elif endog.ndim > 1 and endog.shape[1] > 1:
             y = endog[:, 0]
             # overwrite self.freq_weights for deviance below
             self.n = endog.sum(1)

--- a/statsmodels/genmod/generalized_linear_model.py
+++ b/statsmodels/genmod/generalized_linear_model.py
@@ -258,6 +258,8 @@ class GLM(base.LikelihoodModel):
     appropriate.
 
     """ % {'extra_params': base._missing_param_doc}
+    # Maximum number of endogenous variables when using a formula
+    _formula_max_endog = 2
 
     def __init__(self, endog, exog, family=None, offset=None,
                  exposure=None, freq_weights=None, var_weights=None,

--- a/statsmodels/multivariate/manova.py
+++ b/statsmodels/multivariate/manova.py
@@ -52,8 +52,11 @@ class MANOVA(Model):
 
     References
     ----------
-    .. [*] ftp://public.dhe.ibm.com/software/analytics/spss/documentation/statistics/20.0/en/client/Manuals/IBM_SPSS_Statistics_Algorithms.pdf
+    .. [*] ftp://public.dhe.ibm.com/software/analytics/spss/documentation/
+       statistics/20.0/en/client/Manuals/IBM_SPSS_Statistics_Algorithms.pdf
     """
+    _formula_max_endog = None
+
     def __init__(self, endog, exog, missing='none', hasconst=None, **kwargs):
         if len(endog.shape) == 1 or endog.shape[1] == 1:
             raise ValueError('There must be more than one dependent variable'

--- a/statsmodels/multivariate/multivariate_ols.py
+++ b/statsmodels/multivariate/multivariate_ols.py
@@ -386,6 +386,8 @@ class _MultivariateOLS(Model):
     exog : array
         See Parameters.
     """
+    _formula_max_endog = None
+
     def __init__(self, endog, exog, missing='none', hasconst=None, **kwargs):
         if len(endog.shape) == 1 or endog.shape[1] == 1:
             raise ValueError('There must be more than one dependent variable'


### PR DESCRIPTION
Add a class variable that limits the number of endog variables

closes #2733

- [X] closes #2733
- [X] tests added / passed. 
- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
