### PR TITLE
MAINT: Deprecate recarray support

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,7 @@ filterwarnings =
     error:the 'lags' keyword is deprecated:FutureWarning:
     error:nobs is deprecated in favor of lagsDeprecationWarning:
     error:The default pvalmethod will change:FutureWarning:
+    error:recarray support has been deprecated:FutureWarning:
 markers =
     example: mark a test that runs example code
     matplotlib: mark a test that requires matplotlib

--- a/statsmodels/base/data.py
+++ b/statsmodels/base/data.py
@@ -59,6 +59,10 @@ class ModelData(object):
 
     def __init__(self, endog, exog=None, missing='none', hasconst=None,
                  **kwargs):
+        if data_util._is_recarray(endog) or data_util._is_recarray(exog):
+            import warnings
+            from statsmodels.tools.sm_exceptions import recarray_warning
+            warnings.warn(recarray_warning, FutureWarning)
         if 'design_info' in kwargs:
             self.design_info = kwargs.pop('design_info')
         if 'formula' in kwargs:

--- a/statsmodels/base/tests/test_data.py
+++ b/statsmodels/base/tests/test_data.py
@@ -187,7 +187,8 @@ class TestRecarrays(TestArrays):
                                            ('x_2', 'f8')]).view(np.recarray)
         exog['const'] = 1
         cls.exog = exog
-        cls.data = sm_data.handle_data(cls.endog, cls.exog)
+        with pytest.warns(FutureWarning, match="recarray support"):
+            cls.data = sm_data.handle_data(cls.endog, cls.exog)
         cls.xnames = ['const', 'x_1', 'x_2']
         cls.ynames = 'y_1'
 
@@ -207,7 +208,8 @@ class TestStructarrays(TestArrays):
                                            ('x_2', 'f8')]).view(np.recarray)
         exog['const'] = 1
         cls.exog = exog
-        cls.data = sm_data.handle_data(cls.endog, cls.exog)
+        with pytest.warns(FutureWarning, match="recarray support"):
+            cls.data = sm_data.handle_data(cls.endog, cls.exog)
         cls.xnames = ['const', 'x_1', 'x_2']
         cls.ynames = 'y_1'
 

--- a/statsmodels/genmod/tests/results/results_glm.py
+++ b/statsmodels/genmod/tests/results/results_glm.py
@@ -5,12 +5,13 @@ Hard-coded from R or Stata.  Note that some of the remaining discrepancy vs.
 Stata may be because Stata uses ML by default unless you specifically ask for
 IRLS.
 """
+import os
+
 import numpy as np
 import pandas as pd
-from . import glm_test_resids
-import os
-from statsmodels.api import add_constant, categorical
 
+from statsmodels.api import add_constant, categorical
+from . import glm_test_resids
 
 # Test Precisions
 DECIMAL_4 = 4
@@ -701,19 +702,12 @@ class Lbw(object):
         filename = os.path.join(os.path.dirname(os.path.abspath(__file__)),
                                 "stata_lbw_glm.csv")
 
-        data = pd.read_csv(filename).to_records(index=False)
-        # categorical does not work with pandas
-        data = categorical(data, col='race', drop=True)
+        data = pd.read_csv(filename)
+        dummies = pd.get_dummies(data.race, prefix="race", drop_first=False)
+        data = pd.concat([data, dummies], 1)
         self.endog = data.low
-        design = np.column_stack((
-            data['age'],
-            data['lwt'],
-            data['race_black'],
-            data['race_other'],
-            data['smoke'],
-            data['ptl'],
-            data['ht'],
-            data['ui']))
+        design = data[["age", "lwt", "race_black", "race_other", "smoke",
+                       "ptl", "ht", "ui"]]
         self.exog = add_constant(design, prepend=False)
         # Results for Canonical Logit Link
         self.params = (

--- a/statsmodels/sandbox/descstats.py
+++ b/statsmodels/sandbox/descstats.py
@@ -35,6 +35,11 @@ def descstats(data, cols=None, axis=0):
     '''
 
     x = np.array(data)  # or rather, the data we're interested in
+    if isinstance(x, np.recarray):
+        # deprecated: remove recarray support after 0.12
+        import warnings
+        from statsmodels.tools.sm_exceptions import recarray_warning
+        warnings.warn(recarray_warning, FutureWarning)
     if cols is None:
 #       if isinstance(x, np.recarray):
 #            cols = np.array(len(x.dtype.names))

--- a/statsmodels/tools/data.py
+++ b/statsmodels/tools/data.py
@@ -49,6 +49,9 @@ def interpret_data(data, colnames=None, rownames=None):
     """
     if isinstance(data, np.ndarray):
         if _is_structured_ndarray(data):
