### PR TITLE
BUG: regression, allow remove_data to remove wendog, wexog, wresid

### DIFF
--- a/statsmodels/base/tests/test_shrink_pickle.py
+++ b/statsmodels/base/tests/test_shrink_pickle.py
@@ -40,6 +40,7 @@ class RemoveDataPickle(object):
         cls.exog = x
         cls.xf = 0.25 * np.ones((2, 4))
         cls.predict_kwds = {}
+        cls.reduction_factor = 0.1
 
     def test_remove_data_pickle(self):
 
@@ -77,7 +78,7 @@ class RemoveDataPickle(object):
         # for testing attach res
         self.res = res
         msg = 'pickle length not %d < %d' % (nbytes, orig_nbytes)
-        assert nbytes < orig_nbytes, msg
+        assert nbytes < orig_nbytes * self.reduction_factor, msg
         pred3 = results.predict(xf, **pred_kwds)
 
         if isinstance(pred1, pd.Series) and isinstance(pred3, pd.Series):
@@ -266,6 +267,7 @@ class TestPickleFormula(RemoveDataPickle):
         cls.exog = pd.DataFrame(x, columns=["A", "B", "C"])
         cls.xf = pd.DataFrame(0.25 * np.ones((2, 3)),
                               columns=cls.exog.columns)
+        cls.reduction_factor = 0.5
 
     def setup(self):
         x = self.exog
@@ -288,6 +290,7 @@ class TestPickleFormula2(RemoveDataPickle):
         cls.data = pd.DataFrame(data, columns=["Y", "A", "B", "C"])
         cls.xf = pd.DataFrame(0.25 * np.ones((2, 3)),
                               columns=cls.data.columns[1:])
+        cls.reduction_factor = 0.5
 
     def setup(self):
         self.results = sm.OLS.from_formula("Y ~ A + B + C",

--- a/statsmodels/regression/linear_model.py
+++ b/statsmodels/regression/linear_model.py
@@ -188,7 +188,7 @@ class RegressionModel(base.LikelihoodModel):
     """
     def __init__(self, endog, exog, **kwargs):
         super(RegressionModel, self).__init__(endog, exog, **kwargs)
-        self._data_attr.extend(['pinv_wexog', 'weights'])
+        self._data_attr.extend(['pinv_wexog', 'wendog', 'wexog', 'weights'])
 
     def initialize(self):
         """Initialize model components."""
@@ -1558,8 +1558,6 @@ class RegressionResults(base.LikelihoodModelResults):
         super(RegressionResults, self).__init__(
             model, params, normalized_cov_params, scale)
 
-        # Keep wresid since needed by predict
-        self._data_in_cache.remove("wresid")
         self._cache = {}
         if hasattr(model, 'wexog_singular_values'):
             self._wexog_singular_values = model.wexog_singular_values

--- a/statsmodels/regression/tests/test_predict.py
+++ b/statsmodels/regression/tests/test_predict.py
@@ -265,10 +265,15 @@ def test_predict_remove_data():
     endog = [i + np.random.normal(scale=0.1) for i in range(100)]
     exog = [i for i in range(100)]
     model = OLS(endog, exog, weights=[1 for _ in range(100)]).fit()
+    # we need to compute scale before we remove wendog, wexog
+    model.scale
     model.remove_data()
     scalar = model.get_prediction(1).predicted_mean
-    one_d = model.get_prediction([1]).predicted_mean
+    pred = model.get_prediction([1])
+    one_d = pred.predicted_mean
     assert_allclose(scalar, one_d)
+    # smoke test for inferenctial part
+    pred.summary_frame()
 
     series = model.get_prediction(pd.Series([1])).predicted_mean
     assert_allclose(scalar, series)


### PR DESCRIPTION
This partially reverts changes in OLS for remove_data in #6888, now wendog, wexog and wresid are removed again
reported in https://github.com/statsmodels/statsmodels/issues/7494#issuecomment-878322999

unit test changed to call results `scale` before remove_data, so that get_prediction works #6887

This does not revert changes other than wendog, wexog and wresid
~e.g. RLM `sresid` is not removed after 6888, which I guess can also be reverted.~
**correction**, I read that part too fast, sresid is in cache list and is removed. 
(In unit test case, RLM size shrinks to less than 3% of original size)

open question: Why did unit tests not catch that remove_data didn't remove the `wxxx` arrays?

