### PR TITLE
BUG: Fix access to normal_reference_constant

### DIFF
--- a/statsmodels/nonparametric/bandwidths.py
+++ b/statsmodels/nonparametric/bandwidths.py
@@ -90,7 +90,7 @@ def bw_silverman(x, kernel=None):
     return .9 * A * n ** (-0.2)
 
 
-def bw_normal_reference(x, kernel=kernels.Gaussian):
+def bw_normal_reference(x, kernel=None):
     """
     Plug-in bandwidth with kernel specific constant based on normal reference.
 
@@ -104,6 +104,7 @@ def bw_normal_reference(x, kernel=kernels.Gaussian):
         Array for which to get the bandwidth
     kernel : CustomKernel object
         Used to calculate the constant for the plug-in bandwidth.
+        The default is a Gaussian kernel.
 
     Returns
     -------
@@ -128,6 +129,8 @@ def bw_normal_reference(x, kernel=kernels.Gaussian):
     Silverman, B.W. (1986) `Density Estimation.`
     Hansen, B.E. (2009) `Lecture Notes on Nonparametrics.`
     """
+    if kernel is None:
+        kernel = kernels.Gaussian()
     C = kernel.normal_reference_constant
     A = _select_sigma(x)
     n = len(x)

--- a/statsmodels/nonparametric/tests/test_bandwidths.py
+++ b/statsmodels/nonparametric/tests/test_bandwidths.py
@@ -12,6 +12,7 @@ from scipy import stats
 from statsmodels.sandbox.nonparametric import kernels
 from statsmodels.distributions.mixture_rvs import mixture_rvs
 from statsmodels.nonparametric.bandwidths import select_bandwidth
+from statsmodels.nonparametric.bandwidths import bw_normal_reference
 
 
 from numpy.testing import assert_allclose
@@ -39,6 +40,12 @@ class TestBandwidthCalculation(object):
             bw_calc[ii] = select_bandwidth(Xi, bw, kern)
 
         assert_allclose(bw_expected, bw_calc)
+
+    def test_calculate_normal_reference_bandwidth(self):
+        # Should be the same as the Gaussian Kernel
+        bw_expected = 0.29781147113698891
+        bw = bw_normal_reference(Xi)
+        assert_allclose(bw, bw_expected)
 
 
 class CheckNormalReferenceConstant(object):


### PR DESCRIPTION
kernel.normal_reference_constant is a property and it is only
accessible on an instantiated object. This commit enforces that
in the bw_normal_reference function.

- [ ] closes #xxxx
- [x] tests added / passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
