### PR TITLE
BUG: Enforce type check in recursive_olsresiduals

### DIFF
--- a/statsmodels/regression/tests/test_recursive_ls.py
+++ b/statsmodels/regression/tests/test_recursive_ls.py
@@ -338,6 +338,17 @@ def test_resid_recursive():
     assert_allclose(res.resid_recursive[2:], desired_resid_recursive)
 
 
+def test_recursive_olsresiduals_bad_input(reset_randomstate):
+    from statsmodels.tsa.arima.model import ARIMA
+    e = np.random.standard_normal(250)
+    y = e.copy()
+    for i in range(1, y.shape[0]):
+        y[i] += 0.1 + 0.8 * y[i - 1] + e[i]
+    res = ARIMA(y[20:], order=(1,0,0), trend="c").fit()
+    with pytest.raises(TypeError, match="res a regression results instance"):
+        recursive_olsresiduals(res)
+
+
 def test_cusum():
     mod = RecursiveLS(endog, exog)
     res = mod.fit()

--- a/statsmodels/stats/diagnostic.py
+++ b/statsmodels/stats/diagnostic.py
@@ -1447,6 +1447,8 @@ def recursive_olsresiduals(res, skip=None, lamda=0.0, alpha=0.95,
     Journal of the Royal Statistical Society. Series B (Methodological) 37,
     no. 2 (1975): 149-192.
     """
+    if not isinstance(res, RegressionResultsWrapper):
+        raise TypeError("res a regression results instance")
     y = res.model.endog
     x = res.model.exog
     order_by = array_like(order_by, "order_by", dtype="int", optional=True,


### PR DESCRIPTION
Check res type

closes #8222

- [X] closes #8222
- [X] tests added / passed. 
- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
