### PR TITLE
BUG: proportions_chisquare prevent integer overflow 

### DIFF
--- a/statsmodels/stats/proportion.py
+++ b/statsmodels/stats/proportion.py
@@ -748,8 +748,11 @@ def _table_proportion(count, nobs):
     recent scipy has more elaborate contingency table functions
 
     '''
+    count = np.asarray(count)
+    dt = np.promote_types(count.dtype, np.float64)
+    count = np.asarray(count, dtype=dt)
     table = np.column_stack((count, nobs - count))
-    expected = table.sum(0) * table.sum(1)[:,None] * 1. / table.sum()
+    expected = table.sum(0) * table.sum(1)[:, None] * 1. / table.sum()
     n_rows = table.shape[0]
     return table, expected, n_rows
 

--- a/statsmodels/stats/tests/test_proportion.py
+++ b/statsmodels/stats/tests/test_proportion.py
@@ -583,6 +583,16 @@ def test_proportion_ztests():
     # test only p-value
     assert_almost_equal(res1[1], res2[1], decimal=13)
 
+    # test with integers, issue #7603
+    res1 = smprop.proportions_ztest(np.asarray([15, 10]),
+                                    np.asarray([20, 50000]),
+                                    value=0, prop_var=None)
+    res2 = smprop.proportions_chisquare(np.asarray([15, 10]),
+                                        np.asarray([20, 50000]))
+    # test only p-value
+    assert_almost_equal(res1[1], res2[1], decimal=13)
+    assert_array_less(0, res2[-1][1])  # expected should be positive
+
 
 def test_confint_2indep():
     # alpha = 0.05


### PR DESCRIPTION
closes #7603

use dtype at least float64 in _table_proportion

(aside: complex numbers will not work because, scipy distribution norm uses special function that doesn't support complex for cdf, ppf)