### PR TITLE
BUG: normal_sample_size_one_tail, fix std_alt default, minimum nobs

### DIFF
--- a/statsmodels/stats/power.py
+++ b/statsmodels/stats/power.py
@@ -168,7 +168,7 @@ def normal_power_het(diff, nobs, alpha, std_null=1., std_alternative=None,
 
 
 def normal_sample_size_one_tail(diff, power, alpha, std_null=1.,
-                                 std_alternative=None):
+                                std_alternative=None):
     """explicit sample size computation if only one tail is relevant
 
     The sample size is based on the power in one tail assuming that the
@@ -182,29 +182,39 @@ def normal_sample_size_one_tail(diff, power, alpha, std_null=1.,
     diff : float
         difference in the estimated means or statistics under the alternative.
     power : float in interval (0,1)
-        power of the test, e.g. 0.8, is one minus the probability of a type II error.
-        Power is the probability that the test correctly rejects the Null
-        Hypothesis if the Alternative Hypothesis is true.
+        power of the test, e.g. 0.8, is one minus the probability of a type II
+        error. Power is the probability that the test correctly rejects the
+        Null Hypothesis if the Alternative Hypothesis is true.
     alpha : float in interval (0,1)
         significance level, e.g. 0.05, is the probability of a type I
         error, that is wrong rejections if the Null Hypothesis is true.
+        Note: alpha is used for one tail. Use alpha/2 for two-sided
+        alternative.
     std_null : float
         standard deviation under the Null hypothesis without division by
         sqrt(nobs)
     std_alternative : float
         standard deviation under the Alternative hypothesis without division
-        by sqrt(nobs)
+        by sqrt(nobs). Defaults to None. If None, ``std_alternative`` is set
+        to the value of ``std_null``.
 
     Returns
     -------
     nobs : float
-        sample size to achieve the desired power
+        Sample size to achieve (at least) the desired power.
+        If the minimum power is satisfied for all positive sample sizes, then
+        ``nobs`` will be zero. This will be the case when power <= alpha if
+        std_alternative is equal to std_null.
 
     """
 
+    if std_alternative is None:
+        std_alternative = std_null
+
     crit_power = stats.norm.isf(power)
     crit = stats.norm.isf(alpha)
-    n1 = ((crit * std_null - crit_power * std_alternative) / diff)**2
+    n1 = (np.maximum(crit * std_null - crit_power * std_alternative, 0)
+          / diff)**2
     return n1
 
 

--- a/statsmodels/stats/tests/test_power.py
+++ b/statsmodels/stats/tests/test_power.py
@@ -14,7 +14,7 @@ import warnings
 
 import numpy as np
 from numpy.testing import (assert_almost_equal, assert_allclose, assert_raises,
-                           assert_equal, assert_warns)
+                           assert_equal, assert_warns, assert_array_equal)
 import pytest
 
 import statsmodels.stats.power as smp
@@ -772,3 +772,22 @@ def test_power_solver_warn():
                               alternative='larger')
         assert_equal(nip.cache_fit_res[0], 0)
         assert_equal(len(nip.cache_fit_res), 3)
+
+
+def test_normal_sample_size_one_tail():
+    # Test that using default value of std_alternative does not raise an
+    # exception. A power of 0.8 and alpha of 0.05 were chosen to reflect
+    # commonly used values in hypothesis testing. Difference in means and
+    # standard deviation of null population were chosen somewhat arbitrarily --
+    # there's nothing special about those values. Return value doesn't matter
+    # for this "test", so long as an exception is not raised.
+    smp.normal_sample_size_one_tail(5, 0.8, 0.05, 2, std_alternative=None)
+
+    # Test that zero is returned in the correct elements if power is less
+    # than alpha.
+    alphas = np.asarray([0.01, 0.05, 0.1, 0.5, 0.8])
+    powers = np.asarray([0.99, 0.95, 0.9, 0.5, 0.2])
+    # zero_mask = np.where(alphas - powers > 0, 0.0, alphas - powers)
+    nobs_with_zeros = smp.normal_sample_size_one_tail(5, powers, alphas, 2, 2)
+    # check_nans = np.isnan(zero_mask) == np.isnan(nobs_with_nans)
+    assert_array_equal(nobs_with_zeros[powers <= alphas], 0)


### PR DESCRIPTION
 closes #8507

this is an updated version of #8507, using original author

changes compared to previous PR, mainly that I keep power in [0,1] in docstring
