### PR TITLE
BUG: fix raise exception on granger causality test

### DIFF
--- a/statsmodels/tsa/stattools.py
+++ b/statsmodels/tsa/stattools.py
@@ -1336,18 +1336,17 @@ def grangercausalitytests(x, maxlag, addconst=True, verbose=True):
     addconst = bool_like(addconst, "addconst")
     verbose = bool_like(verbose, "verbose")
     try:
+        maxlag = int_like(maxlag, "maxlag")
+        if maxlag <= 0:
+            raise ValueError("maxlag must a a positive integer")
+        lags = np.arange(1, maxlag + 1)
+    except TypeError:
         lags = np.array([int(lag) for lag in maxlag])
         maxlag = lags.max()
         if lags.min() <= 0 or lags.size == 0:
             raise ValueError(
                 "maxlag must be a non-empty list containing only "
-                "positive integers"
-            )
-    except Exception:
-        maxlag = int_like(maxlag, "maxlag")
-        if maxlag <= 0:
-            raise ValueError("maxlag must a a positive integer")
-        lags = np.arange(1, maxlag + 1)
+                "positive integers")
 
     if x.shape[0] <= 3 * maxlag + int(addconst):
         raise ValueError(

--- a/statsmodels/tsa/tests/test_stattools.py
+++ b/statsmodels/tsa/tests/test_stattools.py
@@ -481,6 +481,13 @@ class TestGrangerCausality(object):
         with pytest.raises(ValueError, match="x contains NaN"):
             grangercausalitytests(x, 2)
 
+    def test_granger_fails_on_zero_lag(self, reset_randomstate):
+        x = np.random.rand(1000, 2)
+        with pytest.raises(
+                ValueError,
+                match="maxlag must be a non-empty list containing only positive integers"):
+            grangercausalitytests(x, [0, 1, 2])
+
 
 class TestKPSS:
     """


### PR DESCRIPTION
Issue #6876: Fix for the appropriate behavior when passing a list
containing a zero lag to `maxlag` (e.g. `[0, 1, 2]`), now it raises
`ValueError`

- [x] closes #6876
- [ ] tests added / passed.
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
