### PR TITLE
REF/BUG generic likelihood LLRMixin use df_resid instead of df_model for llr_pvalue

### DIFF
--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -2445,7 +2445,13 @@ class _LLRMixin():
         statistic greater than llr.  llr has a chi-squared distribution
         with degrees of freedom `df_model`.
         """
-        return stats.distributions.chi2.sf(self.llr, self.df_model)
+        # see also RegressionModel compare_lr_test
+        llr = self.llr
+        df_full = self.df_resid
+        df_restr = self.df_resid_null
+        lrdf = (df_restr - df_full)
+        self.df_lr_null = lrdf
+        return stats.distributions.chi2.sf(llr, lrdf)
 
     def set_null_options(self, llnull=None, attach_results=True, **kwargs):
         """
@@ -2532,6 +2538,8 @@ class _LLRMixin():
         if getattr(self, '_attach_nullmodel', False) is not False:
             self.res_null = res_null
 
+        self.k_null = len(res_null.params)
+        self.df_resid_null = res_null.df_resid
         return res_null.llf
 
 

--- a/statsmodels/othermod/tests/test_beta.py
+++ b/statsmodels/othermod/tests/test_beta.py
@@ -188,6 +188,23 @@ class TestBetaMeth():
         assert_equal(res1.df_resid, res2.df_residual)
         assert_equal(res1.nobs, res2.nobs)
 
+        # null model compared to R betareg and lmtest
+        df_c = res1.df_resid_null - res1.df_resid
+        assert_equal(res1.k_null, 2)
+
+        # > lrt = lrtest(res_meth_null, res_meth)  # results from R
+        pv = 7.21872953868659e-18
+        lln = 60.88809589492269
+        llf = 104.14802840534323
+        chisq = 86.51986502084107
+        dfc = 4
+        # stats.chi2.sf(86.51986502093865, 4)
+        assert_equal(df_c, dfc)
+        assert_allclose(res1.llf, llf, rtol=1e-10)
+        assert_allclose(res1.llnull, lln, rtol=1e-10)
+        assert_allclose(res1.llr, chisq, rtol=1e-10)
+        assert_allclose(res1.llr_pvalue, pv, rtol=1e-6)
+
     def test_resid(self):
         res1 = self.res1
         res2 = self.res2


### PR DESCRIPTION
fixes bug with incorrect df constraints in llr_pvalue for beta regression
https://github.com/statsmodels/statsmodels/issues/7584#issuecomment-881689009

fix is to use the difference in df_resid following the pattern of `RegressionResults.compare_lr_test`

df_model is still ambiguous across models, and currently not counting number of slope parameters.
see https://github.com/statsmodels/statsmodels/issues/1723#issuecomment-881904749
