### PR TITLE
BUG: fix error in Poisson when offset or exposure is a pd.Series

### DIFF
--- a/statsmodels/discrete/discrete_model.py
+++ b/statsmodels/discrete/discrete_model.py
@@ -768,7 +768,10 @@ class CountModel(DiscreteModel):
         super().__init__(endog, exog, check_rank, missing=missing,
                          offset=offset, exposure=exposure, **kwargs)
         if exposure is not None:
+            self.exposure = np.asarray(self.exposure)
             self.exposure = np.log(self.exposure)
+        if offset is not None:
+            self.offset = np.asarray(self.offset)
         self._check_inputs(self.offset, self.exposure, self.endog)
         if offset is None:
             delattr(self, 'offset')

--- a/statsmodels/discrete/tests/test_count_model.py
+++ b/statsmodels/discrete/tests/test_count_model.py
@@ -40,10 +40,10 @@ class CheckGeneric(CheckModelMixin):
 
         alpha = np.ones(len(self.res1.params))
         alpha[-2:] = 0
-        res_reg = model.fit_regularized(alpha=alpha*0.01, disp=0, maxiter=500)
+        res_reg = model.fit_regularized(alpha=alpha * 0.01, disp=0, maxiter=500)
 
         assert_allclose(res_reg.params[2:], self.res1.params[2:],
-            atol=5e-2, rtol=5e-2)
+                        atol=5e-2, rtol=5e-2)
 
     def test_init_keys(self):
         init_kwds = self.res1.model._get_init_kwds()
@@ -58,7 +58,7 @@ class CheckGeneric(CheckModelMixin):
         exog_null = self.res1.res_null.model.exog
         exog_infl_null = self.res1.res_null.model.exog_infl
         assert_array_equal(exog_infl_null.shape,
-                     (len(self.res1.model.exog), 1))
+                           (len(self.res1.model.exog), 1))
         assert_equal(np.ptp(exog_null), 0)
         assert_equal(np.ptp(exog_infl_null), 0)
 
@@ -68,16 +68,17 @@ class CheckGeneric(CheckModelMixin):
         # GH 4581
         assert 'Covariance Type:' in str(summ)
 
+
 class TestZeroInflatedModel_logit(CheckGeneric):
     @classmethod
     def setup_class(cls):
         data = sm.datasets.randhie.load(as_pandas=False)
         cls.endog = data.endog
-        exog = sm.add_constant(data.exog[:,1:4], prepend=False)
-        exog_infl = sm.add_constant(data.exog[:,0], prepend=False)
+        exog = sm.add_constant(data.exog[:, 1:4], prepend=False)
+        exog_infl = sm.add_constant(data.exog[:, 0], prepend=False)
         cls.res1 = sm.ZeroInflatedPoisson(data.endog, exog,
-            exog_infl=exog_infl, inflation='logit').fit(method='newton', maxiter=500,
-                                                        disp=0)
+                                          exog_infl=exog_infl, inflation='logit').fit(method='newton', maxiter=500,
+                                                                                      disp=0)
         # for llnull test
         cls.res1._results._attach_nullmodel = True
         cls.init_keys = ['exog_infl', 'exposure', 'inflation', 'offset']
@@ -85,16 +86,17 @@ class TestZeroInflatedModel_logit(CheckGeneric):
         res2 = RandHIE.zero_inflated_poisson_logit
         cls.res2 = res2
 
+
 class TestZeroInflatedModel_probit(CheckGeneric):
     @classmethod
     def setup_class(cls):
         data = sm.datasets.randhie.load(as_pandas=False)
         cls.endog = data.endog
-        exog = sm.add_constant(data.exog[:,1:4], prepend=False)
-        exog_infl = sm.add_constant(data.exog[:,0], prepend=False)
+        exog = sm.add_constant(data.exog[:, 1:4], prepend=False)
+        exog_infl = sm.add_constant(data.exog[:, 0], prepend=False)
         cls.res1 = sm.ZeroInflatedPoisson(data.endog, exog,
-            exog_infl=exog_infl, inflation='probit').fit(method='newton', maxiter=500,
-                                                         disp=0)
+                                          exog_infl=exog_infl, inflation='probit').fit(method='newton', maxiter=500,
+                                                                                       disp=0)
         # for llnull test
         cls.res1._results._attach_nullmodel = True
         cls.init_keys = ['exog_infl', 'exposure', 'inflation', 'offset']
