### PR TITLE
BUG/ENH: Fix sim smoother nan, dims / add options

### DIFF
--- a/statsmodels/tsa/statespace/_filters/_conventional.pyx.in
+++ b/statsmodels/tsa/statespace/_filters/_conventional.pyx.in
@@ -301,10 +301,13 @@ cdef int {{prefix}}updating_conventional({{prefix}}KalmanFilter kfilter, {{prefi
     if not kfilter.converged:
         # T_t P_t Z_t' F_t^{-1}
         # $(m \times p) = (m \times m) (m \times p)$
-        blas.{{prefix}}gemm("N", "N", &model._k_states, &model._k_endog, &model._k_states,
-              &alpha, model._transition, &kfilter.k_states,
-                      &kfilter.CtmpW[0, 0], &kfilter.k_states,
-              &beta, kfilter._kalman_gain, &kfilter.k_states)
+        if model.identity_transition:
+            blas.{{prefix}}copy(&model._k_endogstates, &kfilter.CtmpW[0, 0], &inc, kfilter._kalman_gain, &inc)
+        else:
+            blas.{{prefix}}gemm("N", "N", &model._k_states, &model._k_endog, &model._k_states,
+                &alpha, model._transition, &kfilter.k_states,
+                        &kfilter.CtmpW[0, 0], &kfilter.k_states,
+                &beta, kfilter._kalman_gain, &kfilter.k_states)
 
     return 0
 
@@ -324,10 +327,13 @@ cdef int {{prefix}}prediction_conventional({{prefix}}KalmanFilter kfilter, {{pre
     # #### Predicted state for time t+1
     # $a_{t+1} = T_t a_{t|t} + c_t$
     blas.{{prefix}}copy(&model._k_states, model._state_intercept, &inc, kfilter._predicted_state, &inc)
-    blas.{{prefix}}gemv("N", &model._k_states, &model._k_states,
-          &alpha, model._transition, &model._k_states,
-                  kfilter._filtered_state, &inc,
-          &alpha, kfilter._predicted_state, &inc)
+    if model.identity_transition:
+        blas.{{prefix}}axpy(&model._k_states, &alpha, kfilter._filtered_state, &inc, kfilter._predicted_state, &inc)
+    else:
+        blas.{{prefix}}gemv("N", &model._k_states, &model._k_states,
+            &alpha, model._transition, &model._k_states,
+                    kfilter._filtered_state, &inc,
+            &alpha, kfilter._predicted_state, &inc)
 
     # #### Predicted state covariance matrix for time t+1
     # $P_{t+1} = T_t P_{t|t} T_t' + Q_t^*$
@@ -358,17 +364,20 @@ cdef int {{prefix}}prediction_conventional({{prefix}}KalmanFilter kfilter, {{pre
             # Kalman filter prediction step
             # $\\#_0 = T_t P_{t|t} $
 
-            # $(m \times m) = (m \times m) (m \times m)$
-            blas.{{prefix}}gemm("N", "N", &model._k_states, &model._k_states, &model._k_states,
-                  &alpha, model._transition, &model._k_states,
-                          kfilter._filtered_state_cov, &kfilter.k_states,
-                  &beta, kfilter._tmp0, &kfilter.k_states)
-            # $P_{t+1} = 1.0 \\#_0 T_t' + 1.0 \\#$  
-            # $(m \times m) = (m \times m) (m \times m) + (m \times m)$
-            blas.{{prefix}}gemm("N", "T", &model._k_states, &model._k_states, &model._k_states,
-                  &alpha, kfilter._tmp0, &kfilter.k_states,
-                          model._transition, &model._k_states,
-                  &alpha, kfilter._predicted_state_cov, &kfilter.k_states)
+            if model.identity_transition:
+                blas.{{prefix}}axpy(&model._k_states2, &alpha, kfilter._filtered_state_cov, &inc, kfilter._predicted_state_cov, &inc)
+            else:
+                # $(m \times m) = (m \times m) (m \times m)$
+                blas.{{prefix}}gemm("N", "N", &model._k_states, &model._k_states, &model._k_states,
+                    &alpha, model._transition, &model._k_states,
+                            kfilter._filtered_state_cov, &kfilter.k_states,
+                    &beta, kfilter._tmp0, &kfilter.k_states)
+                # $P_{t+1} = 1.0 \\#_0 T_t' + 1.0 \\#$  
+                # $(m \times m) = (m \times m) (m \times m) + (m \times m)$
+                blas.{{prefix}}gemm("N", "T", &model._k_states, &model._k_states, &model._k_states,
+                    &alpha, kfilter._tmp0, &kfilter.k_states,
+                            model._transition, &model._k_states,
+                    &alpha, kfilter._predicted_state_cov, &kfilter.k_states)
 
     return 0
 

--- a/statsmodels/tsa/statespace/_representation.pxd
+++ b/statsmodels/tsa/statespace/_representation.pxd
@@ -30,7 +30,7 @@ cdef class sStatespace(object):
     cdef public int diagonal_obs_cov
     cdef readonly int _diagonal_obs_cov
     cdef public int subset_design
-    cdef public int companion_transition
+    cdef public int companion_transition, identity_transition
 
     # Temporary arrays
     cdef np.float32_t [::1,:] tmp
@@ -107,7 +107,7 @@ cdef class dStatespace(object):
     cdef public int diagonal_obs_cov
     cdef readonly int _diagonal_obs_cov
     cdef public int subset_design
-    cdef public int companion_transition
+    cdef public int companion_transition, identity_transition
 
     # Temporary arrays
     cdef np.float64_t [::1,:] tmp
@@ -184,7 +184,7 @@ cdef class cStatespace(object):
     cdef public int diagonal_obs_cov
     cdef readonly int _diagonal_obs_cov
     cdef public int subset_design
-    cdef public int companion_transition
+    cdef public int companion_transition, identity_transition
 
     # Temporary arrays
     cdef np.complex64_t [::1,:] tmp
@@ -261,7 +261,7 @@ cdef class zStatespace(object):
     cdef public int diagonal_obs_cov
     cdef readonly int _diagonal_obs_cov
     cdef public int subset_design
-    cdef public int companion_transition
+    cdef public int companion_transition, identity_transition
 
     # Temporary arrays
     cdef np.complex128_t [::1,:] tmp

--- a/statsmodels/tsa/statespace/_simulation_smoother.pxd
+++ b/statsmodels/tsa/statespace/_simulation_smoother.pxd
@@ -53,10 +53,13 @@ cdef class sSimulationSmoother(object):
     # ### Simulation parameters
     cdef public int simulation_output
     cdef public int has_missing
+    cdef public int simulate_only
 
     # ### Random variates
-    cdef int n_disturbance_variates
-    cdef readonly np.float32_t [:] disturbance_variates
+    cdef int n_measurement_disturbance_variates
+    cdef readonly np.float32_t [:] measurement_disturbance_variates
+    cdef int n_state_disturbance_variates
+    cdef readonly np.float32_t [:] state_disturbance_variates
     cdef int n_initial_state_variates
     cdef readonly np.float32_t [:] initial_state_variates
 
@@ -79,13 +82,16 @@ cdef class sSimulationSmoother(object):
 
     # ### Parameters
     cdef readonly int nobs
-    cdef readonly int pretransformed_disturbance_variates
+    cdef readonly int pretransformed_measurement_disturbance_variates
+    cdef readonly int pretransformed_state_disturbance_variates
     cdef readonly int pretransformed_initial_state_variates
     cdef readonly int fixed_initial_state
 
-    cpdef draw_disturbance_variates(self)
-    cpdef draw_initial_state_variates(self)
-    cpdef set_disturbance_variates(self, np.float32_t [:] variates, int pretransformed=*)
+    cpdef draw_measurement_disturbance_variates(self, random_state)
+    cpdef draw_state_disturbance_variates(self, random_state)
+    cpdef draw_initial_state_variates(self, random_state)
+    cpdef set_measurement_disturbance_variates(self, np.float32_t [:] variates, int pretransformed=*)
+    cpdef set_state_disturbance_variates(self, np.float32_t [:] variates, int pretransformed=*)
     cpdef set_initial_state_variates(self, np.float32_t [:] variates, int pretransformed=*)
     cpdef set_initial_state(self, np.float32_t [:] initial_state)
     cpdef simulate(self, int simulation_output=*)
@@ -122,10 +128,13 @@ cdef class dSimulationSmoother(object):
     # ### Simulation parameters
     cdef public int simulation_output
     cdef public int has_missing
+    cdef public int simulate_only
 
     # ### Random variates
-    cdef int n_disturbance_variates
-    cdef readonly np.float64_t [:] disturbance_variates
+    cdef int n_measurement_disturbance_variates
+    cdef readonly np.float64_t [:] measurement_disturbance_variates
+    cdef int n_state_disturbance_variates
+    cdef readonly np.float64_t [:] state_disturbance_variates
     cdef int n_initial_state_variates
     cdef readonly np.float64_t [:] initial_state_variates
 
@@ -148,13 +157,16 @@ cdef class dSimulationSmoother(object):
 
     # ### Parameters
     cdef readonly int nobs
-    cdef readonly int pretransformed_disturbance_variates
+    cdef readonly int pretransformed_measurement_disturbance_variates
+    cdef readonly int pretransformed_state_disturbance_variates
     cdef readonly int pretransformed_initial_state_variates
     cdef readonly int fixed_initial_state
 
-    cpdef draw_disturbance_variates(self)
-    cpdef draw_initial_state_variates(self)
-    cpdef set_disturbance_variates(self, np.float64_t [:] variates, int pretransformed=*)
+    cpdef draw_measurement_disturbance_variates(self, random_state)
+    cpdef draw_state_disturbance_variates(self, random_state)
+    cpdef draw_initial_state_variates(self, random_state)
+    cpdef set_measurement_disturbance_variates(self, np.float64_t [:] variates, int pretransformed=*)
+    cpdef set_state_disturbance_variates(self, np.float64_t [:] variates, int pretransformed=*)
     cpdef set_initial_state_variates(self, np.float64_t [:] variates, int pretransformed=*)
     cpdef set_initial_state(self, np.float64_t [:] initial_state)
     cpdef simulate(self, int simulation_output=*)
@@ -191,10 +203,13 @@ cdef class cSimulationSmoother(object):
     # ### Simulation parameters
     cdef public int simulation_output
     cdef public int has_missing
+    cdef public int simulate_only
 
     # ### Random variates
-    cdef int n_disturbance_variates
-    cdef readonly np.complex64_t [:] disturbance_variates
+    cdef int n_measurement_disturbance_variates
+    cdef readonly np.complex64_t [:] measurement_disturbance_variates
+    cdef int n_state_disturbance_variates
+    cdef readonly np.complex64_t [:] state_disturbance_variates
     cdef int n_initial_state_variates
     cdef readonly np.complex64_t [:] initial_state_variates
 
@@ -217,13 +232,16 @@ cdef class cSimulationSmoother(object):
 
     # ### Parameters
     cdef readonly int nobs
-    cdef readonly int pretransformed_disturbance_variates
+    cdef readonly int pretransformed_measurement_disturbance_variates
+    cdef readonly int pretransformed_state_disturbance_variates
     cdef readonly int pretransformed_initial_state_variates
     cdef readonly int fixed_initial_state
 
-    cpdef draw_disturbance_variates(self)
-    cpdef draw_initial_state_variates(self)
-    cpdef set_disturbance_variates(self, np.complex64_t [:] variates, int pretransformed=*)
+    cpdef draw_measurement_disturbance_variates(self, random_state)
+    cpdef draw_state_disturbance_variates(self, random_state)
+    cpdef draw_initial_state_variates(self, random_state)
+    cpdef set_measurement_disturbance_variates(self, np.complex64_t [:] variates, int pretransformed=*)
+    cpdef set_state_disturbance_variates(self, np.complex64_t [:] variates, int pretransformed=*)
     cpdef set_initial_state_variates(self, np.complex64_t [:] variates, int pretransformed=*)
     cpdef set_initial_state(self, np.complex64_t [:] initial_state)
     cpdef simulate(self, int simulation_output=*)
@@ -260,10 +278,13 @@ cdef class zSimulationSmoother(object):
     # ### Simulation parameters
     cdef public int simulation_output
     cdef public int has_missing
+    cdef public int simulate_only
 
     # ### Random variates
-    cdef int n_disturbance_variates
-    cdef readonly np.complex128_t [:] disturbance_variates
+    cdef int n_measurement_disturbance_variates
+    cdef readonly np.complex128_t [:] measurement_disturbance_variates
+    cdef int n_state_disturbance_variates
+    cdef readonly np.complex128_t [:] state_disturbance_variates
     cdef int n_initial_state_variates
     cdef readonly np.complex128_t [:] initial_state_variates
 
@@ -286,13 +307,16 @@ cdef class zSimulationSmoother(object):
 
     # ### Parameters
     cdef readonly int nobs
-    cdef readonly int pretransformed_disturbance_variates
+    cdef readonly int pretransformed_measurement_disturbance_variates
+    cdef readonly int pretransformed_state_disturbance_variates
     cdef readonly int pretransformed_initial_state_variates
     cdef readonly int fixed_initial_state
 
-    cpdef draw_disturbance_variates(self)
-    cpdef draw_initial_state_variates(self)
-    cpdef set_disturbance_variates(self, np.complex128_t [:] variates, int pretransformed=*)
+    cpdef draw_measurement_disturbance_variates(self, random_state)
+    cpdef draw_state_disturbance_variates(self, random_state)
+    cpdef draw_initial_state_variates(self, random_state)
+    cpdef set_measurement_disturbance_variates(self, np.complex128_t [:] variates, int pretransformed=*)
+    cpdef set_state_disturbance_variates(self, np.complex128_t [:] variates, int pretransformed=*)
     cpdef set_initial_state_variates(self, np.complex128_t [:] variates, int pretransformed=*)
     cpdef set_initial_state(self, np.complex128_t [:] initial_state)
     cpdef simulate(self, int simulation_output=*)

--- a/statsmodels/tsa/statespace/_simulation_smoother.pyx.in
+++ b/statsmodels/tsa/statespace/_simulation_smoother.pyx.in
@@ -68,55 +68,6 @@ if prefix == 's':
 }}
 
 cdef class {{prefix}}SimulationSmoother(object):
-    # ### Statespace model
-    # cdef readonly {{prefix}}Statespace model
-    # ### Kalman filter
-    # cdef readonly {{prefix}}KalmanFilter kfilter
-    # ### Kalman smoother
-    # cdef readonly {{prefix}}KalmanSmoother smoother
-
-    # ### Simulated Statespace model
-    # cdef readonly {{prefix}}Statespace simulated_model
-    # ### Simulated Kalman filter
-    # cdef readonly {{prefix}}KalmanFilter simulated_kfilter
-    # ### Simulated Kalman smoother
-    # cdef readonly {{prefix}}KalmanSmoother simulated_smoother
-
-    # ### Secondary Simulated Statespace model
-    # Note: currently only used in the case of missing data
-    # cdef readonly {{prefix}}Statespace secondary_simulated_model
-    # ### Simulated Kalman filter
-    # cdef readonly {{prefix}}KalmanFilter secondary_simulated_kfilter
-    # ### Simulated Kalman smoother
-    # cdef readonly {{prefix}}KalmanSmoother secondary_simulated_smoother
-
-    # ### Simulation parameters
-    # cdef public int simulation_output
-    # cdef readonly int has_missing
-
-    # ### Random variates
-    # cdef int n_disturbance_variates
-    # cdef readonly {{cython_type}} [:] disturbance_variates
-    # cdef int n_initial_state_variates
-    # cdef readonly {{cython_type}} [:] initial_state_variates
-
-    # ### Simulated Data
-    # cdef readonly {{cython_type}} [::1,:] simulated_measurement_disturbance
-    # cdef readonly {{cython_type}} [::1,:] simulated_state_disturbance
-    # cdef readonly {{cython_type}} [::1,:] simulated_state
-
-    # ### Generated Data
-    # cdef readonly {{cython_type}} [::1,:] generated_obs
-    # cdef readonly {{cython_type}} [::1,:] generated_state
-
-    # ### Temporary arrays
-    # cdef readonly {{cython_type}} [::1,:] tmp0, tmp1, tmp2
-
-    # ### Pointers
-    # cdef {{cython_type}} * _tmp0
-    # cdef {{cython_type}} * _tmp1
-    # cdef {{cython_type}} * _tmp2
-
     def __init__(self,
                  {{prefix}}Statespace model,
                  int filter_method=FILTER_CONVENTIONAL,
@@ -130,6 +81,9 @@ cdef class {{prefix}}SimulationSmoother(object):
                  int simulation_output=SIMULATE_ALL,
                  int nobs=-1):
         cdef int inc = 1
+        # If nobs != 1, then we are only simulating a new series (i.e. we are
+        # not simulation smoothing)
+        self.simulate_only = (nobs != -1)
         cdef:
             np.npy_intp dim1[1]
             np.npy_intp dim2[2]
@@ -151,9 +105,19 @@ cdef class {{prefix}}SimulationSmoother(object):
         self.nobs = nobs
         nobs_endog = self.nobs * model.k_endog
 
-        self.pretransformed_disturbance_variates = False
+        self.pretransformed_measurement_disturbance_variates = False
+        self.pretransformed_state_disturbance_variates = False
         self.pretransformed_initial_state_variates = False
         self.fixed_initial_state = False
+
+        # If we are setting `nobs`, then we are *not* simulation smoothing
+        if self.simulate_only and simulation_output != 0:
+            raise ValueError('Setting the `nobs` variable is not compatible'
+                             ' simulation smoothing (this is because simulation'
+                             ' operates over the entire given sample - if you'
+                             ' only need a simulation for a subset, this'
+                             ' subset can be take from the simulation'
+                             ' created for the entire sample).')
 
         # Model objects
         self.model = model
@@ -174,6 +138,11 @@ cdef class {{prefix}}SimulationSmoother(object):
             model.transition, model.state_intercept, model.selection,
             model.state_cov
         )
+        self.simulated_model.identity_transition = self.model.identity_transition
+        if not self.simulate_only:
+            self.simulated_model.has_missing = model.has_missing
+            self.simulated_model.nmissing[:] = model.nmissing[:]
+            self.simulated_model.missing[:] = model.missing[:]
         self.simulated_kfilter = {{prefix}}KalmanFilter(
             self.simulated_model, filter_method, inversion_method,
             stability_method, conserve_memory, filter_timing,
@@ -190,6 +159,7 @@ cdef class {{prefix}}SimulationSmoother(object):
         # allow drawing multiple samples at the same time, see Durbin and
         # Koopman (2002).
         self.has_missing = model.has_missing
+
         if self.has_missing:
             dim2[0] = model.k_endog; dim2[1] = self.nobs;
             secondary_obs = np.PyArray_ZEROS(2, dim2, {{typenum}}, FORTRAN)
@@ -199,6 +169,11 @@ cdef class {{prefix}}SimulationSmoother(object):
                 model.transition, model.state_intercept, model.selection,
                 model.state_cov
             )
+            self.secondary_simulated_model.identity_transition = self.model.identity_transition
+            if not self.simulate_only:
+                self.secondary_simulated_model.has_missing = model.has_missing
+                self.secondary_simulated_model.nmissing[:] = model.nmissing[:]
+                self.secondary_simulated_model.missing[:] = model.missing[:]
             self.secondary_simulated_kfilter = {{prefix}}KalmanFilter(
                 self.secondary_simulated_model, filter_method, inversion_method,
                 stability_method, conserve_memory, filter_timing,
@@ -227,12 +202,15 @@ cdef class {{prefix}}SimulationSmoother(object):
 
         # Parameters
         self.simulation_output = simulation_output
-        self.n_disturbance_variates = self.nobs * (self.model.k_endog + self.model.k_posdef)
+        self.n_measurement_disturbance_variates = self.nobs * self.model.k_endog
+        self.n_state_disturbance_variates = self.nobs * self.model.k_posdef
         self.n_initial_state_variates = self.model.k_states
 
         # Random variates
-        dim1[0] = self.n_disturbance_variates;
-        self.disturbance_variates = np.PyArray_ZEROS(1, dim1, {{typenum}}, FORTRAN)
+        dim1[0] = self.n_measurement_disturbance_variates;
+        self.measurement_disturbance_variates = np.PyArray_ZEROS(1, dim1, {{typenum}}, FORTRAN)
+        dim1[0] = self.n_state_disturbance_variates;
+        self.state_disturbance_variates = np.PyArray_ZEROS(1, dim1, {{typenum}}, FORTRAN)
         dim1[0] = self.n_initial_state_variates;
         self.initial_state_variates = np.PyArray_ZEROS(1, dim1, {{typenum}}, FORTRAN)
 
@@ -273,7 +251,8 @@ cdef class {{prefix}}SimulationSmoother(object):
                 self.model.tolerance, self.model.loglikelihood_burn, self.simulated_smoother.smoother_output,
                 self.simulation_output, self.nobs, self.pretransformed_variates)
         state = {
-            'disturbance_variates': np.array(self.disturbance_variates, copy=True, order='F'),
+            'measurement_disturbance_variates': np.array(self.measurement_disturbance_variates, copy=True, order='F'),
+            'state_disturbance_variates': np.array(self.state_disturbance_variates, copy=True, order='F'),
             'initial_state_variates': np.array(self.initial_state_variates, copy=True, order='F'),
             'simulated_measurement_disturbance': np.array(self.simulated_measurement_disturbance, copy=True, order='F'),
             'simulated_state_disturbance': np.array(self.simulated_state_disturbance, copy=True, order='F'),
@@ -287,7 +266,8 @@ cdef class {{prefix}}SimulationSmoother(object):
         return (self.__class__, args, state)
 
     def __setstate__(self, state):
-        self.disturbance_variates = state['disturbance_variates']
+        self.measurement_disturbance_variates = state['measurement_disturbance_variates']
+        self.state_disturbance_variates = state['state_disturbance_variates']
         self.initial_state_variates = state['initial_state_variates']
         self.simulated_measurement_disturbance  = state['simulated_measurement_disturbance']
         self.simulated_state_disturbance = state['simulated_state_disturbance']
@@ -303,22 +283,32 @@ cdef class {{prefix}}SimulationSmoother(object):
         self._tmp1 = &self.tmp1[0,0]
         self._tmp2 = &self.tmp2[0,0]
 
+    cpdef draw_measurement_disturbance_variates(self, random_state):
+        self.measurement_disturbance_variates = random_state.normal(size=self.n_measurement_disturbance_variates)
+        self.pretransformed_measurement_disturbance_variates = False
 
-    cpdef draw_disturbance_variates(self):
-        self.disturbance_variates = np.random.normal(size=self.n_disturbance_variates)
-        self.pretransformed_disturbance_variates = False
+    cpdef draw_state_disturbance_variates(self, random_state):
+        self.state_disturbance_variates = random_state.normal(size=self.n_state_disturbance_variates)
+        self.pretransformed_state_disturbance_variates = False
 
-    cpdef draw_initial_state_variates(self):
-        self.initial_state_variates = np.random.normal(size=self.n_initial_state_variates)
+    cpdef draw_initial_state_variates(self, random_state):
+        self.initial_state_variates = random_state.normal(size=self.n_initial_state_variates)
         self.pretransformed_initial_state_variates = False
         self.fixed_initial_state = False
 
-    cpdef set_disturbance_variates(self, {{cython_type}} [:] variates, int pretransformed=0):
+    cpdef set_measurement_disturbance_variates(self, {{cython_type}} [:] variates, int pretransformed=0):
         # TODO allow variates to be an iterator or callback
-        tools.validate_vector_shape('disturbance variates', &variates.shape[0],
-                                    self.n_disturbance_variates)
-        self.disturbance_variates = variates
-        self.pretransformed_disturbance_variates = pretransformed
+        tools.validate_vector_shape('measurement disturbance variates', &variates.shape[0],
+                                    self.n_measurement_disturbance_variates)
+        self.measurement_disturbance_variates = variates
+        self.pretransformed_measurement_disturbance_variates = pretransformed
+
+    cpdef set_state_disturbance_variates(self, {{cython_type}} [:] variates, int pretransformed=0):
+        # TODO allow variates to be an iterator or callback
+        tools.validate_vector_shape('state disturbance variates', &variates.shape[0],
+                                    self.n_state_disturbance_variates)
+        self.state_disturbance_variates = variates
+        self.pretransformed_state_disturbance_variates = pretransformed
 
     cpdef set_initial_state_variates(self, {{cython_type}} [:] variates, int pretransformed=0):
         # Note that the initial state is set to be:
@@ -400,22 +390,21 @@ cdef class {{prefix}}SimulationSmoother(object):
             if not self.pretransformed_initial_state_variates:
                 self.transform_variates(&self.generated_state[0,0], self._tmp0, k_states)
             # In the case of no missing data, we want to keep the initial state at zero
-            if self.has_missing:
+            if self.has_missing or self.simulate_only:
                 blas.{{prefix}}axpy(&k_states, &alpha, &self.model.initial_state[0], &inc, &self.generated_state[0,0], &inc)
-
 
         self.simulated_kfilter.seek(0) # reset the filter
         if self.has_missing:
             self.secondary_simulated_kfilter.seek(0) # reset the filter
         measurement_idx = 0
-        state_idx = nobs_endog
+        state_idx = 0
         # Note: it is only when we are simulating a series that we might have
         # self.model.nobs != self.simulated_model.nobs, and in that case we do
         # not need to copy over the observations.
         # TODO: Need more explicit support for the pure simulation case, both
         # to avoid errors (like the copy statement below) and because we can
         # probably speed up the process by not running the filter parts.
-        if not self.has_missing and (self.model.nobs == self.simulated_model.nobs):
+        if not (self.has_missing or self.simulate_only):
             # reset the obs data in the primary simulated model
             # (but only if there is not missing data - in that case we will
             # combine the actual data with the generated data in the primary
@@ -429,34 +418,33 @@ cdef class {{prefix}}SimulationSmoother(object):
             #      alpha_{t+1}^+ = c_t + T_t alpha_t^+ + eta_t^+
 
             #    Measurement disturbance (eps)
-            # self._tmp1 = chol(H_t)
-            if t == 0 or self.model.obs_cov.shape[2] > 1:
-                self.cholesky(&self.model.obs_cov[0,0,t], self._tmp1, k_endog)
+            if not self.pretransformed_measurement_disturbance_variates:
+                # self._tmp1 = chol(H_t)
+                if t == 0 or self.model.obs_cov.shape[2] > 1:
+                    self.cholesky(&self.model.obs_cov[0,0,t], self._tmp1, k_endog)
 
-            # eps_t^+ = ind_eps * chol(H_t)
-            if not self.pretransformed_disturbance_variates:
-                self.transform_variates(&self.disturbance_variates[measurement_idx], self._tmp1, k_endog)
+                # eps_t^+ = ind_eps * chol(H_t)
+                self.transform_variates(&self.measurement_disturbance_variates[measurement_idx], self._tmp1, k_endog)
             # y_t^+
-            self.generate_obs(t, &self.generated_obs[0,t], &self.generated_state[0,t], &self.disturbance_variates[measurement_idx])
+            self.generate_obs(t, &self.generated_obs[0,t], &self.generated_state[0,t], &self.measurement_disturbance_variates[measurement_idx])
 
             measurement_idx += k_endog
 
             #    State disturbance (eta)
-            # self._tmp1 = chol(Q_t)
-            if t == 0 or self.model.state_cov.shape[2] > 1:
-                self.cholesky(&self.model.state_cov[0,0,t], self._tmp2, k_posdef)
-
-            # eta_t^+ = ind_eta * chol(Q_t)
-            if not self.pretransformed_disturbance_variates:
-                self.transform_variates(&self.disturbance_variates[state_idx], self._tmp2, k_posdef)
+            if not self.pretransformed_state_disturbance_variates:
+                # self._tmp2 = chol(Q_t)
+                if t == 0 or self.model.state_cov.shape[2] > 1:
+                    self.cholesky(&self.model.state_cov[0,0,t], self._tmp2, k_posdef)
+                # eta_t^+ = ind_eta * chol(Q_t)
+                self.transform_variates(&self.state_disturbance_variates[state_idx], self._tmp2, k_posdef)
             # alpha_t+1^+
-            self.generate_state(t, &self.generated_state[0,t+1], &self.generated_state[0,t], &self.disturbance_variates[state_idx])
+            self.generate_state(t, &self.generated_state[0,t+1], &self.generated_state[0,t], &self.state_disturbance_variates[state_idx])
 
             state_idx += k_posdef
 
             # If we are just generating new series (i.e. all we want is
             # generated_obs, generated_state), go to the next iteration
-            if self.simulation_output == 0:
+            if self.simulation_output == 0 or self.simulate_only:
                 continue
 
             # Typically, rather than running the Kalman filter separately for
@@ -513,6 +501,7 @@ cdef class {{prefix}}SimulationSmoother(object):
             if self.simulation_output & SIMULATE_DISTURBANCE:
                 # If there are partially missing entries, we need to re-order
                 # the smoothed measurment disturbances.
+                tools.{{prefix}}reorder_missing_vector(self.simulated_smoother.smoothed_measurement_disturbance, self.model.missing)
                 tools.{{prefix}}reorder_missing_vector(self.secondary_simulated_smoother.smoothed_measurement_disturbance, self.model.missing)
                 blas.{{prefix}}swap(&nobs_endog, &self.simulated_smoother.smoothed_measurement_disturbance[0,0], &inc,
                                                  &self.secondary_simulated_smoother.smoothed_measurement_disturbance[0,0], &inc)
@@ -540,7 +529,7 @@ cdef class {{prefix}}SimulationSmoother(object):
                 dim2[0] = k_endog; dim2[1] = self.nobs;
                 collapsing_obs = np.PyArray_ZEROS(2, dim2, {{typenum}}, FORTRAN)
                 nobs_endog = k_endog * self.nobs
-                blas.{{prefix}}copy(&nobs_endog, &self.disturbance_variates[0], &inc, &collapsing_obs[0, 0], &inc)
+                blas.{{prefix}}copy(&nobs_endog, &self.measurement_disturbance_variates[0], &inc, &collapsing_obs[0, 0], &inc)
                 nobs_endog = nobs_kstates
 
                 collapsing_model = {{prefix}}Statespace(
@@ -555,13 +544,13 @@ cdef class {{prefix}}SimulationSmoother(object):
                                              self.simulated_kfilter.filter_method & FILTER_COLLAPSED)
                     blas.{{prefix}}copy(&k_states, &collapsing_model.collapse_obs[0], &inc, &self.simulated_measurement_disturbance[0,t], &inc)
             else:
-                blas.{{prefix}}copy(&nobs_endog, &self.disturbance_variates[0], &inc, &self.simulated_measurement_disturbance[0,0], &inc)
+                blas.{{prefix}}copy(&nobs_endog, &self.measurement_disturbance_variates[0], &inc, &self.simulated_measurement_disturbance[0,0], &inc)
 
             blas.{{prefix}}axpy(&nobs_endog, &alpha, &self.simulated_smoother.smoothed_measurement_disturbance[0,0], &inc,
                                                      &self.simulated_measurement_disturbance[0,0], &inc)
 
             # \tilde eta_t = \hat eta_t^* + eta_t^+
-            blas.{{prefix}}copy(&nobs_posdef, &self.disturbance_variates[k_endog * self.nobs], &inc, &self.simulated_state_disturbance[0,0], &inc)
+            blas.{{prefix}}copy(&nobs_posdef, &self.state_disturbance_variates[0], &inc, &self.simulated_state_disturbance[0,0], &inc)
             blas.{{prefix}}axpy(&nobs_posdef, &alpha, &self.simulated_smoother.smoothed_state_disturbance[0,0], &inc,
                                                      &self.simulated_state_disturbance[0,0], &inc)
 
@@ -629,10 +618,13 @@ cdef class {{prefix}}SimulationSmoother(object):
                             &alpha, state, &inc)
 
         # alpha_{t+1} = T_t alpha_t + \\#
-        blas.{{prefix}}gemv("N", &k_states, &k_states,
-                            &alpha, &self.model.transition[0,0,transition_t], &k_states,
-                                    input_state, &inc,
-                            &alpha, state, &inc)
+        if self.model.identity_transition:
+            blas.{{prefix}}axpy(&k_states, &alpha, input_state, &inc, state, &inc)
+        else:
+            blas.{{prefix}}gemv("N", &k_states, &k_states,
+                                &alpha, &self.model.transition[0,0,transition_t], &k_states,
+                                        input_state, &inc,
+                                &alpha, state, &inc)
 
     cdef void cholesky(self, {{cython_type}} * source, {{cython_type}} * destination, int n):
         cdef:

--- a/statsmodels/tsa/statespace/_smoothers/_conventional.pyx.in
+++ b/statsmodels/tsa/statespace/_smoothers/_conventional.pyx.in
@@ -102,10 +102,13 @@ cdef int {{prefix}}smoothed_estimators_missing_conventional({{prefix}}KalmanSmoo
     # as scaled_smoothed_estimator[t-1] because we actually need to store
     # T+1 of them (r_{T-1} to r_{-1} -> r_T to r_0)
     if smoother.smoother_output & (SMOOTHER_STATE | SMOOTHER_DISTURBANCE):
-        blas.{{prefix}}gemv("T", &model._k_states, &model._k_states,
-                  &alpha, model._transition, &model._k_states,
-                          smoother._input_scaled_smoothed_estimator, &inc,
-                  &beta, smoother._scaled_smoothed_estimator, &inc)
+        if model.identity_transition:
+            blas.{{prefix}}copy(&model._k_states, smoother._input_scaled_smoothed_estimator, &inc, smoother._scaled_smoothed_estimator, &inc)
+        else:
+            blas.{{prefix}}gemv("T", &model._k_states, &model._k_states,
+                    &alpha, model._transition, &model._k_states,
+                            smoother._input_scaled_smoothed_estimator, &inc,
+                    &beta, smoother._scaled_smoothed_estimator, &inc)
 
     # Scaled smoothed estimator covariance matrix  
     # $N_{t-1} = T_t' N_t T_t$  
@@ -114,14 +117,17 @@ cdef int {{prefix}}smoothed_estimators_missing_conventional({{prefix}}KalmanSmoo
     # than as scaled_smoothed_estimator_cov[t-1] because we actually
     # need to store T+1 of them (N_{T-1} to N_{-1} -> N_T to N_0)
     if smoother.smoother_output & (SMOOTHER_STATE_COV | SMOOTHER_DISTURBANCE_COV):
-        blas.{{prefix}}gemm("N", "N", &model._k_states, &model._k_states, &model._k_states,
-                  &alpha, smoother._input_scaled_smoothed_estimator_cov, &kfilter.k_states,
-                          model._transition, &model._k_states,
-                  &beta, smoother._tmp0, &kfilter.k_states)
-        blas.{{prefix}}gemm("T", "N", &kfilter.k_states, &kfilter.k_states, &kfilter.k_states,
-                  &alpha, model._transition, &model._k_states,
-                          smoother._tmp0, &kfilter.k_states,
-                  &beta, smoother._scaled_smoothed_estimator_cov, &kfilter.k_states)
+        if model.identity_transition:
+            blas.{{prefix}}copy(&model._k_states2, smoother._input_scaled_smoothed_estimator_cov, &inc, smoother._scaled_smoothed_estimator_cov, &inc)
+        else:
+            blas.{{prefix}}gemm("N", "N", &model._k_states, &model._k_states, &model._k_states,
+                      &alpha, smoother._input_scaled_smoothed_estimator_cov, &kfilter.k_states,
+                              model._transition, &model._k_states,
+                      &beta, smoother._tmp0, &kfilter.k_states)
+            blas.{{prefix}}gemm("T", "N", &kfilter.k_states, &kfilter.k_states, &kfilter.k_states,
+                      &alpha, model._transition, &model._k_states,
+                              smoother._tmp0, &kfilter.k_states,
+                      &beta, smoother._scaled_smoothed_estimator_cov, &kfilter.k_states)
 
     # $L_t = T_t$  
     blas.{{prefix}}copy(&model._k_states2, model._transition, &inc, smoother._tmpL, &inc)
@@ -223,7 +229,7 @@ cdef int {{prefix}}smoothed_estimators_measurement_conventional({{prefix}}Kalman
                           smoother._input_scaled_smoothed_estimator, &inc,
                   &alpha, smoother._smoothing_error, &inc)
 
-    # $L_t = (T_t - K_t Z_t)$  
+    # $L_t = (T_t - K_t Z_t)$  = (T_t - T_t P_t Z_t' F_t^{-1} Z_t)
     # $(m \times m) = (m \times m) + (m \times p) (p \times m)$
     # (this is required for any type of smoothing)
     blas.{{prefix}}copy(&model._k_states2, model._transition, &inc, smoother._tmpL, &inc)

--- a/statsmodels/tsa/statespace/kalman_filter.py
+++ b/statsmodels/tsa/statespace/kalman_filter.py
@@ -1093,7 +1093,12 @@ class KalmanFilter(Representation):
         return llf_obs
 
     def simulate(self, nsimulations, measurement_shocks=None,
-                 state_shocks=None, initial_state=None):
+                 state_shocks=None, initial_state=None,
+                 pretransformed_measurement_shocks=True,
+                 pretransformed_state_shocks=True,
+                 pretransformed_initial_state=True,
+                 simulator=None, return_simulator=False,
+                 random_state=None):
         r"""
         Simulate a new time series following the state space model
 
@@ -1124,6 +1129,35 @@ class KalmanFilter(Representation):
             the model has not been initialized, then a vector of zeros is used.
             Note that this is not included in the returned `simulated_states`
             array.
+        pretransformed_measurement_shocks : bool, optional
+            If `measurement_shocks` is provided, this flag indicates whether it
+            should be directly used as the shocks. If False, then it is assumed
+            to contain draws from the standard Normal distribution that must be
+            transformed using the `obs_cov` covariance matrix. Default is True.
+        pretransformed_state_shocks : bool, optional
+            If `state_shocks` is provided, this flag indicates whether it
+            should be directly used as the shocks. If False, then it is assumed
+            to contain draws from the standard Normal distribution that must be
+            transformed using the `state_cov` covariance matrix. Default is
+            True.
+        pretransformed_initial_state : bool, optional
+            If `initial_state` is provided, this flag indicates whether it
+            should be directly used as the initial_state. If False, then it is
+            assumed to contain draws from the standard Normal distribution that
+            must be transformed using the `initial_state_cov` covariance matrix.
+            Default is True.
+        return_simulator : bool, optional
+            Whether or not to return the simulator object. Typically used to
+            improve performance when performing repeated sampling. Default is
+            False.
+        random_state : {None, int, `numpy.random.Generator`,
+                        `numpy.random.RandomState`}, optional
+            If `seed` is None (or `np.random`), the `numpy.random.RandomState`
+            singleton is used.
+            If `seed` is an int, a new ``RandomState`` instance is used,
+            seeded with `seed`.
+            If `seed` is already a ``Generator`` or ``RandomState`` instance
+            then that instance is used.
 
         Returns
         -------
@@ -1131,6 +1165,10 @@ class KalmanFilter(Representation):
             An (nsimulations x k_endog) array of simulated observations.
         simulated_states : ndarray
             An (nsimulations x k_states) array of simulated states.
+        simulator : SimulationSmoothResults
+            If `return_simulator=True`, then an instance of a simulator is
+            returned, which can be reused for additional simulations of the
+            same size.
         """
         time_invariant = self.time_invariant
         # Check for valid number of simulations
@@ -1138,85 +1176,22 @@ class KalmanFilter(Representation):
             raise ValueError('In a time-varying model, cannot create more'
                              ' simulations than there are observations.')
 
-        # Check / generate measurement shocks
-        if measurement_shocks is not None:
-            measurement_shocks = np.array(measurement_shocks)
-            if measurement_shocks.ndim == 0:
-                measurement_shocks = measurement_shocks[np.newaxis, np.newaxis]
-            elif measurement_shocks.ndim == 1:
-                measurement_shocks = measurement_shocks[:, np.newaxis]
-            required_shape = (nsimulations, self.k_endog)
-            try:
-                measurement_shocks = measurement_shocks.reshape(required_shape)
-            except ValueError:
-                raise ValueError('Provided measurement shocks are not of the'
-                                 ' appropriate shape. Required %s, got %s.'
-                                 % (str(required_shape),
-                                    str(measurement_shocks.shape)))
-        elif self.shapes['obs_cov'][-1] == 1:
-            measurement_shocks = np.random.multivariate_normal(
-                mean=np.zeros(self.k_endog), cov=self['obs_cov'],
-                size=nsimulations)
+        return self._simulate(
+            nsimulations,
+            measurement_disturbance_variates=measurement_shocks,
+            state_disturbance_variates=state_shocks,
+            initial_state_variates=initial_state,
+            pretransformed_measurement_disturbance_variates=(
+                pretransformed_measurement_shocks),
+            pretransformed_state_disturbance_variates=(
+                pretransformed_state_shocks),
+            pretransformed_initial_state_variates=(
+                pretransformed_initial_state),
+            simulator=simulator, return_simulator=return_simulator,
+            random_state=random_state)
 
-        # Check / generate state shocks
-        if state_shocks is not None:
-            state_shocks = np.array(state_shocks)
-            if state_shocks.ndim == 0:
-                state_shocks = state_shocks[np.newaxis, np.newaxis]
-            elif state_shocks.ndim == 1:
-                state_shocks = state_shocks[:, np.newaxis]
-            required_shape = (nsimulations, self.k_posdef)
-            try:
-                state_shocks = state_shocks.reshape(required_shape)
-            except ValueError:
-                raise ValueError('Provided state shocks are not of the'
-                                 ' appropriate shape. Required %s, got %s.'
-                                 % (str(required_shape),
-                                    str(state_shocks.shape)))
-        elif self.shapes['state_cov'][-1] == 1:
-            state_shocks = np.random.multivariate_normal(
-                mean=np.zeros(self.k_posdef), cov=self['state_cov'],
-                size=nsimulations)
-
-        # Handle time-varying case
-        tvp = (self.shapes['obs_cov'][-1] > 1 or
-               self.shapes['state_cov'][-1] > 1)
-        if tvp and measurement_shocks is None:
-            measurement_shocks = np.zeros((nsimulations, self.k_endog))
-            for i in range(nsimulations):
-                measurement_shocks[i] = np.random.multivariate_normal(
-                    mean=np.zeros(self.k_endog),
-                    cov=self['obs_cov', ..., i])
-        if tvp and state_shocks is None:
-            state_shocks = np.zeros((nsimulations, self.k_posdef))
-            for i in range(nsimulations):
-                state_shocks[i] = np.random.multivariate_normal(
-                    mean=np.zeros(self.k_posdef),
-                    cov=self['state_cov', ..., i])
-
-        # Get the initial states
-        if initial_state is not None:
-            initial_state = np.array(initial_state)
-            if initial_state.ndim == 0:
-                initial_state = initial_state[np.newaxis]
-            elif (initial_state.ndim > 1 and
-                  not initial_state.shape == (self.k_states, 1)):
-                raise ValueError('Invalid shape of provided initial state'
-                                 ' vector. Required (%d, 1)' % self.k_states)
-        elif self.initialization is not None:
-            out = self.initialization(model=self)
-            initial_state = out[0] + np.random.multivariate_normal(
-                np.zeros_like(out[0]), out[2])
-        else:
-            # TODO: deprecate this, since we really should not be simulating
-            # unless we have an initialization.
-            initial_state = np.zeros(self.k_states)
-
-        return self._simulate(nsimulations, measurement_shocks, state_shocks,
-                              initial_state)
-
-    def _simulate(self, nsimulations, measurement_shocks, state_shocks,
-                  initial_state):
+    def _simulate(self, nsimulations, simulator=None, random_state=None,
+                  **kwargs):
         raise NotImplementedError('Simulation only available through'
                                   ' the simulation smoother.')
 

--- a/statsmodels/tsa/statespace/kalman_filter.py
+++ b/statsmodels/tsa/statespace/kalman_filter.py
@@ -1144,8 +1144,8 @@ class KalmanFilter(Representation):
             If `initial_state` is provided, this flag indicates whether it
             should be directly used as the initial_state. If False, then it is
             assumed to contain draws from the standard Normal distribution that
-            must be transformed using the `initial_state_cov` covariance matrix.
-            Default is True.
+            must be transformed using the `initial_state_cov` covariance
+            matrix. Default is True.
         return_simulator : bool, optional
             Whether or not to return the simulator object. Typically used to
             improve performance when performing repeated sampling. Default is

--- a/statsmodels/tsa/statespace/mlemodel.py
+++ b/statsmodels/tsa/statespace/mlemodel.py
@@ -1930,8 +1930,8 @@ class MLEModel(tsbase.TimeSeriesModel):
             If `initial_state` is provided, this flag indicates whether it
             should be directly used as the initial_state. If False, then it is
             assumed to contain draws from the standard Normal distribution that
-            must be transformed using the `initial_state_cov` covariance matrix.
-            Default is True.
+            must be transformed using the `initial_state_cov` covariance
+            matrix. Default is True.
         random_state : {None, int, `numpy.random.Generator`,
                         `numpy.random.RandomState`}, optional
             If `seed` is None (or `np.random`), the `numpy.random.RandomState`
@@ -3601,8 +3601,8 @@ class MLEResults(tsbase.TimeSeriesModelResults):
             If `initial_state` is provided, this flag indicates whether it
             should be directly used as the initial_state. If False, then it is
             assumed to contain draws from the standard Normal distribution that
-            must be transformed using the `initial_state_cov` covariance matrix.
-            Default is True.
+            must be transformed using the `initial_state_cov` covariance
+            matrix. Default is True.
         random_state : {None, int, `numpy.random.Generator`,
                         `numpy.random.RandomState`}, optional
             If `seed` is None (or `np.random`), the `numpy.random.RandomState`

--- a/statsmodels/tsa/statespace/simulation_smoother.py
+++ b/statsmodels/tsa/statespace/simulation_smoother.py
@@ -170,7 +170,8 @@ class SimulationSmoother(KalmanSmoother):
         simulated_obs = np.array(simulator.generated_obs, copy=True)
         simulated_state = np.array(simulator.generated_state, copy=True)
 
-        out = (simulated_obs.T[:nsimulations], simulated_state.T[:nsimulations])
+        out = (simulated_obs.T[:nsimulations],
+               simulated_state.T[:nsimulations])
         if return_simulator:
             out = out + (simulator,)
         return out
@@ -591,8 +592,8 @@ class SimulationSmoothResults:
             If `measurement_disturbance_variates` is provided, this flag
             indicates whether it should be directly used as the shocks. If
             False, then it is assumed to contain draws from the standard Normal
-            distribution that must be transformed using the `obs_cov` covariance
-            matrix. Default is False.
+            distribution that must be transformed using the `obs_cov`
+            covariance matrix. Default is False.
         pretransformed_state_disturbance_variates : bool, optional
             If `state_disturbance_variates` is provided, this flag indicates
             whether it should be directly used as the shocks. If False, then it
@@ -600,11 +601,11 @@ class SimulationSmoothResults:
             that must be transformed using the `state_cov` covariance matrix.
             Default is False.
         pretransformed_initial_state_variates : bool, optional
-            If `initial_state_variates` is provided, this flag indicates whether
-            it should be directly used as the initial_state. If False, then it
-            is assumed to contain draws from the standard Normal distribution
-            that must be transformed using the `initial_state_cov` covariance
-            matrix. Default is False.
+            If `initial_state_variates` is provided, this flag indicates
+            whether it should be directly used as the initial_state. If False,
+            then it is assumed to contain draws from the standard Normal
+            distribution that must be transformed using the `initial_state_cov`
+            covariance matrix. Default is False.
         random_state : {None, int, `numpy.random.Generator`,
                         `numpy.random.RandomState`}, optional
             If `seed` is None (or `np.random`), the `numpy.random.RandomState`
@@ -634,10 +635,9 @@ class SimulationSmoothResults:
                                  ' `state_disturbance_variates`.')
             if disturbance_variates is not None:
                 disturbance_variates = disturbance_variates.ravel()
-                measurement_disturbance_variates = (
-                    disturbance_variates[:self.model.nobs * self.model.k_endog])
-                state_disturbance_variates = (
-                    disturbance_variates[self.model.nobs * self.model.k_endog:])
+                n_mds = self.model.nobs * self.model.k_endog
+                measurement_disturbance_variates = disturbance_variates[:n_mds]
+                state_disturbance_variates = disturbance_variates[n_mds:]
         if pretransformed is not None:
             msg = ('`pretransformed` keyword is deprecated, use'
                    ' `pretransformed_measurement_disturbance_variates` and'
@@ -650,7 +650,8 @@ class SimulationSmoothResults:
                     ' `pretransformed_measurement_disturbance_variates` or'
                     ' `pretransformed_state_disturbance_variates`.')
             if pretransformed is not None:
-                pretransformed_measurement_disturbance_variates = pretransformed
+                pretransformed_measurement_disturbance_variates = (
+                    pretransformed)
                 pretransformed_state_disturbance_variates = pretransformed
 
         if pretransformed_measurement_disturbance_variates is None:
@@ -724,8 +725,8 @@ class SimulationSmoothResults:
             # Note: there is a third option, which is to set the initial state
             # variates with pretransformed = True. However, this option simply
             # eliminates the multiplication by the Cholesky factor of the
-            # initial state cov, but still adds the initial state mean. It's not
-            # clear when this would be useful...
+            # initial state cov, but still adds the initial state mean. It's
+            # not clear when this would be useful...
         else:
             self._simulation_smoother.draw_initial_state_variates(
                 random_state)

--- a/statsmodels/tsa/statespace/tests/test_collapsed.py
+++ b/statsmodels/tsa/statespace/tests/test_collapsed.py
@@ -201,16 +201,18 @@ class TestTrivariateConventional(Trivariate):
     @classmethod
     def setup_class(cls, dtype=float, **kwargs):
         super(TestTrivariateConventional, cls).setup_class(dtype, **kwargs)
-        n_disturbance_variates = (
-            (cls.model.k_endog + cls.model.k_posdef) * cls.model.nobs
-        )
+
+        nobs = cls.model.nobs
+        k_endog = cls.model.k_endog
+        k_posdef = cls.model.k_posdef
 
         # Collapsed filtering, smoothing, and simulation smoothing
         cls.model.filter_conventional = True
         cls.model.filter_collapsed = True
         cls.results_b = cls.model.smooth()
         cls.sim_b = cls.model.simulation_smoother(
-            disturbance_variates=np.zeros(n_disturbance_variates),
+            measurement_disturbance_variates=np.zeros(nobs * k_endog),
+            state_disturbance_variates=np.zeros(nobs * k_posdef),
             initial_state_variates=np.zeros(cls.model.k_states)
         )
 
@@ -218,7 +220,8 @@ class TestTrivariateConventional(Trivariate):
         cls.model.filter_collapsed = False
         cls.results_a = cls.model.smooth()
         cls.sim_a = cls.model.simulation_smoother(
-            disturbance_variates=np.zeros(n_disturbance_variates),
+            measurement_disturbance_variates=np.zeros(nobs * k_endog),
+            state_disturbance_variates=np.zeros(nobs * k_posdef),
             initial_state_variates=np.zeros(cls.model.k_states)
         )
 
@@ -238,9 +241,9 @@ class TestTrivariateConventionalPartialMissing(Trivariate):
     def setup_class(cls, dtype=float, **kwargs):
         super(TestTrivariateConventionalPartialMissing, cls).setup_class(
             dtype, **kwargs)
-        n_disturbance_variates = (
-            (cls.model.k_endog + cls.model.k_posdef) * cls.model.nobs
-        )
+        nobs = cls.model.nobs
+        k_endog = cls.model.k_endog
+        k_posdef = cls.model.k_posdef
 
         # Set partially missing data
         cls.model.endog[:2, 10:180] = np.nan
@@ -250,7 +253,8 @@ class TestTrivariateConventionalPartialMissing(Trivariate):
         cls.model.filter_collapsed = True
         cls.results_b = cls.model.smooth()
         cls.sim_b = cls.model.simulation_smoother(
-            disturbance_variates=np.zeros(n_disturbance_variates),
+            measurement_disturbance_variates=np.zeros(nobs * k_endog),
+            state_disturbance_variates=np.zeros(nobs * k_posdef),
             initial_state_variates=np.zeros(cls.model.k_states)
         )
 
@@ -258,7 +262,8 @@ class TestTrivariateConventionalPartialMissing(Trivariate):
         cls.model.filter_collapsed = False
         cls.results_a = cls.model.smooth()
         cls.sim_a = cls.model.simulation_smoother(
-            disturbance_variates=np.zeros(n_disturbance_variates),
+            measurement_disturbance_variates=np.zeros(nobs * k_endog),
+            state_disturbance_variates=np.zeros(nobs * k_posdef),
             initial_state_variates=np.zeros(cls.model.k_states)
         )
 
@@ -279,9 +284,9 @@ class TestTrivariateConventionalAllMissing(Trivariate):
     def setup_class(cls, dtype=float, **kwargs):
         super(TestTrivariateConventionalAllMissing, cls).setup_class(
             dtype, **kwargs)
-        n_disturbance_variates = (
-            (cls.model.k_endog + cls.model.k_posdef) * cls.model.nobs
-        )
+        nobs = cls.model.nobs
+        k_endog = cls.model.k_endog
+        k_posdef = cls.model.k_posdef
 
         # Set partially missing data
         cls.model.endog[:, 10:180] = np.nan
@@ -291,7 +296,8 @@ class TestTrivariateConventionalAllMissing(Trivariate):
         cls.model.filter_collapsed = True
         cls.results_b = cls.model.smooth()
         cls.sim_b = cls.model.simulation_smoother(
-            disturbance_variates=np.zeros(n_disturbance_variates),
+            measurement_disturbance_variates=np.zeros(nobs * k_endog),
+            state_disturbance_variates=np.zeros(nobs * k_posdef),
             initial_state_variates=np.zeros(cls.model.k_states)
         )
 
@@ -299,7 +305,8 @@ class TestTrivariateConventionalAllMissing(Trivariate):
         cls.model.filter_collapsed = False
         cls.results_a = cls.model.smooth()
         cls.sim_a = cls.model.simulation_smoother(
-            disturbance_variates=np.zeros(n_disturbance_variates),
+            measurement_disturbance_variates=np.zeros(nobs * k_endog),
+            state_disturbance_variates=np.zeros(nobs * k_posdef),
             initial_state_variates=np.zeros(cls.model.k_states)
         )
 
@@ -319,16 +326,17 @@ class TestTrivariateUnivariate(Trivariate):
     @classmethod
     def setup_class(cls, dtype=float, **kwargs):
         super(TestTrivariateUnivariate, cls).setup_class(dtype, **kwargs)
-        n_disturbance_variates = (
-            (cls.model.k_endog + cls.model.k_posdef) * cls.model.nobs
-        )
+        nobs = cls.model.nobs
+        k_endog = cls.model.k_endog
+        k_posdef = cls.model.k_posdef
 
         # Collapsed filtering, smoothing, and simulation smoothing
         cls.model.filter_univariate = True
         cls.model.filter_collapsed = True
         cls.results_b = cls.model.smooth()
         cls.sim_b = cls.model.simulation_smoother(
-            disturbance_variates=np.zeros(n_disturbance_variates),
+            measurement_disturbance_variates=np.zeros(nobs * k_endog),
+            state_disturbance_variates=np.zeros(nobs * k_posdef),
             initial_state_variates=np.zeros(cls.model.k_states)
         )
 
@@ -336,7 +344,8 @@ class TestTrivariateUnivariate(Trivariate):
         cls.model.filter_collapsed = False
         cls.results_a = cls.model.smooth()
         cls.sim_a = cls.model.simulation_smoother(
-            disturbance_variates=np.zeros(n_disturbance_variates),
+            measurement_disturbance_variates=np.zeros(nobs * k_endog),
+            state_disturbance_variates=np.zeros(nobs * k_posdef),
             initial_state_variates=np.zeros(cls.model.k_states)
         )
 
@@ -356,9 +365,9 @@ class TestTrivariateUnivariatePartialMissing(Trivariate):
     def setup_class(cls, dtype=float, **kwargs):
         super(TestTrivariateUnivariatePartialMissing, cls).setup_class(
             dtype, **kwargs)
-        n_disturbance_variates = (
-            (cls.model.k_endog + cls.model.k_posdef) * cls.model.nobs
-        )
+        nobs = cls.model.nobs
+        k_endog = cls.model.k_endog
+        k_posdef = cls.model.k_posdef
 
         # Set partially missing data
         cls.model.endog[:2, 10:180] = np.nan
@@ -368,7 +377,8 @@ class TestTrivariateUnivariatePartialMissing(Trivariate):
         cls.model.filter_collapsed = True
         cls.results_b = cls.model.smooth()
         cls.sim_b = cls.model.simulation_smoother(
-            disturbance_variates=np.zeros(n_disturbance_variates),
+            measurement_disturbance_variates=np.zeros(nobs * k_endog),
+            state_disturbance_variates=np.zeros(nobs * k_posdef),
             initial_state_variates=np.zeros(cls.model.k_states)
         )
 
@@ -376,7 +386,8 @@ class TestTrivariateUnivariatePartialMissing(Trivariate):
         cls.model.filter_collapsed = False
         cls.results_a = cls.model.smooth()
         cls.sim_a = cls.model.simulation_smoother(
-            disturbance_variates=np.zeros(n_disturbance_variates),
+            measurement_disturbance_variates=np.zeros(nobs * k_endog),
+            state_disturbance_variates=np.zeros(nobs * k_posdef),
             initial_state_variates=np.zeros(cls.model.k_states)
         )
 
@@ -397,9 +408,9 @@ class TestTrivariateUnivariateAllMissing(Trivariate):
     def setup_class(cls, dtype=float, **kwargs):
         super(TestTrivariateUnivariateAllMissing, cls).setup_class(
             dtype, **kwargs)
-        n_disturbance_variates = (
-            (cls.model.k_endog + cls.model.k_posdef) * cls.model.nobs
-        )
+        nobs = cls.model.nobs
+        k_endog = cls.model.k_endog
+        k_posdef = cls.model.k_posdef
 
         # Set partially missing data
         cls.model.endog[:, 10:180] = np.nan
@@ -409,7 +420,8 @@ class TestTrivariateUnivariateAllMissing(Trivariate):
         cls.model.filter_collapsed = True
         cls.results_b = cls.model.smooth()
         cls.sim_b = cls.model.simulation_smoother(
-            disturbance_variates=np.zeros(n_disturbance_variates),
+            measurement_disturbance_variates=np.zeros(nobs * k_endog),
+            state_disturbance_variates=np.zeros(nobs * k_posdef),
             initial_state_variates=np.zeros(cls.model.k_states)
         )
 
@@ -417,7 +429,8 @@ class TestTrivariateUnivariateAllMissing(Trivariate):
         cls.model.filter_collapsed = False
         cls.results_a = cls.model.smooth()
         cls.sim_a = cls.model.simulation_smoother(
-            disturbance_variates=np.zeros(n_disturbance_variates),
+            measurement_disturbance_variates=np.zeros(nobs * k_endog),
+            state_disturbance_variates=np.zeros(nobs * k_posdef),
             initial_state_variates=np.zeros(cls.model.k_states)
         )
 
@@ -488,24 +501,30 @@ class TestDFM:
         mod = cls.create_model(obs, **kwargs)
         cls.model = mod.ssm
 
-        n_disturbance_variates = (
-            (cls.model.k_endog + cls.model.k_posdef) * cls.model.nobs
-        )
+        nobs = cls.model.nobs
+        k_endog = cls.model.k_endog
+        k_posdef = cls.model.k_posdef
+
         np.random.seed(1234)
-        dv = np.random.normal(size=n_disturbance_variates)
+        mdv = np.random.normal(size=nobs * k_endog)
+        sdv = np.random.normal(size=nobs * k_posdef)
         isv = np.random.normal(size=cls.model.k_states)
 
         # Collapsed filtering, smoothing, and simulation smoothing
         cls.model.filter_collapsed = True
         cls.results_b = cls.model.smooth()
         cls.sim_b = cls.model.simulation_smoother()
-        cls.sim_b.simulate(disturbance_variates=dv, initial_state_variates=isv)
+        cls.sim_b.simulate(measurement_disturbance_variates=mdv,
+                           state_disturbance_variates=sdv,
+                           initial_state_variates=isv)
 
         # Conventional filtering, smoothing, and simulation smoothing
         cls.model.filter_collapsed = False
         cls.results_a = cls.model.smooth()
         cls.sim_a = cls.model.simulation_smoother()
-        cls.sim_a.simulate(disturbance_variates=dv, initial_state_variates=isv)
+        cls.sim_a.simulate(measurement_disturbance_variates=mdv,
+                           state_disturbance_variates=sdv,
+                           initial_state_variates=isv)
 
         # Create the model with augmented state space
         kwargs.pop('filter_collapsed', None)

--- a/statsmodels/tsa/statespace/tests/test_collapsed.py
+++ b/statsmodels/tsa/statespace/tests/test_collapsed.py
@@ -233,7 +233,7 @@ class TestTrivariateConventionalAlternate(TestTrivariateConventional):
             alternate_timing=True, *args, **kwargs)
 
     def test_using_alterate(self):
-        assert(self.model._kalman_filter.filter_timing == 1)
+        assert self.model._kalman_filter.filter_timing == 1
 
 
 class TestTrivariateConventionalPartialMissing(Trivariate):
@@ -276,7 +276,7 @@ class TestTrivariateConventionalPartialMissingAlternate(
               cls).setup_class(alternate_timing=True, *args, **kwargs)
 
     def test_using_alterate(self):
-        assert(self.model._kalman_filter.filter_timing == 1)
+        assert self.model._kalman_filter.filter_timing == 1
 
 
 class TestTrivariateConventionalAllMissing(Trivariate):
@@ -319,7 +319,7 @@ class TestTrivariateConventionalAllMissingAlternate(
             alternate_timing=True, *args, **kwargs)
 
     def test_using_alterate(self):
-        assert(self.model._kalman_filter.filter_timing == 1)
+        assert self.model._kalman_filter.filter_timing == 1
 
 
 class TestTrivariateUnivariate(Trivariate):
@@ -357,7 +357,7 @@ class TestTrivariateUnivariateAlternate(TestTrivariateUnivariate):
             alternate_timing=True, *args, **kwargs)
 
     def test_using_alterate(self):
-        assert(self.model._kalman_filter.filter_timing == 1)
+        assert self.model._kalman_filter.filter_timing == 1
 
 
 class TestTrivariateUnivariatePartialMissing(Trivariate):
@@ -400,7 +400,7 @@ class TestTrivariateUnivariatePartialMissingAlternate(
               cls).setup_class(alternate_timing=True, *args, **kwargs)
 
     def test_using_alterate(self):
-        assert(self.model._kalman_filter.filter_timing == 1)
+        assert self.model._kalman_filter.filter_timing == 1
 
 
 class TestTrivariateUnivariateAllMissing(Trivariate):
@@ -443,7 +443,7 @@ class TestTrivariateUnivariateAllMissingAlternate(
             alternate_timing=True, *args, **kwargs)
 
     def test_using_alterate(self):
-        assert(self.model._kalman_filter.filter_timing == 1)
+        assert self.model._kalman_filter.filter_timing == 1
 
 
 class TestDFM:

--- a/statsmodels/tsa/statespace/tests/test_multivariate_switch_univariate.py
+++ b/statsmodels/tsa/statespace/tests/test_multivariate_switch_univariate.py
@@ -393,17 +393,13 @@ def test_simulation_smoothing(missing):
     sim_uv = mod_uv.simulation_smoother()
 
     # Test for basic simulationg of a new observed series
-    np.random.seed(1234)
-    simulate_switch = mod_switch.simulate([], 10)
-    np.random.seed(1234)
-    simulate_uv = mod_uv.simulate([], 10)
+    simulate_switch = mod_switch.simulate([], 10, random_state=1234)
+    simulate_uv = mod_uv.simulate([], 10, random_state=1234)
     assert_allclose(simulate_switch, simulate_uv)
 
     # Perform simulation smoothing
-    np.random.seed(1234)
-    sim_switch.simulate()
-    np.random.seed(1234)
-    sim_uv.simulate()
+    sim_switch.simulate(random_state=1234)
+    sim_uv.simulate(random_state=1234)
 
     # Make sure that switching happened in the first model but not the second
     kfilter = sim_switch._simulation_smoother.simulated_kfilter

--- a/statsmodels/tsa/statespace/tests/test_simulation_smoothing.py
+++ b/statsmodels/tsa/statespace/tests/test_simulation_smoothing.py
@@ -543,8 +543,6 @@ class MultivariateVAR:
 
         nobs = self.model.nobs
         k_endog = self.model.k_endog
-        k_posdef = self.model.ssm.k_posdef
-        k_states = self.model.k_states
 
         # Simulate with known variates
         # TODO
@@ -714,7 +712,7 @@ def test_deprecated_arguments_univariate():
 
     with pytest.deprecated_call():
         sim.simulate(disturbance_variates=np.r_[mds, sds],
-                    initial_state_variates=np.zeros(1))
+                     initial_state_variates=np.zeros(1))
     actual = sim.simulated_state[0]
 
     # Test using deprecated `pretransformed`
@@ -737,7 +735,6 @@ def test_deprecated_arguments_univariate():
 
 
 def test_deprecated_arguments_multivariate():
-    nobs = 5
     endog = np.array([[0.3, 1.4],
                       [-0.1, 0.6],
                       [0.2, 0.7],

--- a/statsmodels/tsa/statespace/tests/test_smoothing.py
+++ b/statsmodels/tsa/statespace/tests/test_smoothing.py
@@ -72,12 +72,13 @@ class TestStatesAR3:
                 cls.results.smoother_results.smoothed_state_cov[:, :, i])
 
         # Perform simulation smoothing
-        n_disturbance_variates = (
-            (cls.model.k_endog + cls.model.ssm.k_posdef) * cls.model.nobs
-        )
+        nobs = cls.model.nobs
+        k_endog = cls.model.k_endog
+        k_posdef = cls.model.ssm.k_posdef
         cls.sim = cls.model.simulation_smoother(filter_timing=0)
         cls.sim.simulate(
-            disturbance_variates=np.zeros(n_disturbance_variates),
+            measurement_disturbance_variates=np.zeros(nobs * k_endog),
+            state_disturbance_variates=np.zeros(nobs * k_posdef),
             initial_state_variates=np.zeros(cls.model.k_states)
         )
 
@@ -257,12 +258,13 @@ class TestStatesMissingAR3:
                 cls.results.smoothed_state_cov[:, :, i])
 
         # Perform simulation smoothing
-        n_disturbance_variates = (
-            (cls.model.k_endog + cls.model.k_posdef) * cls.model.nobs
-        )
+        nobs = cls.model.nobs
+        k_endog = cls.model.k_endog
+        k_posdef = cls.model.ssm.k_posdef
         cls.sim = cls.model.simulation_smoother()
         cls.sim.simulate(
-            disturbance_variates=np.zeros(n_disturbance_variates),
+            measurement_disturbance_variates=np.zeros(nobs * k_endog),
+            state_disturbance_variates=np.zeros(nobs * k_posdef),
             initial_state_variates=np.zeros(cls.model.k_states)
         )
 

--- a/statsmodels/tsa/statespace/tests/test_univariate.py
+++ b/statsmodels/tsa/statespace/tests/test_univariate.py
@@ -245,7 +245,7 @@ class TestClark1989Alternate(TestClark1989):
                                                        *args, **kwargs)
 
     def test_using_alterate(self):
-        assert(self.model._kalman_filter.filter_timing == 1)
+        assert self.model._kalman_filter.filter_timing == 1
 
 
 class MultivariateMissingGeneralObsCov:


### PR DESCRIPTION
- [x] tests added / passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message.

This improves the state space simulation smoother in a couple of ways:

**Bugs**

- Fixes a bug with incorrect simulation smoothing draws for periods with NaN `endog` values
- Fixes a bug that could occur if the dimensions of the state space system matrices changed between `simulate` calls (e.g. one example would be if a model with a time-invariant intercept switched to a time-varying intercept between `simulate` calls)

**Enhancements**

- Adds a `random_state` argument to all simulate / simulation smoother methods (implemented the same as in [scipy rvs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.rv_continuous.rvs.html))
- Improves the flexibility of specifying the shocks