### PR TITLE
BUG: Ensure warning does not raise

### DIFF
--- a/statsmodels/tsa/exponential_smoothing/base.py
+++ b/statsmodels/tsa/exponential_smoothing/base.py
@@ -18,6 +18,7 @@ from statsmodels.tools.numdiff import (
 )
 from statsmodels.tools.tools import pinv_extended
 import statsmodels.tsa.base.tsa_model as tsbase
+from statsmodels.tsa.statespace.tools import _safe_cond
 
 
 class StateSpaceMLEModel(tsbase.TimeSeriesModel):
@@ -971,7 +972,7 @@ class StateSpaceMLEResults(tsbase.TimeSeriesModelResults):
             etext.append(
                 "Covariance matrix is singular or near-singular,"
                 " with condition number %6.3g. Standard errors may be"
-                " unstable." % np.linalg.cond(cov_params)
+                " unstable." % _safe_cond(cov_params)
             )
 
         if etext:

--- a/statsmodels/tsa/regime_switching/markov_switching.py
+++ b/statsmodels/tsa/regime_switching/markov_switching.py
@@ -30,7 +30,11 @@ from statsmodels.tsa.regime_switching._kim_smoother import (
     skim_smoother_log,
     zkim_smoother_log,
 )
-from statsmodels.tsa.statespace.tools import find_best_blas_type, prepare_exog
+from statsmodels.tsa.statespace.tools import (
+    find_best_blas_type,
+    prepare_exog,
+    _safe_cond
+)
 
 prefix_hamilton_filter_log_map = {
     's': shamilton_filter_log, 'd': dhamilton_filter_log,
@@ -2110,10 +2114,11 @@ class MarkovSwitchingResults(tsbase.TimeSeriesModelResults):
         etext = []
         if hasattr(self, 'cov_type') and 'description' in self.cov_kwds:
             etext.append(self.cov_kwds['description'])
+
         if self._rank < len(self.params):
             etext.append("Covariance matrix is singular or near-singular,"
                          " with condition number %6.3g. Standard errors may be"
-                         " unstable." % np.linalg.cond(self.cov_params()))
+                         " unstable." % _safe_cond(self.cov_params()))
 
         if etext:
             etext = ["[{0}] {1}".format(i + 1, text)

--- a/statsmodels/tsa/statespace/mlemodel.py
+++ b/statsmodels/tsa/statespace/mlemodel.py
@@ -33,7 +33,7 @@ from .simulation_smoother import SimulationSmoother
 from .kalman_smoother import SmootherResults
 from .kalman_filter import INVERT_UNIVARIATE, SOLVE_LU, MEMORY_CONSERVE
 from .initialization import Initialization
-from .tools import prepare_exog, concat
+from .tools import prepare_exog, concat, _safe_cond
 
 
 def _handle_args(names, defaults, *args, **kwargs):
@@ -4517,7 +4517,7 @@ class MLEResults(tsbase.TimeSeriesModelResults):
                 cov_params = cov_params[mask]
             etext.append("Covariance matrix is singular or near-singular,"
                          " with condition number %6.3g. Standard errors may be"
-                         " unstable." % np.linalg.cond(cov_params))
+                         " unstable." % _safe_cond(cov_params))
 
         if etext:
             etext = ["[{0}] {1}".format(i + 1, text)

--- a/statsmodels/tsa/statespace/tools.py
+++ b/statsmodels/tsa/statespace/tools.py
@@ -1881,3 +1881,14 @@ def prepare_trend_data(polynomial_trend, k_trend, nobs, offset=1):
         i += 1
 
     return trend_data
+
+
+def _safe_cond(a):
+    """Compute condition while protecting from LinAlgError"""
+    try:
+        return np.linalg.cond(a)
+    except np.linalg.LinAlgError:
+        if np.any(np.isnan(a)):
+            return np.nan
+        else:
+            return np.inf


### PR DESCRIPTION
Protect cond in case of nan or inf

- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
