### PR TITLE
ENH/BUG: archimedean k_dim > 2, deriv inverse in generator transform

### DIFF
--- a/statsmodels/distributions/copula/_special.py
+++ b/statsmodels/distributions/copula/_special.py
@@ -1,0 +1,110 @@
+"""
+
+Special functions for copulas not available in scipy
+
+Created on Jan. 27, 2023
+"""
+
+import numpy as np
+from scipy.special import factorial
+
+
+class Sterling1():
+    """Stirling numbers of the first kind
+    """
+    # based on
+    # https://rosettacode.org/wiki/Stirling_numbers_of_the_first_kind#Python
+
+    def __init__(self):
+        self._cache = {}
+
+    def __call__(self, n, k):
+        key = str(n) + "," + str(k)
+
+        if key in self._cache.keys():
+            return self._cache[key]
+        if n == k == 0:
+            return 1
+        if n > 0 and k == 0:
+            return 0
+        if k > n:
+            return 0
+        result = sterling1(n - 1, k - 1) + (n - 1) * sterling1(n - 1, k)
+        self._cache[key] = result
+        return result
+
+    def clear_cache(self):
+        """clear cache of Sterling numbers
+        """
+        self._cache = {}
+
+
+sterling1 = Sterling1()
+
+
+class Sterling2():
+    """Stirling numbers of the second kind
+    """
+    # based on
+    # https://rosettacode.org/wiki/Stirling_numbers_of_the_second_kind#Python
+
+    def __init__(self):
+        self._cache = {}
+
+    def __call__(self, n, k):
+        key = str(n) + "," + str(k)
+
+        if key in self._cache.keys():
+            return self._cache[key]
+        if n == k == 0:
+            return 1
+        if (n > 0 and k == 0) or (n == 0 and k > 0):
+            return 0
+        if n == k:
+            return 1
+        if k > n:
+            return 0
+        result = k * sterling2(n - 1, k) + sterling2(n - 1, k - 1)
+        self._cache[key] = result
+        return result
+
+    def clear_cache(self):
+        """clear cache of Sterling numbers
+        """
+        self._cache = {}
+
+
+sterling2 = Sterling2()
+
+
+def li3(z):
+    """Polylogarithm for negative integer order -3
+
+    Li(-3, z)
+    """
+    return z * (1 + 4 * z + z**2) / (1 - z)**4
+
+
+def li4(z):
+    """Polylogarithm for negative integer order -4
+
+    Li(-4, z)
+    """
+    return z * (1 + z) * (1 + 10 * z + z**2) / (1 - z)**5
+
+
+def lin(n, z):
+    """Polylogarithm for negative integer order -n
+
+    Li(-n, z)
+
+    https://en.wikipedia.org/wiki/Polylogarithm#Particular_values
+    """
+    if np.size(z) > 1:
+        z = np.array(z)[..., None]
+
+    k = np.arange(n+1)
+    st2 = np.array([sterling2(n + 1, ki + 1) for ki in k])
+    res = (-1)**(n+1) * np.sum(factorial(k) * st2 * (-1 / (1 - z))**(k+1),
+                               axis=-1)
+    return res

--- a/statsmodels/distributions/copula/archimedean.py
+++ b/statsmodels/distributions/copula/archimedean.py
@@ -178,10 +178,13 @@ class ClaytonCopula(ArchimedeanCopula):
     def pdf(self, u, args=()):
         u = np.atleast_2d(u)
         th, = self._handle_args(args)
-        a = (th + 1) * np.prod(u, axis=1) ** -(th + 1)
-        b = np.sum(u ** -th, axis=1) - 1
-        c = -(2 * th + 1) / th
-        return a * b ** c
+        if u.shape[1] == 2:
+            a = (th + 1) * np.prod(u, axis=1) ** -(th + 1)
+            b = np.sum(u ** -th, axis=1) - 1
+            c = -(2 * th + 1) / th
+            return a * b ** c
+        else:
+            return super().pdf(u, args)
 
     def logpdf(self, u, args=()):
         # we skip Archimedean logpdf, that uses numdiff
