### PR TITLE
BUG: seasonal_decompose creates duplicates plots when used without plt.show()

### DIFF
--- a/statsmodels/tsa/seasonal.py
+++ b/statsmodels/tsa/seasonal.py
@@ -356,5 +356,4 @@ class DecomposeResult:
             title(name)
             ax.set_xlim(xlim)
 
-        fig.tight_layout()
-        return fig
+        return fig.tight_layout()


### PR DESCRIPTION
Minor quality of life fix, but 
```python
import random
from statsmodels.tsa.seasonal import seasonal_decompose
idx = pd.date_range(start="2020-01-01", end ="2022-01-01", freq ="M")
test_df = pd.DataFrame({"values": [random.randint(0,100) for x in range(0,24)]}, index = idx)
seasonal_decompose(test_df).plot()
``` 

without an accompanying `plt.show()` line creates two copies of the same plot. A simple edit in the DecomposeResult class addresses this.

It's a quick one line fix so I'm not sure it warrants opening an issue. It's my first time contributing to a project, so let me know, thanks.

- [x] Closes None (Not Applicable)
- [x ] No tests added / passed. (Not Applicable
- [ x] code/documentation is well formatted.  
- [x ] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 






<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
