### PR TITLE
MAINT: Remove FutureWarnings

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -51,6 +51,8 @@ filterwarnings =
     error:Only PeriodIndexes, DatetimeIndexes:UserWarning
     error:the 'unbiased'' keyword is deprecated:FutureWarning
     error:unbiased is deprecated in factor of adjusted:FutureWarning
+    error:categorical is deprecated:FutureWarning
+    error:After 0.13 initialization:FutureWarning
 markers =
     example: mark a test that runs example code
     matplotlib: mark a test that requires matplotlib

--- a/statsmodels/discrete/discrete_model.py
+++ b/statsmodels/discrete/discrete_model.py
@@ -110,15 +110,16 @@ _check_rank_doc = """
 
 # helper for MNLogit (will be generally useful later)
 def _numpy_to_dummies(endog):
-    if endog.dtype.kind in ['S', 'O']:
-        endog_dummies, ynames = tools.categorical(endog, drop=True,
-                                                  dictnames=True)
-    elif endog.ndim == 2:
+    if endog.ndim == 2 and endog.dtype.kind not in ["S", "O"]:
         endog_dummies = endog
         ynames = range(endog.shape[1])
     else:
-        endog_dummies, ynames = tools.categorical(endog, drop=True,
-                                                  dictnames=True)
+        dummies = get_dummies(endog, drop_first=False)
+        ynames = {i: dummies.columns[i] for i in range(dummies.shape[1])}
+        endog_dummies = np.asarray(dummies, dtype=float)
+
+        return endog_dummies, ynames
+
     return endog_dummies, ynames
 
 

--- a/statsmodels/imputation/tests/test_ros.py
+++ b/statsmodels/imputation/tests/test_ros.py
@@ -3,6 +3,7 @@ from statsmodels.compat.pandas import assert_series_equal, assert_frame_equal
 from io import StringIO
 from textwrap import dedent
 
+import numpy as np
 import numpy.testing as npt
 
 import numpy
@@ -379,10 +380,10 @@ class CheckROSMixin(object):
             'ncen_equal', 'prob_exceedance'
         ]
         cohn = ros.cohn_numbers(self.df, self.rescol, self.cencol)
+        # Use round in place of the deprecated check_less_precise arg
         assert_frame_equal(
-            cohn[cols],
-            self.expected_cohn[cols],
-            check_less_precise=True,
+            np.round(cohn[cols], 3),
+            np.round(self.expected_cohn[cols], 3),
         )
 
 

--- a/statsmodels/regression/_tools.py
+++ b/statsmodels/regression/_tools.py
@@ -55,7 +55,7 @@ class _MinimalWLS(object):
         if np.isscalar(weights):
             self.wexog = w_half * exog
         else:
-            self.wexog = w_half[:, None] * exog
+            self.wexog = np.asarray(w_half)[:, None] * exog
 
     def fit(self, method='pinv'):
         """

--- a/statsmodels/tools/tests/test_tools.py
+++ b/statsmodels/tools/tests/test_tools.py
@@ -17,6 +17,8 @@ from statsmodels.datasets import longley
 from statsmodels.tools import tools
 from statsmodels.tools.tools import pinv_extended
 
+# Ignore future warnings from test code
+pytestmark = pytest.mark.filterwarnings("ignore:categorical is deprecated:FutureWarning")
 
 @pytest.fixture(scope='module')
 def string_var():

--- a/statsmodels/tsa/ar_model.py
+++ b/statsmodels/tsa/ar_model.py
@@ -516,7 +516,7 @@ class AutoReg(tsa_model.TimeSeriesModel):
         n_values = end - start
         if not isinstance(self.data.orig_endog, (pd.Series, pd.DataFrame)):
             return prediction[-n_values:]
-        index = self.data.orig_endog.index
+        index = self._index
         if end > self.endog.shape[0]:
             freq = getattr(index, 'freq', None)
             if freq:

--- a/statsmodels/tsa/deterministic.py
+++ b/statsmodels/tsa/deterministic.py
@@ -570,7 +570,7 @@ class CalendarDeterminsticTerm(DeterministicTerm, ABC):
     ) -> np.ndarray:
         if isinstance(index, pd.PeriodIndex):
             index = index.to_timestamp()
