### PR TITLE
ENH: Add exact diffuse initialization as an option for SARIMAX, UnobservedComponents

### DIFF
--- a/statsmodels/tsa/statespace/mlemodel.py
+++ b/statsmodels/tsa/statespace/mlemodel.py
@@ -1063,7 +1063,8 @@ class MLEModel(tsbase.TimeSeriesModel):
         tmp = np.zeros((self.k_endog, self.k_endog, self.nobs, n), dtype=dtype)
 
         information_matrix = np.zeros((n, n), dtype=dtype)
-        for t in range(self.ssm.loglikelihood_burn, self.nobs):
+        d = np.maximum(self.ssm.loglikelihood_burn, res.nobs_diffuse)
+        for t in range(d, self.nobs):
             inv_forecasts_error_cov[:, :, t] = (
                 np.linalg.inv(res.forecasts_error_cov[:, :, t])
             )

--- a/statsmodels/tsa/statespace/sarimax.py
+++ b/statsmodels/tsa/statespace/sarimax.py
@@ -102,6 +102,10 @@ class SARIMAX(MLEModel):
         The offset at which to start time trend values. Default is 1, so that
         if `trend='t'` the trend is equal to 1, 2, ..., nobs. Typically is only
         set when the model created by extending a previous dataset.
+    use_exact_diffuse : bool, optional
+        Whether or not to use exact diffuse initialization for non-stationary
+        states. Default is False (in which case approximate diffuse
+        initialization is used).
     **kwargs
         Keyword arguments may be used to provide default values for state space
         matrices or for Kalman filtering options. See `Representation`, and

--- a/statsmodels/tsa/statespace/sarimax.py
+++ b/statsmodels/tsa/statespace/sarimax.py
@@ -305,7 +305,7 @@ class SARIMAX(MLEModel):
                  mle_regression=True, simple_differencing=False,
                  enforce_stationarity=True, enforce_invertibility=True,
                  hamilton_representation=False, concentrate_scale=False,
-                 trend_offset=1, **kwargs):
+                 trend_offset=1, use_exact_diffuse=False, **kwargs):
 
         # Model parameters
         self.seasonal_periods = seasonal_order[3]
@@ -317,6 +317,7 @@ class SARIMAX(MLEModel):
         self.enforce_invertibility = enforce_invertibility
         self.hamilton_representation = hamilton_representation
         self.concentrate_scale = concentrate_scale
+        self.use_exact_diffuse = use_exact_diffuse
 
         # Save given orders
         self.order = order
@@ -453,11 +454,6 @@ class SARIMAX(MLEModel):
         if self.state_regression:
             k_states += self.k_exog
 
-        # Number of diffuse states
-        k_diffuse_states = k_states
-        if self.enforce_stationarity:
-            k_diffuse_states -= self._k_order
-
         # Number of positive definite elements of the state covariance matrix
         k_posdef = int(self._k_order > 0)
         # Only have an error component to the states if k_posdef > 0
@@ -470,6 +466,9 @@ class SARIMAX(MLEModel):
         # variance
         if self.state_regression:
             kwargs.setdefault('initial_variance', 1e10)
