### PR TITLE
DOC: fix several doc issues in stats functions

### DIFF
--- a/statsmodels/stats/oneway.py
+++ b/statsmodels/stats/oneway.py
@@ -180,7 +180,7 @@ def effectsize_oneway(means, vars_, nobs, use_var="unequal", ddof_between=0):
 
 
 def convert_effectsize_fsqu(f2=None, eta2=None):
-    """convert squared effect sizes in f family
+    """Convert squared effect sizes in f family
 
     f2 is signal to noise ratio, var_explained / var_residual
 
@@ -455,7 +455,7 @@ def confint_effectsize_oneway(f_stat, df, alpha=0.05, nobs=None):
 def anova_generic(means, variances, nobs, use_var="unequal",
                   welch_correction=True, info=None):
     """
-    Oneway anova based on summary statistics
+    Oneway Anova based on summary statistics
 
     Parameters
     ----------
@@ -558,7 +558,7 @@ def anova_generic(means, variances, nobs, use_var="unequal",
 
 def anova_oneway(data, groups=None, use_var="unequal", welch_correction=True,
                  trim_frac=0):
-    """oneway anova
+    """Oneway Anova
 
     This implements standard anova, Welch and Brown-Forsythe, and trimmed
     (Yuen) variants of those.
@@ -862,6 +862,10 @@ def equivalence_oneway(data, equiv_margin, groups=None, use_var="unequal",
         The two main attributes are test statistic `statistic` and p-value
         `pvalue`.
 
+    See Also
+    --------
+    anova_oneway
+    equivalence_scale_oneway
     """
 
     # use anova to compute summary statistics and f-statistic
