### PR TITLE
ENH/BUG: update ARIMA models trend term handling

### DIFF
--- a/statsmodels/tsa/arima/tests/test_model.py
+++ b/statsmodels/tsa/arima/tests/test_model.py
@@ -239,9 +239,24 @@ def test_clone():
     endog = dta['realgdp'].iloc[:100]
     exog = np.arange(endog.shape[0])
     check_cloned(ARIMA(endog, order=(2, 1, 1), seasonal_order=(1, 1, 2, 4),
-                       exog=exog, trend='c', concentrate_scale=True),
+                       exog=exog, trend=[0, 0, 1], concentrate_scale=True),
                  endog, exog=exog)
 
+
+def test_constant_integrated_model_error():
+    with pytest.raises(ValueError, match="In models with integration"):
+        ARIMA(np.ones(100), order=(1, 1, 0), trend='c')
+
+    with pytest.raises(ValueError, match="In models with integration"):
+        ARIMA(np.ones(100), order=(1, 0, 0), seasonal_order=(1, 1, 0, 6),
+              trend='c')
+
+    with pytest.raises(ValueError, match="In models with integration"):
+        ARIMA(np.ones(100), order=(1, 2, 0), trend='t')
+
+    with pytest.raises(ValueError, match="In models with integration"):
+        ARIMA(np.ones(100), order=(1, 1, 0), seasonal_order=(1, 1, 0, 6),
+              trend='t')
 
 def test_append():
     endog = dta['infl'].iloc[:100].values

--- a/statsmodels/tsa/statespace/sarimax.py
+++ b/statsmodels/tsa/statespace/sarimax.py
@@ -1732,7 +1732,7 @@ class SARIMAX(MLEModel):
         # Create extended model
         if extend_kwargs is None:
             extend_kwargs = {}
-        if not self.simple_differencing and self._k_trend > 0:
+        if not self.simple_differencing and self.k_trend > 0:
             extend_kwargs.setdefault(
                 'trend_offset', self.trend_offset + self.nobs)
         extend_kwargs.setdefault('validate_specification', False)


### PR DESCRIPTION
- [x] closes #7191
- [x] tests added / passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message.

New behavior is:

1. Raises a `ValueError` if you try to specify a trend term that is not identified given the model's order of integration
2. Fixes a bug when forecasting with a time trend (not a constant, but t, t^2, etc.)
