### PR TITLE
BUG: fix percentiles being dropped in Description frame.

### DIFF
--- a/statsmodels/stats/descriptivestats.py
+++ b/statsmodels/stats/descriptivestats.py
@@ -506,6 +506,9 @@ class Description:
             output = f"{{0:{fmt}}}%"
             perc.index = [output.format(val) for val in index]
 
+        # Add in the names of the percentiles to the output
+        self._stats = self._stats + perc.index.tolist()
+
         return self._reorder(pd.concat([results_df, perc], 0))
 
     @cache_readonly

--- a/statsmodels/stats/tests/test_descriptivestats.py
+++ b/statsmodels/stats/tests/test_descriptivestats.py
@@ -155,7 +155,15 @@ def test_description_basic(df):
 def test_odd_percentiles(df):
     percentiles = np.linspace(7.0, 93.0, 13)
     res = Description(df, percentiles=percentiles)
-    print(res.frame.index)
+    stats = [
+        'nobs', 'missing', 'mean', 'std_err', 'upper_ci', 'lower_ci', 'std',
+        'iqr', 'iqr_normal', 'mad', 'mad_normal', 'coef_var', 'range', 'max',
+        'min', 'skew', 'kurtosis', 'jarque_bera', 'jarque_bera_pval', 'mode',
+        'mode_freq', 'median', 'distinct', 'top_1', 'top_2', 'top_3', 'top_4',
+        'top_5', 'freq_1', 'freq_2', 'freq_3', 'freq_4', 'freq_5', '7.0%',
+        '14.1%', '21.3%', '28.5%', '35.6%', '42.8%', '50.0%', '57.1%', '64.3%',
+        '71.5%', '78.6%', '85.8%', '93.0%']
+    assert_equal(res.frame.index.tolist(), stats)
 
 
 def test_large_ntop(df):


### PR DESCRIPTION
- [x] closes #7316
- [x] tests added / passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message

@bashtage I am not very familiar with this function, so if you have a moment to check if I did something sensible, that would be great!