### PR TITLE
Fix of #6173: SARIMAX throwing different errors when length of endogenous var is too low

### DIFF
--- a/statsmodels/graphics/tsaplots.py
+++ b/statsmodels/graphics/tsaplots.py
@@ -16,7 +16,10 @@ def _prepare_data_corr_plot(x, lags, zero):
         lim = min(int(np.ceil(10 * np.log10(nobs))), nobs - 1)
         lags = np.arange(not zero, lim + 1)
     elif np.isscalar(lags):
-        lags = np.arange(not zero, int(lags) + 1)  # +1 for zero lag
+        if lags ==0:
+            lags = np.arange(not zero, 1)  # +1 for zero lag
+        else:
+            lags = np.arange(not zero, int(lags))  # +1 for zero lag
     else:
         irregular = True
         lags = np.asanyarray(lags).astype(np.int)

--- a/statsmodels/graphics/tsaplots.py
+++ b/statsmodels/graphics/tsaplots.py
@@ -156,7 +156,6 @@ def plot_acf(x, ax=None, lags=None, *, alpha=.05, use_vlines=True,
                 missing=missing)
     if alpha is not None:
         acf_x, confint = acf_x
-
     _plot_corr(ax, title, acf_x, confint, lags, irregular, use_vlines,
                vlines_kwargs, **kwargs)
 

--- a/statsmodels/graphics/tsaplots.py
+++ b/statsmodels/graphics/tsaplots.py
@@ -19,7 +19,7 @@ def _prepare_data_corr_plot(x, lags, zero):
         if lags ==0:
             lags = np.arange(not zero, 1)  # 1 for zero lag
         else:
-            lags = np.arange(not zero, int(lags))
+            lags = np.arange(not zero, max(int(lags), x.shape[0]))
     else:
         irregular = True
         lags = np.asanyarray(lags).astype(np.int)

--- a/statsmodels/graphics/tsaplots.py
+++ b/statsmodels/graphics/tsaplots.py
@@ -17,9 +17,9 @@ def _prepare_data_corr_plot(x, lags, zero):
         lags = np.arange(not zero, lim + 1)
     elif np.isscalar(lags):
         if lags ==0:
-            lags = np.arange(not zero, 1)  # +1 for zero lag
+            lags = np.arange(not zero, 1)  # 1 for zero lag
         else:
-            lags = np.arange(not zero, int(lags))  # +1 for zero lag
+            lags = np.arange(not zero, int(lags))
     else:
         irregular = True
         lags = np.asanyarray(lags).astype(np.int)

--- a/statsmodels/tsa/statespace/mlemodel.py
+++ b/statsmodels/tsa/statespace/mlemodel.py
@@ -3914,7 +3914,13 @@ class MLEResults(tsbase.TimeSeriesModelResults):
             assert(resid.size>=d)
         except AssertionError:
             import sys
-            print("Residue less than or equal to maximum of burnt/diffused residuals", file=sys.stderr)
+            print("Length of endogenous variable less than or equal to maximum of burnt/diffused residuals", file=sys.stderr)
+            return None
+        try:
+            assert(resid.size>=lags)
+        except AssertionError:
+            import sys
+            print("Length of endogenous variable less than or equal to lags", file=sys.stderr)
             return None
 
 

--- a/statsmodels/tsa/statespace/mlemodel.py
+++ b/statsmodels/tsa/statespace/mlemodel.py
@@ -3910,6 +3910,13 @@ class MLEResults(tsbase.TimeSeriesModelResults):
         # Eliminate residuals associated with burned or diffuse likelihoods
         d = np.maximum(self.loglikelihood_burn, self.nobs_diffuse)
         resid = self.filter_results.standardized_forecasts_error[variable, d:]
+        try:
+            assert(resid.size>=d)
+        except AssertionError:
+            import sys
+            print("Residue less than or equal to maximum of burnt/diffused residuals", file=sys.stderr)
+            return None
+
 
         # Top-left: residuals vs time
         ax = fig.add_subplot(221)

--- a/statsmodels/tsa/stattools.py
+++ b/statsmodels/tsa/stattools.py
@@ -600,7 +600,7 @@ def acf(x, unbiased=False, nlags=None, qstat=False, fft=None, alpha=None,
     if not (qstat or alpha):
         return acf
     if alpha is not None:
-        varacf = np.ones(nlags + 1) / nobs
+        varacf = np.ones(len(acf)) / nobs
         varacf[0] = 0
         varacf[1] = 1. / nobs
         varacf[2:] *= 1 + 2 * np.cumsum(acf[1:-1] ** 2)


### PR DESCRIPTION
… solved it by raising errors, or catching the case of lags= 0 explicitly etc.

- [x] closes #6173 
- [ ] tests added / passed. 
- [ ] code/documentation is well formatted.  
- [ ] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
