### PR TITLE
MAINT: Remove DataFrame.append usage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ requires = [
     "numpy==1.17.4; python_version=='3.7'",
     "numpy==1.17.4; python_version=='3.8'",
     "numpy==1.19.4; python_version=='3.9'",
-    "numpy; python_version>'3.9'",
+    "numpy==1.21.4; python_version=='3.10'",
+    "numpy; python_version>'3.10'",
     "scipy>=1.3",
 ]

--- a/statsmodels/base/_prediction_inference.py
+++ b/statsmodels/base/_prediction_inference.py
@@ -431,12 +431,11 @@ def get_prediction_glm(self, exog=None, transform=True,
         Instance of linear prediction results used for confidence intervals
         based on endpoint transformation.
     link : instance of link function
-        If no link function is provided, then the ``mmodel.family.link` is
-        used.
+        If no link function is provided, then the `model.family.link` is used.
     pred_kwds : dict
         Some models can take additional keyword arguments, such as offset or
-        additional exog in multi-part models.
-        See the predict method of the model for the details.
+        additional exog in multi-part models. See the predict method of the
+        model for the details.
 
     Returns
     -------

--- a/statsmodels/discrete/count_model.py
+++ b/statsmodels/discrete/count_model.py
@@ -984,14 +984,14 @@ class ZeroInflatedResults(CountResults):
 
     def get_influence(self):
         """
-        Get an instance of MLEInfluence with influence and outlier measures
+        Influence and outlier measures
 
         See notes section for influence measures that do not apply for
         zero inflated models.
 
         Returns
         -------
-        infl : MLEInfluence instance
+        MLEInfluence
             The instance has methods to calculate the main influence and
             outlier measures as attributes.
 
@@ -1002,17 +1002,15 @@ class ZeroInflatedResults(CountResults):
         Notes
         -----
         ZeroInflated models have functions that are not differentiable
-        with respect to sample endog if endog=0.
-        This means that generalized leverage cannot be computed in the usual
-        definition.
+        with respect to sample endog if endog=0. This means that generalized
+        leverage cannot be computed in the usual definition.
 
-        Currently, both the generalized leverage, in `hat_matrix_diag attribute
-        and studetized residuals are not available.
-        In the influence plot generalized leverage is replaced by a hat matrix
-        diagonal that only takes combined exog into account, computed in the
-        same way as for OLS. This is a measure for exog outliers but does
-        not take specific features of the model into account.
-
+        Currently, both the generalized leverage, in `hat_matrix_diag`
+        attribute and studetized residuals are not available. In the influence
+        plot generalized leverage is replaced by a hat matrix diagonal that
+        only takes combined exog into account, computed in the same way as
+        for OLS. This is a measure for exog outliers but does not take
+        specific features of the model into account.
         """
         # same as sumper in DiscreteResults, only added for docstring
         from statsmodels.stats.outliers_influence import MLEInfluence

--- a/statsmodels/genmod/generalized_linear_model.py
+++ b/statsmodels/genmod/generalized_linear_model.py
@@ -1452,6 +1452,7 @@ class GLM(base.LikelihoodModel):
 get_prediction_doc = Docstring(pred.get_prediction_glm.__doc__)
 get_prediction_doc.remove_parameters("pred_kwds")
 
+
 class GLMResults(base.LikelihoodModelResults):
     """
     Class to contain GLM results.

--- a/statsmodels/stats/tests/test_anova_rm.py
+++ b/statsmodels/stats/tests/test_anova_rm.py
@@ -140,7 +140,8 @@ def test_repeated_measures_unbalanced_data():
 
 def test_repeated_measures_aggregation():
     df1 = AnovaRM(data, 'DV', 'id', within=['A', 'B', 'D']).fit()
-    df2 = AnovaRM(data.append(data), 'DV', 'id', within=['A', 'B', 'D'],
+    double_data = pd.concat([data, data], axis=0)
+    df2 = AnovaRM(double_data, 'DV', 'id', within=['A', 'B', 'D'],
                   aggregate_func=np.mean).fit()
 
     assert_frame_equal(df1.anova_table, df2.anova_table)
@@ -156,12 +157,13 @@ def test_repeated_measures_aggregation_one_subject_duplicated():
 
 
 def test_repeated_measures_aggregate_func():
-    assert_raises(ValueError, AnovaRM, data.append(data), 'DV', 'id',
+    double_data = pd.concat([data, data], axis=0)
+    assert_raises(ValueError, AnovaRM, double_data, 'DV', 'id',
                   within=['A', 'B', 'D'])
 
-    m1 = AnovaRM(data.append(data), 'DV', 'id', within=['A', 'B', 'D'],
+    m1 = AnovaRM(double_data, 'DV', 'id', within=['A', 'B', 'D'],
                  aggregate_func=np.mean)
-    m2 = AnovaRM(data.append(data), 'DV', 'id', within=['A', 'B', 'D'],
+    m2 = AnovaRM(double_data, 'DV', 'id', within=['A', 'B', 'D'],
                  aggregate_func=np.median)
 
     assert_raises(AssertionError, assert_equal,
@@ -170,10 +172,11 @@ def test_repeated_measures_aggregate_func():
 
 
 def test_repeated_measures_aggregate_func_mean():
-    m1 = AnovaRM(data.append(data), 'DV', 'id', within=['A', 'B', 'D'],
+    double_data = pd.concat([data, data], axis=0)
+    m1 = AnovaRM(double_data, 'DV', 'id', within=['A', 'B', 'D'],
                  aggregate_func=np.mean)
 
-    m2 = AnovaRM(data.append(data), 'DV', 'id', within=['A', 'B', 'D'],
+    m2 = AnovaRM(double_data, 'DV', 'id', within=['A', 'B', 'D'],
                  aggregate_func='mean')
 
     assert_equal(m1.aggregate_func, m2.aggregate_func)
@@ -191,7 +194,8 @@ def test_repeated_measures_aggregate_compare_with_ezANOVA():
         index=pd.Index(['A', 'B', 'D', 'A:B', 'A:D', 'B:D', 'A:B:D']))
     ez = ez[['F Value', 'Num DF', 'Den DF', 'Pr > F']]
 
-    df = (AnovaRM(data.append(data), 'DV', 'id', within=['A', 'B', 'D'],
+    double_data = pd.concat([data, data], axis=0)
+    df = (AnovaRM(double_data, 'DV', 'id', within=['A', 'B', 'D'],
                   aggregate_func=np.mean)
           .fit()
           .anova_table)

--- a/statsmodels/stats/tests/test_anova_rm.py
+++ b/statsmodels/stats/tests/test_anova_rm.py
@@ -6,7 +6,6 @@ from statsmodels.stats.anova import AnovaRM
 from numpy.testing import (assert_array_almost_equal, assert_raises,
                            assert_equal)
 
-
 DV = [7, 3, 6, 6, 5, 8, 6, 7,
       7, 11, 9, 11, 10, 10, 11, 11,
       8, 14, 10, 11, 12, 10, 11, 12,
@@ -108,13 +107,13 @@ def test_three_factors_repeated_measures_anova():
     Results reproduces R `ezANOVA` function from library ez
     """
     df = AnovaRM(data, 'DV', 'id', within=['A', 'B', 'D']).fit()
-    a = [[1,  7,  8.7650709, 0.021087505],
-         [2, 14,  8.4985785, 0.003833921],
-         [1,  7, 20.5076546, 0.002704428],
-         [2, 14,  0.8457797, 0.450021759],
-         [1,  7, 21.7593382, 0.002301792],
-         [2, 14,  6.2416695, 0.011536846],
-         [2, 14,  5.4253359, 0.018010647]]
+    a = [[1, 7, 8.7650709, 0.021087505],
+         [2, 14, 8.4985785, 0.003833921],
+         [1, 7, 20.5076546, 0.002704428],
+         [2, 14, 0.8457797, 0.450021759],
+         [1, 7, 21.7593382, 0.002301792],
+         [2, 14, 6.2416695, 0.011536846],
+         [2, 14, 5.4253359, 0.018010647]]
     assert_array_almost_equal(df.anova_table.iloc[:, [1, 2, 0, 3]].values,
                               a, decimal=5)
 
@@ -149,7 +148,9 @@ def test_repeated_measures_aggregation():
 
 def test_repeated_measures_aggregation_one_subject_duplicated():
     df1 = AnovaRM(data, 'DV', 'id', within=['A', 'B', 'D']).fit()
-    df2 = AnovaRM(data.append(data.loc[data['id'] == '1', :]).reset_index(),
+    data2 = pd.concat([data, data.loc[data['id'] == '1', :]], axis=0)
+    data2 = data2.reset_index()
+    df2 = AnovaRM(data2,
                   'DV', 'id', within=['A', 'B', 'D'],
                   aggregate_func=np.mean).fit()
 

--- a/statsmodels/tsa/vector_ar/tests/test_var.py
+++ b/statsmodels/tsa/vector_ar/tests/test_var.py
@@ -870,9 +870,9 @@ class TestVARExtras(object):
         fc3 = res_lin_trend2.forecast(
             res_lin_trend2.endog[-2:], h, exog_future=exf2
         )
-        assert_allclose(fc2, fc1, rtol=1e-12)
-        assert_allclose(fc3, fc1, rtol=1e-12)
-        assert_allclose(fc3, fc2, rtol=1e-12)
+        assert_allclose(fc2, fc1, rtol=1e-12, atol=1e-12)
+        assert_allclose(fc3, fc1, rtol=1e-12, atol=1e-12)
+        assert_allclose(fc3, fc2, rtol=1e-12, atol=1e-12)
 
         fci1 = res_lin_trend.forecast_interval(res_lin_trend.endog[-2:], h)
         exf = np.arange(len(data), len(data) + h)


### PR DESCRIPTION
DataFrame append is deprecated in favor of concat(*,axis=0)

- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
