### PR TITLE
ENH: automatic lag selection for Box-Pierce, Ljung-Box #6645

### DIFF
--- a/statsmodels/stats/diagnostic.py
+++ b/statsmodels/stats/diagnostic.py
@@ -575,7 +575,7 @@ def acorr_ljungbox_automatic(x, boxpierce=False, model_df=0, return_df=None):
     nobs = x.shape[0]
     maxlag = nobs - 1
 
-    #Compute threshold metrics
+    # Compute threshold metrics
     sacf = acf(x, nlags=maxlag, fft=False)
     sacf2 = sacf[1:maxlag + 1] ** 2 / (nobs - np.arange(1, maxlag + 1))
     q = 2.4
@@ -584,11 +584,11 @@ def acorr_ljungbox_automatic(x, boxpierce=False, model_df=0, return_df=None):
 
     if not boxpierce:
         lags = get_optimal_length(threshold_metric, threshold, maxlag,
-                  lambda p: nobs * (nobs + 2) * np.cumsum(sacf2)[p - 1])
+                        lambda p: nobs * (nobs + 2) * np.cumsum(sacf2)[p - 1])
         return acorr_ljungbox(x, lags, False, model_df, None, return_df)
 
     lags = get_optimal_length(threshold_metric, threshold, maxlag,
-                  lambda p: nobs * np.cumsum(sacf[1:maxlag + 1] ** 2)[p - 1])
+                        lambda p: nobs * np.cumsum(sacf[1:maxlag + 1] ** 2)[p - 1])
     return acorr_ljungbox(x, lags, True, model_df, None, return_df)
 
 

--- a/statsmodels/stats/diagnostic.py
+++ b/statsmodels/stats/diagnostic.py
@@ -550,7 +550,7 @@ def acorr_ljungbox_automatic(x, boxpierce=False, model_df=0, return_df=None):
         .. [*] Green, W. "Econometric Analysis," 5th ed., Pearson, 2003.
         """
     from statsmodels.tsa.stattools import acf
-    # Get Optimal lag value
+
     def get_optimal_length(threshold_metric, threshold, maxlag, func):
         optimal_lag = 0
         least_penalised = 0

--- a/statsmodels/stats/diagnostic.py
+++ b/statsmodels/stats/diagnostic.py
@@ -435,8 +435,8 @@ def acorr_ljungbox(x, lags=None, boxpierce=False, model_df=0, period=None,
         to return the DataFrame or False to continue returning the 2 - 4
         output. If None (the default), a warning is raised.
     auto_lag: bool, default False
-        Flag indicating whether to automatically determine the optimal lag length
-        based on threshold of maximum correlation value.
+        Flag indicating whether to automatically determine the optimal lag
+        length based on threshold of maximum correlation value.
 
     Returns
     -------

--- a/statsmodels/stats/diagnostic.py
+++ b/statsmodels/stats/diagnostic.py
@@ -539,11 +539,13 @@ def acorr_ljungbox(x, lags=None, boxpierce=False, model_df=0, period=None,
 
     return qljungbox, pval, qboxpierce, pvalbp
 
+
 def acorr_ljungbox_automatic(x, boxpierce=False, model_df=0, return_df=None):
     """
-        A wrapper around the original Ljungbox method to automatically determine
-        the optimal lag length, based on a penalty which switches between AIC and
-        BIC based on a threshold value, as depicted in the reference below.
+        # A wrapper around the original Ljungbox method to automatically
+        determine the optimal lag length, based on a penalty which switches
+        between AIC and BIC based on a threshold value, as depicted in the
+        reference below.
 
         References
         ----------
