### PR TITLE
DOC: Fix notebook

### DIFF
--- a/examples/notebooks/statespace_sarimax_stata.ipynb
+++ b/examples/notebooks/statespace_sarimax_stata.ipynb
@@ -30,9 +30,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "%matplotlib inline"
@@ -41,9 +39,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import numpy as np\n",
@@ -53,7 +49,9 @@
     "import matplotlib.pyplot as plt\n",
     "from datetime import datetime\n",
     "import requests\n",
-    "from io import BytesIO"
+    "from io import BytesIO\n",
+    "# Register converters to avoid warnings\n",
+    "pd.plotting.register_matplotlib_converters()"
    ]
   },
   {
@@ -97,18 +95,18 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Dataset\n",
     "wpi1 = requests.get('https://www.stata-press.com/data/r12/wpi1.dta').content\n",
     "data = pd.read_stata(BytesIO(wpi1))\n",
     "data.index = data.t\n",
+    "# Set the frequency\n",
+    "data.index.freq=\"QS-OCT\"\n",
     "\n",
     "# Fit the model\n",
-    "mod = sm.tsa.statespace.SARIMAX(data['wpi'], trend='c', order=(1,1,(1,0,0,1)))\n",
+    "mod = sm.tsa.statespace.SARIMAX(data['wpi'], trend='c', order=(1,1,1))\n",
     "res = mod.fit(disp=False)\n",
     "print(res.summary())"
    ]
@@ -120,12 +118,12 @@
     "Thus the maximum likelihood estimates imply that for the process above, we have:\n",
     "\n",
     "$$\n",
-    "\\Delta y_t = 0.1050 + 0.8740 \\Delta y_{t-1} - 0.4206 \\epsilon_{t-1} + \\epsilon_{t}\n",
+    "\\Delta y_t = 0.1050 + 0.8742 \\Delta y_{t-1} - 0.4120 \\epsilon_{t-1} + \\epsilon_{t}\n",
     "$$\n",
     "\n",
-    "where $\\epsilon_{t} \\sim N(0, 0.5226)$. Finally, recall that $c = (1 - \\phi_1) \\beta_0$, and here $c = 0.1050$ and $\\phi_1 = 0.8740$. To compare with the output from Stata, we could calculate the mean:\n",
+    "where $\\epsilon_{t} \\sim N(0, 0.5257)$. Finally, recall that $c = (1 - \\phi_1) \\beta_0$, and here $c = 0.0943$ and $\\phi_1 = 0.8742$. To compare with the output from Stata, we could calculate the mean:\n",
     "\n",
-    "$$\\beta_0 = \\frac{c}{1 - \\phi_1} = \\frac{0.1050}{1 - 0.8740} = 0.83$$\n",
+    "$$\\beta_0 = \\frac{c}{1 - \\phi_1} = \\frac{0.0943}{1 - 0.8742} = 0.7496$$\n",
     "\n",
     "**Note**: these values are slightly different from the values in the Stata documentation because the optimizer in statsmodels has found parameters here that yield a higher likelihood. Nonetheless, they are very close."
    ]
@@ -157,14 +155,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Dataset\n",
     "data = pd.read_stata(BytesIO(wpi1))\n",
     "data.index = data.t\n",
+    "data.index.freq=\"QS-OCT\"\n",
+    "\n",
     "data['ln_wpi'] = np.log(data['wpi'])\n",
     "data['D.ln_wpi'] = data['ln_wpi'].diff()"
    ]
@@ -172,9 +170,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Graph data\n",
@@ -193,9 +189,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Graph data\n",
@@ -258,13 +252,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Fit the model\n",
-    "mod = sm.tsa.statespace.SARIMAX(data['ln_wpi'], trend='c', order=(1,1,1))\n",
+    "mod = sm.tsa.statespace.SARIMAX(data['ln_wpi'], trend='c', order=(1,1,(1,0,0,1)))\n",
     "res = mod.fit(disp=False)\n",
     "print(res.summary())"
    ]
@@ -338,9 +330,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Dataset\n",
@@ -400,15 +390,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Dataset\n",
     "friedman2 = requests.get('https://www.stata-press.com/data/r12/friedman2.dta').content\n",
     "data = pd.read_stata(BytesIO(friedman2))\n",
     "data.index = data.time\n",
+    "data.index.freq = \"QS-OCT\"\n",
     "\n",
     "# Variables\n",
     "endog = data.loc['1959':'1981', 'consump']\n",
@@ -434,14 +423,13 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Dataset\n",
     "raw = pd.read_stata(BytesIO(friedman2))\n",
     "raw.index = raw.time\n",
+    "raw.index.freq = \"QS-OCT\"\n",
     "data = raw.loc[:'1981']\n",
     "\n",
     "# Variables\n",
@@ -465,9 +453,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "mod = sm.tsa.statespace.SARIMAX(endog, exog=exog, order=(1,0,1))\n",
@@ -486,9 +472,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# In-sample one-step-ahead predictions\n",
@@ -510,9 +494,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Dynamic predictions\n",
@@ -530,9 +512,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Graph\n",
@@ -564,9 +544,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Prediction error\n",
@@ -613,9 +591,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.3"
+   "version": "3.7.5"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }


### PR DESCRIPTION
Fix SARIMAX stata notebook to have correct examples in correct cells

- [ ] closes #xxxx
- [ ] tests added / passed. 
- [ ] code/documentation is well formatted.  
- [ ] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
