### PR TITLE
ENH: Improve warning message in KPSS

### DIFF
--- a/statsmodels/tsa/statespace/tests/test_exact_diffuse_filtering.py
+++ b/statsmodels/tsa/statespace/tests/test_exact_diffuse_filtering.py
@@ -40,6 +40,7 @@ the diffuse observations.
 Author: Chad Fulton
 License: Simplified-BSD
 """
+from statsmodels.compat.platform import PLATFORM_WIN
 
 import numpy as np
 import pandas as pd
@@ -1011,15 +1012,17 @@ def test_nondiagonal_obs_cov(reset_randomstate):
     mod.ssm.filter_univariate = True
     res2 = mod.smooth([])
 
+    atol = 0.002 if PLATFORM_WIN else 1e-5
+    rtol = 0.002 if PLATFORM_WIN else 1e-6
     # Here we'll just test a few values
-    assert_allclose(res1.llf, res2.llf, rtol=1e-6, atol=1e-5)
+    assert_allclose(res1.llf, res2.llf, rtol=rtol, atol=atol)
     assert_allclose(res1.forecasts[0], res2.forecasts[0],
-                    rtol=1e-6, atol=1e-5)
+                    rtol=rtol, atol=atol)
     assert_allclose(res1.filtered_state, res2.filtered_state,
-                    rtol=1e-6, atol=1e-5)
+                    rtol=rtol, atol=atol)
     assert_allclose(res1.filtered_state_cov, res2.filtered_state_cov,
-                    rtol=1e-6, atol=1e-5)
+                    rtol=rtol, atol=atol)
     assert_allclose(res1.smoothed_state, res2.smoothed_state,
-                    rtol=1e-6, atol=1e-5)
+                    rtol=rtol, atol=atol)
     assert_allclose(res1.smoothed_state_cov, res2.smoothed_state_cov,
-                    rtol=1e-6, atol=1e-5)
+                    rtol=rtol, atol=atol)

--- a/statsmodels/tsa/stattools.py
+++ b/statsmodels/tsa/stattools.py
@@ -1681,10 +1681,14 @@ def kpss(x, regression='c', nlags=None, store=False):
     kpss_stat = eta / s_hat
     p_value = np.interp(kpss_stat, crit, pvals)
 
+    warn_msg = """\
+The test statistic is outside of the range of p-values available in the
+look-up table. The actual p-value is {direction} than the p-value returned.
+"""
     if p_value == pvals[-1]:
-        warn("p-value is smaller than the indicated p-value", InterpolationWarning)
+        warn(warn_msg.format(direction="smaller"), InterpolationWarning)
     elif p_value == pvals[0]:
-        warn("p-value is greater than the indicated p-value", InterpolationWarning)
+        warn(warn_msg.format(direction="greater"), InterpolationWarning)
 
     crit_dict = {'10%': crit[0], '5%': crit[1], '2.5%': crit[2], '1%': crit[3]}
 

--- a/statsmodels/tsa/tests/test_stattools.py
+++ b/statsmodels/tsa/tests/test_stattools.py
@@ -482,12 +482,7 @@ class TestGrangerCausality(object):
             grangercausalitytests(x, 2)
 
 
-class SetupKPSS(object):
-    data = macrodata.load_pandas()
-    x = data.data['realgdp'].values
-
-
-class TestKPSS(SetupKPSS):
+class TestKPSS:
     """
     R-code
     ------
@@ -498,6 +493,10 @@ class TestKPSS(SetupKPSS):
     In this context, x is the vector containing the
     macrodata['realgdp'] series.
     """
+    @classmethod
+    def setup(cls):
+        cls.data = macrodata.load_pandas()
+        cls.x = cls.data.data['realgdp'].values
 
     def test_fail_nonvector_input(self, reset_randomstate):
         # should be fine


### PR DESCRIPTION
Improve warning message to be more exaplantory
Relax tolerance on randomly failing test

closes #6684
xref #6468

- [X] closes #6684
- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
