### PR TITLE
MAINT: Remove pandas warning from pytest errors

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -43,7 +43,6 @@ filterwarnings =
     error:recarray support has been deprecated:FutureWarning
     error:The value returned will change to a:FutureWarning
     error:The default value of lags:FutureWarning
-    error::pandas.core.common.SettingWithCopyWarning
     error:non-integer arg n is deprecated:DeprecationWarning
     error:Creating an ndarray:numpy.VisibleDeprecationWarning
     error:The default number of lags:FutureWarning:

--- a/statsmodels/stats/descriptivestats.py
+++ b/statsmodels/stats/descriptivestats.py
@@ -392,6 +392,9 @@ class Description:
 
         def _mode(ser):
             mode_res = stats.mode(ser.dropna())
+            # Changes in SciPy 1.10
+            if np.isscalar(mode_res[0]):
+                return float(mode_res[0]), mode_res[1]
             if mode_res[0].shape[0] > 0:
                 return [float(val) for val in mode_res]
             return np.nan, np.nan


### PR DESCRIPTION
- [X] closes #8318
- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
