### PR TITLE
Added label option to summary.to_latex()

### DIFF
--- a/statsmodels/iolib/summary2.py
+++ b/statsmodels/iolib/summary2.py
@@ -199,8 +199,14 @@ class Summary(object):
 
         return tab
 
-    def as_latex(self):
+    def as_latex(self, label=''):
         """Generate LaTeX Summary Table
+
+        Parameters
+        ----------
+        label : str
+            Label of the summary table that can be referenced
+            in a latex document (optional)
         """
         tables = self.tables
         settings = self.settings
@@ -210,6 +216,8 @@ class Summary(object):
             title = '\\caption{' + title + '}'
         else:
             title = '\\caption{}'
+
+        label = '\\label{' + label + '}'
 
         simple_tables = _simple_tables(tables, settings)
         tab = [x.as_latex_tabular() for x in simple_tables]
@@ -222,7 +230,7 @@ class Summary(object):
             # create single tabular object for summary_col
             tab = re.sub(to_replace, r'\\midrule\n', tab)
 
-        out = '\\begin{table}', title, tab, '\\end{table}'
+        out = '\\begin{table}', title, label, tab, '\\end{table}'
         out = '\n'.join(out)
         return out
 

--- a/statsmodels/iolib/tests/test_summary2.py
+++ b/statsmodels/iolib/tests/test_summary2.py
@@ -17,6 +17,7 @@ class TestSummaryLatex(object):
         desired = r'''
 \begin{table}
 \caption{}
+\label{}
 \begin{center}
 \begin{tabular}{lll}
 \hline


### PR DESCRIPTION

Proposing a label option to the statsmodels.iolib.summary2.Summary class such that the resulting latex table can be referenced in a latex document.

Below a small example showing the latex table with label:
```
import pandas as pd
import statsmodels.formula.api as smf
import numpy as np

df = pd.DataFrame(np.random.rand(10, 3), columns=['var1', 'var2', 'var3'])
dependent_variable = 'var1'
expression = 'var3'
formula = 'Q("{}") ~ {}'.format(dependent_variable, expression)
model = smf.mixedlm(formula, df, groups='var2')
fit = model.fit()
summary = fit.summary()
summary.label = 'MyLabel'
latex_summary = summary.as_latex()
print(latex_summary)
```
```
\begin{table}
\caption{Mixed Linear Model Regression Results}
\label{MyLabel}
\begin{center}
\begin{tabular}{llll}
\hline
Model:            & MixedLM & Dependent Variable: & Q("var1")  \\
No. Observations: & 10      & Method:             & REML       \\
No. Groups:       & 10      & Scale:              & 0.0616     \\
Min. group size:  & 1       & Likelihood:         & -4.1766    \\
Max. group size:  & 1       & Converged:          & Yes        \\
Mean group size:  & 1.0     &                     &            \\
\hline
\end{tabular}
\end{center}
\hline
\begin{center}
\begin{tabular}{lcccccc}
\hline
          & Coef.  & Std.Err. &   z    & P$> |$z$|$ & [0.025 & 0.975]  \\
\hline
\hline
\end{tabular}
\begin{tabular}{lllllll}
Intercept & 0.642  & 0.031    & 20.609 & 0.000       & 0.581  & 0.704   \\
var3      & -0.258 & 0.203    & -1.275 & 0.202       & -0.655 & 0.139   \\
var2 Var  & 0.062  &          &        &             &        &         \\
\hline
\end{tabular}
\end{center}
\end{table}
```