### PR TITLE
 BUG: Incorrect TSA index if loc resolves to slice

### DIFF
--- a/statsmodels/tsa/base/tsa_model.py
+++ b/statsmodels/tsa/base/tsa_model.py
@@ -377,7 +377,7 @@ class TimeSeriesModel(base.LikelihoodModel):
 
         # Return the index through the end of the loc / slice
         if isinstance(loc, slice):
-            end = loc.stop
+            end = loc.stop - 1
         else:
             end = loc
 


### PR DESCRIPTION
- [x] closes #6129
- [x] tests added / passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message.

Fixes the behavior in `_get_index_loc` if Pandas returns a slice from the `get_loc` index method. This previously caused an extra element to sometimes get returned in `_get_prediction_index`.