### PR TITLE
ENH/TST: archimedean rvs for k_dim>2, test/gof tools

### DIFF
--- a/statsmodels/distributions/copula/archimedean.py
+++ b/statsmodels/distributions/copula/archimedean.py
@@ -176,9 +176,6 @@ class ClaytonCopula(ArchimedeanCopula):
         self.theta = theta
 
     def rvs(self, nobs=1, args=(), random_state=None):
-        # if self.k_dim != 2:
-        #     msg = "rvs is only available for bivariate copula"
-        #     raise NotImplementedError(msg)
         rng = check_random_state(random_state)
         th, = self._handle_args(args)
         x = rng.random((nobs, self.k_dim))
@@ -249,9 +246,6 @@ class FrankCopula(ArchimedeanCopula):
         self.theta = theta
 
     def rvs(self, nobs=1, args=(), random_state=None):
-        if self.k_dim != 2:
-            msg = "rvs is only available for bivariate copula"
-            raise NotImplementedError(msg)
         rng = check_random_state(random_state)
         th, = self._handle_args(args)
         x = rng.random((nobs, self.k_dim))
@@ -379,9 +373,6 @@ class GumbelCopula(ArchimedeanCopula):
         self.theta = theta
 
     def rvs(self, nobs=1, args=(), random_state=None):
-        if self.k_dim != 2:
-            msg = "rvs is only available for bivariate copula"
-            raise NotImplementedError(msg)
         rng = check_random_state(random_state)
         th, = self._handle_args(args)
         x = rng.random((nobs, self.k_dim))
@@ -390,7 +381,12 @@ class GumbelCopula(ArchimedeanCopula):
             np.cos(np.pi / (2 * th)) ** th,
             size=(nobs, 1), random_state=rng
         )
-        return np.exp(-(-np.log(x) / v) ** (1. / th))
+
+        if self.k_dim != 2:
+            rv = np.exp(-(-np.log(x) / v) ** (1. / th))
+        else:
+            rv = self.transform.inverse(- np.log(x) / v, th)
+        return rv
 
     def pdf(self, u, args=()):
         u = self._handle_u(u)

--- a/statsmodels/distributions/copula/archimedean.py
+++ b/statsmodels/distributions/copula/archimedean.py
@@ -176,14 +176,18 @@ class ClaytonCopula(ArchimedeanCopula):
         self.theta = theta
 
     def rvs(self, nobs=1, args=(), random_state=None):
-        if self.k_dim != 2:
-            msg = "rvs is only available for bivariate copula"
-            raise NotImplementedError(msg)
+        # if self.k_dim != 2:
+        #     msg = "rvs is only available for bivariate copula"
+        #     raise NotImplementedError(msg)
         rng = check_random_state(random_state)
         th, = self._handle_args(args)
         x = rng.random((nobs, self.k_dim))
         v = stats.gamma(1. / th).rvs(size=(nobs, 1), random_state=rng)
-        return (1 - np.log(x) / v) ** (-1. / th)
+        if self.k_dim != 2:
+            rv = (1 - np.log(x) / v) ** (-1. / th)
+        else:
+            rv = self.transform.inverse(- np.log(x) / v, th)
+        return rv
 
     def pdf(self, u, args=()):
         u = self._handle_u(u)

--- a/statsmodels/distributions/copula/copulas.py
+++ b/statsmodels/distributions/copula/copulas.py
@@ -487,13 +487,17 @@ class Copula(ABC):
         corr_param : float
             Correlation parameter of the copula, ``theta`` in Archimedean and
             pearson correlation in elliptical.