+            import warnings
+            from statsmodels.tools.sm_exceptions import recarray_warning
+            warnings.warn(recarray_warning, FutureWarning)
             if colnames is None:
                 colnames = data.dtype.names
             values = struct_to_ndarray(data)

--- a/statsmodels/tools/sm_exceptions.py
+++ b/statsmodels/tools/sm_exceptions.py
@@ -127,6 +127,17 @@ class CollinearityWarning(ModelWarning):
     pass
 
 
+recarray_warning = """\
+recarray support has been deprecated and will be removed after 0.12.  Please \
+use pandas DataFrames and Series for structured data.
+
+You can suppress this warning using
+
+from warnings import filterwarnings
+filterwarnings("ignore", message="recarray support", category=FutureWarning)
+"""
+
+
 warnings.simplefilter('always', category=ModelWarning)
 warnings.simplefilter("always", (ConvergenceWarning, CacheWriteWarning,
                                  IterationLimitWarning, InvalidTestWarning))

--- a/statsmodels/tools/tests/test_data.py
+++ b/statsmodels/tools/tests/test_data.py
@@ -1,7 +1,9 @@
 import pandas
 import numpy as np
+import pytest
 
 from statsmodels.tools import data
+
 
 def test_missing_data_pandas():
     """
@@ -17,7 +19,8 @@ def test_structarray():
     X = np.random.random((9,)).view([('var1', 'f8'),
                                         ('var2', 'f8'),
                                         ('var3', 'f8')])
-    vals, cnames, rnames = data.interpret_data(X)
+    with pytest.warns(FutureWarning, match="recarray support"):
+        vals, cnames, rnames = data.interpret_data(X)
     np.testing.assert_equal(cnames, X.dtype.names)
     np.testing.assert_equal(vals, X.view((float,3)))
     np.testing.assert_equal(rnames, None)
@@ -26,7 +29,8 @@ def test_recarray():
     X = np.random.random((9,)).view([('var1', 'f8'),
                                         ('var2', 'f8'),
                                         ('var3', 'f8')])
-    vals, cnames, rnames = data.interpret_data(X.view(np.recarray))
+    with pytest.warns(FutureWarning, match="recarray support"):
+        vals, cnames, rnames = data.interpret_data(X.view(np.recarray))
     np.testing.assert_equal(cnames, X.dtype.names)
     np.testing.assert_equal(vals, X.view((float,3)))
     np.testing.assert_equal(rnames, None)

--- a/statsmodels/tools/tests/test_tools.py
+++ b/statsmodels/tools/tests/test_tools.py
@@ -73,7 +73,8 @@ class TestTools(object):
                       (7, 'abcd', 2.0, 4.0),
                       (21, 'abcd', 2.0, 8.0)], dt)
         x = x.view(np.recarray)
-        y = tools.add_constant(x)
+        with pytest.warns(FutureWarning, match="recarray support"):
+            y = tools.add_constant(x)
         assert_equal(y['const'],np.array([1.0,1.0,1.0]))
         for f in x.dtype.fields:
             assert y[f].dtype == x[f].dtype
@@ -246,7 +247,8 @@ class TestCategoricalNumerical(object):
         assert_equal(des.shape[1],5)
 
     def test_recarray2d(self):
-        des = tools.categorical(self.recdes, col='instrument')
+        with pytest.warns(FutureWarning, match="recarray support"):
+            des = tools.categorical(self.recdes, col='instrument')
         # better way to do this?
         test_des = np.column_stack(([des[_] for _ in des.dtype.names[-5:]]))
         assert_array_equal(test_des, self.dummy)
@@ -255,62 +257,72 @@ class TestCategoricalNumerical(object):
     def test_recarray2d_error(self):
         arr = np.c_[self.recdes, self.recdes]
         with pytest.raises(IndexError, match='col is None and the input'):
-            tools.categorical(arr, col=None)
+            with pytest.warns(FutureWarning, match="recarray support"):
+                tools.categorical(arr, col=None)
 
     def test_recarray2dint(self):
-        des = tools.categorical(self.recdes, col=2)
+        with pytest.warns(FutureWarning, match="recarray support"):
+            des = tools.categorical(self.recdes, col=2)
         test_des = np.column_stack(([des[_] for _ in des.dtype.names[-5:]]))
         assert_array_equal(test_des, self.dummy)
         assert_equal(len(des.dtype.names), 9)
 
     def test_recarray1d(self):
         instr = self.structdes['instrument'].view(np.recarray)
-        dum = tools.categorical(instr)
+        with pytest.warns(FutureWarning, match="recarray support"):
+            dum = tools.categorical(instr)
         test_dum = np.column_stack(([dum[_] for _ in dum.dtype.names[-5:]]))
         assert_array_equal(test_dum, self.dummy)
         assert_equal(len(dum.dtype.names), 6)
 
     def test_recarray1d_drop(self):
         instr = self.structdes['instrument'].view(np.recarray)
-        dum = tools.categorical(instr, drop=True)
+        with pytest.warns(FutureWarning, match="recarray support"):
+            dum = tools.categorical(instr, drop=True)
         test_dum = np.column_stack(([dum[_] for _ in dum.dtype.names]))
         assert_array_equal(test_dum, self.dummy)
         assert_equal(len(dum.dtype.names), 5)
 
     def test_recarray2d_drop(self):
-        des = tools.categorical(self.recdes, col='instrument', drop=True)
+        with pytest.warns(FutureWarning, match="recarray support"):
+            des = tools.categorical(self.recdes, col='instrument', drop=True)
         test_des = np.column_stack(([des[_] for _ in des.dtype.names[-5:]]))
         assert_array_equal(test_des, self.dummy)
         assert_equal(len(des.dtype.names), 8)
 
     def test_structarray2d(self):
-        des = tools.categorical(self.structdes, col='instrument')
+        with pytest.warns(FutureWarning, match="recarray support"):
+            des = tools.categorical(self.structdes, col='instrument')
         test_des = np.column_stack(([des[_] for _ in des.dtype.names[-5:]]))
         assert_array_equal(test_des, self.dummy)
         assert_equal(len(des.dtype.names), 9)
 
     def test_structarray2dint(self):
-        des = tools.categorical(self.structdes, col=2)
+        with pytest.warns(FutureWarning, match="recarray support"):
+            des = tools.categorical(self.structdes, col=2)
         test_des = np.column_stack(([des[_] for _ in des.dtype.names[-5:]]))
         assert_array_equal(test_des, self.dummy)
         assert_equal(len(des.dtype.names), 9)
 
     def test_structarray1d(self):
         instr = self.structdes['instrument'].view(dtype=[('var1', 'f4')])
-        dum = tools.categorical(instr)
+        with pytest.warns(FutureWarning, match="recarray support"):
+            dum = tools.categorical(instr)
         test_dum = np.column_stack(([dum[_] for _ in dum.dtype.names[-5:]]))
         assert_array_equal(test_dum, self.dummy)
         assert_equal(len(dum.dtype.names), 6)
 
     def test_structarray2d_drop(self):
-        des = tools.categorical(self.structdes, col='instrument', drop=True)
+        with pytest.warns(FutureWarning, match="recarray support"):
+            des = tools.categorical(self.structdes, col='instrument', drop=True)
         test_des = np.column_stack(([des[_] for _ in des.dtype.names[-5:]]))
         assert_array_equal(test_des, self.dummy)
         assert_equal(len(des.dtype.names), 8)
 
     def test_structarray1d_drop(self):
         instr = self.structdes['instrument'].view(dtype=[('var1', 'f4')])
-        dum = tools.categorical(instr, drop=True)
+        with pytest.warns(FutureWarning, match="recarray support"):
+            dum = tools.categorical(instr, drop=True)
         test_dum = np.column_stack(([dum[_] for _ in dum.dtype.names]))
         assert_array_equal(test_dum, self.dummy)
         assert_equal(len(dum.dtype.names), 5)
@@ -398,66 +410,76 @@ class TestCategoricalString(TestCategoricalNumerical):
         assert_equal(des.shape[1], 5)
 
     def test_recarray2d(self):
-        des = tools.categorical(self.recdes, col='str_instr')
+        with pytest.warns(FutureWarning, match="recarray support"):
+            des = tools.categorical(self.recdes, col='str_instr')
         # TODO: better way to do this?
         test_des = np.column_stack(([des[_] for _ in des.dtype.names[-5:]]))
         assert_array_equal(test_des, self.dummy)
         assert_equal(len(des.dtype.names), 9)
 
     def test_recarray2dint(self):
-        des = tools.categorical(self.recdes, col=3)
+        with pytest.warns(FutureWarning, match="recarray support"):
+            des = tools.categorical(self.recdes, col=3)
         test_des = np.column_stack(([des[_] for _ in des.dtype.names[-5:]]))
         assert_array_equal(test_des, self.dummy)
         assert_equal(len(des.dtype.names), 9)
 
     def test_recarray1d(self):
         instr = self.structdes['str_instr'].view(np.recarray)
-        dum = tools.categorical(instr)
+        with pytest.warns(FutureWarning, match="recarray support"):
+            dum = tools.categorical(instr)
         test_dum = np.column_stack(([dum[_] for _ in dum.dtype.names[-5:]]))
         assert_array_equal(test_dum, self.dummy)
         assert_equal(len(dum.dtype.names), 6)
 
     def test_recarray1d_drop(self):
         instr = self.structdes['str_instr'].view(np.recarray)
-        dum = tools.categorical(instr, drop=True)
+        with pytest.warns(FutureWarning, match="recarray support"):
+            dum = tools.categorical(instr, drop=True)
         test_dum = np.column_stack(([dum[_] for _ in dum.dtype.names]))
         assert_array_equal(test_dum, self.dummy)
         assert_equal(len(dum.dtype.names), 5)
 
     def test_recarray2d_drop(self):
-        des = tools.categorical(self.recdes, col='str_instr', drop=True)
+        with pytest.warns(FutureWarning, match="recarray support"):
+            des = tools.categorical(self.recdes, col='str_instr', drop=True)
         test_des = np.column_stack(([des[_] for _ in des.dtype.names[-5:]]))
         assert_array_equal(test_des, self.dummy)
         assert_equal(len(des.dtype.names), 8)
 
     def test_structarray2d(self):
-        des = tools.categorical(self.structdes, col='str_instr')
+        with pytest.warns(FutureWarning, match="recarray support"):
+            des = tools.categorical(self.structdes, col='str_instr')
         test_des = np.column_stack(([des[_] for _ in des.dtype.names[-5:]]))
         assert_array_equal(test_des, self.dummy)
         assert_equal(len(des.dtype.names), 9)
 
     def test_structarray2dint(self):
-        des = tools.categorical(self.structdes, col=3)
+        with pytest.warns(FutureWarning, match="recarray support"):
+            des = tools.categorical(self.structdes, col=3)
         test_des = np.column_stack(([des[_] for _ in des.dtype.names[-5:]]))
         assert_array_equal(test_des, self.dummy)
         assert_equal(len(des.dtype.names), 9)
 
     def test_structarray1d(self):
         instr = self.structdes['str_instr'].view(dtype=[('var1', 'a10')])
-        dum = tools.categorical(instr)
+        with pytest.warns(FutureWarning, match="recarray support"):
+            dum = tools.categorical(instr)
         test_dum = np.column_stack(([dum[_] for _ in dum.dtype.names[-5:]]))
         assert_array_equal(test_dum, self.dummy)
         assert_equal(len(dum.dtype.names), 6)
 
     def test_structarray2d_drop(self):
-        des = tools.categorical(self.structdes, col='str_instr', drop=True)
+        with pytest.warns(FutureWarning, match="recarray support"):
+            des = tools.categorical(self.structdes, col='str_instr', drop=True)
         test_des = np.column_stack(([des[_] for _ in des.dtype.names[-5:]]))
         assert_array_equal(test_des, self.dummy)
         assert_equal(len(des.dtype.names), 8)
 
     def test_structarray1d_drop(self):
         instr = self.structdes['str_instr'].view(dtype=[('var1', 'a10')])
-        dum = tools.categorical(instr, drop=True)
+        with pytest.warns(FutureWarning, match="recarray support"):
+            dum = tools.categorical(instr, drop=True)
         test_dum = np.column_stack(([dum[_] for _ in dum.dtype.names]))
         assert_array_equal(test_dum, self.dummy)
         assert_equal(len(dum.dtype.names), 5)
@@ -485,14 +507,16 @@ class TestCategoricalString(TestCategoricalNumerical):
 
 def test_rec_issue302():
     arr = np.rec.fromrecords([[10], [11]], names='group')
-    actual = tools.categorical(arr)
+    with pytest.warns(FutureWarning, match="recarray support"):
+        actual = tools.categorical(arr)
     expected = np.rec.array([(10, 1.0, 0.0), (11, 0.0, 1.0)],
         dtype=[('group', int), ('group_10', float), ('group_11', float)])
     assert_array_equal(actual, expected)
 
 def test_issue302():
     arr = np.rec.fromrecords([[10, 12], [11, 13]], names=['group', 'whatever'])
-    actual = tools.categorical(arr, col=['group'])
+    with pytest.warns(FutureWarning, match="recarray support"):
+        actual = tools.categorical(arr, col=['group'])
     expected = np.rec.array([(10, 12, 1.0, 0.0), (11, 13, 0.0, 1.0)],
         dtype=[('group', int), ('whatever', int), ('group_10', float),
                ('group_11', float)])

--- a/statsmodels/tools/tools.py
+++ b/statsmodels/tools/tools.py
@@ -188,6 +188,10 @@ def categorical(data, col=None, dictnames=False, drop=False):
         return dummies
     # catch recarrays and structured arrays
     elif data.dtype.names or data.__class__ is np.recarray:
+        # deprecated: remove path after 0.12
+        import warnings
+        from statsmodels.tools.sm_exceptions import recarray_warning
+        warnings.warn(recarray_warning, FutureWarning)
         if not col and np.squeeze(data).ndim > 1:
             raise IndexError("col is None and the input array is not 1d")
         if isinstance(col, int):
@@ -305,6 +309,11 @@ def add_constant(data, prepend=True, has_constant='skip'):
     column's name is 'const'.
     """
     if _is_using_pandas(data, None) or _is_recarray(data):
