### PR TITLE
DOC: Update dev page flake8 command to follow PULL_REQUEST_TEMPLATE.md

### DIFF
--- a/docs/source/dev/index.rst
+++ b/docs/source/dev/index.rst
@@ -52,7 +52,7 @@ greatly helps the job of maintaining and releasing the software a shared effort.
   Check that the build output does not have *any* warnings due to your changes.
 - Follow `PEP8 <https://www.python.org/dev/peps/pep-0008/>`_ style guidelines
   wherever possible. Compare your code to what's in main by running
-  ``git diff upstream/main -u -- "*.py" | flake8 --diff`` prior to submitting.
+  ``git diff upstream/main -u -- "*.py" | flake8 --diff --isolated`` prior to submitting.
 - Finally, please add your changes to the release notes. Open the
   ``docs/source/release/versionX.X.rst`` file that has the version number of the
   next release and add your changes to the appropriate section.


### PR DESCRIPTION
Is there any reason we should have different flake8 commands (`--isolated`) on the [dev page](https://github.com/statsmodels/statsmodels/blob/main/docs/source/dev/index.rst) and on the [pull request template](https://github.com/statsmodels/statsmodels/blob/main/.github/PULL_REQUEST_TEMPLATE.md) (or just see details below)? e.g. slowdown from the additional rules?

Making this PR in case this was unintended. :)

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
