### PR TITLE
CI: Add Python 3.11 jobs

### DIFF
--- a/tools/ci/azure/azure_template_posix.yml
+++ b/tools/ci/azure/azure_template_posix.yml
@@ -17,6 +17,9 @@ jobs:
   strategy:
     matrix:
       ${{ if eq(parameters.name, 'Linux') }}:
+        python_311_latest:
+          python.version: '3.11'
+          lint: true
         python_310_latest:
           python.version: '3.10'
           lint: true
@@ -54,12 +57,12 @@ jobs:
           PANDAS: 1.1.5
           MATPLOTLIB: 3.4.3
           lint: true
-        python_310_pre:
-          python.version: '3.10'
+        python_311_pre:
+          python.version: '3.11'
           pip.pre: true
       ${{ if eq(parameters.name, 'macOS') }}:
-        python39_macos_latest:
-          python.version: '3.9'
+        python311_macos_latest:
+          python.version: '3.11'
     maxParallel: 10
 
   steps:

--- a/tools/ci/azure/azure_template_posix.yml
+++ b/tools/ci/azure/azure_template_posix.yml
@@ -62,7 +62,7 @@ jobs:
           pip.pre: true
       ${{ if eq(parameters.name, 'macOS') }}:
         python311_macos_latest:
-          python.version: '3.11'
+          python.version: '3.11-dev'
     maxParallel: 10
 
   steps:
@@ -70,6 +70,7 @@ jobs:
     inputs:
       versionSpec: '$(python.version)'
       architecture: 'x64'
+      allowUnstable: true
     displayName: 'Use Python $(python.version)'
 
   - bash: |

--- a/tools/ci/azure/azure_template_windows.yml
+++ b/tools/ci/azure/azure_template_windows.yml
@@ -25,6 +25,9 @@ jobs:
       python310_win_latest:
         python.version: '3.10'
         python.architecture: 'x64'
+      python311_win_latest:
+        python.version: '3.11'
+        python.architecture: 'x64'
     maxParallel: 10
 
   steps:
@@ -39,7 +42,7 @@ jobs:
     displayName: 'Update essentials'
 
   - script: |
-      python -m pip install -r requirements.txt 
+      python -m pip install -r requirements.txt
       python -m pip install -r requirements-dev.txt
     displayName: 'Install dependencies'
 


### PR DESCRIPTION
Add Python 3.11 jobs to the Azure pipelines CI.

- [x] part of #8287
- [x] tests added / passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 