### PR TITLE
DOC: added detailed ValueError to prepare_trend_spec()

### DIFF
--- a/statsmodels/tsa/statespace/tools.py
+++ b/statsmodels/tsa/statespace/tools.py
@@ -1864,9 +1864,10 @@ def prepare_trend_spec(trend):
             polynomial_trend = (trend > 0).astype(int)
         else:
             raise ValueError(
-                "Valid trend inputs are 'c' (constant), 't' (linear trend in time), 'ct' "
-                "(both), 'ctt' (both with trend squared) or an interable defining a "
-                f"polynomial, e.g., [1, 1, 0, 1] is a + b*t + ct**3. Received {trend}"
+                "Valid trend inputs are 'c' (constant), 't' (linear trend in "
+                "time), 'ct' (both), 'ctt' (both with trend squared) or an "
+                "interable defining a polynomial, e.g., [1, 1, 0, 1] is a + "
+                f"b*t + ct**3. Received {trend}"
             )
 
     # Note: k_trend is not the degree of the trend polynomial, because e.g.

--- a/statsmodels/tsa/statespace/tools.py
+++ b/statsmodels/tsa/statespace/tools.py
@@ -1866,8 +1866,8 @@ def prepare_trend_spec(trend):
             raise ValueError(
                 "Valid trend inputs are 'c' (constant), 't' (linear trend in "
                 "time), 'ct' (both), 'ctt' (both with trend squared) or an "
-                "interable defining a polynomial, e.g., [1, 1, 0, 1] is a + "
-                f"b*t + ct**3. Received {trend}"
+                "interable defining a polynomial, e.g., [1, 1, 0, 1] is `a + "
+                f"b*t + ct**3`. Received {trend}"
             )
 
     # Note: k_trend is not the degree of the trend polynomial, because e.g.

--- a/statsmodels/tsa/statespace/tools.py
+++ b/statsmodels/tsa/statespace/tools.py
@@ -1863,7 +1863,11 @@ def prepare_trend_spec(trend):
         if trend.ndim > 0:
             polynomial_trend = (trend > 0).astype(int)
         else:
-            raise ValueError('Invalid trend method.')
+            raise ValueError(
+                "Valid trend inputs are 'c' (constant), 't' (linear trend in time), 'ct' (both), 'ctt' (both with "
+                "trend squared) or an interable defining a polynomial, e.g., [1, 1, 0, 1] is a + b*t + ct**3. "
+                f"Received {trend}"
+            )
 
     # Note: k_trend is not the degree of the trend polynomial, because e.g.
     # k_trend = 1 corresponds to the degree zero polynomial (with only a

--- a/statsmodels/tsa/statespace/tools.py
+++ b/statsmodels/tsa/statespace/tools.py
@@ -1864,9 +1864,9 @@ def prepare_trend_spec(trend):
             polynomial_trend = (trend > 0).astype(int)
         else:
             raise ValueError(
-                "Valid trend inputs are 'c' (constant), 't' (linear trend in time), 'ct' (both), 'ctt' (both with "
-                "trend squared) or an interable defining a polynomial, e.g., [1, 1, 0, 1] is a + b*t + ct**3. "
-                f"Received {trend}"
+                "Valid trend inputs are 'c' (constant), 't' (linear trend in time), 'ct' "
+                "(both), 'ctt' (both with trend squared) or an interable defining a "
+                f"polynomial, e.g., [1, 1, 0, 1] is a + b*t + ct**3. Received {trend}"
             )
 
     # Note: k_trend is not the degree of the trend polynomial, because e.g.


### PR DESCRIPTION
I've added a much more detailed `ValueError` to `prepare_trend_spec`. The original gave the user no help whatsoever if they passed anything incorrect. 

It's my first time contributing to a project of this size. I'm not sure what kind of change this is but seems to fit DOC more than anything else? I've checked it passes flake8, is there anything else I need to do?

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
