### PR TITLE
BUG: GenericLikelihood Results hasattr for df_resid is always true, s…

### DIFF
--- a/statsmodels/distributions/discrete.py
+++ b/statsmodels/distributions/discrete.py
@@ -405,7 +405,8 @@ class DiscretizedModel(GenericLikelihoodModel):
         super().__init__(endog, exog, distr=distr)
         self._init_keys.append('distr')
         self.df_resid = len(endog) - distr.k_shapes
-        self.df_model = distr.k_shapes  # no constant subtracted
+        self.df_model = 0
+        self.k_extra = distr.k_shapes  # no constant subtracted
         self.k_constant = 0
         self.nparams = distr.k_shapes  # needed for start_params
         self.start_params = 0.5 * np.ones(self.nparams)

--- a/statsmodels/distributions/tests/test_discrete.py
+++ b/statsmodels/distributions/tests/test_discrete.py
@@ -419,7 +419,7 @@ class TestDiscretizedGammaEx():
             params=[3.52636, 0.425617],
             llf=-187.469,
             chi2=1.701208,  # chisquare test
-            df_model=2,
+            df_model=0,
             p=0.4272,  # p-value for chi2
             aic=378.938,
             probs=[46.48, 73.72, 27.88, 6.5, 1.42])

--- a/statsmodels/miscmodels/count.py
+++ b/statsmodels/miscmodels/count.py
@@ -162,9 +162,9 @@ class PoissonZiGMLE(GenericLikelihoodModel):
 
     def __init__(self, endog, exog=None, offset=None, missing='none', **kwds):
         # let them be none in case user wants to use inheritance
-
+        self.k_extra = 1
         super(PoissonZiGMLE, self).__init__(endog, exog, missing=missing,
-                **kwds)
+                extra_params_names=["zi"], **kwds)
         if offset is not None:
             if offset.ndim == 1:
                 offset = offset[:,None] #need column
@@ -178,9 +178,12 @@ class PoissonZiGMLE(GenericLikelihoodModel):
         self.nparams = self.exog.shape[1]
         #what's the shape in regression for exog if only constant
         self.start_params = np.hstack((np.ones(self.nparams), 0))
+        # need to add zi params to nparams
+        self.nparams += 1
         self.cloneattr = ['start_params']
-        #needed for t_test and summary
-        self.exog_names.append('zi')
+        # needed for t_test and summary
+        # Note: no added to super __init__ which also adjusts df_resid
+        # self.exog_names.append('zi')
 
 
     # original copied from discretemod.Poisson

--- a/statsmodels/miscmodels/ordinal_model.py
+++ b/statsmodels/miscmodels/ordinal_model.py
@@ -158,8 +158,8 @@ class OrderedModel(GenericLikelihoodModel):
 
         # adjust df
         self.k_extra = self.k_levels - 1
-        self.df_model = self.k_vars + self.k_extra
-        self.df_resid = self.nobs - self.df_model
+        self.df_model = self.k_vars
+        self.df_resid = self.nobs - (self.k_vars + self.k_extra)
 
         self.results_class = OrderedResults
 

