### PR TITLE
MAINT: Remove unintended print statements

### DIFF
--- a/statsmodels/discrete/tests/test_predict.py
+++ b/statsmodels/discrete/tests/test_predict.py
@@ -355,7 +355,6 @@ def test_distr(case):
     if issubclass(cls_model, BinaryModel):
         y = (y > 0.5).astype(float)
 
-    print("\n\n", cls_model, kwds)
     mod = cls_model(y, x, **kwds)
     # res = mod.fit()
     params_dgp = params

--- a/statsmodels/stats/_adnorm.py
+++ b/statsmodels/stats/_adnorm.py
@@ -46,12 +46,9 @@ def anderson_statistic(x, dist='norm', fit=True, params=(), axis=0):
             s = np.expand_dims(np.std(x, ddof=1, axis=axis), axis)
             w = (y - xbar) / s
             z = stats.norm.cdf(w)
-            # print z
         elif callable(dist):
             params = dist.fit(x)
-            # print params
             z = dist.cdf(y, *params)
-            print(z)
         else:
             raise ValueError("dist must be 'norm' or a Callable")
     else:

--- a/statsmodels/tests/test_x13.py
+++ b/statsmodels/tests/test_x13.py
@@ -1,8 +1,10 @@
 import pandas as pd
+
 from statsmodels.tsa.x13 import _make_var_names
 
 
 def test_make_var_names():
-    # Check that _make_var_names return the corrent name when exog is pandas Series
-    exog = pd.Series([1,2,3], name='abc')
+    # Check that _make_var_names return the current name when exog is
+    # a pandas Series
+    exog = pd.Series([1, 2, 3], name="abc")
     assert _make_var_names(exog) == exog.name

--- a/statsmodels/tsa/ar_model.py
+++ b/statsmodels/tsa/ar_model.py
@@ -315,7 +315,6 @@ class AutoReg(tsa_model.TimeSeriesModel):
                 assert isinstance(val, int)
                 _lags.append(val)
             _lags_arr: NDArray = np.array(sorted(_lags))
-            print(_lags_arr)
             if (
                 np.any(_lags_arr < 1)
                 or np.unique(_lags_arr).shape[0] != _lags_arr.shape[0]


### PR DESCRIPTION
Remove a few print statements in functions

closes #8345

- [X] closes #8345
- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
