### PR TITLE
BUG: SARIMAX: basic validation for order, seasonal_order

### DIFF
--- a/statsmodels/tsa/statespace/sarimax.py
+++ b/statsmodels/tsa/statespace/sarimax.py
@@ -324,6 +324,18 @@ class SARIMAX(MLEModel):
                  hamilton_representation=False, concentrate_scale=False,
                  trend_offset=1, use_exact_diffuse=False, **kwargs):
 
+        # Save given orders
+        self.order = order
+        self.seasonal_order = seasonal_order
+
+        # Validate orders
+        if len(self.order) != 3:
+            raise ValueError('`order` argument must be an iterable with three'
+                             ' elements.')
+        if len(self.seasonal_order) != 4:
+            raise ValueError('`seasonal_order` argument must be an iterable'
+                             ' with four elements.')
+
         # Model parameters
         self.seasonal_periods = seasonal_order[3]
         self.measurement_error = measurement_error
@@ -335,10 +347,6 @@ class SARIMAX(MLEModel):
         self.hamilton_representation = hamilton_representation
         self.concentrate_scale = concentrate_scale
         self.use_exact_diffuse = use_exact_diffuse
-
-        # Save given orders
-        self.order = order
-        self.seasonal_order = seasonal_order
 
         # Enforce non-MLE coefficients if time varying coefficients is
         # specified
@@ -419,6 +427,15 @@ class SARIMAX(MLEModel):
         self.k_seasonal_ma_params = (
             int(np.sum(self.polynomial_seasonal_ma) - 1)
         )
+
+        # Make sure we don't have a seasonal specification without a valid
+        # seasonal period.
+        if self.seasonal_order[3] == 1:
+            raise ValueError('Seasonal period must be greater than 1.')
+        if self.seasonal_order[3] == 0 and (self.k_seasonal_ar > 0 or
+                                            self.k_seasonal_ma > 0):
+            raise ValueError('Seasonal AR or MA components cannot be set when'
+                             ' the given seasonal period is equal to 0.')
 
         # Make internal copies of the differencing orders because if we use
         # simple differencing, then we will need to internally use zeros after

--- a/statsmodels/tsa/statespace/tests/test_sarimax.py
+++ b/statsmodels/tsa/statespace/tests/test_sarimax.py
@@ -2177,11 +2177,6 @@ def test_arima000():
     res = mod.smooth(mod.start_params)
     assert_allclose(res.smoothed_state[1:, 1:], endog.diff()[1:].T)
 
-    # SARIMA(0, 1, 0)x(0, 1, 0, 1)
-    mod = sarimax.SARIMAX(endog, order=(0, 1, 0), measurement_error=True,
-                          seasonal_order=(0, 1, 0, 1))
-    res = mod.smooth(mod.start_params)
-
     # Exogenous variables
     error = np.random.normal(size=nobs)
     endog = np.ones(nobs) * 10 + error

--- a/statsmodels/tsa/statespace/tests/test_sarimax.py
+++ b/statsmodels/tsa/statespace/tests/test_sarimax.py
@@ -2676,3 +2676,27 @@ def test_simple_differencing_strindex():
 
     assert_(mod._index.equals(pd.RangeIndex(start=0, stop=len(values) - 1)))
     assert_(mod.data.row_labels.equals(index[1:]))
+
+
+def test_invalid_order():
+    endog = np.zeros(10)
+    with pytest.raises(ValueError):
+        sarimax.SARIMAX(endog, order=(1,))
+    with pytest.raises(ValueError):
+        sarimax.SARIMAX(endog, order=(1, 2, 3, 4))
+
+
+def test_invalid_seasonal_order():
+    endog = np.zeros(10)
+    with pytest.raises(ValueError):
+        sarimax.SARIMAX(endog, seasonal_order=(1,))
+    with pytest.raises(ValueError):
+        sarimax.SARIMAX(endog, seasonal_order=(1, 2, 3, 4, 5))
+    with pytest.raises(ValueError):
+        sarimax.SARIMAX(endog, seasonal_order=(1, 0, 0, 0))
+    with pytest.raises(ValueError):
+        sarimax.SARIMAX(endog, seasonal_order=(0, 0, 1, 0))
+    with pytest.raises(ValueError):
+        sarimax.SARIMAX(endog, seasonal_order=(1, 0, 1, 0))
+    with pytest.raises(ValueError):
+        sarimax.SARIMAX(endog, seasonal_order=(0, 0, 0, 1))


### PR DESCRIPTION
- [x] closes #6013
- [x] tests added / passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message.