### PR TITLE
fix typo in ets error

### DIFF
--- a/statsmodels/tsa/exponential_smoothing/ets.py
+++ b/statsmodels/tsa/exponential_smoothing/ets.py
@@ -471,7 +471,7 @@ class ETSModel(base.StateSpaceMLEModel):
             or self.seasonal == "mul"
         ):
             raise ValueError(
-                "endog must be strictly positive when using"
+                "endog must be strictly positive when using "
                 "multiplicative error, trend or seasonal components."
             )
         if self.damped_trend and not self.has_trend:


### PR DESCRIPTION
Small typo fix for the error raised when endog is not strictly positive and multiplicative components are chosen.

from: 
```python
ValueError: endog must be strictly positive when usingmultiplicative error, trend or seasonal components.
```

to:
```python
ValueError: endog must be strictly positive when using multiplicative error, trend or seasonal components.
```