### PR TITLE
DOC: Restore test() autosummary

### DIFF
--- a/docs/source/dev/test_notes.rst
+++ b/docs/source/dev/test_notes.rst
@@ -193,3 +193,21 @@ a module (``statsmodels.regression.test()``).  This method allows tests to be
 run from an install copy of statsmodels even it is was not installed using the
 *editable* flag as described above. This method is required for testing wheels in
 release builds and is **not** recommended for development.
+
+Using this method, all tests are run using:
+
+.. code-block:: python
+
+   import statsmodels.api as sm
+   sm.test()
+
+Submodules tests are run using:
+
+.. code-block:: python
+
+    sm.discrete.test()
+
+.. autosummary::
+   :toctree: generated/
+
+   ~statsmodels.__init__.test


### PR DESCRIPTION
Restore accidentally deleted summary for test

- [ ] closes #xxxx
- [ ] tests added / passed. 
- [ ] code/documentation is well formatted.  
- [ ] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
