### PR TITLE
Update interactions_anova.ipynb

### DIFF
--- a/examples/notebooks/interactions_anova.ipynb
+++ b/examples/notebooks/interactions_anova.ipynb
@@ -11,7 +11,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note: This script is based heavily on Jonathan Taylor's class notes http://www.stanford.edu/class/stats191/interactions.html\n",
+    "Note: This script is based heavily on Jonathan Taylor's class notes https://web.stanford.edu/class/stats191/notebooks/Interactions.html\n",
     "\n",
     "Download and format data:"
    ]


### PR DESCRIPTION
Fix URL that has been changed.

Nothing material has changed, it is trivial to verify that the old URL results in a 404 error while the new link returns content from the aforementioned course that this example is based on.