### PR TITLE
ENH: Raise when invalid optimization options passed to optimizer

### DIFF
--- a/statsmodels/base/_penalized.py
+++ b/statsmodels/base/_penalized.py
@@ -192,8 +192,11 @@ class PenalizedMixin(object):
         # TODO: temporary hack, need extra fit kwds
         # we need to rule out fit methods in a model that will not work with
         # penalization
-        if hasattr(self, 'family'):  # assume this identifies GLM
-            kwds.update({'max_start_irls' : 0})
+        from statsmodels.gam.generalized_additive_model import GLMGam
+        from statsmodels.genmod.generalized_linear_model import GLM
+        # Only for fit methods supporting max_start_irls
+        if isinstance(self, (GLM, GLMGam)):
+            kwds.update({'max_start_irls': 0})
 
         # currently we use `bfgs` by default
         if method is None:

--- a/statsmodels/discrete/tests/test_count_model.py
+++ b/statsmodels/discrete/tests/test_count_model.py
@@ -45,7 +45,7 @@ class CheckGeneric(CheckModelMixin):
 
         alpha = np.ones(len(self.res1.params))
         alpha[-2:] = 0
-        res_reg = model.fit_regularized(alpha=alpha*0.01, disp=0, maxiter=500)
+        res_reg = model.fit_regularized(alpha=alpha*0.01, disp=False, maxiter=500)
 
         assert_allclose(res_reg.params[2:], self.res1.params[2:],
             atol=5e-2, rtol=5e-2)
@@ -83,7 +83,7 @@ class TestZeroInflatedModel_logit(CheckGeneric):
         exog_infl = sm.add_constant(data.exog[:,0], prepend=False)
         cls.res1 = sm.ZeroInflatedPoisson(data.endog, exog,
             exog_infl=exog_infl, inflation='logit').fit(method='newton', maxiter=500,
-                                                        disp=0)
+                                                        disp=False)
         # for llnull test
         cls.res1._results._attach_nullmodel = True
         cls.init_keys = ['exog_infl', 'exposure', 'inflation', 'offset']
@@ -101,7 +101,7 @@ class TestZeroInflatedModel_probit(CheckGeneric):
         exog_infl = sm.add_constant(data.exog[:,0], prepend=False)
         cls.res1 = sm.ZeroInflatedPoisson(data.endog, exog,
             exog_infl=exog_infl, inflation='probit').fit(method='newton', maxiter=500,
-                                                         disp=0)
+                                                         disp=False)
         # for llnull test
         cls.res1._results._attach_nullmodel = True
         cls.init_keys = ['exog_infl', 'exposure', 'inflation', 'offset']
@@ -124,7 +124,7 @@ class TestZeroInflatedModel_offset(CheckGeneric):
         cls.res1 = sm.ZeroInflatedPoisson(data.endog, exog,
             exog_infl=exog_infl, offset=data.exog[:,7]).fit(method='newton',
                                                             maxiter=500,
-                                                            disp=0)
+                                                            disp=False)
         # for llnull test
         cls.res1._results._attach_nullmodel = True
         cls.init_keys = ['exog_infl', 'exposure', 'inflation', 'offset']
@@ -140,7 +140,7 @@ class TestZeroInflatedModel_offset(CheckGeneric):
         model3 = sm.ZeroInflatedPoisson(model1.endog, model1.exog,
             exog_infl=model1.exog_infl, exposure=np.exp(offset))
         res3 = model3.fit(start_params=self.res1.params,
-                          method='newton', maxiter=500, disp=0)
+                          method='newton', maxiter=500, disp=False)
 
         assert_allclose(res3.params, self.res1.params, atol=1e-6, rtol=1e-6)
         fitted1 = self.res1.predict()
@@ -191,7 +191,7 @@ class TestZeroInflatedModelPandas(CheckGeneric):
         model = sm.ZeroInflatedPoisson(data.endog, exog,
             exog_infl=exog_infl, inflation='logit')
         cls.res1 = model.fit(start_params=start_params, method='newton',
-                             maxiter=500, disp=0)
+                             maxiter=500, disp=False)
         # for llnull test
         cls.res1._results._attach_nullmodel = True
         cls.init_keys = ['exog_infl', 'exposure', 'inflation', 'offset']
@@ -227,7 +227,7 @@ class TestZeroInflatedPoisson_predict(object):
         cls.endog = sm.distributions.zipoisson.rvs(mu_true, 0.05,
                                                    size=mu_true.shape)
         model = sm.ZeroInflatedPoisson(cls.endog, exog)
