### PR TITLE
ENH: Add missing keyword argument to plot_acf

### DIFF
--- a/statsmodels/graphics/tests/test_tsaplots.py
+++ b/statsmodels/graphics/tests/test_tsaplots.py
@@ -139,6 +139,33 @@ def test_plot_acf_kwargs(close_figures):
 
 
 @pytest.mark.matplotlib
+def test_plot_acf_missing(close_figures):
+    # Just test that it runs.
+    fig = plt.figure()
+    ax = fig.add_subplot(111)
+
+    ar = np.r_[1., -0.9]
+    ma = np.r_[1., 0.9]
+    armaprocess = tsp.ArmaProcess(ar, ma)
+    rs = np.random.RandomState(1234)
+    acf = armaprocess.generate_sample(100, distrvs=rs.standard_normal)
+    acf[::13] = np.nan
+
+    buff = BytesIO()
+    plot_acf(acf, ax=ax, missing='drop')
+    fig.savefig(buff, format='rgba')
+    buff.seek(0)
+
+    fig = plt.figure()
+    ax = fig.add_subplot(111)
+    buff_conservative = BytesIO()
+    plot_acf(acf, ax=ax, missing='conservative')
+    fig.savefig(buff_conservative, format='rgba')
+    buff_conservative.seek(0)
+    assert_(buff.read() != buff_conservative.read())
+
+
+@pytest.mark.matplotlib
 def test_plot_pacf_irregular(close_figures):
     # Just test that it runs.
     fig = plt.figure()

--- a/statsmodels/graphics/tsaplots.py
+++ b/statsmodels/graphics/tsaplots.py
@@ -57,10 +57,11 @@ def _plot_corr(ax, title, acf_x, confint, lags, irregular, use_vlines,
                         confint[:, 1] - acf_x, alpha=.25)
 
 
-def plot_acf(x, ax=None, lags=None, alpha=.05, use_vlines=True, unbiased=False,
-             fft=False, title='Autocorrelation', zero=True,
-             vlines_kwargs=None, **kwargs):
-    """Plot the autocorrelation function
+def plot_acf(x, ax=None, lags=None, *, alpha=.05, use_vlines=True,
+             unbiased=False, fft=False, missing='none',
+             title='Autocorrelation', zero=True, vlines_kwargs=None, **kwargs):
+    """
+    Plot the autocorrelation function
 
     Plots lags on the horizontal and the correlations on vertical axis.
 
@@ -88,6 +89,9 @@ def plot_acf(x, ax=None, lags=None, alpha=.05, use_vlines=True, unbiased=False,
         If True, then denominators for autocovariance are n-k, otherwise n
     fft : bool, optional
         If True, computes the ACF via FFT.
+    missing : str, optional
+        A string in ['none', 'raise', 'conservative', 'drop'] specifying how
+        the NaNs are to be treated.
     title : str, optional
         Title to place on plot.  Default is 'Autocorrelation'
     zero : bool, optional
@@ -145,12 +149,10 @@ def plot_acf(x, ax=None, lags=None, alpha=.05, use_vlines=True, unbiased=False,
 
     confint = None
     # acf has different return type based on alpha
-    if alpha is None:
-        acf_x = acf(x, nlags=nlags, alpha=alpha, fft=fft,
-                    unbiased=unbiased)
-    else:
-        acf_x, confint = acf(x, nlags=nlags, alpha=alpha, fft=fft,
-                             unbiased=unbiased)
+    acf_x = acf(x, nlags=nlags, alpha=alpha, fft=fft, unbiased=unbiased,
+                missing=missing)
+    if alpha is not None:
+        acf_x, confint = acf_x
 
     _plot_corr(ax, title, acf_x, confint, lags, irregular, use_vlines,
                vlines_kwargs, **kwargs)


### PR DESCRIPTION
Add missing
Restict most keyword to be keyword only

closes #6209

- [x] closes #6209
- [x] tests added / passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
