### PR TITLE
ENH: init to dimension of x matrix rather than rank

### DIFF
--- a/docs/source/release/version0.11.rst
+++ b/docs/source/release/version0.11.rst
@@ -212,6 +212,7 @@ Submodules
 - Prepare for Rolling Least Squares  (:pr:`6056`)
 - Improve regression doc strings  (:pr:`6077`)
 - Fix summary table header for mixedlm  (:pr:`6217`)
+- Modify quantile regression initialization to use X dimension rather than rank (:pr:`6397`)
 
 
 ``robust``

--- a/statsmodels/regression/quantile_regression.py
+++ b/statsmodels/regression/quantile_regression.py
@@ -144,7 +144,7 @@ class QuantReg(RegressionModel):
         n_iter = 0
         xstar = exog
 
-        beta = np.ones(exog_rank)
+        beta = np.ones(exog.shape[1])
         # TODO: better start, initial beta is used only for convergence check
 
         # Note the following does not work yet,

--- a/statsmodels/regression/tests/test_quantile_regression.py
+++ b/statsmodels/regression/tests/test_quantile_regression.py
@@ -1,8 +1,8 @@
 import scipy.stats
 import numpy as np
-import statsmodels.api as sm
 from numpy.testing import assert_allclose, assert_equal, assert_almost_equal
 from patsy import dmatrices  # pylint: disable=E0611
+import statsmodels.api as sm
 from statsmodels.regression.quantile_regression import QuantReg
 from .results.results_quantile_regression import (
     biweight_chamberlain, biweight_hsheather, biweight_bofinger,
@@ -281,3 +281,26 @@ def test_alpha_summary():
     summ_20 = res.summary(alpha=.2)
     assert '[0.025      0.975]' not in str(summ_20)
     assert '[0.1        0.9]' in str(summ_20)
+
+
+def test_collinear_matrix():
+    X = np.array([[1, 0, .5], [1, 0, .8],
+                  [1, 0, 1.5], [1, 0, .25]], dtype=np.float64)
+    y = np.array([0, 1, 2, 3], dtype=np.float64)
+
+    est_collinear = QuantReg(y, X).fit(0.5)
+    assert len(est_collinear.params) == X.shape[1]
+
+
+def test_nontrivial_singular_matrix():
+    x_one = np.random.random(1000)
+    x_two = np.random.random(1000)*10
+    x_three = np.random.random(1000)
+    intercept = np.ones(1000)
+
+    y = np.random.random(1000)*5
+    X = np.column_stack((intercept, x_one, x_two, x_three, x_one))
+
+    assert np.linalg.matrix_rank(X) < X.shape[1]
+    est_singular = QuantReg(y, X).fit(0.5)
+    assert len(est_singular.params) == X.shape[1]


### PR DESCRIPTION
- [x] closes #2597
- [x] tests added / passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

Updating quantile regression to initialize using the dimension of the X matrix rather than the rank. This might break things, so testing before finalizing the PR. Will add a test or three if current test suite passes with the change.

**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
