### PR TITLE
BUG: Fix STLForecast when start is None

### DIFF
--- a/statsmodels/tsa/forecasting/stl.py
+++ b/statsmodels/tsa/forecasting/stl.py
@@ -364,7 +364,9 @@ class STLForecastResults:
             Array containing the seasibak predictions.
         """
         data = PandasData(pd.Series(self._endog), index=self._index)
-        (start, end, out_of_sample, prediction_index,) = get_prediction_index(
+        if start is None:
+            start = 0
+        (start, end, out_of_sample, prediction_index) = get_prediction_index(
             start, end, self._nobs, self._index, data=data
         )
 
@@ -496,10 +498,8 @@ class STLForecastResults:
         pred = self._model_result.get_prediction(
             start=start, end=end, dynamic=dynamic, **kwargs
         )
-        seasonal_prediction = self._get_seasonal_prediction(
-            start, end, dynamic
-        )
+        seasonal_prediction = self._get_seasonal_prediction(start, end, dynamic)
         mean = pred.predicted_mean + seasonal_prediction
         return PredictionResults(
-            mean, pred.var_pred_mean, dist="norm", row_labels=pred.row_labels,
+            mean, pred.var_pred_mean, dist="norm", row_labels=pred.row_labels
         )


### PR DESCRIPTION
Ensure that start is correctly defined when None

xref #7309

- [X] tests added / passed. 
- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
