### PR TITLE
ENH: McFadden and Cox-Snell Pseudo R-square added to GLM. See statsmodels/statsmodels#5861

### DIFF
--- a/statsmodels/genmod/generalized_linear_model.py
+++ b/statsmodels/genmod/generalized_linear_model.py
@@ -47,9 +47,6 @@ from statsmodels.tools.sm_exceptions import (PerfectSeparationError,
 
 from numpy.linalg.linalg import LinAlgError
 
-from math import exp  # need this for calculating Pseudo-Rsquare value
-from decimal import Decimal  # need this for calculating Pseudo-Rsquare value
-
 __all__ = ['GLM', 'PredictionResults']
 
 
@@ -1721,14 +1718,9 @@ class GLMResults(base.LikelihoodModelResults):
     @cache_readonly
     def prsquared_cox_snell(self):
         """
-        Lnull:  value of the likelihood function for a model with no predictors
-        Lf:  value of the likelihood for the model being estimated
-        nobs:  The number of observations n
-        Cox & Snell's pseudo-R-squared.  `1 - (Lnull / Lf)^(2/nobs)`
+        Cox & Snell's pseudo-R-squared.  `1 - exp( (llnull - llf)*(2/nobs) )`
         """
-        Lnull = Decimal(exp(1))**Decimal(self.llnull)
-        Lf = Decimal(exp(1))**Decimal(self.llf)
-        return round( 1 - pow( (Lnull/Lf) , Decimal(2/self.nobs) ) , 5)
+        return 1 - np.exp( (self.llnull - self.llf)*(2/self.nobs) )
 
     @cached_value
     def aic(self):

--- a/statsmodels/genmod/tests/results/results_glm.py
+++ b/statsmodels/genmod/tests/results/results_glm.py
@@ -85,6 +85,9 @@ class Longley(object):
         # TODO: taken from Stata; not available in sm yet
         self.chi2 = 1981.711859508729
 
+        self.prsquared = 0.90
+        self.prsquared_cox_snell = 1.00
+
         # self.pearson_chi2 = 836424.1293162981   # from Stata (?)
         self.fittedvalues = np.array([
             60055.659970240202, 61216.013942398131,
@@ -626,6 +629,8 @@ class Star98(object):
         self.llf_Stata = -2998.612927807218
         self.scale = 1.
         self.pearson_chi2 = 4051.921614
+        self.prsquared = 0.8346
+        self.prsquared_cox_snell = 1.0000
         self.resids = glm_test_resids.star98_resids
         self.fittedvalues = np.array([
             0.5833118,   0.75144661,  0.50058272, 0.68534524,  0.32251021,
@@ -795,6 +800,8 @@ class Scotvote(object):
         # self.llf = -82.47352  # Very close to ours as is
         self.scale = 0.003584283
         self.pearson_chi2 = .0860228056
+        self.prsquared = 0.429
+        self.prsquared_cox_snell = 0.97971
         self.resids = glm_test_resids.scotvote_resids
         self.fittedvalues = np.array([
             57.80431482,  53.2733447, 50.56347993, 58.33003783,

--- a/statsmodels/genmod/tests/test_glm.py
+++ b/statsmodels/genmod/tests/test_glm.py
@@ -191,15 +191,13 @@ class CheckModelResultsMixin(object):
             assert_allclose(self.res1.pearson_chi2, self.res2.pearson_chi2,
                             atol=1e-6, rtol=1e-6)
 
-    decimal_prsquared = DECIMAL_2
     def test_prsquared(self):
         if hasattr(self.res2, 'prsquared'):
-            assert_almost_equal(self.res1.prsquared, self.res2.prsquared, self.decimal_prsquared)
+            assert_allclose(self.res1.prsquared, self.res2.prsquared, rtol=0.05)
 
-    decimal_prsquared_cox_snell = DECIMAL_2
     def test_prsquared_cox_snell(self):
         if hasattr(self.res2, 'prsquared_cox_snell'):
-            assert_almost_equal(float(self.res1.prsquared_cox_snell), self.res2.prsquared_cox_snell, self.decimal_prsquared_cox_snell)
+            assert_allclose(float(self.res1.prsquared_cox_snell), self.res2.prsquared_cox_snell, rtol=0.05)
 
     @pytest.mark.smoke
     def test_summary(self):

--- a/statsmodels/genmod/tests/test_glm.py
+++ b/statsmodels/genmod/tests/test_glm.py
@@ -191,6 +191,16 @@ class CheckModelResultsMixin(object):
             assert_allclose(self.res1.pearson_chi2, self.res2.pearson_chi2,
                             atol=1e-6, rtol=1e-6)
 
+    decimal_prsquared = DECIMAL_2
+    def test_prsquared(self):
+        if hasattr(self.res2, 'prsquared'):
+            assert_almost_equal(self.res1.prsquared, self.res2.prsquared, self.decimal_prsquared)
+
+    decimal_prsquared_cox_snell = DECIMAL_2
+    def test_prsquared_cox_snell(self):
+        if hasattr(self.res2, 'prsquared_cox_snell'):
+            assert_almost_equal(float(self.res1.prsquared_cox_snell), self.res2.prsquared_cox_snell, self.decimal_prsquared_cox_snell)
+
     @pytest.mark.smoke
     def test_summary(self):
         self.res1.summary()


### PR DESCRIPTION
- [x] closes statsmodels/statsmodels#5861
- [x] tests added / passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 


The GLM does not have McFadden's Pseudo R-square in its _result.summary()_.
The GLM have McFadden's Pseudo R-square in its _result.summary2()_.

I have added two functions in the file   _statsmodels/genmod/generalized_linear_model.py_

1. prsquared  (McFadden's Pseudo R-square)
2. prsquared_cox_snell  (Cox & Snell's Pseudo R-square)


And two test cases are added in the file   _statsmodels/genmod/tests/test_glm.py_

1. test_prsquared
2. test_prsquared_cox_snell


Below test cases are passed

1.   pytest statsmodels\genmod\tests\test_glm.py::TestGlmBinomial::test_prsquared
2.   pytest statsmodels\genmod\tests\test_glm.py::TestGlmBinomial::test_prsquared_cox_snell
3.   pytest statsmodels\genmod\tests\test_glm.py::TestGlmGamma::test_prsquared
4.   pytest statsmodels\genmod\tests\test_glm.py::TestGlmGamma::test_prsquared_cox_snell
5.   pytest statsmodels\genmod\tests\test_glm.py::TestGlmGaussian::test_prsquared
6.   pytest statsmodels\genmod\tests\test_glm.py::TestGlmGaussian::test_prsquared_cox_snell

After above code changes, GLM will have McFadden's Pseudo R-square in _result.summary()_.

```
import statsmodels.api as sm
data = sm.datasets.star98.load(as_pandas=False)
data.exog = sm.add_constant(data.exog, prepend=False)
glm_binom = sm.GLM(data.endog, data.exog, family=sm.families.Binomial())
res = glm_binom.fit()
print(res.summary())
print(f"McFadden's pseudo-R-squared: {res.prsquared}")
print(f"Cox & Snell's pseudo-R-squared: {res.prsquared_cox_snell}")
print(res.summary2())
```

McFadden's Pseudo R-square in _result.summary()_  is almost equal to McFadden's Pseudo R-square in _result.summary()2_.
Cox & Snell's Pseudo R-square can be obtained by   _result.prsquared_cox_snell_.

<details>

**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in master and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/master -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>