### PR TITLE
ENH: use scipy.stats.studentized_range in tukey hsd when available

### DIFF
--- a/statsmodels/sandbox/stats/multicomp.py
+++ b/statsmodels/sandbox/stats/multicomp.py
@@ -61,6 +61,8 @@ TODO
 
 
 '''
+from collections import namedtuple
+
 from statsmodels.compat.python import lzip, lrange
 
 import copy
@@ -77,11 +79,13 @@ from statsmodels.graphics import utils
 from statsmodels.tools.sm_exceptions import ValueWarning
 
 try:
+    # Studentized Range in SciPy 1.7+
     from scipy.stats import studentized_range
-    qsturng = studentized_range.ppf
-    psturng = studentized_range.sf
 except ImportError:
     from statsmodels.stats.libqsturng import qsturng, psturng
+    studentized_range_tuple = namedtuple('studentized_range', ['ppf', 'sf'])
+    studentized_range = studentized_range_tuple(ppf=qsturng, sf=psturng)
+
 
 qcrit = '''
   2     3     4     5     6     7     8     9     10
@@ -160,7 +164,7 @@ def get_tukeyQcrit2(k, df, alpha=0.05):
 
     not enough error checking for limitations
     '''
-    return qsturng(1-alpha, k, df)
+    return studentized_range.ppf(1-alpha, k, df)
 
 
 def get_tukey_pvalue(k, df, q):
@@ -177,7 +181,7 @@ def get_tukey_pvalue(k, df, q):
         quantile value of Studentized Range
 
     '''
-    return psturng(q, k, df)
+    return studentized_range.sf(q, k, df)
 
 
 def Tukeythreegene(first, second, third):

--- a/statsmodels/sandbox/stats/multicomp.py
+++ b/statsmodels/sandbox/stats/multicomp.py
@@ -76,6 +76,13 @@ from statsmodels.stats.multitest import multipletests, _ecdf as ecdf, fdrcorrect
 from statsmodels.graphics import utils
 from statsmodels.tools.sm_exceptions import ValueWarning
 
+try:
+    from scipy.stats import studentized_range
+    qsturng = studentized_range.ppf
+    psturng = studentized_range.sf
+except ImportError:
+    from statsmodels.stats.libqsturng import qsturng, psturng
+
 qcrit = '''
   2     3     4     5     6     7     8     9     10
 5   3.64 5.70   4.60 6.98   5.22 7.80   5.67 8.42   6.03 8.91   6.33 9.32   6.58 9.67   6.80 9.97   6.99 10.24
@@ -153,7 +160,6 @@ def get_tukeyQcrit2(k, df, alpha=0.05):
 
     not enough error checking for limitations
     '''
-    from statsmodels.stats.libqsturng import qsturng
     return qsturng(1-alpha, k, df)
 
 
@@ -171,8 +177,6 @@ def get_tukey_pvalue(k, df, q):
         quantile value of Studentized Range
 
     '''
-
-    from statsmodels.stats.libqsturng import psturng
     return psturng(q, k, df)
 
 

--- a/statsmodels/stats/tests/test_multi.py
+++ b/statsmodels/stats/tests/test_multi.py
@@ -23,6 +23,8 @@ from statsmodels.stats.multitest import (multipletests, fdrcorrection,
                                          local_fdr, multitest_methods_names)
 from statsmodels.stats.multicomp import tukeyhsd
 from scipy.stats.distributions import norm
+import scipy
+from packaging import version
 
 pval0 = np.array([
     0.838541367553,  0.642193923795,  0.680845947633,
@@ -389,8 +391,13 @@ def test_tukeyhsd():
 
     # check p-values (divergence of high values is expected)
     small_pvals_idx = [2, 5, 7, 9]
+
+    # Remove this check when minimum SciPy version is 1.7+ (gh-8035)
+    scipy_version = (version.parse(scipy.version.version) >=
+                     version.parse('1.7.0'))
+    rtol = 1e-5 if scipy_version else 1e-2
     assert_allclose(myres[8][small_pvals_idx], res[small_pvals_idx, 3],
-                    rtol=1e-3)
+                    rtol=rtol)
 
 
 def test_local_fdr():

--- a/statsmodels/stats/tests/test_multi.py
+++ b/statsmodels/stats/tests/test_multi.py
@@ -381,7 +381,7 @@ def test_tukeyhsd():
         [-19.016667, -37.204253, -0.8290806, 0.037710044]])
 
     m_r = [94.39167, 102.54167,  91.13333, 118.20000,  99.18333]
-    myres = tukeyhsd(m_r, 6, 110.8, alpha=0.05, df=4)
+    myres = tukeyhsd(m_r, 6, 110.8254416667, alpha=0.05, df=4)
     pairs, reject, meandiffs, std_pairs, confint, q_crit = myres[:6]
     assert_almost_equal(meandiffs, res[:, 0], decimal=5)
     assert_almost_equal(confint, res[:, 1:3], decimal=2)

--- a/statsmodels/stats/tests/test_pairwise.py
+++ b/statsmodels/stats/tests/test_pairwise.py
@@ -365,4 +365,4 @@ class TestTuckeyHSD4(CheckTuckeyHSDMixin):
         cls.reject2 = np.array([False, False, False,  True, False, False,  True, False,  True, False])
 
     def test_hochberg_intervals(self):
-        assert_almost_equal(self.res.halfwidths, self.halfwidth2, 14)
+        assert_almost_equal(self.res.halfwidths, self.halfwidth2, 4)


### PR DESCRIPTION
This PR replaces use of statsmodels' studentized range distribution functions (`statsmodels.stats.libqsturng.qsturng`, `statsmodels.stats.libqsturng.psturng`) with those from SciPy when `scipy.stats.studentized_range` is available (SciPy 1.7.0+).

Speed is maintained, and results are more accurate because SciPy's implementation evaluates the integral for the provided arguments rather than interpolating from tabulated results.

For example, this box and whiskey plot (from [here](https://zenodo.org/record/5151976#.YekY3_7MKUk)) compares the relative accuracy of the studentized range CDF in SciPy, statsmodels, and R (ptukey) across a wide range of inputs.


<img width="868" alt="Screen Shot 2022-01-24 at 9 27 21 PM" src="https://user-images.githubusercontent.com/44255917/150916550-99966463-89d5-4419-9f08-e247bc5c148f.png">



- [ ] closes #xxxx
- [x] tests added / passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
