### PR TITLE
TST: Remove print statement in MSTL test fixture

### DIFF
--- a/statsmodels/tsa/stl/tests/test_mstl.py
+++ b/statsmodels/tsa/stl/tests/test_mstl.py
@@ -10,7 +10,6 @@ from statsmodels.tsa.seasonal import MSTL
 @pytest.fixture(scope="function")
 def mstl_results():
     cur_dir = Path(__file__).parent.resolve()
-    print(cur_dir)
     file_path = cur_dir / "results/mstl_test_results.csv"
     return pd.read_csv(file_path)
 


### PR DESCRIPTION
This PR removes a print statement in a fixture in the MSTL tests. 