### PR TITLE
DOC: Documentation for release v0.11

### DIFF
--- a/docs/source/release/version0.11.rst
+++ b/docs/source/release/version0.11.rst
@@ -103,7 +103,86 @@ Submodules
 ~~~~~~~
 
 
+New AR model
+""""""""""""
 
+- Model class: `sm.tsa.AutoReg`
+- Estimates parameters using conditional MLE (OLS)
+- Adds the ability to specify exogenous variables, include time trends,
+  and add seasonal dummies.
+- The function `sm.tsa.ar_model.ar_select_order` performs lag length selection
+  for AutoReg models.
+
+New ARIMA model
+"""""""""""""""
+
+- Model class: `sm.tsa.arima.ARIMA`
+- Incorporates a variety of SARIMA estimators
+    - MLE via state space methods (SARIMA models)
+    - MLE via innovations algorithm (SARIMA models)
+    - Hannan-Rissanen (ARIMA models)
+    - Burg's method (AR models)
+    - Innovations algorithm (MA models)
+    - Yule-Walker (AR models)
+- Handles exogenous regressors via GLS or by MLE with state space methods.
+- Is part of the class of state space models and so inherits some additional
+  functionality.
+
+More robust regime switching models
+"""""""""""""""""""""""""""""""""""
+
+- Implementation of the Hamilton filter and Kim smoother in log space avoids
+  underflow errors.
+
+``tsa.statespace``
+~~~~~~~~~~~~~~~~~~
+
+Linear exponential smoothing models
+"""""""""""""""""""""""""""""""""""
+
+- Model class: `sm.tsa.statespace.ExponentialSmoothing`
+- Alternative to `sm.tsa.ExponentialSmoothing`
+- Only supports linear models
+- Is part of the class of state space models and so inherits some additional
+  functionality.
+
+Methods to apply parameters fitted on one dataset to another dataset
+""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+- Methods: `extend`, `append`, and `apply`, for state space results classes
+- These methods allow applying fitted parameters from a training dataset to a
+  test dataset in various ways
+- Useful for conveniently performing cross-validation exercises
+
+Method to hold some parameters fixed at known values
+""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+- Methods: `fix_params` and `fit_constrained`, for state space model classes
+- These methods allow setting some parameters to known values and then
+  estimating the remaining parameters
+
+Option for low memory operations
+""""""""""""""""""""""""""""""""
+
+- Argument: `low_memory=True`, for `fit`, `filter`, and `smooth`
+- Only a subset of results are available when using this option, but it does
+  allow for prediction, diagnostics, and forecasting
+- Useful to speed up cross-validation exercises
+
+Improved access to state estimates
+""""""""""""""""""""""""""""""""""
+
+- Attribute: `states`, for state space results classes
+- Wraps estimated states (predicted, filtered, smoothed) as Pandas objects with
+  the appropriate index.
+- Adds human-readable names for states, where possible.
+
+Improved simulation and impulse responses for time-varying models
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+- Argument: `anchor' allows specifying the period after which to begin the
+  simulation.
+- Example: to simulate data following the sample period, use `anchor='end'`
 
 ``maintenance``
 ~~~~~~~~~~~~~~~

--- a/docs/source/statespace.rst
+++ b/docs/source/statespace.rst
@@ -18,7 +18,7 @@ A general state space model is of the form
 .. math::
 
   y_t & = Z_t \alpha_t + d_t + \varepsilon_t \\
-  \alpha_t & = T_t \alpha_{t-1} + c_t + R_t \eta_t \\
+  \alpha_{t+1} & = T_t \alpha_t + c_t + R_t \eta_t \\
 
 where :math:`y_t` refers to the observation vector at time :math:`t`,
 :math:`\alpha_t` refers to the (unobserved) state vector at time
@@ -62,17 +62,18 @@ state space form. Recall that an AR(2) model is often written as:
 
 .. math::
 
-   y_t = \phi_1 y_{t-1} + \phi_2 y_{t-2} + \epsilon_t
+   y_t = \phi_1 y_{t-1} + \phi_2 y_{t-2} + \epsilon_t,
+   \quad \epsilon_t \sim N(0, \sigma^2)
 
 This can be put into state space form in the following way:
 
 .. math::
 
    y_t & = \begin{bmatrix} 1 & 0 \end{bmatrix} \alpha_t \\
-   \alpha_t & = \begin{bmatrix}
+   \alpha_{t+1} & = \begin{bmatrix}
       \phi_1 & \phi_2 \\
            1 &      0
-   \end{bmatrix} \alpha_{t-1} + \begin{bmatrix} 1 \\ 0 \end{bmatrix} \eta_t
+   \end{bmatrix} \alpha_t + \begin{bmatrix} 1 \\ 0 \end{bmatrix} \eta_t
 
 Where
 
@@ -89,7 +90,7 @@ and
            1 &      0
    \end{bmatrix} \\
    R_t \equiv R & = \begin{bmatrix} 1 \\ 0 \end{bmatrix} \\
-   \eta_t & \sim N(0, \sigma^2)
+   \eta_t \equiv \epsilon_{t+1} & \sim N(0, \sigma^2)
 
 There are three unknown parameters in this model:
 :math:`\phi_1, \phi_2, \sigma^2`.

--- a/docs/source/statespace.rst
+++ b/docs/source/statespace.rst
@@ -275,6 +275,77 @@ For an example of the use of this model, see the `Dynamic Factor example noteboo
    # individual estimated factors on endogenous variables.
    fig_dfm = res_ll.plot_coefficients_of_determination()
 
