### PR TITLE
MAINT: Remove inhonogenous array constructor

### DIFF
--- a/statsmodels/tsa/statespace/_quarterly_ar1.py
+++ b/statsmodels/tsa/statespace/_quarterly_ar1.py
@@ -194,14 +194,16 @@ class QuarterlyAR1(mlemodel.MLEModel):
         return params1
 
     def transform_params(self, unconstrained):
-        return np.array([
+        # array no longer accepts inhomogeneous inputs
+        return np.hstack([
             constrain_stationary_univariate(unconstrained[:1]),
             unconstrained[1]**2])
 
     def untransform_params(self, constrained):
-        return np.array([
+        # array no longer accepts inhomogeneous inputs
+        return np.hstack([
             unconstrain_stationary_univariate(constrained[:1]),
-            constrained[1]**0.5])
+            constrained[1] ** 0.5])
 
     def update(self, params, **kwargs):
         super().update(params, **kwargs)


### PR DESCRIPTION
Use hstack in place of calling array to avoid future NumPy breaking change

- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
