### PR TITLE
DOC: Fix broken links with 404 error

### DIFF
--- a/docs/source/dev/index.rst
+++ b/docs/source/dev/index.rst
@@ -40,7 +40,7 @@ greatly helps the job of maintaining and releasing the software a shared effort.
 - Code submissions must always include tests. See our notes on :ref:`testing`.
 - Each function, class, method, and attribute needs to be documented using
   docstrings. We conform to the
-  `numpy docstring standard <https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt#docstring-standard>`_.
+  `numpy docstring standard <https://numpy.org/doc/stable/docs/howto_document.html#docstring-standard>`_.
 - If you are adding new functionality, you need to add it to the documentation
   by editing (or creating) the appropriate file in ``docs/source``.
 - Make sure your documentation changes parse correctly. Change into the

--- a/docs/source/imputation.rst
+++ b/docs/source/imputation.rst
@@ -56,5 +56,5 @@ Implementation Details
 ----------------------
 
 Internally, this function uses
-`pandas.isnull <https://pandas.pydata.org/pandas-docs/stable/missing_data.html#working-with-missing-data>`_.
+`pandas.isnull <https://pandas.pydata.org/pandas-docs/stable/user_guide/missing_data.html#working-with-missing-data>`_.
 Anything that returns True from this function will be treated as missing data.

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -20,7 +20,7 @@ statsmodels supports Python 3.6, 3.7 and 3.8.
 Anaconda
 --------
 statsmodels is available through conda provided by
-`Anaconda <https://www.continuum.io/downloads>`__. The latest release can
+`Anaconda <https://www.anaconda.com/products/individual#Downloads>`__. The latest release can
 be installed using:
 
 .. code-block:: bash
@@ -160,6 +160,6 @@ Optional Dependencies
   the test suite.
 * `IPython <https://ipython.org>`__ >= 5.0 is required to build the
   docs locally or to use the notebooks.
-* `joblib <http://pythonhosted.org/joblib/>`__ >= 0.9 can be used to accelerate distributed
+* `joblib <https://joblib.readthedocs.io/>`__ >= 0.9 can be used to accelerate distributed
   estimation for certain models.
 * `jupyter <https://jupyter.org/>`__ is needed to run the notebooks.

--- a/docs/source/mixed_linear.rst
+++ b/docs/source/mixed_linear.rst
@@ -166,7 +166,7 @@ Lindstrom and Bates.
 The following two documents are written more from the perspective of
 users:
 
-* http://lme4.r-forge.r-project.org/lMMwR/lrgprt.pdf
+* https://r-forge.r-project.org/scm/viewvc.php/*checkout*/www/lMMwR/lrgprt.pdf?revision=949&root=lme4&pathrev=1781
 
 * http://lme4.r-forge.r-project.org/slides/2009-07-07-Rennes/3Longitudinal-4.pdf
 

--- a/docs/source/sandbox.rst
+++ b/docs/source/sandbox.rst
@@ -41,7 +41,7 @@ Moving Window Statistics
 
 Most moving window statistics, like rolling mean, moments (up to 4th order), min,
 max, mean, and variance, are covered by the functions for `Moving (rolling)
-statistics/moments <https://pandas.pydata.org/pandas-docs/stable/computation.html#moving-rolling-statistics-moments>`_ in Pandas.
+statistics/moments <https://pandas.pydata.org/pandas-docs/stable/user_guide/computation.html#window-functions>`_ in Pandas.
 
 .. module:: statsmodels.sandbox.tsa
    :synopsis: Experimental time-series analysis models

--- a/statsmodels/nonparametric/_kernel_base.py
+++ b/statsmodels/nonparametric/_kernel_base.py
@@ -375,7 +375,7 @@ class EstimatorSettings(object):
         ``joblib.Parallel``.  Default is -1, meaning ``n_cores - 1``, with
         ``n_cores`` the number of available CPU cores.
         See the `joblib documentation
-        <https://pythonhosted.org/joblib/parallel.html>`_ for more details.
+        <https://joblib.readthedocs.io/en/latest/generated/joblib.Parallel.html>`_ for more details.
 
     Examples
     --------


### PR DESCRIPTION
- [x] closes #6745 (partially)
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

This PR updates links with 404 error. There are still links where the page exists, but not the anchor (mostly links to SAS documentation).
