### PR TITLE
ENH: Start move to scalar test statistics

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -65,6 +65,7 @@ filterwarnings =
     error:The default method:FutureWarning:
     error:trend 'nc' has been renamed to 'n':FutureWarning:
     error:Keyword arguments have been passed:FutureWarning:
+    error:The behavior of wald_test:FutureWarning
 markers =
     example: mark a test that runs example code
     matplotlib: mark a test that requires matplotlib

--- a/statsmodels/base/tests/test_generic_methods.py
+++ b/statsmodels/base/tests/test_generic_methods.py
@@ -506,7 +506,7 @@ class CheckAnovaMixin(object):
 
     def test_combined(self):
         res = self.res
-        wa = res.wald_test_terms(skip_single=False, combine_terms=['Duration', 'Weight'])
+        wa = res.wald_test_terms(skip_single=False, combine_terms=['Duration', 'Weight'], scalar=True)
         eye = np.eye(len(res.params))
         c_const = eye[0]
         c_w = eye[[2,3]]
@@ -520,7 +520,7 @@ class CheckAnovaMixin(object):
     def test_categories(self):
         # test only multicolumn terms
         res = self.res
-        wa = res.wald_test_terms(skip_single=True)
+        wa = res.wald_test_terms(skip_single=True, scalar=True)
         eye = np.eye(len(res.params))
         c_w = eye[[2,3]]
         c_dw = eye[[4,5]]
@@ -530,7 +530,7 @@ class CheckAnovaMixin(object):
 
 def compare_waldres(res, wa, constrasts):
     for i, c in enumerate(constrasts):
-        wt = res.wald_test(c)
+        wt = res.wald_test(c, scalar=True)
         assert_allclose(wa.table.values[i, 0], wt.statistic)
         assert_allclose(wa.table.values[i, 1], wt.pvalue)
         df = c.shape[0] if c.ndim == 2 else 1
@@ -572,7 +572,8 @@ class TestWaldAnovaOLS(CheckAnovaMixin):
 
         res = sm.OLS(endog, exog).fit()
         wa = res.wald_test_terms(skip_single=False,
-                                 combine_terms=['Duration', 'Weight'])
+                                 combine_terms=['Duration', 'Weight'],
+                                 scalar=True)
         eye = np.eye(len(res.params))
 
         c_single = [row for row in eye]

--- a/statsmodels/discrete/tests/test_discrete.py
+++ b/statsmodels/discrete/tests/test_discrete.py
@@ -1771,7 +1771,8 @@ class TestGeneralizedPoisson_p2(object):
         assert_allclose(self.res1.llf, self.res2.llf)
 
     def test_wald(self):
-        result = self.res1.wald_test(np.eye(len(self.res1.params))[:-2])
+        result = self.res1.wald_test(np.eye(len(self.res1.params))[:-2],
+                                     scalar=True)
         assert_allclose(result.statistic, self.res2.wald_statistic)
         assert_allclose(result.pvalue, self.res2.wald_pvalue, atol=1e-15)
 

--- a/statsmodels/gam/tests/test_penalized.py
+++ b/statsmodels/gam/tests/test_penalized.py
@@ -608,7 +608,8 @@ class TestGAMMPGBSPoisson(CheckGAMMixin):
         res2 = self.res2
         wtt = res1.wald_test_terms(skip_single=True,
                                    combine_terms=['fuel', 'drive',
-                                                  'weight', 'hp'])
+                                                  'weight', 'hp'],
+                                   scalar=True)
         # mgcv has term test for linear part
         assert_allclose(wtt.statistic[:2], res2.pTerms_chi_sq, rtol=1e-7)
         assert_allclose(wtt.pvalues[:2], res2.pTerms_pv, rtol=1e-6)

--- a/statsmodels/genmod/tests/test_constrained.py
+++ b/statsmodels/genmod/tests/test_constrained.py
@@ -235,8 +235,8 @@ class TestGLMBinomialCountConstrained(ConstrainedCompareMixin):
         use_f = False
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', ValueWarning)
-            wt2 = res2.wald_test(np.eye(k2)[1:], use_f=use_f)
-            wt1 = res1.wald_test(np.eye(k1)[1:], use_f=use_f)
+            wt2 = res2.wald_test(np.eye(k2)[1:], use_f=use_f, scalar=True)
+            wt1 = res1.wald_test(np.eye(k1)[1:], use_f=use_f, scalar=True)
         assert_allclose(wt2.pvalue, wt1.pvalue, atol=1e-20) # pvalue = 0
         assert_allclose(wt2.statistic, wt1.statistic, rtol=1e-8)
         assert_equal(wt2.df_denom, wt1.df_denom)
