### PR TITLE
ENH/BUG: get_prediction for more models and cases

### DIFF
--- a/statsmodels/base/_prediction_inference.py
+++ b/statsmodels/base/_prediction_inference.py
@@ -478,6 +478,73 @@ def get_prediction_glm(self, exog=None, transform=True,
         row_labels=row_labels, linpred=linpred, link=link)
 
 
+def get_prediction_linear(self, exog=None, transform=True,
+                          row_labels=None, pred_kwds=None, index=None):
+    """
+    Compute prediction results for linear prediction.
+
+    Parameters
+    ----------
+    exog : array_like, optional
+        The values for which you want to predict.
+    transform : bool, optional
+        If the model was fit via a formula, do you want to pass
+        exog through the formula. Default is True. E.g., if you fit
+        a model y ~ log(x1) + log(x2), and transform is True, then
+        you can pass a data structure that contains x1 and x2 in
+        their original form. Otherwise, you'd need to log the data
+        first.
+    row_labels : list of str or None
+        If row_lables are provided, then they will replace the generated
+        labels.
+    pred_kwargs :
+        Some models can take additional keyword arguments, such as offset or
+        additional exog in multi-part models.
+        See the predict method of the model for the details.
+    index : slice or array-index
+        Is used to select rows and columns of cov_params, if the prediction
+        function only depends on a subset of parameters.
+
+    Returns
+    -------
+    prediction_results : PredictionResults
+        The prediction results instance contains prediction and prediction
+        variance and can on demand calculate confidence intervals and summary
+        tables for the prediction.
+    """
+
+    # prepare exog and row_labels, based on base Results.predict
+    exog, row_labels = _get_exog_predict(
+        self,
+        exog=exog,
+        transform=transform,
+        row_labels=row_labels,
+        )
+
+    if pred_kwds is None:
+        pred_kwds = {}
+
+    k1 = exog.shape[1]
+    if len(self.params > k1):
+        # TODO: we allow endpoint transformation only for the first link
+        index = np.arange(k1)
+    else:
+        index = None
+    # get linear prediction and standard errors
+    covb = self.cov_params(column=index)
+    var_pred = (exog * np.dot(covb, exog.T).T).sum(1)
+    pred_kwds_linear = pred_kwds.copy()
+    pred_kwds_linear["which"] = "linear"
+    predicted = self.model.predict(self.params, exog, **pred_kwds_linear)
+
+    dist = ['norm', 't'][self.use_t]
+    res = PredictionResultsBase(predicted, var_pred,
+                                df=self.df_resid, dist=dist,
+                                row_labels=row_labels
+                                )
+    return res
+
+
 def get_prediction_monotonic(self, exog=None, transform=True,
                              row_labels=None, link=None,
                              pred_kwds=None, index=None):

--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -2729,6 +2729,7 @@ class GenericLikelihoodModelResults(LikelihoodModelResults, ResultMixin):
             transform=True,
             row_labels=None,
             average=False,
