### PR TITLE
DOC: add a missing parameter description in UnobservedComponentsResults

### DIFF
--- a/statsmodels/tsa/statespace/structural.py
+++ b/statsmodels/tsa/statespace/structural.py
@@ -1557,6 +1557,10 @@ class UnobservedComponentsResults(MLEResults):
             results are available otherwise 'filtered'.
         alpha : float, optional
             The confidence intervals for the components are (1 - alpha) %
+        observed : bool, optional
+            Whether or not to plot the observed series against
+            one-step-ahead predictions.
+            Default is True.
         level : bool, optional
             Whether or not to plot the level component, if applicable.
             Default is True.


### PR DESCRIPTION
I added description of `observed` parameter to [docs of UnobservedComponentsResults.plot_components()](https://www.statsmodels.org/stable/generated/statsmodels.tsa.statespace.structural.UnobservedComponentsResults.plot_components.html#statsmodels.tsa.statespace.structural.UnobservedComponentsResults.plot_components) because it is missing.


- [x] code/documentation is well formatted.  
- [x] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 
