### PR TITLE
DOC: Seasonality in SARIMAX Notebook

### DIFF
--- a/examples/notebooks/statespace_sarimax_stata.ipynb
+++ b/examples/notebooks/statespace_sarimax_stata.ipynb
@@ -108,7 +108,7 @@
     "data.index = data.t\n",
     "\n",
     "# Fit the model\n",
-    "mod = sm.tsa.statespace.SARIMAX(data['wpi'], trend='c', order=(1,1,1))\n",
+    "mod = sm.tsa.statespace.SARIMAX(data['wpi'], trend='c', order=(1,1,(1,0,0,1)))\n",
     "res = mod.fit(disp=False)\n",
     "print(res.summary())"
    ]


### PR DESCRIPTION
changed `order=(1,1,1)` to `order=(1,1,(1,0,0,1))`

closes #6037
