### PR TITLE
BUG: Fix squeeze when nsimulation is 1

### DIFF
--- a/statsmodels/tsa/holtwinters/results.py
+++ b/statsmodels/tsa/holtwinters/results.py
@@ -743,10 +743,11 @@ class HoltWintersResults(Results):
         if use_boxcox:
             y = inv_boxcox(y, lamda)
 
-        sim = np.squeeze(y)
+        sim = np.atleast_1d(np.squeeze(y))
+        if y.shape[0] == 1 and y.size > 1:
+            sim = sim[None, :]
         # Wrap data / squeeze where appropriate
-        use_pandas = isinstance(self.model.data, PandasData)
-        if not use_pandas:
+        if not isinstance(self.model.data, PandasData):
             return sim
 
         _, _, _, index = self.model._get_prediction_index(

--- a/statsmodels/tsa/holtwinters/tests/test_holtwinters.py
+++ b/statsmodels/tsa/holtwinters/tests/test_holtwinters.py
@@ -358,7 +358,10 @@ class TestHoltWinters(object):
     @pytest.mark.xfail(reason="Optimizer does not converge", strict=False)
     def test_forecast(self):
         fit1 = ExponentialSmoothing(
-            self.aust, seasonal_periods=4, trend="add", seasonal="add",
+            self.aust,
+            seasonal_periods=4,
+            trend="add",
+            seasonal="add",
         ).fit(method="bh", use_brute=True)
         assert_almost_equal(
             fit1.forecast(steps=4), [60.9542, 36.8505, 46.1628, 50.1272], 3
@@ -884,8 +887,10 @@ def test_float_boxcox(trend, seasonal):
     assert_allclose(res.params["use_boxcox"], 0.5)
     with pytest.warns(FutureWarning):
         res = ExponentialSmoothing(
-            housing_data, trend=trend, seasonal=seasonal
-        ).fit(use_boxcox = 0.5)
+            housing_data,
+            trend=trend,
+            seasonal=seasonal,
+        ).fit(use_boxcox=0.5)
     assert_allclose(res.params["use_boxcox"], 0.5)
 
 
@@ -1624,7 +1629,10 @@ def test_error_initialization(ses):
         ExponentialSmoothing(ses, initial_seasonal=[1.0, 0.2, 0.05, 4])
     with pytest.raises(ValueError):
         ExponentialSmoothing(
-            ses, trend="add", initialization_method="known", initial_level=1.0,
+            ses,
+            trend="add",
+            initialization_method="known",
+            initial_level=1.0,
         )
     with pytest.raises(ValueError):
         ExponentialSmoothing(
@@ -1963,3 +1971,28 @@ def test_boxcox_components(ses):
     assert not hasattr(res, "_untransformed_level")
     assert not hasattr(res, "_untransformed_trend")
     assert not hasattr(res, "_untransformed_seasonal")
+
+
+@pytest.mark.parametrize("repetitions", [1, 10])
+@pytest.mark.parametrize("random_errors", [None, "bootstrap"])
+def test_forecast_1_simulation(austourists, random_errors, repetitions):
+    # GH 7053
+    fit = ExponentialSmoothing(
+        austourists,
+        seasonal_periods=4,
+        trend="add",
+        seasonal="add",
+        damped_trend=True,
+        initialization_method="estimated",
+    ).fit()
+
+    sim = fit.simulate(
+        1, anchor=0, random_errors=random_errors, repetitions=repetitions
+    )
+    expected_shape = (1,) if repetitions == 1 else (1, repetitions)
+    assert sim.shape == expected_shape
+    sim = fit.simulate(
+        10, anchor=0, random_errors=random_errors, repetitions=repetitions
+    )
+    expected_shape = (10,) if repetitions == 1 else (10, repetitions)
+    assert sim.shape == expected_shape


### PR DESCRIPTION
Avoid oversqueezing the array

closes #7053

- [x] closes #xxxx
- [ ] tests added / passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
