### PR TITLE
ENH: Add small sample df adjustment option to test_serial_correlation

### DIFF
--- a/statsmodels/tsa/statespace/tests/test_mlemodel.py
+++ b/statsmodels/tsa/statespace/tests/test_mlemodel.py
@@ -851,6 +851,27 @@ def test_diagnostics():
         res.test_serial_correlation(method='boxpierce')
 
 
+def test_small_sample_serial_correlation_test():
+    # Test the Ljung Box serial correlation test for small samples with df
+    # adjustment using the Nile dataset. Ljung-Box statistic and p-value
+    # are compared to R's Arima() and checkresiduals() functions in forecast
+    # package:
+    # library(forecast)
+    # fit <- Arima(y, order=c(1,0,1), include.constant=FALSE)
+    # checkresiduals(fit, lag=10)
+    from statsmodels.tsa.statespace.sarimax import SARIMAX
+    niledata = nile.data.load_pandas().data
+    niledata.index = pd.date_range('1871-01-01', '1970-01-01', freq='AS')
+    mod = SARIMAX(
+        endog=niledata['volume'], order=(1, 0, 1), trend='n',
+        freq=niledata.index.freq)
+    res = mod.fit()
+
+    actual = res.test_serial_correlation(
+        method='ljungbox', lags=10, df_adjust=True)[0, :, -1]
+    assert_allclose(actual, [14.116, 0.0788], atol=1e-3)
+
+
 def test_diagnostics_nile_eviews():
     # Test the diagnostic tests using the Nile dataset. Results are from
     # "Fitting State Space Models with EViews" (Van den Bossche 2011,


### PR DESCRIPTION
The sample code below demonstrates the discrepancy of statsmodels output of Ljung-Box serial correlation test p-value due to faulty degrees of freedom used in the test. The correct version should include subtraction of estimated model's degrees of freedom. This change will significantly align the output with R's Arima() output given by checkresiduals(). The remaining differences are probably due to different state space representation used and other minor technical differences.

**Statsmodels version**: 0.12.1
```
import pandas as pd
import numpy as np
import statsmodels.tsa.api as tsa
import rpy2
import warnings
from scipy.stats import boxcox
from statsmodels.tsa.arima.model import ARIMA
warnings.filterwarnings("ignore")
%load_ext rpy2.ipython

passengers = pd.read_csv('https://raw.githubusercontent.com/jbrownlee/Datasets/master/airline-passengers.csv', 
                         index_col=0, header=0, names=['month', 'observed_raw'])
passengers.index = pd.date_range("1949-01", freq="MS", periods=144)
passengers['observed_transformed'], lmbda = boxcox(passengers['observed_raw'])

model = tsa.STLForecast(
    endog=passengers['observed_transformed'], model=ARIMA, seasonal=33, 
    model_kwargs={'order': (2,1,1), 'trend': 'n', 'freq': passengers.index.freq}, period=12
).fit()

residual_acf = pd.DataFrame({
    'residual_acf': tsa.acf(model.model_result.filter_results.standardized_forecasts_error[0], 
                            adjusted=False, nlags=10, qstat=True, fft=False, alpha=0.05)[0][1:], 
    'q_statistic': model.model_result.test_serial_correlation(method='ljungbox', lags=10)[0][0],
    'p_value': model.model_result.test_serial_correlation(method='ljungbox', lags=10)[0][1]}, index=np.arange(1, 11)).T

pasengers_seasonally_adjusted = model.result.resid + model.result.trend  
residual_acf
```
The R output:
```
%%R -i pasengers_seasonally_adjusted -w 600 -h 600
library(fpp2)
library(forecast)
fit <- Arima(pasengers_seasonally_adjusted, order=c(2,1,1), include.constant=FALSE)
checkresiduals(fit)
fit 
```
**R output**:
![image](https://user-images.githubusercontent.com/44208384/103798825-8be86f80-504a-11eb-966b-d82ae1f1a6e7.png)

**Original statsmodels output**:
![image](https://user-images.githubusercontent.com/44208384/103798379-e503d380-5049-11eb-88dc-7da7ee25e6c9.png)

**Fixed statsmodels output**:
![image](https://user-images.githubusercontent.com/44208384/103798512-1ed4da00-504a-11eb-8ac6-18fd867257e6.png)





