### PR TITLE
ENH: random number generation wrapper for rng, qrng

### DIFF
--- a/statsmodels/distributions/copula/archimedean.py
+++ b/statsmodels/distributions/copula/archimedean.py
@@ -10,10 +10,10 @@ import sys
 
 import numpy as np
 from scipy import stats, integrate, optimize
-from scipy._lib._util import check_random_state  # noqa
 
 from . import transforms
 from .copulas import Copula
+from statsmodels.tools.rng_qrng import check_random_state
 
 
 class ArchimedeanCopula(Copula):

--- a/statsmodels/distributions/copula/copulas.py
+++ b/statsmodels/distributions/copula/copulas.py
@@ -15,9 +15,9 @@ from abc import ABC, abstractmethod
 import numpy as np
 from scipy import stats
 from scipy.special import expm1
-from scipy._lib._util import check_random_state
 
 from statsmodels.graphics import utils
+from statsmodels.tools.rng_qrng import check_random_state
 
 
 def copula_bv_indep(u, v):

--- a/statsmodels/distributions/copula/other_copulas.py
+++ b/statsmodels/distributions/copula/other_copulas.py
@@ -8,8 +8,8 @@ License: BSD-3
 """
 import numpy as np
 from scipy import stats
-from scipy._lib._util import check_random_state  # noqa
 
+from statsmodels.tools.rng_qrng import check_random_state
 from statsmodels.distributions.copula.copulas import Copula
 
 

--- a/statsmodels/distributions/copula/tests/test_copula.py
+++ b/statsmodels/distributions/copula/tests/test_copula.py
@@ -333,9 +333,9 @@ class CheckCopula:
         pass
 
     def test_random(self):
-        np.random.seed(987124)
         nobs = 2000
-        self.rvs = rvs = self.copula.random(nobs)
+        rng = np.random.default_rng(276586223967191651449357908970930003177)
+        self.rvs = rvs = self.copula.random(nobs, random_state=rng)
         assert rvs.shape == (nobs, 2)
         assert_array_almost_equal(np.mean(rvs, axis=0),
                                   np.repeat(0.5, self.dim), decimal=2)

--- a/statsmodels/distributions/copula/tests/test_copula.py
+++ b/statsmodels/distributions/copula/tests/test_copula.py
@@ -334,7 +334,7 @@ class CheckCopula:
 
     def test_random(self):
         nobs = 2000
-        rng = np.random.default_rng(276586223967191651449357908970930003177)
+        rng = np.random.RandomState(27658622)
         self.rvs = rvs = self.copula.random(nobs, random_state=rng)
         assert rvs.shape == (nobs, 2)
         assert_array_almost_equal(np.mean(rvs, axis=0),

--- a/statsmodels/tools/rng_qrng.py
+++ b/statsmodels/tools/rng_qrng.py
@@ -29,10 +29,10 @@ def check_random_state(seed=None):
         Random number generator.
 
     """
-    if hasattr(stats.qmc, "QMCEngine"):
-        if isinstance(seed, stats.qmc.QMCEngine):
-            return seed
-    if isinstance(seed, np.random.RandomState):
+    if hasattr(stats, "qmc") and \
+            isinstance(seed, stats.qmc.QMCEngine):
         return seed
-
-    return np.random.default_rng(seed)
+    elif isinstance(seed, np.random.RandomState):
+        return seed
+    else:
+        return np.random.default_rng(seed)

--- a/statsmodels/tools/rng_qrng.py
+++ b/statsmodels/tools/rng_qrng.py
@@ -1,0 +1,50 @@
+import numbers
+
+import numpy as np
+import scipy.stats as stats
+
+
+def check_random_state(seed=None):
+    """Turn `seed` into a random number generator.
+
+    Parameters
+    ----------
+    seed : {None, int, `numpy.random.Generator`,
+            `numpy.random.RandomState`, `scipy.stats.qmc.QMCEngine`}, optional
+
+        If `seed` is None fresh, unpredictable entropy will be pulled
+        from the OS and `numpy.random.Generator` is used.
+        If `seed` is an int, a new ``Generator`` instance is used,
+        seeded with `seed`.
+        If `seed` is already a ``Generator``, ``RandomState`` or
+        `scipy.stats.qmc.QMCEngine` instance then
+        that instance is used.
+
+        `scipy.stats.qmc.QMCEngine` requires SciPy >=1.7. It also means
+        that the generator only have the method ``random``.
+
+    Returns
+    -------
+    seed : {`numpy.random.Generator`, `numpy.random.RandomState`}
+        Random number generator.
+
+    """
+    if seed is None or isinstance(seed, (numbers.Integral, np.integer)):
+        if not hasattr(np.random, 'Generator'):
+            # This can be removed once numpy 1.16 is dropped
+            msg = ("NumPy 1.16 doesn't have Generator, use either "
+                   "NumPy >= 1.17 or `seed=np.random.RandomState(seed)`")
+            raise ValueError(msg)
+        return np.random.default_rng(seed)
+    elif isinstance(seed, np.random.RandomState):
+        return seed
+    elif isinstance(seed, np.random.Generator):
+        # The two checks can be merged once numpy 1.16 is dropped
+        return seed
+    elif isinstance(seed, np.random.Generator):
+        return seed
+    elif hasattr(stats.qmc, 'QMCEngine') and isinstance(seed, stats.qmc.QMCEngine):
+        return seed
+    else:
+        raise ValueError('%r cannot be used to seed a numpy.random.Generator'
+                         ' instance' % seed)

