### PR TITLE
MAINT: numpydoc should work now

### DIFF
--- a/tools/ci/docbuild_install.sh
+++ b/tools/ci/docbuild_install.sh
@@ -13,6 +13,3 @@ pip install sphinx sphinx-material jupyter nbconvert numpydoc pyyaml doctr panda
 # Add pymc3 and theano for statespace_sarimax_pymc3.
 echo conda install theano pymc3 -y
 conda install theano pymc3 -y
-
-# TODO: Remove after release of numpydoc 1.1.0
-pip install git+https://github.com/numpy/numpydoc.git --upgrade || true


### PR DESCRIPTION
- [X] closes #xxxx
- [X] tests added / passed. 
- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

Looks like they've pushed the new numpydoc to pypi.

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