+
+        # Handle non-default loglikelihood burn
+        self._loglikelihood_burn = kwargs.get('loglikelihood_burn', None)
 
         # Number of parameters
         self.k_params = (
@@ -506,10 +505,6 @@ class SARIMAX(MLEModel):
         self.nobs = len(endog)
         self.k_states = k_states
         self.k_posdef = k_posdef
-
-        # By default, do not calculate likelihood while it is controlled by
-        # diffuse initial conditions.
-        kwargs.setdefault('loglikelihood_burn', k_diffuse_states)
 
         # Initialize the statespace
         super(SARIMAX, self).__init__(
@@ -645,6 +640,17 @@ class SARIMAX(MLEModel):
         """Initialize default"""
         if approximate_diffuse_variance is None:
             approximate_diffuse_variance = self.ssm.initial_variance
+        if self.use_exact_diffuse:
+            diffuse_type = 'diffuse'
+        else:
+            diffuse_type = 'approximate_diffuse'
+
+            # Set the loglikelihood burn parameter, if not given in constructor
+            if self._loglikelihood_burn is None:
+                k_diffuse_states = self.k_states
+                if self.enforce_stationarity:
+                    k_diffuse_states -= self._k_order
+                self.loglikelihood_burn = k_diffuse_states
 
         init = Initialization(
             self.k_states,
@@ -652,7 +658,7 @@ class SARIMAX(MLEModel):
 
         if self.enforce_stationarity:
             # Differencing operators are at the beginning
-            init.set((0, self._k_states_diff), 'approximate_diffuse')
+            init.set((0, self._k_states_diff), diffuse_type)
             # Stationary component in the middle
             init.set((self._k_states_diff,
                       self._k_states_diff + self._k_order),
@@ -660,11 +666,11 @@ class SARIMAX(MLEModel):
             # Regression components at the end
             init.set((self._k_states_diff + self._k_order,
                       self._k_states_diff + self._k_order + self.k_exog),
-                     'approximate_diffuse')
+                     diffuse_type)
         # If we're not enforcing a stationarity, then we cannot initialize a
         # stationary component
         else:
-            init.set(None, 'approximate_diffuse')
+            init.set(None, diffuse_type)
 
         self.ssm.initialization = init
 

--- a/statsmodels/tsa/statespace/structural.py
+++ b/statsmodels/tsa/statespace/structural.py
@@ -102,6 +102,10 @@ class UnobservedComponents(MLEModel):
         allow the cyclical component to be between 1.5 and 12 years; depending
         on the frequency of the endogenous variable, this will imply different
         specific bounds.
+    use_exact_diffuse : bool, optional
+        Whether or not to use exact diffuse initialization for non-stationary
+        states. Default is False (in which case approximate diffuse
+        initialization is used).
 
     Notes
     -----

--- a/statsmodels/tsa/statespace/structural.py
+++ b/statsmodels/tsa/statespace/structural.py
@@ -356,7 +356,7 @@ class UnobservedComponents(MLEModel):
                  stochastic_freq_seasonal=None,
                  stochastic_cycle=False,
                  damped_cycle=False, cycle_period_bounds=None,
-                 mle_regression=True,
+                 mle_regression=True, use_exact_diffuse=False,
                  **kwargs):
 
         # Model options
@@ -395,6 +395,7 @@ class UnobservedComponents(MLEModel):
 
         self.damped_cycle = damped_cycle
         self.mle_regression = mle_regression
+        self.use_exact_diffuse = use_exact_diffuse
 
         # Check for string trend/level specification
         self.trend_specification = None
@@ -550,18 +551,17 @@ class UnobservedComponents(MLEModel):
             self.autoregressive
         )
 
-        # The ar states are initialized as stationary, so they do not need to
-        # be burned.
-        loglikelihood_burn = kwargs.get('loglikelihood_burn',
-                                        k_states
-                                        - self.ar_order)
+        # Handle non-default loglikelihood burn
+        self._loglikelihood_burn = kwargs.get('loglikelihood_burn', None)
 
         # We can still estimate the model with just the irregular component,
         # just need to have one state that does nothing.
+        self._unused_state = False
         if k_states == 0:
             if not self.irregular:
                 raise ValueError('Model has no components specified.')
             k_states = 1
+            self._unused_state = True
         if k_posdef == 0:
             k_posdef = 1
 
@@ -574,9 +574,6 @@ class UnobservedComponents(MLEModel):
         # Set as time-varying model if we have exog
         if self.k_exog > 0:
             self.ssm._time_invariant = False
-
-        # Initialize the model
-        self.ssm.loglikelihood_burn = loglikelihood_burn
 
         # Need to reset the MLE names (since when they were first set, `setup`
         # had not been run (and could not have been at that point))
@@ -782,24 +779,40 @@ class UnobservedComponents(MLEModel):
     def initialize_default(self, approximate_diffuse_variance=None):
         if approximate_diffuse_variance is None:
             approximate_diffuse_variance = self.ssm.initial_variance
+        if self.use_exact_diffuse:
+            diffuse_type = 'diffuse'
+        else:
+            diffuse_type = 'approximate_diffuse'
+
+            # Set the loglikelihood burn parameter, if not given in constructor
+            if self._loglikelihood_burn is None:
+                k_diffuse_states = (
+                    self.k_states - int(self._unused_state) - self.ar_order)
+                self.loglikelihood_burn = k_diffuse_states
 
         init = Initialization(
             self.k_states,
             approximate_diffuse_variance=approximate_diffuse_variance)
 
-        if self.autoregressive:
+        if self._unused_state:
+            # If this flag is set, it means we have a model with just an
+            # irregular component and nothing else. The state is then
+            # irrelevant and we can't put it as diffuse, since then the filter
+            # will never leave the diffuse state.
+            init.set(0, 'known', constant=[0])
+        elif self.autoregressive:
             offset = (self.level + self.trend +
                       self._k_seasonal_states +
                       self._k_freq_seas_states +
                       self._k_cycle_states)
             length = self.ar_order
-            init.set((0, offset), 'approximate_diffuse')
+            init.set((0, offset), diffuse_type)
             init.set((offset, offset + length), 'stationary')
-            init.set((offset + length, self.k_states), 'approximate_diffuse')
+            init.set((offset + length, self.k_states), diffuse_type)
         # If we do not have an autoregressive component, then everything has
         # a diffuse initialization
         else:
-            init.set(None, 'approximate_diffuse')
+            init.set(None, diffuse_type)
 
         self.ssm.initialization = init
 

--- a/statsmodels/tsa/statespace/tests/results/results_structural.py
+++ b/statsmodels/tsa/statespace/tests/results/results_structural.py
@@ -1,5 +1,5 @@
 """
-Results for SARIMAX tests
+Results for structural tests
 
 Results from R, KFAS library using script `test_ucm.R`.
 See also Stata time series documentation.
@@ -9,6 +9,8 @@ License: Simplified-BSD
 """
 from numpy import pi
 
+LOG2PI = 0.9189385332046727
+
 irregular = {
     'models': [
         {'irregular': True},
@@ -16,6 +18,7 @@ irregular = {
         {'level': 'ntrend'},
     ],
     'params': [36.74687342],
+    'start_params': [30],
     'llf': -653.8562525,
     'kwargs': {}
 }
@@ -29,6 +32,7 @@ fixed_intercept = {
         {'level': 'fixed intercept'},
     ],
     'params': [2.127438969],
+    'start_params': [1.],
     'llf': -365.5289923,
     'kwargs': {}
 }
@@ -40,6 +44,7 @@ deterministic_constant = {
         {'level': 'dconstant'},
     ],
     'params': [2.127438969],
+    'start_params': [1.],
     'llf': -365.5289923,
     'kwargs': {}
 }
