### PR TITLE
BUG: state space: integer params can cause imaginary output

### DIFF
--- a/statsmodels/tsa/statespace/mlemodel.py
+++ b/statsmodels/tsa/statespace/mlemodel.py
@@ -1634,6 +1634,10 @@ class MLEModel(tsbase.TimeSeriesModel):
                       return_jacobian=False):
         params = np.array(params, ndmin=1)
 
+        # Never want integer dtype, so convert to floats
+        if np.issubdtype(params.dtype, np.integer):
+            params = params.astype(np.float64)
+
         if not includes_fixed and self._has_fixed_params:
             k_params = len(self.param_names)
             new_params = np.zeros(k_params, dtype=params.dtype) * np.nan

--- a/statsmodels/tsa/statespace/tests/test_mlemodel.py
+++ b/statsmodels/tsa/statespace/tests/test_mlemodel.py
@@ -1102,7 +1102,7 @@ def test_append_extend_apply_invalid():
 
 
 def test_integer_params():
-    # See GH#....
+    # See GH#6335
     mod = sarimax.SARIMAX([1, 1, 1], order=(1, 0, 0), exog=[2, 2, 2],
                           concentrate_scale=True)
     res = mod.filter([1, 0])

--- a/statsmodels/tsa/statespace/tests/test_mlemodel.py
+++ b/statsmodels/tsa/statespace/tests/test_mlemodel.py
@@ -1099,3 +1099,12 @@ def test_append_extend_apply_invalid():
     message = 'The indices for endog and exog are not aligned'
     with pytest.raises(ValueError, match=message):
         res2.extend(endog4, exog=not_cts)
+
+
+def test_integer_params():
+    # See GH#....
+    mod = sarimax.SARIMAX([1, 1, 1], order=(1, 0, 0), exog=[2, 2, 2],
+                          concentrate_scale=True)
+    res = mod.filter([1, 0])
+    p = res.predict(end=5, dynamic=True, exog=[3, 3, 4])
+    assert_equal(p.dtype, np.float64)


### PR DESCRIPTION
Closes #6335

Just adds an explicit type cast when integer parameters are given to `filter`, etc.

Usually only happens in testing, since otherwise not all (or any) parameters will be integers.