### PR TITLE
ENH: Fix lilliefors results for single-column DataFrames

### DIFF
--- a/statsmodels/stats/_lilliefors.py
+++ b/statsmodels/stats/_lilliefors.py
@@ -266,7 +266,10 @@ def kstest_fit(x, dist='norm', pvalmethod="table"):
     pvalmethod = string_like(pvalmethod,
                              "pvalmethod",
                              options=("approx", "table"))
-    x = np.asarray(x)
+    x = np.squeeze(np.asarray(x))
+    if x.ndim != 1:
+        raise ValueError(f"Array `x` with shape {x.shape} cannot be squeezed"
+                         f" into a 1d array")
     nobs = len(x)
 
     if dist == 'norm':

--- a/statsmodels/stats/_lilliefors.py
+++ b/statsmodels/stats/_lilliefors.py
@@ -266,10 +266,13 @@ def kstest_fit(x, dist='norm', pvalmethod="table"):
     pvalmethod = string_like(pvalmethod,
                              "pvalmethod",
                              options=("approx", "table"))
-    x = np.squeeze(np.asarray(x))
-    if x.ndim != 1:
-        raise ValueError(f"Array `x` with shape {x.shape} cannot be squeezed"
-                         f" into a 1d array")
+    x = np.asarray(x)
+    if x.ndim == 2 and x.shape[1] == 1:
+        x = x[:, 0]
+    elif x.ndim != 1:
+        raise ValueError("Invalid parameter `x`: must be a one-dimensional"
+                         " array-like or a single-column DataFrame")
+
     nobs = len(x)
 
     if dist == 'norm':

--- a/statsmodels/stats/tests/test_lilliefors.py
+++ b/statsmodels/stats/tests/test_lilliefors.py
@@ -84,6 +84,16 @@ class TestLilliefors(object):
         x = np.random.randn(10000)
         lilliefors(x, pvalmethod='approx')
 
+    def test_single_column_2d_array(self):
+        np.random.seed(3975)
+        x_n = stats.norm.rvs(size=500)
+        x_n = x_n.reshape(-1, 1)
+
+        d_ks_norm, p_norm = lilliefors(x_n, dist='norm', pvalmethod='approx')
+
+        assert_almost_equal(d_ks_norm, 0.025957, decimal=3)
+        assert_almost_equal(p_norm, 0.64175, decimal=3)
+
     def test_single_column_dataframe(self):
         np.random.seed(3975)
         x_n = stats.norm.rvs(size=500)
@@ -93,6 +103,22 @@ class TestLilliefors(object):
 
         assert_almost_equal(d_ks_norm, 0.025957, decimal=3)
         assert_almost_equal(p_norm, 0.64175, decimal=3)
+
+    def test_multiple_column_2d_array(self):
+        np.random.seed(3975)
+        x_n = stats.norm.rvs(size=500)
+        multiple_column_2d_array = np.array([x_n, x_n]).T
+
+        with pytest.raises(ValueError):
+            lilliefors(multiple_column_2d_array, dist='norm', pvalmethod='approx')
+
+    def test_multiple_column_dataframe(self):
+        np.random.seed(3975)
+        x_n = stats.norm.rvs(size=500)
+        multiple_column_df = pd.DataFrame(data=[x_n, x_n])
+
+        with pytest.raises(ValueError):
+            lilliefors(multiple_column_df, dist='norm', pvalmethod='approx')
 
 
 def test_get_lilliefors_errors(reset_randomstate):

--- a/statsmodels/stats/tests/test_lilliefors.py
+++ b/statsmodels/stats/tests/test_lilliefors.py
@@ -99,7 +99,8 @@ class TestLilliefors(object):
         x_n = stats.norm.rvs(size=500)
         single_column_df = pd.DataFrame(data=x_n)
 
-        d_ks_norm, p_norm = lilliefors(single_column_df, dist='norm', pvalmethod='approx')
+        d_ks_norm, p_norm = lilliefors(single_column_df, dist='norm',
+                                       pvalmethod='approx')
 
         assert_almost_equal(d_ks_norm, 0.025957, decimal=3)
         assert_almost_equal(p_norm, 0.64175, decimal=3)
@@ -110,7 +111,8 @@ class TestLilliefors(object):
         multiple_column_2d_array = np.array([x_n, x_n]).T
 
         with pytest.raises(ValueError):
-            lilliefors(multiple_column_2d_array, dist='norm', pvalmethod='approx')
+            lilliefors(multiple_column_2d_array, dist='norm',
+                       pvalmethod='approx')
 
     def test_multiple_column_dataframe(self):
         np.random.seed(3975)

--- a/statsmodels/stats/tests/test_lilliefors.py
+++ b/statsmodels/stats/tests/test_lilliefors.py
@@ -84,43 +84,42 @@ class TestLilliefors(object):
         x = np.random.randn(10000)
         lilliefors(x, pvalmethod='approx')
 