@@ -582,12 +584,13 @@ def acorr_ljungbox_automatic(x, boxpierce=False, model_df=0, return_df=None):
 
     if not boxpierce:
         lags = get_optimal_length(threshold_metric, threshold, maxlag,
-                                  lambda p: nobs * (nobs + 2) * np.cumsum(sacf2)[p - 1])
+                  lambda p: nobs * (nobs + 2) * np.cumsum(sacf2)[p - 1])
         return acorr_ljungbox(x, lags, False, model_df, None, return_df)
 
     lags = get_optimal_length(threshold_metric, threshold, maxlag,
-                              lambda p: nobs * np.cumsum(sacf[1:maxlag + 1] ** 2)[p - 1])
+                  lambda p: nobs * np.cumsum(sacf[1:maxlag + 1] ** 2)[p - 1])
     return acorr_ljungbox(x, lags, True, model_df, None, return_df)
+
 
 @deprecate_kwarg("maxlag", "nlags")
 def acorr_lm(resid, nlags=None, autolag="AIC", store=False, *, period=None,

--- a/statsmodels/stats/diagnostic.py
+++ b/statsmodels/stats/diagnostic.py
@@ -396,7 +396,7 @@ def compare_encompassing(results_x, results_z, cov_type="nonrobust",
 
 
 def acorr_ljungbox(x, lags=None, boxpierce=False, model_df=0, period=None,
-                   return_df=None):
+                   return_df=None, auto_lag=False):
     """
     Ljung-Box test of autocorrelation in residuals.
 
@@ -434,6 +434,9 @@ def acorr_ljungbox(x, lags=None, boxpierce=False, model_df=0, period=None,
         After 0.12, this will become the only return method.  Set to True
         to return the DataFrame or False to continue returning the 2 - 4
         output. If None (the default), a warning is raised.
+    auto_lag: bool, default False
+        Flag indicating whether to automatically determine the optimal lag length
+        based on threshold of maximum correlation value.
 
     Returns
     -------
@@ -467,6 +470,9 @@ def acorr_ljungbox(x, lags=None, boxpierce=False, model_df=0, period=None,
     References
     ----------
     .. [*] Green, W. "Econometric Analysis," 5th ed., Pearson, 2003.
+    .. [*] J. Carlos Escanciano, Ignacio N. Lobato
+          "An automatic Portmanteau test for serial correlation".,
+          Volume 151, 2009.
 
     Examples
     --------
@@ -477,6 +483,25 @@ def acorr_ljungbox(x, lags=None, boxpierce=False, model_df=0, period=None,
            lb_stat     lb_pvalue
     10  214.106992  1.827374e-40
     """
+    def get_optimal_length(threshold_metric, threshold, maxlag, func):
+        optimal_lag = 0
+        least_penalised = 0
+
+        for lags in range(1, maxlag + 1):
+            if (threshold_metric <= threshold):
+                penalty = lags * np.log(nobs)
+            else:
+                penalty = 2 * lags
+
+            test_statistic = func(lags)
+            penalised = test_statistic - penalty
+            if (penalised > least_penalised):
+                optimal_lag = lags
+                least_penalised = penalised
+
+        return optimal_lag
+    # Avoid cyclic import
+    from statsmodels.tsa.stattools import acf
     x = array_like(x, "x")
     period = int_like(period, "period", optional=True)
     return_df = bool_like(return_df, "return_df", optional=True)
@@ -486,7 +511,31 @@ def acorr_ljungbox(x, lags=None, boxpierce=False, model_df=0, period=None,
     if model_df < 0:
         raise ValueError("model_df must be >= 0")
     nobs = x.shape[0]
-    if period is not None:
+    if auto_lag:
+        maxlag = nobs - 1
+
+        # Compute threshold metrics
+        sacf = acf(x, nlags=maxlag, fft=False)
+        sacf2 = sacf[1:maxlag + 1] ** 2 / (nobs - np.arange(1, maxlag + 1))
+        q = 2.4
+        threshold = np.sqrt(q * np.log(nobs))
+        threshold_metric = max(np.abs(sacf)) * np.sqrt(nobs)
+
+        if not boxpierce:
+            lags = get_optimal_length(
+                threshold_metric,
+                threshold, maxlag,
+                lambda p: nobs * (nobs + 2) * np.cumsum(sacf2)[p - 1])
+        else:
+            lags = get_optimal_length(
+                threshold_metric,
+                threshold,
+                maxlag,
+                lambda p: nobs * np.cumsum(sacf[1:maxlag + 1] ** 2)[p - 1])
+
+        lags = int_like(lags, "lags")
+        lags = np.arange(1, lags + 1)
+    elif period is not None:
         lags = np.arange(1, min(nobs // 5, 2 * period) + 1, dtype=np.int)
     elif lags is None:
         # TODO: Switch to min(10, nobs//5) after 0.12
@@ -503,8 +552,6 @@ def acorr_ljungbox(x, lags=None, boxpierce=False, model_df=0, period=None,
     lags = array_like(lags, "lags", dtype="int")
     maxlag = lags.max()
 
-    # Avoid cyclic import
-    from statsmodels.tsa.stattools import acf
     # normalize by nobs not (nobs-nlags)
     # SS: unbiased=False is default now
     sacf = acf(x, nlags=maxlag, fft=False)
@@ -538,58 +585,6 @@ def acorr_ljungbox(x, lags=None, boxpierce=False, model_df=0, period=None,
                             index=lags)
 
     return qljungbox, pval, qboxpierce, pvalbp
-
-
-def acorr_ljungbox_automatic(x, boxpierce=False, model_df=0, return_df=None):
-    """
-        # A wrapper around the original Ljungbox method to automatically
-        determine the optimal lag length, based on a penalty which switches
-        between AIC and BIC based on a threshold value, as depicted in the
-        reference below.
-
-        References
-        ----------
-        .. [*] Green, W. "Econometric Analysis," 5th ed., Pearson, 2003.
-        """
-    from statsmodels.tsa.stattools import acf
-
-    def get_optimal_length(threshold_metric, threshold, maxlag, func):
-        optimal_lag = 0
-        least_penalised = 0
-
-        for lags in range(1, maxlag + 1):
-            if (threshold_metric <= threshold):
-                penalty = lags * np.log(nobs)
-            else:
-                penalty = 2 * lags
-
-            test_statistic = func(lags)
-            penalised = test_statistic - penalty
-            if (penalised > least_penalised):
-                optimal_lag = lags
-                least_penalised = penalised
-
-        return optimal_lag
-
-    x = array_like(x, "x")
-    nobs = x.shape[0]
-    maxlag = nobs - 1
-
-    # Compute threshold metrics
-    sacf = acf(x, nlags=maxlag, fft=False)
-    sacf2 = sacf[1:maxlag + 1] ** 2 / (nobs - np.arange(1, maxlag + 1))
-    q = 2.4
-    threshold = np.sqrt(q * np.log(nobs))
-    threshold_metric = max(np.abs(sacf)) * np.sqrt(nobs)
-
-    if not boxpierce:
-        lags = get_optimal_length(threshold_metric, threshold, maxlag,
-                        lambda p: nobs * (nobs + 2) * np.cumsum(sacf2)[p - 1])
-        return acorr_ljungbox(x, lags, False, model_df, None, return_df)
-
-    lags = get_optimal_length(threshold_metric, threshold, maxlag,
-                        lambda p: nobs * np.cumsum(sacf[1:maxlag + 1] ** 2)[p - 1])
-    return acorr_ljungbox(x, lags, True, model_df, None, return_df)
 
 
 @deprecate_kwarg("maxlag", "nlags")

--- a/statsmodels/stats/tests/test_diagnostic.py
+++ b/statsmodels/stats/tests/test_diagnostic.py
@@ -1087,6 +1087,16 @@ def test_ljungbox_dof_adj():
     assert np.all(np.isnan(res2[1][:4]))
     assert np.all(res2[1][4:] <= res1[1][4:])
 
+def test_ljungbox_auto_lag_selection():
+    data = sunspots.load_pandas().data['SUNACTIVITY']
+    res = AutoReg(data, 4, old_names=False).fit()
+    resid = res.resid
+    res1 = smsdia.acorr_ljungbox_automatic(resid, return_df=False)
+    res2 = smsdia.acorr_ljungbox_automatic(resid, model_df=4, return_df=False)
+    assert_allclose(res1[0], res2[0])
+    assert np.all(np.isnan(res2[1][:4]))
+    assert np.all(res2[1][4:] <= res1[1][4:])
+
 
 def test_ljungbox_errors_warnings():
     data = sunspots.load_pandas().data['SUNACTIVITY']

--- a/statsmodels/stats/tests/test_diagnostic.py
+++ b/statsmodels/stats/tests/test_diagnostic.py
@@ -1092,8 +1092,8 @@ def test_ljungbox_auto_lag_selection():
     data = sunspots.load_pandas().data['SUNACTIVITY']
     res = AutoReg(data, 4, old_names=False).fit()
     resid = res.resid
-    res1 = smsdia.acorr_ljungbox_automatic(resid, return_df=False)
-    res2 = smsdia.acorr_ljungbox_automatic(resid, model_df=4, return_df=False)
+    res1 = smsdia.acorr_ljungbox(resid, return_df=False, auto_lag=True)
+    res2 = smsdia.acorr_ljungbox(resid, model_df=4, return_df=False, auto_lag=True)
     assert_allclose(res1[0], res2[0])
     assert np.all(np.isnan(res2[1][:4]))
     assert np.all(res2[1][4:] <= res1[1][4:])

--- a/statsmodels/stats/tests/test_diagnostic.py
+++ b/statsmodels/stats/tests/test_diagnostic.py
@@ -1087,6 +1087,7 @@ def test_ljungbox_dof_adj():
     assert np.all(np.isnan(res2[1][:4]))
     assert np.all(res2[1][4:] <= res1[1][4:])
 
+
 def test_ljungbox_auto_lag_selection():
     data = sunspots.load_pandas().data['SUNACTIVITY']
     res = AutoReg(data, 4, old_names=False).fit()

--- a/statsmodels/stats/tests/test_diagnostic.py
+++ b/statsmodels/stats/tests/test_diagnostic.py
@@ -1092,8 +1092,13 @@ def test_ljungbox_auto_lag_selection():
     data = sunspots.load_pandas().data['SUNACTIVITY']
     res = AutoReg(data, 4, old_names=False).fit()
     resid = res.resid
-    res1 = smsdia.acorr_ljungbox(resid, return_df=False, auto_lag=True)
-    res2 = smsdia.acorr_ljungbox(resid, model_df=4, return_df=False, auto_lag=True)
+    res1 = smsdia.acorr_ljungbox(resid,
+                                 return_df=False,
+                                 auto_lag=True)
+    res2 = smsdia.acorr_ljungbox(resid,
+                                 model_df=4,
+                                 return_df=False,
+                                 auto_lag=True)
     assert_allclose(res1[0], res2[0])
     assert np.all(np.isnan(res2[1][:4]))
     assert np.all(res2[1][4:] <= res1[1][4:])


### PR DESCRIPTION
- [x] closes #xxxx
- [x] tests added / passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

With reference to issue [#6645](https://github.com/statsmodels/statsmodels/issues/6645)

Automatic lag selection according to the reference below for Box-Pierce, Ljung-Box. According to the reference at page8, it introduces a penalty term, which switches between AIC and BIC depending on the value of correlation. This penalty term penalises the test statistic and the optimal lag length is one which is able to maximise the test statistic after applying the penalty.

A q value of 2.4 is recommended in the reference for the penalty term according to other research results quoted.

[Reference](https://www.sciencedirect.com/science/article/abs/pii/S0304407609000773?via%3Dihub#!)

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
