### PR TITLE
BUG: Insufficient input checks in QuantReg

### DIFF
--- a/statsmodels/regression/quantile_regression.py
+++ b/statsmodels/regression/quantile_regression.py
@@ -116,7 +116,7 @@ class QuantReg(RegressionModel):
             - chamberlain: Chamberlain (1994)
         """
 
-        if q < 0 or q > 1:
+        if q <= 0 or q >= 1:
             raise Exception('p must be between 0 and 1')
 
         kern_names = ['biw', 'cos', 'epa', 'gau', 'par']

--- a/statsmodels/regression/quantile_regression.py
+++ b/statsmodels/regression/quantile_regression.py
@@ -91,7 +91,7 @@ class QuantReg(RegressionModel):
         Parameters
         ----------
         q : float
-            Quantile must be between 0 and 1
+            Quantile must be strictly between 0 and 1
         vcov : str, method used to calculate the variance-covariance matrix
             of the parameters. Default is ``robust``:
 
@@ -117,7 +117,7 @@ class QuantReg(RegressionModel):
         """
 
         if q <= 0 or q >= 1:
-            raise Exception('p must be between 0 and 1')
+            raise Exception('p must be strictly between 0 and 1')
 
         kern_names = ['biw', 'cos', 'epa', 'gau', 'par']
         if kernel not in kern_names:


### PR DESCRIPTION
- [x] tests added / passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

When calling [`QuantReg.fit()`](https://www.statsmodels.org/devel/generated/statsmodels.regression.quantile_regression.QuantReg.fit.html#statsmodels.regression.quantile_regression.QuantReg.fit), the parameter `q` (indicating the quantile) is checked to be within the interval [0, 1] (lines [119-120](https://github.com/statsmodels/statsmodels/blob/d4d46c84bba5bfd58f94b6954046ff90fab84a6b/statsmodels/regression/quantile_regression.py#L119)). However, also values of q=0 or q=1 will cause the fit() method to crash (raising `numpy.linalg.LinAlgError: SVD did not converge`). The reason for this behavior is in the way the residuals are weighted in line [174](https://github.com/statsmodels/statsmodels/blob/d4d46c84bba5bfd58f94b6954046ff90fab84a6b/statsmodels/regression/quantile_regression.py#L174). If q is 0 or 1, this will lead to entries in `resid` being 0, which will lead to entries in `xstar` being `inf` (after the division in line [176](https://github.com/statsmodels/statsmodels/blob/d4d46c84bba5bfd58f94b6954046ff90fab84a6b/statsmodels/regression/quantile_regression.py#L176)) and eventually to to above described error when calculating the SVD.

All this PR does is extending the initial check on `q` to also raise an exception, if `q=0` or `q=1`.
