### PR TITLE
MAINT: Fix future warnings

### DIFF
--- a/lint.sh
+++ b/lint.sh
@@ -90,6 +90,7 @@ if [ "$LINT" == true ]; then
         statsmodels/graphics/api.py \
         statsmodels/graphics/functional.py \
         statsmodels/graphics/tests/test_agreement.py \
+        statsmodels/graphics/tests/test_boxplots.py \
         statsmodels/graphics/tests/test_correlation.py \
         statsmodels/graphics/tests/test_functional.py \
         statsmodels/graphics/tests/test_gofplots.py \

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,6 +42,7 @@ filterwarnings =
     error:The default value of lags:FutureWarning
     error::pandas.core.common.SettingWithCopyWarning
     error:non-integer arg n is deprecated:DeprecationWarning
+    error:Creating an ndarray:numpy.VisibleDeprecationWarning
 markers =
     example: mark a test that runs example code
     matplotlib: mark a test that requires matplotlib

--- a/statsmodels/graphics/boxplots.py
+++ b/statsmodels/graphics/boxplots.py
@@ -13,8 +13,9 @@ __all__ = ['violinplot', 'beanplot']
 
 
 def violinplot(data, ax=None, labels=None, positions=None, side='both',
-               show_boxplot=True, plot_opts={}):
-    """Make a violin plot of each dataset in the `data` sequence.
+               show_boxplot=True, plot_opts=None):
+    """
+    Make a violin plot of each dataset in the `data` sequence.
 
     A violin plot is a boxplot combined with a kernel density estimate of the
     probability density function per point.
