### PR TITLE
removed additional hline between tabulars

### DIFF
--- a/statsmodels/iolib/summary2.py
+++ b/statsmodels/iolib/summary2.py
@@ -213,7 +213,7 @@ class Summary(object):
 
         simple_tables = _simple_tables(tables, settings)
         tab = [x.as_latex_tabular() for x in simple_tables]
-        tab = '\n\\hline\n'.join(tab)
+        tab = '\n\n'.join(tab)
 
         to_replace = ('\\\\hline\\n\\\\hline\\n\\\\'
                       'end{tabular}\\n\\\\begin{tabular}{.*}\\n')


### PR DESCRIPTION
Proposing to remove the hline between the tabulars of the latex table created by the "to_latex()" function of the statsmodels.iolib.summary2.Summary class.

# Example:
```
import pandas as pd
import statsmodels.formula.api as smf
import numpy as np
df = pd.DataFrame(np.random.rand(10, 3), columns=['var1', 'var2', 'var3'])
dependent_variable = 'var1'
expression = 'var3'
formula = 'Q("{}") ~ {}'.format(dependent_variable, expression)
model = smf.mixedlm(formula, df, groups='var2')
fit = model.fit()
summary = fit.summary()
latex_summary = summary.as_latex()
print(latex_summary)
```

## Current behavior:
![image](https://user-images.githubusercontent.com/43926224/88071737-810d5180-cb74-11ea-98bd-0179f45d99d8.png)

## New behavior:
![image](https://user-images.githubusercontent.com/43926224/88071847-a13d1080-cb74-11ea-8d1c-65c9f68f2510.png)
