### PR TITLE
ENH: Include figsize as parameter for IRF plot

### DIFF
--- a/statsmodels/tsa/vector_ar/irf.py
+++ b/statsmodels/tsa/vector_ar/irf.py
@@ -109,7 +109,7 @@ class BaseIRAnalysis(object):
             pass {'fontsize' : 8} or some number to your taste.
         plot_params : dict
 
-        figsize: (int, int), default (10, 10)
+        figsize: (float, float), default (10, 10)
             Figure size (width, height in inches)
         plot_stderr: bool, default True
             Plot standard impulse response error bands
@@ -195,7 +195,7 @@ class BaseIRAnalysis(object):
             pass {'fontsize' : 8} or some number to your taste.
         plot_params : dict
 
-        figsize: (int, int), default (10, 10)
+        figsize: (float, float), default (10, 10)
             Figure size (width, height in inches)
         plot_stderr: bool, default True
             Plot standard impulse response error bands

--- a/statsmodels/tsa/vector_ar/irf.py
+++ b/statsmodels/tsa/vector_ar/irf.py
@@ -87,7 +87,7 @@ class BaseIRAnalysis(object):
     def cum_effect_cov(self, *args, **kwargs):
         raise NotImplementedError
 
-    def plot(self, orth=False, impulse=None, response=None,
+    def plot(self, orth=False, *, impulse=None, response=None,
              signif=0.05, plot_params=None, figsize=(10, 10),
              subplot_params=None, plot_stderr=True, stderr_type='asym',
              repl=1000, seed=None, component=None):
@@ -173,7 +173,7 @@ class BaseIRAnalysis(object):
                                      stderr_type=stderr_type)
         return fig
 
-    def plot_cum_effects(self, orth=False, impulse=None, response=None,
+    def plot_cum_effects(self, orth=False, *, impulse=None, response=None,
                          signif=0.05, plot_params=None, figsize=(10, 10),
                          subplot_params=None, plot_stderr=True,
                          stderr_type='asym', repl=1000, seed=None):

--- a/statsmodels/tsa/vector_ar/irf.py
+++ b/statsmodels/tsa/vector_ar/irf.py
@@ -88,9 +88,9 @@ class BaseIRAnalysis(object):
         raise NotImplementedError
 
     def plot(self, orth=False, impulse=None, response=None,
-             signif=0.05, plot_params=None, figsize=(10,10), subplot_params=None,
-             plot_stderr=True, stderr_type='asym', repl=1000,
-             seed=None, component=None):
+             signif=0.05, plot_params=None, figsize=(10, 10),
+             subplot_params=None, plot_stderr=True, stderr_type='asym',
+             repl=1000, seed=None, component=None):
         """
         Plot impulse responses
 

--- a/statsmodels/tsa/vector_ar/irf.py
+++ b/statsmodels/tsa/vector_ar/irf.py
@@ -88,7 +88,7 @@ class BaseIRAnalysis(object):
         raise NotImplementedError
 
     def plot(self, orth=False, impulse=None, response=None,
-             signif=0.05, plot_params=None, subplot_params=None,
+             signif=0.05, plot_params=None, figsize=(10,10), subplot_params=None,
              plot_stderr=True, stderr_type='asym', repl=1000,
              seed=None, component=None):
         """
@@ -109,6 +109,8 @@ class BaseIRAnalysis(object):
             pass {'fontsize' : 8} or some number to your taste.
         plot_params : dict
 
+        figsize: (int, int), default (10, 10)
+            Figure size (width, height in inches)
         plot_stderr: bool, default True
             Plot standard impulse response error bands
         stderr_type: str
@@ -167,11 +169,12 @@ class BaseIRAnalysis(object):
                                      self.model.names, title, signif=signif,
                                      subplot_params=subplot_params,
                                      plot_params=plot_params,
+                                     figsize=figsize,
                                      stderr_type=stderr_type)
         return fig
 
     def plot_cum_effects(self, orth=False, impulse=None, response=None,
-                         signif=0.05, plot_params=None,
+                         signif=0.05, plot_params=None, figsize=(10, 10),
                          subplot_params=None, plot_stderr=True,
                          stderr_type='asym', repl=1000, seed=None):
         """
@@ -192,6 +195,8 @@ class BaseIRAnalysis(object):
             pass {'fontsize' : 8} or some number to your taste.
         plot_params : dict
 
+        figsize: (int, int), default (10, 10)
+            Figure size (width, height in inches)
         plot_stderr: bool, default True
             Plot standard impulse response error bands
         stderr_type: str
@@ -228,6 +233,7 @@ class BaseIRAnalysis(object):
                                      hlines=lr_effects,
                                      subplot_params=subplot_params,
                                      plot_params=plot_params,
+                                     figsize=figsize,
                                      stderr_type=stderr_type)
         return fig
 

--- a/statsmodels/tsa/vector_ar/tests/test_var.py
+++ b/statsmodels/tsa/vector_ar/tests/test_var.py
@@ -209,6 +209,7 @@ class CheckIRF(object):
         self.irf.plot_cum_effects(orth=True)
         self.irf.plot_cum_effects(impulse=0, response=1, orth=True)
 
+    @pytest.mark.matplotlib
     def test_plot_figsizes(self):
         assert_equal(self.irf.plot().get_size_inches(), (10, 10))
         assert_equal(

--- a/statsmodels/tsa/vector_ar/tests/test_var.py
+++ b/statsmodels/tsa/vector_ar/tests/test_var.py
@@ -209,6 +209,17 @@ class CheckIRF(object):
         self.irf.plot_cum_effects(orth=True)
         self.irf.plot_cum_effects(impulse=0, response=1, orth=True)
 
+    def test_plot_figsizes(self):
+        assert_equal(self.irf.plot().get_size_inches(), (10, 10))
+        assert_equal(
+            self.irf.plot(figsize=(14, 10)).get_size_inches(),
+            (14, 10))
+
+        assert_equal(self.irf.plot_cum_effects().get_size_inches(), (10, 10))
+        assert_equal(
+            self.irf.plot_cum_effects(figsize=(14, 10)).get_size_inches(),
+            (14, 10))
+
 
 @pytest.mark.smoke
 class CheckFEVD(object):


### PR DESCRIPTION
Include figsize as parameter for IRF-related plots, since it is available for [`irf_grid_plot`](https://github.com/statsmodels/statsmodels/blob/master/statsmodels/tsa/vector_ar/plotting.py#L188). Without this, it is still possible to change the figure size, but it has to be done afterwards through `fig.set_size_inches(x, y)`, so this PR brings ease to the customization of figure size.

- [ ] closes #xxxx
- [ ] tests added / passed. 
- [ ] code/documentation is well formatted.  
- [ ] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
