### PR TITLE
BUG: fix wrong axis label in qqplot_2samples

### DIFF
--- a/statsmodels/graphics/gofplots.py
+++ b/statsmodels/graphics/gofplots.py
@@ -770,7 +770,7 @@ def qqplot_2samples(
         data2 = ProbPlot(data2)
     if data2.data.shape[0] >= data1.data.shape[0]:
         fig = data1.qqplot(
-            xlabel=xlabel, ylabel=ylabel, line=line, other=data2, ax=ax
+            xlabel=ylabel, ylabel=xlabel, line=line, other=data2, ax=ax
         )
     else:
         fig = data2.qqplot(

--- a/statsmodels/graphics/gofplots.py
+++ b/statsmodels/graphics/gofplots.py
@@ -774,7 +774,7 @@ def qqplot_2samples(
         )
     else:
         fig = data2.qqplot(
-            xlabel=ylabel, ylabel=xlabel, line=line, other=data1, ax=ax
+            xlabel=xlabel, ylabel=ylabel, line=line, other=data1, ax=ax
         )
 
     return fig


### PR DESCRIPTION
The label location is wrong in qqplot_2samples. When data1 and data2 are of equal sizes, x_label will correspond to data2, which is wrong, (it should correspond to data1). 

BTW, why permitting different data sizes here? To me, it doesn't make sense for a Q-Q plot to have different sample sizes on data1 and data2.

Not sure how to add a test for plot, but this code can produce results needed:

d1 = np.arange(3)
d2 = np.arange(0,30,10)
pp_x = sm.ProbPlot(d1)
pp_y = sm.ProbPlot(d2)
qqplot_2samples(pp_x, pp_y,xlabel="d1")
new_qqplot_2samples(pp_x, pp_y,xlabel="d1")


- [ ] closes #xxxx
- [x] tests added / passed. 
- [ ] code/documentation is well formatted.  
- [ ] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
