### PR TITLE
BUG: Remove unnecessary squeeze in ETS

### DIFF
--- a/statsmodels/tsa/exponential_smoothing/base.py
+++ b/statsmodels/tsa/exponential_smoothing/base.py
@@ -205,7 +205,6 @@ class StateSpaceMLEModel(tsbase.TimeSeriesModel):
         # - 1 x 1: squeeze only second axis
         if data.ndim > 1 and data.shape[1] == 1:
             data = np.squeeze(data, axis=1)
-        data = np.squeeze(data)
         if self.use_pandas:
             _, _, _, index = self._get_prediction_index(start_idx, end_idx)
             if data.ndim < 2:

--- a/statsmodels/tsa/tests/test_exponential_smoothing.py
+++ b/statsmodels/tsa/tests/test_exponential_smoothing.py
@@ -1005,3 +1005,28 @@ def test_exact_prediction_intervals(austourists_model_fit):
     fit.model = DummyModel("AAA")
     s_AAA = fit._relative_forecast_variance(steps)
     assert_almost_equal(s_AAdA, s_AAA, 2)
+
+
+def test_one_step_ahead(setup_model):
+    model, params, results_R = setup_model
+    model2 = ETSModel(
+        pd.Series(model.endog),
+        seasonal_periods=model.seasonal_periods,
+        error=model.error,
+        trend=model.trend,
+        seasonal=model.seasonal,
+        damped_trend=model.damped_trend,
+    )
+    res = model2.smooth(params)
+
+    fcast1 = res.forecast(steps=1)
+    fcast2 = res.forecast(steps=2)
+    assert_allclose(fcast1.iloc[0], fcast2.iloc[0])
+
+    pred1 = res.get_prediction(start=model2.nobs, end=model2.nobs,
+                               simulate_repetitions=2)
+    pred2 = res.get_prediction(start=model2.nobs, end=model2.nobs + 1,
+                               simulate_repetitions=2)
+    df1 = pred1.summary_frame(alpha=0.05)
+    df2 = pred1.summary_frame(alpha=0.05)
+    assert_allclose(df1.iloc[0, 0], df2.iloc[0, 0])


### PR DESCRIPTION
- [x] closes #7175
- [x] tests added / passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message.

Just removed an unnecessary `squeeze`.