### PR TITLE
ENH: Return self from KDEUnivariate fit

### DIFF
--- a/statsmodels/nonparametric/kde.py
+++ b/statsmodels/nonparametric/kde.py
@@ -120,6 +120,11 @@ class KDEUnivariate(object):
             -/+ cut*bw*{min(X) or max(X)}
         adjust : float
             An adjustment factor for the bw. Bandwidth becomes bw * adjust.
+
+        Returns
+        -------
+        KDEUnivariate
+            The instance fit,
         """
         try:
             bw = float(bw)
@@ -152,6 +157,7 @@ class KDEUnivariate(object):
         if weights is not None:
             self.kernel.weights /= weights.sum()
         self._cache = {}
+        return self
 
     @cache_readonly
     def cdf(self):

--- a/statsmodels/nonparametric/tests/test_kde.py
+++ b/statsmodels/nonparametric/tests/test_kde.py
@@ -341,3 +341,10 @@ def test_kde_bw_positive():
     kde = KDE(x)
     kde.fit()
     assert kde.bw > 0
+
+
+def test_fit_self(reset_randomstate):
+    x = np.random.standard_normal(100)
+    kde = KDE(x)
+    assert isinstance(kde, KDE)
+    assert isinstance(kde.fit(), KDE)


### PR DESCRIPTION
Return the fitted instance to simplify chaining

- [X] xref #6988 
- [X] tests added / passed. 
- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
