### PR TITLE
ENH: Adding an if clause in regression.rolling.WLS._fit_single to avo…

### DIFF
--- a/statsmodels/regression/rolling.py
+++ b/statsmodels/regression/rolling.py
@@ -223,7 +223,8 @@ class RollingWLS(object):
         if nobs < self._min_nobs:
             return
         try:
-            wxpwxi = np.linalg.inv(wxpwx)
+            if (method == "inv") or not params_only:
+                wxpwxi = np.linalg.inv(wxpwx)
             if method == "inv":
                 params = wxpwxi @ wxpwy
             else:

--- a/statsmodels/regression/tests/test_rolling.py
+++ b/statsmodels/regression/tests/test_rolling.py
@@ -286,7 +286,7 @@ def test_params_only(basic_data, method):
     res = mod.fit(method=method, params_only=False)
     res_params_only = mod.fit(method=method, params_only=True)
     assert_array_equal(res_params_only.params, res.params)
-    
+
 
 def test_min_nobs(basic_data):
     y, x, w = basic_data

--- a/statsmodels/regression/tests/test_rolling.py
+++ b/statsmodels/regression/tests/test_rolling.py
@@ -279,6 +279,15 @@ def test_methods(basic_data, params_only):
     assert_allclose(res_inv.params, res_pinv.params)
 
 
+@pytest.mark.parametrize("method", ["inv", "lstsq", "pinv"])
+def test_params_only(basic_data, method):
+    y, x, _ = basic_data
+    mod = RollingOLS(y, x, 150)
+    res = mod.fit(method=method, params_only=False)
+    res_params_only = mod.fit(method=method, params_only=True)
+    assert_array_equal(res_params_only.params, res.params)
+    
+
 def test_min_nobs(basic_data):
     y, x, w = basic_data
     if not np.any(np.isnan(np.asarray(x))):

--- a/statsmodels/regression/tests/test_rolling.py
+++ b/statsmodels/regression/tests/test_rolling.py
@@ -268,12 +268,13 @@ def test_plot():
     res.plot_recursive_coefficient(alpha=None, figsize=(30, 7))
 
 
-def test_methods(basic_data):
+@pytest.mark.parametrize("params_only", [True, False])
+def test_methods(basic_data, params_only):
     y, x, _ = basic_data
     mod = RollingOLS(y, x, 150)
-    res_inv = mod.fit(method="inv")
-    res_lstsq = mod.fit(method="lstsq")
-    res_pinv = mod.fit(method="pinv")
+    res_inv = mod.fit(method="inv", params_only=params_only)
+    res_lstsq = mod.fit(method="lstsq", params_only=params_only)
+    res_pinv = mod.fit(method="pinv", params_only=params_only)
     assert_allclose(res_inv.params, res_lstsq.params)
     assert_allclose(res_inv.params, res_pinv.params)
 

--- a/statsmodels/regression/tests/test_rolling.py
+++ b/statsmodels/regression/tests/test_rolling.py
@@ -285,7 +285,8 @@ def test_params_only(basic_data, method):
     mod = RollingOLS(y, x, 150)
     res = mod.fit(method=method, params_only=False)
     res_params_only = mod.fit(method=method, params_only=True)
-    assert_array_equal(res_params_only.params, res.params)
+    # use assert_allclose to incorporate for numerical errors on x86 platforms
+    assert_allclose(res_params_only.params, res.params)
 
 
 def test_min_nobs(basic_data):


### PR DESCRIPTION
…id unnecessary calls of np.linalg.inv

- [x] closes #7140
- [x] tests added/passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>

I ran the following code to compare the performance:
```python
import timeit
import numpy as np
from statsmodels.regression import rolling

data_x = np.random.normal(size=(500, 20))
data_y = np.random.normal(size=500)

def f():
    rolling.RollingWLS(data_y, data_x, window=450, min_nobs=450).fit(params_only=True, method='inv')
    
def g():
    rolling.RollingWLS(data_y, data_x, window=450, min_nobs=450).fit(params_only=True, method='pinv')
    
def h():
    rolling.RollingWLS(data_y, data_x, window=450, min_nobs=450).fit(params_only=True, method='lstsq')
    

print("Time for 'inv': ", timeit.timeit("f()", setup="from __main__ import f", number=1000))
print("Time for 'pinv': ", timeit.timeit("g()", setup="from __main__ import g", number=1000))
print("Time for 'lstsq': ", timeit.timeit("h()", setup="from __main__ import h", number=1000))
```

 __before__ the change:
```
Time for 'inv':  9.21082185799969
Time for 'pinv':  66.74583183600043
Time for 'lstsq':  45.32076134499948
```
__after__ the change:
```
Time for 'inv':  8.389769997997064
Time for 'pinv':  25.263389345000178
Time for 'lstsq':  16.581308099001035
```

**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
