### PR TITLE
BUG: ETS loglike indexing bug when y_hat == 0

### DIFF
--- a/statsmodels/tsa/exponential_smoothing/ets.py
+++ b/statsmodels/tsa/exponential_smoothing/ets.py
@@ -1165,7 +1165,7 @@ class ETSModel(base.StateSpaceMLEModel):
             # parameterizations, we clip negative values to very small positive
             # values so that the log-transformation yields very large negative
             # values.
-            yhat[yhat <= 0] = 1 / (1e-8 * (1 + np.abs(yhat[yhat < 0])))
+            yhat[yhat <= 0] = 1 / (1e-8 * (1 + np.abs(yhat[yhat <= 0])))
             logL -= np.sum(np.log(yhat))
         return logL
 


### PR DESCRIPTION
- [x] closes #8353
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message.

The issue is that the left-hand side uses a mask `y_hat <= 0` while the right-hand side uses a mask `y_hat < 0`. This is obviously a problem in the corner-case that some y_hat == 0.