### PR TITLE
MAINT: Change default lag in serial correlation tests

### DIFF
--- a/statsmodels/tsa/statespace/tests/test_conserve_memory.py
+++ b/statsmodels/tsa/statespace/tests/test_conserve_memory.py
@@ -288,8 +288,10 @@ def test_fittedvalues_resid_predict(conserve_memory):
                     res2.test_normality('jarquebera'))
     assert_allclose(res1.test_heteroskedasticity('breakvar'),
                     res2.test_heteroskedasticity('breakvar'))
-    assert_allclose(res1.test_serial_correlation('ljungbox'),
-                    res2.test_serial_correlation('ljungbox'))
+    with pytest.warns(FutureWarning):
+        actual = res1.test_serial_correlation('ljungbox')
+        desired = res2.test_serial_correlation('ljungbox')
+    assert_allclose(actual, desired)
 
 
 def test_get_prediction_memory_conserve():

--- a/statsmodels/tsa/statespace/tests/test_fixed_params.py
+++ b/statsmodels/tsa/statespace/tests/test_fixed_params.py
@@ -462,8 +462,10 @@ def check_results(res1, res2, check_lutkepohl=False, check_params=True):
     assert_allclose(res2.test_heteroskedasticity('breakvar'),
                     res1.test_heteroskedasticity('breakvar'))
 
-    assert_allclose(res2.test_serial_correlation('ljungbox'),
-                    res1.test_serial_correlation('ljungbox'))
+    with pytest.warns(FutureWarning):
+        actual = res2.test_serial_correlation('ljungbox')
+        desired = res1.test_serial_correlation('ljungbox')
+    assert_allclose(actual, desired)
 
 
 def test_sarimax_nonconsecutive():

--- a/statsmodels/tsa/statespace/tests/test_mlemodel.py
+++ b/statsmodels/tsa/statespace/tests/test_mlemodel.py
@@ -836,17 +836,19 @@ def test_diagnostics():
     with pytest.raises(NotImplementedError):
         res.test_heteroskedasticity(method='invalid')
 
-    actual = res.test_serial_correlation(method=None)
-    desired = res.test_serial_correlation(method='ljungbox')
+    with pytest.warns(FutureWarning):
+        actual = res.test_serial_correlation(method=None)
+    with pytest.warns(FutureWarning):
+        desired = res.test_serial_correlation(method='ljungbox')
     assert_allclose(actual, desired)
 
     with pytest.raises(NotImplementedError):
         res.test_serial_correlation(method='invalid')
 
     # Smoke tests for other options
-    actual = res.test_heteroskedasticity(method=None, alternative='d',
-                                         use_f=False)
-    desired = res.test_serial_correlation(method='boxpierce')
+    res.test_heteroskedasticity(method=None, alternative='d', use_f=False)
+    with pytest.warns(FutureWarning):
+        res.test_serial_correlation(method='boxpierce')
 
 
 def test_diagnostics_nile_eviews():

--- a/statsmodels/tsa/statespace/tests/test_sarimax.py
+++ b/statsmodels/tsa/statespace/tests/test_sarimax.py
@@ -2364,8 +2364,10 @@ def check_concentrated_scale(filter_univariate=False):
         desired = res_orig.test_heteroskedasticity(method='breakvar')
         assert_allclose(actual, desired, rtol=1e-5, atol=atol)
 
-        actual = res_conc.test_serial_correlation(method='ljungbox')
-        desired = res_orig.test_serial_correlation(method='ljungbox')
+        with pytest.warns(FutureWarning):
+            actual = res_conc.test_serial_correlation(method='ljungbox')
+        with pytest.warns(FutureWarning):
+            desired = res_orig.test_serial_correlation(method='ljungbox')
         assert_allclose(actual, desired, rtol=1e-5, atol=atol)
 
         # Test predict

--- a/statsmodels/tsa/tests/test_ar.py
+++ b/statsmodels/tsa/tests/test_ar.py
@@ -784,9 +784,11 @@ def test_parameterless_autoreg():
                     'remove_data', 'save', 't_test', 't_test_pairwise',
                     'wald_test', 'wald_test_terms'):
             continue
+        warning = None if attr != "test_serial_correlation" else FutureWarning
         attr = getattr(res, attr)
         if callable(attr):
-            attr()
+            with pytest.warns(warning):
+                attr()
         else:
             assert isinstance(attr, object)
 


### PR DESCRIPTION
Change the default lag to use a smaller value in serial correlation tests

closes #3381

- [x] closes #3381
- [x] tests added / passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
