### PR TITLE
BUG: Raise on incorrectly sized exog

### DIFF
--- a/statsmodels/tsa/vector_ar/tests/test_var.py
+++ b/statsmodels/tsa/vector_ar/tests/test_var.py
@@ -783,6 +783,10 @@ class TestVARExtras(object):
         exf = np.arange(len(data), len(data) + h)
         fc2 = res_lin_trend1.forecast(res_lin_trend1.endog[-2:], h,
                                       exog_future=exf)
+        with pytest.raises(ValueError, match="exog_future only has"):
+            wrong_exf = np.arange(len(data), len(data) + h // 2)
+            res_lin_trend1.forecast(res_lin_trend1.endog[-2:], h,
+                                    exog_future=wrong_exf)
         exf2 = exf[:, None]**[0, 1]
         fc3 = res_lin_trend2.forecast(res_lin_trend2.endog[-2:], h,
                                       exog_future=exf2)

--- a/statsmodels/tsa/vector_ar/var_model.py
+++ b/statsmodels/tsa/vector_ar/var_model.py
@@ -24,6 +24,7 @@ from statsmodels.iolib.table import SimpleTable
 from statsmodels.tools.decorators import cache_readonly, deprecated_alias
 from statsmodels.tools.linalg import logdet_symm
 from statsmodels.tools.sm_exceptions import OutputWarning
+from statsmodels.tools.validation import array_like
 from statsmodels.tsa.tsatools import vec, unvec, duplication_matrix
 from statsmodels.tsa.vector_ar import output, plotting, util
 from statsmodels.tsa.vector_ar.hypothesis_test_results import \
@@ -1030,6 +1031,15 @@ class VARProcess(object):
         if self.exog is not None and exog_future is None:
             raise ValueError("Please provide an exog_future argument to "
                              "the forecast method.")
+
+        exog_future = array_like(exog_future, "exog_future", optional=True, ndim=2)
+        if exog_future is not None:
+            if exog_future.shape[0] != steps:
+                err_msg = f"""\
+exog_future only has {exog_future.shape[0]} observations. It must have \
+steps ({steps}) observations.
+"""
+                raise ValueError(err_msg)
         trend_coefs = None if self.coefs_exog.size == 0 else self.coefs_exog.T
 
         exogs = []


### PR DESCRIPTION
Raise ValueError when exog has incorrect size

closes #6636

- [X] closes #6636
- [X] tests added / passed. 
- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
