### PR TITLE
BUG: denominator needs to be a vector

### DIFF
--- a/statsmodels/sandbox/distributions/multivariate.py
+++ b/statsmodels/sandbox/distributions/multivariate.py
@@ -110,7 +110,7 @@ def multivariate_t_rvs(m, S, df=np.inf, n=1):
     m = np.asarray(m)
     d = len(m)
     if df == np.inf:
-        x = 1.
+        x = np.ones(n)
     else:
         x = np.random.chisquare(df, n)/df
     z = np.random.multivariate_normal(np.zeros(d),S,(n,))


### PR DESCRIPTION
multivariate_t_rvs function currently seems to fail with "cannot apply subscript to float" in df==np.inf case

- [ ] closes #xxxx
- [ ] tests added / passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
