### PR TITLE
BUG: dynamic is incorrect when not an int in statespace get_prediction

### DIFF
--- a/statsmodels/tsa/statespace/mlemodel.py
+++ b/statsmodels/tsa/statespace/mlemodel.py
@@ -8,6 +8,7 @@ License: Simplified-BSD
 import contextlib
 import warnings
 
+import datetime as dt
 from types import SimpleNamespace
 import numpy as np
 import pandas as pd
@@ -3266,9 +3267,9 @@ class MLEResults(tsbase.TimeSeriesModelResults):
 
         Returns
         -------
-        forecast : ndarray
-            Array of out of in-sample predictions and / or out-of-sample
-            forecasts. An (npredict x k_endog) array.
+        forecast : PredictionResults
+            PredictionResults instance containing in-sample predictions and
+            out-of-sample forecasts.
         """
         if start is None:
             start = 0
@@ -3278,8 +3279,10 @@ class MLEResults(tsbase.TimeSeriesModelResults):
             self.model._get_prediction_index(start, end, index))
 
         # Handle `dynamic`
-        if isinstance(dynamic, (bytes, str)):
+        if isinstance(dynamic, (str, dt.datetime, pd.Timestamp)):
             dynamic, _, _ = self.model._get_index_loc(dynamic)
+            # Convert to offset relative to start
+            dynamic = dynamic - start
 
         # If we have out-of-sample forecasting and `exog` or in general any
         # kind of time-varying state space model, then we need to create an

--- a/statsmodels/tsa/statespace/tests/test_sarimax.py
+++ b/statsmodels/tsa/statespace/tests/test_sarimax.py
@@ -2709,3 +2709,20 @@ def test_invalid_seasonal_order():
         sarimax.SARIMAX(endog, seasonal_order=(1, 0, 1, 0))
     with pytest.raises(ValueError):
         sarimax.SARIMAX(endog, seasonal_order=(0, 0, 0, 1))
+
+
+def test_dynamic_str():
+    data = results_sarimax.wpi1_stationary["data"]
+    index = pd.date_range("1980-1-1", freq="MS", periods=len(data))
+    series = pd.Series(data, index=index)
+    mod = sarimax.SARIMAX(series, order=(1, 1, 0), trend="c")
+    res = mod.fit()
+    dynamic = index[-12]
+    desired = res.get_prediction(index[-24], dynamic=12)
+    actual = res.get_prediction(index[-24], dynamic=dynamic)
+    assert_allclose(actual.predicted_mean, desired.predicted_mean)
+    actual = res.get_prediction(index[-24], dynamic=dynamic.to_pydatetime())
+    assert_allclose(actual.predicted_mean, desired.predicted_mean)
+    actual = res.get_prediction(index[-24],
+                                dynamic=dynamic.strftime("%Y-%m-%d"))
+    assert_allclose(actual.predicted_mean, desired.predicted_mean)


### PR DESCRIPTION
@ChadFulton Seems to be a bug in get_prediction with dynamic not an int.  I also pulled some code to share with other forecasting methods.

- [X] tests added / passed. 
- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
