### PR TITLE
BUG: Fix ARMA so that it works with exog when trend=nc

### DIFF
--- a/statsmodels/tsa/arima_model.py
+++ b/statsmodels/tsa/arima_model.py
@@ -21,7 +21,7 @@ from statsmodels.regression.linear_model import yule_walker, OLS
 from statsmodels.tools.decorators import cache_readonly
 from statsmodels.tools.numdiff import approx_hess_cs, approx_fprime_cs
 from statsmodels.tools.sm_exceptions import SpecificationWarning
-from statsmodels.tools.validation import array_like
+from statsmodels.tools.validation import array_like, string_like
 from statsmodels.tsa.ar_model import AR
 from statsmodels.tsa.arima_process import arma2ma
 from statsmodels.tsa.base import tsa_model
@@ -422,12 +422,7 @@ def _make_arma_exog(endog, exog, trend):
         exog = np.ones((len(endog), 1))
     elif exog is not None and trend == 'c':  # constant plus exogenous
         exog = add_trend(exog, trend='c', prepend=True, has_constant='raise')
-    elif exog is not None and trend == 'nc':
-        # make sure it's not holding constant from last run
-        if exog.var() == 0:
-            exog = None
-        k_trend = 0
-    if trend == 'nc':
+    elif trend == 'nc':
         k_trend = 0
     return k_trend, exog
 
@@ -931,6 +926,7 @@ matches the number of out-of-sample forecasts ({1})'
         r, order = 'F')
 
         """
+        trend = string_like(trend, 'trend', options=('nc', 'c'))
         if self._fit_params is not None:
             fp = (trend, method)
             if self._fit_params != fp:

--- a/statsmodels/tsa/tests/test_arima.py
+++ b/statsmodels/tsa/tests/test_arima.py
@@ -2734,3 +2734,10 @@ def test_nan_exog_arima_d1():
     x.iloc[0] = np.nan
     with pytest.raises(MissingDataError):
         ARIMA(y, (0, 1, 1), exog=x)
+
+
+def test_arma_exog_const_trend_nc(reset_randomstate):
+    y = np.random.randn(1000)
+    x = np.ones((1000, 1))
+    res = ARMA(y, (2, 1), exog=x).fit(trend='nc')
+    assert res.params.shape[0] == 4


### PR DESCRIPTION
Remove legacy hack that changed exog structure

- [X] tests added / passed. 
- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
