### PR TITLE
DOC: Fix `fdrcorrection` docstring missing `is_sorted` parameter

### DIFF
--- a/statsmodels/stats/multitest.py
+++ b/statsmodels/stats/multitest.py
@@ -278,7 +278,11 @@ def fdrcorrection(pvals, alpha=0.05, method='indep', is_sorted=False):
         set of p-values of the individual tests.
     alpha : float
         error rate
-    method : {'indep', 'negcorr')
+    method : {'indep', 'negcorr'}
+    is_sorted : bool
+        If False (default), the p_values will be sorted, but the corrected
+        pvalues are in the original order. If True, then it assumed that the
+        pvalues are already sorted in ascending order.
 
     Returns
     -------


### PR DESCRIPTION
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

A very quick documentation PR, since I noticed argument description of `statsmodels.stats.multitest.fdrcorrection` was missing documentation for the `is_sorted` parameter. 
I copied the text from `statsmodels.stats.multitest.multipletests`.

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
