### PR TITLE
BUG: Fix auto lag selection in acorr_ljungbox #8338

### DIFF
--- a/statsmodels/stats/diagnostic.py
+++ b/statsmodels/stats/diagnostic.py
@@ -416,25 +416,27 @@ def acorr_ljungbox(x, lags=None, boxpierce=False, model_df=0, period=None,
         sacf = acf(x, nlags=maxlag, fft=False)
 
         if not boxpierce:
-            q_sacf = (nobs * (nobs + 2) * np.cumsum(sacf[1:maxlag + 1] ** 2
-                / (nobs - np.arange(1, maxlag + 1))))
+            q_sacf = (
+                    nobs * (nobs + 2) * np.cumsum(sacf[1:maxlag + 1] ** 2
+                    / (nobs - np.arange(1, maxlag + 1)))
+                    )
         else:
             q_sacf = nobs * np.cumsum(sacf[1:maxlag + 1] ** 2)
 
-        #obtain thresholds
+        # obtain thresholds
         q = 2.4
         threshold = np.sqrt(q * np.log(nobs))
         threshold_metric = np.abs(sacf).max() * np.sqrt(nobs)
 
-        #compute penalized sum of squared autocorrelations
+        # compute penalized sum of squared autocorrelations
         if (threshold_metric <= threshold):
             q_sacf = q_sacf - (np.arange(1, nobs) * np.log(nobs))
         else:
             q_sacf = q_sacf - (2 * np.arange(1, nobs))
 
-        #note: np.argmax returns first (i.e., smallest) index of largest value
+        # note: np.argmax returns first (i.e., smallest) index of largest value
         lags = np.argmax(q_sacf)
-        lags = max(1, lags) #optimal lag has to be at least 1
+        lags = max(1, lags)  # optimal lag has to be at least 1
         lags = int_like(lags, "lags")
         lags = np.arange(1, lags + 1)
     elif period is not None:

--- a/statsmodels/stats/diagnostic.py
+++ b/statsmodels/stats/diagnostic.py
@@ -399,23 +399,6 @@ def acorr_ljungbox(x, lags=None, boxpierce=False, model_df=0, period=None,
            lb_stat     lb_pvalue
     10  214.106992  1.827374e-40
     """
-    def get_optimal_length(threshold_metric, threshold, maxlag, func):
-        optimal_lag = 0
-        least_penalised = 0
-
-        for lags in range(1, maxlag + 1):
-            if (threshold_metric <= threshold):
-                penalty = lags * np.log(nobs)
-            else:
-                penalty = 2 * lags
-
-            test_statistic = func(lags)
-            penalised = test_statistic - penalty
-            if (penalised > least_penalised):
-                optimal_lag = lags
-                least_penalised = penalised
-
-        return optimal_lag
     # Avoid cyclic import
     from statsmodels.tsa.stattools import acf
     x = array_like(x, "x")
@@ -429,25 +412,29 @@ def acorr_ljungbox(x, lags=None, boxpierce=False, model_df=0, period=None,
     if auto_lag:
         maxlag = nobs - 1
 
-        # Compute threshold metrics
+        # Compute sum of squared autocorrelations
         sacf = acf(x, nlags=maxlag, fft=False)
-        sacf2 = sacf[1:maxlag + 1] ** 2 / (nobs - np.arange(1, maxlag + 1))
-        q = 2.4
-        threshold = np.sqrt(q * np.log(nobs))
-        threshold_metric = max(np.abs(sacf)) * np.sqrt(nobs)
 
         if not boxpierce:
-            lags = get_optimal_length(
-                threshold_metric,
-                threshold, maxlag,
-                lambda p: nobs * (nobs + 2) * np.cumsum(sacf2)[p - 1])
+            q_sacf = (nobs * (nobs + 2) * np.cumsum(sacf[1:maxlag + 1] ** 2
+                / (nobs - np.arange(1, maxlag + 1))))
         else:
-            lags = get_optimal_length(
-                threshold_metric,
-                threshold,
-                maxlag,
-                lambda p: nobs * np.cumsum(sacf[1:maxlag + 1] ** 2)[p - 1])
+            q_sacf = nobs * np.cumsum(sacf[1:maxlag + 1] ** 2)
+        
+        #obtain thresholds
+        q = 2.4
+        threshold = np.sqrt(q * np.log(nobs))
+        threshold_metric = np.abs(sacf).max() * np.sqrt(nobs)
+        
+        #compute penalized sum of squared autocorrelations
+        if (threshold_metric <= threshold):
+            q_sacf = q_sacf - (np.arange(1, nobs) * np.log(nobs))
+        else:
+            q_sacf = q_sacf - (2 * np.arange(1, nobs)) 
 
+        #note: np.argmax returns first (i.e., smallest) index of largest value
+        lags = np.argmax(q_sacf)
+        lags = max(1, lags) #optimal lag has to be at least 1
         lags = int_like(lags, "lags")
         lags = np.arange(1, lags + 1)
     elif period is not None:

--- a/statsmodels/stats/diagnostic.py
+++ b/statsmodels/stats/diagnostic.py
@@ -420,17 +420,17 @@ def acorr_ljungbox(x, lags=None, boxpierce=False, model_df=0, period=None,
                 / (nobs - np.arange(1, maxlag + 1))))
         else:
             q_sacf = nobs * np.cumsum(sacf[1:maxlag + 1] ** 2)
-        
+
         #obtain thresholds
         q = 2.4
         threshold = np.sqrt(q * np.log(nobs))
         threshold_metric = np.abs(sacf).max() * np.sqrt(nobs)
-        
+
         #compute penalized sum of squared autocorrelations
         if (threshold_metric <= threshold):
             q_sacf = q_sacf - (np.arange(1, nobs) * np.log(nobs))
         else:
-            q_sacf = q_sacf - (2 * np.arange(1, nobs)) 
+            q_sacf = q_sacf - (2 * np.arange(1, nobs))
 
         #note: np.argmax returns first (i.e., smallest) index of largest value
         lags = np.argmax(q_sacf)

--- a/statsmodels/stats/diagnostic.py
+++ b/statsmodels/stats/diagnostic.py
@@ -416,9 +416,9 @@ def acorr_ljungbox(x, lags=None, boxpierce=False, model_df=0, period=None,
         sacf = acf(x, nlags=maxlag, fft=False)
 
         if not boxpierce:
-            q_sacf = (
-                    nobs * (nobs + 2) * np.cumsum(sacf[1:maxlag + 1] ** 2
-                    / (nobs - np.arange(1, maxlag + 1))))
+            q_sacf = (nobs * (nobs + 2) *
+                      np.cumsum(sacf[1:maxlag + 1] ** 2
+                                / (nobs - np.arange(1, maxlag + 1))))
         else:
             q_sacf = nobs * np.cumsum(sacf[1:maxlag + 1] ** 2)
 

--- a/statsmodels/stats/diagnostic.py
+++ b/statsmodels/stats/diagnostic.py
@@ -418,8 +418,7 @@ def acorr_ljungbox(x, lags=None, boxpierce=False, model_df=0, period=None,
         if not boxpierce:
             q_sacf = (
                     nobs * (nobs + 2) * np.cumsum(sacf[1:maxlag + 1] ** 2
-                    / (nobs - np.arange(1, maxlag + 1)))
-                    )
+                    / (nobs - np.arange(1, maxlag + 1))))
         else:
             q_sacf = nobs * np.cumsum(sacf[1:maxlag + 1] ** 2)
 

--- a/statsmodels/stats/tests/test_diagnostic.py
+++ b/statsmodels/stats/tests/test_diagnostic.py
@@ -1716,9 +1716,9 @@ def test_ljungbox_auto_lag_selection():
 
 
 def test_ljungbox_auto_lag_whitenoise():
-    data = np.random.rand(1000) #white noise process
+    data = np.random.rand(1000) # white noise process
     res = smsdia.acorr_ljungbox(data, auto_lag=True)
-    #TODO: compare selected lags with Stata/ R to confirm that corect auto_lag is selected
+    #TODO: compare selected lags with Stata/ R to confirm that correct auto_lag is selected
     assert res.shape[0] >= 1 #auto lag selected must be at least 1
 
 

--- a/statsmodels/stats/tests/test_diagnostic.py
+++ b/statsmodels/stats/tests/test_diagnostic.py
@@ -1705,9 +1705,11 @@ def test_ljungbox_auto_lag_selection():
     data = sunspots.load_pandas().data["SUNACTIVITY"]
     res = AutoReg(data, 4, old_names=False).fit()
     resid = res.resid
-    res1 = smsdia.acorr_ljungbox(resid)
-    res2 = smsdia.acorr_ljungbox(resid, model_df=4)
+    res1 = smsdia.acorr_ljungbox(resid, auto_lag=True)
+    res2 = smsdia.acorr_ljungbox(resid, model_df=4, auto_lag=True)
     assert_allclose(res1.iloc[:, 0], res2.iloc[:, 0])
+    assert res1.shape[0] >= 1
+    assert res2.shape[0] >= 1
     assert np.all(np.isnan(res2.iloc[:4, 1]))
     assert np.all(res2.iloc[4:, 1] <= res1.iloc[4:, 1])
 

--- a/statsmodels/stats/tests/test_diagnostic.py
+++ b/statsmodels/stats/tests/test_diagnostic.py
@@ -1708,6 +1708,7 @@ def test_ljungbox_auto_lag_selection():
     res1 = smsdia.acorr_ljungbox(resid, auto_lag=True)
     res2 = smsdia.acorr_ljungbox(resid, model_df=4, auto_lag=True)
     assert_allclose(res1.iloc[:, 0], res2.iloc[:, 0])
+    #TODO: compare selected lags with Stata/ R to confirm that corect auto_lag is selected
     assert res1.shape[0] >= 1
     assert res2.shape[0] >= 1
     assert np.all(np.isnan(res2.iloc[:4, 1]))
@@ -1717,6 +1718,7 @@ def test_ljungbox_auto_lag_selection():
 def test_ljungbox_auto_lag_whitenoise():
     data = np.random.rand(1000) #white noise process
     res = smsdia.acorr_ljungbox(data, auto_lag=True)
+    #TODO: compare selected lags with Stata/ R to confirm that corect auto_lag is selected
     assert res.shape[0] >= 1 #auto lag selected must be at least 1
 
 

--- a/statsmodels/stats/tests/test_diagnostic.py
+++ b/statsmodels/stats/tests/test_diagnostic.py
@@ -1708,7 +1708,8 @@ def test_ljungbox_auto_lag_selection():
     res1 = smsdia.acorr_ljungbox(resid, auto_lag=True)
     res2 = smsdia.acorr_ljungbox(resid, model_df=4, auto_lag=True)
     assert_allclose(res1.iloc[:, 0], res2.iloc[:, 0])
-    #TODO: compare selected lags with Stata/ R to confirm that corect auto_lag is selected
+    # TODO: compare selected lags with Stata/ R to confirm 
+    # that corect auto_lag is selected
     assert res1.shape[0] >= 1
     assert res2.shape[0] >= 1
     assert np.all(np.isnan(res2.iloc[:4, 1]))
@@ -1716,10 +1717,11 @@ def test_ljungbox_auto_lag_selection():
 
 
 def test_ljungbox_auto_lag_whitenoise():
-    data = np.random.rand(1000) # white noise process
+    data = np.random.rand(1000)  # white noise process
     res = smsdia.acorr_ljungbox(data, auto_lag=True)
-    #TODO: compare selected lags with Stata/ R to confirm that correct auto_lag is selected
-    assert res.shape[0] >= 1 #auto lag selected must be at least 1
+    # TODO: compare selected lags with Stata/ R to confirm 
+    # that correct auto_lag is selected
+    assert res.shape[0] >= 1  # auto lag selected must be at least 1
 
 
 def test_ljungbox_errors_warnings():

--- a/statsmodels/stats/tests/test_diagnostic.py
+++ b/statsmodels/stats/tests/test_diagnostic.py
@@ -1714,6 +1714,12 @@ def test_ljungbox_auto_lag_selection():
     assert np.all(res2.iloc[4:, 1] <= res1.iloc[4:, 1])
 
 
+def test_ljungbox_auto_lag_whitenoise():
+    data = np.random.rand(1000) #white noise process
+    res = smsdia.acorr_ljungbox(data, auto_lag=True)
+    assert res.shape[0] >= 1 #auto lag selected must be at least 1
+
+
 def test_ljungbox_errors_warnings():
     data = sunspots.load_pandas().data["SUNACTIVITY"]
     with pytest.raises(ValueError, match="model_df must"):

--- a/statsmodels/stats/tests/test_diagnostic.py
+++ b/statsmodels/stats/tests/test_diagnostic.py
@@ -1708,7 +1708,7 @@ def test_ljungbox_auto_lag_selection(reset_randomstate):
     res1 = smsdia.acorr_ljungbox(resid, auto_lag=True)
     res2 = smsdia.acorr_ljungbox(resid, model_df=4, auto_lag=True)
     assert_allclose(res1.iloc[:, 0], res2.iloc[:, 0])
-    # TODO: compare selected lags with Stata/ R to confirm 
+    # TODO: compare selected lags with Stata/ R to confirm
     # that corect auto_lag is selected
     assert res1.shape[0] >= 1
     assert res2.shape[0] >= 1
@@ -1719,7 +1719,7 @@ def test_ljungbox_auto_lag_selection(reset_randomstate):
 def test_ljungbox_auto_lag_whitenoise(reset_randomstate):
     data = np.random.randn(1000)  # white noise process
     res = smsdia.acorr_ljungbox(data, auto_lag=True)
-    # TODO: compare selected lags with Stata/ R to confirm 
+    # TODO: compare selected lags with Stata/ R to confirm
     # that correct auto_lag is selected
     assert res.shape[0] >= 1  # auto lag selected must be at least 1
 

--- a/statsmodels/stats/tests/test_diagnostic.py
+++ b/statsmodels/stats/tests/test_diagnostic.py
@@ -1701,7 +1701,7 @@ def test_ljungbox_dof_adj():
     assert np.all(res2.iloc[4:, 1] <= res1.iloc[4:, 1])
 
 
-def test_ljungbox_auto_lag_selection():
+def test_ljungbox_auto_lag_selection(reset_randomstate):
     data = sunspots.load_pandas().data["SUNACTIVITY"]
     res = AutoReg(data, 4, old_names=False).fit()
     resid = res.resid
@@ -1716,8 +1716,8 @@ def test_ljungbox_auto_lag_selection():
     assert np.all(res2.iloc[4:, 1] <= res1.iloc[4:, 1])
 
 
-def test_ljungbox_auto_lag_whitenoise():
-    data = np.random.rand(1000)  # white noise process
+def test_ljungbox_auto_lag_whitenoise(reset_randomstate):
+    data = np.random.randn(1000)  # white noise process
     res = smsdia.acorr_ljungbox(data, auto_lag=True)
     # TODO: compare selected lags with Stata/ R to confirm 
     # that correct auto_lag is selected


### PR DESCRIPTION
- [x] closes #8338
- [x] tests added / passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

Corrected the implementation of optimal lag selection (Escanciano & Lobato, J. of Econometrics, 2009). `auto_lag = True` does not return a zero-size array ValueError when data is a non-autocorrelated series. Added test and corrected the previous test for this which did not flag `auto_lag = True` and therefore did not test this feature. Need additional test to compare to R results.

<details>

The `get_optimal_length` inner function of the `acorr_ljungbox` function calculated the optimal lag incorrectly. First, the optimal lag was initialized to `0`, which then caused an empty array to be initialized. The function barfed when the `max()` of this array was attempted, returning a "ValueError: zero-size array to reduction operation maximum which has no identity". Second, the least penalized LjungBox value was initialized at `0` and compared to subsequent values in a loop. However, the least penalized LB value can be less than zero, especially when the data series displays low autocorrelation. Thus, optimal lags were incorrectly calculated.

This fix eliminates `get_optimal_length` and instead performs an array-based calculation of optimal lag length. Returns a minimum lag of 1, as described in [1]. Further, it supports optimal lag calculation for low autocorrelation series (for e.g., a white noise process).

- No changes made to docstrings; some changes to inline comments
- New test for `auto_lag = True` when data is white noise process to replicate the problem and show resolution
- **IMPORTANT**: Need test to compare to results in R/Stata for additional confirmation

_[1] J. Carlos Escanciano, Ignacio N. Lobato “An automatic Portmanteau test for serial correlation”., J. of Econometrics Volume 151, 2009._

</details>