### PR TITLE
BUG: parameter names in DynamicFactor for unstructured error covariance matrix

### DIFF
--- a/statsmodels/tsa/statespace/dynamic_factor.py
+++ b/statsmodels/tsa/statespace/dynamic_factor.py
@@ -600,8 +600,7 @@ class DynamicFactor(MLEModel):
             ]
         elif self.error_cov_type == 'unstructured':
             param_names += [
-                ('sqrt.var.%s' % endog_names[i] if i == j else
-                 'sqrt.cov.%s.%s' % (endog_names[j], endog_names[i]))
+                'cov.chol[%d,%d]' % (i + 1, j + 1)
                 for i in range(self.k_endog)
                 for j in range(i+1)
             ]

--- a/statsmodels/tsa/statespace/tests/test_dynamic_factor.py
+++ b/statsmodels/tsa/statespace/tests/test_dynamic_factor.py
@@ -554,22 +554,22 @@ class TestDynamicFactor_general_errors(CheckDynamicFactor):
         # -> Check that we have the right coefficients
         offset = self.model.k_endog * self.model.k_factors
         assert re.search(
-            'sqrt.var.dln_inv +' + forg(params[offset + 0], prec=4),
+            r'cov.chol\[1,1\] +' + forg(params[offset + 0], prec=4),
             table)
         assert re.search(
-            'sqrt.cov.dln_inv.dln_inc +' + forg(params[offset + 1], prec=4),
+            r'cov.chol\[2,1\] +' + forg(params[offset + 1], prec=4),
             table)
         assert re.search(
-            'sqrt.var.dln_inc +' + forg(params[offset + 2], prec=4),
+            r'cov.chol\[2,2\] +' + forg(params[offset + 2], prec=4),
             table)
         assert re.search(
-            'sqrt.cov.dln_inv.dln_consump +' + forg(params[offset+3], prec=4),
+            r'cov.chol\[3,1\] +' + forg(params[offset+3], prec=4),
             table)
         assert re.search(
-            'sqrt.cov.dln_inc.dln_consump +' + forg(params[offset+4], prec=4),
+            r'cov.chol\[3,2\] +' + forg(params[offset+4], prec=4),
             table)
         assert re.search(
-            'sqrt.var.dln_consump +' + forg(params[offset + 5], prec=4),
+            r'cov.chol\[3,3\] +' + forg(params[offset + 5], prec=4),
             table)
 
 

--- a/statsmodels/tsa/statespace/tests/test_fixed_params.py
+++ b/statsmodels/tsa/statespace/tests/test_fixed_params.py
@@ -269,8 +269,8 @@ def test_dynamic_factor_invalid():
         endog[['cpi', 'realgdp']], k_factors=1, factor_order=1,
         error_cov_type='unstructured')
     constraints = {
-        'loading.f1.cpi': 1., 'loading.f1.realgdp': 1., 'sqrt.var.cpi': 0.5,
-        'sqrt.cov.cpi.realgdp': 0.1}
+        'loading.f1.cpi': 1., 'loading.f1.realgdp': 1., 'cov.chol[1,1]': 0.5,
+        'cov.chol[2,1]': 0.1}
     with mod6.fix_params(constraints):
         assert_(mod6._has_fixed_params)
         assert_equal(mod6._fixed_params, constraints)
@@ -561,7 +561,7 @@ def test_dynamic_factor_diag_error_cov():
     mod2 = dynamic_factor.DynamicFactor(
         endog, k_factors=1, factor_order=1, error_cov_type='unstructured')
 
-    constraints = {'sqrt.cov.cpi.realgdp': 0}
+    constraints = {'cov.chol[2,1]': 0}
 
     # Start pretty close to optimum to speed up test
     start_params = [-4.5e-06, -1.0e-05, 9.9e-01, 9.9e-01, -1.4e-01]
@@ -571,7 +571,7 @@ def test_dynamic_factor_diag_error_cov():
 
     # Check that the right parameters were fixed
     assert_equal(res1.fixed_params, [])
-    assert_equal(res2.fixed_params, ['sqrt.cov.cpi.realgdp'])
+    assert_equal(res2.fixed_params, ['cov.chol[2,1]'])
 
     # Check that MLE finds the same parameters in either case
     # (need to account for the fact that diagonal params are variances but


### PR DESCRIPTION
- [x] closes #5989
- [x] tests passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message.