@@ -51,6 +56,7 @@ local_level = {
         {'level': 'llevel'}
     ],
     'params': [4.256647886e-06, 1.182078808e-01],
+    'start_params': [1e-4, 1e-2],
     'llf': -70.97242557,
     'kwargs': {}
 }
@@ -62,6 +68,7 @@ random_walk = {
         {'level': 'rwalk'},
     ],
     'params': [0.1182174646],
+    'start_params': [0.5],
     'llf': -70.96771641,
     'kwargs': {}
 }
@@ -76,6 +83,7 @@ fixed_slope = {
         {'level': 'fixed slope'},
     ],
     'params': [2.134137554],
+    'start_params': [1.],
     'llf': -370.7758666,
     'kwargs': {}
 }
@@ -87,6 +95,7 @@ deterministic_trend = {
         {'level': 'dtrend'},
     ],
     'params': [2.134137554],
+    'start_params': [1.],
     'llf': -370.7758666,
     'kwargs': {}
 }
@@ -99,6 +108,7 @@ local_linear_deterministic_trend = {
         {'level': 'lldtrend'},
     ],
     'params': [4.457592057e-06, 1.184455029e-01],
+    'start_params': [1e-5, 1e-2],
     'llf': -73.47291031,
     'kwargs': {}
 }
@@ -110,6 +120,7 @@ random_walk_with_drift = {
         {'level': 'rwdrift'},
     ],
     'params': [0.1184499547],
+    'start_params': [0.5],
     'llf': -73.46798576,
     'kwargs': {}
 }
@@ -122,6 +133,7 @@ local_linear_trend = {
         {'level': 'lltrend'}
     ],
     'params': [1.339852549e-06, 1.008704925e-02, 6.091760810e-02],
+    'start_params': [1e-5, 1e-4, 1e-4],
     'llf': -31.15640107,
     'kwargs': {}
 }
@@ -134,6 +146,7 @@ smooth_trend = {
         {'level': 'strend'},
     ],
     'params': [0.0008824099119, 0.0753064234342],
+    'start_params': [1e-2, 1e-2],
     'llf': -31.92261408,
     'kwargs': {}
 }
@@ -145,6 +158,7 @@ random_trend = {
         {'level': 'rtrend'},
     ],
     'params': [0.08054724989],
+    'start_params': [1e-2],
     'llf': -32.05607557,
     'kwargs': {}
 }
@@ -152,33 +166,49 @@ random_trend = {
 cycle = {
     'models': [{'irregular': True, 'cycle': True, 'stochastic_cycle': True,
                 'damped_cycle': True}],
+    'params': [37.57197079, 0.1, 2*pi/10, 1],
+    'start_params': [30, 0.001, 2*pi/20, 0.5],
+    'llf': -656.6568684,
+    'kwargs': {}
+}
+
+cycle_approx_diffuse = cycle.copy()
+cycle_approx_diffuse.update({
     'params': [37.57197224, 0.1, 2*pi/10, 1],
     'llf': -672.3102588,
-    'kwargs': {
-        # Required due to the way KFAS estimated loglikelihood which P1inf is
-        # set in the R code
-        'loglikelihood_burn': 0
-    }
-}
+    'kwargs': {'loglikelihood_burn': 0}})
 
 seasonal = {
     'models': [{'irregular': True, 'seasonal': 4}],
-    'params': [38.1704278, 0.1],
-    'llf': -678.8138005,
-    'kwargs': {'loglikelihood_burn': 0},
+    'params': [38.17043009, 0.1],
+    'start_params': [30, 0.001],
+    'llf': -655.3337155,
+    'kwargs': {},
     'rtol': 1e-6
 }
+
+seasonal_approx_diffuse = seasonal.copy()
+seasonal_approx_diffuse.update({
+    'params': [38.1704278, 0.1],
+    'llf': -678.8138005,
+    'kwargs': {'loglikelihood_burn': 0}})
 
 freq_seasonal = {
     'models': [{'irregular': True,
                 'freq_seasonal': [{'period': 5}]}],
     'params': [38.95352534, 0.05],
-    'llf': -688.9697249,
+    'start_params': [30, 0.001],
+    'llf': -657.6629457,
     'rtol': 1e-6,
-    'kwargs': {
-        'loglikelihood_burn': 0  # No idea why KFAS includes all data in this
-    }
+    'kwargs': {}
 }
