### PR TITLE
[maintenance/0.13.x] Merge pull request #8041 from bashtage/pin-numpydoc

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -31,7 +31,7 @@ pyyaml
 pandas-datareader
 simplegeneric
 seaborn
-numpydoc
+numpydoc<1.2
 theano-pymc
 pymc3
 arviz


### PR DESCRIPTION
# Backport

This is an automatic backport to `maintenance/0.13.x` of:
 - #8041

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)