### PR TITLE
MAINT: Relax tolerance on VAR test

### DIFF
--- a/statsmodels/tsa/vector_ar/tests/test_var.py
+++ b/statsmodels/tsa/vector_ar/tests/test_var.py
@@ -883,9 +883,9 @@ class TestVARExtras(object):
         fci3 = res_lin_trend2.forecast_interval(
             res_lin_trend2.endog[-2:], h, exog_future=exf2
         )
-        assert_allclose(fci2, fci1, rtol=1e-12)
-        assert_allclose(fci3, fci1, rtol=1e-12)
-        assert_allclose(fci3, fci2, rtol=1e-12)
+        assert_allclose(fci2, fci1, rtol=1e-12, atol=1e-12)
+        assert_allclose(fci3, fci1, rtol=1e-12, atol=1e-12)
+        assert_allclose(fci3, fci2, rtol=1e-12, atol=1e-12)
 
     def test_multiple_simulations(self):
         res0 = self.res0


### PR DESCRIPTION
Relax tolerance to ensure test passes on recent NumPy

- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
