### PR TITLE
 BUG: fix #8227 wrong standard error of the mean 

### DIFF
--- a/statsmodels/stats/descriptivestats.py
+++ b/statsmodels/stats/descriptivestats.py
@@ -384,7 +384,7 @@ class Description:
         mean = df.mean()
         mad = (df - mean).abs().mean()
         std_err = std.copy()
-        std_err.loc[count > 0] /= count.loc[count > 0]
+        std_err.loc[count > 0] /= count.loc[count > 0] ** 0.5
         if self._use_t:
             q = stats.t(count - 1).ppf(1.0 - self._alpha / 2)
         else:

--- a/statsmodels/stats/tests/test_descriptivestats.py
+++ b/statsmodels/stats/tests/test_descriptivestats.py
@@ -1,6 +1,7 @@
 import numpy as np
 from numpy.testing import assert_almost_equal, assert_equal
 import pandas as pd
+import scipy.stats
 import pytest
 
 from statsmodels.iolib.table import SimpleTable
@@ -167,6 +168,16 @@ def test_extension_types(df):
     df.loc[df.index[::2], "d"] = pd.NA
     res = Description(df)
     np.testing.assert_allclose(res.frame.c, res.frame.d)
+
+
+def test_std_err(df):
+    """
+    Test the standard error of the mean matches result from scipy.stats.sem
+    """
+    np.testing.assert_allclose(
+        Description(df["a"]).frame.loc["std_err"],
+        scipy.stats.sem(df["a"])
+    )
 
 
 def test_describe(df):


### PR DESCRIPTION
- [ ] closes #8227 
- [ ] tests added / passed. 
- [ ] code/documentation is well formatted.  
- [ ] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
