### PR TITLE
WIP ENH: add asymmetric kernels for kde and cdf, for unit interval and R+

### DIFF
--- a/docs/source/nonparametric.rst
+++ b/docs/source/nonparametric.rst
@@ -68,7 +68,7 @@ References
 * Racine, J. Li, Q. "Kernel Estimation of Multivariate Conditional
   Distributions Annals of Economics and Finance 5, 211-235 (2004)
 * Liu, R., Yang, L. "Kernel estimation of multivariate
-  cumulative distribution function." Journal of Nonparametric Statistics 
+  cumulative distribution function." Journal of Nonparametric Statistics
   (2008)
 * Li, R., Ju, G. "Nonparametric Estimation of Multivariate CDF
   with Categorical and Continuous Data." Working Paper
@@ -128,6 +128,61 @@ helper functions for kernel bandwidths
 
 There are some examples for nonlinear functions in
 :mod:`statsmodels.nonparametric.dgp_examples`
+
+
+Asymmetric Kernels
+------------------
+
+Asymmetric kernels like beta for the unit interval and gamma for positive
+valued random variables avoid problems at the boundary of the support of the
+distribution.
+
+Statsmodels has preliminary support for estimating density and cumulative
+distribution function using kernels for the unit interval, ``beta`` or the
+positive real line, all other kernels.
+
+Several of the kernels for the positive real line assume that the density at
+the zero boundary is zero. The gamma kernel also allows the case of positive
+or unbound density at the zero boundary.
+
+There are currently no defaults and no support for choosing the bandwidth. the
+user has to provide the bandwidth.
+
+The functions to compute kernel density and kernel cdf are
+
+.. currentmodule:: statsmodels.nonparametric.kernels_asymmetric
+.. autosummary::
+   :toctree: generated/
+
+   pdf_kernel_asym
+   cdf_kernel_asym
+
+The available kernel functions for pdf and cdf are
+
+.. autosummary::
+   :toctree: generated/
+
+   kernel_pdf_beta
+   kernel_pdf_beta2
+   kernel_pdf_bs
+   kernel_pdf_gamma
+   kernel_pdf_gamma2
+   kernel_pdf_invgamma
+   kernel_pdf_invgauss
+   kernel_pdf_lognorm
+   kernel_pdf_recipinvgauss
+   kernel_pdf_weibull
+   kernel_cdf_beta
+   kernel_cdf_beta2
+   kernel_cdf_bs
+   kernel_cdf_gamma
+   kernel_cdf_gamma2
+   kernel_cdf_invgamma
+   kernel_cdf_invgauss
+   kernel_cdf_lognorm
+   kernel_cdf_recipinvgauss
+   kernel_cdf_weibull
+
 
 The sandbox.nonparametric contains additional insufficiently tested classes
 for testing functional form and for semi-linear and single index models.

--- a/statsmodels/nonparametric/kernels_asymmetric.py
+++ b/statsmodels/nonparametric/kernels_asymmetric.py
@@ -12,9 +12,11 @@ from scipy import stats, special
 
 
 def pdf_kernel_asym(x, sample, bw, kernel_type, weights=None):
+    if np.size(x) > 1:
+        x = np.asarray(x)[:, None]
 
     kfunc = kernel_dict_pdf[kernel_type]
-    pdfi = kfunc(x, sample, bw, return_comp=True)
+    pdfi = kfunc(x, sample, bw)
 
     if weights is None:
         return pdfi.mean(-1)
@@ -23,9 +25,11 @@ def pdf_kernel_asym(x, sample, bw, kernel_type, weights=None):
 
 
 def cdf_kernel_asym(x, sample, bw, kernel_type, weights=None):
+    if np.size(x) > 1:
+        x = np.asarray(x)[:, None]
 
     kfunc = kernel_dict_cdf[kernel_type]
-    cdfi = kfunc(x, sample, bw, return_comp=True)
+    cdfi = kfunc(x, sample, bw)
 
     if weights is None:
         return cdfi.mean(-1)
@@ -33,7 +37,7 @@ def cdf_kernel_asym(x, sample, bw, kernel_type, weights=None):
         return cdfi @ weights
 
 
-def kernel_pdf_gamma(x, sample, bw, return_comp=False):
+def kernel_pdf_gamma(x, sample, bw):
     """gamma kernel for pdf
 
     Reference
@@ -42,14 +46,10 @@ def kernel_pdf_gamma(x, sample, bw, return_comp=False):
     """
 
     pdfi = stats.gamma.pdf(sample, x / bw + 1, scale=bw)
-
-    if return_comp:
-        return pdfi
-    else:
-        return pdfi.mean(-1)
+    return pdfi
 
 
-def kernel_cdf_gamma(x, sample, bw, return_comp=False):
+def kernel_cdf_gamma(x, sample, bw):
     """gamma kernel for cdf
 
     Reference
@@ -58,11 +58,7 @@ def kernel_cdf_gamma(x, sample, bw, return_comp=False):
     """
     # it uses the survival function, but I don't know why.
     cdfi = stats.gamma.sf(sample, x / bw + 1, scale=bw)
-
-    if return_comp:
-        return cdfi
-    else:
-        return cdfi.mean(-1)
+    return cdfi
 
 
 def _kernel_pdf_gamma(x, sample, bw):
@@ -74,7 +70,7 @@ def _kernel_pdf_gamma(x, sample, bw):
     neighborhood of zero boundary is small.
 
     """
-    return stats.gamma.pdf(sample, x / bw, scale=bw).mean(-1)
+    return stats.gamma.pdf(sample, x / bw, scale=bw)
 
 
 def _kernel_cdf_gamma(x, sample, bw):
@@ -86,7 +82,7 @@ def _kernel_cdf_gamma(x, sample, bw):
     neighborhood of zero boundary is small.
 
     """
-    return stats.gamma.sf(sample, x / bw, scale=bw).mean(-1)
+    return stats.gamma.sf(sample, x / bw, scale=bw)
 
 
 def kernel_pdf_gamma2(x, sample, bw):
@@ -104,7 +100,7 @@ def kernel_pdf_gamma2(x, sample, bw):
         a = x / bw
         mask = x < 2 * bw
         a[mask] = a[mask]**2 + 1
-    pdf = stats.gamma.pdf(sample, a, scale=bw).mean(-1)
+    pdf = stats.gamma.pdf(sample, a, scale=bw)
 
     return pdf
 
@@ -124,7 +120,7 @@ def kernel_cdf_gamma2(x, sample, bw):
         a = x / bw
         mask = x < 2 * bw
         a[mask] = a[mask]**2 + 1
-    pdf = stats.gamma.sf(sample, a, scale=bw).mean(-1)
+    pdf = stats.gamma.sf(sample, a, scale=bw)
 
     return pdf
 
@@ -134,7 +130,7 @@ def kernel_pdf_invgamma(x, sample, bw):
 
     de Micheaux, Ouimet (arxiv Nov 2020) for cdf kernel
     """
-    return stats.invgamma.pdf(sample, 1 / bw + 1, scale=x / bw).mean(-1)
+    return stats.invgamma.pdf(sample, 1 / bw + 1, scale=x / bw)
 
 
 def kernel_cdf_invgamma(x, sample, bw):
@@ -142,15 +138,15 @@ def kernel_cdf_invgamma(x, sample, bw):
 
     de Micheaux, Ouimet (arxiv Nov 2020) for cdf kernel
     """
-    return stats.invgamma.sf(sample, 1 / bw + 1, scale=x / bw).mean(-1)
+    return stats.invgamma.sf(sample, 1 / bw + 1, scale=x / bw)
 
 
 def kernel_pdf_beta(x, sample, bw):
-    return stats.beta.pdf(sample, x / bw + 1, (1 - x) / bw + 1).mean(-1)
+    return stats.beta.pdf(sample, x / bw + 1, (1 - x) / bw + 1)
 
 
 def kernel_cdf_beta(x, sample, bw):
-    return stats.beta.sf(sample, x / bw + 1, (1 - x) / bw + 1).mean(-1)
+    return stats.beta.sf(sample, x / bw + 1, (1 - x) / bw + 1)
 
 
 def kernel_pdf_beta2(x, sample, bw):
@@ -170,13 +166,13 @@ def kernel_pdf_beta2(x, sample, bw):
         # without vectorizing:
         if x < 2 * bw:
             a = a1 - np.sqrt(a2 - x**2 - x / bw)
-            pdf = stats.beta.pdf(sample, a, (1 - x) / bw).mean(-1)
+            pdf = stats.beta.pdf(sample, a, (1 - x) / bw)
         elif x > (1 - 2 * bw):
             x_ = 1 - x
             a = a1 - np.sqrt(a2 - x_**2 - x_ / bw)
-            pdf = stats.beta.pdf(sample, x / bw, a).mean(-1)
+            pdf = stats.beta.pdf(sample, x / bw, a)
         else:
-            pdf = stats.beta.pdf(sample, x / bw, (1 - x) / bw).mean(-1)
+            pdf = stats.beta.pdf(sample, x / bw, (1 - x) / bw)
     else:
         alpha = x / bw
         beta = (1 - x) / bw
@@ -189,7 +185,7 @@ def kernel_pdf_beta2(x, sample, bw):
         x_ = 1 - x[mask_upp]
         beta[mask_upp] = a1 - np.sqrt(a2 - x_**2 - x_ / bw)
 
-        pdf = stats.beta.pdf(sample, alpha, beta).mean(-1)
+        pdf = stats.beta.pdf(sample, alpha, beta)
 
     return pdf
 
