### PR TITLE
BUG: Ensure inputs are finite in granger causalty test

### DIFF
--- a/statsmodels/tsa/stattools.py
+++ b/statsmodels/tsa/stattools.py
@@ -1127,7 +1127,8 @@ def grangercausalitytests(x, maxlag, addconst=True, verbose=True):
     ----------
     x : array_like
         The data for test whether the time series in the second column Granger
-        causes the time series in the first column.
+        causes the time series in the first column. Missing values are not
+        supported.
     maxlag : {int, Iterable[int]}
         If an integer, computes the test for all lags up to maxlag. If an
         iterable, computes the tests only for the lags in maxlag.
@@ -1185,6 +1186,8 @@ def grangercausalitytests(x, maxlag, addconst=True, verbose=True):
     >>> gc_res = grangercausalitytests(data, [4])
     """
     x = array_like(x, 'x', ndim=2)
+    if not np.isfinite(x).all():
+        raise ValueError('x contains NaN or inf values.')
     addconst = bool_like(addconst, 'addconst')
     verbose = bool_like(verbose, 'verbose')
     try:

--- a/statsmodels/tsa/tests/test_stattools.py
+++ b/statsmodels/tsa/tests/test_stattools.py
@@ -463,9 +463,17 @@ class TestGrangerCausality(object):
 
     def test_granger_fails_on_nobs_check(self, reset_randomstate):
         # Test that if maxlag is too large, Granger Test raises a clear error.
-        X = np.random.rand(10, 2)
-        grangercausalitytests(X, 2, verbose=False)  # This should pass.
-        assert_raises(ValueError, grangercausalitytests, X, 3, verbose=False)
+        x = np.random.rand(10, 2)
+        grangercausalitytests(x, 2, verbose=False)  # This should pass.
+        with pytest.raises(ValueError):
+            grangercausalitytests(x, 3, verbose=False)
+
+    def test_granger_fails_on_finite_check(self, reset_randomstate):
+        x = np.random.rand(1000, 2)
+        x[500, 0] = np.nan
+        x[750, 1] = np.inf
+        with pytest.raises(ValueError, match="x contains NaN"):
+            grangercausalitytests(x, 2)
 
 
 class SetupKPSS(object):


### PR DESCRIPTION
Add a check for finite values

closes #2344

- [ ] closes #xxxx
- [ ] tests added / passed. 
- [ ] code/documentation is well formatted.  
- [ ] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
