### PR TITLE
MAINT: Revert exception to warning

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -63,6 +63,7 @@ filterwarnings =
     error:The `inplace` parameter in pandas::
     error:The default method:FutureWarning:
     error:trend 'nc' has been renamed to 'n':FutureWarning:
+    error:Keyword arguments have been passed:FutureWarning:
 markers =
     example: mark a test that runs example code
     matplotlib: mark a test that requires matplotlib

--- a/statsmodels/base/tests/test_generic_methods.py
+++ b/statsmodels/base/tests/test_generic_methods.py
@@ -209,9 +209,9 @@ class CheckGenericMixin(object):
 
             if use_start_params:
                 start_params = np.zeros(k_vars + k_extra)
-                method =  self.results.mle_settings['optimizer']
+                method = self.results.mle_settings['optimizer']
                 # string in `method` is not mutable, so no need for copy
-                sp =  self.results.mle_settings['start_params'].copy()
+                sp = self.results.mle_settings['start_params'].copy()
                 if self.transform_index is not None:
                     # work around internal transform_params, currently in NB
                     sp[self.transform_index] = np.exp(sp[self.transform_index])
@@ -388,7 +388,10 @@ class TestGenericLogit(CheckGenericMixin):
         model = sm.Logit(y_bin, x)  #, exposure=np.ones(nobs), offset=np.zeros(nobs)) #bug with default
         # use start_params to converge faster
         start_params = np.array([-0.73403806, -1.00901514, -0.97754543, -0.95648212])
-        self.results = model.fit(start_params=start_params, method='bfgs', disp=0)
+        with pytest.warns(FutureWarning,
+                          match="Keyword arguments have been passed"):
+            self.results = model.fit(start_params=start_params,
+                                     method='bfgs', disp=0, tol=1e-5)
 
 
 class TestGenericRLM(CheckGenericMixin):


### PR DESCRIPTION
Change exception to a warning and warn of future exception

- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
