### PR TITLE
TST: Fix wrong test

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,10 @@ filterwarnings =
     error:Care should be used:UserWarning
     error::statsmodels.tools.sm_exceptions.HypothesisTestWarning
     error::statsmodels.tools.sm_exceptions.SpecificationWarning
+    error:load will return datasets:FutureWarning:
+    error:the 'lags' keyword is deprecated:FutureWarning:
+    error:nobs is deprecated in favor of lagsDeprecationWarning:
+    error:The default pvalmethod will change:FutureWarning:
 markers =
     example: mark a test that runs example code
     matplotlib: mark a test that requires matplotlib

--- a/statsmodels/stats/tests/test_diagnostic.py
+++ b/statsmodels/stats/tests/test_diagnostic.py
@@ -603,9 +603,9 @@ class TestDiagnosticG(object):
         lilliefors3 = dict(statistic=0.1333956004203103,
                            pvalue=0.455683, parameters=(), distr='-')
 
-        lf1 = smsdia.lilliefors(res.resid)
-        lf2 = smsdia.lilliefors(res.resid**2)
-        lf3 = smsdia.lilliefors(res.resid[:20])
+        lf1 = smsdia.lilliefors(res.resid, pvalmethod='approx')
+        lf2 = smsdia.lilliefors(res.resid**2, pvalmethod='approx')
+        lf3 = smsdia.lilliefors(res.resid[:20], pvalmethod='approx')
 
         compare_t_est(lf1, lilliefors1, decimal=(14, 14))
         compare_t_est(lf2, lilliefors2, decimal=(14, 14))  # pvalue very small

--- a/statsmodels/stats/tests/test_oaxaca.py
+++ b/statsmodels/stats/tests/test_oaxaca.py
@@ -5,13 +5,14 @@
 # are from using the oaxaca command in STATA.
 
 import numpy as np
-from statsmodels.datasets.ccard.data import load, load_pandas
-from statsmodels.tools.tools import add_constant
-from statsmodels.stats.oaxaca import OaxacaBlinder
 
-df = load()
+from statsmodels.datasets.ccard.data import load_pandas
+from statsmodels.stats.oaxaca import OaxacaBlinder
+from statsmodels.tools.tools import add_constant
+
 pandas_df = load_pandas()
-endog, exog = df.endog, add_constant(df.exog, prepend=False)
+endog = pandas_df.endog.values
+exog = add_constant(pandas_df.exog.values, prepend=False)
 pd_endog, pd_exog = pandas_df.endog, add_constant(
     pandas_df.exog, prepend=False)
 
@@ -79,11 +80,7 @@ class TestOaxacaPandas(object):
 class TestOaxacaPandasNoSwap(object):
     @classmethod
     def setup_class(cls):
-        cls.model = OaxacaBlinder(
-            pd_endog,
-            pd_exog,
-            'OWNRENT',
-            swap=False)
+        cls.model = OaxacaBlinder(pd_endog, pd_exog, 'OWNRENT', swap=False)
 
     def test_results(self):
         stata_results = np.array([-158.7504, -83.29674, 162.9978, -238.4515])
@@ -103,10 +100,9 @@ class TestOaxacaPandasNoSwap(object):
 class TestOaxacaNoConstPassed(object):
     @classmethod
     def setup_class(cls):
-        cls.model = OaxacaBlinder(
-                                df.endog,
-                                df.exog, 3,
-                                hasconst=False)
+        cls.model = OaxacaBlinder(pandas_df.endog.values,
+                                  pandas_df.exog.values,
+                                  3, hasconst=False)
 
     def test_results(self):
         stata_results = np.array([158.7504, 321.7482, 75.45371, -238.4515])
@@ -126,12 +122,9 @@ class TestOaxacaNoConstPassed(object):
 class TestOaxacaNoSwapNoConstPassed(object):
     @classmethod
     def setup_class(cls):
-        cls.model = OaxacaBlinder(
-                                df.endog,
-                                df.exog,
-                                3,
-                                hasconst=False,
-                                swap=False)
+        cls.model = OaxacaBlinder(pandas_df.endog.values,
+                                  pandas_df.exog.values,
+                                  3, hasconst=False, swap=False)
 
     def test_results(self):
         stata_results = np.array([-158.7504, -83.29674, 162.9978, -238.4515])
@@ -151,11 +144,9 @@ class TestOaxacaNoSwapNoConstPassed(object):
 class TestOaxacaPandasNoConstPassed(object):
     @classmethod
     def setup_class(cls):
-        cls.model = OaxacaBlinder(
-            pandas_df.endog,
-            pandas_df.exog,
-            'OWNRENT',
-            hasconst=False)
+        cls.model = OaxacaBlinder(pandas_df.endog,
+                                  pandas_df.exog,
+                                  'OWNRENT', hasconst=False)
 
     def test_results(self):
         stata_results = np.array([158.7504, 321.7482, 75.45371, -238.4515])
@@ -175,12 +166,8 @@ class TestOaxacaPandasNoConstPassed(object):
 class TestOaxacaPandasNoSwapNoConstPassed(object):
     @classmethod
     def setup_class(cls):
-        cls.model = OaxacaBlinder(
-                                pandas_df.endog,
-                                pandas_df.exog,
-                                'OWNRENT',
-                                hasconst=False,
-                                swap=False)
+        cls.model = OaxacaBlinder(pandas_df.endog, pandas_df.exog,
+                                  'OWNRENT', hasconst=False, swap=False)
 
     def test_results(self):
         stata_results = np.array([-158.7504, -83.29674, 162.9978, -238.4515])

--- a/statsmodels/tools/tests/test_docstring.py
+++ b/statsmodels/tools/tests/test_docstring.py
@@ -155,14 +155,14 @@ def test_bad():
 
 
 def test_empty_ds():
-    ds = Docstring('')
+    ds = Docstring(None)
     ds.replace_block('summary', ['The is the new summary.'])
 
     ds.remove_parameters('x')
 
     new = Parameter('w', 'ndarray', ['An array input.'])
     ds.insert_parameters('y', new)
-    assert str(ds) == ''
+    assert str(ds) == 'None'
 
 
 def test_yield_return():

--- a/statsmodels/tsa/tests/test_stattools.py
+++ b/statsmodels/tsa/tests/test_stattools.py
@@ -505,7 +505,7 @@ class TestKPSS(SetupKPSS):
             kpss(self.x, 'CT', nlags='legacy')
 
         assert_raises(ValueError, kpss, self.x, "unclear hypothesis",
-                      lags='legacy')
+                      nlags='legacy')
 
     def test_teststat(self):
         with pytest.warns(InterpolationWarning):


### PR DESCRIPTION
Correct wrong docstring test
Silence warnings during test run

- [X] tests added / passed. 
- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