@@ -244,8 +244,8 @@ class TestGLMBinomialCountConstrained(ConstrainedCompareMixin):
         use_f = True
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', ValueWarning)
-            wt2 = res2.wald_test(np.eye(k2)[1:], use_f=use_f)
-            wt1 = res1.wald_test(np.eye(k1)[1:], use_f=use_f)
+            wt2 = res2.wald_test(np.eye(k2)[1:], use_f=use_f, scalar=True)
+            wt1 = res1.wald_test(np.eye(k1)[1:], use_f=use_f, scalar=True)
         assert_allclose(wt2.pvalue, wt1.pvalue, rtol=1) # pvalue = 8e-273
         assert_allclose(wt2.statistic, wt1.statistic, rtol=1e-8)
         assert_equal(wt2.df_denom, wt1.df_denom)

--- a/statsmodels/genmod/tests/test_score_test.py
+++ b/statsmodels/genmod/tests/test_score_test.py
@@ -26,7 +26,7 @@ class CheckScoreTest():
         res_constr = mod_full.fit_constrained('x5=0, x6=0')
         res_drop = mod_drop.fit()
 
-        wald = res_full.wald_test(restriction)
+        wald = res_full.wald_test(restriction, scalar=True)
         # note: need to use method for res_constr for correct df_resid
         lm_constr = np.hstack(res_constr.score_test())
         lm_extra = np.hstack(score_test(res_drop, exog_extra=self.exog_extra))
@@ -34,7 +34,7 @@ class CheckScoreTest():
             params_constrained=res_constr.params,
             k_constraints=res_constr.k_constr))
 
-        res_wald = np.hstack([wald.statistic.squeeze(), wald.pvalue, [wald.df_denom]])
+        res_wald = np.hstack([wald.statistic, wald.pvalue, [wald.df_denom]])
         assert_allclose(lm_constr, res_wald, rtol=self.rtol_ws, atol=self.atol_ws)
         assert_allclose(lm_extra, res_wald, rtol=self.rtol_ws, atol=self.atol_ws)
         assert_allclose(lm_constr, lm_extra, rtol=1e-12, atol=1e-14)
@@ -44,12 +44,12 @@ class CheckScoreTest():
 
         cov_type='HC0'
         res_full_hc = mod_full.fit(cov_type=cov_type, start_params=res_full.params)
-        wald = res_full_hc.wald_test(restriction)
+        wald = res_full_hc.wald_test(restriction, scalar=True)
         lm_constr = np.hstack(score_test(res_constr, cov_type=cov_type))
         lm_extra = np.hstack(score_test(res_drop, exog_extra=self.exog_extra,
                                         cov_type=cov_type))
 
-        res_wald = np.hstack([wald.statistic.squeeze(), wald.pvalue, [wald.df_denom]])
+        res_wald = np.hstack([wald.statistic, wald.pvalue, [wald.df_denom]])
         assert_allclose(lm_constr, res_wald, rtol=self.rtol_ws, atol=self.atol_ws)
         assert_allclose(lm_extra, res_wald, rtol=self.rtol_ws, atol=self.atol_ws)
         assert_allclose(lm_constr, lm_extra, rtol=1e-13)

--- a/statsmodels/sandbox/regression/tests/test_gmm.py
+++ b/statsmodels/sandbox/regression/tests/test_gmm.py
@@ -236,7 +236,7 @@ class CheckGMM(object):
         # assert_allclose(res_f.pvalue, res2.Fp, rtol=1e-08, atol=0)
 
         # Smoke test for Wald
-        res_wald = res1.wald_test(restriction[:-1])
+        res_wald = res1.wald_test(restriction[:-1], scalar=True)
 
     @pytest.mark.smoke
     def test_summary(self):

