### PR TITLE
ENH: and vlines option to plot_fit

### DIFF
--- a/statsmodels/graphics/regressionplots.py
+++ b/statsmodels/graphics/regressionplots.py
@@ -151,10 +151,10 @@ def plot_fit(results, exog_idx, y_true=None, ax=None, vlines=True, **kwargs):
         ax.plot(x1, y_true[x1_argsort], 'b-', label='True values')
     title = 'Fitted values versus %s' % exog_name
 
-    _, iv_l, iv_u = wls_prediction_std(results)
     ax.plot(x1, results.fittedvalues[x1_argsort], 'D', color='r',
             label='fitted', **kwargs)
     if vlines is True:
+        _, iv_l, iv_u = wls_prediction_std(results)
         ax.vlines(x1, iv_l[x1_argsort], iv_u[x1_argsort], linewidth=1,
                   color='k', alpha=.7)
     #ax.fill_between(x1, iv_l[x1_argsort], iv_u[x1_argsort], alpha=0.1,

--- a/statsmodels/graphics/regressionplots.py
+++ b/statsmodels/graphics/regressionplots.py
@@ -91,7 +91,7 @@ def plot_fit(results, exog_idx, y_true=None, ax=None, vlines=True, **kwargs):
         If given, this subplot is used to plot in instead of a new figure being
         created.
     vlines : bool
-        (optional) If this not True, then the uncertainty of the fot is not
+        (optional) If this not True, then the uncertainty of the fit is not
         plotted.
     **kwargs
         The keyword arguments are passed to the plot command for the fitted

--- a/statsmodels/graphics/regressionplots.py
+++ b/statsmodels/graphics/regressionplots.py
@@ -73,7 +73,7 @@ def add_lowess(ax, lines_idx=0, frac=.2, **lowess_kwargs):
     return ax.figure
 
 
-def plot_fit(results, exog_idx, y_true=None, ax=None, **kwargs):
+def plot_fit(results, exog_idx, y_true=None, ax=None, vlines=True, **kwargs):
     """Plot fit against one regressor.
 
     This creates one graph with the scatterplot of observed values compared to
@@ -86,10 +86,13 @@ def plot_fit(results, exog_idx, y_true=None, ax=None, **kwargs):
     x_var : int or str
         Name or index of regressor in exog matrix.
     y_true : array_like
-        (optional) If this is not None, then the array is added to the plot
+        (optional) If this is not None, then the array is added to the plot.
     ax : Matplotlib AxesSubplot instance, optional
         If given, this subplot is used to plot in instead of a new figure being
         created.
+    vlines : bool
+        (optional) If this not True, then the uncertainty of the fot is not
+        plotted.
     **kwargs
         The keyword arguments are passed to the plot command for the fitted
         values points.
@@ -148,11 +151,12 @@ def plot_fit(results, exog_idx, y_true=None, ax=None, **kwargs):
         ax.plot(x1, y_true[x1_argsort], 'b-', label='True values')
     title = 'Fitted values versus %s' % exog_name
 
-    prstd, iv_l, iv_u = wls_prediction_std(results)
+    _, iv_l, iv_u = wls_prediction_std(results)
     ax.plot(x1, results.fittedvalues[x1_argsort], 'D', color='r',
             label='fitted', **kwargs)
-    ax.vlines(x1, iv_l[x1_argsort], iv_u[x1_argsort], linewidth=1, color='k',
-              alpha=.7)
+    if vlines is True:
+        ax.vlines(x1, iv_l[x1_argsort], iv_u[x1_argsort], linewidth=1,
+                  color='k', alpha=.7)
     #ax.fill_between(x1, iv_l[x1_argsort], iv_u[x1_argsort], alpha=0.1,
     #                    color='k')
     ax.set_title(title)


### PR DESCRIPTION
make vlines optional in regression plot


- [NA] closes #xxxx
- [see info below] tests added / passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>

```
import numpy as np
import statsmodels.api as sm
import matplotlib.pyplot as plt
from statsmodels.graphics import utils
from statsmodels.tools.tools import maybe_unwrap_results
from statsmodels.sandbox.regression.predstd import wls_prediction_std

data = sm.datasets.statecrime.load_pandas().data
murder = data['murder']
X = data['poverty'].to_frame()
X["constant"] = 1
y = murder
model = sm.OLS(y, X)
results = model.fit()

fig, ax = plt.subplots()
exog_idx = 0
kwargs = {}
vlines=True

fig, ax = utils.create_mpl_ax(ax)
exog_name, exog_idx = utils.maybe_name_or_idx(exog_idx, results.model)
results = maybe_unwrap_results(results)
y = results.model.endog
x1 = results.model.exog[:, exog_idx]
x1_argsort = np.argsort(x1)
y = y[x1_argsort]
x1 = x1[x1_argsort]
ax.plot(x1, y, 'bo', label=results.model.endog_names)
title = 'Fitted values versus %s' % exog_name
prstd, iv_l, iv_u = wls_prediction_std(results)
ax.plot(x1, results.fittedvalues[x1_argsort], 'D', color='r', label='fitted', **kwargs)
if vlines is True:
    ax.vlines(x1, iv_l[x1_argsort], iv_u[x1_argsort], linewidth=1, color='k', alpha=.7)
```
![Capture](https://user-images.githubusercontent.com/17162724/69444111-ad3ead00-0d1d-11ea-8e54-3e150738fb46.PNG)

```
fig, ax = plt.subplots()
exog_idx = 0
kwargs = {}
vlines = False

fig, ax = utils.create_mpl_ax(ax)
exog_name, exog_idx = utils.maybe_name_or_idx(exog_idx, results.model)
results = maybe_unwrap_results(results)
y = results.model.endog
x1 = results.model.exog[:, exog_idx]
x1_argsort = np.argsort(x1)
y = y[x1_argsort]
x1 = x1[x1_argsort]
ax.plot(x1, y, 'bo', label=results.model.endog_names)
title = 'Fitted values versus %s' % exog_name
prstd, iv_l, iv_u = wls_prediction_std(results)
ax.plot(x1, results.fittedvalues[x1_argsort], 'D', color='r', label='fitted', **kwargs)
if vlines is True:
    ax.vlines(x1, iv_l[x1_argsort], iv_u[x1_argsort], linewidth=1, color='k', alpha=.7)
```
![Capture2](https://user-images.githubusercontent.com/17162724/69444200-d8c19780-0d1d-11ea-85c3-55f15128ba7e.PNG)


