### PR TITLE
BUG: GLM score_test, use correct df_resid

### DIFF
--- a/statsmodels/base/_parameter_inference.py
+++ b/statsmodels/base/_parameter_inference.py
@@ -79,7 +79,7 @@ def _lm_robust(score, constraint_matrix, score_deriv_inv, cov_score,
 
 def score_test(self, exog_extra=None, params_constrained=None,
                hypothesis='joint', cov_type=None, cov_kwds=None,
-               k_constraints=None, observed=True):
+               k_constraints=None, scale=None, observed=True):
     """score test for restrictions or for omitted variables
 
     Null Hypothesis : constraints are satisfied
@@ -193,8 +193,17 @@ def score_test(self, exog_extra=None, params_constrained=None,
                 raise ValueError('if exog_extra is None, then k_constraints'
                                  'needs to be given')
 
-        score = model.score(params_constrained)
-        score_obs = model.score_obs(params_constrained)
+        # we need to use results scale as additional parameter
+        if scale is not None:
+            # we need to use results scale as additional parameter, gh #7840
+            score_kwd = {'scale': scale}
+            hess_kwd['scale'] = scale
+        else:
+            score_kwd = {}
+
+        # duplicate computation of score, might not be needed
+        score = model.score(params_constrained, **score_kwd)
+        score_obs = model.score_obs(params_constrained, **score_kwd)
         hessian = model.hessian(params_constrained, **hess_kwd)
 
     else:

--- a/statsmodels/genmod/generalized_linear_model.py
+++ b/statsmodels/genmod/generalized_linear_model.py
@@ -1931,12 +1931,21 @@ class GLMResults(base.LikelihoodModelResults):
             warnings.warn("score test has not been verified with var_weights",
                           UserWarning)
 
+        # We need to temporarily change model.df_resid for scale computation
+        # TODO: find a nicer way. gh #7840
+        mod_df_resid = self.model.df_resid
+        self.model.df_resid = self.df_resid
+        if k_constraints is not None:
+            self.model.df_resid += k_constraints
         res = pinfer.score_test(self, exog_extra=exog_extra,
                                 params_constrained=params_constrained,
                                 hypothesis=hypothesis,
                                 cov_type=cov_type, cov_kwds=cov_kwds,
                                 k_constraints=k_constraints,
+                                scale=None,
                                 observed=observed)
+
+        self.model.df_resid = mod_df_resid
         return res
 
     def get_hat_matrix_diag(self, observed=True):

--- a/statsmodels/genmod/tests/test_score_test.py
+++ b/statsmodels/genmod/tests/test_score_test.py
@@ -16,7 +16,60 @@ import statsmodels.stats._diagnostic_other as diao
 from statsmodels.base._parameter_inference import score_test
 
 
-class TestScoreTest(object):
+class CheckScoreTest():
+
+    def test_wald_score(self):
+        mod_full = self.model_full
+        mod_drop = self.model_drop
+        restriction = 'x5=0, x6=0'
+        res_full = mod_full.fit()
+        res_constr = mod_full.fit_constrained('x5=0, x6=0')
+        res_drop = mod_drop.fit()
+
+        wald = res_full.wald_test(restriction)
+        # note: need to use method for res_constr for correct df_resid
+        lm_constr = np.hstack(res_constr.score_test())
+        lm_extra = np.hstack(score_test(res_drop, exog_extra=self.exog_extra))
+        lm_full = np.hstack(res_full.score_test(
+            params_constrained=res_constr.params,
+            k_constraints=res_constr.k_constr))
+
+        res_wald = np.hstack([wald.statistic.squeeze(), wald.pvalue, [wald.df_denom]])
+        assert_allclose(lm_constr, res_wald, rtol=self.rtol_ws, atol=self.atol_ws)
+        assert_allclose(lm_extra, res_wald, rtol=self.rtol_ws, atol=self.atol_ws)
+        assert_allclose(lm_constr, lm_extra, rtol=1e-12, atol=1e-14)
+        assert_allclose(lm_full, lm_extra, rtol=1e-12, atol=1e-14)
+        # regression number
+        assert_allclose(lm_constr[1], self.res_pvalue[0], rtol=1e-12, atol=1e-14)
+
+        cov_type='HC0'
+        res_full_hc = mod_full.fit(cov_type=cov_type, start_params=res_full.params)
+        wald = res_full_hc.wald_test(restriction)
+        lm_constr = np.hstack(score_test(res_constr, cov_type=cov_type))
+        lm_extra = np.hstack(score_test(res_drop, exog_extra=self.exog_extra,
+                                        cov_type=cov_type))
+
+        res_wald = np.hstack([wald.statistic.squeeze(), wald.pvalue, [wald.df_denom]])
+        assert_allclose(lm_constr, res_wald, rtol=self.rtol_ws, atol=self.atol_ws)
+        assert_allclose(lm_extra, res_wald, rtol=self.rtol_ws, atol=self.atol_ws)
+        assert_allclose(lm_constr, lm_extra, rtol=1e-13)
+        # regression number
+        assert_allclose(lm_constr[1], self.res_pvalue[1], rtol=1e-12, atol=1e-14)
+
+        if not self.skip_wooldridge:
+            # compare with Wooldridge auxiliary regression
+            # does not work for Poisson, even with family attribute
+            # diao.lm_test_glm assumes fittedvalues is mean (not linear pred)
+            lm_wooldridge = diao.lm_test_glm(res_drop, self.exog_extra)
+            assert_allclose(lm_wooldridge.pval1, self.res_pvalue[0],
+                            rtol=1e-12, atol=1e-14)
+            assert_allclose(lm_wooldridge.pval3, self.res_pvalue[1],
+                            rtol=self.rtol_wooldridge)
+            # smoke test
+            lm_wooldridge.summary()
+
+
+class TestScoreTest(CheckScoreTest):
     # compares score to wald, and regression test for pvalues
     rtol_ws = 5e-3
     atol_ws = 0
@@ -57,50 +110,6 @@ class TestScoreTest(object):
         cls.model_full = GLM(y, xx, family=families.Poisson())
         cls.model_drop = GLM(y, x, family=families.Poisson())
 
-    def test_wald_score(self):
-        mod_full = self.model_full
-        mod_drop = self.model_drop
-        restriction = 'x5=0, x6=0'
-        res_full = mod_full.fit()
-        res_constr = mod_full.fit_constrained('x5=0, x6=0')
-        res_drop = mod_drop.fit()
-
-        wald = res_full.wald_test(restriction)
-        lm_constr = np.hstack(score_test(res_constr))
-        lm_extra = np.hstack(score_test(res_drop, exog_extra=self.exog_extra))
-
-        res_wald = np.hstack([wald.statistic.squeeze(), wald.pvalue, [wald.df_denom]])
-        assert_allclose(lm_constr, res_wald, rtol=self.rtol_ws, atol=self.atol_ws)
-        assert_allclose(lm_extra, res_wald, rtol=self.rtol_ws, atol=self.atol_ws)
-        assert_allclose(lm_constr, lm_extra, rtol=1e-12, atol=1e-14)
-        # regression number
-        assert_allclose(lm_constr[1], self.res_pvalue[0], rtol=1e-12, atol=1e-14)
-
-        cov_type='HC0'
-        res_full_hc = mod_full.fit(cov_type=cov_type, start_params=res_full.params)
-        wald = res_full_hc.wald_test(restriction)
-        lm_constr = np.hstack(score_test(res_constr, cov_type=cov_type))
-        lm_extra = np.hstack(score_test(res_drop, exog_extra=self.exog_extra,
-                                        cov_type=cov_type))
-
-        res_wald = np.hstack([wald.statistic.squeeze(), wald.pvalue, [wald.df_denom]])
-        assert_allclose(lm_constr, res_wald, rtol=self.rtol_ws, atol=self.atol_ws)
-        assert_allclose(lm_extra, res_wald, rtol=self.rtol_ws, atol=self.atol_ws)
-        assert_allclose(lm_constr, lm_extra, rtol=1e-13)
-        # regression number
-        assert_allclose(lm_constr[1], self.res_pvalue[1], rtol=1e-12, atol=1e-14)
-
-        if not self.skip_wooldridge:
-            # compare with Wooldridge auxiliary regression
-            # does not work for Poisson, even with family attribute
-            # diao.lm_test_glm assumes fittedvalues is mean (not linear pred)
-            lm_wooldridge = diao.lm_test_glm(res_drop, self.exog_extra)
-            assert_allclose(lm_wooldridge.pval1, self.res_pvalue[0],
-                            rtol=1e-12, atol=1e-14)
-            assert_allclose(lm_wooldridge.pval3, self.res_pvalue[1],
-                            rtol=self.rtol_wooldridge)
-            # smoke test
-            lm_wooldridge.summary()
 
     def test_dispersion(self):
         res_drop = self.model_drop.fit()
@@ -199,3 +208,36 @@ class TestScoreTestPoissonDispersed(TestScoreTestPoisson):
         [4.2714141112771529e+00, 1.9423733575592056e-05]
         ])
     res_disptest_g = [17.670784788586968, 2.6262956791721383e-05]
+
+
+class TestScoreTestGaussian(CheckScoreTest):
+    # compares score to wald, and regression test for pvalues
+    rtol_ws = 0.01
+    atol_ws = 0
+    rtol_wooldridge = 0.06
+    dispersed = False
+    # regression numbers for nonrobust and HC0
+    res_pvalue = [0.44423875090566467, 0.4370837418475849]
+    # TODO: check why wooldrige is not very close, which pval1, pval2, pval3 ?
+    skip_wooldridge = True
+
+    @classmethod
+    def setup_class(cls):
+        nobs, k_vars = 500, 5
+
+        np.random.seed(786452)
+        x = np.random.randn(nobs, k_vars)
+        x[:, 0] = 1
+        x2 = np.random.randn(nobs, 2)
+        xx = np.column_stack((x, x2))
+
+        if cls.dispersed:
+            het = np.random.randn(nobs)
+            y = np.random.randn(nobs) + x.sum(1) * 0.5 + het
+            #y_mc = np.random.negative_binomial(np.exp(x.sum(1) * 0.5), 2)
+        else:
+            y = np.random.randn(nobs) + x.sum(1) * 0.5
+
+        cls.exog_extra = x2
+        cls.model_full = GLM(y, xx, family=families.Gaussian())
+        cls.model_drop = GLM(y, x, family=families.Gaussian())


### PR DESCRIPTION
see #7840 only relevant if scale is estimated

The fix here temporarily resets `model.df_resid` inside `GLMResults.score_test`.
The standalone score_test function cannot be used in the res_constrained and res_full cases because it doesn't adjust the df_resid for the constrained scale estimation.

I also added `scale` as argument to `_parameter_inference.score_test` function, but it is currently not used.

aside: 
for GLM-Gaussian, the unit test for wooldridge fails. I didn't check whether that is an equivalent test in this case.
It looks like the score_test versions correspond to different wooldridge pvaluex version than in poisson case.
currently skipped