### PR TITLE
MAINT: Catch and fix warnings

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -1,5 +1,8 @@
 ---
+engines:
+ pylint:
+   enabled: true
+   python_version: 2
 exclude_paths:
   - '**/_version.py'
   - 'versioneer.py'
-

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,17 +17,27 @@ filterwarnings =
     ignore:Method .ptp is deprecated:FutureWarning:numpy.core.fromnumeric
     ignore::DeprecationWarning:nbconvert.exporters.exporter_locator
     ignore:Using or importing the ABCs:DeprecationWarning:jinja2.utils
-    error:genfromdta:FutureWarning:
-    error:StataReader:FutureWarning:
+    error:genfromdta:FutureWarning
+    error:StataReader:FutureWarning
     error:Estimation of VARMA:statsmodels.tools.sm_exceptions.EstimationWarning
     error:Care should be used:UserWarning
     error::statsmodels.tools.sm_exceptions.HypothesisTestWarning
     error::statsmodels.tools.sm_exceptions.SpecificationWarning
-    error:load will return datasets:FutureWarning:
-    error:the 'lags' keyword is deprecated:FutureWarning:
-    error:nobs is deprecated in favor of lagsDeprecationWarning:
-    error:The default pvalmethod will change:FutureWarning:
-    error:recarray support has been deprecated:FutureWarning:
+    error:load will return datasets:FutureWarning
+    error:the 'lags' keyword is deprecated:FutureWarning
+    error:nobs is deprecated in favor of lags:DeprecationWarning
+    error:The default pvalmethod will change:FutureWarning
+    error:Using an implicitly registered:FutureWarning
+    error:recarray support:FutureWarning
+    error:An unsupported index:statsmodels.tools.sm_exceptions.ValueWarning
+    error:No supported index is:statsmodels.tools.sm_exceptions.ValueWarning
+    error:Anscombe residuals:FutureWarning
+    error:Calling Family:DeprecationWarning
+    error:SIR.fit_regularized did not:UserWarning
+    error:the 'sigma' keyword:FutureWarning
+    error:tight_layout:UserWarning
+    error:statsmodels.tsa.AR has been deprecated:FutureWarning
+    error:Using deprecated variance components:UserWarning
 markers =
     example: mark a test that runs example code
     matplotlib: mark a test that requires matplotlib

--- a/statsmodels/conftest.py
+++ b/statsmodels/conftest.py
@@ -53,6 +53,11 @@ def pytest_configure(config):
     try:
         import matplotlib
         matplotlib.use('agg')
+        try:
+            from pandas.plotting import register_matplotlib_converters
+            register_matplotlib_converters()
+        except ImportError:
+            pass
     except ImportError:
         pass
 

--- a/statsmodels/genmod/tests/test_glm.py
+++ b/statsmodels/genmod/tests/test_glm.py
@@ -461,7 +461,6 @@ class TestGlmBernoulli(CheckModelResultsMixin, CheckComparisonMixin):
         modd = discrete.Logit(cls.res2.endog, cls.res2.exog)
         cls.resd = modd.fit(start_params=cls.res1.params * 0.9, disp=False)
 
-
     def test_score_r(self):
         res1 = self.res1
         res2 = self.res2
