### PR TITLE
DOC: augmented docstrings from statsmodels.base.optimizer

### DIFF
--- a/statsmodels/base/optimizer.py
+++ b/statsmodels/base/optimizer.py
@@ -656,7 +656,7 @@ def _fit_nm(f, score, start_params, fargs, kwargs, disp=True,
             maxiter=100, callback=None, retall=False,
             full_output=True, hess=None):
     """
-    Fit using Newton-Raphson algorithm.
+    Fit using Nelder-Mead algorithm.
 
     Parameters
     ----------

--- a/statsmodels/base/optimizer.py
+++ b/statsmodels/base/optimizer.py
@@ -22,9 +22,21 @@ class Optimizer(object):
 
         Parameters
         ----------
+        objective : function
+            Objective function to be minimized.
+        gradient : function
+            The gradient of the objective function.
         start_params : array_like, optional
             Initial guess of the solution for the loglikelihood maximization.
             The default is an array of zeros.
+        fargs : tuple
+            Extra arguments passed to the objective function, i.e.
+            objective(x,*args)
+        kwargs : tuple
+            Extra keyworded arguments passed to the objective function, i.e.
+            objective(x,**kwargs)
+        hessian : str, optional
+            Method for computing the Hessian matrix, if applicable.
         method : str {'newton','nm','bfgs','powell','cg','ncg','basinhopping',
             'minimize'}
             Method can be 'newton' for Newton-Raphson, 'nm' for Nelder-Mead,
@@ -47,9 +59,6 @@ class Optimizer(object):
             See LikelihoodModelResults notes section for more information.
         disp : bool
             Set to True to print convergence messages.
-        fargs : tuple
-            Extra arguments passed to the likelihood function, i.e.,
-            loglike(x,*args)
         callback : callable callback(xk)
             Called after each iteration, as callback(xk), where xk is the
             current parameter vector.
@@ -253,8 +262,52 @@ class Optimizer(object):
 
 
 def _fit_minimize(f, score, start_params, fargs, kwargs, disp=True,
-                        maxiter=100, callback=None, retall=False,
-                        full_output=True, hess=None):
+                  maxiter=100, callback=None, retall=False,
+                  full_output=True, hess=None):
+    """
+    Fit using scipy minimize, where kwarg `min_method` defines the algorithm.
+
+    Parameters
+    ----------
+    f : function
+        Returns negative log likelihood given parameters.
+    score : function
+        Returns gradient of negative log likelihood with respect to params.
+    start_params : array_like, optional
+        Initial guess of the solution for the loglikelihood maximization.
+        The default is an array of zeros.
+    fargs : tuple
+        Extra arguments passed to the objective function, i.e.
+        objective(x,*args)
+    kwargs : tuple
+        Extra keyworded arguments passed to the objective function, i.e.
+        objective(x,**kwargs)
+    disp : bool
+        Set to True to print convergence messages.
+    maxiter : int
+        The maximum number of iterations to perform.
+    callback : callable callback(xk)
+        Called after each iteration, as callback(xk), where xk is the
+        current parameter vector.
+    retall : bool
+        Set to True to return list of solutions at each iteration.
+        Available in Results object's mle_retvals attribute.
+    full_output : bool
+        Set to True to have all available output in the Results object's
+        mle_retvals attribute. The output is dependent on the solver.
+        See LikelihoodModelResults notes section for more information.
+    hess : str, optional
+        Method for computing the Hessian matrix, if applicable.
+
+    Returns
+    -------
+    xopt : ndarray
+        The solution to the objective function
+    retvals : dict, None
+        If `full_output` is True then this is a dictionary which holds
+        information returned from the solver used. If it is False, this is
+        None.
+    """
     kwargs.setdefault('min_method', 'BFGS')
 
     # prepare options dict for minimize
@@ -303,8 +356,54 @@ def _fit_minimize(f, score, start_params, fargs, kwargs, disp=True,
 
 
 def _fit_newton(f, score, start_params, fargs, kwargs, disp=True,
-                    maxiter=100, callback=None, retall=False,
-                    full_output=True, hess=None, ridge_factor=1e-10):
+                maxiter=100, callback=None, retall=False,
+                full_output=True, hess=None, ridge_factor=1e-10):
+    """
+    Fit using Newton-Raphson algorithm.
+
+    Parameters
+    ----------
+    f : function
+        Returns negative log likelihood given parameters.
+    score : function
+        Returns gradient of negative log likelihood with respect to params.
+    start_params : array_like, optional
+        Initial guess of the solution for the loglikelihood maximization.
+        The default is an array of zeros.
+    fargs : tuple
+        Extra arguments passed to the objective function, i.e.
+        objective(x,*args)
+    kwargs : tuple
+        Extra keyworded arguments passed to the objective function, i.e.
+        objective(x,**kwargs)
+    disp : bool
+        Set to True to print convergence messages.
+    maxiter : int
+        The maximum number of iterations to perform.
+    callback : callable callback(xk)
+        Called after each iteration, as callback(xk), where xk is the
+        current parameter vector.
+    retall : bool
+        Set to True to return list of solutions at each iteration.
+        Available in Results object's mle_retvals attribute.
+    full_output : bool
+        Set to True to have all available output in the Results object's
+        mle_retvals attribute. The output is dependent on the solver.
+        See LikelihoodModelResults notes section for more information.
+    hess : str, optional
+        Method for computing the Hessian matrix, if applicable.
+    ridge_factor : float
+        Regularization factor for Hessian matrix.
+
+    Returns
+    -------
+    xopt : ndarray
+        The solution to the objective function
+    retvals : dict, None
+        If `full_output` is True then this is a dictionary which holds
+        information returned from the solver used. If it is False, this is
+        None.
+    """
     tol = kwargs.setdefault('tol', 1e-8)
     iterations = 0
     oldparams = np.inf
@@ -360,8 +459,52 @@ def _fit_newton(f, score, start_params, fargs, kwargs, disp=True,
 
 
 def _fit_bfgs(f, score, start_params, fargs, kwargs, disp=True,
-                    maxiter=100, callback=None, retall=False,
-                    full_output=True, hess=None):
+              maxiter=100, callback=None, retall=False,
+              full_output=True, hess=None):
+    """
+    Fit using Broyden-Fletcher-Goldfarb-Shannon algorithm.
+
+    Parameters
+    ----------
+    f : function
+        Returns negative log likelihood given parameters.
+    score : function
+        Returns gradient of negative log likelihood with respect to params.
+    start_params : array_like, optional
+        Initial guess of the solution for the loglikelihood maximization.
+        The default is an array of zeros.
+    fargs : tuple
+        Extra arguments passed to the objective function, i.e.
+        objective(x,*args)
+    kwargs : tuple
+        Extra keyworded arguments passed to the objective function, i.e.
+        objective(x,**kwargs)
+    disp : bool
+        Set to True to print convergence messages.
+    maxiter : int
+        The maximum number of iterations to perform.
+    callback : callable callback(xk)
+        Called after each iteration, as callback(xk), where xk is the
+        current parameter vector.
+    retall : bool
+        Set to True to return list of solutions at each iteration.
+        Available in Results object's mle_retvals attribute.
+    full_output : bool
+        Set to True to have all available output in the Results object's
+        mle_retvals attribute. The output is dependent on the solver.
+        See LikelihoodModelResults notes section for more information.
+    hess : str, optional
+        Method for computing the Hessian matrix, if applicable.
+
+    Returns
+    -------
+    xopt : ndarray
+        The solution to the objective function
+    retvals : dict, None
+        If `full_output` is True then this is a dictionary which holds
+        information returned from the solver used. If it is False, this is
+        None.
+    """
     gtol = kwargs.setdefault('gtol', 1.0000000000000001e-05)
     norm = kwargs.setdefault('norm', np.Inf)
     epsilon = kwargs.setdefault('epsilon', 1.4901161193847656e-08)
@@ -391,7 +534,7 @@ def _fit_bfgs(f, score, start_params, fargs, kwargs, disp=True,
 def _fit_lbfgs(f, score, start_params, fargs, kwargs, disp=True, maxiter=100,
                callback=None, retall=False, full_output=True, hess=None):
     """
