### PR TITLE
Add games howell test

### DIFF
--- a/docs/source/stats.rst
+++ b/docs/source/stats.rst
@@ -209,8 +209,11 @@ Multiple Tests and Multiple Comparison Procedures
 
 `multipletests` is a function for p-value correction, which also includes p-value
 correction based on fdr in `fdrcorrection`.
-`tukeyhsd` performs simultaneous testing for the comparison of (independent) means.
-These three functions are verified.
+`tukeyhsd` performs simultaneous testing for the comparison of (independent)
+means assuming equal variance and samples sizes.
+`gameshowell` like tukeyhsd performs simultaneous testing for the comparison of
+(independent) means but does not assume equal variance nor equal sample sizes.
+These four functions are verified.
 GroupsStats and MultiComparison are convenience classes to multiple comparisons similar
 to one way ANOVA, but still in development
 
@@ -234,6 +237,7 @@ to one way ANOVA, but still in development
    GroupsStats
    MultiComparison
    TukeyHSDResults
+   GamesHowellResults
 
 .. module:: statsmodels.stats.multicomp
    :synopsis: Methods for controlling size while performing multiple comparisons
@@ -244,6 +248,7 @@ to one way ANOVA, but still in development
    :toctree: generated/
 
    pairwise_tukeyhsd
+   pariwise_games_howell
 
 .. module:: statsmodels.stats.multitest
    :synopsis: Multiple testing p-value and FDR adjustments

--- a/statsmodels/sandbox/stats/multicomp.py
+++ b/statsmodels/sandbox/stats/multicomp.py
@@ -61,20 +61,36 @@ TODO
 
 
 '''
-from statsmodels.compat.python import lzip, lrange
-
 import copy
 import math
+from collections import defaultdict
 
 import numpy as np
+import networkx as nx
+import pandas as pd
 from numpy.testing import assert_almost_equal, assert_equal
 from scipy import stats, interpolate
 
+from statsmodels.compat.python import lzip, lrange
 from statsmodels.iolib.table import SimpleTable
-#temporary circular import
-from statsmodels.stats.multitest import multipletests, _ecdf as ecdf, fdrcorrection as fdrcorrection0, fdrcorrection_twostage
 from statsmodels.graphics import utils
 from statsmodels.tools.sm_exceptions import ValueWarning
+from statsmodels.stats.libqsturng import psturng, qsturng
+#temporary circular import
+from statsmodels.stats.multitest import multipletests, _ecdf as ecdf, fdrcorrection as fdrcorrection0, fdrcorrection_twostage
+
+GROUP_1_COL = 'group1'
+GROUP_2_COL = 'group2'
+MEAN_DIFFERENCE_COL = "mean_difference"
+DEGREES_FREEDOM_COL = "degrees_freedom"
+P_VALUE_COL = "p_value"
+ADJ_P_VALUE_COL = "p_adj"
+STANDARD_ERROR_COL = "standard_error"
+STAT_COL = "stat"
+Q_COL = "q"
+CI_LOWER_LIMIT_COL = "lower"
+CI_UPPER_LIMIT_COL = "upper"
+REJECT_COL = "reject"
 
 qcrit = '''
   2     3     4     5     6     7     8     9     10
@@ -363,7 +379,6 @@ def maxzerodown(x):
     return maxz, allzeros
 
 
-
 def rejectionline(n, alpha=0.5):
     '''reference line for rejection in multiple tests
 
@@ -374,10 +389,6 @@ def rejectionline(n, alpha=0.5):
     t = np.arange(n)/float(n)
     frej = t/( t * (1-alpha) + alpha)
     return frej
-
-
-
-
 
 
 #I do not remember what I changed or why 2 versions,
@@ -394,7 +405,6 @@ def fdrcorrection_bak(pvals, alpha=0.05, method='indep'):
 
     '''
     pvals = np.asarray(pvals)
-
 
     pvals_sortind = np.argsort(pvals)
     pvals_sorted = pvals[pvals_sortind]