@@ -502,26 +501,27 @@ class TestGlmBernoulli(CheckModelResultsMixin, CheckComparisonMixin):
         s**2
         """
 
-#class TestGlmBernoulliIdentity(CheckModelResultsMixin):
+# class TestGlmBernoulliIdentity(CheckModelResultsMixin):
 #    pass
 
-#class TestGlmBernoulliLog(CheckModelResultsMixin):
+# class TestGlmBernoulliLog(CheckModelResultsMixin):
 #    pass
 
-#class TestGlmBernoulliProbit(CheckModelResultsMixin):
+# class TestGlmBernoulliProbit(CheckModelResultsMixin):
 #    pass
 
-#class TestGlmBernoulliCloglog(CheckModelResultsMixin):
+# class TestGlmBernoulliCloglog(CheckModelResultsMixin):
 #    pass
 
-#class TestGlmBernoulliPower(CheckModelResultsMixin):
+# class TestGlmBernoulliPower(CheckModelResultsMixin):
 #    pass
 
-#class TestGlmBernoulliLoglog(CheckModelResultsMixin):
+# class TestGlmBernoulliLoglog(CheckModelResultsMixin):
 #    pass
 
-#class test_glm_bernoulli_logc(CheckModelResultsMixin):
+# class test_glm_bernoulli_logc(CheckModelResultsMixin):
 #    pass
+
 
 class TestGlmGamma(CheckModelResultsMixin):
 
@@ -548,6 +548,7 @@ class TestGlmGamma(CheckModelResultsMixin):
         res2.aic_R += 2 # R does not count degree of freedom for scale with gamma
         cls.res2 = res2
 
+
 class TestGlmGammaLog(CheckModelResultsMixin):
     @classmethod
     def setup_class(cls):
@@ -570,6 +571,7 @@ class TestGlmGammaLog(CheckModelResultsMixin):
 #            family=r.Gamma(link="log"))
 #        cls.res2.null_deviance = 27.92207137420696 # From R (bug in rpy)
 #        cls.res2.bic = -154.1582089453923 # from Stata
+
 
 class TestGlmGammaIdentity(CheckModelResultsMixin):
     @classmethod
@@ -621,6 +623,7 @@ class TestGlmPoisson(CheckModelResultsMixin, CheckComparisonMixin):
 #class TestGlmPoissonPower(CheckModelResultsMixin):
 #    pass
 
+
 class TestGlmInvgauss(CheckModelResultsMixin):
     @classmethod
     def setup_class(cls):
@@ -644,6 +647,7 @@ class TestGlmInvgauss(CheckModelResultsMixin):
         cls.res1 = res1
         cls.res2 = res2
 
+
 class TestGlmInvgaussLog(CheckModelResultsMixin):
     @classmethod
     def setup_class(cls):
@@ -666,6 +670,7 @@ class TestGlmInvgaussLog(CheckModelResultsMixin):
 #            family=r.inverse_gaussian(link="log"))
 #        cls.res2.null_deviance = 335.1539777981053 # from R, Rpy bug
 #        cls.res2.llf = -12162.72308 # from Stata, R's has big rounding diff
+
 
 class TestGlmInvgaussIdentity(CheckModelResultsMixin):
     @classmethod
@@ -693,6 +698,7 @@ class TestGlmInvgaussIdentity(CheckModelResultsMixin):
 #            family=r.inverse_gaussian(link="identity"))
 #        cls.res2.null_deviance = 335.1539777981053 # from R, Rpy bug
 #        cls.res2.llf = -12163.25545    # from Stata, big diff with R
+
 
 class TestGlmNegbinomial(CheckModelResultsMixin):
     @classmethod
@@ -854,7 +860,7 @@ def test_perfect_pred():
         assert_raises(PerfectSeparationError, glm.fit)
 
 
-def test_score_test_OLS():
+def test_score_test_ols():
     # nicer example than Longley
     from statsmodels.regression.linear_model import OLS
     np.random.seed(5)
@@ -887,7 +893,7 @@ def test_attribute_writable_resettable():
     assert_equal(glm_model2.family.link.power, 1.0)
 
 
-class Test_start_params(CheckModelResultsMixin):
+class TestStartParams(CheckModelResultsMixin):
     @classmethod
     def setup_class(cls):
         '''

--- a/statsmodels/miscmodels/tests/test_tarma.py
+++ b/statsmodels/miscmodels/tests/test_tarma.py
@@ -7,24 +7,25 @@ Author: Josef Perktold
 """
 from functools import partial
 
-import pytest
 import numpy as np
+import pytest
 from numpy.testing import assert_allclose
 
-from statsmodels.tsa.arima_process import arma_generate_sample
 from statsmodels.miscmodels.tmodel import TArma
+from statsmodels.tsa.arima_process import arma_generate_sample
 from statsmodels.tsa.arma_mle import Arma
 
 
 class CheckTArmaMixin(object):
 
     def test_params(self):
-        attrs =  ['params', 'bse', 'tvalues', 'pvalues', 'bsejhj', 'bsejac']
+        attrs = ['params', 'bse', 'tvalues', 'pvalues', 'bsejhj', 'bsejac']
         for row, attr in enumerate(attrs):
-            assert_allclose(getattr(self.res, attr), self.res1_table[row], atol=1e-4,
-                             rtol=1e-3)
+            assert_allclose(getattr(self.res, attr), self.res1_table[row],
+                            atol=1e-4, rtol=1e-3)
 
