### PR TITLE
    BUG: SARIMAX throwing different errors when length of endogenous var is too low

### DIFF
--- a/statsmodels/tsa/statespace/mlemodel.py
+++ b/statsmodels/tsa/statespace/mlemodel.py
@@ -4280,6 +4280,13 @@ class MLEResults(tsbase.TimeSeriesModelResults):
             self.filter_results.standardized_forecasts_error[variable, d:],
             index=ix)
 
+        if resid.shape[0] < max(d, lags):
+            raise ValueError(
+                "Length of endogenous variable must be larger the the number "
+                "of lags used in the model and the number of observations "
+                "burned in the log-likelihood calculation."
+            )
+
         # Top-left: residuals vs time
         ax = fig.add_subplot(221)
         resid.dropna().plot(ax=ax)

--- a/statsmodels/tsa/statespace/tests/test_sarimax.py
+++ b/statsmodels/tsa/statespace/tests/test_sarimax.py
@@ -2726,3 +2726,27 @@ def test_dynamic_str():
     actual = res.get_prediction(index[-24],
                                 dynamic=dynamic.strftime("%Y-%m-%d"))
     assert_allclose(actual.predicted_mean, desired.predicted_mean)
+
+
+@pytest.mark.matplotlib
+def test_plot_too_few_obs(reset_randomstate):
+    # GH 6173
+    # SO https://stackoverflow.com/questions/55930880/
+    #    arima-models-plot-diagnostics-share-error/58051895#58051895
+    mod = sarimax.SARIMAX(
+        np.random.normal(size=10), order=(10, 0, 0), enforce_stationarity=False
+    )
+    results = mod.fit()
+    with pytest.raises(ValueError, match="Length of endogenous"):
+        results.plot_diagnostics(figsize=(15, 5))
+    y = np.random.standard_normal(9)
+    mod = sarimax.SARIMAX(
+        y,
+        order=(1, 1, 1),
+        seasonal_order=(1, 1, 0, 12),
+        enforce_stationarity=False,
+        enforce_invertibility=False,
+    )
+    results = mod.fit()
+    with pytest.raises(ValueError, match="Length of endogenous"):
+        results.plot_diagnostics(figsize=(30, 15))

--- a/statsmodels/tsa/stattools.py
+++ b/statsmodels/tsa/stattools.py
@@ -673,7 +673,7 @@ def acf(
     if not (qstat or alpha):
         return acf
     if alpha is not None:
-        varacf = np.ones(nlags + 1) / nobs
+        varacf = np.ones_like(acf) / nobs
         varacf[0] = 0
         varacf[1] = 1.0 / nobs
         varacf[2:] *= 1 + 2 * np.cumsum(acf[1:-1] ** 2)


### PR DESCRIPTION
- [X] closes #6173 
- [X] closes #6762
- [X] tests added / passed. 
- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
