### PR TITLE
BUG: Correct VAR sumary when model contains exog variables

### DIFF
--- a/statsmodels/tsa/vector_ar/output.py
+++ b/statsmodels/tsa/vector_ar/output.py
@@ -152,11 +152,10 @@ class VARSummary(object):
         header = ('coefficient','std. error','t-stat','prob')
 
         buf = StringIO()
-        dim = k * model.k_ar + model.k_trend
+        dim = k * model.k_ar + model.k_trend + model.k_exog_user
         for i in range(k):
             section = "Results for equation %s" % model.names[i]
             buf.write(section + '\n')
-            #print >> buf, section
 
             table = SimpleTable(data[dim * i : dim * (i + 1)], header,
                                 Xnames, title=None, txt_fmt = self.default_fmt)

--- a/statsmodels/tsa/vector_ar/tests/test_var.py
+++ b/statsmodels/tsa/vector_ar/tests/test_var.py
@@ -2,29 +2,24 @@
 """
 Test VAR Model
 """
-from statsmodels.compat.python import iteritems, lrange
-
-from io import StringIO, BytesIO
-import warnings
-
 import os
 import sys
+import warnings
+from io import StringIO, BytesIO
 
 import numpy as np
 import pandas as pd
-from pandas.util.testing import assert_index_equal
 import pytest
-
-
-import statsmodels.api as sm
-import statsmodels.tsa.vector_ar.util as util
-import statsmodels.tools.data as data_util
-from statsmodels.tsa.vector_ar.var_model import VAR, var_acf
-from statsmodels.tools.sm_exceptions import ValueWarning
-
-
 from numpy.testing import (assert_almost_equal, assert_equal,
                            assert_allclose)
+from pandas.util.testing import assert_index_equal
+
+import statsmodels.api as sm
+import statsmodels.tools.data as data_util
+import statsmodels.tsa.vector_ar.util as util
+from statsmodels.compat.python import iteritems, lrange
+from statsmodels.tools.sm_exceptions import ValueWarning
+from statsmodels.tsa.vector_ar.var_model import VAR, var_acf
 
 DECIMAL_12 = 12
 DECIMAL_6 = 6
@@ -817,3 +812,28 @@ def test_var_cov_params_pandas(bivariate_var_data):
     index = pd.MultiIndex.from_product((exog_names, ('x', 'y')))
     assert_index_equal(cov.index, cov.columns)
     assert_index_equal(cov.index, index)
+
+
+def test_summaries_exog(reset_randomstate):
+    y = np.random.standard_normal((500, 6))
+    df = pd.DataFrame(y)
+    cols = (["endog_{0}".format(i) for i in range(2)] +
+            ["exog_{0}".format(i) for i in range(4)])
+    df.columns = cols
+    df.index = pd.date_range('1-1-1950', periods=500, freq="MS")
+    endog = df.iloc[:, :2]
+    exog = df.iloc[:, 2:]
+
+    res = VAR(endog=endog, exog=exog).fit(maxlags=0)
+    summ = res.summary().summary
+    assert 'exog0' in summ
+    assert 'exog1' in summ
+    assert 'exog2' in summ
+    assert 'exog3' in summ
+
+    res = VAR(endog=endog, exog=exog).fit(maxlags=2)
+    summ = res.summary().summary
+    assert 'exog0' in summ
+    assert 'exog1' in summ
+    assert 'exog2' in summ
+    assert 'exog3' in summ

--- a/statsmodels/tsa/vector_ar/var_model.py
+++ b/statsmodels/tsa/vector_ar/var_model.py
@@ -603,13 +603,14 @@ class VAR(TimeSeriesModel):
             "nc" - co constant, no trend
             Note that these are prepended to the columns of the dataset.
 
-        Notes
-        -----
-        Lütkepohl pp. 146-153
-
         Returns
         -------
-        est : VARResultsWrapper
+        VARResults
+            Estimation results
+
+        Notes
+        -----
+        See Lütkepohl pp. 146-153 for implementation details.
         """
         lags = maxlags
 


### PR DESCRIPTION
Ensure that dimension is correct when model contains exogenous variables

closes #6203

- [X] closes #6203
- [X] tests added / passed. 
- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
