### PR TITLE
BUG: RecursiveLS should not allow `fix_params` method.

### DIFF
--- a/statsmodels/regression/recursive_ls.py
+++ b/statsmodels/regression/recursive_ls.py
@@ -136,6 +136,10 @@ class RecursiveLS(MLEModel):
         return super(MLEModel, cls).from_formula(formula, data, subset,
                                                  constraints=constraints)
 
+    def _validate_can_fix_params(self, param_names):
+        raise ValueError('No parameters can be fixed in the recursive least'
+                         ' squares model.')
+
     def fit(self):
         """
         Fits the model by application of the Kalman filter

--- a/statsmodels/regression/tests/test_recursive_ls.py
+++ b/statsmodels/regression/tests/test_recursive_ls.py
@@ -472,3 +472,15 @@ def test_multiple_constraints():
     llf_alternative = np.log(norm.pdf(res.resid_recursive, loc=0,
                                       scale=scale_alternative**0.5)).sum()
     assert_allclose(llf_alternative, desired)
+
+
+def test_fix_params():
+    mod = RecursiveLS([0, 1, 0, 1], [1, 1, 1, 1])
+    with pytest.raises(ValueError, match=('No parameters can be fixed in the'
+                                          ' recursive least')):
+        with mod.fix_params({'const': 0.1}):
+            mod.fit()
+
+    with pytest.raises(ValueError, match=('No parameters can be fixed in the'
+                                          ' recursive least')):
+        mod.fit_constrained({'const': 0.1})


### PR DESCRIPTION
- [x] tests added / passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message.

`RecursiveLS` can only allow parameter constraints via the constructor (because the way it is implemented changes the dimensions of the state vector, which is set in the constructor).