### PR TITLE
MAINT: Limit linting

### DIFF
--- a/tools/ci/azure/azure_template_posix.yml
+++ b/tools/ci/azure/azure_template_posix.yml
@@ -19,10 +19,12 @@ jobs:
       ${{ if eq(parameters.name, 'Linux') }}:
         python_39:
           python.version: '3.9'
+          lint: true
         python_38:
           python.version: '3.8'
           USE_MATPLOTLIB: false
           USE_CVXOPT: false
+          lint: true
         python37:
           python.version: '3.7'
           use.conda: true
@@ -46,7 +48,7 @@ jobs:
           SCIPY: 1.2.3
           PANDAS: 0.23.4
           MATPLOTLIB: 2.2.5
-          LINT: true
+          lint: true
         python_39_pre:
           python.version: '3.9'
           pip.pre: true
@@ -73,9 +75,6 @@ jobs:
   - script: |
       source tools/ci/azure/install-posix.sh
     displayName: 'Install dependencies'
-
-  - script: LINT=true ./lint.sh
-    displayName: 'Check style'
 
   - script: python -m pip list
     displayName: 'List Configuration (PyPI)'
@@ -135,6 +134,10 @@ jobs:
       testResultsFiles: '**/test-results.xml'
       testRunTitle: 'Python $(python.version)'
     condition: succeededOrFailed()
+
+  - script: ./lint.sh
+    displayName: 'Check style'
+    condition: eq(variables['lint'], 'true')
 
   - task: PublishCodeCoverageResults@1
     inputs:


### PR DESCRIPTION
Limit linting to one per distinct version

- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
