### PR TITLE
ENH: state space: add revisions to news, decomposition of smoothed states/signals

### DIFF
--- a/statsmodels/tsa/statespace/_tools.pyx.in
+++ b/statsmodels/tsa/statespace/_tools.pyx.in
@@ -4,7 +4,7 @@
 """
 State Space Model - Cython tools
 
-Author: Chad Fulton  
+Author: Chad Fulton
 License: Simplified-BSD
 """
 
@@ -1154,22 +1154,22 @@ cdef int _{{prefix}}select_cov(int k_states, int k_posdef, int k_states_total,
     # (i.e k_posdof == 0)
     if k_posdef > 0:
 
-        # #### Calculate selected state covariance matrix 
+        # #### Calculate selected state covariance matrix
         # $Q_t^* = R_t Q_t R_t'$
-        # 
+        #
         # Combine a selection matrix and a covariance matrix to get
         # a simplified (but possibly singular) "selected" covariance
         # matrix (see e.g. Durbin and Koopman p. 43)
 
-        # `tmp0` array used here, dimension $(m \times r)$ 
+        # `tmp0` array used here, dimension $(m \times r)$
 
-        # $\\#_0 = 1.0 * R_t Q_t$ 
+        # $\\#_0 = 1.0 * R_t Q_t$
         # $(m \times r) = (m \times r) (r \times r)$
         blas.{{prefix}}gemm("N", "N", &k_states, &k_posdef, &k_posdef,
               &alpha, selection, &k_states_total,
                       cov, &k_posdef,
               &beta, tmp, &k_states)
-        # $Q_t^* = 1.0 * \\#_0 R_t'$ 
+        # $Q_t^* = 1.0 * \\#_0 R_t'$
         # $(m \times m) = (m \times r) (m \times r)'$
         blas.{{prefix}}gemm("N", "T", &k_states, &k_states, &k_posdef,
               &alpha, tmp, &k_states,
@@ -1207,7 +1207,7 @@ cpdef _{{prefix}}compute_smoothed_state_weights(
         {{cython_type}} gamma = -1.0
         {{cython_type}} scalar
         {{cython_type}} [::1, :, :] Hi_W, K, prior_weights
-        {{cython_type}} [::1, :, :, :] weights
+        {{cython_type}} [::1, :, :, :] weights, state_intercept_weights
         {{cython_type}} [::1, :] tmp, F, Fi, FiZ
         {{cython_type}} * _Pt
         {{cython_type}} * _Z
@@ -1238,12 +1238,15 @@ cpdef _{{prefix}}compute_smoothed_state_weights(
     # Hi_W = np.zeros((p, m, n), order='F')
     # K = np.zeros((p, m, n), order='F')
     # weights = np.zeros((m, p, n, n), order='F') * np.nan
+    # state_intercept_weights = np.zeros((m, m, n, n), order='F') * np.nan
     # tmp = np.zeros((m, m), order='F')
     # F = np.zeros((p, p), order='F')
     # Fi = np.zeros((p, p), order='F')
     # FiZ = np.zeros((p, m), order='F')
     dim4[0] = m; dim4[1] = p; dim4[2] = n; dim4[3] = n;
     weights = np.PyArray_ZEROS(4, dim4, {{typenum}}, FORTRAN) * np.nan
+    dim4[0] = m; dim4[1] = m; dim4[2] = n; dim4[3] = n;
+    state_intercept_weights = np.PyArray_ZEROS(4, dim4, {{typenum}}, FORTRAN) * np.nan
     dim3[0] = p; dim3[1] = m; dim3[2] = n;
     Hi_W = np.PyArray_ZEROS(3, dim3, {{typenum}}, FORTRAN)
     K = np.PyArray_ZEROS(3, dim3, {{typenum}}, FORTRAN)
@@ -1369,7 +1372,7 @@ cpdef _{{prefix}}compute_smoothed_state_weights(
             kfilter.tmp0[i, i] = kfilter.tmp0[i, i] + 1
 
         # This is the weight of the prior on the smoothed state at
-        # time t > 0
+        # time t == 0
         if t == 0 and compute_prior_weights:
             blas.{{prefix}}copy(&kfilter.k_states2, kfilter._tmp0, &inc, &prior_weights[0, 0, t], &inc)
 
@@ -1394,12 +1397,17 @@ cpdef _{{prefix}}compute_smoothed_state_weights(
             # - if j not in compute_j, then we only need to update
             #   tmp = tmp @ L[j] (as in the conventional case), since
             #   L[j] = \prod_i L_{j, i}
-            if store_j[j] and p_j > 0:
-                # weights[:, :p_j, t, j] = tmp @ K[j][:, :p_j]
-                blas.{{prefix}}gemm("N", "N", &model._k_states, &p_j, &model._k_states,
-                                    &alpha, kfilter._tmp0, &kfilter.k_states,
-                                            _K, &kfilter.k_states,
-                                    &beta, &weights[0, 0, t, j], &kfilter.k_states)
+            if store_j[j]:
+                if p_j > 0:
+                    # weights[:, :p_j, t, j] = tmp @ K[j][:, :p_j]
+                    blas.{{prefix}}gemm("N", "N", &model._k_states, &p_j, &model._k_states,
+                                        &alpha, kfilter._tmp0, &kfilter.k_states,
+                                                _K, &kfilter.k_states,
+                                        &beta, &weights[0, 0, t, j], &kfilter.k_states)
+
+                # state_intercept_weights[:, :, t, j] = -tmp
+                blas.{{prefix}}copy(&kfilter.k_states2, kfilter._tmp0, &inc,
+                                                        &state_intercept_weights[0, 0, t, j], &inc)
 
             if j > min_j or (j == 0 and compute_prior_weights):
                 # tmp = tmp @ L
@@ -1427,12 +1435,26 @@ cpdef _{{prefix}}compute_smoothed_state_weights(
         # would follow the j < t formula.
         j = t
         p_j = p - model.nmissing[t]
-        # weights[:, :p_j, t, j] = Pt @ Hi_W[j, :p_j].T
-        if store_j[j] and p_j > 0:
-            blas.{{prefix}}gemm("N", "T", &model._k_states, &p_j, &model._k_states,
-                                &scale, &kfilter.predicted_state_cov[0, 0, t], &kfilter.k_states,
-                                         &Hi_W[0, 0, j], &model.k_endog,
-                                &beta, &weights[0, 0, t, j], &kfilter.k_states)
+        if store_j[j]:
+            if p_j > 0:
+                # weights[:, :p_j, t, j] = Pt @ Hi_W[j, :p_j].T
+                blas.{{prefix}}gemm("N", "T", &model._k_states, &p_j, &model._k_states,
+                                    &scale, &kfilter.predicted_state_cov[0, 0, t], &kfilter.k_states,
+                                            &Hi_W[0, 0, j], &model.k_endog,
+                                    &beta, &weights[0, 0, t, j], &kfilter.k_states)
+
+            # state_intercept_weights[:, :, t, j] = -(Pt @ Lt' @ Nt)
+            # Note: normally would need to multiply Pt by scale and divide Nt
+            # by `scale`, but since they're being multiplied here, the scale terms
+            # cancel out.
+            blas.{{prefix}}gemm("T", "N", &model._k_states, &model._k_states, &model._k_states,
+                            &gamma, &smoother.innovations_transition[0, 0, t], &kfilter.k_states,
+                                    &smoother.scaled_smoothed_estimator_cov[0, 0, t + 1], &kfilter.k_states,
+                            &beta, kfilter._tmp00, &kfilter.k_states)
+            blas.{{prefix}}gemm("N", "N", &model._k_states, &model._k_states, &model._k_states,
+                            &alpha, &kfilter.predicted_state_cov[0, 0, t], &kfilter.k_states,
+                                    kfilter._tmp00, &kfilter.k_states,
+                            &beta, &state_intercept_weights[0, 0, t, j], &kfilter.k_states)
 
         # Forwards from j = t+1, t+2, ..., max_j
         # tmp = Pt
@@ -1449,13 +1471,26 @@ cpdef _{{prefix}}compute_smoothed_state_weights(
             blas.{{prefix}}copy(&kfilter.k_states2, kfilter._tmp00, &inc,
                                                         kfilter._tmp0, &inc)
 
-            if store_j[j] and p_j > 0:
-                # weights[:, :p_j, t, j] = tmp @ Hi_W[j, :p_j].T
-                blas.{{prefix}}gemm("N", "T", &model._k_states, &p_j, &model._k_states,
-                                    &alpha, kfilter._tmp0, &kfilter.k_states,
-                                            &Hi_W[0, 0, j], &p,
-                                    &beta, &weights[0, 0, t, j], &kfilter.k_states)
+            if store_j[j]:
+                if p_j > 0:
+                    # weights[:, :p_j, t, j] = tmp @ Hi_W[j, :p_j].T
+                    blas.{{prefix}}gemm("N", "T", &model._k_states, &p_j, &model._k_states,
+                                        &alpha, kfilter._tmp0, &kfilter.k_states,
+                                                &Hi_W[0, 0, j], &p,
+                                        &beta, &weights[0, 0, t, j], &kfilter.k_states)
 
-    return np.array(weights), np.array(prior_weights), np.array(Hi_W)
+                # state_intercept_weights[:, :, t, j] = -(tmp @ N_j)
+                # TODO: can re-organize to avoid redoing the tmp @ L multiplication
+                scalar = -1 / scale
+                blas.{{prefix}}gemm("N", "T", &model._k_states, &model._k_states, &model._k_states,
+                            &alpha, kfilter._tmp0, &kfilter.k_states,
+                                    &smoother.innovations_transition[0, 0, j], &kfilter.k_states,
+                            &beta, kfilter._tmp00, &kfilter.k_states)
+                blas.{{prefix}}gemm("N", "N", &model._k_states, &model._k_states, &model._k_states,
+                                &scalar, kfilter._tmp00, &kfilter.k_states,
+                                        &smoother.scaled_smoothed_estimator_cov[0, 0, j + 1], &kfilter.k_states,
+                                &beta, &state_intercept_weights[0, 0, t, j], &kfilter.k_states)
+
+    return np.array(weights), np.array(state_intercept_weights), np.array(prior_weights), np.array(Hi_W)
 
 {{endfor}}

--- a/statsmodels/tsa/statespace/initialization.py
+++ b/statsmodels/tsa/statespace/initialization.py
@@ -209,6 +209,149 @@ class Initialization(object):
             self.set(None, initialization_type, constant=constant,
                      stationary_cov=stationary_cov)
 
+    @classmethod
+    def from_components(cls, k_states, a=None, Pstar=None, Pinf=None, A=None,
+                        R0=None, Q0=None):
+        r"""
+        Construct initialization object from component matrices
+
+        Parameters
+        ----------
+        a : array_like, optional
+            Vector of constant values describing the mean of the stationary
+            component of the initial state.
+        Pstar : array_like, optional
+            Stationary component of the initial state covariance matrix. If
+            given, should be a matrix shaped `k_states x k_states`. The
+            submatrix associated with the diffuse states should contain zeros.
+            Note that by definition, `Pstar = R0 @ Q0 @ R0.T`, so either
+            `R0,Q0` or `Pstar` may be given, but not both.
+        Pinf : array_like, optional
+            Diffuse component of the initial state covariance matrix. If given,
+            should be a matrix shaped `k_states x k_states` with ones in the
+            diagonal positions corresponding to states with diffuse
+            initialization and zeros otherwise. Note that by definition,
+            `Pinf = A @ A.T`, so either `A` or `Pinf` may be given, but not
+            both.
+        A : array_like, optional
+            Diffuse selection matrix, used in the definition of the diffuse
+            initial state covariance matrix. If given, should be a
+            `k_states x k_diffuse_states` matrix that contains the subset of
+            the columns of the identity matrix that correspond to states with
+            diffuse initialization. Note that by definition, `Pinf = A @ A.T`,
+            so either `A` or `Pinf` may be given, but not both.
+        R0 : array_like, optional
+            Stationary selection matrix, used in the definition of the
+            stationary initial state covariance matrix. If given, should be a
+            `k_states x k_nondiffuse_states` matrix that contains the subset of
+            the columns of the identity matrix that correspond to states with a
+            non-diffuse initialization. Note that by definition,
+            `Pstar = R0 @ Q0 @ R0.T`, so either `R0,Q0` or `Pstar` may be
+            given, but not both.
+        Q0 : array_like, optional
+            Covariance matrix associated with stationary initial states. If
+            given, should be a matrix shaped
+            `k_nondiffuse_states x k_nondiffuse_states`.
+            Note that by definition, `Pstar = R0 @ Q0 @ R0.T`, so either
+            `R0,Q0` or `Pstar` may be given, but not both.
+
+        Returns
+        -------
+        initialization
+            Initialization object.
+
+        Notes
+        -----
+        The matrices `a, Pstar, Pinf, A, R0, Q0` and the process for
+        initializing the state space model is as given in Chapter 5 of [1]_.
+        For the definitions of these matrices, see equation (5.2) and the
+        subsequent discussion there.
+
+        References
+        ----------
+        .. [*] Durbin, James, and Siem Jan Koopman. 2012.
+           Time Series Analysis by State Space Methods: Second Edition.
+           Oxford University Press.
+        """
+        k_states = k_states
+
+        # Standardize the input
+        a = tools._atleast_1d(a)
+        Pstar, Pinf, A, R0, Q0 = tools._atleast_2d(Pstar, Pinf, A, R0, Q0)
+
+        # Validate the diffuse component
+        if Pstar is not None and (R0 is not None or Q0 is not None):
+            raise ValueError('Cannot specify the initial state covariance both'
+                            ' as `Pstar` and as the components R0 and Q0'
+                            '  (because `Pstar` is defined such that'
+                            " `Pstar=R0 Q0 R0'`).")
+        if Pinf is not None and A is not None:
+            raise ValueError('Cannot specify both the diffuse covariance'
+                            ' matrix `Pinf` and the selection matrix for'
+                            ' diffuse elements, A, (because Pinf is defined'
+                            " such that `Pinf=A A'`).")
+        elif A is not None:
+            Pinf = np.dot(A, A.T)
+
+        # Validate the non-diffuse component
+        if a is None:
+            a = np.zeros(k_states)
+        if len(a) != k_states:
+            raise ValueError('Must provide constant initialization vector for'
+                            ' the entire state vector.')
+        if R0 is not None or Q0 is not None:
+            if R0 is None or Q0 is None:
+                raise ValueError('If specifying either of R0 or Q0 then you'
+                                ' must specify both R0 and Q0.')
+            Pstar = R0.dot(Q0).dot(R0.T)
+
+        # Handle the diffuse component
+        diffuse_ix = []
+        if Pinf is not None:
+            diffuse_ix = np.where(np.diagonal(Pinf))[0].tolist()
+
+            if Pstar is not None:
+                for i in diffuse_ix:
+                    if not (np.all(Pstar[i] == 0) and
+                            np.all(Pstar[:, i] == 0)):
+                        raise ValueError(f'The state at position {i} was'
+                                        ' specified as diffuse in Pinf, but'
+                                        ' also contains a non-diffuse diagonal'
+                                        ' or off-diagonal in Pstar.')
+        k_diffuse_states = len(diffuse_ix)
+
+        nondiffuse_ix = [i for i in np.arange(k_states) if i not in diffuse_ix]
+        k_nondiffuse_states = k_states - k_diffuse_states
+
+        # If there are non-diffuse states, require Pstar
+        if Pstar is None and k_nondiffuse_states > 0:
+            raise ValueError('Must provide initial covariance matrix for'
+                            ' non-diffuse states.')
+
+        # Construct the initialization
+        init = cls(k_states)
+        if nondiffuse_ix:
+            nondiffuse_groups = np.split(
+                nondiffuse_ix, np.where(np.diff(nondiffuse_ix) != 1)[0] + 1)
+        else:
+            nondiffuse_groups = []
+        for group in nondiffuse_groups:
+            s = slice(group[0], group[-1] + 1)
+            init.set(s, 'known', constant=a[s], stationary_cov=Pstar[s, s])
+        for i in diffuse_ix:
+            init.set(i, 'diffuse')
+
+        return init
+
+    @classmethod
+    def from_results(cls, filter_results):
+        a = filter_results.initial_state
+        Pstar = filter_results.initial_state_cov
+        Pinf = filter_results.initial_diffuse_state_cov
+
+        return cls.from_components(filter_results.model.k_states,
+                                   a=a, Pstar=Pstar, Pinf=Pinf)
+
     def __setitem__(self, index, initialization_type):
         self.set(index, initialization_type)
 

--- a/statsmodels/tsa/statespace/initialization.py
+++ b/statsmodels/tsa/statespace/initialization.py
@@ -316,8 +316,8 @@ class Initialization(object):
                             np.all(Pstar[:, i] == 0)):
                         raise ValueError(f'The state at position {i} was'
                                          ' specified as diffuse in Pinf, but'
-                                         ' also contains a non-diffuse diagonal'
-                                         ' or off-diagonal in Pstar.')
+                                         ' also contains a non-diffuse'
+                                         ' diagonal or off-diagonal in Pstar.')
         k_diffuse_states = len(diffuse_ix)
 
         nondiffuse_ix = [i for i in np.arange(k_states) if i not in diffuse_ix]

--- a/statsmodels/tsa/statespace/initialization.py
+++ b/statsmodels/tsa/statespace/initialization.py
@@ -282,14 +282,14 @@ class Initialization(object):
         # Validate the diffuse component
         if Pstar is not None and (R0 is not None or Q0 is not None):
             raise ValueError('Cannot specify the initial state covariance both'
-                            ' as `Pstar` and as the components R0 and Q0'
-                            '  (because `Pstar` is defined such that'
-                            " `Pstar=R0 Q0 R0'`).")
+                             ' as `Pstar` and as the components R0 and Q0'
+                             '  (because `Pstar` is defined such that'
+                             " `Pstar=R0 Q0 R0'`).")
         if Pinf is not None and A is not None:
             raise ValueError('Cannot specify both the diffuse covariance'
-                            ' matrix `Pinf` and the selection matrix for'
-                            ' diffuse elements, A, (because Pinf is defined'
-                            " such that `Pinf=A A'`).")
+                             ' matrix `Pinf` and the selection matrix for'
+                             ' diffuse elements, A, (because Pinf is defined'
+                             " such that `Pinf=A A'`).")
         elif A is not None:
             Pinf = np.dot(A, A.T)
 
@@ -298,11 +298,11 @@ class Initialization(object):
             a = np.zeros(k_states)
         if len(a) != k_states:
             raise ValueError('Must provide constant initialization vector for'
-                            ' the entire state vector.')
+                             ' the entire state vector.')
         if R0 is not None or Q0 is not None:
             if R0 is None or Q0 is None:
                 raise ValueError('If specifying either of R0 or Q0 then you'
-                                ' must specify both R0 and Q0.')
+                                 ' must specify both R0 and Q0.')
             Pstar = R0.dot(Q0).dot(R0.T)
 
         # Handle the diffuse component
@@ -315,9 +315,9 @@ class Initialization(object):
                     if not (np.all(Pstar[i] == 0) and
                             np.all(Pstar[:, i] == 0)):
                         raise ValueError(f'The state at position {i} was'
-                                        ' specified as diffuse in Pinf, but'
-                                        ' also contains a non-diffuse diagonal'
-                                        ' or off-diagonal in Pstar.')
+                                         ' specified as diffuse in Pinf, but'
+                                         ' also contains a non-diffuse diagonal'
+                                         ' or off-diagonal in Pstar.')
         k_diffuse_states = len(diffuse_ix)
 
         nondiffuse_ix = [i for i in np.arange(k_states) if i not in diffuse_ix]
@@ -326,7 +326,7 @@ class Initialization(object):
         # If there are non-diffuse states, require Pstar
         if Pstar is None and k_nondiffuse_states > 0:
             raise ValueError('Must provide initial covariance matrix for'
-                            ' non-diffuse states.')
+                             ' non-diffuse states.')
 
         # Construct the initialization
         init = cls(k_states)

