### PR TITLE
MAINT: Remove 32-bit testing

### DIFF
--- a/tools/ci/azure/azure_template_windows.yml
+++ b/tools/ci/azure/azure_template_windows.yml
@@ -19,9 +19,9 @@ jobs:
       python37_win_latest:
         python.version: '3.7'
         python.architecture: 'x64'
-      python38_win_32_bit_latest:
+      python38_win_latest:
         python.version: '3.8'
-        python.architecture: 'x86'
+        python.architecture: 'x64'
       python39_win_latest:
         python.version: '3.9'
         python.architecture: 'x64'

--- a/tools/nbgenerate.py
+++ b/tools/nbgenerate.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 import argparse
+import asyncio
 from functools import partial
 import hashlib
 import io
@@ -21,6 +22,10 @@ try:
 except ImportError:
     has_futures = False
 
+if sys.platform == 'win32':
+    # Set the policy to prevent "Event loop is closed" error on Windows
+    # https://github.com/encode/httpx/issues/914
+    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
 
 init()
 


### PR DESCRIPTION
Remove 32-bit testing
Small fix to nbgenerate

- [X] closes #7463 
- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
