### PR TITLE
MAINT/DOC: Clarify patsy 0.5.1 is required

### DIFF
--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -17,7 +17,7 @@ pandas >= 0.21
 
     pandas.pydata.org
 
-patsy >= 0.5.0
+patsy >= 0.5.1
 
     patsy.readthedocs.org
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -134,7 +134,7 @@ The current minimum dependencies are:
 * `NumPy <https://www.scipy.org/>`__ >= 1.14
 * `SciPy <https://www.scipy.org/>`__ >= 1.0
 * `Pandas <https://pandas.pydata.org/>`__ >= 0.21
-* `Patsy <https://patsy.readthedocs.io/en/latest/>`__ >= 0.5.0
+* `Patsy <https://patsy.readthedocs.io/en/latest/>`__ >= 0.5.1
 
 Cython is required to build from a git checkout but not to run or install from PyPI:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy>=1.14
 scipy>=1.0
 pandas>=0.21
-patsy>=0.5
+patsy>=0.5.1
 


### PR DESCRIPTION
Clarify patsy requirement

closes #6267

- [X] closes #6267
- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 
