### PR TITLE
ENH: add discretized count distribution

### DIFF
--- a/docs/source/distributions.rst
+++ b/docs/source/distributions.rst
@@ -27,6 +27,34 @@ Empirical Distributions
    StepFunction
    monotone_fn_inverter
 
+Count Distributions
+-------------------
+
+The `discrete` module contains classes for count distributions that are based
+on discretizing a continouus distribution, and specific count distributions
+that are not available in scipy.distributions like generalized poisson and
+zero-inflated count models.
+
+The latter are mainly in support of the corresponding models in
+`statsmodels.discrete`. Some methods are not specifically implemented and will
+use potentially slow inherited generic methods.
+
+.. module:: statsmodels.distributions.discrete
+   :synopsis: Support for count distributions
+
+.. currentmodule:: statsmodels.distributions.discrete
+
+.. autosummary::
+   :toctree: generated/
+
+   DiscretizedCount
+   DiscretizedModel
+   genpoisson_p
+   zigenpoisson
+   zinegbin
+   zipoisson
+
+
 Distribution Extras
 -------------------
 

--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -2398,8 +2398,10 @@ class ResultMixin(object):
                 exog_resamp = self.exog[rvsind, :]
             else:
                 exog_resamp = None
+            # build auxiliary model and fit
+            init_kwds = self.model._get_init_kwds()
             fitmod = self.model.__class__(self.endog[rvsind],
-                                          exog=exog_resamp)
+                                          exog=exog_resamp, **init_kwds)
             if hascloneattr:
                 for attr in self.model.cloneattr:
                     setattr(fitmod, attr, getattr(self.model, attr))

--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -2281,7 +2281,9 @@ class ResultMixin(object):
         # collect different ways of defining the number of parameters, used for
         # aic, bic
         if hasattr(self, 'df_model'):
-            if hasattr(self, 'hasconst'):
+            if hasattr(self, 'k_constant'):
+                hasconst = self.k_constant
+            elif hasattr(self, 'hasconst'):
                 hasconst = self.hasconst
             else:
                 # default assumption