-        cls.res = model.fit(method='bfgs', maxiter=5000, maxfun=5000, disp=0)
+        cls.res = model.fit(method='bfgs', maxiter=5000, disp=False)
 
         cls.params_true = [mu_true,  0.05, nobs]
 
@@ -287,7 +287,7 @@ class TestZeroInflatedGeneralizedPoisson(CheckGeneric):
         exog = sm.add_constant(data.exog[:,1:4], prepend=False)
         exog_infl = sm.add_constant(data.exog[:,0], prepend=False)
         cls.res1 = sm.ZeroInflatedGeneralizedPoisson(data.endog, exog,
-            exog_infl=exog_infl, p=1).fit(method='newton', maxiter=500, disp=0)
+            exog_infl=exog_infl, p=1).fit(method='newton', maxiter=500, disp=False)
         # for llnull test
         cls.res1._results._attach_nullmodel = True
         cls.init_keys = ['exog_infl', 'exposure', 'inflation', 'offset', 'p']
@@ -317,7 +317,7 @@ class TestZeroInflatedGeneralizedPoisson(CheckGeneric):
 
         res_ncg = model.fit(start_params=start_params,
                             method='minimize', min_method="trust-ncg",
-                            maxiter=500, disp=0)
+                            maxiter=500, disp=False)
 
         assert_allclose(res_ncg.params, self.res2.params,
                         atol=1e-3, rtol=0.04)
@@ -327,7 +327,7 @@ class TestZeroInflatedGeneralizedPoisson(CheckGeneric):
 
         res_dog = model.fit(start_params=start_params,
                             method='minimize', min_method="dogleg",
-                            maxiter=500, disp=0)
+                            maxiter=500, disp=False)
 
         assert_allclose(res_dog.params, self.res2.params,
                         atol=1e-3, rtol=3e-3)
@@ -340,7 +340,7 @@ class TestZeroInflatedGeneralizedPoisson(CheckGeneric):
         seed = {'seed': random_state}
         res_bh = model.fit(start_params=start_params,
                            method='basinhopping', niter=500, stepsize=0.1,
-                           niter_success=None, disp=0, interval=1, **seed)
+                           niter_success=None, disp=False, interval=1, **seed)
 
         assert_allclose(res_bh.params, self.res2.params,
                         atol=1e-4, rtol=1e-4)
@@ -361,7 +361,7 @@ class TestZeroInflatedGeneralizedPoisson_predict(object):
         cls.endog = sm.distributions.zigenpoisson.rvs(mu_true, expected_params[-1],
                                                       2, 0.5, size=mu_true.shape)
         model = sm.ZeroInflatedGeneralizedPoisson(cls.endog, exog, p=2)
-        cls.res = model.fit(method='bfgs', maxiter=5000, maxfun=5000, disp=0)
+        cls.res = model.fit(method='bfgs', maxiter=5000, disp=False)
 
         cls.params_true = [mu_true, expected_params[-1], 2,  0.5, nobs]
 
@@ -421,7 +421,7 @@ class TestZeroInflatedNegativeBinomialP(CheckGeneric):
         sp = np.array([1.88, -10.28, -0.20, 1.14, 1.34])
         cls.res1 = sm.ZeroInflatedNegativeBinomialP(data.endog, exog,
             exog_infl=exog_infl, p=2).fit(start_params=sp, method='nm',
-                                          xtol=1e-6, maxiter=5000, disp=0)
+                                          xtol=1e-6, maxiter=5000, disp=False)
         # for llnull test
         cls.res1._results._attach_nullmodel = True
         cls.init_keys = ['exog_infl', 'exposure', 'inflation', 'offset', 'p']
@@ -444,7 +444,7 @@ class TestZeroInflatedNegativeBinomialP(CheckGeneric):
 
         alpha = np.ones(len(self.res1.params))
         alpha[-2:] = 0
-        res_reg = model.fit_regularized(alpha=alpha*0.01, disp=0, maxiter=500)
+        res_reg = model.fit_regularized(alpha=alpha*0.01, disp=False, maxiter=500)
 
         assert_allclose(res_reg.params[2:], self.res1.params[2:],
             atol=1e-1, rtol=1e-1)
@@ -458,7 +458,7 @@ class TestZeroInflatedNegativeBinomialP(CheckGeneric):
 
         res_ncg = model.fit(start_params=start_params,
                             method='minimize', min_method="trust-ncg",
-                            maxiter=500, disp=0)
+                            maxiter=500, disp=False)
 
         assert_allclose(res_ncg.params, self.res2.params,
                         atol=1e-3, rtol=0.03)