--- a/statsmodels/tsa/statespace/kalman_smoother.py
+++ b/statsmodels/tsa/statespace/kalman_smoother.py
@@ -13,7 +13,7 @@ from statsmodels.tsa.statespace.kalman_filter import (KalmanFilter,
                                                       FilterResults)
 from statsmodels.tsa.statespace.tools import (
     reorder_missing_matrix, reorder_missing_vector, copy_index_matrix)
-from statsmodels.tsa.statespace import tools
+from statsmodels.tsa.statespace import tools, initialization
 
 SMOOTHER_STATE = 0x01              # Durbin and Koopman (2012), Chapter 4.4.2
 SMOOTHER_STATE_COV = 0x02          # ibid., Chapter 4.4.3
@@ -1048,7 +1048,7 @@ class SmootherResults(FilterResults):
         return acov
 
     def news(self, previous, t=None, start=None, end=None,
-             revised=None, design=None):
+             revised=None, design=None, state_index=None):
         r"""
         Compute the news and impacts associated with a data release
 
@@ -1076,6 +1076,12 @@ class SmootherResults(FilterResults):
             model has a time-varying design matrix, and the argument `t` is out
             of this model's sample, then a new design matrix for period `t`
             must be provided. Unused otherwise.
+        state_index : array_like, optional
+            An optional index specifying a subset of states to use when
+            constructing the impacts of revisions and news. For example, if
+            `state_index=[0, 1]` is passed, then only the impacts to the
+            observed variables arising from the impacts to the first two
+            states will be returned.
 
         Returns
         -------
@@ -1097,14 +1103,18 @@ class SmootherResults(FilterResults):
               were newly incorporated in a data release (but not including
               revisions to data points that already existed in the previous
               release). In [1]_, this is described as "news" in equation (17).
+            - `revisions`
             - `gain`: the gain matrix associated with the "Kalman-like" update
               from the news, E[y I'] E[I I']^{-1}. In [1]_, this can be found
               in the equation For E[y_{k,t_k} \mid I_{v+1}] in the middle of
               page 17.
+            - `revision_weights`
             - `update_forecasts`: forecasts of the updated periods used to
               construct the news, E[y^u | previous].
             - `update_realized`: realizations of the updated periods used to
               construct the news, y^u.
+            - `revised_prev`
+            - `revised`
             - `prev_impacted_forecasts`: previous forecast of the periods of
               interest, E[y^i | previous].
             - `post_impacted_forecasts`: forecast of the periods of interest
@@ -1119,7 +1129,8 @@ class SmootherResults(FilterResults):
         -----
         This method computes the effect of new data (e.g. from a new data
         release) on smoothed forecasts produced by a state space model, as
-        described in [1]_.
+        described in [1]_. It also computes the effect of revised data on
+        smoothed forecasts.
 
         References
         ----------
@@ -1183,7 +1194,12 @@ class SmootherResults(FilterResults):
                 raise ValueError(error_ss % f'time-invariant {key} while'
                                  ' `previous` does not')
 
-        # We cannot forecast out-of-sample periods in a time-varying models
+        # Standardize
+        if state_index is not None:
+            state_index = np.atleast_1d(
+                np.sort(np.array(state_index, dtype=int)))
+
+        # We cannot forecast out-of-sample periods in a time-varying model
         if end > self.nobs and not self.model.time_invariant:
             raise RuntimeError('Cannot compute the impacts of news on periods'
                                ' outside of the sample in time-varying'
@@ -1203,68 +1219,119 @@ class SmootherResults(FilterResults):
         revisions_ix, updates_ix = previous.model.diff_endog(self.endog.T)
 
         # Compute prev / post impact forecasts
-        prev_impacted_forecasts = (
-            previous.smoothed_forecasts[..., start:end])
-        if end > previous.nobs:
-            predict_start = max(start, previous.nobs)
-            p = previous.predict(
-                start=predict_start, end=end, **extend_kwargs)
-            prev_impacted_forecasts = np.concatenate(
-                (prev_impacted_forecasts, p.forecasts), axis=1)
-        post_impacted_forecasts = (
-            self.smoothed_forecasts[..., start:end])
-        if end > self.nobs:
-            predict_start = max(start, self.nobs)
-            p = self.predict(start=predict_start, end=end, **extend_kwargs)
-            post_impacted_forecasts = np.concatenate(
-                (post_impacted_forecasts, p.forecasts), axis=1)
+        prev_impacted_forecasts = previous.predict(
+            start=start, end=end, **extend_kwargs).smoothed_forecasts
+        post_impacted_forecasts = self.predict(
+            start=start, end=end).smoothed_forecasts
 
-        # If we have revisions to previous data, then we need to construct a
-        # new results set that only includes those revisions
-        if len(revisions_ix) > 0 and revised is None:
+        # Get revision weights, impacts, and forecasts
+        if len(revisions_ix) > 0:
+            revised_endog = self.endog[:, :previous.nobs].copy()
+            revised_endog[previous.missing.astype(bool)] = np.nan
+
+            # Compute the revisions
+            revised_j, revised_p = zip(*revisions_ix)
+            compute_j = np.arange(revised_j[0], revised_j[-1] + 1)
+            revised_prev = previous.endog.T[compute_j]
+            revised = revised_endog.T[compute_j]
+            revisions = (revised - revised_prev)
+
+            # Compute the weights of the smoothed state vector
+            compute_t = np.arange(start, end)
+            ix = np.ix_(compute_t, compute_j)
+
+            # Construct a model from which we can create weights for impacts
+            # through `end`
+            # Construct endog for the new model
+            tmp_endog = revised_endog.T.copy()
+            tmp_nobs = max(end, previous.nobs)
+            oos_nobs = tmp_nobs - previous.nobs
+            if oos_nobs > 0:
+                tmp_endog = np.concatenate([
+                    tmp_endog, np.zeros((oos_nobs, self.k_endog)) * np.nan
+                ], axis=0)
+
             # Copy time-varying matrices (required by clone)
             clone_kwargs = {}
             for key in self.model.shapes.keys():
                 if key == 'obs':
                     continue
-                prev_mat = getattr(previous, key)
-                if prev_mat.shape[-1] > 1:
-                    clone_kwargs[key] = prev_mat
+                mat = getattr(self, key)
+                if mat.shape[-1] > 1:
+                    clone_kwargs[key] = mat[..., :tmp_nobs]
 
-            rev_endog = self.endog.T[:previous.nobs].copy()
-            rev_endog[previous.missing.astype(bool).T] = np.nan
-            rev_mod = previous.model.clone(rev_endog, **clone_kwargs)
-            # TODO: performance: can get a performance improvement for large
-            #       models with `update_filter=False, update_smoother=False`,
-            #       but then will need to manually populate the fields that we
-            #       need for what we do below (i.e. we call
-            #       `smoothed_forecasts` and `predict`)
-            # TODO: performance: we don't need to smooth back through the
-            #       entire sample for what we're doing, since we only need
-            #       smoothed_forecasts for the impact period
-            revised = rev_mod.smooth()
+            rev_mod = previous.model.clone(tmp_endog, **clone_kwargs)
+            init = initialization.Initialization.from_results(self)
+            rev_mod.initialize(init)
+            revision_results = rev_mod.smooth()
 
-        # Compute impacts from the revisions, if any
-        if len(revisions_ix) > 0:
-            # Compute the effect of revisions on forecasts of the impacted
-            # variables
-            revised_impact_forecasts = (
-                revised.smoothed_forecasts[..., start:end])
+            smoothed_state_weights, _ = tools._compute_smoothed_state_weights(
+                rev_mod, compute_t=compute_t, compute_j=compute_j,
+                compute_prior_weights=False, scale=previous.scale)
+            smoothed_state_weights = smoothed_state_weights[ix]
 
-            if end > revised.nobs:
-                predict_start = max(start, revised.nobs)
-                p = revised.predict(
-                    start=predict_start, end=end, **extend_kwargs)
-                revised_impact_forecasts = np.concatenate(
-                    (revised_impact_forecasts, p.forecasts), axis=1)
+            # Convert the weights in terms of smoothed forecasts
+            # t, j, m, p, i
+            ZT = rev_mod.design.T
+            if ZT.shape[0] > 1:
+                ZT = ZT[compute_t]
 
-            revision_impacts = (revised_impact_forecasts -
-                                prev_impacted_forecasts).T
+            # Subset the states used for the impacts if applicable
+            if state_index is not None:
+                ZT = ZT[:, state_index, :]
+                smoothed_state_weights = (
+                    smoothed_state_weights[:, :, state_index])
+
+            # Multiplication gives: t, j, m, p * t, j, m, p, k
+            # Sum along axis=2 gives: t, j, p, k
+            # Transpose to: t, j, k, p (i.e. like t, j, m, p but with k instead
+            # of m)
+            revision_weights = np.nansum(
+                smoothed_state_weights[..., None]
+                * ZT[:, None, :, None, :], axis=2).transpose(0, 1, 3, 2)
+
+            # Multiplication gives: t, j, k, p * t, j, k, p
+            # Sum along axes 1, 3 gives: t, k
+            # This is also a valid way to compute impacts, but it employes
+            # unnecessary multiplications with zeros; it is better to use the
+            # below method that flattens the revision indices before computing
+            # the impacts
+            # revision_impacts = np.nansum(
+            #     revision_weights * revisions[None, :, None, :], axis=(1, 3))
+
+            # Flatten the weights and revisions along the revised j, k
+            # dimensions so that we only retain the actual revision elements
+            ix_j = revised_j - revised_j[0]
+            # Shape is: t, k, j * p
+            # Note: have to transpose first so that the two advanced indexes
+            # are next to each other, so that "the dimensions from the
+            # advanced indexing operations are inserted into the result
+            # array at the same spot as they were in the initial array"
+            # (see https://numpy.org/doc/stable/user/basics.indexing.html,
+            # "Combining advanced and basic indexing")
+            revision_weights = (
+                revision_weights.transpose(0, 2, 1, 3)[:, :, ix_j, revised_p])
+            # Shape is j * k
+            revisions = revisions[ix_j, revised_p]
+            # Shape is t, k
+            revision_impacts = revision_weights @ revisions
+
+            # Similarly, flatten the revised and revised_prev series
+            revised = revised[ix_j, revised_p]
+            revised_prev = revised_prev[ix_j, revised_p]
+
+            # Squeeze if `t` argument used
             if t is not None:
+                revision_weights = revision_weights[0]
                 revision_impacts = revision_impacts[0]
         else:
-            revised = previous
+            revised_endog = None
+            revised = None
+            revised_prev = None
+            revisions = None
+            revision_weights = None
             revision_impacts = None
+            revision_results = None
 
         # Now handle updates
         if len(updates_ix) > 0:
@@ -1272,30 +1339,15 @@ class SmootherResults(FilterResults):
             update_t, update_k = zip(*updates_ix)
             update_start_t = np.min(update_t)
             update_end_t = np.max(update_t)
-            update_end_insample_t = np.minimum(revised.nobs - 1, update_end_t)
-            update_nforecast = update_end_t - update_end_insample_t
 
-            # For the in-sample periods, get out the smoothed forecasts for
-            # the updated variables for each relevant time period
-            i1 = update_start_t
-            i2 = update_end_insample_t + 1
-            if i2 > i1:
-                forecasts_insample = revised.smoothed_forecasts[:, i1:i2]
+            if revision_results is None:
+                forecasts = previous.predict(
+                    start=update_start_t, end=update_end_t + 1,
+                    **extend_kwargs).smoothed_forecasts.T
             else:
-                forecasts_insample = np.zeros((self.k_endog, 0))
-
-            # For the out-of-sample periods, predicted and smoothed forecasts
-            # for the updated variables are the same
-            if update_nforecast > 0:
-                forecast_start = previous.nobs
-                forecast_end = forecast_start + update_nforecast
-                p = revised.predict(
-                    start=forecast_start, end=forecast_end, **extend_kwargs)
-                forecasts_oos = p.forecasts
-            else:
-                forecasts_oos = np.zeros((self.k_endog, 0))
-            forecasts = np.c_[forecasts_insample, forecasts_oos].T
-
+                forecasts = revision_results.predict(
+                    start=update_start_t,
+                    end=update_end_t + 1).smoothed_forecasts.T
             realized = self.endog.T[update_start_t:update_end_t + 1]
             forecasts_error = realized - forecasts
 
@@ -1312,6 +1364,8 @@ class SmootherResults(FilterResults):
             elif end <= self.nobs:
                 design = self.design[..., start:end].transpose(2, 0, 1)
             else:
+                # Note: this case is no longer possible, since above we raise
+                # ValueError for time-varying case with end > self.nobs
                 if design is None:
                     raise ValueError('Model has time-varying design matrix, so'
                                      ' an updated time-varying matrix for'
@@ -1320,8 +1374,16 @@ class SmootherResults(FilterResults):
                     design = design[None, ...]
                 else:
                     design = design.transpose(2, 0, 1)
-            state_gain = revised.smoothed_state_gain(
+
+            state_gain = previous.smoothed_state_gain(
                 updates_ix, start=start, end=end, extend_kwargs=extend_kwargs)
+
+            # Subset the states used for the impacts if applicable
+            if state_index is not None:
+                design = design[:, :, state_index]
+                state_gain = state_gain[:, state_index]
+
+            # Compute the gain in terms of observed variables
             obs_gain = design @ state_gain
 
             # Get the news
@@ -1348,26 +1410,36 @@ class SmootherResults(FilterResults):
             revision_impacts=revision_impacts,
             # news = A = y^u - E[y^u | previous]
             news=update_forecasts_error,
+            # revivions y^r(updated) - y^r(previous)
+            revisions=revisions,
             # gain matrix = E[y A'] E[A A']^{-1}
             gain=obs_gain,
+            # gain matrix = E[y A'] E[A A']^{-1}
+            revision_weights=revision_weights,
             # forecasts of the updated periods used to construct the news
-            # = E[y^u | previous]
+            # = E[y^u | revised]
             update_forecasts=update_forecasts,
             # realizations of the updated periods used to construct the news
             # = y^u
             update_realized=update_realized,
+            # revised observations of the periods that were revised
+            # = y^r_{revised}
+            revised=revised,
+            # previous observations of the periods that were revised
+            # = y^r_{previous}
+            revised_prev=revised_prev,
             # previous forecast of the periods of interest, E[y^i | previous]
             prev_impacted_forecasts=prev_impacted_forecasts,
             # post. forecast of the periods of interest, E[y^i | post]
             post_impacted_forecasts=post_impacted_forecasts,
             # results object associated with the revision
-            revision_results=None,
+            revision_results=revision_results,
             # list of (x, y) positions of revisions to endog
             revisions_ix=revisions_ix,
             # list of (x, y) positions of updates to endog
-            updates_ix=updates_ix)
-        if len(revisions_ix) > 0:
-            out.revision_results = revised
+            updates_ix=updates_ix,
+            # index of state variables used to compute impacts
+            state_index=state_index)
 
         return out
 

--- a/statsmodels/tsa/statespace/mlemodel.py
+++ b/statsmodels/tsa/statespace/mlemodel.py
@@ -35,7 +35,7 @@ from .simulation_smoother import SimulationSmoother
 from .kalman_smoother import SmootherResults
 from .kalman_filter import INVERT_UNIVARIATE, SOLVE_LU, MEMORY_CONSERVE
 from .initialization import Initialization
-from .tools import prepare_exog, concat, _safe_cond
+from .tools import prepare_exog, concat, _safe_cond, get_impact_dates
 
 
 def _handle_args(names, defaults, *args, **kwargs):
@@ -3731,98 +3731,8 @@ class MLEResults(tsbase.TimeSeriesModelResults):
 
         return res
 
-    def _news_previous_results(self, previous, start, end, periods):
-        # Compute the news
-        out = self.smoother_results.news(previous.smoother_results,
-                                         start=start, end=end)
-        return out
-
-    def _news_updated_results(self, updated, start, end, periods):
-        return updated._news_previous_results(self, start, end, periods)
-
-    def _news_previous_data(self, endog, start, end, periods, exog):
-        previous = self.apply(endog, exog=exog, copy_initialization=True)
-        return self._news_previous_results(previous, start, end, periods)
-
-    def _news_updated_data(self, endog, start, end, periods, exog):
-        updated = self.apply(endog, exog=exog, copy_initialization=True)
-        return self._news_updated_results(updated, start, end, periods)
-
-    def news(self, comparison, impact_date=None, impacted_variable=None,
-             start=None, end=None, periods=None, exog=None,
-             comparison_type=None, return_raw=False, tolerance=1e-10,
-             **kwargs):
-        """
-        Compute impacts from updated data (news and revisions)
-
-        Parameters
-        ----------
-        comparison : array_like or MLEResults
-            An updated dataset with updated and/or revised data from which the
-            news can be computed, or an updated or previous results object
-            to use in computing the news.
-        impact_date : int, str, or datetime, optional
-            A single specific period of impacts from news and revisions to
-            compute. Can also be a date string to parse or a datetime type.
-            This argument cannot be used in combination with `start`, `end`, or
-            `periods`. Default is the first out-of-sample observation.
-        impacted_variable : str, list, array, or slice, optional
-            Observation variable label or slice of labels specifying that only
-            specific impacted variables should be shown in the News output. The
-            impacted variable(s) describe the variables that were *affected* by
-            the news. If you do not know the labels for the variables, check
-            the `endog_names` attribute of the model instance.
-        start : int, str, or datetime, optional
-            The first period of impacts from news and revisions to compute.
-            Can also be a date string to parse or a datetime type. Default is
-            the first out-of-sample observation.
-        end : int, str, or datetime, optional
-            The last period of impacts from news and revisions to compute.
-            Can also be a date string to parse or a datetime type. Default is
-            the first out-of-sample observation.
-        periods : int, optional
-            The number of periods of impacts from news and revisions to
-            compute.
-        exog : array_like, optional
-            Array of exogenous regressors for the out-of-sample period, if
-            applicable.
-        comparison_type : {None, 'previous', 'updated'}
-            This denotes whether the `comparison` argument represents a
-            *previous* results object or dataset or an *updated* results object
-            or dataset. If not specified, then an attempt is made to determine
-            the comparison type.
-        return_raw : bool, optional
-            Whether or not to return only the specific output or a full
-            results object. Default is to return a full results object.
-        tolerance : float, optional
-            The numerical threshold for determining zero impact. Default is
-            that any impact less than 1e-10 is assumed to be zero.
-
-        Returns
-        -------
-        NewsResults
-            Impacts of data revisions and news on estimates
-
-        References
-        ----------
-        .. [1] Bańbura, Marta, and Michele Modugno.
-               "Maximum likelihood estimation of factor models on datasets with
-               arbitrary pattern of missing data."
-               Journal of Applied Econometrics 29, no. 1 (2014): 133-160.
-        .. [2] Bańbura, Marta, Domenico Giannone, and Lucrezia Reichlin.
-               "Nowcasting."
-               The Oxford Handbook of Economic Forecasting. July 8, 2011.
-        .. [3] Bańbura, Marta, Domenico Giannone, Michele Modugno, and Lucrezia
-               Reichlin.
-               "Now-casting and the real-time data flow."
-               In Handbook of economic forecasting, vol. 2, pp. 195-237.
-               Elsevier, 2013.
-        """
-        # Validate input
-        if self.smoother_results is None:
-            raise ValueError('Cannot compute news without Kalman smoother'
-                             ' results.')
-
+    def _get_previous_updated(self, comparison, exog=None,
+                              comparison_type=None, **kwargs):
         # If we were given data, create a new results object
         comparison_dataset = not isinstance(
             comparison, (MLEResults, MLEResultsWrapper))
@@ -3888,40 +3798,133 @@ class MLEResults(tsbase.TimeSeriesModelResults):
                              ' news by comparing this results set to previous'
                              ' results objects.')
 
-        # Handle start, end, periods
-        # There doesn't seem to be any universal defaults that both (a) make
-        # sense for all data update combinations, and (b) work with both
-        # time-invariant and time-varying models. So we require that the user
-        # specify exactly two of start, end, periods.
-        if impact_date is not None:
-            if not (start is None and end is None and periods is None):
-                raise ValueError('Cannot use the `impact_date` argument in'
-                                 ' combination with `start`, `end`, or'
-                                 ' `periods`.')
-            start = impact_date
-            periods = 1
-        if start is None and end is None and periods is None:
-            start = previous.nobs - 1
-            end = previous.nobs - 1
-        if int(start is None) + int(end is None) + int(periods is None) != 1:
-            raise ValueError('Of the three parameters: start, end, and'
-                             ' periods, exactly two must be specified')
-        # If we have the `periods` object, we need to convert `start`/`end` to
-        # integers so that we can compute the other one. That's because
-        # _get_prediction_index doesn't support a `periods` argument
-        elif start is not None and periods is not None:
-            start, _, _, _ = self.model._get_prediction_index(start, start)
-            end = start + (periods - 1)
-        elif end is not None and periods is not None:
-            _, end, _, _ = self.model._get_prediction_index(end, end)
-            start = end - (periods - 1)
-        elif start is not None and end is not None:
-            pass
+        return previous, updated, comparison_dataset
 
-        # Get the integer-based start, end and the prediction index
-        start, end, out_of_sample, prediction_index = (
-            updated.model._get_prediction_index(start, end))
-        end = end + out_of_sample
+    def _news_previous_results(self, previous, start, end, periods,
+                               state_index=None):
+        # Compute the news
+        out = self.smoother_results.news(previous.smoother_results,
+                                         start=start, end=end,
+                                         state_index=state_index)
+        return out
+
+    def _news_updated_results(self, updated, start, end, periods,
+                              state_index=None):
+        return updated._news_previous_results(self, start, end, periods,
+                                              state_index=state_index)
+
+    def _news_previous_data(self, endog, start, end, periods, exog,
+                            state_index=None):
+        previous = self.apply(endog, exog=exog, copy_initialization=True)
+        return self._news_previous_results(previous, start, end, periods,
+                                           state_index=state_index)
+
+    def _news_updated_data(self, endog, start, end, periods, exog,
+                           state_index=None):
+        updated = self.apply(endog, exog=exog, copy_initialization=True)
+        return self._news_updated_results(updated, start, end, periods,
+                                          state_index=state_index)
+
+    def news(self, comparison, impact_date=None, impacted_variable=None,
+             start=None, end=None, periods=None, exog=None,
+             comparison_type=None, state_index=None, return_raw=False,
+             tolerance=1e-10, **kwargs):
+        """
+        Compute impacts from updated data (news and revisions)
+
+        Parameters
+        ----------
+        comparison : array_like or MLEResults
+            An updated dataset with updated and/or revised data from which the
+            news can be computed, or an updated or previous results object
+            to use in computing the news.
+        impact_date : int, str, or datetime, optional
+            A single specific period of impacts from news and revisions to
+            compute. Can also be a date string to parse or a datetime type.
+            This argument cannot be used in combination with `start`, `end`, or
+            `periods`. Default is the first out-of-sample observation.
+        impacted_variable : str, list, array, or slice, optional
+            Observation variable label or slice of labels specifying that only
+            specific impacted variables should be shown in the News output. The
+            impacted variable(s) describe the variables that were *affected* by
+            the news. If you do not know the labels for the variables, check
+            the `endog_names` attribute of the model instance.
+        start : int, str, or datetime, optional
+            The first period of impacts from news and revisions to compute.
+            Can also be a date string to parse or a datetime type. Default is
+            the first out-of-sample observation.
+        end : int, str, or datetime, optional
+            The last period of impacts from news and revisions to compute.
+            Can also be a date string to parse or a datetime type. Default is
+            the first out-of-sample observation.
+        periods : int, optional
+            The number of periods of impacts from news and revisions to
+            compute.
+        exog : array_like, optional
+            Array of exogenous regressors for the out-of-sample period, if
+            applicable.
+        comparison_type : {None, 'previous', 'updated'}
+            This denotes whether the `comparison` argument represents a
+            *previous* results object or dataset or an *updated* results object
+            or dataset. If not specified, then an attempt is made to determine
+            the comparison type.
+        state_index : array_like, optional
+            An optional index specifying a subset of states to use when
+            constructing the impacts of revisions and news. For example, if
+            `state_index=[0, 1]` is passed, then only the impacts to the
+            observed variables arising from the impacts to the first two
+            states will be returned. Default is to use all states.
+        return_raw : bool, optional
+            Whether or not to return only the specific output or a full
+            results object. Default is to return a full results object.
+        tolerance : float, optional
+            The numerical threshold for determining zero impact. Default is
+            that any impact less than 1e-10 is assumed to be zero.
+
+        Returns
+        -------
+        NewsResults
+            Impacts of data revisions and news on estimates
+
+        References
+        ----------
+        .. [1] Bańbura, Marta, and Michele Modugno.
+               "Maximum likelihood estimation of factor models on datasets with
+               arbitrary pattern of missing data."
+               Journal of Applied Econometrics 29, no. 1 (2014): 133-160.
+        .. [2] Bańbura, Marta, Domenico Giannone, and Lucrezia Reichlin.
+               "Nowcasting."
+               The Oxford Handbook of Economic Forecasting. July 8, 2011.
+        .. [3] Bańbura, Marta, Domenico Giannone, Michele Modugno, and Lucrezia
+               Reichlin.
+               "Now-casting and the real-time data flow."
+               In Handbook of economic forecasting, vol. 2, pp. 195-237.
+               Elsevier, 2013.
+        """
+        # Validate input
+        if self.smoother_results is None:
+            raise ValueError('Cannot compute news without Kalman smoother'
+                             ' results.')
+
+        if state_index is not None:
+            state_index = np.sort(np.array(state_index, dtype=int))
+            if state_index[0] < 0:
+                raise ValueError('Cannot include negative indexes in'
+                                 ' `state_index`.')
+            if state_index[-1] >= self.model.k_states:
+                raise ValueError(f'Given state index {state_index[-1]} is too'
+                                 ' large for the number of states in the model'
+                                 f' ({self.model.k_states}).')
+
+        # Get the previous and updated results objects from `self` and
+        # `comparison`:
+        previous, updated, comparison_dataset = self._get_previous_updated(
+            comparison, exog=exog, comparison_type=comparison_type, **kwargs)
+
+        # Handle start, end, periods
+        start, end, prediction_index = get_impact_dates(
+            previous_model=previous.model, updated_model=updated.model,
+            impact_date=impact_date, start=start, end=end, periods=periods)
 
         # News results will always use Pandas, so if the model's data was not
         # from Pandas, we'll create an index, as if the model's data had been
@@ -3975,7 +3978,8 @@ class MLEResults(tsbase.TimeSeriesModelResults):
 
         # Compute the news
         news_results = (
-            updated._news_previous_results(previous, start, end + 1, periods))
+            updated._news_previous_results(previous, start, end + 1, periods,
+                                           state_index=state_index))
 
         if not return_raw:
             news_results = NewsResults(
@@ -4114,10 +4118,7 @@ class MLEResults(tsbase.TimeSeriesModelResults):
                                         columns=self.model.exog_names)
 
         if copy_initialization:
-            res = self.filter_results
-            init = Initialization(
-                self.model.k_states, 'known', constant=res.initial_state,
-                stationary_cov=res.initial_state_cov)
+            init = Initialization.from_results(self.filter_results)
             kwargs.setdefault('initialization', init)
 
         mod = self.model.clone(new_endog, exog=new_exog, **kwargs)
@@ -4307,10 +4308,7 @@ class MLEResults(tsbase.TimeSeriesModelResults):
         mod = self.model.clone(endog, exog=exog, **kwargs)
 
         if copy_initialization:
-            res = self.filter_results
-            init = Initialization(
-                self.model.k_states, 'known', constant=res.initial_state,
-                stationary_cov=res.initial_state_cov)
+            init = Initialization.from_results(self.filter_results)
             mod.ssm.initialization = init
 
         res = self._apply(mod, refit=refit, fit_kwargs=fit_kwargs, **kwargs)

--- a/statsmodels/tsa/statespace/news.py
+++ b/statsmodels/tsa/statespace/news.py
@@ -60,12 +60,23 @@ class NewsResults(object):
         E[y^u | post] - E[y^u | revisions] where y^u are the updated variables.
     weights : pd.Series
         Weights describing the effect of news on variables of interest.
+    revisions : pd.Series
+        The revisions betwen the current and previously observed data
+        y^r_{revised} - y^r_{previous} where y^r are the revised variables.
+    revision_weights : pd.Series
+        Weights describing the effect of revisions on variables of interest.
     update_forecasts : pd.Series
         Forecasts based on the previous dataset of the variables that were
         updated, E[y^u | previous].
     update_realized : pd.Series
         Actual observed data associated with the variables that were
         updated, y^u
+    revised_prev : pd.Series
+        Previously observed data associated with the variables that were
+        revised, y^r_{previous}
+    revised : pd.Series
+        Currently observed data associated with the variables that were
+        revised, y^r_{revised}
     prev_impacted_forecasts : pd.Series
         Previous forecast of the variables of interest, E[y^i | previous].
     post_impacted_forecasts : pd.Series
@@ -79,6 +90,8 @@ class NewsResults(object):
         The integer locations of the updated data points.
     updates_ix : pd.DataFrame
         The label-based locations of updated data points.
+    state_index : array_like
+        Index of state variables used to compute impacts.
 
     References
     ----------
@@ -156,39 +169,78 @@ class NewsResults(object):
         else:
             self.updates_ix = iloc.copy()
 
-        # Wrap forecasts and forecasts errors
-        ix = pd.MultiIndex.from_arrays([self.updates_ix['update date'],
-                                        self.updates_ix['updated variable']])
+        # Index of the state variables used
+        self.state_index = news_results.state_index
 
-        # E[y^u | post] - E[y^u | previous]
+        # Wrap forecasts and forecasts errors
+        r_ix = pd.MultiIndex.from_arrays([
+            self.revisions_ix['revision date'],
+            self.revisions_ix['revised variable']])
+        u_ix = pd.MultiIndex.from_arrays([
+            self.updates_ix['update date'],
+            self.updates_ix['updated variable']])
+
+        # E[y^u | post] - E[y^u | revisions]
         if news_results.news is None:
-            self.news = pd.Series([], index=ix, name='news',
+            self.news = pd.Series([], index=u_ix, name='news',
                                   dtype=model.params.dtype)
         else:
-            self.news = pd.Series(news_results.news, index=ix, name='news')
-        # E[y^u | previous]
+            self.news = pd.Series(news_results.news, index=u_ix, name='news')
+        # E[y^u | revisions] - E[y^u | previous]
+        if news_results.revisions is None:
+            self.revisions = pd.Series([], index=r_ix, name='revision',
+                                       dtype=model.params.dtype)
+        else:
+            self.revisions = pd.Series(news_results.revisions, index=r_ix,
+                                       name='revision')
+        # E[y^u | revised]
         if news_results.update_forecasts is None:
-            self.update_forecasts = pd.Series([], index=ix,
+            self.update_forecasts = pd.Series([], index=u_ix,
                                               dtype=model.params.dtype)
         else:
             self.update_forecasts = pd.Series(
-                news_results.update_forecasts, index=ix)
+                news_results.update_forecasts, index=u_ix)
+        # y^r_{revised}
+        if news_results.revised is None:
+            self.revised = pd.Series([], index=r_ix, dtype=model.params.dtype,
+                                     name='revised')
+        else:
+            self.revised = pd.Series(news_results.revised, index=r_ix,
+                                     name='revised')
+        # y^r_{previous}
+        if news_results.revised_prev is None:
+            self.revised_prev = pd.Series([], index=r_ix,
+                                          dtype=model.params.dtype)
+        else:
+            self.revised_prev = pd.Series(
+                news_results.revised_prev, index=r_ix)
         # y^u
         if news_results.update_realized is None:
-            self.update_realized = pd.Series([], index=ix,
+            self.update_realized = pd.Series([], index=u_ix,
                                              dtype=model.params.dtype)
         else:
             self.update_realized = pd.Series(
-                news_results.update_realized, index=ix)
+                news_results.update_realized, index=u_ix)
         cols = pd.MultiIndex.from_product([self.row_labels, columns])
         # reshaped version of gain matrix E[y A'] E[A A']^{-1}
         if len(self.updates_iloc):
-            weights = news_results.gain.transpose(0, 1, 2).reshape(
-                len(cols), len(ix))
+            weights = news_results.gain.reshape(
+                len(cols), len(u_ix))
         else:
-            weights = np.zeros((len(cols), len(ix)))
-        self.weights = pd.DataFrame(weights, index=cols, columns=ix).T
+            weights = np.zeros((len(cols), len(u_ix)))
+        self.weights = pd.DataFrame(weights, index=cols, columns=u_ix).T
         self.weights.columns.names = ['impact date', 'impacted variable']
+
+        # reshaped version of revision_weights
+        if len(self.revisions_iloc):
+            revision_weights = news_results.revision_weights.reshape(
+                len(cols), len(r_ix))
+        else:
+            revision_weights = np.zeros((len(cols), len(r_ix)))
+        self.revision_weights = pd.DataFrame(
+            revision_weights, index=cols, columns=r_ix).T
+        self.revision_weights.columns.names = [
+            'impact date', 'impacted variable']
 
     @property
     def impacted_variable(self):
@@ -227,17 +279,10 @@ class NewsResults(object):
         data_updates
         """
         # Save revisions data
