### PR TITLE
ENH: state space: compute smoothed state autocovariance matrices for arbitrary lags

### DIFF
--- a/statsmodels/tsa/statespace/_kalman_smoother.pxd
+++ b/statsmodels/tsa/statespace/_kalman_smoother.pxd
@@ -53,7 +53,7 @@ cdef class sKalmanSmoother(object):
     cdef readonly np.float32_t [::1,:,:] smoothed_measurement_disturbance_cov
     cdef readonly np.float32_t [::1,:,:] smoothed_state_disturbance_cov
 
-    cdef readonly np.float32_t [::1,:,:] smoothed_state_autocov
+    cdef readonly np.float32_t [::1,:,:] smoothed_state_autocov, innovations_transition
     cdef readonly np.float32_t [::1,:] tmp_autocov
 
     cdef readonly np.float32_t [::1,:] scaled_smoothed_diffuse_estimator
@@ -96,6 +96,7 @@ cdef class sKalmanSmoother(object):
     cdef np.float32_t * _smoothed_measurement_disturbance_cov
     cdef np.float32_t * _smoothed_state_disturbance_cov
 
+    cdef np.float32_t * _innovations_transition
     cdef np.float32_t * _smoothed_state_autocov
     cdef np.float32_t * _tmp_autocov
 
@@ -165,7 +166,7 @@ cdef class dKalmanSmoother(object):
     cdef readonly np.float64_t [::1,:,:] smoothed_measurement_disturbance_cov
     cdef readonly np.float64_t [::1,:,:] smoothed_state_disturbance_cov
 
-    cdef readonly np.float64_t [::1,:,:] smoothed_state_autocov
+    cdef readonly np.float64_t [::1,:,:] smoothed_state_autocov, innovations_transition
     cdef readonly np.float64_t [::1,:] tmp_autocov
 
     cdef readonly np.float64_t [::1,:] scaled_smoothed_diffuse_estimator
@@ -208,6 +209,7 @@ cdef class dKalmanSmoother(object):
     cdef np.float64_t * _smoothed_measurement_disturbance_cov
     cdef np.float64_t * _smoothed_state_disturbance_cov
 
+    cdef np.float64_t * _innovations_transition
     cdef np.float64_t * _smoothed_state_autocov
     cdef np.float64_t * _tmp_autocov
 
@@ -277,7 +279,7 @@ cdef class cKalmanSmoother(object):
     cdef readonly np.complex64_t [::1,:,:] smoothed_measurement_disturbance_cov
     cdef readonly np.complex64_t [::1,:,:] smoothed_state_disturbance_cov
 
-    cdef readonly np.complex64_t [::1,:,:] smoothed_state_autocov
+    cdef readonly np.complex64_t [::1,:,:] smoothed_state_autocov, innovations_transition
     cdef readonly np.complex64_t [::1,:] tmp_autocov
 
     cdef readonly np.complex64_t [::1,:] scaled_smoothed_diffuse_estimator
@@ -320,6 +322,7 @@ cdef class cKalmanSmoother(object):
     cdef np.complex64_t * _smoothed_measurement_disturbance_cov
     cdef np.complex64_t * _smoothed_state_disturbance_cov
 
+    cdef np.complex64_t * _innovations_transition
     cdef np.complex64_t * _smoothed_state_autocov
     cdef np.complex64_t * _tmp_autocov
 
@@ -389,7 +392,7 @@ cdef class zKalmanSmoother(object):
     cdef readonly np.complex128_t [::1,:,:] smoothed_measurement_disturbance_cov
     cdef readonly np.complex128_t [::1,:,:] smoothed_state_disturbance_cov
 
-    cdef readonly np.complex128_t [::1,:,:] smoothed_state_autocov
+    cdef readonly np.complex128_t [::1,:,:] smoothed_state_autocov, innovations_transition
     cdef readonly np.complex128_t [::1,:] tmp_autocov
 
     cdef readonly np.complex128_t [::1,:] scaled_smoothed_diffuse_estimator
@@ -432,6 +435,7 @@ cdef class zKalmanSmoother(object):
     cdef np.complex128_t * _smoothed_measurement_disturbance_cov
     cdef np.complex128_t * _smoothed_state_disturbance_cov
 
+    cdef np.complex128_t * _innovations_transition
     cdef np.complex128_t * _smoothed_state_autocov
     cdef np.complex128_t * _tmp_autocov
 

