### PR TITLE
Update pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 # These are strictly build requirements. Runtime requirements are listed in
 # INSTALL_REQUIRES in setup.py
 requires = [
-    "setuptools>=59.2.0",
+    "setuptools<65.6.0",
     "cython>=0.29.26,<3",  # Sync with CYTHON_MIN_VER in setup
     # Workaround for oldest supported numpy using 1.21.6, but SciPy 1.9.2+ requiring 1.22.3+
     "oldest-supported-numpy; python_version!='3.10' or platform_system!='Windows' or platform_python_implementation=='PyPy'",


### PR DESCRIPTION
update to be able to build when using docker because of setuptools change to 65.6.0

I am proposing this just to be able to run my Docker containers that make use of statsmodels. It`s a quick fix and then maybe I could help with the larger numpy problem, to migrate to >1.23.0