### PR TITLE
ENH: improve univariate smoother performance

### DIFF
--- a/statsmodels/tsa/statespace/_kalman_filter.pxd
+++ b/statsmodels/tsa/statespace/_kalman_filter.pxd
@@ -84,6 +84,8 @@ cdef class sKalmanFilter(object):
     cdef public int filter_timing
     cdef readonly int loglikelihood_burn
 
+    cdef public int [:] univariate_filter
+
     # ### Kalman filter properties
     cdef readonly np.float32_t [:] loglikelihood, scale
     cdef readonly np.float32_t [::1,:] filtered_state, predicted_state, forecast, forecast_error, standardized_forecast_error
@@ -237,6 +239,8 @@ cdef class dKalmanFilter(object):
     cdef public int filter_timing
     cdef readonly int loglikelihood_burn
 
+    cdef public int [:] univariate_filter
+
     # ### Kalman filter properties
     cdef readonly np.float64_t [:] loglikelihood, scale
     cdef readonly np.float64_t [::1,:] filtered_state, predicted_state, forecast, forecast_error, standardized_forecast_error
@@ -388,6 +392,8 @@ cdef class cKalmanFilter(object):
     cdef readonly int conserve_memory
     cdef public int filter_timing
     cdef readonly int loglikelihood_burn
+
+    cdef public int [:] univariate_filter
 
     # ### Kalman filter properties
     cdef readonly np.complex64_t [:] loglikelihood, scale
@@ -541,6 +547,8 @@ cdef class zKalmanFilter(object):
     cdef readonly int conserve_memory
     cdef public int filter_timing
     cdef readonly int loglikelihood_burn
+
+    cdef public int [:] univariate_filter
 
     # ### Kalman filter properties
     cdef readonly np.complex128_t [:] loglikelihood, scale

--- a/statsmodels/tsa/statespace/_kalman_filter.pyx.in
+++ b/statsmodels/tsa/statespace/_kalman_filter.pyx.in
@@ -429,6 +429,7 @@ cdef class {{prefix}}KalmanFilter(object):
                  'forecast_error_ipiv': np.array(self.forecast_error_ipiv, copy=True, order='F'),
                  'forecast_error_work': np.array(self.forecast_error_work, copy=True, order='F'),
                  'kalman_gain': np.array(self.kalman_gain, copy=True, order='F'),
+                 'univariate_filter': np.array(self.univariate_filter, copy=True, order='F'),
                  'loglikelihood': np.array(self.loglikelihood, copy=True, order='F'),
                  'predicted_state': np.array(self.predicted_state, copy=True, order='F'),
                  'predicted_state_cov': np.array(self.predicted_state_cov, copy=True, order='F'),
@@ -472,6 +473,7 @@ cdef class {{prefix}}KalmanFilter(object):
         self.forecast_error_ipiv = state['forecast_error_ipiv']
         self.forecast_error_work = state['forecast_error_work']
         self.kalman_gain = state['kalman_gain']
+        self.univariate_filter = state['univariate_filter']
         self.loglikelihood = state['loglikelihood']
         self.predicted_state = state['predicted_state']
         self.predicted_state_cov = state['predicted_state_cov']
@@ -517,6 +519,9 @@ cdef class {{prefix}}KalmanFilter(object):
             np.npy_intp dim3[3]
         cdef int storage
         # #### Allocate arrays for calculations
+
+        dim1[0] = self.model.nobs;
+        self.univariate_filter = np.PyArray_ZEROS(1, dim1, np.NPY_INT32, FORTRAN)
 
         # Arrays for Kalman filter output
 
@@ -805,6 +810,12 @@ cdef class {{prefix}}KalmanFilter(object):
             # Reset matrices
             self.allocate_arrays()
 
+            # Reset the flag for using the univariate method
+            if filter_method & FILTER_UNIVARIATE:
+                self.univariate_filter[:] = 1
+            else:
+                self.univariate_filter[:] = 0
+
             # Seek to the beginning
             self.seek(0, True)
 
@@ -826,6 +837,11 @@ cdef class {{prefix}}KalmanFilter(object):
             self.nobs_kendog_univariate_singular = 0
             self.converged = 0
             self.period_converged = 0
+
+            if self.filter_method & FILTER_UNIVARIATE:
+                self.univariate_filter[:] = 1
+            else:
+                self.univariate_filter[:] = 0
 
     def __iter__(self):
         return self
@@ -874,6 +890,13 @@ cdef class {{prefix}}KalmanFilter(object):
             self.loglikelihood[self.t] = 0
             self.scale[self.t] = 0
 
+        # Clear convergence flag if we've just switched the filter type
+        # (this should only happen in contrived cases though, since after we've
+        # successfully converged, the inversion step won't fail anymore)
+        if (self.converged and self.univariate_filter[self.t] != self.univariate_filter[self.t - 1]):
+            self.converged = 0
+            self.period_converged = 0
+
         # Initialize pointers to current-iteration objects
         self.initialize_statespace_object_pointers()
         self.initialize_filter_object_pointers()
@@ -920,12 +943,38 @@ cdef class {{prefix}}KalmanFilter(object):
             self._filtered_state = &self.filtered_state[0, filtered_mean_t]
             self._filtered_state_cov = &self.filtered_state_cov[0, 0, filtered_cov_t]
 
+        # Clear `forecasts_error_cov` if we switched from multivariate to
+        # univariate (because we might have off-diagonal elements stored from
+        # a previous multivariate run that wouldn't have been cleared yet)
+        if self.univariate_filter[self.t] == 1 and (self.t == 0 or self.univariate_filter[self.t - 1] == 0):
+            self.forecast_error_cov[..., self.t:] = 0
+
         # Form forecasts
         self.forecasting(self, self.model)
         # self._forecasting()
 
         # Perform `forecast_error_cov` inversion (or decomposition)
-        self.determinant = self.inversion(self, self.model, self.determinant)
+        try:
+            self.determinant = self.inversion(self, self.model, self.determinant)
+        except np.linalg.LinAlgError:
+            # If the multivariate filter fails here due to a singular forecast
+            # error covariance matrix, then we can try to fall back to the
+            # univariate filter
+            # If we were already using the univariate filter, raise the
+            # exception
+            if not ((self.inversion_method & INVERT_UNIVARIATE) or
+                    (self.inversion_method & SOLVE_CHOLESKY)):
+                raise NotImplementedError(
+                    'Singular forecast error covariance matrix detected, but'
+                    ' multivariate filter cannot fall back to univariate'
+                    ' filter when the inversion method is set to anything'
+                    ' other than INVERT_UNIVARIATE or SOLVE_CHOLESKY.')
+            elif self.univariate_filter[self.t]:
+                raise
+            else:
+                self.univariate_filter[self.t] = 1
+                next(self)
+                return
         # self.determinant = self._inversion()
 
         # Updating step
@@ -986,14 +1035,17 @@ cdef class {{prefix}}KalmanFilter(object):
         cdef:
             int transform_diagonalize = 0
             int transform_generalized_collapse = 0
+            int reset = 0
 
         # Determine which transformations need to be made
         transform_generalized_collapse = self.filter_method & FILTER_COLLAPSED
-        transform_diagonalize = self.filter_method & FILTER_UNIVARIATE
+        transform_diagonalize = self.univariate_filter[self.t]
+        if self.t > 0:
+            reset = self.univariate_filter[self.t] != self.univariate_filter[self.t - 1]
 
         # Initialize object-level pointers to statespace arrays
         #self.model.initialize_object_pointers(self.t)
-        self.model.seek(self.t, transform_diagonalize, transform_generalized_collapse)
+        self.model.seek(self.t, transform_diagonalize, transform_generalized_collapse, reset)
 
         # Handle missing data
         if self.model._nmissing > 0 or (self.model.has_missing and self.filter_method & FILTER_UNIVARIATE):
@@ -1064,10 +1116,10 @@ cdef class {{prefix}}KalmanFilter(object):
             blas.{{prefix}}copy(&self.model._k_states2, self.model._initial_diffuse_state_cov, &inc, self._input_diffuse_state_cov, &inc)
 
         # Now we can check if we are in a diffuse period. If we are but we are
-        # not generally using the univariate method, then we may need to re-do
-        # the diagonalization transformation (since in diffuse periods we
-        # always use the univariate method)
-        if not (self.filter_method & FILTER_UNIVARIATE) and self.check_diffuse():
+        # not using the univariate method, then we may need to perform the
+        # diagonalization transformation (since in diffuse periods we always
+        # use the univariate method)
+        if not self.univariate_filter[self.t] and self.check_diffuse():
             self.model.transform_diagonalize(self.model.t, self.model._previous_t)
 
         # Initialize object-level pointers to output arrays
@@ -1116,7 +1168,7 @@ cdef class {{prefix}}KalmanFilter(object):
             self.calculate_scale = {{prefix}}scale_univariate
             self.prediction = {{prefix}}prediction_univariate_diffuse
         # Univariate method
-        elif self.filter_method & FILTER_UNIVARIATE:
+        elif self.univariate_filter[self.t]:
             self.forecasting = {{prefix}}forecast_univariate
             self.updating = {{prefix}}updating_univariate
             self.inversion = {{prefix}}inverse_noop_univariate

--- a/statsmodels/tsa/statespace/_kalman_smoother.pyx.in
+++ b/statsmodels/tsa/statespace/_kalman_smoother.pyx.in
@@ -542,6 +542,23 @@ cdef class {{prefix}}KalmanSmoother(object):
         # Initialize pointers to appropriate Kalman smoothing functions
         self.initialize_function_pointers()
 
+        # Clear measurement disturbance variables` if we switched from
+        # multivariate to univariate (because we might have off-diagonal
+        # elements stored from a previous multivariate run that wouldn't have
+        # been cleared yet)
+        if self.t > 0 and self.kfilter.univariate_filter[self.t] == 0 and self.kfilter.univariate_filter[self.t - 1] == 1:
+            if self._smooth_method & SMOOTH_CLASSICAL:
+                raise NotImplementedError(
+                    'Cannot use classical smoothing when the multivariate'
+                    ' filter has fallen back to univariate filtering.')
+            if self._smooth_method & SMOOTH_ALTERNATIVE:
+                raise NotImplementedError(
+                    'Cannot use alternative smoothing when the multivariate'
+                    ' filter has fallen back to univariate filtering.')
+            self.smoothing_error[..., :self.t] = 0
+            self.smoothed_measurement_disturbance_cov[..., :self.t] = 0
+            self.innovations_transition[..., :self.t] = 0
+
         # Conventional timing of the measurement step of the scaled smoothed
         # estimator and covariance matrix, smoothing error  
         # $L_t, r_{t-1}, N_{t-1}, u_t$