-    Fit model using L-BFGS algorithm
+    Fit using Limited-memory Broyden-Fletcher-Goldfarb-Shannon algorithm.
 
     Parameters
     ----------
@@ -399,6 +542,40 @@ def _fit_lbfgs(f, score, start_params, fargs, kwargs, disp=True, maxiter=100,
         Returns negative log likelihood given parameters.
     score : function
         Returns gradient of negative log likelihood with respect to params.
+    start_params : array_like, optional
+        Initial guess of the solution for the loglikelihood maximization.
+        The default is an array of zeros.
+    fargs : tuple
+        Extra arguments passed to the objective function, i.e.
+        objective(x,*args)
+    kwargs : tuple
+        Extra keyworded arguments passed to the objective function, i.e.
+        objective(x,**kwargs)
+    disp : bool
+        Set to True to print convergence messages.
+    maxiter : int
+        The maximum number of iterations to perform.
+    callback : callable callback(xk)
+        Called after each iteration, as callback(xk), where xk is the
+        current parameter vector.
+    retall : bool
+        Set to True to return list of solutions at each iteration.
+        Available in Results object's mle_retvals attribute.
+    full_output : bool
+        Set to True to have all available output in the Results object's
+        mle_retvals attribute. The output is dependent on the solver.
+        See LikelihoodModelResults notes section for more information.
+    hess : str, optional
+        Method for computing the Hessian matrix, if applicable.
+
+    Returns
+    -------
+    xopt : ndarray
+        The solution to the objective function
+    retvals : dict, None
+        If `full_output` is True then this is a dictionary which holds
+        information returned from the solver used. If it is False, this is
+        None.
 
     Notes
     -----
@@ -476,8 +653,52 @@ def _fit_lbfgs(f, score, start_params, fargs, kwargs, disp=True, maxiter=100,
 
 
 def _fit_nm(f, score, start_params, fargs, kwargs, disp=True,
-                maxiter=100, callback=None, retall=False,
-                full_output=True, hess=None):
+            maxiter=100, callback=None, retall=False,
+            full_output=True, hess=None):
+    """
+    Fit using Newton-Raphson algorithm.
+
+    Parameters
+    ----------
+    f : function
+        Returns negative log likelihood given parameters.
+    score : function
+        Returns gradient of negative log likelihood with respect to params.
+    start_params : array_like, optional
+        Initial guess of the solution for the loglikelihood maximization.
+        The default is an array of zeros.
+    fargs : tuple
+        Extra arguments passed to the objective function, i.e.
+        objective(x,*args)
+    kwargs : tuple
+        Extra keyworded arguments passed to the objective function, i.e.
+        objective(x,**kwargs)
+    disp : bool
+        Set to True to print convergence messages.
+    maxiter : int
+        The maximum number of iterations to perform.
+    callback : callable callback(xk)
+        Called after each iteration, as callback(xk), where xk is the
+        current parameter vector.
+    retall : bool
+        Set to True to return list of solutions at each iteration.
+        Available in Results object's mle_retvals attribute.
+    full_output : bool
+        Set to True to have all available output in the Results object's
+        mle_retvals attribute. The output is dependent on the solver.
+        See LikelihoodModelResults notes section for more information.
+    hess : str, optional
+        Method for computing the Hessian matrix, if applicable.
+
+    Returns
+    -------
+    xopt : ndarray
+        The solution to the objective function
+    retvals : dict, None
+        If `full_output` is True then this is a dictionary which holds
+        information returned from the solver used. If it is False, this is
+        None.
+    """
     xtol = kwargs.setdefault('xtol', 0.0001)
     ftol = kwargs.setdefault('ftol', 0.0001)
     maxfun = kwargs.setdefault('maxfun', None)
@@ -504,8 +725,52 @@ def _fit_nm(f, score, start_params, fargs, kwargs, disp=True,
 
 
 def _fit_cg(f, score, start_params, fargs, kwargs, disp=True,
-                maxiter=100, callback=None, retall=False,
-                full_output=True, hess=None):
+            maxiter=100, callback=None, retall=False,
+            full_output=True, hess=None):
+    """
+    Fit using Conjugate Gradient algorithm.
+
+    Parameters
+    ----------
+    f : function
+        Returns negative log likelihood given parameters.
+    score : function
+        Returns gradient of negative log likelihood with respect to params.
+    start_params : array_like, optional
+        Initial guess of the solution for the loglikelihood maximization.
+        The default is an array of zeros.
+    fargs : tuple
+        Extra arguments passed to the objective function, i.e.
+        objective(x,*args)
+    kwargs : tuple
+        Extra keyworded arguments passed to the objective function, i.e.
+        objective(x,**kwargs)
+    disp : bool
+        Set to True to print convergence messages.
+    maxiter : int
+        The maximum number of iterations to perform.
+    callback : callable callback(xk)
+        Called after each iteration, as callback(xk), where xk is the
+        current parameter vector.
+    retall : bool
+        Set to True to return list of solutions at each iteration.
+        Available in Results object's mle_retvals attribute.
+    full_output : bool
+        Set to True to have all available output in the Results object's
+        mle_retvals attribute. The output is dependent on the solver.
+        See LikelihoodModelResults notes section for more information.
+    hess : str, optional
+        Method for computing the Hessian matrix, if applicable.
+
+    Returns
+    -------
+    xopt : ndarray
+        The solution to the objective function
+    retvals : dict, None
+        If `full_output` is True then this is a dictionary which holds
+        information returned from the solver used. If it is False, this is
+        None.
+    """
     gtol = kwargs.setdefault('gtol', 1.0000000000000001e-05)
     norm = kwargs.setdefault('norm', np.Inf)
     epsilon = kwargs.setdefault('epsilon', 1.4901161193847656e-08)
@@ -532,8 +797,52 @@ def _fit_cg(f, score, start_params, fargs, kwargs, disp=True,
 
 
 def _fit_ncg(f, score, start_params, fargs, kwargs, disp=True,
-                 maxiter=100, callback=None, retall=False,
-                 full_output=True, hess=None):
+             maxiter=100, callback=None, retall=False,
+             full_output=True, hess=None):
+    """
+    Fit using Newton Conjugate Gradient algorithm.
+
+    Parameters
+    ----------
+    f : function
+        Returns negative log likelihood given parameters.
+    score : function
+        Returns gradient of negative log likelihood with respect to params.
+    start_params : array_like, optional
+        Initial guess of the solution for the loglikelihood maximization.
+        The default is an array of zeros.
+    fargs : tuple
+        Extra arguments passed to the objective function, i.e.
+        objective(x,*args)
+    kwargs : tuple
+        Extra keyworded arguments passed to the objective function, i.e.
+        objective(x,**kwargs)
+    disp : bool
+        Set to True to print convergence messages.
+    maxiter : int
+        The maximum number of iterations to perform.
+    callback : callable callback(xk)
+        Called after each iteration, as callback(xk), where xk is the
+        current parameter vector.
+    retall : bool
+        Set to True to return list of solutions at each iteration.
+        Available in Results object's mle_retvals attribute.
+    full_output : bool
+        Set to True to have all available output in the Results object's
+        mle_retvals attribute. The output is dependent on the solver.
+        See LikelihoodModelResults notes section for more information.
+    hess : str, optional
+        Method for computing the Hessian matrix, if applicable.
+
+    Returns
+    -------
+    xopt : ndarray
+        The solution to the objective function
+    retvals : dict, None
+        If `full_output` is True then this is a dictionary which holds
+        information returned from the solver used. If it is False, this is
+        None.
+    """
     fhess_p = kwargs.setdefault('fhess_p', None)
     avextol = kwargs.setdefault('avextol', 1.0000000000000001e-05)
     epsilon = kwargs.setdefault('epsilon', 1.4901161193847656e-08)
@@ -562,8 +871,52 @@ def _fit_ncg(f, score, start_params, fargs, kwargs, disp=True,
 
 
 def _fit_powell(f, score, start_params, fargs, kwargs, disp=True,
-                    maxiter=100, callback=None, retall=False,
-                    full_output=True, hess=None):
+                maxiter=100, callback=None, retall=False,
+                full_output=True, hess=None):
+    """
+    Fit using Powell's conjugate direction algorithm.
+
+    Parameters
+    ----------
+    f : function
+        Returns negative log likelihood given parameters.
+    score : function
+        Returns gradient of negative log likelihood with respect to params.
+    start_params : array_like, optional
+        Initial guess of the solution for the loglikelihood maximization.
+        The default is an array of zeros.
+    fargs : tuple
+        Extra arguments passed to the objective function, i.e.
+        objective(x,*args)
+    kwargs : tuple
+        Extra keyworded arguments passed to the objective function, i.e.
+        objective(x,**kwargs)
+    disp : bool
+        Set to True to print convergence messages.
+    maxiter : int
+        The maximum number of iterations to perform.
+    callback : callable callback(xk)
+        Called after each iteration, as callback(xk), where xk is the
+        current parameter vector.
+    retall : bool
+        Set to True to return list of solutions at each iteration.
+        Available in Results object's mle_retvals attribute.
+    full_output : bool
+        Set to True to have all available output in the Results object's
+        mle_retvals attribute. The output is dependent on the solver.
+        See LikelihoodModelResults notes section for more information.
+    hess : str, optional
+        Method for computing the Hessian matrix, if applicable.
+
+    Returns
+    -------
+    xopt : ndarray
+        The solution to the objective function
+    retvals : dict, None
+        If `full_output` is True then this is a dictionary which holds
+        information returned from the solver used. If it is False, this is
+        None.
+    """
     xtol = kwargs.setdefault('xtol', 0.0001)
     ftol = kwargs.setdefault('ftol', 0.0001)
     maxfun = kwargs.setdefault('maxfun', None)
@@ -593,9 +946,52 @@ def _fit_powell(f, score, start_params, fargs, kwargs, disp=True,
 
 
 def _fit_basinhopping(f, score, start_params, fargs, kwargs, disp=True,
-                          maxiter=100, callback=None, retall=False,
-                          full_output=True, hess=None):
+                      maxiter=100, callback=None, retall=False,
+                      full_output=True, hess=None):
+    """
+    Fit using Basin-hopping algorithm.
 
+    Parameters
+    ----------
+    f : function
+        Returns negative log likelihood given parameters.
+    score : function
+        Returns gradient of negative log likelihood with respect to params.
+    start_params : array_like, optional
+        Initial guess of the solution for the loglikelihood maximization.
+        The default is an array of zeros.
+    fargs : tuple
+        Extra arguments passed to the objective function, i.e.
+        objective(x,*args)
+    kwargs : tuple
+        Extra keyworded arguments passed to the objective function, i.e.
+        objective(x,**kwargs)
+    disp : bool
+        Set to True to print convergence messages.
+    maxiter : int
+        The maximum number of iterations to perform.
+    callback : callable callback(xk)
+        Called after each iteration, as callback(xk), where xk is the
+        current parameter vector.
+    retall : bool
+        Set to True to return list of solutions at each iteration.
+        Available in Results object's mle_retvals attribute.
+    full_output : bool
+        Set to True to have all available output in the Results object's
+        mle_retvals attribute. The output is dependent on the solver.
+        See LikelihoodModelResults notes section for more information.
+    hess : str, optional
+        Method for computing the Hessian matrix, if applicable.
+
+    Returns
+    -------
+    xopt : ndarray
+        The solution to the objective function
+    retvals : dict, None
+        If `full_output` is True then this is a dictionary which holds
+        information returned from the solver used. If it is False, this is
+        None.
+    """
     from copy import copy
     kwargs = copy(kwargs)
     niter = kwargs.setdefault('niter', 100)


### PR DESCRIPTION
- [ N/A] closes #xxxx
- [ N/A] tests added / passed. 
- [ x] code/documentation is well formatted.  
- [ x] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>
Added docstrings for statsmodels.base.optimizer as first contribution.

**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