--- a/statsmodels/tools/rng_qrng.py
+++ b/statsmodels/tools/rng_qrng.py
@@ -31,7 +31,8 @@ def check_random_state(seed=None):
     """
     if isinstance(seed, np.random.RandomState):
         return seed
-    elif hasattr(stats.qmc, "QMCEngine") and isinstance(seed, stats.qmc.QMCEngine):
+    elif hasattr(stats.qmc, "QMCEngine") and \
+            isinstance(seed, stats.qmc.QMCEngine):
         return seed
     else:
         return np.random.default_rng(seed)

--- a/statsmodels/tools/rng_qrng.py
+++ b/statsmodels/tools/rng_qrng.py
@@ -1,6 +1,3 @@
-import numbers
-from collections import Sequence
-
 import numpy as np
 import scipy.stats as stats
 
@@ -32,12 +29,9 @@ def check_random_state(seed=None):
         Random number generator.
 
     """
-    if seed is None or isinstance(seed, (numbers.Integral, np.integer, Sequence)):
-        return np.random.default_rng(seed)
-    elif isinstance(seed, (np.random.RandomState, np.random.Generator)):
+    if isinstance(seed, np.random.RandomState):
         return seed
     elif hasattr(stats.qmc, "QMCEngine") and isinstance(seed, stats.qmc.QMCEngine):
         return seed
     else:
-        raise ValueError(f"{seed:r} cannot be used to seed a"
-                         " numpy.random.Generator instance")
+        return np.random.default_rng(seed)

--- a/statsmodels/tools/rng_qrng.py
+++ b/statsmodels/tools/rng_qrng.py
@@ -29,10 +29,10 @@ def check_random_state(seed=None):
         Random number generator.
 
     """
+    if hasattr(stats.qmc, "QMCEngine"):
+        if isinstance(seed, stats.qmc.QMCEngine):
+            return seed
     if isinstance(seed, np.random.RandomState):
         return seed
-    elif hasattr(stats.qmc, "QMCEngine") and \
-            isinstance(seed, stats.qmc.QMCEngine):
-        return seed
-    else:
-        return np.random.default_rng(seed)
+
+    return np.random.default_rng(seed)

--- a/statsmodels/tools/rng_qrng.py
+++ b/statsmodels/tools/rng_qrng.py
@@ -1,4 +1,5 @@
 import numbers
+from collections import Sequence
 
 import numpy as np
 import scipy.stats as stats
@@ -9,13 +10,13 @@ def check_random_state(seed=None):
 
     Parameters
     ----------
-    seed : {None, int, `numpy.random.Generator`,
+    seed : {None, int, array_like[ints], `numpy.random.Generator`,
             `numpy.random.RandomState`, `scipy.stats.qmc.QMCEngine`}, optional
 
         If `seed` is None fresh, unpredictable entropy will be pulled
         from the OS and `numpy.random.Generator` is used.
-        If `seed` is an int, a new ``Generator`` instance is used,
-        seeded with `seed`.
+        If `seed` is an int or ``array_like[ints]``, a new ``Generator``
+        instance is used, seeded with `seed`.
         If `seed` is already a ``Generator``, ``RandomState`` or
         `scipy.stats.qmc.QMCEngine` instance then
         that instance is used.
@@ -25,26 +26,18 @@ def check_random_state(seed=None):
 
     Returns
     -------
-    seed : {`numpy.random.Generator`, `numpy.random.RandomState`}
+    seed : {`numpy.random.Generator`, `numpy.random.RandomState`,
+            `scipy.stats.qmc.QMCEngine`}
+
         Random number generator.
 
     """
-    if seed is None or isinstance(seed, (numbers.Integral, np.integer)):
-        if not hasattr(np.random, 'Generator'):
-            # This can be removed once numpy 1.16 is dropped
-            msg = ("NumPy 1.16 doesn't have Generator, use either "
-                   "NumPy >= 1.17 or `seed=np.random.RandomState(seed)`")
-            raise ValueError(msg)
+    if seed is None or isinstance(seed, (numbers.Integral, np.integer, Sequence)):
         return np.random.default_rng(seed)
-    elif isinstance(seed, np.random.RandomState):
+    elif isinstance(seed, (np.random.RandomState, np.random.Generator)):
         return seed
-    elif isinstance(seed, np.random.Generator):
-        # The two checks can be merged once numpy 1.16 is dropped
-        return seed
-    elif isinstance(seed, np.random.Generator):
-        return seed
-    elif hasattr(stats.qmc, 'QMCEngine') and isinstance(seed, stats.qmc.QMCEngine):
+    elif hasattr(stats.qmc, "QMCEngine") and isinstance(seed, stats.qmc.QMCEngine):
         return seed
     else:
-        raise ValueError('%r cannot be used to seed a numpy.random.Generator'
-                         ' instance' % seed)
+        raise ValueError(f"{seed:r} cannot be used to seed a"
+                         " numpy.random.Generator instance")


### PR DESCRIPTION
This is another follow up of #7254 which adds a wrapper around `np.random.Generator` and alike.

It is similar to the one in SciPy for QMC, but it also allows to pass along an instance of `scipy.qmc.QMCEngine`. This way we can use QMC with copula.

c.f. discussion https://github.com/statsmodels/statsmodels/pull/7408#issuecomment-888266539

cc @josef-pkt 