-        assert_allclose(self.res.conf_int(), self.res1_conf_int, atol=1e-4, rtol=1e-3)
+        assert_allclose(self.res.conf_int(), self.res1_conf_int, atol=1e-4,
+                        rtol=1e-3)
 
     @pytest.mark.smoke
     def test_smoke(self):  # TODO: break into well-scoped tests
@@ -34,7 +35,6 @@ class CheckTArmaMixin(object):
         self.res.f_test(rmat)
 
     def test_fit_ls(self):
-
         assert_allclose(self.res_ls[0], self.ls_params, atol=1e-4, rtol=1e-3)
         self.res_ls[1]
         # this is bse unscaled I think
@@ -43,17 +43,16 @@ class CheckTArmaMixin(object):
 
 
 class TestTArma(CheckTArmaMixin):
-    #regression test for TArma
+    # regression test for TArma
 
     @classmethod
     def setup_class(cls):
-
         nobs = 500
         ar = [1, -0.5, 0.1]
         ma = [1, 0.7]
         dist = partial(np.random.standard_t, 3)
         np.random.seed(8659567)
-        x = arma_generate_sample(ar, ma, nobs, sigma=1, distrvs=dist,
+        x = arma_generate_sample(ar, ma, nobs, scale=1, distrvs=dist,
                                  burnin=500)
 
         mod = TArma(x)
@@ -64,35 +63,34 @@ class TestTArma(CheckTArmaMixin):
                               method='nm', disp=False)
 
         cls.res1_table = np.array(
-          [[  0.46157133,  -0.07694534,   0.70051876,  2.88693312,  0.97283396],
-           [  0.04957594,   0.04345499,   0.03492473,  0.40854823,  0.05568439],
-           [  9.31038915,  -1.7706905 ,  20.05795605,  7.06632146, 17.47049812],
-           [  0.        ,   0.07661218,   0.        ,  0.        ,  0.        ],
-           [  0.05487968,   0.04213054,   0.03102404,  0.37860956,  0.05228474],
-           [  0.04649728,   0.04569133,   0.03990779,  0.44315449,  0.05996759]])
+            [[0.46157133, -0.07694534, 0.70051876, 2.88693312, 0.97283396],
+             [0.04957594, 0.04345499, 0.03492473, 0.40854823, 0.05568439],
+             [9.31038915, -1.77069050, 20.05795605, 7.06632146, 17.47049812],
+             [0.00000000, 0.07661218, 0.00000000, 0.00000000, 0.00000000],
+             [0.05487968, 0.04213054, 0.03102404, 0.37860956, 0.05228474],
+             [0.04649728, 0.04569133, 0.03990779, 0.44315449, 0.05996759]])
 
-        cls.res1_conf_int = np.array([[ 0.36440426,  0.55873839],
-                                   [-0.16211556,  0.00822488],
-                                   [ 0.63206754,  0.76896998],
-                                   [ 2.08619331,  3.68767294],
-                                   [ 0.86369457,  1.08197335]])
+        cls.res1_conf_int = np.array([[0.36440426, 0.55873839],
+                                      [-0.16211556, 0.00822488],
+                                      [0.63206754, 0.76896998],
+                                      [2.08619331, 3.68767294],
+                                      [0.86369457, 1.08197335]])
 
+        cls.ls_params = np.array([0.43393123, -0.08402678, 0.73293058])
+        cls.ls_bse = np.array([0.03777410, 0.03567847, 0.02744488])
 
-        cls.ls_params = np.array([ 0.43393123, -0.08402678,  0.73293058])
-        cls.ls_bse = np.array([ 0.0377741 ,  0.03567847,  0.02744488])
 
 class TestArma(CheckTArmaMixin):
-    #regression test for TArma
+    # regression test for TArma
 
     @classmethod
     def setup_class(cls):
-
         nobs = 500
         ar = [1, -0.5, 0.1]
         ma = [1, 0.7]
         dist = partial(np.random.standard_t, 3)
         np.random.seed(8659567)
