### PR TITLE
BUG: Fix ValueError output in lagmat when using pandas

### DIFF
--- a/statsmodels/tsa/tsatools.py
+++ b/statsmodels/tsa/tsatools.py
@@ -383,7 +383,7 @@ def lagmat(x,
     trim = trim.lower()
     if is_pandas and trim in ("none", "backward"):
         raise ValueError(
-            "trim cannot be 'none' or 'forward' when used on "
+            "trim cannot be 'none' or 'backward' when used on "
             "Series or DataFrames"
         )
 


### PR DESCRIPTION
Fixes the error message in `lagmat` when `trim="backward"` and `use_pandas=True`. The current error message incorrectly states that `trim="forward"` and `use_pandas=True` are incompatible. 
