### PR TITLE
MAINT: Add slim to summary docstring

### DIFF
--- a/statsmodels/regression/linear_model.py
+++ b/statsmodels/regression/linear_model.py
@@ -30,11 +30,12 @@ R. Davidson and J.G. MacKinnon.  "Econometric Theory and Methods," Oxford,
 
 W. Green.  "Econometric Analysis," 5th ed., Pearson, 2003.
 """
-
+from __future__ import annotations
 
 from statsmodels.compat.pandas import Appender
 from statsmodels.compat.python import lrange, lzip
 
+from typing import Sequence
 import warnings
 
 import numpy as np
@@ -47,12 +48,9 @@ from statsmodels.emplike.elregress import _ELRegOpts
 # need import in module instead of lazily to copy `__doc__`
 from statsmodels.regression._prediction import PredictionResults
 from statsmodels.tools.decorators import cache_readonly, cache_writable
-from statsmodels.tools.sm_exceptions import (
-    InvalidTestWarning,
-    ValueWarning,
-    )
+from statsmodels.tools.sm_exceptions import InvalidTestWarning, ValueWarning
 from statsmodels.tools.tools import pinv_extended
-from statsmodels.tools.validation import string_like
+from statsmodels.tools.validation import bool_like, float_like, string_like
 
 from . import _prediction as pred
 
@@ -2642,7 +2640,14 @@ class RegressionResults(base.LikelihoodModelResults):
             self, exog=exog, transform=transform, weights=weights,
             row_labels=row_labels, **kwargs)
 
-    def summary(self, yname=None, xname=None, title=None, alpha=.05, slim=False):
+    def summary(
+            self,
+            yname: str | None = None,
+            xname: Sequence[str] | None = None,
+            title: str | None = None,
+            alpha: float = 0.05,
+            slim: bool = False,
+    ):
         """
         Summarize the Regression Results.
 
@@ -2657,8 +2662,11 @@ class RegressionResults(base.LikelihoodModelResults):
         title : str, optional
             Title for the top table. If not None, then this replaces the
             default title.
-        alpha : float
+        alpha : float, optional
             The significance level for the confidence intervals.
+        slim : bool, optional
+            Flag indicating to produce reduced set or diagnostic information.
+            Default is False.
 
         Returns
         -------
@@ -2674,7 +2682,9 @@ class RegressionResults(base.LikelihoodModelResults):
             durbin_watson,
             jarque_bera,
             omni_normtest,
-            )
+        )
+        alpha = float_like(alpha, "alpha", optional=False)
+        slim = bool_like(slim, "slim", optional=False, strict=True)
 
         jb, jbpv, skew, kurtosis = jarque_bera(self.wresid)
         omni, omnipv = omni_normtest(self.wresid)
@@ -2724,8 +2734,7 @@ class RegressionResults(base.LikelihoodModelResults):
             slimlist = ['Dep. Variable:', 'Model:', 'No. Observations:',
                         'Covariance Type:', 'R-squared:', 'Adj. R-squared:',
                         'F-statistic:', 'Prob (F-statistic):']
-            diagn_left = []
-            diagn_right = []
+            diagn_left = diagn_right = []
             top_left = [elem for elem in top_left if elem[0] in slimlist]
             top_right = [elem for elem in top_right if elem[0] in slimlist]
         else:
@@ -2793,8 +2802,14 @@ class RegressionResults(base.LikelihoodModelResults):
 
         return smry
 
-    def summary2(self, yname=None, xname=None, title=None, alpha=.05,
-                 float_format="%.4f"):
+    def summary2(
+            self,
+            yname: str | None = None,
+            xname: Sequence[str] | None = None,
+            title: str | None = None,
+            alpha: float = 0.05,
+            float_format: str = "%.4f",
+    ):
         """
         Experimental summary function to summarize the regression results.
 

--- a/statsmodels/regression/tests/test_regression.py
+++ b/statsmodels/regression/tests/test_regression.py
@@ -1608,3 +1608,15 @@ def test_condition_number(reset_randomstate):
     res = OLS(y, x).fit()
     assert_allclose(res.condition_number, np.sqrt(np.linalg.cond(x.T @ x)))
     assert_allclose(res.condition_number, np.linalg.cond(x))
+
+
+def test_slim_summary(reset_randomstate):
+    y = np.random.standard_normal(100)
+    x = np.random.standard_normal((100, 1))
+    x = x + np.random.standard_normal((100, 5))
+    res = OLS(y, x).fit()
+    summ = res.summary()
+    summ2 = res.summary()
+    slim_summ = res.summary(slim=True)
+    assert str(summ) == str(summ2)
+    assert str(slim_summ) != str(summ)


### PR DESCRIPTION
Add optional parameter slim to docstring of summary

- [X] closes #7979
- [X] tests added / passed. 
- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
