### PR TITLE
MAINT: Use loadscope to avoid rerunning setup

### DIFF
--- a/examples/notebooks/exponential_smoothing.ipynb
+++ b/examples/notebooks/exponential_smoothing.ipynb
@@ -489,7 +489,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.8.8"
   },
   "latex_envs": {
    "LaTeX_envs_menu_present": true,
@@ -534,5 +534,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }

--- a/tools/ci/azure/azure_template_posix.yml
+++ b/tools/ci/azure/azure_template_posix.yml
@@ -116,8 +116,8 @@ jobs:
       if [[ ${COVERAGE} == "true" ]]; then
         export COVERAGE_OPTS="--cov-config .coveragerc --cov=statsmodels --cov-report xml:coverage.xml --cov-report term"
       fi
-      echo pytest -m "${PYTEST_PATTERN}" --skip-examples --junitxml=junit/test-results.xml -n auto --durations=25 ${COVERAGE_OPTS} statsmodels
-      pytest -m "${PYTEST_PATTERN}" --skip-examples --junitxml=junit/test-results.xml -n auto --durations=25 ${COVERAGE_OPTS} statsmodels
+      echo pytest -m "${PYTEST_PATTERN}" --skip-examples --junitxml=junit/test-results.xml -n auto --dist loadscope --durations=25 ${COVERAGE_OPTS} statsmodels
+      pytest -m "${PYTEST_PATTERN}" --skip-examples --junitxml=junit/test-results.xml -n auto --dist loadscope --durations=25 ${COVERAGE_OPTS} statsmodels
     displayName: 'Run tests (editable)'
     condition: and(ne(variables['test.install'], 'true'), ne(variables['pip.pre'], 'true'))
 
@@ -126,8 +126,8 @@ jobs:
       if [[ ${COVERAGE} == "true" ]]; then
         export COVERAGE_OPTS="--cov-config .coveragerc --cov=statsmodels --cov-report xml:coverage.xml --cov-report term"
       fi
-      echo pytest -m "${PYTEST_PATTERN}" --skip-examples --junitxml=junit/test-results.xml -n auto --durations=25 ${COVERAGE_OPTS} statsmodels
-      pytest -m "${PYTEST_PATTERN}" --skip-examples --junitxml=junit/test-results.xml -n auto --durations=25 ${COVERAGE_OPTS} statsmodels
+      echo pytest -m "${PYTEST_PATTERN}" --skip-examples --junitxml=junit/test-results.xml -n auto --dist loadscope --durations=25 ${COVERAGE_OPTS} statsmodels
+      pytest -m "${PYTEST_PATTERN}" --skip-examples --junitxml=junit/test-results.xml -n auto --dist loadscope --durations=25 ${COVERAGE_OPTS} statsmodels
     displayName: 'Run tests (pip pre)'
     condition: and(ne(variables['test.install'], 'true'), eq(variables['pip.pre'], 'true'))
     continueOnError: true

--- a/tools/ci/run_test.bat
+++ b/tools/ci/run_test.bat
@@ -3,8 +3,8 @@
 @IF not Defined PYTEST_DIRECTIVES GOTO :RUN_FROM_INSTALL
 
 @echo Running test from %CD%
-@echo pytest -n auto -r s statsmodels --skip-examples %PYTEST_DIRECTIVES%
-pytest -n auto -r s statsmodels --skip-examples %PYTEST_DIRECTIVES%
+@echo pytest -n auto -r s statsmodels --dist loadscope --skip-examples %PYTEST_DIRECTIVES%
+pytest -n auto -r s statsmodels --dist loadscope --skip-examples %PYTEST_DIRECTIVES%
 
 @GOTO :End
 


### PR DESCRIPTION
Use --dist loadscope to avoid rerunning setup when running tests

- [ ] closes #xxxx
- [ ] tests added / passed. 
- [ ] code/documentation is well formatted.  
- [ ] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
