### PR TITLE
DOC: Add docstring to string_like method

### DIFF
--- a/statsmodels/tools/validation/validation.py
+++ b/statsmodels/tools/validation/validation.py
@@ -91,6 +91,7 @@ def array_like(
     >>> a = array_like(pd.Series(x), 'x', ndim=1)
     >>> a.shape
     (4,)
+
     >>> type(a.orig)
     pandas.core.series.Series
 
@@ -395,6 +396,34 @@ def float_like(value, name, optional=False, strict=False):
 
 
 def string_like(value, name, optional=False, options=None, lower=True):
+    """
+    Check if object is string-like and raise if not
+
+    Parameters
+    ----------
+    value : object
+        Value to verify.
+    name : str
+        Variable name for exceptions.
+    optional : bool
+        Flag indicating whether None is allowed.
+    options : tuple[str]
+        Allowed values for input parameter `value`.
+    lower : bool
+        Convert all case-based characters in `value` into lowercase.
+
+    Returns
+    -------
+    str
+        The validated input
+
+    Raises
+    ------
+    TypeError
+        If the value is not a string or None when optional is True.
+    ValueError
+        If the input is not in ``options`` when ``options`` is set.
+    """
     if value is None:
         return None
     if not isinstance(value, str):


### PR DESCRIPTION
Add docstring to string_like method

- [X] closes #6970
- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