-        x = arma_generate_sample(ar, ma, nobs, sigma=1, distrvs=dist,
+        x = arma_generate_sample(ar, ma, nobs, scale=1, distrvs=dist,
                                  burnin=500)
 
         mod = Arma(x)
@@ -103,17 +101,17 @@ class TestArma(CheckTArmaMixin):
                               method='nm', disp=False)
 
         cls.res1_table = np.array(
-          [[  0.4339072 ,  -0.08402653,   0.73292344,   1.61661128],
-           [  0.05854268,   0.05562941,   0.04034178,   0.0511207 ],
-           [  7.4118102 ,  -1.51046975,  18.16785075,  31.62341666],
-           [  0.        ,   0.1309236 ,   0.        ,   0.        ],
-           [  0.06713617,   0.05469138,   0.03785006,   0.1071093 ],
-           [  0.05504093,   0.0574849 ,   0.04350945,   0.02510928]])
+            [[0.43390720, -0.08402653, 0.73292344, 1.61661128],
+             [0.05854268, 0.055629410, 0.04034178, 0.05112070],
+             [7.41181020, -1.51046975, 18.16785075, 31.62341666],
+             [0.00000000, 0.130923600, 0.00000000, 0.00000000],
+             [0.06713617, 0.054691380, 0.03785006, 0.10710930],
+             [0.05504093, 0.057484900, 0.04350945, 0.02510928]])
 
-        cls.res1_conf_int = np.array([[ 0.31916567,  0.54864874],
-                               [-0.19305817,  0.0250051 ],
-                               [ 0.65385501,  0.81199188],
-                               [ 1.51641655,  1.71680602]])
+        cls.res1_conf_int = np.array([[0.31916567, 0.54864874],
+                                      [-0.19305817, 0.02500510],
+                                      [0.65385501, 0.81199188],
+                                      [1.51641655, 1.71680602]])
 
-        cls.ls_params = np.array([ 0.43393123, -0.08402678,  0.73293058])
-        cls.ls_bse = np.array([ 0.0377741 ,  0.03567847,  0.02744488])
+        cls.ls_params = np.array([0.43393123, -0.08402678, 0.73293058])
+        cls.ls_bse = np.array([0.0377741, 0.03567847, 0.02744488])

--- a/statsmodels/regression/tests/test_dimred.py
+++ b/statsmodels/regression/tests/test_dimred.py
@@ -1,5 +1,7 @@
 import numpy as np
 import pandas as pd
+import pytest
+
 from statsmodels.regression.dimred import (
      SlicedInverseReg, SAVE, PHD, CORE)
 from numpy.testing import (assert_equal, assert_allclose)
@@ -81,7 +83,8 @@ def test_sir_regularized_numdiff():
     for i in range(p-2):
         fmat[i, i:i+3] = [1, -2, 1]
 
-    _ = model.fit_regularized(2, 3*fmat)
+    with pytest.warns(UserWarning, match="SIR.fit_regularized did not"):
+        _ = model.fit_regularized(2, 3*fmat)
 
     # Compare the gradients to the numerical derivatives
     for _ in range(5):
@@ -153,7 +156,11 @@ def test_sir_regularized_2d():
     fmat = np.zeros((1, p))
 
     for d in 1, 2, 3, 4:
-        rslt2 = model.fit_regularized(d, fmat)
+        if d < 3:
+            rslt2 = model.fit_regularized(d, fmat)
+        else:
+            with pytest.warns(UserWarning, match="SIR.fit_regularized did"):
+                rslt2 = model.fit_regularized(d, fmat)
         pa1 = rslt1.params[:, 0:d]
         pa1, _, _ = np.linalg.svd(pa1, 0)
         pa2 = rslt2.params

--- a/statsmodels/regression/tests/test_lme.py
+++ b/statsmodels/regression/tests/test_lme.py
@@ -122,13 +122,14 @@ class TestMixedLM(object):
             vc["a"][i] = exog_vc[ix, 0:2]
             vc["b"][i] = exog_vc[ix, 2:3]
 