+
+freq_seasonal_approx_diffuse = freq_seasonal.copy()
+freq_seasonal_approx_diffuse.update({
+    'params': [38.95353592, 0.05],
+    'llf': -688.9697249,
+    'kwargs': {'loglikelihood_burn': 0}})
+
 reg = {
     # Note: The test needs to fill in exog=np.log(dta['realgdp'])
     'models': [
@@ -187,14 +217,17 @@ reg = {
         {'level': 'ntrend', 'exog': True, 'mle_regression': False},
         {'level': 'ntrend', 'exog': 'numpy', 'mle_regression': False},
     ],
+    'params': [2.215438082],
+    'start_params': [1.],
+    'llf': -371.7966543,
+    'kwargs': {}
+}
+
+reg_approx_diffuse = reg.copy()
+reg_approx_diffuse.update({
     'params': [2.215447924],
     'llf': -379.6233483,
-    'kwargs': {
-        # Required due to the way KFAS estimated loglikelihood which P1inf is
-        # set in the R code
-        'loglikelihood_burn': 0
-    }
-}
+    'kwargs': {'loglikelihood_burn': 0}})
 
 rtrend_ar1 = {
     'models': [
@@ -204,11 +237,30 @@ rtrend_ar1 = {
         {'level': 'rtrend', 'autoregressive': 1}
     ],
     'params': [0.0609, 0.0097, 0.9592],
+    'start_params': [0.01, 0.001, 0.1],
     'llf': -31.15629379,
     'kwargs': {}
 }
 
 lltrend_cycle_seasonal_reg_ar1 = {
+    # Note: The test needs to fill in exog=np.log(dta['realgdp'])
+    'models': [
+        # Complete specification
+        {'irregular': True, 'level': True, 'stochastic_level': True,
+         'trend': True, 'stochastic_trend': True, 'cycle': True,
+         'stochastic_cycle': True, 'seasonal': 4, 'autoregressive': 1,
+         'exog': True, 'mle_regression': False},
+    ],
+    'params': [0.0001, 0.01, 0.06, 0.0001, 0.0001, 0.1, 2*pi / 10, 0.2],
+    'start_params': [0.0001, 0.01, 0.06, 0.0001, 0.0001, 0.1, 2*pi / 10, 0.2],
+    'llf': -105.8936568,
+    'kwargs': {},
+    # No need to try to find the maximum for this really weird model.
+    'maxiter': 5
+}
+
+
+lltrend_cycle_seasonal_reg_ar1_approx_diffuse = {
     # Note: The test needs to fill in exog=np.log(dta['realgdp'])
     'models': [
         # Complete specification
@@ -247,10 +299,13 @@ lltrend_cycle_seasonal_reg_ar1 = {
          'cycle_period_bounds': (1.5*12, 12*12)},
     ],
     'params': [0.0001, 0.01, 0.06, 0.0001, 0.0001, 0.1, 2*pi / 10, 0.2],
+    'start_params': [0.0001, 0.01, 0.06, 0.0001, 0.0001, 0.1, 2*pi / 10, 0.2],
     'llf': -168.5258709,
     'kwargs': {
         # Required due to the way KFAS estimated loglikelihood which P1inf is
         # set in the R code
         'loglikelihood_burn': 0
-    }
+    },
+    # No need to try to find the maximum for this really weird model.
+    'maxiter': 5
 }

--- a/statsmodels/tsa/statespace/tests/results/test_ucm.R
+++ b/statsmodels/tsa/statespace/tests/results/test_ucm.R
@@ -1,16 +1,21 @@
 library(KFAS)
-library(rucm)
+# library(rucm)
 options(digits=10)
 
 dta <- read.csv('datasets/macrodata/macrodata.csv')
 
 # Irregular (ntrend)
-mod_ntrend <- SSModel(dta$unemp ~ -1 + SSMcustom(Z=matrix(0), matrix(0), matrix(0), matrix(0)), H=matrix(NA))
+mod_ntrend <- SSModel(
+  dta$unemp ~ -1 + SSMcustom(Z=matrix(0), matrix(0), matrix(0),
+                             matrix(0)),
+  H=matrix(NA))
 res_ntrend <- fitSSM(inits=c(log(var(dta$unemp))), model=mod_ntrend,
                      method="BFGS", control=list(REPORT=1, trace=1))
 
 print(exp(res_ntrend$optim.out$par)) # 36.74687342
 print(res_ntrend$optim.out$value)    # 653.8562525
+
+# ----------------------------------------------------------------------------
 
 # Irregular + Deterministic trend (dconstant)
 mod_dconstant <- SSModel(dta$unemp ~ SSMtrend(Q=matrix(0)), H=matrix(NA))
