### PR TITLE
DOC: fix misleading ETSModel example

### DIFF
--- a/examples/notebooks/ets.ipynb
+++ b/examples/notebooks/ets.ipynb
@@ -105,16 +105,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model = ETSModel(oil, error='add', trend='add', damped_trend=True)\n",
+    "model = ETSModel(oil)\n",
     "fit = model.fit(maxiter=10000)\n",
-    "oil.plot(label='data')\n",
+    "oil.plot(label=\"data\")\n",
     "fit.fittedvalues.plot(label='statsmodels fit')\n",
     "plt.ylabel(\"Annual oil production in Saudi Arabia (Mt)\");\n",
     "\n",
     "# obtained from R\n",
     "params_R = [0.99989969, 0.11888177503085334, 0.80000197, 36.46466837, 34.72584983]\n",
     "yhat = model.smooth(params_R).fittedvalues\n",
-    "yhat.plot(label='R fit', linestyle='--')\n",
+    "yhat.plot(label=\"R fit\", linestyle=\"--\")\n",
     "\n",
     "plt.legend();"
    ]
@@ -123,7 +123,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "By default the initial states are considered to be fitting parameters and are estimated by maximizing log-likelihood. Additionally it is possible to only use a heuristic for the initial values. In this case this leads to better agreement with the R implementation."
+    "By default the initial states are considered to be fitting parameters and are estimated by maximizing log-likelihood. It is possible to only use a heuristic for the initial values:"
    ]
   },
   {
@@ -132,8 +132,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model_heuristic = ETSModel(oil, error='add', trend='add', damped_trend=True,\n",
-    "                          initialization_method='heuristic')\n",
+    "model_heuristic = ETSModel(oil, initialization_method='heuristic')\n",
     "fit_heuristic = model_heuristic.fit()\n",
     "oil.plot(label='data')\n",
     "fit.fittedvalues.plot(label='estimated')\n",
@@ -152,8 +151,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The fitted parameters and some other measures are shown using `fit.summary()`. Here we can see that the log-likelihood of the model using fitted initial states is a bit lower than the one using a heuristic for the initial states.\n",
-    "Additionally, we see that $\\beta$ (`smoothing_trend`) is at the boundary of the default parameter bounds, and therefore it's not possible to estimate confidence intervals for $\\beta$."
+    "The fitted parameters and some other measures are shown using `fit.summary()`. Here we can see that the log-likelihood of the model using fitted initial states is fractionally lower than the one using a heuristic for the initial states."
    ]
   },
   {
@@ -355,9 +353,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.4"
+   "version": "3.7.8"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
- [x] closes #7365 
- [x] documentation is well formatted.  
- [x] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 