### PR TITLE
DOC: misc fixes in docstr of fdrcorrection

### DIFF
--- a/statsmodels/stats/multitest.py
+++ b/statsmodels/stats/multitest.py
@@ -264,14 +264,15 @@ def multipletests(pvals, alpha=0.05, method='hs', is_sorted=False,
 
 
 def fdrcorrection(pvals, alpha=0.05, method='indep', is_sorted=False):
-    '''pvalue correction for false discovery rate.
+    '''
+    pvalue correction for false discovery rate.
 
     This covers Benjamini/Hochberg for independent or positively correlated and
     Benjamini/Yekutieli for general or negatively correlated tests.
 
     Parameters
     ----------
-    pvals : array_like, must be 1 dimensional
+    pvals : array_like, 1d
         Set of p-values of the individual tests.
     alpha : float, optional
         Family-wise error rate. Defaults to ``0.05``.
@@ -289,7 +290,7 @@ def fdrcorrection(pvals, alpha=0.05, method='indep', is_sorted=False):
 
     Returns
     -------
-    rejected : ndarray of bools
+    rejected : ndarray, bool
         True if a hypothesis is rejected, False if not
     pvalue-corrected : ndarray
         pvalues adjusted for multiple hypothesis testing to limit FDR

--- a/statsmodels/stats/multitest.py
+++ b/statsmodels/stats/multitest.py
@@ -264,49 +264,57 @@ def multipletests(pvals, alpha=0.05, method='hs', is_sorted=False,
 
 
 def fdrcorrection(pvals, alpha=0.05, method='indep', is_sorted=False):
-    '''pvalue correction for false discovery rate
+    '''pvalue correction for false discovery rate.
 
     This covers Benjamini/Hochberg for independent or positively correlated and
-    Benjamini/Yekutieli for general or negatively correlated tests. Both are
-    available in the function multipletests, as method=`fdr_bh`, resp. `fdr_by`.
+    Benjamini/Yekutieli for general or negatively correlated tests.
 
     Parameters
     ----------
-    pvals : array_like
-        set of p-values of the individual tests.
-    alpha : float
-        error rate
-    method : {'indep', 'negcorr'}
-    is_sorted : bool
+    pvals : array_like, must be 1 dimensional
+        Set of p-values of the individual tests.
+    alpha : float, optional
+        Family-wise error rate. Defaults to ``0.05``.
+    method : {'i', 'indep', 'p', 'poscorr', 'n', 'negcorr'}, optional
+        Which method to use for FDR correction.
+        ``{'i', 'indep', 'p', 'poscorr'}`` all refer to ``fdr_bh``
+        (Benjamini/Hochberg for independent or positively
+        correlated tests). ``{'n', 'negcorr'}`` both refer to ``fdr_by``
+        (Benjamini/Yekutieli for general or negatively correlated tests).
+        Defaults to ``'indep'``.
+    is_sorted : bool, optional
         If False (default), the p_values will be sorted, but the corrected
         pvalues are in the original order. If True, then it assumed that the
         pvalues are already sorted in ascending order.
 
     Returns
     -------
-    rejected : ndarray, bool
+    rejected : ndarray of bools
         True if a hypothesis is rejected, False if not
     pvalue-corrected : ndarray
         pvalues adjusted for multiple hypothesis testing to limit FDR
 
     Notes
     -----
-
     If there is prior information on the fraction of true hypothesis, then alpha
-    should be set to alpha * m/m_0 where m is the number of tests,
+    should be set to ``alpha * m/m_0`` where m is the number of tests,
     given by the p-values, and m_0 is an estimate of the true hypothesis.
     (see Benjamini, Krieger and Yekuteli)
 
     The two-step method of Benjamini, Krieger and Yekutiel that estimates the number
     of false hypotheses will be available (soon).
 
-    Method names can be abbreviated to first letter, 'i' or 'p' for fdr_bh and 'n' for
-    fdr_by.
+    Both methods exposed via this function (Benjamini/Hochberg, Benjamini/Yekutieli)
+    are also available in the function ``multipletests``, as ``method="fdr_bh"`` and
+    ``method="fdr_by"``, respectively.
 
-
+    See also
+    --------
+    multipletests
 
     '''
     pvals = np.asarray(pvals)
+    assert pvals.ndim == 1, "pvals must be 1-dimensional, that is of shape (n,)"
 
     if not is_sorted:
         pvals_sortind = np.argsort(pvals)


### PR DESCRIPTION
Here I fix the docstr of `statsmodels.stats.multitest.fdrcorrection`. Prior to this PR, the help would skip the parameter documentation after `method`, because its description was not fully populated, see this screenshot.

![image](https://user-images.githubusercontent.com/9084751/116736418-2866c100-a9f0-11eb-908c-aed95df56520.png)

This is now fixed.

Furthermore I added to the documentation that `pvals` is expected to be a 1D array (or array_like), and added an assert line in the beginning of the function to warn users if they pass something else.


- ~~[ ] closes #xxxx~~
- [ ] tests ~~added~~ / passed. 
- [ ] code/documentation is well formatted.  
- [ ] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
