### PR TITLE
Make glm's predict function return numpy array even if exposure is a pandas series

### DIFF
--- a/statsmodels/genmod/generalized_linear_model.py
+++ b/statsmodels/genmod/generalized_linear_model.py
@@ -870,7 +870,7 @@ class GLM(base.LikelihoodModel):
         elif exposure is None:
             exposure = 0.
         else:
-            exposure = np.log(exposure)
+            exposure = np.log(np.asarray(exposure))
 
         if exog is None:
             exog = self.exog

--- a/statsmodels/genmod/tests/test_glm.py
+++ b/statsmodels/genmod/tests/test_glm.py
@@ -844,6 +844,12 @@ class TestGlmPoissonOffset(CheckModelResultsMixin):
         pred2 = mod3.predict(exog=exog1, offset=2*offset, linear=True)
         assert_almost_equal(pred2, pred1+offset)
 
+        # Passing exposure as a pandas series should not effect output type
+        assert isinstance(
+            mod1.predict(exog=exog1, exposure=pd.Series(exposure1)),
+            np.ndarray
+        )
+
 
 def test_perfect_pred():
     cur_dir = os.path.dirname(os.path.abspath(__file__))


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed. 
- [ ] code/documentation is well formatted.  
- [ ] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 
<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
