### PR TITLE
Add Statsmodels logo to Readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,6 @@
+.. image:: docs/source/images/statsmodels-logo-v2-horizontal.svg
+  :alt: Statsmodels logo
+
 |PyPI Version| |Conda Version| |License| |Azure CI Build Status|
 |Codecov Coverage| |Coveralls Coverage| |PyPI downloads| |Conda downloads|
 


### PR DESCRIPTION
Add the [Statsmodels logo](https://www.statsmodels.org/stable/about.html#brand-marks) to the Readme to increase the brand recognizability of Statsmodels.

![](https://www.statsmodels.org/stable/_images/statsmodels-logo-v2-horizontal.svg)

- [x] code/documentation is well formatted.  
