### PR TITLE
Changes made in the documentation on endogeneity

### DIFF
--- a/docs/source/endog_exog.rst
+++ b/docs/source/endog_exog.rst
@@ -79,7 +79,7 @@ It is up to the user to know (or to consult a text book to find out) what the
 underlying statistical assumptions for the models are. As an example, ``exog``
 in ``OLS`` can have lagged dependent variables if the error or noise term is
 independently distributed over time (or uncorrelated over time). However, if
-the error terms are autocorrelated, then OLS does not have good statistical
+the error terms are autocorrelated in the presense of lagged dependent variables, then OLS does not have good statistical
 properties (is inconsistent) and the correct model will be ARMAX.
 ``statsmodels`` has functions for regression diagnostics to test whether some of
 the assumptions are justified or not.

--- a/docs/source/endog_exog.rst
+++ b/docs/source/endog_exog.rst
@@ -79,8 +79,9 @@ It is up to the user to know (or to consult a text book to find out) what the
 underlying statistical assumptions for the models are. As an example, ``exog``
 in ``OLS`` can have lagged dependent variables if the error or noise term is
 independently distributed over time (or uncorrelated over time). However, if
-the error terms are autocorrelated in the presense of lagged dependent variables, then OLS does not have good statistical
-properties (is inconsistent) and the correct model will be ARMAX.
-``statsmodels`` has functions for regression diagnostics to test whether some of
-the assumptions are justified or not.
+the error terms are autocorrelated in the presense of lagged dependent
+variables, then OLS does not have good statistical properties (is inconsistent)
+and the correct model will be ARMAX. ``statsmodels`` has functions for
+regression diagnostics to test whether some of the assumptions are justified or
+not.
 


### PR DESCRIPTION
- [ ] closes #4199
- [ ] tests added / passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>
Changes were made to the page [http://www.statsmodels.org/dev/endog_exog.html]
At the bottom, the sentence "if the error terms are autocorrelated, then OLS does not have good statistical properties (is inconsistent)' was modified to "However, if the error terms are autocorrelated in the presense of lagged dependent variables, then, OLS does not have good statistical properties (is inconsistent)"

