### PR TITLE
DOC: Fix doc errrors affecting build

### DIFF
--- a/docs/source/examples/index.rst
+++ b/docs/source/examples/index.rst
@@ -46,6 +46,7 @@ We also encourage users to submit their own examples, tutorials or cool
    notebooks/generated/regression_plots
    notebooks/generated/robust_models_0
    notebooks/generated/robust_models_1
+   notebooks/generated/rolling_ls
    notebooks/generated/statespace_arma_0
    notebooks/generated/statespace_concentrated_scale
    notebooks/generated/statespace_cycles


### PR DESCRIPTION
Avoid repeat of docstring in ARResults.predict
Add missign notebook to build

- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
