### PR TITLE
MAINT: Remove distutils

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,11 +5,10 @@ python -m pip install -e .
 pytest --cov=statsmodels statsmodels
 coverage html
 """
-from setuptools import Extension, find_packages, setup
+from setuptools import Command, Extension, find_packages, setup
 from setuptools.dist import Distribution
 
 from collections import defaultdict
-from distutils.command.clean import clean
 import fnmatch
 import os
 from os.path import join as pjoin, relpath
@@ -192,7 +191,7 @@ statespace_exts = [
 ]
 
 
-class CleanCommand(clean):
+class CleanCommand(Command):
     def run(self):
         msg = """
 
@@ -208,17 +207,17 @@ Use one of:
 
 
 def update_extension(extension, requires_math=True):
-    import numpy  # noqa: F811
-    from numpy.distutils.log import set_verbosity
-    from numpy.distutils.misc_util import get_info
+    import numpy as np
 
-    set_verbosity(1)
-
-    numpy_includes = [numpy.get_include()]
+    numpy_includes = [np.get_include()]
     extra_incl = pkg_resources.resource_filename("numpy", "core/include")
     numpy_includes += [extra_incl]
     numpy_includes = list(set(numpy_includes))
-    numpy_math_libs = get_info("npymath")
+    numpy_math_libs = {
+        "include_dirs": [np.get_include()],
+        "library_dirs": [os.path.join(np.get_include(), '..', 'lib')],
+        "libraries": ["npymath"]
+    }
 
     if not hasattr(extension, "include_dirs"):
         return


### PR DESCRIPTION
distutils is deprecated and is no longer needed

- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