@@ -560,7 +577,10 @@ cdef class {{prefix}}KalmanSmoother(object):
             self.smooth_estimators_measurement(self, self.kfilter, self.model)
 
         # Smoothed state autocovariance matrix
-        blas.{{prefix}}copy(&self.kfilter.k_states2, self._tmpL, &inc, self._innovations_transition, &inc)
+        if diffuse:
+            blas.{{prefix}}copy(&self.kfilter.k_states2, self.kfilter._tmpL0, &inc, self._innovations_transition, &inc)
+        else:
+            blas.{{prefix}}copy(&self.kfilter.k_states2, self._tmpL, &inc, self._innovations_transition, &inc)
         if self.smoother_output & SMOOTHER_STATE_AUTOCOV:
             if diffuse:
                 {{prefix}}smoothed_state_autocov_univariate_diffuse(self, self.kfilter, self.model)
@@ -579,13 +599,21 @@ cdef class {{prefix}}KalmanSmoother(object):
         # Time step of the scaled smoothed estimator and covariance matrix
         self.smooth_estimators_time(self, self.kfilter, self.model)
 
-        # Since the exact diffuse filtering and smoothing only uses the
-        # univariate method, if non-univariate filtering methods are used for
-        # the remaining filtering and smoothing, we need to run one or more
+        # When switching from the non-univariate filtering methods to the
+        # univariate filtering method, we need to run one or more
         # univariate time smoothing steps to get the appropriate values (e.g.
         # for scaled_smoothed_estimator). Moreover, the alternative and
         # classical methods have different timing.
-        if self.kfilter.nobs_diffuse > 0 and self.t == self.kfilter.nobs_diffuse:
+        # This happens in two cases:
+        # 1. Exact diffuse filtering and smoothing only uses the univariate
+        #    method, so if non-univariate filtering methods are used for
+        #    the remaining filtering and smoothing then we need to run this.
+        # 2. If the multivariate filtering method failed in a particular time
+        #    step (due to a singular forecast error covariance matrix) and
+        #    the univariate method was used as a fallback, then we need to run
+        #    this.
+        if ((self.kfilter.nobs_diffuse > 0 and self.t == self.kfilter.nobs_diffuse) or
+                (self.t > 0 and self.kfilter.univariate_filter[self.t] == 0 and self.kfilter.univariate_filter[self.t-1] == 1)):
             t = self.t
             if self._smooth_method & SMOOTH_CONVENTIONAL:
                 {{prefix}}smoothed_estimators_time_univariate(self, self.kfilter, self.model)
@@ -627,7 +655,7 @@ cdef class {{prefix}}KalmanSmoother(object):
         # Determine which transformations (would) need to be made
         transform_generalized_collapse = self.kfilter.filter_method & FILTER_COLLAPSED
         if not transform_generalized_collapse:
-            transform_diagonalize = self.kfilter.filter_method & FILTER_UNIVARIATE
+            transform_diagonalize = self.kfilter.univariate_filter[self.t]
 
         # Initialize object-level pointers to statespace arrays
         # Note: does not matter what transformations were required for the
@@ -726,6 +754,12 @@ cdef class {{prefix}}KalmanSmoother(object):
             self.smooth_estimators_time = {{prefix}}smoothed_estimators_time_univariate_diffuse
             self.smooth_state = {{prefix}}smoothed_state_univariate_diffuse
             self.smooth_disturbances = {{prefix}}smoothed_disturbances_univariate_diffuse
+        # Univariate (modified Bryson-Frazier) smoother
+        elif (self._smooth_method & SMOOTH_UNIVARIATE) or self.kfilter.univariate_filter[self.t]:
+            self.smooth_estimators_measurement = {{prefix}}smoothed_estimators_measurement_univariate
+            self.smooth_estimators_time = {{prefix}}smoothed_estimators_time_univariate
+            self.smooth_state = {{prefix}}smoothed_state_conventional
+            self.smooth_disturbances = {{prefix}}smoothed_disturbances_univariate
         # Multivariate modified Bryson-Frazier smoother
         elif self._smooth_method & SMOOTH_ALTERNATIVE:
             self.smooth_estimators_measurement = {{prefix}}smoothed_estimators_measurement_alternative
@@ -738,12 +772,6 @@ cdef class {{prefix}}KalmanSmoother(object):
             self.smooth_estimators_time = {{prefix}}smoothed_estimators_time_classical
             self.smooth_state = {{prefix}}smoothed_state_classical
             self.smooth_disturbances = {{prefix}}smoothed_disturbances_conventional
-        # Univariate (modified Bryson-Frazier) smoother
-        elif self._smooth_method & SMOOTH_UNIVARIATE:
-            self.smooth_estimators_measurement = {{prefix}}smoothed_estimators_measurement_univariate
-            self.smooth_estimators_time = {{prefix}}smoothed_estimators_time_univariate
-            self.smooth_state = {{prefix}}smoothed_state_conventional
-            self.smooth_disturbances = {{prefix}}smoothed_disturbances_univariate
         # Multivariate conventional (Durbin and Koopman) smoother
         elif self._smooth_method & SMOOTH_CONVENTIONAL:
             self.smooth_estimators_measurement = {{prefix}}smoothed_estimators_measurement_conventional
@@ -756,7 +784,7 @@ cdef class {{prefix}}KalmanSmoother(object):
         # Handle completely missing data
         # (All methods except the conventional method can use the same routines in this case)
         # This is essentially just an application of the smoothed_estimators_time_* step.
-        if self._smooth_method & SMOOTH_CONVENTIONAL and self.model._nmissing == self.model.k_endog:
+        if not diffuse and self._smooth_method & SMOOTH_CONVENTIONAL and self.model._nmissing == self.model.k_endog:
             # Change the smoothing functions to take into account a missing observation
             self.smooth_estimators_measurement = {{prefix}}smoothed_estimators_missing_conventional
             # (no need to change the state smoothing recursion)

--- a/statsmodels/tsa/statespace/_representation.pxd
+++ b/statsmodels/tsa/statespace/_representation.pxd
@@ -76,16 +76,16 @@ cdef class sStatespace(object):
     cdef readonly int _nmissing
 
     # Functions
-    cpdef seek(self, unsigned int t, unsigned int transform_diagonalize, unsigned int transform_generalized_collapse)
+    cpdef seek(self, unsigned int t, unsigned int transform_diagonalize, unsigned int transform_generalized_collapse, unsigned int reset=*)
 
     cdef void set_dimensions(self, unsigned int k_endog, unsigned int k_states, unsigned int k_posdef)
     cdef void select_state_cov(self, unsigned int t)
     cdef int select_missing(self, unsigned int t)
     cdef void _select_missing_entire_obs(self, unsigned int t)
     cdef void _select_missing_partial_obs(self, unsigned int t)
-    cdef void transform(self, unsigned int t, unsigned int previous_t, unsigned int transform_diagonalize, unsigned int transform_generalized_collapse) except *
-    cdef void transform_diagonalize(self, unsigned int t, unsigned int previous_t) except *
-    cdef int transform_generalized_collapse(self, unsigned int t, unsigned int previous_t) except *
+    cdef void transform(self, unsigned int t, unsigned int previous_t, unsigned int transform_diagonalize, unsigned int transform_generalized_collapse, unsigned int reset=*) except *
+    cdef void transform_diagonalize(self, unsigned int t, unsigned int previous_t, unsigned int reset=*) except *
+    cdef int transform_generalized_collapse(self, unsigned int t, unsigned int previous_t, unsigned int reset=*) except *
 
 cdef class dStatespace(object):
     # Statespace dimensions
@@ -153,16 +153,16 @@ cdef class dStatespace(object):
     cdef readonly int _nmissing
 
     # Functions
-    cpdef seek(self, unsigned int t, unsigned int transform_diagonalize, unsigned int transform_generalized_collapse)
+    cpdef seek(self, unsigned int t, unsigned int transform_diagonalize, unsigned int transform_generalized_collapse, unsigned int reset=*)
 
     cdef void set_dimensions(self, unsigned int k_endog, unsigned int k_states, unsigned int k_posdef)
     cdef void select_state_cov(self, unsigned int t)
     cdef int select_missing(self, unsigned int t)
     cdef void _select_missing_entire_obs(self, unsigned int t)
     cdef void _select_missing_partial_obs(self, unsigned int t)
-    cdef void transform(self, unsigned int t, unsigned int previous_t, unsigned int transform_diagonalize, unsigned int transform_generalized_collapse) except *
-    cdef void transform_diagonalize(self, unsigned int t, unsigned int previous_t) except *
-    cdef int transform_generalized_collapse(self, unsigned int t, unsigned int previous_t) except *
+    cdef void transform(self, unsigned int t, unsigned int previous_t, unsigned int transform_diagonalize, unsigned int transform_generalized_collapse, unsigned int reset=*) except *
+    cdef void transform_diagonalize(self, unsigned int t, unsigned int previous_t, unsigned int reset=*) except *
+    cdef int transform_generalized_collapse(self, unsigned int t, unsigned int previous_t, unsigned int reset=*) except *
 
 cdef class cStatespace(object):
     # Statespace dimensions
@@ -230,16 +230,16 @@ cdef class cStatespace(object):
     cdef readonly int _nmissing
 
     # Functions
-    cpdef seek(self, unsigned int t, unsigned int transform_diagonalize, unsigned int transform_generalized_collapse)
+    cpdef seek(self, unsigned int t, unsigned int transform_diagonalize, unsigned int transform_generalized_collapse, unsigned int reset=*)
 
     cdef void set_dimensions(self, unsigned int k_endog, unsigned int k_states, unsigned int k_posdef)
     cdef void select_state_cov(self, unsigned int t)
     cdef int select_missing(self, unsigned int t)
     cdef void _select_missing_entire_obs(self, unsigned int t)
     cdef void _select_missing_partial_obs(self, unsigned int t)
