### PR TITLE
MAINT: Workaround NumPy ptp issue

### DIFF
--- a/statsmodels/base/data.py
+++ b/statsmodels/base/data.py
@@ -128,10 +128,11 @@ class ModelData(object):
         else:
             # detect where the constant is
             check_implicit = False
-            ptp_ = np.ptp(self.exog, axis=0)
-            if not np.isfinite(ptp_).all():
+            exog_max = np.max(self.exog, axis=0)
+            if not np.isfinite(exog_max).all():
                 raise MissingDataError('exog contains inf or nans')
-            const_idx = np.where(ptp_ == 0)[0].squeeze()
+            exog_min = np.min(self.exog, axis=0)
+            const_idx = np.where(exog_max == exog_min)[0].squeeze()
             self.k_constant = const_idx.size
 
             if self.k_constant == 1:

--- a/statsmodels/regression/tests/test_regression.py
+++ b/statsmodels/regression/tests/test_regression.py
@@ -1344,3 +1344,11 @@ def test_sqrt_lasso():
         # Regression test the parameters
         assert_allclose(rslt.params[0:5], expected_params[refit],
                 rtol=1e-5, atol=1e-5)
+
+
+def test_bool_regressor(reset_randomstate):
+    exog = np.random.randint(0, 2, size=(100, 2)).astype(bool)
+    endog = np.random.standard_normal(100)
+    bool_res = OLS(endog, exog).fit()
+    res = OLS(endog, exog.astype(np.double)).fit()
+    assert_allclose(bool_res.params, res.params)


### PR DESCRIPTION
Workaround for bool data when using ptp
Also silences pandas ptp warning in this location

xref numpy/numpy#15057

- [ ] closes #xxxx
- [ ] tests added / passed. 
- [ ] code/documentation is well formatted.  
- [ ] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
