### PR TITLE
BLD: Azure: Mac OSX 10.13 -> 10.14

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,7 +20,7 @@ jobs:
 - template: tools/ci/azure_template.yml
   parameters:
     name: macOS
-    vmImage: xcode9-macos10.13
+    vmImage: macOS-10.14
 
 - template: tools/ci/azure_template.yml
   parameters:


### PR DESCRIPTION
Our Azure CI currently runs against Mac OS X 10.13, which is [being removed](https://devblogs.microsoft.com/devops/removing-older-images-in-azure-pipelines-hosted-pools/) in favor of Mac OS X 10.14.

Currently, Azure is running hour-long "brownouts" every day, but 10.13 will be removed on March 23.

This PR (hopefully) updates our CI job to use Mac OS X 10.14.