@@ -499,7 +509,7 @@ def tiecorrect(xranks):
 
 
 class GroupsStats(object):
-    '''
+    """
     statistics by groups (another version)
 
     groupstats as a class with lazy evaluation (not yet - decorators are still
@@ -511,7 +521,7 @@ class GroupsStats(object):
 
     TODO: incomplete doc strings
 
-    '''
+    """
 
     def __init__(self, x, useranks=False, uni=None, intlab=None):
         '''descriptive statistics by groups
@@ -536,14 +546,12 @@ class GroupsStats(object):
 
         self.useranks = useranks
 
-
         self.uni = uni
         self.intlab = intlab
         self.groupnobs = groupnobs = np.bincount(intlab)
 
         #temporary until separated and made all lazy
         self.runbasic(useranks=useranks)
-
 
 
     def runbasic_old(self, useranks=False):
@@ -585,18 +593,19 @@ class GroupsStats(object):
         self.groupmeanfilter = grouprankmean[self.intlab]
         #return grouprankmean[intlab]
 
-    def groupdemean(self):
-        """groupdemean"""
+    def groupedmean(self):
+        """groupedmean"""
         return self.xx - self.groupmeanfilter
 
     def groupsswithin(self):
         """groupsswithin"""
-        xtmp = self.groupdemean()
+        xtmp = self.groupedmean()
         return np.bincount(self.intlab, weights=xtmp**2)
 
     def groupvarwithin(self):
         """groupvarwithin"""
         return self.groupsswithin()/(self.groupnobs-1) #.sum()
+
 
 class TukeyHSDResults(object):
     """Results from Tukey HSD test, with additional plot methods
@@ -648,7 +657,6 @@ class TukeyHSDResults(object):
         '''Summary table that can be printed
         '''
         return self._results_table