@@ -251,7 +254,7 @@ class FrankCopula(ArchimedeanCopula):
         u = np.atleast_2d(u)
         th, = self._handle_args(args)
         if u.shape[-1] != 2:
-            return super().pdf(u)
+            return super().pdf(u, th)
 
         g_ = np.exp(-th * np.sum(u, axis=1)) - 1
         g1 = np.exp(-th) - 1
@@ -287,7 +290,7 @@ class FrankCopula(ArchimedeanCopula):
         else:
             # for now use generic from base Copula class, log(self.pdf(...))
             # we skip Archimedean logpdf, that uses numdiff
-            super(ArchimedeanCopula, self).logpdf(u, args)
+            return super(FrankCopula, self).logpdf(u, args)
 
     def cdfcond_2g1(self, u, args=()):
         """Conditional cdf of second component given the value of first.
@@ -380,19 +383,22 @@ class GumbelCopula(ArchimedeanCopula):
     def pdf(self, u, args=()):
         u = np.atleast_2d(u)
         th, = self._handle_args(args)
-        xy = -np.log(u)
-        xy_theta = xy ** th
+        if u.shape[-1] == 2:
+            xy = -np.log(u)
+            xy_theta = xy ** th
 
-        sum_xy_theta = np.sum(xy_theta, axis=1)
-        sum_xy_theta_theta = sum_xy_theta ** (1.0 / th)
+            sum_xy_theta = np.sum(xy_theta, axis=1)
+            sum_xy_theta_theta = sum_xy_theta ** (1.0 / th)
 
-        a = np.exp(-sum_xy_theta_theta)
-        b = sum_xy_theta_theta + th - 1.0
-        c = sum_xy_theta ** (1.0 / th - 2)
-        d = np.prod(xy, axis=1) ** (th - 1.0)
-        e = np.prod(u, axis=1) ** (- 1.0)
+            a = np.exp(-sum_xy_theta_theta)
+            b = sum_xy_theta_theta + th - 1.0
+            c = sum_xy_theta ** (1.0 / th - 2)
+            d = np.prod(xy, axis=1) ** (th - 1.0)
+            e = np.prod(u, axis=1) ** (- 1.0)
 
-        return a * b * c * d * e
+            return a * b * c * d * e
+        else:
+            return super().pdf(u, args)
 
     def cdf(self, u, args=()):
         u = np.atleast_2d(u)

--- a/statsmodels/distributions/copula/archimedean.py
+++ b/statsmodels/distributions/copula/archimedean.py
@@ -188,7 +188,7 @@ class ClaytonCopula(ArchimedeanCopula):
 
     def logpdf(self, u, args=()):
         # we skip Archimedean logpdf, that uses numdiff
-        return super(ArchimedeanCopula, self).logpdf(u, args=args)
+        return super().logpdf(u, args=args)
 
     def cdf(self, u, args=()):
         u = np.atleast_2d(u)
@@ -290,7 +290,7 @@ class FrankCopula(ArchimedeanCopula):
         else:
             # for now use generic from base Copula class, log(self.pdf(...))
             # we skip Archimedean logpdf, that uses numdiff
-            return super(FrankCopula, self).logpdf(u, args)
+            return super().logpdf(u, args)
 
     def cdfcond_2g1(self, u, args=()):
         """Conditional cdf of second component given the value of first.
@@ -409,7 +409,7 @@ class GumbelCopula(ArchimedeanCopula):
 
     def logpdf(self, u, args=()):
         # we skip Archimedean logpdf, that uses numdiff
-        return super(ArchimedeanCopula, self).logpdf(u, args=args)
+        return super().logpdf(u, args=args)
 
     def tau(self, theta=None):
         # Joe 2014 p. 172

--- a/statsmodels/distributions/copula/archimedean.py
+++ b/statsmodels/distributions/copula/archimedean.py
@@ -63,9 +63,20 @@ class ArchimedeanCopula(Copula):
 
         return args
 
