### PR TITLE
ENH: Supporting custom kernel in local linear kernel regression

### DIFF
--- a/statsmodels/nonparametric/_kernel_base.py
+++ b/statsmodels/nonparametric/_kernel_base.py
@@ -28,7 +28,8 @@ kernel_func = dict(wangryzin=kernels.wang_ryzin,
                    gaussian_cdf=kernels.gaussian_cdf,
                    aitchisonaitken_cdf=kernels.aitchison_aitken_cdf,
                    wangryzin_cdf=kernels.wang_ryzin_cdf,
-                   d_gaussian=kernels.d_gaussian)
+                   d_gaussian=kernels.d_gaussian,
+                   tricube=kernels.tricube)
 
 
 def _compute_min_std_IQR(data):

--- a/statsmodels/nonparametric/kernel_regression.py
+++ b/statsmodels/nonparametric/kernel_regression.py
@@ -99,7 +99,6 @@ class KernelReg(GenericKDE):
         self.ckertype = ckertype
         self.okertype = okertype
         self.ukertype = ukertype
-
         if not (self.ckertype in kernel_func and self.ukertype in kernel_func
                 and self.okertype in kernel_func):
             raise ValueError('user specified kernel must be a supported '
@@ -516,7 +515,6 @@ class KernelCensoredReg(KernelReg):
         self.ckertype = ckertype
         self.okertype = okertype
         self.ukertype = ukertype
-        
         if not (self.ckertype in kernel_func and self.ukertype in kernel_func
                 and self.okertype in kernel_func):
             raise ValueError('user specified kernel must be a supported '

--- a/statsmodels/nonparametric/kernel_regression.py
+++ b/statsmodels/nonparametric/kernel_regression.py
@@ -49,7 +49,9 @@ class KernelReg(GenericKDE):
     Calculates the conditional mean ``E[y|X]`` where ``y = g(X) + e``.
     Note that the "local constant" type of regression provided here is also
     known as Nadaraya-Watson kernel regression; "local linear" is an extension
-    of that which suffers less from bias issues at the edge of the support.
+    of that which suffers less from bias issues at the edge of the support. Note
+    that specifying a custom kernel works only with "local linear" kernel
+    regression. For example, a custom ``tricube`` kernel yields LOESS regression.
 
     Parameters
     ----------

--- a/statsmodels/nonparametric/kernel_regression.py
+++ b/statsmodels/nonparametric/kernel_regression.py
@@ -99,6 +99,7 @@ class KernelReg(GenericKDE):
         self.ckertype = ckertype
         self.okertype = okertype
         self.ukertype = ukertype
+
         if not (self.ckertype in kernel_func and self.ukertype in kernel_func
                 and self.okertype in kernel_func):
             raise ValueError('user specified kernel must be a supported '
@@ -515,6 +516,7 @@ class KernelCensoredReg(KernelReg):
         self.ckertype = ckertype
         self.okertype = okertype
         self.ukertype = ukertype
+        
         if not (self.ckertype in kernel_func and self.ukertype in kernel_func
                 and self.okertype in kernel_func):
             raise ValueError('user specified kernel must be a supported '

--- a/statsmodels/nonparametric/kernel_regression.py
+++ b/statsmodels/nonparametric/kernel_regression.py
@@ -36,7 +36,7 @@ from scipy import optimize
 from scipy.stats.mstats import mquantiles
 
 from ._kernel_base import GenericKDE, EstimatorSettings, gpke, \
-    LeaveOneOut, _get_type_pos, _adjust_shape, _compute_min_std_IQR
+    LeaveOneOut, _get_type_pos, _adjust_shape, _compute_min_std_IQR, kernel_func
 
 
 __all__ = ['KernelReg', 'KernelCensoredReg']
@@ -99,6 +99,11 @@ class KernelReg(GenericKDE):
         self.ckertype = ckertype
         self.okertype = okertype
         self.ukertype = ukertype
+        if not (self.ckertype in kernel_func and self.ukertype in kernel_func
+                and self.okertype in kernel_func):
+            raise ValueError('user specified kernel must be a supported '
+                             'kernel from statsmodels.nonparametric.kernels.')
+
         self.k_vars = len(self.var_type)
         self.endog = _adjust_shape(endog, 1)
         self.exog = _adjust_shape(exog, self.k_vars)
@@ -510,6 +515,11 @@ class KernelCensoredReg(KernelReg):
         self.ckertype = ckertype
         self.okertype = okertype
         self.ukertype = ukertype
+        if not (self.ckertype in kernel_func and self.ukertype in kernel_func
+                and self.okertype in kernel_func):
+            raise ValueError('user specified kernel must be a supported '
+                             'kernel from statsmodels.nonparametric.kernels.')
+
         self.k_vars = len(self.var_type)
         self.endog = _adjust_shape(endog, 1)
         self.exog = _adjust_shape(exog, self.k_vars)

--- a/statsmodels/nonparametric/kernels.py
+++ b/statsmodels/nonparametric/kernels.py
@@ -125,6 +125,28 @@ def gaussian(h, Xi, x):
     return (1. / np.sqrt(2 * np.pi)) * np.exp(-(Xi - x)**2 / (h**2 * 2.))
 
 
+def tricube(h, Xi, x):
+    """
+    Tricube Kernel for continuous variables
+    Parameters
+    ----------
+    h : 1-D ndarray, shape (K,)
+        The bandwidths used to estimate the value of the kernel function.
+    Xi : 1-D ndarray, shape (K,)
+        The value of the training set.
+    x : 1-D ndarray, shape (K,)
+        The value at which the kernel density is being estimated.
+
+    Returns
+    -------
+    kernel_value : ndarray, shape (nobs, K)
+        The value of the kernel function at each training point for each var.
+    """
+    u = (Xi - x) / h
+    u[np.abs(u) > 1] = 0
+    return (70. / 81) * (1 - np.abs(u)**3)**3
+
+
 def gaussian_convolution(h, Xi, x):
     """ Calculates the Gaussian Convolution Kernel """
     return (1. / np.sqrt(4 * np.pi)) * np.exp(- (Xi - x)**2 / (h**2 * 4.))

--- a/statsmodels/nonparametric/tests/test_kernel_regression.py
+++ b/statsmodels/nonparametric/tests/test_kernel_regression.py
@@ -345,6 +345,18 @@ class TestKernelReg(KernelRegressionTestBase):
         npt.assert_allclose(sm_mean, R_mean, atol=1e-2)
         npt.assert_allclose(sm_R2, R_R2, atol=1e-2)
 
+    def test_invalid_kernel(self):
+        # silverman kernel is not currently in statsmodels kernel library
+        with pytest.raises(ValueError):
+            nparam.KernelReg(endog=[self.y], exog=[self.c1, self.c2],
+                             reg_type='ll', var_type='cc', bw='cv_ls',
+                             ckertype='silverman')
+
+        with pytest.raises(ValueError):
+            nparam.KernelCensoredReg(endog=[self.y], exog=[self.c1, self.c2],
+                                     reg_type='ll', var_type='cc', bw='cv_ls',
+                                     censor_val=0, ckertype='silverman')
+
     def test_efficient_user_specificed_bw(self):
 
         bw_user=[0.23, 434697.22]

--- a/statsmodels/nonparametric/tests/test_kernel_regression.py
+++ b/statsmodels/nonparametric/tests/test_kernel_regression.py
@@ -345,18 +345,6 @@ class TestKernelReg(KernelRegressionTestBase):
         npt.assert_allclose(sm_mean, R_mean, atol=1e-2)
         npt.assert_allclose(sm_R2, R_R2, atol=1e-2)
 
-    def test_invalid_kernel(self):
-        # silverman kernel is not currently in statsmodels kernel library
-        with pytest.raises(ValueError):
-            nparam.KernelReg(endog=[self.y], exog=[self.c1, self.c2],
-                             reg_type='ll', var_type='cc', bw='cv_ls',
-                             ckertype='silverman')
-
-        with pytest.raises(ValueError):
-            nparam.KernelCensoredReg(endog=[self.y], exog=[self.c1, self.c2],
-                                     reg_type='ll', var_type='cc', bw='cv_ls',
-                                     censor_val=0, ckertype='silverman')
-
     def test_efficient_user_specificed_bw(self):
 
         bw_user=[0.23, 434697.22]
@@ -390,3 +378,16 @@ def test_invalid_bw():
     y = x ** 2
     with pytest.raises(ValueError):
         nparam.KernelReg(x, y, 'c', bw=[12.5, 1.])
+
+
+def test_invalid_kernel():
+    x = np.arange(400)
+    y = x ** 2
+    # silverman kernel is not currently in statsmodels kernel library
+    with pytest.raises(ValueError):
+        nparam.KernelReg(x, y, reg_type='ll', var_type='cc', bw='cv_ls',
+                         ckertype='silverman')
+
+    with pytest.raises(ValueError):
+        nparam.KernelCensoredReg(x, y, reg_type='ll', var_type='cc', bw='cv_ls',
+                                 censor_val=0, ckertype='silverman')

--- a/statsmodels/nonparametric/tests/test_kernel_regression.py
+++ b/statsmodels/nonparametric/tests/test_kernel_regression.py
@@ -305,6 +305,46 @@ class TestKernelReg(KernelRegressionTestBase):
         sig_var2 = model.sig_test([1], nboot=nboot)  # H0: b2 = 0
         npt.assert_equal(sig_var2 == 'Not Significant', True)
 
+    def test_user_specified_kernel(self):
+        model = nparam.KernelReg(endog=[self.y], exog=[self.c1, self.c2],
+                                 reg_type='ll', var_type='cc', bw='cv_ls',
+                                 ckertype='tricube')
+        # Bandwidth
+        sm_bw = model.bw
+        R_bw = [0.581663, 0.5652]
+        # Conditional Mean
+        sm_mean, sm_mfx = model.fit()
+        sm_mean = sm_mean[0:5]
+        sm_mfx = sm_mfx[0:5]
+        R_mean = [30.926714, 36.994604, 44.438358, 40.680598, 35.961593]
+        # R-Squared
+        sm_R2 = model.r_squared()
+        R_R2 = 0.934825
+
+        npt.assert_allclose(sm_bw, R_bw, atol=1e-2)
+        npt.assert_allclose(sm_mean, R_mean, atol=1e-2)
+        npt.assert_allclose(sm_R2, R_R2, atol=1e-2)
+
+    def test_censored_user_specified_kernel(self):
+        model = nparam.KernelCensoredReg(endog=[self.y], exog=[self.c1, self.c2],
+                                 reg_type='ll', var_type='cc', bw='cv_ls',
+                                 censor_val=0, ckertype='tricube')
+        # Bandwidth
+        sm_bw = model.bw
+        R_bw = [0.581663, 0.5652]
+        # Conditional Mean
+        sm_mean, sm_mfx = model.fit()
+        sm_mean = sm_mean[0:5]
+        sm_mfx = sm_mfx[0:5]
+        R_mean = [29.205526, 29.538008, 31.667581, 31.978866, 30.926714]
+        # R-Squared
+        sm_R2 = model.r_squared()
+        R_R2 = 0.934825
+
+        npt.assert_allclose(sm_bw, R_bw, atol=1e-2)
+        npt.assert_allclose(sm_mean, R_mean, atol=1e-2)
+        npt.assert_allclose(sm_R2, R_R2, atol=1e-2)
+
     def test_efficient_user_specificed_bw(self):
 
         bw_user=[0.23, 434697.22]

--- a/statsmodels/sandbox/nonparametric/kernel_extras.py
+++ b/statsmodels/sandbox/nonparametric/kernel_extras.py
@@ -200,6 +200,9 @@ class SingleIndexModel(KernelReg):
         self.exog = _adjust_shape(exog, self.K)
         self.nobs = np.shape(self.exog)[0]
         self.data_type = self.var_type
+        self.ckertype = 'gaussian'
+        self.okertype = 'wangryzin'
+        self.ukertype = 'aitchisonaitken'
         self.func = self._est_loc_linear
 
         self.b, self.bw = self._est_b_bw()
@@ -318,6 +321,9 @@ class SemiLinear(KernelReg):
         self.nobs = np.shape(self.exog)[0]
         self.var_type = var_type
         self.data_type = self.var_type
+        self.ckertype = 'gaussian'
+        self.okertype = 'wangryzin'
+        self.ukertype = 'aitchisonaitken'
         self.func = self._est_loc_linear
 
         self.b, self.bw = self._est_b_bw()


### PR DESCRIPTION
Currently, KernelRegression supports only the Gaussian kernel. By adding the kernel as a parameter to the class, we can support custom kernels for the local linear mode of kernel regression.

This is useful for performing other nonparametric regressions. For example, this would now support the LOESS regression, which can be achieved by specifying local linear mode, and a tricube kernel. 

This PR also adds the tricube kernel to statsmodels library of kernels.