### PR TITLE
ENH: MLEInfluence for two-part models, extra params, BetaModel

### DIFF
--- a/statsmodels/discrete/tests/test_predict.py
+++ b/statsmodels/discrete/tests/test_predict.py
@@ -222,6 +222,20 @@ class CheckExtras():
                             cov_type="HC0")
         assert sc2_hc[1] > 0.01
 
+    def test_influence(self):
+        # currently only smoke test
+        res1 = self.res1
+        from statsmodels.stats.outliers_influence import MLEInfluence
+
+        influ = MLEInfluence(res1)
+        attrs = ['cooks_distance', 'd_fittedvalues', 'd_fittedvalues_scaled',
+                 'd_params', 'dfbetas', 'hat_matrix_diag', 'resid_studentized'
+                 ]
+        for attr in attrs:
+            getattr(influ, attr)
+
+        influ.summary_frame()
+
 
 class TestNegativeBinomialPPredict(CheckPredict, CheckExtras):
 

--- a/statsmodels/othermod/tests/test_beta.py
+++ b/statsmodels/othermod/tests/test_beta.py
@@ -370,3 +370,17 @@ class TestBetaIncome():
         sc2_hc = score_test(resr, exog_extra=(None, exog_prec_extra),
                             cov_type="HC0")
         assert_allclose(sc2_hc[:2], sc1_hc[:2])
+
+    def test_influence(self):
+        # currently only smoke test
+        res1 = self.res1
+        from statsmodels.stats.outliers_influence import MLEInfluence
+
+        influ = MLEInfluence(res1)
+        attrs = ['cooks_distance', 'd_fittedvalues', 'd_fittedvalues_scaled',
+                 'd_params', 'dfbetas', 'hat_matrix_diag', 'resid_studentized'
+                 ]
+        for attr in attrs:
+            getattr(influ, attr)
+
+        influ.summary_frame()

--- a/statsmodels/stats/outliers_influence.py
+++ b/statsmodels/stats/outliers_influence.py
@@ -369,7 +369,8 @@ class MLEInfluence(_BaseInfluenceMixin):
         self.nobs, self.k_vars = results.model.exog.shape
         self.endog = endog if endog is not None else results.model.endog
         self.exog = exog if exog is not None else results.model.exog
-        self.resid = resid if resid is not None else results.resid_pearson
+        self.resid = resid if resid is not None else (
+            getattr(results, "resid_pearson", None))
         self.scale = scale if scale is not None else results.scale
         self.cov_params = (cov_params if cov_params is not None
                            else results.cov_params())

--- a/statsmodels/stats/outliers_influence.py
+++ b/statsmodels/stats/outliers_influence.py
@@ -463,6 +463,10 @@ class MLEInfluence(_BaseInfluenceMixin):
         from statsmodels.genmod.generalized_linear_model import GLM
         sf = self.results.model.score_factor(self.results.params)
         hf = self.results.model.hessian_factor(self.results.params)
+        if isinstance(sf, tuple):
+            sf = sf[0]
+        if isinstance(hf, tuple):
+            hf = hf[0]
         if not isinstance(self.results.model, GLM):
             # hessian_factor in GLM has wrong sign
             hf = -hf


### PR DESCRIPTION
It works but I have not looked at the results numbers yet, only smoke test

uses numdiff for `_deriv_score_obs_dendog`, see #7891

`_deriv_score_obs_dendog` takes derivative w.r.t. endog
this might be a problem in discrete models
count models NBP, GPP should be ok
Probit will likely be a problem, and we cannot use complex step derivatives.
I'm not sure whether definitions used in MLEInfluence apply to Probit.

Standardized score residuals use sf[0] / hf[0]. Does this work in general? 
Do we need the same for the second score_factor?

Note, `_deriv_mean_dparams` needs to be w.r.t. full params even if mean only depends on mean params (for consistent shape with hessian)

R betareg has some of the influence outlier measures to test against.
