### PR TITLE
BUG/ENH: fix max in tost_proportions_2indep, vectorize tost

### DIFF
--- a/statsmodels/stats/nonparametric.py
+++ b/statsmodels/stats/nonparametric.py
@@ -220,7 +220,7 @@ class RankCompareResult(HolderTuple):
         t1 = self.test_prob_superior(low, alternative='larger')
         t2 = self.test_prob_superior(upp, alternative='smaller')
 
-        # idx_max = 0 if t1.pvalue < t2.pvalue else 1
+        # idx_max = 1 if t1.pvalue < t2.pvalue else 0
         idx_max = np.asarray(t1.pvalue < t2.pvalue, int)
         title = "Equivalence test for Prob(x1 > x2) + 0.5 Prob(x1 = x2) "
         res = HolderTuple(statistic=np.choose(idx_max,

--- a/statsmodels/stats/rates.py
+++ b/statsmodels/stats/rates.py
@@ -1152,9 +1152,13 @@ def tost_poisson_2indep(count1, exposure1, count2, exposure2, low, upp,
                               compare=compare,
                               alternative='smaller')
 
-    idx_max = 0 if tt1.pvalue > tt2.pvalue else 1
-    res = HolderTuple(statistic=[tt1.statistic, tt2.statistic][idx_max],
-                      pvalue=[tt1.pvalue, tt2.pvalue][idx_max],
+    # idx_max = 1 if t1.pvalue < t2.pvalue else 0
+    idx_max = np.asarray(tt1.pvalue < tt2.pvalue, int)
+    statistic = np.choose(idx_max, [tt1.statistic, tt2.statistic])
+    pvalue = np.choose(idx_max, [tt1.pvalue, tt2.pvalue])
+
+    res = HolderTuple(statistic=statistic,
+                      pvalue=pvalue,
                       method=method,
                       compare=compare,
                       equiv_limits=(low, upp),

--- a/statsmodels/stats/tests/test_nonparametric.py
+++ b/statsmodels/stats/tests/test_nonparametric.py
@@ -391,9 +391,15 @@ def test_rank_compare_2indep1():
     assert_allclose(res_ub[1], 0.05, rtol=1e-13)
 
     # test consistency of tost and confint
-    res_tost = res.tost_prob_superior(*ci)
-    assert_allclose(res_tost.results_smaller.pvalue, 0.025, rtol=1e-13)
+    # lower margin is binding, alternative larger
+    res_tost = res.tost_prob_superior(ci[0], ci[1] * 1.05)
     assert_allclose(res_tost.results_larger.pvalue, 0.025, rtol=1e-13)
+    assert_allclose(res_tost.pvalue, 0.025, rtol=1e-13)
+
+    # upper margin is binding, alternative smaller
+    res_tost = res.tost_prob_superior(ci[0] * 0.85, ci[1])
+    assert_allclose(res_tost.results_smaller.pvalue, 0.025, rtol=1e-13)
+    assert_allclose(res_tost.pvalue, 0.025, rtol=1e-13)
 
     # use t-distribution
     # our ranking is defined as reversed from lawstat, and BM article
@@ -419,9 +425,15 @@ def test_rank_compare_2indep1():
     assert_allclose(res_ub[1], 0.05, rtol=1e-11)
 
     # test consistency of tost and confint
-    res_tost = res.tost_prob_superior(*ci)
-    assert_allclose(res_tost.results_smaller.pvalue, 0.025, rtol=1e-11)
-    assert_allclose(res_tost.results_larger.pvalue, 0.025, rtol=1e-11)
+    # lower margin is binding, alternative larger
+    res_tost = res.tost_prob_superior(ci[0], ci[1] * 1.05)
+    assert_allclose(res_tost.results_larger.pvalue, 0.025, rtol=1e-10)
+    assert_allclose(res_tost.pvalue, 0.025, rtol=1e-10)
+
+    # upper margin is binding, alternative smaller
+    res_tost = res.tost_prob_superior(ci[0] * 0.85, ci[1])
+    assert_allclose(res_tost.results_smaller.pvalue, 0.025, rtol=1e-10)
+    assert_allclose(res_tost.pvalue, 0.025, rtol=1e-10)
 
     # extras
     # cohen's d

--- a/statsmodels/stats/tests/test_rates_poisson.py
+++ b/statsmodels/stats/tests/test_rates_poisson.py
@@ -783,6 +783,34 @@ class TestMethodsCompare2indep():
 
             assert_allclose(tst2.pvalue, tst.pvalue, rtol=1e-12)
 
+        # check vectorized equivalence test
+        if compare == "ratio":
+            f = 1.5
+            low, upp = 1 / f, f
+        else:
+            v = 0.5
+            low, upp = -v, v
+
+        tst0 = smr.tost_poisson_2indep(count1[0], n1[0], count2[0], n2[0],
+                                       low, upp,
+                                       method=meth,
+                                       compare=compare)
+        tst1 = smr.tost_poisson_2indep(count1[1], n1[1], count2[1], n2[1],
+                                       low, upp,
+                                       method=meth,
+                                       compare=compare)
+
+        tst2 = smr.tost_poisson_2indep(count1, n1, count2, n2, low, upp,
+                                       method=meth,
+                                       compare=compare)
+        assert tst2.statistic.shape == (2,)
+        assert tst2.pvalue.shape == (2,)
+
+        assert_allclose(tst2.statistic[0], tst0.statistic, rtol=1e-12)
+        assert_allclose(tst2.pvalue[0], tst0.pvalue, rtol=1e-12)
+        assert_allclose(tst2.statistic[1], tst1.statistic, rtol=1e-12)
+        assert_allclose(tst2.pvalue[1], tst1.pvalue, rtol=1e-12)
+
 
 def test_y_grid_regression():
     y_grid = arange(1000)


### PR DESCRIPTION
closes #8213

- fix max for tost_proportions_2indep, with vectorization
- vectorizes tost poisson 2indep
- better unit tests for nonparametric rankcompare tost

these are the only newer tost functions

old tost functions are in proportions for one sample and in weightstats
Those functions return simple tuple with numbers, not a HolderTuple or Holder instance.


