### PR TITLE
CI: Use stable Python 3.11 on macOS

### DIFF
--- a/tools/ci/azure/azure_template_posix.yml
+++ b/tools/ci/azure/azure_template_posix.yml
@@ -62,7 +62,7 @@ jobs:
           pip.pre: true
       ${{ if eq(parameters.name, 'macOS') }}:
         python311_macos_latest:
-          python.version: '3.11-dev'
+          python.version: '3.11'
     maxParallel: 10
 
   steps:
@@ -70,7 +70,6 @@ jobs:
     inputs:
       versionSpec: '$(python.version)'
       architecture: 'x64'
-      allowUnstable: true
     displayName: 'Use Python $(python.version)'
 
   - bash: |


### PR DESCRIPTION
Reverts commit 99428667f since the stable Python 3.11.0 has been added to the macOS runner images (see https://github.com/actions/setup-python/issues/531#issuecomment-1291855440).

Part of #8287, reverts the second commit of #8431. 