+    def _handle_u(self, u):
+        u = np.asarray(u)
+        if u.shape[-1] != self.k_dim:
+            import warnings
+            warnings.warn("u has different dimension than k_dim. "
+                          "This will raise exception in future versions",
+                          FutureWarning)
+
+        return u
+
     def cdf(self, u, args=()):
         """Evaluate cdf of Archimedean copula."""
         args = self._handle_args(args)
+        u = self._handle_u(u)
         axis = -1
         phi = self.transform.evaluate
         phi_inv = self.transform.inverse
@@ -77,9 +88,9 @@ class ArchimedeanCopula(Copula):
 
     def pdf(self, u, args=()):
         """Evaluate pdf of Archimedean copula."""
+        u = self._handle_u(u)
         args = self._handle_args(args)
         axis = -1
-        u = np.asarray(u)
 
         phi_d1 = self.transform.deriv
         if u.shape[-1] == 2:
@@ -105,11 +116,10 @@ class ArchimedeanCopula(Copula):
 
     def logpdf(self, u, args=()):
         """Evaluate log pdf of multivariate Archimedean copula."""
-        # TODO: replace by formulas, and exp in pdf
-        # return np.log(self.pdf(u, args))
+
+        u = self._handle_u(u)
         args = self._handle_args(args)
         axis = -1
-        u = np.asarray(u)
 
         phi_d1 = self.transform.deriv
         if u.shape[-1] == 2:
@@ -176,11 +186,11 @@ class ClaytonCopula(ArchimedeanCopula):
         return (1 - np.log(x) / v) ** (-1. / th)
 
     def pdf(self, u, args=()):
-        u = np.atleast_2d(u)
+        u = self._handle_u(u)
         th, = self._handle_args(args)
-        if u.shape[1] == 2:
-            a = (th + 1) * np.prod(u, axis=1) ** -(th + 1)
-            b = np.sum(u ** -th, axis=1) - 1
+        if u.shape[-1] == 2:
+            a = (th + 1) * np.prod(u, axis=-1) ** -(th + 1)
+            b = np.sum(u ** -th, axis=-1) - 1
             c = -(2 * th + 1) / th
             return a * b ** c
         else:
@@ -191,10 +201,10 @@ class ClaytonCopula(ArchimedeanCopula):
         return super().logpdf(u, args=args)
 
     def cdf(self, u, args=()):
-        u = np.atleast_2d(u)
+        u = self._handle_u(u)
         th, = self._handle_args(args)
         d = u.shape[-1]  # self.k_dim
-        return (np.sum(u ** (-th), axis=1) - d + 1) ** (-1.0 / th)
+        return (np.sum(u ** (-th), axis=-1) - d + 1) ** (-1.0 / th)
 
     def tau(self, theta=None):
         # Joe 2014 p. 168
@@ -251,33 +261,31 @@ class FrankCopula(ArchimedeanCopula):
     # todo: check expm1 and log1p for improved numerical precision
 
     def pdf(self, u, args=()):
-        u = np.atleast_2d(u)
+        u = self._handle_u(u)
         th, = self._handle_args(args)
         if u.shape[-1] != 2:
             return super().pdf(u, th)
 
-        g_ = np.exp(-th * np.sum(u, axis=1)) - 1
+        g_ = np.exp(-th * np.sum(u, axis=-1)) - 1
         g1 = np.exp(-th) - 1
 
         num = -th * g1 * (1 + g_)
-        aux = np.prod(np.exp(-th * u) - 1, axis=1) + g1
+        aux = np.prod(np.exp(-th * u) - 1, axis=-1) + g1
         den = aux ** 2
         return num / den
 
     def cdf(self, u, args=()):
-        u = np.atleast_2d(u)
+        u = self._handle_u(u)
         th, = self._handle_args(args)
         dim = u.shape[-1]
-        # if dim != 2:
-        #     return super().cdf(u)
 
-        num = np.prod(1 - np.exp(- th * u), axis=1)
+        num = np.prod(1 - np.exp(- th * u), axis=-1)
         den = (1 - np.exp(-th)) ** (dim - 1)
 
         return -1.0 / th * np.log(1 - num / den)
 
     def logpdf(self, u, args=()):
