### PR TITLE
Clarify output size in statsmodels.tsa.stattools

### DIFF
--- a/statsmodels/tsa/stattools.py
+++ b/statsmodels/tsa/stattools.py
@@ -585,8 +585,8 @@ def acf(
        If True, then denominators for autocovariance are n-k, otherwise n.
     nlags : int, optional
         Number of lags to return autocorrelation for. If not provided,
-        uses min(10 * np.log10(nobs), nobs - 1). Note: the acf at lag 0 (ie., 1)
-        is returned in addition to nlags.
+        uses min(10 * np.log10(nobs), nobs - 1).
+        Note: the acf at lag 0 (ie., 1) is returned in addition to nlags.
     qstat : bool, default False
         If True, returns the Ljung-Box q statistic for each autocorrelation
         coefficient.  See q_stat for more information.
@@ -631,7 +631,8 @@ def acf(
     acf : ndarray
         The autocorrelation function, nlags+1 elements including lag zero.
     confint : ndarray, optional
-        Confidence intervals for the ACF, 2*(nlags+1) elements including lag zero.
+        Confidence intervals for the ACF, 2*(nlags+1) elements including
+        lag zero.
         Returned if alpha is not None.
     qstat : ndarray, optional
         The Ljung-Box Q-Statistic, nlags elements (excludes lag zero).
@@ -938,7 +939,8 @@ def pacf(x, nlags=None, method="ywadjusted", alpha=None):
     pacf : ndarray
         Partial autocorrelations, nlags+1 elements including lag zero.
     confint : ndarray, optional
-        Confidence intervals for the PACF, 2*(nlags+1) elements including lag zero. Returned if confint is not None.
+        Confidence intervals for the PACF, 2*(nlags+1) elements including lag
+        zero. Returned if confint is not None.
 
     See Also
     --------

--- a/statsmodels/tsa/stattools.py
+++ b/statsmodels/tsa/stattools.py
@@ -629,10 +629,11 @@ def acf(
     Returns
     -------
     acf : ndarray
-        The autocorrelation function, nlags+1 elements including lag zero.
-    confint : ndarray, optional
-        Confidence intervals for the ACF, 2*(nlags+1) elements including
+        The autocorrelation function, nlags+1 elements since it includes
         lag zero.
+    confint : ndarray, optional
+        Confidence intervals for the ACF, 2*(nlags+1) elements since it
+        includes lag zero.
         Returned if alpha is not None.
     qstat : ndarray, optional
         The Ljung-Box Q-Statistic, nlags elements (excludes lag zero).
@@ -937,10 +938,10 @@ def pacf(x, nlags=None, method="ywadjusted", alpha=None):
     Returns
     -------
     pacf : ndarray
-        Partial autocorrelations, nlags+1 elements including lag zero.
+        Partial autocorrelations, nlags+1 elements since it includes lag zero
     confint : ndarray, optional
-        Confidence intervals for the PACF, 2*(nlags+1) elements including lag
-        zero. Returned if confint is not None.
+        Confidence intervals for the PACF, 2*(nlags+1) elements since it
+        includes lag zero. Returned if confint is not None.
 
     See Also
     --------

--- a/statsmodels/tsa/stattools.py
+++ b/statsmodels/tsa/stattools.py
@@ -585,7 +585,8 @@ def acf(
        If True, then denominators for autocovariance are n-k, otherwise n.
     nlags : int, optional
         Number of lags to return autocorrelation for. If not provided,
-        uses min(10 * np.log10(nobs), nobs - 1).
+        uses min(10 * np.log10(nobs), nobs - 1). Note: the acf at lag 0 (ie., 1)
+        is returned in addition to nlags.
     qstat : bool, default False
         If True, returns the Ljung-Box q statistic for each autocorrelation
         coefficient.  See q_stat for more information.
@@ -628,13 +629,16 @@ def acf(
     Returns
     -------
     acf : ndarray
-        The autocorrelation function.
+        The autocorrelation function, nlags+1 elements including lag zero.
     confint : ndarray, optional
-        Confidence intervals for the ACF. Returned if alpha is not None.
+        Confidence intervals for the ACF, 2*(nlags+1) elements including lag zero.
+        Returned if alpha is not None.
     qstat : ndarray, optional
-        The Ljung-Box Q-Statistic.  Returned if q_stat is True.
+        The Ljung-Box Q-Statistic, nlags elements (excludes lag zero).
+        Returned if q_stat is True.
     pvalues : ndarray, optional
-        The p-values associated with the Q-statistics.  Returned if q_stat is
+        The p-values associated with the Q-statistics, nlags elements
+        (excludes lag zero). Returned if q_stat is
         True.
 
     Notes
@@ -905,7 +909,8 @@ def pacf(x, nlags=None, method="ywadjusted", alpha=None):
         Observations of time series for which pacf is calculated.
     nlags : int, optional
         Number of lags to return autocorrelation for. If not provided,
-        uses min(10 * np.log10(nobs), nobs // 2 - 1).
+        uses min(10 * np.log10(nobs), nobs // 2 - 1). Note: the acf at lag 0
+        (ie., 1) is returned in addition to nlags.
     method : str, default "ywunbiased"
         Specifies which method for the calculations to use.
 
@@ -931,9 +936,9 @@ def pacf(x, nlags=None, method="ywadjusted", alpha=None):
     Returns
     -------
     pacf : ndarray
-        Partial autocorrelations, nlags elements, including lag zero.
+        Partial autocorrelations, nlags+1 elements including lag zero.
     confint : ndarray, optional
-        Confidence intervals for the PACF. Returned if confint is not None.
+        Confidence intervals for the PACF, 2*(nlags+1) elements including lag zero. Returned if confint is not None.
 
     See Also
     --------


### PR DESCRIPTION
DOC: Clarify output size in statsmodels.tsa.stattools.acf and statsmodels.tsa.stattools.pacf: nlags behaved unpredictably and still does, but at least it now does so explicitly.

- [ ] closes #7818
- [ ] no tests necessary: docs
- [ ] code/documentation is well formatted.  
- [ ] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
