### PR TITLE
BUG: Allow all appropriate links in a Family

### DIFF
--- a/statsmodels/genmod/families/family.py
+++ b/statsmodels/genmod/families/family.py
@@ -390,14 +390,14 @@ class Poisson(Family):
     statsmodels.genmod.families.family.Family : Parent class for all links.
     :ref:`links` : Further details on links.
     """
-    links = [L.log, L.identity, L.sqrt]
+    links = [L.Log, L.identity, L.sqrt]
     variance = V.mu
     valid = [0, np.inf]
     safe_links = [L.Log, ]
 
     def __init__(self, link=None):
         if link is None:
-            link = L.log()
+            link = L.Log()
         super(Poisson, self).__init__(link=link, variance=Poisson.variance)
 
     def _resid_dev(self, endog, mu):
@@ -539,7 +539,7 @@ class Gaussian(Family):
     :ref:`links` : Further details on links.
     """
 
-    links = [L.log, L.identity, L.inverse_power]
+    links = [L.Log, L.identity, L.inverse_power]
     variance = V.constant
     safe_links = links
 
@@ -704,7 +704,7 @@ class Gamma(Family):
     statsmodels.genmod.families.family.Family : Parent class for all links.
     :ref:`links` : Further details on links.
     """
-    links = [L.log, L.identity, L.inverse_power]
+    links = [L.Log, L.identity, L.inverse_power]
     variance = V.mu_squared
     safe_links = [L.Log, ]
 
@@ -875,7 +875,7 @@ class Binomial(Family):
     number of trials for each row.
     """
 
