### PR TITLE
[maintenance/0.13.x] Merge pull request #7989 from bashtage/try-oldest-supported-numpy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,10 +3,6 @@ requires = [
     "setuptools",
     "wheel",
     "cython>=0.29.22",
-    "numpy==1.17.4; python_version=='3.7'",
-    "numpy==1.17.4; python_version=='3.8'",
-    "numpy==1.19.4; python_version=='3.9'",
-    "numpy==1.21.4; python_version=='3.10'",
-    "numpy; python_version>'3.10'",
+    "oldest-supported-numpy",
     "scipy>=1.3",
 ]


### PR DESCRIPTION
# Backport

This is an automatic backport to `maintenance/0.13.x` of:
 - #7989

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)