### PR TITLE
BUG: Correct dimension when data removed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ matrix:
         - PYTHON=3.7
         - PANDAS=0.25
         - NUMPY=1.17
-        - SCIPY=1.3
+        - SCIPY=1.4
         - COVERAGE=true
         - PYTEST_OPTIONS=
     # Python 3.6 + legacy blas + older pandas
@@ -66,7 +66,7 @@ matrix:
         - PYTHON=3.6
         - NUMPY=1.16
         - PANDAS=0.24
-        - SCIPY=1.2
+        - SCIPY=1.3
         - BLAS="nomkl blas=*=openblas"
         - COVERAGE=true
         - PYTEST_OPTIONS=
@@ -75,7 +75,7 @@ matrix:
       env:
         - PYTHON=3.6
         - NUMPY=1.15
-        - SCIPY=1.1
+        - SCIPY=1.2
         - PANDAS=0.23
         - MATPLOTLIB=2
         - LINT=true

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -132,7 +132,7 @@ The current minimum dependencies are:
 
 * `Python <https://www.python.org>`__ >= 3.6
 * `NumPy <https://www.scipy.org/>`__ >= 1.15
-* `SciPy <https://www.scipy.org/>`__ >= 1.1
+* `SciPy <https://www.scipy.org/>`__ >= 1.2
 * `Pandas <https://pandas.pydata.org/>`__ >= 0.23
 * `Patsy <https://patsy.readthedocs.io/en/latest/>`__ >= 0.5.1
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,5 +6,5 @@ requires = [
     "numpy==1.15.4; python_version=='3.6'",
     "numpy==1.15.4; python_version=='3.7'",
     "numpy==1.17.5; python_version>='3.8'",
-    "scipy>=1.1",
+    "scipy>=1.2",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 numpy>=1.15
-scipy>=1.1
+scipy>=1.2
 pandas>=0.23
 patsy>=0.5.1

--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -988,6 +988,8 @@ class Results(object):
         self.__dict__.update(kwd)
         self.initialize(model, params, **kwd)
         self._data_attr = []
+        # Variables to clear from cache
+        self._data_in_cache = ['fittedvalues', 'resid', 'wresid']
 
     def initialize(self, model, params, **kwargs):
         """
@@ -2191,8 +2193,8 @@ class LikelihoodModelResults(Results):
         model._data_attr : arrays attached to both the model instance
             and the results instance with the same attribute name.
 
-        result.data_in_cache : arrays that may exist as values in
-            result._cache (TODO : should privatize name)
+        result._data_in_cache : arrays that may exist as values in
+            result._cache
 
         result._data_attr_model : arrays attached to the model
             instance but not to the results instance
@@ -2239,9 +2241,7 @@ class LikelihoodModelResults(Results):
                 continue
             wipe(self, att)
 
-        data_in_cache = getattr(self, 'data_in_cache', [])
-        data_in_cache += ['fittedvalues', 'resid', 'wresid']
-        for key in data_in_cache:
+        for key in self._data_in_cache:
             try:
                 self._cache[key] = None
             except (AttributeError, KeyError):

--- a/statsmodels/genmod/generalized_linear_model.py
+++ b/statsmodels/genmod/generalized_linear_model.py
@@ -1463,8 +1463,7 @@ class GLMResults(base.LikelihoodModelResults):
         # for remove data and pickle without large arrays
         self._data_attr.extend(['results_constrained', '_freq_weights',
                                 '_var_weights', '_iweights'])
-        self.data_in_cache = getattr(self, 'data_in_cache', [])
-        self.data_in_cache.extend(['null', 'mu'])
+        self._data_in_cache.extend(['null', 'mu'])
         self._data_attr_model = getattr(self, '_data_attr_model', [])
         self._data_attr_model.append('mu')
 

--- a/statsmodels/regression/_prediction.py
+++ b/statsmodels/regression/_prediction.py
@@ -157,10 +157,12 @@ def get_prediction(self, exog=None, transform=True, weights=None,
                 row_labels = None
 
         exog = np.asarray(exog)
-        if exog.ndim == 1 and (self.model.exog is None or
-                               self.model.exog.ndim == 1 or
-                               self.model.exog.shape[1] == 1):
-            exog = exog[:, None]
+        if exog.ndim == 1:
+            # Params informs whether a row or column vector
+            if self.params.shape[0] > 1:
+                exog = exog[None, :]
+            else:
+                exog = exog[:, None]
         exog = np.atleast_2d(exog)  # needed in count model shape[1]
     else:
         exog = self.model.exog

--- a/statsmodels/regression/_prediction.py
+++ b/statsmodels/regression/_prediction.py
@@ -157,7 +157,8 @@ def get_prediction(self, exog=None, transform=True, weights=None,
                 row_labels = None
 
         exog = np.asarray(exog)
-        if exog.ndim == 1 and (self.model.exog.ndim == 1 or
+        if exog.ndim == 1 and (self.model.exog is None or
+                               self.model.exog.ndim == 1 or
                                self.model.exog.shape[1] == 1):
             exog = exog[:, None]
         exog = np.atleast_2d(exog)  # needed in count model shape[1]

--- a/statsmodels/regression/linear_model.py
+++ b/statsmodels/regression/linear_model.py
@@ -188,7 +188,7 @@ class RegressionModel(base.LikelihoodModel):
     """
     def __init__(self, endog, exog, **kwargs):
         super(RegressionModel, self).__init__(endog, exog, **kwargs)
-        self._data_attr.extend(['pinv_wexog', 'wendog', 'wexog', 'weights'])
+        self._data_attr.extend(['pinv_wexog', 'weights'])
 
     def initialize(self):
         """Initialize model components."""
@@ -1554,6 +1554,8 @@ class RegressionResults(base.LikelihoodModelResults):
         super(RegressionResults, self).__init__(
             model, params, normalized_cov_params, scale)
 
+        # Keep wresid since needed by predict
+        self._data_in_cache.remove("wresid")
         self._cache = {}
         if hasattr(model, 'wexog_singular_values'):
             self._wexog_singular_values = model.wexog_singular_values

--- a/statsmodels/regression/rolling.py
+++ b/statsmodels/regression/rolling.py
@@ -473,6 +473,7 @@ class RollingRegressionResults(object):
     cov_type : str
         Name of covariance estimator
     """
+    _data_in_cache = tuple()
 
     def __init__(
         self, model, store: RollingStore, k_constant, use_t, cov_type

--- a/statsmodels/regression/tests/test_predict.py
+++ b/statsmodels/regression/tests/test_predict.py
@@ -8,6 +8,7 @@ author: Josef Perktold
 
 import numpy as np
 from numpy.testing import assert_allclose, assert_equal
+import pandas as pd
 
 from statsmodels.regression.linear_model import OLS, WLS
 from statsmodels.sandbox.regression.predstd import wls_prediction_std
@@ -132,7 +133,6 @@ class TestWLSPrediction(object):
         mod_wls = WLS(y, X, weights=1./w)
         cls.res_wls = mod_wls.fit()
 
-
     def test_ci(self):
         res_wls = self.res_wls
         prstd, iv_l, iv_u = wls_prediction_std(res_wls)
@@ -159,7 +159,7 @@ class TestWLSPrediction(object):
 
         # check that list works, issue 4437
         x = res_wls.model.exog.mean(0)
-        pred_res3 = res_wls.get_prediction(x)
+        pred_res3 = res_wls.get_prediction([x])
         ci3 = pred_res3.conf_int(obs=True)
         pred_res3b = res_wls.get_prediction(x.tolist())
         ci3b = pred_res3b.conf_int(obs=True)
@@ -265,9 +265,10 @@ def test_predict_remove_data():
     endog = [i + np.random.normal(scale=0.1) for i in range(100)]
     exog = [i for i in range(100)]
     model = OLS(endog, exog, weights=[1 for _ in range(100)]).fit()
-    model.get_prediction(1)
     model.remove_data()
-    # works fine
     scalar = model.get_prediction(1).predicted_mean
     one_d = model.get_prediction([1]).predicted_mean
     assert_allclose(scalar, one_d)
+
+    series = model.get_prediction(pd.Series([1])).predicted_mean
+    assert_allclose(scalar, series)

--- a/statsmodels/regression/tests/test_predict.py
+++ b/statsmodels/regression/tests/test_predict.py
@@ -258,3 +258,16 @@ class TestWLSPrediction(object):
         assert_allclose(ci3b, ci3, rtol=1e-13)
         res_df = pred_res3b.summary_frame()
         assert_equal(res_df.index.values, [0, 1])
+
+
+def test_predict_remove_data():
+    # GH6887
+    endog = [i + np.random.normal(scale=0.1) for i in range(100)]
+    exog = [i for i in range(100)]
+    model = OLS(endog, exog, weights=[1 for _ in range(100)]).fit()
+    model.get_prediction(1)
+    model.remove_data()
+    # works fine
+    scalar = model.get_prediction(1).predicted_mean
+    one_d = model.get_prediction([1]).predicted_mean
+    assert_allclose(scalar, one_d)

--- a/statsmodels/robust/robust_linear_model.py
+++ b/statsmodels/robust/robust_linear_model.py
@@ -407,7 +407,7 @@ class RLMResults(base.LikelihoodModelResults):
         self.nobs = model.nobs
         self._cache = {}
         # for remove_data
-        self.data_in_cache = ['sresid']
+        self._data_in_cache.extend(['sresid'])
 
         self.cov_params_default = self.bcov_scaled
         # TODO: "pvals" should come from chisq on bse?

--- a/statsmodels/stats/contingency_tables.py
+++ b/statsmodels/stats/contingency_tables.py
@@ -1333,7 +1333,7 @@ def mcnemar(table, exact=True, correction=True):
     if exact:
         statistic = np.minimum(n1, n2)
         # binom is symmetric with p=0.5
-        # SciPy 1.7+ required int arguments
+        # SciPy 1.7+ requires int arguments
         int_sum = int(n1 + n2)
         if int_sum != (n1 + n2):
             warnings.warn("exact can only be used with tables containing "

--- a/statsmodels/tests/test_package.py
+++ b/statsmodels/tests/test_package.py
@@ -1,10 +1,6 @@
 import subprocess
 import sys
 
-import pytest
-
-from statsmodels.compat.scipy import SCIPY_11
-
 
 def test_lazy_imports():
     # Check that when statsmodels.api is imported, matplotlib is _not_ imported
@@ -19,7 +15,6 @@ def test_lazy_imports():
     assert rc == 0
 
 
-@pytest.mark.skipif(SCIPY_11, reason='SciPy raises on -OO')
 def test_docstring_optimization_compat():
     # GH#5235 check that importing with stripped docstrings does not raise
     cmd = sys.executable + ' -OO -c "import statsmodels.api as sm"'

--- a/statsmodels/tsa/exponential_smoothing/initialization.py
+++ b/statsmodels/tsa/exponential_smoothing/initialization.py
@@ -46,7 +46,7 @@ def _initialization_heuristic(endog, trend=False, seasonal=False,
 
     # Seasonal component
     initial_seasonal = None
-    if seasonal is not None:
+    if seasonal:
         # Calculate the number of full cycles to use
         if nobs < 2 * seasonal_periods:
             raise ValueError('Cannot compute initial seasonals using'

--- a/statsmodels/tsa/statespace/mlemodel.py
+++ b/statsmodels/tsa/statespace/mlemodel.py
@@ -2417,8 +2417,6 @@ class MLEResults(tsbase.TimeSeriesModelResults):
         self._data_attr_model.extend(['ssm'])
         self._data_attr.extend(extra_arrays)
         self._data_attr.extend(['filter_results', 'smoother_results'])
-        self.data_in_cache = getattr(self, 'data_in_cache', [])
-        self.data_in_cache.extend([])
 
     def _get_robustcov_results(self, cov_type='opg', **kwargs):
         """

--- a/statsmodels/tsa/statespace/tools.py
+++ b/statsmodels/tsa/statespace/tools.py
@@ -561,14 +561,14 @@ def _constrain_sv_less_than_one_python(unconstrained, order=None,
         Partial autocorrelation matrices. Should be a list of length
         `order`, where each element is an array sized `k_endog` x `k_endog`.
 
+    See Also
+    --------
+    constrain_stationary_multivariate
+
     Notes
     -----
     Corresponds to Lemma 2.2 in Ansley and Kohn (1986). See
     `constrain_stationary_multivariate` for more details.
-
-    There is a Cython implementation of this function that can be much faster,
-    but which requires SciPy 0.14.0 or greater. See
-    `constrain_stationary_multivariate` for details.
     """
 
     from scipy import linalg
@@ -620,14 +620,14 @@ def _compute_coefficients_from_multivariate_pacf_python(
         Transformed coefficient matrices leading to a stationary VAR
         representation.
 
+    See Also
+    --------
+    constrain_stationary_multivariate
+
     Notes
     -----
     Corresponds to Lemma 2.1 in Ansley and Kohn (1986). See
     `constrain_stationary_multivariate` for more details.
-
-    There is a Cython implementation of this function that can be much faster,
-    but which requires SciPy 0.14.0 or greater. See
-    `constrain_stationary_multivariate` for details.
     """
     from scipy import linalg
 
@@ -931,6 +931,10 @@ def _unconstrain_sv_less_than_one(constrained, order=None, k_endog=None):
         Unconstrained matrices. A list of length `order`, where each element is
         an array sized `k_endog` x `k_endog`.
 
+    See Also
+    --------
+    unconstrain_stationary_multivariate
+
     Notes
     -----
     Corresponds to the inverse of Lemma 2.2 in Ansley and Kohn (1986). See
@@ -1162,6 +1166,10 @@ def _compute_multivariate_pacf_from_autocovariances(autocovariances,
     pacf : list
         List of first `order` multivariate partial autocorrelations.
 
+    See Also
+    --------
+    unconstrain_stationary_multivariate
+
     Notes
     -----
     Note that this computes multivariate partial autocorrelations.
@@ -1169,8 +1177,6 @@ def _compute_multivariate_pacf_from_autocovariances(autocovariances,
     Corresponds to the inverse of Lemma 2.1 in Ansley and Kohn (1986). See
     `unconstrain_stationary_multivariate` for more details.
 
-    Notes
-    -----
     Computes sample partial autocorrelations if sample autocovariances are
     given.
     """
@@ -1326,6 +1332,10 @@ def _compute_multivariate_pacf_from_coefficients(constrained, error_variance,
     pacf : list
         List of first `order` multivariate partial autocorrelations.
 
+    See Also
+    --------
+    unconstrain_stationary_multivariate
+
     Notes
     -----
     Note that this computes multivariate partial autocorrelations.
@@ -1335,7 +1345,6 @@ def _compute_multivariate_pacf_from_coefficients(constrained, error_variance,
 
     Notes
     -----
-
     Coefficients are assumed to be provided from the VAR model:
 
     .. math::


### PR DESCRIPTION
Correct exog dimension when data has been removed

closes #6887

- [X] closes #6887
- [X] tests added / passed. 
- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
