### PR TITLE
BUG: param names with higher order trend in VARMAX

### DIFF
--- a/statsmodels/tsa/statespace/tests/test_varmax.py
+++ b/statsmodels/tsa/statespace/tests/test_varmax.py
@@ -1223,3 +1223,60 @@ def test_vma1_exog():
     # Have to ignore first 2 observations due to differences in initialization
     assert_allclose(res_mva.llf_obs[2:],
                     (res_ma1.llf_obs + res_ma2.llf_obs)[2:])
+
+
+def test_param_names_trend():
+    endog = np.zeros((3, 2))
+    base_names = ['L1.y1.y1', 'L1.y2.y1', 'L1.y1.y2', 'L1.y2.y2',
+                  'sqrt.var.y1', 'sqrt.cov.y1.y2', 'sqrt.var.y2']
+    base_params = [0.5, 0, 0, 0.4, 1.0, 0.0, 1.0]
+
+    # No trend
+    mod = varmax.VARMAX(endog, order=(1, 0), trend='n')
+    desired = base_names
+    assert_equal(mod.param_names, desired)
+
+    # Intercept
+    mod = varmax.VARMAX(endog, order=(1, 0), trend=[1])
+    desired = ['intercept.y1', 'intercept.y2'] + base_names
+    assert_equal(mod.param_names, desired)
+    mod.update([1.2, -0.5] + base_params)
+    assert_allclose(mod['state_intercept'], [1.2, -0.5])
+
+    # Intercept + drift
+    mod = varmax.VARMAX(endog, order=(1, 0), trend=[1, 1])
+    desired = (['intercept.y1', 'drift.y1',
+                'intercept.y2', 'drift.y2'] + base_names)
+    assert_equal(mod.param_names, desired)
+    mod.update([1.2, 0, -0.5, 0] + base_params)
+    assert_allclose(mod['state_intercept', 0], 1.2)
+    assert_allclose(mod['state_intercept', 1], -0.5)
+    mod.update([0, 1, 0, 1.1] + base_params)
+    assert_allclose(mod['state_intercept', 0], np.arange(2, 5))
+    assert_allclose(mod['state_intercept', 1], 1.1 * np.arange(2, 5))
+    mod.update([1.2, 1, -0.5, 1.1] + base_params)
+    assert_allclose(mod['state_intercept', 0], 1.2 + np.arange(2, 5))
+    assert_allclose(mod['state_intercept', 1], -0.5 + 1.1 * np.arange(2, 5))
+
+    # Drift only
+    mod = varmax.VARMAX(endog, order=(1, 0), trend=[0, 1])
+    desired = ['drift.y1', 'drift.y2'] + base_names
+    assert_equal(mod.param_names, desired)
+    mod.update([1, 1.1] + base_params)
+    assert_allclose(mod['state_intercept', 0], np.arange(2, 5))
+    assert_allclose(mod['state_intercept', 1], 1.1 * np.arange(2, 5))
+
+    # Intercept + third order
+    mod = varmax.VARMAX(endog, order=(1, 0), trend=[1, 0, 1])
+    desired = (['intercept.y1', 'trend.2.y1',
+                'intercept.y2', 'trend.2.y2'] + base_names)
+    assert_equal(mod.param_names, desired)
+    mod.update([1.2, 0, -0.5, 0] + base_params)
+    assert_allclose(mod['state_intercept', 0], 1.2)
+    assert_allclose(mod['state_intercept', 1], -0.5)
+    mod.update([0, 1, 0, 1.1] + base_params)
+    assert_allclose(mod['state_intercept', 0], np.arange(2, 5)**2)
+    assert_allclose(mod['state_intercept', 1], 1.1 * np.arange(2, 5)**2)
+    mod.update([1.2, 1, -0.5, 1.1] + base_params)
+    assert_allclose(mod['state_intercept', 0], 1.2 + np.arange(2, 5)**2)
+    assert_allclose(mod['state_intercept', 1], -0.5 + 1.1 * np.arange(2, 5)**2)

--- a/statsmodels/tsa/statespace/varmax.py
+++ b/statsmodels/tsa/statespace/varmax.py
@@ -454,16 +454,14 @@ class VARMAX(MLEModel):
 
         # 1. Intercept terms
         if self.k_trend > 0:
-            for i in self.polynomial_trend.nonzero()[0]:
-                if i == 0:
-                    param_names += ['intercept.%s' % endog_names[j]
-                                    for j in range(self.k_endog)]
-                elif i == 1:
-                    param_names += ['drift.%s' % endog_names[j]
-                                    for j in range(self.k_endog)]
-                else:
-                    param_names += ['trend.%d.%s' % (i, endog_names[j])
-                                    for j in range(self.k_endog)]
+            for j in range(self.k_endog):
+                for i in self.polynomial_trend.nonzero()[0]:
+                    if i == 0:
+                        param_names += ['intercept.%s' % endog_names[j]]
+                    elif i == 1:
+                        param_names += ['drift.%s' % endog_names[j]]
+                    else:
+                        param_names += ['trend.%d.%s' % (i, endog_names[j])]
 
         # 2. AR terms
         param_names += [
@@ -724,7 +722,7 @@ class VARMAX(MLEModel):
             # just += later
             if not self.mle_regression:
                 zero = np.array(0, dtype=params.dtype)
-                self.ssm[self._idx_state_intercept] = zero
+                self.ssm['state_intercept', :] = zero
 
             trend_params = params[self._params_trend].reshape(
                 self.k_endog, self.k_trend).T


### PR DESCRIPTION
- [x] closes #7009 
- [x] tests added / passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message.

Fixes incorrect ordering of drift / higher order trend terms in the parameter names list for VARMAX.