-        u = np.atleast_2d(u)
+        u = self._handle_u(u)
         th, = self._handle_args(args)
         if u.shape[-1] == 2:
             # bivariate case
@@ -295,7 +303,7 @@ class FrankCopula(ArchimedeanCopula):
     def cdfcond_2g1(self, u, args=()):
         """Conditional cdf of second component given the value of first.
         """
-        u = np.atleast_2d(u)
+        u = self._handle_u(u)
         th, = self._handle_args(args)
         if u.shape[-1] == 2:
             # bivariate case
@@ -381,29 +389,29 @@ class GumbelCopula(ArchimedeanCopula):
         return np.exp(-(-np.log(x) / v) ** (1. / th))
 
     def pdf(self, u, args=()):
-        u = np.atleast_2d(u)
+        u = self._handle_u(u)
         th, = self._handle_args(args)
         if u.shape[-1] == 2:
             xy = -np.log(u)
             xy_theta = xy ** th
 
-            sum_xy_theta = np.sum(xy_theta, axis=1)
+            sum_xy_theta = np.sum(xy_theta, axis=-1)
             sum_xy_theta_theta = sum_xy_theta ** (1.0 / th)
 
             a = np.exp(-sum_xy_theta_theta)
             b = sum_xy_theta_theta + th - 1.0
             c = sum_xy_theta ** (1.0 / th - 2)
-            d = np.prod(xy, axis=1) ** (th - 1.0)
-            e = np.prod(u, axis=1) ** (- 1.0)
+            d = np.prod(xy, axis=-1) ** (th - 1.0)
+            e = np.prod(u, axis=-1) ** (- 1.0)
 
             return a * b * c * d * e
         else:
             return super().pdf(u, args)
 
     def cdf(self, u, args=()):
-        u = np.atleast_2d(u)
+        u = self._handle_u(u)
         th, = self._handle_args(args)
-        h = np.sum((-np.log(u)) ** th, axis=1)
+        h = np.sum((-np.log(u)) ** th, axis=-1)
         cdf = np.exp(-h ** (1.0 / th))
         return cdf
 

--- a/statsmodels/distributions/copula/copulas.py
+++ b/statsmodels/distributions/copula/copulas.py
@@ -264,9 +264,6 @@ class Copula(ABC):
 
     def __init__(self, k_dim=2):
         self.k_dim = k_dim
