### PR TITLE
DOC/MAINT: Fix doc errors and silence warning

### DIFF
--- a/statsmodels/duration/hazard_regression.py
+++ b/statsmodels/duration/hazard_regression.py
@@ -1297,7 +1297,7 @@ class PHReg(model.LikelihoodModel):
             The proportional hazards model parameters.
         scale : float
             Present for compatibility, not used.
-        exog : array-like
+        exog : array_like
             A design matrix, defaults to model.exog.
 
         Returns

--- a/statsmodels/regression/dimred.py
+++ b/statsmodels/regression/dimred.py
@@ -165,7 +165,7 @@ class SlicedInverseReg(_DimReductionRegression):
         ----------
         ndim : int
             The number of EDR directions to estimate
-        pen_mat : array-like
+        pen_mat : array_like
             A 2d array such that the squared Frobenius norm of
             `dot(pen_mat, dirs)`` is added to the objective function,
             where `dirs` is an orthogonal array whose columns span

--- a/statsmodels/robust/robust_linear_model.py
+++ b/statsmodels/robust/robust_linear_model.py
@@ -230,7 +230,7 @@ class RLM(base.LikelihoodModel):
             If `update_scale` is False then the scale estimate for the
             weights is held constant over the iteration.  Otherwise, it
             is updated for each fit in the iteration.  Default is True.
-        start_params : array-like, optional
+        start_params : array_like, optional
             Initial guess of the solution of the optimizer. If not provided,
             the initial parameters are computed using OLS.
 

--- a/statsmodels/tools/docstring.py
+++ b/statsmodels/tools/docstring.py
@@ -618,7 +618,8 @@ class Docstring(object):
         if block_name not in self._ds:
             raise ValueError('{0} is not a block in the '
                              'docstring'.format(block_name))
-        if not isinstance(block, list):
+        if not isinstance(block, list) and \
+                isinstance(self._ds[block_name], list):
             block = [block]
         self._ds[block_name] = block
 

--- a/statsmodels/tsa/_stl.pyx
+++ b/statsmodels/tsa/_stl.pyx
@@ -111,7 +111,7 @@ cdef class STL(object):
 
     Parameters
     ----------
-    endog : array-like
+    endog : array_like
         Data to be decomposed. Must be squeezable to 1-d.
     period : {int, None}, optional
         Periodicity of the sequence. If None and endog is a pandas Series or

--- a/statsmodels/tsa/arima/model.py
+++ b/statsmodels/tsa/arima/model.py
@@ -77,7 +77,7 @@ class ARIMA(sarimax.SARIMAX):
         The offset at which to start time trend values. Default is 1, so that
         if `trend='t'` the trend is equal to 1, 2, ..., nobs. Typically is only
         set when the model created by extending a previous dataset.
-    dates : array-like of datetime, optional
+    dates : array_like of datetime, optional
         If no index is given by `endog` or `exog`, an array-like object of
         datetime objects can be provided.
     freq : str, optional

--- a/statsmodels/tsa/arima/specification.py
+++ b/statsmodels/tsa/arima/specification.py
@@ -81,7 +81,7 @@ class SARIMAXSpecification(object):
         out of the likelihood. This reduces the number of parameters by one.
         This is only applicable when considering estimation by numerical
         maximum likelihood.
-    dates : array-like of datetime, optional
+    dates : array_like of datetime, optional
         If no index is given by `endog` or `exog`, an array-like object of
         datetime objects can be provided.
     freq : str, optional

--- a/statsmodels/tsa/statespace/mlemodel.py
+++ b/statsmodels/tsa/statespace/mlemodel.py
@@ -4302,7 +4302,9 @@ class MLEResults(tsbase.TimeSeriesModelResults):
         except Exception:  # FIXME: catch something specific
             het = np.array([[np.nan]*2])
         try:
-            lb = self.test_serial_correlation(method='ljungbox')
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", category=FutureWarning)
+                lb = self.test_serial_correlation(method='ljungbox')
         except Exception:  # FIXME: catch something specific
             lb = np.array([[np.nan]*2]).reshape(1, 2, 1)
         try:


### PR DESCRIPTION
Silence warning and fix documentation errors

- [X] tests added / passed. 
- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