-        delta = index.to_perioddelta(self._freq)
+        delta = index - index.to_period(self._freq).to_timestamp()
         pi = index.to_period(self._freq)
         gap = (pi + 1).to_timestamp() - pi.to_timestamp()
         return to_numpy(delta) / to_numpy(gap)

--- a/statsmodels/tsa/holtwinters/model.py
+++ b/statsmodels/tsa/holtwinters/model.py
@@ -403,10 +403,6 @@ class ExponentialSmoothing(TimeSeriesModel):
 
     def _initialize(self):
         if self._initialization_method is None:
-            warnings.warn(
-                "After 0.13 initialization must be handled at model creation",
-                FutureWarning,
-            )
             msg = "initial_{0} given but no initialization method specified."
             if self._initial_level is not None:
                 raise ValueError(msg.format("level"))
@@ -414,6 +410,10 @@ class ExponentialSmoothing(TimeSeriesModel):
                 raise ValueError(msg.format("trend"))
             if self._initial_seasonal is not None:
                 raise ValueError(msg.format("seasonal"))
+            warnings.warn(
+                "After 0.13 initialization must be handled at model creation",
+                FutureWarning,
+            )
             return
         if self._initialization_method == "known":
             return self._initialize_known()

--- a/statsmodels/tsa/holtwinters/tests/test_holtwinters.py
+++ b/statsmodels/tsa/holtwinters/tests/test_holtwinters.py
@@ -311,10 +311,18 @@ class TestHoltWinters(object):
 
     def test_predict(self):
         fit1 = ExponentialSmoothing(
-            self.aust, seasonal_periods=4, trend="add", seasonal="mul"
+            self.aust,
+            seasonal_periods=4,
+            trend="add",
+            seasonal="mul",
+            initialization_method="estimated",
         ).fit(start_params=self.start_params)
         fit2 = ExponentialSmoothing(
-            self.aust, seasonal_periods=4, trend="add", seasonal="mul"
+            self.aust,
+            seasonal_periods=4,
+            trend="add",
+            seasonal="mul",
+            initialization_method="estimated",
         ).fit(start_params=self.start_params)
         # fit3 = ExponentialSmoothing(self.aust, seasonal_periods=4,
         # trend='add', seasonal='mul').fit(remove_bias=True,
@@ -336,7 +344,11 @@ class TestHoltWinters(object):
 
     def test_ndarray(self):
         fit1 = ExponentialSmoothing(
-            self.aust.values, seasonal_periods=4, trend="add", seasonal="mul"
+            self.aust.values,
+            seasonal_periods=4,
+            trend="add",
+            seasonal="mul",
+            initialization_method="estimated",
         ).fit(start_params=self.start_params)
         assert_almost_equal(
             fit1.forecast(4), [61.3083, 37.3730, 46.9652, 51.5578], 3
@@ -353,9 +365,15 @@ class TestHoltWinters(object):
         )
 
     def test_simple_exp_smoothing(self):