@@ -468,7 +468,7 @@ class TestZeroInflatedNegativeBinomialP(CheckGeneric):
 
         res_dog = model.fit(start_params=start_params,
                             method='minimize', min_method="dogleg",
-                            maxiter=500, disp=0)
+                            maxiter=500, disp=False)
 
         assert_allclose(res_dog.params, self.res2.params,
                         atol=1e-3, rtol=3e-3)
@@ -478,7 +478,7 @@ class TestZeroInflatedNegativeBinomialP(CheckGeneric):
 
         res_bh = model.fit(start_params=start_params,
                            method='basinhopping', maxiter=500,
-                           niter_success=3, disp=0)
+                           niter_success=3, disp=False)
 
         assert_allclose(res_bh.params, self.res2.params,
                         atol=1e-4, rtol=3e-4)
@@ -503,7 +503,7 @@ class TestZeroInflatedNegativeBinomialP_predict(object):
         cls.endog = sm.distributions.zinegbin.rvs(mu_true,
                     expected_params[-1], 2, prob_infl, size=mu_true.shape)
         model = sm.ZeroInflatedNegativeBinomialP(cls.endog, exog, p=2)
-        cls.res = model.fit(method='bfgs', maxiter=5000, maxfun=5000, disp=0)
+        cls.res = model.fit(method='bfgs', maxiter=5000, disp=False)
 
         # attach others
         cls.prob_infl = prob_infl
@@ -641,7 +641,7 @@ class TestZeroInflatedNegativeBinomialP_predict2(object):
         mod = sm.ZeroInflatedNegativeBinomialP(
             cls.endog, exog, exog_infl=exog, p=2)
         res = mod.fit(start_params=start_params, method="bfgs",
-                      maxiter=1000, disp=0)
+                      maxiter=1000, disp=False)
 
         cls.res = res
 

--- a/statsmodels/discrete/tests/test_diagnostic.py
+++ b/statsmodels/discrete/tests/test_diagnostic.py
@@ -36,7 +36,7 @@ class TestCountDiagnostic(object):
         #                                2, 0.01, size=mu_true.shape)
 
         model_poi = Poisson(endog_poi, exog)
-        res_poi = model_poi.fit(method='bfgs', maxiter=5000, maxfun=5000)
+        res_poi = model_poi.fit(method='bfgs', maxiter=5000)
         cls.exog = exog
         cls.endog = endog_poi
         cls.res = res_poi

--- a/statsmodels/discrete/tests/test_discrete.py
+++ b/statsmodels/discrete/tests/test_discrete.py
@@ -807,7 +807,7 @@ class TestMNLogitL1Compatability(CheckL1Compatability):
         # Actually drop the last columnand do an unregularized fit
         exog_no_PSI = data.exog[:, :cls.m]
         cls.res_unreg = MNLogit(data.endog, exog_no_PSI).fit(
-            disp=0, tol=1e-15, method='bfgs', maxiter=1000)
+            disp=0, gtol=1e-15, method='bfgs', maxiter=1000)
 
     def test_t_test(self):
         m = self.m
@@ -919,7 +919,7 @@ class TestL1AlphaZeroMNLogit(CompareL1):
         cls.res1 = MNLogit(data.endog, data.exog).fit_regularized(
                 method="l1", alpha=0, disp=0, acc=1e-15, maxiter=1000,
                 trim_mode='auto', auto_trim_tol=0.01)
-        cls.res2 = MNLogit(data.endog, data.exog).fit(disp=0, tol=1e-15,
+        cls.res2 = MNLogit(data.endog, data.exog).fit(disp=0, gtol=1e-15,
                                                       method='bfgs',
                                                       maxiter=1000)
 
@@ -2395,7 +2395,7 @@ def test_optim_kwds_prelim():
     # GPP with p=1.5 converges correctly,
     # GPP fails when p=2 even with good start_params
     model = GeneralizedPoisson(y, exog, offset=offset, p=1.5)
-    res = model.fit(disp=0, maxiter=200, optim_kwds_prelim=optim_kwds_prelim )
+    res = model.fit(disp=0, maxiter=200, optim_kwds_prelim=optim_kwds_prelim)
 
     assert_allclose(res.mle_settings['start_params'][:-1], res_poi.params,
                     rtol=1e-4)

--- a/statsmodels/gam/tests/test_gam.py
+++ b/statsmodels/gam/tests/test_gam.py
@@ -181,7 +181,7 @@ def test_gam_glm():
 
     glm_gam = GLMGam(y, smoother=bsplines, alpha=alpha)
     res_glm_gam = glm_gam.fit(method='bfgs', max_start_irls=0,
-                              disp=1, maxiter=10000, maxfun=5000)
+                              disp=1, maxiter=10000)
     y_gam0 = np.dot(bsplines.basis, res_glm_gam.params)
     y_gam = np.asarray(res_glm_gam.fittedvalues)
     assert_allclose(y_gam, y_gam0, rtol=1e-10)
