### PR TITLE
BUG: use self.data consistently

### DIFF
--- a/statsmodels/sandbox/stats/multicomp.py
+++ b/statsmodels/sandbox/stats/multicomp.py
@@ -822,7 +822,7 @@ class MultiComparison(object):
                 idx = np.where(self.groups == name)[0]
                 count += len(idx)
                 self.groupintlab[idx] = np.where(self.groupsunique == name)[0]
-            if count != data.shape[0]:
+            if count != self.data.shape[0]:
                 #raise ValueError('group_order does not contain all groups')
                 # warn and keep only observations with label in group_order
                 import warnings


### PR DESCRIPTION
The __init__ for MultiComparison defines self.data = np.asarray(data) where data is an input.

However on the line modified in this PR it calculates data.shape which fails for the case where data is, say, an array-like object without defined shape e.g. a list. 

The change is to use self.data.shape instead, which will  be defined.