### PR TITLE
BUG: fix lowess spikes/nans from epsilon values

### DIFF
--- a/statsmodels/nonparametric/tests/test_lowess.py
+++ b/statsmodels/nonparametric/tests/test_lowess.py
@@ -158,6 +158,26 @@ class TestLowess(object):
         actual_lowess4 = lowess(y, x, xvals = actual_lowess[perm_idx,0], return_sorted=False)
         assert_almost_equal(actual_lowess[perm_idx,1], actual_lowess4, decimal=13)
 
+    def test_duplicate_xs(self):
+        # see 2449
+        # Generate cases with many duplicate x values
+        x = [0] + [1]*100 + [2]*100 + [3]
+        y = x + np.random.normal(size=len(x))*1e-8
+        result = lowess(y, x, frac=50/len(x), it=1)
+        # fit values should be approximately averages of values at
+        # a particular fit, which in this case are just equal to x
+        assert_almost_equal(result[1:-1,1], x[1:-1], decimal=7)
+
+    def test_spike(self):
+        # see 7700
+        # Create a curve that is easy to fit at first but gets harder further along.
+        # This used to give an outlier bad fit at position 961
+        x = np.linspace(0,10,1001)
+        y = np.cos(x**2/5)
+        result = lowess(y, x, frac=11/len(x), it=1)
+        assert_(np.all(result[:,1] > np.min(y) - 0.1))
+        assert_(np.all(result[:,1] < np.max(y) + 0.1))
+
 
 def test_returns_inputs():
     # see 1960


### PR DESCRIPTION
Resolves two issues in `nonparametric.lowess` where zeros or near-zero values could cause unreliable results.

Tests are added for both of these cases.

- [x] closes #7700 and #2449
- [x] tests added / passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>

**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
