### PR TITLE
ENH: Add discrete methods

### DIFF
--- a/statsmodels/distributions/discrete.py
+++ b/statsmodels/distributions/discrete.py
@@ -51,6 +51,14 @@ class zipoisson_gen(rv_discrete):
         x[q < w] = 0
         return x
 
+    def _mean(self, mu, w):
+        return (1 - w) * mu
+
+    def _var(self, mu, w):
+        dispersion_factor = 1 + w * mu
+        var = (dispersion_factor * self._mean(mu, w)).mean()
+        return var
+
 zipoisson = zipoisson_gen(name='zipoisson',
                           longname='Zero Inflated Poisson')
 
@@ -69,6 +77,15 @@ class zigeneralizedpoisson_gen(rv_discrete):
 
     def _pmf(self, x, mu, alpha, p, w):
         return np.exp(self._logpmf(x, mu, alpha, p, w))
+
+    def _mean(self, mu, alpha, p, w):
+        return (1 - w) * mu
+
+    def _var(self, mu, alpha, p, w):
+        p = p - 1
+        dispersion_factor = (1 + alpha * mu ** p) ** 2 + w * mu
+        var = (dispersion_factor * self._mean(mu, alpha, p, w)).mean()
+        return var
 
 zigenpoisson = zigeneralizedpoisson_gen(name='zigenpoisson',
     longname='Zero Inflated Generalized Poisson')
@@ -103,6 +120,14 @@ class zinegativebinomial_gen(rv_discrete):
         # set to zero if in the zi range
         x[q < w] = 0
         return x
+
+    def _mean(self, mu, alpha, p, w):
+        return (1 - w) * mu
+
+    def _var(self, mu, alpha, p, w):
+        dispersion_factor = 1 + alpha * mu ** (p - 1) + w * mu
+        var = (dispersion_factor * self._mean(mu, alpha, p, w)).mean()
+        return var
 
     def convert_params(self, mu, alpha, p):
         size = 1. / alpha * mu**(2-p)

--- a/statsmodels/distributions/discrete.py
+++ b/statsmodels/distributions/discrete.py
@@ -43,7 +43,7 @@ class zipoisson_gen(rv_discrete):
         # construct cdf from standard poisson's cdf and the w inflation of zero
         return w + poisson(mu=mu).cdf(x) * (1 - w)
 
-    def _pff(self, q, mu, w):
+    def _ppf(self, q, mu, w):
         # we just translated and stretched q to remove zi
         q_mod = (q - w) / (1 - w)
         x = poisson(mu=mu).ppf(q_mod)
@@ -58,6 +58,9 @@ class zipoisson_gen(rv_discrete):
         dispersion_factor = 1 + w * mu
         var = (dispersion_factor * self._mean(mu, w)).mean()
         return var
+
+    def _moment(self, n, mu, w):
+        return (1 - w) * poisson(mu).moment(n)
 
 zipoisson = zipoisson_gen(name='zipoisson',
                           longname='Zero Inflated Poisson')
@@ -112,7 +115,7 @@ class zinegativebinomial_gen(rv_discrete):
         # construct cdf from standard negative binomial cdf and the w inflation of zero
         return w + nbinom.cdf(x, s, p) * (1 - w)
 
-    def _pff(self, q, mu, alpha, p, w):
+    def _ppf(self, q, mu, alpha, p, w):
         s, p = self.convert_params(mu, alpha, p)
         # we just translated and stretched q to remove zi
         q_mod = (q - w) / (1 - w)
@@ -128,6 +131,10 @@ class zinegativebinomial_gen(rv_discrete):
         dispersion_factor = 1 + alpha * mu ** (p - 1) + w * mu
         var = (dispersion_factor * self._mean(mu, alpha, p, w)).mean()
         return var
+
+    def _moment(self, n, mu, alpha, p, w):
+        s, p = self.convert_params(mu, alpha, p, w)
+        return (1 - w) * nbinom.moment(n, s, p)
 
     def convert_params(self, mu, alpha, p):
         size = 1. / alpha * mu**(2-p)

--- a/statsmodels/distributions/discrete.py
+++ b/statsmodels/distributions/discrete.py
@@ -62,6 +62,7 @@ class zipoisson_gen(rv_discrete):
     def _moment(self, n, mu, w):
         return (1 - w) * poisson(mu).moment(n)
 
