### PR TITLE
BUG: Allow Series as exog in predict

### DIFF
--- a/statsmodels/formula/tests/test_formula.py
+++ b/statsmodels/formula/tests/test_formula.py
@@ -233,3 +233,14 @@ def test_formula_environment():
     assert 'z' in model.exog_names
     with pytest.raises(TypeError):
         ols('y ~ x', eval_env='env', data=df)
+
+
+def test_formula_predict_series_exog():
+    # GH-6509
+    x = np.random.standard_normal((1000, 2))
+    data_full = pd.DataFrame(x, columns=["y", "x"])
+    data = data_full.iloc[:500]
+    res = ols(formula='y ~ x', data=data).fit()
+    oos = data_full.iloc[500:]["x"]
+    prediction = res.get_prediction(oos)
+    assert prediction.predicted_mean.shape[0] == 500

--- a/statsmodels/genmod/_prediction.py
+++ b/statsmodels/genmod/_prediction.py
@@ -9,7 +9,7 @@ License: BSD-3
 
 import numpy as np
 from scipy import stats
-
+import pandas as pd
 
 # this is similar to ContrastResults after t_test, partially copied and adjusted
 class PredictionResults(object):
@@ -122,7 +122,6 @@ class PredictionResults(object):
     def summary_frame(self, alpha=0.05):
         """Summary frame"""
         # TODO: finish and cleanup
-        import pandas as pd
         #ci_obs = self.conf_int(alpha=alpha, obs=True) # need to split
         ci_mean = self.conf_int(alpha=alpha)
         to_include = {}
@@ -178,8 +177,9 @@ def get_prediction_glm(self, exog=None, transform=True, weights=None,
     # prepare exog and row_labels, based on base Results.predict
     if transform and hasattr(self.model, 'formula') and exog is not None:
         from patsy import dmatrix
-        exog = dmatrix(self.model.data.design_info,
-                       exog)
+        if isinstance(exog, pd.Series):
+            exog = pd.DataFrame(exog)
+        exog = dmatrix(self.model.data.design_info, exog)
 
     if exog is not None:
         if row_labels is None:

--- a/statsmodels/regression/_prediction.py
+++ b/statsmodels/regression/_prediction.py
@@ -9,6 +9,7 @@ License: BSD-3
 
 import numpy as np
 from scipy import stats
+import pandas as pd
 
 
 # this is similar to ContrastResults after t_test, copied and adjusted
@@ -88,7 +89,6 @@ class PredictionResults(object):
 
     def summary_frame(self, alpha=0.05):
         # TODO: finish and cleanup
-        import pandas as pd
         ci_obs = self.conf_int(alpha=alpha, obs=True)  # need to split
         ci_mean = self.conf_int(alpha=alpha, obs=False)
         to_include = {}
@@ -145,6 +145,9 @@ def get_prediction(self, exog=None, transform=True, weights=None,
     # prepare exog and row_labels, based on base Results.predict
     if transform and hasattr(self.model, 'formula') and exog is not None:
         from patsy import dmatrix
+        if isinstance(exog, pd.Series):
+            # GH-6509
+            exog = pd.DataFrame(exog)
         exog = dmatrix(self.model.data.design_info, exog)
 
     if exog is not None:


### PR DESCRIPTION
ALlow Series to be used as exog in predict

closes #6509

- [X] closes #6509
- [X] tests added / passed. 
- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
