### PR TITLE
DOC: fix instance of underline length that causes numpydoc 1.2 exception.

### DIFF
--- a/statsmodels/robust/scale.py
+++ b/statsmodels/robust/scale.py
@@ -339,7 +339,7 @@ class HuberScale(object):
         Return's Huber's scale computed as below
 
     Notes
-    --------
+    -----
     Huber's scale is the iterative solution to
 
     scale_(i+1)**2 = 1/(n*h)*sum(chi(r/sigma_i)*sigma_i**2


### PR DESCRIPTION
The exception is raised on a code path that raises a UserWarning, so fixing the cause of the warning avoids the exception.

This addresses the particular cause of the issue raised in numpy/numpydoc#362, and will allow `statsmodels` to build successfully with `numpydoc v1.2`. There will be other UserWarnings due to header underline-length mismatches but none hit the error path that causes the exception.