### PR TITLE
DOC: fix ZivotAndrewsUnitRoot.run() docstring

### DIFF
--- a/statsmodels/tsa/stattools.py
+++ b/statsmodels/tsa/stattools.py
@@ -2513,7 +2513,7 @@ class ZivotAndrewsUnitRoot(object):
         bpidx : int
             The index of x corresponding to endogenously calculated break period
             with values in the range [0..nobs-1].
-        
+
         Notes
         -----
         H0 = unit root with a single structural break


### PR DESCRIPTION
- [x] closes #7811
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>

`baselag` was placed before `bpidx` in the documentation to match the return output from the `ZivotAndrewsUnitRoot.run()` method.

</details>
