### PR TITLE
BUG: Ensure text comparrison is lower

### DIFF
--- a/statsmodels/tsa/stattools.py
+++ b/statsmodels/tsa/stattools.py
@@ -1978,7 +1978,7 @@ class ZivotAndrewsUnitRoot(object):
         regression = string_like(regression, 'regression',
                                  options=('c', 't', 'ct'))
         autolag = string_like(autolag, 'autolag',
-                              options=('AIC', 'BIC', 't-stat'), optional=True)
+                              options=('aic', 'bic', 't-stat'), optional=True)
         if trim < 0 or trim > (1. / 3.):
             raise ValueError('trim value must be a float in range [0, 1/3)')
         nobs = x.shape[0]

--- a/statsmodels/tsa/tests/test_stattools.py
+++ b/statsmodels/tsa/tests/test_stattools.py
@@ -994,6 +994,11 @@ class TestZivotAndrews(SetupZivotAndrews):
         with pytest.raises(ValueError):
             zivot_andrews(self.fail_mdl, autolag='None')
 
+    @pytest.mark.parametrize('autolag', ["AIC", "aic", "Aic"])
+    def test_autolag_case_sensitivity(self, autolag):
+        res = zivot_andrews(self.fail_mdl, autolag=autolag)
+        assert res[3] == 1
+
     # following tests compare results to R package urca.ur.za (1.13-0)
     def test_rgnp_case(self):
         res = zivot_andrews(self.fail_mdl, maxlag=8, regression='c',


### PR DESCRIPTION
Ensure the lwoer case comparrisons use lower case

close #6624

- [X] closes #6624
- [X] tests added / passed. 
- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
