### PR TITLE
GEE inputs: handle lists and tuples

### DIFF
--- a/statsmodels/genmod/generalized_estimating_equations.py
+++ b/statsmodels/genmod/generalized_estimating_equations.py
@@ -522,8 +522,6 @@ class GEE(GLM):
                 exposure = exposure[ii]
             del kwargs["missing_idx"]
 
-        _check_args(endog, exog, groups, time, offset, exposure)
-
         self.missing = missing
         self.dep_data = dep_data
         self.constraint = constraint
@@ -541,6 +539,15 @@ class GEE(GLM):
                                   exposure=exposure, weights=weights,
                                   dep_data=dep_data, missing=missing,
                                   family=family, **kwargs)
+
+        _check_args(
+            self.endog,
+            self.exog,
+            self.groups,
+            self.time,
+            getattr(self, "offset", None),
+            getattr(self, "exposure", None),
+        )
 
         self._init_keys.extend(["update_dep", "constraint", "family",
                                 "cov_struct"])


### PR DESCRIPTION
[GEE's documentation](https://www.statsmodels.org/dev/generated/statsmodels.genmod.generalized_estimating_equations.GEE.html) says that `endog`, `exog`, `groups`, `time`, and `offset` can all be array-like, which "includes lists ... and tuples".

However, lists and tuples are not currently supported. The `GEE` class inherits from `GLM` but uses its own function to check inputs, `_check_args` [here](https://github.com/statsmodels/statsmodels/blob/main/statsmodels/genmod/generalized_estimating_equations.py#L463-L479). That function assumes that each of the inputs has a `size` attribute, without first checking their types.

`GLM` seems to do type checking and conversion with the `handle_data` function, [here](https://github.com/statsmodels/statsmodels/blob/main/statsmodels/base/data.py#L665-L674).

This PR simply copies relevant lines from GLM's function into GEE's function and adds a few similar lines. An existing test is duplicated, with the only change being that inputs are made into lists and tuples before passing to `GEE`.

- [x] tests added / passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message.

