### PR TITLE
DOC: Fix spelling in ARDL

### DIFF
--- a/statsmodels/tsa/ardl/model.py
+++ b/statsmodels/tsa/ardl/model.py
@@ -233,8 +233,8 @@ class ARDL(AutoReg):
         can be omitted if using a pandas object for endog that contains a
         recognized frequency.
     missing : {"none", "drop", "raise"}, optional
-        Available options are 'none', 'drop', and 'raise'. If 'none', no nan
-        checking is done. If 'drop', any observations with nans are dropped.
+        Available options are 'none', 'drop', and 'raise'. If 'none', no NaN
+        checking is done. If 'drop', any observations with NaNs are dropped.
         If 'raise', an error is raised. Default is 'none'.
 
     Notes
@@ -580,7 +580,7 @@ class ARDL(AutoReg):
             raise ValueError(
                 f"The number of regressors ({reg.shape[1]}) including "
                 "deterministics, lags of the endog, lags of the exogenous, "
-                "and fixed regressors is larer than the sample available "
+                "and fixed regressors is larger than the sample available "
                 f"for estimation ({reg.shape[0]})."
             )
         return self.data.endog[self._hold_back :], reg
@@ -912,7 +912,7 @@ class ARDL(AutoReg):
             that contains a recognized frequency.
         missing : {"none", "drop", "raise"}, optional
             Available options are 'none', 'drop', and 'raise'. If 'none', no
-            nan checking is done. If 'drop', any observations with nans are
+            NaN checking is done. If 'drop', any observations with NaNs are
             dropped. If 'raise', an error is raised. Default is 'none'.
 
         Returns
@@ -1243,7 +1243,7 @@ class ARDLResults(AutoRegResults):
 
         Returns
         -------
-        smry : Summary instance
+        Summary
             This holds the summary table and text, which can be printed or
             converted to various output formats.
 
@@ -1426,8 +1426,8 @@ def ardl_select_order(
         can be omitted if using a pandas object for endog that contains a
         recognized frequency.
     missing : {"none", "drop", "raise"}, optional
-        Available options are 'none', 'drop', and 'raise'. If 'none', no nan
-        checking is done. If 'drop', any observations with nans are dropped.
+        Available options are 'none', 'drop', and 'raise'. If 'none', no NaN
+        checking is done. If 'drop', any observations with NaNs are dropped.
         If 'raise', an error is raised. Default is 'none'.
 
     Returns
@@ -1662,8 +1662,8 @@ class UECM(ARDL):
         can be omitted if using a pandas object for endog that contains a
         recognized frequency.
     missing : {"none", "drop", "raise"}, optional
-        Available options are 'none', 'drop', and 'raise'. If 'none', no nan
-        checking is done. If 'drop', any observations with nans are dropped.
+        Available options are 'none', 'drop', and 'raise'. If 'none', no NaN
+        checking is done. If 'drop', any observations with NaNs are dropped.
         If 'raise', an error is raised. Default is 'none'.
 
     Notes
@@ -1904,7 +1904,7 @@ class UECM(ARDL):
             raise ValueError(
                 f"The number of regressors ({reg.shape[1]}) including "
                 "deterministics, lags of the endog, lags of the exogenous, "
-                "and fixed regressors is larer than the sample available "
+                "and fixed regressors is larger than the sample available "
                 f"for estimation ({reg.shape[0]})."
             )
         return np.squeeze(y)[self._hold_back :], reg


### PR DESCRIPTION
Fix spelling of a few words in ARDL

- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
