### PR TITLE
DOC/ENH: make it easier to find the page of UnobservedComponentsResults

### DIFF
--- a/statsmodels/tsa/statespace/mlemodel.py
+++ b/statsmodels/tsa/statespace/mlemodel.py
@@ -632,12 +632,14 @@ class MLEModel(tsbase.TimeSeriesModel):
 
         Returns
         -------
-        MLEResults
+        results
+            Results object holding results from fitting a state space model.
 
         See Also
         --------
         statsmodels.base.model.LikelihoodModel.fit
         statsmodels.tsa.statespace.mlemodel.MLEResults
+        statsmodels.tsa.statespace.structural.UnobservedComponentsResults
         """
         if start_params is None:
             start_params = self.start_params

--- a/statsmodels/tsa/statespace/structural.py
+++ b/statsmodels/tsa/statespace/structural.py
@@ -105,6 +105,11 @@ class UnobservedComponents(MLEModel):
         states. Default is False (in which case approximate diffuse
         initialization is used).
 
+    See Also
+    --------
+    statsmodels.tsa.statespace.structural.UnobservedComponentsResults
+    statsmodels.tsa.statespace.mlemodel.MLEModel
+
     Notes
     -----
 


### PR DESCRIPTION
I added links to the doc of [UnobservedComponentsResult](https://www.statsmodels.org/stable/generated/statsmodels.tsa.statespace.structural.UnobservedComponentsResults.html#statsmodels.tsa.statespace.structural.UnobservedComponentsResults) in docs of [MLEModel.fit](https://www.statsmodels.org/stable/generated/statsmodels.tsa.statespace.mlemodel.MLEModel.fit.html#statsmodels.tsa.statespace.mlemodel.MLEModel.fit) and [UnobservedComponents](https://www.statsmodels.org/stable/generated/statsmodels.tsa.statespace.structural.UnobservedComponents.html#statsmodels.tsa.statespace.structural.UnobservedComponents).
The purpose of this PR is that users will be able to find the page of UnobservedComponentsResults more easily.

In the current documentation, users cannot find the doc of UnobservedComponentsResults
from the page of [UnobservedComponents.fit](https://www.statsmodels.org/stable/generated/statsmodels.tsa.statespace.structural.UnobservedComponents.fit.html#statsmodels.tsa.statespace.structural.UnobservedComponents.fit) because this method is inherited from MLEModel.fit (see also #7274).
In order to solve this, I added link to UnobservedComponentsResults in the doc of MLEModel.fit.

I also added link to UnobservedComponentsResults in the doc of UnobservedComponents
because UnobservedComponentsResults is returned in other related methods such as [filter](https://www.statsmodels.org/stable/generated/statsmodels.tsa.statespace.structural.UnobservedComponents.filter.html#statsmodels.tsa.statespace.structural.UnobservedComponents.filter) and [smooth](https://www.statsmodels.org/stable/generated/statsmodels.tsa.statespace.structural.UnobservedComponents.smooth.html#statsmodels.tsa.statespace.structural.UnobservedComponents.smooth).
See also the doc of [MLEModel](https://www.statsmodels.org/stable/generated/statsmodels.tsa.statespace.mlemodel.MLEModel.html#statsmodels.tsa.statespace.mlemodel.MLEModel) and you will find that [MLEResults](https://www.statsmodels.org/stable/generated/statsmodels.tsa.statespace.mlemodel.MLEResults.html#statsmodels.tsa.statespace.mlemodel.MLEResults) is linked in the same way as this modification.

- [x] closes #7274 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 