### PR TITLE
Bug fix ETSModel get prediction

### DIFF
--- a/statsmodels/tsa/exponential_smoothing/ets.py
+++ b/statsmodels/tsa/exponential_smoothing/ets.py
@@ -1892,7 +1892,7 @@ class ETSResults(base.StateSpaceMLEResults):
         )
         # if end was outside of the sample, it is now the last point in the
         # sample
-        if start > end + out_of_sample + 1:
+        if start > end:
             raise ValueError(
                 "Prediction start cannot lie outside of the sample."
             )

--- a/statsmodels/tsa/exponential_smoothing/tests/test_get_prediction.py
+++ b/statsmodels/tsa/exponential_smoothing/tests/test_get_prediction.py
@@ -1,0 +1,17 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from statsmodels.tsa.api import ETSModel
+
+
+def test_prediction_start_out_of_sample():
+    values = np.arange(100)* (1+np.random.randn(100)/10)
+    dates = [np.datetime64('today') + np.timedelta64(-101+i) for i in range(100)]
+    train_x = pd.Series(values, index=dates).asfreq(freq='D')
+    model = ETSModel(train_x, trend='add')
+    fit = model.fit()
+
+    with pytest.raises(ValueError, match="Prediction start cannot lie outside of the sample."):
+        prediction = fit.get_prediction(start=np.datetime64('today'),
+                     end=np.datetime64('today') + np.timedelta64(5))


### PR DESCRIPTION
- [x] closes #7018  
- [x] tests added / passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>
Have changed the logic under _handle_prediction_index to properly raise error when start is out-of-sample, as pointed out in #7018. Additionally, I've added test case to make sure a ValueError is raised with the proper error message.

**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