+Linear Exponential Smoothing Models
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The `ExponentialSmoothing` class is an implementation of linear exponential
+smoothing models using a state space approach.
+
+**Note**: this model is available at `sm.tsa.statespace.ExponentialSmoothing`;
+it is not the same as the model available at `sm.tsa.ExponentialSmoothing`.
+See below for details of the differences between these classes.
+
+.. autosummary::
+   :toctree: generated/
+
+   exponential_smoothing.ExponentialSmoothing
+   exponential_smoothing.ExponentialSmoothingResults
+
+A very brief code snippet follows:
+
+.. code-block:: python
+
+   # Load the statsmodels api
+   import statsmodels.api as sm
+
+   # Load your dataset
+   endog = pd.read_csv('your/dataset/here.csv')
+
+   # Simple exponential smoothing, denoted (A,N,N)
+   mod_ses = sm.tsa.statespace.ExponentialSmoothing(endog)
+   res_ses = mod_ses.fit()
+
+   # Holt's linear method, denoted (A,A,N)
+   mod_h = sm.tsa.statespace.ExponentialSmoothing(endog, trend=True)
+   res_h = mod_h.fit()
+
+   # Damped trend model, denoted (A,Ad,N)
+   mod_dt = sm.tsa.statespace.ExponentialSmoothing(endog, trend=True,
+                                                   damped_trend=True)
+   res_dt = mod_dt.fit()
+
+   # Holt-Winters' trend and seasonality method, denoted (A,A,A)
+   # (assuming that `endog` has a seasonal periodicity of 4, for example if it
+   # is quarterly data).
+   mod_hw = sm.tsa.statespace.ExponentialSmoothing(endog, trend=True,
+                                                   seasonal=4)
+   res_hw = mod_hw.fit()
+
+**Differences between Statsmodels' exponential smoothing model classes**
+
+There are several differences between this model class, available at
+`sm.tsa.statespace.ExponentialSmoothing`, and the model class available at
+`sm.tsa.ExponentialSmoothing`.
+
+- This model class only supports *linear* exponential smoothing models, while
+  `sm.tsa.ExponentialSmoothing` also supports multiplicative models.
+- This model class puts the exponential smoothing models into state space form
+  and then applies the Kalman filter to estimate the states, while
+  `sm.tsa.ExponentialSmoothing` is based on exponential smoothing recurisions.
+  In some cases, this can mean that estimating parameters with this model class
+  will be somewhat slower than with `sm.tsa.ExponentialSmoothing`.
+- This model class can produce confidence intervals for forecasts, based on an
+  assumption of Gaussian errors, while `sm.tsa.ExponentialSmoothing` does not
+  support confidence intervals.
+- This model class supports concentrating initial values out of the objective
+  function, which can improve performance when there are many initial states to
+  estimate (for example when the seasonal periodicity is large).
+- This model class supports many advanced features available to state space
+  models, such as diagnostics and fixed parameters.
+
+**Note**: this class is based on a "multiple sources of error" (MSOE) state
+space formulation and not a "single source of error" (SSOE) formulation.
+
 Custom state space models
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/source/tsa.rst
+++ b/docs/source/tsa.rst
@@ -130,8 +130,19 @@ deprecated.
 Autoregressive Moving-Average Processes (ARMA) and Kalman Filter
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Beginning in version 0.11, Statsmodels has introduced a new class dedicated to
-ARIMA models that should be the starting point for for most users:
+Basic ARIMA model and results classes are as follows:
+
+.. autosummary::
+   :toctree: generated/
+
+   arima_model.ARMA
+   arima_model.ARMAResults
+   arima_model.ARIMA
+   arima_model.ARIMAResults
+
+However, beginning in version 0.11, Statsmodels has introduced a new class
+dedicated to ARIMA models. While this class is still in a testing phase, it
+should by the starting point for for most users going forwards:
 
 .. currentmodule:: statsmodels.tsa
 
@@ -147,16 +158,6 @@ Kalman filter). Since it is a special case of the `SARIMAX` model, it includes
 all features of :ref:`state space <statespace>` models (including
 preciction / forecasting, residual diagnostics, simulation and impulse
 responses, etc.).
