### PR TITLE
BUG: Change trend initialization in STL

### DIFF
--- a/statsmodels/tsa/tests/test_stl.py
+++ b/statsmodels/tsa/tests/test_stl.py
@@ -269,3 +269,24 @@ def test_plot(default_kwargs):
     class_kwargs['endog'] = pd.Series(class_kwargs['endog'], name='CO2')
     res = STL(**class_kwargs).fit()
     res.plot()
+
+
+def test_default_trend(default_kwargs):
+    # GH 6686
+    class_kwargs, _, _ = _to_class_kwargs(default_kwargs)
+    class_kwargs["seasonal"] = 17
+    class_kwargs["trend"] = None
+    mod = STL(**class_kwargs)
+    period = class_kwargs["period"]
+    seasonal = class_kwargs["seasonal"]
+    expected = int(np.ceil(1.5 * period / (1 - 1.5 / seasonal)))
+    expected += 1 if expected % 2 == 0 else 0
+    assert mod.config["trend"] == expected
+
+    class_kwargs["seasonal"] = 7
+    mod = STL(**class_kwargs)
+    period = class_kwargs["period"]
+    seasonal = class_kwargs["seasonal"]
+    expected = int(np.ceil(1.5 * period / (1 - 1.5 / seasonal)))
+    expected += 1 if expected % 2 == 0 else 0
+    assert mod.config["trend"] == expected


### PR DESCRIPTION
Change initialization to match suggestion in STLEZ function

closes #6701

- [x] closes #6701
- [x] tests added / passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
