### PR TITLE
MAINT: Replace Warnings with Notes in regression summary

### DIFF
--- a/statsmodels/regression/linear_model.py
+++ b/statsmodels/regression/linear_model.py
@@ -2680,7 +2680,7 @@ class RegressionResults(base.LikelihoodModelResults):
         if etext:
             etext = ["[{0}] {1}".format(i + 1, text)
                      for i, text in enumerate(etext)]
-            etext.insert(0, "Warnings:")
+            etext.insert(0, "Notes:")
             smry.add_extra_txt(etext)
 
         return smry

--- a/statsmodels/regression/tests/test_regression.py
+++ b/statsmodels/regression/tests/test_regression.py
@@ -1015,7 +1015,7 @@ def test_summary_as_latex():
 %\\caption{OLS Regression Results}
 \\end{center}
 
-Warnings: \\newline
+Notes: \\newline
  [1] Standard Errors assume that the covariance matrix of the errors is correctly specified. \\newline
  [2] The condition number is large, 4.86e+09. This might indicate that there are \\newline
  strong multicollinearity or other numerical problems."""


### PR DESCRIPTION
Remove Warnings and lable them as notes

closes #6821

- [x] closes #xxxx
- [x] tests added / passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
