### PR TITLE
Specify impulse to impulse_responses in VARMAX notebook

### DIFF
--- a/examples/notebooks/statespace_varmax.ipynb
+++ b/examples/notebooks/statespace_varmax.ipynb
@@ -101,7 +101,7 @@
    },
    "outputs": [],
    "source": [
-    "ax = res.impulse_responses(10, orthogonalized=True).plot(figsize=(13,3))\n",
+    "ax = res.impulse_responses(10, orthogonalized=True, impulse=[1, 0]).plot(figsize=(13,3))\n",
     "ax.set(xlabel='t', title='Responses to a shock to `dln_inv`');"
    ]
   },


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed. 
- [ ] code/documentation is well formatted.  
- [ ] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

The usage of the impulse response function is different between `vector_ar` and `statespace`.
When it comes to `vector_ar`, all directions of impulses can be calculated all at once, but in `statespace`, a shock should be put as an argument of `impulse_responses`. Otherwise, it is implicitly given to a first column.
I feel that to prevent confusion, showing how to give a shock is beneficial to users.


<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
