### PR TITLE
DOC: Fix number if notebook text

### DIFF
--- a/examples/notebooks/statespace_sarimax_stata.ipynb
+++ b/examples/notebooks/statespace_sarimax_stata.ipynb
@@ -118,14 +118,14 @@
     "Thus the maximum likelihood estimates imply that for the process above, we have:\n",
     "\n",
     "$$\n",
-    "\\Delta y_t = 0.1050 + 0.8742 \\Delta y_{t-1} - 0.4120 \\epsilon_{t-1} + \\epsilon_{t}\n",
+    "\\Delta y_t = 0.0943 + 0.8742 \\Delta y_{t-1} - 0.4120 \\epsilon_{t-1} + \\epsilon_{t}\n",
     "$$\n",
     "\n",
     "where $\\epsilon_{t} \\sim N(0, 0.5257)$. Finally, recall that $c = (1 - \\phi_1) \\beta_0$, and here $c = 0.0943$ and $\\phi_1 = 0.8742$. To compare with the output from Stata, we could calculate the mean:\n",
     "\n",
     "$$\\beta_0 = \\frac{c}{1 - \\phi_1} = \\frac{0.0943}{1 - 0.8742} = 0.7496$$\n",
     "\n",
-    "**Note**: these values are slightly different from the values in the Stata documentation because the optimizer in statsmodels has found parameters here that yield a higher likelihood. Nonetheless, they are very close."
+    "**Note**: This value is virtually identical to the value in the Stata documentation, $\\beta_0 = 0.7498$. The slight difference is likely down to rounding and subtle differences in stopping criterion of the numerical optimizers used."
    ]
   },
   {
@@ -591,7 +591,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.5"
+   "version": "3.7.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
closes #6683

- [X] closes #6683
- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