-        if k_dim > 2:
-            import warnings
-            warnings.warn("copulas for more than 2 dimension is untested")
 
     def rvs(self, nobs=1, args=(), random_state=None):
         """Draw `n` in the half-open interval ``[0, 1)``.

--- a/statsmodels/distributions/copula/extreme_value.py
+++ b/statsmodels/distributions/copula/extreme_value.py
@@ -56,6 +56,8 @@ class ExtremeValueCopula(Copula):
         self.transform = transform
         self.k_args = transform.k_args
         self.args = args
+        if k_dim != 2:
+            raise ValueError("Only bivariate EV copulas are available.")
 
     def _handle_args(self, args):
         # TODO: how to we handle non-tuple args? two we allow single values?

--- a/statsmodels/distributions/copula/other_copulas.py
+++ b/statsmodels/distributions/copula/other_copulas.py
@@ -55,7 +55,7 @@ class IndependenceCopula(Copula):
         return np.ones(len(u))
 
     def cdf(self, u, args=()):
-        return np.prod(u, axis=1)
+        return np.prod(u, axis=-1)
 
     def tau(self):
         return 0

--- a/statsmodels/distributions/copula/other_copulas.py
+++ b/statsmodels/distributions/copula/other_copulas.py
@@ -52,7 +52,8 @@ class IndependenceCopula(Copula):
         return x
 
     def pdf(self, u, args=()):
-        return np.ones(len(u))
+        u = np.asarray(u)
+        return np.ones(u.shape[:-1])
 
     def cdf(self, u, args=()):
         return np.prod(u, axis=-1)

--- a/statsmodels/distributions/copula/tests/test_copula.py
+++ b/statsmodels/distributions/copula/tests/test_copula.py
@@ -207,6 +207,17 @@ def test_copulas(case):
     logpdf1 = ca.logpdf(u, args=args)
     assert_allclose(logpdf1, np.log(pdf2), rtol=1e-13)
 
+    # compare with specific copula class
+    ca2 = cop()
+    cdf3 = ca2.cdf(u, args=args)
+    pdf3 = ca2.pdf(u, args=args)
+    logpdf3 = ca2.logpdf(u, args=args)
+    assert_allclose(cdf3, cdf2, rtol=1e-13)
+    assert_allclose(pdf3, pdf2, rtol=1e-13)
+
+    logpdf1 = ca.logpdf(u, args=args)
+    assert_allclose(logpdf3, np.log(pdf2), rtol=1e-13)
+
 
 @pytest.mark.parametrize("case", ev_list)
 def test_ev_copula_distr(case):

--- a/statsmodels/distributions/copula/tests/test_copula.py
+++ b/statsmodels/distributions/copula/tests/test_copula.py
@@ -90,11 +90,26 @@ ev_dep_list = [
 
 
 cop_list = [
-    [tra.TransfFrank, 0.5, 0.9, (2,), 0.4710805107852225, 0.9257812360337806],
-    [tra.TransfGumbel, 0.5, 0.9, (2,), 0.4960348880595387, 0.3973548776136501],
-    [tra.TransfClayton, 0.5, 0.9, (2,), 0.485954322440435, 0.8921974147432954],
-    [tra.TransfIndep, 0.5, 0.5, (), 0.25, 1],
-]
+    [tra.TransfFrank, [0.5, 0.9], (2,), 0.4710805107852225, 0.9257812360337806,
+     FrankCopula],
+    [tra.TransfGumbel, [0.5, 0.9], (2,), 0.4960348880595387, 0.3973548776136501,
+     GumbelCopula],
+    [tra.TransfClayton, [0.5, 0.9], (2,), 0.485954322440435, 0.8921974147432954,
+     ClaytonCopula],
+    [tra.TransfIndep, [0.5, 0.5], (), 0.25, 1, IndependenceCopula],
+    ]
+
+
+# separate mv list because test_copulas_distr not yet adjusted
+copk_list = [
+    [tra.TransfGumbel, [0.6, 0.5, 0.9], (2,), 0.4200146617837097,
+     0.7507987484870147, GumbelCopula],
+    [tra.TransfClayton, [0.6, 0.5, 0.9], (2,), 0.4078289289864994,
+     1.430033358494079, ClaytonCopula],
+    [tra.TransfFrank, [0.6, 0.5, 0.9], (2,), 0.3397845258821868,
+     1.123811705698149, FrankCopula],
+    ]
+
 
 gev_list = [
     # [cop.transform_tawn, 0.5, 0.9, (0.5, 0.5, 0.5), 0.4724570876035117],
@@ -179,17 +194,17 @@ def test_ev_dep(case):
     assert_allclose(df, res2, rtol=1e-13)
 
 
-@pytest.mark.parametrize("case", cop_list)
+@pytest.mark.parametrize("case", cop_list + copk_list)
 def test_copulas(case):
     # check ev copulas, cdf and transform against R `copula` package
-    cop_tr, v1, v2, args, cdf2, pdf2 = case
+    cop_tr, u, args, cdf2, pdf2, cop = case
     ca = ArchimedeanCopula(cop_tr())
-    cdf1 = ca.cdf([v1, v2], args=args)
-    pdf1 = ca.pdf([v1, v2], args=args)
+    cdf1 = ca.cdf(u, args=args)
+    pdf1 = ca.pdf(u, args=args)
     assert_allclose(cdf1, cdf2, rtol=1e-13)
     assert_allclose(pdf1, pdf2, rtol=1e-13)
 
-    logpdf1 = ca.logpdf([v1, v2], args=args)
+    logpdf1 = ca.logpdf(u, args=args)
     assert_allclose(logpdf1, np.log(pdf2), rtol=1e-13)
 
 
@@ -226,8 +241,8 @@ def test_ev_copula_distr(case):
 @pytest.mark.parametrize("case", cop_list)
 def test_copulas_distr(case):
     # check ev copulas, cdf and transform against R `copula` package
-    cop_tr, v1, v2, args, cdf2, pdf2 = case
-    u = [v1, v2]
+    cop_tr, u, args, cdf2, pdf2, cop = case
+
     ca = ArchimedeanCopula(cop_tr())
     cdf1 = ca.cdf(u, args=args)
     pdf1 = ca.pdf(u, args=args)
@@ -256,7 +271,7 @@ def test_copulas_distr(case):
     assert cdfd.shape == (3,)
 
     # check mv, check at marginal cdf
-    cdfmv = ca.cdf([v1, v2, 1], args=args)
+    cdfmv = ca.cdf(list(u) + [1], args=args)
     assert_allclose(cdfmv, cdf1, rtol=1e-13)
     assert cdfd.shape == (3,)
 

--- a/statsmodels/distributions/copula/tests/test_copula.py
+++ b/statsmodels/distributions/copula/tests/test_copula.py
@@ -90,24 +90,33 @@ ev_dep_list = [
 
 
 cop_list = [
-    [tra.TransfFrank, [0.5, 0.9], (2,), 0.4710805107852225, 0.9257812360337806,
-     FrankCopula],
-    [tra.TransfGumbel, [0.5, 0.9], (2,), 0.4960348880595387, 0.3973548776136501,
-     GumbelCopula],
-    [tra.TransfClayton, [0.5, 0.9], (2,), 0.485954322440435, 0.8921974147432954,
-     ClaytonCopula],
+    [tra.TransfFrank, [0.5, 0.9], (2,), 0.4710805107852225,
+     0.9257812360337806, FrankCopula],
+    [tra.TransfGumbel, [0.5, 0.9], (2,), 0.4960348880595387,
+     0.3973548776136501, GumbelCopula],
+    [tra.TransfClayton, [0.5, 0.9], (2,), 0.485954322440435,
+     0.8921974147432954, ClaytonCopula],
     [tra.TransfIndep, [0.5, 0.5], (), 0.25, 1, IndependenceCopula],
     ]
 
 
 # separate mv list because test_copulas_distr not yet adjusted
 copk_list = [
+    # k_dim = 3
     [tra.TransfGumbel, [0.6, 0.5, 0.9], (2,), 0.4200146617837097,
      0.7507987484870147, GumbelCopula],
     [tra.TransfClayton, [0.6, 0.5, 0.9], (2,), 0.4078289289864994,
      1.430033358494079, ClaytonCopula],
     [tra.TransfFrank, [0.6, 0.5, 0.9], (2,), 0.3397845258821868,
      1.123811705698149, FrankCopula],
+    # k_dim = 4
+    [tra.TransfGumbel, [0.6, 0.5, 0.9, 0.1], (2,), 0.08538643946528957,
+     0.05130542596740889, GumbelCopula],
+    [tra.TransfClayton, [0.6, 0.5, 0.9, 0.1], (2,), 0.09758427058689817,
+     0.00428071573295176, ClaytonCopula],
+    [tra.TransfFrank, [0.6, 0.5, 0.9, 0.1], (2,), 0.05456579067435671,
+     0.4089534511841545, FrankCopula],
+    [tra.TransfIndep, [0.5, 0.5, 0.5, 0.5], (), 0.0625, 1, IndependenceCopula],
     ]
 
 
@@ -203,6 +212,7 @@ def test_copulas(case):
     pdf1 = ca.pdf(u, args=args)
     assert_allclose(cdf1, cdf2, rtol=1e-13)
     assert_allclose(pdf1, pdf2, rtol=1e-13)
+    assert cdf1.shape == ()
 
     logpdf1 = ca.logpdf(u, args=args)
     assert_allclose(logpdf1, np.log(pdf2), rtol=1e-13)
@@ -214,9 +224,8 @@ def test_copulas(case):
     logpdf3 = ca2.logpdf(u, args=args)
     assert_allclose(cdf3, cdf2, rtol=1e-13)
     assert_allclose(pdf3, pdf2, rtol=1e-13)
-
-    logpdf1 = ca.logpdf(u, args=args)
     assert_allclose(logpdf3, np.log(pdf2), rtol=1e-13)
+    # assert cdf3.shape == ()  # currently fails
 
 
 @pytest.mark.parametrize("case", ev_list)
@@ -249,16 +258,20 @@ def test_ev_copula_distr(case):
         assert cdfd.shape == (3,)
 
 
-@pytest.mark.parametrize("case", cop_list)
+@pytest.mark.parametrize("case", cop_list + copk_list)
 def test_copulas_distr(case):
     # check ev copulas, cdf and transform against R `copula` package
     cop_tr, u, args, cdf2, pdf2, cop = case
+    k_dim = np.asarray(u).shape[-1]
 
     ca = ArchimedeanCopula(cop_tr())
     cdf1 = ca.cdf(u, args=args)
     pdf1 = ca.pdf(u, args=args)
 
-    cad = CopulaDistribution(ca, [uniform, uniform], cop_args=args)
+    marginals = [uniform] * k_dim
+    cad = CopulaDistribution(ca, marginals, cop_args=args)
+    # TODO: check also for specific archimedean classes
+    # cad = CopulaDistribution(cop(), marginals, cop_args=args)
     cdfd = cad.cdf(np.array(u), cop_args=args)
     assert_allclose(cdfd, cdf1, rtol=1e-13)
     assert cdfd.shape == ()

--- a/statsmodels/distributions/copula/transforms.py
+++ b/statsmodels/distributions/copula/transforms.py
@@ -210,6 +210,9 @@ class TransfIndep(Transforms):
     def deriv3_inverse(self, phi, *args):
         return -np.exp(-phi)
 
+    def deriv4_inverse(self, phi, *args):
+        return np.exp(-phi)
+
 
 class _TransfPower(Transforms):
     """generic multivariate Archimedean copula with additional power transforms