-    cdef void transform(self, unsigned int t, unsigned int previous_t, unsigned int transform_diagonalize, unsigned int transform_generalized_collapse) except *
-    cdef void transform_diagonalize(self, unsigned int t, unsigned int previous_t) except *
-    cdef int transform_generalized_collapse(self, unsigned int t, unsigned int previous_t) except *
+    cdef void transform(self, unsigned int t, unsigned int previous_t, unsigned int transform_diagonalize, unsigned int transform_generalized_collapse, unsigned int reset=*) except *
+    cdef void transform_diagonalize(self, unsigned int t, unsigned int previous_t, unsigned int reset=*) except *
+    cdef int transform_generalized_collapse(self, unsigned int t, unsigned int previous_t, unsigned int reset=*) except *
 
 cdef class zStatespace(object):
     # Statespace dimensions
@@ -307,16 +307,16 @@ cdef class zStatespace(object):
     cdef readonly int _nmissing
 
     # Functions
-    cpdef seek(self, unsigned int t, unsigned int transform_diagonalize, unsigned int transform_generalized_collapse)
+    cpdef seek(self, unsigned int t, unsigned int transform_diagonalize, unsigned int transform_generalized_collapse, unsigned int reset=*)
 
     cdef void set_dimensions(self, unsigned int k_endog, unsigned int k_states, unsigned int k_posdef)
     cdef void select_state_cov(self, unsigned int t)
     cdef int select_missing(self, unsigned int t)
     cdef void _select_missing_entire_obs(self, unsigned int t)
     cdef void _select_missing_partial_obs(self, unsigned int t)
