### PR TITLE
BUG: improve sidak multipletest precision close to zero

### DIFF
--- a/statsmodels/stats/multitest.py
+++ b/statsmodels/stats/multitest.py
@@ -170,8 +170,10 @@ def multipletests(pvals, alpha=0.05, method='hs', is_sorted=False,
         reject = ~notreject
         del notreject
 
-        pvals_corrected_raw = 1 - np.power((1. - pvals),
-                                           np.arange(ntests, 0, -1))
+        # It's eqivalent to 1 - np.power((1. - pvals),
+        #                           np.arange(ntests, 0, -1))
+        # but prevents the issue of the floating point precision
+        pvals_corrected_raw = -np.expm1(np.arange(ntests, 0, -1)*np.log1p(-pvals))
         pvals_corrected = np.maximum.accumulate(pvals_corrected_raw)
         del pvals_corrected_raw
 

--- a/statsmodels/stats/multitest.py
+++ b/statsmodels/stats/multitest.py
@@ -152,7 +152,7 @@ def multipletests(pvals, alpha=0.05, method='hs', is_sorted=False,
 
     elif method.lower() in ['s', 'sidak']:
         reject = pvals <= alphacSidak
-        pvals_corrected = 1 - np.power((1. - pvals), ntests)
+        pvals_corrected = -np.expm1(ntests * np.log1p(-pvals))
 
     elif method.lower() in ['hs', 'holm-sidak']:
         alphacSidak_all = 1 - np.power((1. - alphaf),
@@ -173,7 +173,8 @@ def multipletests(pvals, alpha=0.05, method='hs', is_sorted=False,
         # It's eqivalent to 1 - np.power((1. - pvals),
         #                           np.arange(ntests, 0, -1))
         # but prevents the issue of the floating point precision
-        pvals_corrected_raw = -np.expm1(np.arange(ntests, 0, -1)*np.log1p(-pvals))
+        pvals_corrected_raw = -np.expm1(np.arange(ntests, 0, -1) *
+                                        np.log1p(-pvals))
         pvals_corrected = np.maximum.accumulate(pvals_corrected_raw)
         del pvals_corrected_raw
 

--- a/statsmodels/stats/tests/test_multi.py
+++ b/statsmodels/stats/tests/test_multi.py
@@ -343,11 +343,12 @@ def test_issorted(method):
     assert_allclose(res2[0][sortrevind], res1[0], rtol=1e-10)
 
 
-def test_floating_precision():
+@pytest.mark.parametrize('method', sorted(multitest_methods_names))
+def test_floating_precision(method):
     # issue #7465
     pvals = np.full(6000, 0.99)
     pvals[0] = 1.138569e-56
-    assert multipletests(pvals, method='hs')[1][0] != 0
+    assert multipletests(pvals, method=method)[1][0] > 1e-60
 
 
 def test_tukeyhsd():

--- a/statsmodels/stats/tests/test_multi.py
+++ b/statsmodels/stats/tests/test_multi.py
@@ -343,6 +343,13 @@ def test_issorted(method):
     assert_allclose(res2[0][sortrevind], res1[0], rtol=1e-10)
 
 
+def test_floating_precision():
+    # issue #7465
+    pvals = np.full(6000, 0.99)
+    pvals[0] = 1.138569e-56
+    assert multipletests(pvals, method='hs')[1][0] != 0
+
+
 def test_tukeyhsd():
     # example multicomp in R p 83
 


### PR DESCRIPTION
see issue, closes #7465 closes #7466

updated PR #7466

corrects both cases of sidak "s" and "hs"
