### PR TITLE
changed month abbreviations in month_plot pt2

### DIFF
--- a/statsmodels/graphics/tests/test_tsaplots.py
+++ b/statsmodels/graphics/tests/test_tsaplots.py
@@ -3,26 +3,25 @@ from statsmodels.compat.python import lmap
 from io import BytesIO
 
 import numpy as np
+from numpy.testing import assert_, assert_equal
 import pandas as pd
-from numpy.testing import assert_equal, assert_
 import pytest
 
-import statsmodels.api as sm
+from statsmodels import api as sm
 from statsmodels.graphics.tsaplots import (
+    month_plot,
     plot_acf,
     plot_pacf,
-    month_plot,
+    plot_predict,
     quarter_plot,
     seasonal_plot,
-    plot_predict,
 )
-import statsmodels.tsa.arima_process as tsp
+from statsmodels.tsa import arima_process as tsp
 from statsmodels.tsa.ar_model import AutoReg
 from statsmodels.tsa.arima.model import ARIMA
 
-
 try:
-    import matplotlib.pyplot as plt
+    from matplotlib import pyplot as plt
 except ImportError:
     pass
 

--- a/statsmodels/graphics/tests/test_tsaplots.py
+++ b/statsmodels/graphics/tests/test_tsaplots.py
@@ -1,5 +1,6 @@
 from statsmodels.compat.python import lmap
 
+import calendar
 from io import BytesIO
 
 import numpy as np
@@ -209,6 +210,15 @@ def test_plot_month(close_figures):
     # test with a TimeSeries PeriodIndex
     dta.index = pd.PeriodIndex(dates, freq="M")
     fig = month_plot(dta)
+
+    # test localized xlabels
+    with calendar.different_locale("DE_de"):
+        fig = month_plot(dta)
+        labels = [_.get_text() for _ in fig.axes[0].get_xticklabels()]
+        expected = ['Jan', 'Feb', 'Mär', 'Apr', 'Mai', 'Jun', 'Jul',
+                    'Aug', 'Sep', 'Okt', 'Nov', 'Dez']
+        for x, y in zip(labels, expected):
+            assert x == y
 
 
 @pytest.mark.matplotlib

--- a/statsmodels/graphics/tsaplots.py
+++ b/statsmodels/graphics/tsaplots.py
@@ -1,6 +1,7 @@
 """Correlation plot functions."""
-
 from statsmodels.compat.pandas import deprecate_kwarg
+
+import calendar
 
 import numpy as np
 import pandas as pd
@@ -407,8 +408,8 @@ def month_plot(x, dates=None, ylabel=None, ax=None):
     else:
         x = pd.Series(x, index=pd.PeriodIndex(dates, freq="M"))
 
-    xticklabels = ["Jan", "Feb", "Mar", "Apr", "May", "Jun",
-                   "Jul", "Aug", "Sept", "Oct", "Nov", "Dec"]
+    # there's no zero month
+    xticklabels = list(calendar.month_abbr)[1:]
     return seasonal_plot(
         x.groupby(lambda y: y.month), xticklabels, ylabel=ylabel, ax=ax
     )

--- a/statsmodels/graphics/tsaplots.py
+++ b/statsmodels/graphics/tsaplots.py
@@ -407,7 +407,7 @@ def month_plot(x, dates=None, ylabel=None, ax=None):
     else:
         x = pd.Series(x, index=pd.PeriodIndex(dates, freq="M"))
 
-    xticklabels = ["j", "f", "m", "a", "m", "j", "j", "a", "s", "o", "n", "d"]
+    xticklabels = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sept", "Oct", "Nov", "Dec"]
     return seasonal_plot(
         x.groupby(lambda y: y.month), xticklabels, ylabel=ylabel, ax=ax
     )

--- a/statsmodels/graphics/tsaplots.py
+++ b/statsmodels/graphics/tsaplots.py
@@ -407,7 +407,8 @@ def month_plot(x, dates=None, ylabel=None, ax=None):
     else:
         x = pd.Series(x, index=pd.PeriodIndex(dates, freq="M"))
 
-    xticklabels = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sept", "Oct", "Nov", "Dec"]
+    xticklabels = ["Jan", "Feb", "Mar", "Apr", "May", "Jun",
+                   "Jul", "Aug", "Sept", "Oct", "Nov", "Dec"]
     return seasonal_plot(
         x.groupby(lambda y: y.month), xticklabels, ylabel=ylabel, ax=ax
     )


### PR DESCRIPTION
to use three letter abbreviations (i.e. 'Jan', 'Feb') instead a single letter abbreviation (i.e. 'j', 'f')

sorry I'm not completely sure on how to use github, I just made a small change on how months are displayed so it looks prettier

- [ ] closes #xxxx
- [x] tests added / passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