@@ -211,13 +207,13 @@ def kernel_cdf_beta2(x, sample, bw):
         # without vectorizing:
         if x < 2 * bw:
             a = a1 - np.sqrt(a2 - x**2 - x / bw)
-            pdf = stats.beta.sf(sample, a, (1 - x) / bw).mean(-1)
+            pdf = stats.beta.sf(sample, a, (1 - x) / bw)
         elif x > (1 - 2 * bw):
             x_ = 1 - x
             a = a1 - np.sqrt(a2 - x_**2 - x_ / bw)
-            pdf = stats.beta.sf(sample, x / bw, a).mean(-1)
+            pdf = stats.beta.sf(sample, x / bw, a)
         else:
-            pdf = stats.beta.sf(sample, x / bw, (1 - x) / bw).mean(-1)
+            pdf = stats.beta.sf(sample, x / bw, (1 - x) / bw)
     else:
         alpha = x / bw
         beta = (1 - x) / bw
@@ -230,7 +226,7 @@ def kernel_cdf_beta2(x, sample, bw):
         x_ = 1 - x[mask_upp]
         beta[mask_upp] = a1 - np.sqrt(a2 - x_**2 - x_ / bw)
 
-        pdf = stats.beta.sf(sample, alpha, beta).mean(-1)
+        pdf = stats.beta.sf(sample, alpha, beta)
 
     return pdf
 
@@ -242,7 +238,7 @@ def kernel_pdf_invgauss(x, sample, bw):
     """
     m = x
     lam = 1 / bw
-    return stats.invgauss.pdf(sample, m / lam, scale=lam).mean(-1)
+    return stats.invgauss.pdf(sample, m / lam, scale=lam)
 
 
 def kernel_pdf_invgauss_(x, sample, bw):
@@ -262,7 +258,7 @@ def kernel_cdf_invgauss(x, sample, bw):
     """
     m = x
     lam = 1 / bw
-    return stats.invgauss.sf(sample, m / lam, scale=lam).mean(-1)
+    return stats.invgauss.sf(sample, m / lam, scale=lam)
 
 
 def kernel_pdf_recipinvgauss(x, sample, bw):
@@ -274,7 +270,7 @@ def kernel_pdf_recipinvgauss(x, sample, bw):
     # references use m, lambda parameterization
     m = 1 / (x - bw)
     lam = 1 / bw
-    return stats.recipinvgauss.pdf(sample, m / lam, scale=1 / lam).mean(-1)
+    return stats.recipinvgauss.pdf(sample, m / lam, scale=1 / lam)
 
 
 def kernel_pdf_recipinvgauss_(x, sample, bw):
@@ -286,7 +282,7 @@ def kernel_pdf_recipinvgauss_(x, sample, bw):
     pdf = (1 / np.sqrt(2 * np.pi * bw * sample) *
            np.exp(- (x - bw) / (2 * bw) * sample / (x - bw) - 2 +
                   (x - bw) / sample))
-    return pdf.mean(-1)
+    return pdf
 
 
 def kernel_cdf_recipinvgauss(x, sample, bw):
@@ -298,7 +294,7 @@ def kernel_cdf_recipinvgauss(x, sample, bw):
     # references use m, lambda parameterization
     m = 1 / (x - bw)
     lam = 1 / bw
-    return stats.recipinvgauss.sf(sample, m / lam, scale=1 / lam).mean(-1)
+    return stats.recipinvgauss.sf(sample, m / lam, scale=1 / lam)
 
 
 def kernel_pdf_bs(x, sample, bw):
@@ -307,7 +303,7 @@ def kernel_pdf_bs(x, sample, bw):
     Jin, Kawczak 2003
     """
     # need shape-scale parameterization for scipy
-    return stats.fatiguelife.pdf(sample, bw, scale=x).mean(-1)
+    return stats.fatiguelife.pdf(sample, bw, scale=x)
 
 
 def kernel_cdf_bs(x, sample, bw):
@@ -316,7 +312,7 @@ def kernel_cdf_bs(x, sample, bw):
     Jin, Kawczak 2003
     """
     # need shape-scale parameterization for scipy
-    return stats.fatiguelife.sf(sample, bw, scale=x).mean(-1)
+    return stats.fatiguelife.sf(sample, bw, scale=x)
 
 
 def kernel_pdf_lognorm(x, sample, bw):
@@ -332,7 +328,7 @@ def kernel_pdf_lognorm(x, sample, bw):
     #    variance of normal pdf
     # bw = np.exp(bw_**2 / 4) - 1  # this is inverse transformation
     bw_ = np.sqrt(4*np.log(1+bw))
-    return stats.lognorm.pdf(sample, bw_, scale=x).mean(-1)
+    return stats.lognorm.pdf(sample, bw_, scale=x)
 
 
 def kernel_cdf_lognorm(x, sample, bw):
@@ -348,7 +344,7 @@ def kernel_cdf_lognorm(x, sample, bw):
     #    variance of normal pdf
     # bw = np.exp(bw_**2 / 4) - 1  # this is inverse transformation
     bw_ = np.sqrt(4*np.log(1+bw))
-    return stats.lognorm.sf(sample, bw_, scale=x).mean(-1)
+    return stats.lognorm.sf(sample, bw_, scale=x)
 
 
 def kernel_pdf_lognorm_(x, sample, bw):
@@ -370,7 +366,7 @@ def kernel_pdf_weibull(x, sample, bw):
     # need shape-scale parameterization for scipy
     # references use m, lambda parameterization
     return stats.weibull_min.pdf(sample, 1 / bw,
-                                 scale=x / special.gamma(1 + bw)).mean(-1)
+                                 scale=x / special.gamma(1 + bw))
 
 
 def kernel_cdf_weibull(x, sample, bw):
@@ -381,7 +377,7 @@ def kernel_cdf_weibull(x, sample, bw):
     # need shape-scale parameterization for scipy
     # references use m, lambda parameterization
     return stats.weibull_min.sf(sample, 1 / bw,
-                                scale=x / special.gamma(1 + bw)).mean(-1)
+                                scale=x / special.gamma(1 + bw))
 
 
 # produced wth

