### PR TITLE
BUG: Use correct exog names

### DIFF
--- a/statsmodels/tsa/vector_ar/tests/test_var.py
+++ b/statsmodels/tsa/vector_ar/tests/test_var.py
@@ -831,14 +831,14 @@ def test_summaries_exog(reset_randomstate):
 
     res = VAR(endog=endog, exog=exog).fit(maxlags=0)
     summ = res.summary().summary
-    assert 'exog0' in summ
-    assert 'exog1' in summ
-    assert 'exog2' in summ
-    assert 'exog3' in summ
+    assert 'exog_0' in summ
+    assert 'exog_1' in summ
+    assert 'exog_2' in summ
+    assert 'exog_3' in summ
 
     res = VAR(endog=endog, exog=exog).fit(maxlags=2)
     summ = res.summary().summary
-    assert 'exog0' in summ
-    assert 'exog1' in summ
-    assert 'exog2' in summ
-    assert 'exog3' in summ
+    assert 'exog_0' in summ
+    assert 'exog_1' in summ
+    assert 'exog_2' in summ
+    assert 'exog_3' in summ

--- a/statsmodels/tsa/vector_ar/util.py
+++ b/statsmodels/tsa/vector_ar/util.py
@@ -79,8 +79,18 @@ def make_lag_names(names, lag_order, trendorder=1, exog=None):
     if trendorder > 2:
         lag_names.insert(2, 'trend**2')
     if exog is not None:
+        if isinstance(exog, pd.Series):
+            exog = pd.DataFrame(exog)
+        elif not hasattr(exog, 'ndim'):
+            exog = np.asarray(exog)
+        if exog.ndim == 1:
+            exog = exog[:, None]
         for i in range(exog.shape[1]):
-            lag_names.insert(trendorder + i, "exog" + str(i))
+            if isinstance(exog, pd.DataFrame):
+                exog_name = str(exog.columns[i])
+            else:
+                exog_name = "exog" + str(i)
+            lag_names.insert(trendorder + i, exog_name)
     return lag_names
 
 

--- a/statsmodels/tsa/vector_ar/var_model.py
+++ b/statsmodels/tsa/vector_ar/var_model.py
@@ -626,14 +626,18 @@ class VAR(TimeSeriesModel):
                 lags = 1
 
         k_trend = util.get_trendorder(trend)
+        orig_exog_names = self.exog_names
         self.exog_names = util.make_lag_names(self.endog_names, lags, k_trend)
         self.nobs = self.n_totobs - lags
 
         # add exog to data.xnames (necessary because the length of xnames also
         # determines the allowed size of VARResults.params)
         if self.exog is not None:
-            x_names_to_add = [("exog%d" % i)
-                              for i in range(self.exog.shape[1])]
+            if orig_exog_names:
+                x_names_to_add = orig_exog_names
+            else:
+                x_names_to_add = [("exog%d" % i)
+                                  for i in range(self.exog.shape[1])]
             self.data.xnames = (self.data.xnames[:k_trend] +
                                 x_names_to_add +
                                 self.data.xnames[k_trend:])
@@ -1207,7 +1211,8 @@ class VARResults(VARProcess):
         self.nobs = self.n_totobs - lag_order
         self.trend = trend
         k_trend = util.get_trendorder(trend)
-        self.exog_names = util.make_lag_names(names, lag_order, k_trend, exog)
+        self.exog_names = util.make_lag_names(names, lag_order, k_trend,
+                                              model.data.orig_exog)
         self.params = params
         self.exog = exog
 


### PR DESCRIPTION
Use user supplied exog names if available

closes #6376

- [X] closes #6376
- [X] tests added / passed. 
- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
