### PR TITLE
REF: More descriptive error message for recursive least squares parameter constraints.

### DIFF
--- a/statsmodels/regression/recursive_ls.py
+++ b/statsmodels/regression/recursive_ls.py
@@ -137,8 +137,10 @@ class RecursiveLS(MLEModel):
                                                  constraints=constraints)
 
     def _validate_can_fix_params(self, param_names):
-        raise ValueError('No parameters can be fixed in the recursive least'
-                         ' squares model.')
+        raise ValueError('Linear constraints on coefficients should be given'
+                         ' using the `constraints` argument in constructing.'
+                         ' the model. Other parameter constraints are not'
+                         ' available in the resursive least squares model.')
 
     def fit(self):
         """

--- a/statsmodels/regression/tests/test_recursive_ls.py
+++ b/statsmodels/regression/tests/test_recursive_ls.py
@@ -476,11 +476,11 @@ def test_multiple_constraints():
 
 def test_fix_params():
     mod = RecursiveLS([0, 1, 0, 1], [1, 1, 1, 1])
-    with pytest.raises(ValueError, match=('No parameters can be fixed in the'
-                                          ' recursive least')):
+    with pytest.raises(ValueError, match=('Linear constraints on coefficients'
+                                          ' should be given')):
         with mod.fix_params({'const': 0.1}):
             mod.fit()
 
-    with pytest.raises(ValueError, match=('No parameters can be fixed in the'
-                                          ' recursive least')):
+    with pytest.raises(ValueError, match=('Linear constraints on coefficients'
+                                          ' should be given')):
         mod.fit_constrained({'const': 0.1})


### PR DESCRIPTION
Follow-up to #6415 that just improves the error message so that users know how to impose valid constraints in `RecursiveLS` models even though `fix_params` doesn't work.