### PR TITLE
BUG: Fix exposure/offset handling in GEEResults

### DIFF
--- a/statsmodels/genmod/generalized_estimating_equations.py
+++ b/statsmodels/genmod/generalized_estimating_equations.py
@@ -611,8 +611,8 @@ class GEE(GLM):
             self.time = np.concatenate(self.time_li)
 
         if (self._offset_exposure is None or
-           (np.isscalar(self._offset_exposure) and
-            self._offset_exposure == 0.)):
+            (np.isscalar(self._offset_exposure) and
+             self._offset_exposure == 0.)):
             self.offset_li = None
         else:
             self.offset_li = self.cluster_list(self._offset_exposure)

--- a/statsmodels/genmod/generalized_estimating_equations.py
+++ b/statsmodels/genmod/generalized_estimating_equations.py
@@ -1735,6 +1735,13 @@ class GEEResults(GLMResults):
                 raise ValueError('cov_type in argument is different from '
                                  'already attached cov_type')
 
+    @cache_readonly
+    def resid(self):
+        """
+        The response residuals.
+        """
+        return self.resid_response
+
     def standard_errors(self, cov_type="robust"):
         """
         This is a convenience function that returns the standard
@@ -1772,14 +1779,6 @@ class GEEResults(GLMResults):
     @cache_readonly
     def bse(self):
         return self.standard_errors(self.cov_type)
-
-    @cache_readonly
-    def resid(self):
-        """
-        Returns the residuals, the endogeneous data minus the fitted
-        values from the model.
-        """
-        return self.model.endog - self.fittedvalues
 
     def score_test(self):
         """
@@ -1880,38 +1879,6 @@ class GEEResults(GLMResults):
     split_resid = resid_split
     centered_resid = resid_centered
     split_centered_resid = resid_centered_split
-
-    @cache_readonly
-    def resid_response(self):
-        return self.model.endog - self.fittedvalues
-
-    @cache_readonly
-    def resid_pearson(self):
-        val = self.model.endog - self.fittedvalues
-        val = val / np.sqrt(self.family.variance(self.fittedvalues))
-        return val
-
-    @cache_readonly
-    def resid_working(self):
-        val = self.resid_response
-        val = val * self.family.link.deriv(self.fittedvalues)
-        return val
-
-    @cache_readonly
-    def resid_anscombe(self):
-        return self.family.resid_anscombe(self.model.endog, self.fittedvalues)
-
-    @cache_readonly
-    def resid_deviance(self):
-        return self.family.resid_dev(self.model.endog, self.fittedvalues)
-
-    @cache_readonly
-    def fittedvalues(self):
-        """
-        Returns the fitted values from the model.
-        """
-        return self.model.family.link.inverse(np.dot(self.model.exog,
-                                                     self.params))
 
     @Appender(_plot_added_variable_doc % {'extra_params_doc': ''})
     def plot_added_variable(self, focus_exog, resid_type=None,

--- a/statsmodels/genmod/generalized_estimating_equations.py
+++ b/statsmodels/genmod/generalized_estimating_equations.py
@@ -611,7 +611,8 @@ class GEE(GLM):
             self.time = np.concatenate(self.time_li)
 
         if (self._offset_exposure is None or
-           (np.isscalar(self._offset_exposure) and self._offset_exposure == 0.)):
+           (np.isscalar(self._offset_exposure) and
+            self._offset_exposure == 0.)):
             self.offset_li = None
         else:
             self.offset_li = self.cluster_list(self._offset_exposure)

--- a/statsmodels/genmod/generalized_estimating_equations.py
+++ b/statsmodels/genmod/generalized_estimating_equations.py
@@ -611,7 +611,7 @@ class GEE(GLM):
             self.time = np.concatenate(self.time_li)
 
         if (self._offset_exposure is None or
-            (np.isscalar(self._offset_exposure) and self._offset_exposure == 0.)):
+           (np.isscalar(self._offset_exposure) and self._offset_exposure == 0.)):
             self.offset_li = None
         else:
             self.offset_li = self.cluster_list(self._offset_exposure)

--- a/statsmodels/genmod/generalized_linear_model.py
+++ b/statsmodels/genmod/generalized_linear_model.py
@@ -1564,8 +1564,12 @@ class GLMResults(base.LikelihoodModelResults):
     @cached_data
     def fittedvalues(self):
         """
-        Linear predicted values for the fitted model.
-        dot(exog, params)
+        The estimated mean response.
+
+        This is the value of the inverse of the link function at
+        lin_pred, where lin_pred is the linear predicted value
+        obtained by multiplying the design matrix by the coefficient
+        vector.
         """
         return self.mu
 

--- a/statsmodels/genmod/generalized_linear_model.py
+++ b/statsmodels/genmod/generalized_linear_model.py
@@ -1476,7 +1476,7 @@ class GLMResults(base.LikelihoodModelResults):
     @cached_data
     def resid_response(self):
         """
-        Respnose residuals.  The response residuals are defined as
+        Response residuals.  The response residuals are defined as
         `endog` - `fittedvalues`
         """
         return self._n_trials * (self._endog-self.mu)


### PR DESCRIPTION
- [x] closes #5253
- [ ] tests added / passed. 
- [ ] code/documentation is well formatted.  
- [ ] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

WIP to address this bug.  Subclass GEE and GEEResults from GLM and GLMResults.

**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
