### PR TITLE
MAINT: Stop testing on old, bugy SciPy

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -12,7 +12,6 @@ graft statsmodels/datasets
 graft statsmodels/sandbox/regression/data
 graft statsmodels/sandbox/tests
 graft statsmodels/sandbox/tsa/examples
-graft statsmodels/tsa/vector_ar/data
 recursive-include docs/source *
 exclude docs/source/generated/*
 recursive-include docs/sphinxext *

--- a/statsmodels/compat/scipy.py
+++ b/statsmodels/compat/scipy.py
@@ -1,4 +1,10 @@
+from distutils.version import LooseVersion
+
 import numpy as np
+import scipy
+
+SCIPY_11 = (LooseVersion(scipy.__version__) < LooseVersion('1.2.0') and
+            LooseVersion(scipy.__version__) >= LooseVersion('1.1.0'))
 
 
 def _next_regular(target):

--- a/statsmodels/tests/test_package.py
+++ b/statsmodels/tests/test_package.py
@@ -1,6 +1,9 @@
 import subprocess
 
+import pytest
+
 from statsmodels.compat.platform import PLATFORM_WIN
+from statsmodels.compat.scipy import SCIPY_11
 
 
 def test_lazy_imports():
@@ -19,6 +22,7 @@ def test_lazy_imports():
     assert rc == 0
 
 
+@pytest.mark.skipif(SCIPY_11, reason='SciPy raises on -OO')
 def test_docstring_optimization_compat():
     # GH#5235 check that importing with stripped docstrings doesn't raise
     p = subprocess.Popen('python -OO -c "import statsmodels.api as sm"',


### PR DESCRIPTION
Prevent -OO test from running on buggy scipy

- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