-
-The old ARIMA model and results classes are still available:
-
-.. autosummary::
-   :toctree: generated/
-
-   arima_model.ARMA
-   arima_model.ARMAResults
-   arima_model.ARIMA
-   arima_model.ARIMAResults
 
 Exponential Smoothing
 ~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/tsa.rst
+++ b/docs/source/tsa.rst
@@ -100,25 +100,55 @@ statsmodels.tsa.api and their result classes
 Univariate Autoregressive Processes (AR)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+Beginning in version 0.11, Statsmodels has introduced a new class dedicated to
+autoregressive models.
+
 .. currentmodule:: statsmodels.tsa
 
 .. autosummary::
    :toctree: generated/
 
-   ar_model.AR
    ar_model.AutoReg
-   ar_model.ARResults
    ar_model.AutoRegResults
    ar_model.ar_select_order
 
+The `ar_model.AutoReg` model estimates parameters using conditional MLE (OLS),
+and supports exogenous regressors (an AR-X model) and seasonal effects.
+
+AR-X and related models can also be fitted with the `arima.ARIMA` class and the
+`SARIMAX` class (using full MLE via the Kalman Filter).
+
+Finally, the old class, `ar_model.AR`, is still available but it has been
+deprecated.
+
+.. autosummary::
+   :toctree: generated/
+
+   ar_model.AR
+   ar_model.ARResults
 
 Autoregressive Moving-Average Processes (ARMA) and Kalman Filter
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+Beginning in version 0.11, Statsmodels has introduced a new class dedicated to
+ARIMA models that should be the starting point for for most users:
+
 .. currentmodule:: statsmodels.tsa
 
-The basic ARIMA model and results classes that should be the starting point for
-for most users are:
+.. autosummary::
+   :toctree: generated/
+
+   arima.model.ARIMA
+   arima.model.ARIMAResults
+
+The `arima.model.ARIMA` model allows estimating parameters by various methods
+(including conditional MLE via the Hannan-Rissanen method and full MLE via the
+Kalman filter). Since it is a special case of the `SARIMAX` model, it includes
+all features of :ref:`state space <statespace>` models (including
+preciction / forecasting, residual diagnostics, simulation and impulse
+responses, etc.).
+
+The old ARIMA model and results classes are still available:
 
 .. autosummary::
    :toctree: generated/
@@ -128,23 +158,10 @@ for most users are:
    arima_model.ARIMA
    arima_model.ARIMAResults
 
-Some advanced underlying low-level classes and functions that can be used to
-compute the log-likelihood function for ARMA-type models include (note that
-these are rarely needed by end-users):
-
-.. autosummary::
-   :toctree: generated/
-
-   kalmanf.kalmanfilter.KalmanFilter
-   innovations.arma_innovations.arma_innovations
-   innovations.arma_innovations.arma_loglike
-   innovations.arma_innovations.arma_loglikeobs
-   innovations.arma_innovations.arma_score
-   innovations.arma_innovations.arma_scoreobs
-
-
 Exponential Smoothing
 ~~~~~~~~~~~~~~~~~~~~~
+
+Linear and non-linear exponential smoothing models are available:
 
 .. currentmodule:: statsmodels.tsa
 
@@ -155,6 +172,21 @@ Exponential Smoothing
    holtwinters.SimpleExpSmoothing
    holtwinters.Holt
    holtwinters.HoltWintersResults
+
+Linear exponential smoothing models have also been separately implemented as a
+special case of the state space framework. Although this approach does not
+allow for the non-linear (multiplicative) exponential smoothing models, it
+includes all features of :ref:`state space <statespace>` models (including
+preciction / forecasting, residual diagnostics, simulation and impulse
+responses, etc.).
+
+.. currentmodule:: statsmodels.tsa
+
+.. autosummary::
+   :toctree: generated/
+
+   statespace.exponential_smoothing.ExponentialSmoothing
+   statespace.exponential_smoothing.ExponentialSmoothingResults
 
 
 ARMA Process

--- a/docs/source/tsa.rst
+++ b/docs/source/tsa.rst
@@ -142,7 +142,7 @@ Basic ARIMA model and results classes are as follows:
 
 However, beginning in version 0.11, Statsmodels has introduced a new class
 dedicated to ARIMA models. While this class is still in a testing phase, it
-should by the starting point for for most users going forwards:
+should be the starting point for for most users going forwards:
 
 .. currentmodule:: statsmodels.tsa
 


### PR DESCRIPTION
This PR adds documentation and release notes for several important improvements, including:

- New AR model, AutoReg (#6087)
- New ARIMA model (#5827)
- More robust regime switching models (#5826)
- State space improvements:
    - Linear exponential smoothing models (#6179)
    - Apply fitted parameters to new data (#5915)
    - Fixed parameters (#5735)
    - Low memory options (#6071 and follow-ups)
    - Improved access to state estimates (#6181)
    - Improvements to simulate/IRF for time-varying models (#6280)

Any improvements or corrections would be greatly appreciated.

@bashtage this edits `version0.11.rst` directly: is this okay to do since we have the new script for generating this file?