### PR TITLE
Updated durbin_watson Docstring and Tests

### DIFF
--- a/statsmodels/stats/stattools.py
+++ b/statsmodels/stats/stattools.py
@@ -11,14 +11,17 @@ import numpy as np
 from statsmodels.tools.sm_exceptions import ValueWarning
 
 
-# TODO: these are pretty straightforward but they should be tested
 def durbin_watson(resids, axis=0):
     r"""
-    Calculates the Durbin-Watson statistic
+    Calculates the Durbin-Watson statistic.
 
     Parameters
     ----------
     resids : array_like
+        Data for which to compute the Durbin-Watson statistic. Usually
+        regression model residuals.
+    axis : int, optional
+        Axis to use if data has more than 1 dimension. Default is 0.
 
     Returns
     -------
@@ -27,8 +30,9 @@ def durbin_watson(resids, axis=0):
 
     Notes
     -----
-    The null hypothesis of the test is that there is no serial correlation.
-    The Durbin-Watson test statistics is defined as:
+    The null hypothesis of the test is that there is no serial correlation
+    in the residuals.
+    The Durbin-Watson test statistic is defined as:
 
     .. math::
 

--- a/statsmodels/stats/tests/test_statstools.py
+++ b/statsmodels/stats/tests/test_statstools.py
@@ -44,6 +44,11 @@ def test_durbin_watson():
     st_R = 0.921488912587806
     assert_almost_equal(durbin_watson(x[1:] + 0.9 * x[:-1]), st_R, 14)
 
+    X = np.array([x, x])
+    st_R = 1.95298958377419
+    assert_almost_equal(durbin_watson(X, axis=1), np.array([st_R, st_R]), 14)
+    assert_almost_equal(durbin_watson(X.T, axis=0), np.array([st_R, st_R]), 14)
+
 
 def test_omni_normtest():
     #tests against R fBasics


### PR DESCRIPTION
Tests for the function durbin_watson function in stats/stattools.py already exist in the stats/tests folder, so I removed the TODO asking for this. Also added new tests which test the function when the input array is multi-dimensional. Also cleaned up the docstring of the function a little.

Note: when updating the docstring, e.g. when adding information on the 'axis' parameter (which was not previously there), I have chosen to be consistent with the jarque_bera function in the same module.

This is my first statsmodels PR. Please let me know if I need to edit anything :).

- [ ] closes #xxxx
- [ ] tests added / passed. 
- [ ] code/documentation is well formatted.  
- [ ] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
