### PR TITLE
ENH: Add option for original Breusch-Pagan heteroscedasticity test

### DIFF
--- a/statsmodels/stats/diagnostic.py
+++ b/statsmodels/stats/diagnostic.py
@@ -824,7 +824,7 @@ def acorr_breusch_godfrey(res, nlags=None, store=False):
         return lm, lmpval, fval, fpval
 
 
-def het_breuschpagan(resid, exog_het, iid=True):
+def het_breuschpagan(resid, exog_het, robust=False):
     r"""
     Breusch-Pagan Lagrange Multiplier test for heteroscedasticity
 
@@ -845,9 +845,10 @@ def het_breuschpagan(resid, exog_het, iid=True):
     exog_het : array_like
         This contains variables suspected of being related to
         heteroscedasticity in resid.
-    iid : bool, default True
+    robust : bool, default False
         Flag indicating whether to use the Koenker version of the
-        test (default) or the original Breusch–Pagan version.
+        test (default) which assumes independent and identically distributed
+        error terms, or the original Breusch–Pagan version.
 
     Returns
     -------
@@ -877,7 +878,7 @@ def het_breuschpagan(resid, exog_het, iid=True):
 
     This is calculated using the generic formula for LM test using $R^2$
     (Greene, section 17.6) and not with the explicit formula
-    (Greene, section 11.4.3), unless `iid` is set to False.
+    (Greene, section 11.4.3), unless `robust` is set to True.
     The degrees of freedom for the p-value assume x is full rank.
 
     References
@@ -893,13 +894,13 @@ def het_breuschpagan(resid, exog_het, iid=True):
 
     x = np.asarray(exog_het)
     y = np.asarray(resid) ** 2
-    if not iid:
+    if robust:
         y = y / np.mean(y)
     nobs, nvars = x.shape
     resols = OLS(y, x).fit()
     fval = resols.fvalue
     fpval = resols.f_pvalue
-    lm = nobs * resols.rsquared if iid else resols.ess/2
+    lm = nobs * resols.rsquared if not robust else resols.ess/2
     # Note: degrees of freedom for LM test is nvars minus constant
     return lm, stats.chi2.sf(lm, nvars - 1), fval, fpval
 

--- a/statsmodels/stats/diagnostic.py
+++ b/statsmodels/stats/diagnostic.py
@@ -824,7 +824,7 @@ def acorr_breusch_godfrey(res, nlags=None, store=False):
         return lm, lmpval, fval, fpval
 
 
-def het_breuschpagan(resid, exog_het, robust=False):
+def het_breuschpagan(resid, exog_het, robust=True):
     r"""
     Breusch-Pagan Lagrange Multiplier test for heteroscedasticity
 
@@ -878,7 +878,7 @@ def het_breuschpagan(resid, exog_het, robust=False):
 
     This is calculated using the generic formula for LM test using $R^2$
     (Greene, section 17.6) and not with the explicit formula
-    (Greene, section 11.4.3), unless `robust` is set to True.
+    (Greene, section 11.4.3), unless `robust` is set to False.
     The degrees of freedom for the p-value assume x is full rank.
 
     References
@@ -894,13 +894,13 @@ def het_breuschpagan(resid, exog_het, robust=False):
 
     x = np.asarray(exog_het)
     y = np.asarray(resid) ** 2
-    if robust:
+    if not robust:
         y = y / np.mean(y)
     nobs, nvars = x.shape
     resols = OLS(y, x).fit()
     fval = resols.fvalue
     fpval = resols.f_pvalue
-    lm = nobs * resols.rsquared if not robust else resols.ess/2
+    lm = nobs * resols.rsquared if robust else resols.ess / 2
     # Note: degrees of freedom for LM test is nvars minus constant
     return lm, stats.chi2.sf(lm, nvars - 1), fval, fpval
 

--- a/statsmodels/stats/diagnostic.py
+++ b/statsmodels/stats/diagnostic.py
@@ -845,10 +845,11 @@ def het_breuschpagan(resid, exog_het, robust=True):
     exog_het : array_like
         This contains variables suspected of being related to
         heteroscedasticity in resid.
-    robust : bool, default False
+    robust : bool, default True
         Flag indicating whether to use the Koenker version of the
         test (default) which assumes independent and identically distributed
-        error terms, or the original Breusch–Pagan version.
+        error terms, or the original Breusch-Pagan version which assumes
+        residuals are normally distributed.
 
     Returns
     -------

--- a/statsmodels/stats/tests/test_diagnostic.py
+++ b/statsmodels/stats/tests/test_diagnostic.py
@@ -194,6 +194,15 @@ class TestDiagnosticG(object):
         bp = smsdia.het_breuschpagan(res.resid, res.model.exog)
         compare_to_reference(bp, bptest, decimal=(12, 12))
 
+    def test_het_breusch_pagan_original(self):
+        res = self.res
+
+        bptest = dict(statistic=1.302014063483341, pvalue=0.5215203247110649,
+                      parameters=(2,), distr='f')
+
+        bp = smsdia.het_breuschpagan(res.resid, res.model.exog, iid=False)
+        compare_to_reference(bp, bptest, decimal=(12, 12))
+
     def test_het_white(self):
         res = self.res
 

--- a/statsmodels/stats/tests/test_diagnostic.py
+++ b/statsmodels/stats/tests/test_diagnostic.py
@@ -200,7 +200,7 @@ class TestDiagnosticG(object):
         bptest = dict(statistic=1.302014063483341, pvalue=0.5215203247110649,
                       parameters=(2,), distr='f')
 
-        bp = smsdia.het_breuschpagan(res.resid, res.model.exog, iid=False)
+        bp = smsdia.het_breuschpagan(res.resid, res.model.exog, robust=True)
         compare_to_reference(bp, bptest, decimal=(12, 12))
 
     def test_het_white(self):

--- a/statsmodels/stats/tests/test_diagnostic.py
+++ b/statsmodels/stats/tests/test_diagnostic.py
@@ -194,13 +194,13 @@ class TestDiagnosticG(object):
         bp = smsdia.het_breuschpagan(res.resid, res.model.exog)
         compare_to_reference(bp, bptest, decimal=(12, 12))
 
-    def test_het_breusch_pagan_original(self):
+    def test_het_breusch_pagan_nonrobust(self):
         res = self.res
 
         bptest = dict(statistic=1.302014063483341, pvalue=0.5215203247110649,
                       parameters=(2,), distr='f')
 
-        bp = smsdia.het_breuschpagan(res.resid, res.model.exog, robust=True)
+        bp = smsdia.het_breuschpagan(res.resid, res.model.exog, robust=False)
         compare_to_reference(bp, bptest, decimal=(12, 12))
 
     def test_het_white(self):


### PR DESCRIPTION
- [x] tests added / passed  
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message. 

This adds as an option to run the original heteroscedasticity test described by Breusch-Pagan.

I recently spent a few hours researching why the results from `het_breuschpagan` did not match Stata's output, only to realize that the standard heteroscedasticity test used in Stata is not implemented in Statsmodels. Instead Statsmodels uses a modified version, described by Koenker (1981). The existing implementation is equivalent to the Stata commands `estat hettest, iid` and `estat hettest, fstat`. By setting the parameter `iid=False`, the first two return values are now identical to Stata's default (`estat hettest`).