### PR TITLE
ENH: Add RUR stationarity test to statsmodels.tsa.stattools

### DIFF
--- a/docs/source/api-structure.rst
+++ b/docs/source/api-structure.rst
@@ -47,9 +47,9 @@ the namespace exploration features of IPython, Spyder, IDLE, etc.):
     ['AR', 'ARMA', 'SVAR', 'VAR', '__builtins__', '__doc__',
     '__file__', '__name__', '__package__', 'acf', 'acovf', 'add_lag',
     'add_trend', 'adfuller', 'ccf', 'ccovf', 'datetools', 'detrend',
-    'filters', 'grangercausalitytests', 'interp', 'lagmat', 'lagmat2ds',
-    'pacf', 'pacf_ols', 'pacf_yw', 'periodogram', 'q_stat', 'stattools',
-    'tsatools', 'var']
+    'filters', 'grangercausalitytests', 'interp', 'lagmat', 'lagmat2ds', 'kpss',
+    'pacf', 'pacf_ols', 'pacf_yw', 'periodogram', 'q_stat', 'range_unit_root_test',
+    'stattools', 'tsatools', 'var']
 
 Notes
 ^^^^^

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -139,6 +139,8 @@ Statistics and Tests
    ~statsmodels.tsa.stattools.pacf_ols
    ~statsmodels.tsa.stattools.pacf_yw
    ~statsmodels.tsa.stattools.q_stat
+   ~statsmodels.tsa.stattools.range_unit_root_test
+
 
 Univariate Time-Series Analysis
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/tsa.rst
+++ b/docs/source/tsa.rst
@@ -75,6 +75,7 @@ Descriptive Statistics and Tests
    stattools.ccf
    stattools.adfuller
    stattools.kpss
+   stattools.range_unit_root_test
    stattools.zivot_andrews
    stattools.coint
    stattools.bds