@@ -20,13 +25,18 @@ res_dconstant <- fitSSM(inits=c(log(var(dta$unemp))), model=mod_dconstant,
 print(exp(res_dconstant$optim.out$par)) # 2.127438969
 print(res_dconstant$optim.out$value)    # 365.5289923
 
+# ----------------------------------------------------------------------------
+
 # Local level (llevel)
 mod_llevel <- SSModel(dta$unemp ~ SSMtrend(Q=matrix(NA)), H=matrix(NA))
-res_llevel <- fitSSM(inits=c(log(var(dta$unemp)), log(var(dta$unemp))), model=mod_llevel,
-                     method="BFGS", control=list(REPORT=1, trace=1))
+res_llevel <- fitSSM(inits=c(log(var(dta$unemp)), log(var(dta$unemp))),
+                     model=mod_llevel, method="BFGS",
+                     control=list(REPORT=1, trace=1))
 
 print(exp(res_llevel$optim.out$par)) # [1.182078808e-01, 4.256647886e-06]
 print(res_llevel$optim.out$value)    # 70.97242557
+
+# ----------------------------------------------------------------------------
 
 # Random walk (rwalk)
 mod_rwalk <- SSModel(dta$unemp ~ SSMtrend(Q=matrix(NA)), H=matrix(0))
@@ -36,110 +46,218 @@ res_rwalk <- fitSSM(inits=c(log(var(dta$unemp))), model=mod_rwalk,
 print(exp(res_rwalk$optim.out$par)) # 0.1182174646
 print(res_rwalk$optim.out$value)    # 70.96771641
 
+# ----------------------------------------------------------------------------
+
 # Deterministic trend (dtrend)
-mod_dtrend <- SSModel(dta$unemp ~ SSMtrend(2, Q=list(matrix(0), matrix(0))), H=matrix(NA))
+mod_dtrend <- SSModel(dta$unemp ~ SSMtrend(2, Q=list(matrix(0), matrix(0))),
+                      H=matrix(NA))
 res_dtrend <- fitSSM(inits=c(log(var(dta$unemp))), model=mod_dtrend,
                      method="BFGS", control=list(REPORT=1, trace=1))
 
 print(exp(res_dtrend$optim.out$par)) # 2.134137554
 print(res_dtrend$optim.out$value)    # 370.7758666
 
+# ----------------------------------------------------------------------------
+
 # Local level with deterministic trend (lldtrend)
-mod_lldtrend <- SSModel(dta$unemp ~ SSMtrend(2, Q=list(matrix(NA), matrix(0))), H=matrix(NA))
-res_lldtrend <- fitSSM(inits=c(log(var(dta$unemp)), log(var(dta$unemp))), model=mod_lldtrend,
-                       method="BFGS", control=list(REPORT=1, trace=1))
+mod_lldtrend <- SSModel(dta$unemp ~ SSMtrend(2, Q=list(matrix(NA), matrix(0))),
+                        H=matrix(NA))
+res_lldtrend <- fitSSM(inits=c(log(var(dta$unemp)), log(var(dta$unemp))),
+                       model=mod_lldtrend, method="BFGS",
+                       control=list(REPORT=1, trace=1))
 
 print(exp(res_lldtrend$optim.out$par)) # [1.184455029e-01, 4.457592057e-06]
 print(res_lldtrend$optim.out$value)    # 73.47291031
 
+# ----------------------------------------------------------------------------
+
 # Random walk with drift (rwdrift)
-mod_rwdrift <- SSModel(dta$unemp ~ SSMtrend(2, Q=list(matrix(NA), matrix(0))), H=matrix(0))
+mod_rwdrift <- SSModel(dta$unemp ~ SSMtrend(2, Q=list(matrix(NA), matrix(0))),
+                       H=matrix(0))
 res_rwdrift <- fitSSM(inits=c(log(var(dta$unemp))), model=mod_rwdrift,
                       method="BFGS", control=list(REPORT=1, trace=1))
 
 print(exp(res_rwdrift$optim.out$par)) # [0.1184499547]
 print(res_rwdrift$optim.out$value)    # 73.46798576
 
-# Local linear trend (lltrend)
-mod_lltrend <- SSModel(dta$unemp ~ SSMtrend(2, Q=list(matrix(NA), matrix(NA))), H=matrix(NA))
-res_lltrend <- fitSSM(inits=c(log(var(dta$unemp)), log(var(dta$unemp)), log(var(dta$unemp))), model=mod_lltrend,
-                      method="BFGS", control=list(REPORT=1, trace=1))
+# ----------------------------------------------------------------------------
 
-print(exp(res_lltrend$optim.out$par)) # [1.008704925e-02, 6.091760810e-02, 1.339852549e-06]
+# Local linear trend (lltrend)
+mod_lltrend <- SSModel(dta$unemp ~ SSMtrend(2, Q=list(matrix(NA), matrix(NA))),
+                       H=matrix(NA))
+res_lltrend <- fitSSM(inits=c(log(var(dta$unemp)), log(var(dta$unemp)),
+                              log(var(dta$unemp))),
+                      model=mod_lltrend, method="BFGS",
+                      control=list(REPORT=1, trace=1))
+
+print(exp(res_lltrend$optim.out$par)) # [1.008704925e-02, 6.091760810e-02,
+                                      #  1.339852549e-06]
 print(res_lltrend$optim.out$value)    # 31.15640107
 
+# ----------------------------------------------------------------------------
+
 # Smooth trend (strend)
-mod_strend <- SSModel(dta$unemp ~ SSMtrend(2, Q=list(matrix(0), matrix(NA))), H=matrix(NA))
-res_strend <- fitSSM(inits=c(log(var(dta$unemp)), log(var(dta$unemp))), model=mod_strend,
-                     method="BFGS", control=list(REPORT=1, trace=1))
+mod_strend <- SSModel(dta$unemp ~ SSMtrend(2, Q=list(matrix(0), matrix(NA))),
+                      H=matrix(NA))
+res_strend <- fitSSM(inits=c(log(var(dta$unemp)), log(var(dta$unemp))),
+                     model=mod_strend, method="BFGS",
+                     control=list(REPORT=1, trace=1))
 
 print(exp(res_strend$optim.out$par)) # [0.0753064234342, 0.0008824099119]
 print(res_strend$optim.out$value)    # 31.92261408
 
+# ----------------------------------------------------------------------------
+
 # Random trend (rtrend)
-mod_rtrend <- SSModel(dta$unemp ~ SSMtrend(2, Q=list(matrix(0), matrix(NA))), H=matrix(0))
+mod_rtrend <- SSModel(dta$unemp ~ SSMtrend(2, Q=list(matrix(0), matrix(NA))),
+                      H=matrix(0))
 res_rtrend <- fitSSM(inits=c(log(var(dta$unemp))), model=mod_rtrend,
                      method="BFGS", control=list(REPORT=1, trace=1))
 
 print(exp(res_rtrend$optim.out$par)) # [0.08054724989]
 print(res_rtrend$optim.out$value)    # 32.05607557
 
-# Cycle (with fixed period=10, cycle variance=0.1)
-# Note: matching this requires setting loglikelihood_burn = 0
-mod_cycle <- SSModel(dta$unemp ~ -1 + SSMcycle(10, Q=matrix(0.1), P1=diag(2)*1e6), H=matrix(NA))
+# ----------------------------------------------------------------------------
+
+# Cycle (exact diffuse) (with fixed period=10, cycle variance=0.1)
+mod_cycle <- SSModel(dta$unemp ~ -1 + SSMcycle(10, Q=matrix(0.1)),
+                     H=matrix(NA))
 res_cycle <- fitSSM(inits=c(log(var(dta$unemp))), model=mod_cycle,
-                     method="BFGS", control=list(REPORT=1, trace=1))
+                    method="BFGS", control=list(REPORT=1, trace=1))
 
-print(exp(res_cycle$optim.out$par)) # [37.57197224]
-print(res_cycle$optim.out$value)    # 672.3102588
+print(exp(res_cycle$optim.out$par)) # [37.57197079]
+print(res_cycle$optim.out$value)    # 656.6568684
 
-# Seasonal (with fixed period=4, seasonal variance=0.1)
-# Note: matching this requires setting loglikelihood_burn=0
-mod_seasonal <- SSModel(dta$unemp ~ -1 + SSMseasonal(4, Q=matrix(0.1), sea.type='dummy', P1=diag(rep(1e6, 3))), H=matrix(NA))
+# Cycle (approximate diffuse) (with fixed period=10, cycle variance=0.1)
+# Note: matching this requires setting loglikelihood_burn = 0
+mod_cycle_approx_diffuse <- SSModel(
+  dta$unemp ~ -1 + SSMcycle(10, Q=matrix(0.1), P1=diag(2)*1e6), H=matrix(NA))
+res_cycle_approx_diffuse <- fitSSM(inits=c(log(var(dta$unemp))),
+                     model=mod_cycle_approx_diffuse, method="BFGS",
+                     control=list(REPORT=1, trace=1))
+
+print(exp(res_cycle_approx_diffuse$optim.out$par)) # [37.57197224]
+print(res_cycle_approx_diffuse$optim.out$value)    # 672.3102588
+
+# ----------------------------------------------------------------------------
+
+# Seasonal (exact diffuse) (with fixed period=4, seasonal variance=0.1)
+mod_seasonal <- SSModel(
+  dta$unemp ~ -1 + SSMseasonal(4, Q=matrix(0.1), sea.type='dummy'),
+  H=matrix(NA))
 res_seasonal <- fitSSM(inits=c(log(var(dta$unemp))), model=mod_seasonal,
                        method="BFGS", control=list(REPORT=1, trace=1))
 
 print(exp(res_seasonal$optim.out$par)) # [38.17043009]
-print(res_seasonal$optim.out$value)    # 678.8138005
+print(res_seasonal$optim.out$value)    # 655.3337155
 
-# Trig Seasonal (with fixed period=5, full number of harmonics, seasonal variance=.05)
+# Seasonal (approximate diffuse) (with fixed period=4, seasonal variance=0.1)
 # Note: matching this requires setting loglikelihood_burn=0
-mod_trig_seasonal <- SSModel(dta$unemp ~ -1 + SSMseasonal(5, Q=0.05, sea.type='trigonometric', P1=diag(rep(1e6, 4))), H=matrix(NA))
-res_trig_seasonal <- fitSSM(inits=c(log(var(dta$unemp))), model=mod_trig_seasonal,
-                       method="BFGS", control=list(REPORT=1, trace=1))
+mod_seasonal_approx_diffuse <- SSModel(
+  dta$unemp ~ -1 + SSMseasonal(4, Q=matrix(0.1), sea.type='dummy',
+                               P1=diag(rep(1e6, 3))),
+  H=matrix(NA))
+res_seasonal_approx_diffuse <- fitSSM(
+  inits=c(log(var(dta$unemp))), model=mod_seasonal_approx_diffuse,
+  method="BFGS", control=list(REPORT=1, trace=1))
 
-print(exp(res_trig_seasonal$optim.out$par)) # [38.95352534]
-print(res_trig_seasonal$optim.out$value)    # 688.9697249
+print(exp(res_seasonal_approx_diffuse$optim.out$par)) # [38.1704278]
+print(res_seasonal_approx_diffuse$optim.out$value)    # 678.8138005
 
+# ----------------------------------------------------------------------------
 
-# Regression
+# Trig Seasonal (exact diffuse)
+# (with fixed period=5, full number of harmonics, seasonal variance=.05)
+mod_trig_seasonal <- SSModel(
+  dta$unemp ~ -1 + SSMseasonal(5, Q=0.05, sea.type='trigonometric'),
+  H=matrix(NA))
+res_trig_seasonal <- fitSSM(
+  inits=c(log(var(dta$unemp))), model=mod_trig_seasonal, method="BFGS",
+  control=list(REPORT=1, trace=1))
+
+print(exp(res_trig_seasonal$optim.out$par)) # [38.95353592]
+print(res_trig_seasonal$optim.out$value)    # 657.6629457
+
+# Trig Seasonal (approximate diffuse)
+# (with fixed period=5, full number of harmonics, seasonal variance=.05)
+# Note: matching this requires setting loglikelihood_burn=0
+mod_trig_seasonal_approx_diffuse <- SSModel(
+  dta$unemp ~ -1 + SSMseasonal(5, Q=0.05, sea.type='trigonometric',
+                               P1=diag(rep(1e6, 4))),
+  H=matrix(NA))
+res_trig_seasonal_approx_diffuse <- fitSSM(
+  inits=c(log(var(dta$unemp))), model=mod_trig_seasonal_approx_diffuse,
+  method="BFGS", control=list(REPORT=1, trace=1))
+
+print(exp(res_trig_seasonal_approx_diffuse$optim.out$par)) # [38.95352534]
+print(res_trig_seasonal_approx_diffuse$optim.out$value)    # 688.9697249
+
+# ----------------------------------------------------------------------------
+
+# Regression (exact diffuse)
 # Note: matching this requires setting loglikelihood_burn = 0
-mod_reg <- SSModel(dta$unemp ~ -1 + SSMregression(~-1+log(realgdp), data=dta, P1=diag(1)*1e6), H=matrix(NA))
+mod_reg <- SSModel(dta$unemp ~ -1 + SSMregression(~-1+log(realgdp), data=dta),
+                   H=matrix(NA))
 res_reg <- fitSSM(inits=c(log(var(dta$unemp))), model=mod_reg,
                        method="BFGS", control=list(REPORT=1, trace=1))
 
-print(exp(res_reg$optim.out$par)) # [2.215447924]
-print(res_reg$optim.out$value)    # 379.6233483
+print(exp(res_reg$optim.out$par)) # [2.215438082]
+print(res_reg$optim.out$value)    # 371.7966543
+
+# Regression (approximate diffuse)
+# Note: matching this requires setting loglikelihood_burn = 0
+mod_reg_approx_diffuse <- SSModel(
+  dta$unemp ~ -1 + SSMregression(~-1+log(realgdp), data=dta, P1=diag(1)*1e6),
+  H=matrix(NA))
+res_reg_approx_diffuse <- fitSSM(
+  inits=c(log(var(dta$unemp))), model=mod_reg_approx_diffuse,
+  method="BFGS", control=list(REPORT=1, trace=1))
+
+print(exp(res_reg_approx_diffuse$optim.out$par)) # [2.215447924]
+print(res_reg_approx_diffuse$optim.out$value)    # 379.6233483
+
+# ----------------------------------------------------------------------------
 
 # Random trend + AR(1)
 # Note: KFAS does not want to estimate these parameters, so just fix them
 # to the MLE estimates from Statsmodels and compare the loglikelihood
 # mod.update([])
-mod_rtrend_ar1 <- SSModel(dta$unemp ~ SSMtrend(2, Q=list(matrix(0), matrix(0.0609))) + SSMarima(ar=c(0.9592), Q=matrix(0.0097)), H=matrix(0))
+mod_rtrend_ar1 <- SSModel(
+  dta$unemp ~ SSMtrend(2, Q=list(matrix(0), matrix(0.0609)))
+    + SSMarima(ar=c(0.9592), Q=matrix(0.0097)),
+  H=matrix(0))
 out_rtrend_ar1 <- KFS(mod_rtrend_ar1)
 
 print(out_rtrend_ar1$logLik)    # -31.15629379
 
+# ----------------------------------------------------------------------------
+
 # Local linear trend + Cycle + Seasonal + Regression + AR(1)
-# Note: matching this requires setting loglikelihood_burn = 0, and
+# (exact diffuse)
 # mod.update([0.0001, 0.01, 0.06, 0.0001, 0.0001, 0.1, 2*np.pi / 10, 0.2])
 mod_lltrend_cycle_seasonal_reg_ar1 <- SSModel(
-  dta$unemp ~ SSMtrend(2, Q=list(matrix(0.01), matrix(0.06)), P1=diag(2)*1e6) +
-              SSMcycle(10, Q=matrix(0.0001), P1=diag(2)*1e6) +
-              SSMseasonal(4, Q=matrix(0.0001), P1=diag(3)*1e6) +
-              SSMregression(~-1+log(realgdp), data=dta, P1=diag(1)*1e6) +
+  dta$unemp ~ SSMtrend(2, Q=list(matrix(0.01), matrix(0.06))) +
+              SSMcycle(10, Q=matrix(0.0001)) +
+              SSMseasonal(4, Q=matrix(0.0001)) +
+              SSMregression(~-1+log(realgdp), data=dta) +
               SSMarima(ar=c(0.2), Q=matrix(0.1)),
 H=matrix(0.0001))
 out_lltrend_cycle_seasonal_reg_ar1 <- KFS(mod_lltrend_cycle_seasonal_reg_ar1)
 
-print(out_lltrend_cycle_seasonal_reg_ar1$logLik)    # -168.5258709
+print(out_lltrend_cycle_seasonal_reg_ar1$logLik)    # -105.8936568
+
+# Local linear trend + Cycle + Seasonal + Regression + AR(1)
+# (approximate diffuse)
+# Note: matching this requires setting loglikelihood_burn = 0, and
+# mod.update([0.0001, 0.01, 0.06, 0.0001, 0.0001, 0.1, 2*np.pi / 10, 0.2])
+mod_lltrend_cycle_seasonal_reg_ar1_approx_diffuse <- SSModel(
+  dta$unemp ~ SSMtrend(2, Q=list(matrix(0.01), matrix(0.06)), P1=diag(2)*1e6)
+              + SSMcycle(10, Q=matrix(0.0001), P1=diag(2)*1e6)
+              + SSMseasonal(4, Q=matrix(0.0001), P1=diag(3)*1e6)
+              + SSMregression(~-1+log(realgdp), data=dta, P1=diag(1)*1e6)
+              + SSMarima(ar=c(0.2), Q=matrix(0.1)),
+  H=matrix(0.0001))
+out_lltrend_cycle_seasonal_reg_ar1_approx_diffuse <- (
+  KFS(mod_lltrend_cycle_seasonal_reg_ar1_approx_diffuse))
+
+print(out_lltrend_cycle_seasonal_reg_ar1_approx_diffuse$logLik)  # -168.5258709

--- a/statsmodels/tsa/statespace/tests/test_mlemodel.py
+++ b/statsmodels/tsa/statespace/tests/test_mlemodel.py
@@ -45,7 +45,8 @@ def get_dummy_mod(fit=True, pandas=False):
 
     mod = sarimax.SARIMAX(
         endog, exog=exog, order=(0, 0, 0),
-        time_varying_regression=True, mle_regression=False)
+        time_varying_regression=True, mle_regression=False,
+        use_exact_diffuse=True)
 
     if fit:
         with warnings.catch_warnings():
