### PR TITLE
A small typo in GAM

### DIFF
--- a/statsmodels/gam/generalized_additive_model.py
+++ b/statsmodels/gam/generalized_additive_model.py
@@ -315,7 +315,7 @@ class GLMGamResults(GLMResults):
         ----------
         smooth_index : int
             index of the smooth term within list of smooth terms
-        plot_se : book
+        plot_se : bool
             If plot_se is true, then the confidence interval for the linear
             prediction will be added to the plot.
         cpr : bool


### PR DESCRIPTION
Fixing a small typo in plot_partial function's docstring.
