### PR TITLE
ENH: Make additive noise optional for ProcessReg

### DIFF
--- a/statsmodels/regression/process_regression.py
+++ b/statsmodels/regression/process_regression.py
@@ -587,7 +587,8 @@ class ProcessMLE(base.LikelihoodModel):
             # The derivatives with respect to the standard deviation parameters
             if self._has_noise:
                 sno = no_i[:, None]**2 * exog_noise_i
-                score[pm + pv + ps:] -= np.dot(cmi.flat[::cm.shape[0] + 1], sno)
+                score[pm + pv + ps:] -= np.dot(cmi.flat[::cm.shape[0] + 1],
+                    sno)
                 bm = np.dot(cmi, np.dot(rx, cmi))
                 score[pm + pv + ps:] += np.dot(bm.flat[::bm.shape[0] + 1], sno)
 
@@ -860,7 +861,7 @@ class ProcessMLEResults(base.GenericLikelihoodModelResults):
         df = pd.DataFrame()
 
         typ = (["Mean"] * self.k_exog + ["Scale"] * self.k_scale +
-                      ["Smooth"] * self.k_smooth)
+            ["Smooth"] * self.k_smooth)
         if self._has_noise:
             typ += ["SD"] * self.k_noise
         df["Type"] = typ

--- a/statsmodels/regression/process_regression.py
+++ b/statsmodels/regression/process_regression.py
@@ -588,7 +588,7 @@ class ProcessMLE(base.LikelihoodModel):
             if self._has_noise:
                 sno = no_i[:, None]**2 * exog_noise_i
                 score[pm + pv + ps:] -= np.dot(cmi.flat[::cm.shape[0] + 1],
-                    sno)
+                         sno)
                 bm = np.dot(cmi, np.dot(rx, cmi))
                 score[pm + pv + ps:] += np.dot(bm.flat[::bm.shape[0] + 1], sno)
 
@@ -861,7 +861,7 @@ class ProcessMLEResults(base.GenericLikelihoodModelResults):
         df = pd.DataFrame()
 
         typ = (["Mean"] * self.k_exog + ["Scale"] * self.k_scale +
-            ["Smooth"] * self.k_smooth)
+               ["Smooth"] * self.k_smooth)
         if self._has_noise:
             typ += ["SD"] * self.k_noise
         df["Type"] = typ

