### PR TITLE
MAINT: Relax tolerance on test that randomly fails

### DIFF
--- a/statsmodels/tsa/statespace/tests/test_exact_diffuse_filtering.py
+++ b/statsmodels/tsa/statespace/tests/test_exact_diffuse_filtering.py
@@ -1012,11 +1012,14 @@ def test_nondiagonal_obs_cov(reset_randomstate):
     res2 = mod.smooth([])
 
     # Here we'll just test a few values
-    assert_allclose(res1.llf, res2.llf)
-    assert_allclose(res1.forecasts[0], res2.forecasts[0])
-    assert_allclose(res1.filtered_state, res2.filtered_state)
+    assert_allclose(res1.llf, res2.llf, rtol=1e-6, atol=1e-5)
+    assert_allclose(res1.forecasts[0], res2.forecasts[0],
+                    rtol=1e-6, atol=1e-5)
+    assert_allclose(res1.filtered_state, res2.filtered_state,
+                    rtol=1e-6, atol=1e-5)
     assert_allclose(res1.filtered_state_cov, res2.filtered_state_cov,
                     rtol=1e-6, atol=1e-5)
-    assert_allclose(res1.smoothed_state, res2.smoothed_state)
+    assert_allclose(res1.smoothed_state, res2.smoothed_state,
+                    rtol=1e-6, atol=1e-5)
     assert_allclose(res1.smoothed_state_cov, res2.smoothed_state_cov,
                     rtol=1e-6, atol=1e-5)


### PR DESCRIPTION
Relax tolerance to eliminate random failure

- [ ] closes #xxxx
- [ ] tests added / passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