--- a/statsmodels/tsa/api.py
+++ b/statsmodels/tsa/api.py
@@ -25,6 +25,7 @@ __all__ = [
     "add_lag",
     "add_trend",
     "adfuller",
+    "range_unit_root_test",
     "arima",
     "arma_generate_sample",
     "arma_order_select_ic",
@@ -94,6 +95,7 @@ from .stattools import (
     pacf_ols,
     pacf_yw,
     q_stat,
+    range_unit_root_test,
 )
 from .tsatools import add_lag, add_trend, detrend, lagmat, lagmat2ds
 from .vector_ar.svar_model import SVAR

--- a/statsmodels/tsa/stattools.py
+++ b/statsmodels/tsa/stattools.py
@@ -2254,8 +2254,8 @@ look-up table. The actual p-value is {direction} than the p-value returned.
         rstore = ResultsStore()
         rstore.nobs = nobs
 
-        rstore.H0 = "The series is not {0} stationary"
-        rstore.HA = "The series is {0} stationary"
+        rstore.H0 = "The series is not stationary"
+        rstore.HA = "The series is stationary"
 
         return rur_stat, p_value, crit_dict, rstore
     else:

--- a/statsmodels/tsa/stattools.py
+++ b/statsmodels/tsa/stattools.py
@@ -12,6 +12,7 @@ import numpy as np
 from numpy.linalg import LinAlgError
 import pandas as pd
 from scipy import stats
+from scipy.interpolate import interp1d
 
 from statsmodels.regression.linear_model import OLS, yule_walker
 from statsmodels.tools.sm_exceptions import (
@@ -54,6 +55,7 @@ __all__ = [
     "levinson_durbin_pacf",
     "levinson_durbin",
     "zivot_andrews",
+    "rur",
 ]
 
 SQRTEPS = np.sqrt(np.finfo(np.double).eps)
@@ -2133,6 +2135,142 @@ def _kpss_autolag(resids, nobs):
     gamma_hat = 1.1447 * np.power(s_hat * s_hat, pwr)
     autolags = int(gamma_hat * np.power(nobs, pwr))
     return autolags
+
+def rur(x, store=False):
+    """
+    Range unit-root test for stationarity.
+
+    Computes the Range Unit-Root (RUR) test for the null
+    hypothesis that x is stationary.
+
+    Parameters
+    ----------
+    x : array_like, 1d
+        The data series to test.
+    store : bool
+        If True, then a result instance is returned additionally to
+        the RUR statistic (default is False).
+
+    Returns
+    -------
+    rur_stat : float
+        The RUR test statistic.
+    p_value : float
+        The p-value of the test. The p-value is interpolated from
+        Table 1 in Aparicio et al. (2006), and a boundary point
+        is returned if the test statistic is outside the table of
+        critical values, that is, if the p-value is outside the
+        interval (0.01, 0.1).
+    crit : dict
+        The critical values at 10%, 5%, 2.5% and 1%. Based on
+        Aparicio et al. (2006).
+    resstore : (optional) instance of ResultStore
+        An instance of a dummy class with results attached as attributes.
+
+    Notes
+    -----
+    The p-values are interpolated from
+    Table 1 of Aparicio et al. (2006). If the computed statistic is
+    outside the table of critical values, then a warning message is
+    generated.
+
+    Missing values are not handled.
+
+    References
+    ----------
+    .. [1] Aparicio, F., Escribano A., Sipols, A.E. (2006). Range Unit-Root (RUR)
+        tests: robust against nonlinearities, error distributions, structural breaks
+        and outliers. Journal of Time Series Analysis, 27 (4): 545-576.
+    """
+    x = array_like(x, "x")
+    store = bool_like(store, "store")
+
+    nobs = x.shape[0]
+
+    # if m is not one, n != m * n
+    if nobs != x.size:
+        raise ValueError("x of shape {0} not understood".format(x.shape))
+
+    # Table from [1] has been replicated using 200,000 samples
+    # Critical values for new n_obs values have been identified
+    pvals = [0.01, 0.025, 0.05, 0.10, 0.90, 0.95]
+    n = np.array([25, 50, 100, 150, 200, 250, 500, 1000, 2000, 3000, 4000, 5000])
+    crit = np.array([
+        [0.6626, 0.8126, 0.9192, 1.0712, 2.4863, 2.7312],
+        [0.7977, 0.9274, 1.0478, 1.1964, 2.6821, 2.9613],
+        [0.907, 1.0243, 1.1412, 1.2888, 2.8317, 3.1393],
+        [0.9543, 1.0768, 1.1869, 1.3294, 2.8915, 3.2049],
+        [0.9833, 1.0984, 1.2101, 1.3494, 2.9308, 3.2482],
+        [0.9982, 1.1137, 1.2242, 1.3632, 2.9571, 3.2482],
+        [1.0494, 1.1643, 1.2712, 1.4076, 3.0207, 3.3584],
+        [1.0846, 1.1959, 1.2988, 1.4344, 3.0653, 3.4073],
+        [1.1121, 1.2200, 1.3230, 1.4556, 3.0948, 3.4439],
+        [1.1204, 1.2295, 1.3318, 1.4656, 3.1054, 3.4632],
+        [1.1309, 1.2347, 1.3318, 1.4693, 3.1165, 3.4717],
+        [1.1377, 1.2402, 1.3408, 1.4729, 3.1252, 3.4807]
+    ])
+
+    # Interpolation for nobs
+    XX = np.array([nobs])
+
+    inter_crit = np.zeros((len(XX), crit.shape[1]))
+    for i in range(crit.shape[1]):
+        f = interp1d(n, crit[:, i])
+        for j in range(len(XX)):
+            inter_crit[j, i] = f(XX[j])
+
+    # Calculate RUR stat
+    count = 0
+    max_p = x[0]
+    min_p = x[0]
+
+    for v in x[1:]:
+        if v > max_p:
+            max_p = v
+            count = count + 1
+        if v < min_p:
+            min_p = v
+            count = count + 1
+
+    rur_stat = count / np.sqrt(len(x))
+
+    k = len(pvals)-1
+    for i in range(len(pvals)-1,-1,-1):
+        if rur_stat < inter_crit[0,i]:
+            k = i
+        else:
+            break
+
+    p_value = pvals[k]
+
+    warn_msg = """\
+The test statistic is outside of the range of p-values available in the
+look-up table. The actual p-value is {direction} than the p-value returned.
+"""
+    if p_value == pvals[-1]:
+        warnings.warn(
+            warn_msg.format(direction="smaller"), InterpolationWarning
+        )
+    elif p_value == pvals[0]:
+        warnings.warn(
+            warn_msg.format(direction="greater"), InterpolationWarning
+        )
+
+    crit_dict = {"10%": inter_crit[0,3], "5%": inter_crit[0,2], "2.5%": inter_crit[0,1], "1%": inter_crit[0,0]}
+
+    if store:
+        from statsmodels.stats.diagnostic import ResultsStore
+
+        rstore = ResultsStore()
+        rstore.nobs = nobs
+
+        stationary_type = "level" if hypo == "c" else "trend"
+        rstore.H0 = "The series is {0} stationary".format(stationary_type)
+        rstore.HA = "The series is not {0} stationary".format(stationary_type)
+
+        return rur_stat, p_value, crit_dict, rstore
+    else:
+        return rur_stat, p_value, crit_dict
 
 
 class ZivotAndrewsUnitRoot(object):

--- a/statsmodels/tsa/stattools.py
+++ b/statsmodels/tsa/stattools.py
@@ -2264,9 +2264,8 @@ look-up table. The actual p-value is {direction} than the p-value returned.
         rstore = ResultsStore()
         rstore.nobs = nobs
 
-        stationary_type = "level" if hypo == "c" else "trend"
-        rstore.H0 = "The series is {0} stationary".format(stationary_type)
-        rstore.HA = "The series is not {0} stationary".format(stationary_type)
+        rstore.H0 = "The series is not {0} stationary"
+        rstore.HA = "The series is {0} stationary"
 
         return rur_stat, p_value, crit_dict, rstore
     else:

--- a/statsmodels/tsa/stattools.py
+++ b/statsmodels/tsa/stattools.py
@@ -2244,7 +2244,7 @@ look-up table. The actual p-value is {direction} than the p-value returned.
         direction="larger"
 
     if direction:
-        warnings.warn( warn_msg.format(direction=direction), InterpolationWarning )
+        warnings.warn(warn_msg.format(direction=direction), InterpolationWarning)
 
     crit_dict = {"10%": inter_crit[0,3], "5%": inter_crit[0,2], "2.5%": inter_crit[0,1], "1%": inter_crit[0,0]}
 

--- a/statsmodels/tsa/tests/test_stattools.py
+++ b/statsmodels/tsa/tests/test_stattools.py
@@ -44,8 +44,13 @@ from statsmodels.tsa.stattools import (
     pacf_burg,
     pacf_ols,
     pacf_yw,
+    range_unit_root_test,
     zivot_andrews,
 )
+
+# Remove imports when range unit root test gets an R implementation
+from statsmodels.tools.validation import array_like, bool_like
+from scipy.interpolate import interp1d
 
 DECIMAL_8 = 8
 DECIMAL_6 = 6
@@ -820,6 +825,140 @@ class TestKPSS:
     def test_deprecation(self):
         with pytest.warns(FutureWarning):
             kpss(self.x, "c")
+
+
+class TestRUR:
+    """
+    Simple implementation
+    ------
+    Since an R implementation of the test cannot be found, the method is tested against
+    a simple implementation using a for loop.
+    In this context, x is the vector containing the
+    macrodata['realgdp'] series.
+    """
+
+    @classmethod
+    def setup(cls):
+        cls.data = macrodata.load_pandas()
+        cls.x = cls.data.data["realgdp"].values
+
+    # To be removed when range unit test gets an R implementation
+    def simple_rur(self, x, store=False):
+        x = array_like(x, "x")
+        store = bool_like(store, "store")
+
+        nobs = x.shape[0]
+
+        # if m is not one, n != m * n
+        if nobs != x.size:
+            raise ValueError("x of shape {0} not understood".format(x.shape))
+
+        # Table from [1] has been replicated using 200,000 samples
+        # Critical values for new n_obs values have been identified
+        pvals = [0.01, 0.025, 0.05, 0.10, 0.90, 0.95]
+        n = np.array([25, 50, 100, 150, 200, 250, 500, 1000, 2000, 3000, 4000, 5000])
+        crit = np.array([
+            [0.6626, 0.8126, 0.9192, 1.0712, 2.4863, 2.7312],
+            [0.7977, 0.9274, 1.0478, 1.1964, 2.6821, 2.9613],
+            [0.907, 1.0243, 1.1412, 1.2888, 2.8317, 3.1393],
+            [0.9543, 1.0768, 1.1869, 1.3294, 2.8915, 3.2049],
+            [0.9833, 1.0984, 1.2101, 1.3494, 2.9308, 3.2482],
+            [0.9982, 1.1137, 1.2242, 1.3632, 2.9571, 3.2482],
+            [1.0494, 1.1643, 1.2712, 1.4076, 3.0207, 3.3584],
+            [1.0846, 1.1959, 1.2988, 1.4344, 3.0653, 3.4073],
+            [1.1121, 1.2200, 1.3230, 1.4556, 3.0948, 3.4439],
+            [1.1204, 1.2295, 1.3318, 1.4656, 3.1054, 3.4632],
+            [1.1309, 1.2347, 1.3318, 1.4693, 3.1165, 3.4717],
+            [1.1377, 1.2402, 1.3408, 1.4729, 3.1252, 3.4807]
+        ])
+
+        # Interpolation for nobs
+        inter_crit = np.zeros((1, crit.shape[1]))
+        for i in range(crit.shape[1]):
+            f = interp1d(n, crit[:, i])
+            inter_crit[0, i] = f(nobs)
+
+        # Calculate RUR stat
+        count = 0
+
+        max_p = x[0]
+        min_p = x[0]
+
+        for v in x[1:]:
+            if v > max_p:
+                max_p = v
+                count = count + 1
+            if v < min_p:
+                min_p = v
+                count = count + 1
+
+        rur_stat = count / np.sqrt(len(x))
+
+        k = len(pvals) - 1
+        for i in range(len(pvals) - 1, -1, -1):
+            if rur_stat < inter_crit[0, i]:
+                k = i
+            else:
+                break
+
+        p_value = pvals[k]
+
+        warn_msg = """\
+        The test statistic is outside of the range of p-values available in the
+        look-up table. The actual p-value is {direction} than the p-value returned.
+        """
+        direction = ""
+        if p_value == pvals[-1]:
+            direction = "smaller"
+        elif p_value == pvals[0]:
+            direction = "larger"
+
+        if direction:
+            warnings.warn(warn_msg.format(direction=direction), InterpolationWarning)
+
+        crit_dict = {"10%": inter_crit[0, 3], "5%": inter_crit[0, 2], "2.5%": inter_crit[0, 1], "1%": inter_crit[0, 0]}
+
+        if store:
+            from statsmodels.stats.diagnostic import ResultsStore
+
+            rstore = ResultsStore()
+            rstore.nobs = nobs
+
+            rstore.H0 = "The series is not stationary"
+            rstore.HA = "The series is stationary"
+
+            return rur_stat, p_value, crit_dict, rstore
+        else:
+            return rur_stat, p_value, crit_dict
+
+    def test_fail_nonvector_input(self, reset_randomstate):
+        with pytest.warns(InterpolationWarning):
+            range_unit_root_test(self.x)
+
+        x = np.random.rand(20, 2)
+        assert_raises(ValueError, range_unit_root_test, x)
+
+
+    def test_teststat(self):
+        with pytest.warns(InterpolationWarning):
+            rur_stat, _, _ = range_unit_root_test(self.x)
+            simple_rur_stat, _, _ = self.simple_rur(self.x)
+        assert_almost_equal(rur_stat, simple_rur_stat, DECIMAL_3)
+
+
+    def test_pval(self):
+        with pytest.warns(InterpolationWarning):
+            _, pval, _ = range_unit_root_test(self.x)
+            _, simple_pval, _ = self.simple_rur(self.x)
+        assert_equal(pval, simple_pval)
+
+
+    def test_store(self):
+        with pytest.warns(InterpolationWarning):
+            _, _, _, store = range_unit_root_test(self.x, True)
+
+        # assert attributes, and make sure they're correct
+        assert_equal(store.nobs, len(self.x))
 
 
 def test_pandasacovf():


### PR DESCRIPTION
The RUR test implementation comes from the paper  "Range Unit-Root tests" by Aparicio et Al. [2006]

The critical values table has been recalculate with more iterations than the paper.

- [x] closes #xxxx
- [x] tests added / passed. 
- [ ] code/documentation is well formatted.  
- [x] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
