### PR TITLE
ENH: Column name can be passed as an argument in `impulse_responses` in `VARMAX`

### DIFF
--- a/statsmodels/tsa/statespace/mlemodel.py
+++ b/statsmodels/tsa/statespace/mlemodel.py
@@ -2165,7 +2165,7 @@ class MLEModel(tsbase.TimeSeriesModel):
 
         # Compute the impulse responses
 
-        # convert endog name to indexes
+        # Convert endog name to index
         use_pandas = isinstance(self.data, PandasData)
         if type(impulse) == str:
             if not use_pandas:

--- a/statsmodels/tsa/statespace/mlemodel.py
+++ b/statsmodels/tsa/statespace/mlemodel.py
@@ -2164,6 +2164,14 @@ class MLEModel(tsbase.TimeSeriesModel):
                                     start=iloc, end=end, **kwargs)
 
         # Compute the impulse responses
+
+        # convert endog name to indexes
+        use_pandas = isinstance(self.data, PandasData)
+        if type(impulse) == str:
+            if not use_pandas:
+                raise ValueError('Endog must be pd.DataFrame.')
+            impulse = self.endog_names.index(impulse)
+
         irfs = sim_model.impulse_responses(
             steps, impulse, orthogonalized, cumulative)
 
@@ -2172,7 +2180,6 @@ class MLEModel(tsbase.TimeSeriesModel):
             irfs = irfs[:, 0]
 
         # Wrap data / squeeze where appropriate
-        use_pandas = isinstance(self.data, PandasData)
         if use_pandas:
             if self.k_endog == 1:
                 irfs = pd.Series(irfs, name=self.endog_names)
@@ -3490,12 +3497,11 @@ class MLEResults(tsbase.TimeSeriesModelResults):
             Default is 1. Note that for time-invariant models, the initial
             impulse is not counted as a step, so if `steps=1`, the output will
             have 2 entries.
-        impulse : int or array_like
+        impulse : int, str or array_like
             If an integer, the state innovation to pulse; must be between 0
-            and `k_posdef-1`. Alternatively, a custom impulse vector may be
-            provided; must be shaped `k_posdef x 1`.
-
-            e.g. 
+            and `k_posdef-1`. If an str, type of endog must be `pd.DataFrame`.
+            Alternatively, a custom impulse vector may be provided; must be 
+            shaped `k_posdef x 1`.
         orthogonalized : bool, optional
             Whether or not to perform impulse using orthogonalized innovations.
             Note that this will also affect custum `impulse` vectors. Default

--- a/statsmodels/tsa/statespace/mlemodel.py
+++ b/statsmodels/tsa/statespace/mlemodel.py
@@ -3494,6 +3494,8 @@ class MLEResults(tsbase.TimeSeriesModelResults):
             If an integer, the state innovation to pulse; must be between 0
             and `k_posdef-1`. Alternatively, a custom impulse vector may be
             provided; must be shaped `k_posdef x 1`.
+
+            e.g. 
         orthogonalized : bool, optional
             Whether or not to perform impulse using orthogonalized innovations.
             Note that this will also affect custum `impulse` vectors. Default

--- a/statsmodels/tsa/statespace/mlemodel.py
+++ b/statsmodels/tsa/statespace/mlemodel.py
@@ -2021,10 +2021,12 @@ class MLEModel(tsbase.TimeSeriesModel):
             Default is 1. Note that for time-invariant models, the initial
             impulse is not counted as a step, so if `steps=1`, the output will
             have 2 entries.
-        impulse : int or array_like
+        impulse : int, str or array_like
             If an integer, the state innovation to pulse; must be between 0
-            and `k_posdef-1`. Alternatively, a custom impulse vector may be
-            provided; must be shaped `k_posdef x 1`.
+            and `k_posdef-1`. If a str, it indicates which column of df
+            the unit (1) impulse is given.
+            Alternatively, a custom impulse vector may be provided; must be
+            shaped `k_posdef x 1`.
         orthogonalized : bool, optional
             Whether or not to perform impulse using orthogonalized innovations.
             Note that this will also affect custum `impulse` vectors. Default
@@ -3499,8 +3501,9 @@ class MLEResults(tsbase.TimeSeriesModelResults):
             have 2 entries.
         impulse : int, str or array_like
             If an integer, the state innovation to pulse; must be between 0
-            and `k_posdef-1`. If an str, type of endog must be `pd.DataFrame`.
-            Alternatively, a custom impulse vector may be provided; must be 
+            and `k_posdef-1`. If a str, it indicates which column of df
+            the unit (1) impulse is given.
+            Alternatively, a custom impulse vector may be provided; must be
             shaped `k_posdef x 1`.
         orthogonalized : bool, optional
             Whether or not to perform impulse using orthogonalized innovations.


### PR DESCRIPTION
- [x] closes #7503
- [x] tests added / passed. 
- [ ] code/documentation is well formatted.  
- [ ] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

By this PR, when endog is `pd.DataFrame`,
the column name can be passed as an argument in `impulse_responses` in `VARMAX`.
I believe if users choose to use `pd.DataFrame` as `endog`, they should like to specify the index of the column by column name.

<details>

</details>