--- a/statsmodels/distributions/copula/transforms.py
+++ b/statsmodels/distributions/copula/transforms.py
@@ -11,7 +11,7 @@ License: BSD-3
 import warnings
 
 import numpy as np
-from scipy.special import expm1
+from scipy.special import expm1, gamma
 
 
 # not used yet
@@ -19,6 +19,15 @@ class Transforms:
 
     def __init__(self):
         pass
+
+    def deriv2_inverse(self, phi, args):
+        t = self.inverse(phi, args)
+        phi_d1 = self.deriv(t, args)
+        phi_d2 = self.deriv2(t, args)
+        return np.abs(phi_d2 / phi_d1**3)
+
+    def derivk_inverse(self, k, phi, theta):
+        raise NotImplementedError("not yet implemented")
 
 
 class TransfFrank(Transforms):
@@ -46,6 +55,32 @@ class TransfFrank(Transforms):
         d2 = - theta**2 * tmp / (tmp - 1)**2
         return d2
 
+    def deriv2_inverse(self, phi, theta):
+
+        et = np.exp(theta)
+        ept = np.exp(phi + theta)
+        d2 = (et - 1) * ept / (theta * (ept - et + 1)**2)
+        return d2
+
+    def deriv3_inverse(self, phi, theta):
+        et = np.exp(theta)
+        ept = np.exp(phi + theta)
+        d3 = -(((et - 1) * ept * (ept + et - 1)) /
+               (theta * (ept - et + 1)**3))
+        return d3
+
+    def deriv4_inverse(self, phi, theta):
+        et = np.exp(theta)
+        ept = np.exp(phi + theta)
+        p = phi
+        b = theta
+        d4 = ((et - 1) * ept *
+              (-4 * ept + np.exp(2 * (p + b)) + 4 * np.exp(p + 2 * b) -
+               2 * et + np.exp(2 * b) + 1)
+              ) / (b * (ept - et + 1)**4)
+
+        return d4
+
     def is_completly_monotonic(self, theta):
         # range of theta for which it is copula for d>2 (more than 2 rvs)
         return theta > 0 & theta < 1
