### PR TITLE
DOC: Fix the version that appears in the documentaion

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -98,8 +98,8 @@ release = __version__
 from distutils.version import LooseVersion
 
 lv = LooseVersion(release)
-full_version = version = short_version = lv.version
 commit = ''
+full_version = short_version = version = release
 if '+' in lv.version:
     short_version = lv.vstring[:lv.vstring.index('+')]
     commit = lv.version[lv.version.index('+') + 1]


### PR DESCRIPTION
Fix the version that appears in a release

- [ ] closes #xxxx
- [ ] tests added / passed. 
- [ ] code/documentation is well formatted.  
- [ ] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
