### PR TITLE
ENH add  tricube kernel

### DIFF
--- a/statsmodels/nonparametric/kde.py
+++ b/statsmodels/nonparametric/kde.py
@@ -33,6 +33,7 @@ kernel_switch = dict(
     triw=kernels.Triweight,
     cos=kernels.Cosine,
     cos2=kernels.Cosine2,
+    tric=kernels.Tricube
 )
 
 

--- a/statsmodels/nonparametric/tests/test_kernels.py
+++ b/statsmodels/nonparametric/tests/test_kernels.py
@@ -149,3 +149,19 @@ class TestBiweight(CheckKernelMixin):
     kern = kernels.Biweight()
     se_n_diff = 9
     low_rtol = 0.3
+
+
+def test_tricube():
+    # > library(kedd)
+    # > xx = c(-1., -0.75, -0.5, -0.25, 0., 0.25, 0.5, 0.75, 1.)
+    # > res = kernel.fun(x = xx, kernel="tricube",deriv.order=0)
+    # > res$kx
+
+    res_kx = [
+        0.0000000000000000, 0.1669853116259163, 0.5789448302469136,
+        0.8243179321289062, 0.8641975308641975, 0.8243179321289062,
+        0.5789448302469136, 0.1669853116259163, 0.0000000000000000
+        ]
+    xx = np.linspace(-1, 1, 9)
+    kx = kernels.Tricube()(xx)
+    assert_allclose(kx, res_kx, rtol=1e-10)

--- a/statsmodels/sandbox/nonparametric/kernels.py
+++ b/statsmodels/sandbox/nonparametric/kernels.py
@@ -563,3 +563,16 @@ class Cosine2(CustomKernel):
         self._L2Norm = 1.5
         self._kernel_var = 0.03267274151216444  # = 1/12. - 0.5 / np.pi**2
         self._order = 2
+
+class Tricube(CustomKernel):
+    """
+    Tricube Kernel
+
+    K(u) = 0.864197530864 * (1 - abs(x)**3)**3 between -1.0 and 1.0
+    """
+    def __init__(self,h=1.0):
+        CustomKernel.__init__(self,shape=lambda x: 0.864197530864 * (1 - abs(x)**3)**3,
+                              h=h, domain=[-1.0, 1.0], norm = 1.0)
+        self._L2Norm = 175.0/247.0
+        self._kernel_var = 35.0/243.0
+        self._order = 2


### PR DESCRIPTION
closes #7671
closes #7663

rebase and squashed version of #7671 plus one simple unit test against R package kedd

other kernels are unit tested against Stata, and Stata doesn't have tricube (neither does base R stats)

R package kdensity has tricube, but doesn't have public function to evaluate kernel directly
distr6 package looks good, but I cannot install it on my slightly older R version.