### PR TITLE
ENH: Allow custom bandwidth functions in KDEUnivariate fit

### DIFF
--- a/lint.sh
+++ b/lint.sh
@@ -116,6 +116,7 @@ if [ "$LINT" == true ]; then
         statsmodels/multivariate/tests/results/ \
         statsmodels/nonparametric/__init__.py \
         statsmodels/nonparametric/api.py \
+        statsmodels/nonparametric/kde.py \
         statsmodels/nonparametric/tests/results/ \
         statsmodels/regression/__init__.py \
         statsmodels/regression/_prediction.py \

--- a/statsmodels/nonparametric/kde.py
+++ b/statsmodels/nonparametric/kde.py
@@ -13,30 +13,37 @@ Silverman, B.W.  Density Estimation for Statistics and Data Analysis.
 """
 import numpy as np
 from scipy import integrate, stats
+
 from statsmodels.sandbox.nonparametric import kernels
 from statsmodels.tools.decorators import cache_readonly
-from statsmodels.tools.validation import array_like
+from statsmodels.tools.validation import array_like, float_like
+
 from . import bandwidths
-from .kdetools import (forrt, revrt, silverman_transform)
+from .kdetools import forrt, revrt, silverman_transform
 from .linbin import fast_linbin
 
-#### Kernels Switch for estimators ####
+# Kernels Switch for estimators
 
-kernel_switch = dict(gau=kernels.Gaussian, epa=kernels.Epanechnikov,
-                    uni=kernels.Uniform, tri=kernels.Triangular,
-                    biw=kernels.Biweight, triw=kernels.Triweight,
-                    cos=kernels.Cosine, cos2=kernels.Cosine2)
+kernel_switch = dict(
+    gau=kernels.Gaussian,
+    epa=kernels.Epanechnikov,
+    uni=kernels.Uniform,
+    tri=kernels.Triangular,
+    biw=kernels.Biweight,
+    triw=kernels.Triweight,
+    cos=kernels.Cosine,
+    cos2=kernels.Cosine2,
+)
+
 
 def _checkisfit(self):
     try:
         self.density
-    except:
+    except Exception:
         raise ValueError("Call fit to fit the density first")
 
 
-#### Kernel Density Estimator Class ###
-
-
+# Kernel Density Estimator Class
 class KDEUnivariate(object):
     """
     Univariate Kernel Density Estimator.
@@ -77,8 +84,17 @@ class KDEUnivariate(object):
     def __init__(self, endog):
         self.endog = array_like(endog, "endog", ndim=1, contiguous=True)
 
-    def fit(self, kernel="gau", bw="normal_reference", fft=True, weights=None,
-            gridsize=None, adjust=1, cut=3, clip=(-np.inf, np.inf)):
+    def fit(
+        self,
+        kernel="gau",
+        bw="normal_reference",
+        fft=True,
+        weights=None,
+        gridsize=None,
+        adjust=1,
+        cut=3,
+        clip=(-np.inf, np.inf),
+    ):
         """
         Attach the density estimate to the KDEUnivariate class.
 
@@ -99,17 +115,19 @@ class KDEUnivariate(object):
             The bandwidth to use. Choices are:
 
             - "scott" - 1.059 * A * nobs ** (-1/5.), where A is
-              `min(std(X),IQR/1.34)`
+              `min(std(x),IQR/1.34)`
             - "silverman" - .9 * A * nobs ** (-1/5.), where A is
-              `min(std(X),IQR/1.34)`
+              `min(std(x),IQR/1.34)`
             - "normal_reference" - C * A * nobs ** (-1/5.), where C is
               calculated from the kernel. Equivalent (up to 2 dp) to the
               "scott" bandwidth for gaussian kernels. See bandwidths.py
-            - If a float is given, it is the bandwidth.
+            - If a float is given, its value is used as the bandwidth.
             - If a callable is given, it's return value is used.
-              The callable should take exactly two parameters ie. fn(X, kern)
-                X    - the clipped input data
-                kern - the kernel instance used
+              The callable should take exactly two parameters, i.e.,
+              fn(x, kern), and return a float, where:
+
+              * x - the clipped input data
+              * kern - the kernel instance used
 
         fft : bool
             Whether or not to use FFT. FFT implementation is more
@@ -117,11 +135,11 @@ class KDEUnivariate(object):
             is implemented. If FFT is False, then a 'nobs' x 'gridsize'
             intermediate array is created.
         gridsize : int
-            If gridsize is None, max(len(X), 50) is used.
+            If gridsize is None, max(len(x), 50) is used.
         cut : float
             Defines the length of the grid past the lowest and highest values
-            of X so that the kernel goes to zero. The end points are
-            -/+ cut*bw*{min(X) or max(X)}
+            of x so that the kernel goes to zero. The end points are
+            -/+ cut*bw*{min(x) or max(x)}
         adjust : float
             An adjustment factor for the bw. Bandwidth becomes bw * adjust.
 
@@ -130,11 +148,13 @@ class KDEUnivariate(object):
         KDEUnivariate
             The instance fit,
         """