+        if _is_recarray(data):
+            # deprecated: remove recarray support after 0.12
+            import warnings
+            from statsmodels.tools.sm_exceptions import recarray_warning
+            warnings.warn(recarray_warning, FutureWarning)
         from statsmodels.tsa.tsatools import add_trend
         return add_trend(data, trend='c', prepend=prepend, has_constant=has_constant)
 

--- a/statsmodels/tsa/tests/test_tsa_tools.py
+++ b/statsmodels/tsa/tests/test_tsa_tools.py
@@ -484,19 +484,21 @@ class TestAddTrend(object):
 
     def test_recarray(self):
         recarray = pd.DataFrame(self.arr_2d).to_records(index=False)
-        appended = tools.add_trend(recarray)
+        with pytest.warns(FutureWarning, match="recarray support"):
+            appended = tools.add_trend(recarray)
         expected = pd.DataFrame(self.arr_2d)
         expected['const'] = self.c
         expected = expected.to_records(index=False)
         assert_equal(expected, appended)
-
-        prepended = tools.add_trend(recarray, prepend=True)
+        with pytest.warns(FutureWarning, match="recarray support"):
+            prepended = tools.add_trend(recarray, prepend=True)
         expected = pd.DataFrame(self.arr_2d)
         expected.insert(0, 'const', self.c)
         expected = expected.to_records(index=False)
         assert_equal(expected, prepended)
 