@@ -106,17 +108,18 @@ class TestZeroInflatedModel_probit(CheckGeneric):
     def test_fit_regularized(self):
         super().test_fit_regularized()
 
+
 class TestZeroInflatedModel_offset(CheckGeneric):
     @classmethod
     def setup_class(cls):
         data = sm.datasets.randhie.load(as_pandas=False)
         cls.endog = data.endog
-        exog = sm.add_constant(data.exog[:,1:4], prepend=False)
-        exog_infl = sm.add_constant(data.exog[:,0], prepend=False)
+        exog = sm.add_constant(data.exog[:, 1:4], prepend=False)
+        exog_infl = sm.add_constant(data.exog[:, 0], prepend=False)
         cls.res1 = sm.ZeroInflatedPoisson(data.endog, exog,
-            exog_infl=exog_infl, offset=data.exog[:,7]).fit(method='newton',
-                                                            maxiter=500,
-                                                            disp=0)
+                                          exog_infl=exog_infl, offset=data.exog[:, 7]).fit(method='newton',
+                                                                                           maxiter=500,
+                                                                                           disp=0)
         # for llnull test
         cls.res1._results._attach_nullmodel = True
         cls.init_keys = ['exog_infl', 'exposure', 'inflation', 'offset']
@@ -130,7 +133,7 @@ class TestZeroInflatedModel_offset(CheckGeneric):
         model1 = self.res1.model
         offset = model1.offset
         model3 = sm.ZeroInflatedPoisson(model1.endog, model1.exog,
-            exog_infl=model1.exog_infl, exposure=np.exp(offset))
+                                        exog_infl=model1.exog_infl, exposure=np.exp(offset))
         res3 = model3.fit(start_params=self.res1.params,
                           method='newton', maxiter=500, disp=0)
 
@@ -147,7 +150,6 @@ class TestZeroInflatedModel_offset(CheckGeneric):
         fitted3_0 = res3.predict(exog=ex, exog_infl=ex_infl,
                                  exposure=np.exp(offset))
         assert_allclose(fitted3_0, fitted1_0, atol=1e-6, rtol=1e-6)
-
 
         ex = model1.exog[:10:2]
         ex_infl = model1.exog_infl[:10:2]
@@ -174,14 +176,14 @@ class TestZeroInflatedModelPandas(CheckGeneric):
         data = sm.datasets.randhie.load_pandas()
         cls.endog = data.endog
         cls.data = data
-        exog = sm.add_constant(data.exog.iloc[:,1:4], prepend=False)
-        exog_infl = sm.add_constant(data.exog.iloc[:,0], prepend=False)
+        exog = sm.add_constant(data.exog.iloc[:, 1:4], prepend=False)
+        exog_infl = sm.add_constant(data.exog.iloc[:, 0], prepend=False)
         # we do not need to verify convergence here
         start_params = np.asarray([0.10337834587498942, -1.0459825102508549,
                                    -0.08219794475894268, 0.00856917434709146,
                                    -0.026795737379474334, 1.4823632430107334])
         model = sm.ZeroInflatedPoisson(data.endog, exog,
-            exog_infl=exog_infl, inflation='logit')
+                                       exog_infl=exog_infl, inflation='logit')
         cls.res1 = model.fit(start_params=start_params, method='newton',
                              maxiter=500, disp=0)
         # for llnull test
@@ -198,12 +200,12 @@ class TestZeroInflatedModelPandas(CheckGeneric):
         assert_array_equal(self.res1.params.index.tolist(), param_names)
         assert_array_equal(self.res1.bse.index.tolist(), param_names)
 
-        exog = sm.add_constant(self.data.exog.iloc[:,1:4], prepend=True)
-        exog_infl = sm.add_constant(self.data.exog.iloc[:,0], prepend=True)
+        exog = sm.add_constant(self.data.exog.iloc[:, 1:4], prepend=True)
+        exog_infl = sm.add_constant(self.data.exog.iloc[:, 0], prepend=True)
         param_names = ['inflate_const', 'inflate_lncoins', 'const', 'idp',
                        'lpi', 'fmde']
         model = sm.ZeroInflatedPoisson(self.data.endog, exog,
-            exog_infl=exog_infl, inflation='logit')
+                                       exog_infl=exog_infl, inflation='logit')
         assert_array_equal(model.exog_names, param_names)
 
 
