### PR TITLE
Update proportion.py

### DIFF
--- a/statsmodels/stats/proportion.py
+++ b/statsmodels/stats/proportion.py
@@ -979,9 +979,6 @@ def proportions_chisquare_allpairs(count, nobs, multitest_method='hs'):
         the number of successes in nobs trials.
     nobs : int
         the number of trials or observations.
-    prop : float, optional
-        The probability of success under the null hypothesis,
-        `0 <= prop <= 1`. The default value is `prop = 0.5`
     multitest_method : str
         This chooses the method for the multiple testing p-value correction,
         that is used as default in the results.
@@ -1021,9 +1018,6 @@ def proportions_chisquare_pairscontrol(count, nobs, value=None,
         the number of successes in nobs trials.
     nobs : int
         the number of trials or observations.
-    prop : float, optional
-        The probability of success under the null hypothesis,
-        `0 <= prop <= 1`. The default value is `prop = 0.5`
     multitest_method : str
         This chooses the method for the multiple testing p-value correction,
         that is used as default in the results.


### PR DESCRIPTION
Remove docstring for arguments that don't exist in _proportion_chisquare_allpairs_ and _proportion_chisquare_pairscontrol_

closes #7776