### PR TITLE
DOC: added content for two headings in VAR docs

### DIFF
--- a/docs/source/vector_ar.rst
+++ b/docs/source/vector_ar.rst
@@ -27,7 +27,7 @@ and their lagged values is the *vector autoregression process*:
 
 .. math::
 
-   Y_t = A_1 Y_{t-1} + \ldots + A_p Y_{t-p} + u_t
+   Y_t = \nu + A_1 Y_{t-1} + \ldots + A_p Y_{t-p} + u_t
 
    u_t \sim {\sf Normal}(0, \Sigma_u)
 
@@ -315,8 +315,23 @@ F-test.
 Normality
 ~~~~~~~~~
 
+As pointed out in the beginning of this document, the white noise component
+:math:`u_t` is assumed to be normally distributed. While this assumption
+is not required for parameter estimates to be consistent or asymptotically
+normal, results are generally more reliable in finite samples when residuals
+are Gaussian white noise. To test whether this assumption is consistent with
+a data set, :class:`VARResults` offers the `test_normality` method.
+
+.. ipython:: python
+
+    results.test_normality()
+
 Whiteness of residuals
 ~~~~~~~~~~~~~~~~~~~~~~
+
+To test the whiteness of the estimation residuals (this means absence of
+significant residual autocorrelations) one can use the `test_whiteness`
+method of :class:`VARResults`.
 
 Dynamic Vector Autoregressions
 ------------------------------


### PR DESCRIPTION
[skip ci]
Add documentation

closes #2869

- [X] closes #2869
- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
