### PR TITLE
BUG: Correct seasonal order

### DIFF
--- a/statsmodels/tsa/statespace/exponential_smoothing.py
+++ b/statsmodels/tsa/statespace/exponential_smoothing.py
@@ -4,7 +4,6 @@ Linear exponential smoothing models
 Author: Chad Fulton
 License: BSD-3
 """
-
 import numpy as np
 import pandas as pd
 from statsmodels.base.data import PandasData
@@ -105,6 +104,15 @@ class ExponentialSmoothing(MLEModel):
         self.damped_trend = bool_like(damped_trend, 'damped_trend')
         self.seasonal_periods = int_like(seasonal, 'seasonal', optional=True)
         self.seasonal = self.seasonal_periods is not None
+        if seasonal:
+            import warnings
+
+            warnings.warn(
+                "ExponentialSmoothing should not be used with seasonal "
+                "terms. It has a serious bug that has not been fixed. "
+                "Instead use ETSModel.",
+                RuntimeWarning
+            )
         self.initialization_method = string_like(
             initialization_method, 'initialization_method').lower()
         self.concentrate_scale = bool_like(concentrate_scale,


### PR DESCRIPTION
Reverse seasonal during model intialization

- [X] closes #7893
- [x] tests added / passed. 
- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
