### PR TITLE
REF: Don't validate specification in SARIMAX when cloning to get extended time varying matrices

### DIFF
--- a/statsmodels/tsa/arima/model.py
+++ b/statsmodels/tsa/arima/model.py
@@ -110,7 +110,7 @@ class ARIMA(sarimax.SARIMAX):
                  seasonal_order=(0, 0, 0, 0), trend=None,
                  enforce_stationarity=True, enforce_invertibility=True,
                  concentrate_scale=False, trend_offset=1, dates=None,
-                 freq=None, missing='none'):
+                 freq=None, missing='none', validate_specification=True):
         # Default for trend
         # 'c' if there is no integration and 'n' otherwise
         # TODO: if trend='c', then we could alternatively use `demean=True` in
@@ -131,7 +131,8 @@ class ARIMA(sarimax.SARIMAX):
             endog, exog=exog, order=order, seasonal_order=seasonal_order,
             trend=trend, enforce_stationarity=None, enforce_invertibility=None,
             concentrate_scale=concentrate_scale, trend_offset=trend_offset,
-            dates=dates, freq=freq, missing=missing)
+            dates=dates, freq=freq, missing=missing,
+            validate_specification=validate_specification)
         exog = self._spec_arima._model.data.orig_exog
 
         # Keep the given `exog` by removing the prepended trend variables
@@ -152,7 +153,7 @@ class ARIMA(sarimax.SARIMAX):
             enforce_stationarity=enforce_stationarity,
             enforce_invertibility=enforce_invertibility,
             concentrate_scale=concentrate_scale, dates=dates, freq=freq,
-            missing=missing)
+            missing=missing, validate_specification=validate_specification)
         self.trend = trend
 
         # Save the input exog and input exog names, so that we can refer to

--- a/statsmodels/tsa/statespace/sarimax.py
+++ b/statsmodels/tsa/statespace/sarimax.py
@@ -322,13 +322,14 @@ class SARIMAX(MLEModel):
                  enforce_stationarity=True, enforce_invertibility=True,
                  hamilton_representation=False, concentrate_scale=False,
                  trend_offset=1, use_exact_diffuse=False, dates=None,
-                 freq=None, missing='none', **kwargs):
+                 freq=None, missing='none', validate_specification=True,
+                 **kwargs):
 
         self._spec = SARIMAXSpecification(
             endog, exog=exog, order=order, seasonal_order=seasonal_order,
             trend=trend, enforce_stationarity=None, enforce_invertibility=None,
             concentrate_scale=concentrate_scale, dates=dates, freq=freq,
-            missing=missing)
+            missing=missing, validate_specification=validate_specification)
         self._params = SARIMAXParams(self._spec)
 
         # Save given orders
@@ -1734,10 +1735,11 @@ class SARIMAX(MLEModel):
         if not self.simple_differencing and self._k_trend > 0:
             extend_kwargs.setdefault(
                 'trend_offset', self.trend_offset + self.nobs)
+        extend_kwargs.setdefault('validate_specification', False)
         mod_extend = self.clone(
             endog=tmp_endog, exog=tmp_exog, **extend_kwargs)
         mod_extend.update(params, transformed=transformed,
-                          includes_fixed=includes_fixed)
+                          includes_fixed=includes_fixed,)
 
         # Retrieve the extensions to the time-varying system matrices
         # and put them in kwargs

--- a/statsmodels/tsa/statespace/tests/test_sarimax.py
+++ b/statsmodels/tsa/statespace/tests/test_sarimax.py
@@ -2763,3 +2763,20 @@ def test_sarimax_starting_values_few_obsevations(reset_randomstate):
     assert np.all(
         np.isfinite(sarimax_model.predict(start=len(y), end=len(y) + 11))
     )
+
+
+def test_sarimax_forecast_exog_trend(reset_randomstate):
+    # Test that an error is not raised that the given `exog` for the forecast
+    # period is a constant when forecating with an intercept
+    # GH 7019
+    y = np.zeros(10)
+    x = np.zeros(10)
+
+    mod = sarimax.SARIMAX(endog=y, exog=x, order=(1, 0, 0), trend='c')
+    res = mod.smooth([0.2, 0.4, 0.5, 1.0])
+
+    # Test for h=1
+    assert_allclose(res.forecast(1, exog=1), 0.2 + 0.4)
+
+    # Test for h=2
+    assert_allclose(res.forecast(2, exog=[1., 1.]), 0.2 + 0.4, 0.2 + 0.4 + 0.5)


### PR DESCRIPTION
- [x] closes #7019
- [x] tests added / passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message.