### PR TITLE
Correct small typo in Theta model Notebook

### DIFF
--- a/examples/notebooks/theta-model.ipynb
+++ b/examples/notebooks/theta-model.ipynb
@@ -158,7 +158,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We could alternatively fir the log of the data.  Here it makes more sense to force the deseasonalizing to use the additive method, if needed.  We also fit the model parameters using MLE.  This method fits the IMA\n",
+    "We could alternatively fit the log of the data.  Here it makes more sense to force the deseasonalizing to use the additive method, if needed.  We also fit the model parameters using MLE.  This method fits the IMA\n",
     "\n",
     "$$ X_t = X_{t-1} + \\gamma\\epsilon_{t-1} + \\epsilon_t $$\n",
     "\n",


### PR DESCRIPTION
This is just a small typo correction on a notebook example. No code component was modified. 