### PR TITLE
TST: Relax tolerance on random failure

### DIFF
--- a/statsmodels/tsa/statespace/tests/test_dynamic_factor_mq.py
+++ b/statsmodels/tsa/statespace/tests/test_dynamic_factor_mq.py
@@ -1061,8 +1061,8 @@ def test_quasi_newton_fitting(reset_randomstate):
     res_em = mod_dfm.fit(start_params, em_initialization=False)
     params_em = res_em.params.copy()
 
-    assert_allclose(res_lbfgs.llf, res_em.llf, atol=1e-2)
-    assert_allclose(params_lbfgs, params_em, atol=1e-2)
+    assert_allclose(res_lbfgs.llf, res_em.llf, atol=5e-2, rtol=1e-5)
+    assert_allclose(params_lbfgs, params_em, atol=5e-2, rtol=1e-5)
 
     # Check lbfgs and em converge to the same thing: idiosyncratic_ar1=True
     res_lbfgs = mod_dfm_ar1.fit(method='lbfgs')
@@ -1074,8 +1074,8 @@ def test_quasi_newton_fitting(reset_randomstate):
     res_em = mod_dfm_ar1.fit(params_lbfgs, em_initialization=False)
     params_em = res_em.params.copy()
 
-    assert_allclose(res_lbfgs.llf, res_em.llf, atol=1e-2)
-    assert_allclose(params_lbfgs, params_em, atol=1e-2)
+    assert_allclose(res_lbfgs.llf, res_em.llf, atol=5e-2, rtol=1e-5)
+    assert_allclose(params_lbfgs, params_em, atol=5e-2, rtol=1e-5)
 
 
 def test_summary(reset_randomstate):


### PR DESCRIPTION
Relax tolerance on test that fails occasionally

- [ ] closes #xxxx
- [ ] tests added / passed. 
- [ ] code/documentation is well formatted.  
- [ ] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
