### PR TITLE
ENH/BUG: robust.scale.iqr does need centering, since quantiles are translation equivariant

### DIFF
--- a/statsmodels/robust/scale.py
+++ b/statsmodels/robust/scale.py
@@ -72,7 +72,9 @@ def iqr(a, c=Gaussian.ppf(3/4) - Gaussian.ppf(1/4), axis=0):
     a = array_like(a, 'a', ndim=None)
     c = float_like(c, 'c')
 
-    if a.size == 0:
+    if a.ndim == 0:
+        raise ValueError("a should have at least one dimension")
+    elif a.size == 0:
         return np.nan
     else:
         quantiles = np.quantile(a, [0.25, 0.75], axis=axis)

--- a/statsmodels/robust/scale.py
+++ b/statsmodels/robust/scale.py
@@ -49,7 +49,7 @@ def mad(a, c=Gaussian.ppf(3/4.), axis=0, center=np.median):
     return np.median((np.abs(a-center)) / c, axis=axis)
 
 
-def iqr(a, c=Gaussian.ppf(3/4) - Gaussian.ppf(1/4), axis=0, center=np.median):
+def iqr(a, c=Gaussian.ppf(3/4) - Gaussian.ppf(1/4), axis=0):
     """
     The normalized interquartile range along given axis of an array
 
@@ -64,10 +64,6 @@ def iqr(a, c=Gaussian.ppf(3/4) - Gaussian.ppf(1/4), axis=0, center=np.median):
         approximately 1.349.
     axis : int, optional
         The default is 0. Can also be None.
-    center : callable or float
-        If a callable is provided, such as the default `np.median` then it
-        is expected to be called center(a). The axis argument will be applied
-        via np.apply_over_axes. Otherwise, provide a float.
 
     Returns
     -------
@@ -79,11 +75,7 @@ def iqr(a, c=Gaussian.ppf(3/4) - Gaussian.ppf(1/4), axis=0, center=np.median):
     if a.size == 0:
         return np.nan
     else:
-        if callable(center) and a.size:
-            center = np.apply_over_axes(center, a, axis)
-        else:
-            center = 0.0
-        quantiles = np.quantile(a - center, [0.25, 0.75], axis=axis)
+        quantiles = np.quantile(a, [0.25, 0.75], axis=axis)
         return np.squeeze(np.diff(quantiles, axis=0) / c)
 
 

--- a/statsmodels/robust/tests/test_scale.py
+++ b/statsmodels/robust/tests/test_scale.py
@@ -5,6 +5,7 @@ Test functions for models.robust.scale
 import numpy as np
 from numpy.random import standard_normal
 from numpy.testing import assert_almost_equal, assert_equal
+import pytest
 # Example from Section 5.5, Venables & Ripley (2002)
 
 import statsmodels.robust.scale as scale
@@ -118,7 +119,9 @@ class TestIqr(object):
         assert_equal(scale.iqr(empty, axis=1), np.empty((10, 0)))
         empty = np.empty((100, 100, 0, 0))
         assert_equal(scale.iqr(empty, axis=-1), np.empty((100, 100, 0)))
-
+        empty = np.empty(shape=())
+        with pytest.raises(ValueError):
+            scale.iqr(empty)
 
 class TestIqrAxes(object):
     @classmethod

--- a/statsmodels/robust/tests/test_scale.py
+++ b/statsmodels/robust/tests/test_scale.py
@@ -123,6 +123,7 @@ class TestIqr(object):
         with pytest.raises(ValueError):
             scale.iqr(empty)
 
+
 class TestIqrAxes(object):
     @classmethod
     def setup_class(cls):

--- a/statsmodels/robust/tests/test_scale.py
+++ b/statsmodels/robust/tests/test_scale.py
@@ -119,10 +119,6 @@ class TestIqr(object):
         empty = np.empty((100, 100, 0, 0))
         assert_equal(scale.iqr(empty, axis=-1), np.empty((100, 100, 0)))
 
-    def test_iqr_center(self):
-        n = scale.iqr(self.X, center=0)
-        assert_equal(n.shape, (10,))
-
 
 class TestIqrAxes(object):
     @classmethod


### PR DESCRIPTION
This is regarding the recently added robust.scale.iqr, which computes the normalized interquartile range. Since quantiles are translation equivariant, the interquartile range as an estimate of scale does not need centering. Centering, as implemented now, does not hurt either, it is inconsequential, but there is no need for it. This PR simply removes centering from robust.scale.iqr.

- [Y] tests added / passed. 
- [Y] code/documentation is well formatted.  
- [Y] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>

**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
