### PR TITLE
BUG/ENH: Poisson offset rebased

### DIFF
--- a/statsmodels/discrete/discrete_model.py
+++ b/statsmodels/discrete/discrete_model.py
@@ -774,7 +774,10 @@ class CountModel(DiscreteModel):
         super().__init__(endog, exog, check_rank, missing=missing,
                          offset=offset, exposure=exposure, **kwargs)
         if exposure is not None:
+            self.exposure = np.asarray(self.exposure)
             self.exposure = np.log(self.exposure)
+        if offset is not None:
+            self.offset = np.asarray(self.offset)
         self._check_inputs(self.offset, self.exposure, self.endog)
         if offset is None:
             delattr(self, 'offset')

--- a/statsmodels/discrete/tests/test_count_model.py
+++ b/statsmodels/discrete/tests/test_count_model.py
@@ -649,11 +649,13 @@ class TestPandasOffset:
 
     def test_pd_offset_exposure(self):
         endog = pd.DataFrame({'F': [0.0, 0.0, 0.0, 0.0, 1.0]})
-        exog = pd.DataFrame({'I': [1.0, 1.0, 1.0, 1.0, 1.0], 'C': [0.0, 1.0, 0.0, 1.0, 0.0]})
-        exposure = pd.Series([1, 1, 1, 2, 1])
+        exog = pd.DataFrame({'I': [1.0, 1.0, 1.0, 1.0, 1.0],
+                             'C': [0.0, 1.0, 0.0, 1.0, 0.0]})
+        exposure = pd.Series([1., 1, 1, 2, 1])
         offset = pd.Series([1, 1, 1, 2, 1])
         sm.Poisson(endog=endog, exog=exog, offset=offset).fit()
         inflations = ['logit', 'probit']
         for inflation in inflations:
-            sm.ZeroInflatedPoisson(endog=endog, exog=exog, exposure=exposure, exog_infl=exog,
+            sm.ZeroInflatedPoisson(endog=endog, exog=exog["I"],
+                                   exposure=exposure,
                                    inflation=inflation).fit()


### PR DESCRIPTION
closes #7015 closes #7127

this is a rebased and a bit cleaned up version of #7127

- remove pep-8 reformatting of entire module
- adjust test case so we don't get warnings