--- a/statsmodels/miscmodels/tests/test_generic_mle.py
+++ b/statsmodels/miscmodels/tests/test_generic_mle.py
@@ -12,7 +12,7 @@ from scipy import stats
 from statsmodels.base.model import GenericLikelihoodModel
 
 from numpy.testing import (assert_array_less, assert_almost_equal,
-                           assert_allclose, assert_)
+                           assert_allclose)
 
 class MyPareto(GenericLikelihoodModel):
     '''Maximum Likelihood Estimation pareto distribution

--- a/statsmodels/miscmodels/tests/test_generic_mle.py
+++ b/statsmodels/miscmodels/tests/test_generic_mle.py
@@ -22,6 +22,9 @@ class MyPareto(GenericLikelihoodModel):
 
     def initialize(self):   #TODO needed or not
         super(MyPareto, self).initialize()
+        extra_params_names = ['shape', 'loc', 'scale']
+        self._set_extra_params_names(extra_params_names)
+
         #start_params needs to be attribute
         self.start_params = np.array([1.5, self.endog.min() - 1.5, 1.])
 
@@ -95,10 +98,18 @@ class CheckGenericMixin:
             assert_allclose(self.res1.bsejhj, self.res1.bsejac,
                             rtol=0.05, atol=1.5)
 
-
-
-
-
+    def test_df(self):
+        res = self.res1
+        k_extra = getattr(self, "k_extra", 0)
+        if res.model.exog is not None:
+            nobs, k_vars = res.model.exog.shape
+            k_constant = 1
+        else:
+            nobs, k_vars = res.model.endog.shape[0], 0
+            k_constant = 0
+        assert res.df_resid == nobs - k_vars - k_extra
+        assert res.df_model == k_vars - k_constant
+        assert len(res.params) == k_vars + k_extra
 
 
 class TestMyPareto1(CheckGenericMixin):
@@ -113,12 +124,14 @@ class TestMyPareto1(CheckGenericMixin):
         mod_par = MyPareto(rvs)
         mod_par.fixed_params = None
         mod_par.fixed_paramsmask = None
-        mod_par.df_model = 3
-        mod_par.df_resid = mod_par.endog.shape[0] - mod_par.df_model
+        mod_par.df_model = 0
+        mod_par.k_extra = k_extra = 3
+        mod_par.df_resid = mod_par.endog.shape[0] - mod_par.df_model -  k_extra
         mod_par.data.xnames = ['shape', 'loc', 'scale']
 
         cls.mod = mod_par
         cls.res1 = mod_par.fit(disp=None)
+        cls.k_extra = k_extra
 
         # Note: possible problem with parameters close to min data boundary
         # see issue #968
@@ -148,12 +161,14 @@ class TestMyParetoRestriction(CheckGenericMixin):
         mod_par.fixed_params = fixdf
         mod_par.fixed_paramsmask = np.isnan(fixdf)
         mod_par.start_params = mod_par.start_params[mod_par.fixed_paramsmask]
-        mod_par.df_model = 2
-        mod_par.df_resid = mod_par.endog.shape[0] - mod_par.df_model
+        mod_par.df_model = 0
+        mod_par.k_extra = k_extra = 2
+        mod_par.df_resid = mod_par.endog.shape[0] - mod_par.df_model - k_extra
         mod_par.data.xnames = ['shape', 'scale']
 
         cls.mod = mod_par
         cls.res1 = mod_par.fit(disp=None)
+        cls.k_extra = k_extra
 
         # Note: loc is fixed, no problems with parameters close to min data
         cls.skip_bsejac = False
@@ -172,8 +187,13 @@ class TwoPeakLLHNoExog(GenericLikelihoodModel):
         # so we re-use their PDFs here
         self.signal = signal
         self.background = background
-        super(TwoPeakLLHNoExog, self).__init__(endog=endog, exog=exog,
-                                         *args, **kwargs)
+        super(TwoPeakLLHNoExog, self).__init__(
+            endog=endog,
+            exog=exog,
+            *args,
+            extra_params_names=self.exog_names,
+            **kwargs
+            )
 
     def loglike(self, params):        # pylint: disable=E0202
         return -self.nloglike(params)
@@ -225,7 +245,8 @@ class TestTwoPeakLLHNoExog:
         res = llh_noexog.fit()
         assert_allclose(res.params, self.params, rtol=1e-1)
         # TODO: nan if exog is None,
-        assert_(np.isnan(res.df_resid))
+        assert res.df_resid == 248
+        assert res.df_model == 0
         res_bs = res.bootstrap(nrep=50)
         assert_allclose(res_bs[2].mean(0), self.params, rtol=1e-1)
         # SMOKE test,

--- a/statsmodels/miscmodels/tests/test_poisson.py
+++ b/statsmodels/miscmodels/tests/test_poisson.py
@@ -45,6 +45,14 @@ class CompareMixin:
         assert_almost_equal(tt.tvalue, self.res.tvalues, DEC)
         assert_almost_equal(pvalue, self.res.pvalues, DEC)
 
+    def test_df(self):
+        res = self.res
+        k_extra = getattr(self, "k_extra", 0)
+        nobs, k_vars = res.model.exog.shape
+        assert res.df_resid == nobs - k_vars - k_extra
+        assert res.df_model == k_vars - 1  # -1 for constant
+        assert len(res.params) == k_vars + k_extra
+
     @pytest.mark.smoke
     def test_summary(self):
         self.res.summary()
@@ -144,6 +152,7 @@ class TestPoissonOffset(CompareMixin):
         #assert_almost_equal(self.res.tval, self.res_glm.t()[1:], DEC)
         #assert_almost_equal(self.res.params, self.res_discrete.params)
 
+
 #DEC = DEC - 1
 class TestPoissonZi(CompareMixin):
     #this uses the first exog to construct an offset variable
@@ -158,7 +167,7 @@ class TestPoissonZi(CompareMixin):
         data_exog = sm.add_constant(data_exog, prepend=False)
         xbeta = 1 + 0.1*rvs.sum(1)
         data_endog = np.random.poisson(np.exp(xbeta))
-
+        cls.k_extra = 1
 
         mod_glm = sm.GLM(data_endog, data_exog, family=sm.families.Poisson())
         cls.res_glm = mod_glm.fit()

--- a/statsmodels/miscmodels/tests/test_tmodel.py
+++ b/statsmodels/miscmodels/tests/test_tmodel.py
@@ -116,6 +116,14 @@ class CheckTLinearModelMixin:
         assert_allclose(res1.model.endog, resf.model.endog, rtol=1e-10)
         assert_allclose(res1.model.exog, resf.model.exog, rtol=1e-10)
 
+    def test_df(self):
+        res = self.res1
+        k_extra = getattr(self, "k_extra", 0)
+        nobs, k_vars = res.model.exog.shape
+        assert res.df_resid == nobs - k_vars - k_extra
+        assert res.df_model == k_vars - 1  # -1 for constant
+        assert len(res.params) == k_vars + k_extra
+
     @pytest.mark.smoke
     def test_smoke(self):  # TODO: break into well-scoped tests
         res1 = self.res1
@@ -147,6 +155,7 @@ class TestTModel(CheckTLinearModelMixin):
         cls.res2 = res2
         cls.res1 = res  # take from module scope temporarily
         cls.resf = resf
+        cls.k_extra = 2
 
 
 class TestTModelFixed:
@@ -166,6 +175,7 @@ class TestTModelFixed:
         #cls.res2 = res2
         cls.res1 = res  # take from module scope temporarily
         cls.resf = resf
+        cls.k_extra = 1
 
     @pytest.mark.smoke
     def test_smoke(self):  # TODO: break into well-scoped tests

--- a/statsmodels/miscmodels/tmodel.py
+++ b/statsmodels/miscmodels/tmodel.py
@@ -60,6 +60,7 @@ class TLinearModel(GenericLikelihoodModel):
     '''
 
     def initialize(self):
