### PR TITLE
MAINT: bump SciPy to versions supporting python 3.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,5 +7,5 @@ requires = [
     "numpy==1.17.4; python_version=='3.8'",
     "numpy==1.19.4; python_version=='3.9'",
     "numpy; python_version>'3.9'",
-    "scipy>=1.3",
+    "scipy>=1.6",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 numpy>=1.17
-scipy>=1.3
+scipy>=1.6
 pandas>=0.25
 patsy>=0.5.1

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ except ImportError:
 # Key Values that Change Each Release
 ###############################################################################
 SETUP_REQUIREMENTS = {'numpy': '1.17',  # released July 2019
-                      'scipy': '1.3',  # released May 2019
+                      'scipy': '1.6',  # released Dec 2020
                       }
 
 REQ_NOT_MET_MSG = """


### PR DESCRIPTION
Minimal SciPy version supporting Python 3.7 is SciPy 1.6.