--- a/statsmodels/nonparametric/kernels_asymmetric.py
+++ b/statsmodels/nonparametric/kernels_asymmetric.py
@@ -1,0 +1,315 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Mon Mar  8 11:12:24 2021
+
+Author: Josef Perktold
+License: BSD-3
+
+"""
+
+import numpy as np
+from scipy import stats, special
+
+
+def kernel_pdf_gamma(x, sample, bw):
+    """gamma kernel for pdf
+
+    Reference
+    Chen 2000
+    Bouezmarni and Scaillet 2205
+    """
+    return stats.gamma.pdf(sample, x / bw + 1, scale=bw).mean(-1)
+
+
+def kernel_cdf_gamma(x, sample, bw):
+    """gamma kernel for cdf
+
+    Reference
+    Chen 2000
+    Bouezmarni and Scaillet 2205
+    """
+    # it uses the survival function, but I don't know why.
+    return stats.gamma.sf(sample, x / bw + 1, scale=bw).mean(-1)
+
+
+def _kernel_pdf_gamma(x, sample, bw):
+    """gamma kernel for pdf, without boundary corrected part
+
+    drops `+ 1` in shape parameter
+
+    It should be possible to use this if probability in
+    neighborhood of zero boundary is small.
+
+    """
+    return stats.gamma.pdf(sample, x / bw, scale=bw).mean()
+
+
+def _kernel_cdf_gamma(x, sample, bw):
+    """gamma kernel for cdf, without boundary corrected part
+
+    drops `+ 1` in shape parameter
+
+    It should be possible to use this if probability in
+    neighborhood of zero boundary is small.
+
+    """
+    return stats.gamma.sf(sample, x / bw, scale=bw).mean()
+
+
+def kernel_pdf_gamma2(x, sample, bw):
+    """gamma kernel for pdf with boundary correction
+
+    """
+    # without vectorizing:
+    if np.size(x) == 1:
+        if x < 2 * bw:
+            a = (x / bw)**2 + 1
+        else:
+            a = x / bw
+    else:
+        a = x / bw
+        a[x < 2 * bw] = a**2 + 1
+    pdf = stats.gamma.pdf(sample, a, scale=bw).mean()
+
+    return pdf
+
+
+def kernel_cdf_gamma2(x, sample, bw):
+    """gamma kernel for pdf with boundary correction
+
+    """
+    # without vectorizing:
+    if np.size(x) == 1:
+        if x < 2 * bw:
+            a = (x / bw)**2 + 1
+        else:
+            a = x / bw
+    else:
+        a = x / bw
+        a[x < 2 * bw] = a**2 + 1
+    pdf = stats.gamma.sf(sample, a, scale=bw).mean()
+
+    return pdf
+
+
+def kernel_pdf_invgamma(x, sample, bw):
+    """inverse gamma kernel for pdf
+
+    de Micheaux, Ouimet (arxiv Nov 2020) for cdf kernel
+    """
+    return stats.invgamma.pdf(sample, 1 / bw + 1, scale=x / bw).mean()
+
+
+def kernel_cdf_invgamma(x, sample, bw):
+    """inverse gamma kernel for pdf
+
+    de Micheaux, Ouimet (arxiv Nov 2020) for cdf kernel
+    """
+    return stats.invgamma.sf(sample, 1 / bw + 1, scale=x / bw).mean()
+
+
+def kernel_pdf_beta(x, sample, bw):
+    return stats.beta.pdf(sample, x / bw + 1, (1 - x) / bw + 1).mean()
+
+
+def kernel_cdf_beta(x, sample, bw):
+    return stats.beta.sf(sample, x / bw + 1, (1 - x) / bw + 1).mean()
+
+
+def kernel_pdf_beta2(x, sample, bw):
+    """beta kernel for pdf with boundary correction
+
+    not vectorized in x
+
+    Chen 1999
+    """
+    # a = 2 * bw**2 + 2.5 -
+    #     np.sqrt(4 * bw**4 + 6 * bw**2 + 2.25 - x**2 - x / bw)
+    # terms a1 and a2 are independent of x
+    a1 = 2 * bw**2 + 2.5
+    a2 = 4 * bw**4 + 6 * bw**2 + 2.25
+    if x < 2 * bw:
+        a = a1 - np.sqrt(a2 - x**2 - x / bw)
+        pdf = stats.beta.pdf(sample, a, (1 - x) / bw).mean()
+    elif x > (1 - 2 * bw):
+        x_ = 1 - x
+        a = a1 - np.sqrt(a2 - x_**2 - x_ / bw)
+        pdf = stats.beta.pdf(sample, x / bw, a).mean()
+    else:
+        pdf = stats.beta.pdf(sample, x / bw, (1 - x) / bw).mean()
+
+    return pdf
+
+
+def kernel_cdf_beta2(x, sample, bw):
+    """beta kernel for pdf with boundary correction
+
+    not vectorized in x
+
+    Chen 1999
+    """
+    # a = 2 * bw**2 + 2.5 -
+    #     np.sqrt(4 * bw**4 + 6 * bw**2 + 2.25 - x**2 - x / bw)
+    # terms a1 and a2 are independent of x
+    a1 = 2 * bw**2 + 2.5
+    a2 = 4 * bw**4 + 6 * bw**2 + 2.25
+    if x < 2 * bw:
+        a = a1 - np.sqrt(a2 - x**2 - x / bw)
+        pdf = stats.beta.sf(sample, a, (1 - x) / bw).mean()
+    elif x > (1 - 2 * bw):
+        x_ = 1 - x
+        a = a1 - np.sqrt(a2 - x_**2 - x_ / bw)
+        pdf = stats.beta.sf(sample, x / bw, a).mean()
+    else:
+        pdf = stats.beta.sf(sample, x / bw, (1 - x) / bw).mean()
+
+    return pdf
+
+
+def kernel_pdf_invgauss(x, sample, bw):
+    """inverse gaussian kernel density
+
+    Scaillet 2004
+    """
+    m = x
+    lam = 1 / bw
+    return stats.invgauss.pdf(sample, m / lam, scale=lam).mean()
+
+
+def kernel_pdf_invgauss_(x, sample, bw):
+    """inverse gaussian kernel density, explicit formula
+
+    Scaillet 2004
+    """
+    pdf = (1 / np.sqrt(2 * np.pi * bw * sample**3) *
+           np.exp(- 1 / (2 * bw * x) * (sample / x - 2 + x / sample)))
+    return pdf.mean()
+
+
+def kernel_cdf_invgauss(x, sample, bw):
+    """inverse gaussian kernel for cdf
+
+    Scaillet 2004
+    """
+    m = x
+    lam = 1 / bw
+    return stats.invgauss.sf(sample, m / lam, scale=lam).mean()
+
+
+def kernel_pdf_recipinvgauss(x, sample, bw):
+    """reciprocal inverse gaussian kernel density
+
+    Scaillet 2004
+    """
+    # need shape-scale parameterization for scipy
+    # references use m, lambda parameterization
+    m = 1 / (x - bw)
+    lam = 1 / bw
+    return stats.recipinvgauss.pdf(sample, m / lam, scale=1 / lam).mean()
+
+
+def kernel_pdf_recipinvgauss_(x, sample, bw):
+    """reciprocal inverse gaussian kernel density, explicit formula
+
+    Scaillet 2004
+    """
+
+    pdf = (1 / np.sqrt(2 * np.pi * bw * sample) *
+           np.exp(- (x - bw) / (2 * bw) * sample / (x - bw) - 2 +
+                  (x - bw) / sample))
+    return pdf.mean()
+
+
+def kernel_cdf_recipinvgauss(x, sample, bw):
+    """reciprocal inverse gaussian kernel for cdf
+
+    Scaillet 2004
+    """
+    # need shape-scale parameterization for scipy
+    # references use m, lambda parameterization
+    m = 1 / (x - bw)
+    lam = 1 / bw
+    return stats.recipinvgauss.sf(sample, m / lam, scale=1 / lam).mean()
+
+
+def kernel_pdf_bs(x, sample, bw):
+    """birnbaum saunders (normal distribution) kernel density
+
+    Jin, Kawczak 2003
+    """
+    # need shape-scale parameterization for scipy
+    return stats.fatiguelife.pdf(sample, bw, scale=x).mean()
+
+
+def kernel_cdf_bs(x, sample, bw):
+    """birnbaum saunders (normal distribution) kernel cdf
+
+    Jin, Kawczak 2003
+    """
+    # need shape-scale parameterization for scipy
+    return stats.fatiguelife.sf(sample, bw, scale=x).mean()
+
+
+def kernel_pdf_lognorm(x, sample, bw):
+    """log-normal kernel density
+
+    Jin, Kawczak 2003
+    """
+
+    # need shape-scale parameterization for scipy
+    # not sure why JK picked this normalization, makes required bw small
+    # maybe we should skip this transformation and just use bw
+    # Funke and Kawka 2015 (table 1) use bw (or bw**2) corresponding to
+    #    variance of normal pdf
+    # bw = np.exp(bw_**2 / 4) - 1  # this is inverse transformation
+    bw_ = np.sqrt(4*np.log(1+bw))
+    return stats.lognorm.pdf(sample, bw_, scale=x).mean()
+
+
+def kernel_cdf_lognorm(x, sample, bw):
+    """log-normal kernel cdf
+
+    Jin, Kawczak 2003
+    """
+
+    # need shape-scale parameterization for scipy
+    # not sure why JK picked this normalization, makes required bw small
+    # maybe we should skip this transformation and just use bw
+    # Funke and Kawka 2015 (table 1) use bw (or bw**2) corresponding to
+    #    variance of normal pdf
+    # bw = np.exp(bw_**2 / 4) - 1  # this is inverse transformation
+    bw_ = np.sqrt(4*np.log(1+bw))
+    return stats.lognorm.sf(sample, bw_, scale=x).mean()
+
+
+def kernel_pdf_lognorm_(x, sample, bw):
+    """log-normal kernel density
+
+    Jin, Kawczak 2003
+    """
+    term = 8 * np.log(1 + bw)  # this is 2 * variance in normal pdf
+    pdf = (1 / np.sqrt(term * np.pi) / sample *
+           np.exp(- (np.log(x) - np.log(sample))**2 / term))
+    return pdf.mean()
+
+
+def kernel_pdf_weibull(x, sample, bw):
+    """weibull kernel density
+
+    Mombeni et al. for distribution, i.e. cdf, kernel
+    """
+    # need shape-scale parameterization for scipy
+    # references use m, lambda parameterization
+    return stats.weibull_min.pdf(sample, 1 / bw,
+                                 scale=x / special.gamma(1 + bw)).mean()
+
+
+def kernel_cdf_weibull(x, sample, bw):
+    """weibull kernel density
+
+    Mombeni et al. for distribution, i.e. cdf, kernel
+    """
+    # need shape-scale parameterization for scipy
+    # references use m, lambda parameterization
+    return stats.weibull_min.sf(sample, 1 / bw,
+                                scale=x / special.gamma(1 + bw)).mean()

--- a/statsmodels/nonparametric/kernels_asymmetric.py
+++ b/statsmodels/nonparametric/kernels_asymmetric.py
@@ -1,5 +1,40 @@
 # -*- coding: utf-8 -*-
-"""
+"""Asymmetric kernels for R+ and unit interval
+
+References
+----------
+
+.. [1] Bouezmarni, Taoufik, and Olivier Scaillet. 2005. “Consistency of
+   Asymmetric Kernel Density Estimators and Smoothed Histograms with
+   Application to Income Data.” Econometric Theory 21 (2): 390–412.
+
+.. [2] Chen, Song Xi. 1999. “Beta Kernel Estimators for Density Functions.”
+   Computational Statistics & Data Analysis 31 (2): 131–45.
+   https://doi.org/10.1016/S0167-9473(99)00010-9.
+
+.. [3] Chen, Song Xi. 2000. “Probability Density Function Estimation Using
+   Gamma Kernels.”
+   Annals of the Institute of Statistical Mathematics 52 (3): 471–80.
+   https://doi.org/10.1023/A:1004165218295.
+
+.. [4] Jin, Xiaodong, and Janusz Kawczak. 2003. “Birnbaum-Saunders and
+   Lognormal Kernel Estimators for Modelling Durations in High Frequency
+   Financial Data.” Annals of Economics and Finance 4: 103–24.
+
+.. [5] Micheaux, Pierre Lafaye de, and Frédéric Ouimet. 2020. “A Study of Seven
+   Asymmetric Kernels for the Estimation of Cumulative Distribution Functions,”
+   November. https://arxiv.org/abs/2011.14893v1.
+
+.. [6] Mombeni, Habib Allah, B Masouri, and Mohammad Reza Akhoond. 2019.
+   “Asymmetric Kernels for Boundary Modification in Distribution Function
+   Estimation.” REVSTAT, 1–27.
+
+.. [7] Scaillet, O. 2004. “Density Estimation Using Inverse and Reciprocal
+   Inverse Gaussian Kernels.”
+   Journal of Nonparametric Statistics 16 (1–2): 217–26.
+   https://doi.org/10.1080/10485250310001624819.
+
+
 Created on Mon Mar  8 11:12:24 2021
 
 Author: Josef Perktold
@@ -11,39 +46,55 @@ import numpy as np
 from scipy import stats, special
 
 
+doc_params = """\
+Parameters
+    ----------
+    x : array_like, float
+        Points for which density is evaluated. ``x`` can be scalar or 1-dim.
+    sample : ndarray, 1-d
+        Sample from which kde is computed.
+    bw : float
+        Bandwidth parameter, there is currently no default value for it.
+
+    Returns
+    -------
+    Components for kernel estimation"""
+
+
 def pdf_kernel_asym(x, sample, bw, kernel_type, weights=None, batch_size=10):
-    """density estimate based on asymmetric kernel
+    """Density estimate based on asymmetric kernel.
 
     Parameters
     ----------
     x : array_like, float
-        points for which density is evaluated. ``x`` can be scalar or 1-dim.
+        Points for which density is evaluated. ``x`` can be scalar or 1-dim.
     sample : ndarray, 1-d
-        sample from which kde is computed
+        Sample from which kernel estimate is computed
     bw : float
-        bandwidth parameter, there is currently no default value for it
+        Bandwidth parameter, there is currently no default value for it
     kernel_type : str or callable
-        kernel name or kernel function
-        currently supported kernel names are ...
-     weights : None or ndarray
+        Kernel name or kernel function
+        Currently supported kernel names are "beta", "beta2", "gamma",
+        "gamma2", "bs", "invgamma", "invgauss", "lognorm", "pdf",
+        "recipinvgauss" and "weibull".
+    weights : None or ndarray
         If weights is not None, then kernel for sample points are weighted
         by it. No weights corresponds to uniform weighting of each component
         with 1 / nobs, where nobs is the size of `sample`
-     batch_size : float
-         If x is an 1-dim array, then points can be evaluated in vectorized
-         for. To limit the amount of memory, a loop can work in batches.
-         The number of batches is determined so that the intermediate array
-         sizes are limited by
+    batch_size : float
+        If x is an 1-dim array, then points can be evaluated in vectorized
+        for. To limit the amount of memory, a loop can work in batches.
+        The number of batches is determined so that the intermediate array
+        sizes are limited by
 
-         ``np.size(batch) * len(sample) < batch_size * 1000``
+        ``np.size(batch) * len(sample) < batch_size * 1000``
 
-         Default is to have at most 10000 elements in intermediate arrays.
+        Default is to have at most 10000 elements in intermediate arrays.
 
     Returns
     -------
     pdf : float or ndarray
-        estimate pdf at points x. ``pdf`` has the same size or shape as x.
-
+        Estimate of pdf at points x. ``pdf`` has the same size or shape as x.
     """
 
     if callable(kernel_type):