-        fit1 = SimpleExpSmoothing(self.oildata_oil).fit(0.2, optimized=False)
-        fit2 = SimpleExpSmoothing(self.oildata_oil).fit(0.6, optimized=False)
-        fit3 = SimpleExpSmoothing(self.oildata_oil).fit()
+        fit1 = SimpleExpSmoothing(
+            self.oildata_oil, initialization_method="legacy-heuristic"
+        ).fit(0.2, optimized=False)
+        fit2 = SimpleExpSmoothing(
+            self.oildata_oil, initialization_method="legacy-heuristic"
+        ).fit(0.6, optimized=False)
+        fit3 = SimpleExpSmoothing(
+            self.oildata_oil, initialization_method="estimated"
+        ).fit()
         assert_almost_equal(fit1.forecast(1), [484.802468], 4)
         assert_almost_equal(
             fit1.level,
@@ -381,15 +399,19 @@ class TestHoltWinters(object):
         assert_almost_equal(fit3.params["initial_level"], 447.478440, 3)
 
     def test_holt(self):
-        fit1 = Holt(self.air_ausair).fit(
-            smoothing_level=0.8, smoothing_trend=0.2, optimized=False
-        )
-        fit2 = Holt(self.air_ausair, exponential=True).fit(
-            smoothing_level=0.8, smoothing_trend=0.2, optimized=False
-        )
-        fit3 = Holt(self.air_ausair, damped_trend=True).fit(
-            smoothing_level=0.8, smoothing_trend=0.2
-        )
+        fit1 = Holt(
+            self.air_ausair, initialization_method="legacy-heuristic"
+        ).fit(smoothing_level=0.8, smoothing_trend=0.2, optimized=False)
+        fit2 = Holt(
+            self.air_ausair,
+            exponential=True,
+            initialization_method="legacy-heuristic",
+        ).fit(smoothing_level=0.8, smoothing_trend=0.2, optimized=False)
+        fit3 = Holt(
+            self.air_ausair,
+            damped_trend=True,
+            initialization_method="estimated",
+        ).fit(smoothing_level=0.8, smoothing_trend=0.2)
         assert_almost_equal(
             fit1.forecast(5), [43.76, 45.59, 47.43, 49.27, 51.10], 2
         )
@@ -446,11 +468,20 @@ class TestHoltWinters(object):
     @pytest.mark.smoke
     def test_holt_damp_fit(self):
         # Smoke test for parameter estimation
-        fit1 = SimpleExpSmoothing(self.livestock2_livestock).fit()
-        mod4 = Holt(self.livestock2_livestock, damped_trend=True)
+        fit1 = SimpleExpSmoothing(
+            self.livestock2_livestock, initialization_method="estimated"
+        ).fit()
+        mod4 = Holt(
+            self.livestock2_livestock,
+            damped_trend=True,
+            initialization_method="estimated",
+        )
         fit4 = mod4.fit(damping_trend=0.98, method="least_squares")
         mod5 = Holt(
-            self.livestock2_livestock, exponential=True, damped_trend=True
+            self.livestock2_livestock,
+            exponential=True,
+            damped_trend=True,
+            initialization_method="estimated",
         )
         fit5 = mod5.fit()
         # We accept the below values as we getting a better SSE than text book
@@ -473,7 +504,7 @@ class TestHoltWinters(object):
         assert_almost_equal(fit5.params["damping_trend"], 0.98, 2)
         assert_almost_equal(fit5.params["initial_level"], 258.95, 1)
         assert_almost_equal(fit5.params["initial_trend"], 1.04, 2)
-        assert_almost_equal(fit5.sse, 6082.00, 2)  # 6100.11
+        assert_almost_equal(fit5.sse, 6082.00, 1)  # 6100.11
 
     def test_holt_damp_r(self):
         # Test the damping parameters against the R forecast packages `ets`
@@ -481,7 +512,8 @@ class TestHoltWinters(object):
         # livestock2_livestock <- c(...)
         # res <- ets(livestock2_livestock, model='AAN', damped_trend=TRUE,
         #            phi=0.98)
-        mod = Holt(self.livestock2_livestock, damped_trend=True)
+        with pytest.warns(FutureWarning):
+            mod = Holt(self.livestock2_livestock, damped_trend=True)
         params = {
             "smoothing_level": 0.97402626,
             "smoothing_trend": 0.00010006,
@@ -641,10 +673,15 @@ class TestHoltWinters(object):
             seasonal_periods=4,
             trend="additive",
             seasonal="additive",
+            initialization_method="estimated",
         )
         fit1 = mod.fit(use_boxcox=True)
         fit2 = ExponentialSmoothing(
-            self.aust, seasonal_periods=4, trend="add", seasonal="mul"
+            self.aust,
+            seasonal_periods=4,
+            trend="add",
+            seasonal="mul",
+            initialization_method="estimated",
         ).fit(use_boxcox=True)
         assert_almost_equal(
             fit1.forecast(8),
@@ -657,13 +694,18 @@ class TestHoltWinters(object):
             2,
         )
         ExponentialSmoothing(
-            self.aust, seasonal_periods=4, trend="mul", seasonal="add"
+            self.aust,
+            seasonal_periods=4,
+            trend="mul",
+            seasonal="add",
+            initialization_method="estimated",
         ).fit(use_boxcox="log")
         ExponentialSmoothing(
             self.aust,
             seasonal_periods=4,
             trend="multiplicative",
             seasonal="multiplicative",
+            initialization_method="estimated",
         ).fit(use_boxcox="log")
         # Skip since estimator is unstable
         # assert_almost_equal(fit5.forecast(1), [60.60], 2)
@@ -673,7 +715,10 @@ class TestHoltWinters(object):
     # @pytest.mark.xfail(reason='Optimizer does not converge')
     def test_hw_seasonal_buggy(self):
         fit3 = ExponentialSmoothing(
-            self.aust, seasonal_periods=4, seasonal="add"
+            self.aust,
+            seasonal_periods=4,
+            seasonal="add",
+            initialization_method="estimated",
         ).fit(use_boxcox=True)
         assert_almost_equal(
             fit3.forecast(8),
@@ -690,7 +735,10 @@ class TestHoltWinters(object):
             2,
         )
         fit4 = ExponentialSmoothing(
-            self.aust, seasonal_periods=4, seasonal="mul"
+            self.aust,
+            seasonal_periods=4,
+            seasonal="mul",
+            initialization_method="estimated",
         ).fit(use_boxcox=True)
         assert_almost_equal(
             fit4.forecast(8),
@@ -750,8 +798,10 @@ def test_infer_freq():
     hd2 = housing_data.copy()
     hd2.index = list(hd2.index)
     with warnings.catch_warnings(record=True) as w:
-        mod = ExponentialSmoothing(hd2, trend="add", seasonal="add")
-        assert len(w) == 2
+        mod = ExponentialSmoothing(
+            hd2, trend="add", seasonal="add", initialization_method="estimated"
+        )
+        assert len(w) == 1
         assert "ValueWarning" in str(w[0])
     assert mod.seasonal_periods == 12
 
@@ -775,13 +825,14 @@ def test_start_params(trend, seasonal):
 
 
 def test_no_params_to_optimize():
-    mod = ExponentialSmoothing(housing_data)
+    with pytest.warns(FutureWarning):
+        mod = ExponentialSmoothing(housing_data)
     with pytest.warns(EstimationWarning):
         mod.fit(smoothing_level=0.5, initial_level=housing_data.iloc[0])
 
 
 def test_invalid_start_param_length():
-    mod = ExponentialSmoothing(housing_data)
+    mod = ExponentialSmoothing(housing_data, initialization_method="estimated")
     with pytest.raises(ValueError):
         mod.fit(start_params=np.array([0.5]))
 
@@ -878,7 +929,7 @@ def test_equivalence_cython_python(trend, seasonal):
 
 
 def test_direct_holt_add():
-    mod = SimpleExpSmoothing(housing_data)
+    mod = SimpleExpSmoothing(housing_data, initialization_method="estimated")
     res = mod.fit()
     x = np.squeeze(np.asarray(mod.endog))
     alpha = res.params["smoothing_level"]
@@ -890,7 +941,9 @@ def test_direct_holt_add():
     assert_allclose(f, res.level.iloc[-1] * np.ones(5))
     assert_allclose(f, res.forecast(5))
 
-    mod = ExponentialSmoothing(housing_data, trend="add")
+    mod = ExponentialSmoothing(
+        housing_data, trend="add", initialization_method="estimated"
+    )
     res = mod.fit()
     x = np.squeeze(np.asarray(mod.endog))
     alpha = res.params["smoothing_level"]
@@ -920,13 +973,20 @@ def test_integer_array(reset_randomstate):
     y_star = np.cumsum(e[:, 0])
     y = y_star + e[:, 1]
     y = y.astype(int)
-    res = ExponentialSmoothing(y, trend="add").fit()
+    res = ExponentialSmoothing(
+        y, trend="add", initialization_method="estimated"
+    ).fit()
     assert res.params["smoothing_level"] != 0.0
 
 
 def test_damping_trend_zero():
     endog = np.arange(10)
-    mod = ExponentialSmoothing(endog, trend="add", damped_trend=True)
+    mod = ExponentialSmoothing(
+        endog,
+        trend="add",
+        damped_trend=True,
+        initialization_method="estimated",
+    )
     res1 = mod.fit(smoothing_level=1, smoothing_trend=0.0, damping_trend=1e-20)
     pred1 = res1.predict(start=0)
     assert_allclose(pred1, np.r_[0.0, np.arange(9)], atol=1e-10)
@@ -1398,19 +1458,20 @@ def test_simulate_expected_r(
         return
 
     # create HoltWintersResults object with same parameters as in R
-    fit = ExponentialSmoothing(
-        austourists,
-        seasonal_periods=4,
-        trend=trend,
-        seasonal=seasonal,
-        damped_trend=damped,
-    ).fit(
-        smoothing_level=state["alpha"],
-        smoothing_trend=state["beta"],
-        smoothing_seasonal=state["gamma"],
-        damping_trend=state["phi"],
-        optimized=False,
-    )
+    with pytest.warns(FutureWarning):
+        fit = ExponentialSmoothing(
+            austourists,
+            seasonal_periods=4,
+            trend=trend,
+            seasonal=seasonal,
+            damped_trend=damped,
+        ).fit(
+            smoothing_level=state["alpha"],
+            smoothing_trend=state["beta"],
+            smoothing_seasonal=state["gamma"],
+            damping_trend=state["phi"],
+            optimized=False,
+        )
 
     # set the same final state as in R
     fit.level[-1] = state["l"]
@@ -1440,6 +1501,7 @@ def test_simulate_keywords(austourists):
         trend="add",
         seasonal="add",
         damped_trend=True,
+        initialization_method="estimated",
     ).fit()
 
     # test anchor
@@ -1481,6 +1543,7 @@ def test_simulate_boxcox(austourists):
         trend="add",
         seasonal="mul",
         damped_trend=False,
+        initialization_method="estimated",
     ).fit(use_boxcox=True)
     expected = fit.forecast(4).values
 
@@ -1587,7 +1650,7 @@ def test_error_initialization(ses):
 def test_alternative_minimizers(method, ses):
     sv = np.array([0.77, 11.00])
     minimize_kwargs = {}
-    mod = ExponentialSmoothing(ses)
+    mod = ExponentialSmoothing(ses, initialization_method="estimated")
     res = mod.fit(
         method=method, start_params=sv, minimize_kwargs=minimize_kwargs
     )
@@ -1596,7 +1659,7 @@ def test_alternative_minimizers(method, ses):
 
 
 def test_minimizer_kwargs_error(ses):
-    mod = ExponentialSmoothing(ses)
+    mod = ExponentialSmoothing(ses, initialization_method="estimated")
     kwargs = {"args": "anything"}
     with pytest.raises(ValueError):
         mod.fit(minimize_kwargs=kwargs)
@@ -1656,8 +1719,12 @@ def test_bad_bounds(ses):
 
 def test_valid_bounds(ses):
     bounds = {"smoothing_level": (0.1, 1.0)}
-    res = ExponentialSmoothing(ses, bounds=bounds).fit(method="least_squares")
-    res2 = ExponentialSmoothing(ses).fit(method="least_squares")
+    res = ExponentialSmoothing(
+        ses, bounds=bounds, initialization_method="estimated"
+    ).fit(method="least_squares")
+    res2 = ExponentialSmoothing(ses, initialization_method="estimated").fit(
+        method="least_squares"
+    )
     assert_allclose(
         res.params["smoothing_level"],
         res2.params["smoothing_level"],
@@ -1666,17 +1733,21 @@ def test_valid_bounds(ses):
 
 
 def test_fixed_basic(ses):
-    mod = ExponentialSmoothing(ses)
+    mod = ExponentialSmoothing(ses, initialization_method="estimated")
     with mod.fix_params({"smoothing_level": 0.3}):
         res = mod.fit()
     assert res.params["smoothing_level"] == 0.3
 
-    mod = ExponentialSmoothing(ses, trend="add", damped_trend=True)
+    mod = ExponentialSmoothing(
+        ses, trend="add", damped_trend=True, initialization_method="estimated"
+    )
     with mod.fix_params({"damping_trend": 0.98}):
         res = mod.fit()
     assert res.params["damping_trend"] == 0.98
 
-    mod = ExponentialSmoothing(ses, trend="add", seasonal="add")
+    mod = ExponentialSmoothing(
+        ses, trend="add", seasonal="add", initialization_method="estimated"
+    )
     with mod.fix_params({"smoothing_seasonal": 0.1, "smoothing_level": 0.2}):
         res = mod.fit()
     assert res.params["smoothing_seasonal"] == 0.1
@@ -1684,18 +1755,22 @@ def test_fixed_basic(ses):
 
 
 def test_fixed_errors(ses):
-    mod = ExponentialSmoothing(ses)
+    mod = ExponentialSmoothing(ses, initialization_method="estimated")
     with pytest.raises(KeyError):
         with mod.fix_params({"smoothing_trend": 0.3}):
             pass
     with pytest.raises(ValueError):
         with mod.fix_params({"smoothing_level": -0.3}):
             pass
-    mod = ExponentialSmoothing(ses, trend="add")
+    mod = ExponentialSmoothing(
+        ses, trend="add", initialization_method="estimated"
+    )
     with pytest.raises(ValueError):
         with mod.fix_params({"smoothing_level": 0.3, "smoothing_trend": 0.4}):
             pass
-    mod = ExponentialSmoothing(ses, trend="add", seasonal="add")
+    mod = ExponentialSmoothing(
+        ses, trend="add", seasonal="add", initialization_method="estimated"
+    )
     with pytest.raises(ValueError):
         with mod.fix_params(
             {"smoothing_level": 0.3, "smoothing_seasonal": 0.8}
@@ -1703,7 +1778,13 @@ def test_fixed_errors(ses):
             pass
 
     bounds = {"smoothing_level": (0.4, 0.8), "smoothing_seasonal": (0.7, 0.9)}
-    mod = ExponentialSmoothing(ses, trend="add", seasonal="add", bounds=bounds)
+    mod = ExponentialSmoothing(
+        ses,
+        trend="add",
+        seasonal="add",
+        bounds=bounds,
+        initialization_method="estimated",
+    )
     with pytest.raises(ValueError, match="After adjusting for user-provided"):
         with mod.fix_params(
             {"smoothing_trend": 0.3, "smoothing_seasonal": 0.6}
@@ -1714,7 +1795,9 @@ def test_fixed_errors(ses):
 @pytest.mark.parametrize("trend", ["add", None])
 @pytest.mark.parametrize("seasonal", ["add", None])
 def test_brute(ses, trend, seasonal):
-    mod = ExponentialSmoothing(ses, trend=trend, seasonal=seasonal)
+    mod = ExponentialSmoothing(
+        ses, trend=trend, seasonal=seasonal, initialization_method="estimated"
+    )
     res = mod.fit(use_brute=True)
     assert res.mle_retvals.success
 
@@ -1745,7 +1828,7 @@ def test_fix_set_parameters(ses):
 
 
 def test_fix_unfixable(ses):
-    mod = ExponentialSmoothing(ses)
+    mod = ExponentialSmoothing(ses, initialization_method="estimated")
     with pytest.raises(ValueError, match="Cannot fix a parameter"):
         with mod.fix_params({"smoothing_level": 0.25}):
             mod.fit(smoothing_level=0.2)
@@ -1754,10 +1837,17 @@ def test_fix_unfixable(ses):
 def test_infeasible_bounds(ses):
     bounds = {"smoothing_level": (0.1, 0.2), "smoothing_trend": (0.3, 0.4)}
     with pytest.raises(ValueError, match="The bounds for smoothing_trend"):
-        ExponentialSmoothing(ses, trend="add", bounds=bounds).fit()
+        ExponentialSmoothing(
+            ses, trend="add", bounds=bounds, initialization_method="estimated"
+        ).fit()
     bounds = {"smoothing_level": (0.3, 0.5), "smoothing_seasonal": (0.7, 0.8)}
     with pytest.raises(ValueError, match="The bounds for smoothing_seasonal"):
-        ExponentialSmoothing(ses, seasonal="add", bounds=bounds).fit()
+        ExponentialSmoothing(
+            ses,
+            seasonal="add",
+            bounds=bounds,
+            initialization_method="estimated",
+        ).fit()
 
 
 @pytest.mark.parametrize(

--- a/statsmodels/tsa/tests/test_exponential_smoothing.py
+++ b/statsmodels/tsa/tests/test_exponential_smoothing.py
@@ -621,7 +621,7 @@ def test_convergence_simple():
     for i in range(1, e.shape[0]):
         y[i] = y[i - 1] - 0.2 * e[i - 1] + e[i]
     y = y[200:]
-    res = ExponentialSmoothing(y).fit()
+    res = ExponentialSmoothing(y, initialization_method="estimated").fit()
     ets_res = ETSModel(y).fit()
 
     # the smoothing level should be very similar, the initial state might be


### PR DESCRIPTION
Remove future warnings from pandas, NumPy and internal

- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
