### PR TITLE
MAINT: Fix issue with ragged array

### DIFF
--- a/statsmodels/graphics/boxplots.py
+++ b/statsmodels/graphics/boxplots.py
@@ -125,7 +125,7 @@ def violinplot(data, ax=None, labels=None, positions=None, side='both',
     .. plot:: plots/graphics_boxplot_violinplot.py
     """
     plot_opts = {} if plot_opts is None else plot_opts
-    if np.size(data) == 0:
+    if max([np.size(arr) for arr in data]) == 0:
         msg = "No Data to make Violin: Try again!"
         raise ValueError(msg)
 

--- a/statsmodels/stats/libqsturng/qsturng_.py
+++ b/statsmodels/stats/libqsturng/qsturng_.py
@@ -821,7 +821,8 @@ def _psturng(q, r, v):
     if q < 0.:
         raise ValueError('q should be >= 0')
 
-    opt_func = lambda p, r, v : abs(_qsturng(p, r, v) - q)
+    def opt_func(p, r, v):
+        return abs(_qsturng(p, r, v) - q)
 
     if v == 1:
         if q < _qsturng(.9, r, 1):


### PR DESCRIPTION
Fix issue which creates ragged arracy.

- [ ] closes #xxxx
- [ ] tests added / passed. 
- [ ] code/documentation is well formatted.  
- [ ] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
