### PR TITLE
DOC: Changes summary_col's docstring to match variables

### DIFF
--- a/statsmodels/iolib/summary2.py
+++ b/statsmodels/iolib/summary2.py
@@ -480,7 +480,7 @@ def summary_col(results, float_format='%.4f', model_names=(), stars=False,
     drop_omitted : bool, optional
         Includes regressors that are not specified in regressor_order. If
         False, regressors not specified will be appended to end of the list.
-        If True, only regressors in regressors_list will be included.
+        If True, only regressors in regressor_order will be included.
     """
 
     if not isinstance(results, list):


### PR DESCRIPTION
The docstring now refers to regressor_order, not regressors_list, to match the variable name that the function asks for.

- [X] code/documentation is well formatted.  
- [X] properly formatted commit message.