### PR TITLE
DOC: Make deprecations more visible

### DIFF
--- a/docs/source/_static/stylesheets/deprecation.css
+++ b/docs/source/_static/stylesheets/deprecation.css
@@ -1,0 +1,15 @@
+.md-typeset div.deprecated {
+    font-size: 0.85rem;
+    box-shadow: 0 2px 2px 0 rgba(0,0,0,.14), 0 1px 5px 0 rgba(0,0,0,.12), 0 3px 1px -2px rgba(0,0,0,.2);
+    position: relative;
+    margin: 1.5625em 0;
+    padding: 0 .6rem;
+    border-left: .2rem solid #ff1744;
+    border-radius: .1rem;
+    overflow: auto;
+}
+
+.md-typeset span.deprecated {
+    font-weight: 700;
+    color: #ff1744;
+}

--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -10,4 +10,5 @@
   <meta name="msapplication-TileColor" content="#2b5797">
   <meta name="msapplication-config" content="{{ pathto('_static/icons/browserconfig.xml', 1) }}">
   <link rel="stylesheet" href="{{ pathto('_static/stylesheets/examples.css', 1) }}">
+  <link rel="stylesheet" href="{{ pathto('_static/stylesheets/deprecation.css', 1) }}">
 {%- endblock %}


### PR DESCRIPTION
Improve deprecation presentation in the docs

- [ ] closes #xxxx
- [ ] tests added / passed. 
- [ ] code/documentation is well formatted.  
- [ ] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
