### PR TITLE
ENH/REF: discrete add get_distribution, add which="var" for NBP, GPP

### DIFF
--- a/statsmodels/discrete/count_model.py
+++ b/statsmodels/discrete/count_model.py
@@ -581,6 +581,18 @@ class ZeroInflatedPoisson(GenericZeroInflated):
         start_params = np.append(np.ones(self.k_inflate) * 0.1, start_params)
         return start_params
 
+    def get_distribution(self, params, exog=None, exog_infl=None,
+                         exposure=None, offset=None):
+        """get frozen instance of distribution
+        """
+        mu = self.predict(params, exog=exog, exog_infl=exog_infl,
+                          exposure=exposure, offset=offset, which="mean-main")
+        w = self.predict(params, exog=exog, exog_infl=exog_infl,
+                         exposure=exposure, offset=offset, which="prob-main")
+
+        distr = self.distribution(mu[:, None], 1 - w[:, None])
+        return distr
+
 
 class ZeroInflatedGeneralizedPoisson(GenericZeroInflated):
     __doc__ = """
@@ -635,7 +647,7 @@ class ZeroInflatedGeneralizedPoisson(GenericZeroInflated):
         params_infl = params[:self.k_inflate]
         params_main = params[self.k_inflate:]
 
-        p = self.model_main.parameterization
+        p = self.model_main.parameterization + 1
         if y_values is None:
             y_values = np.atleast_2d(np.arange(0, np.max(self.endog)+1))
 
@@ -660,6 +672,18 @@ class ZeroInflatedGeneralizedPoisson(GenericZeroInflated):
                 exog_infl=self.exog_infl).fit(disp=0).params
         start_params = np.append(start_params, 0.1)
         return start_params
+
+    def get_distribution(self, params, exog=None, exog_infl=None,
+                         exposure=None, offset=None):
+        """get frozen instance of distribution
+        """
+        p = self.model_main.parameterization + 1
+        mu = self.predict(params, exog=exog, exog_infl=exog_infl,
+                          exposure=exposure, offset=offset, which="mean-main")
+        w = self.predict(params, exog=exog, exog_infl=exog_infl,
+                         exposure=exposure, offset=offset, which="prob-main")
+        distr = self.distribution(mu[:, None], params[-1], p, 1 - w[:, None])
+        return distr
 
 
 class ZeroInflatedNegativeBinomialP(GenericZeroInflated):
@@ -740,6 +764,19 @@ class ZeroInflatedNegativeBinomialP(GenericZeroInflated):
             start_params = self.model_main.fit(disp=0, method='nm').params
         start_params = np.append(np.zeros(self.k_inflate), start_params)
         return start_params
+
+    def get_distribution(self, params, exog=None, exog_infl=None,
+                         exposure=None, offset=None):
+        """get frozen instance of distribution
+        """
+        p = self.model_main.parameterization
+        mu = self.predict(params, exog=exog, exog_infl=exog_infl,
+                          exposure=exposure, offset=offset, which="mean-main")
+        w = self.predict(params, exog=exog, exog_infl=exog_infl,
+                         exposure=exposure, offset=offset, which="prob-main")
+
+        distr = self.distribution(mu[:, None], params[-1], p, 1 - w[:, None])
+        return distr
 
 
 class ZeroInflatedResults(CountResults):

--- a/statsmodels/discrete/discrete_model.py
+++ b/statsmodels/discrete/discrete_model.py
@@ -4353,6 +4353,15 @@ class DiscreteResults(base.LikelihoodModelResults):
         return self.model.endog - self.predict()
 
     @cache_readonly
+    def resid_pearson(self):
+        """
+        Pearson residuals defined as response residuals divided by standard
+        deviation implied by the model.
+        """
+        var_ = self.predict(which="var")
+        return self.resid_response / np.sqrt(var_)
+
+    @cache_readonly
     def aic(self):
         """
         Akaike information criterion.  `-2*(llf - p)` where `p` is the number

