### PR TITLE
Improve the stability form regression models with multicollinearity (…

### DIFF
--- a/statsmodels/regression/linear_model.py
+++ b/statsmodels/regression/linear_model.py
@@ -39,6 +39,7 @@ import numpy as np
 from scipy.linalg import toeplitz
 from scipy import stats
 from scipy import optimize
+import scipy.linalg as linalg
 
 from statsmodels.tools.tools import pinv_extended
 from statsmodels.tools.decorators import (cache_readonly,
@@ -262,7 +263,8 @@ class RegressionModel(base.LikelihoodModel):
         method : str, optional
             Can be "pinv", "qr".  "pinv" uses the Moore-Penrose pseudoinverse
             to solve the least squares problem. "qr" uses the QR
-            factorization.
+            factorization. "qr-pivot" uses the
+            QR decomposition with pivoting and better handling of multicollinearity.
         cov_type : str, optional
             See `regression.linear_model.RegressionResults` for a description
             of the available covariance estimators.
@@ -330,6 +332,40 @@ class RegressionModel(base.LikelihoodModel):
             # used in ANOVA
             self.effects = effects = np.dot(Q.T, self.wendog)
             beta = np.linalg.solve(R, effects)
+        elif method == "qr-pivot":
+            Q, R, P = linalg.qr(self.wexog, mode='economic', pivoting=True)
+            self.exog_Q, self.exog_R, self.exog_P = Q, R, P
+
+            # Cache singular values from R.
+            self.wexog_singular_values = np.linalg.svd(R, 0, 0)
+            if 'tol' in kwargs:
+                tol = kwargs['tol']
+            else:
+                tol = 1e-7
+
+            singular_preds = abs(np.diagonal(R)) < tol
+            n_singular = sum(singular_preds)
+            n_preds = len(singular_preds)
+            self.rank = n_preds - n_singular
+            sortP = np.argsort(P)
+
+            if n_singular > 0:
+                rng = range(self.rank)
+                Qq = Q[:, rng]
+                Rr = R[rng, :][:, rng]
+                effects = np.dot(Qq.T, self.wendog)
+                beta = linalg.solve_triangular(Rr, effects)
+                beta = np.concatenate((beta, np.repeat(0.0, n_singular)))[sortP]
+                self.effects = np.concatenate((effects, np.repeat(np.NaN, n_singular)))
+                normalized_cov_params = np.linalg.inv(np.dot(Rr.T, Rr))
+
+                normalized_cov_params = np.vstack((normalized_cov_params, np.zeros((n_singular, self.rank))))
+                normalized_cov_params = np.hstack((normalized_cov_params, np.zeros((n_preds, n_singular))))
+                self.normalized_cov_params = normalized_cov_params[sortP, :][:, sortP]
+            else:
+                self.effects = np.dot(Q.T, self.wendog)
+                beta = linalg.solve_triangular(R, self.effects)[sortP]
+                self.normalized_cov_params = np.linalg.inv(np.dot(R.T, R))[sortP, :][:, sortP]
         else:
             raise ValueError('method has to be "pinv" or "qr"')
 


### PR DESCRIPTION
…WLS, OLS, GLM or any other model that uses WLS) Pseudo Inverse (method=‘pinv’) may product unstable results coefficients (params) values that are extremely larg. The current QR decomposition (mothod=‘qr’) decomposition does not handle the multicollinearity in practice, because of numerical errors in the process of calculating the eigenvalues and the rank of the R matrix.

- [ ] closes #xxxx
- [ ] tests added / passed. 
- [ ] code/documentation is well formatted.  
- [ ] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