@@ -214,23 +216,23 @@ class TestZeroInflatedPoisson_predict(object):
         np.random.seed(999)
         nobs = 2000
         exog = np.ones((nobs, 2))
-        exog[:nobs//2, 1] = 2
+        exog[:nobs // 2, 1] = 2
         mu_true = exog.dot(expected_params)
         cls.endog = sm.distributions.zipoisson.rvs(mu_true, 0.05,
                                                    size=mu_true.shape)
         model = sm.ZeroInflatedPoisson(cls.endog, exog)
         cls.res = model.fit(method='bfgs', maxiter=5000, maxfun=5000, disp=0)
 
-        cls.params_true = [mu_true,  0.05, nobs]
+        cls.params_true = [mu_true, 0.05, nobs]
 
     def test_mean(self):
         def compute_conf_interval_95(mu, prob_infl, nobs):
             dispersion_factor = 1 + prob_infl * mu
 
             # scalar variance of the mixture of zip
-            var = (dispersion_factor*(1-prob_infl)*mu).mean()
-            var += (((1-prob_infl)*mu)**2).mean()
-            var -= (((1-prob_infl)*mu).mean())**2
+            var = (dispersion_factor * (1 - prob_infl) * mu).mean()
+            var += (((1 - prob_infl) * mu) ** 2).mean()
+            var -= (((1 - prob_infl) * mu).mean()) ** 2
             std = np.sqrt(var)
             # Central limit theorem
             conf_intv_95 = 2 * std / np.sqrt(nobs)
@@ -246,10 +248,10 @@ class TestZeroInflatedPoisson_predict(object):
             # a non-negative term accounting for the (weighted)
             # dispersion of the means, see stats.stackexchange #16609 and
             #  Casella & Berger's Statistical Inference (Example 10.2.1)
-            prob_infl = 1-prob_main
-            var = (dispersion_factor*(1-prob_infl)*mu).mean()
-            var += (((1-prob_infl)*mu)**2).mean()
-            var -= (((1-prob_infl)*mu).mean())**2
+            prob_infl = 1 - prob_main
+            var = (dispersion_factor * (1 - prob_infl) * mu).mean()
+            var += (((1 - prob_infl) * mu) ** 2).mean()
+            var -= (((1 - prob_infl) * mu).mean()) ** 2
             return var
 
         res = self.res
@@ -275,10 +277,10 @@ class TestZeroInflatedGeneralizedPoisson(CheckGeneric):
     def setup_class(cls):
         data = sm.datasets.randhie.load(as_pandas=False)
         cls.endog = data.endog
-        exog = sm.add_constant(data.exog[:,1:4], prepend=False)
-        exog_infl = sm.add_constant(data.exog[:,0], prepend=False)
+        exog = sm.add_constant(data.exog[:, 1:4], prepend=False)
+        exog_infl = sm.add_constant(data.exog[:, 0], prepend=False)
         cls.res1 = sm.ZeroInflatedGeneralizedPoisson(data.endog, exog,
-            exog_infl=exog_infl, p=1).fit(method='newton', maxiter=500, disp=0)
+                                                     exog_infl=exog_infl, p=1).fit(method='newton', maxiter=500, disp=0)
         # for llnull test
         cls.res1._results._attach_nullmodel = True
         cls.init_keys = ['exog_infl', 'exposure', 'inflation', 'offset', 'p']
@@ -338,7 +340,8 @@ class TestZeroInflatedGeneralizedPoisson(CheckGeneric):
         assert_allclose(res_bh.bse, self.res2.bse,
                         atol=1e-3, rtol=0.6)
         # skip, res_bh reports converged is false but params agree
-        #assert_(res_bh.mle_retvals['converged'] is True)
+        # assert_(res_bh.mle_retvals['converged'] is True)
+
 
 class TestZeroInflatedGeneralizedPoisson_predict(object):
     @classmethod
@@ -347,24 +350,24 @@ class TestZeroInflatedGeneralizedPoisson_predict(object):
         np.random.seed(999)
         nobs = 2000
         exog = np.ones((nobs, 2))
-        exog[:nobs//2, 1] = 2
+        exog[:nobs // 2, 1] = 2
         mu_true = exog.dot(expected_params[:-1])
         cls.endog = sm.distributions.zigenpoisson.rvs(mu_true, expected_params[-1],
                                                       2, 0.5, size=mu_true.shape)
         model = sm.ZeroInflatedGeneralizedPoisson(cls.endog, exog, p=2)
         cls.res = model.fit(method='bfgs', maxiter=5000, maxfun=5000, disp=0)
 
-        cls.params_true = [mu_true, expected_params[-1], 2,  0.5, nobs]
+        cls.params_true = [mu_true, expected_params[-1], 2, 0.5, nobs]
 
     def test_mean(self):
         def compute_conf_interval_95(mu, alpha, p, prob_infl, nobs):
-            p = p-1
-            dispersion_factor = (1 + alpha * mu**p)**2 + prob_infl * mu
+            p = p - 1
+            dispersion_factor = (1 + alpha * mu ** p) ** 2 + prob_infl * mu
 
             # scalar variance of the mixture of zip
-            var = (dispersion_factor*(1-prob_infl)*mu).mean()
-            var += (((1-prob_infl)*mu)**2).mean()
-            var -= (((1-prob_infl)*mu).mean())**2
+            var = (dispersion_factor * (1 - prob_infl) * mu).mean()
+            var += (((1 - prob_infl) * mu) ** 2).mean()
+            var -= (((1 - prob_infl) * mu).mean()) ** 2
             std = np.sqrt(var)
             # Central limit theorem
             conf_intv_95 = 2 * std / np.sqrt(nobs)
@@ -376,10 +379,10 @@ class TestZeroInflatedGeneralizedPoisson_predict(object):
 
     def test_var(self):
         def compute_mixture_var(dispersion_factor, prob_main, mu):
-            prob_infl = 1-prob_main
-            var = (dispersion_factor*(1-prob_infl)*mu).mean()
-            var += (((1-prob_infl)*mu)**2).mean()
-            var -= (((1-prob_infl)*mu).mean())**2
+            prob_infl = 1 - prob_main
+            var = (dispersion_factor * (1 - prob_infl) * mu).mean()
+            var += (((1 - prob_infl) * mu) ** 2).mean()
+            var -= (((1 - prob_infl) * mu).mean()) ** 2
             return var
 
         res = self.res
@@ -404,14 +407,14 @@ class TestZeroInflatedNegativeBinomialP(CheckGeneric):
     def setup_class(cls):
         data = sm.datasets.randhie.load(as_pandas=False)
         cls.endog = data.endog
-        exog = sm.add_constant(data.exog[:,1], prepend=False)
-        exog_infl = sm.add_constant(data.exog[:,0], prepend=False)
+        exog = sm.add_constant(data.exog[:, 1], prepend=False)
+        exog_infl = sm.add_constant(data.exog[:, 0], prepend=False)
         # cheating for now, parameters are not well identified in this dataset
         # see https://github.com/statsmodels/statsmodels/pull/3928#issuecomment-331724022
         sp = np.array([1.88, -10.28, -0.20, 1.14, 1.34])
         cls.res1 = sm.ZeroInflatedNegativeBinomialP(data.endog, exog,
-            exog_infl=exog_infl, p=2).fit(start_params=sp, method='nm',
-                                          xtol=1e-6, maxiter=5000, disp=0)
+                                                    exog_infl=exog_infl, p=2).fit(start_params=sp, method='nm',
+                                                                                  xtol=1e-6, maxiter=5000, disp=0)
         # for llnull test
         cls.res1._results._attach_nullmodel = True
         cls.init_keys = ['exog_infl', 'exposure', 'inflation', 'offset', 'p']
@@ -434,10 +437,10 @@ class TestZeroInflatedNegativeBinomialP(CheckGeneric):
 
         alpha = np.ones(len(self.res1.params))
         alpha[-2:] = 0
-        res_reg = model.fit_regularized(alpha=alpha*0.01, disp=0, maxiter=500)
+        res_reg = model.fit_regularized(alpha=alpha * 0.01, disp=0, maxiter=500)
 
         assert_allclose(res_reg.params[2:], self.res1.params[2:],
-            atol=1e-1, rtol=1e-1)
+                        atol=1e-1, rtol=1e-1)
 
     # possibly slow, adds 25 seconds
     def test_minimize(self, reset_randomstate):
@@ -475,45 +478,44 @@ class TestZeroInflatedNegativeBinomialP(CheckGeneric):
         assert_allclose(res_bh.bse, self.res2.bse,
                         atol=1e-3, rtol=1e-3)
         # skip, res_bh reports converged is false but params agree
-        #assert_(res_bh.mle_retvals['converged'] is True)
+        # assert_(res_bh.mle_retvals['converged'] is True)
 
 
 class TestZeroInflatedNegativeBinomialP_predict(object):
     @classmethod
     def setup_class(cls):
-
         expected_params = [1, 1, 0.5]
         np.random.seed(999)
         nobs = 5000
         exog = np.ones((nobs, 2))
-        exog[:nobs//2, 1] = 0
+        exog[:nobs // 2, 1] = 0
 
         prob_infl = 0.15
         mu_true = np.exp(exog.dot(expected_params[:-1]))
         cls.endog = sm.distributions.zinegbin.rvs(mu_true,
-                    expected_params[-1], 2, prob_infl, size=mu_true.shape)
+                                                  expected_params[-1], 2, prob_infl, size=mu_true.shape)
         model = sm.ZeroInflatedNegativeBinomialP(cls.endog, exog, p=2)
         cls.res = model.fit(method='bfgs', maxiter=5000, maxfun=5000, disp=0)
 
         # attach others
         cls.prob_infl = prob_infl
-        cls.params_true = [mu_true, expected_params[-1], 2,  prob_infl, nobs]
+        cls.params_true = [mu_true, expected_params[-1], 2, prob_infl, nobs]
 
     def test_mean(self):
         def compute_conf_interval_95(mu, alpha, p, prob_infl, nobs):
-            dispersion_factor = 1 + alpha * mu**(p-1) + prob_infl * mu
+            dispersion_factor = 1 + alpha * mu ** (p - 1) + prob_infl * mu
 
             # scalar variance of the mixture of zip
-            var = (dispersion_factor*(1-prob_infl)*mu).mean()
-            var += (((1-prob_infl)*mu)**2).mean()
-            var -= (((1-prob_infl)*mu).mean())**2
+            var = (dispersion_factor * (1 - prob_infl) * mu).mean()
+            var += (((1 - prob_infl) * mu) ** 2).mean()
+            var -= (((1 - prob_infl) * mu).mean()) ** 2
             std = np.sqrt(var)
             # Central limit theorem
             conf_intv_95 = 2 * std / np.sqrt(nobs)
             return conf_intv_95
 
         conf_interval_95 = compute_conf_interval_95(*self.params_true)
-        mean_true = ((1-self.prob_infl)*self.params_true[0]).mean()
+        mean_true = ((1 - self.prob_infl) * self.params_true[0]).mean()
         assert_allclose(self.res.predict().mean(),
                         mean_true, atol=conf_interval_95, rtol=0)
 
@@ -539,14 +541,14 @@ class TestZeroInflatedNegativeBinomialP_predict(object):
         endog = res.model.endog
 
         pr = res.predict(which='prob')
-        pr2 = sm.distributions.zinegbin.pmf(np.arange(pr.shape[1])[:,None],
-            res.predict(), 0.5, 2, self.prob_infl).T
+        pr2 = sm.distributions.zinegbin.pmf(np.arange(pr.shape[1])[:, None],
+                                            res.predict(), 0.5, 2, self.prob_infl).T
         assert_allclose(pr, pr2, rtol=0.1, atol=0.1)
         prm = pr.mean(0)
         pr2m = pr2.mean(0)
         freq = np.bincount(endog.astype(int)) / len(endog)
-        assert_allclose(((pr2m - prm)**2).mean(), 0, rtol=1e-10, atol=5e-4)
-        assert_allclose(((prm - freq)**2).mean(), 0, rtol=1e-10, atol=1e-4)
+        assert_allclose(((pr2m - prm) ** 2).mean(), 0, rtol=1e-10, atol=5e-4)
+        assert_allclose(((prm - freq) ** 2).mean(), 0, rtol=1e-10, atol=1e-4)
 
     def test_predict_generic_zi(self):
         # These tests do not use numbers from other packages.
@@ -567,9 +569,9 @@ class TestZeroInflatedNegativeBinomialP_predict(object):
                                    exog_infl=np.asarray([[1], [1]]),
                                    which='prob')
         # no default for exog_infl yet
-        #probs_unique = res.predict(exog=[[1, 0], [1, 1]], which='prob')
+        # probs_unique = res.predict(exog=[[1, 0], [1, 1]], which='prob')
 
-        probs_unique2 = probs[[1, nobs-1]]
+        probs_unique2 = probs[[1, nobs - 1]]
 
         assert_allclose(probs_unique, probs_unique2, atol=1e-10)
 
@@ -582,8 +584,8 @@ class TestZeroInflatedNegativeBinomialP_predict(object):
                                         exog_infl=np.asarray([[1], [1]]),
                                         which='prob-main')
         probs_main = res.predict(which='prob-main')
