### PR TITLE
MAINT: Deprecate cols in conf_int

### DIFF
--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -2120,6 +2120,13 @@ class LikelihoodModelResults(Results):
         cols : array_like, optional
             Specifies which confidence intervals to return.
 
+        .. deprecated: 0.13
+
+           cols is deprecated and will be removed after 0.14 is released.
+           cols only works when inputs are NumPy arrays and will fail
+           when using pandas Series or DataFrames as input. You can
+           subset the confidence intervals using slices.
+
         Returns
         -------
         array_like
@@ -2167,6 +2174,14 @@ class LikelihoodModelResults(Results):
         lower = params - q * bse
         upper = params + q * bse
         if cols is not None:
+            warnings.warn(
+                "cols is deprecated and will be removed after 0.14 is "
+                "released. cols only works when inputs are NumPy arrays and "
+                "will fail when using pandas Series or DataFrames as input. "
+                "Subsets of confidence intervals can be selected using slices "
+                "of the full confidence interval array.",
+                FutureWarning
+            )
             cols = np.asarray(cols)
             lower = lower[cols]
             upper = upper[cols]


### PR DESCRIPTION
Deprecate a feature that does nto work with pandas and is
hard to get to work correctly

closes #1956

- [x] closes #xxxx
- [x] tests added / passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
