### PR TITLE
MAINT: Silence warning

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -66,6 +66,7 @@ filterwarnings =
     error:trend 'nc' has been renamed to 'n':FutureWarning:
     error:Keyword arguments have been passed:FutureWarning:
     error:The behavior of wald_test:FutureWarning
+    error:cols is deprecated and will be removed after:FutureWarning
 markers =
     example: mark a test that runs example code
     matplotlib: mark a test that requires matplotlib

--- a/statsmodels/regression/tests/test_regression.py
+++ b/statsmodels/regression/tests/test_regression.py
@@ -86,7 +86,8 @@ class CheckRegressionResults(object):
 
     def test_conf_int_subset(self):
         if len(self.res1.params) > 1:
-            ci1 = self.res1.conf_int(cols=(1, 2))
+            with pytest.warns(FutureWarning, match="cols is"):
+                ci1 = self.res1.conf_int(cols=(1, 2))
             ci2 = self.res1.conf_int()[1:3]
             assert_almost_equal(ci1, ci2, self.decimal_conf_int_subset)
         else:

--- a/statsmodels/regression/tests/test_rolling.py
+++ b/statsmodels/regression/tests/test_rolling.py
@@ -137,14 +137,11 @@ def test_against_wls_inference(data, use_t, cov_type):
     y, x, w = data
     mod = RollingWLS(y, x, window=100, weights=w)
     res = mod.fit(use_t=use_t, cov_type=cov_type)
-    ci_cols = ci = res.conf_int()
-    test_cols = x.shape[1] > 3
+    ci = res.conf_int()
 
     # This is a smoke test of cov_params to make sure it works
     res.cov_params()
 
-    if test_cols:
-        ci_cols = res.conf_int(cols=[0, 2])
     # Skip to improve performance
     for i in range(100, y.shape[0]):
         _y = get_sub(y, i, 100)
@@ -167,14 +164,6 @@ def test_against_wls_inference(data, use_t, cov_type):
         else:
             ci_val = ci[i - 1].T
         assert_allclose(ci_val, wls_ci)
-        if test_cols:
-            wls_ci = wls.conf_int(cols=[0, 2])
-            if isinstance(ci_cols, pd.DataFrame):
-                ci_val = ci_cols.iloc[i - 1]
-                ci_val = np.asarray(ci_val).reshape((-1, 2))
-            else:
-                ci_val = ci_cols[i - 1].T
-            assert_allclose(ci_val, wls_ci)
 
 
 def test_raise(data):


### PR DESCRIPTION
Silence warning about cols being deprecated

- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
