### PR TITLE
DOC: fix sidebartoc

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -172,7 +172,7 @@ html_theme_options = {
     'base_url': base_url,
     'repo_url': 'https://github.com/statsmodels/statsmodels',
     'repo_name': 'statsmodels',
-    'globaltoc_depth': 1,
+    'globaltoc_depth': 3,
     'globaltoc_collapse': True,
     'globaltoc_includehidden': True,
     'color_primary': 'indigo',
@@ -230,7 +230,8 @@ html_static_path = ['_static']
 
 # Custom sidebar templates, maps document names to template names.
 html_sidebars = {
-    'index': ['indexsidebar.html', 'searchbox.html', 'sidelinks.html']}
+    "**": ["logo-text.html", "globaltoc.html", "localtoc.html", "searchbox.html"]
+}
 
 # Additional templates that should be rendered to pages, maps page names to
 # template names.


### PR DESCRIPTION
- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

The html sidebars need 'globaltoc.html' for the sidebar to work. Also, I think a toc depth of 3 makes sense...