+            agg_weights=None,
             **kwargs
             ):
         """
@@ -2758,6 +2759,9 @@ class GenericLikelihoodModelResults(LikelihoodModelResults, ResultMixin):
             over observation is used.
             If average is False, then the results are the predictions for all
             observations, i.e. same length as ``exog``.
+        agg_weights : ndarray, optional
+            Aggregation weights, only used if average is True.
+            The weights are not normalized.
         **kwargs :
             Some models can take additional keyword arguments, such as offset,
             exposure or additional exog in multi-part models like zero inflated
@@ -2786,6 +2790,7 @@ class GenericLikelihoodModelResults(LikelihoodModelResults, ResultMixin):
             transform=transform,
             row_labels=row_labels,
             average=average,
+            agg_weights=agg_weights,
             pred_kwds=pred_kwds
             )
         return res

--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -2722,6 +2722,74 @@ class GenericLikelihoodModelResults(LikelihoodModelResults, ResultMixin):
         if self.df_resid != self.nobs - k_params:
             warnings.warn("df_resid differs from nobs - nparams")
 
+    def get_prediction(
+            self,
+            exog=None,
+            which="mean",
+            transform=True,
+            row_labels=None,
+            average=False,
+            **kwargs
+            ):
+        """
+        Compute prediction results when endpoint transformation is valid.
+
+        Parameters
+        ----------
+        exog : array_like, optional
+            The values for which you want to predict.
+        transform : bool, optional
+            If the model was fit via a formula, do you want to pass
+            exog through the formula. Default is True. E.g., if you fit
+            a model y ~ log(x1) + log(x2), and transform is True, then
+            you can pass a data structure that contains x1 and x2 in
+            their original form. Otherwise, you'd need to log the data
+            first.
+        which : str
+            Which statistic is to be predicted. Default is "mean".
+            The available statistics and options depend on the model.
+            see the model.predict docstring
+        row_labels : list of str or None
+            If row_lables are provided, then they will replace the generated
+            labels.
+        average : bool
+            If average is True, then the mean prediction is computed, that is,
+            predictions are computed for individual exog and then the average
+            over observation is used.
+            If average is False, then the results are the predictions for all
+            observations, i.e. same length as ``exog``.
+        **kwargs :
+            Some models can take additional keyword arguments, such as offset,
+            exposure or additional exog in multi-part models like zero inflated
+            models.
+            See the predict method of the model for the details.
+
+        Returns
+        -------
+        prediction_results : PredictionResults
+            The prediction results instance contains prediction and prediction
+            variance and can on demand calculate confidence intervals and
+            summary dataframe for the prediction.
+
+        Notes
+        -----
+        Status: new in 0.14, experimental
+        """
+        from statsmodels.base._prediction_inference import get_prediction
+
+        pred_kwds = kwargs
+
+        res = get_prediction(
+            self,
+            exog=exog,
+            which=which,
+            transform=transform,
+            row_labels=row_labels,
+            average=average,
+            pred_kwds=pred_kwds
+            )
+        return res
+
     def summary(self, yname=None, xname=None, title=None, alpha=.05):
         """Summarize the Regression Results
 

--- a/statsmodels/discrete/count_model.py
+++ b/statsmodels/discrete/count_model.py
@@ -746,7 +746,7 @@ class ZeroInflatedResults(CountResults):
 
     def get_prediction(self, exog=None, exog_infl=None, exposure=None,
                        offset=None, which='mean', average=False,
-                       y_values=None,
+                       agg_weights=None, y_values=None,
                        transform=True, row_labels=None):
 
         import statsmodels.base._prediction_inference as pred
@@ -760,6 +760,7 @@ class ZeroInflatedResults(CountResults):
 
         res = pred.get_prediction_delta(self, exog=exog, which=which,
                                         average=average,
+                                        agg_weights=agg_weights,
                                         pred_kwds=pred_kwds)
         return res
 

--- a/statsmodels/discrete/discrete_model.py
+++ b/statsmodels/discrete/discrete_model.py
@@ -4270,49 +4270,15 @@ class DiscreteResults(base.LikelihoodModelResults):
         if y_values is not None:
             pred_kwds["y_values"] = y_values
 
-        if which == "linear":
-            res = pred.get_prediction_linear(
-                self,
-                exog=exog,
-                transform=transform,
-                row_labels=row_labels,
-                pred_kwds=pred_kwds,
-                )
-
-        elif which == "mean" and (average is False):
-            # endpoint transformation
-            if self.model.k_extra > 0:
-                # TODO:
-                index = np.arange(self.model.exog.shape[1])
-            else:
-                index = None
-
-            pred_kwds["which"] = which
-            # TODO: add link or ilink to all link based models (except zi
-            link = getattr(self.model, "link", None)
-            if link is None:
-                from statsmodels.genmod.families import links
-                link = links.Log()
-            res = pred.get_prediction_monotonic(
-                self,
-                exog=exog,
-                transform=transform,
-                row_labels=row_labels,
-                link=link,
-                pred_kwds=pred_kwds,
-                index=index,
-                )
-
-        else:
-            # which is not mean or linear, or we need averaging
-            res = pred.get_prediction_delta(
-                self,
-                exog=exog,
-                which=which,
-                average=average,
-                pred_kwds=pred_kwds,
-                )
-
+        res = pred.get_prediction(
+            self,
+            exog=exog,
+            which=which,
+            transform=transform,
+            row_labels=row_labels,
+            average=average,
+            pred_kwds=pred_kwds
+            )
         return res
 
     def _get_endog_name(self, yname, yname_list):