-        try:
-            bw = float(bw)
-            self.bw_method = "user-given"
-        except:
+        if isinstance(bw, str):
             self.bw_method = bw
+        else:
+            self.bw_method = "user-given"
+            if not callable(bw):
+                bw = float_like(bw, "bw")
+
         endog = self.endog
 
         if fft:
@@ -144,18 +164,32 @@ class KDEUnivariate(object):
             if weights is not None:
                 msg = "Weights are not implemented for fft"
                 raise NotImplementedError(msg)
-            density, grid, bw = kdensityfft(endog, kernel=kernel, bw=bw,
-                    adjust=adjust, weights=weights, gridsize=gridsize,
-                    clip=clip, cut=cut)
+            density, grid, bw = kdensityfft(
+                endog,
+                kernel=kernel,
+                bw=bw,
+                adjust=adjust,
+                weights=weights,
+                gridsize=gridsize,
+                clip=clip,
+                cut=cut,
+            )
         else:
-            density, grid, bw = kdensity(endog, kernel=kernel, bw=bw,
-                    adjust=adjust, weights=weights, gridsize=gridsize,
-                    clip=clip, cut=cut)
+            density, grid, bw = kdensity(
+                endog,
+                kernel=kernel,
+                bw=bw,
+                adjust=adjust,
+                weights=weights,
+                gridsize=gridsize,
+                clip=clip,
+                cut=cut,
+            )
         self.density = density
         self.support = grid
         self.bw = bw
-        self.kernel = kernel_switch[kernel](h=bw) # we instantiate twice,
-                                                # should this passed to funcs?
+        self.kernel = kernel_switch[kernel](h=bw)  # we instantiate twice,
+        # should this passed to funcs?
         # put here to ensure empty cache after re-fit with new options
         self.kernel.weights = weights
         if weights is not None:
@@ -174,18 +208,22 @@ class KDEUnivariate(object):
         """
         _checkisfit(self)
         kern = self.kernel
-        if kern.domain is None: # TODO: test for grid point at domain bound
-            a,b = -np.inf,np.inf
+        if kern.domain is None:  # TODO: test for grid point at domain bound
+            a, b = -np.inf, np.inf
         else:
-            a,b = kern.domain
-        func = lambda x,s: kern.density(s,x)
+            a, b = kern.domain
+
+        def func(x, s):
+            return kern.density(s, x)
 
         support = self.support
-        support = np.r_[a,support]
+        support = np.r_[a, support]
         gridsize = len(support)
         endog = self.endog
-        probs = [integrate.quad(func, support[i - 1], support[i],
-                    args=endog)[0] for i in range(1, gridsize)]
+        probs = [
+            integrate.quad(func, support[i - 1], support[i], args=endog)[0]
+            for i in range(1, gridsize)
+        ]
         return np.cumsum(probs)
 
     @cache_readonly
@@ -224,9 +262,9 @@ class KDEUnivariate(object):
         """
         _checkisfit(self)
 
-        def entr(x,s):
-            pdf = kern.density(s,x)
-            return pdf*np.log(pdf+1e-12)
+        def entr(x, s):
+            pdf = kern.density(s, x)
+            return pdf * np.log(pdf + 1e-12)
 
         kern = self.kernel
 
