### PR TITLE
BUG: Factor fit ml em resets seed (rebased)

### DIFF
--- a/statsmodels/multivariate/factor.py
+++ b/statsmodels/multivariate/factor.py
@@ -433,12 +433,13 @@ class Factor(Model):
 
         return FactorResults(self)
 
-    def _fit_ml_em(self, iter):
+    def _fit_ml_em(self, iter, random_state=None):
         """estimate Factor model using EM algorithm
         """
         # Starting values
-        np.random.seed(3427)
-        load = 0.1*np.random.normal(size=(self.k_endog, self.n_factor))
+        if random_state is None:
+            random_state = np.random.RandomState(3427)
+        load = 0.1 * random_state.standard_normal(size=(self.k_endog, self.n_factor))
         uniq = 0.5 * np.ones(self.k_endog)
 
         for k in range(iter):

--- a/statsmodels/multivariate/tests/test_ml_factor.py
+++ b/statsmodels/multivariate/tests/test_ml_factor.py
@@ -78,7 +78,7 @@ def test_exact_em():
             s = np.sqrt(np.diag(c))
             c /= np.outer(s, s)
             fa = Factor(corr=c, n_factor=n_factor, method='ml')
-            load_e, uniq_e = fa._fit_ml_em(200)
+            load_e, uniq_e = fa._fit_ml_em(2000)
             c_e = np.dot(load_e, load_e.T)
             c_e.flat[::c_e.shape[0]+1] += uniq_e
             assert_allclose(c_e, c, rtol=1e-4, atol=1e-4)


### PR DESCRIPTION
rebased version #7358   multivariate `Factor1 resets global numpy random state with seed

closes #7357 closes #7358

I edited the unit test during interactive rebase
convert docstring to code comment
remove unused variable
squashed 2 of the 3 commits

this is bug fix, not systematically adding random state 