### PR TITLE
fix(setup): use correct setuptools backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,3 +8,4 @@ requires = [
     "oldest-supported-numpy",
     "scipy>=1.3",
 ]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -12,13 +12,20 @@ from collections import defaultdict
 from distutils.command.clean import clean
 import fnmatch
 import os
-from os.path import abspath, join as pjoin, relpath, split
+from os.path import join as pjoin, relpath, split
+from pathlib import Path
 import shutil
 import sys
 
 import pkg_resources
 
+SETUP_DIR = Path(__file__).parent.resolve()
+
+sys.path.append(str(SETUP_DIR))
 import versioneer
+
+del sys.path[-1]
+
 
 try:
     # SM_FORCE_C is a testing shim to force setup to use C source files
@@ -79,9 +86,7 @@ EXTRAS_REQUIRE = {
 ###############################################################################
 DISTNAME = "statsmodels"
 DESCRIPTION = "Statistical computations and models for Python"
-SETUP_DIR = split(abspath(__file__))[0]
-with open(pjoin(SETUP_DIR, "README.rst")) as readme:
-    README = readme.read()
+README = SETUP_DIR.joinpath("README.rst").read_text()
 LONG_DESCRIPTION = README
 MAINTAINER = "statsmodels Developers"
 MAINTAINER_EMAIL = "pystatsmodels@googlegroups.com"

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ import pkg_resources
 SETUP_DIR = Path(__file__).parent.resolve()
 
 sys.path.append(str(SETUP_DIR))
-import versioneer
+import versioneer  # noqa: E402
 
 del sys.path[-1]
 
@@ -59,7 +59,7 @@ INSTALL_REQUIREMENTS = {
     "scipy": "1.4",  # released December 2019
     "pandas": "1.0",  # released January 2020
     "patsy": "0.5.2",  # released January 2018
-    "packaging": "21.3"  # released Nov 2021
+    "packaging": "21.3",  # released Nov 2021
 }
 
 CYTHON_MIN_VER = "0.29.26"  # released 2020

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ from collections import defaultdict
 from distutils.command.clean import clean
 import fnmatch
 import os
-from os.path import join as pjoin, relpath, split
+from os.path import join as pjoin, relpath
 from pathlib import Path
 import shutil
 import sys


### PR DESCRIPTION
The default is `build-backend = "setuptools.build_meta:__legacy__"`, which is not ideal. This field really shouldn't have been optional, but it was.

The legacy backend injects the local path - that has to be done by hand with the non-legacy backend, since packages are discouraged from importing in setup.py. If that makes a difference, that will also have to be added here.

- [ ] closes #xxxx
- [ ] tests added / passed. 
- [ ] code/documentation is well formatted.  
- [ ] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

Oops, didn't format the commit message. Can reformat after tests run.

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
