### PR TITLE
ENH: add burg as an option for method to pacf

### DIFF
--- a/statsmodels/tsa/stattools.py
+++ b/statsmodels/tsa/stattools.py
@@ -925,6 +925,7 @@ def pacf(x, nlags=None, method="ywadjusted", alpha=None):
           correction.
         - "ldb" or "ldbiased" : Levinson-Durbin recursion without bias
           correction.
+        - "burg" :  Burg"s partial autocorrelation estimator.
 
     alpha : float, optional
         If a number is given, the confidence intervals for the given level are
@@ -983,6 +984,7 @@ def pacf(x, nlags=None, method="ywadjusted", alpha=None):
         "ldb",
         "ldbiased",
         "ld_biased",
+        "burg"
     )
     x = array_like(x, "x", maxdim=2)
     method = string_like(method, "method", options=methods)
@@ -1010,6 +1012,8 @@ def pacf(x, nlags=None, method="ywadjusted", alpha=None):
         acv = acovf(x, adjusted=True, fft=False)
         ld_ = levinson_durbin(acv, nlags=nlags, isacov=True)
         ret = ld_[2]
+    elif method == "burg":
+        ret, _ = pacf_burg(x, nlags=nlags, demean=True)
     # inconsistent naming with ywmle
     else:  # method in ("ldb", "ldbiased", "ld_biased")
         acv = acovf(x, adjusted=False, fft=False)

--- a/statsmodels/tsa/tests/test_stattools.py
+++ b/statsmodels/tsa/tests/test_stattools.py
@@ -349,6 +349,10 @@ class TestPACF(CheckCorrGram):
         pacfld = pacf(self.x, nlags=40, method="lda")
         assert_almost_equal(pacfyw, pacfld, DECIMAL_8)
 
+    def test_burg(self):
+        pacfburg_, _ = pacf_burg(self.x, nlags=40)
+        pacfburg = pacf(self.x, nlags=40, method="burg")
+        assert_almost_equal(pacfburg_, pacfburg, DECIMAL_8)
 
 class TestBreakvarHeteroskedasticityTest(object):
     from scipy.stats import chi2, f


### PR DESCRIPTION
This PR adds `"burg"` as an option for the method argument in `pacf` which enables the option to use the already implemented `pacf_burg` function via `pacf(x, method="burg")`. Feedback would be appreciated in particular for the added test.

- [ ] closes #xxxx
- [x] tests added / passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
