### PR TITLE
Simulate correct number of observations #6748

### DIFF
--- a/statsmodels/tsa/vector_ar/var_model.py
+++ b/statsmodels/tsa/vector_ar/var_model.py
@@ -1609,7 +1609,7 @@ class VARResults(VARProcess):
         intercept = self.intercept
         nobs = self.nobs
         nobs_original = nobs + k_ar
-        
+
         ma_coll = np.zeros((repl, steps + 1, neqs, neqs))
 
         def fill_coll(sim):

--- a/statsmodels/tsa/vector_ar/var_model.py
+++ b/statsmodels/tsa/vector_ar/var_model.py
@@ -1608,7 +1608,8 @@ class VARResults(VARProcess):
         sigma_u = self.sigma_u
         intercept = self.intercept
         nobs = self.nobs
-
+        nobs_original = nobs + k_ar
+        
         ma_coll = np.zeros((repl, steps + 1, neqs, neqs))
 
         def fill_coll(sim):
@@ -1619,7 +1620,7 @@ class VARResults(VARProcess):
         for i in range(repl):
             # discard first burn to eliminate correct for starting bias
             sim = util.varsim(coefs, intercept, sigma_u,
-                              seed=seed, steps=nobs+burn)
+                              seed=seed, steps=nobs_original+burn)
             sim = sim[burn:]
             ma_coll[i, :, :, :] = fill_coll(sim)
 


### PR DESCRIPTION
`nobs` is # of observations without the initial observations (`k_ar`). The irf simulation should include initial observations (`nobs_original = nobs + k_ar`).

- [ ] closes #6748
- [ ] tests added / passed. 
- [ ] code/documentation is well formatted.  
- [ ] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
