### PR TITLE
Discrete scorefactor offset rebased3

### DIFF
--- a/statsmodels/base/_parameter_inference.py
+++ b/statsmodels/base/_parameter_inference.py
@@ -245,7 +245,8 @@ def score_test(self, exog_extra=None, params_constrained=None,
         pval = stats.chi2.sf(chi2stat, k_constraints)
         return chi2stat, pval
     else:
-        raise NotImplementedError('only cov_type "nonrobust" is available')
+        msg = 'Only cov_type "nonrobust" and "HC0" are available.'
+        raise NotImplementedError(msg)
 
     if hypothesis == 'joint':
         chi2stat = score.dot(np.linalg.solve(cov_score_test, score[:, None]))

--- a/statsmodels/base/_parameter_inference.py
+++ b/statsmodels/base/_parameter_inference.py
@@ -9,7 +9,7 @@ import numpy as np
 from scipy import stats
 
 
-# this is a copy from stats._diagnostic_other
+# this is a copy from stats._diagnostic_other to avoid circular imports
 def _lm_robust(score, constraint_matrix, score_deriv_inv, cov_score,
                cov_params=None):
     '''general formula for score/LM test
@@ -216,7 +216,11 @@ def score_test(self, exog_extra=None, params_constrained=None,
         score = score_obs.sum(0)
         hessian_factor = model.hessian_factor(params_constrained,
                                               **hess_kwd)
-        hessian = -np.dot(ex.T * hessian_factor, ex)
+        # see #4714
+        from statsmodels.genmod.generalized_linear_model import GLM
+        if isinstance(model, GLM):
+            hessian_factor *= -1
+        hessian = np.dot(ex.T * hessian_factor, ex)
 
     if cov_type == 'nonrobust':
         cov_score_test = -hessian

--- a/statsmodels/discrete/discrete_model.py
+++ b/statsmodels/discrete/discrete_model.py
@@ -34,6 +34,7 @@ import statsmodels.base.model as base
 import statsmodels.base.wrapper as wrap
 from statsmodels.base._constraints import fit_constrained_wrap
 import statsmodels.base._parameter_inference as pinf
+infer = pinf   # alias, 2 different shorcut names
 
 from statsmodels.distributions import genpoisson_p
 import statsmodels.regression.linear_model as lm
@@ -4168,6 +4169,20 @@ class DiscreteResults(base.LikelihoodModelResults):
             return pinf.gbic(self)
         else:
             raise ValueError("Name of information criterion not recognized.")
+
+    def score_test(self, exog_extra=None, params_constrained=None,
+                   hypothesis='joint', cov_type=None, cov_kwds=None,
+                   k_constraints=None, observed=True):
+
+        res = infer.score_test(self, exog_extra=exog_extra,
+                               params_constrained=params_constrained,
+                               hypothesis=hypothesis,
+                               cov_type=cov_type, cov_kwds=cov_kwds,
+                               k_constraints=k_constraints,
+                               observed=observed)
+        return res
+
+    score_test.__doc__ = infer.score_test.__doc__
 
     def _get_endog_name(self, yname, yname_list):
         if yname is None:

--- a/statsmodels/discrete/discrete_model.py
+++ b/statsmodels/discrete/discrete_model.py
@@ -1758,7 +1758,6 @@ class GeneralizedPoisson(CountModel):
 
         params = params[:-1]
         p = self.parameterization
-        exog = self.exog
         y = self.endog[:,None]
         mu = self.predict(params)[:,None]
         mu_p = np.power(mu, p)
@@ -1797,7 +1796,6 @@ class GeneralizedPoisson(CountModel):
             alpha = params[-1]
         params = params[:-1]
         p = self.parameterization
-        exog = self.exog
         y = self.endog[:,None]
         mu = self.predict(params)[:,None]
         mu_p = np.power(mu, p)
@@ -1923,7 +1921,7 @@ class GeneralizedPoisson(CountModel):
         dmudb = mu
 
         # for dl/dlinpred dparams
-        nobs, k_vars = exog.shape
+        nobs = exog.shape[0]
         hess_fact = np.empty((nobs, 3))
 
 
@@ -2103,7 +2101,6 @@ class Logit(BinaryModel):
         logistic distribution is symmetric.
         """
         q = 2*self.endog - 1
-        X = self.exog
         linpred = self.predict(params, linear=True)
         return np.sum(np.log(self.cdf(q * linpred)))
 
@@ -2135,7 +2132,6 @@ class Logit(BinaryModel):
         logistic distribution is symmetric.
         """
         q = 2*self.endog - 1
-        X = self.exog
         linpred = self.predict(params, linear=True)
         return np.log(self.cdf(q * linpred))
 
@@ -2217,7 +2213,6 @@ class Logit(BinaryModel):
         .. math:: \\ln\\lambda_{i}=x_{i}\\beta
         """
         y = self.endog
-        X = self.exog
         fitted = self.predict(params)
         return (y - fitted)
 
@@ -2259,7 +2254,6 @@ class Logit(BinaryModel):
             The Hessian factor, second derivative of loglikelihood function
             with respect to the linear predictor evaluated at `params`
         """
-        X = self.exog
         L = self.predict(params)
         return -L * (1 - L)
 
@@ -2412,7 +2406,6 @@ class Probit(BinaryModel):
         """
 
         q = 2*self.endog - 1
-        X = self.exog
         linpred = self.predict(params, linear=True)
         return np.log(np.clip(self.cdf(q*linpred), FLOAT_EPS, 1))
 
@@ -2504,7 +2497,6 @@ class Probit(BinaryModel):
         normal distribution is symmetric.
         """
         y = self.endog
-        X = self.exog
         XB = self.predict(params, linear=True)
         q = 2*y - 1
         # clip to get rid of invalid divide complaint
@@ -2568,7 +2560,6 @@ class Probit(BinaryModel):
 
         and :math:`q=2y-1`
         """
-        X = self.exog
         XB = self.predict(params, linear=True)
         q = 2 * self.endog - 1
         L = q * self.pdf(q * XB) / self.cdf(q * XB)
@@ -3187,7 +3178,7 @@ class NegativeBinomial(CountModel):
         hess_arr[tri_idx] = hess_arr.T[tri_idx]
 
         # for dl/dparams dalpha
-        da1 = -alpha**-2
+        # da1 = -alpha**-2
         dldpda = np.sum(-a1 * dparams + exog * a1 *
                         (-trigamma*mu/alpha**2 - prob), axis=0)
 
@@ -3752,7 +3743,6 @@ class NegativeBinomialP(CountModel):
     def _get_start_params_null(self):
         offset = getattr(self, "offset", 0)
         exposure = getattr(self, "exposure", 0)
-        q = self.parameterization - 1
 
         const = (self.endog / np.exp(offset + exposure)).mean()
         params = [np.log(const)]
@@ -4823,7 +4813,6 @@ class MultinomialResults(DiscreteResults):
             except TypeError:
                 ynames[i] = str(ynames[i])
         if issue_warning:
-            import warnings
             warnings.warn(msg, SpecificationWarning)
 
         return ynames

--- a/statsmodels/discrete/discrete_model.py
+++ b/statsmodels/discrete/discrete_model.py
@@ -33,9 +33,7 @@ from statsmodels.base.l1_slsqp import fit_l1_slsqp
 import statsmodels.base.model as base
 import statsmodels.base.wrapper as wrap
 from statsmodels.base._constraints import fit_constrained_wrap
-import statsmodels.base._parameter_inference as pinf
-infer = pinf   # alias, 2 different shorcut names
-
+import statsmodels.base._parameter_inference as pinfer
 from statsmodels.distributions import genpoisson_p
 import statsmodels.regression.linear_model as lm
 from statsmodels.tools import data as data_tools, tools
@@ -4128,7 +4126,7 @@ class DiscreteResults(base.LikelihoodModelResults):
 
     @cache_readonly
     def im_ratio(self):
-        return pinf.im_ratio(self)
+        return pinfer.im_ratio(self)
 
     def info_criteria(self, crit, dk_params=0):
         """Return an information criterion for the model.
@@ -4164,9 +4162,9 @@ class DiscreteResults(base.LikelihoodModelResults):
             bic = -2*self.llf + k_params*np.log(nobs)
             return bic
         elif crit == "tic":
-            return pinf.tic(self)
+            return pinfer.tic(self)
         elif crit == "gbic":
-            return pinf.gbic(self)
+            return pinfer.gbic(self)
         else:
             raise ValueError("Name of information criterion not recognized.")
 
@@ -4174,15 +4172,15 @@ class DiscreteResults(base.LikelihoodModelResults):
                    hypothesis='joint', cov_type=None, cov_kwds=None,
                    k_constraints=None, observed=True):
 
-        res = infer.score_test(self, exog_extra=exog_extra,
-                               params_constrained=params_constrained,
-                               hypothesis=hypothesis,
-                               cov_type=cov_type, cov_kwds=cov_kwds,
-                               k_constraints=k_constraints,
-                               observed=observed)
+        res = pinfer.score_test(self, exog_extra=exog_extra,
+                                params_constrained=params_constrained,
+                                hypothesis=hypothesis,
+                                cov_type=cov_type, cov_kwds=cov_kwds,
+                                k_constraints=k_constraints,
+                                observed=observed)
         return res
 
-    score_test.__doc__ = infer.score_test.__doc__
+    score_test.__doc__ = pinfer.score_test.__doc__
 
     def _get_endog_name(self, yname, yname_list):
         if yname is None:

--- a/statsmodels/discrete/discrete_model.py
+++ b/statsmodels/discrete/discrete_model.py
@@ -1724,6 +1724,32 @@ class GeneralizedPoisson(CountModel):
         else:
             return score
 
+    def score_factor(self, params):
+        if self._transparams:
+            alpha = np.exp(params[-1])
+        else:
+            alpha = params[-1]
+
+        params = params[:-1]
+        p = self.parameterization
+        exog = self.exog
+        y = self.endog[:,None]
+        mu = self.predict(params)[:,None]
+        mu_p = np.power(mu, p)
+        a1 = 1 + alpha * mu_p
+        a2 = mu + alpha * mu_p * y
+        a3 = alpha * p * mu ** (p - 1)
+        a4 = a3 * y
+        dmudb = mu
+
+        dalpha = (mu_p * (y * ((y - 1) / a2 - 2 / a1) + a2 / a1**2))
+        dparams = dmudb * (-a4 / a1 +
+                           a3 * a2 / (a1 ** 2) +
+                           (1 + a4) * ((y - 1) / a2 - 1 / a1) +
+                           1 / mu)
+
+        return np.column_stack((dparams, dalpha))
+
     def _score_p(self, params):
         """
         Generalized Poisson model derivative of the log-likelihood by p-parameter
@@ -1830,6 +1856,89 @@ class GeneralizedPoisson(CountModel):
         hess_arr[-1,-1] = dldada.sum()
 
         return hess_arr
+
+    def hessian_factor(self, params):
+        """
+        Generalized Poisson model Hessian matrix of the loglikelihood
+
+        Parameters
+        ----------
+        params : array-like
+            The parameters of the model
+
+        Returns
+        -------
+        hess : ndarray, (nobs, 3)
+            The Hessian factor, second derivative of loglikelihood function
+            with respect to linear predictor and dispersion parameter
+            evaluated at `params`
+            The first column contains the second derivative w.r.t. linpred,
+            the second column contains the cross derivative, and the
+            third column contains the second derivative w.r.t. the dispersion
+            parameter.
+
+        """
+        if self._transparams:
+            alpha = np.exp(params[-1])
+        else:
+            alpha = params[-1]
+
+        params = params[:-1]
+        p = self.parameterization
+        exog = self.exog
+        y = self.endog #[:,None]
+        mu = self.predict(params)  # [:,None]
+        mu_p = np.power(mu, p)
+        a1 = 1 + alpha * mu_p
+        a2 = mu + alpha * mu_p * y
+        a3 = alpha * p * mu ** (p - 1)
+        a4 = a3 * y
+        a5 = p * mu ** (p - 1)
+        dmudb = mu
+
+        # for dl/dlinpred dparams
+        nobs, k_vars = exog.shape
+        hess_fact = np.empty((nobs, 3))
+
+
+        hess_fact[:, 0] = mu * (
+             mu * (a3 * a4 / a1**2 -
+                   2 * a3**2 * a2 / a1**3 +
+                   2 * a3 * (a4 + 1) / a1**2 -
+                   a4 * p / (mu * a1) +
+                   a3 * p * a2 / (mu * a1**2) +
+                   a4 / (mu * a1) -
+                   a3 * a2 / (mu * a1**2) +
+                   (y - 1) * a4 * (p - 1) / (a2 * mu) -
+                   (y - 1) * (1 + a4)**2 / a2**2 -
+                   a4 * (p - 1) / (a1 * mu) -
+                   1 / mu**2) +
+             (-a4 / a1 +
+              a3 * a2 / a1**2 +
+              (y - 1) * (1 + a4) / a2 -
+              (1 + a4) / a1 +
+              1 / mu))
+
+        # for dl/dlinpred dalpha
+        dldpda = ((2 * a4 * mu_p / a1**2 -
+                         2 * a3 * mu_p * a2 / a1**3 -
+                         mu_p * y * (y - 1) * (1 + a4) / a2**2 +
+                         mu_p * (1 + a4) / a1**2 +
+                         a5 * y * (y - 1) / a2 -
+                         2 * a5 * y / a1 +
+                         a5 * a2 / a1**2) * dmudb)
+
+        hess_fact[:, 1] = dldpda
+
+        # for dl/dalpha dalpha
+        dldada = mu_p**2 * (3 * y / a1**2 -
+                            (y / a2)**2. * (y - 1) -
+                            2 * a2 / a1**3)
+
+        hess_fact[:, 2] = dldada
+
+        return hess_fact
+
 
     def predict(self, params, exog=None, exposure=None, offset=None,
                 which='mean'):
@@ -2054,7 +2163,7 @@ class Logit(BinaryModel):
 
     def score_factor(self, params):
         """
-        Logit model score_factor for each observation
+        Logit model derivative of the log-likelihood with respect to linpred.
 
         Parameters
         ----------
@@ -2063,8 +2172,9 @@ class Logit(BinaryModel):
 
         Returns
         -------
-        score : array_like
-            The score factor (nobs, ) of the model evaluated at `params`
+        score_factor : array_like
+            The derivative of the loglikelihood for each observation evaluated
+            at `params`.
 
         Notes
         -----
@@ -2118,7 +2228,6 @@ class Logit(BinaryModel):
         hess : ndarray, (nobs,)
             The Hessian factor, second derivative of loglikelihood function
             with respect to the linear predictor evaluated at `params`
-
         """
         X = self.exog
         L = self.cdf(np.dot(X, params))
@@ -2338,6 +2447,39 @@ class Probit(BinaryModel):
         L = q*self.pdf(q*XB)/np.clip(self.cdf(q*XB), FLOAT_EPS, 1 - FLOAT_EPS)
         return L[:,None] * X
 
+    def score_factor(self, params):
+        """
+        Probit model Jacobian for each observation
+
+        Parameters
+        ----------
+        params : array-like
+            The parameters of the model
+
+        Returns
+        -------
+        score_factor : array_like (nobs,)
+            The derivative of the loglikelihood function for each observation
+            with respect to linear predictor evaluated at `params`
+
+        Notes
+        -----
+        .. math:: \\frac{\\partial\\ln L_{i}}{\\partial\\beta}=\\left[\\frac{q_{i}\\phi\\left(q_{i}x_{i}^{\\prime}\\beta\\right)}{\\Phi\\left(q_{i}x_{i}^{\\prime}\\beta\\right)}\\right]x_{i}
+
+        for observations :math:`i=1,...,n`
+
+        Where :math:`q=2y-1`. This simplification comes from the fact that the
+        normal distribution is symmetric.
+        """
+        y = self.endog
+        X = self.exog
+        XB = np.dot(X,params)
+        q = 2*y - 1
+        # clip to get rid of invalid divide complaint
+        L = q*self.pdf(q*XB)/np.clip(self.cdf(q*XB), FLOAT_EPS, 1 - FLOAT_EPS)
+        return L
+
+
     def hessian(self, params):
         """
         Probit model Hessian matrix of the log-likelihood
@@ -2368,6 +2510,37 @@ class Probit(BinaryModel):
         q = 2*self.endog - 1
         L = q*self.pdf(q*XB)/self.cdf(q*XB)
         return np.dot(-L*(L+XB)*X.T,X)
+
+    def hessian_factor(self, params):
+        """
+        Probit model Hessian factor of the log-likelihood
+
+        Parameters
+        ----------
+        params : array-like
+            The parameters of the model
+
+        Returns
+        -------
+        hess : ndarray, (nobs,)
+            The Hessian factor, second derivative of loglikelihood function
+            with respect to linear predictor evaluated at `params`
+
+        Notes
+        -----
+        .. math:: \\frac{\\partial^{2}\\ln L}{\\partial\\beta\\partial\\beta^{\\prime}}=-\\lambda_{i}\\left(\\lambda_{i}+x_{i}^{\\prime}\\beta\\right)x_{i}x_{i}^{\\prime}
+
+        where
+
+        .. math:: \\lambda_{i}=\\frac{q_{i}\\phi\\left(q_{i}x_{i}^{\\prime}\\beta\\right)}{\\Phi\\left(q_{i}x_{i}^{\\prime}\\beta\\right)}
+
+        and :math:`q=2y-1`
+        """
+        X = self.exog
+        XB = np.dot(X,params)
+        q = 2 * self.endog - 1
+        L = q * self.pdf(q * XB) / self.cdf(q * XB)
+        return -L * (L + XB)
 
     @Appender(DiscreteModel.fit.__doc__)
     def fit(self, start_params=None, method='newton', maxiter=35,
@@ -3358,6 +3531,49 @@ class NegativeBinomialP(CountModel):
         else:
             return score
 
+    def score_factor(self, params):
+        """
+        Generalized Negative Binomial (NB-P) model score (gradient) vector of the log-likelihood for each observations.
+
+        Parameters
+        ----------
+        params : array-like
+            The parameters of the model
+
+        Returns
+        -------
+        score : ndarray, 1-D
+            The score vector of the model, i.e. the first derivative of the
+            loglikelihood function, evaluated at `params`
+        """
+        if self._transparams:
+            alpha = np.exp(params[-1])
+        else:
+            alpha = params[-1]
+
+        params = params[:-1]
+        p = 2 - self.parameterization
+        y = self.endog
+
+        mu = self.predict(params)
+        mu_p = mu**p
+        a1 = mu_p / alpha
+        a2 = mu + a1
+        a3 = y + a1
+        a4 = p * a1 / mu
+
+        dgpart = digamma(a3) - digamma(a1)
+
+        dparams = ((a4 * dgpart -
+                   a3 / a2) +
+                   y / mu + a4 * (1 - a3 / a2 + np.log(a1 / a2)))
+        dparams = (mu * dparams).T
+        dalpha = (-a1 / alpha * (dgpart +
+                                 np.log(a1 / a2) +
+                                 1 - a3 / a2))
+
+        return np.column_stack((dparams, dalpha))
+
     def hessian(self, params):
         """
         Generalized Negative Binomial (NB-P) model hessian maxtrix of the log-likelihood
@@ -3432,6 +3648,73 @@ class NegativeBinomialP(CountModel):
         hess_arr[tri_idx] = hess_arr.T[tri_idx]
 
         return hess_arr
+
+    def hessian_factor(self, params):
+        """
+        Generalized Negative Binomial (NB-P) model hessian maxtrix of the log-likelihood
+
+        Parameters
+        ----------
+        params : array-like
+            The parameters of the model
+
+        Returns
+        -------
+        hessian : ndarray, 2-D
+            The hessian matrix of the model.
+        """
+        if self._transparams:
+            alpha = np.exp(params[-1])
+        else:
+            alpha = params[-1]
+        params = params[:-1]
+
+        p = 2 - self.parameterization
+        y = self.endog
+        exog = self.exog
+        mu = self.predict(params)
+
+        mu_p = mu**p
+        a1 = mu_p / alpha
+        a2 = mu + a1
+        a3 = y + a1
+        a4 = p * a1 / mu
+        a5 = a4 * p / mu
+
+        dgpart = digamma(a3) - digamma(a1)
+
+        nobs = exog.shape[0]
+        hess_fact = np.zeros((nobs, 3))
+
+        coeff = mu**2 * (((1 + a4)**2 * a3 / a2**2 -
+                          a3 * (a5 - a4 / mu) / a2 -
+                          y / mu**2 -
+                          2 * a4 * (1 + a4) / a2 +
+                          a5 * (np.log(a1) - np.log(a2) + dgpart + 2) -
+                          a4 * (np.log(a1) - np.log(a2) + dgpart + 1) / mu -
+                          a4**2 * (polygamma(1, a1) - polygamma(1, a3))) +
+                         (-(1 + a4) * a3 / a2 +
+                          y / mu +
+                          a4 * (np.log(a1) - np.log(a2) + dgpart + 1)) / mu)
+
+        hess_fact[:, 0] = coeff
+
+        hess_fact[:, 1] = (mu * a1 *
+                ((1 + a4) * (1 - a3 / a2) / a2 -
+                 p * (np.log(a1 / a2) + dgpart + 2) / mu +
+                 p * (a3 / mu + a4) / a2 +
+                 a4 * (polygamma(1, a1) - polygamma(1, a3))) / alpha)
+
+        da2 = (a1 * (2 * np.log(a1 / a2) +
+                     2 * dgpart + 3 -
+                     2 * a3 / a2 - a1 * polygamma(1, a1) +
+                     a1 * polygamma(1, a3) - 2 * a1 / a2 +
+                     a1 * a3 / a2**2) / alpha**2)
+
+        hess_fact[:, 2] = da2
+
+        return hess_fact
+
 
     @Appender(_get_start_params_null_docs)
     def _get_start_params_null(self):

--- a/statsmodels/discrete/discrete_model.py
+++ b/statsmodels/discrete/discrete_model.py
@@ -32,7 +32,9 @@ from statsmodels.base.data import handle_data  # for mnlogit
 from statsmodels.base.l1_slsqp import fit_l1_slsqp
 import statsmodels.base.model as base
 import statsmodels.base.wrapper as wrap
+from statsmodels.base._constraints import fit_constrained_wrap
 import statsmodels.base._parameter_inference as pinf
+
 from statsmodels.distributions import genpoisson_p
 import statsmodels.regression.linear_model as lm
 from statsmodels.tools import data as data_tools, tools
@@ -42,6 +44,7 @@ from statsmodels.tools.sm_exceptions import (
     PerfectSeparationError,
     SpecificationWarning,
 )
+
 
 try:
     import cvxopt  # noqa:F401
@@ -532,6 +535,14 @@ class BinaryModel(DiscreteModel):
 
         discretefit = L1BinaryResults(self, bnryfit)
         return L1BinaryResultsWrapper(discretefit)
+
+    def fit_constrained(self, constraints, start_params=None, **fit_kwds):
+
+        res = fit_constrained_wrap(self, constraints, start_params=None,
+                                   **fit_kwds)
+        return res
+
+    fit_constrained.__doc__ = fit_constrained_wrap.__doc__
 
     def _derivative_predict(self, params, exog=None, transform='dydx',
                             offset=None):

--- a/statsmodels/discrete/tests/test_constrained.py
+++ b/statsmodels/discrete/tests/test_constrained.py
@@ -404,7 +404,6 @@ class CheckGLMConstrainedMixin(CheckPoissonConstrainedMixin):
         res2 = self.res2  # reference results
         res1 = self.res1m
 
-        # FIXME: dont leave commented-out
         # assert_allclose(res1.aic, res2.aic, rtol=1e-10)  # far away
         # Stata aic in ereturn and in estat ic are very different
         # we have the same as estat ic
@@ -418,10 +417,8 @@ class CheckGLMConstrainedMixin(CheckPoissonConstrainedMixin):
             # FutureWarning for BIC changes
             assert_allclose(res1.bic, res2.bic, rtol=1e-10)
         # bic is deviance based
-        # FIXME: dont leave commented-out
         #  assert_allclose(res1.bic, res2.infocrit[5], rtol=1e-10)
         assert_allclose(res1.deviance, res2.deviance, rtol=1e-10)
-        # FIXME: dont leave commented-out
         # TODO: which chi2 are these
         # assert_allclose(res1.pearson_chi2, res2.chi2, rtol=1e-10)
 

--- a/statsmodels/discrete/tests/test_constrained.py
+++ b/statsmodels/discrete/tests/test_constrained.py
@@ -454,7 +454,7 @@ class TestLogitConstrained1(CheckGLMConstrainedMixin):
         # params sequence same as Stata, but Stata reports param = nan
         # and we have param = value = 0
 
-        #res1ul = Logit(data.endog, data.exog).fit(method="newton", disp=0)
+        # res1ul = Logit(data.endog, data.exog).fit(method="newton", disp=0)
         cls.res2 = reslogit.results_constraint1
 
         mod1 = Logit(spector_data.endog, spector_data.exog)
@@ -562,7 +562,7 @@ class TestLogitConstrained2HC(CheckGLMConstrainedMixin):
     @classmethod
     def setup_class(cls):
         cls.idx = slice(None)  # params sequence same as Stata
-        #res1ul = Logit(data.endog, data.exog).fit(method="newton", disp=0)
+        # res1ul = Logit(data.endog, data.exog).fit(method="newton", disp=0)
         cls.res2 = reslogit.results_constraint2_robust
 
         mod1 = Logit(spector_data.endog, spector_data.exog)

--- a/statsmodels/discrete/tests/test_constrained.py
+++ b/statsmodels/discrete/tests/test_constrained.py
@@ -16,7 +16,7 @@ import pytest
 
 from statsmodels import datasets
 from statsmodels.base._constraints import fit_constrained
-from statsmodels.discrete.discrete_model import Poisson
+from statsmodels.discrete.discrete_model import Poisson, Logit
 from statsmodels.genmod import families
 from statsmodels.genmod.generalized_linear_model import GLM
 from statsmodels.tools.tools import add_constant
@@ -446,6 +446,31 @@ class TestGLMLogitConstrained1(CheckGLMConstrainedMixin):
         cls.res1 = fit_constrained(mod1, R, q)
 
 
+class TestLogitConstrained1(CheckGLMConstrainedMixin):
+
+    @classmethod
+    def setup_class(cls):
+        cls.idx = slice(None)
+        # params sequence same as Stata, but Stata reports param = nan
+        # and we have param = value = 0
+
+        #res1ul = Logit(data.endog, data.exog).fit(method="newton", disp=0)
+        cls.res2 = reslogit.results_constraint1
+
+        mod1 = Logit(spector_data.endog, spector_data.exog)
+
+        constr = 'x1 = 2.8'
+        # newton doesn't work, raises hessian singular
+        cls.res1m = mod1.fit_constrained(constr, method='bfgs')
+
+        R, q = cls.res1m.constraints.coefs, cls.res1m.constraints.constants
+        cls.res1 = fit_constrained(mod1, R, q, fit_kwds={'method': 'bfgs'})
+
+    @pytest.mark.skip(reason='not a GLM')
+    def test_glm(self):
+        return
+
+
 class TestGLMLogitConstrained2(CheckGLMConstrainedMixin):
 
     @classmethod
@@ -530,6 +555,38 @@ class TestGLMLogitConstrained2HC(CheckGLMConstrainedMixin):
                                                          'cov_type': cov_type,
                                                          'cov_kwds': cov_kwds})
         cls.constraints_rq = (R, q)
+
+
+class TestLogitConstrained2HC(CheckGLMConstrainedMixin):
+
+    @classmethod
+    def setup_class(cls):
+        cls.idx = slice(None)  # params sequence same as Stata
+        #res1ul = Logit(data.endog, data.exog).fit(method="newton", disp=0)
+        cls.res2 = reslogit.results_constraint2_robust
+
+        mod1 = Logit(spector_data.endog, spector_data.exog)
+
+        # not used to match Stata for HC
+        # nobs, k_params = mod1.exog.shape
+        # k_params -= 1   # one constraint
+        cov_type = 'HC0'
+        cov_kwds = {'scaling_factor': 32/31}
+        # looks like nobs / (nobs - 1) and not (nobs - 1.) / (nobs - k_params)}
+        constr = 'x1 - x3 = 0'
+        cls.res1m = mod1.fit_constrained(constr, cov_type=cov_type,
+                                         cov_kwds=cov_kwds, tol=1e-10,
+                                         )
+
+        R, q = cls.res1m.constraints.coefs, cls.res1m.constraints.constants
+        cls.res1 = fit_constrained(mod1, R, q, fit_kwds={'tol': 1e-10,
+                                                         'cov_type': cov_type,
+                                                         'cov_kwds': cov_kwds})
+        cls.constraints_rq = (R, q)
+
+    @pytest.mark.skip(reason='not a GLM')
+    def test_glm(self):
+        return
 
 
 def junk():  # FIXME: make this into a test, or move/remove

--- a/statsmodels/discrete/tests/test_discrete.py
+++ b/statsmodels/discrete/tests/test_discrete.py
@@ -85,6 +85,45 @@ def load_randhie():
     data.exog = np.asarray(data.exog, dtype=float)
     return data
 
+def check_jac(self):
+    # moved from CheckModelResults
+    res1 = self.res1
+    exog = self.res1.model.exog
+    #basic cross check
+    jacsum = self.res1.model.score_obs(self.res1.params).sum(0)
+    score = self.res1.model.score(self.res1.params)
+    assert_almost_equal(jacsum, score, DECIMAL_9) #Poisson has low precision ?
+
+    if isinstance(res1.model, (NegativeBinomial, MNLogit)):
+        # skip the rest
+        return
+
+    # check score_factor
+    # TODO: change when score_obs uses score_factor for DRYing
+    s1 = res1.model.score_obs(res1.params)
+    sf = res1.model.score_factor(res1.params)
+    if sf.ndim == 1:
+        s2 = sf[:, None] * exog
+    elif sf.ndim == 2:
+        s2 = np.column_stack((sf[:, :1] * exog, sf[:, 1:]))
+
+    assert_allclose(s2, s1, rtol=1e-10)
+
+    # check hessian_factor
+    h1 = res1.model.hessian(res1.params)
+    hf = res1.model.hessian_factor(res1.params)
+    if sf.ndim == 1:
+        h2 = (hf * exog.T).dot(exog)
+    elif sf.ndim == 2:
+        h00 = (hf[:, 0] * exog.T).dot(exog)
+        h10 = np.atleast_2d(hf[:, 1].T.dot(exog))
+        h11 = np.atleast_2d(hf[:, 2].sum(0))
+        h2 = np.vstack((np.column_stack((h00, h10.T)),
+                        np.column_stack((h10, h11))))
+
+    assert_allclose(h2, h1, rtol=1e-10)
+
+
 class CheckModelMixin(object):
     # Assertions about the Model object, as opposed to the Results
     # Assumes that mixed-in class implements:
@@ -170,10 +209,7 @@ class CheckModelResults(CheckModelMixin):
         assert_almost_equal(llobssum, self.res1.llf, DECIMAL_14)
 
     def test_jac(self):
-        #basic cross check
-        jacsum = self.res1.model.score_obs(self.res1.params).sum(0)
-        score = self.res1.model.score(self.res1.params)
-        assert_almost_equal(jacsum, score, DECIMAL_9) #Poisson has low precision ?
+        check_jac(self)
 
     def test_summary_latex(self):
         # see #7747, last line of top table was dropped
@@ -1920,6 +1956,10 @@ class TestGeneralizedPoisson_underdispersion(object):
         # numbers are regression test, we should not reject
         assert_allclose(chi2[:], (0.5511787456691261, 0.9901293016678583),
                         rtol=0.01)
+
+    def test_jac(self):
+        self.res1 = self.res
+        check_jac(self)
 
 
 class TestNegativeBinomialPNB2Newton(CheckNegBinMixin, CheckModelResults):

--- a/statsmodels/discrete/tests/test_sandwich_cov.py
+++ b/statsmodels/discrete/tests/test_sandwich_cov.py
@@ -485,6 +485,20 @@ class CheckDiscreteGLM(object):
         hessf2 = res2.model.hessian_factor(res1.params, **kwds)
         assert_allclose(sgn * hessf1, hessf2, rtol=1e-10)
 
+    def test_score_test(self):
+        res1 = self.res1
+        res2 = self.res2
+
+        if isinstance(res2.model, OLS):
+            # skip
+            return
+
+        fitted = self.res1.fittedvalues
+        exog_extra = np.column_stack((fitted**2, fitted**3))
+        res_lm1 = res1.score_test(exog_extra, cov_type='nonrobust')
+        res_lm2 = res2.score_test(exog_extra, cov_type='nonrobust')
+        assert_allclose(np.hstack(res_lm1), np.hstack(res_lm2), rtol=5e-7)
+
 
 class TestGLMPoisson(CheckDiscreteGLM):
 

--- a/statsmodels/discrete/tests/test_sandwich_cov.py
+++ b/statsmodels/discrete/tests/test_sandwich_cov.py
@@ -441,8 +441,8 @@ class CheckDiscreteGLM(object):
     # compare GLM with other models, no verified reference results
 
     def test_basic(self):
-        res1 = self.res1
-        res2 = self.res2
+        res1 = self.res1  # GLM model
+        res2 = self.res2  # comparison model, discrete or OLS
 
         assert_equal(res1.cov_type, self.cov_type)
         assert_equal(res2.cov_type, self.cov_type)
@@ -450,6 +450,56 @@ class CheckDiscreteGLM(object):
         rtol = getattr(res1, 'rtol', 1e-13)
         assert_allclose(res1.params, res2.params, rtol=rtol)
         assert_allclose(res1.bse, res2.bse, rtol=1e-10)
+
+    def test_score_hessian(self):
+        res1 = self.res1
+        res2 = self.res2
+
+        # We need to fix scale in GLM and OLS,
+        # discrete MLE have it always fixed
+        if isinstance(res2.model, OLS):
+            kwds = {'scale': res2.scale}
+        else:
+            kwds = {}
+        if isinstance(res2.model, OLS):
+            sgn = + 1
+        else:
+            sgn = -1  # see #4714
+
+        score1 = res1.model.score(res1.params * 0.98, scale=res1.scale)
+        score2 = res2.model.score(res1.params * 0.98, **kwds)
+        assert_allclose(score1, score2, rtol=1e-13)
+
+        hess1 = res1.model.hessian(res1.params, scale=res1.scale)
+        hess2 = res2.model.hessian(res1.params, **kwds)
+        assert_allclose(hess1, hess2, rtol=1e-10)
+
+        if isinstance(res2.model, OLS):
+            # skip the rest
+            return
+        scoref1 = res1.model.score_factor(res1.params, scale=res1.scale)
+        scoref2 = res2.model.score_factor(res1.params, **kwds)
+        assert_allclose(scoref1, scoref2, rtol=1e-10)
+
+        hessf1 = res1.model.hessian_factor(res1.params, scale=res1.scale)
+        hessf2 = res2.model.hessian_factor(res1.params, **kwds)
+        assert_allclose(sgn * hessf1, hessf2, rtol=1e-10)
+
+
+class TestGLMPoisson(CheckDiscreteGLM):
+
+    @classmethod
+    def setup_class(cls):
+        endog_count = np.random.poisson(endog)
+        cls.cov_type = 'HC0'
+
+        mod1 = GLM(endog_count, exog, family=families.Poisson())
+        cls.res1 = mod1.fit(cov_type='HC0')
+
+        mod1 = smd.Poisson(endog_count, exog)
+        cls.res2 = mod1.fit(cov_type='HC0')
+
+        cls.res1.rtol = 1e-11
 
 
 class TestGLMLogit(CheckDiscreteGLM):

--- a/statsmodels/discrete/tests/test_sandwich_cov.py
+++ b/statsmodels/discrete/tests/test_sandwich_cov.py
@@ -504,6 +504,7 @@ class TestGLMPoisson(CheckDiscreteGLM):
 
     @classmethod
     def setup_class(cls):
+        np.random.seed(987125643)  # not intentional seed
         endog_count = np.random.poisson(endog)
         cls.cov_type = 'HC0'
 

--- a/statsmodels/discrete/tests/test_sandwich_cov.py
+++ b/statsmodels/discrete/tests/test_sandwich_cov.py
@@ -516,6 +516,20 @@ class TestGLMLogit(CheckDiscreteGLM):
         cls.res2 = mod1.fit(cov_type='cluster', cov_kwds=dict(groups=group))
 
 
+class TestGLMLogitOffset(CheckDiscreteGLM):
+
+    @classmethod
+    def setup_class(cls):
+        endog_bin = (endog > endog.mean()).astype(int)
+        cls.cov_type = 'cluster'
+        offset = np.ones(endog_bin.shape[0])
+
+        mod1 = GLM(endog_bin, exog, family=families.Binomial(), offset=offset)
+        cls.res1 = mod1.fit(cov_type='cluster', cov_kwds=dict(groups=group))
+
+        mod1 = smd.Logit(endog_bin, exog, offset=offset)
+        cls.res2 = mod1.fit(cov_type='cluster', cov_kwds=dict(groups=group))
+
 class TestGLMProbit(CheckDiscreteGLM):
 
     @classmethod
@@ -542,6 +556,25 @@ class TestGLMProbit(CheckDiscreteGLM):
         hess1 = res1.model.hessian(res1.params)
         hess2 = res2.model.hessian(res1.params)
         assert_allclose(hess1, hess2, rtol=1e-13)
+
+
+class TestGLMProbitOffset(CheckDiscreteGLM):
+
+    @classmethod
+    def setup_class(cls):
+        endog_bin = (endog > endog.mean()).astype(int)
+        cls.cov_type = 'cluster'
+        offset = np.ones(endog_bin.shape[0])
+
+        mod1 = GLM(endog_bin, exog,
+                   family=families.Binomial(link=links.probit()),
+                   offset=offset)
+        cls.res1 = mod1.fit(method='newton',
+                            cov_type='cluster', cov_kwds=dict(groups=group))
+
+        mod1 = smd.Probit(endog_bin, exog, offset=offset)
+        cls.res2 = mod1.fit(cov_type='cluster', cov_kwds=dict(groups=group))
+        cls.rtol = 1e-6
 
 
 class TestGLMGaussNonRobust(CheckDiscreteGLM):

--- a/statsmodels/genmod/generalized_linear_model.py
+++ b/statsmodels/genmod/generalized_linear_model.py
@@ -26,7 +26,11 @@ from numpy.linalg.linalg import LinAlgError
 
 import statsmodels.base.model as base
 import statsmodels.base.wrapper as wrap
+
 from statsmodels.genmod._prediction import PredictionResults
+import statsmodels.base._parameter_inference as infer
+import statsmodels.regression._tools as reg_tools
+
 from statsmodels.graphics._regressionplots_doc import (
     _plot_added_variable_doc,
     _plot_ceres_residuals_doc,
@@ -1918,6 +1922,22 @@ class GLMResults(base.LikelihoodModelResults):
                                       pred_kwds=pred_kwds)
 
         return res
+
+    get_prediction.__doc__ = pred.get_prediction_glm.__doc__
+
+    def score_test(self, exog_extra=None, params_constrained=None,
+                   hypothesis='joint', cov_type=None, cov_kwds=None,
+                   k_constraints=None, observed=True):
+
+        res = infer.score_test(self, exog_extra=exog_extra,
+                               params_constrained=params_constrained,
+                               hypothesis=hypothesis,
+                               cov_type=cov_type, cov_kwds=cov_kwds,
+                               k_constraints=k_constraints,
+                               observed=observed)
+        return res
+
+    score_test.__doc__ = infer.score_test.__doc__
 
     def get_hat_matrix_diag(self, observed=True):
         """

--- a/statsmodels/genmod/generalized_linear_model.py
+++ b/statsmodels/genmod/generalized_linear_model.py
@@ -1372,7 +1372,6 @@ class GLM(base.LikelihoodModel):
         params = mr.x
 
         if not mr.success:
-            import warnings
             ngrad = np.sqrt(np.sum(mr.jac**2))
             msg = "GLM ridge optimization may have failed, |grad|=%f" % ngrad
             warnings.warn(msg)
@@ -1526,14 +1525,12 @@ class GLMResults(base.LikelihoodModelResults):
         # temporary warning
         ct = (cov_type == 'nonrobust') or (cov_type.upper().startswith('HC'))
         if self.model._has_freq_weights and not ct:
-            import warnings
 
             from statsmodels.tools.sm_exceptions import SpecificationWarning
             warnings.warn('cov_type not fully supported with freq_weights',
                           SpecificationWarning)
 
         if self.model._has_var_weights and not ct:
-            import warnings
 
             from statsmodels.tools.sm_exceptions import SpecificationWarning
             warnings.warn('cov_type not fully supported with var_weights',
@@ -1922,11 +1919,17 @@ class GLMResults(base.LikelihoodModelResults):
 
         return res
 
-    get_prediction.__doc__ = pred.get_prediction_glm.__doc__
-
+    @Appender(pinfer.score_test.__doc__)
     def score_test(self, exog_extra=None, params_constrained=None,
                    hypothesis='joint', cov_type=None, cov_kwds=None,
                    k_constraints=None, observed=True):
+
+        if self.model._has_freq_weights is True:
+            warnings.warn("score test has not been verified with freq_weights",
+                          UserWarning)
+        if self.model._has_var_weights is True:
+            warnings.warn("score test has not been verified with var_weights",
+                          UserWarning)
 
         res = pinfer.score_test(self, exog_extra=exog_extra,
                                 params_constrained=params_constrained,
@@ -1935,8 +1938,6 @@ class GLMResults(base.LikelihoodModelResults):
                                 k_constraints=k_constraints,
                                 observed=observed)
         return res
-
-    score_test.__doc__ = pinfer.score_test.__doc__
 
     def get_hat_matrix_diag(self, observed=True):
         """

--- a/statsmodels/genmod/generalized_linear_model.py
+++ b/statsmodels/genmod/generalized_linear_model.py
@@ -28,8 +28,7 @@ import statsmodels.base.model as base
 import statsmodels.base.wrapper as wrap
 
 from statsmodels.genmod._prediction import PredictionResults
-import statsmodels.base._parameter_inference as infer
-import statsmodels.regression._tools as reg_tools
+import statsmodels.base._parameter_inference as pinfer
 
 from statsmodels.graphics._regressionplots_doc import (
     _plot_added_variable_doc,
@@ -1929,15 +1928,15 @@ class GLMResults(base.LikelihoodModelResults):
                    hypothesis='joint', cov_type=None, cov_kwds=None,
                    k_constraints=None, observed=True):
 
-        res = infer.score_test(self, exog_extra=exog_extra,
-                               params_constrained=params_constrained,
-                               hypothesis=hypothesis,
-                               cov_type=cov_type, cov_kwds=cov_kwds,
-                               k_constraints=k_constraints,
-                               observed=observed)
+        res = pinfer.score_test(self, exog_extra=exog_extra,
+                                params_constrained=params_constrained,
+                                hypothesis=hypothesis,
+                                cov_type=cov_type, cov_kwds=cov_kwds,
+                                k_constraints=k_constraints,
+                                observed=observed)
         return res
 
-    score_test.__doc__ = infer.score_test.__doc__
+    score_test.__doc__ = pinfer.score_test.__doc__
 
     def get_hat_matrix_diag(self, observed=True):
         """

--- a/statsmodels/stats/outliers_influence.py
+++ b/statsmodels/stats/outliers_influence.py
@@ -460,8 +460,13 @@ class MLEInfluence(_BaseInfluenceMixin):
         experimental, agrees with GLMInfluence for Binomial and Gaussian.
         no reference for this
         """
+        from statsmodels.genmod.generalized_linear_model import GLM
         sf = self.results.model.score_factor(self.results.params)
         hf = self.results.model.hessian_factor(self.results.params)
+        if not isinstance(self.results.model, GLM):
+            # hessian_factor in GLM has wrong sign
+            hf = -hf
+
         return sf / np.sqrt(hf) / np.sqrt(1 - self.hat_matrix_diag)
 
     @cache_readonly


### PR DESCRIPTION
rebased version of #5711
no code removed (like NB, GPP score factor in first commit)
Logit score_factor is already in main

possible problems
sign of hessian factor, not sure how GLM and discrete really compare
docstrings need review, Resolving merge conflicts might not have left good docstrings.
duplicate shortcut name for `base._parameter_inference `infer` and `pinf`

**included in PR:**

- offset in BinaryModel
  - possible problem in MNLogit, not supported
  - possible problem new code added to main after changes in this PR, needs checking
- fit_constrained in BinaryModel
- score_test in GLMResults
- score_test in Discretresults
  - will likely not work in several models needs checking maybe inherited too high in class hierarchy 
- score_factor, hessian_factor in Probit
- score_factor, hessian_factor in GeneralizedPoisson and NBP,  needs decision what to do with it