@@ -123,7 +124,7 @@ def violinplot(data, ax=None, labels=None, positions=None, side='both',
 
     .. plot:: plots/graphics_boxplot_violinplot.py
     """
-
+    plot_opts = {} if plot_opts is None else plot_opts
     if np.size(data) == 0:
         msg = "No Data to make Violin: Try again!"
         raise ValueError(msg)
@@ -141,8 +142,7 @@ def violinplot(data, ax=None, labels=None, positions=None, side='both',
 
     # Plot violins.
     for pos_data, pos in zip(data, positions):
-        xvals, violin = _single_violin(ax, pos, pos_data, width, side,
-                                       plot_opts)
+        _single_violin(ax, pos, pos_data, width, side, plot_opts)
 
     if show_boxplot:
         ax.boxplot(data, notch=1, positions=positions, vert=1)

--- a/statsmodels/graphics/tests/test_boxplots.py
+++ b/statsmodels/graphics/tests/test_boxplots.py
@@ -10,61 +10,89 @@ except ImportError:
     pass
 
 
-@pytest.mark.matplotlib
-def test_violinplot_beanplot(close_figures):
+@pytest.fixture(scope="module")
+def age_and_labels():
     # Test violinplot and beanplot with the same dataset.
     data = anes96.load_pandas()
     party_ID = np.arange(7)
     labels = ["Strong Democrat", "Weak Democrat", "Independent-Democrat",
               "Independent-Independent", "Independent-Republican",
               "Weak Republican", "Strong Republican"]
-
     age = [data.exog['age'][data.endog == id] for id in party_ID]
+    return age, labels
 
-    fig = plt.figure()
-    ax = fig.add_subplot(111)
+
+@pytest.mark.matplotlib
+def test_violinplot(age_and_labels, close_figures):
+    age, labels = age_and_labels
+
+    fig, ax = plt.subplots(1, 1)
     violinplot(age, ax=ax, labels=labels,
-               plot_opts={'cutoff_val':5, 'cutoff_type':'abs',
-                          'label_fontsize':'small',
-                          'label_rotation':30})
+               plot_opts={'cutoff_val': 5, 'cutoff_type': 'abs',
+                          'label_fontsize': 'small',
+                          'label_rotation': 30})
 
-    fig = plt.figure()
-    ax = fig.add_subplot(111)
+
+@pytest.mark.matplotlib
+def test_violinplot_bw_factor(age_and_labels, close_figures):
+    age, labels = age_and_labels
+
+    fig, ax = plt.subplots(1, 1)
     violinplot(age, ax=ax, labels=labels,
-               plot_opts={'cutoff_val':5, 'cutoff_type':'abs',
-                          'label_fontsize':'small',
-                          'label_rotation':30,
-                          'bw_factor':.2})
+               plot_opts={'cutoff_val': 5, 'cutoff_type': 'abs',
+                          'label_fontsize': 'small',
+                          'label_rotation': 30,
+                          'bw_factor': .2})
 
-    fig = plt.figure()
-    ax = fig.add_subplot(111)
+
+@pytest.mark.matplotlib
+def test_beanplot(age_and_labels, close_figures):
+    age, labels = age_and_labels
+
+    fig, ax = plt.subplots(1, 1)
     beanplot(age, ax=ax, labels=labels,
-             plot_opts={'cutoff_val':5, 'cutoff_type':'abs',
-                        'label_fontsize':'small',
-                        'label_rotation':30})
+             plot_opts={'cutoff_val': 5, 'cutoff_type': 'abs',
+                        'label_fontsize': 'small',
+                        'label_rotation': 30})
 
-    fig = plt.figure()
-    ax = fig.add_subplot(111)
+
+@pytest.mark.matplotlib
+def test_beanplot_jitter(age_and_labels, close_figures):
+    age, labels = age_and_labels
+
+    fig, ax = plt.subplots(1, 1)
     beanplot(age, ax=ax, labels=labels, jitter=True,
              plot_opts={'cutoff_val': 5, 'cutoff_type': 'abs',
                         'label_fontsize': 'small',
                         'label_rotation': 30})
 
-    fig = plt.figure()
-    ax = fig.add_subplot(111)
+
+@pytest.mark.matplotlib
+def test_beanplot_side_right(age_and_labels, close_figures):
+    age, labels = age_and_labels
+
+    fig, ax = plt.subplots(1, 1)
     beanplot(age, ax=ax, labels=labels, jitter=True, side='right',
              plot_opts={'cutoff_val': 5, 'cutoff_type': 'abs',
                         'label_fontsize': 'small',
                         'label_rotation': 30})
 
-    fig = plt.figure()
-    ax = fig.add_subplot(111)
+
+@pytest.mark.matplotlib
+def test_beanplot_side_left(age_and_labels, close_figures):
+    age, labels = age_and_labels
+
+    fig, ax = plt.subplots(1, 1)
     beanplot(age, ax=ax, labels=labels, jitter=True, side='left',
              plot_opts={'cutoff_val': 5, 'cutoff_type': 'abs',
                         'label_fontsize': 'small',
                         'label_rotation': 30})
 
-    fig = plt.figure()
-    ax = fig.add_subplot(111)
+
+@pytest.mark.matplotlib
+def test_beanplot_legend_text(age_and_labels, close_figures):
+    age, labels = age_and_labels
+
+    fig, ax = plt.subplots(1, 1)
     beanplot(age, ax=ax, labels=labels,
              plot_opts={'bean_legend_text': 'text'})

--- a/statsmodels/tsa/innovations/tests/test_cython_arma_innovations_fast.py
+++ b/statsmodels/tsa/innovations/tests/test_cython_arma_innovations_fast.py
@@ -38,10 +38,9 @@ def test_brockwell_davis_ex533():
     # through by sigma^2
     arma_process_acovf /= sigma2
     unconditional_variance /= sigma2
-    out = np.array(_arma_innovations.darma_transformed_acovf_fast(
-        ar, ma, arma_process_acovf))
-    acovf = np.array(out[0])
-    acovf2 = np.array(out[1])
+    transformed_acovf = _arma_innovations.darma_transformed_acovf_fast(
+        ar, ma, arma_process_acovf)
+    acovf, acovf2 = (np.array(arr) for arr in transformed_acovf)
 
     # `acovf` is an m^2 x m^2 matrix, where m = max(p, q)
     # but it is only valid for the autocovariances of the first m observations
@@ -144,10 +143,9 @@ def test_brockwell_davis_ex534():
                     [7.17133, 6.44139, 5.06027], atol=1e-5)
 
     # Next, get the autocovariance of the transformed process
-    out = np.array(_arma_innovations.darma_transformed_acovf_fast(
-        ar, ma, arma_process_acovf))
-    acovf = np.array(out[0])
-    acovf2 = np.array(out[1])
+    transformed_acovf = _arma_innovations.darma_transformed_acovf_fast(
+        ar, ma, arma_process_acovf)
+    acovf, acovf2 = (np.array(arr) for arr in transformed_acovf)
     # See test_brockwell_davis_ex533 for details on acovf vs acovf2
 
     # Test acovf
@@ -226,8 +224,9 @@ def test_innovations_algo_filter_kalman_filter(ar_params, ma_params, sigma2):
 
     # Innovations algorithm approach
     arma_process_acovf = arma_acovf(ar, ma, nobs=nobs, sigma2=sigma2)
-    acovf, acovf2 = np.array(_arma_innovations.darma_transformed_acovf_fast(
-                     ar, ma, arma_process_acovf / sigma2))
+    transformed_acov = _arma_innovations.darma_transformed_acovf_fast(
+        ar, ma, arma_process_acovf / sigma2)
+    acovf, acovf2 = (np.array(mv) for mv in transformed_acov)
     theta, r = _arma_innovations.darma_innovations_algo_fast(
         nobs, ar_params, ma_params, acovf, acovf2)
     u = _arma_innovations.darma_innovations_filter(endog, ar_params, ma_params,

--- a/statsmodels/tsa/tests/test_arima.py
+++ b/statsmodels/tsa/tests/test_arima.py
@@ -2686,7 +2686,7 @@ def test_arma_repeated_fit():
     arma = ARMA(x, (1, 1))
     res = arma.fit(trend='c', disp=-1)
     repeat = arma.fit(trend='c', disp=-1)
-    rtol = 1e-5 if PLATFORM_WIN32 else 1e-7
+    rtol = 1e-4 if PLATFORM_WIN32 else 1e-7
     assert_allclose(res.params, repeat.params, rtol=rtol)
     assert isinstance(res.summary().as_text(), str)
     assert isinstance(repeat.summary().as_text(), str)


### PR DESCRIPTION
Fix future warnings from numpy about ragged arrays

- [ ] closes #xxxx
- [ ] tests added / passed. 
- [ ] code/documentation is well formatted.  
- [ ] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
