### PR TITLE
BUG: Hannan-Rissanen third stage is invalid if non-stationary/invertible

### DIFF
--- a/statsmodels/tsa/arima/estimators/tests/test_hannan_rissanen.py
+++ b/statsmodels/tsa/arima/estimators/tests/test_hannan_rissanen.py
@@ -94,9 +94,9 @@ def test_nonconsecutive_lags():
     hannan_rissanen(endog, ar_order=0, ma_order=0)
 
 
-@pytest.mark.xfail(reason='TODO: improve check/conversions on datatype.')
-def test_overflow_error():
-    endog = np.arange(100)
-    # TODO: this currently raises an overflow error, because we aren't
-    # forcing a conversion from int to float
-    hannan_rissanen(endog, ma_order=1, demean=False)
+def test_unbiased_error():
+    # Test that we get the appropriate error when we specify unbiased=True
+    # but the second-stage yields non-stationary parameters.
+    endog = (np.arange(1000) * 1.0)
+    with pytest.raises(ValueError, match='Cannot perform third step'):
+        hannan_rissanen(endog, ar_order=1, ma_order=1, unbiased=True)

--- a/statsmodels/tsa/arima/tests/test_model.py
+++ b/statsmodels/tsa/arima/tests/test_model.py
@@ -104,8 +104,8 @@ def test_burg():
 
 
 def test_hannan_rissanen():
-    # Test for basic use of Yule-Walker estimation
-    endog = dta['infl'].iloc[:100]
+    # Test for basic use of Hannan-Rissanen estimation
+    endog = dta['infl'].diff().iloc[1:101]
 
     # ARMA(1, 1), no trend (since trend would imply GLS estimation)
     desired_p, _ = hannan_rissanen(


### PR DESCRIPTION
- [x] tests added / passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message.

See #6238 for the report of the underling issue that this PR resolves, which is essentially an overflow error from generating an intermediate series for the unbiasing step if the estimated parameters are non-stationary / non-invertible.