+
 zipoisson = zipoisson_gen(name='zipoisson',
                           longname='Zero Inflated Poisson')
 
@@ -90,8 +91,11 @@ class zigeneralizedpoisson_gen(rv_discrete):
         var = (dispersion_factor * self._mean(mu, alpha, p, w)).mean()
         return var
 
-zigenpoisson = zigeneralizedpoisson_gen(name='zigenpoisson',
+
+zigenpoisson = zigeneralizedpoisson_gen(
+    name='zigenpoisson',
     longname='Zero Inflated Generalized Poisson')
+
 
 class zinegativebinomial_gen(rv_discrete):
     '''Zero Inflated Generalized Negative Binomial distribution
@@ -112,7 +116,8 @@ class zinegativebinomial_gen(rv_discrete):
 
     def _cdf(self, x, mu, alpha, p, w):
         s, p = self.convert_params(mu, alpha, p)
-        # construct cdf from standard negative binomial cdf and the w inflation of zero
+        # construct cdf from standard negative binomial cdf
+        # and the w inflation of zero
         return w + nbinom.cdf(x, s, p) * (1 - w)
 
     def _ppf(self, q, mu, alpha, p, w):

--- a/statsmodels/distributions/discrete.py
+++ b/statsmodels/distributions/discrete.py
@@ -138,7 +138,7 @@ class zinegativebinomial_gen(rv_discrete):
         return var
 
     def _moment(self, n, mu, alpha, p, w):
-        s, p = self.convert_params(mu, alpha, p, w)
+        s, p = self.convert_params(mu, alpha, p)
         return (1 - w) * nbinom.moment(n, s, p)
 
     def convert_params(self, mu, alpha, p):

--- a/statsmodels/distributions/tests/test_discrete.py
+++ b/statsmodels/distributions/tests/test_discrete.py
@@ -56,6 +56,15 @@ class TestZIPoisson(object):
         zipoisson_logpmf = sm.distributions.zipoisson.logpmf(7, 3, 0.1)
         assert_allclose(poisson_logpmf, zipoisson_logpmf, rtol=5e-2, atol=5e-2)
 
+    def test_cdf_zero(self):
+        poisson_cdf = poisson.cdf(3, 2)
+        zipoisson_cdf = sm.distributions.zipoisson.cdf(3, 2, 0)
+        assert_allclose(poisson_cdf, zipoisson_cdf, rtol=1e-12)
+
+    def test_ppf_zero(self):
+        poisson_ppf = poisson.ppf(5, 1)
+        zipoisson_ppf = sm.distributions.zipoisson.ppf(5, 1, 0)
+        assert_allclose(poisson_ppf, zipoisson_ppf, rtol=1e-12)
 
 class TestZIGeneralizedPoisson(object):
     def test_pmf_zero(self):
@@ -95,6 +104,20 @@ class TestZiNBP(object):
         tnb_logpmf = sm.distributions.zinegbin.logpmf(200, 10, 1, 2, 0.01)
         assert_allclose(nb_logpmf, tnb_logpmf, rtol=1e-2, atol=1e-2)
 
+    def test_cdf_p2(self):
+        n, p = sm.distributions.zinegbin.convert_params(30, 0.1, 2)
+        nbinom_cdf = nbinom.cdf(10, n, p)
+        zinbinom_cdf = sm.distributions.zinegbin.cdf(10, 30, 0.1, 2, 0)
+        print(nbinom_cdf, zinbinom_cdf)
+        assert_allclose(nbinom_cdf, zinbinom_cdf, rtol=1e-12, atol=1e-12)
+
+    def test_ppf_p2(self):
+        n, p = sm.distributions.zinegbin.convert_params(100, 1, 2)
+        nbinom_ppf = nbinom.ppf(0.27, n, p)
+        zinbinom_ppf = sm.distributions.zinegbin.ppf(0.27, 100, 1, 2, 0)
+        print(nbinom_ppf, zinbinom_ppf)
+        assert_allclose(nbinom_ppf, zinbinom_ppf, rtol=1e-12, atol=1e-12)
+
     def test_pmf(self):
         n, p = sm.distributions.zinegbin.convert_params(1, 0.9, 1)
         nb_logpmf = nbinom.pmf(2, n, p)
@@ -106,3 +129,26 @@ class TestZiNBP(object):
         nb_logpmf = nbinom.logpmf(2, n, p)
         tnb_logpmf = sm.distributions.zinegbin.logpmf(2, 5, 1, 1, 0.005)
         assert_allclose(nb_logpmf, tnb_logpmf, rtol=1e-2, atol=1e-2)
+
+    def test_cdf(self):
+        n, p = sm.distributions.zinegbin.convert_params(1, 0.9, 1)
+        nbinom_cdf = nbinom.cdf(2, n, p)
+        zinbinom_cdf = sm.distributions.zinegbin.cdf(2, 1, 0.9, 2, 0)
+        assert_allclose(nbinom_cdf, zinbinom_cdf, rtol=1e-12, atol=1e-12)
+
+    def test_ppf(self):
+        n, p = sm.distributions.zinegbin.convert_params(5, 1, 1)
+        nbinom_ppf = nbinom.ppf(0.71, n, p)
+        zinbinom_ppf = sm.distributions.zinegbin.ppf(0.71, 5, 1, 1, 0)
+        assert_allclose(nbinom_ppf, zinbinom_ppf, rtol=1e-12, atol=1e-12)
+
+    def test_convert(self):
+        n, p = sm.distributions.zinegbin.convert_params(25, 0.85, 2)
+        n_true, p_true = 1.1764705882352942, 0.04494382022471911
+        assert_allclose(n, n_true, rtol=1e-12, atol=1e-12)
+        assert_allclose(p, p_true, rtol=1e-12, atol=1e-12)
+
+        n, p = sm.distributions.zinegbin.convert_params(7, 0.17, 1)
+        n_true, p_true = 41.17647058823529, 0.8547008547008547
+        assert_allclose(n, n_true, rtol=1e-12, atol=1e-12)
+        assert_allclose(p, p_true, rtol=1e-12, atol=1e-12)

--- a/statsmodels/distributions/tests/test_discrete.py
+++ b/statsmodels/distributions/tests/test_discrete.py
@@ -66,6 +66,22 @@ class TestZIPoisson(object):
         zipoisson_ppf = sm.distributions.zipoisson.ppf(5, 1, 0)
         assert_allclose(poisson_ppf, zipoisson_ppf, rtol=1e-12)
 
+    def test_mean_var(self):
+        poisson_mean, poisson_var = poisson.mean(12), poisson.var(12)
+        zipoisson_mean = sm.distributions.zipoisson.mean(12, 0)
+        zipoisson_var = sm.distributions.zipoisson.mean(12, 0)
+        assert_allclose(poisson_mean, zipoisson_mean, rtol=1e-10)
+        assert_allclose(poisson_var, zipoisson_var, rtol=1e-10)
+
+    def test_moments(self):
+        poisson_m1, poisson_m2 = poisson.moment(1, 12), poisson.moment(2, 12)
+        zip_m0 = sm.distributions.zipoisson.moment(0, 12, 0)
+        zip_m1 = sm.distributions.zipoisson.moment(1, 12, 0)
+        zip_m2 = sm.distributions.zipoisson.moment(2, 12, 0)
+        assert_allclose(1, zip_m0, rtol=1e-10)
+        assert_allclose(poisson_m1, zip_m1, rtol=1e-10)
+        assert_allclose(poisson_m2, zip_m2, rtol=1e-10)
+
 class TestZIGeneralizedPoisson(object):
     def test_pmf_zero(self):
         gp_pmf = sm.distributions.genpoisson_p.pmf(3, 2, 1, 1)
@@ -108,15 +124,31 @@ class TestZiNBP(object):
         n, p = sm.distributions.zinegbin.convert_params(30, 0.1, 2)
         nbinom_cdf = nbinom.cdf(10, n, p)
         zinbinom_cdf = sm.distributions.zinegbin.cdf(10, 30, 0.1, 2, 0)
-        print(nbinom_cdf, zinbinom_cdf)
         assert_allclose(nbinom_cdf, zinbinom_cdf, rtol=1e-12, atol=1e-12)
 
     def test_ppf_p2(self):
         n, p = sm.distributions.zinegbin.convert_params(100, 1, 2)
         nbinom_ppf = nbinom.ppf(0.27, n, p)
         zinbinom_ppf = sm.distributions.zinegbin.ppf(0.27, 100, 1, 2, 0)
-        print(nbinom_ppf, zinbinom_ppf)
         assert_allclose(nbinom_ppf, zinbinom_ppf, rtol=1e-12, atol=1e-12)
+
+    def test_mran_var_p2(self):
+        n, p = sm.distributions.zinegbin.convert_params(7, 1, 2)
+        nbinom_mean, nbinom_var = nbinom.mean(n, p), nbinom.var(n, p)
+        zinb_mean = sm.distributions.zinegbin.mean(7, 1, 2, 0)
+        zinb_var = sm.distributions.zinegbin.var(7, 1, 2, 0)
+        assert_allclose(nbinom_mean, zinb_mean, rtol=1e-10)
+        assert_allclose(nbinom_var, zinb_var, rtol=1e-10)
+
+    def test_moments_p2(self):
+        n, p = sm.distributions.zinegbin.convert_params(7, 1, 2)
+        nb_m1, nb_m2 = nbinom.moment(1, n, p), nbinom.moment(2, n, p)
+        zinb_m0 = sm.distributions.zinegbin.moment(0, 7, 1, 2, 0)
+        zinb_m1 = sm.distributions.zinegbin.moment(1, 7, 1, 2, 0)
+        zinb_m2 = sm.distributions.zinegbin.moment(2, 7, 1, 2, 0)
+        assert_allclose(1, zinb_m0, rtol=1e-10)
+        assert_allclose(nb_m1, zinb_m1, rtol=1e-10)
+        assert_allclose(nb_m2, zinb_m2, rtol=1e-10)
 
     def test_pmf(self):
         n, p = sm.distributions.zinegbin.convert_params(1, 0.9, 1)
@@ -152,3 +184,21 @@ class TestZiNBP(object):
         n_true, p_true = 41.17647058823529, 0.8547008547008547
         assert_allclose(n, n_true, rtol=1e-12, atol=1e-12)
         assert_allclose(p, p_true, rtol=1e-12, atol=1e-12)
+
+    def test_mean_var(self):
+        n, p = sm.distributions.zinegbin.convert_params(9, 1, 1)
+        nbinom_mean, nbinom_var = nbinom.mean(n, p), nbinom.var(n, p)
+        zinb_mean = sm.distributions.zinegbin.mean(9, 1, 1, 0)
+        zinb_var = sm.distributions.zinegbin.var(9, 1, 1, 0)
+        assert_allclose(nbinom_mean, zinb_mean, rtol=1e-10)
+        assert_allclose(nbinom_var, zinb_var, rtol=1e-10)
+
+    def test_moments(self):
+        n, p = sm.distributions.zinegbin.convert_params(9, 1, 1)
+        nb_m1, nb_m2 = nbinom.moment(1, n, p), nbinom.moment(2, n, p)
+        zinb_m0 = sm.distributions.zinegbin.moment(0, 9, 1, 1, 0)
+        zinb_m1 = sm.distributions.zinegbin.moment(1, 9, 1, 1, 0)
+        zinb_m2 = sm.distributions.zinegbin.moment(2, 9, 1, 1, 0)
+        assert_allclose(1, zinb_m0, rtol=1e-10)
+        assert_allclose(nb_m1, zinb_m1, rtol=1e-10)
+        assert_allclose(nb_m2, zinb_m2, rtol=1e-10)

--- a/statsmodels/distributions/tests/test_discrete.py
+++ b/statsmodels/distributions/tests/test_discrete.py
@@ -82,6 +82,7 @@ class TestZIPoisson(object):
         assert_allclose(poisson_m1, zip_m1, rtol=1e-10)
         assert_allclose(poisson_m2, zip_m2, rtol=1e-10)
 
+
 class TestZIGeneralizedPoisson(object):
     def test_pmf_zero(self):
         gp_pmf = sm.distributions.genpoisson_p.pmf(3, 2, 1, 1)


### PR DESCRIPTION
- [ ] closes #6617 

#6617 shows that some `count` distributions are really slow when `mu` is high. This comes from the fact that those distributions only rely on `logpmf` to compute everything so it is slow. 

Some classic functions or statistics can be computed by leveraging the non-zero-inflated distributions that is well known and efficiently implemented in `SciPy`. 

This PR adds `._cdf()`, `._ppf() `and other methods to `zipoisson` and `zinegbin` that can speed things up by a few orders of magnitude. (400s reduced to 0.020s for `zipoisson(mu=10000, w=0.3).rvs(size=100)`). Tests are similar to what was already proposed for `.pmf()` and `.logpmf()` with the zero-inflation parameter `w` set to 0. 

Things are more complicated for `zigenpoisson` so it is left aside.
