### PR TITLE
MAINT: Allow skip if rdataset fails

### DIFF
--- a/statsmodels/stats/tests/test_dist_dependant_measures.py
+++ b/statsmodels/stats/tests/test_dist_dependant_measures.py
@@ -1,9 +1,10 @@
 import numpy as np
 from numpy.testing import assert_almost_equal
-from pytest import raises as assert_raises, warns as assert_warns
+import pytest
 
-import statsmodels.stats.dist_dependence_measures as ddm
+from statsmodels.datasets.tests.test_utils import IGNORED_EXCEPTIONS
 from statsmodels.datasets import get_rdataset
+import statsmodels.stats.dist_dependence_measures as ddm
 
 
 class TestDistDependenceMeasures(object):
@@ -57,11 +58,11 @@ class TestDistDependenceMeasures(object):
         cls.pval_asym_exp = 0.00452
 
     def test_input_validation_nobs(self):
-        with assert_raises(ValueError, match="same number of observations"):
+        with pytest.raises(ValueError, match="same number of observations"):
             ddm.distance_covariance_test(self.x[:2, :], self.y)
 
     def test_input_validation_unknown_method(self):
-        with assert_raises(ValueError, match="Unknown 'method' parameter"):
+        with pytest.raises(ValueError, match="Unknown 'method' parameter"):
             ddm.distance_covariance_test(self.x, self.y, method="wrong_name")
 
     def test_statistic_value_asym_method(self):
@@ -82,7 +83,7 @@ class TestDistDependenceMeasures(object):
 
     def test_fallback_to_asym_method(self):
         match_text = "The asymptotic approximation will be used"
-        with assert_warns(UserWarning, match=match_text):
+        with pytest.warns(UserWarning, match=match_text):
             statistic, pval, _ = ddm.distance_covariance_test(
                 self.x, self.y, method="emp", B=200
             )
@@ -131,7 +132,11 @@ class TestDistDependenceMeasures(object):
              dCov
         0.1025087
         """
-        iris = get_rdataset("iris").data.values[:, :4]
+        try:
+            iris = get_rdataset("iris").data.values[:, :4]
+        except IGNORED_EXCEPTIONS:
+            pytest.skip('Failed with HTTPError or URLError, these are random')
+
         x = iris[:50]
         y = iris[50:100]
 
@@ -167,7 +172,11 @@ class TestDistDependenceMeasures(object):
             dCov
         30.01526
         """
-        quakes = get_rdataset("quakes").data.values[:, :3]
+        try:
+            quakes = get_rdataset("quakes").data.values[:, :3]
+        except IGNORED_EXCEPTIONS:
+            pytest.skip('Failed with HTTPError or URLError, these are random')
+
         x = quakes[:50]
         y = quakes[50:100]
 


### PR DESCRIPTION
Allow test ot be skipped when data is not available

- [ ] closes #xxxx
- [ ] tests added / passed. 
- [ ] code/documentation is well formatted.  
- [ ] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
