### PR TITLE
BACKPORT: Merge pull request #7839 from guilhermesilveira/main

### DIFF
--- a/statsmodels/stats/weightstats.py
+++ b/statsmodels/stats/weightstats.py
@@ -920,7 +920,7 @@ class CompareMeans(object):
         usevar : str, 'pooled' or 'unequal'
             If ``pooled``, then the standard deviation of the samples is
             assumed to be the same. If ``unequal``, then the variance of
-            Welsh ttest will be used, and the degrees of freedom are those
+            Welch ttest will be used, and the degrees of freedom are those
             of Satterthwaite if ``use_t`` is True.
         value : float
             difference between the means under the Null hypothesis.
@@ -1030,7 +1030,7 @@ class CompareMeans(object):
 
         usevar : str, 'pooled' or 'unequal'
             If ``pooled``, then the standard deviation of the samples is assumed to be
-            the same. If ``unequal``, then Welsh ttest with Satterthwait degrees
+            the same. If ``unequal``, then Welch ttest with Satterthwait degrees
             of freedom is used
         value : float
             difference between the means under the Null hypothesis.
@@ -1135,7 +1135,7 @@ class CompareMeans(object):
 
         usevar : str, 'pooled' or 'unequal'
             If ``pooled``, then the standard deviation of the samples is assumed to be
-            the same. If ``unequal``, then Welsh ttest with Satterthwait degrees
+            the same. If ``unequal``, then Welch ttest with Satterthwait degrees
             of freedom is used
 
         Returns
@@ -1186,7 +1186,7 @@ class CompareMeans(object):
 
         usevar : str, 'pooled' or 'unequal'
             If ``pooled``, then the standard deviation of the samples is assumed to be
-            the same. If ``unequal``, then Welsh ttest with Satterthwait degrees
+            the same. If ``unequal``, then Welch ttest with Satterthwait degrees
             of freedom is used
 
         Returns
@@ -1224,7 +1224,7 @@ class CompareMeans(object):
             equivalence interval low < m1 - m2 < upp
         usevar : str, 'pooled' or 'unequal'
             If ``pooled``, then the standard deviation of the samples is assumed to be
-            the same. If ``unequal``, then Welsh ttest with Satterthwait degrees
+            the same. If ``unequal``, then Welch ttest with Satterthwait degrees
             of freedom is used
 
         Returns
@@ -1251,7 +1251,7 @@ class CompareMeans(object):
             equivalence interval low < m1 - m2 < upp
         usevar : str, 'pooled' or 'unequal'
             If ``pooled``, then the standard deviation of the samples is assumed to be
-            the same. If ``unequal``, then Welsh ttest with Satterthwait degrees
+            the same. If ``unequal``, then Welch ttest with Satterthwait degrees
             of freedom is used
 
         Returns
@@ -1312,7 +1312,7 @@ def ttest_ind(
 
     usevar : str, 'pooled' or 'unequal'
         If ``pooled``, then the standard deviation of the samples is assumed to be
-        the same. If ``unequal``, then Welsh ttest with Satterthwait degrees
+        the same. If ``unequal``, then Welch ttest with Satterthwait degrees
         of freedom is used
     weights : tuple of None or ndarrays
         Case weights for the two samples. For details on weights see
@@ -1368,7 +1368,7 @@ def ttost_ind(
         equivalence interval low < m1 - m2 < upp
     usevar : str, 'pooled' or 'unequal'
         If ``pooled``, then the standard deviation of the samples is assumed to be
-        the same. If ``unequal``, then Welsh ttest with Satterthwait degrees
+        the same. If ``unequal``, then Welch ttest with Satterthwait degrees
         of freedom is used
     weights : tuple of None or ndarrays
         Case weights for the two samples. For details on weights see


### PR DESCRIPTION
DOC: Fixes typo "Welsh ttest" to "Welch ttest"

- [ ] closes #xxxx
- [ ] tests added / passed. 
- [ ] code/documentation is well formatted.  
- [ ] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
