### PR TITLE
CI: use legacy pip solver to trigger a build with --pre packages

### DIFF
--- a/tools/ci/travis_pip.sh
+++ b/tools/ci/travis_pip.sh
@@ -41,5 +41,5 @@ python -m pip install --upgrade pip
 pip install ${EXTRA_PIP_FLAGS} ${PKGS} ${DEPEND_ALWAYS}
 
 if [ "${PIP_PRE}" = true ]; then
-  pip install -i https://pypi.anaconda.org/scipy-wheels-nightly/simple numpy pandas scipy --upgrade
+  pip install -i https://pypi.anaconda.org/scipy-wheels-nightly/simple numpy pandas scipy --upgrade --use-deprecated=legacy-resolver
 fi


### PR DESCRIPTION
This doesn't necessarily needs to be merged, but I wanted to check that statsmodels' CI is passing with pandas' latest version, and currently that build is not running because of https://github.com/scipy/scipy/issues/13196