### PR TITLE
REF/BUG: don't attach patsy constraint instance 

### DIFF
--- a/statsmodels/base/_constraints.py
+++ b/statsmodels/base/_constraints.py
@@ -10,6 +10,90 @@ License: BSD-3
 import numpy as np
 
 
+class LinearConstraints(object):
+    """Class to hold linear constraints information
+
+    Affine constraints are defined as ``R b = q` where `R` is the constraints
+    matrix and `q` are the constraints values and `b` are the parameters.
+
+    This is in analogy to patsy's LinearConstraints class but can be pickled.
+
+    Parameters
+    ----------
+    constraint_matrix : ndarray
+        R matrix, 2-dim with number of columns equal to the number of
+        parameters. Each row defines one constraint.
+    constraint_values : ndarray
+        1-dim array of constant values
+    variable_names : list of strings
+        parameter names, used only for display
+    kwds : keyword arguments
+        keywords are attached to the instance.
+
+    """
+
+    def __init__(self, constraint_matrix, constraint_values,
+                 variable_names, **kwds):
+
+        self.constraint_matrix = constraint_matrix
+        self.constraint_values = constraint_values
+        self.variable_names = variable_names
+
+        # alias for patsy compatibility
+        self.coefs = constraint_matrix
+        self.constants = constraint_values
+
+        self.__dict__.update(kwds)
+        self.tuple = (self.constraint_matrix, self.constraint_values)
+
+    def __iter__(self):
+        yield from self.tuple
+
+    def __getitem__(self, idx):
+        return self.tuple[idx]
+
+    def __str__(self):
+        def prod_string(v, name):
+            v = np.abs(v)
+            if v != 1:
+                ss = str(v) + " * " + name
+            else:
+                ss = name
+            return ss
+
+        constraints_strings = []
+        for r, q in zip(*self):
+            ss = []
+            for v, name in zip(r, self.variable_names):
+                if v != 0 and ss == []:
+                    ss += prod_string(v, name)
+                elif v > 0:
+                    ss += " + " + prod_string(v, name)
+                elif v < 0:
+                    ss += " - " + prod_string(np.abs(v), name)
+            ss += " = " + str(q.item())
+            constraints_strings.append(''.join(ss))
+
+        return '\n'.join(constraints_strings)
+
+    @classmethod
+    def from_patsy(cls, lc):
+        """class method to create instance from patsy instance
+
+        Parameters
+        ----------
+        lc : instance
+            instance of patsy LinearConstraint, or other instances that have
+            attributes ``lc.coefs, lc.constants, lc.variable_names``
+
+        Returns
+        -------
+        instance of this class
+
+        """
+        return cls(lc.coefs, lc.constants, lc.variable_names)
+
+
 class TransformRestriction(object):
     """Transformation for linear constraints `R params = q`
 
@@ -304,7 +388,7 @@ def fit_constrained_wrap(model, constraints, start_params=None, **fit_kwds):
     k_constr = len(q)
     res._results.df_resid += k_constr
     res._results.df_model -= k_constr
-    res._results.constraints = lc
+    res._results.constraints = LinearConstraints.from_patsy(lc)
     res._results.k_constr = k_constr
     res._results.results_constrained = res_constr
     return res

--- a/statsmodels/base/_parameter_inference.py
+++ b/statsmodels/base/_parameter_inference.py
@@ -182,8 +182,12 @@ def score_test(self, exog_extra=None, params_constrained=None,
     if exog_extra is None:
 
         if hasattr(self, 'constraints'):
-            k_constraints = self.constraints.coefs.shape[0]
-            r_matrix = self.constraints.coefs
+            if isinstance(self.constraints, tuple):
+                r_matrix = self.constraints[0]
+            else:
+                r_matrix = self.constraints.coefs
+            k_constraints = r_matrix.shape[0]
+
         else:
             if k_constraints is None:
                 raise ValueError('if exog_extra is None, then k_constraints'

--- a/statsmodels/base/tests/test_shrink_pickle.py
+++ b/statsmodels/base/tests/test_shrink_pickle.py
@@ -252,6 +252,16 @@ class TestRemoveDataPickleGLM(RemoveDataPickle):
         assert 'bic' in res._cache
 
 
+class TestRemoveDataPickleGLMConstrained(RemoveDataPickle):
+
+    def setup(self):
+        # fit for each test, because results will be changed by test
+        x = self.exog
+        np.random.seed(987689)
+        y = x.sum(1) + np.random.randn(x.shape[0])
+        self.results = sm.GLM(y, self.exog).fit_constrained("x1=x2")
+
+
 class TestPickleFormula(RemoveDataPickle):
     @classmethod
     def setup_class(cls):

--- a/statsmodels/discrete/discrete_model.py
+++ b/statsmodels/discrete/discrete_model.py
@@ -1124,7 +1124,8 @@ class Poisson(CountModel):
         #       patched version
         # TODO: decide whether to move the imports
         from patsy import DesignInfo
-        from statsmodels.base._constraints import fit_constrained
+        from statsmodels.base._constraints import (fit_constrained,
+                                                   LinearConstraints)
 
         # same pattern as in base.LikelihoodModel.t_test
         lc = DesignInfo(self.exog_names).linear_constraint(constraints)
@@ -1152,11 +1153,10 @@ class Poisson(CountModel):
         k_constr = len(q)
         res._results.df_resid += k_constr
         res._results.df_model -= k_constr
-        res._results.constraints = lc
+        res._results.constraints = LinearConstraints.from_patsy(lc)
         res._results.k_constr = k_constr
         res._results.results_constrained = res_constr
         return res
-
 
     def score(self, params):
         """

