### PR TITLE
Remove typo in plot_pacf example

### DIFF
--- a/statsmodels/graphics/tsaplots.py
+++ b/statsmodels/graphics/tsaplots.py
@@ -331,7 +331,7 @@ def plot_pacf(
     >>> dta = sm.datasets.sunspots.load_pandas().data
     >>> dta.index = pd.Index(sm.tsa.datetools.dates_from_range('1700', '2008'))
     >>> del dta["YEAR"]
-    >>> sm.graphics.tsa.plot_acf(dta.values.squeeze(), lags=40)
+    >>> sm.graphics.tsa.plot_pacf(dta.values.squeeze(), lags=40)
     >>> plt.show()
 
     .. plot:: plots/graphics_tsa_plot_pacf.py


### PR DESCRIPTION
example contained "sm.graphics.tsa.plot_acf", should be 'sm.graphics.tsa.plot_pacf'. (According 'plots/graphics_tsa_plot_pacf.py' already looks fine.)

