### PR TITLE
Use np.linalg.solve() instead of np.linalg.inv() in Newton-Raphson Algorithm

### DIFF
--- a/statsmodels/base/optimizer.py
+++ b/statsmodels/base/optimizer.py
@@ -418,8 +418,7 @@ def _fit_newton(f, score, start_params, fargs, kwargs, disp=True,
         if not np.all(ridge_factor == 0):
             H[np.diag_indices(H.shape[0])] += ridge_factor
         oldparams = newparams
-        newparams = oldparams - np.dot(np.linalg.inv(H),
-                score(oldparams))
+        newparams = oldparams - np.linalg.solve(H, score(oldparams))
         if retall:
             history.append(newparams)
         if callback is not None:


### PR DESCRIPTION
Greetings, I just found this line in the implementation of the Newton-Raphson Algorithm (statsmodels/base/optimizer.py:421):

`newparams = oldparams - np.dot(np.linalg.inv(H),
                score(oldparams))`

The issue here is that it uses `np.linalg.inv` to solve a linear equation system which is slower and less accurate than the alternative method `np.linalg.solve`.

This is why in this PR I suggest to change the line as follows:

`newparams = oldparams - np.linalg.solve(H, score(oldparams))`

To back up my claim that this will increase accuracy and performance, you can find a related post on stackoverflow here:

[Why does numpy.linalg.solve() offer more precise matrix inversions than numpy.linalg.inv()?](https://stackoverflow.com/questions/31256252/why-does-numpy-linalg-solve-offer-more-precise-matrix-inversions-than-numpy-li)

I'm curious to hear your thoughts.

Christian

- [ ] closes #xxxx
- [x] tests added / passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
