### PR TITLE
BUG: Fix accepting of eval environment for formula

### DIFF
--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -159,7 +159,7 @@ class Model(object):
         elif eval_env == -1:
             from patsy import EvalEnvironment
             eval_env = EvalEnvironment({})
-        else:
+        elif isinstance(eval_env, int):
             eval_env += 1  # we're going down the stack again
         missing = kwargs.get('missing', 'drop')
         if missing == 'none':  # with patsy it's drop or raise. let's raise.

--- a/statsmodels/formula/tests/test_formula.py
+++ b/statsmodels/formula/tests/test_formula.py
@@ -229,12 +229,8 @@ def test_predict_nondataframe():
 
 def test_formula_environment():
     df = pd.DataFrame({'x': [1, 2, 3], 'y': [2, 4, 6]})
-    env = patsy.EvalEnvironment({})
-
-    try:
-        ols('y ~ x', eval_env=env, data=df)
-    except Exception:
-        raise
-
+    env = patsy.EvalEnvironment([{'z': [3, 6, 9]}])
+    model = ols('y ~ x + z', eval_env=env, data=df)
+    assert 'z' in model.exog_names
     with pytest.raises(TypeError):
         ols('y ~ x', eval_env='env', data=df)

--- a/statsmodels/formula/tests/test_formula.py
+++ b/statsmodels/formula/tests/test_formula.py
@@ -225,3 +225,16 @@ def test_predict_nondataframe():
     error = patsy.PatsyError
     with pytest.raises(error):
         fit.predict([0.25])
+
+
+def test_formula_environment():
+    df = pd.DataFrame({'x': [1, 2, 3], 'y': [2, 4, 6]})
+    env = patsy.EvalEnvironment({})
+
+    try:
+        ols('y ~ x', eval_env=env, data=df)
+    except Exception:
+        raise
+
+    with pytest.raises(TypeError):
+        ols('y ~ x', eval_env='env', data=df)


### PR DESCRIPTION
According model.from_formula documentation, the `eval_env`
parameter can be a `patsy.EvalEnvironment` but this type was
not properly handled.

- [x] closes #6151
- [x] tests added / passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message.