### PR TITLE
ENH:  Improve cdflink, add probit, cauchy derivatives

### DIFF
--- a/statsmodels/discrete/tests/test_sandwich_cov.py
+++ b/statsmodels/discrete/tests/test_sandwich_cov.py
@@ -491,7 +491,7 @@ class TestGLMProbit(CheckDiscreteGLM):
 
         hess1 = res1.model.hessian(res1.params)
         hess2 = res2.model.hessian(res1.params)
-        assert_allclose(hess1, hess2, rtol=1e-10)
+        assert_allclose(hess1, hess2, rtol=1e-13)
 
 
 class TestGLMGaussNonRobust(CheckDiscreteGLM):

--- a/statsmodels/genmod/families/family.py
+++ b/statsmodels/genmod/families/family.py
@@ -890,8 +890,8 @@ class Binomial(Family):
            resid\_dev_i = 2 * n * (endog_i * \ln(endog_i /\mu_i) +
            (1 - endog_i) * \ln((1 - endog_i) / (1 - \mu_i)))
         """
-        endog_mu = self._clean(endog / mu)
-        n_endog_mu = self._clean((1. - endog) / (1. - mu))
+        endog_mu = self._clean(endog / (mu + 1e-20))
+        n_endog_mu = self._clean((1. - endog) / (1. - mu + 1e-20))
         resid_dev = endog * np.log(endog_mu) + (1 - endog) * np.log(n_endog_mu)
         return 2 * self.n * resid_dev
 
@@ -943,8 +943,8 @@ class Binomial(Family):
 
         # note that mu is still in (0,1), i.e. not converted back
         return (special.gammaln(n + 1) - special.gammaln(y + 1) -
-                special.gammaln(n - y + 1) + y * np.log(mu / (1 - mu)) +
-                n * np.log(1 - mu)) * var_weights
+                special.gammaln(n - y + 1) + y * np.log(mu / (1 - mu + 1e-20)) +
+                n * np.log(1 - mu + 1e-20)) * var_weights
 
     def resid_anscombe(self, endog, mu, var_weights=1., scale=1.):
         r'''

--- a/statsmodels/genmod/families/tests/test_link.py
+++ b/statsmodels/genmod/families/tests/test_link.py
@@ -73,9 +73,6 @@ def test_deriv2():
     np.random.seed(24235)
 
     for link in Links:
-        # TODO: Resolve errors with the numeric derivatives
-        if isinstance(link, links.probit):
-            continue
         for k in range(10):
             p = np.random.uniform(0, 1)
             p = np.clip(p, 0.01, 0.99)
@@ -83,7 +80,7 @@ def test_deriv2():
                 p = np.clip(p, 0.03, 0.97)
             d = link.deriv2(p)
             da = nd.approx_fprime(np.r_[p], link.deriv)
-            assert_allclose(d, da, rtol=1e-6, atol=1e-6,
+            assert_allclose(d, da, rtol=5e-6, atol=1e-6,
                             err_msg=str(link))
 
 


### PR DESCRIPTION
see #1878, mainly improvement to precision and speed of probit deriv2

add some analytical derivatives,
use inverse function properties for deriv2 instead of inverse_deriv2.

also removes numdiff default for inverse_deriv2 for CDFLink,
backwards incompatible, if someone has a subclass of CDFLink and relies on this.

