### PR TITLE
TST: stats moment_helpers use random state in unit test

### DIFF
--- a/statsmodels/stats/tests/test_moment_helpers.py
+++ b/statsmodels/stats/tests/test_moment_helpers.py
@@ -90,7 +90,7 @@ def test_moment_conversion(mom):
 
 
 rs = np.random.RandomState(12345)
-random_vals = np.random.randint(0, 100, 12).reshape(4, 3)
+random_vals = rs.randint(0, 100, 12).reshape(4, 3)
 multidimension_test_vals = [np.array([[5., 10., 1.],
                                       [5., 10., 1.],
                                       [5., 10., 1.],


### PR DESCRIPTION
see https://github.com/statsmodels/statsmodels/issues/6796#issuecomment-641463139

unit test defines random state instance but doesn't use it