### PR TITLE
DOC/TST: minor fixes for holtwinters simulate

### DIFF
--- a/statsmodels/tsa/holtwinters.py
+++ b/statsmodels/tsa/holtwinters.py
@@ -531,26 +531,26 @@ class HoltWintersResults(Results):
 
         .. math::
 
-           B_t = b_{t-1} \circ_d \phi\\
-           L_t = l_{t-1} \circ_b B_t\\
-           S_t = s_{t-m}\\
-           Y_t = L_t \circ_s S_t,
+           B_t &= b_{t-1} \circ_d \phi\\
+           L_t &= l_{t-1} \circ_b B_t\\
+           S_t &= s_{t-m}\\
+           Y_t &= L_t \circ_s S_t,
 
         where :math:`\circ_d` is the operation linking trend and damping
         parameter (multiplication if the trend is additive, power if the trend
         is multiplicative), :math:`\circ_b` is the operation linking level and
         trend (addition if the trend is additive, multiplication if the trend
-        is multiplicative), and :math:'\circ_s` is the operation linking
+        is multiplicative), and :math:`\circ_s` is the operation linking
         seasonality to the rest.
 
         The state space equations can then be formulated as
 
         .. math::
 
-           y_t = Y_t + \eta \cdot e_t\\
-           l_t = L_t + \alpha \cdot (M_e \cdot L_t + \kappa_l) \cdot e_t\\
-           b_t = B_t + \beta \cdot (M_e \cdot B_t + \kappa_b) \cdot e_t\\
-           s_t = S_t + \gamma \cdot (M_e \cdot S_t + \kappa_s) \cdot e_t\\
+           y_t &= Y_t + \eta \cdot e_t\\
+           l_t &= L_t + \alpha \cdot (M_e \cdot L_t + \kappa_l) \cdot e_t\\
+           b_t &= B_t + \beta \cdot (M_e \cdot B_t + \kappa_b) \cdot e_t\\
+           s_t &= S_t + \gamma \cdot (M_e \cdot S_t + \kappa_s) \cdot e_t\\
 
         with
 

--- a/statsmodels/tsa/tests/test_holtwinters.py
+++ b/statsmodels/tsa/tests/test_holtwinters.py
@@ -875,7 +875,7 @@ def test_simulate_boxcox(austourists):
     ).fit(use_boxcox=True)
     expected = fit.forecast(4).values
 
-    res = fit.simulate(4, repetitions=10).values
+    res = fit.simulate(4, repetitions=10, random_state=0).values
     mean = np.mean(res, axis=1)
 
     assert np.all(np.abs(mean - expected) < 5)


### PR DESCRIPTION
Just two very small additions to #6560:

- I fixed the alignment of equations in the docstring of simulate
- I saw that one of the new tests was failing. I added a seed to the RNG to prevent it from failing due to RNG randomness.