### PR TITLE
Use sharex=True in plotting seasonal decomposition

### DIFF
--- a/statsmodels/tsa/seasonal.py
+++ b/statsmodels/tsa/seasonal.py
@@ -342,7 +342,7 @@ class DecomposeResult:
         else:
             xlim = (0, self._observed.shape[0] - 1)
 
-        fig, axs = plt.subplots(len(series), 1)
+        fig, axs = plt.subplots(len(series), 1, sharex=True)
         for i, (ax, (series, def_name)) in enumerate(zip(axs, series)):
             if def_name != "residual":
                 ax.plot(series)


### PR DESCRIPTION
This is a tiny change in the `plot` method of `DecomposeResult` (in statsmodels.tsa.seasonal). I started to use it just a few minutes ago on a quite long time series (8760 samples), so that in a interactive Matlplotlib plot, it is useful to zoom horizontally. Unfortunately, the horizontal zooms are not in sync.

Adding `sharex=True` in the call to `plt.subplots` allows synchronizing the zoom between all seasonal components.

An alternative would be to have this synchronization optional (one extra parameter to `DecomposeResult.plot`), but I don't see a  use case which needs *dis*-synchronization, what do you think?