### PR TITLE
BUG: acorr_breusch_godfrey, problem with regressions without const or exogs

### DIFF
--- a/statsmodels/stats/diagnostic.py
+++ b/statsmodels/stats/diagnostic.py
@@ -802,7 +802,10 @@ def acorr_breusch_godfrey(res, nlags=None, store=False):
     nobs = xdall.shape[0]
     xdall = np.c_[np.ones((nobs, 1)), xdall]
     xshort = x[-nobs:]
-    exog = np.column_stack((exog_old, xdall))
+    if exog_old is None:
+        exog = xdall
+    else:
+        exog = np.column_stack((exog_old, xdall))
     k_vars = exog.shape[1]
 
     resols = OLS(xshort, exog).fit()

--- a/statsmodels/stats/tests/test_diagnostic.py
+++ b/statsmodels/stats/tests/test_diagnostic.py
@@ -28,6 +28,7 @@ from statsmodels.regression.linear_model import OLS
 from statsmodels.tools.tools import Bunch
 from statsmodels.tools.tools import add_constant
 from statsmodels.tsa.ar_model import AutoReg
+from statsmodels.tsa.arima_model import ARMA
 
 cur_dir = os.path.abspath(os.path.dirname(__file__))
 
@@ -286,6 +287,11 @@ class TestDiagnosticG(object):
         res = Bunch(resid=np.empty((100, 2)))
         with pytest.raises(ValueError, match='Model resid must be a 1d array'):
             smsdia.acorr_breusch_godfrey(res)
+
+    def test_acorr_breusch_godfrey_exogs(self):
+        data = sunspots.load_pandas().data['SUNACTIVITY']
+        res = ARMA(data, (1, 0)).fit(disp=False, trend='nc')
+        smsdia.acorr_breusch_godfrey(res, nlags=1)
 
     def test_acorr_ljung_box(self):
 


### PR DESCRIPTION
In ARMA models without constant (or ARMAX without constant and without exogs) the acorr_breusch_godfrey method don't check if res.model.exog is None.

If it's None then where is a ValueError. I add a check before use exog, if is None, then we use only the lags terms.

- [X] closes #6642
- [X] tests added / passed. 
- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 