### PR TITLE
Turn relative import into an absolute import

### DIFF
--- a/statsmodels/__init__.py
+++ b/statsmodels/__init__.py
@@ -1,5 +1,5 @@
 
-from ._version import get_versions
+from statsmodels._version import get_versions
 
 debug_warnings = False
 


### PR DESCRIPTION
Turn relative import into an absolute import to work around the issue with pyinstaller.

- [ ] closes #6029
- [ ] tests added / passed. 
- [ ] code/documentation is well formatted.  
- [ ] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html#writing-the-commit-message). 