+            If k_dim > 2, then average tau is used.
         """
         x = np.asarray(data)
-        if x.shape[1] != 2:
-            import warnings
-            warnings.warn("currently only first pair of data are used"
-                          " to compute kendall's tau")
-        tau = stats.kendalltau(x[:, 0], x[:, 1])[0]
+
+        if x.shape[1] == 2:
+            tau = stats.kendalltau(x[:, 0], x[:, 1])[0]
+        else:
+            k = self.k_dim
+            taus = [stats.kendalltau(x[..., i], x[..., j])[0]
+                    for i in range(k) for j in range(i+1, k)]
+            tau = np.mean(taus)
         return self._arg_from_tau(tau)
 
     def _arg_from_tau(self, tau):

--- a/statsmodels/distributions/copula/elliptical.py
+++ b/statsmodels/distributions/copula/elliptical.py
@@ -184,6 +184,7 @@ class GaussianCopula(EllipticalCopula):
             corr = np.array([[1., corr], [corr, 1.]])
 
         self.corr = np.asarray(corr)
+        self.args = (self.corr,)
         self.distr_uv = stats.norm
         self.distr_mv = stats.multivariate_normal(
             cov=corr, allow_singular=allow_singular)
@@ -252,6 +253,7 @@ class StudentTCopula(EllipticalCopula):
 
         self.df = df
         self.corr = np.asarray(corr)
+        self.args = (corr, df)
         # both uv and mv are frozen distributions
         self.distr_uv = stats.t(df=df)
         self.distr_mv = multivariate_t(shape=corr, df=df)

--- a/statsmodels/distributions/copula/elliptical.py
+++ b/statsmodels/distributions/copula/elliptical.py
@@ -93,6 +93,35 @@ class EllipticalCopula(Copula):
         corr = np.sin(tau * np.pi / 2)
         return corr
 
+    def fit_corr_param(self, data):
+        """Copula correlation parameter using Kendall's tau of sample data.
+
+        Parameters
+        ----------
+        data : array_like
+            Sample data used to fit `theta` using Kendall's tau.
+
+        Returns
+        -------
+        corr_param : float
+            Correlation parameter of the copula, ``theta`` in Archimedean and
+            pearson correlation in elliptical.
+            If k_dim > 2, then average tau is used.
+        """
+        x = np.asarray(data)
+
+        if x.shape[1] == 2:
+            tau = stats.kendalltau(x[:, 0], x[:, 1])[0]
+        else:
+            k = self.k_dim
+            tau = np.eye(k)
+            for i in range(k):
+                for j in range(i+1, k):
+                    tau_ij = stats.kendalltau(x[..., i], x[..., j])[0]
+                    tau[i, j] = tau[j, i] = tau_ij
+
+        return self._arg_from_tau(tau)
+
 
 class GaussianCopula(EllipticalCopula):
     r"""Gaussian copula.

--- a/statsmodels/distributions/copula/extreme_value.py
+++ b/statsmodels/distributions/copula/extreme_value.py
@@ -159,3 +159,6 @@ class ExtremeValueCopula(Copula):
         where t = np.log(v)/np.log(u*v)
         """
         raise NotImplementedError
+
+    def fit_corr_param(self, data):
+        raise NotImplementedError

--- a/statsmodels/distributions/copula/tests/test_copula.py
+++ b/statsmodels/distributions/copula/tests/test_copula.py
@@ -158,7 +158,7 @@ def check_cop_rvs(cop, rvs=None, nobs=2000, k=10, use_pdf=True):
         nobs = rvs.shape[0]
     freq = frequencies_fromdata(rvs, k, use_ranks=True)
     pdfg = approx_copula_pdf(cop, k_bins=k, force_uniform=True,
-                             use_pdf=use_pdf).T
+                             use_pdf=use_pdf)
     count_pdf = pdfg * nobs
 
     freq = freq.ravel()
@@ -507,9 +507,9 @@ class CheckRvsDim():
 
         k = self.dim
         assert k == rvs.shape[1]
-        
+
         tau_cop = self.copula.tau()
-        
+
         if np.ndim(tau_cop) == 2:
             # elliptical copula with tau matrix
             tau = np.eye(k)
@@ -523,7 +523,7 @@ class CheckRvsDim():
                     for i in range(k) for j in range(i+1, k)]
             tau = np.mean(taus)
             atol = 0
-        
+
         assert_allclose(tau, tau_cop, rtol=0.05, atol=atol)
         theta_est = self.copula.fit_corr_param(rvs)
         # specific to archimedean

--- a/statsmodels/distributions/copula/tests/test_copula.py
+++ b/statsmodels/distributions/copula/tests/test_copula.py
@@ -154,13 +154,18 @@ gev_list = [
 def check_cop_rvs(cop, rvs=None, nobs=2000, k=10, use_pdf=True):
     if rvs is None:
         rvs = cop.rvs(nobs)
+    else:
+        nobs = rvs.shape[0]
     freq = frequencies_fromdata(rvs, k, use_ranks=True)
     if use_pdf:
-        pdfg = approx_copula_pdf(cop, k_bins=k, force_uniform=True)
+        pdfg = approx_copula_pdf(cop, k_bins=k, force_uniform=False) #True)
         count_pdf = pdfg * nobs
     else:
         # use copula cdf if available
         raise NotImplementedError
+
+    freq = freq.ravel()
+    count_pdf = count_pdf.ravel()
     mask = count_pdf < 2
     if mask.sum() > 5:
         cp = count_pdf[mask]

--- a/statsmodels/distributions/tools.py
+++ b/statsmodels/distributions/tools.py
@@ -240,8 +240,9 @@ def frequencies_fromdata(data, k_bins, use_ranks=True):
     future. API will change.
     """
     data = np.asarray(data)
