### PR TITLE
ENH: append, extend check that index matches model

### DIFF
--- a/statsmodels/tsa/statespace/tests/test_mlemodel.py
+++ b/statsmodels/tsa/statespace/tests/test_mlemodel.py
@@ -1040,3 +1040,62 @@ def test_append_extend_apply_invalid():
     assert_raises(ValueError, res1.append, endog2, fit_kwargs={'cov_kwds': {}})
     assert_raises(ValueError, res1.extend, endog2, fit_kwargs={'cov_kwds': {}})
     assert_raises(ValueError, res1.apply, endog2, fit_kwargs={'cov_kwds': {}})
+
+    # Test for exception when given a different frequency
+    wrong_freq = niledata.iloc[20:40]
+    wrong_freq.index = pd.date_range(
+        start=niledata.index[0], periods=len(wrong_freq), freq='MS')
+    message = ('Given `endog` does not have an index that extends the index of'
+               ' the model. Expected index frequency is')
+    with pytest.raises(ValueError, match=message):
+        res1.append(wrong_freq)
+    with pytest.raises(ValueError, match=message):
+        res1.extend(wrong_freq)
+    message = ('Given `exog` does not have an index that extends the index of'
+               ' the model. Expected index frequency is')
+    with pytest.raises(ValueError, match=message):
+        res1.append(endog2, exog=wrong_freq)
+    message = 'The indices for endog and exog are not aligned'
+    with pytest.raises(ValueError, match=message):
+        res1.extend(endog2, exog=wrong_freq)
+
+    # Test for exception when given the same frequency but not right after the
+    # end of model
+    not_cts = niledata.iloc[21:41]
+    message = ('Given `endog` does not have an index that extends the index of'
+               ' the model.$')
+    with pytest.raises(ValueError, match=message):
+        res1.append(not_cts)
+    with pytest.raises(ValueError, match=message):
+        res1.extend(not_cts)
+    message = ('Given `exog` does not have an index that extends the index of'
+               ' the model.$')
+    with pytest.raises(ValueError, match=message):
+        res1.append(endog2, exog=not_cts)
+    message = 'The indices for endog and exog are not aligned'
+    with pytest.raises(ValueError, match=message):
+        res1.extend(endog2, exog=not_cts)
+
+    # # Test for problems with non-date indexes
+    endog3 = pd.Series(niledata.iloc[:20].values)
+    endog4 = pd.Series(niledata.iloc[:40].values)[20:]
+    mod2 = sarimax.SARIMAX(endog3, order=(1, 0, 0), exog=endog3,
+                           concentrate_scale=True)
+    res2 = mod2.smooth([0.2, 0.5])
+
+    # Test for exception when given the same frequency but not right after the
+    # end of model
+    not_cts = pd.Series(niledata[:41].values)[21:]
+    message = ('Given `endog` does not have an index that extends the index of'
+               ' the model.$')
+    with pytest.raises(ValueError, match=message):
+        res2.append(not_cts)
+    with pytest.raises(ValueError, match=message):
+        res2.extend(not_cts)
+    message = ('Given `exog` does not have an index that extends the index of'
+               ' the model.$')
+    with pytest.raises(ValueError, match=message):
+        res2.append(endog4, exog=not_cts)
+    message = 'The indices for endog and exog are not aligned'
+    with pytest.raises(ValueError, match=message):
+        res2.extend(endog4, exog=not_cts)

--- a/statsmodels/tsa/statespace/tools.py
+++ b/statsmodels/tsa/statespace/tools.py
@@ -306,6 +306,22 @@ def concat(series, axis=0, allow_mix=False):
     is_pandas = np.r_[[_is_using_pandas(s, None) for s in series]]
 
     if np.all(is_pandas):
+        if isinstance(series[0], pd.DataFrame):
+            base_columns = series[0].columns
+        else:
+            base_columns = pd.Index([series[0].name])
+        for s in series[1:]:
+            if isinstance(s, pd.DataFrame):
+                s_columns = s.columns
+            else:
+                s_columns = pd.Index([s.name])
+
+            if axis == 0 and not base_columns.equals(s_columns):
+                raise ValueError('Columns must match to concatenate along'
+                                 ' rows.')
+            elif axis == 1 and not series[0].index.equals(s.index):
+                raise ValueError('Index must match to concatenate along'
+                                 ' columns.')
         concatenated = pd.concat(series, axis=axis)
     elif np.all(~is_pandas) or allow_mix:
         concatenated = np.concatenate(series, axis=axis)


### PR DESCRIPTION
Closes #6301.

Raises an understandable exception when `append` or `extend` is called with data that has an index that does not appear to extend the model's index.

Tests added.