### PR TITLE
Update book reference in ETS example

### DIFF
--- a/examples/notebooks/ets.ipynb
+++ b/examples/notebooks/ets.ipynb
@@ -17,7 +17,7 @@
     "\n",
     "However, not all of these methods are stable. Refer to [1] and references therein for more info about model stability.\n",
     "\n",
-    "[1] Hyndman, Rob J., and George Athanasopoulos. *Forecasting: principles and practice*, 3rd edition, OTexts, 2019. https://www.otexts.org/fpp3/7"
+    "[1] Hyndman, Rob J., and Athanasopoulos, George. *Forecasting: principles and practice*, 3rd edition, OTexts, 2021. https://otexts.com/fpp3/expsmooth.html"
    ]
   },
   {


### PR DESCRIPTION
Minor doc update to fix 404 error in the ETS example
- Before PR: link https://otexts.com/fpp3/7 leads to 404 error
  - notice that the older link https://otexts.com/fpp/7 does work but gets redirected on the 2nd edition https://otexts.com/fpp2/expsmooth.html
- After PR: working link to Ch 8 "Exponential smoothing" is now https://otexts.com/fpp3/expsmooth.html

For completeness, the same book chapter is referenced in the [exponential_smoothing.ipynb](https://github.com/statsmodels/statsmodels/blob/main/examples/notebooks/exponential_smoothing.ipynb) notebook, but this is the older & safe link https://otexts.com/fpp/7 so it's OK.