--- a/statsmodels/distributions/discrete.py
+++ b/statsmodels/distributions/discrete.py
@@ -155,15 +155,46 @@ zinegbin = zinegativebinomial_gen(name='zinegbin',
 class DiscretizedCount(rv_discrete):
     """Count distribution based on discretized distribution
 
+    Parameters
+    ----------
+    distr : distribution instance
+    d_offset : float
+        Offset for integer interval, default is zero.
+        The discrete random variable is ``y = floor(x + offset)`` where x is
+        the continuous random variable.
+        Warning: not verified for all methods.
+    add_scale : bool
+        If True (default), then the scale of the base distribution is added
+        as parameter for the discrete distribution. The scale parameter is in
+        the last position.
+    kwds : keyword arguments
+        The extra keyword arguments are used delegated to the ``__init__`` of
+        the super class.
+        Their usage has not been checked, e.g. currently the support of the
+        distribution is assumed to be all non-negative integers.
+
     Notes
     -----
     `loc` argument is currently not supported, scale is not available for
     discrete distributions in scipy. The scale parameter of the underlying
     continuous distribution is the last shape parameter in this
-    DiscretizedCount distribution.
+    DiscretizedCount distribution if ``add_scale`` is True.
+
+    The implementation was based mainly on [1]_ and [2]_. However, many new
+    discrete distributions have been developed based on the approach that we
+    use here. Note, that in many cases authors reparameterize the distribution,
+    while this class inherits the parameterization from the underlying
+    continuous distribution.
 
     References
     ----------
+    .. [1] Chakraborty, Subrata, and Dhrubajyoti Chakravarty. "Discrete gamma
+       distributions: Properties and parameter estimations." Communications in
+       Statistics-Theory and Methods 41, no. 18 (2012): 3301-3324.
+
+    .. [2] Alzaatreh, Ayman, Carl Lee, and Felix Famoye. 2012. “On the Discrete
+       Analogues of Continuous Distributions.” Statistical Methodology 9 (6):
+       589–603.
 
 
     """
@@ -264,8 +295,37 @@ class DiscretizedCount(rv_discrete):
         return q
 
 
-class _DiscretizedModel(GenericLikelihoodModel):
+class DiscretizedModel(GenericLikelihoodModel):
     """experimental model to fit discretized distribution
+
+    Count models based on discretized distributions can be used to model
+    data that is under- or over-dispersed relative to Poisson or that has
+    heavier tails.
+
+    Parameters
+    ----------
+    endog : array_like, 1-D
+        Univariate data for fitting the distribution.
+    exog : None
+        Explanatory variables are not supported. The ``exog`` argument is
+        only included for consistency in the signature across models.
+    distr : DiscretizedCount instance
+        (required) Instance of a DiscretizedCount distribution.
+
+    See Also
+    --------
+    DiscretizedCount
+
+    Examples
+    --------
+    >>> from scipy import stats
+    >>> from statsmodels.distributions.discrete import (
+            DiscretizedCount, DiscretizedModel)
+
+    >>> dd = DiscretizedCount(stats.gamma)
+    >>> mod = DiscretizedModel(y, distr=dd)
+    >>> res = mod.fit()
+    >>> probs = res.predict(which="probs", k_max=5)
 
     """
     def __init__(self, endog, exog=None, distr=None):

--- a/statsmodels/distributions/discrete.py
+++ b/statsmodels/distributions/discrete.py
@@ -162,6 +162,10 @@ class DiscretizedCount(rv_discrete):
     continuous distribution is the last shape parameter in this
     DiscretizedCount distribution.
 
+    References
+    ----------
+
+
     """
 
     def __new__(cls, *args, **kwds):
@@ -236,11 +240,13 @@ class _DiscretizedModel(GenericLikelihoodModel):
     def __init__(self, endog, exog=None, distr=None):
         if exog is not None:
             raise ValueError("exog is not supported")
-        self.distr = distr
-        super().__init__(endog, exog)
+
+        super().__init__(endog, exog, distr=distr)
+        self._init_keys.append('distr')
         self.df_resid = len(endog) - distr.k_shapes
         self.df_model = distr.k_shapes  # no constant subtracted
         self.k_constant = 0
+        self.nparams = distr.k_shapes  # needed for start_params
 
     def loglike(self, params):
 

--- a/statsmodels/distributions/tests/test_discrete.py
+++ b/statsmodels/distributions/tests/test_discrete.py
@@ -261,13 +261,18 @@ class CheckDiscretized():
         assert_allclose(p2, p, rtol=1e-13)
         cdf2 = dp.cdf(xi, *paramd)
         assert_allclose(cdf2, cdf, rtol=1e-13)
+        sf = dp.sf(xi, *paramd)
+        assert_allclose(sf, 1 - cdf, rtol=1e-13)
 
         nobs = 2000
 
-        xx = dp.rvs(*paramd, size=nobs)
+        xx = dp.rvs(*paramd, size=nobs)  # , random_state=987146)
+        # check that we go a non-trivial rvs
+        assert len(xx) == nobs
+        assert xx.var() > 0.001
         mod = _DiscretizedModel(xx, distr=dp)
         res = mod.fit(start_params=start_params)
-        p = mod.predict(res.params)
+        p = mod.predict(res.params, which="probs")
         args = self.convert_params(res.params)
         p1 = -np.diff(ddistr.sf(np.arange(21), *args))
         assert_allclose(p, p1, rtol=1e-13)
@@ -283,10 +288,38 @@ class CheckDiscretized():
             k = 10
             freq[k - 1] += freq[k:].sum()
             freq = freq[:k]
-        p = mod.predict(res.params, k_max=k)
+        p = mod.predict(res.params, which="probs", k_max=k)
         p[k - 1] += 1 - p[:k].sum()
         tchi2 = stats.chisquare(freq, p[:k] * nobs)
         assert tchi2.pvalue > 0.01
+
+        # estimated distribution methods rvs, ppf
+        # frozen distribution with estimated parameters
+        # Todo results method
+        dfr = mod.get_distr(res.params)
+        nobs_rvs = 500
+        rvs = dfr.rvs(size=nobs_rvs)
+        freq = np.bincount(rvs)
+        p = mod.predict(res.params, which="probs", k_max=nobs_rvs)
+        k = len(freq)
+        p[k - 1] += 1 - p[:k].sum()
+        tchi2 = stats.chisquare(freq, p[:k] * nobs_rvs)
+        assert tchi2.pvalue > 0.01
+
+        # round trip cdf-ppf
+        q = dfr.ppf(dfr.cdf(np.arange(-1, 5) + 1e-6))
+        q1 = np.array([-1.,  1.,  2.,  3.,  4.,  5.])
+        assert_equal(q, q1)
+        p = np.maximum(dfr.cdf(np.arange(-1, 5)) - 1e-6, 0)
+        q = dfr.ppf(p)
+        q1 = np.arange(-1, 5)
+        assert_equal(q, q1)
+        q = dfr.ppf(dfr.cdf(np.arange(5)))
+        q1 = np.arange(0, 5)
+        assert_equal(q, q1)
+        q = dfr.isf(1 - dfr.cdf(np.arange(-1, 5) + 1e-6))
+        q1 = np.array([-1.,  1.,  2.,  3.,  4.,  5.])
+        assert_equal(q, q1)
 
 
 class TestDiscretizedGamma(CheckDiscretized):
@@ -344,46 +377,98 @@ class TestDiscretizedBurr12(CheckDiscretized):
 class TestDiscretizedGammaEx():
     # strike outbreaks example from Ch... 2012
 
-    # expand frequencies to observations, (no freq_weights yet)
-    freq = [46, 76, 24, 9, 1]
-    y = np.repeat(np.arange(5), freq)
-    # results from article table 7
-    res1 = Bunch(
-        params=[3.52636, 0.425617],
-        llf=-187.469,
-        chi2=1.701208,  # chisquare test
-        df_model=2,
-        p=0.4272,  # p-value for chi2
-        aic=378.938,
-        probs=[46.48, 73.72, 27.88, 6.5, 1.42])
+    def test_all(self):
+        # expand frequencies to observations, (no freq_weights yet)
+        freq = [46, 76, 24, 9, 1]
+        y = np.repeat(np.arange(5), freq)
+        # results from article table 7
+        res1 = Bunch(
+            params=[3.52636, 0.425617],
+            llf=-187.469,
+            chi2=1.701208,  # chisquare test
+            df_model=2,
+            p=0.4272,  # p-value for chi2
+            aic=378.938,
+            probs=[46.48, 73.72, 27.88, 6.5, 1.42])
 
-    dp = DiscretizedCount(stats.gamma)
-    mod = _DiscretizedModel(y, distr=dp)
-    res = mod.fit(start_params=[1, 1])
-    nobs = len(y)
+        dp = DiscretizedCount(stats.gamma)
+        mod = _DiscretizedModel(y, distr=dp)
+        res = mod.fit(start_params=[1, 1])
+        nobs = len(y)
 
-    assert_allclose(res.params, res1.params, rtol=1e-5)
-    assert_allclose(res.llf, res1.llf, atol=6e-3)
-    assert_allclose(res.aic, res1.aic, atol=6e-3)
-    assert_equal(res.df_model, res1.df_model)
+        assert_allclose(res.params, res1.params, rtol=1e-5)
+        assert_allclose(res.llf, res1.llf, atol=6e-3)
+        assert_allclose(res.aic, res1.aic, atol=6e-3)
+        assert_equal(res.df_model, res1.df_model)
 
-    probs = mod.predict(res.params)
-    probs_trunc = probs[:len(res1.probs)]
-    probs_trunc[-1] += 1 - probs_trunc.sum()
-    assert_allclose(probs_trunc * nobs, res1.probs, atol=6e-2)
+        probs = mod.predict(res.params, which="probs")
+        probs_trunc = probs[:len(res1.probs)]
+        probs_trunc[-1] += 1 - probs_trunc.sum()
+        assert_allclose(probs_trunc * nobs, res1.probs, atol=6e-2)
 
-    assert_allclose(np.sum(freq), (probs_trunc * nobs).sum(), rtol=1e-10)
-    res_chi2 = stats.chisquare(freq, probs_trunc * nobs, ddof=len(res.params))
-    # regression test, numbers from running test
-    # close but not identical to article
-    assert_allclose(res_chi2.statistic, 1.70409356, rtol=1e-7)
-    assert_allclose(res_chi2.pvalue, 0.42654100, rtol=1e-7)
+        assert_allclose(np.sum(freq), (probs_trunc * nobs).sum(), rtol=1e-10)
+        res_chi2 = stats.chisquare(freq, probs_trunc * nobs,
+                                   ddof=len(res.params))
+        # regression test, numbers from running test
+        # close but not identical to article
+        assert_allclose(res_chi2.statistic, 1.70409356, rtol=1e-7)
+        assert_allclose(res_chi2.pvalue, 0.42654100, rtol=1e-7)
 
-    # smoke test for summary
-    res.summary()
+        # smoke test for summary
+        res.summary()
 
-    np.random.seed(987146)
-    res_boots = res.bootstrap()
-    # only loose check, small default n_rep=100, agreement at around 3%
-    assert_allclose(res.params, res_boots[0], rtol=0.05)
-    assert_allclose(res.bse, res_boots[1], rtol=0.05)
+        np.random.seed(987146)
+        res_boots = res.bootstrap()
+        # only loose check, small default n_rep=100, agreement at around 3%
+        assert_allclose(res.params, res_boots[0], rtol=0.05)
+        assert_allclose(res.bse, res_boots[1], rtol=0.05)
+
+
+class TestGeometric():
+
+    def test_all(self):
+        p_geom = 0.6
+        scale_dexpon = -1 / np.log(1-p_geom)
+        dgeo = stats.geom(p_geom, loc=-1)
+        dpg = DiscretizedCount(stats.expon)(scale_dexpon)
+
+        xi = np.arange(6)
+        pmf1 = dgeo.pmf(xi)
+        pmf = dpg.pmf(xi)
+        assert_allclose(pmf, pmf1, rtol=1e-10)
+        cdf1 = dgeo.cdf(xi)
+        cdf = dpg.cdf(xi)
+        assert_allclose(cdf, cdf1, rtol=1e-10)
+        sf1 = dgeo.sf(xi)
+        sf = dpg.sf(xi)
+        assert_allclose(sf, sf1, rtol=1e-10)
+
+        ppf1 = dgeo.ppf(cdf1)
+        ppf = dpg.ppf(cdf1)
+        assert_equal(ppf, ppf1)
+        ppf1 = dgeo.ppf(cdf1 - 1e-8)
+        ppf = dpg.ppf(cdf1 - 1e-8)
+        assert_equal(ppf, ppf1)
+        ppf1 = dgeo.ppf(cdf1 + 1e-8)
+        ppf = dpg.ppf(cdf1 + 1e-8)
+        assert_equal(ppf, ppf1)
+        ppf1 = dgeo.ppf(0)  # incorrect in scipy < 1.5.0
+        ppf = dpg.ppf(0)
+        assert_equal(ppf, -1)
+
+        # isf
+        isf1 = dgeo.isf(sf1)
+        isf = dpg.isf(sf1)
+        assert_equal(isf, isf1)
+        isf1 = dgeo.isf(sf1 - 1e-8)
+        isf = dpg.isf(sf1 - 1e-8)
+        assert_equal(isf, isf1)
+        isf1 = dgeo.isf(sf1 + 1e-8)
+        isf = dpg.isf(sf1 + 1e-8)
+        assert_equal(isf, isf1)
+        isf1 = dgeo.isf(0)
+        isf = dpg.isf(0)
+        assert_equal(isf, isf1)  # inf
+        isf1 = dgeo.isf(1)  # currently incorrect in scipy
+        isf = dpg.isf(1)
+        assert_equal(isf, -1)

--- a/statsmodels/distributions/tests/test_discrete.py
+++ b/statsmodels/distributions/tests/test_discrete.py
@@ -7,7 +7,7 @@ from scipy.stats import poisson, nbinom
 from numpy.testing import assert_allclose, assert_equal
 
 from statsmodels.distributions.discrete import (
-    DiscretizedCount, _DiscretizedModel)
+    DiscretizedCount, DiscretizedModel)
 
 from statsmodels.tools.tools import Bunch
 
@@ -270,7 +270,7 @@ class CheckDiscretized():
         # check that we go a non-trivial rvs
         assert len(xx) == nobs
         assert xx.var() > 0.001
-        mod = _DiscretizedModel(xx, distr=dp)
+        mod = DiscretizedModel(xx, distr=dp)
         res = mod.fit(start_params=start_params)
         p = mod.predict(res.params, which="probs")
         args = self.convert_params(res.params)
@@ -392,7 +392,7 @@ class TestDiscretizedGammaEx():
             probs=[46.48, 73.72, 27.88, 6.5, 1.42])
 
         dp = DiscretizedCount(stats.gamma)
-        mod = _DiscretizedModel(y, distr=dp)
+        mod = DiscretizedModel(y, distr=dp)
         res = mod.fit(start_params=[1, 1])
         nobs = len(y)
 

--- a/statsmodels/distributions/tests/test_discrete.py
+++ b/statsmodels/distributions/tests/test_discrete.py
@@ -226,7 +226,7 @@ class TestZiNBP(object):
         assert_allclose(nb_m2, zinb_m2, rtol=1e-10)
 
 
-class TestDiscretized():
+class TestDiscretizedGamma():
 
     def test_basic(self):
         np.random.seed(987146)
@@ -266,6 +266,51 @@ class TestDiscretized():
         freq = np.bincount(xx.astype(int))
         # truncate at last observed
         k = len(freq)
+        p[k - 1] += 1 - p[:k].sum()
+        tchi2 = stats.chisquare(freq, p[:k] * nobs)
+        assert tchi2.pvalue > 0.01
+
+
+class TestDiscretizedExponential():
+
+    def test_basic(self):
+        np.random.seed(987146)
+        d_offset = 0
+        paramg = (0, 5)  # include constant so we can use args in gamma
+        paramd = (5,)
+        dp = DiscretizedCount(stats.expon, d_offset)
+        assert dp.shapes == "s"
+        xi = np.arange(5)
+        p = dp._pmf(xi, *paramd)
+
+        cdf1 = stats.expon.cdf(xi, *paramg)
+        p1 = np.diff(cdf1)
+        assert_allclose(p[: len(p1)], p1, rtol=1e-13)
+        cdf = dp._cdf(xi, *paramd)
+        assert_allclose(cdf[: len(cdf1) - 1], cdf1[1:], rtol=1e-13)
+
+        # check that scipy dispatch methods work
+        p2 = dp.pmf(xi, *paramd)
+        assert_allclose(p2, p, rtol=1e-13)
+        cdf2 = dp.cdf(xi, *paramd)
+        assert_allclose(cdf2, cdf, rtol=1e-13)
+
+        nobs = 2000
+
+        xx = dp.rvs(*paramd, size=nobs)
+        mod = _DiscretizedModel(xx, distr=dp)
+        res = mod.fit(start_params=[5])
+        p = mod.predict(res.params)
+        p1 = -np.diff(stats.expon.sf(np.arange(21), *(0, res.params[0],)))
+        assert_allclose(p, p1, rtol=1e-13)
+
+        # using cdf limits precision to computation around 1
+        p1 = np.diff(stats.expon.cdf(np.arange(21), *(0, res.params[0])))
+        assert_allclose(p, p1, rtol=1e-13, atol=1e-15)
+        freq = np.bincount(xx.astype(int))
+        # truncate at last observed
+        k = len(freq)
+        p = mod.predict(res.params, k_max=k)
         p[k - 1] += 1 - p[:k].sum()
         tchi2 = stats.chisquare(freq, p[:k] * nobs)
         assert tchi2.pvalue > 0.01


### PR DESCRIPTION
see #7479 count models based on discretizing a continuous distribution

**update:**
this now also includes two fixes for base GenericLikelihood Mixin
- fix aic of k_constant=0
- fix bootstrap when recreating model with `init_keys`

open decision: do we use scale keyword of underlying  distribution, or do we handle scale explicitly instead of delegating?
**update:** decided: explicit scale internally, 

currently: parameter, args handling is inconistent in scale, it's a shape parameter for the discrete discretized distribution.
if we use scale keyword, then it will not work if the underlying distribution is discrete, which doesn't allow `scale`

