### PR TITLE
Fixed the shifted column names in summary.to_latex()

### DIFF
--- a/statsmodels/iolib/summary2.py
+++ b/statsmodels/iolib/summary2.py
@@ -206,6 +206,12 @@ class Summary(object):
         settings = self.settings
         title = self.title
 
+        table1 = tables[1].reset_index()
+        table1 = table1.T.reset_index().T.reset_index(drop=True)
+        table1.iloc[0, 0] = ''
+        tables[1] = table1
+        settings[1]['index'] = settings[1]['header'] = False
+
         if title is not None:
             title = '\\caption{' + title + '}'
         else:

--- a/statsmodels/iolib/summary2.py
+++ b/statsmodels/iolib/summary2.py
@@ -218,7 +218,14 @@ class Summary(object):
             title = '\\caption{}'
 
         simple_tables = _simple_tables(tables, settings)
-        tab = [x.as_latex_tabular() for x in simple_tables]
+
+        tab = []
+        for i, x in enumerate(simple_tables):
+            if i == 1:
+                tab.append(x.as_latex_tabular(cmidrule=True))
+            else:
+                tab.append(x.as_latex_tabular())
+
         tab = '\n\\hline\n'.join(tab)
 
         to_replace = ('\\\\hline\\n\\\\hline\\n\\\\'

--- a/statsmodels/iolib/table.py
+++ b/statsmodels/iolib/table.py
@@ -404,9 +404,14 @@ class SimpleTable(list):
         formatted_rows.append('</table>')
         return '\n'.join(formatted_rows)
 
-    def as_latex_tabular(self, center=True, **fmt_dict):
+    def as_latex_tabular(self, center=True, cmidrule=True, **fmt_dict):
         '''Return string, the table as a LaTeX tabular environment.
-        Note: will require the booktabs package.'''
+        Note: will require the booktabs package.
+        Parameters
+        ----------
+        cmidrule : bool
+            bool indicating if a cmidrule is added below the row indexes
+        '''
         # fetch the text format, override with fmt_dict
         fmt = self._get_fmt('latex', **fmt_dict)
 
@@ -440,6 +445,8 @@ class SimpleTable(list):
             if row != last:
                 formatted_rows.append(
                     row.as_string(output_format='latex', **fmt))
+                if cmidrule:
+                    formatted_rows.append('\\cmidrule(l){1-1}')
             prev_aligns = aligns
         # tabular does not support caption, but make it available for
         # figure environment


### PR DESCRIPTION
Proposing a fix to an issue with shifted column names when creating a latex table with the "to_latex()" function of the statsmodels.iolib.summary2.Summary class.

Currently when creating a latex table of the summary class, the column names of the second table of the summary get placed in a separate tabular, which results in them not being aligned with the rest of the table.

My proposed fix could be applied directly by an user to the summary dataframes before applying the ".to_latex()" function, though it is very unintuitive. It would be much more user-friendly if the formatting was handled directly by the "to_latex()" function.

This fix might not be the cleanest solution, the intention of this PR is more to raise awareness of the issue while indicating where the issue comes from.

# Example:
```
import pandas as pd
import statsmodels.formula.api as smf
import numpy as np

df = pd.DataFrame(np.random.rand(10, 3), columns=['var1', 'var2', 'var3'])
dependent_variable = 'var1'
expression = 'var3'
formula = 'Q("{}") ~ {}'.format(dependent_variable, expression)
model = smf.mixedlm(formula, df, groups='var2')
fit = model.fit()
summary = fit.summary()
latex_summary = summary.as_latex()
print(latex_summary)
```
## Current behaviour:
```
\begin{table}
\caption{Mixed Linear Model Regression Results}
\begin{center}
\begin{tabular}{llll}
\hline
Model:            & MixedLM & Dependent Variable: & Q("var1")  \\
No. Observations: & 10      & Method:             & REML       \\
No. Groups:       & 10      & Scale:              & 0.0710     \\
Min. group size:  & 1       & Likelihood:         & -4.5306    \\
Max. group size:  & 1       & Converged:          & Yes        \\
Mean group size:  & 1.0     &                     &            \\
\hline
\end{tabular}
\end{center}
\hline
\begin{center}
\begin{tabular}{lcccccc}
\hline
          & Coef.  & Std.Err. &   z    & P$> |$z$|$ & [0.025 & 0.975]  \\
\hline
\hline
\end{tabular}
\begin{tabular}{lllllll}
Intercept & 0.475  & 0.290    & 1.638  & 0.101       & -0.093 & 1.043   \\
var3      & -0.024 & 0.444    & -0.055 & 0.956       & -0.895 & 0.847   \\
var2 Var  & 0.071  &          &        &             &        &         \\
\hline
\end{tabular}
\end{center}
\end{table}
```
Which results in:
![image](https://user-images.githubusercontent.com/43926224/87946131-eb08f680-caa1-11ea-98a7-71d95a8d3f64.png)

## New behaviour:

```
\begin{table}
\caption{Mixed Linear Model Regression Results}
\begin{center}
\begin{tabular}{llll}
\hline
Model:            & MixedLM & Dependent Variable: & Q("var1")  \\
No. Observations: & 10      & Method:             & REML       \\
No. Groups:       & 10      & Scale:              & 0.0308     \\
Min. group size:  & 1       & Likelihood:         & -1.0323    \\
Max. group size:  & 1       & Converged:          & Yes        \\
Mean group size:  & 1.0     &                     &            \\
\hline
\end{tabular}
\end{center}
\hline
\begin{center}
\begin{tabular}{lllllll}
\hline
          & Coef.  & Std.Err. & z      & P$> |$z$|$ & [0.025 & 0.975]  \\
Intercept & 0.972  & 0.191    & 5.097  & 0.000       & 0.598  & 1.346   \\
var3      & -0.955 & 0.343    & -2.785 & 0.005       & -1.627 & -0.283  \\
var2 Var  & 0.031  &          &        &             &        &         \\
\hline
\end{tabular}
\end{center}
\end{table}
```
Which results in:

![image](https://user-images.githubusercontent.com/43926224/87946601-85693a00-caa2-11ea-9318-a45f54f15087.png)
