### PR TITLE
ENH: Add pandas dataframe capability to variance_inflation_factor

### DIFF
--- a/statsmodels/stats/outliers_influence.py
+++ b/statsmodels/stats/outliers_influence.py
@@ -9,6 +9,7 @@ License: BSD-3
 from collections import defaultdict
 
 import numpy as np
+import pandas as pd
 
 from statsmodels.compat.python import lzip
 from statsmodels.compat.pandas import Appender
@@ -186,7 +187,11 @@ def variance_inflation_factor(exog, exog_idx):
     https://en.wikipedia.org/wiki/Variance_inflation_factor
     """
     k_vars = exog.shape[1]
-    x_i = exog[:, exog_idx]
+    x_i = None
+    if isinstance(exog, pd.DataFrame):
+        x_i = exog.iloc[:, exog_idx]
+    else:
+        x_i = exog[:, exog_idx]
     mask = np.arange(k_vars) != exog_idx
     x_noti = exog[:, mask]
     r_squared_i = OLS(x_i, x_noti).fit().rsquared

--- a/statsmodels/stats/tests/test_outliers_influence.py
+++ b/statsmodels/stats/tests/test_outliers_influence.py
@@ -1,6 +1,6 @@
 from numpy.testing import assert_almost_equal
 
-from statsmodels.datasets import statecrime, get_rdataset
+from statsmodels.datasets import statecrime
 from statsmodels.regression.linear_model import OLS
 from statsmodels.stats.outliers_influence import reset_ramsey
 from statsmodels.stats.outliers_influence import variance_inflation_factor

--- a/statsmodels/stats/tests/test_outliers_influence.py
+++ b/statsmodels/stats/tests/test_outliers_influence.py
@@ -1,9 +1,12 @@
 from numpy.testing import assert_almost_equal
 
-from statsmodels.datasets import statecrime
+from statsmodels.datasets import statecrime, get_rdataset
 from statsmodels.regression.linear_model import OLS
 from statsmodels.stats.outliers_influence import reset_ramsey
+from statsmodels.stats.outliers_influence import variance_inflation_factor
 from statsmodels.tools import add_constant
+
+import numpy as np
 
 data = statecrime.load_pandas().data
 
@@ -14,3 +17,8 @@ def test_reset_stata():
     stat = reset_ramsey(res, degree=4)
     assert_almost_equal(stat.fvalue[0, 0], 1.52, decimal=2)
     assert_almost_equal(stat.pvalue, 0.2221, decimal=4)
+
+    exog_idx = list(data.columns).index('urban')
+    X_arr = np.asarray(data)
+    vif = variance_inflation_factor(X_arr, exog_idx)
+    assert_almost_equal(vif, 16.4394, decimal=4)


### PR DESCRIPTION
Proposing a small change to the variance_inflation_factor() method in the outliers_influence package, in order to allow `exog` input to be a pandas DataFrame as well as a numpy array.

In the test, the value computed for the VIF using my proposed code edit with a pandas dataframe input is 16.4394, which I compare to the value computed using the current state of the method, taking an array as input. 