-
 
     def _simultaneous_ci(self):
         """Compute simultaneous confidence intervals for comparison of means.
@@ -729,7 +737,6 @@ class TukeyHSDResults(object):
             self._simultaneous_ci()
         means = self._multicomp.groupstats.groupmean
 
-
         sigidx = []
         nsigidx = []
         minrange = [means[i] - self.halfwidths[i] for i in range(len(means))]
@@ -777,6 +784,88 @@ class TukeyHSDResults(object):
         ax1.set_xlabel(xlabel if xlabel is not None else '')
         ax1.set_ylabel(ylabel if ylabel is not None else '')
         return fig
+
+class GamesHowellResults():
+    def __init__(self, mc_object, gh_results):
+
+        self._multicomp = mc_object
+        self._results = gh_results
+        # Taken out of _multicomp for ease of access for unknowledgeable users
+        self.data = self._multicomp.data
+        self.groups = self._multicomp.groups
+        self.groupsunique = self._multicomp.groupsunique
+        self.groupmeans = self._multicomp.groupstats.groupmean
+
+    def summary(self):
+        """
+
+        :return:
+        """
+        return pd.DataFrame(self._results)
+
+    def summary_stats_table(self):
+            """Summary table that can be printed
+            """
+            results_table = SimpleTable(self._results, headers=results.dtype.names)
+            results_table.title = f"Multiple Comparison of Means - Games Howell, FWER={alpha}"
+            return str(self._results_table)
+
+    def connecting_letters(self, sig_level = 0.05):
+        """
+        Table that illustrates significant and non-significant comparisons with connecting numbers.
+        Levels not connected by the same number are significantly different. Levels connected by the
+        same number are not significantly different. JMP uses letters rather than numbers and we follow
+        that naming convention.
+        Args:
+            df (pd.DataFrame: data frame containg grp_col and obs_col which is the comparison data.
+            grp_col (str): the name of the column of df with the levels or group names.
+            obs_col (str): the column of df with the observations.
+            posthoc_df (pd.DataFrame): the dataframe returned by games_howell or a tukeyHSD function.
+            sig_level (float): The significance cut-off.
+
+        Returns (pd.DataFrame): The numbered are such that if strains in the grp_col do not share a
+            number they are significantly different.
+
+        """
+        posthoc_df = self.summary()
+        not_different = posthoc_df[posthoc_df[ADJ_P_VALUE_COL] > sig_level]
+        not_diff_pairs = not_different[[GROUP_1_COL, GROUP_2_COL]].drop_duplicates()
+        letters_graph = nx.Graph()
+
+        # The posthoc df defines a graph where nodes are group names (strains) and an edge connects two groups
+        # if they are not statistically significantly different.
+        # First add nodes (necessary in case there are nodes without any edges)
+        for group in self.groupsunique:
+            letters_graph.add_node(group)
+        # Then add edges
+        for _, pair_row in not_diff_pairs.iterrows():
+            letters_graph.add_edge(pair_row[GROUP_1_COL], pair_row[GROUP_2_COL])
+
+        # Each connecting letters group is equivalent to a maximal clique in this graph.
+        # Finding these cliques returns quickly for the scale of data we're looking at currently.
+        # However, if this changes, we could
+        # try to leverage the structure of the graph to make this search smarter (since labels are associated with
+        # one-dimensional observations there is some kind of linear ordering structure that could help determine which
+        # edges are possible or not in this graph)
+        cliques = sorted(list(nx.find_cliques(letters_graph)))
+        label_to_connecting_letters = defaultdict(list)
+        for i, clique in enumerate(cliques):
+            # Each clique is just a list of group names
+            for label in clique:
+                label_to_connecting_letters[label].append(i + 1)
+
+        connecting_letters_df_rows = []
+        for label, connecting_letters in label_to_connecting_letters.items():
+            label_idx = np.where(self.groupsunique == label)
+            mean = self.groupmeans[label_idx][0] #remove list level for dataframe
+            row = {"group": label, "mean": mean}
+            for connecting_letter in connecting_letters:
+                row[str(connecting_letter)] = str(connecting_letter)
+            connecting_letters_df_rows.append(row)
+
+        letter_frame = pd.DataFrame(connecting_letters_df_rows).sort_values(["group"])
+        letter_frame.replace(np.NaN, "", inplace=True)
+        return letter_frame
 
 
 class MultiComparison(object):
@@ -931,23 +1020,23 @@ class MultiComparison(object):
                                   np.round(res[:,0],4),
                                   np.round(res[:,1],4),
                                   reject),
-                       dtype=[('group1', object),
-                              ('group2', object),
-                              ('stat',float),
-                              ('pval',float),
-                              ('reject', np.bool8)])
+                       dtype=[(GROUP_1_COL, object),
+                              (GROUP_2_COL, object),
+                              (STAT_COL,float),
+                              (P_VALUE_COL,float),
+                              (REJECT_COL, np.bool8)])
         else:
             resarr = np.array(lzip(self.groupsunique[i1], self.groupsunique[i2],
                                   np.round(res[:,0],4),
                                   np.round(res[:,1],4),
                                   np.round(pvals_corrected,4),
                                   reject),
-                       dtype=[('group1', object),
-                              ('group2', object),
-                              ('stat',float),
-                              ('pval',float),
-                              ('pval_corr',float),
-                              ('reject', np.bool8)])
+                       dtype=[(GROUP_1_COL, object),
+                              (GROUP_2_COL, object),
+                              (STAT_COL,float),
+                              (P_VALUE_COL,float),
+                              (ADJ_P_VALUE_COL,float),
+                              (REJECT_COL, np.bool8)])
         results_table = SimpleTable(resarr, headers=resarr.dtype.names)
         results_table.title = (
             'Test Multiple Comparison %s \n%s%4.2f method=%s'
@@ -981,7 +1070,7 @@ class MultiComparison(object):
         gnobs = self.groupstats.groupnobs
         # var_ = self.groupstats.groupvarwithin()
         # #possibly an error in varcorrection in this case
-        var_ = np.var(self.groupstats.groupdemean(), ddof=len(gmeans))
+        var_ = np.var(self.groupstats.groupedmean(), ddof=len(gmeans))
         # res contains: 0:(idx1, idx2), 1:reject, 2:meandiffs, 3: std_pairs,
         # 4:confint, 5:q_crit, 6:df_total, 7:reject2, 8: pvals
         res = tukeyhsd(gmeans, gnobs, var_, df=None, alpha=alpha, q_crit=None)
@@ -993,19 +1082,68 @@ class MultiComparison(object):
                                np.round(res[4][:, 0], 4),
                                np.round(res[4][:, 1], 4),
                                res[1]),
-                          dtype=[('group1', object),
-                                 ('group2', object),
-                                 ('meandiff', float),
-                                 ('p-adj', float),
-                                 ('lower', float),
-                                 ('upper', float),
-                                 ('reject', np.bool8)])
+                          dtype=[(GROUP_1_COL, object),
+                                 (GROUP_2_COL, object),
+                                 (MEAN_DIFFERENCE_COL, float),
+                                 (ADJ_P_VALUE_COL, float),
+                                 (CI_LOWER_LIMIT_COL, float),
+                                 (CI_UPPER_LIMIT_COL, float),
+                                 (REJECT_COL, np.bool8)])
         results_table = SimpleTable(resarr, headers=resarr.dtype.names)
         results_table.title = 'Multiple Comparison of Means - Tukey HSD, ' + \
                               'FWER=%4.2f' % alpha
 
         return TukeyHSDResults(self, results_table, res[5], res[1], res[2],
                                res[3], res[4], res[6], res[7], var_, res[8])
+
+    def games_howell(self, alpha=0.05):
+        self.groupstats = GroupsStats(
+            np.column_stack([self.data, self.groupintlab]), useranks=False
+        )
+
+        # These return the right values and we should revisit the groupstats class to clean up.
+        groupmeans = self.groupstats.groupmean
+        groupvars = self.groupstats.groupvarwithin()
+        groupnobs = self.groupstats.groupnobs
+
+        (
+            idx,
+            difference_pairs,
+            stderr_pairs,
+            q_crit_values,
+            degrees_freedom_pairs,
+            p_values,
+            ci_lower_limits,
+            ci_upper_limits,
+        )= games_howell(groupmeans, groupvars, groupnobs)
+
+
+        results = np.array(
+            lzip(
+                self.groupsunique[idx[0]],
+                self.groupsunique[idx[1]],
+                np.round(difference_pairs, 4),
+                np.round(stderr_pairs, 4),
+                np.round(q_crit_values, 4),
+                np.round(degrees_freedom_pairs, 4),
+                np.round(p_values, 4),
+                np.round(ci_lower_limits, 4),
+                np.round(ci_upper_limits, 4)
+            ),
+            dtype=[
+                (GROUP_1_COL, object),
+                (GROUP_2_COL, object),
+                (MEAN_DIFFERENCE_COL, float),
+                (STANDARD_ERROR_COL, float),
+                (Q_COL, float),
+                (DEGREES_FREEDOM_COL, float),
+                (ADJ_P_VALUE_COL, float),
+                (CI_LOWER_LIMIT_COL, float),
+                (CI_UPPER_LIMIT_COL, float),
+            ],
+        )
+
+        return GamesHowellResults(self, results)
 
 
 def rankdata(x):
@@ -1425,6 +1563,70 @@ def distance_st_range(mean_all, nobs_all, var_all, df=None, triu=False):
     st_range = np.abs(meandiffs) / std_pairs #studentized range statistic
 
     return st_range, meandiffs, std_pairs, (idx1,idx2)  #return square arrays
+
+def stderr_pairs_unequal(std_all, nobs_all):
+    """
+
+    :param std_all:
+    :param nobs_all:
+    :return:
+    """
+    std_1, std_2 = np.meshgrid(std_all, std_all)
+    n_1, n_2 = np.meshgrid(nobs_all, nobs_all)
+    return np.sqrt(0.5 * ((std_1 ** 2) / n_1 + (std_2 ** 2) / n_2))
+
+def games_howell(mean_all, var_all, nobs_all, alpha=0.05):
+    """
+    Parameters
+    ----------
+    """
+    n_means = len(mean_all)
+    df_all = 1./(nobs_all - 1)
+    var_pairs, degrees_freedom = varcorrection_pairs_unequal(var_all, nobs_all, df_all)
+
+    std_all = np.sqrt(var_all)
+    stderrs = stderr_pairs_unequal(std_all, nobs_all)
+
+    m_1, m_2 = np.meshgrid(mean_all, mean_all)
+    differences = m_1 - m_2
+
+    q_stats = abs(differences)/stderrs
+
+    idx1, idx2 = np.triu_indices(n_means, 1)
+    difference_pairs = differences[idx1, idx2]
+    degrees_freedom_pairs = degrees_freedom[idx1, idx2]
+    q_stat_pairs = q_stats[idx1, idx2]
+    stderr_pairs = stderrs[idx1, idx2]
+
+    print(q_stat_pairs)
+    print(degrees_freedom_pairs)
+
+    num_groups = len(difference_pairs)
+
+    # psturng takes in q value, number of groups, and degrees of freedom and returns p(X > q)
+    # qsturng takes in probability, number of groups and degrees of freedom and returns q st.
+    # P(X < q) = p
+    psturng_vec = np.vectorize(psturng)
+    qsturng_vec = np.vectorize(qsturng)
+
+    # This might be where my troubles are since qsturng is already vectorized on degrees_freedom_pairs.
+    q_crit_values = qsturng_vec(1 - alpha, num_groups, degrees_freedom_pairs)
+    p_values = psturng_vec(q_stat_pairs, num_groups, degrees_freedom_pairs)
+
+    ci_lower_limits = difference_pairs - stderr_pairs * q_crit_values
+    ci_upper_limits = difference_pairs + stderr_pairs * q_crit_values
+
+    return (
+        (idx1, idx2),
+        difference_pairs,
+        stderr_pairs,
+        q_stat_pairs,
+        degrees_freedom_pairs,
+        p_values,
+        ci_lower_limits,
+        ci_upper_limits
+    )
+
 
 
 def contrast_allpairs(nm):

--- a/statsmodels/stats/libqsturng/qsturng_.py
+++ b/statsmodels/stats/libqsturng/qsturng_.py
@@ -824,7 +824,7 @@ def _psturng(q, r, v):
     def opt_func(p, r, v):
         return np.squeeze(abs(_qsturng(p, r, v) - q))
 
-    if 1 <= v < 2:
+    if v == 1:
         if q < _qsturng(.9, r, 1):
             return .1
         elif q > _qsturng(.999, r, 1):

--- a/statsmodels/stats/libqsturng/qsturng_.py
+++ b/statsmodels/stats/libqsturng/qsturng_.py
@@ -824,7 +824,7 @@ def _psturng(q, r, v):
     def opt_func(p, r, v):
         return np.squeeze(abs(_qsturng(p, r, v) - q))
 
-    if v == 1:
+    if 1 <= v < 2:
         if q < _qsturng(.9, r, 1):
             return .1
         elif q > _qsturng(.999, r, 1):

--- a/statsmodels/stats/multicomp.py
+++ b/statsmodels/stats/multicomp.py
@@ -6,9 +6,9 @@ Author: Josef Perktold
 """
 
 from statsmodels.sandbox.stats.multicomp import (  # noqa:F401
-    tukeyhsd, MultiComparison)
+    tukeyhsd, games_howell, MultiComparison)
 
