### PR TITLE
BUG: Fix start params computation with few nobs

### DIFF
--- a/statsmodels/tsa/statespace/sarimax.py
+++ b/statsmodels/tsa/statespace/sarimax.py
@@ -897,7 +897,10 @@ class SARIMAX(MLEModel):
             params_ma = params[offset:k_params_ma + offset]
             offset += k_params_ma
         if residuals is not None:
-            params_variance = (residuals[k_params_ma:]**2).mean()
+            if len(residuals) > 1:
+                params_variance = (residuals[k_params_ma:] ** 2).mean()
+            else:
+                params_variance = np.var(endog)
 
         return (params_trend, params_ar, params_ma,
                 params_variance)

--- a/statsmodels/tsa/statespace/tests/test_sarimax.py
+++ b/statsmodels/tsa/statespace/tests/test_sarimax.py
@@ -2750,3 +2750,16 @@ def test_plot_too_few_obs(reset_randomstate):
     results = mod.fit()
     with pytest.raises(ValueError, match="Length of endogenous"):
         results.plot_diagnostics(figsize=(30, 15))
+
+
+def test_sarimax_starting_values_few_obsevations(reset_randomstate):
+    # GH 6396, 6801
+    y = np.random.standard_normal(17)
+
+    sarimax_model = sarimax.SARIMAX(
+        endog=y, order=(1, 1, 1), seasonal_order=(0, 1, 0, 12), trend="n"
+    ).fit(disp=False)
+
+    assert np.all(
+        np.isfinite(sarimax_model.predict(start=len(y), end=len(y) + 11))
+    )


### PR DESCRIPTION
- [X] closes #6396
- [X] closes #6801
- [X] tests added / passed. 
- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