@@ -235,7 +273,7 @@ class KDEUnivariate(object):
         else:
             a, b = -np.inf, np.inf
         endog = self.endog
-        #TODO: below could run into integr problems, cf. stats.dist._entropy
+        # TODO: below could run into integr problems, cf. stats.dist._entropy
         return -integrate.quad(entr, a, b, args=(endog,))[0]
 
     @cache_readonly
@@ -265,16 +303,24 @@ class KDEUnivariate(object):
         return self.kernel.density(self.endog, point)
 
 
-#### Kernel Density Estimator Functions ####
-
-def kdensity(X, kernel="gau", bw="normal_reference", weights=None, gridsize=None,
-             adjust=1, clip=(-np.inf, np.inf), cut=3, retgrid=True):
+# Kernel Density Estimator Functions
+def kdensity(
+    x,
+    kernel="gau",
+    bw="normal_reference",
+    weights=None,
+    gridsize=None,
+    adjust=1,
+    clip=(-np.inf, np.inf),
+    cut=3,
+    retgrid=True,
+):
     """
     Rosenblatt-Parzen univariate kernel density estimator.
 
     Parameters
     ----------
-    X : array_like
+    x : array_like
         The variable for which the density estimate is desired.
     kernel : str
         The Kernel to be used. Choices are
@@ -286,27 +332,37 @@ def kdensity(X, kernel="gau", bw="normal_reference", weights=None, gridsize=None
         - "triw" for triweight
         - "uni" for uniform
     bw : str, float, callable
-        "scott" - 1.059 * A * nobs ** (-1/5.), where A is min(std(X),IQR/1.34)
-        "silverman" - .9 * A * nobs ** (-1/5.), where A is min(std(X),IQR/1.34)
-        If a float is given, it is the bandwidth.
-        If a callable is given, it's return value is used.
-        The callable should take exactly two parameters ie. fn(X, kern)
-          X    - the clipped input data
-          kern - the kernel instance used
+        The bandwidth to use. Choices are:
+
+        - "scott" - 1.059 * A * nobs ** (-1/5.), where A is
+          `min(std(x),IQR/1.34)`
+        - "silverman" - .9 * A * nobs ** (-1/5.), where A is
+          `min(std(x),IQR/1.34)`
+        - "normal_reference" - C * A * nobs ** (-1/5.), where C is
+          calculated from the kernel. Equivalent (up to 2 dp) to the
+          "scott" bandwidth for gaussian kernels. See bandwidths.py
+        - If a float is given, its value is used as the bandwidth.
+        - If a callable is given, it's return value is used.
+          The callable should take exactly two parameters, i.e.,
+          fn(x, kern), and return a float, where:
+
+          * x - the clipped input data
+          * kern - the kernel instance used
+
     weights : array or None
-        Optional  weights. If the X value is clipped, then this weight is
+        Optional  weights. If the x value is clipped, then this weight is
         also dropped.
     gridsize : int
-        If gridsize is None, max(len(X), 50) is used.
+        If gridsize is None, max(len(x), 50) is used.
     adjust : float
         An adjustment factor for the bw. Bandwidth becomes bw * adjust.
     clip : tuple
-        Observations in X that are outside of the range given by clip are
-        dropped. The number of observations in X is then shortened.
+        Observations in x that are outside of the range given by clip are
+        dropped. The number of observations in x is then shortened.
     cut : float
-        Defines the length of the grid past the lowest and highest values of X
+        Defines the length of the grid past the lowest and highest values of x
         so that the kernel goes to zero. The end points are
-        -/+ cut*bw*{min(X) or max(X)}
+        -/+ cut*bw*{min(x) or max(x)}
     retgrid : bool
         Whether or not to return the grid over which the density is estimated.
 
@@ -322,16 +378,16 @@ def kdensity(X, kernel="gau", bw="normal_reference", weights=None, gridsize=None
     Creates an intermediate (`gridsize` x `nobs`) array. Use FFT for a more
     computationally efficient version.
     """
-    X = np.asarray(X)
-    if X.ndim == 1:
-        X = X[:, None]
-    clip_x = np.logical_and(X > clip[0], X < clip[1])
-    X = X[clip_x]
+    x = np.asarray(x)
+    if x.ndim == 1:
+        x = x[:, None]
+    clip_x = np.logical_and(x > clip[0], x < clip[1])
+    x = x[clip_x]
 
