### PR TITLE
MAINT: fix develop installs

### DIFF
--- a/docs/source/dev/test_notes.rst
+++ b/docs/source/dev/test_notes.rst
@@ -7,11 +7,11 @@ Setting up development environment locally
 ------------------------------------------
 Follow our :ref:`installation instructions <install>` and set up a suitable
 environment to build statsmodels from source. We recommend that you develop
-using a development install of statsmodels by running:
+using a development install of statsmodels in a `venv` by running:
 
 .. code-block:: bash
-
-   python -m pip install -e .
+    python -m venv .venv
+    python -m pip install -e ".[develop]"
 
 from the root directory of the git repository. The flag ``-e`` is for editable.
 
@@ -19,7 +19,7 @@ This command compiles the C code and add statsmodels to your activate python
 environment by creating links from your python environment's libraries
 to the statsmodels source code. Therefore, changes to pure python code will
 be immediately available to the user without a re-install. Changes to C code or
-Cython code require rerunning ``python -m pip install -e .`` before these changes are
+Cython code require rerunning ``python -m pip install -e ".[develop]"`` before these changes are
 available.
 
 Test Driven Development
@@ -37,7 +37,7 @@ Like many packages, statsmodels uses the `pytest testing system <https://docs.py
 Running Tests
 -------------
 Test are run from the command line by calling ``pytest``. Directly running tests using
-pytest requires that statsmodels is installed using ``python -m pip install -e .`` as described
+pytest requires that statsmodels is installed using ``python -m pip install -e ".[develop]"`` as described
 above.
 
 Tests can be run at different levels of granularity:

--- a/setup.py
+++ b/setup.py
@@ -53,11 +53,16 @@ with open("requirements.txt", encoding="utf-8") as req:
     for line in req.readlines():
         INSTALL_REQUIRES.append(line.split("#")[0].strip())
 
+DEVELOP_REQUIRES = []
+with open("requirements-dev.txt", encoding="utf-8") as req:
+    for line in req.readlines():
+        DEVELOP_REQUIRES.append(line.split("#")[0].strip())
+
 CYTHON_MIN_VER = "0.29.26"  # released 2020
 
 EXTRAS_REQUIRE = {
     "build": ["cython>=" + CYTHON_MIN_VER],
-    "develop": ["cython>=" + CYTHON_MIN_VER],
+    "develop": ["cython>=" + CYTHON_MIN_VER] + DEVELOP_REQUIRES,
     "docs": [
         "sphinx",
         "nbconvert",


### PR DESCRIPTION
Fixes the develop installs by reading `requirements-dev.txt` into setup.py and adding it to `extras_require`'s develop.

- [ ] closes #xxxx
- [x] tests added / passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
