### PR TITLE
ENH: Add method and converged attributes to DiscreteModel.

### DIFF
--- a/statsmodels/discrete/discrete_model.py
+++ b/statsmodels/discrete/discrete_model.py
@@ -4346,11 +4346,13 @@ class DiscreteResults(base.LikelihoodModelResults):
         #super(DiscreteResults, self).__init__(model, params,
         #        np.linalg.inv(-hessian), scale=1.)
         self.model = model
+        self.method = "MLE"
         self.df_model = model.df_model
         self.df_resid = model.df_resid
         self._cache = {}
         self.nobs = model.exog.shape[0]
         self.__dict__.update(mlefit.__dict__)
+        self.converged = mlefit.mle_retvals["converged"]
 
         if not hasattr(self, 'cov_type'):
             # do this only if super, i.e. mlefit did not already add cov_type
@@ -4821,7 +4823,7 @@ class DiscreteResults(base.LikelihoodModelResults):
 
         top_left = [('Dep. Variable:', None),
                      ('Model:', [self.model.__class__.__name__]),
-                     ('Method:', ['MLE']),
+                     ('Method:', [self.method]),
                      ('Date:', None),
                      ('Time:', None),
                      ('converged:', ["%s" % self.mle_retvals['converged']]),


### PR DESCRIPTION
- [x] closes (No issue). 
- [ ] tests added / passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

`method`

**Detail**:
This change is very minor. I let DiscreteModel be accessed with two attributes, which are `method` and `converged`. Actually, `converged` attribute can be found in `model.mle_retvals["converged"]`, but I think it is good to set this attribute for consistency with `genmod.generalized_linear_model` and user-friendliness. 

**Notes**:
Currently I can not pass tests after running `pytest statsmodels/discrete/` because of the following lines. When I just installed the current version of statsmodels without any changes, this test again can not be passed... I think my change does not affect the result fof fitting, and actually, other errors are not be raised.
```python
    def test_fit_regularized(self):
        model = self.res1.model
    
        alpha = np.ones(len(self.res1.params))
>       res_reg = model.fit_regularized(alpha=alpha*0.01, disp=0)

statsmodels/discrete/tests/test_truncated_model.py:50: 
~~~~~~
    def qc_results(params, alpha, score, qc_tol, qc_verbose=False):
~~~~~~
>       assert not np.isnan(params).max()
E       AssertionError

statsmodels/base/l1_solvers_common.py:44: AssertionError
```