### PR TITLE
MAINT: Improve testing of grangercausality

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -70,6 +70,7 @@ filterwarnings =
     error:Passing None to catch any warning has been deprecated::
     error:pandas.Int64Index is deprecated::
     error:divide by zero encountered in _binom_pdf:RuntimeWarning
+    error:verbose is deprecated:FutureWarning
 markers =
     example: mark a test that runs example code
     matplotlib: mark a test that requires matplotlib

--- a/statsmodels/tsa/stattools.py
+++ b/statsmodels/tsa/stattools.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 from statsmodels.compat.numpy import lstsq
 from statsmodels.compat.pandas import deprecate_kwarg
-from statsmodels.compat.python import lzip, Literal
+from statsmodels.compat.python import Literal, lzip
 from statsmodels.compat.scipy import _next_regular
 
 from typing import Tuple
@@ -1386,7 +1386,7 @@ def breakvar_heteroskedasticity_test(
     return test_statistic, p_value
 
 
-def grangercausalitytests(x, maxlag, addconst=True, verbose=True):
+def grangercausalitytests(x, maxlag, addconst=True, verbose=None):
     """
     Four tests for granger non causality of 2 time series.
 
@@ -1405,7 +1405,13 @@ def grangercausalitytests(x, maxlag, addconst=True, verbose=True):
     addconst : bool
         Include a constant in the model.
     verbose : bool
-        Print results.
+        Print results. Deprecated
+
+        .. deprecated: 0.14
+
+           verbose is deprecated and will be removed after 0.15 is released
+
+
 
     Returns
     -------
@@ -1459,11 +1465,19 @@ def grangercausalitytests(x, maxlag, addconst=True, verbose=True):
     if not np.isfinite(x).all():
         raise ValueError("x contains NaN or inf values.")
     addconst = bool_like(addconst, "addconst")
-    verbose = bool_like(verbose, "verbose")
+    if verbose is not None:
+        verbose = bool_like(verbose, "verbose")
+        warnings.warn(
+            "verbose is deprecated since functions should not print results",
+            FutureWarning,
+        )
+    else:
+        verbose = True  # old default
+
     try:
         maxlag = int_like(maxlag, "maxlag")
         if maxlag <= 0:
-            raise ValueError("maxlag must a a positive integer")
+            raise ValueError("maxlag must be a positive integer")
         lags = np.arange(1, maxlag + 1)
     except TypeError:
         lags = np.array([int(lag) for lag in maxlag])

--- a/statsmodels/tsa/tests/test_tsa_tools.py
+++ b/statsmodels/tsa/tests/test_tsa_tools.py
@@ -794,6 +794,8 @@ class TestLagmat2DS(object):
 
 def test_grangercausality():
     data = np.random.rand(100, 2)
-    result, models = stattools.grangercausalitytests(data, maxlag=2, verbose=False)[1]
+    with pytest.warns(FutureWarning, match="verbose"):
+        out = stattools.grangercausalitytests(data, maxlag=2, verbose=False)
+    result, models = out[1]
     res2down, res2djoint, rconstr = models
     assert res2djoint.centered_tss is not res2djoint.uncentered_tss


### PR DESCRIPTION
Improve testing
Deprecate verbose

- [X] tests added / passed. 
- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