-        data = self.revisions_ix.copy()
-        data['observed (prev)'] = [
-            self.previous.model.endog[row[0], row[1]]
-            for _, row in self.revisions_iloc.iterrows()]
-        data['revised'] = [
-            self.updated.model.endog[row[0], row[1]]
-            for _, row in self.revisions_iloc.iterrows()]
-        data.index = pd.MultiIndex.from_arrays([data['revision date'],
-                                                data['revised variable']])
-        data = data.sort_index().drop(['revision date',
-                                       'revised variable'], axis=1)
+        data = pd.concat([
+            self.revised.rename('revised'),
+            self.revised_prev.rename('observed (prev)')
+        ], axis=1).sort_index()
         return data
 
     @property
@@ -260,16 +305,12 @@ class NewsResults(object):
 
         See also
         --------
-        data_updates
+        data_revisions
         """
-        data = pd.concat([self.update_realized, self.update_forecasts],
-                         axis=1).sort_index().reset_index()
-        data.columns = (data.columns[:2].tolist() +
-                        ['observed', 'forecast (prev)'])
-        data.index = pd.MultiIndex.from_arrays([data['update date'],
-                                                data['updated variable']])
-        data = data.sort_index().drop(['update date',
-                                       'updated variable'], axis=1)
+        data = pd.concat([
+            self.update_realized.rename('observed'),
+            self.update_forecasts.rename('forecast (prev)')
+        ], axis=1).sort_index()
         return data
 
     @property
@@ -309,7 +350,8 @@ class NewsResults(object):
         release.
 
         This table does not summarize the impacts or show the effect of
-        revisions. That information can be found in the `impacts` table.
+        revisions. That information can be found in the `impacts` or
+        `revision_details_by_impact` tables.
 
         This form of the details table is organized so that the impacted
         dates / variables are first in the index. This is convenient for
@@ -327,6 +369,7 @@ class NewsResults(object):
         See Also
         --------
         details_by_update
+        revision_details_by_update
         impacts
         """
         df = self.weights.stack(level=[0, 1]).rename('weight').to_frame()