--- a/statsmodels/discrete/tests/test_constrained.py
+++ b/statsmodels/discrete/tests/test_constrained.py
@@ -436,7 +436,7 @@ class TestGLMLogitConstrained1(CheckGLMConstrainedMixin):
         constr = 'x1 = 2.8'
         cls.res1m = mod1.fit_constrained(constr)
 
-        R, q = cls.res1m.constraints.coefs, cls.res1m.constraints.constants
+        R, q = cls.res1m.constraints
         cls.res1 = fit_constrained(mod1, R, q)
 
 
@@ -453,6 +453,7 @@ class TestGLMLogitConstrained2(CheckGLMConstrainedMixin):
         constr = 'x1 - x3 = 0'
         cls.res1m = mod1.fit_constrained(constr, atol=1e-10)
 
+        # patsy compatible constraints
         R, q = cls.res1m.constraints.coefs, cls.res1m.constraints.constants
         cls.res1 = fit_constrained(mod1, R, q, fit_kwds={'atol': 1e-10})
         cls.constraints_rq = (R, q)
@@ -472,6 +473,9 @@ class TestGLMLogitConstrained2(CheckGLMConstrainedMixin):
         # trailing text in summary, assumes it's the first extra string
         summ = self.res1m.summary()
         assert_('linear equality constraints' in summ.extra_txt)
+
+        lc_string = str(self.res1m.constraints)
+        assert lc_string == "x1 - x3 = 0.0"
 
     @pytest.mark.smoke
     def test_summary2(self):
@@ -509,7 +513,7 @@ class TestGLMLogitConstrained2HC(CheckGLMConstrainedMixin):
         cls.res1m = mod1.fit_constrained(constr, cov_type=cov_type,
                                          cov_kwds=cov_kwds, atol=1e-10)
 
-        R, q = cls.res1m.constraints.coefs, cls.res1m.constraints.constants
+        R, q = cls.res1m.constraints
         cls.res1 = fit_constrained(mod1, R, q, fit_kwds={'atol': 1e-10,
                                                          'cov_type': cov_type,
                                                          'cov_kwds': cov_kwds})

--- a/statsmodels/genmod/generalized_linear_model.py
+++ b/statsmodels/genmod/generalized_linear_model.py
@@ -1341,7 +1341,8 @@ class GLM(base.LikelihoodModel):
         """
 
         from patsy import DesignInfo
-        from statsmodels.base._constraints import fit_constrained
+        from statsmodels.base._constraints import (fit_constrained,
+                                                   LinearConstraints)
 
         # same pattern as in base.LikelihoodModel.t_test
         lc = DesignInfo(self.exog_names).linear_constraint(constraints)
@@ -1365,7 +1366,7 @@ class GLM(base.LikelihoodModel):
         k_constr = len(q)
         res._results.df_resid += k_constr
         res._results.df_model -= k_constr
-        res._results.constraints = lc
+        res._results.constraints = LinearConstraints.from_patsy(lc)
         res._results.k_constr = k_constr
         res._results.results_constrained = res_constr
         return res


### PR DESCRIPTION
- [ ] closes #6427
- [ ] tests added / passed. 
- [ ] code/documentation is well formatted.  
- [ ] properly formatted commit message. See 


see #6427 
attaches constraints `R, q` instead of patsy constraints instance.

not backwards compatible but in a minor code (mainly as user information so far)

`GLM.score_test` and unit tests needed adjustments