### PR TITLE
BUG: Correct LM Test

### DIFF
--- a/statsmodels/stats/diagnostic.py
+++ b/statsmodels/stats/diagnostic.py
@@ -705,17 +705,17 @@ def acorr_lm(resid, nlags=None, autolag="AIC", store=False, *, period=None,
 
     resols = OLS(xshort, xdall[:, :usedlag + 1]).fit(cov_type=cov_type,
                                                      cov_kwargs=cov_kwargs)
-    fval = resols.fvalue
-    fpval = resols.f_pvalue
+    fval = float(resols.fvalue)
+    fpval = float(resols.f_pvalue)
     if cov_type == "nonrobust":
         lm = (nobs - ddof) * resols.rsquared
         lmpval = stats.chi2.sf(lm, usedlag)
         # Note: deg of freedom for LM test: nvars - constant = lags used
     else:
-        r_matrix = np.hstack((np.ones((usedlag, 1)), np.eye(usedlag)))
+        r_matrix = np.hstack((np.zeros((usedlag, 1)), np.eye(usedlag)))
         test_stat = resols.wald_test(r_matrix, use_f=False)
         lm = float(test_stat.statistic)
-        lmpval = test_stat.pvalue
+        lmpval = float(test_stat.pvalue)
 
     if store:
         res_store.resols = resols


### PR DESCRIPTION
Replace vector of 1s with vector of 0s in acorr lm

- [ ] closes #xxxx
- [ ] tests added / passed. 
- [ ] code/documentation is well formatted.  
- [ ] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