-    links = [L.logit, L.probit, L.cauchy, L.log, L.cloglog, L.loglog,
+    links = [L.Logit, L.probit, L.cauchy, L.Log, L.CLogLog, L.LogLog,
              L.identity]
     variance = V.binary  # this is not used below in an effort to include n
 
@@ -884,7 +884,7 @@ class Binomial(Family):
 
     def __init__(self, link=None):  # , n=1.):
         if link is None:
-            link = L.logit()
+            link = L.Logit()
         # TODO: it *should* work for a constant n>1 actually, if freq_weights
         # is equal to n
         self.n = 1
@@ -1134,7 +1134,7 @@ class InverseGaussian(Family):
     literature as the Wald distribution.
     """
 
-    links = [L.inverse_squared, L.inverse_power, L.identity, L.log]
+    links = [L.inverse_squared, L.inverse_power, L.identity, L.Log]
     variance = V.mu_cubed
     safe_links = [L.inverse_squared, L.Log, ]
 
@@ -1302,7 +1302,7 @@ class NegativeBinomial(Family):
 
     with :math:`E[Y]=\mu\,` and :math:`Var[Y]=\mu+\alpha\mu^2`.
     """
-    links = [L.log, L.cloglog, L.identity, L.nbinom, L.Power]
+    links = [L.Log, L.CLogLog, L.identity, L.NegativeBinomial, L.Power]
     # TODO: add the ability to use the power links with an if test
     # similar to below
     variance = V.nbinom
@@ -1311,7 +1311,7 @@ class NegativeBinomial(Family):
     def __init__(self, link=None, alpha=1.):
         self.alpha = 1. * alpha  # make it at least float
         if link is None:
-            link = L.log()
+            link = L.Log()
         super(NegativeBinomial, self).__init__(
             link=link, variance=V.NegativeBinomial(alpha=self.alpha))
 
@@ -1508,9 +1508,9 @@ class Tweedie(Family):
     estimated using the ``estimate_tweedie_power`` function that is part of the
     statsmodels.genmod.generalized_linear_model.GLM class.
     """
-    links = [L.log, L.Power]
+    links = [L.Log, L.Power]
     variance = V.Power(power=1.5)
-    safe_links = [L.log, L.Power]
+    safe_links = [L.Log, L.Power]
 
     def __init__(self, link=None, var_power=1., eql=False):
         self.var_power = var_power
@@ -1519,7 +1519,7 @@ class Tweedie(Family):
             raise ValueError("Tweedie: if EQL=True then var_power must fall "
                              "between 1 and 2")
         if link is None:
-            link = L.log()
+            link = L.Log()
         super(Tweedie, self).__init__(
             link=link, variance=V.Power(power=var_power * 1.))
 

--- a/statsmodels/genmod/families/tests/test_family.py
+++ b/statsmodels/genmod/families/tests/test_family.py
@@ -1,0 +1,52 @@
+"""
+Test functions for genmod.families.family
+"""
+import pytest
+
+import statsmodels.genmod.families as F
+import statsmodels.genmod.families.links as L
+
+all_links = {
+    L.Logit, L.logit, L.Power, L.inverse_power, L.sqrt, L.inverse_squared,
+    L.identity, L.Log, L.log, L.CDFLink, L.probit, L.cauchy, L.LogLog,
+    L.loglog, L.CLogLog, L.cloglog, L.NegativeBinomial, L.nbinom
+}
+poisson_links = {L.Log, L.log, L.identity, L.sqrt}
+gaussian_links = {L.Log, L.log, L.identity, L.inverse_power}
+gamma_links = {L.Log, L.log, L.identity, L.inverse_power}
+binomial_links = {
+    L.Logit, L.logit, L.probit, L.cauchy, L.Log, L.log, L.CLogLog,
+    L.cloglog, L.LogLog, L.loglog, L.identity
+}
+inverse_gaussian_links = {
+    L.inverse_squared, L.inverse_power, L.identity, L.Log, L.log
+}
+negative_bionomial_links = {
+    L.Log, L.log, L.CLogLog, L.cloglog, L.identity, L.NegativeBinomial,
+    L.nbinom, L.Power
+}
+tweedie_links = {L.Log, L.log, L.Power}
+
+link_cases = [
+    (F.Poisson, poisson_links),
+    (F.Gaussian, gaussian_links),
+    (F.Gamma, gamma_links),
+    (F.Binomial, binomial_links),
+    (F.InverseGaussian, inverse_gaussian_links),
+    (F.NegativeBinomial, negative_bionomial_links),
+    (F.Tweedie, tweedie_links)
+]
+
+
+@pytest.mark.parametrize("family, links", link_cases)
+def test_invalid_family_link(family, links):
+    invalid_links = all_links - links
+    with pytest.raises(ValueError):
+        for link in invalid_links:
+            family(link())
+
+
+@pytest.mark.parametrize("family, links", link_cases)
+def test_family_link(family, links):
+    for link in links:
+        assert family(link())


### PR DESCRIPTION
The list of links in a Family (Poisson, Gaussian, etc.) included the
"aliased" link type instead of the primary link type, when possible.
Poisson, for example, include link.log instead of link.Log.

Using the aliased class in the family link list results in suprising
behavior like this:

```
In [1]: import statsmodels.genmod.families as F

In [2]: import statsmodels.genmod.families.links as L

In [3]: F.Poisson(link=L.log())
Out[3]: <statsmodels.genmod.families.family.Poisson at 0x111da15b0>

In [4]: F.Poisson(link=L.Log())
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-4-47050bb1e621> in <module>
----> 1 F.Poisson(link=L.Log())

~/Documents/old/statsmodels/statsmodels/genmod/families/family.py in __init__(self, link)
    399         if link is None:
    400             link = L.log()
--> 401         super(Poisson, self).__init__(link=link, variance=Poisson.variance)
    402
    403     def _resid_dev(self, endog, mu):

~/Documents/old/statsmodels/statsmodels/genmod/families/family.py in __init__(self, link, variance)
     83             raise TypeError(warnmssg)
     84         else:
---> 85             self.link = link
     86         self.variance = variance
     87

~/Documents/old/statsmodels/statsmodels/genmod/families/family.py in _setlink(self, link)
     64             if not validlink:
     65                 errmsg = "Invalid link for family, should be in %s. (got %s)"
---> 66                 raise ValueError(errmsg % (repr(self.links), link))
     67
     68     def _getlink(self):

ValueError: Invalid link for family, should be in [<class 'statsmodels.genmod.families.links.log'>, <class 'statsmodels.genmod.families.links.identity'>, <class 'statsmodels.genmod.families.links.sqrt'>]. (got <statsmodels.genmod.families.links.Log object at 0x111e7efa0>)
```

L.log works but L.Log doesn't, even though L.log is an simply an "alias"
of L.Log.

By changing the family link lists to use "unaliased" classes (the parent
classes of the various aliases) both L.log and L.Log work as expected.

- [ ] closes #xxxx
- [x] tests added / passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