@@ -877,7 +881,7 @@ def equivalence_oneway(data, equiv_margin, groups=None, use_var="unequal",
 
 
 def _power_equivalence_oneway_emp(f_stat, n_groups, nobs, eps, df, alpha=0.05):
-    """empirical power of oneway equivalence test
+    """Empirical power of oneway equivalence test
 
     This only returns post-hoc, empirical power.
 
@@ -1148,6 +1152,60 @@ def equivalence_scale_oneway(data, equiv_margin, method='bf', center='median',
     absolute deviation are not scaled to correspond to the variance under
     normal distribution.
 
+    Parameters
+    ----------
+    data : tuple of array_like or DataFrame or Series
+        Data for k independent samples, with k >= 2. The data can be provided
+        as a tuple or list of arrays or in long format with outcome
+        observations in ``data`` and group membership in ``groups``.
+    equiv_margin : float
+        Equivalence margin in terms of effect size. Effect size can be chosen
+        with `margin_type`. default is squared Cohen's f.
+    method : {"unequal", "equal" or "bf"}
+        How to treat heteroscedasticity across samples. This is used as
+        `use_var` option in `anova_oneway` and refers to the variance of the
+        transformed data, i.e. assumption is on 4th moment if squares are used
+        as transform.
+        Three approaches are available:
+
+        "unequal" : Variances are not assumed to be equal across samples.
+            Heteroscedasticity is taken into account with Welch Anova and
+            Satterthwaite-Welch degrees of freedom.
+            This is the default.
+        "equal" : Variances are assumed to be equal across samples.
+            This is the standard Anova.
+        "bf" : Variances are not assumed to be equal across samples.
+            The method is Browne-Forsythe (1971) for testing equality of means
+            with the corrected degrees of freedom by Merothra. The original BF
+            degrees of freedom are available as additional attributes in the
+            results instance, ``df_denom2`` and ``p_value2``.
+    center : "median", "mean", "trimmed" or float
+        Statistic used for centering observations. If a float, then this
+        value is used to center. Default is median.
+    transform : "abs", "square" or callable
+        Transformation for the centered observations. If a callable, then this
+        function is called on the centered data.
+        Default is absolute value.
+    trim_frac_mean : float in [0, 0.5)
+        Trim fraction for the trimmed mean when `center` is "trimmed"
+    trim_frac_anova : float in [0, 0.5)
+        Optional trimming for Anova with trimmed mean and Winsorized variances.
+        With the default trim_frac equal to zero, the oneway Anova statistics
+        are computed without trimming. If `trim_frac` is larger than zero,
+        then the largest and smallest observations in each sample are trimmed.
+        see ``trim_frac`` option in `anova_oneway`
+
+    Returns
+    -------
+    results : instance of HolderTuple class
+        The two main attributes are test statistic `statistic` and p-value
+        `pvalue`.
+
+    See Also
+    --------
+    anova_oneway
+    scale_transform
+    equivalence_oneway
     """
     data = map(np.asarray, data)
     xxd = [scale_transform(x, center=center, transform=transform,

--- a/statsmodels/stats/rates.py
+++ b/statsmodels/stats/rates.py
@@ -35,9 +35,9 @@ def test_poisson_2indep(count1, exposure1, count2, exposure2, ratio_null=1,
     exposure1 : float
         Total exposure (time * subjects) in first sample.
     count2 : int
-        Number of events in first sample.
+        Number of events in second sample.
     exposure2 : float
-        Total exposure (time * subjects) in first sample.
+        Total exposure (time * subjects) in second sample.
     ratio: float
         ratio of the two Poisson rates under the Null hypothesis. Default is 1.
     method : string
@@ -55,11 +55,15 @@ def test_poisson_2indep(count1, exposure1, count2, exposure2, ratio_null=1,
         - 'two-sided': H1: ratio of rates is not equal to ratio_null (default)
         - 'larger' :   H1: ratio of rates is larger than ratio_null
         - 'smaller' :  H1: ratio of rates is smaller than ratio_null
+    etest_kwds: dictionary
+        Additional parameters to be passed to the etest_poisson_2indep
+        funtcion, namely ygrid.
 
     Returns
     -------
-    results : Results instance
-        The resulting test statistics and p-values are available as attributes.
+    results : instance of HolderTuple class
+        The two main attributes are test statistic `statistic` and p-value
+        `pvalue`.
 
     Notes
     -----
@@ -78,6 +82,10 @@ def test_poisson_2indep(count1, exposure1, count2, exposure2, ratio_null=1,
     Gu, Ng, Tang, Schucany 2008: Testing the Ratio of Two Poisson Rates,
     Biometrical Journal 50 (2008) 2, 2008
 
+    See Also
+    --------
+    tost_poisson_2indep
+    etest_poisson_2indep
     '''
 
     # shortcut names
@@ -277,9 +285,9 @@ def tost_poisson_2indep(count1, exposure1, count2, exposure2, low, upp,
     exposure1 : float
         Total exposure (time * subjects) in first sample
     count2 : int
-        Number of events in first sample
+        Number of events in second sample
     exposure2 : float
-        Total exposure (time * subjects) in first sample
+        Total exposure (time * subjects) in second sample
     low, upp :
         equivalence margin for the ratio of Poisson rates
     method: string
@@ -291,12 +299,9 @@ def tost_poisson_2indep(count1, exposure1, count2, exposure2, low, upp,
 
     Returns
     -------
-    pvalue : float
-        p-value is the max of the pvalues of the two one-sided tests
-    t1 : test results
-        results instance for one-sided hypothesis at the lower margin
-    t1 : test results
-        results instance for one-sided hypothesis at the upper margin
+    results : instance of HolderTuple class
+        The two main attributes are test statistic `statistic` and p-value
+        `pvalue`.
 
     Notes
     -----
@@ -315,6 +320,9 @@ def tost_poisson_2indep(count1, exposure1, count2, exposure2, low, upp,
     Gu, Ng, Tang, Schucany 2008: Testing the Ratio of Two Poisson Rates,
     Biometrical Journal 50 (2008) 2, 2008
 
+    See Also
+    --------
+    test_poisson_2indep
     '''
 
     tt1 = test_poisson_2indep(count1, exposure1, count2, exposure2,

--- a/statsmodels/stats/robust_compare.py
+++ b/statsmodels/stats/robust_compare.py
@@ -66,7 +66,7 @@ def trimboth(a, proportiontocut, axis=0):
 
 def trim_mean(a, proportiontocut, axis=0):
     """
-    Return mean of array after trimming distribution from both lower and upper
+    Return mean of array after trimming observations from both lower and upper
     tails.
 
     If `proportiontocut` = 0.1, slices off 'leftmost' and 'rightmost' 10% of
@@ -78,7 +78,7 @@ def trim_mean(a, proportiontocut, axis=0):
     a : array_like
         Input array
     proportiontocut : float
-        Fraction to cut off of both tails of the distribution
+        Fraction to cut off of both tails of the observations
     axis : int or None
         Axis along which the trimmed means are computed. The default is axis=0.
         If axis is None then the trimmed mean will be computed for the
@@ -95,7 +95,8 @@ def trim_mean(a, proportiontocut, axis=0):
 
 
 class TrimmedMean(object):
-    """class for trimmed and winsorized one sample statistics
+    """
+    class for trimmed and winsorized one sample statistics
 
     axis is None, i.e. ravelling, is not supported
     """
@@ -242,16 +243,17 @@ def scale_transform(data, center='median', transform='abs', trim_frac=0.2,
     Parameters
     ----------
     data : array_like
-        observations for the data
-    center : str in ['median', 'mean', 'trimmed']
-        the statistic that is used as center for the data transformation
+        Observations for the data.
+    center : "median", "mean", "trimmed" or float
+        Statistic used for centering observations. If a float, then this
+        value is used to center. Default is median.
     transform : 'abs', 'square', 'identity' or a callable
-        the transform for the centered data
+        The transform for the centered data.
     trim_frac : float in [0, 0.5)
         Fraction of observations that are trimmed on each side of the sorted
         observations. This is only used if center is `trimmed`.
     axis : int
-        axis along which the data are transformed when centering.
+        Axis along which the data are transformed when centering.
 
     Returns
     -------


### PR DESCRIPTION
Fixes most of the issues raised in #7032, along with some other minor stuff that I found. The only thing I couldn't figure out how to solve is the duplicate methods entry in the TrimmedMean docs.

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
