### PR TITLE
BUG: pass cov_type, cov_kwargs through ARIMA.fit

### DIFF
--- a/statsmodels/tsa/arima/model.py
+++ b/statsmodels/tsa/arima/model.py
@@ -322,9 +322,9 @@ class ARIMA(sarimax.SARIMAX):
             else:
                 method_kwargs.setdefault('disp', 0)
 
-                res = super(ARIMA, self).fit(return_params=return_params,
-                                             low_memory=low_memory,
-                                             **method_kwargs)
+                res = super(ARIMA, self).fit(
+                    return_params=return_params, low_memory=low_memory,
+                    cov_type=cov_type, cov_kwds=cov_kwds, **method_kwargs)
                 if not return_params:
                     res.fit_details = res.mlefit
         else:

--- a/statsmodels/tsa/arima/tests/test_model.py
+++ b/statsmodels/tsa/arima/tests/test_model.py
@@ -247,3 +247,10 @@ def test_append():
     res2 = mod2.filter(res_e.params)
 
     assert_allclose(res2.llf, res_e.llf)
+
+
+def test_cov_type_none():
+    endog = dta['infl'].iloc[:100].values
+    mod = ARIMA(endog[:50], trend='c')
+    res = mod.fit(cov_type='none')
+    assert_allclose(res.cov_params(), np.nan)


### PR DESCRIPTION
- [x] tests added / passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message.

These arguments were just not included in the `super()` call.