### PR TITLE
BUG: Correct prediction intervals for ThetaModel

### DIFF
--- a/statsmodels/tsa/forecasting/tests/test_theta.py
+++ b/statsmodels/tsa/forecasting/tests/test_theta.py
@@ -104,3 +104,15 @@ def test_forecast_errors(data):
         res.forecast(7, theta=0.99)
     with pytest.raises(ValueError, match="steps must be a positive integer"):
         res.forecast_components(0)
+
+
+def test_pi_width():
+    # GH 7075
+    rs = np.random.RandomState(1233091)
+    y = np.arange(100) + rs.standard_normal(100)
+
+    th = ThetaModel(y, period=12, deseasonalize=False)
+    res = th.fit()
+    pi = res.prediction_intervals(24)
+    d = np.squeeze(np.diff(np.asarray(pi), axis=1))
+    assert np.all(np.diff(d) > 0)

--- a/statsmodels/tsa/forecasting/theta.py
+++ b/statsmodels/tsa/forecasting/theta.py
@@ -574,11 +574,13 @@ class ThetaModelResults:
         -----
         The variance of the h-step forecast is assumed to follow from the
         integrated Moving Average structure of the Theta model, and so is
-        :math:`\sigma^2(\alpha^2 + (h-1))`. The prediction interval assumes
-        that innovations are normally distributed.
+        :math:`\sigma^2(1 + (h-1)(1 + (\alpha-1)^2)`. The prediction interval
+        assumes that innovations are normally distributed.
         """
-        model_alpha = self.params[0]
-        sigma2_h = model_alpha ** 2 + np.arange(steps) * self.sigma2
+        model_alpha = self.params[1]
+        sigma2_h = (
+            1 + np.arange(steps) * (1 + (model_alpha - 1) ** 2)
+        ) * self.sigma2
         sigma_h = np.sqrt(sigma2_h)
         quantile = stats.norm.ppf(alpha / 2)
         predictions = self.forecast(steps, theta)


### PR DESCRIPTION
Prediction intervals are using the wrong expression

- [ ] closes #xxxx
- [X] tests added / passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
