### PR TITLE
BUG: Raise on missing values in OrderedModel

### DIFF
--- a/statsmodels/miscmodels/ordinal_model.py
+++ b/statsmodels/miscmodels/ordinal_model.py
@@ -193,6 +193,7 @@ class OrderedModel(GenericLikelihoodModel):
         if isinstance(endog, pd.Series):
             if isinstance(endog.dtypes, CategoricalDtype):
                 if not endog.dtype.ordered:
+                    import warnings
                     warnings.warn("the endog has ordered == False, "
                                   "risk of capturing a wrong order for the "
                                   "categories. ordered == True preferred.",

--- a/statsmodels/miscmodels/ordinal_model.py
+++ b/statsmodels/miscmodels/ordinal_model.py
@@ -128,6 +128,11 @@ class OrderedModel(GenericLikelihoodModel):
         if not is_pandas:
             if self.endog.ndim == 1:
                 unique, index = np.unique(self.endog, return_inverse=True)
+                # check for missing values
+                if np.isnan(unique).any():
+                    raise ValueError(
+                        "missing values in endog are not supported"
+                    )
                 self.endog = index
                 labels = unique
             elif self.endog.ndim == 2:

--- a/statsmodels/miscmodels/tests/test_ordinal_model.py
+++ b/statsmodels/miscmodels/tests/test_ordinal_model.py
@@ -175,6 +175,10 @@ class TestLogitModel(CheckOrdinalModelMixin):
         with pytest.raises(ValueError):
             OrderedModel(endog, exog)
 
+    @pytest.mark.skipif(
+        not hasattr(pd, "CategoricalDtype"),
+        reason="requires pd.CategoricalDtype",
+    )
     def test_missing_values_pandas(self):
         df = pd.DataFrame(
             {

--- a/statsmodels/miscmodels/tests/test_ordinal_model.py
+++ b/statsmodels/miscmodels/tests/test_ordinal_model.py
@@ -167,6 +167,27 @@ class TestLogitModel(CheckOrdinalModelMixin):
         cls.resf = resf
         cls.resu = resu
 
+    def test_missing_values(self):
+        endog = np.ones(3, dtype=float)
+        endog[2] = np.nan
+        exog = [1, 2, 3]
+
+        with pytest.raises(ValueError):
+            OrderedModel(endog, exog)
+
+    def test_missing_values_pandas(self):
+        df = pd.DataFrame(
+            {
+                "endog": pd.Series(
+                    [1, 2, np.nan],
+                    dtype=pd.CategoricalDtype([1, 2], ordered=True),
+                ),
+                "exog": [1, 2, 3],
+            },
+        )
+        with pytest.raises(ValueError):
+            OrderedModel(df["endog"], df[["exog"]])
+
     def test_postestimation(self):
         res1 = self.res1
         res2 = self.res2


### PR DESCRIPTION
Since it isn't handled, raise instead of behaving weird (see #7353 for an example).

The same condition raises the same error when endog is a pd.Categorical, so this should make things more consistent.

Added tests for both the categorical and numerical cases, since they are handled separately.

Also added a missing `import warnings` discovered while testing when endog is categorical but unordered. I did not add test coverage for this, but it suggests that the the case of `dtype=pd.Categorical(unordered=True)` is not covered, despite there appearing to be unordered tests.

- [x] closes #7353
- [x] tests added / passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
