### PR TITLE
DOC: Fix warning format

### DIFF
--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -2147,11 +2147,11 @@ class LikelihoodModelResults(Results):
         """
         Load a pickled results instance
 
-         .. warning::
+        .. warning::
 
-            Loading pickled models is not secure against erroneous or
-            maliciously constructed data. Never unpickle data received from
-            an untrusted or unauthenticated source.
+           Loading pickled models is not secure against erroneous or
+           maliciously constructed data. Never unpickle data received from
+           an untrusted or unauthenticated source.
 
         Parameters
         ----------

--- a/statsmodels/base/wrapper.py
+++ b/statsmodels/base/wrapper.py
@@ -77,11 +77,11 @@ class ResultsWrapper(object):
         """
         Load a pickled results instance
 
-         .. warning::
+        .. warning::
 
-            Loading pickled models is not secure against erroneous or
-            maliciously constructed data. Never unpickle data received from
-            an untrusted or unauthenticated source.
+           Loading pickled models is not secure against erroneous or
+           maliciously constructed data. Never unpickle data received from
+           an untrusted or unauthenticated source.
 
         Parameters
         ----------


### PR DESCRIPTION
Remove extra space

- [ ] closes #xxxx
- [ ] tests added / passed. 
- [ ] code/documentation is well formatted.  
- [ ] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
