### PR TITLE
DOC: Fix contradicting KPSS-statistics interpretations in stationarity_detrending_adf_kpss.ipynb

### DIFF
--- a/examples/notebooks/stationarity_detrending_adf_kpss.ipynb
+++ b/examples/notebooks/stationarity_detrending_adf_kpss.ipynb
@@ -191,7 +191,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Based upon the significance level of 0.05 and the p-value of the KPSS test, the null hypothesis can not be rejected. Hence, the series is stationary as per the KPSS test. \n",
+    "Based upon the significance level of 0.05 and the p-value of KPSS test, there is evidence for rejecting the null hypothesis in favor of the alternative. Hence, the series is non-stationary as per the KPSS test.\n",
     "\n",
     "It is always better to apply both the tests, so that it can be ensured that the series is truly stationary. Possible outcomes of applying these stationary tests are as follows:\n",
     "\n",


### PR DESCRIPTION
- [x] closes #7089  
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
