### PR TITLE
BUG: Check dtype in KDEUnivariate

### DIFF
--- a/statsmodels/nonparametric/kde.py
+++ b/statsmodels/nonparametric/kde.py
@@ -15,6 +15,7 @@ import numpy as np
 from scipy import integrate, stats
 from statsmodels.sandbox.nonparametric import kernels
 from statsmodels.tools.decorators import cache_readonly
+from statsmodels.tools.validation import array_like
 from . import bandwidths
 from .kdetools import (forrt, revrt, silverman_transform)
 from .linbin import fast_linbin
@@ -75,7 +76,7 @@ class KDEUnivariate(object):
     """
 
     def __init__(self, endog):
-        self.endog = np.asarray(endog)
+        self.endog = array_like(endog, "endog", ndim=1, contiguous=True)
 
     def fit(self, kernel="gau", bw="normal_reference", fft=True, weights=None,
             gridsize=None, adjust=1, cut=3, clip=(-np.inf, np.inf)):

--- a/statsmodels/nonparametric/tests/test_kernel_density.py
+++ b/statsmodels/nonparametric/tests/test_kernel_density.py
@@ -120,6 +120,16 @@ class TestKDEUnivariate(KDETestBase):
         with pytest.raises(RuntimeError, match="Selected KDE bandwidth is 0"):
             kde.fit()
 
+    def test_int(self, reset_randomstate):
+        x = np.random.randint(0, 100, size=1000)
+        kde = nparam.KDEUnivariate(x)
+        kde.fit()
+
+        kde_double = nparam.KDEUnivariate(x.astype("double"))
+        kde_double.fit()
+
+        assert_allclose(kde.bw, kde_double.bw)
+
 
 class TestKDEMultivariate(KDETestBase):
     @pytest.mark.slow

--- a/statsmodels/sandbox/nonparametric/kde2.py
+++ b/statsmodels/sandbox/nonparametric/kde2.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 from statsmodels.compat.python import lzip
+
 import numpy as np
+
+from statsmodels.tools.validation import array_like
 from . import kernels
 
 
@@ -19,7 +22,7 @@ class KDE(object):
     """
     #TODO: amend docs for Nd case?
     def __init__(self, x, kernel=None):
-        x = np.asarray(x)
+        x = array_like(x, "x", maxdim=2, contiguous=True)
         if x.ndim == 1:
             x = x[:,None]
 


### PR DESCRIPTION
Ensure data is dould and contiguous

closes #1915

- [ ] closes #xxxx
- [ ] tests added / passed. 
- [ ] code/documentation is well formatted.  
- [ ] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
