### PR TITLE
BUG: Ensure PACF lag length is sensible

### DIFF
--- a/statsmodels/tsa/tests/test_stattools.py
+++ b/statsmodels/tsa/tests/test_stattools.py
@@ -1048,3 +1048,9 @@ def test_acf_conservate_nanops(reset_randomstate):
     for i in range(1, 10+1):
         expected[i] = np.nansum(resid[i:] * resid[:nobs-i]) / gamma0
     assert_allclose(result, expected, rtol=1e-4, atol=1e-4)
+
+
+def test_pacf_nlags_error(reset_randomstate):
+    e = np.random.standard_normal(100)
+    with pytest.raises(ValueError, match="Can only compute partial"):
+        pacf(e, 50)


### PR DESCRIPTION
Limit lag length to 50% of the same to ensure that the autocovariance
matrix may be positive definite

closes #4663

- [X] closes #4663
- [X] tests added / passed. 
- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