-        probs_main[[0,-1]]
-        assert_allclose(probs_main_unique, probs_main[[0,-1]],  rtol=1e-10)
+        probs_main[[0, -1]]
+        assert_allclose(probs_main_unique, probs_main[[0, -1]], rtol=1e-10)
         assert_allclose(probs_main_unique, 1 - prob_infl, atol=0.01)
 
         pred = res.predict(exog=[[1, 0], [1, 1]],
@@ -623,10 +625,10 @@ class TestZeroInflatedNegativeBinomialP_predict2(object):
         cls.endog = data.endog
         exog = data.exog
         start_params = np.array([
-            -2.83983767, -2.31595924, -3.9263248,  -4.01816431, -5.52251843,
-            -2.4351714,  -4.61636366, -4.17959785, -0.12960256, -0.05653484,
-            -0.21206673,  0.08782572, -0.02991995,  0.22901208,  0.0620983,
-            0.06809681,  0.0841814,   0.185506,    1.36527888])
+            -2.83983767, -2.31595924, -3.9263248, -4.01816431, -5.52251843,
+            -2.4351714, -4.61636366, -4.17959785, -0.12960256, -0.05653484,
+            -0.21206673, 0.08782572, -0.02991995, 0.22901208, 0.0620983,
+            0.06809681, 0.0841814, 0.185506, 1.36527888])
         mod = sm.ZeroInflatedNegativeBinomialP(
             cls.endog, exog, exog_infl=exog, p=2)
         res = mod.fit(start_params=start_params, method="bfgs",

--- a/statsmodels/discrete/tests/test_count_model.py
+++ b/statsmodels/discrete/tests/test_count_model.py
@@ -657,4 +657,3 @@ class TestPandasOffset:
         for inflation in inflations:
             sm.ZeroInflatedPoisson(endog=endog, exog=exog, exposure=exposure, exog_infl=exog,
                                    inflation=inflation).fit()
-

--- a/statsmodels/discrete/tests/test_count_model.py
+++ b/statsmodels/discrete/tests/test_count_model.py
@@ -4,6 +4,7 @@ import numpy as np
 from numpy.testing import (assert_,
                            assert_equal, assert_array_equal, assert_allclose)
 import pytest
+import pandas as pd
 
 import statsmodels.api as sm
 from .results.results_discrete import RandHIE
@@ -66,7 +67,6 @@ class CheckGeneric(CheckModelMixin):
         summ = self.res1.summary()
         # GH 4581
         assert 'Covariance Type:' in str(summ)
-
 
 class TestZeroInflatedModel_logit(CheckGeneric):
     @classmethod
@@ -643,3 +643,18 @@ class TestZeroInflatedNegativeBinomialP_predict2(object):
         mean2 = ((1 - self.res.predict(which='prob-zero').mean()) *
                  self.res.predict(which='mean-nonzero').mean())
         assert_allclose(mean1, mean2, atol=0.2)
+
+
+class TestPandasOffset:
+
+    def test_pd_offset_exposure(self):
+        endog = pd.DataFrame({'F': [0.0, 0.0, 0.0, 0.0, 1.0]})
+        exog = pd.DataFrame({'I': [1.0, 1.0, 1.0, 1.0, 1.0], 'C': [0.0, 1.0, 0.0, 1.0, 0.0]})
+        exposure = pd.Series([1, 1, 1, 2, 1])
+        offset = pd.Series([1, 1, 1, 2, 1])
+        sm.Poisson(endog=endog, exog=exog, offset=offset).fit()
+        inflations = ['logit', 'probit']
+        for inflation in inflations:
+            sm.ZeroInflatedPoisson(endog=endog, exog=exog, exposure=exposure, exog_infl=exog,
+                                   inflation=inflation).fit()
+


### PR DESCRIPTION
- [X] closes #7015
- [X] tests added / passed. 
- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>
Just do np.asarray in the __init__ method of CountModel. Added a test that fails on master but passes here

**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
