### PR TITLE
DOC: Continue fixing docstring formatting

### DIFF
--- a/docs/source/spelling_wordlist.txt
+++ b/docs/source/spelling_wordlist.txt
@@ -2250,3 +2250,4 @@ cosinusoidal
 importances
 datetimes
 comovements
+Bsplines

--- a/docs/themes/statsmodels/static/nature.css_t
+++ b/docs/themes/statsmodels/static/nature.css_t
@@ -363,7 +363,7 @@ div.searchformwrapper {
 .dropdown:hover .dropdown-content {display: block;}
 
 /* Change the background color of the dropdown button when the dropdown content is shown */
-.dropdown:hover .dropbtn {background-color: #ecf1fb;}
+.dropdown:hover .dropbtn {background-color: #4675f3;}
 
 span.pre {
     font-family: 'Roboto Mono', monospace;

--- a/examples/notebooks/statespace_arma_0.ipynb
+++ b/examples/notebooks/statespace_arma_0.ipynb
@@ -56,7 +56,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Subspots Data"
+    "## Sunspots Data"
    ]
   },
   {

--- a/examples/notebooks/statespace_dfm_coincident.ipynb
+++ b/examples/notebooks/statespace_dfm_coincident.ipynb
@@ -759,7 +759,7 @@
     "\n",
     "**`start_params`**\n",
     "\n",
-    "`start_params` are used as initial values in the optimizer. Since we are adding three new parameters, we need to pass those in. If we nad not done this, the optimizer would use the default starting values, which would be three elements short.\n",
+    "`start_params` are used as initial values in the optimizer. Since we are adding three new parameters, we need to pass those in. If we had not done this, the optimizer would use the default starting values, which would be three elements short.\n",
     "\n",
     "**`param_names`**\n",
     "\n",

--- a/examples/notebooks/tsa_arma_0.ipynb
+++ b/examples/notebooks/tsa_arma_0.ipynb
@@ -45,7 +45,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Subspots Data"
+    "## Sunspots Data"
    ]
   },
   {

--- a/examples/python/statespace_arma_0.py
+++ b/examples/python/statespace_arma_0.py
@@ -22,7 +22,7 @@ import statsmodels.api as sm
 
 from statsmodels.graphics.api import qqplot
 
-# ## Subspots Data
+# ## Sunspots Data
 
 print(sm.datasets.sunspots.NOTE)
 

--- a/examples/python/statespace_dfm_coincident.py
+++ b/examples/python/statespace_dfm_coincident.py
@@ -731,7 +731,7 @@ class ExtendedDFM(sm.tsa.DynamicFactor):
 # #### `start_params`
 #
 # `start_params` are used as initial values in the optimizer. Since we are
-# adding three new parameters, we need to pass those in. If we nad not done
+# adding three new parameters, we need to pass those in. If we had not done
 # this, the optimizer would use the default starting values, which would be
 # three elements short.
 #

--- a/examples/python/tsa_arma_0.py
+++ b/examples/python/tsa_arma_0.py
@@ -18,7 +18,7 @@ import statsmodels.api as sm
 
 from statsmodels.graphics.api import qqplot
 
-# ## Subspots Data
+# ## Sunspots Data
 
 print(sm.datasets.sunspots.NOTE)
 

--- a/statsmodels/base/elastic_net.py
+++ b/statsmodels/base/elastic_net.py
@@ -110,7 +110,8 @@ def fit_elasticnet(model, method="coord_descent", maxiter=100,
 
     Returns
     -------
-    A results object.
+    Results
+        A results object.
 
     Notes
     -----

--- a/statsmodels/base/wrapper.py
+++ b/statsmodels/base/wrapper.py
@@ -52,7 +52,7 @@ class ResultsWrapper(object):
 
     def save(self, fname, remove_data=False):
         """
-        Save a pickle of this instance
+        Save a pickle of this instance.
 
         Parameters
         ----------
@@ -73,6 +73,19 @@ class ResultsWrapper(object):
 
     @classmethod
     def load(cls, fname):
+        """
+        Load a pickled results instance.
+
+        Parameters
+        ----------
+        fname : {str, handle}
+            A string filename or a file handle.
+
+        Returns
+        -------
+        Results
+            The unpickled results instance.
+        """
         from statsmodels.iolib.smpickle import load_pickle
         return load_pickle(fname)
 

--- a/statsmodels/discrete/conditional_models.py
+++ b/statsmodels/discrete/conditional_models.py
@@ -158,10 +158,13 @@ class _ConditionalModel(base.LikelihoodModel):
             If True, the model is refit using only the variables that
             have non-zero coefficients in the regularized fit.  The
             refitted model is not regularized.
+        **kwargs
+            Additional keyword argument that are used when fitting the model.
 
         Returns
         -------
-        An array of parameter estimates.
+        Results
+            A results instance.
         """
 
         from statsmodels.base.elastic_net import fit_elasticnet

--- a/statsmodels/discrete/count_model.py
+++ b/statsmodels/discrete/count_model.py
@@ -100,7 +100,7 @@ class GenericZeroInflated(CountModel):
 
     def loglike(self, params):
         """
-        Loglikelihood of Generic Zero Inflated model
+        Loglikelihood of Generic Zero Inflated model.
 
         Parameters
         ----------
@@ -118,13 +118,12 @@ class GenericZeroInflated(CountModel):
         .. math:: \\ln L=\\sum_{y_{i}=0}\\ln(w_{i}+(1-w_{i})*P_{main\\_model})+
             \\sum_{y_{i}>0}(\\ln(1-w_{i})+L_{main\\_model})
             where P - pdf of main model, L - loglike function of main model.
-
         """
         return np.sum(self.loglikeobs(params))
 
     def loglikeobs(self, params):
         """
-        Loglikelihood for observations of Generic Zero Inflated model
+        Loglikelihood for observations of Generic Zero Inflated model.
 
         Parameters
         ----------
@@ -135,7 +134,7 @@ class GenericZeroInflated(CountModel):
         -------
         loglike : ndarray
             The log likelihood for each observation of the model evaluated
-            at `params`. See Notes
+            at `params`. See Notes for definition.
 
         Notes
         --------
@@ -144,7 +143,6 @@ class GenericZeroInflated(CountModel):
             where P - pdf of main model, L - loglike function of main model.
 
         for observations :math:`i=1,...,n`
-
         """
         params_infl = params[:self.k_inflate]
         params_main = params[self.k_inflate:]

--- a/statsmodels/discrete/discrete_model.py
+++ b/statsmodels/discrete/discrete_model.py
@@ -224,6 +224,7 @@ class DiscreteModel(base.LikelihoodModel):
                         qc_verbose=False, **kwargs):
         """
         Fit the model using a regularized maximum likelihood.
+
         The regularization method AND the solver used is determined by the
         argument method.
 
@@ -245,7 +246,7 @@ class DiscreteModel(base.LikelihoodModel):
             Set to True to print convergence messages.
         fargs : tuple
             Extra arguments passed to the likelihood function, i.e.,
-            loglike(x,*args)
+            loglike(x,*args).
         callback : callable callback(xk)
             Called after each iteration, as callback(xk), where xk is the
             current parameter vector.
@@ -253,21 +254,28 @@ class DiscreteModel(base.LikelihoodModel):
             Set to True to return list of solutions at each iteration.
             Available in Results object's mle_retvals attribute.
         alpha : non-negative scalar or numpy array (same size as parameters)
-            The weight multiplying the l1 penalty term
+            The weight multiplying the l1 penalty term.
         trim_mode : 'auto, 'size', or 'off'
             If not 'off', trim (set to zero) parameters that would have been
             zero if the solver reached the theoretical minimum.
             If 'auto', trim params using the Theory above.
-            If 'size', trim params if they have very small absolute value
+            If 'size', trim params if they have very small absolute value.
         size_trim_tol : float or 'auto' (default = 'auto')
-            For use when trim_mode == 'size'
+            Tolerance used when trim_mode == 'size'.
         auto_trim_tol : float
-            For sue when trim_mode == 'auto'.  Use
+            Tolerance used when trim_mode == 'auto'.
         qc_tol : float
             Print warning and do not allow auto trim when (ii) (above) is
             violated by this much.
         qc_verbose : bool
-            If true, print out a full QC report upon failure
+            If true, print out a full QC report upon failure.
+        **kwargs
+            Additional keyword arguments used when fitting the model.
+
+        Returns
+        -------
+        Results
+            A results instance.
 
         Notes
         -----
@@ -289,7 +297,6 @@ class DiscreteModel(base.LikelihoodModel):
                 refinement : int
                     number of iterative refinement steps when solving KKT
                     equations (default: 1).
-
 
         Optimization methodology
 
@@ -3436,8 +3443,9 @@ class DiscreteResults(base.LikelihoodModelResults):
         """
         return stats.distributions.chi2.sf(self.llr, self.df_model)
 
-    def set_null_options(self, llnull=None, attach_results=True, **kwds):
-        """set fit options for Null (constant-only) model
+    def set_null_options(self, llnull=None, attach_results=True, **kwargs):
+        """
+        Set the fit options for the Null (constant-only) model.
 
         This resets the cache for related attributes which is potentially
         fragile. This only sets the option, the null model is estimated
@@ -3445,7 +3453,7 @@ class DiscreteResults(base.LikelihoodModelResults):
 
         Parameters
         ----------
-        llnull : None or float
+        llnull : {None, float}
             If llnull is not None, then the value will be directly assigned to
             the cached attribute "llnull".
         attach_results : bool
@@ -3453,14 +3461,13 @@ class DiscreteResults(base.LikelihoodModelResults):
             model should be attached. By default without calling this method,
             thenull model results are not attached and only the loglikelihood
             value llnull is stored.
-        kwds : keyword arguments
-            `kwds` are directly used as fit keyword arguments for the null
-            model, overriding any provided defaults.
+        **kwargs
+            Additional keyword arguments used as fit keyword arguments for the
+            null model. The override and model default values.
 
-        Returns
-        -------
-        no returns, modifies attributes of this instance
-
+        Notes
+        -----
+        Modifies attributes of this instance, and so has no return.
         """
         # reset cache, note we need to add here anything that depends on
         # llnullor the null model. If something is missing, then the attribute
@@ -3475,7 +3482,7 @@ class DiscreteResults(base.LikelihoodModelResults):
         if llnull is not None:
             self._cache['llnull'] = llnull
         self._attach_nullmodel = attach_results
-        self._optim_kwds_null = kwds
+        self._optim_kwds_null = kwargs
 
     @cache_readonly
     def llnull(self):
@@ -3629,7 +3636,8 @@ class DiscreteResults(base.LikelihoodModelResults):
 
     def summary(self, yname=None, xname=None, title=None, alpha=.05,
                 yname_list=None):
-        """Summarize the Regression Results
+        """
+        Summarize the Regression Results.
 
         Parameters
         ----------
@@ -3652,7 +3660,7 @@ class DiscreteResults(base.LikelihoodModelResults):
 
         See Also
         --------
-        statsmodels.iolib.summary.Summary : class to hold summary results
+        statsmodels.iolib.summary.Summary : Class that hold summary results.
         """
 
         top_left = [('Dep. Variable:', None),
@@ -3699,7 +3707,8 @@ class DiscreteResults(base.LikelihoodModelResults):
 
     def summary2(self, yname=None, xname=None, title=None, alpha=.05,
                  float_format="%.4f"):
-        """Experimental function to summarize regression results
+        """
+        Experimental function to summarize regression results.
 
         Parameters
         ----------
@@ -3724,7 +3733,7 @@ class DiscreteResults(base.LikelihoodModelResults):
 
         See Also
         --------
-        statsmodels.iolib.summary2.Summary : class to hold summary results
+        statsmodels.iolib.summary2.Summary : Class that holds summary results.
         """
         from statsmodels.iolib import summary2
         smry = summary2.Summary()

--- a/statsmodels/duration/hazard_regression.py
+++ b/statsmodels/duration/hazard_regression.py
@@ -427,7 +427,10 @@ class PHReg(model.LikelihoodModel):
             dependent.  If present, the standard errors account for
             this dependence. Does not affect fitted values.
 
-        Returns a PHregResults instance.
+        Returns
+        -------
+        PHRegResults
+            Returns a results instance.
         """
 
         # TODO process for missing values
@@ -473,10 +476,13 @@ class PHReg(model.LikelihoodModel):
             If True, the model is refit using only the variables that
             have non-zero coefficients in the regularized fit.  The
             refitted model is not regularized.
+        **kwargs
+            Additional keyword arguments used to fit the model.
 
         Returns
         -------
-        A results object.
+        PHRegResults
+            Returns a results instance.
 
         Notes
         -----

--- a/statsmodels/genmod/families/family.py
+++ b/statsmodels/genmod/families/family.py
@@ -32,7 +32,7 @@ class Family(object):
 
     See Also
     --------
-    :ref:`links`
+    :ref:`links` : Further details on links.
     """
     # TODO: change these class attributes, use valid somewhere...
     valid = [-np.inf, np.inf]
@@ -389,8 +389,8 @@ class Poisson(Family):
 
     See Also
     --------
-    statsmodels.genmod.families.family.Family
-    :ref:`links`
+    statsmodels.genmod.families.family.Family : Parent class for all links.
+    :ref:`links` : Further details on links.
     """
     links = [L.log, L.identity, L.sqrt]
     variance = V.mu
@@ -515,8 +515,8 @@ class Gaussian(Family):
 
     See Also
     --------
-    statsmodels.genmod.families.family.Family
-    :ref:`links`
+    statsmodels.genmod.families.family.Family : Parent class for all links.
+    :ref:`links` : Further details on links.
     """
 
     links = [L.log, L.identity, L.inverse_power]
@@ -659,8 +659,8 @@ class Gamma(Family):
 
     See Also
     --------
-    statsmodels.genmod.families.family.Family
-    :ref:`links`
+    statsmodels.genmod.families.family.Family : Parent class for all links.
+    :ref:`links` : Further details on links.
     """
     links = [L.log, L.identity, L.inverse_power]
     variance = V.mu_squared
@@ -793,8 +793,8 @@ class Binomial(Family):
 
     See Also
     --------
-    statsmodels.genmod.families.family.Family
-    :ref:`links`
+    statsmodels.genmod.families.family.Family : Parent class for all links.
+    :ref:`links` : Further details on links.
 
     Notes
     -----
@@ -1032,14 +1032,13 @@ class InverseGaussian(Family):
 
     See Also
     --------
-    statsmodels.genmod.families.family.Family
-    :ref:`links`
+    statsmodels.genmod.families.family.Family : Parent class for all links.
+    :ref:`links` : Further details on links.
 
     Notes
     -----
     The inverse Gaussian distribution is sometimes referred to in the
     literature as the Wald distribution.
-
     """
 
     links = [L.inverse_squared, L.inverse_power, L.identity, L.log]
@@ -1170,8 +1169,8 @@ class NegativeBinomial(Family):
 
     See Also
     --------
-    statsmodels.genmod.families.family.Family
-    :ref:`links`
+    statsmodels.genmod.families.family.Family : Parent class for all links.
+    :ref:`links` : Further details on links.
 
     Notes
     -----
@@ -1360,8 +1359,8 @@ class Tweedie(Family):
 
     See Also
     --------
-    statsmodels.genmod.families.family.Family
-    :ref:`links`
+    statsmodels.genmod.families.family.Family : Parent class for all links.
+    :ref:`links` : Further details on links.
 
     Notes
     -----

--- a/statsmodels/genmod/generalized_linear_model.py
+++ b/statsmodels/genmod/generalized_linear_model.py
@@ -1224,10 +1224,13 @@ class GLM(base.LikelihoodModel):
             If True, the model is refit using only the variables that
             have non-zero coefficients in the regularized fit.  The
             refitted model is not regularized.
+        **kwargs
+            Additional keyword arguments used when fitting the model.
 
         Returns
         -------
-        An array, or a GLMResults object of the same type returned by `fit`.
+        GLMResults
+            An array or a GLMResults object, same type returned by `fit`.
 
         Notes
         -----

--- a/statsmodels/graphics/factorplots.py
+++ b/statsmodels/graphics/factorplots.py
@@ -53,7 +53,7 @@ def interaction_plot(x, trace, response, func=np.mean, ax=None, plottype='b',
         If given, must have length == number of levels in trace.
     markers : list, optional
         If given, must have length == number of levels in trace
-    kwargs
+    **kwargs
         These will be passed to the plot command used either plot or scatter.
         If you want to control the overall plotting options, use kwargs.
 

--- a/statsmodels/graphics/regressionplots.py
+++ b/statsmodels/graphics/regressionplots.py
@@ -88,7 +88,7 @@ def plot_fit(results, exog_idx, y_true=None, ax=None, **kwargs):
     ax : Matplotlib AxesSubplot instance, optional
         If given, this subplot is used to plot in instead of a new figure being
         created.
-    kwargs
+    **kwargs
         The keyword arguments are passed to the plot command for the fitted
         values points.
 
@@ -330,7 +330,7 @@ def plot_partregress(endog, exog_i, exog_others, data=None,
     ret_coords : bool
         If True will return the coordinates of the points in the plot. You
         can use this to add your own annotations.
-    kwargs
+    **kwargs
         The keyword arguments passed to plot for the points.
 
     Returns
@@ -752,7 +752,7 @@ def abline_plot(intercept=None, slope=None, horiz=None, vert=None,
         is (intercept, slope)
     ax : axes, optional
         Matplotlib axes instance
-    kwargs
+    **kwargs
         Options passed to matplotlib.pyplot.plt
 
     Returns

--- a/statsmodels/regression/linear_model.py
+++ b/statsmodels/regression/linear_model.py
@@ -84,18 +84,6 @@ _fit_regularized_doc =\
             If True, the model is refit using only the variables that
             have non-zero coefficients in the regularized fit.  The
             refitted model is not regularized.
-        distributed : bool
-            If True, the model uses distributed methods for fitting,
-            will raise an error if True and partitions is None.
-        generator : function
-            The generator used to partition the model, allows for handling
-            of out of memory/parallel computing.
-        partitions : scalar
-            The number of partitions desired for the distributed
-            estimation.
-        threshold : scalar or array_like
-            The threshold below which coefficients are zeroed out,
-            only used for distributed estimation.
         **kwargs
             Additional keyword arguments that contain information used when
             constructing a model using the formula interface.
@@ -245,6 +233,7 @@ class RegressionModel(base.LikelihoodModel):
         self._df_resid = value
 
     def whiten(self, x):
+        """Must be overwritten by individual models."""
         raise NotImplementedError("Subclasses should implement.")
 
     def fit(self, method="pinv", cov_type='nonrobust', cov_kwds=None,
@@ -1625,7 +1614,7 @@ class RegressionResults(base.LikelihoodModelResults):
     @cache_readonly
     def wresid(self):
         """
-        The residuals of the transformed/whitened regressand and regressor(s)
+        The residuals of the transformed/whitened regressand and regressor(s).
         """
         return self.model.wendog - self.model.predict(
             self.params, self.model.wexog)
@@ -1804,7 +1793,7 @@ class RegressionResults(base.LikelihoodModelResults):
 
     @cache_readonly
     def f_pvalue(self):
-        """p-value of the F-statistic"""
+        """The p-value of the F-statistic."""
         return stats.f.sf(self.fvalue, self.df_model, self.df_resid)
 
     @cache_readonly

--- a/statsmodels/stats/contrast.py
+++ b/statsmodels/stats/contrast.py
@@ -596,7 +596,7 @@ def _constraints_factor(encoding_matrix, comparison='pairwise', k_params=None,
 def t_test_pairwise(result, term_name, method='hs', alpha=0.05,
                     factor_labels=None, ignore=False):
     """
-    Perform pairwise t_test with multiple testing corrected p-values
+    Perform pairwise t_test with multiple testing corrected p-values.
 
     This uses the formula design_info encoding contrast matrix and should
     work for all encodings of a main effect.

--- a/statsmodels/tsa/_stl.pyx
+++ b/statsmodels/tsa/_stl.pyx
@@ -101,11 +101,11 @@ def _is_pos_int(x, odd):
 
 cdef class STL(object):
     """
-    STL(y, period=None, seasonal=7, trend=None, low_pass=None, seasonal_deg=0,
-        trend_deg=0, low_pass_deg=0, robust=False, seasonal_jump=1,
-        trend_jump=1, low_pass_jump=1)
+    STL(endog, period=None, seasonal=7, trend=None, low_pass=None,
+        seasonal_deg=0, trend_deg=0, low_pass_deg=0, robust=False,
+        seasonal_jump=1, trend_jump=1, low_pass_jump=1)
 
-    Season-Trend decomposition using LOESS
+    Season-Trend decomposition using LOESS.
 
     Parameters
     ----------
@@ -126,26 +126,29 @@ cdef class STL(object):
         Length of the low-pass filter. Must be an odd integer >=3. If not
         provided, uses the smallest odd integer > period.
     seasonal_deg : int, optional
-        Degree of seasonal LOESS. 0 (constant) or 1 (constant and trend)
+        Degree of seasonal LOESS. 0 (constant) or 1 (constant and trend).
     trend_deg : int, optional
-        Degree of trend LOESS. 0 (constant) or 1 (constant and trend)
+        Degree of trend LOESS. 0 (constant) or 1 (constant and trend).
     low_pass_deg : int, optional
-        Degree of low pass LOESS. 0 (constant) or 1 (constant and trend)
+        Degree of low pass LOESS. 0 (constant) or 1 (constant and trend).
     robust : bool, optional
         Flag indicating whether to use a weighted version that is robust to
-        some forms of outliers
+        some forms of outliers.
     seasonal_jump : int, optional
         Positive integer determining the linear interpolation step. If larger
-        than 1, the LOESS is used every seasonal_jump points and values between
-        the two are linearly interpolated. Higher values reduce estimation time
+        than 1, the LOESS is used every seasonal_jump points and linear
+        interpolation is between fitted points. Higher values reduce
+        estimation time.
     trend_jump : int, optional
         Positive integer determining the linear interpolation step. If larger
         than 1, the LOESS is used every trend_jump points and values between
-        the two are linearly interpolated. Higher values reduce estimation time
+        the two are linearly interpolated. Higher values reduce estimation
+        time.
     low_pass_jump : int, optional
         Positive integer determining the linear interpolation step. If larger
         than 1, the LOESS is used every low_pass_jump points and values between
-        the two are linearly interpolated. Higher values reduce estimation time
+        the two are linearly interpolated. Higher values reduce estimation
+        time.
 
     See Also
     --------

--- a/statsmodels/tsa/arima_model.py
+++ b/statsmodels/tsa/arima_model.py
@@ -910,7 +910,7 @@ matches the number of out-of-sample forecasts ({1})'
             an AR process according to best BIC. If start_ar_lags is not None,
             fits an AR process with a lag length equal to start_ar_lags.
             See ARMA._fit_start_params_hr for more information.
-        kwargs
+        **kwargs
             See Notes for keyword arguments that can be passed to fit.
 
         Returns
@@ -1178,7 +1178,7 @@ class ARIMA(ARMA):
             an AR process according to best BIC. If start_ar_lags is not None,
             fits an AR process with a lag length equal to start_ar_lags.
             See ARMA._fit_start_params_hr for more information.
-        kwargs
+        **kwargs
             See Notes for keyword arguments that can be passed to fit.
 
         Returns

--- a/statsmodels/tsa/seasonal.py
+++ b/statsmodels/tsa/seasonal.py
@@ -60,16 +60,16 @@ def seasonal_mean(x, period):
 def seasonal_decompose(x, model="additive", filt=None, period=None,
                        two_sided=True, extrapolate_trend=0):
     """
-    Seasonal decomposition using moving averages
+    Seasonal decomposition using moving averages.
 
     Parameters
     ----------
     x : array_like
         Time series. If 2d, individual series are in columns. x must contain 2
         complete cycles.
-    model : str {"additive", "multiplicative"}
+    model : {"additive", "multiplicative"}, optional
         Type of seasonal component. Abbreviations are accepted.
-    filt : array_like
+    filt : array_like, optional
         The filter coefficients for filtering out the seasonal component.
         The concrete moving average method used in filtering is determined by
         two_sided.
@@ -77,7 +77,7 @@ def seasonal_decompose(x, model="additive", filt=None, period=None,
         Period of the series. Must be used if x is not a pandas object or if
         the index of x does not have  a frequency. Overrides default
         periodicity of x if x is a pandas object with a timeseries index.
-    two_sided : bool
+    two_sided : bool, optional
         The moving average method used in filtering.
         If True (default), a centered moving average is computed using the
         filt. If False, the filter coefficients are for past values only.
@@ -90,7 +90,7 @@ def seasonal_decompose(x, model="additive", filt=None, period=None,
 
     Returns
     -------
-    results : DecomposeResult
+    DecomposeResult
         A object with seasonal, trend, and resid attributes.
 
     See Also

--- a/statsmodels/tsa/statespace/mlemodel.py
+++ b/statsmodels/tsa/statespace/mlemodel.py
@@ -759,7 +759,7 @@ class MLEModel(tsbase.TimeSeriesModel):
             function.
         transformed : bool, optional
             Whether or not `params` is already transformed. Default is True.
-        kwargs
+        **kwargs
             Additional keyword arguments to pass to the Kalman filter. See
             `KalmanFilter.filter` for more details.
 
@@ -1184,9 +1184,9 @@ class MLEModel(tsbase.TimeSeriesModel):
         ----------
         params : array_like
             Array of parameters at which to evaluate the score.
-        args
+        *args
             Additional positional arguments to the `loglike` method.
-        kwargs
+        **kwargs
             Additional keyword arguments to the `loglike` method.
 
         Returns
@@ -1255,7 +1255,7 @@ class MLEModel(tsbase.TimeSeriesModel):
         ----------
         params : array_like
             Array of parameters at which to evaluate the score.
-        kwargs
+        **kwargs
             Additional arguments to the `loglike` method.
 
         Returns
@@ -1314,9 +1314,9 @@ class MLEModel(tsbase.TimeSeriesModel):
         ----------
         params : array_like
             Array of parameters at which to evaluate the hessian.
-        args
+        *args
             Additional positional arguments to the `loglike` method.
-        kwargs
+        **kwargs
             Additional keyword arguments to the `loglike` method.
 
         Returns

--- a/statsmodels/tsa/statespace/varmax.py
+++ b/statsmodels/tsa/statespace/varmax.py
@@ -67,7 +67,7 @@ class VARMAX(MLEModel):
         The offset at which to start time trend values. Default is 1, so that
         if `trend='t'` the trend is equal to 1, 2, ..., nobs. Typically is only
         set when the model created by extending a previous dataset.
-    kwargs
+    **kwargs
         Keyword arguments may be used to provide default values for state space
         matrices or for Kalman filtering options. See `Representation`, and
         `KalmanFilter` for more details.
@@ -876,7 +876,7 @@ class VARMAXResults(MLEResults):
             prediction; starting with this observation and continuing through
             the end of prediction, forecasted endogenous values will be used
             instead.
-        kwargs
+        **kwargs
             Additional arguments may required for forecasting beyond the end
             of the sample. See `FilterResults.predict` for more details.
 

--- a/statsmodels/tsa/stattools.py
+++ b/statsmodels/tsa/stattools.py
@@ -128,7 +128,7 @@ def _autolag(mod, endog, exog, startlag, maxlag, method, modargs=(),
 def adfuller(x, maxlag=None, regression="c", autolag='AIC',
              store=False, regresults=False):
     """
-    Augmented Dickey-Fuller unit root test
+    Augmented Dickey-Fuller unit root test.
 
     The Augmented Dickey-Fuller test can be used to test for a unit root in a
     univariate process in the presence of serial correlation.
@@ -136,17 +136,20 @@ def adfuller(x, maxlag=None, regression="c", autolag='AIC',
     Parameters
     ----------
     x : array_like, 1d
-        data series
+        The data series to test.
     maxlag : int
-        Maximum lag which is included in test, default 12*(nobs/100)^{1/4}
+        Maximum lag which is included in test, default 12*(nobs/100)^{1/4}.
     regression : {'c','ct','ctt','nc'}
-        Constant and trend order to include in regression
+        Constant and trend order to include in regression.
 
         * 'c' : constant only (default)
         * 'ct' : constant and trend
         * 'ctt' : constant, and linear and quadratic trend
         * 'nc' : no constant, no trend
+
     autolag : {'AIC', 'BIC', 't-stat', None}
+        Method to use when automatically determining the lag.
+
         * if None, then maxlag lags are used
         * if 'AIC' (default) or 'BIC', then the number of lags is chosen
           to minimize the corresponding information criterion
@@ -155,28 +158,28 @@ def adfuller(x, maxlag=None, regression="c", autolag='AIC',
           using a 5%-sized test
     store : bool
         If True, then a result instance is returned additionally to
-        the adf statistic. Default is False
+        the adf statistic. Default is False.
     regresults : bool, optional
-        If True, the full regression results are returned. Default is False
+        If True, the full regression results are returned. Default is False.
 
     Returns
     -------
     adf : float
-        Test statistic
+        The test statistic.
     pvalue : float
-        MacKinnon's approximate p-value based on MacKinnon (1994, 2010)
+        MacKinnon's approximate p-value based on MacKinnon (1994, 2010).
     usedlag : int
-        Number of lags used
+        The number of lags used.
     nobs : int
-        Number of observations used for the ADF regression and calculation of
-        the critical values
+        The number of observations used for the ADF regression and calculation
+        of the critical values.
     critical values : dict
         Critical values for the test statistic at the 1 %, 5 %, and 10 %
-        levels. Based on MacKinnon (2010)
+        levels. Based on MacKinnon (2010).
     icbest : float
         The maximized information criterion if autolag is not None.
     resstore : ResultStore, optional
-        A dummy class with results attached as attributes
+        A dummy class with results attached as attributes.
 
     Notes
     -----
@@ -191,10 +194,6 @@ def adfuller(x, maxlag=None, regression="c", autolag='AIC',
 
     The autolag option and maxlag for it are described in Greene.
 
-    Examples
-    --------
-    See example notebook
-
     References
     ----------
     .. [*] W. Green.  "Econometric Analysis," 5th ed., Pearson, 2003.
@@ -208,6 +207,10 @@ def adfuller(x, maxlag=None, regression="c", autolag='AIC',
     .. [*] MacKinnon, J.G. 2010. "Critical Values for Cointegration Tests."  Queen's
         University, Dept of Economics, Working Papers.  Available at
         http://ideas.repec.org/p/qed/wpaper/1227.html
+
+    Examples
+    --------
+    See example notebook
     """
     x = array_like(x, 'x')
     maxlag = int_like(maxlag, 'maxlag', optional=True)

--- a/statsmodels/tsa/vector_ar/var_model.py
+++ b/statsmodels/tsa/vector_ar/var_model.py
@@ -1296,8 +1296,6 @@ class VARResults(VARProcess):
             not count the zero lag, which will be returned.
         linewidth : int
             The linewidth for the plots.
-        plot_kwargs : kwargs
-            Will be passed to `matplotlib.pyplot.axvlines`
 
         Returns
         -------


### PR DESCRIPTION
Fix more docstrings

- [ ] closes #xxxx
- [ ] tests added / passed. 
- [ ] code/documentation is well formatted.  
- [ ] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
