### PR TITLE
DOC: Change heading levels in MSTL notebook to fix docs

### DIFF
--- a/examples/notebooks/mstl_decomposition.ipynb
+++ b/examples/notebooks/mstl_decomposition.ipynb
@@ -5,12 +5,12 @@
    "id": "special-institution",
    "metadata": {},
    "source": [
-    "# Seasonal-Trend decomposition using LOESS for multiple seasonal components (MSTL)\n",
+    "# Multiple Seasonal-Trend decomposition using LOESS (MSTL)\n",
     "\n",
-    "This note book illustrates the use of `MSTL` [1] to decompose a time series into a: trend component, multiple season components, and a residual component. MSTL uses STL (Seasonal-Trend decomposition using LOESS) to iteratively extract seasonal components from a time series. The key inputs into `MSTL` are:\n",
+    "This notebook illustrates the use of `MSTL` [1] to decompose a time series into a: trend component, multiple seasonal components, and a residual component. MSTL uses STL (Seasonal-Trend decomposition using LOESS) to iteratively extract seasonal components from a time series. The key inputs into `MSTL` are:\n",
     "\n",
     "* `periods` - The period of each seasonal component (e.g., for hourly data with daily and weekly seasonality we would have: `periods=(24, 24*7)`.\n",
-    "* `windows` - The lengths of each seasonal smoother with respect to each period. If these are large then the seasonal component will show less variability over time. Must be odd. If `None` a set of default values chosen by experimentation are chosen from the original paper [1].\n",
+    "* `windows` - The lengths of each seasonal smoother with respect to each period. If these are large then the seasonal component will show less variability over time. Must be odd. If `None` a set of default values determined by experiments in the original paper [1] are used.\n",
     "* `lmbda` - The lambda parameter for a Box-Cox transformation prior to decomposition. If `None` then no transformation is done. If `\"auto\"` then an appropriate value for lambda is automatically selected from the data.\n",
     "* `iterate` - Number of iterations to use to refine the seasonal component.\n",
     "* `stl_kwargs` - All the other parameters which can be passed to STL (e.g., `robust`, `seasonal_deg`, etc.). See [STL docs](https://www.statsmodels.org/dev/generated/statsmodels.tsa.seasonal.STL.html).\n",
@@ -61,7 +61,7 @@
    "id": "226736d1-5edf-475e-8cf6-3bb339ae39f9",
    "metadata": {},
    "source": [
-    "# MSTL on a toy dataset "
+    "## MSTL applied to a toy dataset "
    ]
   },
   {
@@ -69,7 +69,7 @@
    "id": "intensive-disorder",
    "metadata": {},
    "source": [
-    "# Create a toy data set with multiple seasonalities"
+    "### Create a toy dataset with multiple seasonalities"
    ]
   },
   {
@@ -129,7 +129,7 @@
    "id": "acknowledged-updating",
    "metadata": {},
    "source": [
-    "# Apply decomposition"
+    "### Decompose the toy dataset with MSTL"
    ]
   },
   {
@@ -223,7 +223,7 @@
    "id": "floral-matrix",
    "metadata": {},
    "source": [
-    "# Let's use MSTL on a real world dataset"
+    "## MSTL applied to electricity demand dataset"
    ]
   },
   {
@@ -231,7 +231,7 @@
    "id": "legislative-trout",
    "metadata": {},
    "source": [
-    "## Prepare the data"
+    "### Prepare the data"
    ]
   },
   {
@@ -321,7 +321,7 @@
    "id": "returning-commercial",
    "metadata": {},
    "source": [
-    "## Apply MSTL"
+    "### Decompose electricity demand using MSTL"
    ]
   },
   {
@@ -329,7 +329,7 @@
    "id": "bd694778-e8c0-41ee-975f-2e86779f4d2a",
    "metadata": {},
    "source": [
-    "Let's apply MSTL to this dataset! \n",
+    "Let's apply MSTL to this dataset.\n",
     "\n",
     "Note: `stl_kwargs` are set to give results close to [[1]](https://arxiv.org/pdf/2107.13462.pdf) which used R and therefore has a slightly different default settings for the underlying `STL` parameters. It would be rare to manually set `inner_iter` and `outer_iter` explicitly in practice."
    ]


### PR DESCRIPTION
This PR changes the heading levels of the MSTL notebook to correct an issue with the docs (described below). Typos are also corrected and some parts are re-phrased for clarity.

The issue: the [Examples section](https://www.statsmodels.org/devel/examples/index.html) in the docs is currently displaying multiple headings from the MSTL notebook (see image below).

<img width="352" alt="image" src="https://user-images.githubusercontent.com/30973056/162569163-7755936c-2ac6-4c91-a940-3cbc1ca15278.png">
