### PR TITLE
Bug when determine if all rows have same length

### DIFF
--- a/statsmodels/iolib/table.py
+++ b/statsmodels/iolib/table.py
@@ -117,7 +117,7 @@ def csv2st(csvfile, headers=False, stubs=False, title=None):
             stubs = ()
     nrows = len(rows)
     ncols = len(rows[0])
-    if any(nrows != ncols for row in rows):
+    if any(len(row) != ncols for row in rows):
         raise IOError('All rows of CSV file must have same length.')
     return SimpleTable(data=rows, headers=headers, stubs=stubs)
 


### PR DESCRIPTION
Should be the length of each row in all rows (len(row)), but not the number of rows (nrow).

It's an obvious bug, and I don't have the time to actually setup a dev env and run tests. Feel free to close this and fix it yourself.