### PR TITLE
BUG: Fix two bugs in `statsmodels.stats.power.normal_sample_size_one_tail`

### DIFF
--- a/statsmodels/stats/power.py
+++ b/statsmodels/stats/power.py
@@ -200,11 +200,6 @@ def normal_sample_size_one_tail(diff, power, alpha, std_null=1.,
         sample size to achieve the desired power
 
     """
-    if power < alpha:
-        raise ValueError(
-            f"Power cannot be less than alpha; set power >= {alpha} to fix"
-            )
-
     if std_alternative is None:
         std_alternative = 0
 

--- a/statsmodels/stats/power.py
+++ b/statsmodels/stats/power.py
@@ -206,6 +206,14 @@ def normal_sample_size_one_tail(diff, power, alpha, std_null=1.,
     crit_power = stats.norm.isf(power)
     crit = stats.norm.isf(alpha)
     n1 = ((crit * std_null - crit_power * std_alternative) / diff)**2
+
+    # Enforce condition that power >= alpha; return np.nan for elements not
+    # satisfying this condition. np.ones_like used to satisfy broadcastability
+    # constraints and to yield a Boolean array with the same shape as n1.
+    alpha_minus_power = (
+        alpha * np.ones_like(std_null) - power * np.ones_like(std_alternative)
+        ) / np.ones_like(diff)
+    n1 = np.where(alpha_minus_power > 0, np.nan, n1)
     return n1
 
 

--- a/statsmodels/stats/power.py
+++ b/statsmodels/stats/power.py
@@ -186,7 +186,9 @@ def normal_sample_size_one_tail(diff, power, alpha, std_null=1.,
         Null Hypothesis if the Alternative Hypothesis is true.
     alpha : float in interval (0,1)
         significance level, e.g. 0.05, is the probability of a type I error,
-        that is wrong rejections if the Null Hypothesis is true.
+        that is wrong rejections if the Null Hypothesis is true. Use alpha/2 to
+        compute the one tail approximation to the two-sided test, i.e. consider
+        only one tail of two-sided test.
     std_null : float
         standard deviation under the Null hypothesis without division by
         sqrt(nobs)

--- a/statsmodels/stats/power.py
+++ b/statsmodels/stats/power.py
@@ -172,28 +172,27 @@ def normal_sample_size_one_tail(diff, power, alpha, std_null=1.,
     """explicit sample size computation if only one tail is relevant
 
     The sample size is based on the power in one tail assuming that the
-    alternative is in the tail where the test has power that increases
-    with sample size.
-    Use alpha/2 to compute the one tail approximation to the two-sided
-    test, i.e. consider only one tail of two-sided test.
+    alternative is in the tail where the test has power that increases with
+    sample size. Use alpha/2 to compute the one tail approximation to the
+    two-sided test, i.e. consider only one tail of two-sided test.
 
     Parameters
     ----------
     diff : float
         difference in the estimated means or statistics under the alternative.
-    power : float in interval (0,1)
-        power of the test, e.g. 0.8, is one minus the probability of a type II error.
-        Power is the probability that the test correctly rejects the Null
-        Hypothesis if the Alternative Hypothesis is true.
+    power : float in interval [alpha,1)
+        power of the test, e.g. 0.8, is one minus the probability of a type II
+        error. Power is the probability that the test correctly rejects the
+        Null Hypothesis if the Alternative Hypothesis is true.
     alpha : float in interval (0,1)
-        significance level, e.g. 0.05, is the probability of a type I
-        error, that is wrong rejections if the Null Hypothesis is true.
+        significance level, e.g. 0.05, is the probability of a type I error,
+        that is wrong rejections if the Null Hypothesis is true.
     std_null : float
         standard deviation under the Null hypothesis without division by
         sqrt(nobs)
     std_alternative : float
-        standard deviation under the Alternative hypothesis without division
-        by sqrt(nobs)
+        standard deviation under the Alternative hypothesis without division by
+        sqrt(nobs)
 
     Returns
     -------
@@ -201,6 +200,11 @@ def normal_sample_size_one_tail(diff, power, alpha, std_null=1.,
         sample size to achieve the desired power
 
     """
+    if power < alpha:
+        raise ValueError(
+            f"Power cannot be less than alpha; set power >= {alpha} to fix"
+            )
+
     if std_alternative is None:
         std_alternative = 0
 

--- a/statsmodels/stats/power.py
+++ b/statsmodels/stats/power.py
@@ -201,6 +201,8 @@ def normal_sample_size_one_tail(diff, power, alpha, std_null=1.,
         sample size to achieve the desired power
 
     """
+    if std_alternative is None:
+        std_alternative = 0
 
     crit_power = stats.norm.isf(power)
     crit = stats.norm.isf(alpha)

--- a/statsmodels/stats/power.py
+++ b/statsmodels/stats/power.py
@@ -209,15 +209,8 @@ def normal_sample_size_one_tail(diff, power, alpha, std_null=1.,
 
     crit_power = stats.norm.isf(power)
     crit = stats.norm.isf(alpha)
-    n1 = ((crit * std_null - crit_power * std_alternative) / diff)**2
 
-    # Enforce condition that power >= alpha; return np.nan for elements not
-    # satisfying this condition. np.ones_like used to satisfy broadcastability
-    # constraints and to yield a Boolean array with the same shape as n1.
-    alpha_minus_power = (
-        alpha * np.ones_like(std_null) - power * np.ones_like(std_alternative)
-        ) / np.ones_like(diff)
-    n1 = np.where(alpha_minus_power >= 0, 0, n1)
+    n1 = (np.maximum(crit * std_null - crit_power * std_alternative, 0) / diff)**2
     return n1
 
 

--- a/statsmodels/stats/power.py
+++ b/statsmodels/stats/power.py
@@ -180,7 +180,7 @@ def normal_sample_size_one_tail(diff, power, alpha, std_null=1.,
     ----------
     diff : float
         difference in the estimated means or statistics under the alternative.
-    power : float in interval [alpha,1)
+    power : float in interval (alpha,1)
         power of the test, e.g. 0.8, is one minus the probability of a type II
         error. Power is the probability that the test correctly rejects the
         Null Hypothesis if the Alternative Hypothesis is true.
@@ -198,7 +198,8 @@ def normal_sample_size_one_tail(diff, power, alpha, std_null=1.,
     Returns
     -------
     nobs : float
-        sample size to achieve the desired power
+        sample size to achieve the desired power. When power <= alpha, ``nobs``
+        will be zero.
 
     """
     if std_alternative is None:
@@ -214,7 +215,7 @@ def normal_sample_size_one_tail(diff, power, alpha, std_null=1.,
     alpha_minus_power = (
         alpha * np.ones_like(std_null) - power * np.ones_like(std_alternative)
         ) / np.ones_like(diff)
-    n1 = np.where(alpha_minus_power > 0, np.nan, n1)
+    n1 = np.where(alpha_minus_power >= 0, 0, n1)
     return n1
 
 

--- a/statsmodels/stats/power.py
+++ b/statsmodels/stats/power.py
@@ -190,9 +190,10 @@ def normal_sample_size_one_tail(diff, power, alpha, std_null=1.,
     std_null : float
         standard deviation under the Null hypothesis without division by
         sqrt(nobs)
-    std_alternative : float
+    std_alternative : float (optional)
         standard deviation under the Alternative hypothesis without division by
-        sqrt(nobs)
+        sqrt(nobs). Defaults to None. If None, ``std_alternative`` is set to the
+        value of ``std_null``.
 
     Returns
     -------
@@ -201,7 +202,7 @@ def normal_sample_size_one_tail(diff, power, alpha, std_null=1.,
 
     """
     if std_alternative is None:
-        std_alternative = 0
+        std_alternative = std_null
 
     crit_power = stats.norm.isf(power)
     crit = stats.norm.isf(alpha)

--- a/statsmodels/stats/tests/test_power.py
+++ b/statsmodels/stats/tests/test_power.py
@@ -775,6 +775,10 @@ def test_power_solver_warn():
 
 
 def test_normal_sample_size_one_tail():
-    # Test for check that power >= alpha
-    with pytest.raises(ValueError):
-        smp.normal_sample_size_one_tail(1, 0.03, 0.05, 1, 1)
+    # Test that using default value of std_alternative does not raise an
+    # exception. A power of 0.8 and alpha of 0.05 were chosen to reflect
+    # commonly used values in hypothesis testing. Difference in means and
+    # standard deviation of null population were chosen somewhat arbitrarily --
+    # there's nothing special about those values. Return value doesn't matter
+    # for this "test", so long as an exception is not raised.
+    smp.normal_sample_size_one_tail(5, 0.8, 0.05, 2, std_alternative=None)

--- a/statsmodels/stats/tests/test_power.py
+++ b/statsmodels/stats/tests/test_power.py
@@ -782,3 +782,12 @@ def test_normal_sample_size_one_tail():
     # there's nothing special about those values. Return value doesn't matter
     # for this "test", so long as an exception is not raised.
     smp.normal_sample_size_one_tail(5, 0.8, 0.05, 2, std_alternative=None)
+
+    # Test that numpy.nan is returned in the correct elements if power is less than
+    # alpha.
+    alphas = np.asarray([0.01, 0.05, 0.1, 0.5, 0.8])
+    powers = np.asarray([0.99, 0.95, 0.9, 0.5, 0.2])
+    nan_mask = np.where(alphas - powers > 0, np.nan, alphas - powers)
+    sample_sizes_with_nans = smp.normal_sample_size_one_tail(5, powers, alphas, 2, 2)
+    check_nans = np.isnan(nan_mask) == np.isnan(sample_sizes_with_nans)
+    assert np.all(check_nans)

--- a/statsmodels/stats/tests/test_power.py
+++ b/statsmodels/stats/tests/test_power.py
@@ -772,3 +772,9 @@ def test_power_solver_warn():
                               alternative='larger')
         assert_equal(nip.cache_fit_res[0], 0)
         assert_equal(len(nip.cache_fit_res), 3)
+
+
+def test_normal_sample_size_one_tail():
+    # Test for check that power >= alpha
+    with pytest.raises(ValueError):
+        smp.normal_sample_size_one_tail(1, 0.03, 0.05, 1, 1)


### PR DESCRIPTION
- ~~[ ] closes #xxxx~~ (does not apply)
- [x] tests added / passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

This pull request fixes two bugs in `statsmodels.stats.power.normal_sample_size_one_tail`:

1. If the default value of that method's `std_alternative` parameter is used, that method raises an exception because a `float` cannot be multiplied by a `NoneType`. This bug is mitigated by setting the `std_alternative` parameter to zero in the body of that method if its value is `None`.
2. The `power` parameter cannot be less than `alpha`. Admittedly, I don't know why someone would intentionally try to pass arguments satisfying that criterion, but nevertheless, a power less than alpha would be ill-posed. This bug is mitigated by adding a conditional checking this condition; if satisfied, a `ValueError` is raised. The method's documentation has also been updated.

Reviewing the code in `statsmodels.stats.power.normal_sample_size_one_tail` also suggests the implementation might be incorrect: after the mitigations above, assuming `std_alternative` is `None`, and all parameters other than `power` are fixed, the computed sample size will be the same for all valid values of `power`. One possible alternative implementation (omitting docstrings) could be something like:

```python
def normal_sample_size_one_tail(diff, power, alpha, std_null=1.,
                                 std_alternative=None):

    if power < alpha:
        raise ValueError(f"Power cannot be less than alpha; set power >= {alpha} to fix")

    if std_alternative is None:
        std_alternative = 0

    crit_power = stats.norm.isf(power)
    crit = stats.norm.isf(alpha)
    n1 = (std_null ** 2 + std_alternative ** 2) * (crit - crit_power)**2 / (diff ** 2)
    return n1
```
under the assumption that, in the two-sample case, the sample sizes are equal. This expression agrees with a similar expression for the two-sample case on page 490 in Chapter 10 of J. L. Devore, K. N. Berk, *Modern Mathematical Statistics with Applications*, 2nd Edition, in *Springer Texts on Statistics*, and when `std_alternative=0`, it agrees with the expression for the one-sample case on page 441 in Chapter 9 of the same textbook, as well as that on [Wikipedia's page for "sample size determination"](https://en.wikipedia.org/wiki/Sample_size_determination#Cumulative_distribution_function). For the one-tailed, one-sample case, this expression should be exact; for the two-tailed case, it makes the approximation of ignoring the smaller tail's contribution to Type II error. However, changing the implementation would affect some existing tests in `statsmodels/stats/tests/test_proportion.py`, so I have not changed the expression for `n1` in this pull request. If making the change above to the expression for  `n1` is sensible, I would be happy to contribute that change as well.

<details>
**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
