### PR TITLE
ENH: Raise exception when recursive residual is not well defined

### DIFF
--- a/statsmodels/stats/tests/test_diagnostic.py
+++ b/statsmodels/stats/tests/test_diagnostic.py
@@ -423,6 +423,8 @@ class TestDiagnosticG(object):
 
         hc = smsdia.linear_harvey_collier(self.res)
         compare_to_reference(hc, harvey_collier, decimal=(12, 12))
+        hc_skip = smsdia.linear_harvey_collier(self.res, skip=20)
+        assert not np.allclose(hc[0], hc_skip[0])
 
     def test_rainbow(self):
         # rainbow test
@@ -1234,6 +1236,14 @@ def test_rainbow_exception(reset_randomstate):
     res = OLS(np.asarray(y), np.asarray(x)).fit()
     with pytest.raises(TypeError, match="order_by must contain"):
         smsdia.linear_rainbow(res, order_by=("x0",))
+
+
+def test_small_skip(reset_randomstate):
+    y = np.random.standard_normal(10)
+    x = np.random.standard_normal((10, 3))
+    x[:3] = x[:1]
+    with pytest.raises(ValueError, match="The initial regressor matrix,"):
+        smsdia.recursive_olsresiduals(OLS(y, x).fit())
 
 # R code used in testing
 # J test


### PR DESCRIPTION
Raise if the first model has a regressor matrix that is not positive definite

- [X] closes #6602
- [X] tests added / passed. 
- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
