### PR TITLE
Bug fix ets get prediction

### DIFF
--- a/statsmodels/tsa/tests/test_exponential_smoothing.py
+++ b/statsmodels/tsa/tests/test_exponential_smoothing.py
@@ -691,10 +691,34 @@ def test_prediction_results(austourists_model_fit):
     assert len(summary["mean"].values) == 81
     assert np.all(~np.isnan(summary["mean"]))
 
-    # only out of sample prediction
+    # long out of sample, starting in-sample
+    pred = austourists_model_fit.get_prediction(start=67, end=80)
+    summary = pred.summary_frame()
+    assert len(summary["mean"].values) == 14
+    assert np.all(~np.isnan(summary["mean"]))
+
+    # long out of sample, starting at end of sample
+    pred = austourists_model_fit.get_prediction(start=68, end=80)
+    summary = pred.summary_frame()
+    assert len(summary["mean"].values) == 13
+    assert np.all(~np.isnan(summary["mean"]))
+
+    # long out of sample, starting just out of sample
     pred = austourists_model_fit.get_prediction(start=69, end=80)
     summary = pred.summary_frame()
     assert len(summary["mean"].values) == 12
+    assert np.all(~np.isnan(summary["mean"]))
+
+    # long out of sample, starting long out of sample
+    pred = austourists_model_fit.get_prediction(start=79, end=80)
+    summary = pred.summary_frame()
+    assert len(summary["mean"].values) == 2
+    assert np.all(~np.isnan(summary["mean"]))
+
+    # long out of sample, `start`== `end`
+    pred = austourists_model_fit.get_prediction(start=80, end=80)
+    summary = pred.summary_frame()
+    assert len(summary["mean"].values) == 1
     assert np.all(~np.isnan(summary["mean"]))
 
 

--- a/statsmodels/tsa/tests/test_exponential_smoothing.py
+++ b/statsmodels/tsa/tests/test_exponential_smoothing.py
@@ -692,9 +692,9 @@ def test_prediction_results(austourists_model_fit):
     assert np.all(~np.isnan(summary["mean"]))
 
     # only out of sample prediction
-    pred = austourists_model_fit.get_prediction(start=67, end=80)
+    pred = austourists_model_fit.get_prediction(start=69, end=80)
     summary = pred.summary_frame()
-    assert len(summary["mean"].values) == 14
+    assert len(summary["mean"].values) == 12
     assert np.all(~np.isnan(summary["mean"]))
 
 


### PR DESCRIPTION
- [x ] closes #7018 
- [x ] tests added / passed. 
- [x ] code/documentation is well formatted.  
- [x ] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>
Fixed the issue where the ETSModel get_prediction method fails when start is greater than the last index. Modified test case to reflect this use case, which would fail on master and would pass once this branch is merged.

**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