--- a/statsmodels/discrete/discrete_model.py
+++ b/statsmodels/discrete/discrete_model.py
@@ -1656,6 +1656,8 @@ class GeneralizedPoisson(CountModel):
         mu_p = np.power(mu, p)
         a1 = 1 + alpha * mu_p
         a2 = mu + (a1 - 1) * endog
+        a1 = np.maximum(1e-20, a1)
+        a2 = np.maximum(1e-20, a2)
         return (np.log(mu) + (endog - 1) * np.log(a2) - endog *
                 np.log(a1) - gammaln(endog + 1) - a2 / a1)
 

--- a/statsmodels/discrete/tests/test_discrete.py
+++ b/statsmodels/discrete/tests/test_discrete.py
@@ -85,14 +85,19 @@ def load_randhie():
     data.exog = np.asarray(data.exog, dtype=float)
     return data
 
-def check_jac(self):
+
+def check_jac(self, res=None):
     # moved from CheckModelResults
-    res1 = self.res1
-    exog = self.res1.model.exog
-    #basic cross check
-    jacsum = self.res1.model.score_obs(self.res1.params).sum(0)
-    score = self.res1.model.score(self.res1.params)
-    assert_almost_equal(jacsum, score, DECIMAL_9) #Poisson has low precision ?
+    if res is None:
+        res1 = self.res1
+    else:
+        res1 = res
+
+    exog = res1.model.exog
+    # basic cross check
+    jacsum = res1.model.score_obs(res1.params).sum(0)
+    score = res1.model.score(res1.params)
+    assert_almost_equal(jacsum, score, DECIMAL_9) # Poisson has low precision ?
 
     if isinstance(res1.model, (NegativeBinomial, MNLogit)):
         # skip the rest
@@ -124,6 +129,16 @@ def check_jac(self):
                         np.column_stack((h10, h11))))
 
     assert_allclose(h2, h1, rtol=1e-10)
+
+
+def check_distr(res):
+    distr = res.get_distribution()
+    distr1 = res.model.get_distribution(res.params)
+    m = res.predict()
+    m2 = distr.mean()
+    assert_allclose(m, np.squeeze(m2), rtol=1e-10)
+    m2 = distr1.mean()
+    assert_allclose(m, np.squeeze(m2), rtol=1e-10)
 
 
 class CheckModelMixin(object):
@@ -222,6 +237,9 @@ class CheckModelResults(CheckModelMixin):
             # skip MNLogit which creates several params tables
             assert n_lines == 19 + np.size(self.res1.params)
         assert "Covariance Type:" in ltx
+
+    def test_distr(self):
+        check_distr(self.res1)
 
 
 class CheckBinaryResults(CheckModelResults):
@@ -1496,6 +1514,11 @@ class CheckMNLogitBaseZero(CheckModelResults):
     def test_cov_params(self):
         super(CheckMNLogitBaseZero, self).test_cov_params()
 
+    @pytest.mark.xfail(reason="Test has not been implemented for this class.",
+                       strict=True, raises=NotImplementedError)
+    def test_distr(self):
+        super().test_distr()
+
 
 class TestMNLogitNewtonBaseZero(CheckMNLogitBaseZero):
     @classmethod
@@ -1783,6 +1806,12 @@ class TestGeneralizedPoisson_p2(object):
         t_test = self.res1.t_test(unit_matrix)
         assert_allclose(self.res1.tvalues, t_test.tvalue)
 
+    def test_jac(self):
+        check_jac(self)
+
+    def test_distr(self):
+        check_distr(self.res1)
+
 
 class TestGeneralizedPoisson_transparams(object):
     # Test Generalized Poisson model
@@ -1891,6 +1920,9 @@ class TestGeneralizedPoisson_p1(object):
         assert_('p' in kwds)
         assert_equal(kwds['p'], 1)
 
+    def test_distr(self):
+        check_distr(self.res1)
+
 
 class TestGeneralizedPoisson_underdispersion(object):
 
@@ -1961,8 +1993,10 @@ class TestGeneralizedPoisson_underdispersion(object):
                         rtol=0.01)
 
     def test_jac(self):
