### PR TITLE
BUG: Raise in GC test for VAR(0)

### DIFF
--- a/statsmodels/tsa/vector_ar/tests/test_var.py
+++ b/statsmodels/tsa/vector_ar/tests/test_var.py
@@ -378,6 +378,11 @@ class TestVARResults(CheckIRF, CheckFEVD):
         with pytest.raises(Exception):
             self.res.test_causality(0, 1, kind='foo')
 
+    def test_causality_no_lags(self):
+        res = VAR(self.data).fit(maxlags=0)
+        with pytest.raises(RuntimeError, match="0 lags"):
+            res.test_causality(0, 1)
+
     @pytest.mark.smoke
     def test_select_order(self):
         result = self.model.fit(10, ic='aic', verbose=True)

--- a/statsmodels/tsa/vector_ar/var_model.py
+++ b/statsmodels/tsa/vector_ar/var_model.py
@@ -1800,6 +1800,9 @@ class VARResults(VARProcess):
             causing = [self.names[c] for c in caused_ind]
 
         k, p = self.neqs, self.k_ar
+        if p == 0:
+            err = "Cannot test Granger Causality in a model with 0 lags."
+            raise RuntimeError(err)
 
         # number of restrictions
         num_restr = len(causing) * len(caused) * p


### PR DESCRIPTION
Raise when trying to test GC in a model with 0 lags

closes #6274

- [X] closes #6274
- [X] tests added / passed. 
- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
