### PR TITLE
BUG: Runs test numeric cutoff error

### DIFF
--- a/statsmodels/sandbox/stats/runs.py
+++ b/statsmodels/sandbox/stats/runs.py
@@ -132,6 +132,8 @@ def runstest_1samp(x, cutoff='mean', correction=True):
         cutoff = np.mean(x)
     elif cutoff == 'median':
         cutoff = np.median(x)
+    else:
+        cutoff = np.float64(cutoff)
     xindicator = (x >= cutoff).astype(int)
     return Runs(xindicator).runs_test(correction=correction)
 

--- a/statsmodels/sandbox/stats/runs.py
+++ b/statsmodels/sandbox/stats/runs.py
@@ -23,6 +23,7 @@ import numpy as np
 from scipy import stats
 from scipy.special import comb
 import warnings
+from statsmodels.tools.validation import array_like
 
 class Runs(object):
     '''class for runs in a binary sequence
@@ -128,12 +129,13 @@ def runstest_1samp(x, cutoff='mean', correction=True):
 
     '''
 
+    x = array_like(x, "x")
     if cutoff == 'mean':
         cutoff = np.mean(x)
     elif cutoff == 'median':
         cutoff = np.median(x)
     else:
-        cutoff = np.float64(cutoff)
+        cutoff = float(cutoff)
     xindicator = (x >= cutoff).astype(int)
     return Runs(xindicator).runs_test(correction=correction)
 

--- a/statsmodels/sandbox/stats/tests/test_runs.py
+++ b/statsmodels/sandbox/stats/tests/test_runs.py
@@ -27,4 +27,3 @@ def test_numeric_cutoff():
     expected = (-3.944254410803499, 8.004864125547193e-05)
     results = runstest_1samp(x, cutoff=cutoff, correction=False)
     assert_almost_equal(expected, results)
-    

--- a/statsmodels/sandbox/stats/tests/test_runs.py
+++ b/statsmodels/sandbox/stats/tests/test_runs.py
@@ -1,0 +1,30 @@
+"""
+Tests corresponding to sandbox.stats.runs
+"""
+import numpy as np
+from numpy.testing import assert_almost_equal
+from statsmodels.sandbox.stats.runs import runstest_1samp
+
+
+def test_mean_cutoff():
+    x = [1] * 5 + [2] * 6 + [3] * 8
+    cutoff = "mean"
+    expected = (-4.007095978613213, 6.146988816717466e-05)
+    results = runstest_1samp(x, cutoff=cutoff, correction=False)
+    assert_almost_equal(expected, results)
+
+
+def test_median_cutoff():
+    x = [1] * 5 + [2] * 6 + [3] * 8
+    cutoff = "median"
+    expected = (-3.944254410803499, 8.004864125547193e-05)
+    results = runstest_1samp(x, cutoff=cutoff, correction=False)
+    assert_almost_equal(expected, results)
+
+
+def test_numeric_cutoff():
+    x = [1] * 5 + [2] * 6 + [3] * 8
+    cutoff = 2
+    expected = (-3.944254410803499, 8.004864125547193e-05)
+    results = runstest_1samp(x, cutoff=cutoff, correction=False)
+    assert_almost_equal(expected, results)

--- a/statsmodels/sandbox/stats/tests/test_runs.py
+++ b/statsmodels/sandbox/stats/tests/test_runs.py
@@ -1,7 +1,6 @@
 """
 Tests corresponding to sandbox.stats.runs
 """
-import numpy as np
 from numpy.testing import assert_almost_equal
 from statsmodels.sandbox.stats.runs import runstest_1samp
 
@@ -28,3 +27,4 @@ def test_numeric_cutoff():
     expected = (-3.944254410803499, 8.004864125547193e-05)
     results = runstest_1samp(x, cutoff=cutoff, correction=False)
     assert_almost_equal(expected, results)
+    


### PR DESCRIPTION
- [ ] closes #xxxx
- [X] tests added / passed. 
- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

When you try to execute the `runstest_1samp` with the parameter `cutoff` set as a number, it raises a `TypeError`:

> TypeError: '>=' not supported between instances of 'list' and 'int'

I added a conversion to `np.float64` when the `cutoff` is a number.

Here is a snippet that shows the problem:

```{python}
from statsmodels.sandbox.stats.runs import runstest_1samp
import numpy as np


x = [1] * 5 + [2] * 6 + [3] * 8
cutoff = 2
runstest_1samp(x, cutoff=cutoff, correction=False)
```

I didn't add the bugfix correction in the **release notes** because I didn't find a file for `statsmodels==0.12.2`.

**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