@@ -67,6 +102,28 @@ class TransfClayton(Transforms):
 
     def deriv2(self, t, theta):
         return theta * (theta + 1) * np.power(t, -theta-2)
+
+    def deriv_inverse(self, phi, theta):
+        return -(1 + phi)**(-(theta + 1) / theta) / theta
+
+    def deriv2_inverse(self, phi, theta):
+        return ((theta + 1) * (1 + phi)**(-1 / theta - 2)) / theta**2
+
+    def deriv3_inverse(self, phi, theta):
+        th = theta  # shorthand
+        d3 = -((1 + th) * (1 + 2 * th) / th**3 * (1 + phi)**(-1 / th - 3))
+        return d3
+
+    def deriv4_inverse(self, phi, theta):
+        th = theta  # shorthand
+        d4 = ((1 + th) * (1 + 2 * th) * (1 + 3 * th) / th**4
+              ) * (1 + phi)**(-1 / th - 4)
+        return d4
+
+    def derivk_inverse(self, k, phi, theta):
+        thi = 1 / theta  # shorthand
+        d4 = (-1)**k * gamma(k + thi) / gamma(thi) * (1 + phi)**(-(k + thi))
+        return d4
 
     def is_completly_monotonic(self, theta):
         return theta > 0
@@ -98,6 +155,33 @@ class TransfGumbel(Transforms):
 
         return d2
 
