### PR TITLE
ENH: Add append method to AutoRegResults

### DIFF
--- a/statsmodels/tsa/deterministic.py
+++ b/statsmodels/tsa/deterministic.py
@@ -1451,3 +1451,29 @@ differences can be extended when producing out-of-sample forecasts.
             self._extendable = self._index[0] == 0 and np.all(
                 np.diff(self._index) == 1
             )
+
+    def apply(self, index):
+        """
+        Create an identical determinstic process with a different index
+
+        Parameters
+        ----------
+        index : index_like
+            An index-like object. If not an index, it is converted to an
+            index.
+
+        Returns
+        -------
+        DeterministicProcess
+            The deterministic process applied to a different index
+        """
+        return DeterministicProcess(
+            index,
+            period=self._period,
+            constant=self._constant,
+            order=self._order,
+            seasonal=self._seasonal,
+            fourier=self._fourier,
+            additional_terms=self._additional_terms,
+            drop=self._drop,
+        )

--- a/statsmodels/tsa/x13.py
+++ b/statsmodels/tsa/x13.py
@@ -27,6 +27,7 @@ __all__ = ["x13_arima_select_order", "x13_arima_analysis"]
 _binary_names = ('x13as.exe', 'x13as', 'x12a.exe', 'x12a',
                  'x13as_ascii', 'x13as_html')
 
+
 class _freq_to_period:
     def __getitem__(self, key):
         if key.startswith('M'):


### PR DESCRIPTION
Add append to AutoRegResults to correspond to other time-series models

- [ ] tests added / passed. 
- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