@@ -341,6 +384,81 @@ class NewsResults(object):
             df['news'] = []
             df['impact'] = []
         df = df[['observed', 'forecast (prev)', 'news', 'weight', 'impact']]
+        df = df.reorder_levels([2, 3, 0, 1]).sort_index()
+
+        if self.impacted_variable is not None and len(df) > 0:
+            df = df.loc[np.s_[:, self.impacted_variable], :]
+
+        mask = np.abs(df['weight']) > self.tolerance
+        return df[mask]
+
+    @property
+    def revision_details_by_impact(self):
+        """
+        Details of forecast revisions from revised data, organized by impacts
+
+        Returns
+        -------
+        details : pd.DataFrame
+            Index is as MultiIndex consisting of:
+
+            - `impact date`: the date of the impact on the variable of interest
+            - `impacted variable`: the variable that is being impacted
+            - `revision date`: the date of the data revision, that results in
+              `revision` that impacts the forecast of variables of interest
+            - `revised variable`: the variable being revised, that results in
+              `news` that impacts the forecast of variables of interest
+
+            The columns are:
+
+            - `observed (prev)`: the previous value of the observation, as it
+              was given in the previous dataset
+            - `revised`: the value of the revised entry, as it is observed in
+              the new dataset
+            - `revision`: the revision (this is `revised` - `observed (prev)`)
+            - `weight`: the weight describing how the `revision` effects the
+              forecast of the variable of interest
+            - `impact`: the impact of the `revision` on the forecast of the
+              variable of interest
+
+        Notes
+        -----
+        This table decomposes updated forecasts of variables of interest from
+        the `revision` associated with each revised datapoint from the new data
+        release.
+
+        This table does not summarize the impacts or show the effect of
+        new datapoints. That information can be found in the
+        `impacts` or `details_by_impact` tables.
+
+        This form of the details table is organized so that the impacted
+        dates / variables are first in the index. This is convenient for
+        slicing by impacted variables / dates to view the details of data
+        updates for a particular variable or date.
+
+        However, since the `observed (prev)` and `revised` columns have a lot
+        of duplication, printing the entire table gives a result that is less
+        easy to parse than that produced by the `details_by_revision` property.
+        `details_by_revision` contains the same information but is organized to
+        be more convenient for displaying the entire table of detailed
+        revisions. At the same time, `details_by_revision` is less convenient
+        for subsetting.
+
+        See Also
+        --------
+        details_by_revision
+        details_by_impact
+        impacts
+        """
+        weights = self.revision_weights.stack(level=[0, 1])
+        df = pd.concat([
+            self.revised_prev.rename('observed (prev)').reindex(weights.index),
+            self.revised.reindex(weights.index),
+            self.revisions.reindex(weights.index),
+            weights.rename('weight'),
+            (self.revisions * weights).rename('impact'),
+        ], axis=1)
+
         df = df.reorder_levels([2, 3, 0, 1]).sort_index()
 
         if self.impacted_variable is not None and len(df) > 0:
