### PR TITLE
ENH: Improve cov_params in append, extend, apply

### DIFF
--- a/statsmodels/tsa/statespace/tests/test_dynamic_factor.py
+++ b/statsmodels/tsa/statespace/tests/test_dynamic_factor.py
@@ -873,8 +873,8 @@ def test_append_results():
 
     assert_equal(res1.specification, res3.specification)
 
-    for attr in ['nobs', 'llf', 'llf_obs', 'loglikelihood_burn',
-                 'cov_params_default']:
+    assert_allclose(res3.cov_params_default, res2.cov_params_default)
+    for attr in ['nobs', 'llf', 'llf_obs', 'loglikelihood_burn']:
         assert_equal(getattr(res3, attr), getattr(res1, attr))
 
     for attr in [
@@ -951,8 +951,8 @@ def test_apply_results():
 
     assert_equal(res1.specification, res3.specification)
 
-    for attr in ['nobs', 'llf', 'llf_obs', 'loglikelihood_burn',
-                 'cov_params_default']:
+    assert_allclose(res3.cov_params_default, res2.cov_params_default)
+    for attr in ['nobs', 'llf', 'llf_obs', 'loglikelihood_burn']:
         assert_equal(getattr(res3, attr), getattr(res1, attr))
 
     for attr in [

--- a/statsmodels/tsa/statespace/tests/test_mlemodel.py
+++ b/statsmodels/tsa/statespace/tests/test_mlemodel.py
@@ -1016,3 +1016,26 @@ def test_lutkepohl_information_criteria():
     bic = res.info_criteria('bic') - 6 * np.log(res.nobs_effective)
     assert_allclose(aic, true['estat_aic'])
     assert_allclose(bic, true['estat_bic'])
+
+
+def test_append_extend_apply_invalid():
+    # Test for invalid options to append, extend, and apply
+    niledata = nile.data.load_pandas().data['volume']
+    niledata.index = pd.date_range('1871-01-01', '1970-01-01', freq='AS')
+
+    endog1 = niledata.iloc[:20]
+    endog2 = niledata.iloc[20:40]
+
+    mod = sarimax.SARIMAX(endog1, order=(1, 0, 0), concentrate_scale=True)
+    res1 = mod.smooth([0.5])
+
+    assert_raises(ValueError, res1.append, endog2,
+                  fit_kwargs={'cov_type': 'approx'})
+    assert_raises(ValueError, res1.extend, endog2,
+                  fit_kwargs={'cov_type': 'approx'})
+    assert_raises(ValueError, res1.apply, endog2,
+                  fit_kwargs={'cov_type': 'approx'})
+
+    assert_raises(ValueError, res1.append, endog2, fit_kwargs={'cov_kwds': {}})
+    assert_raises(ValueError, res1.extend, endog2, fit_kwargs={'cov_kwds': {}})
+    assert_raises(ValueError, res1.apply, endog2, fit_kwargs={'cov_kwds': {}})

--- a/statsmodels/tsa/statespace/tests/test_sarimax.py
+++ b/statsmodels/tsa/statespace/tests/test_sarimax.py
@@ -2518,8 +2518,8 @@ def test_append_results():
 
     assert_equal(res1.specification, res3.specification)
 
-    for attr in ['nobs', 'llf', 'llf_obs', 'loglikelihood_burn',
-                 'cov_params_default']:
+    assert_allclose(res3.cov_params_default, res2.cov_params_default)
+    for attr in ['nobs', 'llf', 'llf_obs', 'loglikelihood_burn']:
         assert_equal(getattr(res3, attr), getattr(res1, attr))
 
     for attr in [
@@ -2596,8 +2596,8 @@ def test_apply_results():
 
     assert_equal(res1.specification, res3.specification)
 
-    for attr in ['nobs', 'llf', 'llf_obs', 'loglikelihood_burn',
-                 'cov_params_default']:
+    assert_allclose(res3.cov_params_default, res2.cov_params_default)
+    for attr in ['nobs', 'llf', 'llf_obs', 'loglikelihood_burn']:
         assert_equal(getattr(res3, attr), getattr(res1, attr))
 
     for attr in [

--- a/statsmodels/tsa/statespace/tests/test_structural.py
+++ b/statsmodels/tsa/statespace/tests/test_structural.py
@@ -557,8 +557,8 @@ def test_append_results():
 
     assert_equal(res1.specification, res3.specification)
 
-    for attr in ['nobs', 'llf', 'llf_obs', 'loglikelihood_burn',
-                 'cov_params_default']:
+    assert_allclose(res3.cov_params_default, res2.cov_params_default)
+    for attr in ['nobs', 'llf', 'llf_obs', 'loglikelihood_burn']:
         assert_equal(getattr(res3, attr), getattr(res1, attr))
 
     for attr in [
@@ -632,8 +632,8 @@ def test_apply_results():
 
     assert_equal(res1.specification, res3.specification)
 
-    for attr in ['nobs', 'llf', 'llf_obs', 'loglikelihood_burn',
-                 'cov_params_default']:
+    assert_allclose(res3.cov_params_default, res2.cov_params_default)
+    for attr in ['nobs', 'llf', 'llf_obs', 'loglikelihood_burn']:
         assert_equal(getattr(res3, attr), getattr(res1, attr))
 
     for attr in [

--- a/statsmodels/tsa/statespace/tests/test_varmax.py
+++ b/statsmodels/tsa/statespace/tests/test_varmax.py
@@ -1028,8 +1028,8 @@ def test_append_results():
 
     assert_equal(res1.specification, res3.specification)
 
-    for attr in ['nobs', 'llf', 'llf_obs', 'loglikelihood_burn',
-                 'cov_params_default']:
+    assert_allclose(res3.cov_params_default, res2.cov_params_default)
+    for attr in ['nobs', 'llf', 'llf_obs', 'loglikelihood_burn']:
         assert_equal(getattr(res3, attr), getattr(res1, attr))
 
     for attr in [
@@ -1108,8 +1108,8 @@ def test_apply_results():
 
     assert_equal(res1.specification, res3.specification)
 
-    for attr in ['nobs', 'llf', 'llf_obs', 'loglikelihood_burn',
-                 'cov_params_default']:
+    assert_allclose(res3.cov_params_default, res2.cov_params_default)
+    for attr in ['nobs', 'llf', 'llf_obs', 'loglikelihood_burn']:
         assert_equal(getattr(res3, attr), getattr(res1, attr))
 
     for attr in [


### PR DESCRIPTION
- [x] closes #6047
- [x] tests added / passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message

For `append`, `extend`, and `apply`, this passes the `cov_params` to the new results objects and adds a note to the bottom of summary output that parameters and cov_params were not estimated based on the current dataset.

Also makes available `fit_kwargs` to each of the methods.