### PR TITLE
Update dynamic_factor.py

### DIFF
--- a/statsmodels/tsa/statespace/dynamic_factor.py
+++ b/statsmodels/tsa/statespace/dynamic_factor.py
@@ -449,7 +449,7 @@ class DynamicFactor(MLEModel):
         # 1. Factor loadings (estimated via PCA)
         if self.k_factors > 0:
             # Use principal components + OLS as starting values
-            res_pca = PCA(endog, ncomp=self.k_factors)
+            res_pca = PCA(endog, ncomp=self.k_factors, normalize=False)
             mod_ols = OLS(endog, res_pca.factors)
             res_ols = mod_ols.fit()
 


### PR DESCRIPTION
I'm getting a lot of failing to converge errors in simple DFM setups, so I did a bit of digging. 
It would seem that the default factor normalization option in the PCA code doesn't transform res_pca.loadings along with res_pca.factors, so running with normalization=on results in non-zero mean endog in line 464 and throws off error process estimation. As a result either failing to converge or taking forever.

Turning off normalization in line 452 is one option to fix the issue, another is to replace res_pca.loadings.T in line 464 with res_pca.coeff
(Haven't tested that one).


I don't have a specific test to suggest.
Just put a breakpoint on line 464 and do endog.mean

- [ ] closes #xxxx
- [ ] tests added / passed. 
- [ ] code/documentation is well formatted.  
- [ ] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
