### PR TITLE
BUG: raise if non-binary endog in Probit

### DIFF
--- a/statsmodels/discrete/tests/test_discrete.py
+++ b/statsmodels/discrete/tests/test_discrete.py
@@ -1551,7 +1551,9 @@ def test_isdummy():
 def test_non_binary():
     y = [1, 2, 1, 2, 1, 2]
     X = np.random.randn(6, 2)
-    np.testing.assert_raises(ValueError, Logit, y, X)
+    assert_raises(ValueError, Logit, y, X)
+    y = [0, 1, 0, 0, 1, 0.5]
+    assert_raises(ValueError, Probit, y, X)
 
 
 def test_mnlogit_factor():


### PR DESCRIPTION
see #7210  Probit does not support continuous interval data

this PR adds the binary check to Probit and raises for non 0-1 endog.

I didn't change loglike of Logit which is incorrect for continuous data, everything else in Logit seems fine
(changing loglike in Logit will add possible problems with 0 log 0, so refactoring needs to be more careful)