### PR TITLE
MAINT: Remove FutureWarnings

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -54,6 +54,9 @@ filterwarnings =
     error:categorical is deprecated:FutureWarning
     error:After 0.13 initialization:FutureWarning
     error:The bic value:FutureWarning
+    error:Setting initial values:FutureWarning
+    error:Setting use_boxcox:FutureWarning
+    error:``Describe`` has been deprecated:DeprecationWarning
 markers =
     example: mark a test that runs example code
     matplotlib: mark a test that requires matplotlib

--- a/statsmodels/stats/tests/test_descriptivestats.py
+++ b/statsmodels/stats/tests/test_descriptivestats.py
@@ -11,6 +11,10 @@ from statsmodels.stats.descriptivestats import (
     sign_test,
 )
 
+pytestmark = pytest.mark.filterwarnings(
+    "ignore:``Describe`` has been deprecated:DeprecationWarning"
+)
+
 
 @pytest.fixture(scope="function")
 def df():

--- a/statsmodels/tsa/holtwinters/model.py
+++ b/statsmodels/tsa/holtwinters/model.py
@@ -1178,6 +1178,15 @@ class ExponentialSmoothing(TimeSeriesModel):
             res.level = l0
             res.trend = b0
             res.seasonal = s0
+            if self._fixed_parameters:
+                fp = self._fixed_parameters
+                res.alpha = fp.get("smoothing_level", res.alpha)
+                res.beta = fp.get("smoothing_trend", res.beta)
+                res.gamma = fp.get("smoothing_seasonal", res.gamma)
+                res.phi = fp.get("damping_trend", res.phi)
+                res.level = fp.get("initial_level", res.level)
+                res.trend = fp.get("initial_trend", res.trend)
+                res.seasonal = fp.get("initial_seasonal", res.seasonal)
 
         hwfit = self._predict(
             h=0,


### PR DESCRIPTION
Remove internally generated FutureWarnings

- [ ] closes #xxxx
- [ ] tests added / passed. 
- [ ] code/documentation is well formatted.  
- [ ] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