-        model = MixedLM(
-            endog,
-            exog_fe,
-            groups,
-            exog_re,
-            exog_vc=vc,
-            use_sqrt=use_sqrt)
+        with pytest.warns(UserWarning, match="Using deprecated variance"):
+            model = MixedLM(
+                endog,
+                exog_fe,
+                groups,
+                exog_re,
+                exog_vc=vc,
+                use_sqrt=use_sqrt)
         rslt = model.fit(reml=reml)
 
         loglike = loglike_function(
@@ -221,17 +222,13 @@ class TestMixedLM(object):
             ii = np.flatnonzero(groups == k)
             vc["a"][k] = vca[ii][:, None]
             vc["b"][k] = vcb[ii][:, None]
-        rslt = MixedLM(
-            endog, exog, groups=groups, exog_re=exog_re, exog_vc=vc).fit()
-        rslt.profile_re(
-            0, vtype='re', dist_low=1, num_low=3, dist_high=1, num_high=3)
-        rslt.profile_re(
-            'b',
-            vtype='vc',
-            dist_low=0.5,
-            num_low=3,
-            dist_high=0.5,
-            num_high=3)
+        with pytest.warns(UserWarning, match="Using deprecated variance"):
+            rslt = MixedLM(endog, exog, groups=groups,
+                           exog_re=exog_re, exog_vc=vc).fit()
+        rslt.profile_re(0, vtype='re', dist_low=1, num_low=3,
+                        dist_high=1, num_high=3)
+        rslt.profile_re('b', vtype='vc', dist_low=0.5, num_low=3,
+                        dist_high=0.5, num_high=3)
 
     def test_vcomp_1(self):
         # Fit the same model using constrained random effects and
@@ -260,7 +257,8 @@ class TestMixedLM(object):
             ix = model1.row_indices[group]
             exog_vc["a"][group] = exog_re[ix, 0:1]
             exog_vc["b"][group] = exog_re[ix, 1:2]
-        model2 = MixedLM(endog, exog, groups, exog_vc=exog_vc)
+        with pytest.warns(UserWarning, match="Using deprecated variance"):
+            model2 = MixedLM(endog, exog, groups, exog_vc=exog_vc)
         result2 = model2.fit()
         result2.summary()
 
@@ -629,7 +627,9 @@ class TestMixedLM(object):
             ix = np.flatnonzero(groups == group)
             exog_vc["a"][group] = ex_vc[ix, 0:2]
             exog_vc["b"][group] = ex_vc[ix, 2:]
-        model1 = MixedLM(endog, exog, groups, exog_re=exog_re, exog_vc=exog_vc)
+        with pytest.warns(UserWarning, match="Using deprecated variance"):
+            model1 = MixedLM(endog, exog, groups, exog_re=exog_re,
+                             exog_vc=exog_vc)
         result1 = model1.fit()
 
         df = pd.DataFrame(exog[:, 1:], columns=["x1"])

--- a/statsmodels/regression/tests/test_rolling.py
+++ b/statsmodels/regression/tests/test_rolling.py
@@ -256,7 +256,8 @@ def test_plot():
         res.plot_recursive_coefficient(variables='x4')
 
     fig = plt.Figure()
-    out = res.plot_recursive_coefficient(fig=fig)
+    with pytest.warns(UserWarning, match="tight_layout"):
+        out = res.plot_recursive_coefficient(fig=fig)
     assert out is fig
     res.plot_recursive_coefficient(alpha=None, figsize=(30, 7))
 

--- a/statsmodels/sandbox/tests/test_gam.py
+++ b/statsmodels/sandbox/tests/test_gam.py
@@ -162,7 +162,6 @@ class BaseAM(object):
         cls.y_true, cls.x, cls.exog = y_true, x, exog_reduced
 
 
-
 class TestAdditiveModel(BaseAM, CheckAM):
 
     @classmethod
@@ -291,7 +290,7 @@ class TestGAMGaussianLogLink(BaseGAM):
     def setup_class(cls):
         super(TestGAMGaussianLogLink, cls).setup_class()  # initialize DGP
 
-        cls.family = family.Gaussian(links.log)
+        cls.family = family.Gaussian(links.log())
         cls.rvs = stats.norm.rvs
         cls.scale = 5
 

--- a/statsmodels/tsa/tests/test_ar.py
+++ b/statsmodels/tsa/tests/test_ar.py
@@ -854,6 +854,7 @@ class TestAutoRegOLSConstant(CheckAutoRegMixin):
     @classmethod
     def setup_class(cls):
         data = sm.datasets.sunspots.load(as_pandas=True)
+        data.endog.index = list(range(len(data.endog)))
         cls.res1 = AutoReg(data.endog, lags=9).fit()
         cls.res2 = results_ar.ARResultsOLS(constant=True)
 


### PR DESCRIPTION
Fix warnings when fix is available
Catch remaining sm-produced warnings

- [x] closes #xxxx
- [x] tests added / passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