@@ -78,38 +129,39 @@ def pdf_kernel_asym(x, sample, bw, kernel_type, weights=None, batch_size=10):
 
 
 def cdf_kernel_asym(x, sample, bw, kernel_type, weights=None, batch_size=10):
-    """estimate of cumulative distribution based on asymmetric kernel
+    """Estimate of cumulative distribution based on asymmetric kernel.
 
     Parameters
     ----------
     x : array_like, float
-        points for which density is evaluated. ``x`` can be scalar or 1-dim.
+        Points for which density is evaluated. ``x`` can be scalar or 1-dim.
     sample : ndarray, 1-d
-        sample from which kde is computed
+        Sample from which kernel estimate is computed.
     bw : float
-        bandwidth parameter, there is currently no default value for it
+        Bandwidth parameter, there is currently no default value for it.
     kernel_type : str or callable
-        kernel name or kernel function
-        currently supported kernel names are ...
-     weights : None or ndarray
+        Kernel name or kernel function.
+        Currently supported kernel names are "beta", "beta2", "gamma",
+        "gamma2", "bs", "invgamma", "invgauss", "lognorm", "pdf",
+        "recipinvgauss" and "weibull".
+    weights : None or ndarray
         If weights is not None, then kernel for sample points are weighted
         by it. No weights corresponds to uniform weighting of each component
-        with 1 / nobs, where nobs is the size of `sample`
-     batch_size : float
-         If x is an 1-dim array, then points can be evaluated in vectorized
-         for. To limit the amount of memory, a loop can work in batches.
-         The number of batches is determined so that the intermediate array
-         sizes are limited by
+        with 1 / nobs, where nobs is the size of `sample`.
+    batch_size : float
+        If x is an 1-dim array, then points can be evaluated in vectorized
+        for. To limit the amount of memory, a loop can work in batches.
+        The number of batches is determined so that the intermediate array
+        sizes are limited by
 
-         ``np.size(batch) * len(sample) < batch_size * 1000``
+        ``np.size(batch) * len(sample) < batch_size * 1000``.
 
-         Default is to have at most 10000 elements in intermediate arrays.
+        Default is to have at most 10000 elements in intermediate arrays.
 
     Returns
     -------
     cdf : float or ndarray
-        estimate cdf at points x. ``cdf`` has the same size or shape as x.
-
+        Estimate of cdf at points x. ``cdf`` has the same size or shape as x.
     """
 
     if callable(kernel_type):
@@ -143,125 +195,53 @@ def cdf_kernel_asym(x, sample, bw, kernel_type, weights=None, batch_size=10):
     return cdf
 
 
-def kernel_pdf_gamma(x, sample, bw):
-    """gamma kernel for pdf
-
-    Reference
-    Chen 2000
-    Bouezmarni and Scaillet 2205
-    """
-
-    pdfi = stats.gamma.pdf(sample, x / bw + 1, scale=bw)
-    return pdfi
-
-
-def kernel_cdf_gamma(x, sample, bw):
-    """gamma kernel for cdf
-
-    Reference
-    Chen 2000
-    Bouezmarni and Scaillet 2205
-    """
-    # it uses the survival function, but I don't know why.
-    cdfi = stats.gamma.sf(sample, x / bw + 1, scale=bw)
-    return cdfi
-
-
-def _kernel_pdf_gamma(x, sample, bw):
-    """gamma kernel for pdf, without boundary corrected part
-
-    drops `+ 1` in shape parameter
-
-    It should be possible to use this if probability in
-    neighborhood of zero boundary is small.
-
-    """
-    return stats.gamma.pdf(sample, x / bw, scale=bw)
-
-
-def _kernel_cdf_gamma(x, sample, bw):
-    """gamma kernel for cdf, without boundary corrected part
-
-    drops `+ 1` in shape parameter
-
-    It should be possible to use this if probability in
-    neighborhood of zero boundary is small.
-
-    """
-    return stats.gamma.sf(sample, x / bw, scale=bw)
-
-
-def kernel_pdf_gamma2(x, sample, bw):
-    """gamma kernel for pdf with boundary correction
-
-    """
-
-    if np.size(x) == 1:
-        # without vectorizing, easier to read
-        if x < 2 * bw:
-            a = (x / bw)**2 + 1
-        else:
-            a = x / bw
-    else:
-        a = x / bw
-        mask = x < 2 * bw
-        a[mask] = a[mask]**2 + 1
-    pdf = stats.gamma.pdf(sample, a, scale=bw)
-
-    return pdf
-
-
-def kernel_cdf_gamma2(x, sample, bw):
-    """gamma kernel for pdf with boundary correction
-
-    """
-
-    if np.size(x) == 1:
-        # without vectorizing
-        if x < 2 * bw:
-            a = (x / bw)**2 + 1
-        else:
-            a = x / bw
-    else:
-        a = x / bw
-        mask = x < 2 * bw
-        a[mask] = a[mask]**2 + 1
-    pdf = stats.gamma.sf(sample, a, scale=bw)
-
-    return pdf
-
-
-def kernel_pdf_invgamma(x, sample, bw):
-    """inverse gamma kernel for pdf
-
-    de Micheaux, Ouimet (arxiv Nov 2020) for cdf kernel
-    """
-    return stats.invgamma.pdf(sample, 1 / bw + 1, scale=x / bw)
-
-
-def kernel_cdf_invgamma(x, sample, bw):
-    """inverse gamma kernel for pdf
-
-    de Micheaux, Ouimet (arxiv Nov 2020) for cdf kernel
-    """
-    return stats.invgamma.sf(sample, 1 / bw + 1, scale=x / bw)
-
-
 def kernel_pdf_beta(x, sample, bw):
+    # Beta kernel for density, pdf, estimation
     return stats.beta.pdf(sample, x / bw + 1, (1 - x) / bw + 1)
 
 
+kernel_pdf_beta.__doc__ = """\
+    Beta kernel for density, pdf, estimation.
+
+    {doc_params}
+
+    References
+    ----------
+    .. [1] Bouezmarni, Taoufik, and Olivier Scaillet. 2005. “Consistency of
+       Asymmetric Kernel Density Estimators and Smoothed Histograms with
+       Application to Income Data.” Econometric Theory 21 (2): 390–412.
+
+    .. [2] Chen, Song Xi. 1999. “Beta Kernel Estimators for Density Functions.”
+       Computational Statistics & Data Analysis 31 (2): 131–45.
+       https://doi.org/10.1016/S0167-9473(99)00010-9.
+    """.format(doc_params=doc_params)
+
+
 def kernel_cdf_beta(x, sample, bw):
+    # Beta kernel for cumulative distribution, cdf, estimation
     return stats.beta.sf(sample, x / bw + 1, (1 - x) / bw + 1)
 
 
+kernel_cdf_beta.__doc__ = """\
+    Beta kernel for cumulative distribution, cdf, estimation.
+
+    {doc_params}
+
+    References
+    ----------
+    .. [1] Bouezmarni, Taoufik, and Olivier Scaillet. 2005. “Consistency of
+       Asymmetric Kernel Density Estimators and Smoothed Histograms with
+       Application to Income Data.” Econometric Theory 21 (2): 390–412.
+
+    .. [2] Chen, Song Xi. 1999. “Beta Kernel Estimators for Density Functions.”
+       Computational Statistics & Data Analysis 31 (2): 131–45.
+       https://doi.org/10.1016/S0167-9473(99)00010-9.
+    """.format(doc_params=doc_params)
+
+
 def kernel_pdf_beta2(x, sample, bw):
-    """beta kernel for pdf with boundary correction
+    # Beta kernel for density, pdf, estimation with boundary corrections
 
