### PR TITLE
BUG/ENH fix and enh GLM, family get_distribution

### DIFF
--- a/statsmodels/genmod/families/family.py
+++ b/statsmodels/genmod/families/family.py
@@ -1091,7 +1091,7 @@ class Binomial(Family):
         var_weights : array_like
             1d array of variance (analytic) weights. The default is 1.
             var_weights are ignored for Poisson.
-        n_trials : int or float
+        n_trials : int
             Number of trials for the binomial distribution. The default is 1
             which corresponds to a Bernoulli random variable.
 

--- a/statsmodels/genmod/families/family.py
+++ b/statsmodels/genmod/families/family.py
@@ -1078,6 +1078,31 @@ class Binomial(Family):
         resid *= np.sqrt(var_weights)
         return resid
 
+    def get_distribution(self, mu, scale=1., var_weights=1., n_trials=1):
+        r"""
+        Frozen Binomial distribution instance for given parameters
+
+        Parameters
+        ----------
+        mu : ndarray
+            Usually but not always the fitted mean response variable.
+        scale : float
+            The scale parameter is ignored.
+        var_weights : array_like
+            1d array of variance (analytic) weights. The default is 1.
+            var_weights are ignored for Poisson.
+        n_trials : int or float
+            Number of trials for the binomial distribution. The default is 1
+            which corresponds to a Bernoulli random variable.
+
+        Returns
+        -------
+        distribution instance
+
+        """
+
+        return stats.binom(n=n_trials, p=mu)
+
 
 class InverseGaussian(Family):
     """

--- a/statsmodels/genmod/generalized_linear_model.py
+++ b/statsmodels/genmod/generalized_linear_model.py
@@ -899,10 +899,10 @@ class GLM(base.LikelihoodModel):
         else:
             return self.family.fitted(linpred)
 
-    def get_distribution(self, params, scale=1., exog=None, exposure=None,
-                         offset=None, var_weights=1.):
+    def get_distribution(self, params, scale=None, exog=None, exposure=None,
+                         offset=None, var_weights=1., n_trials=1.):
         """
-        Return a random number generator for the predictive distribution.
+        Return a instance of the predictive distribution.
 
         Parameters
         ----------
@@ -912,12 +912,22 @@ class GLM(base.LikelihoodModel):
             The scale parameter.
         exog : array_like
             The predictor variable matrix.
+        offset : array_like or None
+            Offset variable for predicted mean.
+        exposure : array_like or None
+            Log(exposure) will be added to the linear prediction.
+        var_weights : array_like
+            1d array of variance (analytic) weights. The default is None.
+        n_trials : int
+            Number of trials for the binomial distribution. The default is 1
+            which corresponds to a Bernoulli random variable.
 
         Returns
         -------
         gen
-            Frozen random number generator object.  Use the ``rvs`` method to
-            generate random values.
+            Instance of a scipy frozen distribution based on estimated
+            parameters.
+            Use the ``rvs`` method to generate random values.
 
         Notes
         -----
@@ -928,32 +938,22 @@ class GLM(base.LikelihoodModel):
         results will be produced.
         """
         scale = float_like(scale, "scale", optional=True)
-        fit = self.predict(params, exog, exposure, offset, linear=False)
+        # use scale=1, independent of QMLE scale for discrete
+        if isinstance(self.family, (families.Binomial, families.Poisson,
+                                    families.NegativeBinomial)):
+            scale = 1.
 
-        import scipy.stats.distributions as dist
+        mu = self.predict(params, exog, exposure, offset, linear=False)
 
-        if isinstance(self.family, families.Gaussian):
-            return dist.norm(loc=fit, scale=np.sqrt(scale))
+        kwds = {}
+        if (np.any(n_trials != 1) and
+                isinstance(self.family, families.Binomial)):
 
-        elif isinstance(self.family, families.Binomial):
-            return dist.binom(n=1, p=fit)
+            kwds["n_trials"] = n_trials
 
-        elif isinstance(self.family, families.Poisson):
-            return dist.poisson(mu=fit)
-
-        elif isinstance(self.family, families.Gamma):
-            scale_ = scale / var_weights
-            shape = 1 / scale_
-            scale_g = fit * scale_
-            return dist.gamma(shape, scale=scale_g)
-
-        elif isinstance(self.family, families.InverseGaussian):
-            mu = fit * float(scale)
-            return dist.invgauss(mu, scale=1 / scale)
-
-        else:
-            raise ValueError("get_distribution not implemented for %s" %
-                             self.family.name)
+        distr = self.family.get_distribution(mu, scale,
+                                             var_weights=var_weights, **kwds)
+        return distr
 
     def _setup_binomial(self):
         # this checks what kind of data is given for Binomial.

--- a/statsmodels/genmod/generalized_linear_model.py
+++ b/statsmodels/genmod/generalized_linear_model.py
@@ -900,7 +900,7 @@ class GLM(base.LikelihoodModel):
             return self.family.fitted(linpred)
 
     def get_distribution(self, params, scale=1., exog=None, exposure=None,
-                         offset=None):
+                         offset=None, var_weights=1.):
         """
         Return a random number generator for the predictive distribution.
 
@@ -942,8 +942,14 @@ class GLM(base.LikelihoodModel):
             return dist.poisson(mu=fit)
 
         elif isinstance(self.family, families.Gamma):
-            alpha = fit / float(scale)
-            return dist.gamma(alpha, scale=scale)
+            scale_ = scale / var_weights
+            shape = 1 / scale_
+            scale_g = fit * scale_
+            return dist.gamma(shape, scale=scale_g)
+
+        elif isinstance(self.family, families.InverseGaussian):
+            mu = fit * float(scale)
+            return dist.invgauss(mu, scale=1 / scale)
 
         else:
             raise ValueError("get_distribution not implemented for %s" %

--- a/statsmodels/genmod/tests/test_glm.py
+++ b/statsmodels/genmod/tests/test_glm.py
@@ -222,6 +222,10 @@ class CheckModelResultsMixin(object):
         m, v = distr.stats()
         assert_allclose(res1.fittedvalues, m, rtol=1e-13)
         assert_allclose(var_endog, v, rtol=1e-13)
+        # check model method
+        distr2 = res1.model.get_distribution(res1.params, res_scale)
+        for k in distr2.kwds:
+            assert_allclose(distr.kwds[k], distr2.kwds[k], rtol=1e-13)
 
 
 class CheckComparisonMixin(object):
@@ -469,6 +473,12 @@ class TestGlmBinomial(CheckModelResultsMixin):
         m, v = distr.stats()
         assert_allclose(mu_prob * n, m, rtol=1e-13)
         assert_allclose(var_endog * n, v, rtol=1e-13)
+
+        # check model method
+        distr2 = res1.model.get_distribution(res1.params, res_scale,
+                                             n_trials=n)
+        for k in distr2.kwds:
+            assert_allclose(distr.kwds[k], distr2.kwds[k], rtol=1e-13)
 
 
 # FIXME: enable/xfail/skip or delete


### PR DESCRIPTION
see #106, and fixes bug in Gamma parameterization closes #6650

binomial is missing, still to do, design/usage of n_trials?

tweedie is missing but we don't have a distribution for it.
for rvs we could use compound poisson if  `1  < p  < 2` which is the "mixed" range

WIP:
this adds get_distribution to families, 
GLM.get_distribution does not yet delegate to it.
