### PR TITLE
ENH: add dk_params option to GLM info_criteria

### DIFF
--- a/statsmodels/genmod/tests/test_glm.py
+++ b/statsmodels/genmod/tests/test_glm.py
@@ -2540,6 +2540,7 @@ def test_output_exposure_null(reset_randomstate):
     # Check that they are different
     assert np.abs(null_model_without_exposure.llf - model.llnull) > 1
 
+
 def test_qaic():
 
     # Example from documentation of R package MuMIn
@@ -2562,7 +2563,11 @@ def test_qaic():
     # presumably because they count the scale parameter in df.
     # This won't matter when comparing models by differencing
     # QAICs.
+    # Binomial doesn't have a scale parameter, so adding +1 is not correct.
     assert_allclose(qaic, 29.13266, rtol=1e-5, atol=1e-5)
+    qaic1 = r.info_criteria(crit="qaic", scale=scale, dk_params=1)
+    assert_allclose(qaic1, 31.13266, rtol=1e-5, atol=1e-5)
+
 
 def test_tweedie_score():
 

--- a/statsmodels/regression/rolling.py
+++ b/statsmodels/regression/rolling.py
@@ -525,6 +525,10 @@ class RollingRegressionResults(object):
         with np.errstate(divide="ignore"):
             return self._wrap(RegressionResults.bic.func(self))
 
+    def info_criteria(self, crit, dk_params=0):
+        return self._wrap(RegressionResults.info_criteria(
+            self, crit, dk_params=dk_params))
+
     @cache_readonly
     def params(self):
         """Estimated model parameters"""

--- a/statsmodels/regression/tests/test_regression.py
+++ b/statsmodels/regression/tests/test_regression.py
@@ -173,6 +173,15 @@ class CheckRegressionResults(object):
 
     def test_aic(self):
         assert_almost_equal(self.res1.aic, self.res2.aic, self.decimal_aic)
+        # the following just checks the definition
+        aicc1 = self.res1.info_criteria("aicc")
+        k = self.res1.df_model + self.res1.model.k_constant
+        nobs = self.res1.model.nobs
+        aicc2 = self.res1.aic + 2 * (k**2 + k) / (nobs - k - 1)
+        assert_allclose(aicc1, aicc2, rtol=1e-10)
+        hqic1 = self.res1.info_criteria("hqic")
+        hqic2 = (self.res1.aic - 2 * k) + 2 * np.log(np.log(nobs)) * k
+        assert_allclose(hqic1, hqic2, rtol=1e-10)
 
     decimal_bic = DECIMAL_4
 


### PR DESCRIPTION
closes #6577 aic
 #1802 bic and FAQ

this adds dk_params to `GLMResults.info_criteria`
default is unchanged