-    nobs = len(X) # after trim
+    nobs = len(x)  # after trim
 
     if gridsize is None:
-        gridsize = max(nobs,50) # do not need to resize if no FFT
+        gridsize = max(nobs, 50)  # do not need to resize if no FFT
 
         # handle weights
     if weights is None:
@@ -342,7 +398,7 @@ def kdensity(X, kernel="gau", bw="normal_reference", weights=None, gridsize=None
         weights = np.asarray(weights)
 
         if len(weights) != len(clip_x):
-            msg = "The length of the weights must be the same as the given X."
+            msg = "The length of the weights must be the same as the given x."
             raise ValueError(msg)
         weights = weights[clip_x.squeeze()]
         q = weights.sum()
@@ -351,50 +407,65 @@ def kdensity(X, kernel="gau", bw="normal_reference", weights=None, gridsize=None
     kern = kernel_switch[kernel]()
 
     if callable(bw):
-        bw = float(bw(X, kern)) # user passed a callable custom bandwidth function
+        bw = float(bw(x, kern))
+        # user passed a callable custom bandwidth function
+    elif isinstance(bw, str):
+        bw = bandwidths.select_bandwidth(x, bw, kern)
+        # will cross-val fit this pattern?
     else:
-        # if bw is None, select optimal bandwidth for kernel
-        try:
-            bw = float(bw)
-        except:
-            bw = bandwidths.select_bandwidth(X, bw, kern) # will cross-val fit this pattern?
+        bw = float_like(bw, "bw")
+
     bw *= adjust
 
-    a = np.min(X, axis=0) - cut * bw
-    b = np.max(X, axis=0) + cut * bw
+    a = np.min(x, axis=0) - cut * bw
+    b = np.max(x, axis=0) + cut * bw
     grid = np.linspace(a, b, gridsize)
 
-    k = (X.T - grid[:, None])/bw  # uses broadcasting to make a gridsize x nobs
+    k = (
+        x.T - grid[:, None]
+    ) / bw  # uses broadcasting to make a gridsize x nobs
 
     # set kernel bandwidth
     kern.seth(bw)
 
     # truncate to domain
-    if kern.domain is not None: # will not work for piecewise kernels like parzen
+    if (
+        kern.domain is not None
+    ):  # will not work for piecewise kernels like parzen
         z_lo, z_high = kern.domain
         domain_mask = (k < z_lo) | (k > z_high)
-        k = kern(k) # estimate density
+        k = kern(k)  # estimate density
         k[domain_mask] = 0
     else:
-        k = kern(k) # estimate density
+        k = kern(k)  # estimate density
 
-    k[k < 0] = 0 # get rid of any negative values, do we need this?
+    k[k < 0] = 0  # get rid of any negative values, do we need this?
 
-    dens = np.dot(k, weights)/(q*bw)
+    dens = np.dot(k, weights) / (q * bw)
 
     if retgrid:
         return dens, grid, bw
     else:
         return dens, bw
 
-def kdensityfft(X, kernel="gau", bw="normal_reference", weights=None, gridsize=None,
-                adjust=1, clip=(-np.inf, np.inf), cut=3, retgrid=True):
+
+def kdensityfft(
+    x,
+    kernel="gau",
+    bw="normal_reference",
+    weights=None,
+    gridsize=None,
+    adjust=1,
+    clip=(-np.inf, np.inf),
+    cut=3,
+    retgrid=True,
+):
     """
     Rosenblatt-Parzen univariate kernel density estimator
 
     Parameters
     ----------
-    X : array_like
+    x : array_like
         The variable for which the density estimate is desired.
     kernel : str
         ONLY GAUSSIAN IS CURRENTLY IMPLEMENTED.
@@ -407,29 +478,39 @@ def kdensityfft(X, kernel="gau", bw="normal_reference", weights=None, gridsize=N
         "rect" for rectangular
         "tri" for triangular
     bw : str, float, callable
-        "scott" - 1.059 * A * nobs ** (-1/5.), where A is min(std(X),IQR/1.34)
-        "silverman" - .9 * A * nobs ** (-1/5.), where A is min(std(X),IQR/1.34)
-        If a float is given, it is the bandwidth.
-        If a callable is given, it's return value is used.
-        The callable should take exactly two parameters ie. fn(X, kern)
-          X    - the clipped input data
-          kern - the kernel instance used
+        The bandwidth to use. Choices are:
+
+        - "scott" - 1.059 * A * nobs ** (-1/5.), where A is
+          `min(std(x),IQR/1.34)`
+        - "silverman" - .9 * A * nobs ** (-1/5.), where A is
+          `min(std(x),IQR/1.34)`
+        - "normal_reference" - C * A * nobs ** (-1/5.), where C is
+          calculated from the kernel. Equivalent (up to 2 dp) to the
+          "scott" bandwidth for gaussian kernels. See bandwidths.py
+        - If a float is given, its value is used as the bandwidth.
+        - If a callable is given, it's return value is used.
+          The callable should take exactly two parameters, i.e.,
+          fn(x, kern), and return a float, where:
+
+          * x - the clipped input data
+          * kern - the kernel instance used
+
     weights : array or None
         WEIGHTS ARE NOT CURRENTLY IMPLEMENTED.
-        Optional  weights. If the X value is clipped, then this weight is
+        Optional  weights. If the x value is clipped, then this weight is
         also dropped.
     gridsize : int
-        If gridsize is None, min(len(X), 512) is used. Note that the provided
+        If gridsize is None, min(len(x), 512) is used. Note that the provided
         number is rounded up to the next highest power of 2.
     adjust : float
         An adjustment factor for the bw. Bandwidth becomes bw * adjust.
         clip : tuple
-        Observations in X that are outside of the range given by clip are
-        dropped. The number of observations in X is then shortened.
+        Observations in x that are outside of the range given by clip are
+        dropped. The number of observations in x is then shortened.
     cut : float
-        Defines the length of the grid past the lowest and highest values of X
+        Defines the length of the grid past the lowest and highest values of x
         so that the kernel goes to zero. The end points are
-        -/+ cut*bw*{X.min() or X.max()}
+        -/+ cut*bw*{x.min() or x.max()}
     retgrid : bool
         Whether or not to return the grid over which the density is estimated.
 
@@ -461,52 +542,54 @@ def kdensityfft(X, kernel="gau", bw="normal_reference", weights=None, gridsize=N
         the Fast Fourier Transform. Journal of the Royal Statistical Society.
         Series C. 31.2, 93-9.
     """
-    X = np.asarray(X)
-    X = X[np.logical_and(X > clip[0], X < clip[1])] # will not work for two columns.
-                                                # will affect underlying data?
+    x = np.asarray(x)
+    # will not work for two columns.
+    x = x[np.logical_and(x > clip[0], x < clip[1])]
 
     # Get kernel object corresponding to selection
     kern = kernel_switch[kernel]()
 
     if callable(bw):
-        bw = float(bw(X, kern)) # user passed a callable custom bandwidth function
-    else:
+        bw = float(bw(x, kern))
+        # user passed a callable custom bandwidth function
+    elif isinstance(bw, str):
         # if bw is None, select optimal bandwidth for kernel
-        try:
-            bw = float(bw)
-        except:
-            bw = bandwidths.select_bandwidth(X, bw, kern) # will cross-val fit this pattern?
+        bw = bandwidths.select_bandwidth(x, bw, kern)
+        # will cross-val fit this pattern?
+    else:
+        bw = float_like(bw, "bw")
+
     bw *= adjust
 
-    nobs = len(X) # after trim
+    nobs = len(x)  # after trim
 
     # 1 Make grid and discretize the data
     if gridsize is None:
-        gridsize = np.max((nobs, 512.))
-    gridsize = 2**np.ceil(np.log2(gridsize)) # round to next power of 2
+        gridsize = np.max((nobs, 512.0))
+    gridsize = 2 ** np.ceil(np.log2(gridsize))  # round to next power of 2
 
-    a = np.min(X) - cut * bw
-    b = np.max(X) + cut * bw
-    grid,delta = np.linspace(a, b, int(gridsize), retstep=True)
+    a = np.min(x) - cut * bw
+    b = np.max(x) + cut * bw
+    grid, delta = np.linspace(a, b, int(gridsize), retstep=True)
     RANGE = b - a
 
-#TODO: Fix this?
-# This is the Silverman binning function, but I believe it's buggy (SS)
-# weighting according to Silverman
-#    count = counts(X,grid)
-#    binned = np.zeros_like(grid)    #xi_{k} in Silverman
-#    j = 0
-#    for k in range(int(gridsize-1)):
-#        if count[k]>0: # there are points of X in the grid here
-#            Xingrid = X[j:j+count[k]] # get all these points
-#            # get weights at grid[k],grid[k+1]
-#            binned[k] += np.sum(grid[k+1]-Xingrid)
-#            binned[k+1] += np.sum(Xingrid-grid[k])
-#            j += count[k]
-#    binned /= (nobs)*delta**2 # normalize binned to sum to 1/delta
+    # TODO: Fix this?
+    # This is the Silverman binning function, but I believe it's buggy (SS)
+    # weighting according to Silverman
+    #    count = counts(x,grid)
+    #    binned = np.zeros_like(grid)    #xi_{k} in Silverman
+    #    j = 0
+    #    for k in range(int(gridsize-1)):
+    #        if count[k]>0: # there are points of x in the grid here
+    #            Xingrid = x[j:j+count[k]] # get all these points
+    #            # get weights at grid[k],grid[k+1]
+    #            binned[k] += np.sum(grid[k+1]-Xingrid)
+    #            binned[k+1] += np.sum(Xingrid-grid[k])
+    #            j += count[k]
+    #    binned /= (nobs)*delta**2 # normalize binned to sum to 1/delta
 
-#NOTE: THE ABOVE IS WRONG, JUST TRY WITH LINEAR BINNING
-    binned = fast_linbin(X, a, b, gridsize) / (delta * nobs)
+    # NOTE: THE ABOVE IS WRONG, JUST TRY WITH LINEAR BINNING
+    binned = fast_linbin(x, a, b, gridsize) / (delta * nobs)
 
     # step 2 compute FFT of the weights, using Munro (1976) FFT convention
     y = forrt(binned)
@@ -514,10 +597,11 @@ def kdensityfft(X, kernel="gau", bw="normal_reference", weights=None, gridsize=N
     # step 3 and 4 for optimal bw compute zstar and the density estimate f
     # do not have to redo the above if just changing bw, ie., for cross val
 
-#NOTE: silverman_transform is the closed form solution of the FFT of the
-#gaussian kernel. Not yet sure how to generalize it.
-    zstar = silverman_transform(bw, gridsize, RANGE)*y # 3.49 in Silverman
-                                                    # 3.50 w Gaussian kernel
+    # NOTE: silverman_transform is the closed form solution of the FFT of the
+    # gaussian kernel. Not yet sure how to generalize it.
+    zstar = silverman_transform(bw, gridsize, RANGE) * y
+    # 3.49 in Silverman
+    # 3.50 w Gaussian kernel
     f = revrt(zstar)
     if retgrid:
         return f, grid, bw

--- a/statsmodels/nonparametric/tests/test_kde.py
+++ b/statsmodels/nonparametric/tests/test_kde.py
@@ -376,3 +376,15 @@ class TestKDECustomBandwidth(object):
 
         npt.assert_almost_equal(s1, kde.support, self.decimal_density)
         npt.assert_almost_equal(d1, kde.density, self.decimal_density)
+
+    @pytest.mark.parametrize("fft", [True, False])
+    def test_check_is_fit_ok_with_float_bandwidth(self, fft):
+        # Note, we are passing the function, not the string - this is intended
+        kde = self.kde.fit(bw=bandwidths.bw_silverman, fft=fft)
+        s1 = kde.support.copy()
+        d1 = kde.density.copy()
+
+        kde = self.kde.fit(bw=kde.bw, fft=fft)
+
+        npt.assert_almost_equal(s1, kde.support, self.decimal_density)
+        npt.assert_almost_equal(d1, kde.density, self.decimal_density)


### PR DESCRIPTION
- [X] closes #6997 
- [X] closes #6988
- [X] tests added / passed. 
- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
