### PR TITLE
BUG: Ensure exog is well specified

### DIFF
--- a/statsmodels/stats/tests/test_diagnostic.py
+++ b/statsmodels/stats/tests/test_diagnostic.py
@@ -244,6 +244,19 @@ class TestDiagnosticG(object):
         bp = smsdia.het_breuschpagan(res.resid, res.model.exog)
         compare_to_reference(bp, bptest, decimal=(12, 12))
 
+    def test_het_breusch_pagan_1d_err(self):
+        res = self.res
+        x = np.asarray(res.model.exog)[:, -1]
+        with pytest.raises(ValueError, match="The Breusch-Pagan"):
+            smsdia.het_breuschpagan(res.resid, x)
+        x = np.ones_like(x)
+        with pytest.raises(ValueError, match="The Breusch-Pagan"):
+            smsdia.het_breuschpagan(res.resid, x)
+        x = np.asarray(res.model.exog).copy()
+        x[:, 0] = 0
+        with pytest.raises(ValueError, match="The Breusch-Pagan"):
+            smsdia.het_breuschpagan(res.resid, x)
+
     def test_het_breusch_pagan_nonrobust(self):
         res = self.res
 


### PR DESCRIPTION
Require 2 columns including a constant

- [X] tests added / passed. 
- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