--- a/statsmodels/discrete/discrete_model.py
+++ b/statsmodels/discrete/discrete_model.py
@@ -4199,7 +4199,8 @@ class DiscreteResults(base.LikelihoodModelResults):
 
     def get_prediction(self, exog=None,
                        transform=True, which="mean", linear=None,
-                       row_labels=None, average=False, y_values=None,
+                       row_labels=None, average=False,
+                       agg_weights=None, y_values=None,
                        **kwargs):
         """
         Compute prediction results when endpoint transformation is valid.
@@ -4233,6 +4234,9 @@ class DiscreteResults(base.LikelihoodModelResults):
             over observation is used.
             If average is False, then the results are the predictions for all
             observations, i.e. same length as ``exog``.
+        agg_weights : ndarray, optional
+            Aggregation weights, only used if average is True.
+            The weights are not normalized.
         y_values : None or nd_array
             Some predictive statistics like which="prob" are computed at
             values of the response variable. If y_values is not None, then
@@ -4277,6 +4281,7 @@ class DiscreteResults(base.LikelihoodModelResults):
             transform=transform,
             row_labels=row_labels,
             average=average,
+            agg_weights=agg_weights,
             pred_kwds=pred_kwds
             )
         return res

--- a/statsmodels/discrete/discrete_model.py
+++ b/statsmodels/discrete/discrete_model.py
@@ -4261,8 +4261,6 @@ class DiscreteResults(base.LikelihoodModelResults):
         Status: new in 0.14, experimental
         """
 
-        import statsmodels.regression._prediction as linpred
-
         if linear is True:
             # compatibility with old keyword
             which = "linear"
@@ -4273,18 +4271,14 @@ class DiscreteResults(base.LikelihoodModelResults):
             pred_kwds["y_values"] = y_values
 
         if which == "linear":
