### PR TITLE
DOC/SEC: Warn that only trusted files should be unpickled

### DIFF
--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -2145,8 +2145,12 @@ class LikelihoodModelResults(Results):
     @classmethod
     def load(cls, fname):
         """
-        Load a pickled results instance; use only on trusted files,
-        as unpickling can run arbitrary code.
+        Load a pickled results instance; use only on trusted files.
+
+        Unpickling can run arbitrary code from the file being loaded.
+        This allows it to load a wide range of object types, but is
+        also a security risk: calling this on a malicious file can
+        wipe or take over your system.
 
         Parameters
         ----------

--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -2145,7 +2145,8 @@ class LikelihoodModelResults(Results):
     @classmethod
     def load(cls, fname):
         """
-        Load a pickled results instance.
+        Load a pickled results instance; use only on trusted files,
+        as unpickling can run arbitrary code.
 
         Parameters
         ----------

--- a/statsmodels/base/wrapper.py
+++ b/statsmodels/base/wrapper.py
@@ -75,7 +75,8 @@ class ResultsWrapper(object):
     @classmethod
     def load(cls, fname):
         """
-        Load a pickled results instance.
+        Load a pickled results instance; use only on trusted files,
+        as unpickling can run arbitrary code.
 
         Parameters
         ----------

--- a/statsmodels/base/wrapper.py
+++ b/statsmodels/base/wrapper.py
@@ -75,8 +75,12 @@ class ResultsWrapper(object):
     @classmethod
     def load(cls, fname):
         """
-        Load a pickled results instance; use only on trusted files,
-        as unpickling can run arbitrary code.
+        Load a pickled results instance; use only on trusted files.
+
+        Unpickling can run arbitrary code from the file being loaded.
+        This allows it to load a wide range of object types, but is
+        also a security risk: calling this on a malicious file can
+        wipe or take over your system.
 
         Parameters
         ----------

--- a/statsmodels/iolib/smpickle.py
+++ b/statsmodels/iolib/smpickle.py
@@ -19,7 +19,9 @@ def save_pickle(obj, fname):
 
 def load_pickle(fname):
     """
-    Load a previously saved object from file
+    Load a previously saved object; **use only on trusted files**,
+    as unpickling can run arbitrary code.  (i.e. calling this on a
+    malicious file can wipe or take over your system.)
 
     Parameters
     ----------

--- a/statsmodels/iolib/smpickle.py
+++ b/statsmodels/iolib/smpickle.py
@@ -19,9 +19,12 @@ def save_pickle(obj, fname):
 
 def load_pickle(fname):
     """
-    Load a previously saved object; **use only on trusted files**,
-    as unpickling can run arbitrary code.  (i.e. calling this on a
-    malicious file can wipe or take over your system.)
+    Load a previously saved object; **use only on trusted files**.
+
+    Unpickling can run arbitrary code from the file being loaded.
+    This allows it to load a wide range of object types, but is also
+    a security risk: calling this on a malicious file can wipe or
+    take over your system.
 
     Parameters
     ----------


### PR DESCRIPTION
The Python pickle format is intentionally a "can run arbitrary code" format:
https://docs.python.org/3/library/pickle.html#restricting-globals