### PR TITLE
ENH:  hypothesis tests,  confint, power for rates (poisson, negbin)

### DIFF
--- a/docs/source/stats.rst
+++ b/docs/source/stats.rst
@@ -472,12 +472,37 @@ Status: experimental, API might change, added in 0.12
 
 .. currentmodule:: statsmodels.stats.rates
 
+statistical function for one sample
+
+.. autosummary::
+   :toctree: generated
+
+   confint_poisson
+   confint_quantile_poisson
+   test_poisson
+   tolerance_int_poisson
+
+statistical function for two independent samples
+
 .. autosummary::
    :toctree: generated
 
    test_poisson_2indep
    etest_poisson_2indep
+   confint_poisson_2indep
    tost_poisson_2indep
+   nonequivalence_poisson_2indep
+
+functions for statistical power
+
+.. autosummary::
+   :toctree: generated
+
+   power_poisson_2indep
+   power_equivalence_poisson_2indep
+   power_poisson_diff_2indep
+   power_negbin_2indep
+   power_equivalence_neginb_2indep
 
 
 Multivariate

--- a/statsmodels/stats/_inference_tools.py
+++ b/statsmodels/stats/_inference_tools.py
@@ -6,6 +6,7 @@ License: BSD-3
 """
 
 import numpy as np
+from numpy.testing import assert_allclose
 
 
 def _mover_confint(stat1, stat2, ci1, ci2, contrast="diff"):
@@ -27,12 +28,27 @@ def _mover_confint(stat1, stat2, ci1, ci2, contrast="diff"):
         prod = stat1 * stat2
         term1 = stat2**2 - (ci2[1] - stat2)**2
         term2 = stat2**2 - (ci2[0] - stat2)**2
+        low_ = (prod -
+                np.sqrt(prod**2 - term1 * (stat1**2 - (ci1[0] - stat1)**2))
+                ) / term1
+        upp_ = (prod +
+                np.sqrt(prod**2 - term2 * (stat1**2 - (ci1[1] - stat1)**2))
+                ) / term2
+
+        # method 2 Li, Tang, Wong 2014
+        low1, upp1 = ci1
+        low2, upp2 = ci2
+        term1 = upp2 * (2 * stat2 - upp2)
+        term2 = low2 * (2 * stat2 - low2)
         low = (prod -
-               np.sqrt(prod**2 - term1 * (stat1**2 - (ci1[0] - stat1)**2))
+               np.sqrt(prod**2 - term1 * low1 * (2 * stat1 - low1))
                ) / term1
         upp = (prod +
-               np.sqrt(prod**2 - term2 * (stat1**2 - (ci1[1] - stat1)**2))
+               np.sqrt(prod**2 - term2 * upp1 * (2 * stat1 - upp1))
                ) / term2
+
+        assert_allclose((low_, upp_), (low, upp), atol=1e-15, rtol=1e-10)
+
         ci = (low, upp)
 
     return ci
@@ -40,8 +56,8 @@ def _mover_confint(stat1, stat2, ci1, ci2, contrast="diff"):
 
 def _mover_confint_sum(stat, ci):
 
-        stat_ = stat.sum(0)
-        low_half = np.sqrt(np.sum((stat_ - ci[0])**2))
-        upp_half = np.sqrt(np.sum((stat_ - ci[1])**2))
-        ci = (stat - low_half, stat + upp_half)
-        return ci
+    stat_ = stat.sum(0)
+    low_half = np.sqrt(np.sum((stat_ - ci[0])**2))
+    upp_half = np.sqrt(np.sum((stat_ - ci[1])**2))
+    ci = (stat - low_half, stat + upp_half)
+    return ci

--- a/statsmodels/stats/_inference_tools.py
+++ b/statsmodels/stats/_inference_tools.py
@@ -10,6 +10,26 @@ from numpy.testing import assert_allclose
 
 
 def _mover_confint(stat1, stat2, ci1, ci2, contrast="diff"):
+    """
+
+    References
+    ----------
+
+    .. [#] Krishnamoorthy, K., Jie Peng, and Dan Zhang. 2016. “Modified Large
+       Sample Confidence Intervals for Poisson Distributions: Ratio, Weighted
+       Average, and Product of Means.” Communications in Statistics - Theory
+       and Methods 45 (1): 83–97. https://doi.org/10.1080/03610926.2013.821486.
+
+
+    .. [#] Li, Yanhong, John J. Koval, Allan Donner, and G. Y. Zou. 2010.
+       “Interval Estimation for the Area under the Receiver Operating
+       Characteristic Curve When Data Are Subject to Error.” Statistics in
+       Medicine 29 (24): 2521–31. https://doi.org/10.1002/sim.4015.
+
+    .. [#] Zou, G. Y., and A. Donner. 2008. “Construction of Confidence Limits
+       about Effect Measures: A General Approach.” Statistics in Medicine 27
+       (10): 1693–1702. https://doi.org/10.1002/sim.3095.
+    """
 
     if contrast == "diff":
         stat = stat1 - stat2

--- a/statsmodels/stats/_inference_tools.py
+++ b/statsmodels/stats/_inference_tools.py
@@ -1,0 +1,47 @@
+"""
+Created on Mar 30, 2022 1:21:54 PM
+
+Author: Josef Perktold
+License: BSD-3
+"""
+
+import numpy as np
+
+
+def _mover_confint(stat1, stat2, ci1, ci2, contrast="diff"):
+
+    if contrast == "diff":
+        stat = stat1 - stat2
+        low_half = np.sqrt((stat1 - ci1[0])**2 + (stat2 - ci2[1])**2)
+        upp_half = np.sqrt((stat1 - ci1[1])**2 + (stat2 - ci2[0])**2)
+        ci = (stat - low_half, stat + upp_half)
+
+    elif contrast == "sum":
+        stat = stat1 + stat2
+        low_half = np.sqrt((stat1 - ci1[0])**2 + (stat2 - ci2[0])**2)
+        upp_half = np.sqrt((stat1 - ci1[1])**2 + (stat2 - ci2[1])**2)
+        ci = (stat - low_half, stat + upp_half)
+
+    elif contrast == "ratio":
+        # stat = stat1 / stat2
+        prod = stat1 * stat2
+        term1 = stat2**2 - (ci2[1] - stat2)**2
+        term2 = stat2**2 - (ci2[0] - stat2)**2
+        low = (prod -
+               np.sqrt(prod**2 - term1 * (stat1**2 - (ci1[0] - stat1)**2))
+               ) / term1
+        upp = (prod +
+               np.sqrt(prod**2 - term2 * (stat1**2 - (ci1[1] - stat1)**2))
+               ) / term2
+        ci = (low, upp)
+
+    return ci
+
+
+def _mover_confint_sum(stat, ci):
+
+        stat_ = stat.sum(0)
+        low_half = np.sqrt(np.sum((stat_ - ci[0])**2))
+        upp_half = np.sqrt(np.sum((stat_ - ci[1])**2))
+        ci = (stat - low_half, stat + upp_half)
+        return ci

--- a/statsmodels/stats/rates.py
+++ b/statsmodels/stats/rates.py
@@ -143,7 +143,7 @@ def confint_poisson(count, exposure, method=None, alpha=0.05):
     - "exact-c" central confidence interval based on gamma distribution
     - "score" : based on score test, uses variance under null value
     - "wald" : based on wald test, uses variance base on estimated rate.
-    - "waldcc" : based on wald test with 0.5 count added to variance
+    - "waldccv" : based on wald test with 0.5 count added to variance
       computation. This does not use continuity correct for the center of the
       confidence interval.
     - "midp-c" : based on midp correction of central exact confidence interval.
@@ -290,6 +290,8 @@ def confint_poisson(count, exposure, method=None, alpha=0.05):
 
 def _invert_test_confint(count, nobs, alpha=0.05, method="midp-c",
                          method_start="exact-c"):
+    """invert hypothesis test to get confidence interval
+    """
 
     def func(r):
         v = (test_poisson(count, nobs, value=r, method=method)[1] -
@@ -303,9 +305,35 @@ def _invert_test_confint(count, nobs, alpha=0.05, method="midp-c",
     return low[0], upp[0]
 
 
-def test_poisson_2indep(count1, exposure1, count2, exposure2, ratio_null=1,
-                        method='score', alternative='two-sided',
-                        etest_kwds=None):
+def _invert_test_confint_2indep(
+        count1, exposure1, count2, exposure2,
+        alpha=0.05,
+        method="score",
+        compare="diff",
+        method_start="wald"
+        ):
+    """invert hypothesis test to get confidence interval
+    """
+
+    def func(r):
+        v = (test_poisson_2indep(
+             count1, exposure1, count2, exposure2,
+             value=r, method=method, compare=compare
+             )[1] - alpha)**2
+        return v
+
+    ci = confint_poisson_2indep(count1, exposure1, count2, exposure2,
+                                method=method_start, compare=compare)
+    low = optimize.fmin(func, ci[0], xtol=1e-8)#, disp=False)
+    upp = optimize.fmin(func, ci[1], xtol=1e-8) #, disp=False)
+    assert np.size(low) == 1
+    return low[0], upp[0]
+
+
+def test_poisson_2indep(count1, exposure1, count2, exposure2, value=None,
+                        ratio_null=None,
+                        method=None, compare='ratio',
+                        alternative='two-sided', etest_kwds=None):
     '''test for ratio of two sample Poisson intensities
 
     If the two Poisson rates are g1 and g2, then the Null hypothesis is
@@ -339,6 +367,32 @@ def test_poisson_2indep(count1, exposure1, count2, exposure2, ratio_null=1,
         provide pvalues from `etest_poisson_2indep` using score or wald
         statistic respectively.
         see Notes.
+
+        ratio:
+
+        - 'wald': method W1A, wald test, variance based on separate estimates
+        - 'score': method W2A, score test, variance based on estimate under
+          the Null hypothesis
+        - 'wald-log': W3A   not yet available
+        - 'score-log' W4A   not yet available
+        - 'sqrt': W5A, based on variance stabilizing square root transformation
+        - 'exact-cond': exact conditional test based on binomial distribution
+        - 'cond-midp': midpoint-pvalue of exact conditional test
+        - 'etest': etest with score test statistic
+        - 'etest-wald': etest with wald test statistic
+
+        diff:
+
+        - 'wald',
+        - 'waldccv'
+        - 'score' if correction is True, then this uses the degrees of freedom
+           correction ``nobs / (nobs - 1)`` as in Miettinen Nurminen 1985
+
+    compare : {'diff', 'ratio'}
+        If compare is `diff`, then the confidence interval is for
+        diff = rat11 - rate22.
+        If compare is `ratio`, then the confidence interval is for the
+        rate ratio defined by ratio = rate1 / rate2.
     alternative : string
         The alternative hypothesis, H1, has to be one of the following
 
@@ -381,53 +435,96 @@ def test_poisson_2indep(count1, exposure1, count2, exposure2, ratio_null=1,
     # shortcut names
     y1, n1, y2, n2 = count1, exposure1, count2, exposure2
     d = n2 / n1
-    r = ratio_null
-    r_d = r / d
+    rate1, rate2 = y1 / n1, y2 / n2
 
-    if method in ['score']:
-        stat = (y1 - y2 * r_d) / np.sqrt((y1 + y2) * r_d)
-        dist = 'normal'
-    elif method in ['wald']:
-        stat = (y1 - y2 * r_d) / np.sqrt(y1 + y2 * r_d**2)
-        dist = 'normal'
-    elif method in ['sqrt']:
-        stat = 2 * (np.sqrt(y1 + 3 / 8.) - np.sqrt((y2 + 3 / 8.) * r_d))
-        stat /= np.sqrt(1 + r_d)
-        dist = 'normal'
-    elif method in ['exact-cond', 'cond-midp']:
-        from statsmodels.stats import proportion
-        bp = r_d / (1 + r_d)
-        y_total = y1 + y2
-        stat = None
-        # TODO: why y2 in here and not y1, check definition of H1 "larger"
-        pvalue = proportion.binom_test(y1, y_total, prop=bp,
-                                       alternative=alternative)
-        if method in ['cond-midp']:
-            # not inplace in case we still want binom pvalue
-            pvalue = pvalue - 0.5 * stats.binom.pmf(y1, y_total, bp)
+    if compare == 'ratio':
+        if method is None:
+            # default method
+            method = 'score'
 
-        dist = 'binomial'
-    elif method.startswith('etest'):
-        if method.endswith('wald'):
-            method_etest = 'wald'
+        if ratio_null is None and value is None:
+            # default value
+            ratio_null = 1
+        elif ratio_null is not None:
+            # add deprecation warning
+            ratio_null = ratio_null  # just to be explicit
+            value = ratio_null
         else:
-            method_etest = 'score'
-        if etest_kwds is None:
-            etest_kwds = {}
+            ratio_null = value
 
-        stat, pvalue = etest_poisson_2indep(
-            count1, exposure1, count2, exposure2, ratio_null=ratio_null,
-            method=method_etest, alternative=alternative, **etest_kwds)
+        r = ratio_null
+        r_d = r / d
 
-        dist = 'poisson'
+        if method in ['score']:
+            stat = (y1 - y2 * r_d) / np.sqrt((y1 + y2) * r_d)
+            dist = 'normal'
+        elif method in ['wald']:
+            stat = (y1 - y2 * r_d) / np.sqrt(y1 + y2 * r_d**2)
+            dist = 'normal'
+        elif method in ['sqrt']:
+            stat = 2 * (np.sqrt(y1 + 3 / 8.) - np.sqrt((y2 + 3 / 8.) * r_d))
+            stat /= np.sqrt(1 + r_d)
+            dist = 'normal'
+        elif method in ['exact-cond', 'cond-midp']:
+            from statsmodels.stats import proportion
+            bp = r_d / (1 + r_d)
+            y_total = y1 + y2
+            stat = None
+            # TODO: why y2 in here and not y1, check definition of H1 "larger"
+            pvalue = proportion.binom_test(y1, y_total, prop=bp,
+                                           alternative=alternative)
+            if method in ['cond-midp']:
+                # not inplace in case we still want binom pvalue
+                pvalue = pvalue - 0.5 * stats.binom.pmf(y1, y_total, bp)
+
+            dist = 'binomial'
+        elif method.startswith('etest'):
+            if method.endswith('wald'):
+                method_etest = 'wald'
+            else:
+                method_etest = 'score'
+            if etest_kwds is None:
+                etest_kwds = {}
+
+            stat, pvalue = etest_poisson_2indep(
+                count1, exposure1, count2, exposure2, ratio_null=ratio_null,
+                method=method_etest, alternative=alternative, **etest_kwds)
+
+            dist = 'poisson'
+        else:
+            raise ValueError('method not recognized')
+
+    elif compare == "diff":
+        if method in ['wald']:
+            stat = (rate1 - rate2 - value) / np.sqrt(rate1 / n1 + rate2 / n2)
+            dist = 'normal'
+            "waldccv"
+        elif method in ['waldccv']:
+            stat = (rate1 - rate2 - value)
+            stat /= np.sqrt((count2 + 0.5) / n1**2 + (count2 + 0.5) / n2**2)
+            dist = 'normal'
+        elif method in ['score']:
+            # estimate rates with constraint MLE
+            count_pooled = y1 + y2
+            rate_pooled = count_pooled / (n1 + n2)
+            dt = rate_pooled - value
+            r2_cmle = 0.5 * (dt + np.sqrt(dt**2 + 4 * value * y2 / (n1 + n2)))
+            r1_cmle = r2_cmle + value
+
+            stat = ((rate1 - rate2 - value) /
+                    np.sqrt(r1_cmle / n1 + r2_cmle / n2))
+            dist = 'normal'
+        else:
+            raise ValueError('method not recognized')
     else:
-        raise ValueError('method not recognized')
+        raise NotImplementedError('"compare" needs to be ratio or diff')
 
     if dist == 'normal':
         stat, pvalue = _zstat_generic2(stat, 1, alternative)
 
-    rates = (y1 / n1, y2 / n2)
-    ratio = rates[0] / rates[1]
+    rates = (rate1, rate2)
+    ratio = rate1 / rate2
+    diff = rate1 - rate2
     res = HolderTuple(statistic=stat,
                       pvalue=pvalue,
                       distribution=dist,
@@ -435,6 +532,7 @@ def test_poisson_2indep(count1, exposure1, count2, exposure2, ratio_null=1,
                       alternative=alternative,
                       rates=rates,
                       ratio=ratio,
+                      diff=diff,
                       ratio_null=ratio_null)
     return res
 
@@ -647,9 +745,78 @@ def tost_poisson_2indep(count1, exposure1, count2, exposure2, low, upp,
     return res
 
 
+def confint_poisson_2indep(count1, exposure1, count2, exposure2,
+                           method='score', compare='ratio', alpha=0.05,
+                           ):
+    """Confidence interval for ratio of 2 indep poisson rates
+    """
+
+    # shortcut names
+    y1, n1, y2, n2 = count1, exposure1, count2, exposure2
+    rate1, rate2 = y1 / n1, y2 / n2
+    alpha = alpha / 2  # two-sided only
+
+    if compare == "ratio":
+
+        if method == "wald":
+            crit = stats.norm.isf(alpha)
+            c = 0
+            center = (count1 + c) / (count2 + c) * n2 / n1
+            std = np.sqrt(1 / (count1 + c) + 1 / (count2 + c))
+
+            ci = (center * np.exp(- crit * std), center * np.exp(crit * std))
+
+        elif method == "waldcc":
+            crit = stats.norm.isf(alpha)
+            center = (count1 + 0.5) / (count2 + 0.5) * n2 / n1
+            std = np.sqrt(1 / (count1 + 0.5) + 1 / (count2 + 0.5))
+
+            ci = (center * np.exp(- crit * std), center * np.exp(crit * std))
+
+        elif method == "sqrtcc":
+            crit = stats.norm.isf(alpha)
+            center = (count1 + 0.5) * (count2 + 0.5)
+            std = 0.5 * np.sqrt(count1 + 0.5 + count2 + 0.5 - 0.25 * crit)
+            denom = count2 + 0.5 - 0.25 * crit
+
+            low_sqrt = n2 / n1 * (center - crit * std) / denom
+            upp_sqrt = n2 / n1 * (center + crit * std) / denom
+
+            ci = (low_sqrt**2, upp_sqrt**2)
+
+        else:
+            raise ValueError('method not recognized')
+
+    elif compare == "diff":
+
+        if method in ['wald']:
+            crit = stats.norm.isf(alpha)
+            center = rate1 - rate2
+            half = crit * np.sqrt(rate1 / n1 + rate2 / n2)
+            ci = center - half, center + half
+
+        elif method == "score":
+            low, upp = _invert_test_confint_2indep(
+                count1, exposure1, count2, exposure2,
+                alpha=alpha * 2,   # check how alpha is defined
+                method="score",
+                compare="diff",
+                method_start="wald"
+                )
+            ci = (low, upp)
+        else:
+            raise ValueError('method not recognized')
+    else:
+        raise NotImplementedError('"compare" needs to be ratio or diff')
+
+    ci = (np.maximum(ci[0], 0), ci[1])
+    return ci
+
+
 def power_poisson_2indep(rate1, nobs1, rate2, nobs2, exposure, value=0,
                          alpha=0.025, dispersion=1, alternative="smaller"):
     """power for one-sided test of ratio of 2 independent poisson rates
+
     this is currently for superiority and non-inferiority testing
 
     signature not adjusted yet

--- a/statsmodels/stats/rates.py
+++ b/statsmodels/stats/rates.py
@@ -736,7 +736,7 @@ def test_poisson_2indep(count1, exposure1, count2, exposure2, value=None,
     '''
 
     # shortcut names
-    y1, n1, y2, n2 = count1, exposure1, count2, exposure2
+    y1, n1, y2, n2 = map(np.asarray, [count1, exposure1, count2, exposure2])
     d = n2 / n1
     rate1, rate2 = y1 / n1, y2 / n2
     rates_cmle = None
@@ -752,9 +752,9 @@ def test_poisson_2indep(count1, exposure1, count2, exposure2, value=None,
         elif ratio_null is not None:
             warnings.warn("'ratio_null' is deprecated, use 'value' keyword",
                           DeprecationWarning)
-            ratio_null = ratio_null  # just to be explicit  # noqa
             value = ratio_null
         else:
+            # for results holder instance, it still contains ratio_null
             ratio_null = value
 
         r = value
@@ -799,7 +799,7 @@ def test_poisson_2indep(count1, exposure1, count2, exposure2, value=None,
                 etest_kwds = {}
 
             stat, pvalue = etest_poisson_2indep(
-                count1, exposure1, count2, exposure2, ratio_null=ratio_null,
+                count1, exposure1, count2, exposure2, value=value,
                 method=method_etest, alternative=alternative, **etest_kwds)
 
             dist = 'poisson'
@@ -860,6 +860,7 @@ def test_poisson_2indep(count1, exposure1, count2, exposure2, value=None,
     res = HolderTuple(statistic=stat,
                       pvalue=pvalue,
                       distribution=dist,
+                      compare=compare,
                       method=method,
                       alternative=alternative,
                       rates=rates,
@@ -966,7 +967,7 @@ def etest_poisson_2indep(count1, exposure1, count2, exposure2, ratio_null=None,
     Analysis 51 (6): 3085–99. https://doi.org/10.1016/j.csda.2006.02.004.
 
     """
-    y1, n1, y2, n2 = count1, exposure1, count2, exposure2
+    y1, n1, y2, n2 = map(np.asarray, [count1, exposure1, count2, exposure2])
     d = n2 / n1
 
     eps = 1e-20  # avoid zero division in stat_func
@@ -974,14 +975,11 @@ def etest_poisson_2indep(count1, exposure1, count2, exposure2, ratio_null=None,
     if compare == "ratio":
         if ratio_null is None and value is None:
             # default value
-            value = ratio_null = 1
+            value = 1
         elif ratio_null is not None:
             warnings.warn("'ratio_null' is deprecated, use 'value' keyword",
                           DeprecationWarning)
-            ratio_null = ratio_null  # just to be explicit  # noqa
             value = ratio_null
-        else:
-            ratio_null = value
 
         r = value  # rate1 / rate2
         r_d = r / d
@@ -1285,7 +1283,7 @@ def confint_poisson_2indep(count1, exposure1, count2, exposure2,
     """
 
     # shortcut names
-    y1, n1, y2, n2 = count1, exposure1, count2, exposure2
+    y1, n1, y2, n2 = map(np.asarray, [count1, exposure1, count2, exposure2])
     rate1, rate2 = y1 / n1, y2 / n2
     alpha = alpha / 2  # two-sided only
 
@@ -1477,6 +1475,8 @@ def power_poisson_ratio_2indep(
     # TODO: avoid possible circular import, check if needed
     from statsmodels.stats.power import normal_power_het
 
+    rate1, rate2, nobs1 = map(np.asarray, [rate1, rate2, nobs1])
+
     nobs2 = nobs_ratio * nobs1
     v1 = dispersion / exposure * (1 / rate1 + 1 / (nobs_ratio * rate2))
     if method_var == "alt":
@@ -1591,6 +1591,8 @@ def power_equivalence_poisson_2indep(rate1, rate2, nobs1,
        376–87. https://doi.org/10.1002/sim.5947.
     .. [3] PASS documentation
     """
+    rate1, rate2, nobs1 = map(np.asarray, [rate1, rate2, nobs1])
+
     nobs2 = nobs_ratio * nobs1
     v1 = dispersion / exposure * (1 / rate1 + 1 / (nobs_ratio * rate2))
 
@@ -1766,6 +1768,8 @@ def power_poisson_diff_2indep(rate1, rate2, nobs1, nobs_ratio=1, alpha=0.05,
     # TODO: avoid possible circular import, check if needed
     from statsmodels.stats.power import normal_power_het
 
+    rate1, rate2, nobs1 = map(np.asarray, [rate1, rate2, nobs1])
+
     diff = rate1 - rate2
     _, std_null, std_alt = _std_2poisson_power(
         rate1,
@@ -1917,6 +1921,8 @@ def power_negbin_ratio_2indep(
     # TODO: avoid possible circular import, check if needed
     from statsmodels.stats.power import normal_power_het
 
+    rate1, rate2, nobs1 = map(np.asarray, [rate1, rate2, nobs1])
+
     nobs2 = nobs_ratio * nobs1
     v1 = ((1 / rate1 + 1 / (nobs_ratio * rate2)) / exposure +
           (1 + nobs_ratio) / nobs_ratio * dispersion)
@@ -2034,6 +2040,8 @@ def power_equivalence_neginb_2indep(rate1, rate2, nobs1,
        376–87. https://doi.org/10.1002/sim.5947.
     .. [3] PASS documentation
     """
+    rate1, rate2, nobs1 = map(np.asarray, [rate1, rate2, nobs1])
+
     nobs2 = nobs_ratio * nobs1
 
     v1 = ((1 / rate2 + 1 / (nobs_ratio * rate1)) / exposure +

--- a/statsmodels/stats/rates.py
+++ b/statsmodels/stats/rates.py
@@ -147,7 +147,7 @@ def test_poisson(count, nobs, value, method=None, alternative="two-sided",
             msg = 'alternative should be "two-sided", "larger" or "smaller"'
             raise ValueError(msg)
 
-        statistic = None
+        statistic = np.nan
         dist = "Poisson"
 
     elif method == "sqrt":
@@ -780,7 +780,7 @@ def test_poisson_2indep(count1, exposure1, count2, exposure2, value=None,
             from statsmodels.stats import proportion
             bp = r_d / (1 + r_d)
             y_total = y1 + y2
-            stat = None
+            stat = np.nan
             # TODO: why y2 in here and not y1, check definition of H1 "larger"
             pvalue = proportion.binom_test(y1, y_total, prop=bp,
                                            alternative=alternative)
@@ -1173,17 +1173,17 @@ def nonequivalence_poisson_2indep(count1, exposure1, count2, exposure2,
 
     """
     tt1 = test_poisson_2indep(count1, exposure1, count2, exposure2,
-                              ratio_null=low, method=method, compare=compare,
+                              value=low, method=method, compare=compare,
                               alternative='smaller')
     tt2 = test_poisson_2indep(count1, exposure1, count2, exposure2,
-                              ratio_null=upp, method=method,
+                              value=upp, method=method, compare=compare,
                               alternative='larger')
 
     # idx_min = 0 if tt1.pvalue < tt2.pvalue else 1
     idx_min = np.asarray(tt1.pvalue < tt2.pvalue, int)
     pvalue = 2 * np.minimum(tt1.pvalue, tt2.pvalue)
-    np.column_stack([tt1.statistic, tt2.statistic])[idx_min]
-    res = HolderTuple(statistic=stats,
+    statistic = np.choose(idx_min, [tt1.statistic, tt2.statistic])
+    res = HolderTuple(statistic=statistic,
                       pvalue=pvalue,
                       method=method,
                       results_larger=tt1,

--- a/statsmodels/stats/rates.py
+++ b/statsmodels/stats/rates.py
@@ -541,7 +541,7 @@ def test_poisson_2indep(count1, exposure1, count2, exposure2, value=None,
 
     compare : {'diff', 'ratio'}
         If compare is `diff`, then the confidence interval is for
-        diff = rat11 - rate22.
+        diff = rate1 - rate2.
         If compare is `ratio`, then the confidence interval is for the
         rate ratio defined by ratio = rate1 / rate2.
     alternative : string
@@ -1122,40 +1122,6 @@ def confint_poisson_2indep(count1, exposure1, count2, exposure2,
 
 
 def power_poisson_2indep(rate1, nobs1, rate2, nobs2, exposure, value=0,
-                         alpha=0.025, dispersion=1, alternative="smaller"):
-    """power for one-sided test of ratio of 2 independent poisson rates
-
-    this is currently for superiority and non-inferiority testing
-
-    signature not adjusted yet
-
-    incomplete alternatives, var options missing
-    """
-    low = value  # alias from original equivalence test case
-    nobs_ratio = nobs1 / nobs2
-    v1 = dispersion / exposure * (1 / rate2 + 1 / (nobs_ratio * rate1))
-    v0 = v1
-    std0 = np.sqrt(v0)
-    std1 = np.sqrt(v1)
-
-    if alternative == "two-sided":
-        crit = norm.isf(alpha / 2)
-    else:
-        crit = norm.isf(alpha)
-    es = np.log(low) - np.log(rate1 / rate2)
-    pow_ = 0
-    if alternative in ["smaller", "two-sided"]:
-        pow_ = pow_ + norm.cdf((np.sqrt(nobs2) * es - crit * std0) / std1)
-    if alternative in ["larger", "two-sided"]:
-        pow_ = pow_ + norm.sf((np.sqrt(nobs2) * es + crit * std0) / std1)
-
-    if alternative not in ["smaller", "larger", "two-sided"]:
-        raise ValueError("alternative not recognized")
-
-    return pow_
-
-
-def power_poisson_2indep_v2(rate1, nobs1, rate2, nobs2, exposure, value=0,
                             alpha=0.05, dispersion=1, alternative="smaller",
                             method_var="alt",
                             return_results=True):
@@ -1173,7 +1139,7 @@ def power_poisson_2indep_v2(rate1, nobs1, rate2, nobs2, exposure, value=0,
     if method_var == "alt":
         v0 = v1
     elif method_var == "score":
-        #nobs_ratio = 1 / nobs_ratio
+        # nobs_ratio = 1 / nobs_ratio
         v0 = dispersion / exposure * (1 + value / nobs_ratio)**2
         v0 /= value / nobs_ratio * (rate1 + (nobs_ratio * rate2))
     else:
@@ -1207,50 +1173,6 @@ def power_poisson_2indep_v2(rate1, nobs1, rate2, nobs2, exposure, value=0,
 
 
 def power_equivalence_poisson_2indep(rate1, nobs1, rate2, nobs2, exposure,
-                                     low, upp, alpha=0.025, dispersion=1):
-    """power for equivalence test of ratio of 2 independent poisson rates
-
-    WIP missing var option, redundant/unused nobs1
-    """
-    nobs_ratio = nobs2 / nobs1
-    v1 = dispersion / exposure * (1 / rate1 + 1 / (nobs_ratio * rate2))
-    v0_low = v0_upp = v1
-
-    crit = norm.isf(alpha)
-    pow_ = (
-        norm.cdf((np.sqrt(nobs2) * (np.log(rate1 / rate2) - np.log(low))
-                  - crit * np.sqrt(v0_low)) / np.sqrt(v1)) +
-        norm.cdf((np.sqrt(nobs2) * (np.log(upp) - np.log(rate1 / rate2))
-                  - crit * np.sqrt(v0_upp)) / np.sqrt(v1)) - 1
-        )
-    return pow_
-
-
-def power_equivalence_poisson_2indep_v2(rate1, nobs1, rate2, nobs2, exposure,
-                                        low, upp, alpha=0.025, dispersion=1):
-    """power for equivalence test of ratio of 2 independent poisson rates
-
-    WIP missing var option, redundant/unused nobs1
-    """
-    nobs_ratio = nobs2 / nobs1
-    v1 = dispersion / exposure * (1 / rate1 + 1 / (nobs_ratio * rate2))
-    v0_low = v0_upp = v1
-
-    es_low = np.log(rate1 / rate2) - np.log(low)
-    es_upp = np.log(upp) - np.log(rate1 / rate2)
-    std_null_low = np.sqrt(v0_low)
-    std_null_upp = np.sqrt(v0_upp)
-    std_alternative = np.sqrt(v1)
-
-    pow_ = _power_equivalence_het_v0(es_low, es_upp, nobs2, alpha=alpha,
-                                     std_null_low=std_null_low,
-                                     std_null_upp=std_null_upp,
-                                     std_alternative=std_alternative)
-
-    return pow_
-
-
-def power_equivalence_poisson_2indep_v3(rate1, nobs1, rate2, nobs2, exposure,
                                         low, upp, alpha=0.05, dispersion=1,
                                         method_var="alt"):
     """power for equivalence test of ratio of 2 independent poisson rates
@@ -1453,7 +1375,7 @@ def _var_cmle_negbin(rate1, rate2, nobs_ratio, exposure=1, value=1,
     return v * nobs_ratio, r1, r2
 
 
-def power_negbin_2indep_v2(rate1, nobs1, rate2, nobs2, exposure, value=1,
+def power_negbin_2indep(rate1, nobs1, rate2, nobs2, exposure, value=1,
                            alpha=0.05, dispersion=0.01,
                            alternative="two-sided",
                            method_var="alt",
@@ -1512,7 +1434,7 @@ def power_negbin_2indep_v2(rate1, nobs1, rate2, nobs2, exposure, value=1,
     return pow_
 
 
-def power_equivalence_neginb_2indep_v3(rate1, nobs1, rate2, nobs2, exposure,
+def power_equivalence_neginb_2indep(rate1, nobs1, rate2, nobs2, exposure,
                                         low, upp, alpha=0.05, dispersion=0,
                                         method_var="alt"):
     """

--- a/statsmodels/stats/rates.py
+++ b/statsmodels/stats/rates.py
@@ -1368,7 +1368,8 @@ def confint_poisson_2indep(count1, exposure1, count2, exposure2,
 
 
 def power_poisson_ratio_2indep(
-        rate1, nobs1, rate2, nobs2,
+        rate1, rate2, nobs1,
+        nobs_ratio=1,
         exposure=1,
         value=0,
         alpha=0.05,
@@ -1396,7 +1397,7 @@ def power_poisson_ratio_2indep(
     # TODO: avoid possible circular import, check if needed
     from statsmodels.stats.power import normal_power_het
 
-    nobs_ratio = nobs2 / nobs1
+    nobs2 = nobs_ratio * nobs1
     v1 = dispersion / exposure * (1 / rate1 + 1 / (nobs_ratio * rate2))
     if method_var == "alt":
         v0 = v1
@@ -1424,7 +1425,7 @@ def power_poisson_ratio_2indep(
             std_null=std_null,
             std_alt=std_alt,
             nobs1=nobs1,
-            nobs2=nobs_ratio * nobs1,
+            nobs2=nobs2,
             nobs_ratio=nobs_ratio,
             alpha=alpha,
             tuple_=("power",),  # override default
@@ -1434,8 +1435,9 @@ def power_poisson_ratio_2indep(
     return pow_
 
 
-def power_equivalence_poisson_2indep(rate1, nobs1, rate2, nobs2, exposure,
-                                     low, upp, alpha=0.05, dispersion=1,
+def power_equivalence_poisson_2indep(rate1, rate2, nobs1,
+                                     low, upp, nobs_ratio=1,
+                                     exposure=1, alpha=0.05, dispersion=1,
                                      method_var="alt"):
     """power for equivalence test of ratio of 2 independent poisson rates
 
@@ -1450,7 +1452,7 @@ def power_equivalence_poisson_2indep(rate1, nobs1, rate2, nobs2, exposure,
        376–87. https://doi.org/10.1002/sim.5947.
     .. [3] PASS documentation
     """
-    nobs_ratio = nobs2 / nobs1
+    nobs2 = nobs_ratio * nobs1
     v1 = dispersion / exposure * (1 / rate1 + 1 / (nobs_ratio * rate2))
 
     if method_var == "alt":
@@ -1540,7 +1542,7 @@ def _std_2poisson_power(
     return rates_pooled, np.sqrt(v0), np.sqrt(v1)
 
 
-def power_poisson_diff_2indep(diff, rate2, nobs1, nobs_ratio=1, alpha=0.05,
+def power_poisson_diff_2indep(rate1, rate2, nobs1, nobs_ratio=1, alpha=0.05,
                               value=0,
                               method_var="score",
                               alternative='two-sided',
@@ -1604,7 +1606,7 @@ def power_poisson_diff_2indep(diff, rate2, nobs1, nobs_ratio=1, alpha=0.05,
     # TODO: avoid possible circular import, check if needed
     from statsmodels.stats.power import normal_power_het
 
-    rate1 = rate2 + diff
+    diff = rate1 - rate2
     rate_pooled, std_null, std_alt = _std_2poisson_power(
         rate1,
         rate2,
@@ -1668,7 +1670,8 @@ def _var_cmle_negbin(rate1, rate2, nobs_ratio, exposure=1, value=1,
 
 
 def power_negbin_ratio_2indep(
-        rate1, nobs1, rate2, nobs2,
+        rate1, rate2, nobs1,
+        nobs_ratio=1,
         exposure=1,
         value=1,
         alpha=0.05,
@@ -1696,7 +1699,7 @@ def power_negbin_ratio_2indep(
     # TODO: avoid possible circular import, check if needed
     from statsmodels.stats.power import normal_power_het
 
-    nobs_ratio = nobs2 / nobs1
+    nobs2 = nobs_ratio * nobs1
     v1 = ((1 / rate1 + 1 / (nobs_ratio * rate2)) / exposure +
           (1 + nobs_ratio) / nobs_ratio * dispersion)
     if method_var == "alt":
@@ -1729,7 +1732,7 @@ def power_negbin_ratio_2indep(
             std_null=std_null,
             std_alt=std_alt,
             nobs1=nobs1,
-            nobs2=nobs_ratio * nobs1,
+            nobs2=nobs2,
             nobs_ratio=nobs_ratio,
             alpha=alpha,
             tuple_=("power",),  # override default
@@ -1739,8 +1742,9 @@ def power_negbin_ratio_2indep(
     return pow_
 
 
-def power_equivalence_neginb_2indep(rate1, nobs1, rate2, nobs2, exposure,
-                                    low, upp, alpha=0.05, dispersion=0,
+def power_equivalence_neginb_2indep(rate1, rate2, nobs1,
+                                    low, upp, nobs_ratio=1,
+                                    exposure=1, alpha=0.05, dispersion=0,
                                     method_var="alt"):
     """
     Power for equivalence test of ratio of 2 indep. negative binomial rates
@@ -1757,7 +1761,7 @@ def power_equivalence_neginb_2indep(rate1, nobs1, rate2, nobs2, exposure,
        376–87. https://doi.org/10.1002/sim.5947.
     .. [3] PASS documentation
     """
-    nobs_ratio = nobs2 / nobs1
+    nobs2 = nobs_ratio * nobs1
 
     v1 = ((1 / rate2 + 1 / (nobs_ratio * rate1)) / exposure +
           (1 + nobs_ratio) / nobs_ratio * dispersion)

--- a/statsmodels/stats/rates.py
+++ b/statsmodels/stats/rates.py
@@ -18,6 +18,33 @@ from statsmodels.stats._inference_tools import _mover_confint
 norm = stats.norm
 
 
+method_names_poisson_1samp = {
+    "test": [
+        "wald",
+        "score",
+        "exact-c",
+        "midp-c",
+        "waldccv",
+        "sqrt-a",
+        "sqrt-v",
+        "sqrt",
+        ],
+    "confint": [
+        "wald",
+        "score",
+        "exact-c",
+        "midp-c",
+        "jeff",
+        "waldccv",
+        "sqrt-a",
+        "sqrt-v",
+        "sqrt",
+        "sqrt-cent",
+        "sqrt-centcc",
+        ]
+    }
+
+
 def test_poisson(count, nobs, value, method=None, alternative="two-sided",
                  dispersion=1):
     """Test for one sample poisson mean or rate
@@ -531,6 +558,46 @@ def _invert_test_confint_2indep(
     upp = optimize.fmin(func, ci[1], xtol=1e-8, disp=False)
     assert np.size(low) == 1
     return low[0], upp[0]
+
+
+method_names_poisson_2indep = {
+    "test": {
+        "ratio": [
+            "wald",
+            "score",
+            "score-log",
+            "wald-log",
+            "exact-cond",
+            "cond-midp",
+            "sqrt",
+            "etest-score",
+            "etest-wald"
+            ],
+        "diff": [
+            "wald",
+            "score",
+            "waldccv",
+            "etest-score",
+            "etest-wald"
+            ]
+        },
+    "confint": {
+        "ratio": [
+            "waldcc",
+            "score",
+            "score-log",
+            "wald-log",
+            "sqrtcc",
+            "mover",
+            ],
+        "diff": [
+            "wald",
+            "score",
+            "waldccv",
+            "mover"
+            ]
+        }
+    }
 
 
 def test_poisson_2indep(count1, exposure1, count2, exposure2, value=None,

--- a/statsmodels/stats/rates.py
+++ b/statsmodels/stats/rates.py
@@ -9,10 +9,289 @@ License: BSD-3
 import numpy as np
 import warnings
 
-from scipy import stats
+from scipy import stats, optimize
 
 from statsmodels.stats.base import HolderTuple
 from statsmodels.stats.weightstats import _zstat_generic2
+
+# shorthand
+norm = stats.norm
+
+
+def test_poisson(count, nobs, value, method=None, alternative="two-sided",
+                 dispersion=1):
+    """ WIP  test for one sample poisson mean or rate
+
+    See Also
+    --------
+    confint_poisson
+
+    """
+
+    n = nobs  # short hand
+    rate = count / n
+
+    if method is None:
+        msg = "method needs to be specified, currently no default method"
+        raise ValueError(msg)
+
+    dist = "normal"
+
+    if method == "wald":
+        std = np.sqrt(dispersion * rate / n)
+        statistic = (rate - value) / std
+
+    elif method == "waldccv":
+        # WCC in Barker 2002
+        # add 0.5 event, not 0.5 event rate as in waldcc
+        # std = np.sqrt((rate + 0.5 / n) / n)
+        # statistic = (rate + 0.5 / n - value) / std
+        std = np.sqrt((rate + 0.5 / n) / n)
+        statistic = (rate - value) / std
+
+    elif method == "score":
+        std = np.sqrt(dispersion * value / n)
+        statistic = (rate - value) / std
+        pvalue = stats.norm.sf(statistic)
+
+    elif method.startswith("exact-c") or method.startswith("midp-c"):
+        pvalue = 2 * np.minimum(stats.poisson.cdf(count, n * value),
+                                stats.poisson.sf(count - 1, n * value))
+        statistic = None
+        dist = "Poisson"
+
+        if method.startswith("midp-c"):
+            pvalue = pvalue - 0.5 * stats.poisson.pmf(count, n * value)
+
+    elif method == "sqrt-a":
+        # anscombe, based on Swift 2009 (with transformation to rate)
+        std = 0.5
+        statistic = (np.sqrt(count + 3 / 8) - np.sqrt(n * value + 3 / 8)) / std
+
+    elif method == "sqrt-v":
+        # vandenbroucke, based on Swift 2009 (with transformation to rate)
+        std = 0.5
+        crit = stats.norm.isf(0.025)
+        statistic = (np.sqrt(count + (crit**2 + 2) / 12) -
+                     # np.sqrt(n * value + (crit**2 + 2) / 12)) / std
+                     np.sqrt(n * value)) / std
+
+    else:
+        raise ValueError("unknown method")
+
+    if dispersion != 1 and dist != "normal":
+        warnings.warn("Dispersion is ignored with method %s." % method)
+
+    if dist == 'normal':
+        statistic, pvalue = _zstat_generic2(statistic, 1, alternative)
+
+    res = HolderTuple(
+        statistic=statistic,
+        pvalue=np.clip(pvalue, 0, 1),
+        distribution=dist,
+        method=method,
+        alternative=alternative,
+        rate=rate,
+        nobs=n
+        )
+    return res
+
+
+def confint_poisson(count, exposure, method=None, alpha=0.05):
+    """Confidence interval for a Poisson mean or rate
+
+    The function is vectorized for all methods except "midp-c", which uses
+    an iterative method to invert the hypothesis test function.
+
+    All current methods are central, that is the probability of each tail is
+    smaller or equal to alpha / 2. The one-sided interval limits can be
+    obtained by doubling alpha.
+
+    Parameters
+    ----------
+    count : array_like
+        Observed count, number of events.
+    exposure : arrat_like
+        Currently this is total exposure time of the count variable.
+        This will likely change.
+    method : str
+        Method to use for confidence interval
+        This is required, there is currently no default method
+    alpha : float in (0, 1)
+        Signifivance level, nominal coverage of the confidence interval is
+        1 - alpha.
+
+    Returns
+    -------
+    tuple (low, upp) : confidence limits.
+
+    Notes
+    -----
+    Methods are mainly based on Barker (2002) [1]_ and Swift (2009) [3]_.
+
+    Available methods are:
+
+    - "exact-c" central confidence interval based on gamma distribution
+    - "score" : based on score test, uses variance under null value
+    - "wald" : based on wald test, uses variance base on estimated rate.
+    - "waldcc" : based on wald test with 0.5 count added to variance
+      computation. This does not use continuity correct for the center of the
+      confidence interval.
+    - "midp-c" : based on midp correction of central exact confidence interval.
+      this uses numerical inversion of the test function. not vectorized.
+    - "jeffreys" : based on Jeffreys' prior. computed using gamma distribution
+    - "sqrt" : based on square root transformed counts
+    - "sqrt-a" based on Anscombe square root transformation of counts + 3/8.
+    - "sqrt-centcc" will likely be dropped. anscombe with continuity corrected
+      center.
+      (Similar to R survival cipoisson, but without the 3/8 right shift of
+      the confidence interval).
+
+    sqrt-cent is the same as sqrt-a, using a different computation, will be
+    deleted.
+
+    sqrt-v is a corrected square root method attributed to vandenbrouke, which
+    might also be deleted.
+
+    todo:
+    - missing dispersion,
+    - maybe split nobs and exposure (? needed in NB). Exposure could be used
+      to standardize rate.
+    - modified wald, switch method if count=0.
+
+    See Also
+    --------
+    test_poisson
+
+    References
+    ----------
+    .. [1] Barker, Lawrence. 2002. “A Comparison of Nine Confidence Intervals
+       for a Poisson Parameter When the Expected Number of Events Is ≤ 5.”
+       The American Statistician 56 (2): 85–89.
+       https://doi.org/10.1198/000313002317572736.
+    .. [2] Patil, VV, and HV Kulkarni. 2012. “Comparison of Confidence
+       Intervals for the Poisson Mean: Some New Aspects.”
+       REVSTAT–Statistical Journal 10(2): 211–27.
+    .. [3] Swift, Michael Bruce. 2009. “Comparison of Confidence Intervals for
+       a Poisson Mean – Further Considerations.” Communications in Statistics -
+       Theory and Methods 38 (5): 748–59.
+       https://doi.org/10.1080/03610920802255856.
+
+    """
+    n = exposure  # short hand
+    rate = count / exposure
+    alpha = alpha / 2  # two-sided
+
+    if method is None:
+        msg = "method needs to be specified, currently no default method"
+        raise ValueError(msg)
+
+    if method == "wald":
+        whalf = stats.norm.isf(alpha) * np.sqrt(rate / n)
+        ci = (rate - whalf, rate + whalf)
+
+    elif method == "waldccv":
+        # based on WCC in Barker 2002
+        # add 0.5 event, not 0.5 event rate as in BARKER waldcc
+        whalf = stats.norm.isf(alpha) * np.sqrt((rate + 0.5 / n) / n)
+        ci = (rate - whalf, rate + whalf)
+
+    elif method == "score":
+        crit = stats.norm.isf(alpha)
+        center = count + crit**2 / 2
+        whalf = crit * np.sqrt((count + crit**2 / 4))
+        ci = ((center - whalf) / n, (center + whalf) / n)
+
+    elif method == "midp-c":
+        # note local alpha above is for one tail
+        ci = _invert_test_confint(count, n, alpha=2 * alpha, method="midp-c",
+                                  method_start="exact-c")
+
+    elif method == "sqrt":
+        # drop, wrong n
+        crit = stats.norm.isf(alpha)
+        center = rate + crit**2 / (4 * n)
+        whalf = crit * np.sqrt(rate / n)
+        ci = (center - whalf, center + whalf)
+
+    elif method == "sqrt-cent":
+        crit = stats.norm.isf(alpha)
+        center = count + crit**2 / 4
+        whalf = crit * np.sqrt((count + 3 / 8))
+        ci = ((center - whalf) / n, (center + whalf) / n)
+
+    elif method == "sqrt-centcc":
+        # drop with cc, does not match cipoisson in R survival
+        crit = stats.norm.isf(alpha)
+        # avoid sqrt of negative value if count=0
+        center_low = np.sqrt(np.maximum(count + 3 / 8 - 0.5, 0))
+        center_upp = np.sqrt(count + 3 / 8 + 0.5)
+        whalf = crit / 2
+        # above is for ci of count
+        ci = (((np.maximum(center_low - whalf, 0))**2 - 3 / 8) / n,
+              ((center_upp + whalf)**2 - 3 / 8) / n)
+
+        # crit = stats.norm.isf(alpha)
+        # center = count
+        # whalf = crit * np.sqrt((count + 3 / 8 + 0.5))
+        # ci = ((center - whalf - 0.5) / n, (center + whalf + 0.5) / n)
+
+    elif method == "sqrt-a":
+        # anscombe, based on Swift 2009 (with transformation to rate)
+        crit = stats.norm.isf(alpha)
+        center = np.sqrt(count + 3 / 8)
+        whalf = crit / 2
+        # above is for ci of count
+        ci = (((np.maximum(center - whalf, 0))**2 - 3 / 8) / n,
+              ((center + whalf)**2 - 3 / 8) / n)
+
+    elif method == "sqrt-v":
+        # vandenbroucke, based on Swift 2009 (with transformation to rate)
+        crit = stats.norm.isf(alpha)
+        center = np.sqrt(count + (crit**2 + 2) / 12)
+        whalf = crit / 2
+        # above is for ci of count
+        ci = (np.maximum(center - whalf, 0))**2 / n, (center + whalf)**2 / n
+
+    elif method in ["gamma", "exact-c"]:
+        # garwood exact, gamma
+        low = stats.gamma.ppf(alpha, count) / exposure
+        upp = stats.gamma.isf(alpha, count+1) / exposure
+        if np.isnan(low).any():
+            # case with count = 0
+            if np.size(low) == 1:
+                low = 0.0
+            else:
+                low[np.isnan(low)] = 0.0
+
+        ci = (low, upp)
+
+    elif method.startswith("jeff"):
+        # jeffreys, gamma
+        countc = count + 0.5
+        ci = (stats.gamma.ppf(alpha, countc) / exposure,
+              stats.gamma.isf(alpha, countc) / exposure)
+
+    else:
+        raise ValueError("unknown method %s" % method)
+
+    ci = (np.maximum(ci[0], 0), ci[1])
+    return ci
+
+
+def _invert_test_confint(count, nobs, alpha=0.05, method="midp-c",
+                         method_start="exact-c"):
+
+    def func(r):
+        v = (test_poisson(count, nobs, value=r, method=method)[1] -
+             alpha)**2
+        return v
+
+    ci = confint_poisson(count, nobs, method=method_start)
+    low = optimize.fmin(func, ci[0], xtol=1e-8,  disp=False)
+    upp = optimize.fmin(func, ci[1], xtol=1e-8, disp=False)
+    assert np.size(low) == 1
+    return low[0], upp[0]
 
 
 def test_poisson_2indep(count1, exposure1, count2, exposure2, ratio_null=1,
@@ -357,3 +636,144 @@ def tost_poisson_2indep(count1, exposure1, count2, exposure2, low, upp,
                       )
 
     return res
+
+
+def power_poisson_2indep(rate1, nobs1, rate2, nobs2, exposure, value=0,
+                         alpha=0.025, dispersion=1, alternative="smaller"):
+    """power for one-sided test of ratio of 2 independent poisson rates
+    this is currently for superiority and non-inferiority testing
+
+    signature not adjusted yet
+
+    incomplete alternatives, var options missing
+    """
+    low = value  # alias from original equivalence test case
+    nobs_ratio = nobs1 / nobs2
+    v1 = dispersion / exposure * (1 / rate2 + 1 / (nobs_ratio * rate1))
+    v0_low = v0_upp = v1
+
+    crit = norm.isf(alpha)
+    if alternative == "smaller":
+        pow_ = norm.cdf((np.sqrt(nobs2) * (np.log(low) - np.log(rate1 / rate2))
+                        - crit * np.sqrt(v0_low)) / np.sqrt(v1))
+    elif alternative == "larger":
+        pow_ = norm.sf((np.sqrt(nobs2) * (np.log(low) - np.log(rate1 / rate2))
+                       + crit * np.sqrt(v0_low)) / np.sqrt(v1))
+    return pow_
+
+
+def power_equivalence_poisson_2indep(rate1, nobs1, rate2, nobs2, exposure,
+                                     low, upp, alpha=0.025, dispersion=1):
+    """power for equivalence test of ratio of 2 independent poisson rates
+
+    WIP missing var option, redundant/unused nobs1
+    """
+    nobs_ratio = nobs1 / nobs2
+    v1 = dispersion / exposure * (1 / rate2 + 1 / (nobs_ratio * rate1))
+    v0_low = v0_upp = v1
+
+    crit = norm.isf(alpha)
+    pow_ = (
+        norm.cdf((np.sqrt(nobs2) * (np.log(rate1 / rate2) - np.log(low))
+                  - crit * np.sqrt(v0_low)) / np.sqrt(v1)) +
+        norm.cdf((np.sqrt(nobs2) * (np.log(upp) - np.log(rate1 / rate2))
+                  - crit * np.sqrt(v0_upp)) / np.sqrt(v1)) - 1
+        )
+    return pow_
+
+
+def _std_2poisson_power(diff, rate2, nobs_ratio=1, alpha=0.05,
+                        exposure=1, dispersion=1,
+                        value=0):
+    rate1 = rate2 + diff
+    # v1 = dispersion / exposure * (1 / rate2 + 1 / (nobs_ratio * rate1))
+    v1 = rate1 + nobs_ratio * rate2
+    return None, np.sqrt(v1), np.sqrt(v1)
+
+
+def power_ppoisson_diff_2indep(diff, rate2, nobs1, nobs_ratio=1, alpha=0.05,
+                               value=0, alternative='two-sided',
+                               return_results=True):
+    """power for ztest that two independent poisson rates are equal
+
+    Warning preliminary
+    currently wald test type to replicate PASS chapter 436
+    analogy to proportion test (copy paste docstring)
+    TODO: nobs1 or nobs2 in signature
+
+    This assumes that the variance is based on the ?????
+    under the null and the non-pooled variance under the alternative
+
+    Parameters
+    ----------
+    diff : float
+        difference between proportion 1 and 2 under the alternative
+    prop2 : float
+        proportion for the reference case, prop2, proportions for the
+        first case will be computing using p2 and diff
+        p1 = p2 + diff
+    nobs1 : float or int
+        number of observations in sample 1
+    ratio : float
+        sample size ratio, nobs2 = ratio * nobs1
+    alpha : float in interval (0,1)
+        Significance level, e.g. 0.05, is the probability of a type I
+        error, that is wrong rejections if the Null Hypothesis is true.
+    value : float
+        currently only `value=0`, i.e. equality testing, is supported
+    alternative : string, 'two-sided' (default), 'larger', 'smaller'
+        Alternative hypothesis whether the power is calculated for a
+        two-sided (default) or one sided test. The one-sided test can be
+        either 'larger', 'smaller'.
+    return_results : bool
+        If true, then a results instance with extra information is returned,
+        otherwise only the computed power is returned.
+
+    Returns
+    -------
+    results : results instance or float
+        If return_results is True, then a results instance with the
+        information in attributes is returned.
+        If return_results is False, then only the power is returned.
+
+        power : float
+            Power of the test, e.g. 0.8, is one minus the probability of a
+            type II error. Power is the probability that the test correctly
+            rejects the Null Hypothesis if the Alternative Hypothesis is true.
+
+        Other attributes in results instance include :
+
+        p_pooled
+            pooled proportion, used for std_null
+        std_null
+            standard error of difference under the null hypothesis (without
+            sqrt(nobs1))
+        std_alt
+            standard error of difference under the alternative hypothesis
+            (without sqrt(nobs1))
+    """
+    # TODO: avoid possible circular import, check if needed
+    from statsmodels.stats.power import normal_power_het
+
+    p_pooled, std_null, std_alt = _std_2poisson_power(diff, rate2,
+                                                      nobs_ratio=nobs_ratio,
+                                                      alpha=alpha, value=value)
+
+    pow_ = normal_power_het(diff, nobs1, 0.05, std_null=std_null,
+                            std_alternative=std_alt,
+                            alternative=alternative)
+
+    if return_results:
+        res = HolderTuple(
+            power=pow_,
+            p_pooled=p_pooled,
+            std_null=std_null,
+            std_alt=std_alt,
+            nobs1=nobs1,
+            nobs2=nobs_ratio * nobs1,
+            nobs_ratio=nobs_ratio,
+            alpha=alpha,
+            )
+        return res
+    else:
+        return pow_

--- a/statsmodels/stats/rates.py
+++ b/statsmodels/stats/rates.py
@@ -659,15 +659,24 @@ def power_poisson_2indep(rate1, nobs1, rate2, nobs2, exposure, value=0,
     low = value  # alias from original equivalence test case
     nobs_ratio = nobs1 / nobs2
     v1 = dispersion / exposure * (1 / rate2 + 1 / (nobs_ratio * rate1))
-    v0_low = v0_upp = v1
+    v0 = v1
+    std0 = np.sqrt(v0)
+    std1 = np.sqrt(v1)
 
-    crit = norm.isf(alpha)
-    if alternative == "smaller":
-        pow_ = norm.cdf((np.sqrt(nobs2) * (np.log(low) - np.log(rate1 / rate2))
-                        - crit * np.sqrt(v0_low)) / np.sqrt(v1))
-    elif alternative == "larger":
-        pow_ = norm.sf((np.sqrt(nobs2) * (np.log(low) - np.log(rate1 / rate2))
-                       + crit * np.sqrt(v0_low)) / np.sqrt(v1))
+    if alternative == "two-sided":
+        crit = norm.isf(alpha / 2)
+    else:
+        crit = norm.isf(alpha)
+    es = np.log(low) - np.log(rate1 / rate2)
+    pow_ = 0
+    if alternative in ["smaller", "two-sided"]:
+        pow_ = pow_ + norm.cdf((np.sqrt(nobs2) * es - crit * std0) / std1)
+    if alternative in ["larger", "two-sided"]:
+        pow_ = pow_ + norm.sf((np.sqrt(nobs2) * es + crit * std0) / std1)
+
+    if alternative not in ["smaller", "larger", "two-sided"]:
+        raise ValueError("alternative not recognized")
+
     return pow_
 
 

--- a/statsmodels/stats/rates.py
+++ b/statsmodels/stats/rates.py
@@ -691,7 +691,7 @@ def _std_2poisson_power(diff, rate2, nobs_ratio=1, alpha=0.05,
     return None, np.sqrt(v1), np.sqrt(v1)
 
 
-def power_ppoisson_diff_2indep(diff, rate2, nobs1, nobs_ratio=1, alpha=0.05,
+def power_poisson_diff_2indep(diff, rate2, nobs1, nobs_ratio=1, alpha=0.05,
                                value=0, alternative='two-sided',
                                return_results=True):
     """power for ztest that two independent poisson rates are equal
@@ -773,6 +773,7 @@ def power_ppoisson_diff_2indep(diff, rate2, nobs1, nobs_ratio=1, alpha=0.05,
             nobs2=nobs_ratio * nobs1,
             nobs_ratio=nobs_ratio,
             alpha=alpha,
+            tuple_=("power",),  # override default
             )
         return res
     else:

--- a/statsmodels/stats/tests/test_rates_poisson.py
+++ b/statsmodels/stats/tests/test_rates_poisson.py
@@ -829,13 +829,18 @@ def test_poisson_power_2ratio():
     for case in cases:
         rate1, nobs1, nobs2, p = case
         pow_ = power_equivalence_poisson_2indep(
-            rate1, nobs1, rate2, nobs2, exposure, low, upp, alpha=alpha,
+            rate1, rate2, nobs1, low, upp,
+            nobs_ratio=nobs2 / nobs1,
+            exposure=exposure, alpha=alpha,
             dispersion=dispersion)
         assert_allclose(pow_[0], p, atol=5e-5)
 
         # compare other method_var for similar results
         pow_2 = power_equivalence_poisson_2indep(
-            rate1, nobs1, rate2, nobs2, exposure, low, upp, alpha=alpha,
+            rate1, rate2, nobs1, low, upp,
+            nobs_ratio=nobs2 / nobs1,
+            exposure=exposure,
+            alpha=alpha,
             method_var="score",
             dispersion=dispersion)
 
@@ -855,20 +860,22 @@ def test_poisson_power_2ratio():
     for case in cases:
         rate1, nobs1, nobs2, p = case
         pow_ = power_poisson_ratio_2indep(
-            rate1, nobs1, rate2, nobs2,
+            rate1, rate2, nobs1, nobs_ratio=nobs2 / nobs1,
             exposure=exposure, value=low, alpha=0.025, dispersion=1,
             alternative="smaller")
 
         assert_allclose(pow_, p, atol=5e-5)
 
         pow_ = power_poisson_ratio_2indep(
-            rate1, nobs1, rate2, nobs2, exposure, value=low, alpha=0.05,
+            rate1, rate2, nobs1, nobs_ratio=nobs2 / nobs1,
+            exposure=exposure, value=low, alpha=0.05,
             dispersion=1, alternative="two-sided")
         assert_allclose(pow_, p, atol=5e-5)
 
     # check size, power at null
     pow_ = power_poisson_ratio_2indep(
-            rate1, nobs1, rate2, nobs2, exposure, value=rate1 / rate2,
+            rate1, rate2, nobs1, nobs_ratio=nobs2 / nobs1,
+            exposure=exposure, value=rate1 / rate2,
             alpha=0.05, dispersion=1, alternative="two-sided")
     assert_allclose(pow_, 0.05, atol=5e-5)
 
@@ -888,25 +895,29 @@ def test_poisson_power_2ratio():
     for case in cases:
         rate2, nobs1, nobs2, p = case
         pow_ = power_poisson_ratio_2indep(
-            rate1, nobs1, rate2, nobs2, exposure, value=low, alpha=0.025,
+            rate1, rate2, nobs1, nobs_ratio=nobs2 / nobs1,
+            exposure=exposure, value=low, alpha=0.025,
             dispersion=1, alternative="larger")
         assert_allclose(pow_, p, atol=5e-5)
 
         # compare other method_var for similar results
         pow_2 = power_poisson_ratio_2indep(
-            rate1, nobs1, rate2, nobs2, exposure, value=low, alpha=0.025,
+            rate1, rate2, nobs1, nobs_ratio=nobs2 / nobs1,
+            exposure=exposure, value=low, alpha=0.025,
             method_var="score",
             dispersion=1, alternative="larger")
         assert_allclose(pow_2, p, rtol=5e-3)
 
         pow_ = power_poisson_ratio_2indep(
-            rate1, nobs1, rate2, nobs2, exposure, value=low, alpha=0.05,
+            rate1, rate2, nobs1, nobs_ratio=nobs2 / nobs1,
+            exposure=exposure, value=low, alpha=0.05,
             dispersion=1, alternative="two-sided")
         assert_allclose(pow_, p, atol=5e-5)
 
         # compare other method_var for similar results
         pow_2 = power_poisson_ratio_2indep(
-            rate1, nobs1, rate2, nobs2, exposure, value=low, alpha=0.05,
+            rate1, rate2, nobs1, nobs_ratio=nobs2 / nobs1,
+            exposure=exposure, value=low, alpha=0.05,
             method_var="score",
             dispersion=1, alternative="two-sided")
         assert_allclose(pow_2, p, rtol=5e-3)
@@ -928,9 +939,8 @@ def test_power_poisson_equal():
     nobs_ratio = nobs2 / nobs1
     rate1, rate2 = 15, 10
 
-    diff = rate1 - rate2
     pow_ = power_poisson_diff_2indep(
-        diff, rate2, nobs1, nobs_ratio=nobs_ratio, alpha=0.05, value=0,
+        rate1, rate2, nobs1, nobs_ratio=nobs_ratio, alpha=0.05, value=0,
         method_var="alt", alternative='larger', return_results=True)
     assert_allclose(pow_.power, 0.82566, atol=5e-5)
 
@@ -939,7 +949,7 @@ def test_power_poisson_equal():
     # regression numbers but close to exact power in table
 
     pow_ = power_poisson_diff_2indep(
-        0, 0.6, 97, 3 / 2,
+        0.6, 0.6, 97, 3 / 2,
         value=0.3,
         alpha=0.025,
         alternative="smaller",
@@ -949,7 +959,7 @@ def test_power_poisson_equal():
     assert_allclose(pow_.power, 0.802596, atol=5e-5)
 
     pow_ = power_poisson_diff_2indep(
-        0, 0.6, 128, 2 / 3,
+        0.6, 0.6, 128, 2 / 3,
         value=0.3,
         alpha=0.025,
         alternative="smaller",
@@ -972,7 +982,10 @@ def test_power_negbin():
 
     pow1 = 0.90022
     pow_ = power_equivalence_neginb_2indep(
-        rate1, nobs1, rate2, nobs2, exposure, low, upp, alpha=alpha,
+        rate1, rate2, nobs1, low, upp,
+        nobs_ratio=nobs2 / nobs1,
+        exposure=exposure,
+        alpha=alpha,
         dispersion=dispersion, method_var="alt")
     assert_allclose(pow_[0], pow1, atol=5e-5)
 
@@ -980,13 +993,19 @@ def test_power_negbin():
 
     pow1 = 0.90015
     pow_ = power_equivalence_neginb_2indep(
-        rate1, nobs1, rate2, nobs2, exposure, low, upp, alpha=alpha,
+        rate1, rate2, nobs1, low, upp,
+        nobs_ratio=nobs2 / nobs1,
+        exposure=exposure,
+        alpha=alpha,
         dispersion=dispersion, method_var="ftotal")
     assert_allclose(pow_[0], pow1, atol=5e-5)
 
     pow1 = 0.90034
     pow_ = power_equivalence_neginb_2indep(
-        rate1, nobs1, rate2, nobs2, exposure, low, upp, alpha=alpha,
+        rate1, rate2, nobs1, low, upp,
+        nobs_ratio=nobs2 / nobs1,
+        exposure=exposure,
+        alpha=alpha,
         dispersion=dispersion, method_var="score")
     assert_allclose(pow_[0], pow1, atol=5e-5)
 
@@ -1000,7 +1019,8 @@ def test_power_negbin():
     rate2, nobs2, rate1, nobs1, exposure = 0.3, 50, 0.5, 100, 2
     pow1 = 0.6207448
     pow_ = power_negbin_ratio_2indep(
-        rate2, nobs2, rate1, nobs1,
+        rate2, rate1, nobs2,
+        nobs_ratio=nobs1 / nobs2,
         exposure=exposure,
         value=1,
         alpha=alpha, dispersion=0.5,
@@ -1014,7 +1034,9 @@ def test_power_negbin():
     pow1 = 0.5825763
     nobs1, nobs2 = nobs2, nobs1
     pow_ = power_negbin_ratio_2indep(
-        rate2, nobs2, rate1, nobs1, exposure,
+        rate2, rate1, nobs2,
+        nobs_ratio=nobs1 / nobs2,
+        exposure=exposure,
         value=1,
         alpha=alpha, dispersion=0.5,
         alternative="two-sided",
@@ -1027,7 +1049,10 @@ def test_power_negbin():
     #   theta=200000, duration = 2, approach = 3)
     pow1 = 0.7248956
     pow_ = power_negbin_ratio_2indep(
-        rate2, nobs2, rate1, nobs1, exposure, value=1,
+        rate2, rate1, nobs2,
+        nobs_ratio=nobs1 / nobs2,
+        exposure=exposure,
+        value=1,
         alpha=alpha, dispersion=0, alternative="two-sided",
         method_var="score",
         return_results=False)
@@ -1035,7 +1060,10 @@ def test_power_negbin():
     assert_allclose(pow_, pow1, atol=5e-2)
 
     pow_p = power_poisson_ratio_2indep(
-        rate2, nobs2, rate1, nobs1, exposure, value=1,
+        rate2, rate1, nobs2,
+        nobs_ratio=nobs1 / nobs2,
+        exposure=exposure,
+        value=1,
         alpha=alpha, dispersion=1, alternative="two-sided",
         method_var="score",
         return_results=True)
@@ -1046,13 +1074,19 @@ def test_power_negbin():
     # test one-sided
     pow1 = 0.823889
     pow_ = power_negbin_ratio_2indep(
-        rate2, nobs2, rate1, nobs1, exposure, value=1,
+        rate2, rate1, nobs2,
+        nobs_ratio=nobs1 / nobs2,
+        exposure=exposure,
+        value=1,
         alpha=alpha, dispersion=0, alternative="smaller",
         method_var="score",
         return_results=False)
 
     pow_p = power_poisson_ratio_2indep(
-        rate2, nobs2, rate1, nobs1, exposure, value=1,
+        rate2, rate1, nobs2,
+        nobs_ratio=nobs1 / nobs2,
+        exposure=exposure,
+        value=1,
         alpha=alpha, dispersion=1, alternative="smaller",
         method_var="score",
         return_results=True)
@@ -1062,13 +1096,19 @@ def test_power_negbin():
 
     # reverse 2 samples
     pow_ = power_negbin_ratio_2indep(
-        rate1, nobs1, rate2, nobs2, exposure, value=1,
+        rate1, rate2, nobs1,
+        nobs_ratio=nobs2 / nobs1,
+        exposure=exposure,
+        value=1,
         alpha=alpha, dispersion=0, alternative="larger",
         method_var="score",
         return_results=False)
 
     pow_p = power_poisson_ratio_2indep(
-        rate1, nobs1, rate2, nobs2, exposure, value=1,
+        rate1, rate2, nobs1,
+        nobs_ratio=nobs2 / nobs1,
+        exposure=exposure,
+        value=1,
         alpha=alpha, dispersion=1, alternative="larger",
         method_var="score",
         return_results=True)

--- a/statsmodels/stats/tests/test_rates_poisson.py
+++ b/statsmodels/stats/tests/test_rates_poisson.py
@@ -343,31 +343,32 @@ def test_twosample_poisson():
     # I don't know why it's only 2.5 decimal agreement, rounding?
     count1, n1, count2, n2 = 41, 28010, 15, 19017
     s1, pv1 = smr.test_poisson_2indep(count1, n1, count2, n2, method='wald',
-                                      ratio_null=1.5)
+                                      value=1.5)
     pv1r = 0.2309
     assert_allclose(pv1, pv1r*2, rtol=0, atol=5e-4)
     assert_allclose(s1, 0.735447, atol=0, rtol=5e-6)  # regression test
 
     s2, pv2 = smr.test_poisson_2indep(count1, n1, count2, n2, method='score',
-                                      ratio_null=1.5)
+                                      value=1.5)
     pv2r = 0.2398
     assert_allclose(pv2, pv2r*2, rtol=0, atol=5e-4)
     assert_allclose(s2, 0.706631, atol=0, rtol=5e-6)  # regression test
 
     s2, pv2 = smr.test_poisson_2indep(count1, n1, count2, n2,
-                                      method='wald-log', ratio_null=1.5)
+                                      method='wald-log', value=1.5)
     pv2r = 0.2402
     assert_allclose(pv2, pv2r*2, rtol=0, atol=5e-4)
     assert_allclose(s2, 0.7056, atol=0, rtol=5e-4)
 
-    s2, pv2 = smr.test_poisson_2indep(count1, n1, count2, n2,
-                                      method='score-log', ratio_null=1.5)
+    with pytest.warns(DeprecationWarning):
+        s2, pv2 = smr.test_poisson_2indep(count1, n1, count2, n2,
+                                          method='score-log', ratio_null=1.5)
     pv2r = 0.2303
     assert_allclose(pv2, pv2r*2, rtol=0, atol=5e-4)
     assert_allclose(s2, 0.7380, atol=0, rtol=5e-4)
 
     s2, pv2 = smr.test_poisson_2indep(count1, n1, count2, n2, method='sqrt',
-                                      ratio_null=1.5)
+                                      value=1.5)
     pv2r = 0.2499
     assert_allclose(pv2, pv2r*2, rtol=0, atol=5e-3)
     assert_allclose(s2, 0.674401, atol=0, rtol=5e-6)  # regression test
@@ -395,25 +396,25 @@ def test_twosample_poisson():
 
     s2, pv2 = smr.test_poisson_2indep(count1, n1, count2, n2,
                                       method='exact-cond',
-                                      ratio_null=1, alternative='larger')
+                                      value=1, alternative='larger')
     pv2r = 0.000428  # typo in Gu et al, switched pvalues between C and M
     assert_allclose(pv2, pv2r, rtol=0, atol=5e-4)
 
     s2, pv2 = smr.test_poisson_2indep(count1, n1, count2, n2,
                                       method='cond-midp',
-                                      ratio_null=1, alternative='larger')
+                                      value=1, alternative='larger')
     pv2r = 0.000310
     assert_allclose(pv2, pv2r, rtol=0, atol=5e-4)
 
     _, pve1 = etest_poisson_2indep(count1, n1, count2, n2,
                                    method='score',
-                                   ratio_null=1, alternative='larger')
+                                   alternative='larger')
     pve1r = 0.000298
     assert_allclose(pve1, pve1r, rtol=0, atol=5e-4)
 
     _, pve1 = etest_poisson_2indep(count1, n1, count2, n2,
                                    method='wald',
-                                   ratio_null=1, alternative='larger')
+                                   alternative='larger')
     pve1r = 0.000298
     assert_allclose(pve1, pve1r, rtol=0, atol=5e-4)
 
@@ -421,17 +422,17 @@ def test_twosample_poisson():
     # I don't know why it's only 2.5 decimal agreement, rounding?
     count1, n1, count2, n2 = 41, 28010, 15, 19017
     s1, pv1 = smr.test_poisson_2indep(count1, n1, count2, n2, method='wald',
-                                      ratio_null=1.5, alternative='larger')
+                                      value=1.5, alternative='larger')
     pv1r = 0.2309
     assert_allclose(pv1, pv1r, rtol=0, atol=5e-4)
 
     s2, pv2 = smr.test_poisson_2indep(count1, n1, count2, n2, method='score',
-                                      ratio_null=1.5, alternative='larger')
+                                      value=1.5, alternative='larger')
     pv2r = 0.2398
     assert_allclose(pv2, pv2r, rtol=0, atol=5e-4)
 
     s2, pv2 = smr.test_poisson_2indep(count1, n1, count2, n2, method='sqrt',
-                                      ratio_null=1.5, alternative='larger')
+                                      value=1.5, alternative='larger')
     pv2r = 0.2499
     assert_allclose(pv2, pv2r, rtol=0, atol=5e-4)
 
@@ -439,25 +440,25 @@ def test_twosample_poisson():
 
     s2, pv2 = smr.test_poisson_2indep(count1, n1, count2, n2,
                                       method='exact-cond',
-                                      ratio_null=1.5, alternative='larger')
+                                      value=1.5, alternative='larger')
     pv2r = 0.2913
     assert_allclose(pv2, pv2r, rtol=0, atol=5e-4)
 
     s2, pv2 = smr.test_poisson_2indep(count1, n1, count2, n2,
                                       method='cond-midp',
-                                      ratio_null=1.5, alternative='larger')
+                                      value=1.5, alternative='larger')
     pv2r = 0.2450
     assert_allclose(pv2, pv2r, rtol=0, atol=5e-4)
 
     _, pve2 = etest_poisson_2indep(count1, n1, count2, n2,
                                    method='score',
-                                   ratio_null=1.5, alternative='larger')
+                                   value=1.5, alternative='larger')
     pve2r = 0.2453
     assert_allclose(pve2, pve2r, rtol=0, atol=5e-4)
 
     _, pve2 = etest_poisson_2indep(count1, n1, count2, n2,
                                    method='wald',
-                                   ratio_null=1.5, alternative='larger')
+                                   value=1.5, alternative='larger')
     pve2r = 0.2453
     assert_allclose(pve2, pve2r, rtol=0, atol=5e-4)
 
@@ -482,7 +483,6 @@ def test_twosample_poisson_diff(case):
     value = 0
     t = smr.test_poisson_2indep(count1, exposure1, count2, exposure2,
                                 value=value,
-                                ratio_null=None,
                                 method=meth, compare='diff',
                                 alternative='larger', etest_kwds=None)
     assert_allclose((t.statistic, t.pvalue), res1, atol=0.0006)
@@ -490,7 +490,6 @@ def test_twosample_poisson_diff(case):
     value = 0.0002
     t = smr.test_poisson_2indep(count1, exposure1, count2, exposure2,
                                 value=value,
-                                ratio_null=None,
                                 method=meth, compare='diff',
                                 alternative='larger', etest_kwds=None)
     assert_allclose((t.statistic, t.pvalue), res2, atol=0.0007)
@@ -521,28 +520,28 @@ def test_twosample_poisson_r():
     # > pe$p.value
     pv2 = 0.9949053964701466
     rest = smr.test_poisson_2indep(count1, n1, count2, n2, method='cond-midp',
-                                   ratio_null=1.2, alternative='smaller')
+                                   value=1.2, alternative='smaller')
     assert_allclose(rest.pvalue, pv2, rtol=1e-12)
     # > pe = poisson.exact(c(60, 30), c(51477.5, 54308.7), r=1.2,
     #           alternative="greater", tsmethod="minlike", midp=TRUE)
     # > pe$p.value
     pv2 = 0.005094603529853279
     rest = smr.test_poisson_2indep(count1, n1, count2, n2, method='cond-midp',
-                                   ratio_null=1.2, alternative='larger')
+                                   value=1.2, alternative='larger')
     assert_allclose(rest.pvalue, pv2, rtol=1e-12)
     # > pe = poisson.exact(c(60, 30), c(51477.5, 54308.7), r=1.2,
     #           alternative="greater", tsmethod="minlike", midp=FALSE)
     # > pe$p.value
     pv2 = 0.006651774552714537
     rest = smr.test_poisson_2indep(count1, n1, count2, n2, method='exact-cond',
-                                   ratio_null=1.2, alternative='larger')
+                                   value=1.2, alternative='larger')
     assert_allclose(rest.pvalue, pv2, rtol=1e-12)
     # > pe = poisson.exact(c(60, 30), c(51477.5, 54308.7), r=1.2,
     #                      alternative="less", tsmethod="minlike", midp=FALSE)
     # > pe$p.value
     pv2 = 0.9964625674930079
     rest = smr.test_poisson_2indep(count1, n1, count2, n2, method='exact-cond',
-                                   ratio_null=1.2, alternative='smaller')
+                                   value=1.2, alternative='smaller')
     assert_allclose(rest.pvalue, pv2, rtol=1e-12)
 
 
@@ -678,7 +677,7 @@ def test_alternative(case):
     alt, meth = case
     count1, n1, count2, n2 = 6, 51., 1, 54.
     _, pv = smr.test_poisson_2indep(count1, n1, count2, n2, method=meth,
-                                    ratio_null=1.2, alternative=alt)
+                                    value=1.2, alternative=alt)
     assert_allclose(pv, cases_alt[case], rtol=1e-13)
 
 
@@ -717,6 +716,12 @@ class TestMethodsCompare2indep():
         else:
             rtol = 1e-12
         assert_allclose(tst2.pvalue, tst.pvalue, rtol=rtol)
+
+        # check corner case count2 = 0, see issue #8313
+        with pytest.warns(RuntimeWarning):
+            tst = smr.test_poisson_2indep(count1, n1, 0, n2, method=meth,
+                                          compare=compare,
+                                          value=None, alternative='two-sided')
 
     @pytest.mark.parametrize(
         "compare, meth",

--- a/statsmodels/stats/tests/test_rates_poisson.py
+++ b/statsmodels/stats/tests/test_rates_poisson.py
@@ -833,7 +833,7 @@ def test_poisson_power_2ratio():
             nobs_ratio=nobs2 / nobs1,
             exposure=exposure, alpha=alpha,
             dispersion=dispersion)
-        assert_allclose(pow_[0], p, atol=5e-5)
+        assert_allclose(pow_, p, atol=5e-5)
 
         # compare other method_var for similar results
         pow_2 = power_equivalence_poisson_2indep(
@@ -844,7 +844,7 @@ def test_poisson_power_2ratio():
             method_var="score",
             dispersion=dispersion)
 
-        assert_allclose(pow_2[0], p, rtol=5e-3)
+        assert_allclose(pow_2, p, rtol=5e-3)
 
     # check power of onesided test, smaller with a margin
     # non-inferiority
@@ -945,7 +945,7 @@ def test_power_poisson_equal():
     assert_allclose(pow_.power, 0.82566, atol=5e-5)
 
     # This supports now nonzero value
-    # example in table 1 of Stucke, Kieser (2013
+    # example in table 1 of Stucke, Kieser (2013)
     # regression numbers but close to exact power in table
 
     pow_ = power_poisson_diff_2indep(
@@ -987,7 +987,7 @@ def test_power_negbin():
         exposure=exposure,
         alpha=alpha,
         dispersion=dispersion, method_var="alt")
-    assert_allclose(pow_[0], pow1, atol=5e-5)
+    assert_allclose(pow_, pow1, atol=5e-5)
 
     nobs1, nobs2 = 966, 966
 
@@ -998,7 +998,7 @@ def test_power_negbin():
         exposure=exposure,
         alpha=alpha,
         dispersion=dispersion, method_var="ftotal")
-    assert_allclose(pow_[0], pow1, atol=5e-5)
+    assert_allclose(pow_, pow1, atol=5e-5)
 
     pow1 = 0.90034
     pow_ = power_equivalence_neginb_2indep(
@@ -1007,7 +1007,7 @@ def test_power_negbin():
         exposure=exposure,
         alpha=alpha,
         dispersion=dispersion, method_var="score")
-    assert_allclose(pow_[0], pow1, atol=5e-5)
+    assert_allclose(pow_, pow1, atol=5e-5)
 
     # test with unequal sample size agains R
     # R packages MKmisc and PASSED have only equality test, ratio=1, for negbin

--- a/statsmodels/stats/tests/test_rates_poisson.py
+++ b/statsmodels/stats/tests/test_rates_poisson.py
@@ -97,7 +97,7 @@ def test_rate_poisson_r():
     assert_allclose(ci[1], ci2[1], rtol=1e-5)
 
 
-methods_diff = ["wald", "score", #"waldccv",
+methods_diff = ["wald", "score", "waldccv",
                 ]
 
 
@@ -129,6 +129,40 @@ def test_rate_poisson_diff_consistency(method):
 
     assert_allclose(pv1, 0.025, rtol=rtol)
     assert_allclose(pv2, 0.025, rtol=rtol)
+
+
+methods_diff_ratio = ["wald", "score", "etest",
+                      ]
+
+
+@pytest.mark.parametrize('method', methods_diff_ratio)
+def test_rate_poisson_diff_ratio_consistency(method):
+    # check consistency between test for rate and diff for equality null
+    count1, n1, count2, n2 = 30, 400 / 10, 7, 300 / 10   # avoid low=0
+    t1 = smr.test_poisson_2indep(count1, n1, count2, n2,
+                                 method=method, compare="ratio")
+    t2 = smr.test_poisson_2indep(count1, n1, count2, n2,
+                                 method=method, compare="diff")
+
+    assert_allclose(t1.tuple, t2.tuple, rtol=1e-13)
+
+    t1 = smr.test_poisson_2indep(count1, n1, count2, n2,
+                                 method=method, compare="ratio",
+                                 alternative="larger")
+    t2 = smr.test_poisson_2indep(count1, n1, count2, n2,
+                                 method=method, compare="diff",
+                                 alternative="larger")
+
+    assert_allclose(t1.tuple, t2.tuple, rtol=1e-13)
+
+    t1 = smr.test_poisson_2indep(count1, n1, count2, n2,
+                                 method=method, compare="ratio",
+                                 alternative="smaller")
+    t2 = smr.test_poisson_2indep(count1, n1, count2, n2,
+                                 method=method, compare="diff",
+                                 alternative="smaller")
+
+    assert_allclose(t1.tuple, t2.tuple, rtol=1e-13)
 
 
 def test_twosample_poisson():

--- a/statsmodels/stats/tests/test_rates_poisson.py
+++ b/statsmodels/stats/tests/test_rates_poisson.py
@@ -409,6 +409,17 @@ def test_poisson_power_2ratio():
 
         assert_allclose(pow_, p, atol=5e-5)
 
+        pow_ = power_poisson_2indep(
+            rate1, nobs1, rate2, nobs2, exposure, value=low, alpha=0.05,
+            dispersion=1, alternative="two-sided")
+        assert_allclose(pow_, p, atol=5e-5)
+
+    # check size, power at null
+    pow_ = power_poisson_2indep(
+            rate1, nobs1, rate2, nobs2, exposure, value=rate1 / rate2,
+            alpha=0.05, dispersion=1, alternative="two-sided")
+    assert_allclose(pow_, 0.05, atol=5e-5)
+
     # check power of onesided test, larger with a margin (superiority)
     # alternative larger H1: rate1 / rate2 > R
     # here I just reverse the case of smaller alternative
@@ -427,6 +438,11 @@ def test_poisson_power_2ratio():
         pow_ = power_poisson_2indep(
             rate1, nobs1, rate2, nobs2, exposure, value=low, alpha=0.025,
             dispersion=1, alternative="larger")
+        assert_allclose(pow_, p, atol=5e-5)
+
+        pow_ = power_poisson_2indep(
+            rate1, nobs1, rate2, nobs2, exposure, value=low, alpha=0.05,
+            dispersion=1, alternative="two-sided")
         assert_allclose(pow_, p, atol=5e-5)
 
 

--- a/statsmodels/stats/tests/test_rates_poisson.py
+++ b/statsmodels/stats/tests/test_rates_poisson.py
@@ -36,6 +36,15 @@ def test_rate_poisson_consistency(method):
     assert_allclose(pv1, 0.05, rtol=rtol)
     assert_allclose(pv2, 0.05, rtol=rtol)
 
+    # check one-sided, note all confint are central
+    pv1 = smr.test_poisson(count, nobs, value=ci[0], method=method,
+                           alternative="larger").pvalue
+    pv2 = smr.test_poisson(count, nobs, value=ci[1], method=method,
+                           alternative="smaller").pvalue
+
+    assert_allclose(pv1, 0.025, rtol=rtol)
+    assert_allclose(pv2, 0.025, rtol=rtol)
+
 
 def test_rate_poisson_r():
     count, nobs = 15, 400
@@ -79,6 +88,13 @@ def test_rate_poisson_r():
     ci2 = (0.0185227303217751, 0.0564772696782249)
     ci = confint_poisson(count, nobs, method="wald")
     assert_allclose(ci, ci2, rtol=1e-12)
+
+    # from ratesci
+    # rateci(15, 400, distrib = "poi")
+    # I think their lower ci is wrong, it also doesn't match for exact_c
+    ci2 = (0.0243357599260795, 0.0604627555786095)
+    ci = confint_poisson(count, nobs, method="midp-c")
+    assert_allclose(ci[1], ci2[1], rtol=1e-5)
 
 
 def test_twosample_poisson():

--- a/statsmodels/stats/tests/test_rates_poisson.py
+++ b/statsmodels/stats/tests/test_rates_poisson.py
@@ -17,14 +17,11 @@ from statsmodels.stats.rates import (
     etest_poisson_2indep,
     confint_poisson_2indep,
     power_poisson_2indep,
-    power_poisson_2indep_v2,
     power_equivalence_poisson_2indep,
     power_poisson_diff_2indep,
-
-    power_equivalence_neginb_2indep_v3,
-    power_negbin_2indep_v2,
+    power_equivalence_neginb_2indep,
+    power_negbin_2indep,
     )
-
 
 methods = ["wald", "score", "exact-c", "waldccv", "sqrt-a", "sqrt-v", "midp-c",
            ]
@@ -535,7 +532,7 @@ def test_poisson_power_2ratio():
         pow_ = power_equivalence_poisson_2indep(
             rate1, nobs1, rate2, nobs2, exposure, low, upp, alpha=alpha,
             dispersion=dispersion)
-        assert_allclose(pow_, p, atol=5e-5)
+        assert_allclose(pow_[0], p, atol=5e-5)
 
     # check power of onesided test, smaller with a margin
     # non-inferiority
@@ -629,7 +626,7 @@ def test_power_negbin():
     dispersion = 0.35
 
     pow1 = 0.90022
-    pow_ = power_equivalence_neginb_2indep_v3(
+    pow_ = power_equivalence_neginb_2indep(
         rate1, nobs1, rate2, nobs2, exposure, low, upp, alpha=alpha,
         dispersion=dispersion, method_var="alt")
     assert_allclose(pow_[0], pow1, atol=5e-5)
@@ -637,13 +634,13 @@ def test_power_negbin():
     nobs1, nobs2 = 966, 966
 
     pow1 = 0.90015
-    pow_ = power_equivalence_neginb_2indep_v3(
+    pow_ = power_equivalence_neginb_2indep(
         rate1, nobs1, rate2, nobs2, exposure, low, upp, alpha=alpha,
         dispersion=dispersion, method_var="ftotal")
     assert_allclose(pow_[0], pow1, atol=5e-5)
 
     pow1 = 0.90034
-    pow_ = power_equivalence_neginb_2indep_v3(
+    pow_ = power_equivalence_neginb_2indep(
         rate1, nobs1, rate2, nobs2, exposure, low, upp, alpha=alpha,
         dispersion=dispersion, method_var="score")
     assert_allclose(pow_[0], pow1, atol=5e-5)
@@ -657,7 +654,7 @@ def test_power_negbin():
 
     rate2, nobs2, rate1, nobs1, exposure = 0.3, 50, 0.5, 100, 2
     pow1 = 0.6207448
-    pow_ = power_negbin_2indep_v2(rate2, nobs2, rate1, nobs1, exposure,
+    pow_ = power_negbin_2indep(rate2, nobs2, rate1, nobs1, exposure,
                                   value=1,
                                   alpha=alpha, dispersion=0.5,
                                   alternative="two-sided",
@@ -668,7 +665,7 @@ def test_power_negbin():
     # flip nobs ratio
     pow1 = 0.5825763
     nobs1, nobs2 = nobs2, nobs1
-    pow_ = power_negbin_2indep_v2(
+    pow_ = power_negbin_2indep(
         rate2, nobs2, rate1, nobs1, exposure,
         value=1,
         alpha=alpha, dispersion=0.5,
@@ -681,7 +678,7 @@ def test_power_negbin():
     # > power_NegativeBinomial(n1 = 50, n2=100, mu1 = 0.5, mu2 = 0.3,
     #   theta=200000, duration = 2, approach = 3)
     pow1 = 0.7248956
-    pow_ = power_negbin_2indep_v2(
+    pow_ = power_negbin_2indep(
         rate2, nobs2, rate1, nobs1, exposure, value=1,
         alpha=alpha, dispersion=0, alternative="two-sided",
         method_var="score",
@@ -689,7 +686,7 @@ def test_power_negbin():
 
     assert_allclose(pow_, pow1, atol=5e-2)
 
-    pow_p = power_poisson_2indep_v2(
+    pow_p = power_poisson_2indep(
         rate2, nobs2, rate1, nobs1, exposure, value=1,
         alpha=alpha, dispersion=1, alternative="two-sided",
         method_var="score",
@@ -700,13 +697,13 @@ def test_power_negbin():
 
     # test one-sided
     pow1 = 0.823889
-    pow_ = power_negbin_2indep_v2(
+    pow_ = power_negbin_2indep(
         rate2, nobs2, rate1, nobs1, exposure, value=1,
         alpha=alpha, dispersion=0, alternative="smaller",
         method_var="score",
         return_results=False)
 
-    pow_p = power_poisson_2indep_v2(
+    pow_p = power_poisson_2indep(
         rate2, nobs2, rate1, nobs1, exposure, value=1,
         alpha=alpha, dispersion=1, alternative="smaller",
         method_var="score",
@@ -716,13 +713,13 @@ def test_power_negbin():
     assert_allclose(pow_p, pow_, rtol=1e-13)
 
     # reverse 2 samples
-    pow_ = power_negbin_2indep_v2(
+    pow_ = power_negbin_2indep(
         rate1, nobs1, rate2, nobs2, exposure, value=1,
         alpha=alpha, dispersion=0, alternative="larger",
         method_var="score",
         return_results=False)
 
-    pow_p = power_poisson_2indep_v2(
+    pow_p = power_poisson_2indep(
         rate1, nobs1, rate2, nobs2, exposure, value=1,
         alpha=alpha, dispersion=1, alternative="larger",
         method_var="score",


### PR DESCRIPTION
see #8138

collecting functions
It's not clear yet what will be in here and how it will be structured.
literature references are a bit all over the place.
It still open which options and methods will be available.

current plan
- 1 sample poisson
  - test
  - confint
- 2 sample poisson ratio
  - confint to match part of current ratio hypothesis test 
  - power, based on PASS, Zhu and Guo (equivalence, one-sided with a margin)
- 2 sample poisson diff, 
  - confint, mainly mover
  - test ???
  - power ???, maybe only basic wald, equality hypothesis similar to power proportion 2indep
-  negbin  2indep
   - power Zhu, analogy to Poisson
   - test, confint, 1 sample ??? 
 - generic power based on variance functions under null and alternative
 
also includes

confint for poisson quantile and tolerance interval  for predicting new observations. (the same can be added for binomial)
 
no default method for now.
I'm not sure what should be the default.