--- a/statsmodels/tsa/statespace/_kalman_smoother.pyx.in
+++ b/statsmodels/tsa/statespace/_kalman_smoother.pyx.in
@@ -296,6 +296,10 @@ cdef class {{prefix}}KalmanSmoother(object):
         dim3[0] = self.kfilter.k_posdef; dim3[1] = self.kfilter.k_posdef; dim3[2] = self.model.nobs;
         self.smoothed_state_disturbance_cov = np.PyArray_ZEROS(3, dim3, {{typenum}}, FORTRAN)
 
+        # Innovations transition matrix (L_t = T_t - K_t Z_t)
+        dim3[0] = self.kfilter.k_states; dim3[1] = self.kfilter.k_states; dim3[2] = self.model.nobs
+        self.innovations_transition = np.PyArray_ZEROS(3, dim3, {{typenum}}, FORTRAN)
+
         # Smoothed state autocovariance arrays
         dim3[0] = self.kfilter.k_states; dim3[1] = self.kfilter.k_states; dim3[2] = self.model.nobs
         self.smoothed_state_autocov = np.PyArray_ZEROS(3, dim3, {{typenum}}, FORTRAN)
@@ -357,6 +361,7 @@ cdef class {{prefix}}KalmanSmoother(object):
             'smoothed_measurement_disturbance_cov': np.array(self.smoothed_measurement_disturbance_cov, copy=True, order='F'),
             'smoothed_state_disturbance_cov': np.array(self.smoothed_state_disturbance_cov, copy=True, order='F'),
             'smoothed_state_autocov': np.array(self.smoothed_state_autocov, copy=True, order='F'),
+            'innovations_transition': np.array(self.smoothed_state_autocov, copy=True, order='F'),
             'tmp_autocov': np.array(self.tmp_autocov, copy=True, order='F'),
             'scaled_smoothed_diffuse_estimator': np.array(self.scaled_smoothed_diffuse_estimator, copy=True, order='F'),
             'scaled_smoothed_diffuse1_estimator_cov': np.array(self.scaled_smoothed_diffuse1_estimator_cov, copy=True, order='F'),
@@ -383,6 +388,7 @@ cdef class {{prefix}}KalmanSmoother(object):
         self.smoothed_measurement_disturbance_cov = state['smoothed_measurement_disturbance_cov']
         self.smoothed_state_disturbance_cov = state['smoothed_state_disturbance_cov']
         self.smoothed_state_autocov = state['smoothed_state_autocov']
+        self.innovations_transition = state['innovations_transition']
         self.tmp_autocov = state['tmp_autocov']
         self.scaled_smoothed_diffuse_estimator = state['scaled_smoothed_diffuse_estimator']
         self.scaled_smoothed_diffuse1_estimator_cov = state['scaled_smoothed_diffuse1_estimator_cov']
@@ -512,7 +518,7 @@ cdef class {{prefix}}KalmanSmoother(object):
         """
         Perform an iteration of the Kalman smoother
         """
-        cdef int t
+        cdef int t, inc = 1
         cdef int diffuse = self.t < self.kfilter.nobs_diffuse
 
         # Get time subscript, and stop the iterator if at the end
@@ -554,6 +560,7 @@ cdef class {{prefix}}KalmanSmoother(object):
             self.smooth_estimators_measurement(self, self.kfilter, self.model)
 
         # Smoothed state autocovariance matrix
+        blas.{{prefix}}copy(&self.kfilter.k_states2, self._tmpL, &inc, self._innovations_transition, &inc)
         if self.smoother_output & SMOOTHER_STATE_AUTOCOV:
             if diffuse:
                 {{prefix}}smoothed_state_autocov_univariate_diffuse(self, self.kfilter, self.model)
@@ -698,6 +705,7 @@ cdef class {{prefix}}KalmanSmoother(object):
         self._smoothed_measurement_disturbance_cov = &self.smoothed_measurement_disturbance_cov[0, 0, t]
         self._smoothed_state_disturbance_cov = &self.smoothed_state_disturbance_cov[0, 0, t]
 
+        self._innovations_transition = &self.innovations_transition[0, 0, t]
         self._smoothed_state_autocov = &self.smoothed_state_autocov[0, 0, t]
 
         # Diffuse

