### PR TITLE
CI: Add a weekly scheduled run to the Azure pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,6 +2,12 @@
 
 trigger:
 - main
+schedules:
+- cron: "0 6 * * 1"   # Each Monday at 06:00 UTC
+  displayName: Weekly scheduled run
+  branches:
+    include: [main, maintenance/0.13.x]
+  always: true
 
 variables:
   MKL_NUM_THREADS: 1


### PR DESCRIPTION
This PR adds a weekly scheduled run to the Azure pipelines CI. It runs each Monday at 06:00 UTC on the `main` and `maintenance/0.13.x` branches.

Periodically scheduled runs can detect errors and warnings appearing in changes in upstream dependencies or the build environment. By having a scheduled run they can be traced back easier to a dependency or environment change, then if they would pop up in a random PR.

- [x] tests added / passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 
