### PR TITLE
Fixed BSplines to match existing docs

### DIFF
--- a/statsmodels/gam/smooth_basis.py
+++ b/statsmodels/gam/smooth_basis.py
@@ -792,7 +792,6 @@ class AdditiveGamSmoother(with_metaclass(ABCMeta)):
         basis : ndarray
             design matrix for the spline basis for given ``x_new``.
         """
-        x_new = np.asarray(x_new)
         if x_new.ndim == 1:
             x_new = x_new.reshape(-1, 1)
         exog = np.hstack(list(self.smoothers[i].transform(x_new[:, i])
@@ -842,11 +841,11 @@ class BSplines(AdditiveGamSmoother):
         underlying explanatory variable for smooth terms.
         If 2-dimensional, then observations should be in rows and
         explanatory variables in columns.
-    df :  {list[int], int}
+    df :  {int, array_like[int]}
         number of basis functions or degrees of freedom; should be equal
         in length to the number of columns of `x`; may be an integer if
         `x` has one column or is 1-D.
-    degree : {list[int], int}
+    degree : {int, array_like[int]}
         degree(s) of the spline; the same length and type rules apply as
         to `df`
     include_intercept : bool
@@ -913,8 +912,14 @@ class BSplines(AdditiveGamSmoother):
     """
     def __init__(self, x, df, degree, include_intercept=False,
                  constraints=None, variable_names=None, knot_kwds=None):
-        self.degrees = [degree] if isinstance(degree, int) else degree
-        self.dfs = [df] if isinstance(df, int) else df
+        if isinstance(degree, int):
+            self.degrees = np.array([degree], dtype=int)
+        else:
+            self.degrees = degree
+        if isinstance(df, int):
+            self.dfs = np.array([df], dtype=int)
+        else:
+            self.dfs = df
         self.knot_kwds = knot_kwds
         # TODO: move attaching constraints to super call
         self.constraints = constraints

--- a/statsmodels/gam/smooth_basis.py
+++ b/statsmodels/gam/smooth_basis.py
@@ -792,7 +792,7 @@ class AdditiveGamSmoother(with_metaclass(ABCMeta)):
         basis : ndarray
             design matrix for the spline basis for given ``x_new``.
         """
-        if x_new.ndim == 1:
+        if x_new.ndim == 1 and self.k_variables == 1:
             x_new = x_new.reshape(-1, 1)
         exog = np.hstack(list(self.smoothers[i].transform(x_new[:, i])
                          for i in range(self.k_variables)))

--- a/statsmodels/gam/smooth_basis.py
+++ b/statsmodels/gam/smooth_basis.py
@@ -616,7 +616,7 @@ class UnivariateCubicCyclicSplines(UnivariateGamSmoother):
     x : ndarray, 1-D
         underlying explanatory variable for smooth terms.
     df : int
-        numer of basis functions or degrees of freedom
+        number of basis functions or degrees of freedom
     degree : int
         degree of the spline
     include_intercept : bool
@@ -792,6 +792,9 @@ class AdditiveGamSmoother(with_metaclass(ABCMeta)):
         basis : ndarray
             design matrix for the spline basis for given ``x_new``.
         """
+        x_new = np.asarray(x_new)
+        if x_new.ndim == 1:
+            x_new = x_new.reshape(-1, 1)
         exog = np.hstack(list(self.smoothers[i].transform(x_new[:, i])
                          for i in range(self.k_variables)))
         return exog
@@ -839,10 +842,13 @@ class BSplines(AdditiveGamSmoother):
         underlying explanatory variable for smooth terms.
         If 2-dimensional, then observations should be in rows and
         explanatory variables in columns.
-    df :  int
-        numer of basis functions or degrees of freedom
-    degree : int
-        degree of the spline
+    df :  {list[int], int}
+        number of basis functions or degrees of freedom; should be equal
+        in length to the number of columns of `x`; may be an integer if
+        `x` has one column or is 1-D.
+    degree : {list[int], int}
+        degree(s) of the spline; the same length and type rules apply as
+        to `df`
     include_intercept : bool
         If False, then the basis functions are transformed so that they
         do not include a constant. This avoids perfect collinearity if
