### PR TITLE
BUG: Fix indexing with HoltWinters's forecast

### DIFF
--- a/statsmodels/tsa/tests/test_holtwinters.py
+++ b/statsmodels/tsa/tests/test_holtwinters.py
@@ -879,3 +879,14 @@ def test_simulate_boxcox(austourists):
     mean = np.mean(res, axis=1)
 
     assert np.all(np.abs(mean - expected) < 5)
+
+
+@pytest.mark.parametrize("ix", [10, 100, 1000, 2000])
+def test_forecast_index(ix):
+    # GH 6549
+    ts_1 = pd.Series([85601, 89662, 85122, 84400, 78250, 84434, 71072, 70357, 72635, 73210],
+                     index=range(ix, ix + 10))
+    model = ExponentialSmoothing(ts_1, trend='add', damped=False).fit()
+    index = model.forecast(steps=10).index
+    assert index[0] == ix + 10
+    assert index[-1] == ix + 19


### PR DESCRIPTION
Fix index when using int indices

closes #6549

- [ ] closes #xxxx
- [ ] tests added / passed. 
- [ ] code/documentation is well formatted.  
- [ ] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
