### PR TITLE
BUG: Add format to step plots as well as for simple plots

### DIFF
--- a/statsmodels/graphics/gofplots.py
+++ b/statsmodels/graphics/gofplots.py
@@ -989,7 +989,7 @@ def _do_plot(
     ax.set_xmargin(0.02)
 
     if step:
-        ax.step(x, y, where=where, **plot_style)
+        ax.step(x, y, fmt, where=where, **plot_style)
     else:
         ax.plot(x, y, fmt, **plot_style)
     if line:


### PR DESCRIPTION
- [x] tests added / passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

Simply adds `fmt` to `step` plots as well as for simple plots. Can be found only in user's code or in tests. Can be tested well by tests so no tests written.

Origin of this pull request was in #7400 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
