### PR TITLE
docs/add-missing-return-value-from-aggregate-raters-to-doc

### DIFF
--- a/statsmodels/stats/inter_rater.py
+++ b/statsmodels/stats/inter_rater.py
@@ -109,7 +109,8 @@ def aggregate_raters(data, n_cat=None):
     arr : nd_array, (n_rows, n_cat)
         Contains counts of raters that assigned a category level to individuals.
         Subjects are in rows, category levels in columns.
-
+    categories : nd_array, (category_levels)
+        Contains the category levels.
 
     '''
     data = np.asarray(data)

--- a/statsmodels/stats/inter_rater.py
+++ b/statsmodels/stats/inter_rater.py
@@ -109,7 +109,7 @@ def aggregate_raters(data, n_cat=None):
     arr : nd_array, (n_rows, n_cat)
         Contains counts of raters that assigned a category level to individuals.
         Subjects are in rows, category levels in columns.
-    categories : nd_array, (category_levels)
+    categories : nd_array, (n_category_levels,)
         Contains the category levels.
 
     '''

--- a/statsmodels/stats/tests/test_inter_rater.py
+++ b/statsmodels/stats/tests/test_inter_rater.py
@@ -319,7 +319,7 @@ def test_fleiss_kappa_irr():
     fleiss.stat_name = 'z'
     fleiss.statistic = 17.65183
     fleiss.p_value = 0
-    data_ = aggregate_raters(diagnoses)[0]
+    data_, _ = aggregate_raters(diagnoses)
     res1_kappa = fleiss_kappa(data_)
     assert_almost_equal(res1_kappa, fleiss.value, decimal=7)
 
@@ -347,6 +347,7 @@ def test_to_table():
 
 def test_aggregate_raters():
     data = diagnoses
-    resf = aggregate_raters(data)
+    data_, categories = aggregate_raters(data)
     colsum = np.array([26, 26, 30, 55, 43])
-    assert_equal(resf[0].sum(0), colsum)
+    assert_equal(data_.sum(0), colsum)
+    assert_equal(np.unique(diagnoses), categories)


### PR DESCRIPTION
Adds the categories np.ndarray return value to the `aggregate_raters` docstring. It is currently being returned by the function but was undocumented.

Tests were updated to be explicit about unpacking the multiple return values.

- [ ] closes #xxxx
- [x] tests added / passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