-        appended = tools.add_trend(recarray, trend='ctt')
+        with pytest.warns(FutureWarning, match="recarray support"):
+            appended = tools.add_trend(recarray, trend='ctt')
         expected = pd.DataFrame(self.arr_2d)
         expected['const'] = self.c
         expected['trend'] = self.t
@@ -529,7 +531,8 @@ class TestAddTrend(object):
     def test_mixed_recarray(self):
         dt = np.dtype([('c0', np.float64), ('c1', np.int8), ('c2', 'S4')])
         ra = np.array([(1.0, 1, 'aaaa'), (1.1, 2, 'bbbb')], dtype=dt).view(np.recarray)
-        added = tools.add_trend(ra, trend='ct')
+        with pytest.warns(FutureWarning, match="recarray support"):
+            added = tools.add_trend(ra, trend='ct')
         dt = np.dtype([('c0', np.float64), ('c1', np.int8), ('c2', 'S4'), ('const', np.float64), ('trend', np.float64)])
         expected = np.array([(1.0, 1, 'aaaa', 1.0, 1.0), (1.1, 2, 'bbbb', 1.0, 2.0)], dtype=dt).view(np.recarray)
         assert_equal(added, expected)

--- a/statsmodels/tsa/tsatools.py
+++ b/statsmodels/tsa/tsatools.py
@@ -79,6 +79,11 @@ def add_trend(x, trend="c", prepend=False, has_constant='skip'):
     is_pandas = _is_using_pandas(x, None) or is_recarray
     if is_pandas or is_recarray:
         if is_recarray:
+            # deprecated: remove recarray support after 0.12
+            import warnings
+            from statsmodels.tools.sm_exceptions import recarray_warning
+            warnings.warn(recarray_warning, FutureWarning)
+
             descr = x.dtype.descr
             x = pd.DataFrame.from_records(x)
         elif isinstance(x, pd.Series):


### PR DESCRIPTION
Deprecate recarray support with aim to drop after 0.12

closes #1552
closes #2656

- [X] closes #1552, #2656 
- [X] tests added / passed. 
- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
