### PR TITLE
ENH: Adding a method for summary as a pd.DataFrame

### DIFF
--- a/statsmodels/regression/linear_model.py
+++ b/statsmodels/regression/linear_model.py
@@ -2804,28 +2804,17 @@ class RegressionResults(base.LikelihoodModelResults):
             smry.add_text(warn)
 
         return smry
-    
-    
-def summary_df(self, table_index = 1):
-    """
-    Returns only a selected table of summary as a Pandas DataFrame. 
-    
-    By default it selects the table of the coefficients and their significance.
-    """
-    # Getting .summary() table as a pandas DataFrame
-    df_results = pd.DataFrame(self.summary().tables[table_index])
-    
-    # Setting the df index
-    index_col = df_results.iloc[:,0].rename('Variable')
-    df_results.set_index(index_col, inplace=True)
-    
-    # Setting the df header
-    header = list(df_results.iloc[0])
-    df_results = df_results.iloc[1:,1:]
-    df_results.columns = header[1:]
-    
-    return df_results
 
+    def summary_frame(self, table_index = 1):
+    """
+    Summary function that returns the regular summary table as a Pandas dataframe.
+    """
+        if table_index == 1:
+            # Using first row as a header
+            return pd.read_html(self.summary().tables[table_index].as_html(), header=0, index_col=0)[0]
+        else:
+            # Not using first row as a header
+            return pd.read_html(self.summary().tables[table_index].as_html(), index_col=0)[0]
 
 class OLSResults(RegressionResults):
     """

--- a/statsmodels/regression/linear_model.py
+++ b/statsmodels/regression/linear_model.py
@@ -2803,7 +2803,24 @@ class RegressionResults(base.LikelihoodModelResults):
             smry.add_text(warn)
 
         return smry
-
+    
+def summary_df(self, table_index = 1):
+    """
+    Returns only a selected table of summary as a Pandas DataFrame. 
+    
+    By default it selects the coefficient and SD criteria table.
+    """
+    df_results = pd.DataFrame(self.summary().tables[table_index])
+    
+    # setting the header and index
+    index_col = df_results.iloc[:,0].rename('Variable')
+    df_results.set_index(index_col, inplace=True)
+    
+    header = list(df_results.iloc[0])
+    df_results = df_results.iloc[1:,1:]
+    df_results.columns = header[1:]
+    
+    return df_results
 
 class OLSResults(RegressionResults):
     """

--- a/statsmodels/regression/linear_model.py
+++ b/statsmodels/regression/linear_model.py
@@ -38,6 +38,7 @@ from statsmodels.compat.python import lrange, lzip
 import warnings
 
 import numpy as np
+import pandas as pd
 from scipy import optimize, stats
 from scipy.linalg import toeplitz
 
@@ -2804,23 +2805,27 @@ class RegressionResults(base.LikelihoodModelResults):
 
         return smry
     
+    
 def summary_df(self, table_index = 1):
     """
     Returns only a selected table of summary as a Pandas DataFrame. 
     
-    By default it selects the coefficient and SD criteria table.
+    By default it selects the table of the coefficients and their significance.
     """
+    # Getting .summary() table as a pandas DataFrame
     df_results = pd.DataFrame(self.summary().tables[table_index])
     
-    # setting the header and index
+    # Setting the df index
     index_col = df_results.iloc[:,0].rename('Variable')
     df_results.set_index(index_col, inplace=True)
     
+    # Setting the df header
     header = list(df_results.iloc[0])
     df_results = df_results.iloc[1:,1:]
     df_results.columns = header[1:]
     
     return df_results
+
 
 class OLSResults(RegressionResults):
     """

--- a/statsmodels/regression/linear_model.py
+++ b/statsmodels/regression/linear_model.py
@@ -2806,16 +2806,17 @@ class RegressionResults(base.LikelihoodModelResults):
         return smry
 
     def summary_frame(self, table_index = 1):
-    """
-    Summary function that returns the regular summary table as a Pandas dataframe.
-    """
-        if table_index == 1:
-            # Using first row as a header
-            return pd.read_html(self.summary().tables[table_index].as_html(), header=0, index_col=0)[0]
-        else:
-            # Not using first row as a header
-            return pd.read_html(self.summary().tables[table_index].as_html(), index_col=0)[0]
+        """
+        Summary function that returns the regular summary table as a Pandas dataframe.
+        """
+    if table_index == 1:
+        # Using first row as a header
+        return pd.read_html(self.summary().tables[table_index].as_html(), header=0, index_col=0)[0]
+    else:
+        # Not using first row as a header
+        return pd.read_html(self.summary().tables[table_index].as_html(), index_col=0)[0]
 
+        
 class OLSResults(RegressionResults):
     """
     Results class for for an OLS model.


### PR DESCRIPTION
Adding a method that returns summary as a pd.DataFrame and only a selected table of it, because you might not need all of the information. This would help for displaying results in a Jupyter noteboook.

- [ ] closes #xxxx
- [ ] tests added / passed. 
- [ ] code/documentation is well formatted.  
- [ ] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