-            # pred_kwds["linear"] = True  # old keyword
-            pred_kwds["which"] = "linear"
-            # two calls to a get_prediction duplicates exog generation if patsy
-            res_linpred = linpred.get_prediction(
+            res = pred.get_prediction_linear(
                 self,
                 exog=exog,
                 transform=transform,
                 row_labels=row_labels,
                 pred_kwds=pred_kwds,
                 )
-            if which == "linear":
-                res = res_linpred
+
         elif which == "mean" and (average is False):
             # endpoint transformation
             if self.model.k_extra > 0:

--- a/statsmodels/discrete/tests/test_predict.py
+++ b/statsmodels/discrete/tests/test_predict.py
@@ -122,6 +122,19 @@ class CheckPredict():
         stat, _ = pred.t_test(value=pred.predicted)
         assert_equal(stat, 0)
 
+        # test agg_weights
+        df6 = exog[:6]
+        aw = np.zeros(len(res1.model.endog))
+        aw[:6] = 1
+        aw /= aw.mean()
+        pm6 = res1.get_prediction(exog=df6, which="mean", average=True,
+                                  **self.pred_kwds_6)
+        dfm6 = pm6.summary_frame()
+        pmw = res1.get_prediction(which="mean", average=True, agg_weights=aw)
+        dfmw = pmw.summary_frame()
+        assert_allclose(pmw.predicted, pm6.predicted, rtol=1e-13)
+        assert_allclose(dfmw, dfm6, rtol=1e-7)
+
     def test_diagnostic(self):
         # smoke test for now
         res1 = self.res1
@@ -146,6 +159,7 @@ class TestNegativeBinomialPPredict(CheckPredict):
         cls.res1 = res1
         cls.res2 = resp.results_nb_docvis
         cls.pred_kwds_mean = {}
+        cls.pred_kwds_6 = {}
         cls.k_infl = 0
         cls.rtol = 1e-8
 
@@ -180,5 +194,6 @@ class TestZINegativeBinomialPPredict(CheckPredict):
         cls.res1 = res1
         cls.res2 = resp.results_zinb_docvis
         cls.pred_kwds_mean = {"exog_infl": exog_infl.mean(0)}
+        cls.pred_kwds_6 = {"exog_infl": exog_infl[:6]}
         cls.k_infl = 2
         cls.rtol = 1e-4

--- a/statsmodels/discrete/tests/test_predict.py
+++ b/statsmodels/discrete/tests/test_predict.py
@@ -149,6 +149,19 @@ class TestNegativeBinomialPPredict(CheckPredict):
         cls.k_infl = 0
         cls.rtol = 1e-8
 
+    def test_predict_linear(self):
+        res1 = self.res1
+        ex = np.asarray(exog[:5])
+        pred = res1.get_prediction(ex, which="linear", **self.pred_kwds_mean)
+        k_extra = len(res1.params) - ex.shape[1]
+        if k_extra > 0:
+            # not zero-inflated models have params_infl first
+            ex = np.column_stack((ex, np.zeros((ex.shape[0], k_extra))))
+        tt = res1.t_test(ex)
+        cip = pred.conf_int()  # assumes no offset
+        cit = tt.conf_int()
+        assert_allclose(cip, cit, rtol=1e-12)
+
 
 class TestZINegativeBinomialPPredict(CheckPredict):
 

--- a/statsmodels/othermod/betareg.py
+++ b/statsmodels/othermod/betareg.py
@@ -160,21 +160,25 @@ class BetaModel(GenericLikelihoodModel):
         exog : array_like
             Array of predictor variables for mean.
         exog_precision : array_like
-            Array of predictor variables for precision.
+            Array of predictor variables for precision parameter.
         which : str
 
             - "mean" : mean, conditional expectation E(endog | exog)
             - "precision" : predicted precision
-            - "linpred" : linear predictor for the mean function
-            - "linpred_precision" : linear predictor for the precision function
+            - "linear" : linear predictor for the mean function
+            - "linear-precision" : linear predictor for the precision parameter
 
         Returns
         -------
         ndarray, predicted values
         """
+        if which == "linpred":
+            which = "linear"
+        if which in ["linpred_precision", "linear_precision"]:
+            which = "linear-precision"
 
         k_mean = self.exog.shape[1]
-        if which in ["mean",  "linpred"]:
+        if which in ["mean",  "linear"]:
             if exog is None:
                 exog = self.exog
             params_mean = params[:k_mean]
@@ -186,7 +190,7 @@ class BetaModel(GenericLikelihoodModel):
             else:
                 return linpred
 
-        elif which in ["precision", "linpred_precision"]:
+        elif which in ["precision", "linear-precision"]:
             if exog_precision is None:
                 exog_precision = self.exog_precision
             params_prec = params[k_mean:]

--- a/statsmodels/othermod/tests/test_beta.py
+++ b/statsmodels/othermod/tests/test_beta.py
@@ -146,7 +146,7 @@ class TestBetaModel(object):
         distr = rslt.get_distribution()
         mean, var = distr.stats()
         assert_allclose(rslt.fittedvalues, mean, rtol=1e-13)
-        assert_allclose(rslt.model.predict_var(rslt.params), var, rtol=1e-13)
+        assert_allclose(rslt.model._predict_var(rslt.params), var, rtol=1e-13)
         resid = rslt.model.endog - mean
         assert_allclose(rslt.resid, resid, rtol=1e-12)
         assert_allclose(rslt.resid_pearson, resid / np.sqrt(var), rtol=1e-12)
@@ -235,7 +235,7 @@ class TestBetaMeth():
     def test_predict_distribution(self):
         res1 = self.res1
         mean = res1.predict()
-        var_ = res1.model.predict_var(res1.params)
+        var_ = res1.model._predict_var(res1.params)
         distr = res1.get_distribution()
         m2, v2 = distr.stats()
         assert_allclose(mean, m2, rtol=1e-13)
@@ -255,8 +255,8 @@ class TestBetaMeth():
         # todo: prec6 wrong exog if not used as keyword, no exception raised
         prec6 = res1.predict(exog_precision=ex_prec, which="precision",
                              transform=False)
-        var6 = res1.model.predict_var(res1.params, exog=ex,
-                                      exog_precision=ex_prec)
+        var6 = res1.model._predict_var(res1.params, exog=ex,
+                                       exog_precision=ex_prec)
 
         assert_allclose(mean6, mean[:n], rtol=1e-13)
         assert_allclose(prec6, prec[:n], rtol=1e-13)
@@ -300,6 +300,11 @@ class TestBetaMeth():
         dfm = pm.summary_frame()
         assert_allclose(pm.predicted, mean6, rtol=1e-13)
         assert_equal(dfm.shape, (6, 4))
+        pv = res1.get_prediction(exog=df6, exog_precision=ex_prec,
+                                 which="var", average=False)
+        dfv = pv.summary_frame()
+        assert_allclose(pv.predicted, var6, rtol=1e-13)
+        assert_equal(dfv.shape, (6, 4))
         # smoke tests
         res1.get_prediction(which="linear", average=False)
         res1.get_prediction(which="precision", average=True)

--- a/statsmodels/othermod/tests/test_beta.py
+++ b/statsmodels/othermod/tests/test_beta.py
@@ -290,3 +290,19 @@ class TestBetaMeth():
         assert_allclose(v26, v2[:n], rtol=1e-13)
         # check that we don't have pandas in distr
         assert isinstance(distr6f.args[0], np.ndarray)
+
+        # minimal checks for get_prediction
+        pma = res1.get_prediction(which="mean", average=True)
+        dfma = pma.summary_frame()
+        assert_allclose(pma.predicted, mean.mean(), rtol=1e-13)
+        assert_equal(dfma.shape, (1, 4))
+        pm = res1.get_prediction(exog=df6, which="mean", average=False)
+        dfm = pm.summary_frame()
+        assert_allclose(pm.predicted, mean6, rtol=1e-13)
+        assert_equal(dfm.shape, (6, 4))
+        # smoke tests
+        res1.get_prediction(which="linear", average=False)
+        res1.get_prediction(which="precision", average=True)
+        res1.get_prediction(exog_precision=ex_prec, which="precision",
+                            average=False)
+        res1.get_prediction(which="linear-precision", average=True)

--- a/statsmodels/othermod/tests/test_beta.py
+++ b/statsmodels/othermod/tests/test_beta.py
@@ -306,3 +306,16 @@ class TestBetaMeth():
         res1.get_prediction(exog_precision=ex_prec, which="precision",
                             average=False)
         res1.get_prediction(which="linear-precision", average=True)
+
+        # test agg_weights
+        pm = res1.get_prediction(exog=df6, which="mean", average=True)
+        dfm = pm.summary_frame()
+        aw = np.zeros(len(res1.model.endog))
+        aw[:6] = 1
+        aw /= aw.mean()
+        pm6 = res1.get_prediction(exog=df6, which="mean", average=True)
+        dfm6 = pm6.summary_frame()
+        pmw = res1.get_prediction(which="mean", average=True, agg_weights=aw)
+        dfmw = pmw.summary_frame()
+        assert_allclose(pmw.predicted, pm6.predicted, rtol=1e-13)
+        assert_allclose(dfmw, dfm6, rtol=1e-13)


### PR DESCRIPTION
another round for get_predictions

- get_prediction which="linear" didn't work if there are extra_params
- add GenericLikelihoodModelResults.get_prediction
- minimal unit tests for BetaModel get_prediction inherited from GenericLikelihood, no verified se, conf_int
- ...

decision for now:
- get_prediction_linear is only used for first exog in multilink models
- all other linear predictions go through NonlinearDeltaCov. Results will be the same except for numerical derivative
- zero-inflated models have inflation params before main paramss, i.e. params for exog are not first segment of `params`.
  I don't support (for now) using get_prediction_linear for ZI models.
- ...