-    not vectorized in x
-
-    Chen 1999
-    """
     # a = 2 * bw**2 + 2.5 -
     #     np.sqrt(4 * bw**4 + 6 * bw**2 + 2.25 - x**2 - x / bw)
     # terms a1 and a2 are independent of x
@@ -296,13 +276,26 @@ def kernel_pdf_beta2(x, sample, bw):
     return pdf
 
 
+kernel_pdf_beta2.__doc__ = """\
+    Beta kernel for density, pdf, estimation with boundary corrections.
+
+    {doc_params}
+
+    References
+    ----------
+    .. [1] Bouezmarni, Taoufik, and Olivier Scaillet. 2005. “Consistency of
+       Asymmetric Kernel Density Estimators and Smoothed Histograms with
+       Application to Income Data.” Econometric Theory 21 (2): 390–412.
+
+    .. [2] Chen, Song Xi. 1999. “Beta Kernel Estimators for Density Functions.”
+       Computational Statistics & Data Analysis 31 (2): 131–45.
+       https://doi.org/10.1016/S0167-9473(99)00010-9.
+    """.format(doc_params=doc_params)
+
+
 def kernel_cdf_beta2(x, sample, bw):
-    """beta kernel for pdf with boundary correction
+    # Beta kernel for cdf estimation with boundary correction
 
-    not vectorized in x
-
-    Chen 1999
-    """
     # a = 2 * bw**2 + 2.5 -
     #     np.sqrt(4 * bw**4 + 6 * bw**2 + 2.25 - x**2 - x / bw)
     # terms a1 and a2 are independent of x
@@ -337,18 +330,227 @@ def kernel_cdf_beta2(x, sample, bw):
     return pdf
 
 
-def kernel_pdf_invgauss(x, sample, bw):
-    """inverse gaussian kernel density
+kernel_cdf_beta2.__doc__ = """\
+    Beta kernel for cdf estimation with boundary correction.
 
-    Scaillet 2004
+    {doc_params}
+
+    References
+    ----------
+    .. [1] Bouezmarni, Taoufik, and Olivier Scaillet. 2005. “Consistency of
+       Asymmetric Kernel Density Estimators and Smoothed Histograms with
+       Application to Income Data.” Econometric Theory 21 (2): 390–412.
+
+    .. [2] Chen, Song Xi. 1999. “Beta Kernel Estimators for Density Functions.”
+       Computational Statistics & Data Analysis 31 (2): 131–45.
+       https://doi.org/10.1016/S0167-9473(99)00010-9.
+    """.format(doc_params=doc_params)
+
+
+def kernel_pdf_gamma(x, sample, bw):
+    # Gamma kernel for density, pdf, estimation
+    pdfi = stats.gamma.pdf(sample, x / bw + 1, scale=bw)
+    return pdfi
+
+
+kernel_pdf_gamma.__doc__ = """\
+    Gamma kernel for density, pdf, estimation.
+
+    {doc_params}
+
+    References
+    ----------
+    .. [1] Bouezmarni, Taoufik, and Olivier Scaillet. 2005. “Consistency of
+       Asymmetric Kernel Density Estimators and Smoothed Histograms with
+       Application to Income Data.” Econometric Theory 21 (2): 390–412.
+
+    .. [2] Chen, Song Xi. 2000. “Probability Density Function Estimation Using
+       Gamma Krnels.”
+       Annals of the Institute of Statistical Mathematics 52 (3): 471–80.
+       https://doi.org/10.1023/A:1004165218295.
+    """.format(doc_params=doc_params)
+
+
+def kernel_cdf_gamma(x, sample, bw):
+    # Gamma kernel for density, pdf, estimation
+    # kernel cdf uses the survival function, but I don't know why.
+    cdfi = stats.gamma.sf(sample, x / bw + 1, scale=bw)
+    return cdfi
+
+
+kernel_cdf_gamma.__doc__ = """\
+    Gamma kernel for cumulative distribution, cdf, estimation.
+
+    {doc_params}
+
+    References
+    ----------
+    .. [1] Bouezmarni, Taoufik, and Olivier Scaillet. 2005. “Consistency of
+       Asymmetric Kernel Density Estimators and Smoothed Histograms with
+       Application to Income Data.” Econometric Theory 21 (2): 390–412.
+
+    .. [2] Chen, Song Xi. 2000. “Probability Density Function Estimation Using
+       Gamma Krnels.”
+       Annals of the Institute of Statistical Mathematics 52 (3): 471–80.
+       https://doi.org/10.1023/A:1004165218295.
+    """.format(doc_params=doc_params)
+
+
+def _kernel_pdf_gamma(x, sample, bw):
+    """Gamma kernel for pdf, without boundary corrected part.
+
+    drops `+ 1` in shape parameter
+
+    It should be possible to use this if probability in
+    neighborhood of zero boundary is small.
+
     """
+    return stats.gamma.pdf(sample, x / bw, scale=bw)
+
+
+def _kernel_cdf_gamma(x, sample, bw):
+    """Gamma kernel for cdf, without boundary corrected part.
+
+    drops `+ 1` in shape parameter
+
+    It should be possible to use this if probability in
+    neighborhood of zero boundary is small.
+
+    """
+    return stats.gamma.sf(sample, x / bw, scale=bw)
+
+
+def kernel_pdf_gamma2(x, sample, bw):
+    # Gamma kernel for density, pdf, estimation with boundary correction
+    if np.size(x) == 1:
+        # without vectorizing, easier to read
+        if x < 2 * bw:
+            a = (x / bw)**2 + 1
+        else:
+            a = x / bw
+    else:
+        a = x / bw
+        mask = x < 2 * bw
+        a[mask] = a[mask]**2 + 1
+    pdf = stats.gamma.pdf(sample, a, scale=bw)
+
+    return pdf
+
+
+kernel_pdf_gamma2.__doc__ = """\
+    Gamma kernel for density, pdf, estimation with boundary correction.
+
+    {doc_params}
+
+    References
+    ----------
+    .. [1] Bouezmarni, Taoufik, and Olivier Scaillet. 2005. “Consistency of
+       Asymmetric Kernel Density Estimators and Smoothed Histograms with
+       Application to Income Data.” Econometric Theory 21 (2): 390–412.
+
+    .. [2] Chen, Song Xi. 2000. “Probability Density Function Estimation Using
+       Gamma Krnels.”
+       Annals of the Institute of Statistical Mathematics 52 (3): 471–80.
+       https://doi.org/10.1023/A:1004165218295.
+    """.format(doc_params=doc_params)
+
+
+def kernel_cdf_gamma2(x, sample, bw):
+    # Gamma kernel for cdf estimation with boundary correction
+    if np.size(x) == 1:
+        # without vectorizing
+        if x < 2 * bw:
+            a = (x / bw)**2 + 1
+        else:
+            a = x / bw
+    else:
+        a = x / bw
+        mask = x < 2 * bw
+        a[mask] = a[mask]**2 + 1
+    pdf = stats.gamma.sf(sample, a, scale=bw)
+
+    return pdf
+
+
+kernel_cdf_gamma2.__doc__ = """\
+    Gamma kernel for cdf estimation with boundary correction.
+
+    {doc_params}
+
+    References
+    ----------
+    .. [1] Bouezmarni, Taoufik, and Olivier Scaillet. 2005. “Consistency of
+       Asymmetric Kernel Density Estimators and Smoothed Histograms with
+       Application to Income Data.” Econometric Theory 21 (2): 390–412.
+
+    .. [2] Chen, Song Xi. 2000. “Probability Density Function Estimation Using
+       Gamma Krnels.”
+       Annals of the Institute of Statistical Mathematics 52 (3): 471–80.
+       https://doi.org/10.1023/A:1004165218295.
+    """.format(doc_params=doc_params)
+
+
+def kernel_pdf_invgamma(x, sample, bw):
+    # Inverse gamma kernel for density, pdf, estimation
+    return stats.invgamma.pdf(sample, 1 / bw + 1, scale=x / bw)
+
+
+kernel_pdf_invgamma.__doc__ = """\
+    Inverse gamma kernel for density, pdf, estimation.
+
+    Based on cdf kernel by Micheaux and Ouimet (2020)
+
+    {doc_params}
+
+    References
+    ----------
+    .. [1] Micheaux, Pierre Lafaye de, and Frédéric Ouimet. 2020. “A Study of
+       Seven Asymmetric Kernels for the Estimation of Cumulative Distribution
+       Functions,” November. https://arxiv.org/abs/2011.14893v1.
+    """.format(doc_params=doc_params)
+
+
+def kernel_cdf_invgamma(x, sample, bw):
+    # Inverse gamma kernel for cumulative distribution, cdf, estimation
+    return stats.invgamma.sf(sample, 1 / bw + 1, scale=x / bw)
+
+
+kernel_cdf_invgamma.__doc__ = """\
+    Inverse gamma kernel for cumulative distribution, cdf, estimation.
+
+    {doc_params}
+
+    References
+    ----------
+    .. [1] Micheaux, Pierre Lafaye de, and Frédéric Ouimet. 2020. “A Study of
+       Seven Asymmetric Kernels for the Estimation of Cumulative Distribution
+       Functions,” November. https://arxiv.org/abs/2011.14893v1.
+    """.format(doc_params=doc_params)
+
+
+def kernel_pdf_invgauss(x, sample, bw):
+    # Inverse gaussian kernel for density, pdf, estimation
     m = x
     lam = 1 / bw
     return stats.invgauss.pdf(sample, m / lam, scale=lam)
 
 