@@ -374,7 +492,7 @@ class NewsResults(object):
 
             - `news`: the news associated with the update (this is just the
               forecast error: `observed` - `forecast (prev)`)
-            - `weight`: the weight describing how the `news` effects the
+            - `weight`: the weight describing how the `news` affects the
               forecast of the variable of interest
             - `impact`: the impact of the `news` on the forecast of the
               variable of interest
@@ -424,6 +542,86 @@ class NewsResults(object):
                 'forecast (prev)', 'impact date', 'impacted variable']
         df.index = pd.MultiIndex.from_arrays([df[key] for key in keys])
         details = df.drop(keys, axis=1).sort_index()
+
+        if self.impacted_variable is not None and len(df) > 0:
+            details = details.loc[
+                np.s_[:, :, :, :, :, self.impacted_variable], :]
+
+        mask = np.abs(details['weight']) > self.tolerance
+        return details[mask]
+
+    @property
+    def revision_details_by_update(self):
+        """
+        Details of forecast revisions from revisions, organized by updates
+
+        Returns
+        -------
+        details : pd.DataFrame
+            Index is as MultiIndex consisting of:
+
+            - `revision date`: the date of the data revision, that results in
+              `revision` that impacts the forecast of variables of interest
+            - `revised variable`: the variable being revised, that results in
+              `news` that impacts the forecast of variables of interest
+            - `observed (prev)`: the previous value of the observation, as it
+              was given in the previous dataset
+            - `revised`: the value of the revised entry, as it is observed in
+              the new dataset
+            - `impact date`: the date of the impact on the variable of interest
+            - `impacted variable`: the variable that is being impacted
+
+            The columns are:
+
+            - `revision`: the revision (this is `revised` - `observed (prev)`)
+            - `weight`: the weight describing how the `revision` affects the
+              forecast of the variable of interest
+            - `impact`: the impact of the `revision` on the forecast of the
+              variable of interest
+
+        Notes
+        -----
+        This table decomposes updated forecasts of variables of interest from
+        the `revision` associated with each revised datapoint from the new data
+        release.
+
+        This table does not summarize the impacts or show the effect of
+        revisions. That information can be found in the `impacts` table.
+
+        This form of the details table is organized so that the revision
+        dates / variables are first in the index, and in this table the index
+        also contains the previously observed and revised values. This is
+        convenient for displaying the entire table of detailed revisions
+        because it allows sparsifying duplicate entries.
+
+        However, since it includes previous observations and revisions in the
+        index of the table, it is not convenient for subsetting by the variable
+        of interest. Instead, the `revision_details_by_impact` property is
+        organized to make slicing by impacted variables / dates easy. This
+        allows, for example, viewing the details of data revisions on a
+        particular variable or date of interest.
+
+        See Also
+        --------
+        details_by_impact
+        impacts
+        """
+        weights = self.revision_weights.stack(level=[0, 1])
+
+        df = pd.concat([
+            self.revised_prev.rename('observed (prev)').reindex(weights.index),
+            self.revised.reindex(weights.index),
+            self.revisions.reindex(weights.index),
+            weights.rename('weight'),
+            (self.revisions * weights).rename('impact'),
+        ], axis=1)
+
+        details = (df.set_index(['observed (prev)', 'revised'], append=True)
+                     .reorder_levels([
+                         'revision date', 'revised variable', 'revised',
+                         'observed (prev)', 'impact date',
+                         'impacted variable'])
+                     .sort_index())
 
         if self.impacted_variable is not None and len(df) > 0:
             details = details.loc[
@@ -621,15 +819,18 @@ class NewsResults(object):
 
         return impacts_table
 
-    def summary_details(self, impact_date=None, impacted_variable=None,
-                        update_date=None, updated_variable=None,
-                        groupby='update date', sparsify=True,
-                        float_format='%.2f', multiple_tables=False):
+    def summary_details(self, source='news', impact_date=None,
+                        impacted_variable=None, update_date=None,
+                        updated_variable=None, groupby='update date',
+                        sparsify=True, float_format='%.2f',
+                        multiple_tables=False):
         """
-        Create summary table with detailed impacts from news; by date, variable
+        Create summary table with detailed impacts; by date, variable
 
         Parameters
         ----------
+        source : {news, revisions}
+            The source of impacts to summarize. Default is "news".
         impact_date : int, str, datetime, list, array, or slice, optional
             Observation index label or slice of labels specifying particular
             impact periods to display. The impact date(s) describe the periods
@@ -734,7 +935,28 @@ class NewsResults(object):
         if updated_variable is not None:
             s[3] = np.s_[updated_variable]
         s = tuple(s)
-        details = self.details_by_impact.loc[s, :]
+
+        if source == 'news':
+            details = self.details_by_impact.loc[s, :]
+            columns = {
+                'current': 'observed',
+                'prev': 'forecast (prev)',
+                'update date': 'update date',
+                'updated variable': 'updated variable',
+                'news': 'news',
+            }
+        elif source == 'revisions':
+            details = self.revision_details_by_impact.loc[s, :]
+            columns = {
+                'current': 'revised',
+                'prev': 'observed (prev)',
+                'update date': 'revision date',
+                'updated variable': 'revised variable',
+                'news': 'revision',
+            }
+        else:
+            raise ValueError(f'Invalid `source`: {source}. Must be "news" or'
+                             ' "impacts".')
 
         # Make the first index level the groupby level
         groupby = groupby.lower().replace('_', ' ')
@@ -761,8 +983,8 @@ class NewsResults(object):
         # observed into the index
         base_levels = [0, 1, 2, 3]
         if groupby_overall == 'update':
-            details.set_index(['observed', 'forecast (prev)'], append=True,
-                              inplace=True)
+            details.set_index([columns['current'], columns['prev']],
+                              append=True, inplace=True)
             details.index = details.index.reorder_levels([0, 1, 4, 5, 2, 3])
             base_levels = [0, 1, 4, 5]
 
@@ -777,13 +999,15 @@ class NewsResults(object):
                     name = tmp_index.names[i]
                     value = tmp_index.levels[i][0]
                     can_drop = (
-                        (name == 'update date' and update_date is not None) or
-                        (name == 'updated variable' and
-                            updated_variable is not None) or
-                        (name == 'impact date' and impact_date is not None) or
-                        (name == 'impacted variable' and
-                            (impacted_variable is not None or
-                             self.impacted_variable is not None)))
+                        (name == columns['update date']
+                            and update_date is not None) or
+                        (name == columns['updated variable']
+                            and updated_variable is not None) or
+                        (name == 'impact date'
+                            and impact_date is not None) or
+                        (name == 'impacted variable'
+                            and (impacted_variable is not None or
+                                 self.impacted_variable is not None)))
                     if can_drop or not multiple_tables:
                         removed_levels.insert(0, f'{name} = {value}')
                         details.index = tmp_index = tmp_index.droplevel(i)
@@ -806,8 +1030,8 @@ class NewsResults(object):
         # Function to create the table
         def create_table(details, removed_levels):
             # Convert everything to strings
-            for key in ['observed', 'forecast (prev)', 'news', 'weight',
-                        'impact']:
+            for key in [columns['current'], columns['prev'], columns['news'],
+                        'weight', 'impact']:
                 if key in details:
                     args = (
                         # mark_ones
@@ -815,27 +1039,38 @@ class NewsResults(object):
                         # mark_zeroes
                         True if key in ['weight', 'impact'] else False)
                     details[key] = details[key].apply(str_format, args=args)
-            for key in ['update date', 'impact date']:
+            for key in [columns['update date'], 'impact date']:
                 if key in details:
                     details[key] = details[key].apply(str)
 
             # Sparsify index columns
             if sparsify:
-                sparsify_cols = ['update date', 'updated variable',
-                                 'impact date', 'impacted variable']
+                sparsify_cols = [columns['update date'],
+                                 columns['updated variable'], 'impact date',
+                                 'impacted variable']
+                data_cols = [columns['current'], columns['prev']]
                 if groupby_overall == 'update':
-                    sparsify_cols += ['observed', 'forecast (prev)']
+                    # Put data columns first, since we need to do an additional
+                    # check based on the other columns before sparsifying
+                    sparsify_cols = data_cols + sparsify_cols
 
                 for key in sparsify_cols:
                     if key in details:
                         mask = details[key] == details[key].shift(1)
+                        if key in data_cols:
+                            if columns['update date'] in details:
+                                tmp = details[columns['update date']]
+                                mask &= tmp == tmp.shift(1)
+                            if columns['updated variable'] in details:
+                                tmp = details[columns['updated variable']]
+                                mask &= tmp == tmp.shift(1)
                         details.loc[mask, key] = ''
 
             params_data = details.values
-            params_header = details.columns.tolist()
+            params_header = [str(x) for x in details.columns.tolist()]
             params_stubs = None
 
-            title = 'Details'
+            title = f"Details of {source}"
             if len(removed_levels):
                 title += ' for [' + ', '.join(removed_levels) + ']'
             return SimpleTable(params_data, params_header, params_stubs,
@@ -873,8 +1108,11 @@ class NewsResults(object):
             - `revised variable` : variable that was revised at `revision date`
             - `observed (prev)` : the observed value prior to the revision
             - `revised` : the new value after the revision
+            - `revision` : the new value after the revision
         """
-        data = self.data_revisions.sort_index().reset_index()
+        data = pd.merge(
+            self.data_revisions, self.revisions, left_index=True,
+            right_index=True).sort_index().reset_index()
         data[['revision date', 'revised variable']] = (
             data[['revision date', 'revised variable']].applymap(str))
         data.iloc[:, 2:] = data.iloc[:, 2:].applymap(
@@ -950,6 +1188,7 @@ class NewsResults(object):
 
     def summary(self, impact_date=None, impacted_variable=None,
                 update_date=None, updated_variable=None,
+                revision_date=None, revised_variable=None,
                 impacts_groupby='impact date', details_groupby='update date',
                 show_revisions_columns=None, sparsify=True,
                 include_details_tables=None, include_revisions_tables=False,
@@ -984,9 +1223,20 @@ class NewsResults(object):
         updated_variable : str, list, array, or slice, optional
             Observation variable label or slice of labels specifying particular
             updated variables to display. The updated variable(s) describe the
-            variables that were *affected* by the news. If you do not know the
-            labels for the variables, check the `endog_names` attribute of the
-            model instance.
+            variables that newly added in the updated dataset and which
+            generated the news. If you do not know the labels for the
+            variables, check the `endog_names` attribute of the model instance.
+        revision_date : int, str, datetime, list, array, or slice, optional
+            Observation index label or slice of labels specifying particular
+            revision periods to display. The revision date(s) describe the
+            periods in which the data points were revised. See the note on
+            `impact_date` for details about what these labels are.
+        revised_variable : str, list, array, or slice, optional
+            Observation variable label or slice of labels specifying particular
+            revised variables to display. The updated variable(s) describe the
+            variables that were *revised*. If you do not know the labels for
+            the variables, check the `endog_names` attribute of the model
+            instance.
         impacts_groupby : {impact date, impacted date}
             The primary variable for grouping results in the impacts table. The
             default is to group by update date.
@@ -1048,7 +1298,8 @@ class NewsResults(object):
 
         def get_sample(model):
             if model._index_dates:
-                ix = model._index
+                mask = ~np.isnan(model.endog).all(axis=1)
+                ix = model._index[mask]
                 d = ix[0]
                 sample = ['%s' % d]
                 d = ix[-1]
@@ -1067,13 +1318,17 @@ class NewsResults(object):
         top_left = [('Model:', [model_name]),
                     ('Date:', None),
                     ('Time:', None)]
+        if self.state_index is not None:
+            k_states_used = len(self.state_index)
+            if k_states_used != self.model.model.k_states:
+                top_left.append(('# of included states:', [k_states_used]))
 
         top_right = [
             ('Original sample:', [previous_sample[0]]),
             ('', [previous_sample[1]]),
             ('Update through:', [revised_sample[1][2:]]),
-            ('No. Revisions:', [len(self.revisions_ix)]),
-            ('No. New datapoints:', [len(self.updates_ix)])]
+            ('# of revisions:', [len(self.revisions_ix)]),
+            ('# of new datapoints:', [len(self.updates_ix)])]
 
         summary = Summary()
         self.model.endog_names = self.model.model.endog_names
@@ -1098,7 +1353,9 @@ class NewsResults(object):
         # Detail tables
         multiple_tables = self.updated.model.k_endog > 1
         details_tables = self.summary_details(
+            source='news',
             impact_date=impact_date, impacted_variable=impacted_variable,
+            update_date=update_date, updated_variable=updated_variable,
             groupby=details_groupby, sparsify=sparsify,
             float_format=float_format, multiple_tables=multiple_tables)
         if not multiple_tables:
@@ -1114,5 +1371,20 @@ class NewsResults(object):
             summary.tables.insert(
                 table_ix, self.summary_revisions(sparsify=sparsify))
             table_ix += 1
+
+            # Revision detail tables
+            revision_details_tables = self.summary_details(
+                source='revisions',
+                impact_date=impact_date, impacted_variable=impacted_variable,
+                update_date=revision_date, updated_variable=revised_variable,
+                groupby=details_groupby, sparsify=sparsify,
+                float_format=float_format, multiple_tables=multiple_tables)
+            if not multiple_tables:
+                revision_details_tables = [revision_details_tables]
+
+            if include_details_tables:
+                for table in revision_details_tables:
+                    summary.tables.insert(table_ix, table)
+                    table_ix += 1
 
         return summary

--- a/statsmodels/tsa/statespace/representation.py
+++ b/statsmodels/tsa/statespace/representation.py
@@ -810,12 +810,16 @@ class Representation(object):
             self.shapes['obs'] = self.endog.shape
 
     def initialize(self, initialization, approximate_diffuse_variance=None,
-                   constant=None, stationary_cov=None):
+                   constant=None, stationary_cov=None, a=None, Pstar=None,
+                   Pinf=None, A=None, R0=None, Q0=None):
         """Create an Initialization object if necessary"""
         if initialization == 'known':
             initialization = Initialization(self.k_states, 'known',
                                             constant=constant,
                                             stationary_cov=stationary_cov)
+        elif initialization == 'components':
+            initialization = Initialization.from_components(
+                a=a, Pstar=Pstar, Pinf=Pinf, A=A, R0=R0, Q0=Q0)
         elif initialization == 'approximate_diffuse':
             if approximate_diffuse_variance is None:
                 approximate_diffuse_variance = self.initial_variance
@@ -884,6 +888,67 @@ class Representation(object):
 
         self.initialize('approximate_diffuse',
                         approximate_diffuse_variance=variance)
+
+    def initialize_components(self, a=None, Pstar=None, Pinf=None, A=None,
+                              R0=None, Q0=None):
+        """
+        Initialize the statespace model with component matrices
+
+        Parameters
+        ----------
+        a : array_like, optional
+            Vector of constant values describing the mean of the stationary
+            component of the initial state.
+        Pstar : array_like, optional
+            Stationary component of the initial state covariance matrix. If
+            given, should be a matrix shaped `k_states x k_states`. The
+            submatrix associated with the diffuse states should contain zeros.
+            Note that by definition, `Pstar = R0 @ Q0 @ R0.T`, so either
+            `R0,Q0` or `Pstar` may be given, but not both.
+        Pinf : array_like, optional
+            Diffuse component of the initial state covariance matrix. If given,
+            should be a matrix shaped `k_states x k_states` with ones in the
+            diagonal positions corresponding to states with diffuse
+            initialization and zeros otherwise. Note that by definition,
+            `Pinf = A @ A.T`, so either `A` or `Pinf` may be given, but not
+            both.
+        A : array_like, optional
+            Diffuse selection matrix, used in the definition of the diffuse
+            initial state covariance matrix. If given, should be a
+            `k_states x k_diffuse_states` matrix that contains the subset of
+            the columns of the identity matrix that correspond to states with
+            diffuse initialization. Note that by definition, `Pinf = A @ A.T`,
+            so either `A` or `Pinf` may be given, but not both.
+        R0 : array_like, optional
+            Stationary selection matrix, used in the definition of the
+            stationary initial state covariance matrix. If given, should be a
+            `k_states x k_nondiffuse_states` matrix that contains the subset of
+            the columns of the identity matrix that correspond to states with a
+            non-diffuse initialization. Note that by definition,
+            `Pstar = R0 @ Q0 @ R0.T`, so either `R0,Q0` or `Pstar` may be
+            given, but not both.
+        Q0 : array_like, optional
+            Covariance matrix associated with stationary initial states. If
+            given, should be a matrix shaped
+            `k_nondiffuse_states x k_nondiffuse_states`.
+            Note that by definition, `Pstar = R0 @ Q0 @ R0.T`, so either
+            `R0,Q0` or `Pstar` may be given, but not both.
+
+        Notes
+        -----
+        The matrices `a, Pstar, Pinf, A, R0, Q0` and the process for
+        initializing the state space model is as given in Chapter 5 of [1]_.
+        For the definitions of these matrices, see equation (5.2) and the
+        subsequent discussion there.
+
+        References
+        ----------
+        .. [*] Durbin, James, and Siem Jan Koopman. 2012.
+           Time Series Analysis by State Space Methods: Second Edition.
+           Oxford University Press.
+        """
+        self.initialize('components', a=a, Pstar=Pstar, Pinf=Pinf, A=A, R0=R0,
+                        Q0=Q0)
 
     def initialize_stationary(self):
         """

--- a/statsmodels/tsa/statespace/tests/test_decompose.py
+++ b/statsmodels/tsa/statespace/tests/test_decompose.py
@@ -1,0 +1,336 @@
+"""
+Tests for decomposition of objects in state space models
+
+Author: Chad Fulton
+License: Simplified-BSD
+"""
+
+import pytest
+
+import numpy as np
+import pandas as pd
+
+from numpy.testing import assert_allclose
+
+from statsmodels import datasets
+from statsmodels.tsa.statespace import sarimax, varmax, dynamic_factor_mq
+from statsmodels.tsa.statespace.tests.test_impulse_responses import TVSS
+
+
+dta = datasets.macrodata.load_pandas().data
+dta.index = pd.period_range(start='1959Q1', end='2009Q3', freq='Q')
+
+
+@pytest.mark.parametrize('use_exog', [False, True])
+@pytest.mark.parametrize('trend', ['n', 'c', 't'])
+@pytest.mark.parametrize('concentrate_scale', [False, True])
+@pytest.mark.parametrize('measurement_error', [False, True])
+def test_smoothed_decomposition_sarimax(use_exog, trend, concentrate_scale,
+                                        measurement_error):
+    endog = np.array([[0.2, np.nan, 1.2, -0.3, -1.5]]).T
+    exog = np.array([2, 5.3, -1, 3.4, 0.]) if use_exog else None
+
+    trend_params = [0.1]
+    ar_params = [0.5]
+    exog_params = [1.4]
+    meas_err_params = [1.2]
+    cov_params = [0.8]
+
+    params = []
+    if trend in ['c', 't']:
+        params += trend_params
+    if use_exog:
+        params += exog_params
+    params += ar_params
+    if measurement_error:
+        params += meas_err_params
+    if not concentrate_scale:
+        params += cov_params
+
+    # Fit the models
+    mod = sarimax.SARIMAX(endog, order=(1, 0, 0), trend=trend,
+                          exog=exog if use_exog else None,
+                          concentrate_scale=concentrate_scale,
+                          measurement_error=measurement_error)
+    prior_mean = np.array([-0.4])
+    prior_cov = np.eye(1) * 1.2
+    mod.ssm.initialize_known(prior_mean, prior_cov)
+    res = mod.smooth(params)
+
+    # Check smoothed state
+
+    # Get the decomposition of the smoothed state
+    cd, coi, csi, cp = res.get_smoothed_decomposition(
+        decomposition_of='smoothed_state')
+
+    # Sum across contributions (i.e. from observations at each time period and
+    # from the initial state)
+    css = ((cd + coi).sum(axis=1) + csi.sum(axis=1) + cp.sum(axis=1))
+    css = css.unstack(level='state_to').values
+
+    # Summing up all contributions should yield the actual smoothed state,
+    # so the smoothed state vector is the desired result of this test
+    ss = np.array(res.states.smoothed)
+
+    assert_allclose(css, ss, atol=1e-12)
+
+    # Check smoothed signal
+
+    # Use the summed state contributions and multiply by the design matrix
+    # to get the smoothed signal
+    csf = ((css.T * mod['design'][:, :, None]).sum(axis=1)
+           + mod['obs_intercept']).T
+
+    # Summing up all contributions should yield the smoothed prediction of
+    # the observed variables
+    s_sig = res.predict(information_set='smoothed', signal_only=True)
+    sf = res.predict(information_set='smoothed', signal_only=False)
+
+    assert_allclose(csf[:, 0], sf)
+
+    # Now check the smoothed signal against the sum computed from the
+    # decomposed smoothed signal
+    cd, coi, csi, cp = res.get_smoothed_decomposition(
+        decomposition_of='smoothed_signal')
+
+    # Sum across contributions (i.e. from observations and intercepts at each
+    # time period and from the initial state) to get the smoothed signal
+    cs_sig = ((cd + coi).sum(axis=1) + csi.sum(axis=1) + cp.sum(axis=1))
+    cs_sig = cs_sig.unstack(level='variable_to').values
+
+    assert_allclose(cs_sig[:, 0], s_sig, atol=1e-12)
+
+    # Add in the observation intercept to get the smoothed forecast
+    csf = cs_sig + mod['obs_intercept'].T
+
+    assert_allclose(csf[:, 0], sf)
+
+
+@pytest.mark.parametrize('use_exog', [False, True])
+@pytest.mark.parametrize('trend', ['n', 'c', 't'])
+def test_smoothed_decomposition_varmax(use_exog, trend):
+    endog = np.array([[0.2, 1.0],
+                      [-0.3, -0.5],
+                      [0.01, 0.4],
+                      [-0.4, 0.1],
+                      [0.1, 0.05]])
+    endog[0, 0] = np.nan
+    endog[1, :] = np.nan
+    endog[2, 1] = np.nan
+    exog = np.array([2, 5.3, -1, 3.4, 0.]) if use_exog else None
+
+    trend_params = [0.1, 0.2]
+    var_params = [0.5, -0.1, 0.0, 0.2]
+    exog_params = [1., 2.]
+    cov_params = [1., 0., 1.]
+
+    params = []
+    if trend in ['c', 't']:
+        params += trend_params
+    params += var_params
+    if use_exog:
+        params += exog_params
+    params += cov_params
+
+    # Fit the model
+    mod = varmax.VARMAX(endog, order=(1, 0), trend=trend,
+                        exog=exog if use_exog else None)
+    prior_mean = np.array([-0.4, 0.9])
+    prior_cov = np.array([[1.4, 0.3],
+                          [0.3, 2.6]])
+    mod.ssm.initialize_known(prior_mean, prior_cov)
+    res = mod.smooth(params)
+
+    # Check smoothed state
+
+    # Get the decomposition of the smoothed state
+    cd, coi, csi, cp = res.get_smoothed_decomposition(
+        decomposition_of='smoothed_state')
+
+    # Sum across contributions (i.e. from observations at each time period and
+    # from the initial state)
+    css = ((cd + coi).sum(axis=1) + csi.sum(axis=1) + cp.sum(axis=1))
+    css = css.unstack(level='state_to').values
+
+    # Summing up all contributions should yield the actual smoothed state,
+    # so the smoothed state vector is the desired result of this test
+    ss = np.array(res.states.smoothed)
+
+    assert_allclose(css, ss, atol=1e-12)
+
+    # Check smoothed signal
+
+    # Use the summed state contributions and multiply by the design matrix
+    # to get the smoothed signal
+    csf = (css.T * mod['design'][:, :, None]).sum(axis=1).T
+
+    # Summing up all contributions should yield the smoothed prediction of
+    # the observed variables
+    s_sig = res.predict(information_set='smoothed', signal_only=True)
+    sf = res.predict(information_set='smoothed', signal_only=False)
+
+    assert_allclose(csf, sf, atol=1e-12)
+
+    # Now check the smoothed signal against the sum computed from the
+    # decomposed smoothed signal
+    cd, coi, csi, cp = res.get_smoothed_decomposition(
+        decomposition_of='smoothed_signal')
+
+    # Sum across contributions (i.e. from observations and intercepts at each
+    # time period and from the initial state) to get the smoothed signal
+    cs_sig = ((cd + coi).sum(axis=1) + csi.sum(axis=1) + cp.sum(axis=1))
+    cs_sig = cs_sig.unstack(level='variable_to').values
+
+    assert_allclose(cs_sig, s_sig, atol=1e-12)
+
+    # Add in the observation intercept to get the smoothed forecast
+    csf = cs_sig + mod['obs_intercept'].T
+
+    assert_allclose(csf, sf)
+
+
+def test_smoothed_decomposition_dfm_mq():
+    # Create the datasets
+    index_M = pd.period_range(start='2000', periods=12, freq='M')
+    index_Q = pd.period_range(start='2000', periods=4, freq='Q')
+
+    dta_M = pd.DataFrame(np.zeros((12, 2)), index=index_M,
+                         columns=['M0', 'M1'])
+    dta_Q = pd.DataFrame(np.zeros((4, 2)), index=index_Q, columns=['Q0', 'Q1'])
+    # Add some noise so the variables aren't constants
+    dta_M.iloc[0] = 1.
+    dta_Q.iloc[1] = 1.
+    # TODO: remove this once we have the intercept contributions figured out
+    dta_M -= dta_M.mean()
+    dta_Q -= dta_Q.mean()
+
+    # Create the model instance
+    mod = dynamic_factor_mq.DynamicFactorMQ(
+        dta_M, endog_quarterly=dta_Q, factors=1, factor_orders=1,
+        idiosyncratic_ar1=True)
+    params = [
+        0.1, -0.4, 0.2, 0.3,   # loadings
+        0.95, 1.0,             # factor
+        0.5, 0.55, 0.6, 0.65,  # idio ar(1)
+        1.1, 1.2, 1.0, 0.9,    # idio variances
+    ]
+    res = mod.smooth(params)
+
+    # Check smoothed state
+
+    # Get the decomposition of the smoothed state
+    cd, coi, csi, cp = res.get_smoothed_decomposition(
+        decomposition_of='smoothed_state')
+
+    # Sum across contributions (i.e. from observations at each time period and
+    # from the initial state)
+    css = ((cd + coi).sum(axis=1) + csi.sum(axis=1) + cp.sum(axis=1))
+    css = css.unstack(level='state_to')[mod.state_names].values
+
+    # Summing up all contributions should yield the actual smoothed state,
+    # so the smoothed state vector is the desired result of this test
+    ss = np.array(res.states.smoothed)
+
+    assert_allclose(css, ss, atol=1e-12)
+
+    # Check smoothed signal
+
+    # Use the summed state contributions and multiply by the design matrix
+    # to get the smoothed signal
+    csf = (css.T * mod['design'][:, :, None]).sum(axis=1).T
+    # Reverse the standardization
+    csf = (csf.T * mod._endog_std.values[:, None]
+           + mod._endog_mean.values[:, None]).T
+
+    # Summing up all contributions should yield the smoothed prediction of
+    # the observed variables
+    s_sig = res.predict(information_set='smoothed', signal_only=True)
+    sf = res.predict(information_set='smoothed', signal_only=False)
+
+    assert_allclose(csf, sf, atol=1e-12)
+
+    # Now check the smoothed signal against the sum computed from the
+    # decomposed smoothed signal
+    cd, coi, csi, cp = res.get_smoothed_decomposition(
+        decomposition_of='smoothed_signal')
+
+    # Sum across contributions (i.e. from observations and intercepts at each
+    # time period and from the initial state) to get the smoothed signal
+    cs_sig = ((cd + coi).sum(axis=1) + csi.sum(axis=1) + cp.sum(axis=1))
+    cs_sig = cs_sig.unstack(level='variable_to')[mod.endog_names].values
+
+    assert_allclose(cs_sig, s_sig, atol=1e-12)
+
+    # Add in the observation intercept to get the smoothed forecast
+    csf = cs_sig + mod['obs_intercept'].T
+
+    assert_allclose(csf, sf)
+
+
+@pytest.mark.parametrize('univariate', [False, True])
+def test_smoothed_decomposition_TVSS(univariate, reset_randomstate):
+    endog = np.zeros((10, 3))
+    endog[6, 0] = np.nan
+    endog[7, :] = np.nan
+    endog[8, 1] = np.nan
+    mod = TVSS(endog)
+
+    mod['state_intercept'] = np.random.normal(size=(mod.k_states, mod.nobs))
+
+    prior_mean = np.array([1.2, 0.8])
+    prior_cov = np.eye(2)
+    mod.ssm.initialize_known(prior_mean, prior_cov)
+    if univariate:
+        mod.ssm.filter_univariate = True
+    res = mod.smooth([])
+
+    # Check smoothed state
+
+    # Get the decomposition of the smoothed state
+    cd, coi, csi, cp = res.get_smoothed_decomposition(
+        decomposition_of='smoothed_state')
+
+    # Sum across contributions (i.e. from observations at each time period and
+    # from the initial state)
+    css = ((cd + coi).sum(axis=1) + csi.sum(axis=1) + cp.sum(axis=1))
+    css = css.unstack(level='state_to')[mod.state_names].values
+
+    # Summing up all contributions should yield the actual smoothed state,
+    # so the smoothed state vector is the desired result of this test
+    ss = np.array(res.states.smoothed)
+
+    assert_allclose(css, ss, atol=1e-12)
+
+    # Check smoothed signal
+
+    # Use the summed state contributions and multiply by the design matrix
+    # to get the smoothed signal
+    cs_sig = (css.T * mod['design']).sum(axis=1).T
+
+    # Add in the observation intercept to get the smoothed forecast
+    csf = cs_sig + mod['obs_intercept'].T
+
+    # Summing up all contributions should yield the smoothed prediction of
+    # the observed variables
+    s_sig = res.predict(information_set='smoothed', signal_only=True)
+    sf = res.predict(information_set='smoothed', signal_only=False)
+
+    assert_allclose(cs_sig, s_sig, atol=1e-12)
+    assert_allclose(csf, sf, atol=1e-12)
+
+    # Now check the smoothed signal against the sum computed from the
+    # decomposed smoothed signal
+    cd, coi, csi, cp = res.get_smoothed_decomposition(
+        decomposition_of='smoothed_signal')
+
+    # Sum across contributions (i.e. from observations and intercepts at each
+    # time period and from the initial state) to get the smoothed signal
+    cs_sig = ((cd + coi).sum(axis=1) + csi.sum(axis=1) + cp.sum(axis=1))
+    cs_sig = cs_sig.unstack(level='variable_to')[mod.endog_names].values
+
+    assert_allclose(cs_sig, s_sig, atol=1e-12)
+
+    # Add in the observation intercept to get the smoothed forecast
+    csf = cs_sig + mod['obs_intercept'].T
+
+    assert_allclose(csf, sf)

--- a/statsmodels/tsa/statespace/tests/test_dynamic_factor_mq_frbny_nowcast.py
+++ b/statsmodels/tsa/statespace/tests/test_dynamic_factor_mq_frbny_nowcast.py
@@ -426,7 +426,6 @@ def test_news(matlab_results, run):
     # Compute the news
     news = res2.news(res1, impact_date='2016-09', comparison_type='previous')
 
-    print(news.revision_impacts.loc['2016-09', 'GDPC1'])
     assert_allclose(news.revision_impacts.loc['2016-09', 'GDPC1'],
                     results['revision_impacts'])
 

--- a/statsmodels/tsa/statespace/tests/test_news.py
+++ b/statsmodels/tsa/statespace/tests/test_news.py
@@ -178,7 +178,7 @@ def check_news(news, revisions, updates, impact_dates, impacted_variables,
 
     # - Table: data revisions ------------------------------------------------
     assert_equal(news.data_revisions.columns.tolist(),
-                 ['observed (prev)', 'revised'])
+                 ['revised', 'observed (prev)'])
     assert_equal(news.data_revisions.index.names,
                  ['revision date', 'revised variable'])
     assert_(news.data_revisions.index.equals(revisions_index))
@@ -267,8 +267,10 @@ def check_news(news, revisions, updates, impact_dates, impacted_variables,
                     news.post_impacted_forecasts.stack(), atol=1e-12)
 
 
-@pytest.mark.parametrize('revisions', [True, False])
-@pytest.mark.parametrize('updates', [True, False])
+# @pytest.mark.parametrize('revisions', [True, False])
+# @pytest.mark.parametrize('updates', [True, False])
+@pytest.mark.parametrize('revisions', [True])
+@pytest.mark.parametrize('updates', [True])
 def test_sarimax_time_invariant(revisions, updates):
     # Construct previous and updated datasets
     endog = dta['infl'].copy()
@@ -327,6 +329,7 @@ def test_sarimax_time_invariant(revisions, updates):
         updates_index = pd.MultiIndex.from_arrays(
             [[], []], names=['update date', 'updated variable'])
         update_impacts = None
+    print(update_impacts)
 
     # Impact forecasts
     if updates:

--- a/statsmodels/tsa/statespace/tools.py
+++ b/statsmodels/tsa/statespace/tools.py
@@ -1899,6 +1899,7 @@ def _safe_cond(a):
         else:
             return np.inf
 
+
 def _compute_smoothed_state_weights(ssm, compute_t=None, compute_j=None,
                                     compute_prior_weights=None, scale=1.0):
     # Get references to the Cython objects
@@ -2083,7 +2084,6 @@ def compute_smoothed_state_weights(results, compute_t=None, compute_j=None,
         mod.ssm, compute_t=compute_t, compute_j=compute_j,
         compute_prior_weights=compute_prior_weights,
         scale=results.filter_results.scale)
-
 
 
 def get_impact_dates(previous_model, updated_model, impact_date=None,

--- a/statsmodels/tsa/statespace/varmax.py
+++ b/statsmodels/tsa/statespace/varmax.py
@@ -1061,7 +1061,8 @@ class VARMAXResults(MLEResults):
 
         return out
 
-    def _news_previous_results(self, previous, start, end, periods):
+    def _news_previous_results(self, previous, start, end, periods,
+                               state_index=None):
         # We need to figure out the out-of-sample exog, so that we can add back
         # in the last exog, predicted state
         exog = None
@@ -1096,7 +1097,7 @@ class VARMAXResults(MLEResults):
 
             out = self.smoother_results.news(
                 previous.smoother_results, start=start, end=end,
-                revised=revised_results)
+                revised=revised_results, state_index=state_index)
         return out
 
     @Appender(MLEResults.summary.__doc__)


### PR DESCRIPTION
- [x] tests added / passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message.

This PR primarily:

- [x] Adds details to the `news` output of the impacts from revisions to data (i.e. the revision, the weight of the revision, and the impact)
- [x] Adds a new `get_smoothed_decomposition` method to `MLEResults` that decomposes the `smoothed_state` vector or the smoothed "signal" vector into contributions from the data, the prior, and the two intercept terms.

It also:

- [x] Adds the computation of the weights of the observation and state intercepts
- [x] Improves the ability to copy the initialization from an `MLEResults` object to a new model (e.g. via `clone`, `apply`, and `append`). Previously it did not handle the exact diffuse case well.