### PR TITLE
MAINT: Change types for future changes in NumPy

### DIFF
--- a/statsmodels/iolib/tests/test_foreign.py
+++ b/statsmodels/iolib/tests/test_foreign.py
@@ -8,7 +8,7 @@ from io import BytesIO
 
 from numpy.testing import assert_array_equal, assert_, assert_equal
 import numpy as np
-from pandas import DataFrame, isnull
+from pandas import DataFrame, isnull, Timestamp
 import pandas.util.testing as ptesting
 import pytest
 
@@ -161,9 +161,17 @@ def test_genfromdta_datetime():
             dta = genfromdta(os.path.join(curdir,
                                           "results/time_series_examples.dta"),
                              pandas=True)
+    for i, row in enumerate(results):
+        new = []
+        for val in row:
+            if isinstance(val, datetime) and val.year > 2:
+                new.append(Timestamp(val))
+            else:
+                new.append(val)
+        results[i] = new
 
-    assert_array_equal(dta.iloc[0].tolist(), results[0])
-    assert_array_equal(dta.iloc[1].tolist(), results[1])
+    assert dta.iloc[0].tolist() == results[0]
+    assert dta.iloc[1].tolist() == results[1]
 
 
 def test_date_converters():


### PR DESCRIPTION
Change test to use python/pandas types to avoid NumPy casting

- [X] tests added / passed. 
- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
