### PR TITLE
BUG: statespace MLEModel false validation error with nested fix_params (GH7507)

### DIFF
--- a/docs/source/release/version0.13.rst
+++ b/docs/source/release/version0.13.rst
@@ -58,3 +58,6 @@ Submodules
 ~~~~~~~
 - Allow fixing parameters in ARIMA estimator Hannan-Rissanen
   (:pr:`7497`, :pr:`7501`)
+- Fix a false validation error in a rare edge case of nested ``fix_params`` for
+  the following subclasses of ``MLEModel``: ``SARIMAX``, ``VARMAX``,
+  ``DynamicFactor``, ``UnobservedComponents`` (:pr:`7508`)

--- a/statsmodels/tsa/exponential_smoothing/base.py
+++ b/statsmodels/tsa/exponential_smoothing/base.py
@@ -103,7 +103,10 @@ class StateSpaceMLEModel(tsbase.TimeSeriesModel):
         cache_free_params_index = self._free_params_index
 
         # Validate parameter names and values
-        self._validate_can_fix_params(set(params.keys()))
+        all_fixed_param_names = (
+            set(params.keys()) | set(self._fixed_params.keys())
+        )
+        self._validate_can_fix_params(all_fixed_param_names)
 
         # Set the new fixed parameters, keeping the order as given by
         # param_names

--- a/statsmodels/tsa/statespace/mlemodel.py
+++ b/statsmodels/tsa/statespace/mlemodel.py
@@ -492,7 +492,10 @@ class MLEModel(tsbase.TimeSeriesModel):
         cache_free_params_index = self._free_params_index
 
         # Validate parameter names and values
-        self._validate_can_fix_params(set(params.keys()))
+        all_fixed_param_names = (
+            set(params.keys()) | set(self._fixed_params.keys())
+        )
+        self._validate_can_fix_params(all_fixed_param_names)
 
         # Set the new fixed parameters, keeping the order as given by
         # param_names


### PR DESCRIPTION
- [x] closes #7507
- [x] tests added / passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
