### PR TITLE
Plot only unique censored points

### DIFF
--- a/statsmodels/duration/survfunc.py
+++ b/statsmodels/duration/survfunc.py
@@ -798,7 +798,7 @@ def plot_survfunc(survfuncs, ax=None):
 
         # Plot the censored points.
         ii = np.flatnonzero(np.logical_not(sf.status))
-        ti = sf.time[ii]
+        ti = np.unique(sf.time[ii])
         jj = np.searchsorted(surv_times, ti) - 1
         sp = surv_prob[jj]
         ax.plot(ti, sp, '+', ms=12, color=li.get_color(),


### PR DESCRIPTION
When one runs:

```python
sf = sm.SurvfuncRight(df["futime"], df["death"])
sf.plot()
```
The survival function is being plotted along with **all** the censored points.
Some of them are identical points.
I find it unnecessary to plot the same points multiple times. Fixed that.