### PR TITLE
ENH: state space: add wrapped states and, where possible, named states

### DIFF
--- a/statsmodels/tsa/statespace/sarimax.py
+++ b/statsmodels/tsa/statespace/sarimax.py
@@ -1110,6 +1110,24 @@ class SARIMAX(MLEModel):
         ]
 
     @property
+    def state_names(self):
+        # TODO: we may be able to revisit these states to get somewhat more
+        # informative names, but ultimately probably not much better.
+        # TODO: alternatively, we may be able to get better for certain models,
+        # like pure AR models.
+        k_ar_states = self._k_order
+        if not self.simple_differencing:
+            k_ar_states += (self.seasonal_periods * self._k_seasonal_diff +
+                            self._k_diff)
+        names = ['state.%d' % i for i in range(k_ar_states)]
+
+        if self.k_exog > 0 and self.state_regression:
+            names += ['beta.%s' % self.exog_names[i]
+                      for i in range(self.k_exog)]
+
+        return names
+
+    @property
     def model_orders(self):
         """
         The orders of each of the polynomials in the model.

--- a/statsmodels/tsa/statespace/structural.py
+++ b/statsmodels/tsa/statespace/structural.py
@@ -1,6 +1,8 @@
 """
 Univariate structural time series models
 
+TODO: tests: "** On entry to DLASCL, parameter number  4 had an illegal value"
+
 Author: Chad Fulton
 License: Simplified-BSD
 """
@@ -972,6 +974,33 @@ class UnobservedComponents(MLEModel):
             else:
                 param_names.append(key)
         return param_names
+
+    @property
+    def state_names(self):
+        names = []
+        if self.level:
+            names.append('level')
+        if self.trend:
+            names.append('trend')
+        if self.seasonal:
+            names.append('seasonal')
+            names += ['seasonal.L%d' % i
+                      for i in range(1, self._k_seasonal_states)]
+        if self.freq_seasonal:
+            names += ['freq_seasonal.%d' % i
+                      for i in range(self._k_freq_seas_states)]
+        if self.cycle:
+            names += ['cycle', 'cycle.auxilliary']
+        if self.ar_order > 0:
+            names += ['ar.L%d' % i
+                      for i in range(1, self.ar_order + 1)]
+        if self.k_exog > 0 and not self.mle_regression:
+            names += ['beta.%s' % self.exog_names[i]
+                      for i in range(self.k_exog)]
+        if self._unused_state:
+            names += ['dummy']
+
+        return names
 
     def transform_params(self, unconstrained):
         """


### PR DESCRIPTION
Adds a more convenient results attributes, `states`, for accessing predicted, filtered, and smoothed states and covariances.

For example:

```python
mod = sm.tsa.UnobservedComponents(...)
res = mod.fit()

# e.g. (assuming Pandas input was given)
res.states.smoothed['level'].plot()
res.states.smoothed_cov.loc['level', 'level'].plot() . # see below for a question on this approach
```

These are useful for several reasons:

- The filter output (like `res.predicted_state`) are always numpy arrays, so the main goal was to get a new attribute that would wrap the array with a Pandas date index when that's available
- `res.predicted_state` includes an additional element, the "initial" state: unlike e.g. `res.filtered_state` which has length `nobs`, `res.predicted_state` has length `nobs + 1`. This can be a gotcha if you expect the arrays to all line up. With Pandas output, we can index the initial state correctly.

Also adds a new property attribute `state_names` (similar to `param_names`) that can be implemented in state space models to give human-readable names to the state vector elements. This is more useful for some models than others:

- For `UnobservedComponents`, we can usefully name all of the states.
- For `DynamicFactor`, we can usefully name all the states (mostly just the factors and their lags, but also the error terms if those are in the state vector because they have an autoregressive component).
- For `SARIMAX`, I didn't give descriptive names any of the states (except for if regression is done via the sate vector). It's possible with a little bit of thinking we could come up with human-readable names that would describe what the state is capturing, but I don't know if that would be particularly helpful anyway, since I don't know of anything that uses intermediate states from these models.
- `VARMAX` has a similar situation to `SARIMAX`.


**Question**:

I don't know if we've settled on a way to set up the Pandas wrapped version of covariance matrices over time. I think we need a multi-index, but there are two ways to do it:

Option 1: 

```
                     level         trend
1959Q1 level  1.676490e-10  0.000000e+00
       trend  0.000000e+00  0.000000e+00
1959Q2 level  1.676490e-10  1.676490e-10
       trend  1.676490e-10  5.693389e-01
```

Option 2:

```
                     level         trend
level 1959Q1  1.676490e-10  0.000000e+00
trend 1959Q1  0.000000e+00  0.000000e+00
level 1959Q2  1.676490e-10  1.676490e-10
trend 1959Q2  1.676490e-10  5.693389e-01
```

I think Option 1 looks nicer when printed and it was what I was originally thinking of going with, but it is less good for selecting a time series of one of the variances. e.g., under Option 1 you might do:

```python
print(res.state.smoothed_cov.loc[np.s_[:, 'level'], 'level'])
```

and then you get:

```
1959Q1  level    1.676490e-10
1959Q2  level    1.676490e-10
```

Whereas under Option 2, you can do:

```python
print(res.states.filtered_cov.loc['level', 'level'])
```

and then you get:

```
1959Q1    1.676490e-10
1959Q2    1.676490e-10
```

So I am leaning towards Option 2, and this is what the PR currently has implemented. If anyone has any thoughts on this (or options I've missed!), please leave a comment.