### PR TITLE
ENH: stats.base, add HolderTuple, Holder class with indexing

### DIFF
--- a/statsmodels/stats/base.py
+++ b/statsmodels/stats/base.py
@@ -7,6 +7,29 @@ Author: Josef Perktold
 """
 from statsmodels.compat.python import lzip
 import numpy as np
+from statsmodels.tools.testing import Holder
+
+
+class HolderTuple(Holder):
+    """Holder class with indexing
+
+    """
+
+    def __init__(self, tuple_=None, **kwds):
+        super(HolderTuple, self).__init__(**kwds)
+        if tuple_ is not None:
+            self.tuple = tuple(getattr(self, att) for att in tuple_)
+        else:
+            self.tuple = (self.statistic, self.pvalue)
+
+    def __iter__(self):
+        yield from self.tuple
+
+    def __getitem__(self, idx):
+        return self.tuple[idx]
+
+    def __array__(self):
+        return np.asarray(list(self.tuple))
 
 
 class AllPairsResults(object):

--- a/statsmodels/stats/base.py
+++ b/statsmodels/stats/base.py
@@ -28,8 +28,11 @@ class HolderTuple(Holder):
     def __getitem__(self, idx):
         return self.tuple[idx]
 
-    def __array__(self):
-        return np.asarray(list(self.tuple))
+    def __len__(self):
+        return len(self.tuple)
+
+    def __array__(self, dtype=None):
+        return np.asarray(list(self.tuple), dtype=dtype)
 
 
 class AllPairsResults(object):

--- a/statsmodels/stats/tests/test_base.py
+++ b/statsmodels/stats/tests/test_base.py
@@ -8,6 +8,7 @@ from statsmodels.stats.base import HolderTuple
 def test_holdertuple():
     ht = HolderTuple(statistic=5, pvalue=0.1, text="just something",
                      extra=[1, 2, 4])
+    assert_equal(len(ht), 2)
     assert_equal(ht[:], [5, 0.1])
     p, v = ht
     assert_equal([p, v], [5, 0.1])
@@ -16,28 +17,35 @@ def test_holdertuple():
     assert_equal(list(ht), [5, 0.1])
     assert_equal(np.asarray(ht), [5, 0.1])
     assert_equal(np.asarray(ht).dtype, np.float64)
+    x = np.zeros((2, 2))
+    x[0] = ht
+    assert_equal(x, [[5, 0.1], [0, 0]])
+
     assert_equal(pd.Series(ht).values, [5, 0.1])
-    assert_equal(pd.DataFrame([ht, ht]).values, [[5, 0.1],[5, 0.1]])
+    assert_equal(pd.DataFrame([ht, ht]).values, [[5, 0.1], [5, 0.1]])
 
     assert_equal(ht.statistic, 5)
     assert_equal(ht.pvalue, 0.1)
     assert_equal(ht.extra, [1, 2, 4])
-    assert_equal(ht.text, "just something") 
+    assert_equal(ht.text, "just something")
 
 
 def test_holdertuple2():
     ht = HolderTuple(tuple_=("statistic", "extra"), statistic=5, pvalue=0.1,
                      text="just something", extra=[1, 2, 4])
+    assert_equal(len(ht), 2)
     assert_equal(ht[:], [5, [1, 2, 4]])
     p, v = ht
     assert_equal([p, v], [5, [1, 2, 4]])
     p, v = ht[0], ht[1]
     assert_equal([p, v], [5, [1, 2, 4]])
     assert_equal(list(ht), [5, [1, 2, 4]])
-    assert_equal(np.asarray(ht), [5, [1, 2, 4]])
-    assert_equal(np.asarray(ht).dtype, np.dtype('O'))
-    assert_equal(pd.Series(ht).values, [5, [1, 2, 4]])
-    assert_equal(pd.Series(ht).dtype, np.dtype('O'))
+
+    x = np.asarray(ht, dtype=object)
+    assert_equal(x, np.asarray([5, [1, 2, 4]], dtype=object))
+    assert_equal(x.dtype, np.dtype('O'))
+    # assert_equal(pd.Series(ht).values, [5, [1, 2, 4]])
+    # assert_equal(pd.Series(ht).dtype, np.dtype('O'))
 
     assert_equal(ht.statistic, 5)
     assert_equal(ht.pvalue, 0.1)

--- a/statsmodels/stats/tests/test_base.py
+++ b/statsmodels/stats/tests/test_base.py
@@ -1,0 +1,45 @@
+
+import numpy as np
+from numpy.testing import assert_equal
+import pandas as pd
+from statsmodels.stats.base import HolderTuple
+
+
+def test_holdertuple():
+    ht = HolderTuple(statistic=5, pvalue=0.1, text="just something",
+                     extra=[1, 2, 4])
+    assert_equal(ht[:], [5, 0.1])
+    p, v = ht
+    assert_equal([p, v], [5, 0.1])
+    p, v = ht[0], ht[1]
+    assert_equal([p, v], [5, 0.1])
+    assert_equal(list(ht), [5, 0.1])
+    assert_equal(np.asarray(ht), [5, 0.1])
+    assert_equal(np.asarray(ht).dtype, np.float64)
+    assert_equal(pd.Series(ht).values, [5, 0.1])
+    assert_equal(pd.DataFrame([ht, ht]).values, [[5, 0.1],[5, 0.1]])
+
+    assert_equal(ht.statistic, 5)
+    assert_equal(ht.pvalue, 0.1)
+    assert_equal(ht.extra, [1, 2, 4])
+    assert_equal(ht.text, "just something") 
+
+
+def test_holdertuple2():
+    ht = HolderTuple(tuple_=("statistic", "extra"), statistic=5, pvalue=0.1,
+                     text="just something", extra=[1, 2, 4])
+    assert_equal(ht[:], [5, [1, 2, 4]])
+    p, v = ht
+    assert_equal([p, v], [5, [1, 2, 4]])
+    p, v = ht[0], ht[1]
+    assert_equal([p, v], [5, [1, 2, 4]])
+    assert_equal(list(ht), [5, [1, 2, 4]])
+    assert_equal(np.asarray(ht), [5, [1, 2, 4]])
+    assert_equal(np.asarray(ht).dtype, np.dtype('O'))
+    assert_equal(pd.Series(ht).values, [5, [1, 2, 4]])
+    assert_equal(pd.Series(ht).dtype, np.dtype('O'))
+
+    assert_equal(ht.statistic, 5)
+    assert_equal(ht.pvalue, 0.1)
+    assert_equal(ht.extra, [1, 2, 4])
+    assert_equal(ht.text, "just something")


### PR DESCRIPTION
see #6637

I used a version of this for constraints in PR #6521

A Holder class that allows indexing and unpacking, but would still fail if we want to use it as an array or list, e.g. to combine several of those into an array or dataframe.

intended use for returns of hypothesis tests and similar function.