### PR TITLE
GLM negative binomial warns if default used for parameter alpha

### DIFF
--- a/statsmodels/discrete/tests/test_discrete.py
+++ b/statsmodels/discrete/tests/test_discrete.py
@@ -1636,6 +1636,22 @@ def test_issue_341():
     np.testing.assert_equal(res1.predict(x[None]).shape, (1,7))
 
 
+def test_negative_binomial_default_alpha_param():
+    with pytest.warns(UserWarning, match='Negative binomial'
+                      ' dispersion parameter alpha not set'):
+        sm.families.NegativeBinomial()
+    with pytest.warns(UserWarning, match='Negative binomial'
+                      ' dispersion parameter alpha not set'):
+        sm.families.NegativeBinomial(link=sm.families.links.nbinom(alpha=1.0))
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        sm.families.NegativeBinomial(alpha=1.0)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        sm.families.NegativeBinomial(link=sm.families.links.nbinom(alpha=1.0),
+                                     alpha=1.0)
+
+
 def test_iscount():
     X = np.random.random((50, 10))
     X[:,2] = np.random.randint(1, 10, size=50)

--- a/statsmodels/genmod/families/family.py
+++ b/statsmodels/genmod/families/family.py
@@ -8,6 +8,7 @@ The one parameter exponential family distributions used by GLM.
 
 
 import inspect
+import warnings
 
 import numpy as np
 from scipy import special, stats
@@ -1310,6 +1311,9 @@ class NegativeBinomial(Family):
 
     def __init__(self, link=None, alpha=1.):
         self.alpha = 1. * alpha  # make it at least float
+        if alpha is self.__init__.__defaults__[1]:
+            warnings.warn("Negative binomial dispersion parameter alpha not "
+                          f"set. Using default value alpha={alpha}.")
         if link is None:
             link = L.Log()
         super(NegativeBinomial, self).__init__(


### PR DESCRIPTION
- [x] closes #8360 
- [x] tests added / passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

`NegativeBinomial` now warns if default value used for alpha parameter

Tests added to check for warning and ensure that warning not generated if alpha=1.0 explicitly set
