### PR TITLE
MAINT: Start removing pytest warns with None

### DIFF
--- a/statsmodels/genmod/tests/test_glm_weights.py
+++ b/statsmodels/genmod/tests/test_glm_weights.py
@@ -279,7 +279,7 @@ class TestGlmPoissonFwClu(CheckWeight):
         cls.corr_fact = 1 / np.sqrt(n_groups / (n_groups - 1))
         # np.sqrt((wsum - 1.) / wsum)
         cov_kwds = {'groups': gid, 'use_correction': False}
-        with pytest.warns(None):
+        with pytest.warns(SpecificationWarning):
             mod = GLM(cpunish_data.endog, cpunish_data.exog,
                       family=sm.families.Poisson(),
                       freq_weights=fweights)

--- a/statsmodels/regression/tests/test_regression.py
+++ b/statsmodels/regression/tests/test_regression.py
@@ -1587,7 +1587,7 @@ def test_ols_constant(reset_randomstate):
     y = np.random.standard_normal((200))
     x = np.ones((200, 1))
     res = OLS(y, x).fit()
-    with pytest.warns(None) as recording:
+    with warnings.catch_warnings(record=True) as recording:
         assert np.isnan(res.fvalue)
         assert np.isnan(res.f_pvalue)
     assert len(recording) == 0

--- a/statsmodels/tsa/holtwinters/tests/test_holtwinters.py
+++ b/statsmodels/tsa/holtwinters/tests/test_holtwinters.py
@@ -916,9 +916,8 @@ def test_equivalence_cython_python(trend, seasonal):
         initialization_method="estimated",
     )
 
-    with pytest.warns(None):
-        # Overflow in mul-mul case fixed
-        res = mod.fit()
+    # Overflow in mul-mul case fixed
+    res = mod.fit()
     assert isinstance(res.summary().as_text(), str)
 
     params = res.params


### PR DESCRIPTION
Remove explicit use of None in pytest warns

- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
