### PR TITLE
BUG: Correct index location of seasonal

### DIFF
--- a/statsmodels/tsa/forecasting/tests/test_theta.py
+++ b/statsmodels/tsa/forecasting/tests/test_theta.py
@@ -116,3 +116,20 @@ def test_pi_width():
     pi = res.prediction_intervals(24)
     d = np.squeeze(np.diff(np.asarray(pi), axis=1))
     assert np.all(np.diff(d) > 0)
+
+
+# GH7544
+@pytest.mark.parametrize("period", [4, 12])
+def test_forecast_seasonal_alignment(data, period):
+    res = ThetaModel(
+        data,
+        period=period,
+        deseasonalize=True,
+        use_test=False,
+        difference=False,
+    ).fit(use_mle=False)
+    seasonal = res._seasonal
+    comp = res.forecast_components(32)
+    index = np.arange(data.shape[0], data.shape[0] + comp.shape[0])
+    expected = seasonal[index % period]
+    np.testing.assert_allclose(comp.seasonal, expected)

--- a/statsmodels/tsa/forecasting/theta.py
+++ b/statsmodels/tsa/forecasting/theta.py
@@ -462,7 +462,7 @@ class ThetaModelResults:
         if self.model.deseasonalize:
             seasonal = self._seasonal
             period = self.model.period
-            oos_idx = nobs + np.arange(1, steps + 1)
+            oos_idx = nobs + np.arange(steps)
             seasonal_locs = oos_idx % period
             if seasonal.shape[0]:
                 season[:] = seasonal[seasonal_locs]


### PR DESCRIPTION
Correct seasonal index location

- [X] closes #7544
- [x] tests added / passed. 
- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