+    k_dim = data.shape[-1]
     k = k_bins + 1
-    g2 = _Grid([k, k], eps=0)
+    g2 = _Grid([k] * k_dim, eps=0)
     if use_ranks:
         data = _rankdata_no_ties(data) / (data.shape[0] + 1)
         # alternatives: scipy handles ties, but uses np.apply_along_axis
@@ -279,11 +280,13 @@ def approx_copula_pdf(copula, k_bins=10, force_uniform=True):
     This function is intended for internal use and will be generalized in
     future. API will change.
     """
+    k_dim = copula.k_dim
     k = k_bins + 1
-    g = _Grid([k, k], eps=0.1 / k_bins)
-    pdfg = copula.pdf(g.x_flat).reshape(k, k, order="F")
+    g = _Grid([k] * k_dim, eps=0.1 / k_bins)
+    ks = tuple([k] * k_dim)
+    pdfg = copula.pdf(g.x_flat).reshape(*ks, order="F")
     # correct for bin size
-    pdfg *= 1 / k**2
+    pdfg *= 1 / k**k_dim
     ag = average_grid(pdfg)
     if force_uniform:
         pdf_grid = nearest_matrix_margins(ag, maxiter=100, tol=1e-8)

--- a/statsmodels/distributions/tools.py
+++ b/statsmodels/distributions/tools.py
@@ -305,10 +305,10 @@ def approx_copula_pdf(copula, k_bins=10, force_uniform=True, use_pdf=False):
     """
     k_dim = copula.k_dim
     k = k_bins + 1
-    g = _Grid([k] * k_dim, eps=0.1 / k_bins)
     ks = tuple([k] * k_dim)
 
     if use_pdf:
+        g = _Grid([k] * k_dim, eps=0.1 / k_bins)
         pdfg = copula.pdf(g.x_flat).reshape(*ks, order="F")
         # correct for bin size
         pdfg *= 1 / k**k_dim
@@ -318,6 +318,7 @@ def approx_copula_pdf(copula, k_bins=10, force_uniform=True, use_pdf=False):
         else:
             pdf_grid = ag / ag.sum()
     else:
+        g = _Grid([k] * k_dim, eps=1e-6)
         cdfg = copula.cdf(g.x_flat).reshape(*ks, order="F")
         # correct for bin size
         pdf_grid = cdf2prob_grid(cdfg, prepend=None)

--- a/statsmodels/distributions/tools.py
+++ b/statsmodels/distributions/tools.py
@@ -309,7 +309,7 @@ def approx_copula_pdf(copula, k_bins=10, force_uniform=True, use_pdf=False):
 
     if use_pdf:
         g = _Grid([k] * k_dim, eps=0.1 / k_bins)
-        pdfg = copula.pdf(g.x_flat).reshape(*ks, order="F")
+        pdfg = copula.pdf(g.x_flat).reshape(*ks)
         # correct for bin size
         pdfg *= 1 / k**k_dim
         ag = average_grid(pdfg)
@@ -319,7 +319,7 @@ def approx_copula_pdf(copula, k_bins=10, force_uniform=True, use_pdf=False):
             pdf_grid = ag / ag.sum()
     else:
         g = _Grid([k] * k_dim, eps=1e-6)
-        cdfg = copula.cdf(g.x_flat).reshape(*ks, order="F")
+        cdfg = copula.cdf(g.x_flat).reshape(*ks)
         # correct for bin size
         pdf_grid = cdf2prob_grid(cdfg, prepend=None)
         # TODO: check boundary approximation, eg. undefined at zero


### PR DESCRIPTION
trying to extend archimedean rvs to general k_dim

It looks like the current formulas immediately extend to k_dim > 2.

However, I have problems creating unit tests for it.  We need some gof statistics to check whether the generated data has distribution close to the data generating distribution (rvs).
2-dim marginals of k_dim = 3 look good, graphically and with approximate gof test.
But it doesn't work for full  k_dim=3 copula.

Current helper function in test_copula was written for 2-d case and does not work for k_dim=3. When I fix it, it rejects the null for the archimedean. Limitation is that function uses approximation using pdf instead of cdf.
`check_cop_rvs(cop, rvs=None, nobs=2000, k=10, use_pdf=True)`

We need better helper tools for mv distribution approximation for k-dim>2.
eg. in statsmodels.distributions.tools,  approx_copula_pdf,  frequencies_fromdata, and helper functions
no `approx_copula_cdf` yet AFAICS.
`nearest_matrix_margins` is only for k_dim=2, #7444

I had used some of those parts with uncommitted extensions when checking BernsteinDistribution.
related: #7470 #7302
