### PR TITLE
BUG: Fix float index usage in IRF error bands

### DIFF
--- a/statsmodels/tsa/vector_ar/irf.py
+++ b/statsmodels/tsa/vector_ar/irf.py
@@ -392,7 +392,7 @@ class IRAnalysis(BaseIRAnalysis):
         periods = self.periods
         irfs = self._choose_irfs(orth, svar)
         neqs = self.neqs
-        irf_resim = model.irf_resim(orth=orth, repl=repl, T=periods, seed=seed,
+        irf_resim = model.irf_resim(orth=orth, repl=repl, steps=periods, seed=seed,
                                     burn=100)
 
         W, eigva, k = self._eigval_decomp_SZ(irf_resim)
@@ -455,8 +455,8 @@ class IRAnalysis(BaseIRAnalysis):
         periods = self.periods
         irfs = self._choose_irfs(orth, svar)
         neqs = self.neqs
-        irf_resim = model.irf_resim(orth=orth, repl=repl, T=periods, seed=seed,
-                                    burn=100)
+        irf_resim = model.irf_resim(orth=orth, repl=repl, steps=periods,
+                                    seed=seed, burn=100)
         stack = np.zeros((neqs, repl, periods*neqs))
 
         #stack left to right, up and down
@@ -636,7 +636,8 @@ class IRAnalysis(BaseIRAnalysis):
         model = self.model
         periods = self.periods
         return model.irf_errband_mc(orth=orth, repl=repl,
-                                    T=periods, signif=signif, seed=seed, burn=burn, cum=True)
+                                    steps=periods, signif=signif,
+                                    seed=seed, burn=burn, cum=True)
 
     def lr_effect_cov(self, orth=False):
         """

--- a/statsmodels/tsa/vector_ar/irf.py
+++ b/statsmodels/tsa/vector_ar/irf.py
@@ -468,7 +468,7 @@ class IRAnalysis(BaseIRAnalysis):
         stack_cov=np.zeros((neqs, periods*neqs, periods*neqs))
         W = np.zeros((neqs, periods*neqs, periods*neqs))
         eigva = np.zeros((neqs, periods*neqs))
-        k = np.zeros((neqs))
+        k = np.zeros(neqs, dtype=int)
 
         if component is not None:
             if np.size(component) != (neqs):
@@ -522,7 +522,7 @@ class IRAnalysis(BaseIRAnalysis):
 
         W = np.zeros((neqs, neqs, periods, periods))
         eigva = np.zeros((neqs, neqs, periods, 1))
-        k = np.zeros((neqs, neqs))
+        k = np.zeros((neqs, neqs), dtype=int)
 
         for i in range(neqs):
             for j in range(neqs):

--- a/statsmodels/tsa/vector_ar/tests/test_var.py
+++ b/statsmodels/tsa/vector_ar/tests/test_var.py
@@ -898,3 +898,16 @@ def test_correct_nobs():
     results = model.fit(maxlags=1)
     irf = results.irf_resim(orth=False, repl=100, steps=10, seed=1, burn=100, cum=False)
     assert irf.shape == (100, 11, 3, 3)
+
+
+@pytest.mark.slow
+def test_irf_err_bands():
+    # smoke tests
+    data = get_macrodata()
+    model = VAR(data)
+    results = model.fit(maxlags=2)
+    irf = results.irf()
+    bands_sz1 = irf.err_band_sz1()
+    bands_sz2 = irf.err_band_sz2()
+    bands_sz3 = irf.err_band_sz3()
+    bands_mc = irf.errband_mc()


### PR DESCRIPTION
- [x] tests added / passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

Looking over #6769 I noticed that the IRF error bands don't run with default arguments because using floats as indices is an error now. Added smoke tests for this part of the code at least...