@@ -151,9 +152,9 @@ def test_wrapping():
 
     # Test that we can change the following properties: loglikelihood_burn,
     # initial_variance, tolerance
-    assert_equal(mod.loglikelihood_burn, 1)
-    mod.loglikelihood_burn = 0
-    assert_equal(mod.ssm.loglikelihood_burn, 0)
+    assert_equal(mod.loglikelihood_burn, 0)
+    mod.loglikelihood_burn = 1
+    assert_equal(mod.ssm.loglikelihood_burn, 1)
 
     assert_equal(mod.tolerance, mod.ssm.tolerance)
     mod.tolerance = 0.123
@@ -519,7 +520,7 @@ def check_results(pandas):
     assert_almost_equal(res.resid[2:], np.zeros(mod.nobs-2))
 
     # Test loglikelihood_burn
-    assert_equal(res.loglikelihood_burn, 1)
+    assert_equal(res.loglikelihood_burn, 0)
 
 
 def test_results(pandas=False):

--- a/statsmodels/tsa/statespace/tests/test_representation.py
+++ b/statsmodels/tsa/statespace/tests/test_representation.py
@@ -1016,8 +1016,10 @@ def test_standardized_forecasts_error():
     data['lgdp'] = np.log(data['GDP'])
 
     # Fit an ARIMA(1, 1, 0) to log GDP
