### PR TITLE
BUG: fix weightstats quantile for len 1 array

### DIFF
--- a/statsmodels/stats/tests/test_weightstats.py
+++ b/statsmodels/stats/tests/test_weightstats.py
@@ -760,3 +760,10 @@ class TestZTest(object):
 
             ci = d1.zconfint_mean(alternative=alternatives[tc.alternative])
             assert_allclose(ci, tc_conf_int, rtol=1e-10)
+
+
+def test_weightstats_len_1():
+    x1 = [1]
+    w1 = [1]
+    d1 = DescrStatsW(x1, w1)
+    assert (d1.quantile([0.0, 0.5, 1.0]) == 1).all()

--- a/statsmodels/stats/tests/test_weightstats.py
+++ b/statsmodels/stats/tests/test_weightstats.py
@@ -187,14 +187,14 @@ class TestWeightstats(object):
         w2_ = 2. * np.ones(len(x2))
 
         d1 = DescrStatsW(x1)
-#        print ttest_ind(x1, x2)
-#        print ttest_ind(x1, x2, usevar='unequal')
-#        #print ttest_ind(x1, x2, usevar='unequal')
-#        print stats.ttest_ind(x1, x2)
-#        print ttest_ind(x1, x2, usevar='unequal', alternative='larger')
-#        print ttest_ind(x1, x2, usevar='unequal', alternative='smaller')
-#        print ttest_ind(x1, x2, usevar='unequal', weights=(w1_, w2_))
-#        print stats.ttest_ind(np.r_[x1, x1], np.r_[x2,x2])
+        #        print ttest_ind(x1, x2)
+        #        print ttest_ind(x1, x2, usevar='unequal')
+        #        #print ttest_ind(x1, x2, usevar='unequal')
+        #        print stats.ttest_ind(x1, x2)
+        #        print ttest_ind(x1, x2, usevar='unequal', alternative='larger')
+        #        print ttest_ind(x1, x2, usevar='unequal', alternative='smaller')
+        #        print ttest_ind(x1, x2, usevar='unequal', weights=(w1_, w2_))
+        #        print stats.ttest_ind(np.r_[x1, x1], np.r_[x2,x2])
         assert_almost_equal(ttest_ind(x1, x2, weights=(w1_, w2_))[:2],
                             stats.ttest_ind(np.r_[x1, x1], np.r_[x2, x2]))
 
@@ -207,14 +207,14 @@ class TestWeightstats(object):
         d2w = DescrStatsW(x2, weights=w2)
         x1r = d1w.asrepeats()
         x2r = d2w.asrepeats()
-#        print 'random weights'
-#        print ttest_ind(x1, x2, weights=(w1, w2))
-#        print stats.ttest_ind(x1r, x2r)
+        #        print 'random weights'
+        #        print ttest_ind(x1, x2, weights=(w1, w2))
+        #        print stats.ttest_ind(x1r, x2r)
         assert_almost_equal(ttest_ind(x1, x2, weights=(w1, w2))[:2],
                             stats.ttest_ind(x1r, x2r), 14)
         # not the same as new version with random weights/replication
-#        assert x1r.shape[0] == d1w.sum_weights
-#        assert x2r.shape[0] == d2w.sum_weights
+        #        assert x1r.shape[0] == d1w.sum_weights
+        #        assert x2r.shape[0] == d2w.sum_weights
 
         assert_almost_equal(x2r.mean(0), d2w.mean, 14)
         assert_almost_equal(x2r.var(), d2w.var, 14)
@@ -225,10 +225,10 @@ class TestWeightstats(object):
         # TODO: exception in corrcoef (scalar case)
 
         # one-sample tests
-#        print d1.ttest_mean(3)
-#        print stats.ttest_1samp(x1, 3)
-#        print d1w.ttest_mean(3)
-#        print stats.ttest_1samp(x1r, 3)
+        #        print d1.ttest_mean(3)
+        #        print stats.ttest_1samp(x1, 3)
+        #        print d1w.ttest_mean(3)
+        #        print stats.ttest_1samp(x1r, 3)
         assert_almost_equal(d1.ttest_mean(3)[:2], stats.ttest_1samp(x1, 3), 11)
         assert_almost_equal(d1w.ttest_mean(3)[:2],
                             stats.ttest_1samp(x1r, 3), 11)
@@ -248,9 +248,9 @@ class TestWeightstats(object):
         assert_almost_equal(np.cov(x2r_2d.T, bias=1), d2w_2d.cov, 14)
         assert_almost_equal(np.corrcoef(x2r_2d.T), d2w_2d.corrcoef, 14)
 
-#        print d1w_2d.ttest_mean(3)
-#        #scipy.stats.ttest is also vectorized
-#        print stats.ttest_1samp(x1r_2d, 3)
+        #        print d1w_2d.ttest_mean(3)
+        #        #scipy.stats.ttest is also vectorized
+        #        print stats.ttest_1samp(x1r_2d, 3)
         t, p, d = d1w_2d.ttest_mean(3)
         assert_almost_equal([t, p], stats.ttest_1samp(x1r_2d, 3), 11)
         # print [stats.ttest_1samp(xi, 3) for xi in x1r_2d.T]
@@ -767,3 +767,18 @@ def test_weightstats_len_1():
     w1 = [1]
     d1 = DescrStatsW(x1, w1)
     assert (d1.quantile([0.0, 0.5, 1.0]) == 1).all()
+
+
+def test_weightstats_2d_w1():
+    x1 = [[1], [2]]
+    w1 = [[1], [2]]
+    d1 = DescrStatsW(x1, w1)
+    print(len(np.array(w1).shape))
+    assert (d1.quantile([0.5, 1.0]) == 2).all().all()
+
+
+def test_weightstats_2d_w2():
+    x1 = [[1]]
+    w1 = [[1]]
+    d1 = DescrStatsW(x1, w1)
+    assert (d1.quantile([0, 0.5, 1.0]) == 1).all().all()

--- a/statsmodels/stats/weightstats.py
+++ b/statsmodels/stats/weightstats.py
@@ -107,8 +107,10 @@ class DescrStatsW(object):
         if weights is None:
             self.weights = np.ones(self.data.shape[0])
         else:
+            self.weights = np.asarray(weights).astype(float)
             # TODO: why squeeze?
-            self.weights = np.asarray(weights).squeeze().astype(float)
+            if len(weights.shape) > 1:
+                self.weights = self.weights.squeeze()
         self.ddof = ddof
 
     @cache_readonly

--- a/statsmodels/stats/weightstats.py
+++ b/statsmodels/stats/weightstats.py
@@ -109,7 +109,7 @@ class DescrStatsW(object):
         else:
             self.weights = np.asarray(weights).astype(float)
             # TODO: why squeeze?
-            if len(self.weights.shape) > 1:
+            if len(self.weights.shape) > 1 and len(self.weights) > 1:
                 self.weights = self.weights.squeeze()
         self.ddof = ddof
 

--- a/statsmodels/stats/weightstats.py
+++ b/statsmodels/stats/weightstats.py
@@ -109,7 +109,7 @@ class DescrStatsW(object):
         else:
             self.weights = np.asarray(weights).astype(float)
             # TODO: why squeeze?
-            if len(weights.shape) > 1:
+            if len(self.weights.shape) > 1:
                 self.weights = self.weights.squeeze()
         self.ddof = ddof
 


### PR DESCRIPTION
- [X] closes #7046
- [X] tests added / passed. 
- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
