### PR TITLE
REF/ENH: GLM predict which and get_prediction

### DIFF
--- a/statsmodels/base/_prediction_inference.py
+++ b/statsmodels/base/_prediction_inference.py
@@ -775,6 +775,13 @@ def get_prediction(self, exog=None, transform=True, which="mean",
         # TODO: add link or ilink to all link based models (except zi
         link = getattr(self.model, "link", None)
         if link is None:
+            # GLM
+            if hasattr(self.model, "family"):
+                link = getattr(self.model.family, "link", None)
+        if link is None:
+            # defaulting to log link for count models
+            import warnings
+            warnings.warn("using default log-link in get_prediction")
             from statsmodels.genmod.families import links
             link = links.Log()
         res = get_prediction_monotonic(

--- a/statsmodels/discrete/discrete_model.py
+++ b/statsmodels/discrete/discrete_model.py
@@ -984,6 +984,8 @@ class CountModel(DiscreteModel):
             - 'mean' returns the conditional expectation of endog E(y | x),
               i.e. exp of linear predictor.
             - 'linear' returns the linear predictor of the mean function.
+            - 'var' variance of endog implied by the likelihood model
+            - 'prob' predicted probabilities for counts.
 
         linear : bool
             The ``linear` keyword is deprecated and will be removed,

--- a/statsmodels/genmod/tests/test_glm.py
+++ b/statsmodels/genmod/tests/test_glm.py
@@ -304,6 +304,13 @@ class CheckComparisonMixin:
         assert_allclose(predd.summary_frame().values,
                         pred1.summary_frame().values, rtol=1e-6)
 
+        pred1 = self.res1.get_prediction(which="mean")  # GLM
+        predd = self.resd.get_prediction()  # discrete class
+        assert_allclose(predd.predicted, pred1.predicted, rtol=1e-11)
+        assert_allclose(predd.se, pred1.se, rtol=1e-6)
+        assert_allclose(predd.summary_frame().values,
+                        pred1.summary_frame().values, rtol=1e-6)
+
 
 class TestGlmGaussian(CheckModelResultsMixin):
     @classmethod

--- a/statsmodels/genmod/tests/test_glm.py
+++ b/statsmodels/genmod/tests/test_glm.py
@@ -250,6 +250,10 @@ class CheckModelResultsMixin:
         for k in distr2.kwds:
             assert_allclose(distr.kwds[k], distr2.kwds[k], rtol=1e-13)
 
+        # compare var with predict
+        var_ = res1.predict(which="var_unscaled")
+        assert_allclose(var_ * res_scale, var_endog, rtol=1e-13)
+
 
 class CheckComparisonMixin:
 

--- a/statsmodels/genmod/tests/test_glm_weights.py
+++ b/statsmodels/genmod/tests/test_glm_weights.py
@@ -141,7 +141,9 @@ class CheckWeight:
                             atol=1e-6, rtol=1e-6)
 
     def test_getprediction(self):
-        pred = self.res1.get_prediction()
+        with pytest.warns(DeprecationWarning):
+            # deprecation warning for linear keyword
+            pred = self.res1.get_prediction()
         assert_allclose(pred.linpred.se_mean, pred.linpred.se_mean, rtol=1e-10)
 
 


### PR DESCRIPTION
add "which" option to GLM predict

GLM get_prediction returns generic Prediction results classes if which is not None

This is currently backwards compatible, but we will remove the old version when "linear" keyword is removed.
Then only the `which is not None` path will remain, with default which="mean"