### PR TITLE
BUG: Raise on nonstationary parameters when attempting to use GLS

### DIFF
--- a/statsmodels/tsa/arima/estimators/gls.py
+++ b/statsmodels/tsa/arima/estimators/gls.py
@@ -240,6 +240,16 @@ def gls(endog, exog=None, order=(0, 0, 0), seasonal_order=(0, 0, 0, 0),
         # argument applies a Prais-Winsten-type normalization to the first few
         # observations to ensure homoskedasticity). Brockwell and Davis
         # mention that they also take this approach in practice.
+
+        # GH-6540: AR must be stationary
+
+        if not p_arma.is_stationary:
+            raise ValueError(
+                "Roots of the autoregressive parameters indicate that data is"
+                "non-stationary. GLS cannot be used with non-stationary "
+                "parameters. You should consider differencing the model data"
+                "or applying a nonlinear transformation (e.g., natural log)."
+            )
         tmp, _ = arma_innovations.arma_innovations(
             augmented, ar_params=ar_params, ma_params=ma_params,
             normalize=True)

--- a/statsmodels/tsa/arima/tests/test_model.py
+++ b/statsmodels/tsa/arima/tests/test_model.py
@@ -11,8 +11,11 @@ License: BSD-3
 """
 from statsmodels.compat.platform import PLATFORM_WIN32
 
+import io
+
 import numpy as np
 import pandas as pd
+import pytest
 
 from numpy.testing import assert_equal, assert_allclose, assert_raises, assert_
 
@@ -282,3 +285,41 @@ def test_cov_type_none():
     mod = ARIMA(endog[:50], trend='c')
     res = mod.fit(cov_type='none')
     assert_allclose(res.cov_params(), np.nan)
+
+
+def test_nonstationary_gls_error():
+    # GH-6540
+    endog = pd.read_csv(
+        io.StringIO(
+            """\
+data\n
+9.112\n9.102\n9.103\n9.099\n9.094\n9.090\n9.108\n9.088\n9.091\n9.083\n9.095\n
+9.090\n9.098\n9.093\n9.087\n9.088\n9.083\n9.095\n9.077\n9.082\n9.082\n9.081\n
+9.081\n9.079\n9.088\n9.096\n9.081\n9.098\n9.081\n9.094\n9.091\n9.095\n9.097\n
+9.108\n9.104\n9.098\n9.085\n9.093\n9.094\n9.092\n9.093\n9.106\n9.097\n9.108\n
+9.100\n9.106\n9.114\n9.111\n9.097\n9.099\n9.108\n9.108\n9.110\n9.101\n9.111\n
+9.114\n9.111\n9.126\n9.124\n9.112\n9.120\n9.142\n9.136\n9.131\n9.106\n9.112\n
+9.119\n9.125\n9.123\n9.138\n9.133\n9.133\n9.137\n9.133\n9.138\n9.136\n9.128\n
+9.127\n9.143\n9.128\n9.135\n9.133\n9.131\n9.136\n9.120\n9.127\n9.130\n9.116\n
+9.132\n9.128\n9.119\n9.119\n9.110\n9.132\n9.130\n9.124\n9.130\n9.135\n9.135\n
+9.119\n9.119\n9.136\n9.126\n9.122\n9.119\n9.123\n9.121\n9.130\n9.121\n9.119\n
+9.106\n9.118\n9.124\n9.121\n9.127\n9.113\n9.118\n9.103\n9.112\n9.110\n9.111\n
+9.108\n9.113\n9.117\n9.111\n9.100\n9.106\n9.109\n9.113\n9.110\n9.101\n9.113\n
+9.111\n9.101\n9.097\n9.102\n9.100\n9.110\n9.110\n9.096\n9.095\n9.090\n9.104\n
+9.097\n9.099\n9.095\n9.096\n9.085\n9.097\n9.098\n9.090\n9.080\n9.093\n9.085\n
+9.075\n9.067\n9.072\n9.062\n9.068\n9.053\n9.051\n9.049\n9.052\n9.059\n9.070\n
+9.058\n9.074\n9.063\n9.057\n9.062\n9.058\n9.049\n9.047\n9.062\n9.052\n9.052\n
+9.044\n9.060\n9.062\n9.055\n9.058\n9.054\n9.044\n9.047\n9.050\n9.048\n9.041\n
+9.055\n9.051\n9.028\n9.030\n9.029\n9.027\n9.016\n9.023\n9.031\n9.042\n9.035\n
+"""
+        ),
+        index_col=None,
+    )
+    mod = ARIMA(
+        endog,
+        order=(18, 0, 39),
+        enforce_stationarity=False,
+        enforce_invertibility=False,
+    )
+    with pytest.raises(ValueError, match="Roots of the autoregressive"):
+        mod.fit(method="hannan_rissanen", low_memory=True, cov_type="none")

--- a/statsmodels/tsa/innovations/tests/test_arma_innovations.py
+++ b/statsmodels/tsa/innovations/tests/test_arma_innovations.py
@@ -42,3 +42,11 @@ def test_innovations_algo_filter_kalman_filter(ar_params, ma_params, sigma2):
     # Note: the tolerance on the two gets worse as more nobs are added
     assert_allclose(score, mod.score(params), atol=1e-5)
     assert_allclose(score_obs, mod.score_obs(params), atol=1e-5)
+
+
+@pytest.mark.parametrize("ar_params", ([1.9, -0.8], [1.0], [2.0, -1.0]))
+def test_innovations_nonstationary(ar_params):
+    np.random.seed(42)
+    endog = np.random.normal(size=100)
+    with pytest.raises(ValueError, match="The model's autoregressive"):
+        arma_innovations.arma_innovations(endog, ar_params=ar_params)


### PR DESCRIPTION
closes #6540

- [X] closes #6540
- [X] tests added / passed. 
- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
