### PR TITLE
DOC: add missing parameters to docs of UnobservedComponents

### DIFF
--- a/statsmodels/tsa/statespace/structural.py
+++ b/statsmodels/tsa/statespace/structural.py
@@ -102,6 +102,11 @@ class UnobservedComponents(MLEModel):
         allow the cyclical component to be between 1.5 and 12 years; depending
         on the frequency of the endogenous variable, this will imply different
         specific bounds.
+    mle_regression : bool, optional
+        Whether or not to estimate regression coefficients by maximum likelihood
+        as one of hyperparameters. Default is True.
+        If False, the regression coefficients are estimated by recursive OLS,
+        included in the state vector.
     use_exact_diffuse : bool, optional
         Whether or not to use exact diffuse initialization for non-stationary
         states. Default is False (in which case approximate diffuse

--- a/statsmodels/tsa/statespace/structural.py
+++ b/statsmodels/tsa/statespace/structural.py
@@ -52,6 +52,8 @@ class UnobservedComponents(MLEModel):
     Parameters
     ----------
 
+    endog : array_like
+        The observed time-series process :math:`y`
     level : {bool, str}, optional
         Whether or not to include a level component. Default is False. Can also
         be a string specification of the level / trend component; see Notes


### PR DESCRIPTION
I found the description of two parameters (`endog` and `mle_regression`) missing in the docstring of UnobservedComponents.

- [ ] closes #xxxx
- [ ] tests added / passed. 
- [ ] code/documentation is well formatted.  
- [ ] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 