--- a/statsmodels/tsa/statespace/kalman_smoother.py
+++ b/statsmodels/tsa/statespace/kalman_smoother.py
@@ -712,6 +712,8 @@ class SmootherResults(FilterResults):
     def _smoothed_state_autocovariance(self, shift, start, end,
                                        extend_kwargs=None):
         """
+        Compute "forward" autocovariances, Cov(t, t+j)
+
         Parameters
         ----------
         shift : int
@@ -737,7 +739,8 @@ class SmootherResults(FilterResults):
         # Size of returned array in the time dimension
         n = end - start
 
-        n_presample = max(0, -start)
+        # Get number of post-sample periods we need to create an extended
+        # model to compute
         if shift == 0:
             max_insample = self.nobs - shift
         else:

--- a/statsmodels/tsa/statespace/kalman_smoother.py
+++ b/statsmodels/tsa/statespace/kalman_smoother.py
@@ -858,8 +858,8 @@ class SmootherResults(FilterResults):
             N = self.scaled_smoothed_estimator_cov.T[_start:_end]
 
             # If applicable, get the required arrays, out-of-sample
-            if _end - lag > self.nobs + 2:
-                oos_nobs = (_end - 1 - lag) - self.nobs
+            oos_nobs = (_end - 1 - lag) - self.nobs
+            if oos_nobs > 0:
                 oos_endog = np.zeros((oos_nobs, self.k_endog)) * np.nan
 
                 oos_mod = self.model.extend(oos_endog, start=self.nobs,

--- a/statsmodels/tsa/statespace/kalman_smoother.py
+++ b/statsmodels/tsa/statespace/kalman_smoother.py
@@ -548,7 +548,7 @@ class SmootherResults(FilterResults):
         'smoothed_state', 'smoothed_state_cov', 'smoothed_state_autocov',
         'smoothed_measurement_disturbance', 'smoothed_state_disturbance',
         'smoothed_measurement_disturbance_cov',
-        'smoothed_state_disturbance_cov'
+        'smoothed_state_disturbance_cov', 'innovations_transition'
     ]
 
     _smoother_options = KalmanSmoother.smoother_outputs
@@ -658,6 +658,9 @@ class SmootherResults(FilterResults):
                             np.array(getattr(smoother, name, None), copy=True))
             else:
                 setattr(self, name, None)
+
+        self.innovations_transition = (
+            np.array(smoother.innovations_transition, copy=True))
 
         # Diffuse objects
         self.scaled_smoothed_diffuse_estimator = None

--- a/statsmodels/tsa/statespace/tests/test_smoothing.py
+++ b/statsmodels/tsa/statespace/tests/test_smoothing.py
@@ -1066,7 +1066,8 @@ def get_acov_model(missing, filter_univariate, tvp, oos=None, params=None,
         endog = endog.reindex(new_ix)
 
     if not tvp:
-        mod = varmax.VARMAX(endog, order=(4, 0, 0), measurement_error=True)
+        mod = varmax.VARMAX(endog, order=(4, 0, 0), measurement_error=True,
+                            tolerance=0)
         mod.ssm.filter_univariate = filter_univariate
         if params is None:
             params = mod.start_params
@@ -1096,15 +1097,15 @@ def test_smoothed_state_autocovariances_backwards(missing, filter_univariate,
 
     # Test all "backward" autocovariances: Cov(t, t-lag)
     acov1 = res.smoothed_state_autocovariance(1).transpose(2, 0, 1)
-    assert_allclose(acov1[1:, :2, :2], desired_acov1[1:], atol=1e-11)
+    assert_allclose(acov1[1:, :2, :2], desired_acov1[1:])
     assert_equal(acov1[:1], np.nan)
 
     acov2 = res.smoothed_state_autocovariance(2).transpose(2, 0, 1)
-    assert_allclose(acov2[2:, :2, :2], desired_acov2[2:], atol=1e-11)
+    assert_allclose(acov2[2:, :2, :2], desired_acov2[2:])
     assert_equal(acov2[:2], np.nan)
 
     acov3 = res.smoothed_state_autocovariance(3).transpose(2, 0, 1)
-    assert_allclose(acov3[3:, :2, :2], desired_acov3[3:], atol=1e-10)
+    assert_allclose(acov3[3:, :2, :2], desired_acov3[3:])
     assert_equal(acov3[:3], np.nan)
 
     # Test for specific autocovariances
@@ -1178,18 +1179,18 @@ def test_smoothed_state_autocovariances_forwards(missing, filter_univariate,
     # For Cov(t, t+lag), the first out-of-sample forward covariance,
     # Cov(T, T+1), is already available, so we dno't need extend kwaargs
     acov1 = res.smoothed_state_autocovariance(-1).transpose(2, 0, 1)
-    assert_allclose(acov1[:-1, :2, :2], desired_acov1[1:], atol=1e-10)
-    assert_allclose(acov1[-2:, :2, :2], oos_cov[-5:-3, 2:4, :2], atol=1e-10)
+    assert_allclose(acov1[:-1, :2, :2], desired_acov1[1:])
+    assert_allclose(acov1[-2:, :2, :2], oos_cov[-5:-3, 2:4, :2])
 
     acov2 = res.smoothed_state_autocovariance(
         -2, extend_kwargs=extend_kwargs1).transpose(2, 0, 1)
-    assert_allclose(acov2[:-2, :2, :2], desired_acov2[2:], atol=1e-10)
-    assert_allclose(acov2[-2:, :2, :2], oos_cov[-4:-2, 4:6, :2], atol=1e-10)
+    assert_allclose(acov2[:-2, :2, :2], desired_acov2[2:])
+    assert_allclose(acov2[-2:, :2, :2], oos_cov[-4:-2, 4:6, :2])
 
     acov3 = res.smoothed_state_autocovariance(
         -3, extend_kwargs=extend_kwargs2).transpose(2, 0, 1)
-    assert_allclose(acov3[:-3, :2, :2], desired_acov3[3:], atol=1e-10)
-    assert_allclose(acov3[-3:, :2, :2], oos_cov[-4:-1, 6:8, :2], atol=1e-10)
+    assert_allclose(acov3[:-3, :2, :2], desired_acov3[3:])
+    assert_allclose(acov3[-3:, :2, :2], oos_cov[-4:-1, 6:8, :2])
 
     # Test for specific autocovariances
     acov1 = res.smoothed_state_autocovariance(
@@ -1203,10 +1204,10 @@ def test_smoothed_state_autocovariances_forwards(missing, filter_univariate,
 
     acov2 = res.smoothed_state_autocovariance(
         -2, t=mod.nobs, extend_kwargs=extend_kwargs2)
-    assert_allclose(acov2[:2, :2], oos_cov[-2, 4:6, :2], atol=1e-10)
+    assert_allclose(acov2[:2, :2], oos_cov[-2, 4:6, :2])
     acov2 = res.smoothed_state_autocovariance(
         -2, t=mod.nobs - 1, extend_kwargs=extend_kwargs1)
-    assert_allclose(acov2[:2, :2], oos_cov[-3, 4:6, :2], atol=1e-10)
+    assert_allclose(acov2[:2, :2], oos_cov[-3, 4:6, :2])
     acov2 = res.smoothed_state_autocovariance(-2, t=0)
     assert_allclose(acov2[:2, :2], desired_acov2[0 + 2])
     acov2 = res.smoothed_state_autocovariance(
@@ -1265,7 +1266,7 @@ def test_smoothed_state_autocovariances_forwards_oos(missing,
     acov1 = res.smoothed_state_autocovariance(
         -1, end=mod_oos.nobs, extend_kwargs=extend_kwargs).transpose(2, 0, 1)
     assert_equal(acov1.shape, (mod_oos.nobs, mod.k_states, mod.k_states))
-    assert_allclose(acov1[:, :2, :2], desired_acov1[1:], atol=1e-10)
+    assert_allclose(acov1[:, :2, :2], desired_acov1[1:])
 
     # Note: now we can compute up to Cov(mod_oos.nobs - 1, mod_oos.nobs + 1)
     # using a model that has state space matrices defined up to mod_oos.nobs.
@@ -1279,7 +1280,7 @@ def test_smoothed_state_autocovariances_forwards_oos(missing,
         -2, end=mod_oos.nobs - 1,
         extend_kwargs=extend_kwargs).transpose(2, 0, 1)
     assert_equal(acov2.shape, (mod_oos.nobs - 1, mod.k_states, mod.k_states))
-    assert_allclose(acov2[:, :2, :2], desired_acov2[2:], atol=1e-10)
+    assert_allclose(acov2[:, :2, :2], desired_acov2[2:])
 
     # Note: now we can compute up to Cov(mod_oos.nobs - 2, mod_oos.nobs + 1)
     # using a model that has state space matrices defined up to mod_oos.nobs.
@@ -1288,7 +1289,7 @@ def test_smoothed_state_autocovariances_forwards_oos(missing,
         -3, end=mod_oos.nobs - 2,
         extend_kwargs=extend_kwargs).transpose(2, 0, 1)
     assert_equal(acov3.shape, (mod_oos.nobs - 2, mod.k_states, mod.k_states))
-    assert_allclose(acov3[:, :2, :2], desired_acov3[3:], atol=1e-10)
+    assert_allclose(acov3[:, :2, :2], desired_acov3[3:])
 
 
 @pytest.mark.parametrize('missing', ['all', 'partial', 'mixed', None])
@@ -1343,7 +1344,7 @@ def test_smoothed_state_autocovariances_backwards_oos(missing,
     acov1 = res.smoothed_state_autocovariance(
         1, end=end, extend_kwargs=extend_kwargs).transpose(2, 0, 1)
     assert_equal(acov1.shape, (mod_oos.nobs + 1, mod.k_states, mod.k_states))
-    assert_allclose(acov1[1:, :2, :2], desired_acov1[1:], atol=1e-10)
+    assert_allclose(acov1[1:, :2, :2], desired_acov1[1:])
     # We cannot compute Cov(1, 0), so this is always NaNs
     assert_equal(acov1[:1], np.nan)
 
@@ -1352,7 +1353,7 @@ def test_smoothed_state_autocovariances_backwards_oos(missing,
     # is why we don't need to change `end` here relative to the lag=1 case
     acov2 = res.smoothed_state_autocovariance(
         2, end=end, extend_kwargs=extend_kwargs).transpose(2, 0, 1)
-    assert_allclose(acov2[2:, :2, :2], desired_acov2[2:], atol=1e-10)
+    assert_allclose(acov2[2:, :2, :2], desired_acov2[2:])
     # We cannot compute Cov(1, -1) or Cov(2, 0), so this is always NaNs
     assert_equal(acov2[:2], np.nan)
 
@@ -1362,7 +1363,7 @@ def test_smoothed_state_autocovariances_backwards_oos(missing,
     # cases
     acov3 = res.smoothed_state_autocovariance(
         3, end=end, extend_kwargs=extend_kwargs).transpose(2, 0, 1)
-    assert_allclose(acov3[3:, :2, :2], desired_acov3[3:], atol=1e-10)
+    assert_allclose(acov3[3:, :2, :2], desired_acov3[3:])
     # We cannot compute Cov(1, -2), Cov(2, -1), or Cov(3, 0), so this is always
     # NaNs
     assert_equal(acov3[:3], np.nan)

--- a/statsmodels/tsa/statespace/tests/test_smoothing.py
+++ b/statsmodels/tsa/statespace/tests/test_smoothing.py
@@ -18,8 +18,11 @@ import numpy as np
 from numpy.testing import assert_allclose, assert_almost_equal, assert_equal
 import pandas as pd
 
+import pytest
+
 from statsmodels import datasets
-from statsmodels.tsa.statespace import mlemodel, sarimax
+from statsmodels.tsa.statespace import mlemodel, sarimax, varmax
+from statsmodels.tsa.statespace.tests.test_impulse_responses import TVSS
 from statsmodels.tsa.statespace.kalman_filter import FILTER_UNIVARIATE
 from statsmodels.tsa.statespace.kalman_smoother import (
     SMOOTH_CLASSICAL, SMOOTH_ALTERNATIVE,
@@ -1028,3 +1031,284 @@ class TestVARAutocovariancesUnivariateSmoothing(TestVARAutocovariances):
         assert_equal(self.model.ssm._kalman_smoother.smooth_method, 0)
         assert_equal(self.model.ssm._kalman_smoother._smooth_method,
                      SMOOTH_UNIVARIATE)
+
+
+class TVSSWithLags(TVSS):
+    def __init__(self, endog):
+        # TVSS has 2 states, here we will add in 3 lags of those
+        super().__init__(endog, _k_states=8)
+        self['transition', 2:, :6] = np.eye(6)[..., None]
+        # Can't use exact diffuse filtering
+        self.ssm.initialize_approximate_diffuse(1e-4)
+
+
+def get_acov_model(missing, filter_univariate, tvp, oos=None, params=None):
+    dta = datasets.macrodata.load_pandas().data
+    dta.index = pd.date_range(start='1959-01-01', end='2009-7-01',
+                              freq='QS')
+    endog = np.log(dta[['realgdp', 'realcons']]).diff().iloc[1:]
+
+    if missing == 'all':
+        endog.iloc[:5, :] = np.nan
+        endog.iloc[11:13, :] = np.nan
+    elif missing == 'partial':
+        endog.iloc[0:5, 0] = np.nan
+        endog.iloc[11:13, 0] = np.nan
+    elif missing == 'mixed':
+        endog.iloc[0:5, 0] = np.nan
+        endog.iloc[1:7, 1] = np.nan
+        endog.iloc[11:13, 0] = np.nan
+
+    if oos is not None:
+        new_ix = pd.date_range(start=endog.index[0],
+                               periods=len(endog) + oos, freq='QS')
+        endog = endog.reindex(new_ix)
+
+    if not tvp:
+        mod = varmax.VARMAX(endog, order=(4, 0, 0), measurement_error=True)
+        mod.ssm.filter_univariate = filter_univariate
+        if params is None:
+            params = mod.start_params
+        mod.update(params)
+        res = mod.ssm.smooth()
+    else:
+        mod = TVSSWithLags(endog)
+        mod.ssm.filter_univariate = filter_univariate
+        res = mod.ssm.smooth()
+
+    return mod, res
+
+
+@pytest.mark.parametrize('missing', ['all', 'partial', 'mixed', None])
+@pytest.mark.parametrize('filter_univariate', [True, False])
+@pytest.mark.parametrize('tvp', [True, False])
+def test_smoothed_state_autocovariances_backwards(missing, filter_univariate,
+                                                  tvp):
+    r"""
+    Test for Cov(t, t - lag)
+    """
+    _, res = get_acov_model(missing, filter_univariate, tvp)
+
+    cov = np.concatenate(
+        (res.smoothed_state_cov, res.predicted_state_cov[..., -1:]),
+        axis=2).transpose(2, 0, 1)
+    desired_acov1 = cov[:, :2, 2:4]
+    desired_acov2 = cov[:, :2, 4:6]
+    desired_acov3 = cov[:, :2, 6:8]
+
+    # Test all "backward" autocovariances: Cov(t, t-lag)
+    acov1 = res.smoothed_state_autocovariance(1).transpose(2, 0, 1)
+    assert_allclose(acov1[1:, :2, :2], desired_acov1[1:], atol=1e-11)
+    assert_equal(acov1[:1], np.nan)
+
+    acov2 = res.smoothed_state_autocovariance(2).transpose(2, 0, 1)
+    assert_allclose(acov2[2:, :2, :2], desired_acov2[2:], atol=1e-11)
+    assert_equal(acov2[:2], np.nan)
+
+    acov3 = res.smoothed_state_autocovariance(3).transpose(2, 0, 1)
+    assert_allclose(acov3[3:, :2, :2], desired_acov3[3:], atol=1e-10)
+    assert_equal(acov3[:3], np.nan)
+
+    # Test for specific autocovariances
+    acov1 = res.smoothed_state_autocovariance(1, t=0)
+    assert_allclose(acov1, np.nan)
+    acov1 = res.smoothed_state_autocovariance(1, t=1)
+    assert_allclose(acov1[:2, :2], desired_acov1[1])
+    acov1 = res.smoothed_state_autocovariance(
+        1, start=8, end=9).transpose(2, 0, 1)
+    assert_allclose(acov1[:, :2, :2], desired_acov1[8:9])
+
+    acov2 = res.smoothed_state_autocovariance(2, t=0)
+    assert_allclose(acov2, np.nan)
+    acov2 = res.smoothed_state_autocovariance(2, t=1)
+    assert_allclose(acov2, np.nan)
+    acov2 = res.smoothed_state_autocovariance(2, t=2)
+    assert_allclose(acov2[:2, :2], desired_acov2[2])
+    acov2 = res.smoothed_state_autocovariance(
+        2, start=8, end=9).transpose(2, 0, 1)
+    assert_allclose(acov2[:, :2, :2], desired_acov2[8:9])
+
+
+@pytest.mark.parametrize('missing', ['all', 'partial', 'mixed', None])
+@pytest.mark.parametrize('filter_univariate', [True, False])
+@pytest.mark.parametrize('tvp', [True, False])
+def test_smoothed_state_autocovariances_forwards(missing, filter_univariate,
+                                                 tvp):
+    r"""
+    Test for Cov(t, t + lag)
+    """
+    # Basic model
+    mod, res = get_acov_model(missing, filter_univariate, tvp)
+
+    cov = np.concatenate(
+        (res.smoothed_state_cov, res.predicted_state_cov[..., -1:]),
+        axis=2).transpose(2, 0, 1)
+    desired_acov1 = cov[:, 2:4, :2]
+    desired_acov2 = cov[:, 4:6, :2]
+    desired_acov3 = cov[:, 6:8, :2]
+
+    # Test all "forwards" autocovariances: Cov(t, t+lag)
+    acov1 = res.smoothed_state_autocovariance(
+        1, forward_autocovariances=True).transpose(2, 0, 1)
+    assert_allclose(acov1[:-1, :2, :2], desired_acov1[1:], atol=1e-11)
+    assert_equal(acov1[-1:], np.nan)
+
+    acov2 = res.smoothed_state_autocovariance(
+        2, forward_autocovariances=True).transpose(2, 0, 1)
+    assert_allclose(acov2[:-2, :2, :2], desired_acov2[2:], atol=1e-11)
+    assert_equal(acov2[-2:], np.nan)
+
+    acov3 = res.smoothed_state_autocovariance(
+        3, forward_autocovariances=True).transpose(2, 0, 1)
+    assert_allclose(acov3[:-3, :2, :2], desired_acov3[3:], atol=1e-10)
+    assert_equal(acov3[-3:], np.nan)
+
+    # Test for specific autocovariances
+    acov1 = res.smoothed_state_autocovariance(
+        1, t=mod.nobs, forward_autocovariances=True)
+    assert_allclose(acov1, np.nan)
+    acov1 = res.smoothed_state_autocovariance(
+        1, t=0, forward_autocovariances=True)
+    assert_allclose(acov1[:2, :2], desired_acov1[0 + 1])
+    acov1 = res.smoothed_state_autocovariance(
+        1, start=8, end=9, forward_autocovariances=True).transpose(2, 0, 1)
+    assert_allclose(acov1[:, :2, :2], desired_acov1[8 + 1:9 + 1])
+
+    acov2 = res.smoothed_state_autocovariance(
+        2, t=mod.nobs, forward_autocovariances=True)
+    assert_allclose(acov2, np.nan)
+    acov2 = res.smoothed_state_autocovariance(
+        2, t=mod.nobs - 1, forward_autocovariances=True)
+    assert_allclose(acov2, np.nan)
+    acov2 = res.smoothed_state_autocovariance(
+        2, t=0, forward_autocovariances=True)
+    assert_allclose(acov2[:2, :2], desired_acov2[0 + 2])
+    acov2 = res.smoothed_state_autocovariance(
+        2, start=8, end=9, forward_autocovariances=True).transpose(2, 0, 1)
+    assert_allclose(acov2[:, :2, :2], desired_acov2[8 + 2:9 + 2])
+
+
+def test_smoothed_state_autocovariances_forwards_oos(
+        missing=False, filter_univariate=False, tvp=False):
+    # Out-of-sample model
+    # Note: in TVP case, we need to first generate the larger model, and then
+    # create the smaller model with the system matrices from the larger model
+    # (otherwise they will be different, since the matrices are randomly
+    # generated)
+    mod_oos, res_oos = get_acov_model(missing, filter_univariate, tvp, oos=5)
+
+    # Basic model
+    names = ['obs_intercept', 'design', 'obs_cov', 'transition', 'selection',
+             'state_cov']
+    if not tvp:
+        _, res = get_acov_model(missing, filter_univariate, tvp,
+                                params=mod_oos.start_params)
+    else:
+        mod, _ = get_acov_model(missing, filter_univariate, tvp)
+        for name in names:
+            mod[name] = mod_oos[name, ..., :-5]
+        res = mod.ssm.smooth()
+
+    assert_allclose(res_oos.llf, res.llf)
+
+    cov = np.concatenate(
+        (res_oos.smoothed_state_cov, res_oos.predicted_state_cov[..., -1:]),
+        axis=2).transpose(2, 0, 1)
+    desired_acov1 = cov[:, 2:4, :2]
+    desired_acov2 = cov[:, 4:6, :2]
+    desired_acov3 = cov[:, 6:8, :2]
+
+    # Test all "forwards" autocovariances: Cov(t, t+lag)
+    end = mod_oos.nobs + 1
+    acov1 = res.smoothed_state_autocovariance(
+        1, end=end, forward_autocovariances=True).transpose(2, 0, 1)
+    assert_allclose(acov1[:-1, :2, :2], desired_acov1[1:], atol=1e-11)
+    assert_equal(acov1[-1:], np.nan)
+
+    acov2 = res.smoothed_state_autocovariance(
+        2, end=end, forward_autocovariances=True).transpose(2, 0, 1)
+    assert_allclose(acov2[:-2, :2, :2], desired_acov2[2:], atol=1e-11)
+    assert_equal(acov2[-2:], np.nan)
+
+    acov3 = res.smoothed_state_autocovariance(
+        3, end=end, forward_autocovariances=True).transpose(2, 0, 1)
+    assert_allclose(acov3[:-3, :2, :2], desired_acov3[3:], atol=1e-10)
+    assert_equal(acov3[-3:], np.nan)
+
+
+def test_smoothed_state_autocovariances_backwards_oos(
+        missing=False, filter_univariate=False, tvp=True):
+    # Out-of-sample model
+    # Note: in TVP case, we need to first generate the larger model, and then
+    # create the smaller model with the system matrices from the larger model
+    # (otherwise they will be different, since the matrices are randomly
+    # generated)
+    mod_oos, res_oos = get_acov_model(missing, filter_univariate, tvp, oos=5)
+
+    # Basic model
+    names = ['obs_intercept', 'design', 'obs_cov', 'transition', 'selection',
+             'state_cov']
+    if not tvp:
+        _, res = get_acov_model(missing, filter_univariate, tvp,
+                                params=res_oos.params)
+    else:
+        mod, _ = get_acov_model(missing, filter_univariate, tvp)
+        for name in names:
+            mod[name] = mod_oos[name, ..., :-5]
+        res = mod.ssm.smooth()
+
+    assert_allclose(res_oos.llf, res.llf)
+
+    cov = np.concatenate(
+        (res_oos.smoothed_state_cov, res_oos.predicted_state_cov[..., -1:]),
+        axis=2).transpose(2, 0, 1)
+    desired_acov1 = cov[:, :2, 2:4]
+    desired_acov2 = cov[:, :2, 4:6]
+    desired_acov3 = cov[:, :2, 6:8]
+
+    # Test all "forwards" autocovariances: Cov(t, t+lag)
+    end = mod_oos.nobs + 1
+    extend_kwargs = {}
+    # keys = ['design', 'obs_cov',]
+    if tvp:
+        extend_kwargs = {
+            'obs_intercept': mod_oos['obs_intercept', ..., -5:],
+            'design': mod_oos['design', ..., -5:],
+            'obs_cov': mod_oos['obs_cov', ..., -5:],
+            'transition': mod_oos['transition', ..., -5:],
+            'selection': mod_oos['selection', ..., -5:],
+            'state_cov': mod_oos['state_cov', ..., -5:]}
+    acov1 = res.smoothed_state_autocovariance(
+        1, end=end, extend_kwargs=extend_kwargs).transpose(2, 0, 1)
+    assert_allclose(acov1[1:, :2, :2], desired_acov1[1:], atol=1e-11)
+    assert_equal(acov1[:1], np.nan)
+
+    acov2 = res.smoothed_state_autocovariance(
+        2, end=end, extend_kwargs=extend_kwargs).transpose(2, 0, 1)
+    assert_allclose(acov2[2:, :2, :2], desired_acov2[2:], atol=1e-11)
+    assert_equal(acov2[:2], np.nan)
+
+    acov3 = res.smoothed_state_autocovariance(
+        3, end=end, extend_kwargs=extend_kwargs).transpose(2, 0, 1)
+    assert_allclose(acov3[3:, :2, :2], desired_acov3[3:], atol=1e-10)
+    assert_equal(acov3[:3], np.nan)
+
+
+def test_smoothed_state_autocovariances_invalid():
+    # Tests for invalid calls of `smoothed_state_autocovariance`
+    _, res = get_acov_model(missing=False, filter_univariate=False, tvp=False)
+
+    with pytest.raises(ValueError, match='Cannot specify both `t`'):
+        res.smoothed_state_autocovariance(1, t=1, start=1)
+
+    with pytest.raises(ValueError, match='Negative `t`'):
+        res.smoothed_state_autocovariance(1, t=-1)
+
+    with pytest.raises(ValueError, match='Negative `t`'):
+        res.smoothed_state_autocovariance(1, start=-1)
+
+    with pytest.raises(ValueError, match='Negative `t`'):
+        res.smoothed_state_autocovariance(1, end=-1)
+
+    with pytest.raises(ValueError, match='`end` must be after `start`'):
+        res.smoothed_state_autocovariance(1, start=5, end=4)


### PR DESCRIPTION
- [x] tests added / passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message.

We already compute the `lag=1` smoothed autocovariance matrix for the state vector (i.e. Cov(t, t-1)) in the Cython recursions (because it is required for the EM algorithm applied to the transition equation, and so it's best if it's pretty fast).

This PR adds a new `smoothed_state_autocovariance` method to the `SmootherResults` class to allow computing autocovariances with any `lag = 0, +-1, +-2, ...`. One application of this is computing the "news" for nowcasting models, described in Banbura and Modugo (2014). Not in Cython since as far as I know, this is just for postestimation results, and won't be in an inner loop.