### PR TITLE
ENH: state space: Improve low memory usability; allow in fit, loglike

### DIFF
--- a/statsmodels/tsa/statespace/_kalman_smoother.pyx.in
+++ b/statsmodels/tsa/statespace/_kalman_smoother.pyx.in
@@ -253,7 +253,7 @@ cdef class {{prefix}}KalmanSmoother(object):
 
         # Make sure the appropriate output has been stored in the filter
         if self.kfilter.conserve_memory & MEMORY_NO_PREDICTED:
-            raise ValueError('Cannot perform smoothing without all prediced states')
+            raise ValueError('Cannot perform smoothing without all predicted states')
 
         if self.kfilter.conserve_memory & MEMORY_NO_GAIN:
             raise ValueError('Cannot perform smoothing without all Kalman gains')

--- a/statsmodels/tsa/statespace/dynamic_factor.py
+++ b/statsmodels/tsa/statespace/dynamic_factor.py
@@ -948,7 +948,7 @@ class DynamicFactorResults(MLEResults):
     statsmodels.tsa.statespace.kalman_filter.FilterResults
     statsmodels.tsa.statespace.mlemodel.MLEResults
     """
-    def __init__(self, model, params, filter_results, cov_type='opg',
+    def __init__(self, model, params, filter_results, cov_type=None,
                  **kwargs):
         super(DynamicFactorResults, self).__init__(model, params,
                                                    filter_results, cov_type,

--- a/statsmodels/tsa/statespace/sarimax.py
+++ b/statsmodels/tsa/statespace/sarimax.py
@@ -1688,7 +1688,7 @@ class SARIMAXResults(MLEResults):
     statsmodels.tsa.statespace.kalman_filter.FilterResults
     statsmodels.tsa.statespace.mlemodel.MLEResults
     """
-    def __init__(self, model, params, filter_results, cov_type='opg',
+    def __init__(self, model, params, filter_results, cov_type=None,
                  **kwargs):
         super(SARIMAXResults, self).__init__(model, params, filter_results,
                                              cov_type, **kwargs)

--- a/statsmodels/tsa/statespace/structural.py
+++ b/statsmodels/tsa/statespace/structural.py
@@ -1127,7 +1127,7 @@ class UnobservedComponentsResults(MLEResults):
     statsmodels.tsa.statespace.mlemodel.MLEResults
     """
 
-    def __init__(self, model, params, filter_results, cov_type='opg',
+    def __init__(self, model, params, filter_results, cov_type=None,
                  **kwargs):
         super(UnobservedComponentsResults, self).__init__(
             model, params, filter_results, cov_type, **kwargs)

--- a/statsmodels/tsa/statespace/tests/test_prediction.py
+++ b/statsmodels/tsa/statespace/tests/test_prediction.py
@@ -10,7 +10,7 @@ import numpy as np
 import pandas as pd
 
 from statsmodels.tsa.statespace import sarimax
-from numpy.testing import assert_equal, assert_raises, assert_allclose
+from numpy.testing import assert_equal, assert_raises, assert_allclose, assert_
 
 
 def test_predict_dates():
@@ -69,9 +69,9 @@ def test_memory_no_predicted():
 
     # Make sure we really didn't store all of the values in res2
     assert_equal(res1.predicted_state.shape, (1, 5))
-    assert_equal(res2.predicted_state.shape, (1, 3))
+    assert_(res2.predicted_state is None)
     assert_equal(res1.predicted_state_cov.shape, (1, 1, 5))
-    assert_equal(res2.predicted_state_cov.shape, (1, 1, 3))
+    assert_(res2.predicted_state_cov is None)
 
     # Check that we can't do in-sample prediction
     assert_raises(ValueError, res2.predict)

--- a/statsmodels/tsa/statespace/tests/test_representation.py
+++ b/statsmodels/tsa/statespace/tests/test_representation.py
@@ -263,7 +263,7 @@ class TestClark1987ConserveAll(Clark1987):
 
     def test_loglike(self):
         assert_almost_equal(
-            self.results.llf_obs[0], self.true['loglike'], 5
+            self.results.llf, self.true['loglike'], 5
         )
 
     def test_filtered_state(self):
@@ -497,7 +497,7 @@ class TestClark1989ConserveAll(Clark1989):
 
     def test_loglike(self):
         assert_almost_equal(
-            self.results.llf_obs[0], self.true['loglike'], 2
+            self.results.llf, self.true['loglike'], 2
         )
 
     def test_filtered_state(self):
@@ -861,7 +861,6 @@ def test_loglike():
 
     # Test that self.memory_no_likelihood = True raises an error
     mod.memory_no_likelihood = True
-    assert_raises(RuntimeError, mod.loglike)
     assert_raises(RuntimeError, mod.loglikeobs)
 
 

--- a/statsmodels/tsa/statespace/varmax.py
+++ b/statsmodels/tsa/statespace/varmax.py
@@ -778,7 +778,7 @@ class VARMAXResults(MLEResults):
     statsmodels.tsa.statespace.kalman_filter.FilterResults
     statsmodels.tsa.statespace.mlemodel.MLEResults
     """
-    def __init__(self, model, params, filter_results, cov_type='opg',
+    def __init__(self, model, params, filter_results, cov_type=None,
                  cov_kwds=None, **kwargs):
         super(VARMAXResults, self).__init__(model, params, filter_results,
                                             cov_type, cov_kwds, **kwargs)


### PR DESCRIPTION
- [x] helps improve #6034
- [x] tests added / passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message.

This PR improves the usability of memory conservation in state space models. In particular, we can now use maximum memory conservation in combination with `fit` and (since #6064 was merged) out-of-sample forecasting.