### PR TITLE
DOC: Improve regression doc strings

### DIFF
--- a/docs/source/spelling_wordlist.txt
+++ b/docs/source/spelling_wordlist.txt
@@ -2259,3 +2259,4 @@ statawriter
 Nonparameteric
 exceedance
 separatevar
+OaxacaResults

--- a/examples/notebooks/formulas.ipynb
+++ b/examples/notebooks/formulas.ipynb
@@ -127,7 +127,7 @@
     "\n",
     "## OLS regression using formulas\n",
     "\n",
-    "To begin, we fit the linear model described on the [Getting Started](/gettingstarted.html) page. Download the data, subset columns, and list-wise delete to remove missing observations:"
+    "To begin, we fit the linear model described on the [Getting Started](./gettingstarted.html) page. Download the data, subset columns, and list-wise delete to remove missing observations:"
    ]
   },
   {
@@ -200,7 +200,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Patsy's mode advanced features for categorical variables are discussed in: [Patsy: Contrast Coding Systems for categorical variables](/examples/notebooks/generated/contrasts.html)"
+    "Patsy's mode advanced features for categorical variables are discussed in: [Patsy: Contrast Coding Systems for categorical variables](./contrasts.html)"
    ]
   },
   {

--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -252,6 +252,15 @@ class LikelihoodModel(Model):
     def loglike(self, params):
         """
         Log-likelihood of model.
+
+        Parameters
+        ----------
+        params : ndarray
+            The model parameters used to compute the log-likelihood.
+
+        Notes
+        -----
+        Must be overridden by subclasses.
         """
         raise NotImplementedError
 
@@ -983,9 +992,18 @@ class Results(object):
         self.initialize(model, params, **kwd)
         self._data_attr = []
 
-    def initialize(self, model, params, **kwd):
+    def initialize(self, model, params, **kwargs):
         """
         Initialize (possibly re-initialize) a Results instance.
+
+        Parameters
+        ----------
+        model : Model
+            The model instance.
+        params : ndarray
+            The model parameters.
+        **kwargs
+            Any additional keyword arguments required to initialize the model.
         """
         self.params = params
         self.model = model
@@ -1016,7 +1034,7 @@ class Results(object):
 
         Returns
         -------
-        prediction : {ndarray, Series, DataFrame}
+        array_like
             See self.model.predict.
 
         Notes

--- a/statsmodels/base/wrapper.py
+++ b/statsmodels/base/wrapper.py
@@ -1,7 +1,8 @@
-import inspect
-import functools
-
 from statsmodels.compat.python import iteritems
+
+import functools
+import inspect
+from textwrap import dedent
 
 
 class ResultsWrapper(object):
@@ -43,11 +44,11 @@ class ResultsWrapper(object):
         return obj
 
     def __getstate__(self):
-        #print 'pickling wrapper', self.__dict__
+        # print 'pickling wrapper', self.__dict__
         return self.__dict__
 
     def __setstate__(self, dict_):
-        #print 'unpickling wrapper', dict_
+        # print 'unpickling wrapper', dict_
         self.__dict__.update(dict_)
 
     def save(self, fname, remove_data=False):
@@ -111,7 +112,8 @@ def make_wrapper(func, how):
     sig = inspect.signature(func)
     formatted = str(sig)
 
-    wrapper.__doc__ = "%s%s\n%s" % (func.__name__, formatted, wrapper.__doc__)
+    doc = dedent(wrapper.__doc__) if wrapper.__doc__ else ''
+    wrapper.__doc__ = "\n%s%s\n%s" % (func.__name__, formatted, doc)
 
     return wrapper
 

--- a/statsmodels/graphics/regressionplots.py
+++ b/statsmodels/graphics/regressionplots.py
@@ -739,27 +739,29 @@ def plot_ccpr_grid(results, exog_idx=None, grid=None, fig=None):
 def abline_plot(intercept=None, slope=None, horiz=None, vert=None,
                 model_results=None, ax=None, **kwargs):
     """
-    Plots a line given an intercept and slope.
+    Plot a line given an intercept and slope.
 
+    Parameters
+    ----------
     intercept : float
-        The intercept of the line
+        The intercept of the line.
     slope : float
-        The slope of the line
+        The slope of the line.
     horiz : float or array_like
-        Data for horizontal lines on the y-axis
+        Data for horizontal lines on the y-axis.
     vert : array_like
-        Data for verterical lines on the x-axis
+        Data for verterical lines on the x-axis.
     model_results : statsmodels results instance
         Any object that has a two-value `params` attribute. Assumed that it
-        is (intercept, slope)
+        is (intercept, slope).
     ax : axes, optional
-        Matplotlib axes instance
+        Matplotlib axes instance.
     **kwargs
-        Options passed to matplotlib.pyplot.plt
+        Options passed to matplotlib.pyplot.plt.
 
     Returns
     -------
-    fig : Figure
+    Figure
         The figure given by `ax.figure` or a new instance.
 
     Examples
@@ -779,7 +781,6 @@ def abline_plot(intercept=None, slope=None, horiz=None, vert=None,
     >>> plt.show()
 
     .. plot:: plots/graphics_regression_abline.py
-
     """
     if ax is not None:  # get axis limits first thing, do not change these
         x = ax.get_xlim()

--- a/statsmodels/regression/_prediction.py
+++ b/statsmodels/regression/_prediction.py
@@ -14,7 +14,23 @@ from scipy import stats
 # this is similar to ContrastResults after t_test, copied and adjusted
 class PredictionResults(object):
     """
-    Results class for predictions
+    Results class for predictions.
+
+    Parameters
+    ----------
+    predicted_mean : ndarray
+        The array containing the prediction means.
+    var_pred_mean : ndarray
+        The array of the variance of the prediction means.
+    var_resid : ndarray
+        The array of residual variances.
+    df : int
+        The degree of freedom used if dist is 't'.
+    dist : {'norm', 't', object}
+        Either a string for the normal or t distribution or another object
+        that exposes a `ppf` method.
+    row_labels : list[str]
+        Row labels used in summary frame.
     """
 
     def __init__(self, predicted_mean, var_pred_mean, var_resid,
@@ -61,7 +77,6 @@ class PredictionResults(object):
         ci : ndarray, (k_constraints, 2)
             The array has the lower and the upper limit of the confidence
             interval in the columns.
-
         """
 
         se = self.se_obs if obs else self.se_mean
@@ -75,7 +90,7 @@ class PredictionResults(object):
         # TODO: finish and cleanup
         import pandas as pd
         from collections import OrderedDict
-        ci_obs = self.conf_int(alpha=alpha, obs=True) # need to split
+        ci_obs = self.conf_int(alpha=alpha, obs=True)  # need to split
         ci_mean = self.conf_int(alpha=alpha, obs=False)
         to_include = OrderedDict()
         to_include['mean'] = self.predicted_mean
@@ -86,10 +101,10 @@ class PredictionResults(object):
         to_include['obs_ci_upper'] = ci_obs[:, 1]
 
         self.table = to_include
-        #OrderedDict does not work to preserve sequence
+        # OrderedDict does not work to preserve sequence
         # pandas dict does not handle 2d_array
-        #data = np.column_stack(list(to_include.values()))
-        #names = ....
+        # data = np.column_stack(list(to_include.values()))
+        # names = ....
         res = pd.DataFrame(to_include, index=self.row_labels,
                            columns=to_include.keys())
         return res
@@ -157,10 +172,8 @@ def get_prediction(self, exog=None, transform=True, weights=None,
     if weights is not None:
         weights = np.asarray(weights)
         if (weights.size > 1 and
-           (weights.ndim != 1 or weights.shape[0] == exog.shape[1])):
+                (weights.ndim != 1 or weights.shape[0] == exog.shape[1])):
             raise ValueError('weights has wrong shape')
-
-    ### end
 
     if pred_kwds is None:
         pred_kwds = {}

--- a/statsmodels/regression/rolling.py
+++ b/statsmodels/regression/rolling.py
@@ -73,6 +73,7 @@ Rolling %(model)s regression
 See Also
 --------
 statsmodels.regression.linear_model.%(model)s
+    %(model)s estimation and parameter testing.
 
 Notes
 -----

--- a/statsmodels/stats/oaxaca.py
+++ b/statsmodels/stats/oaxaca.py
@@ -81,29 +81,14 @@ class OaxacaBlinder(object):
         See linear_model.RegressionResults.get_robustcov_results for a
         description required keywords for alternative covariance estimators
 
-    Attributes
-    ----------
-    None
-
-    Methods
-    --------
-    three_fold()
-        Returns the three-fold decomposition of Oaxaca-Blinder Results
-        instance
-    two_fold()
-        Returns the two-fold decomposition of the Oaxaca-Blinder
-        Results instance
-
     Notes
     -----
     Please check if your data includes at constant. This will still run, but
     will return incorrect values if set incorrectly.
 
-    Be aware that Python indexes starting at zero.
-
-    You can access the models by using their code and the . syntax.
-    _t_model for the total model, _f_model for the first model,
-    _s_model for the second model.
+    You can access the models by using their code as an attribute, e.g.,
+    _t_model for the total model, _f_model for the first model, _s_model for
+    the second model.
 
     Examples
     --------
@@ -116,18 +101,18 @@ class OaxacaBlinder(object):
 
     >>> model = sm.OaxacaBlinder(df.endog, df.exog, 3, hasconst = False)
     >>> model.two_fold().summary()
-        Oaxaca-Blinder Two-fold Effects
+    Oaxaca-Blinder Two-fold Effects
 
-        Unexplained Effect: 27.94091
-        Explained Effect: 130.80954
-        Gap: 158.75044
+    Unexplained Effect: 27.94091
+    Explained Effect: 130.80954
+    Gap: 158.75044
     >>> model.three_fold().summary()
-        Oaxaca-Blinder Three-fold Effects
+    Oaxaca-Blinder Three-fold Effects
 
-        Characteristic Effect: 321.74824
-        Coefficient Effect: 75.45371
-        Interaction Effect: -238.45151
-        Gap: 158.75044
+    Characteristic Effect: 321.74824
+    Coefficient Effect: 75.45371
+    Interaction Effect: -238.45151
+    Gap: 158.75044
     """
 
     def __init__(self, endog, exog, bifurcate, hasconst=True,
@@ -184,7 +169,8 @@ class OaxacaBlinder(object):
 
         Returns
         -------
-        A OaxacaResults class instance fitted for three-fold decomposition.
+        OaxacaResults
+            A results container for the three-fold decomposition.
         """
 
         self.char_eff = (
@@ -205,7 +191,8 @@ class OaxacaBlinder(object):
 
         Returns
         -------
-        A OaxacaResults class instance fitted for two-fold decomposition.
+        OaxacaResults
+            A results container for the two-fold decomposition.
         """
         self.unexplained = ((self.exog_f_mean
                             @ (self._f_model.params - self.t_params))
@@ -254,14 +241,9 @@ class OaxacaResults:
         This is the gap in the mean differences of the two groups.
 
     Attributes
-    ---------
-    params
-        A list of all values for the fitted model in the above order
-
-    Methods
     ----------
-    summary
-        Prints a summary table of the fitted model
+    params
+        A list of all values for the fitted models.
     """
     def __init__(self, results, model_type):
         self.params = results
@@ -270,29 +252,24 @@ class OaxacaResults:
     def summary(self):
         """
         Print a summary table with the Oaxaca-Blinder effects
-        based on the fitted model
-
-        Returns
-        -------
-        None
         """
         if self.model_type == 2:
-            print(dedent('''\
+            print(dedent("""\
             Oaxaca-Blinder Two-fold Effects
 
             Unexplained Effect: {:.5f}
             Explained Effect: {:.5f}
-            Gap: {:.5f}'''.format(
+            Gap: {:.5f}""".format(
                                 self.params[0], self.params[1],
                                 self.params[2])))
 
         if self.model_type == 3:
-            print(dedent('''\
+            print(dedent("""\
             Oaxaca-Blinder Three-fold Effects
 
             Characteristic Effect: {:.5f}
             Coefficient Effect: {:.5f}
             Interaction Effect: {:.5f}
-            Gap: {:.5f}'''.format(
+            Gap: {:.5f}""".format(
                             self.params[0], self.params[1],
                             self.params[2], self.params[3])))

--- a/statsmodels/tsa/_stl.pyx
+++ b/statsmodels/tsa/_stl.pyx
@@ -271,8 +271,8 @@ cdef class STL(object):
 
         Returns
         -------
-        results : DecomposeResult
-            Estimation results
+        DecomposeResult
+            Estimation results.
         """
         cdef Py_ssize_t i
 

--- a/statsmodels/tsa/interp/denton.py
+++ b/statsmodels/tsa/interp/denton.py
@@ -101,15 +101,18 @@ def dentonm(indicator, benchmark, freq="aq", **kwargs):
         The higher frequency benchmark.  A 1d or 2d data series in columns.
         If 2d, then M series are assumed.
     freq : str {"aq","qm", "other"}
-        "aq" - Benchmarking an annual series to quarterly.
-        "mq" - Benchmarking a quarterly series to monthly.
-        "other" - Custom stride.  A kwarg, k, must be supplied.
+        The frequency to use in the conversion.
+
+        * "aq" - Benchmarking an annual series to quarterly.
+        * "mq" - Benchmarking a quarterly series to monthly.
+        * "other" - Custom stride.  A kwarg, k, must be supplied.
     **kwargs
         Additional keyword argument. For example:
-        k : int
-            The number of high-frequency observations that sum to make an
-            aggregate low-frequency observation. `k` is used with
-            `freq` == "other".
+
+        * k, an int, the number of high-frequency observations that sum to make
+          an aggregate low-frequency observation. `k` is used with
+          `freq` == "other".
+
     Returns
     -------
     transformed : array

--- a/statsmodels/tsa/statespace/sarimax.py
+++ b/statsmodels/tsa/statespace/sarimax.py
@@ -435,7 +435,7 @@ class SARIMAX(MLEModel):
         self.mle_regression = (
             self.mle_regression and exog is not None and self.k_exog > 0
         )
-        # State regression is regression with coefficients estiamted within
+        # State regression is regression with coefficients estimated within
         # the state vector
         self.state_regression = (
             not self.mle_regression and exog is not None and self.k_exog > 0

--- a/statsmodels/tsa/stattools.py
+++ b/statsmodels/tsa/stattools.py
@@ -500,7 +500,7 @@ def q_stat(x, nobs, type=None):
 def acf(x, unbiased=False, nlags=40, qstat=False, fft=None, alpha=None,
         missing='none'):
     """
-    Calcualte the autocorrelation function.
+    Calculate the autocorrelation function.
 
     Parameters
     ----------
@@ -973,7 +973,7 @@ def periodogram(x):
     Returns
     -------
     ndarray
-        The periodgram defined as 1./len(x) * np.abs(np.fft.fft(x))**2.
+        The periodogram defined as 1./len(x) * np.abs(np.fft.fft(x))**2.
 
     References
     ----------

--- a/tools/validate_docstrings.py
+++ b/tools/validate_docstrings.py
@@ -486,7 +486,23 @@ class Docstring(object):
         except (TypeError, ValueError):
             # Some objects, mainly in C extensions do not support introspection
             # of the signature
-            return tuple()
+            try:
+                from numpydoc.docscrape import FunctionDoc
+                doc = FunctionDoc(self.obj)
+                if 'Signature' in doc:
+                    sig = doc['Signature'].split('(')[-1].split(')')[0]
+                    sig = sig.split(',')
+                    params = []
+                    for param in sig:
+                        if param.strip() in ('*', '/'):
+                            continue
+                        param = param.split('=')[0]
+                        params.append(param)
+                    return tuple([param.name for param in doc['Parameters']])
+            except Exception as exc:
+                print('!! numpydoc failed  on {0}!!'.format(str(self.obj)))
+                print(exc)
+                return tuple()
         params = list(sig.parameters.keys())
         out_params = params[:]
         kind = inspect.Parameter.VAR_POSITIONAL


### PR DESCRIPTION
Improve regression doc strings
Fix small spelling errors

- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
