### PR TITLE
MAINT: Skip test on Linux 32

### DIFF
--- a/statsmodels/tsa/tests/test_exponential_smoothing.py
+++ b/statsmodels/tsa/tests/test_exponential_smoothing.py
@@ -783,8 +783,11 @@ def test_results_vs_statespace(statespace_comparison):
         method="breakvar"
     )[0]
     # het[0] is test statistic, het[1] p-value
-    assert_allclose(ets_het[0], statespace_het[0], rtol=0.2)
-    assert_allclose(ets_het[1], statespace_het[1], rtol=0.7)
+    if not PLATFORM_LINUX32:
+        # Skip on Linux-32 bit due to random failures. These values are not
+        # close at all in any way so it isn't clear what this is testing
+        assert_allclose(ets_het[0], statespace_het[0], rtol=0.2)
+        assert_allclose(ets_het[1], statespace_het[1], rtol=0.7)
 
 
 def test_prediction_results_vs_statespace(statespace_comparison):


### PR DESCRIPTION
Skip tests on Linux 32 that repeatedly fail.  Test is not well defined and already
has a very large tolerance

- [ ] closes #xxxx
- [ ] tests added / passed. 
- [ ] code/documentation is well formatted.  
- [ ] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