@@ -615,10 +615,10 @@ def test_glm_pirls_compatibility():
     gam_glm = GLMGam(y, smoother=cs, alpha=alphas)
 
     gam_res_glm = gam_glm.fit(method='nm', max_start_irls=0,
-                              disp=1, maxiter=20000, maxfun=10000)
+                              disp=1, maxiter=20000)
     gam_res_glm = gam_glm.fit(start_params=gam_res_glm.params,
                               method='bfgs', max_start_irls=0,
-                              disp=1, maxiter=20000, maxfun=10000)
+                              disp=1, maxiter=20000)
     gam_res_pirls = gam_pirls.fit()
 
     y_est_glm = np.dot(cs.basis, gam_res_glm.params)
@@ -800,7 +800,7 @@ def test_cov_params():
                     atol=1e-10)
 
     res_glm_gam = glm_gam.fit(method='bfgs', max_start_irls=0,
-                              disp=0, maxiter=5000, maxfun=5000)
+                              disp=0, maxiter=5000)
 
     assert_allclose(res_glm.cov_params(), res_glm_gam.cov_params(),
                     rtol=1e-4, atol=1e-8)

--- a/statsmodels/genmod/generalized_linear_model.py
+++ b/statsmodels/genmod/generalized_linear_model.py
@@ -1074,6 +1074,8 @@ class GLM(base.LikelihoodModel):
                                   cov_kwds=cov_kwds, use_t=use_t, **kwargs)
         else:
             self._optim_hessian = kwargs.get('optim_hessian')
+            if self._optim_hessian is not None:
+                del kwargs['optim_hessian']
             self._tmp_like_exog = np.empty_like(self.exog, dtype=float)
             fit_ = self._fit_gradient(start_params=start_params,
                                       method=method,
@@ -1110,8 +1112,7 @@ class GLM(base.LikelihoodModel):
                                        **kwargs)
             start_params = irls_rslt.params
             del irls_rslt
