### PR TITLE
BUG: Fix covariance estimation in parameterless models

### DIFF
--- a/statsmodels/tools/tools.py
+++ b/statsmodels/tools/tools.py
@@ -377,16 +377,16 @@ def isestimable(c, d):
     return True
 
 
-def pinv_extended(X, rcond=1e-15):
+def pinv_extended(x, rcond=1e-15):
     """
     Return the pinv of an array X as well as the singular values
     used in computation.
 
     Code adapted from numpy.
     """
-    X = np.asarray(X)
-    X = X.conjugate()
-    u, s, vt = np.linalg.svd(X, 0)
+    x = np.asarray(x)
+    x = x.conjugate()
+    u, s, vt = np.linalg.svd(x, False)
     s_orig = np.copy(s)
     m = u.shape[0]
     n = vt.shape[1]

--- a/statsmodels/tsa/statespace/tests/test_exponential_smoothing.py
+++ b/statsmodels/tsa/statespace/tests/test_exponential_smoothing.py
@@ -877,3 +877,13 @@ def test_invalid():
                        match='ExponentialSmoothing does not support `exog`.'):
         mod = ExponentialSmoothing(aust)
         mod.clone(aust, exog=air)
+
+
+def test_parameterless_model(reset_randomstate):
+    # GH 6687
+    x = np.cumsum(np.random.standard_normal(1000))
+    ses = ExponentialSmoothing(x, initial_level=x[0], initialization_method="known")
+    with ses.fix_params({'smoothing_level': 0.5}):
+        res = ses.fit()
+    assert np.isnan(res.bse).all()
+    assert res.fixed_params == ["smoothing_level"]


### PR DESCRIPTION
Fix bug where empty arrays raised in linear algebra functions

closes #6687

- [X] closes #6687
- [X] tests added / passed. 
- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
