### PR TITLE
BUG: use nobs ratio in power and samplesize proportions_2indep

### DIFF
--- a/statsmodels/stats/proportion.py
+++ b/statsmodels/stats/proportion.py
@@ -1891,7 +1891,7 @@ def _std_2prop_power(diff, p2, ratio=1, alpha=0.05, value=0):
     p2_alt = p2
     p1_alt = p2_alt + diff
 
-    std_null = _std_diff_prop(p1_vnull, p2_vnull)
+    std_null = _std_diff_prop(p1_vnull, p2_vnull, ratio=nobs_ratio)
     std_alt = _std_diff_prop(p1_alt, p2_alt, ratio=nobs_ratio)
     return p_pooled, std_null, std_alt
 
@@ -1947,16 +1947,16 @@ def power_proportions_2indep(diff, prop2, nobs1, ratio=1, alpha=0.05,
             pooled proportion, used for std_null
         std_null
             standard error of difference under the null hypothesis (without
-            sqrt(nobs))
+            sqrt(nobs1))
         std_alt
             standard error of difference under the alternative hypothesis
-            (without sqrt(nobs))
+            (without sqrt(nobs1))
     """
     # TODO: avoid possible circular import, check if needed
     from statsmodels.stats.power import normal_power_het
 
-    p_pooled, std_null, std_alt = _std_2prop_power(diff, prop2, ratio=1,
-                                                   alpha=0.05, value=0)
+    p_pooled, std_null, std_alt = _std_2prop_power(diff, prop2, ratio=ratio,
+                                                   alpha=alpha, value=value)
 
     pow_ = normal_power_het(diff, nobs1, alpha, std_null=std_null,
                             std_alternative=std_alt,

--- a/statsmodels/stats/tests/test_proportion.py
+++ b/statsmodels/stats/tests/test_proportion.py
@@ -915,6 +915,16 @@ def test_power_2indep():
                                                alternative='two-sided')
     assert_allclose(n2, n, rtol=1e-13)
 
+    # with nobs ratio != 1
+    # note Stata has reversed ratio compared to ours, see #8049
+    pwr_st = 0.7995659211532175
+    n = 154
+    res = power_proportions_2indep(-0.1, 0.2, n, ratio=2.)
+    assert_allclose(res.power, pwr_st, atol=1e-7)
+
+    n2 = samplesize_proportions_2indep_onetail(-0.1, 0.2, pwr_st, ratio=2)
+    assert_allclose(n2, n, rtol=1e-4)
+
 
 @pytest.mark.parametrize("count", np.arange(10, 90, 5))
 @pytest.mark.parametrize("method", list(probci_methods.keys()) + ["binom_test"])


### PR DESCRIPTION
closes #8049

nobs ratio was not correctly used in power_proportions_2indep and samplesize_proportions_2indep_onetail