### PR TITLE
MAINT: Pin xdist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -112,7 +112,8 @@ before_install:
   - pip install pytest pip pytest-randomly nose jupyter_client nbformat
   # Moved to enable Python 3.8 since cvxopt wheel is not available
   - if [ ${USE_CVXOPT} = true ]; then pip install cvxopt; fi
-  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then pip install "pytest-xdist!=1.30"; fi;
+  # Pin to 1.29 for now due to test discovery issues
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then pip install "pytest-xdist==1.29"; fi;
   - |
     if [ ${COVERAGE} = true ]; then
         pip install codecov coverage coveralls pytest-cov

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,7 +33,8 @@ build_script:
   - SET OMP_NUM_THREADS=1
   - SET OPENBLAS_NUM_THREADS=1
   - If Defined PY_MAJOR_VER ( call tools\ci\appveyor_conda.bat ) else ( call tools\ci\appveyor_pip.bat )
-  - pip install pytest "pytest-xdist!=1.30" pytest-randomly
+  # Pin to 1.29 for now due to test discovery issues
+  - pip install pytest "pytest-xdist==1.29" pytest-randomly
   - if Defined PYTEST_DIRECTIVES ( python setup.py develop ) else ( python setup.py install )
 
 test_script:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,7 +8,8 @@ cvxopt
 # test
 pytest
 pytest-randomly
-pytest-xdist!=1.30
+# Pin to 1.29 due to test discovery issues
+pytest-xdist==1.29
 flake8
 
 # doc


### PR DESCRIPTION
Pin xdist to 1.29 to avoid random test discovery failures

- [x] closes #xxxx
- [x] tests added / passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