-        self.res1 = self.res
-        check_jac(self)
+        check_jac(self, res=self.res)
+
+    def test_distr(self):
+        check_distr(self.res)
 
 
 class TestNegativeBinomialPNB2Newton(CheckNegBinMixin, CheckModelResults):

--- a/statsmodels/discrete/tests/test_discrete.py
+++ b/statsmodels/discrete/tests/test_discrete.py
@@ -1914,10 +1914,14 @@ class TestGeneralizedPoisson_p1(object):
         assert_allclose(res_reg1.bse, self.res1.bse, atol=1e-5)
 
         # check shrinkage, regression numbers
-        assert_allclose((self.res1.params[:-2]**2).mean(), 0.016580955543320779)
-        assert_allclose((res_reg1.params[:-2]**2).mean(), 0.016580734975068664)
-        assert_allclose((res_reg2.params[:-2]**2).mean(), 0.010672558641545994)
-        assert_allclose((res_reg3.params[:-2]**2).mean(), 0.00035544919793048415)
+        assert_allclose((self.res1.params[:-2]**2).mean(),
+                        0.016580955543320779, rtol=1e-5)
+        assert_allclose((res_reg1.params[:-2]**2).mean(),
+                        0.016580734975068664, rtol=1e-5)
+        assert_allclose((res_reg2.params[:-2]**2).mean(),
+                        0.010672558641545994, rtol=1e-5)
+        assert_allclose((res_reg3.params[:-2]**2).mean(),
+                        0.00035544919793048415, rtol=1e-5)
 
     def test_init_kwds(self):
         kwds = self.res1.model._get_init_kwds()

--- a/statsmodels/discrete/tests/test_discrete.py
+++ b/statsmodels/discrete/tests/test_discrete.py
@@ -140,6 +140,10 @@ def check_distr(res):
     m2 = distr1.mean()
     assert_allclose(m, np.squeeze(m2), rtol=1e-10)
 
+    v = res.predict(which="var")
+    v2 = distr.var()
+    assert_allclose(v, np.squeeze(v2), rtol=1e-10)
+
 
 class CheckModelMixin(object):
     # Assertions about the Model object, as opposed to the Results

--- a/statsmodels/discrete/tests/test_predict.py
+++ b/statsmodels/discrete/tests/test_predict.py
@@ -345,7 +345,7 @@ def test_distr(case):
 
     print("\n\n", cls_model, kwds)
     mod = cls_model(y, x, **kwds)
-    res = mod.fit()
+    # res = mod.fit()
     params_dgp = params
     distr = mod.get_distribution(params_dgp)
     try:
@@ -354,7 +354,7 @@ def test_distr(case):
         y2 = distr.rvs(size=nobs).squeeze()
 
     mod = cls_model(y2, x, **kwds)
-    res = mod.fit(start_params=params_dgp)
+    res = mod.fit(start_params=params_dgp, method="bfgs", maxiter=500)
     # params are not close enough to dgp, zero-inflation estimate is noisy
     # assert_allclose(res.params, params_dgp, rtol=0.25)
     distr2 = mod.get_distribution(res.params)
@@ -362,6 +362,10 @@ def test_distr(case):
     assert_allclose(distr2.var().squeeze()[0], y2.var(), rtol=0.2)
     var_ = res.predict(which="var")
     assert_allclose(var_, distr2.var().squeeze(), rtol=1e-12)
+    mean = res.predict()
+
+    assert_allclose(res.resid_pearson, (y2 - mean) / np.sqrt(var_), rtol=1e-13)
+
     if not issubclass(cls_model, BinaryModel):
         dia = res.get_diagnostic()
         # fig = dia.plot_probs();

