### PR TITLE
MAINT: Remove open_help method

### DIFF
--- a/statsmodels/api.py
+++ b/statsmodels/api.py
@@ -54,18 +54,6 @@ from .tools.web import webdoc
 
 load = load_pickle
 
-chmpath = os.path.join(os.path.dirname(__file__), 'statsmodelsdoc.chm')
-if os.path.exists(chmpath):
-    # As of 0.10.0, this is not reached.  See GH#5134
-
-    def open_help(chmpath=chmpath):
-        from subprocess import Popen
-
-        p = Popen(chmpath, shell=True)
-
-del os
-del chmpath
-
 from ._version import get_versions
 __version__ = get_versions()['version']
 del get_versions


### PR DESCRIPTION
Remove unsupported chm help opener

closes #5134

- [X] closes #5134
- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
