### PR TITLE
ENH: allow more than 2 groups for survdiff in statmodels.duration

### DIFF
--- a/statsmodels/duration/survfunc.py
+++ b/statsmodels/duration/survfunc.py
@@ -623,7 +623,7 @@ def survdiff(time, status, group, weight_type=None, strata=None,
             obs += obs1
             var += var1
 
-    chisq = obs.dot(np.linalg.inv(var)).dot(obs)
+    chisq = obs.dot(np.linalg.solve(var, obs))  # (O - E).T * V^(-1) * (O - E)
     pvalue = 1 - chi2.cdf(chisq, len(gr)-1)
 
     return chisq, pvalue

--- a/statsmodels/duration/survfunc.py
+++ b/statsmodels/duration/survfunc.py
@@ -720,7 +720,7 @@ def _survdiff(time, status, group, weight_type, gr, entry=None,
 
         if weights is not None:
             oe = weights * oe
-            var = weights**2 * var
+            var = (weights**2)[:, None] * var
 
         groups_oe.append(oe[ix].sum())
         groups_var.append(var[ix].sum(axis=0))

--- a/statsmodels/duration/tests/test_survfunc.py
+++ b/statsmodels/duration/tests/test_survfunc.py
@@ -148,6 +148,7 @@ def test_survdiff():
     # used for non G-rho family tests but does not seem to support
     # stratification)
 
+    full_df = bmt.copy()
     df = bmt[bmt.Group != "ALL"].copy()
 
     # Not stratified
@@ -164,6 +165,11 @@ def test_survdiff():
                        fh_p=1)
     assert_allclose(stat, 14.84500, atol=1e-4, rtol=1e-4)
 
+    # Not stratified, >2 groups
+    stat, p = survdiff(full_df["T"], full_df.Status, full_df.Group, weight_type="fh",
+                       fh_p=1)
+    assert_allclose(stat, 15.67247, atol=1e-4, rtol=1e-2)
+
     # 5 strata
     strata = np.arange(df.shape[0]) % 5
     df["strata"] = strata
@@ -175,6 +181,13 @@ def test_survdiff():
     stat, p = survdiff(df["T"], df.Status, df.Group, strata=df.strata,
                        weight_type="fh", fh_p=1)
     assert_allclose(stat, 12.73565, atol=1e-4, rtol=1e-4)
+
+    # 5 strata, >2 groups
+    full_strata = np.arange(full_df.shape[0]) % 5
+    full_df["strata"] = full_strata
+    stat, p = survdiff(full_df["T"], full_df.Status, full_df.Group, strata=full_df.strata,
+                       weight_type="fh", fh_p=0.5)
+    assert_allclose(stat, 13.56793, atol=1e-4, rtol=1e-1)
 
     # 8 strata
     df["strata"] = np.arange(df.shape[0]) % 8

--- a/statsmodels/duration/tests/test_survfunc.py
+++ b/statsmodels/duration/tests/test_survfunc.py
@@ -168,7 +168,7 @@ def test_survdiff():
     # Not stratified, >2 groups
     stat, p = survdiff(full_df["T"], full_df.Status, full_df.Group, weight_type="fh",
                        fh_p=1)
-    assert_allclose(stat, 15.67247, atol=1e-4, rtol=1e-2)
+    assert_allclose(stat, 15.67247, atol=1e-4, rtol=1e-4)
 
     # 5 strata
     strata = np.arange(df.shape[0]) % 5
@@ -187,7 +187,7 @@ def test_survdiff():
     full_df["strata"] = full_strata
     stat, p = survdiff(full_df["T"], full_df.Status, full_df.Group, strata=full_df.strata,
                        weight_type="fh", fh_p=0.5)
-    assert_allclose(stat, 13.56793, atol=1e-4, rtol=1e-1)
+    assert_allclose(stat, 13.56793, atol=1e-4, rtol=1e-4)
 
     # 8 strata
     df["strata"] = np.arange(df.shape[0]) % 8

--- a/statsmodels/duration/tests/test_survfunc.py
+++ b/statsmodels/duration/tests/test_survfunc.py
@@ -166,8 +166,8 @@ def test_survdiff():
     assert_allclose(stat, 14.84500, atol=1e-4, rtol=1e-4)
 
     # Not stratified, >2 groups
-    stat, p = survdiff(full_df["T"], full_df.Status, full_df.Group, weight_type="fh",
-                       fh_p=1)
+    stat, p = survdiff(full_df["T"], full_df.Status, full_df.Group,
+                       weight_type="fh", fh_p=1)
     assert_allclose(stat, 15.67247, atol=1e-4, rtol=1e-4)
 
     # 5 strata
@@ -185,8 +185,8 @@ def test_survdiff():
     # 5 strata, >2 groups
     full_strata = np.arange(full_df.shape[0]) % 5
     full_df["strata"] = full_strata
-    stat, p = survdiff(full_df["T"], full_df.Status, full_df.Group, strata=full_df.strata,
-                       weight_type="fh", fh_p=0.5)
+    stat, p = survdiff(full_df["T"], full_df.Status, full_df.Group,
+                       strata=full_df.strata, weight_type="fh", fh_p=0.5)
     assert_allclose(stat, 13.56793, atol=1e-4, rtol=1e-4)
 
     # 8 strata


### PR DESCRIPTION
- [ ] closes #xxxx
- [x] tests added / passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

`Survdiff` conducts logrank test on survival data. Before this PR it was only possible to test survival data with 2 groups, while now it is possible for any N groups.

Calculations based on: https://web.stanford.edu/~lutian/coursepdf/unit6.pdf
But variance taken from: https://web.stanford.edu/~lutian/coursepdf/survweek3.pdf

Tests pass!

(there is also a backport to v0.11.1: https://github.com/statsmodels/statsmodels/pull/6625)

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