-
-        rslt = super(GLM, self).fit(start_params=start_params, tol=tol,
+        rslt = super(GLM, self).fit(start_params=start_params,
                                     maxiter=maxiter, full_output=full_output,
                                     method=method, disp=disp, **kwargs)
 

--- a/statsmodels/othermod/betareg.py
+++ b/statsmodels/othermod/betareg.py
@@ -541,7 +541,7 @@ class BetaModel(GenericLikelihoodModel):
 
         return sp2
 
-    def fit(self, start_params=None, maxiter=1000, maxfun=5000, disp=False,
+    def fit(self, start_params=None, maxiter=1000, disp=False,
             method='bfgs', **kwds):
         """
         Fit the model.
@@ -573,8 +573,8 @@ class BetaModel(GenericLikelihoodModel):
             self.hess_type = "oim"
 
         res = super(BetaModel, self).fit(start_params=start_params,
-                                         maxiter=maxiter, maxfun=maxfun,
-                                         method=method, disp=disp, **kwds)
+                                         maxiter=maxiter, method=method,
+                                         disp=disp, **kwds)
         if not isinstance(res, BetaResultsWrapper):
             # currently GenericLikelihoodModel doe not add wrapper
             res = BetaResultsWrapper(res)

--- a/statsmodels/tsa/arma_mle.py
+++ b/statsmodels/tsa/arma_mle.py
@@ -7,6 +7,7 @@ License: BSD
 TODO: check everywhere initialization of signal.lfilter
 
 """
+import warnings
 
 import numpy as np
 from scipy import signal, optimize
@@ -44,12 +45,17 @@ class Arma(GenericLikelihoodModel):  #switch to generic mle
     """
 
     def __init__(self, endog, exog=None):
+        warnings.warn(
+            "Arma is deprecated and will be removed after 0.13. Use "
+            "statsmodels.tsa.arima.model.ARIMA.",
+            FutureWarning
+        )
         #need to override p,q (nar,nma) correctly
         super(Arma, self).__init__(endog, exog)
         #set default arma(1,1)
         self.nar = 1
         self.nma = 1
-        #self.initialize()
+
 
     def initialize(self):
         pass
@@ -268,7 +274,7 @@ class Arma(GenericLikelihoodModel):  #switch to generic mle
         if start_params is None:
             start_params = np.concatenate((0.05*np.ones(nar + nma), [1]))
         mlefit = super(Arma, self).fit(start_params=start_params,
-                maxiter=maxiter, method=method, tol=tol, **kwds)
+                maxiter=maxiter, method=method, ftol=tol, **kwds)
         #bug fix: running ls and then mle did not overwrite this
         rh = mlefit.params
         self.params = rh

--- a/statsmodels/tsa/statespace/dynamic_factor_mq.py
+++ b/statsmodels/tsa/statespace/dynamic_factor_mq.py
@@ -2337,6 +2337,10 @@ class DynamicFactorMQ(mlemodel.MLEModel):
             basin-hopping solver supports.
         maxiter : int, optional
             The maximum number of iterations to perform.
+        tolerance : float, optional
+            Tolerance to use for convergence checking when using the EM
+            algorithm. To set the tolerance for other methods, pass
+            the optimizer-specific keyword argument(s).
         full_output : bool, optional
             Set to True to have all available output in the Results object's
             mle_retvals attribute. The output is dependent on the solver.
@@ -2411,7 +2415,7 @@ class DynamicFactorMQ(mlemodel.MLEModel):
                 start_params=start_params, transformed=transformed,
                 includes_fixed=includes_fixed, cov_type=cov_type,
                 cov_kwds=cov_kwds, method=method, maxiter=maxiter,
-                tolerance=tolerance, full_output=full_output, disp=disp,
+                full_output=full_output, disp=disp,
                 callback=callback, return_params=return_params,
                 optim_score=optim_score,
                 optim_complex_step=optim_complex_step,

--- a/statsmodels/tsa/statespace/mlemodel.py
+++ b/statsmodels/tsa/statespace/mlemodel.py
@@ -680,6 +680,13 @@ class MLEModel(tsbase.TimeSeriesModel):
             mlefit = Bunch(params=[], mle_retvals=None,
                            mle_settings=None)
         else:
+            # Remove disallowed kwargs
+            disallow = (
+                "concentrate_scale",
+                "enforce_stationarity",
+                "enforce_invertibility"
+            )
+            kwargs = {k: v for k, v in kwargs.items() if k not in disallow}
             # Maximum likelihood estimation
             if flags is None:
                 flags = {}

--- a/statsmodels/tsa/tests/test_exponential_smoothing.py
+++ b/statsmodels/tsa/tests/test_exponential_smoothing.py
@@ -456,7 +456,7 @@ def test_fit_vs_R(setup_model, reset_randomstate):
         start = params
     else:
         start = None
-    fit = model.fit(disp=True, tol=1e-8, start_params=start)
+    fit = model.fit(disp=True, pgtol=1e-8, start_params=start)
 
     # check log likelihood: we want to have a fit that is better, i.e. a fit
     # that has a **higher** log-likelihood

--- a/statsmodels/tsa/vector_ar/svar_model.py
+++ b/statsmodels/tsa/vector_ar/svar_model.py
@@ -253,8 +253,7 @@ class SVAR(tsbase.TimeSeriesModel):
 
         A, B = self._solve_AB(start_params, override=override,
                               solver=solver,
-                              maxiter=maxiter,
-                              maxfun=maxfun)
+                              maxiter=maxiter)
         A_mask = self.A_mask
         B_mask = self.B_mask
 
@@ -324,8 +323,7 @@ class SVAR(tsbase.TimeSeriesModel):
         loglike = self.loglike
         return approx_hess(AB_mask, loglike)
 
-    def _solve_AB(self, start_params, maxiter, maxfun, override=False,
-                  solver='bfgs'):
+    def _solve_AB(self, start_params, maxiter, override=False, solver='bfgs'):
         """
         Solves for MLE estimate of structural parameters
 
@@ -341,8 +339,6 @@ class SVAR(tsbase.TimeSeriesModel):
             conjugate, 'ncg' (non-conjugate gradient), and 'powell'.
         maxiter : int, optional
             The maximum number of iterations. Default is 500.
-        maxfun : int, optional
-            The maximum number of function evalutions.
 
         Returns
         -------
@@ -367,8 +363,7 @@ class SVAR(tsbase.TimeSeriesModel):
 
         retvals = super(SVAR, self).fit(start_params=start_params,
                                         method=solver, maxiter=maxiter,
-                                        maxfun=maxfun, ftol=1e-20,
-                                        disp=0).params
+                                        gtol=1e-20, disp=False).params
 
         A[A_mask] = retvals[:A_len]
         B[B_mask] = retvals[A_len:]


### PR DESCRIPTION
xref #7030


- [X] tests added / passed. 
- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
