### PR TITLE
ENH: add option for slim summary in OLS results

### DIFF
--- a/statsmodels/regression/linear_model.py
+++ b/statsmodels/regression/linear_model.py
@@ -2618,7 +2618,7 @@ class RegressionResults(base.LikelihoodModelResults):
             self, exog=exog, transform=transform, weights=weights,
             row_labels=row_labels, **kwargs)
 
-    def summary(self, yname=None, xname=None, title=None, alpha=.05):
+    def summary(self, yname=None, xname=None, title=None, alpha=.05, slim=False):
         """
         Summarize the Regression Results.
 
@@ -2650,7 +2650,7 @@ class RegressionResults(base.LikelihoodModelResults):
             durbin_watson,
             jarque_bera,
             omni_normtest,
-        )
+            )
 
         jb, jbpv, skew, kurtosis = jarque_bera(self.wresid)
         omni, omnipv = omni_normtest(self.wresid)
@@ -2696,19 +2696,28 @@ class RegressionResults(base.LikelihoodModelResults):
                      ('BIC:', ["%#8.4g" % self.bic])
                      ]
 
-        diagn_left = [('Omnibus:', ["%#6.3f" % omni]),
-                      ('Prob(Omnibus):', ["%#6.3f" % omnipv]),
-                      ('Skew:', ["%#6.3f" % skew]),
-                      ('Kurtosis:', ["%#6.3f" % kurtosis])
-                      ]
+        if slim:
+            slimlist = ['Dep. Variable:', 'Model:', 'No. Observations:',
+                        'Covariance Type:', 'R-squared:', 'Adj. R-squared:',
+                        'F-statistic:', 'Prob (F-statistic):']
+            diagn_left = []
+            diagn_right = []
+            top_left = [elem for elem in top_left if elem[0] in slimlist]
+            top_right = [elem for elem in top_right if elem[0] in slimlist]
+        else:
+            diagn_left = [('Omnibus:', ["%#6.3f" % omni]),
+                          ('Prob(Omnibus):', ["%#6.3f" % omnipv]),
+                          ('Skew:', ["%#6.3f" % skew]),
+                          ('Kurtosis:', ["%#6.3f" % kurtosis])
+                          ]
 
-        diagn_right = [('Durbin-Watson:',
-                        ["%#8.3f" % durbin_watson(self.wresid)]
-                        ),
-                       ('Jarque-Bera (JB):', ["%#8.3f" % jb]),
-                       ('Prob(JB):', ["%#8.3g" % jbpv]),
-                       ('Cond. No.', ["%#8.3g" % condno])
-                       ]
+            diagn_right = [('Durbin-Watson:',
+                            ["%#8.3f" % durbin_watson(self.wresid)]
+                            ),
+                           ('Jarque-Bera (JB):', ["%#8.3f" % jb]),
+                           ('Prob(JB):', ["%#8.3g" % jbpv]),
+                           ('Cond. No.', ["%#8.3g" % condno])
+                           ]
 
         if title is None:
             title = self.model.__class__.__name__ + ' ' + "Regression Results"
@@ -2720,10 +2729,10 @@ class RegressionResults(base.LikelihoodModelResults):
                              yname=yname, xname=xname, title=title)
         smry.add_table_params(self, yname=yname, xname=xname, alpha=alpha,
                               use_t=self.use_t)
-
-        smry.add_table_2cols(self, gleft=diagn_left, gright=diagn_right,
-                             yname=yname, xname=xname,
-                             title="")
+        if not slim:
+            smry.add_table_2cols(self, gleft=diagn_left, gright=diagn_right,
+                                 yname=yname, xname=xname,
+                                 title="")
 
         # add warnings/notes, added to text format only
         etext = []

--- a/statsmodels/regression/tests/test_regression.py
+++ b/statsmodels/regression/tests/test_regression.py
@@ -331,6 +331,12 @@ class TestOLS(CheckRegressionResults):
         model_norm_resid = self.res1.resid_pearson
         assert_almost_equal(model_norm_resid, norm_resid, DECIMAL_7)
 
+    def test_summary_slim(self):
+        # check that slim summary is smaller, does not verify content
+        summ = self.res1.summary(slim=True)
+        assert len(summ.tables) == 2
+        assert len(str(summ)) < 6700
+
     def test_norm_resid_zero_variance(self):
         with warnings.catch_warnings(record=True):
             y = self.res1.model.endog


### PR DESCRIPTION
this adds `slim` option to regression results `summary`

closes #6880

rebased #6880 with interactive editing (preserved original author)

squashed commit, removed formatting changes, fix up pep 8
added a basic unit test that slim only has 2 tables and text length is smaller


```
(Pdb) print(summ)
                            OLS Regression Results
==============================================================================
Dep. Variable:                      y   R-squared:                       0.995
Model:                            OLS   Adj. R-squared:                  0.992
No. Observations:                  16   F-statistic:                     330.3
Covariance Type:            nonrobust   Prob (F-statistic):           4.98e-10
==============================================================================
                 coef    std err          t      P>|t|      [0.025      0.975]
------------------------------------------------------------------------------
x1            15.0619     84.915      0.177      0.863    -177.029     207.153
x2            -0.0358      0.033     -1.070      0.313      -0.112       0.040
x3            -2.0202      0.488     -4.136      0.003      -3.125      -0.915
x4            -1.0332      0.214     -4.822      0.001      -1.518      -0.549
x5            -0.0511      0.226     -0.226      0.826      -0.563       0.460
x6          1829.1515    455.478      4.016      0.003     798.788    2859.515
const      -3.482e+06    8.9e+05     -3.911      0.004    -5.5e+06   -1.47e+06
==============================================================================

Notes:
[1] Standard Errors assume that the covariance matrix of the errors is correctly
 specified.
[2] The condition number is large, 4.86e+09. This might indicate that there are
strong multicollinearity or other numerical problems.

(Pdb) len(str(summ))
1576
(Pdb) len(str(self.res1.summary()))
2366
```