### PR TITLE
BUG/PERF: Improve probit and cauchy link

### DIFF
--- a/statsmodels/discrete/tests/test_sandwich_cov.py
+++ b/statsmodels/discrete/tests/test_sandwich_cov.py
@@ -491,7 +491,7 @@ class TestGLMProbit(CheckDiscreteGLM):
 
         hess1 = res1.model.hessian(res1.params)
         hess2 = res2.model.hessian(res1.params)
-        assert_allclose(hess1, hess2, rtol=1e-10)
+        assert_allclose(hess1, hess2, rtol=1e-13)
 
 
 class TestGLMGaussNonRobust(CheckDiscreteGLM):

--- a/statsmodels/genmod/families/family.py
+++ b/statsmodels/genmod/families/family.py
@@ -890,8 +890,8 @@ class Binomial(Family):
            resid\_dev_i = 2 * n * (endog_i * \ln(endog_i /\mu_i) +
            (1 - endog_i) * \ln((1 - endog_i) / (1 - \mu_i)))
         """
-        endog_mu = self._clean(endog / mu)
-        n_endog_mu = self._clean((1. - endog) / (1. - mu))
+        endog_mu = self._clean(endog / (mu + 1e-20))
+        n_endog_mu = self._clean((1. - endog) / (1. - mu + 1e-20))
         resid_dev = endog * np.log(endog_mu) + (1 - endog) * np.log(n_endog_mu)
         return 2 * self.n * resid_dev
 
@@ -943,8 +943,8 @@ class Binomial(Family):
 
         # note that mu is still in (0,1), i.e. not converted back
         return (special.gammaln(n + 1) - special.gammaln(y + 1) -
-                special.gammaln(n - y + 1) + y * np.log(mu / (1 - mu)) +
-                n * np.log(1 - mu)) * var_weights
+                special.gammaln(n - y + 1) + y * np.log(mu / (1 - mu + 1e-20)) +
+                n * np.log(1 - mu + 1e-20)) * var_weights
 
     def resid_anscombe(self, endog, mu, var_weights=1., scale=1.):
         r'''

--- a/statsmodels/genmod/families/links.py
+++ b/statsmodels/genmod/families/links.py
@@ -708,7 +708,24 @@ class probit(CDFLink):
 
     probit is an alias of CDFLink.
     """
-    pass
+
+    def inverse_deriv2(self, z):
+        """
+        Second derivative of the inverse link function
+
+        This is the derivative of the pdf in a CDFLink
+
+        """
+        return - z * self.dbn.pdf(z)
+
+    def deriv2(self, p):
+        """
+        Second derivative of the link function g''(p)
+
+        """
+        p = self._clean(p)
+        linpred = self.dbn.ppf(p)
+        return linpred / self.dbn.pdf(linpred)**2
 
 
 class cauchy(CDFLink):
@@ -739,9 +756,14 @@ class cauchy(CDFLink):
         g''(p) : ndarray
             Value of the second derivative of Cauchy link function at `p`
         """
+        p = self._clean(p)
         a = np.pi * (p - 0.5)
         d2 = 2 * np.pi**2 * np.sin(a) / np.cos(a)**3
         return d2
+
+    def inverse_deriv2(self, z):
+
+        return - 2 * z / (np.pi * (z**2 + 1)**2)
 
 
 class CLogLog(Logit):

--- a/statsmodels/genmod/families/tests/test_link.py
+++ b/statsmodels/genmod/families/tests/test_link.py
@@ -73,9 +73,6 @@ def test_deriv2():
     np.random.seed(24235)
 
     for link in Links:
-        # TODO: Resolve errors with the numeric derivatives
-        if isinstance(link, links.probit):
-            continue
         for k in range(10):
             p = np.random.uniform(0, 1)
             p = np.clip(p, 0.01, 0.99)
@@ -83,7 +80,7 @@ def test_deriv2():
                 p = np.clip(p, 0.03, 0.97)
             d = link.deriv2(p)
             da = nd.approx_fprime(np.r_[p], link.deriv)
-            assert_allclose(d, da, rtol=1e-6, atol=1e-6,
+            assert_allclose(d, da, rtol=5e-6, atol=1e-6,
                             err_msg=str(link))
 
 


### PR DESCRIPTION
this is #7226 but without the changes to the CDFLink class, i.e. fully backwards compatible

adds explicit deriv2 to probit and cauchy link

I included the changes for zero division in binomial corner cases
