### PR TITLE
MAINT: Fix contrasts for Pandas changes

### DIFF
--- a/examples/notebooks/contrasts.ipynb
+++ b/examples/notebooks/contrasts.ipynb
@@ -443,6 +443,7 @@
    "outputs": [],
    "source": [
     "hsb2[\"readcat\"] = np.asarray(pd.cut(hsb2.read, bins=3))\n",
+    "hsb2[\"readcat\"] = hsb2[\"readcat\"].astype(object)\n",
     "hsb2.groupby(\"readcat\").mean()[\"write\"]"
    ]
   },
@@ -454,7 +455,7 @@
    "source": [
     "from patsy.contrasts import Poly\n",
     "\n",
-    "levels = hsb2.readcat.unique().tolist()\n",
+    "levels = hsb2.readcat.unique()\n",
     "contrast = Poly().code_without_intercept(levels)\n",
     "print(contrast.matrix)"
    ]
@@ -474,13 +475,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As you can see, readcat has a significant linear effect on the dependent variable `write` but not a significant quadratic or cubic effect."
+    "As you can see, readcat has a significant linear effect on the dependent variable `write` but not a significant quadratic effect."
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },


### PR DESCRIPTION
Fix contrasts to always use an object array

- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
