### PR TITLE
BUG: dataframe/series concatenation in statespace results append

### DIFF
--- a/statsmodels/tsa/statespace/tests/test_forecasting.py
+++ b/statsmodels/tsa/statespace/tests/test_forecasting.py
@@ -1,0 +1,49 @@
+r"""
+Tests for forecasting-related features not tested elsewhere
+"""
+
+import numpy as np
+import pandas as pd
+
+import pytest
+from numpy.testing import assert_, assert_equal, assert_allclose
+
+from statsmodels.tsa.statespace import sarimax
+
+
+@pytest.mark.parametrize('data', ['list', 'numpy', 'range', 'date', 'period'])
+def test_append_multistep(data):
+    # Test that `MLEResults.append` works when called repeatedly
+    endog = [1., 0.5, 1.5, 0.9, 0.2, 0.34]
+    if data == 'numpy':
+        endog = np.array(endog)
+    elif data == 'range':
+        endog = pd.Series(endog)
+    elif data == 'date':
+        index = pd.date_range(start='2000-01-01', periods=6, freq='MS')
+        endog = pd.Series(endog, index=index)
+    elif data == 'period':
+        index = pd.period_range(start='2000-01', periods=6, freq='M')
+        endog = pd.Series(endog, index=index)
+
+    # Base model fitting
+    mod = sarimax.SARIMAX(endog[:2], order=(1, 0, 0))
+    res = mod.smooth([0.5, 1.0])
+    assert_allclose(res.model.endog[:, 0], [1., 0.5])
+    assert_allclose(res.forecast(1), 0.25)
+
+    # First append
+    res1 = res.append(endog[2:3])
+    assert_allclose(res1.model.endog[:, 0], [1., 0.5, 1.5])
+    assert_allclose(res1.forecast(1), 0.75)
+
+    # Second append
+    res2 = res1.append(endog[3:5])
+    assert_allclose(res2.model.endog[:, 0], [1., 0.5, 1.5, 0.9, 0.2])
+    assert_allclose(res2.forecast(1), 0.1)
+
+    # Third append
+    res3 = res2.append(endog[5:6])
+    print(res3.model.endog)
+    assert_allclose(res3.model.endog[:, 0], [1., 0.5, 1.5, 0.9, 0.2, 0.34])
+    assert_allclose(res3.forecast(1), 0.17)

--- a/statsmodels/tsa/statespace/tests/test_forecasting.py
+++ b/statsmodels/tsa/statespace/tests/test_forecasting.py
@@ -6,7 +6,7 @@ import numpy as np
 import pandas as pd
 
 import pytest
-from numpy.testing import assert_, assert_equal, assert_allclose
+from numpy.testing import assert_allclose
 
 from statsmodels.tsa.statespace import sarimax
 

--- a/statsmodels/tsa/statespace/tools.py
+++ b/statsmodels/tsa/statespace/tools.py
@@ -310,14 +310,43 @@ def concat(series, axis=0, allow_mix=False):
         objects.
     """
     is_pandas = np.r_[[_is_using_pandas(s, None) for s in series]]
+    ndim = np.r_[[np.ndim(s) for s in series]]
+    max_ndim = np.max(ndim)
+
+    if max_ndim > 2:
+        raise ValueError('`tools.concat` does not support arrays with 3 or'
+                         ' more dimensions.')
+
+    # Make sure the iterable is mutable
+    if isinstance(series, tuple):
+        series = list(series)
+
+    # Standardize ndim
+    for i in range(len(series)):
+        if ndim[i] == 0 and max_ndim == 1:
+            series[i] = np.atleast_1d(series[i])
+        elif ndim[i] == 0 and max_ndim == 2:
+            series[i] = np.atleast_2d(series[i])
+        elif ndim[i] == 1 and max_ndim == 2 and is_pandas[i]:
+            name = series[i].name
+            series[i] = series[i].to_frame()
+            series[i].columns = [name]
+        elif ndim[i] == 1 and max_ndim == 2 and not is_pandas[i]:
+            series[i] = np.atleast_2d(series[i]).T
 
     if np.all(is_pandas):
         if isinstance(series[0], pd.DataFrame):
             base_columns = series[0].columns
         else:
             base_columns = pd.Index([series[0].name])
-        for s in series[1:]:
+        for i in range(1, len(series)):
+            s = series[i]
+
             if isinstance(s, pd.DataFrame):
+                # Handle case where we were passed a dataframe and a series
+                # to concatenate, and the series did not have a name.
+                if s.columns.equals(pd.Index([None])):
+                    s.columns = base_columns[:1]
                 s_columns = s.columns
             else:
                 s_columns = pd.Index([s.name])


### PR DESCRIPTION
- [x] closes #6753
- [x] tests added / passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message.

Fixes the `statsmodels.tsa.statespace.tools.concat` when the objects have different dimensions.