### PR TITLE
BUG: remove k_extra from effects_idx

### DIFF
--- a/statsmodels/discrete/discrete_margins.py
+++ b/statsmodels/discrete/discrete_margins.py
@@ -671,8 +671,8 @@ class DiscreteMargins(object):
         params = results.params
         exog = model.exog.copy() # copy because values are changed
         effects_idx, const_idx =  _get_const_index(exog)
-        if hasattr(model, 'k_extra') and model.k_extra > 0:
-            effects_idx = np.concatenate((effects_idx, np.zeros(model.k_extra, np.bool_)))
+#         if hasattr(model, 'k_extra') and model.k_extra > 0:
+#             effects_idx = np.concatenate((effects_idx, np.zeros(model.k_extra, np.bool_)))
 
         if dummy:
             _check_discrete_args(at, method)


### PR DESCRIPTION
currently just parking a commit with possible solution, needs unit tests.

I ran several cases for NB and GP and they worked after this commit.
I don't see why this extension of effect_idx is needed anymore. Maybe something else fixed the initial problem with margins in NegBin

closes #6763



- [ ] tests added / passed. 
- [ ] code/documentation is well formatted.  



