### PR TITLE
Bugfix tests count model

### DIFF
--- a/statsmodels/discrete/tests/test_count_model.py
+++ b/statsmodels/discrete/tests/test_count_model.py
@@ -235,7 +235,7 @@ class TestZeroInflatedPoisson_predict(object):
         endog = res.model.endog
 
         pr = res.predict(which='prob')
-        pr2 = sm.distributions.zipoisson.pmf(np.arange(7)[:,None],
+        pr2 = sm.distributions.zipoisson.pmf(np.arange(pr.shape[1])[:,None],
             res.predict(), 0.05).T
         assert_allclose(pr, pr2, rtol=0.05, atol=0.05)
 
@@ -338,7 +338,7 @@ class TestZeroInflatedGeneralizedPoisson_predict(object):
         endog = res.model.endog
 
         pr = res.predict(which='prob')
-        pr2 = sm.distributions.zinegbin.pmf(np.arange(12)[:,None],
+        pr2 = sm.distributions.zinegbin.pmf(np.arange(pr.shape[1])[:,None],
             res.predict(), 0.5, 2, 0.5).T
         assert_allclose(pr, pr2, rtol=0.08, atol=0.05)
 

--- a/statsmodels/discrete/tests/test_count_model.py
+++ b/statsmodels/discrete/tests/test_count_model.py
@@ -229,7 +229,8 @@ class TestZeroInflatedPoisson_predict(object):
 
             # scalar variance of the mixture of zip
             var = (dispersion_factor*(1-prob_infl)*mu).mean()
-            var += (((1-prob_infl)*mu)**2).mean() - (((1-prob_infl)*mu).mean())**2
+            var += (((1-prob_infl)*mu)**2).mean()
+            var -= (((1-prob_infl)*mu).mean())**2
             std = np.sqrt(var)
             # Central limit theorem
             conf_intv_95 = 2 * std / np.sqrt(nobs)
@@ -241,12 +242,14 @@ class TestZeroInflatedPoisson_predict(object):
 
     def test_var(self):
         def compute_mixture_var(dispersion_factor, prob_main, mu):
-            # the variance of the mixture is the mixture of the variances
-            # plus a non-negative term accounting for the (weighted) dispersion of the means
-            # see stats.stackexchange #16609 and Casella & Berger's Statistical Inference (Example 10.2.1)
+            # the variance of the mixture is the mixture of the variances plus
+            # a non-negative term accounting for the (weighted)
+            # dispersion of the means, see stats.stackexchange #16609 and
+            #  Casella & Berger's Statistical Inference (Example 10.2.1)
             prob_infl = 1-prob_main
             var = (dispersion_factor*(1-prob_infl)*mu).mean()
-            var += (((1-prob_infl)*mu)**2).mean() - (((1-prob_infl)*mu).mean())**2
+            var += (((1-prob_infl)*mu)**2).mean()
+            var -= (((1-prob_infl)*mu).mean())**2
             return var
 
         res = self.res
@@ -259,12 +262,12 @@ class TestZeroInflatedPoisson_predict(object):
 
     def test_predict_prob(self):
         res = self.res
-        endog = res.model.endog
 
         pr = res.predict(which='prob')
-        pr2 = sm.distributions.zipoisson.pmf(np.arange(pr.shape[1])[:,None],
-            res.predict(), 0.05).T
+        pr2 = sm.distributions.zipoisson.pmf(np.arange(pr.shape[1])[:, None],
+                                             res.predict(), 0.05).T
         assert_allclose(pr, pr2, rtol=0.05, atol=0.05)
+
 
 @pytest.mark.slow
 class TestZeroInflatedGeneralizedPoisson(CheckGeneric):
@@ -360,7 +363,8 @@ class TestZeroInflatedGeneralizedPoisson_predict(object):
 
             # scalar variance of the mixture of zip
             var = (dispersion_factor*(1-prob_infl)*mu).mean()
-            var += (((1-prob_infl)*mu)**2).mean() - (((1-prob_infl)*mu).mean())**2
+            var += (((1-prob_infl)*mu)**2).mean()
+            var -= (((1-prob_infl)*mu).mean())**2
             std = np.sqrt(var)
             # Central limit theorem
             conf_intv_95 = 2 * std / np.sqrt(nobs)
@@ -374,7 +378,8 @@ class TestZeroInflatedGeneralizedPoisson_predict(object):
         def compute_mixture_var(dispersion_factor, prob_main, mu):
             prob_infl = 1-prob_main
             var = (dispersion_factor*(1-prob_infl)*mu).mean()
-            var += (((1-prob_infl)*mu)**2).mean() - (((1-prob_infl)*mu).mean())**2
+            var += (((1-prob_infl)*mu)**2).mean()
+            var -= (((1-prob_infl)*mu).mean())**2
             return var
 
         res = self.res
@@ -387,12 +392,12 @@ class TestZeroInflatedGeneralizedPoisson_predict(object):
 
     def test_predict_prob(self):
         res = self.res
-        endog = res.model.endog
 
         pr = res.predict(which='prob')
-        pr2 = sm.distributions.zinegbin.pmf(np.arange(pr.shape[1])[:,None],
-            res.predict(), 0.5, 2, 0.5).T
+        pr2 = sm.distributions.zinegbin.pmf(np.arange(pr.shape[1])[:, None],
+                                            res.predict(), 0.5, 2, 0.5).T
         assert_allclose(pr, pr2, rtol=0.08, atol=0.05)
+
 
 class TestZeroInflatedNegativeBinomialP(CheckGeneric):
     @classmethod
@@ -500,7 +505,8 @@ class TestZeroInflatedNegativeBinomialP_predict(object):
 
             # scalar variance of the mixture of zip
             var = (dispersion_factor*(1-prob_infl)*mu).mean()
-            var += (((1-prob_infl)*mu)**2).mean() - (((1-prob_infl)*mu).mean())**2
+            var += (((1-prob_infl)*mu)**2).mean()
+            var -= (((1-prob_infl)*mu).mean())**2
             std = np.sqrt(var)
             # Central limit theorem
             conf_intv_95 = 2 * std / np.sqrt(nobs)
@@ -516,7 +522,8 @@ class TestZeroInflatedNegativeBinomialP_predict(object):
         def compute_mixture_var(dispersion_factor, prob_main, mu):
             prob_infl = 1 - prob_main
             var = (dispersion_factor * (1 - prob_infl) * mu).mean()
-            var += (((1 - prob_infl) * mu) ** 2).mean() - (((1 - prob_infl) * mu).mean()) ** 2
+            var += (((1 - prob_infl) * mu) ** 2).mean()
+            var -= (((1 - prob_infl) * mu).mean()) ** 2
             return var
 
         res = self.res

--- a/statsmodels/discrete/tests/test_count_model.py
+++ b/statsmodels/discrete/tests/test_count_model.py
@@ -211,7 +211,7 @@ class TestZeroInflatedPoisson_predict(object):
     @classmethod
     def setup_class(cls):
         expected_params = [1, 0.5]
-        np.random.seed(123)
+        np.random.seed(999)
         nobs = 200
         exog = np.ones((nobs, 2))
         exog[:nobs//2, 1] = 2
@@ -314,7 +314,7 @@ class TestZeroInflatedGeneralizedPoisson_predict(object):
     @classmethod
     def setup_class(cls):
         expected_params = [1, 0.5, 0.5]
-        np.random.seed(1234)
+        np.random.seed(999)
         nobs = 200
         exog = np.ones((nobs, 2))
         exog[:nobs//2, 1] = 2
@@ -426,7 +426,7 @@ class TestZeroInflatedNegativeBinomialP_predict(object):
     def setup_class(cls):
 
         expected_params = [1, 1, 0.5]
-        np.random.seed(987123)
+        np.random.seed(999)
         nobs = 500
         exog = np.ones((nobs, 2))
         exog[:nobs//2, 1] = 0

--- a/statsmodels/discrete/tests/test_count_model.py
+++ b/statsmodels/discrete/tests/test_count_model.py
@@ -226,8 +226,21 @@ class TestZeroInflatedPoisson_predict(object):
                         atol=1e-2, rtol=1e-2)
 
     def test_var(self):
-        assert_allclose((self.res.predict().mean() *
-                        self.res._dispersion_factor.mean()),
+        def compute_mixture_var(dispersion_factor, prob_main, mu):
+            # the variance of the mixture is the mixture of the variances
+            # plus a non-negative term accounting for the (weighted) dispersion of the means
+            # see stats.stackexchange #16609 and Casella & Berger's Statistical Inference (Example 10.2.1)
+            prob_infl = 1-prob_main
+            var = (dispersion_factor*(1-prob_infl)*mu).mean()
+            var += (((1-prob_infl)*mu)**2).mean() - (((1-prob_infl)*mu).mean())**2
+            return var
+
+        res = self.res
+        var_fitted = compute_mixture_var(res._dispersion_factor,
+                                         res.predict(which='prob-main'),
+                                         res.predict(which='mean-main'))
+
+        assert_allclose(var_fitted.mean(),
                         self.endog.var(), atol=5e-2, rtol=5e-2)
 
     def test_predict_prob(self):
@@ -329,8 +342,18 @@ class TestZeroInflatedGeneralizedPoisson_predict(object):
                         atol=1e-4, rtol=1e-4)
 
     def test_var(self):
-        assert_allclose((self.res.predict().mean() *
-                        self.res._dispersion_factor.mean()),
+        def compute_mixture_var(dispersion_factor, prob_main, mu):
+            prob_infl = 1-prob_main
+            var = (dispersion_factor*(1-prob_infl)*mu).mean()
+            var += (((1-prob_infl)*mu)**2).mean() - (((1-prob_infl)*mu).mean())**2
+            return var
+
+        res = self.res
+        var_fitted = compute_mixture_var(res._dispersion_factor,
+                                         res.predict(which='prob-main'),
+                                         res.predict(which='mean-main'))
+
+        assert_allclose(var_fitted.mean(),
                         self.endog.var(), atol=0.05, rtol=0.1)
 
     def test_predict_prob(self):
@@ -447,8 +470,18 @@ class TestZeroInflatedNegativeBinomialP_predict(object):
 
     def test_var(self):
         # todo check precision
-        assert_allclose((self.res.predict().mean() *
-                        self.res._dispersion_factor.mean()),
+        def compute_mixture_var(dispersion_factor, prob_main, mu):
+            prob_infl = 1 - prob_main
+            var = (dispersion_factor * (1 - prob_infl) * mu).mean()
+            var += (((1 - prob_infl) * mu) ** 2).mean() - (((1 - prob_infl) * mu).mean()) ** 2
+            return var
+
+        res = self.res
+        var_fitted = compute_mixture_var(res._dispersion_factor,
+                                         res.predict(which='prob-main'),
+                                         res.predict(which='mean-main'))
+
+        assert_allclose(var_fitted.mean(),
                         self.endog.var(), rtol=0.2)
 
     def test_predict_prob(self):

--- a/statsmodels/discrete/tests/test_count_model.py
+++ b/statsmodels/discrete/tests/test_count_model.py
@@ -212,7 +212,7 @@ class TestZeroInflatedPoisson_predict(object):
     def setup_class(cls):
         expected_params = [1, 0.5]
         np.random.seed(999)
-        nobs = 200
+        nobs = 2000
         exog = np.ones((nobs, 2))
         exog[:nobs//2, 1] = 2
         mu_true = exog.dot(expected_params)
@@ -342,7 +342,7 @@ class TestZeroInflatedGeneralizedPoisson_predict(object):
     def setup_class(cls):
         expected_params = [1, 0.5, 0.5]
         np.random.seed(999)
-        nobs = 200
+        nobs = 2000
         exog = np.ones((nobs, 2))
         exog[:nobs//2, 1] = 2
         mu_true = exog.dot(expected_params[:-1])
@@ -479,7 +479,7 @@ class TestZeroInflatedNegativeBinomialP_predict(object):
 
         expected_params = [1, 1, 0.5]
         np.random.seed(999)
-        nobs = 500
+        nobs = 5000
         exog = np.ones((nobs, 2))
         exog[:nobs//2, 1] = 0
 


### PR DESCRIPTION
- [X] resolves #6617 
- [X] tests added / passed. 
- [X] code/documentation is well formatted.  



While trying to add some methods to the zero-inflated distributions in `discrete.py`, I noticed that the tests in `test_count_model.py` are very sensible. Changing the random seed spaked 5 tests to fail(a2dfaf3).


- `test_var`: the current test approximates the variance of a mixture of distribution by the mean of the variance. I propose to use the exact value which is the mean of variance plus an additional term.(b8cb27b)

- `test_mean`: the tests fails but the values are really close so it is the `rtol` and `atol` that would need fine tuning. I propose to confront the fitted mean of the model versus the theoretical mean computed with the true parameters(current test used mean of the toy data). `rtol` is fixed to describe a 95% confidence interval.(7d5ae5b)

- `test_predict_prob`: The shape of the vector resulting from the `.predict()` method is changing while it is compared to a fixed shape value. Changed it so that it adapts(949bf5f). Also this tests compare the emprical probability(histogram from sampling) versus theoretical probabilities. `nobs` is too low to construct reliable histogram so increased it.(47a2b7f)

The idea is to make tests more reliable so that we can build more stuff without raising moot tests.

I am not familiar with writting that much tests. If you think there is a smarter way to do it that would limit the copy/paste of code, I am more than happy to take comments.(especially for the repetitive computations of the variance).