--- a/statsmodels/discrete/tests/test_predict.py
+++ b/statsmodels/discrete/tests/test_predict.py
@@ -16,6 +16,9 @@ from statsmodels.tools.tools import add_constant
 from statsmodels.base._prediction_inference import PredictionResultsMonotonic
 
 from statsmodels.discrete.discrete_model import (
+    BinaryModel,
+    Logit,
+    Probit,
     Poisson,
     NegativeBinomial,
     NegativeBinomialP,
@@ -299,6 +302,8 @@ mu = np.log(1.5)
 alpha = 1.5
 w = -1.5
 models = [
+    (Logit, {}, np.array([0.1])),
+    (Probit, {}, np.array([0.1])),
     (ZeroInflatedPoisson, {}, np.array([w, mu])),
     (ZeroInflatedGeneralizedPoisson, {}, np.array([w, mu, alpha])),
     (ZeroInflatedGeneralizedPoisson, {"p": 1}, np.array([w, mu, alpha])),
@@ -335,6 +340,9 @@ def test_distr(case):
     np.random.seed(987456348)
 
     cls_model, kwds, params = case
+    if issubclass(cls_model, BinaryModel):
+        y = (y > 0.5).astype(float)
+
     print("\n\n", cls_model, kwds)
     mod = cls_model(y, x, **kwds)
     res = mod.fit()
@@ -354,6 +362,7 @@ def test_distr(case):
     assert_allclose(distr2.var().squeeze()[0], y2.var(), rtol=0.2)
     var_ = res.predict(which="var")
     assert_allclose(var_, distr2.var().squeeze(), rtol=1e-12)
-    dia = res.get_diagnostic()
-    # fig = dia.plot_probs();
-    # fig.suptitle(cls_model.__name__ + repr(kwds), fontsize=16)
+    if not issubclass(cls_model, BinaryModel):
+        dia = res.get_diagnostic()
+        # fig = dia.plot_probs();
+        # fig.suptitle(cls_model.__name__ + repr(kwds), fontsize=16)

--- a/statsmodels/discrete/tests/test_predict.py
+++ b/statsmodels/discrete/tests/test_predict.py
@@ -352,6 +352,8 @@ def test_distr(case):
     distr2 = mod.get_distribution(res.params)
     assert_allclose(distr2.mean().squeeze()[0], y2.mean(), rtol=0.2)
     assert_allclose(distr2.var().squeeze()[0], y2.var(), rtol=0.2)
+    var_ = res.predict(which="var")
+    assert_allclose(var_, distr2.var().squeeze(), rtol=1e-12)
     dia = res.get_diagnostic()
     # fig = dia.plot_probs();
     # fig.suptitle(cls_model.__name__ + repr(kwds), fontsize=16)

--- a/statsmodels/distributions/discrete.py
+++ b/statsmodels/distributions/discrete.py
@@ -23,6 +23,15 @@ class genpoisson_p_gen(rv_discrete):
     def _pmf(self, x, mu, alpha, p):
         return np.exp(self._logpmf(x, mu, alpha, p))
 
+    def mean(self, mu, alpha, p):
+        return mu
+
+    def var(self, mu, alpha, p):
+        dispersion_factor = (1 + alpha * mu**(p - 1))**2
+        var = dispersion_factor * mu
+        return var
+
+
 genpoisson_p = genpoisson_p_gen(name='genpoisson_p',
                                 longname='Generalized Poisson')
 

--- a/statsmodels/distributions/discrete.py
+++ b/statsmodels/distributions/discrete.py
@@ -62,12 +62,12 @@ class zipoisson_gen(rv_discrete):
         x[q < w] = 0
         return x
 
-    def _mean(self, mu, w):
+    def mean(self, mu, w):
         return (1 - w) * mu
 
-    def _var(self, mu, w):
+    def var(self, mu, w):
         dispersion_factor = 1 + w * mu
-        var = (dispersion_factor * self._mean(mu, w))
+        var = (dispersion_factor * self.mean(mu, w))
         return var
 
     def _moment(self, n, mu, w):
@@ -93,13 +93,13 @@ class zigeneralizedpoisson_gen(rv_discrete):
     def _pmf(self, x, mu, alpha, p, w):
         return np.exp(self._logpmf(x, mu, alpha, p, w))
 
-    def _mean(self, mu, alpha, p, w):
+    def mean(self, mu, alpha, p, w):
         return (1 - w) * mu
 
-    def _var(self, mu, alpha, p, w):
+    def var(self, mu, alpha, p, w):
         p = p - 1
         dispersion_factor = (1 + alpha * mu ** p) ** 2 + w * mu
-        var = (dispersion_factor * self._mean(mu, alpha, p, w))
+        var = (dispersion_factor * self.mean(mu, alpha, p, w))
         return var
 
 
@@ -140,12 +140,12 @@ class zinegativebinomial_gen(rv_discrete):
         x[q < w] = 0
         return x
 
-    def _mean(self, mu, alpha, p, w):
+    def mean(self, mu, alpha, p, w):
         return (1 - w) * mu
 
-    def _var(self, mu, alpha, p, w):
+    def var(self, mu, alpha, p, w):
         dispersion_factor = 1 + alpha * mu ** (p - 1) + w * mu
-        var = (dispersion_factor * self._mean(mu, alpha, p, w))
+        var = (dispersion_factor * self.mean(mu, alpha, p, w))
         return var
 
     def _moment(self, n, mu, alpha, p, w):

--- a/statsmodels/distributions/tests/test_discrete.py
+++ b/statsmodels/distributions/tests/test_discrete.py
@@ -82,8 +82,8 @@ class TestZIPoisson(object):
 
         m = np.array([1, 5, 10])
         poisson_mean, poisson_var = poisson.mean(m), poisson.var(m)
-        zipoisson_mean = sm.distributions.zipoisson._mean(m, 0)
-        zipoisson_var = sm.distributions.zipoisson._var(m, 0.0)
+        zipoisson_mean = sm.distributions.zipoisson.mean(m, 0)
+        zipoisson_var = sm.distributions.zipoisson.var(m, 0.0)
         assert_allclose(poisson_mean, zipoisson_mean, rtol=1e-10)
         assert_allclose(poisson_var, zipoisson_var, rtol=1e-10)
 
@@ -123,8 +123,8 @@ class TestZIGeneralizedPoisson(object):
         # compare with Poisson special case
         m = np.array([1, 5, 10])
         poisson_mean, poisson_var = poisson.mean(m), poisson.var(m)
-        zigenpoisson_mean = sm.distributions.zigenpoisson._mean(m, 0, 1, 0)
-        zigenpoisson_var = sm.distributions.zigenpoisson._var(m, 0.0, 1, 0)
+        zigenpoisson_mean = sm.distributions.zigenpoisson.mean(m, 0, 1, 0)
+        zigenpoisson_var = sm.distributions.zigenpoisson.var(m, 0.0, 1, 0)
         assert_allclose(poisson_mean, zigenpoisson_mean, rtol=1e-10)
         assert_allclose(poisson_var, zigenpoisson_var, rtol=1e-10)
 
@@ -212,8 +212,8 @@ class TestZiNBP(object):
         for m in [9, np.array([1, 5, 10])]:
             n, p = sm.distributions.zinegbin.convert_params(m, 1, 1)
             nbinom_mean, nbinom_var = nbinom.mean(n, p), nbinom.var(n, p)
-            zinb_mean = sm.distributions.zinegbin._mean(m, 1, 1, 0)
-            zinb_var = sm.distributions.zinegbin._var(m, 1, 1, 0)
+            zinb_mean = sm.distributions.zinegbin.mean(m, 1, 1, 0)
+            zinb_var = sm.distributions.zinegbin.var(m, 1, 1, 0)
             assert_allclose(nbinom_mean, zinb_mean, rtol=1e-10)
             assert_allclose(nbinom_var, zinb_var, rtol=1e-10)
 


### PR DESCRIPTION
more work on post-estimation for discrete

This also outsources the predict transform exog from base.model.Results.predict to a new private method `_transform_predict_exog`
This helper method is reused in `get_distribution` to avoid code duplication. `get_distribution` does not use the pandas index because return is a scipy frozen distribution instance.


see also #7928 class diagram of unit tests

no get_distribution for MNLogit. I never tried out the scipy multinomial distribution, and don't know if it will work for our case.

This PR has now 
- `get_distribution` for all discrete models except MNLogit. Currently only in model classes not in results classes.
- added predict `which="var"` for count models, not yet zi
