### PR TITLE
MAINT: Ensure r download cache works

### DIFF
--- a/statsmodels/datasets/utils.py
+++ b/statsmodels/datasets/utils.py
@@ -138,7 +138,7 @@ def _urlopen_cached(url, cache):
     from_cache = False
     if cache is not None:
         cache_path = join(cache,
-                          url.split("://")[-1].replace('/', ',') + ".zip")
+                          url.split("://")[-1].replace('/', ',') + "-v2.zip")
         try:
             data = _open_cache(cache_path)
             from_cache = True


### PR DESCRIPTION
Use a new file name pattern to ensure cache is valid
Small improvement to docstring

- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
