### PR TITLE
MAINT: Fix lint and upstream induced changes

### DIFF
--- a/statsmodels/duration/survfunc.py
+++ b/statsmodels/duration/survfunc.py
@@ -781,7 +781,7 @@ def plot_survfunc(survfuncs, ax=None):
     # If we have only a single survival function to plot, put it into
     # a list.
     try:
-        assert(type(survfuncs[0]) is SurvfuncRight)
+        assert type(survfuncs[0]) is SurvfuncRight
     except:
         survfuncs = [survfuncs]
 

--- a/statsmodels/genmod/tests/test_gee.py
+++ b/statsmodels/genmod/tests/test_gee.py
@@ -1625,7 +1625,7 @@ class TestGEE:
             for v in eq.pairs[g].values():
                 for a, b in zip(v[0], v[1]):
                     ky = (a, b)
-                    assert(ky not in ixs)
+                    assert ky not in ixs
                     ixs.add(ky)
 
         # Smoke test  # TODO: pytest.mark.smoke?

--- a/statsmodels/imputation/tests/test_bayes_mi.py
+++ b/statsmodels/imputation/tests/test_bayes_mi.py
@@ -131,11 +131,11 @@ def test_MI_stat():
 
         # Check the SE
         d = np.abs(r.bse[0] - exp[j]) / exp[j]
-        assert(d < 0.03)
+        assert d < 0.03
 
         # Check the FMI
         d = np.abs(r.fmi[0] - fmi[j])
-        assert(d < 0.05)
+        assert d < 0.05
 
 
 def test_mi_formula():

--- a/statsmodels/imputation/tests/test_mice.py
+++ b/statsmodels/imputation/tests/test_mice.py
@@ -99,7 +99,7 @@ class TestMICEData:
         assert_equal(imp_data._cycle_order, ['x5', 'x3', 'x4', 'y', 'x2', 'x1'])
 
         # Should make a copy
-        assert(not (df is imp_data.data))
+        assert not (df is imp_data.data)
 
         (endog_obs, exog_obs, exog_miss,
          predict_obs_kwds, predict_miss_kwds) = imp_data.get_split_data('x3')
@@ -132,12 +132,12 @@ class TestMICEData:
         all_x = []
         for j in range(2):
             x = imp_data.next_sample()
-            assert(isinstance(x, pd.DataFrame))
+            assert isinstance(x, pd.DataFrame)
             assert_equal(df.shape, x.shape)
             all_x.append(x)
 
         # The returned dataframes are all the same object
-        assert(all_x[0] is all_x[1])
+        assert all_x[0] is all_x[1]
 
 
     def test_pertmeth(self):
@@ -193,9 +193,9 @@ class TestMICEData:
                               perturbation_method=pm)
 
             x = idata.next_sample()
-            assert(isinstance(x, pd.DataFrame))
+            assert isinstance(x, pd.DataFrame)
 
-        assert(all([val == (299, 4) for val in hist]))
+        assert all([val == (299, 4) for val in hist])
 
     def test_set_imputer(self):
         # Test with specified perturbation method.
@@ -307,7 +307,7 @@ class TestMICE:
         mi = mice.MICE("y ~ x1 + x2 + x1:x2", sm.OLS, imp_data)
         result = mi.fit(1, 3)
 
-        assert(issubclass(result.__class__, mice.MICEResults))
+        assert issubclass(result.__class__, mice.MICEResults)
 
         # Smoke test for results
         smr = result.summary()
@@ -323,7 +323,7 @@ class TestMICE:
 
         for j in range(3):
             x = mi.next_sample()
-            assert(issubclass(x.__class__, RegressionResultsWrapper))
+            assert issubclass(x.__class__, RegressionResultsWrapper)
 
 
     def test_MICE1_regularized(self):
@@ -345,8 +345,8 @@ class TestMICE:
 
         for j in range(3):
             x = mi.next_sample()
-            assert(isinstance(x, GLMResultsWrapper))
-            assert(isinstance(x.family, sm.families.Binomial))
+            assert isinstance(x, GLMResultsWrapper)
+            assert isinstance(x.family, sm.families.Binomial)
 
     @pytest.mark.slow
     def test_combine(self):

