### PR TITLE
ENH: add get_influence to DiscreteResults

### DIFF
--- a/docs/source/pitfalls.rst
+++ b/docs/source/pitfalls.rst
@@ -1,9 +1,9 @@
 Pitfalls
 ========
 
-This page lists issues which may arise while using statsmodels. These 
+This page lists issues which may arise while using statsmodels. These
 can be the result of data-related or statistical problems, software design,
-"non-standard" use of models, or edge cases. 
+"non-standard" use of models, or edge cases.
 
 statsmodels provides several warnings and helper functions for diagnostic
 checking (see this `blog article
@@ -23,10 +23,10 @@ Repeated calls to fit with different parameters
 Result instances often need to access attributes from the corresponding model
 instance. Fitting a model multiple times with different arguments can change
 model attributes. This means that the result instance may no longer point to
-the correct model attributes after the model has been re-fit. 
+the correct model attributes after the model has been re-fit.
 
 It is therefore best practice to create separate model instances when we want
-to fit a model using different fit function arguments. 
+to fit a model using different fit function arguments.
 
 For example, this works without problem because we are not keeping the results
 instance for further use ::
@@ -54,11 +54,11 @@ Rank deficient exog, perfect multicollinearity
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Models based on linear models, GLS, RLM, GLM and similar, use a generalized
-inverse. This means that: 
+inverse. This means that:
 
 + Rank deficient matrices will not raise an error
 + Cases of almost perfect multicollinearity or ill-conditioned design matrices might produce numerically unstable results. Users need to manually check the rank or condition number of the matrix if this is not the desired behavior
-  
+
 Note: statsmodels currently fails on the NIST benchmark case for Filip if the
 data is not rescaled, see `this blog <http://jpktd.blogspot.ca/2012/03/numerical-accuracy-in-linear-least.html>`_
 
@@ -92,3 +92,27 @@ The only currently known case is a perfect fit in robust linear model estimation
 For RLM, if residuals are equal to zero, then it does not cause an exception,
 but having this perfect fit can produce NaNs in some results (scale=0 and 0/0
 division) (issue #55).
+
+True parameter outside domain of model
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+In some cases domain restrictions for parameters in a model might be
+inconsistent with the data. In those cases, estimation might stop at
+parameter values close to the boundary of the parameter space, but can slso
+fail with runtime errors or produce nans during optimization.
+
+Two examples:
+
+Estimating a negative binomial model when the data is not overdispersed
+relative to Poisson, that is the true model has the same dispersion as Poisson
+or is underdispersed, is inconsistent with the overdispersion assumption of
+the Negative Binomial distribution. The loglikelihood and its derivatives, as
+implemented in statsmodels, cannot be evaluated for dispersion parameter at
+zero dispersion or in a positve neighborhood of zero dispersion.
+
+Zero inflated models currently use either Logit or Probit as model for
+inflation. This means that no inflation is at the boundary of the parameter
+space and zero deflation is outside the valid parameter space.
+When the data has no zero inflation or is zero deflated, then the zero
+inflation model will often fail in the optimization, or end up close to the
+no inflation boundary.

--- a/statsmodels/discrete/count_model.py
+++ b/statsmodels/discrete/count_model.py
@@ -101,6 +101,11 @@ class GenericZeroInflated(CountModel):
         self._init_keys.extend(['exog_infl', 'inflation'])
         self._null_drop_keys = ['exog_infl']
 
+    def _get_exogs(self):
+        """list of exogs, for internal use in post-estimation
+        """
+        return (self.exog, self.exog_infl)
+
     def loglike(self, params):
         """
         Loglikelihood of Generic Zero Inflated model.
@@ -976,6 +981,42 @@ class ZeroInflatedResults(CountResults):
                                         agg_weights=agg_weights,
                                         pred_kwds=pred_kwds)
         return res
+
+    def get_influence(self):
+        """
+        Get an instance of MLEInfluence with influence and outlier measures
+
+        See notes section for influence measures that do not apply for
+        zero inflated models.
+
+        Returns
+        -------
+        infl : MLEInfluence instance
+            The instance has methods to calculate the main influence and
+            outlier measures as attributes.
+
+        See Also
+        --------
+        statsmodels.stats.outliers_influence.MLEInfluence
+
+        Notes
+        -----
+        ZeroInflated models have functions that are not differentiable
+        with respect to sample endog if endog=0.
+        This means that generalized leverage cannot be computed in the usual
+        definition.
+
+        Currently, both the generalized leverage, in `hat_matrix_diag attribute
+        and studetized residuals are not available.
+        In the influence plot generalized leverage is replaced by a hat matrix
+        diagonal that only takes combined exog into account, computed in the
+        same way as for OLS. This is a measure for exog outliers but does
+        not take specific features of the model into account.
+
+        """
+        # same as sumper in DiscreteResults, only added for docstring
+        from statsmodels.stats.outliers_influence import MLEInfluence
+        return MLEInfluence(self)
 
 
 class ZeroInflatedPoissonResults(ZeroInflatedResults):

--- a/statsmodels/discrete/discrete_model.py
+++ b/statsmodels/discrete/discrete_model.py
@@ -632,7 +632,7 @@ class BinaryModel(DiscreteModel):
         The value of the derivative of the expected endog with respect
         to the parameter vector.
         """
-        link = self.family.link
+        link = self.link
         lin_pred = self.predict(params, which="linear")
         idl = link.inverse_deriv(lin_pred)
         dmat = self.exog * idl[:, None]
@@ -4688,6 +4688,23 @@ class DiscreteResults(base.LikelihoodModelResults):
         """
         from statsmodels.discrete.discrete_margins import DiscreteMargins
         return DiscreteMargins(self, (at, method, atexog, dummy, count))
+
+    def get_influence(self):
+        """
+        Get an instance of MLEInfluence with influence and outlier measures
+
+        Returns
+        -------
+        infl : MLEInfluence instance
+            The instance has methods to calculate the main influence and
+            outlier measures as attributes.
+
+        See Also
+        --------
+        statsmodels.stats.outliers_influence.MLEInfluence
+        """
+        from statsmodels.stats.outliers_influence import MLEInfluence
+        return MLEInfluence(self)
 
     def summary(self, yname=None, xname=None, title=None, alpha=.05,
                 yname_list=None):

--- a/statsmodels/discrete/tests/test_predict.py
+++ b/statsmodels/discrete/tests/test_predict.py
@@ -395,3 +395,8 @@ def test_distr(case):
             pass
         resid = influ.resid_score()
         assert resid.shape == (len(y2), )
+
+        try:
+            influ.plot_influence()
+        except ImportError:
+            pass

--- a/statsmodels/discrete/tests/test_predict.py
+++ b/statsmodels/discrete/tests/test_predict.py
@@ -321,9 +321,13 @@ models = [
 
 models_influ = [
     Logit,
+    Probit,
     Poisson,
     NegativeBinomialP,
     GeneralizedPoisson,
+    ZeroInflatedPoisson,
+    ZeroInflatedGeneralizedPoisson,
+    ZeroInflatedNegativeBinomialP,
     ]
 
 
@@ -383,7 +387,11 @@ def test_distr(case):
         influ.summary_frame()
         assert influ.resid.shape == (len(y2), )
 
-        resid = influ.resid_score_factor()
-        assert resid.shape == (len(y2), )
+        try:
+            resid = influ.resid_score_factor()
+            assert resid.shape == (len(y2), )
+        except AttributeError:
+            # no score_factor in ZI models
+            pass
         resid = influ.resid_score()
         assert resid.shape == (len(y2), )

--- a/statsmodels/discrete/tests/test_predict.py
+++ b/statsmodels/discrete/tests/test_predict.py
@@ -382,3 +382,8 @@ def test_distr(case):
         influ = res.get_influence()
         influ.summary_frame()
         assert influ.resid.shape == (len(y2), )
+
+        resid = influ.resid_score_factor()
+        assert resid.shape == (len(y2), )
+        resid = influ.resid_score()
+        assert resid.shape == (len(y2), )

--- a/statsmodels/discrete/tests/test_predict.py
+++ b/statsmodels/discrete/tests/test_predict.py
@@ -6,6 +6,7 @@ Author: Josef Perktod
 License: BSD-3
 """
 
+import warnings
 import numpy as np
 from numpy.testing import assert_allclose, assert_equal
 
@@ -383,8 +384,12 @@ def test_distr(case):
         # fig.suptitle(cls_model.__name__ + repr(kwds), fontsize=16)
 
     if cls_model in models_influ:
-        influ = res.get_influence()
-        influ.summary_frame()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=UserWarning)
+            # ZI models warn about missint hat_matrix_diag
+            influ = res.get_influence()
+            influ.summary_frame()
+
         assert influ.resid.shape == (len(y2), )
 
         try:
@@ -396,7 +401,13 @@ def test_distr(case):
         resid = influ.resid_score()
         assert resid.shape == (len(y2), )
 
+        f_sc = influ.d_fittedvalues_scaled  # requires se from get_prediction()
+        assert f_sc.shape == (len(y2), )
+
         try:
-            influ.plot_influence()
+            with warnings.catch_warnings():
+                # ZI models warn about missint hat_matrix_diag
+                warnings.simplefilter("ignore", category=UserWarning)
+                influ.plot_influence()
         except ImportError:
             pass

--- a/statsmodels/discrete/tests/test_predict.py
+++ b/statsmodels/discrete/tests/test_predict.py
@@ -319,6 +319,13 @@ models = [
     (NegativeBinomial, {"loglike_method": 'geometric'}, np.array([mu])),
     ]
 
+models_influ = [
+    Logit,
+    Poisson,
+    NegativeBinomialP,
+    GeneralizedPoisson,
+    ]
+
 
 def get_data_simulated():
     np.random.seed(987456348)
@@ -370,3 +377,8 @@ def test_distr(case):
         dia = res.get_diagnostic()
         # fig = dia.plot_probs();
         # fig.suptitle(cls_model.__name__ + repr(kwds), fontsize=16)
+
+    if cls_model in models_influ:
+        influ = res.get_influence()
+        influ.summary_frame()
+        assert influ.resid.shape == (len(y2), )

--- a/statsmodels/genmod/generalized_linear_model.py
+++ b/statsmodels/genmod/generalized_linear_model.py
@@ -2003,7 +2003,7 @@ class GLMResults(base.LikelihoodModelResults):
         # using get_hat_matrix_diag has duplicated computation
         hat_matrix_diag = self.get_hat_matrix_diag(observed=observed)
         infl = GLMInfluence(self, endog=wendog, exog=wexog,
-                         resid=self.resid_pearson,
+                         resid=self.resid_pearson / np.sqrt(self.scale),
                          hat_matrix_diag=hat_matrix_diag)
         return infl
 

--- a/statsmodels/othermod/betareg.py
+++ b/statsmodels/othermod/betareg.py
@@ -260,7 +260,7 @@ class BetaModel(GenericLikelihoodModel):
         """
         mean = self.predict(params, exog=exog)
         precision = self._predict_precision(params,
-                                           exog_precision=exog_precision)
+                                            exog_precision=exog_precision)
 
         var_endog = mean * (1 - mean) / (1 + precision)
         return var_endog
@@ -721,8 +721,6 @@ class BetaModel(GenericLikelihoodModel):
 
         return np.column_stack((d1, d2))
 
-
-    # code duplication with results class
     def get_distribution_params(self, params, exog=None, exog_precision=None):
         """
         Return distribution parameters converted from model prediction.
@@ -891,6 +889,40 @@ class BetaResults(GenericLikelihoodModelResults, _LLRMixin):
         args = (np.asarray(arg) for arg in args)
         distr = stats.beta(*args)
         return distr
+
+    def get_influence(self):
+        """
+        Get an instance of MLEInfluence with influence and outlier measures
+
+        Returns
+        -------
+        infl : MLEInfluence instance
+            The instance has methods to calculate the main influence and
+            outlier measures as attributes.
+
+        See Also
+        --------
+        statsmodels.stats.outliers_influence.MLEInfluence
+
+        Notes
+        -----
+        Support for mutli-link and multi-exog models is still experimental
+        in MLEInfluence. Interface and some definitions might still change.
+
+        Note: Difference to R betareg: Betareg has the same general leverage
+        as this model. However, they use a linear approximation hat matrix
+        to scale and studentize influence and residual statistics.
+        MLEInfluence uses the generalized leverage as hat_matrix_diag.
+        Additionally, MLEInfluence uses pearson residuals for residual
+        analusis.
+
+        References
+        ----------
+        todo
+
+        """
+        from statsmodels.stats.outliers_influence import MLEInfluence
+        return MLEInfluence(self)
 
     def bootstrap(self, *args, **kwargs):
         raise NotImplementedError

--- a/statsmodels/othermod/tests/test_beta.py
+++ b/statsmodels/othermod/tests/test_beta.py
@@ -376,11 +376,14 @@ class TestBetaIncome():
         res1 = self.res1
         from statsmodels.stats.outliers_influence import MLEInfluence
 
-        influ = MLEInfluence(res1)
+        influ0 = MLEInfluence(res1)
+        influ = res1.get_influence()
         attrs = ['cooks_distance', 'd_fittedvalues', 'd_fittedvalues_scaled',
                  'd_params', 'dfbetas', 'hat_matrix_diag', 'resid_studentized'
                  ]
         for attr in attrs:
             getattr(influ, attr)
 
-        influ.summary_frame()
+        frame = influ.summary_frame()
+        frame0 = influ0.summary_frame()
+        assert_allclose(frame, frame0, rtol=1e-13, atol=1e-13)

--- a/statsmodels/stats/outliers_influence.py
+++ b/statsmodels/stats/outliers_influence.py
@@ -1444,7 +1444,6 @@ class GLMInfluence(MLEInfluence):
     def _fittedvalues_one(self):
         """experimental code
         """
-        import warnings
         warnings.warn('this ignores offset and exposure', UserWarning)
         # TODO: we need to handle offset, exposure and weights
         # use original model exog not transformed influence exog

--- a/statsmodels/stats/tests/test_influence.py
+++ b/statsmodels/stats/tests/test_influence.py
@@ -66,12 +66,14 @@ class InfluenceCompareExact(object):
 
         cd_rtol = getattr(self, 'cd_rtol', 1e-7)
         assert_allclose(infl0.cooks_distance[0], infl1.cooks_distance[0],
-                        rtol=cd_rtol)
+                        rtol=cd_rtol, atol=1e-14)  # very small values possible
         assert_allclose(infl0.dfbetas, infl1.dfbetas, rtol=1e-9, atol=5e-9)
         assert_allclose(infl0.d_params, infl1.d_params, rtol=1e-9, atol=5e-9)
-        assert_allclose(infl0.d_fittedvalues, infl1.d_fittedvalues, rtol=5e-9)
+        assert_allclose(infl0.d_fittedvalues, infl1.d_fittedvalues,
+                        rtol=5e-9, atol=1e-14)
         assert_allclose(infl0.d_fittedvalues_scaled,
-                        infl1.d_fittedvalues_scaled, rtol=5e-9)
+                        infl1.d_fittedvalues_scaled,
+                        rtol=5e-9, atol=1e-14)
 
     @pytest.mark.smoke
     @pytest.mark.matplotlib
@@ -101,7 +103,7 @@ class InfluenceCompareExact(object):
 
         df0 = infl0.summary_frame()
         df1 = infl1.summary_frame()
-        assert_allclose(df0.values, df1.values, rtol=5e-5)
+        assert_allclose(df0.values, df1.values, rtol=5e-5, atol=1e-14)
         pdt.assert_index_equal(df0.index, df1.index)
 
 
@@ -221,7 +223,8 @@ class TestInfluenceGaussianGLMOLS(InfluenceCompareExact):
                         rtol=1e-12)
         assert_allclose(infl0.resid_studentized,
                         infl1.resid_studentized, rtol=1e-12, atol=1e-7)
-        assert_allclose(infl0.cooks_distance, infl1.cooks_distance, rtol=1e-7)
+        assert_allclose(infl0.cooks_distance, infl1.cooks_distance,
+                        rtol=1e-7, atol=1e-14)  # very small values possible
         assert_allclose(infl0.dfbetas, infl1.dfbetas, rtol=0.1) # changed
         # OLSInfluence only has looo dfbeta/d_params
         assert_allclose(infl0.d_params, infl1.dfbeta, rtol=1e-9, atol=1e-14)
@@ -262,6 +265,44 @@ class TestInfluenceLogitCompare(InfluenceCompareExact):
 
         cls.infl1 = res.get_influence()
         cls.infl0 = res2.get_influence()
+
+
+class TestInfluenceProbitCompare(InfluenceCompareExact):
+
+    @classmethod
+    def setup_class(cls):
+        df = data_bin
+        mod = GLM(df['constrict'], df[['const', 'log_rate', 'log_volumne']],
+                  family=families.Binomial(link=families.links.probit()))
+        res = mod.fit(method="newton", tol=1e-10)
+        from statsmodels.discrete.discrete_model import Probit
+        mod2 = Probit(df['constrict'], df[['const', 'log_rate', 'log_volumne']])
+        res2 = mod2.fit(method="newton", tol=1e-10)
+
+        cls.infl1 = MLEInfluence(res)  # res.get_influence()
+        cls.infl0 = res2.get_influence()
+
+    def test_basics_specific(self):
+        infl1 = self.infl1
+        infl0 = self.infl0
+        res1 = self.infl1.results
+        res0 = self.infl0.results
+
+        assert_allclose(res1.params, res1.params, rtol=1e-10)
+
+        d1 = res1.model._deriv_mean_dparams(res1.params)
+        d0 = res1.model._deriv_mean_dparams(res0.params)
+        assert_allclose(d0, d1, rtol=1e-10)
+
+        d1 = res1.model._deriv_score_obs_dendog(res1.params)
+        d0 = res1.model._deriv_score_obs_dendog(res0.params)
+        assert_allclose(d0, d1, rtol=1e-10)
+
+        s1 = res1.model.score_obs(res1.params)
+        s0 = res1.model.score_obs(res0.params)
+        assert_allclose(s0, s1, rtol=1e-10)
+
+        assert_allclose(infl0.hessian, infl1.hessian, rtol=1e-10)
 
 
 class TestInfluencePoissonCompare(InfluenceCompareExact):


### PR DESCRIPTION
WIP still in design/decision stage

MLEInfluence with resid_pearson default

works for
    Logit,
    Poisson,
    NegativeBinomialP,
    GeneralizedPoisson,

other models are missing derivatives.

currently test failures because definition of `MLEInfluence.resid_studentized` changed, in TestInfluenceGaussianGLMMLE.test_basics