-    cdef void transform(self, unsigned int t, unsigned int previous_t, unsigned int transform_diagonalize, unsigned int transform_generalized_collapse) except *
-    cdef void transform_diagonalize(self, unsigned int t, unsigned int previous_t) except *
-    cdef int transform_generalized_collapse(self, unsigned int t, unsigned int previous_t) except *
+    cdef void transform(self, unsigned int t, unsigned int previous_t, unsigned int transform_diagonalize, unsigned int transform_generalized_collapse, unsigned int reset=*) except *
+    cdef void transform_diagonalize(self, unsigned int t, unsigned int previous_t, unsigned int reset=*) except *
+    cdef int transform_generalized_collapse(self, unsigned int t, unsigned int previous_t, unsigned int reset=*) except *
 
 cdef int sselect_cov(int k, int k_posdef,
                            np.float32_t * tmp,

--- a/statsmodels/tsa/statespace/_representation.pyx.in
+++ b/statsmodels/tsa/statespace/_representation.pyx.in
@@ -527,7 +527,7 @@ cdef class {{prefix}}Statespace(object):
         else:
             self.seek(self.t+1, 0, 0)
 
-    cpdef seek(self, unsigned int t, unsigned int transform_diagonalize, unsigned int transform_generalized_collapse):
+    cpdef seek(self, unsigned int t, unsigned int transform_diagonalize, unsigned int transform_generalized_collapse, unsigned int reset=False):
         self._previous_t = self.t
 
         # Set the global time indicator, if valid
@@ -584,7 +584,7 @@ cdef class {{prefix}}Statespace(object):
         self.set_dimensions(k_endog, self.k_states, self.k_posdef)
 
         # Handle transformations
-        self.transform(t, self._previous_t, transform_diagonalize, transform_generalized_collapse)
+        self.transform(t, self._previous_t, transform_diagonalize, transform_generalized_collapse, reset)
 
     cdef void set_dimensions(self, unsigned int k_endog, unsigned int k_states, unsigned int k_posdef):
         self._k_endog = k_endog
@@ -686,18 +686,18 @@ cdef class {{prefix}}Statespace(object):
         self._design = &self.selected_design[0]
         self._obs_cov = &self.selected_obs_cov[0]
 
-    cdef void transform(self, unsigned int t, unsigned int previous_t, unsigned int transform_diagonalize, unsigned int transform_generalized_collapse) except *:
+    cdef void transform(self, unsigned int t, unsigned int previous_t, unsigned int transform_diagonalize, unsigned int transform_generalized_collapse, unsigned int reset=False) except *:
         # Reset the collapsed loglikelihood
         self.collapse_loglikelihood = 0
 
         if transform_generalized_collapse and not self._k_endog <= self._k_states:
-            k_endog = self.transform_generalized_collapse(t, previous_t)
+            k_endog = self.transform_generalized_collapse(t, previous_t, reset)
             # Reset dimensions
             self.set_dimensions(k_endog, self._k_states, self._k_posdef)
         elif transform_diagonalize and not (self.diagonal_obs_cov == 1):
-            self.transform_diagonalize(t, previous_t)
+            self.transform_diagonalize(t, previous_t, reset)
 
-    cdef void transform_diagonalize(self, unsigned int t, unsigned int previous_t) except *:
+    cdef void transform_diagonalize(self, unsigned int t, unsigned int previous_t, unsigned int reset=False) except *:
         # Note: this assumes that initialize_object_pointers has *already* been done
         # Note: this assumes that select_missing has *already* been done
         # TODO need unit tests, especially for the missing case
@@ -727,7 +727,7 @@ cdef class {{prefix}}Statespace(object):
         if diagonal_obs_cov == -1:
             # We don't need to check for a diagonal covariance matrix each t,
             # except in the following cases:
-            if self._diagonal_obs_cov == -1 or t == 0 or self.obs_cov.shape[2] > 1 or reset_missing:
+            if self._diagonal_obs_cov == -1 or t == 0 or self.obs_cov.shape[2] > 1 or reset_missing or reset:
                 diagonal_obs_cov = 1
                 for i in range(self.k_endog):
                     for j in range(self.k_endog):
@@ -745,7 +745,7 @@ cdef class {{prefix}}Statespace(object):
 
         # If we have a non-diagonal obs cov, we need to compute the cholesky
         # decomposition of *self._obs_cov
-        if t == 0 or self.obs_cov.shape[2] > 1 or reset_missing:
+        if t == 0 or self.obs_cov.shape[2] > 1 or reset_missing or reset:
             # LDL decomposition
             blas.{{prefix}}copy(&self._k_endog2, self._obs_cov, &inc, _transform_cholesky, &inc)
             info = tools._{{prefix}}ldl(_transform_cholesky, self._k_endog)
@@ -775,6 +775,7 @@ cdef class {{prefix}}Statespace(object):
 
         # Solve for y_t^*
         # (unless this is a completely missing observation)
+        # TODO: note that this can cause problems if this function is run twice
         if not self._nmissing == self.k_endog:
             # If we have some missing elements, selected_obs is already populated
             if self._nmissing == 0:
@@ -793,7 +794,7 @@ cdef class {{prefix}}Statespace(object):
             self._obs = &self.selected_obs[0]
 
         # Solve for d_t^*, if necessary
-        if t == 0 or self.obs_intercept.shape[1] > 1 or reset_missing:
+        if t == 0 or self.obs_intercept.shape[1] > 1 or reset_missing or reset:
             blas.{{prefix}}copy(&self._k_endog, self._obs_intercept, &inc, &self.transform_obs_intercept[0], &inc)
             lapack.{{prefix}}trtrs("L", "N", "U", &self._k_endog, &inc,
                         _transform_cholesky, &self.k_endog,
@@ -801,7 +802,7 @@ cdef class {{prefix}}Statespace(object):
                         &info)
 
         # Solve for Z_t^*, if necessary
-        if t == 0 or self.design.shape[2] > 1 or reset_missing:
+        if t == 0 or self.design.shape[2] > 1 or reset_missing or reset:
             blas.{{prefix}}copy(&self._k_endogstates, self._design, &inc, &self.transform_design[0,0], &inc)
             lapack.{{prefix}}trtrs("L", "N", "U", &self._k_endog, &self._k_states,
                         _transform_cholesky, &self.k_endog,
@@ -819,7 +820,7 @@ cdef class {{prefix}}Statespace(object):
         self._obs_cov = &self.transform_obs_cov[0,0]
         self._obs_intercept = &self.transform_obs_intercept[0]
 
-    cdef int transform_generalized_collapse(self, unsigned int t, unsigned int previous_t) except *:
+    cdef int transform_generalized_collapse(self, unsigned int t, unsigned int previous_t, unsigned int reset=True) except *:
         # Note: this assumes that initialize_object_pointers has *already* been done
         # Note: this assumes that select_missing has *already* been done
         # TODO need unit tests, especially for the missing case
@@ -872,7 +873,7 @@ cdef class {{prefix}}Statespace(object):
                                    ' intercept.')
 
         # Perform the Cholesky decomposition of H_t, if necessary
-        if t == 0 or self.obs_cov.shape[2] > 1 or reset_missing:
+        if t == 0 or self.obs_cov.shape[2] > 1 or reset_missing or reset:
             # Cholesky decomposition: $H = L L'$  
             blas.{{prefix}}copy(&self._k_endog2, self._obs_cov, &inc, &self.transform_cholesky[0,0], &inc)
             lapack.{{prefix}}potrf("L", &self._k_endog, &self.transform_cholesky[0,0], &self._k_endog, &info)
@@ -895,7 +896,7 @@ cdef class {{prefix}}Statespace(object):
             self.transform_determinant = self.transform_determinant**2
 
         # Get $Z_t \equiv C^{-1}$, if necessary  
-        if t == 0 or self.obs_cov.shape[2] > 1 or self.design.shape[2] > 1 or reset_missing:
+        if t == 0 or self.obs_cov.shape[2] > 1 or self.design.shape[2] > 1 or reset_missing or reset:
             # Calculate $H_t^{-1} Z_t \equiv (Z_t' H_t^{-1})'$ via Cholesky solver
             blas.{{prefix}}copy(&self._k_endogstates, self._design, &inc, &self.transform_design[0,0], &inc)
             lapack.{{prefix}}potrs("L", &self._k_endog, &k_states,

--- a/statsmodels/tsa/statespace/_simulation_smoother.pyx.in
+++ b/statsmodels/tsa/statespace/_simulation_smoother.pyx.in
@@ -551,7 +551,7 @@ cdef class {{prefix}}SimulationSmoother(object):
                 )
                 collapsing_model.initialized = True
                 for t in range(self.nobs):
-                    collapsing_model.seek(t, self.simulated_kfilter.filter_method & FILTER_UNIVARIATE,
+                    collapsing_model.seek(t, self.simulated_kfilter.univariate_filter[t],
                                              self.simulated_kfilter.filter_method & FILTER_COLLAPSED)
                     blas.{{prefix}}copy(&k_states, &collapsing_model.collapse_obs[0], &inc, &self.simulated_measurement_disturbance[0,t], &inc)
             else:

--- a/statsmodels/tsa/statespace/_smoothers/_univariate.pyx.in
+++ b/statsmodels/tsa/statespace/_smoothers/_univariate.pyx.in
@@ -78,7 +78,7 @@ if combined_prefix == 'z':
 
 cdef int {{prefix}}smoothed_estimators_measurement_univariate({{prefix}}KalmanSmoother smoother, {{prefix}}KalmanFilter kfilter, {{prefix}}Statespace model) except *:
     cdef:
-        int i, j, inc = 1
+        int i, j, k, inc = 1
         {{cython_type}} alpha = 1.0
         {{cython_type}} beta = 0.0
         {{cython_type}} gamma = -1.0
@@ -109,10 +109,9 @@ cdef int {{prefix}}smoothed_estimators_measurement_univariate({{prefix}}KalmanSm
 
     # Iterate
     for i in range(kfilter.k_endog-1,-1,-1):
-        # If we want smoothed disturbances, then we need to calculate
-        # and store K_{t,i}' r_{t,i} for later (otherwise r_{t,i} will not be
-        # available)
-        if smoother.smoother_output & SMOOTHER_DISTURBANCE:
+        if smoother.smoother_output & (SMOOTHER_STATE | SMOOTHER_DISTURBANCE):
+            # K_{t,i}' r_{t,i} (also will need these later for smoothed
+            # disturbances)
             # Note: zdot and cdot are broken, so have to use gemv for those
             {{if combined_prefix == 'd'}}
             smoother._smoothed_measurement_disturbance[i] = (
@@ -126,102 +125,276 @@ cdef int {{prefix}}smoothed_estimators_measurement_univariate({{prefix}}KalmanSm
                            &beta, &smoother._smoothed_measurement_disturbance[i], &inc)
             {{endif}}
 
-        # If we want smoothed disturbance covs, then we need to calculate
-        # and store K_{t,i}' N_{t,i} K_{t,i} for later (otherwise N_{t,i} will not be
-        # available)
-        if smoother.smoother_output & SMOOTHER_DISTURBANCE_COV:
-            blas.{{prefix}}gemv("N", &model._k_states, &model._k_states,
+        if smoother.smoother_output & (SMOOTHER_STATE_COV | SMOOTHER_DISTURBANCE_COV):
+            # K_{t,i}' N_{t,i} K_{t,i} (also will need these later for smoothed
+            # disturbance covs)
+            # Note: uses tmp0
+            # blas.{{prefix}}gemv("N", &model._k_states, &model._k_states,
+            #                          &alpha, smoother._scaled_smoothed_estimator_cov, &kfilter.k_states,
+            #                                  &kfilter._kalman_gain[i*kfilter.k_states], &inc,
+            #                          &beta, smoother._tmp0, &inc)
+            blas.{{prefix}}{{if combined_prefix == 'z'}}he{{else}}sy{{endif}}mv("U", &model._k_states,
                                      &alpha, smoother._scaled_smoothed_estimator_cov, &kfilter.k_states,
                                              &kfilter._kalman_gain[i*kfilter.k_states], &inc,
-                                     &beta, smoother._tmpL, &inc)
+                                     &beta, smoother._tmp0, &inc)
             # Note: zdot and cdot are broken, so have to use gemv for those
             {{if combined_prefix == 'd'}}
             smoother._smoothed_measurement_disturbance_cov[i + i*kfilter.k_endog] = (
                 blas.{{prefix}}dot(&model._k_states, &kfilter._kalman_gain[i*kfilter.k_states], &inc,
-                                                      smoother._tmpL, &inc)
+                                                      smoother._tmp0, &inc)
             )
             {{else}}
             blas.{{prefix}}gemv("N", &inc, &model._k_states,
-                           &alpha, smoother._tmpL, &inc,
+                           &alpha, smoother._tmp0, &inc,
                                    &kfilter._kalman_gain[i*kfilter.k_states], &inc,
                            &beta, &smoother._smoothed_measurement_disturbance_cov[i*kfilter.k_endog + i], &inc)
             {{endif}}
 
-        # $L_{t,i} = (I_m - K_{t,i} Z_{t,i})$  
-        # $(m \times m) = (m \times m) - (m \times 1) (1 \times m)$
-        # blas.{{prefix}}gemm("N", "N", &model._k_states, &model._k_states, &inc,
-        #           &gamma, &kfilter._kalman_gain[i*kfilter.k_states], &kfilter.k_states,
-        #                   &model._design[i], &model._k_endog,
-        #           &beta, smoother._tmpL, &kfilter.k_states)
+        # In most cases we can use an optimized version of these iterations
+        # that e.g. reduces the number of (m x m) matrix multiplications.
+        # However, it can suffer from catestrophic cancellation (especially for
+        # the first period in the approximate diffuse case, and even more so if
+        # the initial variance is increased to e.g. 1e9), and as a result we
+        # fall back to the more-precise-but-slower version (maybe 4x slower
+        # for large state vectors) when numerical problems seems likely.
+        if smoother.t >= kfilter.loglikelihood_burn and kfilter._forecast_error_cov[i*kfilter.k_endog + i]{{if combined_prefix == 'z'}}.real{{endif}} < 1e5:
+            {{prefix}}fast_iter_smoothed_estimators_measurement_univariate(smoother, kfilter, model, i, k_states)
+        else:
+            {{prefix}}precise_iter_smoothed_estimators_measurement_univariate(smoother, kfilter, model, i, k_states)
+
+    # Transition for L
+    blas.{{prefix}}copy(&kfilter.k_states2, smoother._tmpL, &inc, smoother._tmpL2, &inc)
+    blas.{{prefix}}gemm("N", "N", &model._k_states, &model._k_states, &model._k_states,
+                      &alpha, model._transition, &kfilter.k_states,
+                              smoother._tmpL2, &kfilter.k_states,
+                      &beta, smoother._tmpL, &kfilter.k_states)
+
+cdef int {{prefix}}fast_iter_smoothed_estimators_measurement_univariate({{prefix}}KalmanSmoother smoother, {{prefix}}KalmanFilter kfilter, {{prefix}}Statespace model, int i, int k_states):
+    """
+    Faster version of univariate smoother iteration
+
+    Uses the following decompositions:
+
+    $$
+    \begin{aligned}
+    L_{t,i} & = I_m - K_{t,i} Z_{t,i} \\
+    r_{t, i-1} & = Z_{t,i}' F_{t,i}^{-1} v_{t,i} + L_{t,i}' r_{t,i} \\
+    & = Z_{t,i}' F_{t,i}^{-1} v_{t,i} + r_{t,i} - Z_{t,i}' K_{t,i}' r_{t,i} \\
+    & = r_{t,i} + Z_{t,i}' (F_{t,i}^{-1} v_{t,i} - K_{t,i}' r_{t,i}) \\
+    N_{t, i-1} & = Z_{t,i}' F_{t,i}^{-1} Z_{t,i} + L_{t,i}' N_{t,i} L_{t,i} \\
+    & = Z_{t,i}' F_{t,i}^{-1} Z_{t,i} + (I_m - K_{t,i} Z_{t,i})' N_{t,i} (I_m - K_{t,i} Z_{t,i}) \\
+    & = Z_{t,i}' F_{t,i}^{-1} Z_{t,i} + N_{t,i} - Z_{t,i}' K_{t,i}' N_{t,i} - N_{t,i} K_{t,i} Z_{t,i} + Z_{t,i}' K_{t,i}' N_{t,i} K_{t,i} Z_{t,i}  \\
+    \end{aligned}
+    $$
+
+    and
+
+    $$
+    \begin{aligned}
+    L_{t,i} & = I_m - K_{t,i} Z_{t,i} \\
+    L_{t} & = L_{t,n} L_{t,n-1} \dots L_{t,1} \\
+    L_{t}^n & = L_{t,n} \\
+    L_{t}^{n-1} & = L_{t,n} L_{t,n-1} \\
+    & = L_{t,n} (I_m - K_{t,i} Z_{t,i}) \\
+    & = L_{t,n} - L_{t,n} K_{t,i} Z_{t,i} \\
+    L_{t}^{n-2} & = L_{t,n} L_{t,n-1} L_{t,n-2} \\
+    & = L_{t}^{n-1} L_{t,n-2} \\
+    & = L_{t}^{n-1} - L_{t}^{n-1} K_{t,i} Z_{t,i} \\
+    \end{aligned}
+    $$
+    """
+    cdef:
+        int j, k, inc = 1
+        {{cython_type}} alpha = 1.0
+        {{cython_type}} beta = 0.0
+        {{cython_type}} gamma = -1.0
+        {{cython_type}} scalar
+
+    # Accumulate L_{t,i} so that at the end of the iteration we have L_t
+    # L_{t}^n = L_{t,n}
+    if i == kfilter.k_endog - 1:
         # Zero the temporary matrix
-        # blas.{{prefix}}scal(&kfilter.k_states2, &beta, smoother._tmpL, &inc)
         smoother.tmpL[:,:k_states] = 0
+        # blas.{{prefix}}scal(&kfilter.k_states2, &beta, smoother._tmpL, &inc)
         # Create the K_{t,i} Z_{t,i} component
         # (m x p) (m x 1) x (1 x p)
         blas.{{prefix}}ger{{combined_suffix}}(&model._k_states, &k_states,
                   &gamma, &kfilter._kalman_gain[i*kfilter.k_states], &inc,
                           &model._design[i], &model._k_endog,
-                          smoother._tmpL, &kfilter.k_states
-        )
+                          smoother._tmpL, &kfilter.k_states)
         # Add the identity matrix
         for j in range(k_states):
             smoother._tmpL[j + j*kfilter.k_states] = smoother._tmpL[j + j*kfilter.k_states] + 1
+    # L_{t}^{i} = L_{t,i+1} - (L_{t,i+1} K_{t, i}) Z_{t, i}
+    else:
+        # blas.{{prefix}}copy(&kfilter.k_states2, smoother._tmpL, &inc, smoother._tmp0, &inc)
+        # L_t^i K_{t,i} -> tmpL2  (m x m) (m x 1)
+        blas.{{prefix}}gemv("N", &model._k_states, &model._k_states,
+                  &alpha, smoother._tmpL, &kfilter.k_states,
+                          &kfilter._kalman_gain[i*kfilter.k_states], &inc,
+                  &beta, smoother._tmpL2, &inc)
+        # L_t^i - (L_t^i K_{t,i}) Z_{t,i} -> tmpL  (m x 1) (1 x m)
+        # blas.{{prefix}}gemm("N", "N", &model._k_states, &model._k_states, &inc,
+        #           &gamma, smoother._tmpL2, &kfilter.k_states,
+        #                   &model._design[i], &model._k_endog,
+        #           &alpha, smoother._tmpL, &kfilter.k_states)
+        blas.{{prefix}}ger{{combined_suffix}}(&model._k_states, &model._k_states,
+                  &gamma, smoother._tmpL2, &inc,
+                          &model._design[i], &model._k_endog,
+                  smoother._tmpL, &kfilter.k_states)
 
-        # Accumulate L_{t,i} into L_{t} = L_{t,n} L_{t,n-1} ... L_{t,1}
-        if i == kfilter.k_endog-1:
-            blas.{{prefix}}copy(&kfilter.k_states2, smoother._tmpL, &inc, smoother._tmpL2, &inc)
-        else:
-            blas.{{prefix}}copy(&kfilter.k_states2, smoother._tmpL2, &inc, smoother._tmp0, &inc)
-            blas.{{prefix}}gemm("N", "N", &model._k_states, &model._k_states, &model._k_states,
-                      &alpha, smoother._tmp0, &kfilter.k_states,
-                              smoother._tmpL, &kfilter.k_states,
-                      &beta, smoother._tmpL2, &kfilter.k_states)
+    # Scaled smoothed estimator  
+    # $r_{t,i-1} = Z_{t,i}' v_{t,i} / F_{t,i} + L_{t,i}' r_{t,i}$ 
+    # [or] 
+    # $r_{t,i-1} = r_{t,i} + Z_{t,i}' (v_{t,i} / F_{t,i} - K_{t,i}' r_{t,i})$  
+    # Note: save $r_{t-1}$ as scaled_smoothed_estimator[t] rather than
+    # as scaled_smoothed_estimator[t-1] because we actually need to store
+    # T+1 of them (r_{T-1} to r_{-1} -> r_T to r_0)
+    if smoother.smoother_output & (SMOOTHER_STATE | SMOOTHER_DISTURBANCE):
+        scalar = kfilter._tmp2[i] - smoother._smoothed_measurement_disturbance[i]
+        blas.{{prefix}}axpy(&k_states, &scalar, &model._design[i], &model._k_endog,
+                                       smoother._scaled_smoothed_estimator, &inc)
 
-        # Scaled smoothed estimator  
-        # $r_{t,i-1} = Z_{t,i}' v_{t,i} / F_{t,i} + L_{t,i}' r_{t,i}$  
-        # $(m \times 1) = (m \times 1) (1 \times 1) + (m \times m) (m \times 1)$
-        # Note: save $r_{t-1}$ as scaled_smoothed_estimator[t] rather than
-        # as scaled_smoothed_estimator[t-1] because we actually need to store
-        # T+1 of them (r_{T-1} to r_{-1} -> r_T to r_0)
-        if smoother.smoother_output & (SMOOTHER_STATE | SMOOTHER_DISTURBANCE):
-            #blas.{{prefix}}scal(&kfilter.k_states, &beta, smoother._tmp0, &inc)
+    if smoother.smoother_output & (SMOOTHER_STATE_COV | SMOOTHER_DISTURBANCE_COV):
+        # Scaled smoothed estimator covariance matrix  
+        # $N_{t,i-1} = Z_{t,i}' Z_{t,i} / F_{t,i} + L_{t,i}' N_{t,i} L_{t,i}$  
+        # [or]
+        # $N_{t,i-1} = N_{t,i} + Z_{t,i}' Z_{t,i} (K_{t,i}' N_{t, i} K_{t,i} + 1 / F_{t,i}) - (N_{t,i} K_{t,i} Z_{t,i}) - (N_{t,i} K_{t,i} Z_{t,i})' $  
+        # Note: save $N_{t-1}$ as scaled_smoothed_estimator_cov[t] rather
+        # than as scaled_smoothed_estimator_cov[t-1] because we actually
+        # need to store T+1 of them (N_{T-1} to N_{-1} -> N_T to N_0)
 
-            blas.{{prefix}}gemv("T", &model._k_states, &k_states,
-                      &alpha, smoother._tmpL, &kfilter.k_states,
-                              smoother._scaled_smoothed_estimator, &inc,
-                      &beta, smoother._tmp0, &inc)
-            blas.{{prefix}}swap(&k_states, smoother._tmp0, &inc,
-                                           smoother._scaled_smoothed_estimator, &inc)
-            blas.{{prefix}}axpy(&k_states, &kfilter._tmp2[i], &model._design[i], &model._k_endog,
-                                                              smoother._scaled_smoothed_estimator, &inc)
+        # Clear tmpL2 (because ?ger doesn't clear it)
+        smoother.tmpL2[:] = 0
 
-        if smoother.smoother_output & (SMOOTHER_STATE_COV | SMOOTHER_DISTURBANCE_COV):
-            # Scaled smoothed estimator covariance matrix  
-            # $N_{t,i-1} = Z_{t,i}' Z_{t,i} / F_{t,i} + L_{t,i}' N_{t,i} L_{t,i}$  
-            # $(m \times m) = (m \times p) (p \times m) + (m \times m) (m \times m) (m \times m)$  
-            # Note: save $N_{t-1}$ as scaled_smoothed_estimator_cov[t] rather
-            # than as scaled_smoothed_estimator_cov[t-1] because we actually
-            # need to store T+1 of them (N_{T-1} to N_{-1} -> N_T to N_0)
-            blas.{{prefix}}gemm("N", "N", &model._k_states, &model._k_states, &model._k_states,
-                      &alpha, smoother._scaled_smoothed_estimator_cov, &kfilter.k_states,
-                              smoother._tmpL, &kfilter.k_states,
-                      &beta, smoother._tmp0, &kfilter.k_states)
-            blas.{{prefix}}gemm("T", "N", &model._k_states, &model._k_states, &model._k_states,
-                      &alpha, smoother._tmpL, &kfilter.k_states,
-                              smoother._tmp0, &kfilter.k_states,
-                      &beta, smoother._scaled_smoothed_estimator_cov, &kfilter.k_states)
-            blas.{{prefix}}ger{{combined_suffix}}(&model._k_states, &model._k_states,
-                &alpha, &model._design[i], &model._k_endog,
-                        &kfilter._tmp3[i], &kfilter.k_endog,
-                smoother._scaled_smoothed_estimator_cov, &kfilter.k_states
-            )
+        # (N_{t,i} K_{t,i} Z_{t,i})
+        blas.{{prefix}}ger{{combined_suffix}}(&model._k_states, &model._k_states,
+            &alpha, smoother._tmp0, &inc,
+                    &model._design[i], &model._k_endog,
+            smoother._tmpL2, &kfilter.k_states)
 
-    # Replace L with accumulated version
-    # blas.{{prefix}}copy(&kfilter.k_states2, smoother._tmpL2, &inc, smoother._tmpL, &inc)
-    blas.{{prefix}}gemm("N", "N", &model._k_states, &model._k_states, &model._k_states,
-                      &alpha, model._transition, &kfilter.k_states,
-                              smoother._tmpL2, &kfilter.k_states,
-                      &beta, smoother._tmpL, &kfilter.k_states)
+        # (N_{t,i} K_{t,i} Z_{t,i}) + (N_{t,i} K_{t,i} Z_{t,i})'
+        # for j in range(kfilter.k_states):
+        #     k = kfilter.k_states - j
+        #     blas.{{prefix}}axpy(&k, &alpha, &smoother.tmpL2[j, j], &kfilter.k_states,
+        #                                     &smoother.tmpL2[j, j], &inc)
+        #     blas.{{prefix}}copy(&k, &smoother.tmpL2[j, j], &inc,
+        #                             &smoother.tmpL2[j, j], &kfilter.k_states)
+
+        # N_{t,i} - [(N_{t,i} K_{t,i} Z_{t,i}) + (N_{t,i} K_{t,i} Z_{t,i})']
+        # blas.{{prefix}}axpy(&kfilter.k_states2, &gamma, smoother._tmpL2, &inc,
+        #                                         smoother._scaled_smoothed_estimator_cov, &inc)
+        # Below is a faster way to do these ^ two steps
+        for j in range(kfilter.k_states):
+            k = kfilter.k_states - j
+            blas.{{prefix}}axpy(&k, &gamma, &smoother.tmpL2[j, j], &inc,
+                                            &smoother._scaled_smoothed_estimator_cov[j+j*kfilter.k_states], &inc)
+            blas.{{prefix}}axpy(&k, &gamma, &smoother.tmpL2[j, j], &kfilter.k_states,
+                                            &smoother._scaled_smoothed_estimator_cov[j+j*kfilter.k_states], &inc)
+            blas.{{prefix}}copy(&k, &smoother._scaled_smoothed_estimator_cov[j+j*kfilter.k_states], &inc,
+                                    &smoother._scaled_smoothed_estimator_cov[j+j*kfilter.k_states], &kfilter.k_states)
+
+        # N_{t,i-1}
+        scalar = smoother._smoothed_measurement_disturbance_cov[i*kfilter.k_endog + i]
+        if kfilter._forecast_error_cov[i*kfilter.k_endog + i]{{if combined_prefix == 'z'}}.real{{endif}} > kfilter.tolerance_diffuse:
+            scalar = scalar + 1 / kfilter._forecast_error_cov[i*kfilter.k_endog + i]
+        
+        # TODO: replace with syr + fill in upper triangle?
+        blas.{{prefix}}ger{{combined_suffix}}(&model._k_states, &model._k_states,
+            &scalar, &model._design[i], &model._k_endog,
+                    &model._design[i], &model._k_endog,
+            smoother._scaled_smoothed_estimator_cov, &kfilter.k_states)
+        # {{if combined_prefix == 'd'}}
+        # blas.{{prefix}}syr("L", &model._k_states,
+        #     &scalar, &model._design[i], &model._k_endog,
+        #              smoother._scaled_smoothed_estimator_cov, &kfilter.k_states)
+        # {{else}}
+        # blas.{{prefix}}syrk("L", "N", &model._k_states, &inc,
+        #     &scalar, &model._design[i], &model._k_endog,
+        #     &alpha, smoother._scaled_smoothed_estimator_cov, &kfilter.k_states)
+        # {{endif}}
+
+        # for j in range(model._k_states):      # columns
+        #     for k in range(model._k_states):  # rows
+        #         if k > j: # row > column => in lower triangle
+        #             smoother._scaled_smoothed_estimator_cov[j + k*kfilter.k_states] = smoother._scaled_smoothed_estimator_cov[k + j*kfilter.k_states]
+
+
+cdef int {{prefix}}precise_iter_smoothed_estimators_measurement_univariate({{prefix}}KalmanSmoother smoother, {{prefix}}KalmanFilter kfilter, {{prefix}}Statespace model, int i, int k_states):
+    cdef:
+        int j, k, inc = 1
+        {{cython_type}} alpha = 1.0
+        {{cython_type}} beta = 0.0
+        {{cython_type}} gamma = -1.0
+        {{cython_type}} scalar
+
+    # $L_{t,i} = (I_m - K_{t,i} Z_{t,i})$  
+    # $(m \times m) = (m \times m) - (m \times 1) (1 \times m)$
+    # blas.{{prefix}}gemm("N", "N", &model._k_states, &model._k_states, &inc,
+    #           &gamma, &kfilter._kalman_gain[i*kfilter.k_states], &kfilter.k_states,
+    #                   &model._design[i], &model._k_endog,
+    #           &beta, smoother._tmpL, &kfilter.k_states)
+    # Zero the temporary matrix
+    # blas.{{prefix}}scal(&kfilter.k_states2, &beta, smoother._tmpL, &inc)
+    smoother.tmpL2[:,:k_states] = 0
+    # Create the K_{t,i} Z_{t,i} component
+    # (m x p) (m x 1) x (1 x p)
+    blas.{{prefix}}ger{{combined_suffix}}(&model._k_states, &k_states,
+              &gamma, &kfilter._kalman_gain[i*kfilter.k_states], &inc,
+                      &model._design[i], &model._k_endog,
+                      smoother._tmpL2, &kfilter.k_states)
+    # Add the identity matrix
+    for j in range(k_states):
+        smoother._tmpL2[j + j*kfilter.k_states] = smoother._tmpL2[j + j*kfilter.k_states] + 1
+
+    # Accumulate L_{t,i} into L_{t} = L_{t,n} L_{t,n-1} ... L_{t,1}
+    if i == kfilter.k_endog-1:
+        blas.{{prefix}}copy(&kfilter.k_states2, smoother._tmpL2, &inc, smoother._tmpL, &inc)
+    else:
+        blas.{{prefix}}copy(&kfilter.k_states2, smoother._tmpL, &inc, smoother._tmp0, &inc)
+        blas.{{prefix}}gemm("N", "N", &model._k_states, &model._k_states, &model._k_states,
+                  &alpha, smoother._tmp0, &kfilter.k_states,
+                          smoother._tmpL2, &kfilter.k_states,
+                  &beta, smoother._tmpL, &kfilter.k_states)
+
+    # Scaled smoothed estimator  
+    # $r_{t,i-1} = Z_{t,i}' v_{t,i} / F_{t,i} + L_{t,i}' r_{t,i}$  
+    # $(m \times 1) = (m \times 1) (1 \times 1) + (m \times m) (m \times 1)$
+    # Note: save $r_{t-1}$ as scaled_smoothed_estimator[t] rather than
+    # as scaled_smoothed_estimator[t-1] because we actually need to store
+    # T+1 of them (r_{T-1} to r_{-1} -> r_T to r_0)
+    if smoother.smoother_output & (SMOOTHER_STATE | SMOOTHER_DISTURBANCE):
+        #blas.{{prefix}}scal(&kfilter.k_states, &beta, smoother._tmp0, &inc)
+
+        blas.{{prefix}}gemv("T", &model._k_states, &k_states,
+                  &alpha, smoother._tmpL2, &kfilter.k_states,
+                          smoother._scaled_smoothed_estimator, &inc,
+                  &beta, smoother._tmp0, &inc)
+        blas.{{prefix}}swap(&k_states, smoother._tmp0, &inc,
+                                       smoother._scaled_smoothed_estimator, &inc)
+        blas.{{prefix}}axpy(&k_states, &kfilter._tmp2[i], &model._design[i], &model._k_endog,
+                                                          smoother._scaled_smoothed_estimator, &inc)
+
+    if smoother.smoother_output & (SMOOTHER_STATE_COV | SMOOTHER_DISTURBANCE_COV):
+        # Scaled smoothed estimator covariance matrix  
+        # $N_{t,i-1} = Z_{t,i}' Z_{t,i} / F_{t,i} + L_{t,i}' N_{t,i} L_{t,i}$  
+        # $(m \times m) = (m \times p) (p \times m) + (m \times m) (m \times m) (m \times m)$  
+        # Note: save $N_{t-1}$ as scaled_smoothed_estimator_cov[t] rather
+        # than as scaled_smoothed_estimator_cov[t-1] because we actually
+        # need to store T+1 of them (N_{T-1} to N_{-1} -> N_T to N_0)
+        blas.{{prefix}}gemm("N", "N", &model._k_states, &model._k_states, &model._k_states,
+                  &alpha, smoother._scaled_smoothed_estimator_cov, &kfilter.k_states,
+                          smoother._tmpL2, &kfilter.k_states,
+                  &beta, smoother._tmp0, &kfilter.k_states)
+        blas.{{prefix}}gemm("T", "N", &model._k_states, &model._k_states, &model._k_states,
+                  &alpha, smoother._tmpL2, &kfilter.k_states,
+                          smoother._tmp0, &kfilter.k_states,
+                  &beta, smoother._scaled_smoothed_estimator_cov, &kfilter.k_states)
+        blas.{{prefix}}ger{{combined_suffix}}(&model._k_states, &model._k_states,
+            &alpha, &model._design[i], &model._k_endog,
+                    &kfilter._tmp3[i], &kfilter.k_endog,
+            smoother._scaled_smoothed_estimator_cov, &kfilter.k_states)
+
 
 cdef int {{prefix}}smoothed_estimators_time_univariate({{prefix}}KalmanSmoother smoother, {{prefix}}KalmanFilter kfilter, {{prefix}}Statespace model):
     cdef:

--- a/statsmodels/tsa/statespace/_smoothers/_univariate_diffuse.pyx.in
+++ b/statsmodels/tsa/statespace/_smoothers/_univariate_diffuse.pyx.in
@@ -162,6 +162,9 @@ cdef int {{prefix}}smoothed_estimators_measurement_univariate_diffuse({{prefix}}
                 kfilter._tmpL0[j + j*kfilter.k_states] = kfilter._tmpL0[j + j*kfilter.k_states] + 1
         else:
             kfilter.tmpK0[:] = 0
+            kfilter.tmpL0[:] = 0
+            for j in range(kfilter.k_states):
+                kfilter._tmpL0[j + j*kfilter.k_states] = 1
 
         # Cumulate L0 and L1
         blas.{{prefix}}copy(&kfilter.k_states2, smoother._tmpL, &inc, smoother._tmp0, &inc)

--- a/statsmodels/tsa/statespace/tests/test_multivariate_switch_univariate.py
+++ b/statsmodels/tsa/statespace/tests/test_multivariate_switch_univariate.py
@@ -1,0 +1,487 @@
+"""
+Tests for automatic switching of the filter method from multivariate to
+univariate when the forecast error covariance matrix is singular.
+
+Author: Chad Fulton
+License: Simplified-BSD
+
+References
+----------
+
+Kim, Chang-Jin, and Charles R. Nelson. 1999.
+"State-Space Models with Regime Switching:
+Classical and Gibbs-Sampling Approaches with Applications".
+MIT Press Books. The MIT Press.
+
+Hamilton, James D. 1994.
+Time Series Analysis.
+Princeton, N.J.: Princeton University Press.
+"""
+import numpy as np
+import pytest
+
+from statsmodels.tsa.statespace import (
+    mlemodel, sarimax, structural, varmax, dynamic_factor)
+from statsmodels.tsa.statespace.tests.test_impulse_responses import TVSS
+from numpy.testing import assert_allclose
+
+
+def get_model(univariate, missing=None, init=None):
+    if univariate:
+        endog = np.array([0.5, 1.2, -0.2, 0.3, -0.1, 0.4, 1.4, 0.9])
+
+        if missing == 'init':
+            endog[0:2] = np.nan
+        elif missing == 'mixed':
+            endog[2:4] = np.nan
+        elif missing == 'all':
+            endog[:] = np.nan
+
+        mod = mlemodel.MLEModel(endog, k_states=1, k_posdef=1)
+        mod['design', 0, 0] = 1.
+        mod['transition', 0, 0] = 0.5
+        mod['selection', 0, 0] = 1.
+        mod['state_cov', 0, 0] = 1.
+        mod['state_intercept', 0, 0] = 1.
+    else:
+        endog = np.array([[0.5, 1.2, -0.2, 0.3, -0.1, 0.4, 1.4, 0.9],
+                          [-0.2, -0.3, -0.1, 0.1, 0.01, 0.05, -0.13, -0.2]]).T
+
+        if missing == 'init':
+            endog[0:2, :] = np.nan
+        elif missing == 'mixed':
+            endog[2:4, 0] = np.nan
+            endog[3:6, 1] = np.nan
+        elif missing == 'all':
+            endog[:] = np.nan
+
+        mod = mlemodel.MLEModel(endog, k_states=3, k_posdef=2)
+        mod['obs_intercept'] = np.array([0.5, 0.2])
+        mod['design'] = np.array([[0.1, -0.1, 0],
+                                  [0.2, 0.3, 0]])
+        mod['obs_cov'] = np.array([[5, -0.2],
+                                   [-0.2, 3.]])
+
+        mod['transition', 0, 0] = 1
+        mod['transition', 1:, 1:] = np.array([[0.5, -0.1],
+                                              [1., 0.]])
+        mod['selection', :2, :2] = np.eye(2)
+        mod['state_cov'] = np.array([[1.2, 0.2],
+                                     [0.2, 2.5]])
+        mod['state_intercept', :2] = np.array([1., -1.])
+
+    if init == 'diffuse':
+        mod.ssm.initialize_diffuse()
+    elif init == 'approximate_diffuse':
+        mod.ssm.initialize_approximate_diffuse()
+    elif init == 'stationary':
+        mod.ssm.initialize_stationary()
+
+    return mod
+
+
+def check_filter_output(mod, periods, atol=0):
+    if isinstance(mod, mlemodel.MLEModel):
+        # Multivariate filter
+        res_mv = mod.ssm.filter()
+
+        # Manually perform filtering with a switch
+        mod.ssm.filter()
+        kfilter = mod.ssm._kalman_filter
+        kfilter.seek(0, True)
+        kfilter.univariate_filter[periods] = 1
+        for _ in range(mod.nobs):
+            next(kfilter)
+        # Create the results object
+        res_switch = mod.ssm.results_class(mod.ssm)
+        res_switch.update_representation(mod.ssm)
+        res_switch.update_filter(kfilter)
+
+        # Univariate filter
+        mod.ssm.filter_univariate = True
+        res_uv = mod.ssm.filter()
+    else:
+        res_mv, res_switch, res_uv = mod
+
+    # Test attributes that are the same regardless of the univariate or
+    # multivariate method
+    assert_allclose(res_switch.llf, res_mv.llf)
+    assert_allclose(res_switch.llf, res_uv.llf)
+    assert_allclose(res_switch.scale, res_mv.scale)
+    assert_allclose(res_switch.scale, res_uv.scale)
+
+    attrs = ['forecasts_error_diffuse_cov', 'predicted_state',
+             'predicted_state_cov', 'predicted_diffuse_state_cov',
+             'filtered_state', 'filtered_state_cov', 'llf_obs']
+    for attr in attrs:
+        attr_mv = getattr(res_mv, attr)
+        attr_uv = getattr(res_uv, attr)
+        attr_switch = getattr(res_switch, attr)
+        if attr_mv is None:
+            continue
+        assert_allclose(attr_switch, attr_mv, atol=atol)
+        assert_allclose(attr_switch, attr_uv, atol=atol)
+
+    # Test attributes that can differ for the univariate vs multivariate method
+    attrs = ['forecasts_error', 'forecasts_error_cov', 'kalman_gain']
+    for attr in attrs:
+        # Test all periods against the multivariate filter, except for periods
+        # that were switched (it's easiest to just set those values to zero)
+        actual = getattr(res_switch, attr).copy()
+        desired = getattr(res_mv, attr).copy()
+        actual[..., periods] = 0
+        desired[..., periods] = 0
+        assert_allclose(actual, desired, atol=atol)
+
+        # Test switched periods against the univariate filter
+        actual = getattr(res_switch, attr)[..., periods]
+        desired = getattr(res_uv, attr)[..., periods]
+        assert_allclose(actual, desired, atol=atol)
+
+
+def check_smoother_output(mod, periods, atol=1e-12):
+    if isinstance(mod, mlemodel.MLEModel):
+        # Multivariate filter / smoother
+        res_mv = mod.ssm.smooth()
+
+        # Manually perform filtering / smoothing with a switch
+        kfilter = mod.ssm._kalman_filter
+        kfilter.seek(0, True)
+        kfilter.univariate_filter[periods] = 1
+        for _ in range(mod.nobs):
+            next(kfilter)
+        # Create the results object
+        res_switch = mod.ssm.results_class(mod.ssm)
+        res_switch.update_representation(mod.ssm)
+        res_switch.update_filter(kfilter)
+        mod.ssm._kalman_smoother.reset(True)
+        smoother = mod.ssm._smooth()
+        res_switch.update_smoother(smoother)
+
+        # Univariate filter / smoother
+        mod.ssm.filter_univariate = True
+        res_uv = mod.ssm.smooth()
+    else:
+        res_mv, res_switch, res_uv = mod
+
+    # Test attributes that are the same regardless of the univariate or
+    # multivariate method
+    attrs = ['scaled_smoothed_estimator', 'scaled_smoothed_estimator_cov',
+             'smoothed_state', 'smoothed_state_cov', 'smoothed_state_autocov',
+             'smoothed_state_disturbance', 'smoothed_state_disturbance_cov',
+             'innovations_transition']
+    for attr in attrs:
+        attr_mv = getattr(res_mv, attr)
+        attr_uv = getattr(res_uv, attr)
+        attr_switch = getattr(res_switch, attr)
+        if attr_mv is None:
+            continue
+        assert_allclose(attr_uv, attr_mv, atol=atol)
+        assert_allclose(attr_switch, attr_mv, atol=atol)
+        assert_allclose(attr_switch, attr_uv, atol=atol)
+
+    # Test attributes that can differ for the univariate vs multivariate method
+    attrs = ['smoothing_error', 'smoothed_measurement_disturbance',
+             'smoothed_measurement_disturbance_cov']
+    for attr in attrs:
+        attr_mv = getattr(res_mv, attr)
+        attr_uv = getattr(res_uv, attr)
+        attr_switch = getattr(res_switch, attr)
+        if attr_mv is None:
+            continue
+
+        # Test all periods against the multivariate filter, except for periods
+        # that were switched (it's easiest to just set those values to zero)
+        actual = attr_switch.copy()
+        desired = attr_mv.copy()
+        actual[..., periods] = 0
+        desired[..., periods] = 0
+        assert_allclose(actual, desired)
+
+
+@pytest.mark.parametrize('missing', [None, 'init', 'mixed', 'all'])
+def test_basic(missing):
+    # Test that the multivariate filter switches to the univariate filter
+    # when it runs into problems
+    mod = get_model(univariate=True, missing=missing)
+
+    # Here, because of the known initialization with P_0 = [[0]], we will also
+    # have F_0 = 0.
+    # Then the Kalman filter gives P_0|0 = 0, and P_1 = Q = [[1.]]
+    # so that F_1 != 0, and the rest of the periods do not have a singular
+    # forecast error covariance matrix.
+    mod.initialize_known([0], [[0]])
+    mod.ssm.filter()
+    uf = np.array(mod.ssm._kalman_filter.univariate_filter)
+
+    # As a result, we expect that in the period t=0, we had to fall back to the
+    # univariate filter, while in the periods t >= 1, the multivariate filter
+    # works as usual.
+    # However, if the first period is missing (as in init and all), then we
+    # essentially skip the forecast error and forecast error cov computation.
+    # As a result, we don't need to switch to the univariate methods
+    if missing in ['init', 'all']:
+        assert_allclose(uf, 0)
+    else:
+        assert_allclose(uf[0], 1)
+        assert_allclose(uf[1:], 0)
+
+
+@pytest.mark.parametrize('univariate', [True, False])
+@pytest.mark.parametrize('missing', [None, 'init', 'mixed', 'all'])
+@pytest.mark.parametrize(
+    'init', ['stationary', 'diffuse', 'approximate_diffuse'])
+@pytest.mark.parametrize('periods', [np.s_[0], np.s_[4:6], np.s_[:]])
+def test_filter_output(univariate, missing, init, periods):
+    # Test the output when the multivariate filter switches to the univariate
+    # filter
+    mod = get_model(univariate, missing, init)
+    check_filter_output(mod, periods)
+
+
+@pytest.mark.parametrize('univariate', [True, False])
+@pytest.mark.parametrize('missing', [None, 'init', 'mixed', 'all'])
+@pytest.mark.parametrize('init',
+                         ['stationary', 'diffuse', 'approximate_diffuse'])
+@pytest.mark.parametrize('periods', [np.s_[0], np.s_[4:6], np.s_[:]])
+@pytest.mark.parametrize('option', [None, 'alternate_timing'])
+def test_smoother_output(univariate, missing, init, periods, option):
+    # Test the output when the multivariate filter switches to the univariate
+    # filter
+
+    mod = get_model(univariate, missing, init)
+    if option == 'alternate_timing':
+        # Can't use diffuse initialization with alternate timing
+        if init == 'diffuse':
+            return
+        mod.ssm.timing_init_filtered = True
+    atol = 1e-12
+    # Tolerance is lower for approximate diffuse for one attribute in this case
+    if missing == 'init' and init == 'approximate_diffuse':
+        atol = 1e-6
+    check_smoother_output(mod, periods, atol=atol)
+
+
+def test_invalid_options():
+    mod = get_model(univariate=True)
+    mod.initialize_known([0], [[0]])
+
+    mod.ssm.set_inversion_method(0, solve_lu=True)
+    msg = ('Singular forecast error covariance matrix detected, but'
+           ' multivariate filter cannot fall back to univariate'
+           ' filter when the inversion method is set to anything'
+           ' other than INVERT_UNIVARIATE or SOLVE_CHOLESKY.')
+    with pytest.raises(NotImplementedError, match=msg):
+        mod.ssm.filter()
+
+    mod = get_model(univariate=True)
+    mod.initialize_known([0], [[0]])
+    mod.ssm.smooth_classical = True
+    msg = ('Cannot use classical smoothing when the multivariate filter has'
+           ' fallen back to univariate filtering.')
+    with pytest.raises(NotImplementedError, match=msg):
+        mod.ssm.smooth()
+
+    mod = get_model(univariate=True)
+    mod.initialize_known([0], [[0]])
+    mod.ssm.smooth_alternative = True
+    msg = ('Cannot use alternative smoothing when the multivariate filter has'
+           ' fallen back to univariate filtering.')
+    with pytest.raises(NotImplementedError, match=msg):
+        mod.ssm.smooth()
+
+
+@pytest.mark.parametrize('missing', [None, 'init', 'mixed', 'all'])
+@pytest.mark.parametrize('periods', [np.s_[0], np.s_[4:6], np.s_[:]])
+@pytest.mark.parametrize('use_exact_diffuse', [False, True])
+def test_sarimax(missing, periods, use_exact_diffuse):
+    endog = np.array([0.5, 1.2, -0.2, 0.3, -0.1, 0.4, 1.4, 0.9])
+    exog = np.ones_like(endog)
+    if missing == 'init':
+        endog[0:2] = np.nan
+    elif missing == 'mixed':
+        endog[2:4] = np.nan
+    elif missing == 'all':
+        endog[:] = np.nan
+
+    mod = sarimax.SARIMAX(endog, order=(1, 1, 1), trend='t',
+                          seasonal_order=(1, 1, 1, 2), exog=exog,
+                          use_exact_diffuse=use_exact_diffuse)
+    mod.update([0.1, 0.3, 0.5, 0.2, 0.05, -0.1, 1.0])
+    check_filter_output(mod, periods, atol=1e-8)
+    check_smoother_output(mod, periods)
+
+
+@pytest.mark.parametrize('missing', [None, 'init', 'mixed', 'all'])
+@pytest.mark.parametrize('periods', [np.s_[0], np.s_[4:6], np.s_[:]])
+@pytest.mark.parametrize('use_exact_diffuse', [False, True])
+def test_unobserved_components(missing, periods, use_exact_diffuse):
+    endog = np.array([0.5, 1.2, -0.2, 0.3, -0.1, 0.4, 1.4, 0.9])
+    exog = np.ones_like(endog)
+    if missing == 'init':
+        endog[0:2] = np.nan
+    elif missing == 'mixed':
+        endog[2:4] = np.nan
+    elif missing == 'all':
+        endog[:] = np.nan
+
+    mod = structural.UnobservedComponents(
+        endog, 'llevel', exog=exog, seasonal=2, autoregressive=1,
+        use_exact_diffuse=use_exact_diffuse)
+    mod.update([1.0, 0.1, 0.3, 0.05, 0.15, 0.5])
+    check_filter_output(mod, periods)
+    check_smoother_output(mod, periods)
+
+
+@pytest.mark.parametrize('missing', [None, 'init', 'mixed', 'all'])
+@pytest.mark.parametrize('periods', [np.s_[0], np.s_[4:6], np.s_[:]])
+def test_varmax(missing, periods):
+    endog = np.array([[0.5, 1.2, -0.2, 0.3, -0.1, 0.4, 1.4, 0.9],
+                      [-0.2, -0.3, -0.1, 0.1, 0.01, 0.05, -0.13, -0.2]]).T
+    exog = np.ones_like(endog[:, 0])
+    if missing == 'init':
+        endog[0:2, :] = np.nan
+    elif missing == 'mixed':
+        endog[2:4, 0] = np.nan
+        endog[3:6, 1] = np.nan
+    elif missing == 'all':
+        endog[:] = np.nan
+
+    mod = varmax.VARMAX(endog, order=(1, 0), trend='t', exog=exog)
+    mod.update([0.1, -0.1, 0.5, 0.1, -0.05, 0.2, 0.4, 0.25, 1.2, 0.4, 2.3])
+    check_filter_output(mod, periods, atol=1e-12)
+    check_smoother_output(mod, periods)
+
+
+@pytest.mark.parametrize('missing', [None, 'init', 'mixed', 'all'])
+@pytest.mark.parametrize('periods', [np.s_[0], np.s_[4:6], np.s_[:]])
+def test_dynamic_factor(missing, periods):
+    endog = np.array([[0.5, 1.2, -0.2, 0.3, -0.1, 0.4, 1.4, 0.9],
+                      [-0.2, -0.3, -0.1, 0.1, 0.01, 0.05, -0.13, -0.2]]).T
+    exog = np.ones_like(endog[:, 0])
+    if missing == 'init':
+        endog[0:2, :] = np.nan
+    elif missing == 'mixed':
+        endog[2:4, 0] = np.nan
+        endog[3:6, 1] = np.nan
+    elif missing == 'all':
+        endog[:] = np.nan
+
+    mod = dynamic_factor.DynamicFactor(endog, k_factors=1, factor_order=2,
+                                       exog=exog)
+    mod.update([1.0, -0.5, 0.3, -0.1, 1.2, 2.3, 0.5, 0.1])
+    check_filter_output(mod, periods)
+    check_smoother_output(mod, periods)
+
+
+@pytest.mark.parametrize('missing', [None, 'mixed'])
+def test_simulation_smoothing(missing):
+    # Test that the simulation smoother works when the multivariate filter
+    # switches to the univariate filter when it runs into problems
+    # (see test_basic for a description of the model used here)
+
+    # Get the model where switching will occur
+    mod_switch = get_model(univariate=True, missing=missing)
+    mod_switch.initialize_known([0], [[0]])
+    sim_switch = mod_switch.simulation_smoother()
+
+    # Get the model where we have specified univariate filtering (so there is
+    # no need to switch)
+    mod_uv = get_model(univariate=True, missing=missing)
+    mod_uv.initialize_known([0], [[0]])
+    mod_uv.ssm.filter_univariate = True
+    sim_uv = mod_uv.simulation_smoother()
+
+    # Test for basic simulationg of a new observed series
+    np.random.seed(1234)
+    simulate_switch = mod_switch.simulate([], 10)
+    np.random.seed(1234)
+    simulate_uv = mod_uv.simulate([], 10)
+    assert_allclose(simulate_switch, simulate_uv)
+
+    # Perform simulation smoothing
+    np.random.seed(1234)
+    sim_switch.simulate()
+    np.random.seed(1234)
+    sim_uv.simulate()
+
+    # Make sure that switching happened in the first model but not the second
+    kfilter = sim_switch._simulation_smoother.simulated_kfilter
+    uf_switch = np.array(kfilter.univariate_filter, copy=True)
+    assert_allclose(uf_switch[0], 1)
+    assert_allclose(uf_switch[1:], 0)
+    kfilter = sim_uv._simulation_smoother.simulated_kfilter.univariate_filter
+    uf_uv = np.array(kfilter, copy=True)
+    assert_allclose(uf_uv, 1)
+    if missing == 'mixed':
+        kfilter = (sim_switch._simulation_smoother
+                             .secondary_simulated_kfilter.univariate_filter)
+        uf_switch = np.array(kfilter, copy=True)
+        assert_allclose(uf_switch[0], 1)
+        assert_allclose(uf_switch[1:], 0)
+        kfilter = (sim_uv._simulation_smoother
+                         .secondary_simulated_kfilter.univariate_filter)
+        uf_uv = np.array(kfilter, copy=True)
+        assert_allclose(uf_uv, 1)
+
+    # Test all simulation smoothing output
+    attrs = ['generated_measurement_disturbance',
+             'generated_state_disturbance', 'generated_obs', 'generated_state',
+             'simulated_state', 'simulated_measurement_disturbance',
+             'simulated_state_disturbance']
+    for attr in attrs:
+        assert_allclose(getattr(sim_switch, attr), getattr(sim_uv, attr))
+
+
+def test_time_varying_model(reset_randomstate):
+    endog = np.array([[0.5, 1.2, -0.2, 0.3, -0.1, 0.4, 1.4, 0.9],
+                      [-0.2, -0.3, -0.1, 0.1, 0.01, 0.05, -0.13, -0.2]]).T
+
+    # The basic model switches to the univariate method at observation 3,
+    # because the forecast error covariance matrix will have a singular
+    # component corresponding to the first endog variable
+    np.random.seed(1234)
+    mod_switch = TVSS(endog)
+    mod_switch['design', ..., 3] = 0
+    mod_switch['obs_cov', ..., 3] = 0
+    mod_switch['obs_cov', 1, 1, 3] = 1.
+    res_switch = mod_switch.ssm.smooth()
+    kfilter = mod_switch.ssm._kalman_filter
+    uf_switch = np.array(kfilter.univariate_filter, copy=True)
+
+    # Next, this model only uses the univariate method
+    np.random.seed(1234)
+    mod_uv = TVSS(endog)
+    mod_uv['design', ..., 3] = 0
+    mod_uv['obs_cov', ..., 3] = 0
+    mod_uv['obs_cov', 1, 1, 3] = 1.
+    mod_uv.ssm.filter_univariate = True
+    res_uv = mod_uv.ssm.smooth()
+    kfilter = mod_uv.ssm._kalman_filter
+    uf_uv = np.array(kfilter.univariate_filter, copy=True)
+
+    # Finally, this model uses the multivariate method and gets around the
+    # issue by setting the endog variable to NaN that would have contributed
+    # to the singular part of the forecast error covariance matrix
+    np.random.seed(1234)
+    endog_mv = endog.copy()
+    endog_mv[3, 0] = np.nan
+    mod_mv = TVSS(endog_mv)
+    mod_mv['design', ..., 3] = 0
+    mod_mv['obs_cov', ..., 3] = 0
+    mod_mv['obs_cov', 1, 1, 3] = 1.
+    res_mv = mod_mv.ssm.smooth()
+    kfilter = mod_mv.ssm._kalman_filter
+    uf_mv = np.array(kfilter.univariate_filter, copy=True)
+
+    # Make sure that switching happened in the switch model but not in the
+    # other two models
+    assert_allclose(uf_switch[:3], 0)
+    assert_allclose(uf_switch[3], 1)
+    assert_allclose(uf_switch[4:], 0)
+    assert_allclose(uf_uv, 1)
+    assert_allclose(uf_mv, 0)
+
+    # Check filter and smoother output
+    check_filter_output([res_mv, res_switch, res_uv], np.s_[3])
+    check_smoother_output([res_mv, res_switch, res_uv], np.s_[3])


### PR DESCRIPTION
- [x] tests added / passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message.

This PR does the following:

1. Improves the performance of the univariate smoother about 4x in the case of a large state vector.
2. Allows the multivariate filter / smoother to fall back to the univariate filter / smoother when the multivariate filter would fail (i.e. when the forecast error covariance matrix is singular)
3. Fixes a bug in the computation of the "innovation transition" matrix in the diffuse initialization case
4. Fixes a bug with the multivariate smoother in diffuse periods when all observations are missing.

Note that in models with a large number of `endog` variables (e.g. 100+) that also have a large state vector, the univariate smoother can be much slower than the multivariate smoother (e.g. 10x slower), even given the improvements in (1). That's why (2) is useful: it allows using the faster multivariate filter / smoother for all periods in which it can be used, and falls back to the slower univariate approach only for those periods that it is necessary.