-    def test_single_column_2d_array(self):
+    def test_x_dims(self):
         np.random.seed(3975)
         x_n = stats.norm.rvs(size=500)
-        x_n = x_n.reshape(-1, 1)
 
-        d_ks_norm, p_norm = lilliefors(x_n, dist='norm', pvalmethod='approx')
-
+        # 1d array
+        data = x_n
+        d_ks_norm, p_norm = lilliefors(data, dist='norm', pvalmethod='approx')
         assert_almost_equal(d_ks_norm, 0.025957, decimal=3)
         assert_almost_equal(p_norm, 0.64175, decimal=3)
 
-    def test_single_column_dataframe(self):
-        np.random.seed(3975)
-        x_n = stats.norm.rvs(size=500)
-        single_column_df = pd.DataFrame(data=x_n)
-
-        d_ks_norm, p_norm = lilliefors(single_column_df, dist='norm',
-                                       pvalmethod='approx')
-
+        # 2d array with size 1 second dimension
+        data = x_n.reshape(-1, 1)
+        d_ks_norm, p_norm = lilliefors(data, dist='norm', pvalmethod='approx')
         assert_almost_equal(d_ks_norm, 0.025957, decimal=3)
         assert_almost_equal(p_norm, 0.64175, decimal=3)
 
-    def test_multiple_column_2d_array(self):
-        np.random.seed(3975)
-        x_n = stats.norm.rvs(size=500)
-        multiple_column_2d_array = np.array([x_n, x_n]).T
-
+        # 2d array with larger second dimension
+        data = np.array([x_n, x_n]).T
         with pytest.raises(ValueError):
-            lilliefors(multiple_column_2d_array, dist='norm',
-                       pvalmethod='approx')
+            lilliefors(data, dist='norm', pvalmethod='approx')
 
-    def test_multiple_column_dataframe(self):
-        np.random.seed(3975)
-        x_n = stats.norm.rvs(size=500)
-        multiple_column_df = pd.DataFrame(data=[x_n, x_n])
+        # single-column DataFrame
+        data = pd.DataFrame(data=x_n)
+        d_ks_norm, p_norm = lilliefors(data, dist='norm', pvalmethod='approx')
+        assert_almost_equal(d_ks_norm, 0.025957, decimal=3)
+        assert_almost_equal(p_norm, 0.64175, decimal=3)
 
+        # two-column DataFrame
+        data = pd.DataFrame(data=[x_n, x_n])
         with pytest.raises(ValueError):
-            lilliefors(multiple_column_df, dist='norm', pvalmethod='approx')
+            lilliefors(data, dist='norm', pvalmethod='approx')
+
+        # DataFrame with observations in columns
+        data = pd.DataFrame(data=x_n.reshape(-1, 1).T)
+        with pytest.raises(ValueError):
+            lilliefors(data, dist='norm', pvalmethod='approx')
 
 
 def test_get_lilliefors_errors(reset_randomstate):

--- a/statsmodels/stats/tests/test_lilliefors.py
+++ b/statsmodels/stats/tests/test_lilliefors.py
@@ -84,7 +84,7 @@ class TestLilliefors(object):
         x = np.random.randn(10000)
         lilliefors(x, pvalmethod='approx')
 
-    def test_dataframe(self):
+    def test_single_column_dataframe(self):
         np.random.seed(3975)
         x_n = stats.norm.rvs(size=500)
         single_column_df = pd.DataFrame(data=x_n)

--- a/statsmodels/stats/tests/test_lilliefors.py
+++ b/statsmodels/stats/tests/test_lilliefors.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pandas as pd
 import pytest
 from numpy.testing import assert_almost_equal
 from scipy import stats
@@ -82,6 +83,16 @@ class TestLilliefors(object):
     def test_large_sample(self, reset_randomstate):
         x = np.random.randn(10000)
         lilliefors(x, pvalmethod='approx')
+
+    def test_dataframe(self):
+        np.random.seed(3975)
+        x_n = stats.norm.rvs(size=500)
+        single_column_df = pd.DataFrame(data=x_n)
+
+        d_ks_norm, p_norm = lilliefors(single_column_df, dist='norm', pvalmethod='approx')
+
+        assert_almost_equal(d_ks_norm, 0.025957, decimal=3)
+        assert_almost_equal(p_norm, 0.64175, decimal=3)
 
 
 def test_get_lilliefors_errors(reset_randomstate):


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed. 
- [ ] code/documentation is well formatted.  
- [ ] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

The `lilliefors` function is broken on (single-column) DataFrames. The input gets coerced by `np.as_array()` into an array of shape `(N, 1)`, where it should be `(N,)`. This causes problems in the further calculations in the function, leading to incorrect results.

This PR adds a test that reproduces the problem, and fixes it by calling `np.squeeze()` on the array. It also adds raising a `ValueError` when the array cannot be squeezed to a 1d array.