--- a/statsmodels/stats/diagnostic.py
+++ b/statsmodels/stats/diagnostic.py
@@ -303,8 +303,8 @@ def compare_encompassing(results_x, results_z, cov_type="nonrobust",
         res = OLS(endog, aug_reg).fit(cov_type=cov_est, cov_kwds=cov_kwds)
         r_matrix = np.zeros((k_a, k))
         r_matrix[:, -k_a:] = np.eye(k_a)
-        test = res.wald_test(r_matrix, use_f=True)
-        stat, pvalue = float(np.squeeze(test.statistic)), float(test.pvalue)
+        test = res.wald_test(r_matrix, use_f=True, scalar=True)
+        stat, pvalue = test.statistic, test.pvalue
         df_num, df_denom = int(test.df_num), int(test.df_denom)
         return stat, pvalue, df_num, df_denom
 
@@ -593,7 +593,7 @@ def acorr_lm(resid, nlags=None, autolag=None, store=False, *, period=None,
         # Note: deg of freedom for LM test: nvars - constant = lags used
     else:
         r_matrix = np.hstack((np.zeros((usedlag, 1)), np.eye(usedlag)))
-        test_stat = resols.wald_test(r_matrix, use_f=False)
+        test_stat = resols.wald_test(r_matrix, use_f=False, scalar=True)
         lm = float(test_stat.statistic)
         lmpval = float(test_stat.pvalue)
 
@@ -1105,7 +1105,7 @@ def linear_reset(res, power=3, test_type="fitted", use_f=False,
     nrestr = aug_exog.shape[1] - exog.shape[1]
     nparams = aug_exog.shape[1]
     r_mat = np.eye(nrestr, nparams, k=nparams-nrestr)
-    return res.wald_test(r_mat, use_f=use_f)
+    return res.wald_test(r_mat, use_f=use_f, scalar=True)
 
 
 def linear_harvey_collier(res, order_by=None, skip=None):

--- a/statsmodels/stats/tests/test_diagnostic.py
+++ b/statsmodels/stats/tests/test_diagnostic.py
@@ -1723,7 +1723,7 @@ def test_encompasing_direct(cov_type, reset_randomstate):
     direct1 = OLS(y, np.hstack([x1, x[:, 1:], z_extra])).fit(cov_type=cov_type)
     r1 = np.zeros((4, 3 + 1 + 3))
     r1[:, -4:] = np.eye(4)
-    direct_test_1 = direct1.wald_test(r1, use_f=True)
+    direct_test_1 = direct1.wald_test(r1, use_f=True, scalar=True)
     expected = (
         float(np.squeeze(direct_test_1.statistic)),
         float(np.squeeze(direct_test_1.pvalue)),
@@ -1735,7 +1735,7 @@ def test_encompasing_direct(cov_type, reset_randomstate):
     direct2 = OLS(y, np.hstack([z1, x_extra])).fit(cov_type=cov_type)
     r2 = np.zeros((2, 2 + 3 + 2))
     r2[:, -2:] = np.eye(2)
-    direct_test_2 = direct2.wald_test(r2, use_f=True)
+    direct_test_2 = direct2.wald_test(r2, use_f=True, scalar=True)
     expected = (
         float(np.squeeze(direct_test_2.statistic)),
         float(np.squeeze(direct_test_2.pvalue)),

--- a/statsmodels/stats/tests/test_oneway.py
+++ b/statsmodels/stats/tests/test_oneway.py
@@ -466,7 +466,7 @@ class TestOnewayOLS(object):
         v = np.zeros(c_equal.shape[0])
 
         # noncentrality at estimated parameters
-        wt = res_ols.wald_test(c_equal)
+        wt = res_ols.wald_test(c_equal, scalar=True)
         df_num, df_denom = wt.df_num, wt.df_denom
 
         cov_p = res_ols.cov_params()
@@ -495,7 +495,7 @@ class TestOnewayOLS(object):
         params_alt = res_ols.params * 0.75
         # compute constraint value so we can get noncentrality from wald_test
         v_off = _offset_constraint(c_equal, res_ols.params, params_alt)
-        wt_off = res_ols.wald_test((c_equal, v + v_off))
+        wt_off = res_ols.wald_test((c_equal, v + v_off), scalar=True)
         nc_wt_off = wald_test_noncent_generic(params_alt, c_equal, v,
                                               cov_p, diff=None, joint=True)
         assert_allclose(nc_wt_off, wt_off.statistic * wt_off.df_num,

--- a/statsmodels/stats/tests/test_outliers_influence.py
+++ b/statsmodels/stats/tests/test_outliers_influence.py
@@ -15,7 +15,7 @@ def test_reset_stata():
     mod = OLS(data.violent, add_constant(data[["murder", "hs_grad"]]))
     res = mod.fit()
     stat = reset_ramsey(res, degree=4)
-    assert_almost_equal(stat.fvalue[0, 0], 1.52, decimal=2)
+    assert_almost_equal(stat.fvalue, 1.52, decimal=2)
     assert_almost_equal(stat.pvalue, 0.2221, decimal=4)
 
     exog_idx = list(data.columns).index("urban")

--- a/statsmodels/tools/_testing.py
+++ b/statsmodels/tools/_testing.py
@@ -93,12 +93,12 @@ def check_ftest_pvalues(results):
     use_t = res.use_t
     k_vars = len(res.params)
     # check default use_t
-    pvals = [res.wald_test(np.eye(k_vars)[k], use_f=use_t).pvalue
+    pvals = [res.wald_test(np.eye(k_vars)[k], use_f=use_t, scalar=True).pvalue
              for k in range(k_vars)]
     assert_allclose(pvals, res.pvalues, rtol=5e-10, atol=1e-25)
 
     # automatic use_f based on results class use_t
-    pvals = [res.wald_test(np.eye(k_vars)[k]).pvalue
+    pvals = [res.wald_test(np.eye(k_vars)[k], scalar=True).pvalue
              for k in range(k_vars)]
     assert_allclose(pvals, res.pvalues, rtol=5e-10, atol=1e-25)
 

--- a/statsmodels/tsa/tests/test_ar.py
+++ b/statsmodels/tsa/tests/test_ar.py
@@ -191,7 +191,7 @@ def test_other_tests_autoreg(ols_autoreg_result):
     r = np.ones_like(a.params)
     a.t_test(r)
     r = np.eye(a.params.shape[0])
-    a.wald_test(r)
+    a.wald_test(r, scalar=True)
 
 
 # TODO: test likelihood for ARX model?


### PR DESCRIPTION
Begin deprecation cycle to move to wards scalars in scalar test statistics

- [X] closes #7865
- [X] tests added / passed. 
- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