@@ -907,8 +913,8 @@ class BSplines(AdditiveGamSmoother):
     """
     def __init__(self, x, df, degree, include_intercept=False,
                  constraints=None, variable_names=None, knot_kwds=None):
-        self.degrees = degree
-        self.dfs = df
+        self.degrees = [degree] if isinstance(degree, int) else degree
+        self.dfs = [df] if isinstance(df, int) else df
         self.knot_kwds = knot_kwds
         # TODO: move attaching constraints to super call
         self.constraints = constraints

--- a/statsmodels/gam/tests/test_smooth_basis.py
+++ b/statsmodels/gam/tests/test_smooth_basis.py
@@ -30,6 +30,7 @@ def test_multivariate_polynomial_basis():
         uv_basis = UnivariatePolynomialSmoother(x[:, i], degree=deg).basis
         assert_allclose(mps.smoothers[i].basis, uv_basis)
 
+
 @pytest.mark.parametrize(
     "x, df, degree",
     [

--- a/statsmodels/gam/tests/test_smooth_basis.py
+++ b/statsmodels/gam/tests/test_smooth_basis.py
@@ -34,7 +34,11 @@ def test_multivariate_polynomial_basis():
 @pytest.mark.parametrize(
     "x, df, degree",
     [
-        (np.linspace((0, 1), (1, 10), 100), [5, 6], [3, 5]),
+        (
+            np.c_[np.linspace(0, 1, 100), np.linspace(0, 10, 100)],
+            [5, 6],
+            [3, 5]
+        ),
         (np.linspace(0, 1, 100), 6, 3),
     ]
 )

--- a/statsmodels/gam/tests/test_smooth_basis.py
+++ b/statsmodels/gam/tests/test_smooth_basis.py
@@ -34,7 +34,7 @@ def test_multivariate_polynomial_basis():
     "x, df, degree",
     [
         (np.linspace((0, 1), (1, 10), 100), [5, 6], [3, 5]),
-        (np.linspace(0, 1, 100).reshape(-1, 1), 6, 3),
+        (np.linspace(0, 1, 100), 6, 3),
     ]
 )
 def test_bsplines(x, df, degree):

--- a/statsmodels/gam/tests/test_smooth_basis.py
+++ b/statsmodels/gam/tests/test_smooth_basis.py
@@ -6,10 +6,12 @@ Author: Luca Puggini
 
 """
 
+import pytest
 import numpy as np
 from numpy.testing import assert_allclose, assert_equal
 from statsmodels.gam.smooth_basis import (UnivariatePolynomialSmoother,
-                                          PolynomialSmoother)
+                                          PolynomialSmoother,
+                                          BSplines)
 
 
 def test_univariate_polynomial_smoother():
@@ -27,3 +29,14 @@ def test_multivariate_polynomial_basis():
     for i, deg in enumerate(degrees):
         uv_basis = UnivariatePolynomialSmoother(x[:, i], degree=deg).basis
         assert_allclose(mps.smoothers[i].basis, uv_basis)
+
+@pytest.mark.parametrize(
+    "x, df, degree",
+    [
+        (np.linspace((0, 1), (1, 10), 100), [5, 6], [3, 5]),
+        (np.linspace(0, 1, 100).reshape(-1, 1), 6, 3),
+    ]
+)
+def test_bsplines(x, df, degree):
+    bspline = BSplines(x, df, degree)
+    bspline.transform(x)


### PR DESCRIPTION
The docstring for `BSplines` appears to have been copied from that of  `UnivariateCubicCyclicSplines`, as it specified the `df` and `degree` parameters to be integers, but in fact required them to be lists (raising a `TypeError: 'int' object is not subscriptable` if either was an integer)
- Fixed docstring to specify `{list[int], int}` instead
- Implemented support for integers by converting `df` and `degree` to lists if they aren't already

- Added `test_bsplines` parameterised test to test the creation of BSplines instances and the transformation of their original data

- [ ] closes #6914
- [ ] closes #6916 for 1-D ndarrays
- [ ] tests added / passed. 
- [ ] code/documentation is well formatted.  
- [ ] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