-    mod = sarimax.SARIMAX(data['lgdp'], order=(1, 1, 0))
+    mod = sarimax.SARIMAX(data['lgdp'], order=(1, 1, 0),
+                          use_exact_diffuse=True)
     res = mod.fit(disp=-1)
+    d = np.maximum(res.loglikelihood_burn, res.nobs_diffuse)
 
     standardized_forecasts_error = (
         res.filter_results.forecasts_error[0] /
@@ -1025,8 +1027,8 @@ def test_standardized_forecasts_error():
     )
 
     assert_allclose(
-        res.filter_results.standardized_forecasts_error[0],
-        standardized_forecasts_error,
+        res.filter_results.standardized_forecasts_error[0, d:],
+        standardized_forecasts_error[..., d:],
     )
 
 


### PR DESCRIPTION
- [x] tests added / passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message.

Both SARIMAX and UnobservedComponents have used approximate diffuse initialization to handle non-stationary states since they were introduced. We got exact diffuse initialization for custom state space models in v0.10, but there was no option to use it in SARIMAX or UnobservedComponents. This adds a keyword argument `use_exact_diffuse` (default is False, so that approximate diffuse initialization continues to be the default) to the constructor to allow specifying exact diffuse initialization.

(In a future version, we may want to switch the default to exact diffuse initialization.)