+kernel_pdf_invgauss.__doc__ = """\
+    Inverse gaussian kernel for density, pdf, estimation.
+
+    {doc_params}
+
+    References
+    ----------
+    .. [1] Scaillet, O. 2004. “Density Estimation Using Inverse and Reciprocal
+       Inverse Gaussian Kernels.”
+       Journal of Nonparametric Statistics 16 (1–2): 217–26.
+       https://doi.org/10.1080/10485250310001624819.
+    """.format(doc_params=doc_params)
+
+
 def kernel_pdf_invgauss_(x, sample, bw):
-    """inverse gaussian kernel density, explicit formula
+    """Inverse gaussian kernel density, explicit formula.
 
     Scaillet 2004
     """
@@ -358,20 +560,29 @@ def kernel_pdf_invgauss_(x, sample, bw):
 
 
 def kernel_cdf_invgauss(x, sample, bw):
-    """inverse gaussian kernel for cdf
-
-    Scaillet 2004
-    """
+    # Inverse gaussian kernel for cumulative distribution, cdf, estimation
     m = x
     lam = 1 / bw
     return stats.invgauss.sf(sample, m / lam, scale=lam)
 
 
-def kernel_pdf_recipinvgauss(x, sample, bw):
-    """reciprocal inverse gaussian kernel density
+kernel_cdf_invgauss.__doc__ = """\
+    Inverse gaussian kernel for cumulative distribution, cdf, estimation.
 
-    Scaillet 2004
-    """
+    {doc_params}
+
+    References
+    ----------
+    .. [1] Scaillet, O. 2004. “Density Estimation Using Inverse and Reciprocal
+       Inverse Gaussian Kernels.”
+       Journal of Nonparametric Statistics 16 (1–2): 217–26.
+       https://doi.org/10.1080/10485250310001624819.
+    """.format(doc_params=doc_params)
+
+
+def kernel_pdf_recipinvgauss(x, sample, bw):
+    # Reciprocal inverse gaussian kernel for density, pdf, estimation
+
     # need shape-scale parameterization for scipy
     # references use m, lambda parameterization
     m = 1 / (x - bw)
@@ -379,8 +590,22 @@ def kernel_pdf_recipinvgauss(x, sample, bw):
     return stats.recipinvgauss.pdf(sample, m / lam, scale=1 / lam)
 
 
+kernel_pdf_recipinvgauss.__doc__ = """\
+    Reciprocal inverse gaussian kernel for density, pdf, estimation.
+
+    {doc_params}
+
+    References
+    ----------
+    .. [1] Scaillet, O. 2004. “Density Estimation Using Inverse and Reciprocal
+       Inverse Gaussian Kernels.”
+       Journal of Nonparametric Statistics 16 (1–2): 217–26.
+       https://doi.org/10.1080/10485250310001624819.
+    """.format(doc_params=doc_params)
+
+
 def kernel_pdf_recipinvgauss_(x, sample, bw):
-    """reciprocal inverse gaussian kernel density, explicit formula
+    """Reciprocal inverse gaussian kernel density, explicit formula.
 
     Scaillet 2004
     """
@@ -392,10 +617,8 @@ def kernel_pdf_recipinvgauss_(x, sample, bw):
 
 
 def kernel_cdf_recipinvgauss(x, sample, bw):
-    """reciprocal inverse gaussian kernel for cdf
+    # Reciprocal inverse gaussian kernel for cdf estimation
 
-    Scaillet 2004
-    """
     # need shape-scale parameterization for scipy
     # references use m, lambda parameterization
     m = 1 / (x - bw)
@@ -403,29 +626,61 @@ def kernel_cdf_recipinvgauss(x, sample, bw):
     return stats.recipinvgauss.sf(sample, m / lam, scale=1 / lam)
 
 
-def kernel_pdf_bs(x, sample, bw):
-    """birnbaum saunders (normal distribution) kernel density
+kernel_cdf_recipinvgauss.__doc__ = """\
+    Reciprocal inverse gaussian kernel for cdf estimation.
 
-    Jin, Kawczak 2003
-    """
-    # need shape-scale parameterization for scipy
+    {doc_params}
+
+    References
+    ----------
+    .. [1] Scaillet, O. 2004. “Density Estimation Using Inverse and Reciprocal
+       Inverse Gaussian Kernels.”
+       Journal of Nonparametric Statistics 16 (1–2): 217–26.
+       https://doi.org/10.1080/10485250310001624819.
+    """.format(doc_params=doc_params)
+
+
+def kernel_pdf_bs(x, sample, bw):
+    # Birnbaum saunders (normal) kernel for density, pdf, estimation
     return stats.fatiguelife.pdf(sample, bw, scale=x)
 
 
-def kernel_cdf_bs(x, sample, bw):
-    """birnbaum saunders (normal distribution) kernel cdf
+kernel_pdf_bs.__doc__ = """\
+    Birnbaum saunders (normal) kernel for density, pdf, estimation.
 
-    Jin, Kawczak 2003
-    """
-    # need shape-scale parameterization for scipy
+    {doc_params}
+
+    References
+    ----------
+    .. [1] Jin, Xiaodong, and Janusz Kawczak. 2003. “Birnbaum-Saunders and
+       Lognormal Kernel Estimators for Modelling Durations in High Frequency
+       Financial Data.” Annals of Economics and Finance 4: 103–24.
+    """.format(doc_params=doc_params)
+
+
+def kernel_cdf_bs(x, sample, bw):
+    # Birnbaum saunders (normal) kernel for cdf estimation
     return stats.fatiguelife.sf(sample, bw, scale=x)
 
 
-def kernel_pdf_lognorm(x, sample, bw):
-    """log-normal kernel density
+kernel_cdf_bs.__doc__ = """\
+    Birnbaum saunders (normal) kernel for cdf estimation.
 
-    Jin, Kawczak 2003
-    """
+    {doc_params}
+
+    References
+    ----------
+    .. [1] Jin, Xiaodong, and Janusz Kawczak. 2003. “Birnbaum-Saunders and
+       Lognormal Kernel Estimators for Modelling Durations in High Frequency
+       Financial Data.” Annals of Economics and Finance 4: 103–24.
+    .. [2] Mombeni, Habib Allah, B Masouri, and Mohammad Reza Akhoond. 2019.
+       “Asymmetric Kernels for Boundary Modification in Distribution Function
+       Estimation.” REVSTAT, 1–27.
+    """.format(doc_params=doc_params)
+
+
+def kernel_pdf_lognorm(x, sample, bw):
+    # Log-normal kernel for density, pdf, estimation
 
     # need shape-scale parameterization for scipy
     # not sure why JK picked this normalization, makes required bw small
@@ -437,11 +692,25 @@ def kernel_pdf_lognorm(x, sample, bw):
     return stats.lognorm.pdf(sample, bw_, scale=x)
 
 
-def kernel_cdf_lognorm(x, sample, bw):
-    """log-normal kernel cdf
+kernel_pdf_lognorm.__doc__ = """\
+    Log-normal kernel for density, pdf, estimation.
 
-    Jin, Kawczak 2003
-    """
+    {doc_params}
+
+    Notes
+    -----
+    Warning: parameterization of bandwidth will likely be changed
+
+    References
+    ----------
+    .. [1] Jin, Xiaodong, and Janusz Kawczak. 2003. “Birnbaum-Saunders and
+       Lognormal Kernel Estimators for Modelling Durations in High Frequency
+       Financial Data.” Annals of Economics and Finance 4: 103–24.
+    """.format(doc_params=doc_params)
+
+
+def kernel_cdf_lognorm(x, sample, bw):
+    # Log-normal kernel for cumulative distribution, cdf, estimation
 
     # need shape-scale parameterization for scipy
     # not sure why JK picked this normalization, makes required bw small
@@ -453,8 +722,25 @@ def kernel_cdf_lognorm(x, sample, bw):
     return stats.lognorm.sf(sample, bw_, scale=x)
 
 
