### PR TITLE
BLD: Attempt to cache key docbuild files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,14 @@
 # stack
 dist: bionic
 language: python
-cache: pip
+cache:
+  - directories:
+    - $HOME/.cache/pip
+    - $TRAVIS_BUILD_DIR/docs/source/dev/generated
+    - $TRAVIS_BUILD_DIR/docs/source/datasets/generated
+    - $TRAVIS_BUILD_DIR/docs/source/examples/notebooks
+    - $TRAVIS_BUILD_DIR/docs/source/generated
+    - $TRAVIS_BUILD_DIR/docs/build
 
 git:
   depth: 10000


### PR DESCRIPTION
Cache to reduce docbuild time

- [ ] closes #xxxx
- [ ] tests added / passed. 
- [ ] code/documentation is well formatted.  
- [ ] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
