### PR TITLE
TST: Relax tolerance on test that fils Win32

### DIFF
--- a/statsmodels/tsa/arima/tests/test_model.py
+++ b/statsmodels/tsa/arima/tests/test_model.py
@@ -9,6 +9,7 @@ estimators' test functions.
 Author: Chad Fulton
 License: BSD-3
 """
+from statsmodels.compat.platform import PLATFORM_WIN32
 
 import numpy as np
 import pandas as pd
@@ -156,8 +157,9 @@ def test_statespace():
                               include_constant=False)
     mod = ARIMA(endog, order=(1, 0, 1), trend='n')
     res = mod.fit(method='statespace')
-    # Note: atol is required only due to precision issues on Windows
-    assert_allclose(res.params, desired_p.params, atol=1e-4)
+    # Note: tol changes required due to precision issues on Windows
+    rtol = 1e-7 if not PLATFORM_WIN32 else 1e-3
+    assert_allclose(res.params, desired_p.params, rtol=rtol, atol=1e-4)
 
     # ARMA(1, 2), with trend
     desired_p, _ = statespace(endog, order=(1, 0, 2),

--- a/statsmodels/tsa/tests/test_arima.py
+++ b/statsmodels/tsa/tests/test_arima.py
@@ -2230,7 +2230,9 @@ def test_arima111_predict_exog_2127():
     ue = np.array(ue) / 100
     model = ARIMA(ef, (1, 1, 1), exog=ue)
     res = model.fit(transparams=False, pgtol=1e-8, iprint=0, disp=0)
-    assert_equal(res.mle_retvals['warnflag'], 0)
+    if not PLATFORM_WIN32:
+        # Random failures on Win32
+        assert_equal(res.mle_retvals['warnflag'], 0)
     predicts = res.predict(start=len(ef), end=len(ef) + 10,
                            exog=ue[-11:], typ='levels')
 
@@ -2342,7 +2344,7 @@ def test_arima_exog_predict():
 
     # Relax tolerance on OSX due to frequent small failures
     # GH 4657
-    tol = 1e-3 if PLATFORM_OSX or PLATFORM_WIN else 1e-4
+    tol = 1e-2 if PLATFORM_OSX or PLATFORM_WIN else 1e-4
     assert_allclose(predicted_arma_dp,
                     res_d101[-len(predicted_arma_d):], rtol=tol, atol=tol)
     assert_allclose(predicted_arma_fp,


### PR DESCRIPTION
Relax tolerance on test that occasionally fails

- [x] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
