### PR TITLE
MAINT: Avoid passing bad optimization param

### DIFF
--- a/statsmodels/base/optimizer.py
+++ b/statsmodels/base/optimizer.py
@@ -18,7 +18,7 @@ def check_kwargs(kwargs: dict[str, Any], allowed: Sequence[str], method: str):
             f"Keyword arguments have been passed to the optimizer that have "
             f"no effect. The list of allowed keyword arguments for method "
             f"{method} is: {', '.join(allowed)}. The list of unsupported "
-            f"keyword arguments passed include: {', '.join(extra)}. After"
+            f"keyword arguments passed include: {', '.join(extra)}. After "
             f"release 0.14, this will raise.",
             FutureWarning
         )

--- a/statsmodels/tsa/tests/test_exponential_smoothing.py
+++ b/statsmodels/tsa/tests/test_exponential_smoothing.py
@@ -466,7 +466,7 @@ def test_fit_vs_R(setup_model, reset_randomstate):
     try:
         assert loglike >= loglike_R - 1e-4
     except AssertionError:
-        fit = model.fit(disp=True, tol=1e-8, start_params=params)
+        fit = model.fit(disp=True, pgtol=1e-8, start_params=params)
         loglike = fit.llf
         try:
             assert loglike >= loglike_R - 1e-4


### PR DESCRIPTION
Use correct name for kwarg

- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
