### PR TITLE
BUG: Stop transforming ES components

### DIFF
--- a/statsmodels/tsa/holtwinters/model.py
+++ b/statsmodels/tsa/holtwinters/model.py
@@ -1083,7 +1083,7 @@ class ExponentialSmoothing(TimeSeriesModel):
                 )
             warnings.warn(
                 "Setting initial values during fit is deprecated and will be "
-                "removed after 0.13. These should be set during model"
+                "removed after 0.13. These should be set during model "
                 "initialization."
             )
         if use_boxcox is not None:
@@ -1405,19 +1405,7 @@ class ExponentialSmoothing(TimeSeriesModel):
             fitted = trend
         level = lvls[1 : nobs + 1].copy()
         if use_boxcox or use_boxcox == "log" or isinstance(use_boxcox, float):
-            # store untransformed values in private attribute, transforming
-            # here is probably a bug
-            self._untransformed_level = level
-            self._untransformed_trend = _trend
-            self._untransformed_season = season
-
             fitted = inv_boxcox(fitted, lamda)
-            level = inv_boxcox(level, lamda)
-            _trend = detrend(trend[:nobs], level)
-            if seasonal == "add":
-                season = (fitted - inv_boxcox(trend, lamda))[:nobs]
-            else:  # seasonal == 'mul':
-                season = (fitted / inv_boxcox(trend, lamda))[:nobs]
         err = fitted[: -h - 1] - data
         sse = err.T @ err
         # (s0 + gamma) + (b0 + beta) + (l0 + alpha) + phi

--- a/statsmodels/tsa/holtwinters/results.py
+++ b/statsmodels/tsa/holtwinters/results.py
@@ -635,14 +635,9 @@ class HoltWintersResults(Results):
             neutral_s = 0
 
         # set initial values
-        if use_boxcox:
-            level = self.model._untransformed_level
-            _trend = self.model._untransformed_trend
-            season = self.model._untransformed_season
-        else:
-            level = self.level
-            _trend = self.trend
-            season = self.season
+        level = self.level
+        _trend = self.trend
+        season = self.season
         # (notation as in https://otexts.com/fpp2/ets.html)
         y = np.empty((nsimulations, repetitions))
         # lvl instead of l because of E741

--- a/statsmodels/tsa/holtwinters/tests/test_holtwinters.py
+++ b/statsmodels/tsa/holtwinters/tests/test_holtwinters.py
@@ -1851,3 +1851,16 @@ def test_forecast_index_types(ses, index_typ):
         fcast = res.forecast(36)
     assert isinstance(fcast, pd.Series)
     pd.testing.assert_index_equal(fcast.index, fcast_index)
+
+
+def test_boxcox_components(ses):
+    mod = ExponentialSmoothing(
+        ses + 1 - ses.min(), initialization_method="estimated", use_boxcox=True
+    )
+    res = mod.fit()
+    with pytest.raises(AssertionError):
+        # Must be different since level is not transformed
+        assert_allclose(res.level, res.fittedvalues)
+    assert not hasattr(res, "_untransformed_level")
+    assert not hasattr(res, "_untransformed_trend")
+    assert not hasattr(res, "_untransformed_seasonal")


### PR DESCRIPTION
Stop transforming components in ExponentialSmoothing models

closes #6629

- [X] closes #6629
- [X] tests added / passed. 
- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