--- a/statsmodels/regression/process_regression.py
+++ b/statsmodels/regression/process_regression.py
@@ -1,14 +1,14 @@
 # -*- coding: utf-8 -*-
 """
 This module implements maximum likelihood-based estimation (MLE) of
-Gaussian models for finite-dimensional observations made on
+Gaussian regression models for finite-dimensional observations made on
 infinite-dimensional processes.
 
 The ProcessMLE class supports regression analyses on grouped data,
 where the observations within a group are dependent (they are made on
-the same underlying process).  The main application is repeated
-measures regression for temporal (longitudinal) data, in which the
-repeated measures occur at arbitrary real-valued time points.
+the same underlying process).  One use-case is repeated measures
+regression for temporal (longitudinal) data, in which the repeated
+measures occur at arbitrary real-valued time points.
 
 The mean structure is specified as a linear model.  The covariance
 parameters depend on covariates via a link function.
@@ -88,13 +88,12 @@ class GaussianCovariance(ProcessCovariance):
       2}) \cdot \frac{u[i]^{1/4}u[j]^{1/4}}{\sqrt{(u[i] + u[j])/2}}
 
     The ProcessMLE class allows linear models with this covariance
-    structure to be fit using maximum likelihood (ML), which is
-    equivalent to generalized least squares (GLS) in this setting.
+    structure to be fit using maximum likelihood (ML). The mean and
+    covariance parameters of the model are fit jointly.
 
-    The mean and covariance parameters of the model are fit jointly.
     The mean, scaling, and smoothing parameters can be linked to
     covariates.  The mean parameters are linked linearly, and the
-    scaling and smoothing parameters use an exponential link to
+    scaling and smoothing parameters use an log link function to
     preserve positivity.
 
     The reference of Paciorek et al. below provides more details.
@@ -175,10 +174,13 @@ def _check_args(endog, exog, exog_scale, exog_smooth, exog_noise, time,
         exog.shape[0],
         exog_scale.shape[0],
         exog_smooth.shape[0],
-        exog_noise.shape[0],
         len(time),
         len(groups)
     ]
+
+    if exog_noise is not None:
+        v.append(exog_noise.shape[0])
+
     if min(v) != max(v):
         msg = ("The leading dimensions of all array arguments " +
                "must be equal.")
@@ -205,8 +207,8 @@ class ProcessMLE(base.LikelihoodModel):
     The scaling and smoothing parameters can be linked to covariates.
 
     The observed data are modeled as the sum of the Gaussian process
-    realization and independent white noise.  The standard deviation
-    of the white noise can be linked to covariates.
+    realization and (optionally) independent white noise.  The standard
+    deviation of the white noise can be linked to covariates.
 
     The data should be provided in 'long form', with a group label to
     indicate which observations belong to the same group.
@@ -225,7 +227,8 @@ class ProcessMLE(base.LikelihoodModel):
     exog_noise : array_like
         The design matrix for the white noise structure. The
         linear predictor is the log of the white noise standard
-        deviation.
+        deviation.  If None, there is no additive noise (the
+        process is observed directly).
     time : array_like (1-dimensional)
         The univariate index values, used to calculate distances
         between observations in the same group, which determines
@@ -257,6 +260,8 @@ class ProcessMLE(base.LikelihoodModel):
             groups=groups,
             **kwargs)
 
+        self._has_noise = exog_noise is not None
+
         # Create parameter names
         xnames = []
         if hasattr(exog, "columns"):
@@ -274,10 +279,11 @@ class ProcessMLE(base.LikelihoodModel):
         else:
             xnames += ["Smooth%d" % j for j in range(exog_smooth.shape[1])]
 
-        if hasattr(exog_noise, "columns"):
-            xnames += list(exog_noise.columns)
-        else:
-            xnames += ["Noise%d" % j for j in range(exog_noise.shape[1])]
+        if self._has_noise:
+            if hasattr(exog_noise, "columns"):
+                xnames += list(exog_noise.columns)
+            else:
+                xnames += ["Noise%d" % j for j in range(exog_noise.shape[1])]
 
         self.data.param_names = xnames
 
@@ -299,7 +305,8 @@ class ProcessMLE(base.LikelihoodModel):
         self.k_exog = self.exog.shape[1]
         self.k_scale = self.exog_scale.shape[1]
         self.k_smooth = self.exog_smooth.shape[1]
-        self.k_noise = self.exog_noise.shape[1]
+        if self._has_noise:
+            self.k_noise = self.exog_noise.shape[1]
 
     def _split_param_names(self):
         xnames = self.data.param_names
@@ -309,8 +316,13 @@ class ProcessMLE(base.LikelihoodModel):
         scale_names = xnames[q:q+self.k_scale]
         q += self.k_scale
         smooth_names = xnames[q:q+self.k_smooth]
-        q += self.k_noise
-        noise_names = xnames[q:q+self.k_noise]
+
+        if self._has_noise:
+            q += self.k_noise
+            noise_names = xnames[q:q+self.k_noise]
+        else:
+            noise_names = []
+
         return mean_names, scale_names, smooth_names, noise_names
 
     @classmethod
@@ -335,7 +347,7 @@ class ProcessMLE(base.LikelihoodModel):
         if "noise_formula" in kwargs:
             noise_formula = kwargs["noise_formula"]
         else:
-            raise ValueError("noise_formula is a required argument")
+            noise_formula = None
 
         if "time" in kwargs:
             time = kwargs["time"]
@@ -369,10 +381,14 @@ class ProcessMLE(base.LikelihoodModel):
         smooth_names = smooth_design_info.column_names
         exog_smooth = np.asarray(exog_smooth)
 
-        exog_noise = patsy.dmatrix(noise_formula, data)
-        noise_design_info = exog_noise.design_info
-        noise_names = noise_design_info.column_names
-        exog_noise = np.asarray(exog_noise)
+        if noise_formula is not None:
+            exog_noise = patsy.dmatrix(noise_formula, data)
+            noise_design_info = exog_noise.design_info
+            noise_names = noise_design_info.column_names
+            exog_noise = np.asarray(exog_noise)
+        else:
+            exog_noise, noise_design_info, noise_names, exog_noise =\
+                None, None, [], None
 
         mod = super(ProcessMLE, cls).from_formula(
             formula,
@@ -421,7 +437,9 @@ class ProcessMLE(base.LikelihoodModel):
         result = model.fit()
 
         m = self.exog_scale.shape[1] + self.exog_smooth.shape[1]
-        m += self.exog_noise.shape[1]
+
+        if self.exog_noise is not None:
+            m += self.exog_noise.shape[1]
 
         return np.concatenate((result.params, np.zeros(m)))
 
@@ -456,7 +474,8 @@ class ProcessMLE(base.LikelihoodModel):
         sm = np.exp(np.dot(self.exog_smooth, smpar))
 
         # White noise standard deviation
-        no = np.exp(np.dot(self.exog_noise, nopar))
+        if self.exog_noise is not None:
+            no = np.exp(np.dot(self.exog_noise, nopar))
 
         # Get the log-likelihood
         ll = 0.
@@ -464,7 +483,10 @@ class ProcessMLE(base.LikelihoodModel):
 
             # Get the covariance matrix for this person.
             cm = self.cov.get_cov(self.time[ix], sc[ix], sm[ix])
-            cm.flat[::cm.shape[0] + 1] += no[ix]**2
+
+            # The variance of the additive noise, if present.
+            if self.exog_noise is not None:
+                cm.flat[::cm.shape[0] + 1] += no[ix]**2
 
             re = resid[ix]
             ll -= 0.5 * np.linalg.slogdet(cm)[1]
@@ -507,7 +529,8 @@ class ProcessMLE(base.LikelihoodModel):
         sm = np.exp(np.dot(self.exog_smooth, smpar))
 
         # White noise standard deviation
-        no = np.exp(np.dot(self.exog_noise, nopar))
+        if self.exog_noise is not None:
+            no = np.exp(np.dot(self.exog_noise, nopar))
 
         # Get the log-likelihood
         score = np.zeros(len(mnpar) + len(scpar) + len(smpar) + len(nopar))
@@ -515,17 +538,20 @@ class ProcessMLE(base.LikelihoodModel):
 
             sc_i = sc[ix]
             sm_i = sm[ix]
-            no_i = no[ix]
             resid_i = resid[ix]
             time_i = self.time[ix]
             exog_i = self.exog[ix, :]
             exog_scale_i = self.exog_scale[ix, :]
             exog_smooth_i = self.exog_smooth[ix, :]
-            exog_noise_i = self.exog_noise[ix, :]
 
             # Get the covariance matrix for this person.
             cm = self.cov.get_cov(time_i, sc_i, sm_i)
-            cm.flat[::cm.shape[0] + 1] += no[ix]**2
+
+            if self.exog_noise is not None:
+                no_i = no[ix]
+                exog_noise_i = self.exog_noise[ix, :]
+                cm.flat[::cm.shape[0] + 1] += no[ix]**2
+
             cmi = np.linalg.inv(cm)
 
             jacv, jacs = self.cov.jac(time_i, sc_i, sm_i)
@@ -553,10 +579,11 @@ class ProcessMLE(base.LikelihoodModel):
                          0.5 * np.sum(jacs[i] * cmi) * smx[i, :])
 
             # The derivatives with respect to the standard deviation parameters
-            sno = no_i[:, None]**2 * exog_noise_i
-            score[pm + pv + ps:] -= np.dot(cmi.flat[::cm.shape[0] + 1], sno)
-            bm = np.dot(cmi, np.dot(rx, cmi))
-            score[pm + pv + ps:] += np.dot(bm.flat[::bm.shape[0] + 1], sno)
+            if self.exog_noise is not None:
+                sno = no_i[:, None]**2 * exog_noise_i
+                score[pm + pv + ps:] -= np.dot(cmi.flat[::cm.shape[0] + 1], sno)
+                bm = np.dot(cmi, np.dot(rx, cmi))
+                score[pm + pv + ps:] += np.dot(bm.flat[::bm.shape[0] + 1], sno)
 
         if self.verbose:
             print("|G|=", np.sqrt(np.sum(score * score)))
@@ -751,7 +778,10 @@ class ProcessMLEResults(base.GenericLikelihoodModelResults):
         self.k_exog = self.model.exog.shape[1]
         self.k_scale = self.model.exog_scale.shape[1]
         self.k_smooth = self.model.exog_smooth.shape[1]
-        self.k_noise = self.model.exog_noise.shape[1]
+
+        self._has_noise = model._has_noise
+        if model._has_noise:
+            self.k_noise = self.model.exog_noise.shape[1]
 
     def predict(self, exog=None, transform=True, *args, **kwargs):
 
@@ -823,8 +853,12 @@ class ProcessMLEResults(base.GenericLikelihoodModelResults):
 
         df = pd.DataFrame()
 
-        df["Type"] = (["Mean"] * self.k_exog + ["Scale"] * self.k_scale +
-                      ["Smooth"] * self.k_smooth + ["SD"] * self.k_noise)
+        typ = (["Mean"] * self.k_exog + ["Scale"] * self.k_scale +
+                      ["Smooth"] * self.k_smooth)
+        if self._has_noise:
+            typ += ["SD"] * self.k_noise
+        df["Type"] = typ
+
         df["coef"] = self.params
 
         try:

--- a/statsmodels/regression/process_regression.py
+++ b/statsmodels/regression/process_regression.py
@@ -588,7 +588,7 @@ class ProcessMLE(base.LikelihoodModel):
             if self._has_noise:
                 sno = no_i[:, None]**2 * exog_noise_i
                 score[pm + pv + ps:] -= np.dot(cmi.flat[::cm.shape[0] + 1],
-                         sno)
+                                               sno)
                 bm = np.dot(cmi, np.dot(rx, cmi))
                 score[pm + pv + ps:] += np.dot(bm.flat[::bm.shape[0] + 1], sno)
 

--- a/statsmodels/regression/tests/test_processreg.py
+++ b/statsmodels/regression/tests/test_processreg.py
@@ -11,19 +11,25 @@ import collections
 import statsmodels.tools.numdiff as nd
 from numpy.testing import assert_allclose, assert_equal
 
+# Parameters for a test model, with or without additive
+# noise.
+def model1(noise):
 
-def model1():
     mn_par = np.r_[1, 0, -1, 0]
     sc_par = np.r_[1, 1]
     sm_par = np.r_[0.5, 0.1]
-    no_par = np.r_[0.25, 0.25]
+
+    if noise:
+        no_par = np.r_[0.25, 0.25]
+    else:
+        no_par = np.array([])
 
     return mn_par, sc_par, sm_par, no_par
 
 
-def setup1(n, get_model):
+def setup1(n, get_model, noise):
 
-    mn_par, sc_par, sm_par, no_par = get_model()
+    mn_par, sc_par, sm_par, no_par = get_model(noise)
 
     groups = np.kron(np.arange(n // 5), np.ones(5))
     time = np.kron(np.ones(n // 5), np.arange(5))
@@ -36,14 +42,18 @@ def setup1(n, get_model):
     x_sm = np.random.normal(size=(n, len(sm_par)))
     x_sm[:, 0] = 1
     x_sm[:, 1] = time_z
-    x_no = np.random.normal(size=(n, len(no_par)))
-    x_no[:, 0] = 1
-    x_no[:, 1] = time_z
 
     mn = np.dot(x_mean, mn_par)
     sc = np.exp(np.dot(x_sc, sc_par))
     sm = np.exp(np.dot(x_sm, sm_par))
-    no = np.exp(np.dot(x_no, no_par))
+
+    if noise:
+        x_no = np.random.normal(size=(n, len(no_par)))
+        x_no[:, 0] = 1
+        x_no[:, 1] = time_z
+        no = np.exp(np.dot(x_no, no_par))
+    else:
+        x_no = None
 
     y = mn.copy()
 
@@ -59,14 +69,15 @@ def setup1(n, get_model):
         y[ii] += np.dot(r, np.random.normal(size=len(ii)))
 
     # Additive white noise
-    y += no * np.random.normal(size=y.shape)
+    if noise:
+        y += no * np.random.normal(size=y.shape)
 
     return y, x_mean, x_sc, x_sm, x_no, time, groups
 
 
-def run_arrays(n, get_model):
+def run_arrays(n, get_model, noise):
 
-    y, x_mean, x_sc, x_sm, x_no, time, groups = setup1(n, get_model)
+    y, x_mean, x_sc, x_sm, x_no, time, groups = setup1(n, get_model, noise)
 
     preg = ProcessMLE(y, x_mean, x_sc, x_sm, x_no, time, groups)
 
@@ -74,17 +85,18 @@ def run_arrays(n, get_model):
 
 
 @pytest.mark.slow
-def test_arrays():
+@pytest.mark.parametrize("noise", [False, True])
+def test_arrays(noise):
 
     np.random.seed(8234)
 
-    f = run_arrays(1000, model1)
+    f = run_arrays(1000, model1, noise)
     mod = f.model
 
     f.summary()  # Smoke test
 
     # Compare the parameter estimates to population values.
-    epar = np.concatenate(model1())
+    epar = np.concatenate(model1(noise))
     assert_allclose(f.params, epar, atol=0.3, rtol=0.3)
 
     # Test the fitted covariance matrix
@@ -106,9 +118,9 @@ def test_arrays():
     f.t_test(np.eye(len(f.params)))
 
 
-def run_formula(n, get_model):
+def run_formula(n, get_model, noise):
 
-    y, x_mean, x_sc, x_sm, x_no, time, groups = setup1(n, get_model)
+    y, x_mean, x_sc, x_sm, x_no, time, groups = setup1(n, get_model, noise)
 
     df = pd.DataFrame({
         "y": y,
@@ -120,16 +132,23 @@ def run_formula(n, get_model):
         "xsc2": x_sc[:, 1],
         "xsm1": x_sm[:, 0],
         "xsm2": x_sm[:, 1],
-        "xno1": x_no[:, 0],
-        "xno2": x_no[:, 1],
         "time": time,
         "groups": groups
     })
 
+    if noise:
+        df["xno1"] = x_no[:, 0]
+        df["xno2"] = x_no[:, 1]
+
     mean_formula = "y ~ 0 + x1 + x2 + x3 + x4"
     scale_formula = "0 + xsc1 + xsc2"
     smooth_formula = "0 + xsm1 + xsm2"
-    noise_formula = "0 + xno1 + xno2"
+
+    if noise:
+        noise_formula = "0 + xno1 + xno2"
+    else:
+        noise_formula = None
+
     preg = ProcessMLE.from_formula(
         mean_formula,
         data=df,
@@ -144,17 +163,18 @@ def run_formula(n, get_model):
 
 
 @pytest.mark.slow
-def test_formulas():
+@pytest.mark.parametrize("noise", [False, True])
+def test_formulas(noise):
 
     np.random.seed(8789)
 
-    f, df = run_formula(1000, model1)
+    f, df = run_formula(1000, model1, noise)
     mod = f.model
 
     f.summary()  # Smoke test
 
     # Compare the parameter estimates to population values.
-    epar = np.concatenate(model1())
+    epar = np.concatenate(model1(noise))
     assert_allclose(f.params, epar, atol=0.1, rtol=1)
 
     # Test the fitted covariance matrix
@@ -180,16 +200,19 @@ def test_formulas():
 
 
 # Test the score functions using numerical derivatives.
-def test_score_numdiff():
+@pytest.mark.parametrize("noise", [False, True])
+def test_score_numdiff(noise):
 
-    y, x_mean, x_sc, x_sm, x_no, time, groups = setup1(1000, model1)
+    y, x_mean, x_sc, x_sm, x_no, time, groups = setup1(1000, model1, noise)
 
     preg = ProcessMLE(y, x_mean, x_sc, x_sm, x_no, time, groups)
 
     def loglike(x):
         return preg.loglike(x)
 
-    q = x_mean.shape[1] + x_sc.shape[1] + x_sm.shape[1] + x_no.shape[1]
+    q = x_mean.shape[1] + x_sc.shape[1] + x_sm.shape[1]
+    if noise:
+        q += x_no.shape[1]
 
     np.random.seed(342)
 

--- a/statsmodels/regression/tests/test_processreg.py
+++ b/statsmodels/regression/tests/test_processreg.py
@@ -11,6 +11,7 @@ import collections
 import statsmodels.tools.numdiff as nd
 from numpy.testing import assert_allclose, assert_equal
 
+
 # Parameters for a test model, with or without additive
 # noise.
 def model1(noise):


### PR DESCRIPTION
The process noise is white noise that is added to the process realization.  This PR allows that form of variance to be switched off, so that the process is observed directly instead of with additive noise. 