### PR TITLE
ENH: Compute standardized forecast error in diffuse period if possible

### DIFF
--- a/statsmodels/tsa/statespace/_filters/_univariate_diffuse.pyx.in
+++ b/statsmodels/tsa/statespace/_filters/_univariate_diffuse.pyx.in
@@ -151,6 +151,11 @@ cdef int {{prefix}}forecast_univariate_diffuse({{prefix}}KalmanFilter kfilter, {
             kfilter.nobs_kendog_diffuse_nonsingular = kfilter.nobs_kendog_diffuse_nonsingular + 1
             forecast_error_cov_inv = 1.0 / forecast_error_cov
 
+            # Standardized forecasts error
+            if not (kfilter.conserve_memory & MEMORY_NO_STD_FORECAST > 0):
+                kfilter._standardized_forecast_error[i] = (
+                    kfilter._forecast_error[i] * forecast_error_cov_inv**0.5)
+
             # K0 = M[:, i:i+1] / F[i, i]
             blas.{{prefix}}copy(&kfilter.k_states, &kfilter._M[i*kfilter.k_states], &inc, kfilter._tmpK0, &inc)
             blas.{{prefix}}scal(&kfilter.k_states, &forecast_error_cov_inv, kfilter._tmpK0, &inc)


### PR DESCRIPTION
We can compute the standardized forecast error even in periods for which diffuse initialization is still in effect in the case that the diffuse forecast error covariance matrix is equal to zero.

Previously, we just did not compute this quantity at all in diffuse periods.