### PR TITLE
BUG: Handle None in kpss

### DIFF
--- a/statsmodels/tsa/tests/test_stattools.py
+++ b/statsmodels/tsa/tests/test_stattools.py
@@ -17,6 +17,7 @@ from numpy.testing import (
 import pandas as pd
 from pandas import DataFrame, Series, date_range
 import pytest
+from scipy.interpolate import interp1d
 
 from statsmodels.datasets import macrodata, modechoice, nile, randhie, sunspots
 from statsmodels.tools.sm_exceptions import (
@@ -25,15 +26,17 @@ from statsmodels.tools.sm_exceptions import (
     InterpolationWarning,
     MissingDataError,
 )
+# Remove imports when range unit root test gets an R implementation
+from statsmodels.tools.validation import array_like, bool_like
 from statsmodels.tsa.arima_process import arma_acovf
 from statsmodels.tsa.statespace.sarimax import SARIMAX
 from statsmodels.tsa.stattools import (
     acf,
     acovf,
-    ccovf,
     adfuller,
     arma_order_select_ic,
     breakvar_heteroskedasticity_test,
+    ccovf,
     coint,
     grangercausalitytests,
     innovations_algo,
@@ -48,10 +51,6 @@ from statsmodels.tsa.stattools import (
     range_unit_root_test,
     zivot_andrews,
 )
-
-# Remove imports when range unit root test gets an R implementation
-from statsmodels.tools.validation import array_like, bool_like
-from scipy.interpolate import interp1d
 
 DECIMAL_8 = 8
 DECIMAL_6 = 6
@@ -829,6 +828,10 @@ class TestKPSS:
         with pytest.raises(ValueError):
             kpss(self.x, "c", nlags="unknown")
 
+    def test_none(self):
+        with pytest.warns(FutureWarning):
+            kpss(self.x, nlags=None)
+
 
 class TestRUR:
     """
@@ -859,21 +862,25 @@ class TestRUR:
         # Table from [1] has been replicated using 200,000 samples
         # Critical values for new n_obs values have been identified
         pvals = [0.01, 0.025, 0.05, 0.10, 0.90, 0.95]
-        n = np.array([25, 50, 100, 150, 200, 250, 500, 1000, 2000, 3000, 4000, 5000])
-        crit = np.array([
-            [0.6626, 0.8126, 0.9192, 1.0712, 2.4863, 2.7312],
-            [0.7977, 0.9274, 1.0478, 1.1964, 2.6821, 2.9613],
-            [0.907, 1.0243, 1.1412, 1.2888, 2.8317, 3.1393],
-            [0.9543, 1.0768, 1.1869, 1.3294, 2.8915, 3.2049],
-            [0.9833, 1.0984, 1.2101, 1.3494, 2.9308, 3.2482],
-            [0.9982, 1.1137, 1.2242, 1.3632, 2.9571, 3.2482],
-            [1.0494, 1.1643, 1.2712, 1.4076, 3.0207, 3.3584],
-            [1.0846, 1.1959, 1.2988, 1.4344, 3.0653, 3.4073],
-            [1.1121, 1.2200, 1.3230, 1.4556, 3.0948, 3.4439],
-            [1.1204, 1.2295, 1.3318, 1.4656, 3.1054, 3.4632],
-            [1.1309, 1.2347, 1.3318, 1.4693, 3.1165, 3.4717],
-            [1.1377, 1.2402, 1.3408, 1.4729, 3.1252, 3.4807]
-        ])
+        n = np.array(
+            [25, 50, 100, 150, 200, 250, 500, 1000, 2000, 3000, 4000, 5000]
+        )
+        crit = np.array(
+            [
+                [0.6626, 0.8126, 0.9192, 1.0712, 2.4863, 2.7312],
+                [0.7977, 0.9274, 1.0478, 1.1964, 2.6821, 2.9613],
+                [0.907, 1.0243, 1.1412, 1.2888, 2.8317, 3.1393],
+                [0.9543, 1.0768, 1.1869, 1.3294, 2.8915, 3.2049],
+                [0.9833, 1.0984, 1.2101, 1.3494, 2.9308, 3.2482],
+                [0.9982, 1.1137, 1.2242, 1.3632, 2.9571, 3.2482],
+                [1.0494, 1.1643, 1.2712, 1.4076, 3.0207, 3.3584],
+                [1.0846, 1.1959, 1.2988, 1.4344, 3.0653, 3.4073],
+                [1.1121, 1.2200, 1.3230, 1.4556, 3.0948, 3.4439],
+                [1.1204, 1.2295, 1.3318, 1.4656, 3.1054, 3.4632],
+                [1.1309, 1.2347, 1.3318, 1.4693, 3.1165, 3.4717],
+                [1.1377, 1.2402, 1.3408, 1.4729, 3.1252, 3.4807],
+            ]
+        )
 
         # Interpolation for nobs
         inter_crit = np.zeros((1, crit.shape[1]))
@@ -917,9 +924,16 @@ class TestRUR:
             direction = "larger"
 
         if direction:
-            warnings.warn(warn_msg.format(direction=direction), InterpolationWarning)
+            warnings.warn(
+                warn_msg.format(direction=direction), InterpolationWarning
+            )
 
-        crit_dict = {"10%": inter_crit[0, 3], "5%": inter_crit[0, 2], "2.5%": inter_crit[0, 1], "1%": inter_crit[0, 0]}
+        crit_dict = {
+            "10%": inter_crit[0, 3],
+            "5%": inter_crit[0, 2],
+            "2.5%": inter_crit[0, 1],
+            "1%": inter_crit[0, 0],
+        }
 
         if store:
             from statsmodels.stats.diagnostic import ResultsStore
@@ -941,20 +955,17 @@ class TestRUR:
         x = np.random.rand(20, 2)
         assert_raises(ValueError, range_unit_root_test, x)
 
-
     def test_teststat(self):
         with pytest.warns(InterpolationWarning):
             rur_stat, _, _ = range_unit_root_test(self.x)
             simple_rur_stat, _, _ = self.simple_rur(self.x)
         assert_almost_equal(rur_stat, simple_rur_stat, DECIMAL_3)
 
-
     def test_pval(self):
         with pytest.warns(InterpolationWarning):
             _, pval, _ = range_unit_root_test(self.x)
             _, simple_pval, _ = self.simple_rur(self.x)
         assert_equal(pval, simple_pval)
-
 
     def test_store(self):
         with pytest.warns(InterpolationWarning):


### PR DESCRIPTION
Add handler for None in KPSS for backport

closes #7794

- [X] closes #7794
- [X] tests added / passed. 
- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
