### PR TITLE
ENH/BUG: Add flexibility options to plot_diagnostics output. 

### DIFF
--- a/statsmodels/graphics/gofplots.py
+++ b/statsmodels/graphics/gofplots.py
@@ -977,7 +977,8 @@ def _do_plot(
     """
     plot_style = {
         "marker": "o",
-        "markerfacecolor": "blue",
+        "markerfacecolor": "C0",
+        "markeredgecolor": "C0",
         "linestyle": "none",
     }
 

--- a/statsmodels/graphics/tsaplots.py
+++ b/statsmodels/graphics/tsaplots.py
@@ -36,6 +36,7 @@ def _plot_corr(
     irregular,
     use_vlines,
     vlines_kwargs,
+    auto_ylims=False,
     **kwargs,
 ):
     if irregular:
@@ -55,6 +56,11 @@ def _plot_corr(
     ax.margins(0.05)
     ax.plot(lags, acf_x, **kwargs)
     ax.set_title(title)
+
+    ax.set_ylim(-1, 1)
+    if auto_ylims:
+        ax.set_ylim(1.25*np.minimum(min(acf_x), min(confint[:, 0] - acf_x)),
+                    1.25*np.maximum(max(acf_x), max(confint[:, 1] - acf_x)))
 
     if confint is not None:
         if lags[0] == 0:
@@ -82,6 +88,8 @@ def plot_acf(
     missing="none",
     title="Autocorrelation",
     zero=True,
+    auto_ylims=False,
+    bartlett_confint=True,
     vlines_kwargs=None,
     **kwargs,
 ):
@@ -122,6 +130,27 @@ def plot_acf(
     zero : bool, optional
         Flag indicating whether to include the 0-lag autocorrelation.
         Default is True.
+    auto_ylims : bool, optional
+        If True, adjusts automatically the y-axis limits to ACF values.
+    bartlett_confint : bool, default True
+        Confidence intervals for ACF values are generally placed at 2
+        standard errors around r_k. The formula used for standard error
+        depends upon the situation. If the autocorrelations are being used
+        to test for randomness of residuals as part of the ARIMA routine,
+        the standard errors are determined assuming the residuals are white
+        noise. The approximate formula for any lag is that standard error
+        of each r_k = 1/sqrt(N). See section 9.4 of [1] for more details on
+        the 1/sqrt(N) result. For more elementary discussion, see section
+        5.3.2 in [2].
+        For the ACF of raw data, the standard error at a lag k is
+        found as if the right model was an MA(k-1). This allows the
+        possible interpretation that if all autocorrelations past a
+        certain lag are within the limits, the model might be an MA of
+        order defined by the last significant autocorrelation. In this
+        case, a moving average model is assumed for the data and the
+        standard errors for the confidence intervals should be
+        generated using Bartlett's formula. For more details on
+        Bartlett formula result, see section 7.2 in [1].
     vlines_kwargs : dict, optional
         Optional dictionary of keyword arguments that are passed to vlines.
     **kwargs : kwargs, optional
@@ -153,6 +182,12 @@ def plot_acf(
     vertical lines connecting each autocorrelation to the axis.  These options
     must be valid for a LineCollection object.
 
+    References
+    ----------
+    [1] Brockwell and Davis, 1987. Time Series Theory and Methods
+    [2] Brockwell and Davis, 2010. Introduction to Time Series and
+    Forecasting, 2nd edition.
+
     Examples
     --------
     >>> import pandas as pd
@@ -179,6 +214,7 @@ def plot_acf(
         nlags=nlags,
         alpha=alpha,
         fft=fft,
+        bartlett_confint=bartlett_confint,
         adjusted=adjusted,
         missing=missing,
     )
@@ -194,6 +230,7 @@ def plot_acf(
         irregular,
         use_vlines,
         vlines_kwargs,
+        auto_ylims=auto_ylims,
         **kwargs,
     )
 


### PR DESCRIPTION
Although the current implementation of time series diagnostic plots provided by `plot_diagnostics()` method is quite solid, I've identified several aspects that could make the output more visually attractive, giving users more customization options during their analysis of the model's residuals and, most importantly, fixed currently not optimal selection of Bartlett's standard error for ACF values. 

I've been inspired by the well-designed diagnostic plot available in R's `checkresiduals()` and found that statsmodels uses confidence intervals employing Bartlett's formula even for model's residuals, when, according to the theory, the constant s.e. of 1/sqrt(N) should be used instead. This can be confirmed even by looking directly to the code [here](https://github.com/miro-mlynarik/statsmodels/blob/master/statsmodels/tsa/stattools.py#L574), or from external sources: [here](https://online.stat.psu.edu/stat510/lesson/3/3.2)

In addition to this, I've added following enhancements that will hopefully be admitted as useful also after reviewers' evaluation:
- `**kwargs`: This will allow users to customize the correlogram by e.g. turning off the ACF markers (`marker=None`), or zero-th ACF value equal to 1 (`zero=False`).
- `auto_ylims`: If True, and combined with `zero=False`, the correlogram will be automatically and conveniently adjusted to zoom into ACF values and thus allow more precise visual inspection.
- `bartlett_confint`: If False, and combined with `zero=False`, the standard error is calculated using simplified formula appropriate for residuals analysis. The True option will be available for cases of raw data for model identification stage, when MA(k) model is assumed.
- grid and background color additions, so the output resembles R's `checkresidual()` output
- unification of colors:  the QQ-plot will be aligned with other three plots by applying to it the default blue color.

The comparison between current and new proposed version incorporating all changes described above can be best assessed visually here:
![image](https://user-images.githubusercontent.com/44208384/104822417-8d801780-5842-11eb-903b-f12763cefe70.png)

The unit test will be provided tomorrow.
