### PR TITLE
DOC: Fixes typo "Welsh ttest" to "Welch ttest"

### DIFF
--- a/statsmodels/stats/weightstats.py
+++ b/statsmodels/stats/weightstats.py
@@ -920,7 +920,7 @@ class CompareMeans(object):
         usevar : str, 'pooled' or 'unequal'
             If ``pooled``, then the standard deviation of the samples is
             assumed to be the same. If ``unequal``, then the variance of
-            Welsh ttest will be used, and the degrees of freedom are those
+            Welch ttest will be used, and the degrees of freedom are those
             of Satterthwaite if ``use_t`` is True.
         value : float
             difference between the means under the Null hypothesis.
@@ -1030,7 +1030,7 @@ class CompareMeans(object):
 
         usevar : str, 'pooled' or 'unequal'
             If ``pooled``, then the standard deviation of the samples is assumed to be
-            the same. If ``unequal``, then Welsh ttest with Satterthwait degrees
+            the same. If ``unequal``, then Welch ttest with Satterthwait degrees
             of freedom is used
         value : float
             difference between the means under the Null hypothesis.
@@ -1135,7 +1135,7 @@ class CompareMeans(object):
 
         usevar : str, 'pooled' or 'unequal'
             If ``pooled``, then the standard deviation of the samples is assumed to be
-            the same. If ``unequal``, then Welsh ttest with Satterthwait degrees
+            the same. If ``unequal``, then Welch ttest with Satterthwait degrees
             of freedom is used
 
         Returns
@@ -1186,7 +1186,7 @@ class CompareMeans(object):
 
         usevar : str, 'pooled' or 'unequal'
             If ``pooled``, then the standard deviation of the samples is assumed to be
-            the same. If ``unequal``, then Welsh ttest with Satterthwait degrees
+            the same. If ``unequal``, then Welch ttest with Satterthwait degrees
             of freedom is used
 
         Returns
@@ -1224,7 +1224,7 @@ class CompareMeans(object):
             equivalence interval low < m1 - m2 < upp
         usevar : str, 'pooled' or 'unequal'
             If ``pooled``, then the standard deviation of the samples is assumed to be
-            the same. If ``unequal``, then Welsh ttest with Satterthwait degrees
+            the same. If ``unequal``, then Welch ttest with Satterthwait degrees
             of freedom is used
 
         Returns
@@ -1251,7 +1251,7 @@ class CompareMeans(object):
             equivalence interval low < m1 - m2 < upp
         usevar : str, 'pooled' or 'unequal'
             If ``pooled``, then the standard deviation of the samples is assumed to be
-            the same. If ``unequal``, then Welsh ttest with Satterthwait degrees
+            the same. If ``unequal``, then Welch ttest with Satterthwait degrees
             of freedom is used
 
         Returns
@@ -1312,7 +1312,7 @@ def ttest_ind(
 
     usevar : str, 'pooled' or 'unequal'
         If ``pooled``, then the standard deviation of the samples is assumed to be
-        the same. If ``unequal``, then Welsh ttest with Satterthwait degrees
+        the same. If ``unequal``, then Welch ttest with Satterthwait degrees
         of freedom is used
     weights : tuple of None or ndarrays
         Case weights for the two samples. For details on weights see
@@ -1368,7 +1368,7 @@ def ttost_ind(
         equivalence interval low < m1 - m2 < upp
     usevar : str, 'pooled' or 'unequal'
         If ``pooled``, then the standard deviation of the samples is assumed to be
-        the same. If ``unequal``, then Welsh ttest with Satterthwait degrees
+        the same. If ``unequal``, then Welch ttest with Satterthwait degrees
         of freedom is used
     weights : tuple of None or ndarrays
         Case weights for the two samples. For details on weights see


### PR DESCRIPTION
Some mentions to "Welch ttest" were written "Welsh ttest", this commit fixes it.

- [X] closes #7086
- [X] tests added / passed. 
- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

Minor typo change on Docstring, therefore no test was added.
No escape requirement due to the change (LaTeX).
