### PR TITLE
ENH: Improve SARIMAX start_params if too few nobs

### DIFF
--- a/statsmodels/tsa/statespace/tests/test_sarimax.py
+++ b/statsmodels/tsa/statespace/tests/test_sarimax.py
@@ -2617,3 +2617,26 @@ def test_apply_results():
 
     assert_allclose(res3.forecast(10, exog=np.ones(10)),
                     res1.forecast(10, exog=np.ones(10)))
+
+
+def test_start_params_small_nobs():
+    # Test that starting parameters work even when nobs is very small, but
+    # issues a warning.
+    endog = np.log(realgdp_results['value']).diff()[1:].values
+
+    # Regular ARMA
+    mod = sarimax.SARIMAX(endog[:4], order=(4, 0, 0))
+    match = ('Too few observations to estimate starting parameters for ARMA'
+             ' and trend.')
+    with pytest.warns(UserWarning, match=match):
+        start_params = mod.start_params
+        assert_allclose(start_params, [0, 0, 0, 0, np.var(endog[:4])])
+
+    # Seasonal ARMA
+    mod = sarimax.SARIMAX(endog[:4], order=(0, 0, 0),
+                          seasonal_order=(1, 0, 0, 4))
+    match = ('Too few observations to estimate starting parameters for'
+             ' seasonal ARMA.')
+    with pytest.warns(UserWarning, match=match):
+        start_params = mod.start_params
+        assert_allclose(start_params, [0, np.var(endog[:4])])


### PR DESCRIPTION
- [x] tests added / passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message.

Fixes the uninformative `ValueError` ("maxlag should be < nobs") reported in e.g. #4465. Technically, the `ValueError` is being raised during computation of `start_params`, which is not really the place to raise an error about the number of observations. We should probably separately do something more in the `SARIMAX` constructor if given too few observations to estimate the model.

This PR changes the `start_params` behavior to issue a warning if there are not enough observations to compute starting parameters via CSS, and then sets the starting parameters for ar/ma/trend to zeros if they can't be computed.