### PR TITLE
ENH/REF: Scoretest betareg

### DIFF
--- a/statsmodels/base/_parameter_inference.py
+++ b/statsmodels/base/_parameter_inference.py
@@ -166,13 +166,15 @@ def score_test(self, exog_extra=None, params_constrained=None,
     score_obs without degrees of freedom correction.
     """
     # TODO: we are computing unnecessary things for cov_type nonrobust
+    if hasattr(self, "_results"):
+        # use numpy if we have wrapper, not relevant if method
+        self = self._results
     model = self.model
-    nobs = model.endog.shape[0] # model.nobs
+    nobs = model.endog.shape[0]  # model.nobs
     # discrete Poisson does not have nobs
     if params_constrained is None:
         params_constrained = self.params
     cov_type = cov_type if cov_type is not None else self.cov_type
-    # r_matrix = None
 
     if observed is False:
         hess_kwd = {'observed': False}
@@ -215,8 +217,8 @@ def score_test(self, exog_extra=None, params_constrained=None,
                                       'should not be a constrained fit result')
 
         if isinstance(exog_extra, tuple):
-            sh = model._scorehess_extra(params_constrained, *exog_extra,
-                                        **hess_kwd)
+            sh = _scorehess_extra(self, params_constrained, *exog_extra,
+                                  hess_kwds=hess_kwd)
             score_obs, hessian, k_constraints, r_matrix = sh
             score = score_obs.sum(0)
         else:
@@ -284,6 +286,80 @@ def score_test(self, exog_extra=None, params_constrained=None,
         return stat, pval
     else:
         raise NotImplementedError('only hypothesis "joint" is available')
+
+
+def _scorehess_extra(self, params=None, exog_extra=None,
+                     exog2_extra=None, hess_kwds=None):
+    """Experimental helper function for variable addition score test.
+
+    This uses score and hessian factor at the params which should be the
+    params of the restricted model.
+
+    """
+    if hess_kwds is None:
+        hess_kwds = {}
+    # this corresponds to a model methods, so we need only the model
+    model = self.model
+    # as long as we have results instance, we can take params from it
+    if params is None:
+        params = self.params
+
+    # get original exog from model, currently only if exactly 2
+    exog_o1, exog_o2 = model._get_exogs()
+
+    if exog_o2 is None:
+        # if extra params is scalar, as in NB, GPP
+        exog_o2 = np.ones((exog_o1.shape[0], 1))
+
+    k_mean = exog_o1.shape[1]
+    k_prec = exog_o2.shape[1]
+    if exog_extra is not None:
+        exog = np.column_stack((exog_o1, exog_extra))
+    else:
+        exog = exog_o1
+
+    if exog2_extra is not None:
+        exog2 = np.column_stack((exog_o2, exog2_extra))
+    else:
+        exog2 = exog_o2
+
+    k_mean_new = exog.shape[1]
+    k_prec_new = exog2.shape[1]
+    k_cm = k_mean_new - k_mean
+    k_cp = k_prec_new - k_prec
+    k_constraints = k_cm + k_cp
+
+    index_mean = np.arange(k_mean, k_mean_new)
+    index_prec = np.arange(k_mean_new + k_prec, k_mean_new + k_prec_new)
+
+    r_matrix = np.zeros((k_constraints, len(params) + k_constraints))
+    # print(exog.shape, exog2.shape)
+    # print(r_matrix.shape, k_cm, k_cp, k_mean_new, k_prec_new)
+    # print(index_mean, index_prec)
+    r_matrix[:k_cm, index_mean] = np.eye(k_cm)
+    r_matrix[k_cm: k_cm + k_cp, index_prec] = np.eye(k_cp)
+
+    if hasattr(model, "score_hessian_factor"):
+        sf, hf = model.score_hessian_factor(params, return_hessian=True,
+                                            **hess_kwds)
+    else:
+        sf = model.score_factor(params)
+        hf = model.hessian_factor(params, **hess_kwds)
+
+    sf1, sf2 = sf
+    hf11, hf12, hf22 = hf
+
+    # elementwise product for each row (observation)
+    d1 = sf1[:, None] * exog
+    d2 = sf2[:, None] * exog2
+    score_obs = np.column_stack((d1, d2))
+
+    # elementwise product for each row (observation)
+    d11 = (exog.T * hf11).dot(exog)
+    d12 = (exog.T * hf12).dot(exog2)
+    d22 = (exog2.T * hf22).dot(exog2)
+    hessian = np.block([[d11, d12], [d12.T, d22]])
+    return score_obs, hessian, k_constraints, r_matrix
 
 
 def im_ratio(results):

--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -1002,6 +1002,10 @@ class GenericLikelihoodModel(LikelihoodModel):
             else:
                 start_params = 0.1 * np.ones(self.nparams)
 
+        if "cov_type" not in kwargs:
+            # this will add default cov_type name and description
+            kwargs["cov_type"] = 'nonrobust'
+
         fit_method = super(GenericLikelihoodModel, self).fit
         mlefit = fit_method(start_params=start_params,
                             method=method, maxiter=maxiter,

--- a/statsmodels/discrete/discrete_model.py
+++ b/statsmodels/discrete/discrete_model.py
@@ -1537,6 +1537,9 @@ class GeneralizedPoisson(CountModel):
         kwds['p'] = self.parameterization + 1
         return kwds
 
+    def _get_exogs(self):
+        return (self.exog, None)
+
     def loglike(self, params):
         """
         Loglikelihood of Generalized Poisson model
@@ -3448,6 +3451,9 @@ class NegativeBinomialP(CountModel):
         kwds = super()._get_init_kwds()
         kwds['p'] = self.parameterization
         return kwds
+
+    def _get_exogs(self):
+        return (self.exog, None)
 
     def loglike(self, params):
         """

--- a/statsmodels/discrete/tests/test_discrete.py
+++ b/statsmodels/discrete/tests/test_discrete.py
@@ -102,22 +102,24 @@ def check_jac(self):
     # TODO: change when score_obs uses score_factor for DRYing
     s1 = res1.model.score_obs(res1.params)
     sf = res1.model.score_factor(res1.params)
-    if sf.ndim == 1:
+    if not isinstance(sf, tuple):
         s2 = sf[:, None] * exog
-    elif sf.ndim == 2:
-        s2 = np.column_stack((sf[:, :1] * exog, sf[:, 1:]))
+    else:
+        sf0, sf1 = sf
+        s2 = np.column_stack((sf0[:, None] * exog, sf1))
 
     assert_allclose(s2, s1, rtol=1e-10)
 
     # check hessian_factor
     h1 = res1.model.hessian(res1.params)
     hf = res1.model.hessian_factor(res1.params)
-    if sf.ndim == 1:
+    if not isinstance(hf, tuple):
         h2 = (hf * exog.T).dot(exog)
-    elif sf.ndim == 2:
-        h00 = (hf[:, 0] * exog.T).dot(exog)
-        h10 = np.atleast_2d(hf[:, 1].T.dot(exog))
-        h11 = np.atleast_2d(hf[:, 2].sum(0))
+    else:
+        hf0, hf1, hf2 = hf
+        h00 = (hf0 * exog.T).dot(exog)
+        h10 = np.atleast_2d(hf1.T.dot(exog))
+        h11 = np.atleast_2d(hf2.sum(0))
         h2 = np.vstack((np.column_stack((h00, h10.T)),
                         np.column_stack((h10, h11))))
 

--- a/statsmodels/othermod/betareg.py
+++ b/statsmodels/othermod/betareg.py
@@ -551,6 +551,70 @@ class BetaModel(GenericLikelihoodModel):
         d22 = (self.exog_precision.T * hf22).dot(self.exog_precision)
         return np.block([[d11, d12], [d12.T, d22]])
 
+    def _scorehess_extra(self, params, exog_extra=None,
+                         exog_precision_extra=None, observed=None):
+        """Experimental helper function for variable addition score test.
+
+        This will be refactored or replaced.
+
+        This uses score and hessian factor at the params which should be the
+        params of the restricted model.
+
+        """
+        if observed is None:
+            if self.hess_type == "eim":
+                observed = False
+            else:
+                observed = True
+
+        k_mean = self.exog.shape[1]
+        k_prec = self.exog_precision.shape[1]
+        if exog_extra is not None:
+            exog = np.column_stack((self.exog, exog_extra))
+        else:
+            exog = self.exog
+
+        if exog_precision_extra is not None:
+            exog_precision = np.column_stack((self.exog_precision,
+                                              exog_precision_extra))
+        else:
+            exog_precision = self.exog_precision
+
+        k_mean_new = exog.shape[1]
+        k_prec_new = exog_precision.shape[1]
+        k_cm = k_mean_new - k_mean
+        k_cp = k_prec_new - k_prec
+        k_constraints = k_cm + k_cp
+
+        index_mean = np.arange(k_mean, k_mean_new)
+        index_prec = np.arange(k_mean_new + k_prec, k_mean_new + k_prec_new)
+
+        r_matrix = np.zeros((k_constraints, len(params) + k_constraints))
+        # print(exog.shape, exog_precision.shape)
+        # print(r_matrix.shape, k_cm, k_cp, k_mean_new, k_prec_new)
+        # print(index_mean, index_prec)
+        r_matrix[:k_cm, index_mean] = np.eye(k_cm)
+        r_matrix[k_cm: k_cm + k_cp, index_prec] = np.eye(k_cp)
+
+        sf, hf = self.score_hessian_factor(params, return_hessian=True,
+                                           observed=observed)
+
+        sf1, sf2 = sf
+        hf11, hf12, hf22 = hf
+
+        # elementwise product for each row (observation)
+        d1 = sf1[:, None] * exog
+        d2 = sf2[:, None] * exog_precision
+        score_obs = np.column_stack((d1, d2))
+
+        # elementwise product for each row (observation)
+        d11 = (exog.T * hf11).dot(exog)
+        d12 = (exog.T * hf12).dot(exog_precision)
+        d22 = (exog_precision.T * hf22).dot(exog_precision)
+        hessian = np.block([[d11, d12], [d12.T, d22]])
+
+        return score_obs, hessian, k_constraints, r_matrix
+
     def _start_params(self, niter=2, return_intermediate=False):
         """find starting values
 

--- a/statsmodels/othermod/tests/test_beta.py
+++ b/statsmodels/othermod/tests/test_beta.py
@@ -324,3 +324,49 @@ class TestBetaMeth():
         dfmw = pmw.summary_frame()
         assert_allclose(pmw.predicted, pm6.predicted, rtol=1e-13)
         assert_allclose(dfmw, dfm6, rtol=1e-13)
+
+
+class TestBetaIncome():
+
+    @classmethod
+    def setup_class(cls):
+
+        formula = "I(food/income) ~ income + persons"
+        exog_prec = patsy.dmatrix("~ persons", income)
+        mod_income = BetaModel.from_formula(
+            formula,
+            income,
+            exog_precision=exog_prec,
+            link_precision=links.Log()
+            )
+        res_income = mod_income.fit(method="newton")
+
+        mod_restricted = BetaModel.from_formula(
+            formula,
+            income,
+            link_precision=links.Log()
+            )
+        res_restricted = mod_restricted.fit(method="newton")
+
+        cls.res1 = res_income
+        cls.resr = res_restricted
+
+    def test_score_test(self):
+        res1 = self.res1
+        resr = self.resr
+        params_restr = np.concatenate([resr.params, [0]])
+        r_matrix = np.zeros((1, len(params_restr)))
+        r_matrix[0, -1] = 1
+        exog_prec_extra = res1.model.exog_precision[:, 1:]
+
+        from statsmodels.base._parameter_inference import score_test
+        sc1 = score_test(res1, params_constrained=params_restr,
+                         k_constraints=1)
+        sc2 = score_test(resr, exog_extra=(None, exog_prec_extra))
+        assert_allclose(sc2[:2], sc1[:2])
+
+        sc1_hc = score_test(res1, params_constrained=params_restr,
+                            k_constraints=1, r_matrix=r_matrix, cov_type="HC0")
+        sc2_hc = score_test(resr, exog_extra=(None, exog_prec_extra),
+                            cov_type="HC0")
+        assert_allclose(sc2_hc[:2], sc1_hc[:2])


### PR DESCRIPTION
starting to add score_test to multilink model

- score_factor: return tuple, backwards incompatible but internal and newish
- GenericLikelihoodModelResults BUG/ENH no cov_type attribute if nonrobust is not explicitly specified

score_test will be experimental, because I don't have a clear design about how to outsource the relevant multilink computations.
Also models with extra params (but not extra exog) like NBP or GPP will need a different solution than multi-exog models like BetaModel.