+        print("running Tmodel initialize")
         # TODO: here or in __init__
         self.k_vars = self.exog.shape[1]
         if not hasattr(self, 'fix_df'):
@@ -80,10 +81,14 @@ class TLinearModel(GenericLikelihoodModel):
             self.fixed_paramsmask = np.isnan(fixdf)
             extra_params_names = ['scale']
 
+        super(TLinearModel, self).initialize()
+
+        # Note: this needs to be after super initialize
+        # super initialize sets default df_resid,
+        #_set_extra_params_names adjusts it
         self._set_extra_params_names(extra_params_names)
         self._set_start_params()
 
-        super(TLinearModel, self).initialize()
 
     def _set_start_params(self, start_params=None, use_kurtosis=False):
         if start_params is not None:

--- a/statsmodels/othermod/betareg.py
+++ b/statsmodels/othermod/betareg.py
@@ -125,7 +125,8 @@ class BetaModel(GenericLikelihoodModel):
         # self.exog_precision = exog_precision
         # inherited df do not account for precision params
         self.nobs = self.endog.shape[0]
-        self.df_model = self.nparams - 1
+        self.k_extra = 1
+        self.df_model = self.nparams - 2
         self.df_resid = self.nobs - self.nparams
         assert len(self.exog_precision) == len(self.endog)
         self.hess_type = "oim"


### PR DESCRIPTION
This fixes the immediate issue in #8475

no unit tests yet for it
df_model does not take into account that we have nonzero k_null.
see https://github.com/statsmodels/statsmodels/issues/8475#issuecomment-1295269664

There might still be other related problems for other, similar subclasses of GenericLikelihoodModel.

