### PR TITLE
MAINT/TST: Relax test tol for OSX fail

### DIFF
--- a/statsmodels/miscmodels/tests/test_ordinal_model.py
+++ b/statsmodels/miscmodels/tests/test_ordinal_model.py
@@ -256,8 +256,9 @@ class TestProbitModel(CheckOrdinalModelMixin):
         score1 = mod.score(res1.params * fact)
         score_obs_numdiff = mod.score_obs(res1.params * fact)
         score_obs_exog = mod.score_obs_(res1.params * fact)
-        assert_allclose(score_obs_numdiff.sum(0), score1, atol=1e-7)
-        assert_allclose(score_obs_exog.sum(0), score1[:mod.k_vars], atol=1e-7)
+        # Relax atol due to small failures on OSX
+        assert_allclose(score_obs_numdiff.sum(0), score1, atol=1e-6)
+        assert_allclose(score_obs_exog.sum(0), score1[:mod.k_vars], atol=1e-6)
 
         # null model
         mod_null = OrderedModel(mod.endog, None,


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed. 
- [ ] code/documentation is well formatted.  
- [ ] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