+    def deriv2_inverse(self, phi, theta):
+        th = theta  # shorthand
+        d2 = ((phi**(2 / th) + (th - 1) * phi**(1 / th))) / (phi**2 * th**2)
+        d2 *= np.exp(-phi**(1 / th))
+        return d2
+
+    def deriv3_inverse(self, phi, theta):
+        p = phi  # shorthand
+        b = theta
+        d3 = (-p**(3 / b) + (3 - 3 * b) * p**(2 / b) +
+              ((3 - 2 * b) * b - 1) * p**(1 / b)
+              ) / (p * b)**3
+        d3 *= np.exp(-p**(1 / b))
+        return d3
+
+    def deriv4_inverse(self, phi, theta):
+        p = phi  # shorthand
+        b = theta
+        d4 = (((6 * b**3 - 11 * b**2 + 6. * b - 1) * p**(1 / b) +
+               (11 * b**2 - 18 * b + 7) * p**(2 / b) +
+               (6 * (b - 1)) * p**(3 / b) +
+               p**(4 / b))
+              )/(p * b)**4
+
+        d4 *= np.exp(-p**(1 / b))
+        return d4
+
     def is_completly_monotonic(self, theta):
         return theta > 1
 
@@ -119,6 +203,12 @@ class TransfIndep(Transforms):
     def deriv2(self, t, *args):
         t = np.asarray(t)
         return 1. / t**2
+
+    def deriv2_inverse(self, phi, *args):
+        return np.exp(-phi)
+
+    def deriv3_inverse(self, phi, *args):
+        return -np.exp(-phi)
 
 
 class _TransfPower(Transforms):


### PR DESCRIPTION
see #8631
pr will close bug, but maybe not add full extension to k_dim > 3

I will not implement k_dim > 4 for Frank and Gumbel for 0.14. 
Main open question is how to vectorize the special functions. We need our own functions for polylog and sterling numbers and those are not vectorized.

Also, I'm not fixing other methods, e.g. `rvs` raises if k_dim != 2. I don't know how to do those.

This includes, or will include

- bugfixes in cdf for k_dim > 2 of Clayton, explicit formula
- generic pdf for k_dim=2 also uses deriv2_inverse instead of inverting from deriv, deriv2
- explicit 3rd and 4th derivative of generator inverse transforms, Clayton, Frank and Gumbel
- analytical kth derivative of generator inverse transforms for Clayton
- todo: pdf for k_dim > 2 will for now delegate to generic archimedean using generator derivatives

still todo: 
make sure we raise on cases not covered by code
adjust unit tests for copula distribution with k_dim > 2 (not checked yet)

wishlist
- conditional distribution of one component given other or preceding components. It should be possible to compute them using the generator derivatives, but I don't remember details, and don't find references for the details. Some time in the future.
