### PR TITLE
ENH: Update SARIMAX to use SARIMAXSpecification for more consistent input handling

### DIFF
--- a/statsmodels/tsa/arima/specification.py
+++ b/statsmodels/tsa/arima/specification.py
@@ -262,6 +262,14 @@ class SARIMAXSpecification(object):
         elif not has_seasonal_order:
             seasonal_order = (0, 0, 0, 0)
 
+        # Validate shapes of `order`, `seasonal_order`
+        if len(order) != 3:
+            raise ValueError('`order` argument must be an iterable with three'
+                             ' elements.')
+        if len(seasonal_order) != 4:
+            raise ValueError('`seasonal_order` argument must be an iterable'
+                             ' with four elements.')
+
         # Validate differencing parameters
         if order[1] < 0:
             raise ValueError('Cannot specify negative differencing.')
@@ -287,6 +295,8 @@ class SARIMAXSpecification(object):
             int(seasonal_order[3]))
 
         # Validate seasonals
+        if seasonal_order[3] == 1:
+            raise ValueError('Seasonal periodicity must be greater than 1.')
         if ((seasonal_order[0] != 0 or seasonal_order[1] != 0 or
                 seasonal_order[2] != 0) and seasonal_order[3] == 0):
             raise ValueError('Must include nonzero seasonal periodicity if'

--- a/statsmodels/tsa/arima/specification.py
+++ b/statsmodels/tsa/arima/specification.py
@@ -421,6 +421,11 @@ class SARIMAXSpecification(object):
         self.endog = None if faux_endog else self._model.endog
         self.exog = self._model.exog
 
+        # Validate endog shape
+        if not faux_endog and self.endog.ndim > 1 and self.endog.shape[1] > 1:
+            raise ValueError('SARIMAX models require univariate `endog`. Got'
+                             ' shape %s.' % str(self.endog.shape))
+
         self._has_missing = (
             None if faux_endog else np.any(np.isnan(self.endog)))
 

--- a/statsmodels/tsa/arima/tests/test_model.py
+++ b/statsmodels/tsa/arima/tests/test_model.py
@@ -36,13 +36,13 @@ def test_default_trend():
     # Defaults when only endog is specified
     mod = ARIMA(endog)
     # with no integration, default trend a constant
-    assert_equal(mod._spec.trend_order, 0)
+    assert_equal(mod._spec_arima.trend_order, 0)
     assert_allclose(mod.exog, np.ones((mod.nobs, 1)))
 
     # Defaults with integrated model
     mod = ARIMA(endog, order=(0, 1, 0))
     # with no integration, default trend is none
-    assert_equal(mod._spec.trend_order, None)
+    assert_equal(mod._spec_arima.trend_order, None)
     assert_equal(mod.exog, None)
 
 

--- a/statsmodels/tsa/arima/tests/test_specification.py
+++ b/statsmodels/tsa/arima/tests/test_specification.py
@@ -488,6 +488,8 @@ def test_invalid():
     assert_raises(ValueError, specification.SARIMAXSpecification,
                   order=(0, 1.5, 0))
     assert_raises(ValueError, specification.SARIMAXSpecification,
+                  order=(0,))
+    assert_raises(ValueError, specification.SARIMAXSpecification,
                   seasonal_order=(0, 1.5, 0, 4))
     assert_raises(ValueError, specification.SARIMAXSpecification,
                   seasonal_order=(-1, 0, 0, 4))
@@ -501,6 +503,13 @@ def test_invalid():
                   seasonal_order=(1, 0, 0, 0))
     assert_raises(ValueError, specification.SARIMAXSpecification,
                   seasonal_order=(1, 0, 0, -1))
+    assert_raises(ValueError, specification.SARIMAXSpecification,
+                  seasonal_order=(1, 0, 0, 1))
+    assert_raises(ValueError, specification.SARIMAXSpecification,
+                  seasonal_order=(1,))
+
+    assert_raises(ValueError, specification.SARIMAXSpecification,
+                  order=(1, 0, 0), endog=np.zeros((10, 2)))
 
     spec = specification.SARIMAXSpecification(ar_order=1)
     assert_raises(ValueError, spec.join_params)

--- a/statsmodels/tsa/arima/tests/test_tools.py
+++ b/statsmodels/tsa/arima/tests/test_tools.py
@@ -65,6 +65,10 @@ def test_standardize_lag_order_invalid():
     assert_raises(ValueError, standardize_lag_order, -1)
     assert_raises(ValueError, standardize_lag_order,
                   np.arange(4).reshape(2, 2))
+    # Boolean list can't have 2, lag order list can't have 0
+    assert_raises(ValueError, standardize_lag_order, [0, 2])
+    # Can't have duplicates
+    assert_raises(ValueError, standardize_lag_order, [1, 1, 2])
 
 
 def test_validate_basic():

--- a/statsmodels/tsa/arima/tools.py
+++ b/statsmodels/tsa/arima/tools.py
@@ -57,7 +57,7 @@ def standardize_lag_order(order, title=None):
 
     # Only positive integers are valid
     if np.any(order < 0):
-        raise ValueError('Terms in the %s cannot be negative.')
+        raise ValueError('Terms in the %s cannot be negative.' % title)
 
     # Try to squeeze out an irrelevant trailing dimension
     if order.ndim == 2 and order.shape[1] == 1:
@@ -75,7 +75,16 @@ def standardize_lag_order(order, title=None):
         order = 0
     else:
         # Option 2: boolean list
-        if 0 in order or np.sum(order == 1) > 1 and not np.any(order > 1):
+        has_zeros = (0 in order)
+        has_multiple_ones = np.sum(order == 1) > 1
+        has_gt_one = np.any(order > 1)
+        if has_zeros or has_multiple_ones:
+            if has_gt_one:
+                raise ValueError('Invalid %s. Appears to be a boolean list'
+                                 ' (since it contains a 0 element and/or'
+                                 ' multiple elements) but also contains'
+                                 ' elements greater than 1 like a list of'
+                                 ' lag orders.' % title)
             order = (np.where(order == 1)[0] + 1)
 
         # (Default) Option 3: list of lag orders to include
@@ -91,6 +100,11 @@ def standardize_lag_order(order, title=None):
         # Otherwise, convert to list
         else:
             order = order.tolist()
+
+    # Check for duplicates
+    has_duplicate = isinstance(order, list) and np.any(np.diff(order) == 0)
+    if has_duplicate:
+        raise ValueError('Invalid %s. Cannot have duplicate elements.' % title)
 
     return order
 


### PR DESCRIPTION
- [x] closes #6244
- [x] tests added / passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message.

In addition to handling the case of inputting a list of lags to include, this also adds some additional validation with better error messages (e.g. for the case that `endog` is not univariate, now there will be a clear message to that effect).