### PR TITLE
basic support for cluster bootstrap in `fit`

### DIFF
--- a/statsmodels/regression/linear_model.py
+++ b/statsmodels/regression/linear_model.py
@@ -54,6 +54,8 @@ from statsmodels.tools.tools import pinv_extended
 from statsmodels.tools.typing import Float64Array
 from statsmodels.tools.validation import bool_like, float_like, string_like
 
+from wildboottest import wildboottest
+
 from . import _prediction as pred
 
 __docformat__ = 'restructuredtext en'
@@ -2485,6 +2487,9 @@ class RegressionResults(base.LikelihoodModelResults):
             small sample correction.
           ``df_correction`` : bool, optional
             Adjustment to df_resid, see cov_type 'cluster' above
+        
+        - 'wildclusterbootstrap': Wild Cluster Bootstrap p-values Currently does not support standard errors, or variance covariance matrices.
+            ``
 
         **Reminder**: ``use_correction`` in "hac-groupsum" and "hac-panel" is
         not bool, needs to be in {False, 'hac', 'cluster'}.
@@ -2649,6 +2654,25 @@ class RegressionResults(base.LikelihoodModelResults):
                 self, maxlags, time, weights_func=weights_func,
                 use_correction=use_correction)
             res.cov_kwds['description'] = descriptions['HAC-Groupsum']
+        elif cov_type.lower() == 'wildclusterbootstrap':
+            cluster = kwargs['cluster']
+            B = kwargs['B']
+            weights_type = kwargs['weights_type']
+            impose_null = kwargs['impose_null']
+            bootstrap_type = kwargs['bootstrap_type']
+            seed = kwargs['seed']
+            param = kwargs['param']
+            
+            res.cov_params_default = wildboottest(
+                model = res.model,
+                param=param,
+                cluster=cluster,
+                B=B,
+                weights_type=weights_type,
+                impose_null=impose_null,
+                bootstrap_type=bootstrap_type,
+                seed=seed
+            )
         else:
             raise ValueError('cov_type not recognized. See docstring for ' +
                              'available options and spelling')


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed. 
- [ ] code/documentation is well formatted.  
- [ ] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
