### PR TITLE
CI: Update used actions, cache pip deps, Python 3.10

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -7,10 +7,10 @@ on:
 
 jobs:
   backport:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     name: Backport
     steps:
       - name: Backport
-        uses: tibdex/backport@v1
+        uses: tibdex/backport@v2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/generate-documentation.yml
+++ b/.github/workflows/generate-documentation.yml
@@ -17,21 +17,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8]
+        python-version: ["3.10"]
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
     - name: Checkout statsmodels.github.io without token
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 1
         repository: statsmodels/statsmodels.github.io
         path: statsmodels.github.io
       if: ${{ github.event_name == 'pull_request' }}
     - name: Checkout statsmodels.github.io with token
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 1
         repository: statsmodels/statsmodels.github.io
@@ -43,13 +43,14 @@ jobs:
       env:
         EVENT_TYPE: ${{ github.event_name }}
     - name: Install pandoc
-      uses: r-lib/actions/setup-pandoc@v1
+      uses: r-lib/actions/setup-pandoc@v2
     - name: Install graphviz
       uses: ts-graphviz/setup-graphviz@v1
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
+        cache: "pip"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip wheel setuptools


### PR DESCRIPTION
A bit of CI maintenance:
- Update to actions/checkout@v3, actions/setup-python@v3, r-lib/actions/setup-pandoc@v2 and ts-graphviz/setup-graphviz@v2
- Cache packages installed by pip
- Remove the `python -m` part, `pip` is directly callable


Checklist
- [x] tests added / passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 