### PR TITLE
MAINT: Remove redundant definition

### DIFF
--- a/statsmodels/tsa/stattools.py
+++ b/statsmodels/tsa/stattools.py
@@ -60,13 +60,6 @@ __all__ = [
 SQRTEPS = np.sqrt(np.finfo(np.double).eps)
 
 
-# NOTE: now in two places to avoid circular import
-# TODO: I like the bunch pattern for this too.
-class ResultsStore(object):
-    def __str__(self):
-        return self._str  # pylint: disable=E1101
-
-
 def _autolag(
     mod,
     endog,
@@ -299,6 +292,8 @@ def adfuller(
     xdshort = xdiff[-nobs:]
 
     if store:
+        from statsmodels.stats.diagnostic import ResultsStore
+
         resstore = ResultsStore()
     if autolag:
         if regression != "nc":
@@ -1911,6 +1906,8 @@ look-up table. The actual p-value is {direction} than the p-value returned.
     crit_dict = {"10%": crit[0], "5%": crit[1], "2.5%": crit[2], "1%": crit[3]}
 
     if store:
+        from statsmodels.stats.diagnostic import ResultsStore
+
         rstore = ResultsStore()
         rstore.lags = nlags
         rstore.nobs = nobs


### PR DESCRIPTION
Remove redundant definition of ResultsStore in favor of better implementation

- [X] closes #4446
- [X] tests added / passed. 
- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
