### PR TITLE
BUG: Fix conf interval with MI

### DIFF
--- a/statsmodels/tsa/statespace/mlemodel.py
+++ b/statsmodels/tsa/statespace/mlemodel.py
@@ -3704,8 +3704,8 @@ class PredictionResults(pred.PredictionResults):
             ynames = self.model.data.ynames
             if not type(ynames) == list:
                 ynames = [ynames]
-            names = (['lower %s' % name for name in ynames] +
-                     ['upper %s' % name for name in ynames])
+            names = (['lower {0}'.format(name) for name in ynames] +
+                     ['upper {0}'.format(name) for name in ynames])
             conf_int.columns = names
 
         return conf_int

--- a/statsmodels/tsa/statespace/tests/test_exponential_smoothing.py
+++ b/statsmodels/tsa/statespace/tests/test_exponential_smoothing.py
@@ -804,6 +804,26 @@ class TestHoltWintersNoTrendConcentratedInitialization(
         super().setup_class(mod, start_params=start_params, rtol=1e-4)
 
 
+class TestMultiIndex(CheckExponentialSmoothing):
+    @classmethod
+    def setup_class(cls):
+        oildata_copy = oildata.copy()
+        oildata_copy.name = ("oil", "data")
+        mod = ExponentialSmoothing(oildata_copy,
+                                   initialization_method='simple')
+        res = mod.filter([results_params['oil_fpp2']['alpha']])
+
+        super().setup_class('oil_fpp2', res)
+
+    def test_conf_int(self):
+        # Forecast confidence intervals
+        ci_95 = self.forecast.conf_int(alpha=0.05)
+        assert_allclose(ci_95["lower ('oil', 'data')"],
+                        results_predict['%s_lower' % self.name][self.nobs:])
+        assert_allclose(ci_95["upper ('oil', 'data')"],
+                        results_predict['%s_upper' % self.name][self.nobs:])
+
+
 def test_invalid():
     # Tests for invalid model specifications that raise ValueErrors
     with pytest.raises(


### PR DESCRIPTION
Fix confidence interval so that it works with MI series

closes #6296

- [X] closes #6296
- [X] tests added / passed. 
- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