--- a/statsmodels/multivariate/factor_rotation/_gpa_rotation.py
+++ b/statsmodels/multivariate/factor_rotation/_gpa_rotation.py
@@ -244,7 +244,7 @@ def oblimin_objective(L=None, A=None, T=None, gamma=0,
         toggles return of gradient
     """
     if L is None:
-        assert(A is not None and T is not None)
+        assert A is not None and T is not None
         L = rotateA(A, T, rotation_method=rotation_method)
     p, k = L.shape
     L2 = L**2
@@ -308,7 +308,7 @@ def orthomax_objective(L=None, A=None, T=None, gamma=0, return_gradient=True):
     """
     assert 0 <= gamma <= 1, "Gamma should be between 0 and 1"
     if L is None:
-        assert(A is not None and T is not None)
+        assert A is not None and T is not None
         L = rotateA(A, T, rotation_method='orthogonal')
     p, k = L.shape
     L2 = L**2
@@ -391,7 +391,7 @@ def CF_objective(L=None, A=None, T=None, kappa=0,
     """
     assert 0 <= kappa <= 1, "Kappa should be between 0 and 1"
     if L is None:
-        assert(A is not None and T is not None)
+        assert A is not None and T is not None
         L = rotateA(A, T, rotation_method=rotation_method)
     p, k = L.shape
     L2 = L**2
@@ -456,7 +456,7 @@ def vgQ_target(H, L=None, A=None, T=None, rotation_method='orthogonal'):
         should be one of {orthogonal, oblique}
     """
     if L is None:
-        assert(A is not None and T is not None)
+        assert A is not None and T is not None
         L = rotateA(A, T, rotation_method=rotation_method)
     q = np.linalg.norm(L-H, 'fro')**2
     Gq = 2*(L-H)
@@ -499,7 +499,7 @@ def ff_target(H, L=None, A=None, T=None, rotation_method='orthogonal'):
         should be one of {orthogonal, oblique}
     """
     if L is None:
-        assert(A is not None and T is not None)
+        assert A is not None and T is not None
         L = rotateA(A, T, rotation_method=rotation_method)
     return np.linalg.norm(L-H, 'fro')**2
 
@@ -545,7 +545,7 @@ def vgQ_partial_target(H, W=None, L=None, A=None, T=None):
     if W is None:
         return vgQ_target(H, L=L, A=A, T=T)
     if L is None:
-        assert(A is not None and T is not None)
+        assert A is not None and T is not None
         L = rotateA(A, T, rotation_method='orthogonal')
     q = np.linalg.norm(W*(L-H), 'fro')**2
     Gq = 2*W*(L-H)
@@ -587,7 +587,7 @@ def ff_partial_target(H, W=None, L=None, A=None, T=None):
     if W is None:
         return ff_target(H, L=L, A=A, T=T)
     if L is None:
-        assert(A is not None and T is not None)
+        assert A is not None and T is not None
         L = rotateA(A, T, rotation_method='orthogonal')
     q = np.linalg.norm(W*(L-H), 'fro')**2
     return q

--- a/statsmodels/multivariate/tests/test_ml_factor.py
+++ b/statsmodels/multivariate/tests/test_ml_factor.py
@@ -96,9 +96,9 @@ def test_fit_ml_em_random_state():
         Factor(endog=epsilon, n_factor=2, method='ml').fit()
     final = np.random.get_state()
 
-    assert(initial[0] == final[0])
+    assert initial[0] == final[0]
     assert_equal(initial[1], final[1])
-    assert(initial[2:] == final[2:])
+    assert initial[2:] == final[2:]
 
 
 def test_em():

--- a/statsmodels/sandbox/bspline.py
+++ b/statsmodels/sandbox/bspline.py
@@ -497,7 +497,7 @@ class SmoothingSpline(BSpline):
             _g = _band2array(self.g, lower=1, symmetric=True)
             self.coef, _, self.rank = L.lstsq(self.btb + pen*_g, bty)[0:3]
             self.rank = min(self.rank, self.btb.shape[0])
-            del(_g)
+            del _g
         else:
             self.btb = np.zeros(self.g.shape, np.float64)
             nband, nbasis = self.g.shape
@@ -515,9 +515,9 @@ class SmoothingSpline(BSpline):
         self.resid = y * self.weights - np.dot(self.coef, bt)
         self.pen = pen
 
-        del(bty)
-        del(mask)
-        del(bt)
+        del bty
+        del mask
+        del bt
 
     def smooth(self, y, x=None, weights=None):
 

--- a/statsmodels/stats/mediation.py
+++ b/statsmodels/stats/mediation.py
@@ -281,7 +281,9 @@ class Mediation:
             outcome_result = self._fit_model(self.outcome_model, self._outcome_fit_kwargs)
             mediator_result = self._fit_model(self.mediator_model, self._mediator_fit_kwargs)
         elif not method.startswith("boot"):
-            raise("method must be either 'parametric' or 'bootstrap'")
+            raise ValueError(
+                "method must be either 'parametric' or 'bootstrap'"
+            )
 
         indirect_effects = [[], []]
         direct_effects = [[], []]

--- a/statsmodels/stats/tests/test_effectsize.py
+++ b/statsmodels/stats/tests/test_effectsize.py
@@ -47,8 +47,9 @@ def test_noncent_f():
     mean = stats.ncf.mean(df1, df2, res.nc)
     assert_allclose(f_stat, mean, rtol=1e-8)
 
+    # Relax tolerance due to changes in SciPy and Boost
     assert_allclose(stats.ncf.cdf(f_stat, df1, df2, res.confint),
-                    [0.975, 0.025], rtol=1e-10)
+                    [0.975, 0.025], rtol=5e-5)
 
 
 def test_noncent_t():

--- a/statsmodels/tsa/deterministic.py
+++ b/statsmodels/tsa/deterministic.py
@@ -1170,9 +1170,9 @@ class DeterministicProcess:
             self._deterministic_terms.append(TimeTrend(constant, order))
         if seasonal and fourier:
             raise ValueError(
-                """seasonal and fourier can be initialized through the constructor since\
-these will be necessarily perfectly collinear. Instead, you can pass \
-additional components using the additional_terms input."""
+                """seasonal and fourier can be initialized through the \
+constructor since these will be necessarily perfectly collinear. Instead, \
+you can pass additional components using the additional_terms input."""
             )
         if (seasonal or fourier) and period is None:
             if period is None:

--- a/statsmodels/tsa/regime_switching/markov_switching.py
+++ b/statsmodels/tsa/regime_switching/markov_switching.py
@@ -520,7 +520,8 @@ class MarkovSwitching(tsbase.TimeSeriesModel):
         if self.k_regimes < 2:
             raise ValueError('Markov switching models must have at least two'
                              ' regimes.')
-        if not(self.exog_tvtp is None or self.exog_tvtp.shape[0] == self.nobs):
+        if not (self.exog_tvtp is None or
+                self.exog_tvtp.shape[0] == self.nobs):
             raise ValueError('Time-varying transition probabilities exogenous'
                              ' array must have the same number of observations'
                              ' as the endogenous array.')

--- a/statsmodels/tsa/vector_ar/tests/JMulTi_results/parse_jmulti_vecm_output.py
+++ b/statsmodels/tsa/vector_ar/tests/JMulTi_results/parse_jmulti_vecm_output.py
@@ -159,12 +159,12 @@ def load_results_jmulti(dataset):
         if "co" not in dt_string and "lo" not in dt_string \
                 and "s" not in dt_string:
             # JMulTi: no deterministic terms section in VEC representation
-            del(section_header[1])
-            del(sections[1])
+            del section_header[1]
+            del sections[1]
             if "ci" not in dt_string and "li" not in dt_string:
                 # JMulTi: no deterministic section in VAR repr.
-                del(section_header[-1])
-                del(sections[-1])
+                del section_header[-1]
+                del sections[-1]
         results = dict()
         results["est"] = dict.fromkeys(sections)
         results["se"] = dict.fromkeys(sections)


### PR DESCRIPTION
Fix issues due to SciPy boost integration
Fix lint issues in flake8 >= 5

- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