-__all__ = ['tukeyhsd', 'MultiComparison']
+__all__ = ["tukeyhsd", "games_howell", "MultiComparison"]
 
 
 def pairwise_tukeyhsd(endog, groups, alpha=0.05):

--- a/statsmodels/stats/multicomp.py
+++ b/statsmodels/stats/multicomp.py
@@ -42,3 +42,36 @@ def pairwise_tukeyhsd(endog, groups, alpha=0.05):
     """
 
     return MultiComparison(endog, groups).tukeyhsd(alpha=alpha)
+
+
+def pairwise_games_howell(endog, groups, alpha=0.05):
+    """
+    Calculate all pairwise comparisons using Games-Howell.
+
+    Parameters
+    ----------
+    endog : ndarray, float, 1d
+        response variable
+    groups : ndarray, 1d
+        array with groups, can be string or integers
+    alpha : float
+        significance level for the test
+
+    Returns
+    -------
+    results : GamesHowellResults instance
+        A results class containing relevant data and some post-hoc
+        calculations, including adjusted p-value
+
+    Notes
+    -----
+    This is just a wrapper around games_howell method of MultiComparison
+
+    See Also
+    --------
+    MultiComparison
+    games_howell
+    statsmodels.sandbox.stats.multicomp.GamesHowellResults
+    """
+
+    return MultiComparison(endog, groups).games_howell(alpha=alpha)

--- a/statsmodels/stats/tests/test_multi.py
+++ b/statsmodels/stats/tests/test_multi.py
@@ -14,6 +14,7 @@ are tested against R:multtest
 '''
 import pytest
 import numpy as np
+import pandas as pd
 from numpy.testing import (assert_almost_equal, assert_equal,
                            assert_allclose)
 
@@ -21,7 +22,7 @@ from statsmodels.stats.multitest import (multipletests, fdrcorrection,
                                          fdrcorrection_twostage,
                                          NullDistribution,
                                          local_fdr, multitest_methods_names)
-from statsmodels.stats.multicomp import tukeyhsd
+from statsmodels.stats.multicomp import tukeyhsd, games_howell, pairwise_games_howell
 from scipy.stats.distributions import norm
 
 pval0 = np.array([
@@ -383,6 +384,136 @@ def test_tukeyhsd():
     small_pvals_idx = [2, 5, 7, 9]
     assert_allclose(myres[8][small_pvals_idx], res[small_pvals_idx, 3],
                     rtol=1e-3)
+
+
+def test_games_howell():
+    """
+    means and variances for the test come from setting base means where two
+    are the same and two are clearly different and adding noise that means
+    two of the groups should be statistically different from the other two
+    and the two with the same base mean should not be stat different.
+
+    Originally generated as:
+    np.random.seed(20210218)
+    base_means = np.array([0, 0, -5, 5])
+    noise = [np.random.normal(loc=0.0, scale=0.1, size=reps) for reps in [3, 8, 6, 4]]
+
+    All test values computed by hand except for the first p_adj value and the
+    q_crit values for the lower and upper confidence intervals since and these
+    values all agree with this implementation in R (one has to code it up
+    yourself as the package does one work as expected):
+    https://rpubs.com/aaronsc32/games-howell-test
+    """
+    expected_results = pd.DataFrame(
+        {
+            "group1": ["grp_1", "grp_1", "grp_1", "grp_2", "grp_2", "grp_3"],
+            "group2": ["grp_2", "grp_3", "grp_4", "grp_3", "grp_4", "grp_4"],
+            "mean_difference": [0.1209, -4.952, 5.13, -5.0729, 5.009, 10.0819],
+            "standard_error": [0.0484, 0.049, 0.0733, 0.0294, 0.0619, 0.0624],
+            "q": [2.498, 101.0077, 69.9969, 172.7079, 80.9337, 161.6458],
+            "degrees_freedom": [2.8773, 2.995, 4.9695, 11.3508, 3.7219, 3.8199],
+            "p_adj": [0.4339, 0.001, 0.001, 0.001, 0.001, 0.001],
+            "lower": [-0.2195, -5.287, 4.7465, -5.1973, 4.639, 9.7142],
+            "upper": [0.4614, -4.6169, 5.5134, -4.9485, 5.379, 10.4497],
+        }
+    )
+    means = np.array([-0.07022087, 0.05071469, -5.02219617, 5.05973107])
+    vars = np.array([0.01165387, 0.00642479, 0.00553452, 0.02743093])
+    nobs = np.array([3, 8, 6, 4])
+    (
+        pairs,
+        meandiffs,
+        stderr_pairs,
+        q_crit_values,
+        df_pairs,
+        p_values,
+        ci_lower_limits,
+        ci_upper_limits,
+    ) = games_howell(means, vars, nobs)
+    assert_almost_equal(
+        meandiffs, expected_results["mean_difference"].values, decimal=4
+    )
+    assert_almost_equal(
+        stderr_pairs, expected_results["standard_error"].values, decimal=4
+    )
+    assert_almost_equal(q_crit_values, expected_results["q"].values, decimal=4)
+    assert_almost_equal(df_pairs, expected_results["degrees_freedom"].values, decimal=4)
+    assert_almost_equal(p_values, expected_results["p_adj"].values, decimal=4)
+    assert_almost_equal(ci_lower_limits, expected_results["lower"].values, decimal=4)
+    assert_almost_equal(ci_upper_limits, expected_results["upper"].values, decimal=4)
+
+
+def test_connecting_letters():
+    """
+    Uses the same data as the previous test.
+    """
+    expected_results = pd.DataFrame(
+        {
+            "group": ["grp_1", "grp_2", "grp_3", "grp_4"],
+            "mean": [-0.07022087, 0.05071469, -5.02219617, 5.05973107],
+            "1": [1, 1, np.nan, np.nan],
+            "2": [np.nan, np.nan, 2, np.nan],
+            "3": [np.nan, np.nan, np.nan, 3],
+        }
+    )
+    obs = np.array(
+        [
+            3.21810786e-02,
+            -5.98649248e-02,
+            -1.82978761e-01,
+            2.04637431e-01,
+            7.73945782e-02,
+            1.64391654e-02,
+            1.09856344e-01,
+            2.18174810e-02,
+            -5.89446096e-02,
+            3.72352297e-02,
+            -2.71809444e-03,
+            -4.96220130e00,
+            -5.04879548e00,
+            -4.90253767e00,
+            -5.07207031e00,
+            -5.09865647e00,
+            -5.04891580e00,
+            4.90705327e00,
+            5.29484364e00,
+            5.00613229e00,
+            5.03089509e00,
+        ]
+    )
+    grps = np.array(
+        [
+            "grp_1",
+            "grp_1",
+            "grp_1",
+            "grp_2",
+            "grp_2",
+            "grp_2",
+            "grp_2",
+            "grp_2",
+            "grp_2",
+            "grp_2",
+            "grp_2",
+            "grp_3",
+            "grp_3",
+            "grp_3",
+            "grp_3",
+            "grp_3",
+            "grp_3",
+            "grp_4",
+            "grp_4",
+            "grp_4",
+            "grp_4",
+        ]
+    )
+    gh = pairwise_games_howell(obs, grps)
+    # The results have "" for user convenience visually. To test we convert them
+    # to nan.  pd assert frame equal does not handle the "" as expected.
+    cl = gh.connecting_letters().replace("", np.nan)
+    cl = cl.astype({"1": float, "2": float, "3": float})
+    pd.testing.assert_frame_equal(expected_results, cl)
+
+
 
 
 def test_local_fdr():


### PR DESCRIPTION
- [ ] closes #xxxx
- [X] tests added / passed. 
- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

Adding the Games Howell Post Hoc Test.  This is not currently implemented in R or JMP (though there is an add one can get) and AFAIK no other packages.  However, as I note in the tests, you can easily use this [R pub](https://rpubs.com/aaronsc32/games-howell-test#:~:text=Although%20rather%20similar%20to%20Tukey's,equal%20variances%20and%20sample%20sizes.&text=Since%20the%20Games%2DHowell%20test,approaches%20such%20as%20Tukey's%20test) to code up the same test (the pub suggests there is a package one can use, but it does not work, it's better to use the code snippet) and verify the test values.  

Because this test is an alternative to Tukey HSD but does not assume equal variances and sample sizes, I followed the code for that statistical test (as per a discussion in the google group) as a model for where to put functions/add them to classes, etc. as well as for the tests.  This may not be optimal, but follows existing patterns while making sure all new code is well documented and uses `black` for style.

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
