### PR TITLE
BUG: Check dtype for xvals in lowess

### DIFF
--- a/statsmodels/nonparametric/smoothers_lowess.py
+++ b/statsmodels/nonparametric/smoothers_lowess.py
@@ -234,7 +234,7 @@ def lowess(endog, exog, frac=2.0/3.0, it=3, delta=0.0, xvals=None, is_sorted=Fal
                                 frac=frac, it=it-1, delta=delta, given_xvals=False)
         else:
             weights = np.ones_like(x)
-        xvalues = np.ascontiguousarray(xvalues)
+        xvalues = np.ascontiguousarray(xvalues, dtype=float)
         # Then run once more using those supplied weights at the points provided by xvals
         # No extra iterations are performed here since weights are fixed
         res, _ = _lowess(y, x, xvalues, weights,

--- a/statsmodels/nonparametric/tests/test_lowess.py
+++ b/statsmodels/nonparametric/tests/test_lowess.py
@@ -12,13 +12,14 @@ available in R's MASS package.
 import os
 
 import numpy as np
-import pytest
 from numpy.testing import (
-    assert_almost_equal,
     assert_,
-    assert_raises,
+    assert_allclose,
+    assert_almost_equal,
     assert_equal,
+    assert_raises,
 )
+import pytest
 
 from statsmodels.nonparametric.smoothers_lowess import lowess
 
@@ -227,7 +228,8 @@ class TestLowess(object):
 
     def test_spike(self):
         # see 7700
-        # Create a curve that is easy to fit at first but gets harder further along.
+        # Create a curve that is easy to fit at first but gets
+        # harder further along.
         # This used to give an outlier bad fit at position 961
         x = np.linspace(0, 10, 1001)
         y = np.cos(x ** 2 / 5)
@@ -285,3 +287,11 @@ def test_returns_inputs():
     x = np.arange(20)
     result = lowess(y, x, frac=0.4)
     assert_almost_equal(result, np.column_stack((x, y)))
+
+
+def test_xvals_dtype(reset_randomstate):
+    y = [0] * 10 + [1] * 10
+    x = np.arange(20)
+    # Previously raised ValueError: Buffer dtype mismatch
+    results_xvals = lowess(y, x, frac=0.4, xvals=x[:5])
+    assert_allclose(results_xvals, np.zeros(5), atol=1e-12)


### PR DESCRIPTION
Ensure data are converted to contiguous double

- [X] closes #8046
- [X] tests added / passed. 
- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