+kernel_cdf_lognorm.__doc__ = """\
+    Log-normal kernel for cumulative distribution, cdf, estimation.
+
+    {doc_params}
+
+    Notes
+    -----
+    Warning: parameterization of bandwidth will likely be changed
+
+    References
+    ----------
+    .. [1] Jin, Xiaodong, and Janusz Kawczak. 2003. “Birnbaum-Saunders and
+       Lognormal Kernel Estimators for Modelling Durations in High Frequency
+       Financial Data.” Annals of Economics and Finance 4: 103–24.
+    """.format(doc_params=doc_params)
+
+
 def kernel_pdf_lognorm_(x, sample, bw):
-    """log-normal kernel density
+    """Log-normal kernel for density, pdf, estimation, explicit formula.
 
     Jin, Kawczak 2003
     """
@@ -465,25 +751,49 @@ def kernel_pdf_lognorm_(x, sample, bw):
 
 
 def kernel_pdf_weibull(x, sample, bw):
-    """weibull kernel density
+    # Weibull kernel for density, pdf, estimation
 
-    Mombeni et al. for distribution, i.e. cdf, kernel
-    """
     # need shape-scale parameterization for scipy
     # references use m, lambda parameterization
     return stats.weibull_min.pdf(sample, 1 / bw,
                                  scale=x / special.gamma(1 + bw))
 
 
-def kernel_cdf_weibull(x, sample, bw):
-    """weibull kernel density
+kernel_pdf_weibull.__doc__ = """\
+    Weibull kernel for density, pdf, estimation.
 
-    Mombeni et al. for distribution, i.e. cdf, kernel
-    """
+    Based on cdf kernel by Mombeni et al. (2019)
+
+    {doc_params}
+
+    References
+    ----------
+    .. [1] Mombeni, Habib Allah, B Masouri, and Mohammad Reza Akhoond. 2019.
+       “Asymmetric Kernels for Boundary Modification in Distribution Function
+       Estimation.” REVSTAT, 1–27.
+    """.format(doc_params=doc_params)
+
+
+def kernel_cdf_weibull(x, sample, bw):
+    # Weibull kernel for cumulative distribution, cdf, estimation
+
     # need shape-scale parameterization for scipy
     # references use m, lambda parameterization
     return stats.weibull_min.sf(sample, 1 / bw,
                                 scale=x / special.gamma(1 + bw))
+
+
+kernel_cdf_weibull.__doc__ = """\
+    Weibull kernel for cumulative distribution, cdf, estimation.
+
+    {doc_params}
+
+    References
+    ----------
+    .. [1] Mombeni, Habib Allah, B Masouri, and Mohammad Reza Akhoond. 2019.
+       “Asymmetric Kernels for Boundary Modification in Distribution Function
+       Estimation.” REVSTAT, 1–27.
+    """.format(doc_params=doc_params)
 
 
 # produced wth

--- a/statsmodels/nonparametric/tests/test_asymmetric.py
+++ b/statsmodels/nonparametric/tests/test_asymmetric.py
@@ -98,6 +98,60 @@ class TestKernelsRplus(object):
         assert_allclose(kde1, kde, rtol=1e-12)
         assert_allclose(kce1, kce, rtol=1e-12)
 
+    @pytest.mark.parametrize('case', kernels_rplus[:1])
+    def _test_kernels_weights(self, case):
+        name, bw = case
+        rvs = self.rvs
+        x = self.x_plot
+        func_pdf = getattr(kern, "kernel_pdf_" + name)
+        func_cdf = getattr(kern, "kernel_cdf_" + name)
+
+        kde2 = func_pdf(x[:, None], rvs, bw)
+        kce2 = func_cdf(x[:, None], rvs, bw)
+
+        n = len(rvs)
+        w = np.ones(n) / n
+        kde1 = func_pdf(x[:, None], rvs, bw, weights=w)
+        kce1 = func_cdf(x[:, None], rvs, bw, weights=w)
+
+        assert_allclose(kde1, kde2, rtol=1e-12)
+        assert_allclose(kce1, kce2, rtol=1e-12)
+
+        # weights that do not add to 1 are valid, but do not produce pdf, cdf
+        n = len(rvs)
+        w = np.ones(n) / n * 2
+        kde1 = func_pdf(x[:, None], rvs, bw, weights=w)
+        kce1 = func_cdf(x[:, None], rvs, bw, weights=w)
+
+        assert_allclose(kde1, kde2 * 2, rtol=1e-12)
+        assert_allclose(kce1, kce2 * 2, rtol=1e-12)
+
+    @pytest.mark.parametrize('case', kernels_rplus[:1])
+    def test_kernels_weights(self, case):
+        name, bw = case
+        rvs = self.rvs
+        x = self.x_plot
+
+        kde2 = kern.pdf_kernel_asym(x[:, None], rvs, bw, name)
+        kce2 = kern.cdf_kernel_asym(x[:, None], rvs, bw, name)
+
+        n = len(rvs)
+        w = np.ones(n) / n
+        kde1 = kern.pdf_kernel_asym(x[:, None], rvs, bw, name, weights=w)
+        kce1 = kern.cdf_kernel_asym(x[:, None], rvs, bw, name, weights=w)
+
+        assert_allclose(kde1, kde2, rtol=1e-12)
+        assert_allclose(kce1, kce2, rtol=1e-12)
+
+        # weights that do not add to 1 are valid, but do not produce pdf, cdf
+        n = len(rvs)
+        w = np.ones(n) / n * 2
+        kde1 = kern.pdf_kernel_asym(x[:, None], rvs, bw, name, weights=w)
+        kce1 = kern.cdf_kernel_asym(x[:, None], rvs, bw, name, weights=w)
+
+        assert_allclose(kde1, kde2 * 2, rtol=1e-12)
+        assert_allclose(kce1, kce2 * 2, rtol=1e-12)
+
 
 class TestKernelsUnit(TestKernelsRplus):
 

--- a/statsmodels/nonparametric/tests/test_asymmetric.py
+++ b/statsmodels/nonparametric/tests/test_asymmetric.py
@@ -1,0 +1,97 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Mon Mar  8 16:18:21 2021
+
+Author: Josef Perktold
+License: BSD-3
+
+"""
+
+
+import numpy as np
+from numpy.testing import assert_array_less
+from scipy import stats
+import pytest
+
+import statsmodels.nonparametric.kernels_asymmetric as kern
+
+
+kernels_rplus = [("gamma", 0.1),
+                 ("gamma2", 0.1),
+                 ("invgamma", 0.02),
+                 ("invgauss", 0.01),
+                 ("recipinvgauss", 0.1),
+                 ("bs", 0.1),
+                 ("lognorm", 0.01),
+                 ("weibull", 0.1),
+                 ]
+
+kernels_unit = [("beta", 0.005),
+                ("beta2", 0.005),
+                ]
+
+
+class TestKernelsRplus(object):
+
+    @classmethod
+    def setup_class(cls):
+        b = 2
+        scale = 1.5
+        np.random.seed(1)
+        nobs = 1000
+        distr0 = stats.gamma(b, scale=scale)
+        rvs = distr0.rvs(size=nobs)
+        x_plot = np.linspace(0.5, 16, 51) + 1e-13
+
+        cls.rvs = rvs
+        cls.x_plot = x_plot
+        cls.pdf_dgp = distr0.pdf(x_plot)
+        cls.cdf_dgp = distr0.cdf(x_plot)
+        cls.amse_pdf = 1e-4  # tol for average mean squared error
+        cls.amse_cdf = 5e-4
+
+    @pytest.mark.parametrize('case', kernels_rplus)
+    def test_kernels(self, case):
+        name, bw = case
+
+        rvs = self.rvs
+        x_plot = self.x_plot
+
+        kde = []
+        kce = []
+        func_pdf = getattr(kern, "kernel_pdf_" + name)
+        func_cdf = getattr(kern, "kernel_cdf_" + name)
+        for xi in x_plot:
+            kde.append(func_pdf(xi, rvs, bw))
+            kce.append(func_cdf(xi, rvs, bw))
+
+        kde = np.asarray(kde)
+        kce = np.asarray(kce)
+
+        # average mean squared error
+        amse = ((kde - self.pdf_dgp)**2).mean()
+        assert_array_less(amse, self.amse_pdf)
+        amse = ((kce - self.cdf_dgp)**2).mean()
+        assert_array_less(amse, self.amse_cdf)
+
+
+class TestKernelsUnit(TestKernelsRplus):
+
+    @classmethod
+    def setup_class(cls):
+        np.random.seed(987456)
+        nobs = 1000
+        distr0 = stats.beta(2, 3)
+        rvs = distr0.rvs(size=nobs)
+        x_plot = np.linspace(0, 1, 51)
+
+        cls.rvs = rvs
+        cls.x_plot = x_plot
+        cls.pdf_dgp = distr0.pdf(x_plot)
+        cls.cdf_dgp = distr0.cdf(x_plot)
+        cls.amse_pdf = 0.01
+        cls.amse_cdf = 5e-3
+
+    @pytest.mark.parametrize('case', kernels_unit)
+    def test_kernels(self, case):
+        super(TestKernelsUnit, self).test_kernels(case)

--- a/statsmodels/nonparametric/tests/test_asymmetric.py
+++ b/statsmodels/nonparametric/tests/test_asymmetric.py
@@ -31,26 +31,8 @@ kernels_unit = [("beta", 0.005),
                 ]
 
 
-class TestKernelsRplus(object):
+class CheckKernels(object):
 
-    @classmethod
-    def setup_class(cls):
-        b = 2
-        scale = 1.5
-        np.random.seed(1)
-        nobs = 1000
-        distr0 = stats.gamma(b, scale=scale)
-        rvs = distr0.rvs(size=nobs)
-        x_plot = np.linspace(0.5, 16, 51) + 1e-13
-
-        cls.rvs = rvs
-        cls.x_plot = x_plot
-        cls.pdf_dgp = distr0.pdf(x_plot)
-        cls.cdf_dgp = distr0.cdf(x_plot)
-        cls.amse_pdf = 1e-4  # tol for average mean squared error
-        cls.amse_cdf = 5e-4
-
-    @pytest.mark.parametrize('case', kernels_rplus)
     def test_kernels(self, case):
         name, bw = case
 
@@ -72,7 +54,6 @@ class TestKernelsRplus(object):
         amse = ((kce - self.cdf_dgp)**2).mean()
         assert_array_less(amse, self.amse_cdf)
 
-    @pytest.mark.parametrize('case', kernels_rplus[:])
     def test_kernels_vectorized(self, case):
         name, bw = case
 
@@ -94,7 +75,6 @@ class TestKernelsRplus(object):
         assert_allclose(kde1, kde, rtol=1e-12)
         assert_allclose(kce1, kce, rtol=1e-12)
 
-    @pytest.mark.parametrize('case', kernels_rplus)
     def test_kernels_weights(self, case):
         name, bw = case
         rvs = self.rvs
@@ -121,7 +101,39 @@ class TestKernelsRplus(object):
         assert_allclose(kce1, kce2 * 2, rtol=1e-12)
 
 
-class TestKernelsUnit(TestKernelsRplus):
+class TestKernelsRplus(CheckKernels):
+
+    @classmethod
+    def setup_class(cls):
+        b = 2
+        scale = 1.5
+        np.random.seed(1)
+        nobs = 1000
+        distr0 = stats.gamma(b, scale=scale)
+        rvs = distr0.rvs(size=nobs)
+        x_plot = np.linspace(0.5, 16, 51) + 1e-13
+
+        cls.rvs = rvs
+        cls.x_plot = x_plot
+        cls.pdf_dgp = distr0.pdf(x_plot)
+        cls.cdf_dgp = distr0.cdf(x_plot)
+        cls.amse_pdf = 1e-4  # tol for average mean squared error
+        cls.amse_cdf = 5e-4
+
+    @pytest.mark.parametrize('case', kernels_rplus)
+    def test_kernels(self, case):
+        super(TestKernelsRplus, self).test_kernels(case)
+
+    @pytest.mark.parametrize('case', kernels_rplus)
+    def test_kernels_vectorized(self, case):
+        super(TestKernelsRplus, self).test_kernels_vectorized(case)
+
+    @pytest.mark.parametrize('case', kernels_rplus)
+    def test_kernels_weights(self, case):
+        super(TestKernelsRplus, self).test_kernels_weights(case)
+
+
+class TestKernelsUnit(CheckKernels):
 
     @classmethod
     def setup_class(cls):
@@ -146,3 +158,7 @@ class TestKernelsUnit(TestKernelsRplus):
     @pytest.mark.parametrize('case', kernels_unit)
     def test_kernels_vectorized(self, case):
         super(TestKernelsUnit, self).test_kernels_vectorized(case)
+
+    @pytest.mark.parametrize('case', kernels_unit)
+    def test_kernels_weights(self, case):
+        super(TestKernelsUnit, self).test_kernels_weights(case)

--- a/statsmodels/nonparametric/tests/test_asymmetric.py
+++ b/statsmodels/nonparametric/tests/test_asymmetric.py
@@ -59,11 +59,9 @@ class TestKernelsRplus(object):
 
         kde = []
         kce = []
-        func_pdf = getattr(kern, "kernel_pdf_" + name)
-        func_cdf = getattr(kern, "kernel_cdf_" + name)
         for xi in x_plot:
-            kde.append(func_pdf(xi, rvs, bw))
-            kce.append(func_cdf(xi, rvs, bw))
+            kde.append(kern.pdf_kernel_asym(xi, rvs, bw, name))
+            kce.append(kern.cdf_kernel_asym(xi, rvs, bw, name))
 
         kde = np.asarray(kde)
         kce = np.asarray(kce)
@@ -83,62 +81,32 @@ class TestKernelsRplus(object):
 
         kde = []
         kce = []
-        func_pdf = getattr(kern, "kernel_pdf_" + name)
-        func_cdf = getattr(kern, "kernel_cdf_" + name)
         for xi in x_plot:
-            kde.append(func_pdf(xi, rvs, bw))
-            kce.append(func_cdf(xi, rvs, bw))
+            kde.append(kern.pdf_kernel_asym(xi, rvs, bw, name))
+            kce.append(kern.cdf_kernel_asym(xi, rvs, bw, name))
 
         kde = np.asarray(kde)
         kce = np.asarray(kce)
 
-        kde1 = func_pdf(x_plot[:, None], rvs, bw)
-        kce1 = func_cdf(x_plot[:, None], rvs, bw)
+        kde1 = kern.pdf_kernel_asym(x_plot, rvs, bw, name)
+        kce1 = kern.cdf_kernel_asym(x_plot, rvs, bw, name)
 
         assert_allclose(kde1, kde, rtol=1e-12)
         assert_allclose(kce1, kce, rtol=1e-12)
 
-    @pytest.mark.parametrize('case', kernels_rplus[:1])
-    def _test_kernels_weights(self, case):
-        name, bw = case
-        rvs = self.rvs
-        x = self.x_plot
-        func_pdf = getattr(kern, "kernel_pdf_" + name)
-        func_cdf = getattr(kern, "kernel_cdf_" + name)
-
-        kde2 = func_pdf(x[:, None], rvs, bw)
-        kce2 = func_cdf(x[:, None], rvs, bw)
-
-        n = len(rvs)
-        w = np.ones(n) / n
-        kde1 = func_pdf(x[:, None], rvs, bw, weights=w)
-        kce1 = func_cdf(x[:, None], rvs, bw, weights=w)
-
-        assert_allclose(kde1, kde2, rtol=1e-12)
-        assert_allclose(kce1, kce2, rtol=1e-12)
-
-        # weights that do not add to 1 are valid, but do not produce pdf, cdf
-        n = len(rvs)
-        w = np.ones(n) / n * 2
-        kde1 = func_pdf(x[:, None], rvs, bw, weights=w)
-        kce1 = func_cdf(x[:, None], rvs, bw, weights=w)
-
-        assert_allclose(kde1, kde2 * 2, rtol=1e-12)
-        assert_allclose(kce1, kce2 * 2, rtol=1e-12)
-
-    @pytest.mark.parametrize('case', kernels_rplus[:1])
+    @pytest.mark.parametrize('case', kernels_rplus)
     def test_kernels_weights(self, case):
         name, bw = case
         rvs = self.rvs
         x = self.x_plot
 
-        kde2 = kern.pdf_kernel_asym(x[:, None], rvs, bw, name)
-        kce2 = kern.cdf_kernel_asym(x[:, None], rvs, bw, name)
+        kde2 = kern.pdf_kernel_asym(x, rvs, bw, name)
+        kce2 = kern.cdf_kernel_asym(x, rvs, bw, name)
 
         n = len(rvs)
         w = np.ones(n) / n
-        kde1 = kern.pdf_kernel_asym(x[:, None], rvs, bw, name, weights=w)
-        kce1 = kern.cdf_kernel_asym(x[:, None], rvs, bw, name, weights=w)
+        kde1 = kern.pdf_kernel_asym(x, rvs, bw, name, weights=w)
+        kce1 = kern.cdf_kernel_asym(x, rvs, bw, name, weights=w)
 
         assert_allclose(kde1, kde2, rtol=1e-12)
         assert_allclose(kce1, kce2, rtol=1e-12)
@@ -146,8 +114,8 @@ class TestKernelsRplus(object):
         # weights that do not add to 1 are valid, but do not produce pdf, cdf
         n = len(rvs)
         w = np.ones(n) / n * 2
-        kde1 = kern.pdf_kernel_asym(x[:, None], rvs, bw, name, weights=w)
-        kce1 = kern.cdf_kernel_asym(x[:, None], rvs, bw, name, weights=w)
+        kde1 = kern.pdf_kernel_asym(x, rvs, bw, name, weights=w)
+        kce1 = kern.cdf_kernel_asym(x, rvs, bw, name, weights=w)
 
         assert_allclose(kde1, kde2 * 2, rtol=1e-12)
         assert_allclose(kce1, kce2 * 2, rtol=1e-12)
@@ -161,7 +129,8 @@ class TestKernelsUnit(TestKernelsRplus):
         nobs = 1000
         distr0 = stats.beta(2, 3)
         rvs = distr0.rvs(size=nobs)
-        x_plot = np.linspace(0, 1, 51)
+        # Runtime warning if x_plot includes 0
+        x_plot = np.linspace(1e-10, 1, 51)
 
         cls.rvs = rvs
         cls.x_plot = x_plot


### PR DESCRIPTION
see #7346

nonparametric kernel estimation for density and cdf based on asymmetric kernels
kernels are based on the corresponding scipy distribution

for unit interval:

- beta, beta2

for R+:

- gamma, gamma2
- invgamma
- invgauss
- recipinvgauss
- bs (Birnbaum-Saunders)
- log-normal
- weibull  (weibull_min for y>0 )




Status:
currently only checked visually using kde plots for gamma random sample (nobs=1000), plots look good, 
(invgauss is not so good, also weak performance in some references)

I followed parameterization of original articles, but I might want to make them more consistent between them.

no extras, especially no bandwidth defaults or selection




