### PR TITLE
ENH/TST: Possibility of not printing r-squared in summary_col

### DIFF
--- a/statsmodels/iolib/tests/test_summary2.py
+++ b/statsmodels/iolib/tests/test_summary2.py
@@ -183,11 +183,23 @@ def test_ols_summary_rsquared_label():
         assert r2_str in str(reg_without_constant.summary())
 
 
-def test_summary_col_r2():
-    # GH 6578
-    y = [1, 1, 4, 2] * 4
-    x = add_constant([1, 2, 3, 4] * 4)
-    mod = OLS(endog=y, exog=x).fit()
-    table = summary_col(results=mod)
-    assert "R-squared  " in str(table)
-    assert "R-squared Adj." in str(table)
+class TestSummaryLabels:
+    """
+    Test that the labels are correctly set in the summary table"""
+
+    @classmethod
+    def setup_class(cls):
+        y = [1, 1, 4, 2] * 4
+        x = add_constant([1, 2, 3, 4] * 4)
+        cls.mod = OLS(endog=y, exog=x).fit()
+
+    def test_summary_col_r2(self,):
+        # GH 6578
+        table = summary_col(results=self.mod, include_r2=True)
+        assert "R-squared  " in str(table)
+        assert "R-squared Adj." in str(table)
+
+    def test_absence_of_r2(self,):
+        table = summary_col(results=self.mod, include_r2=False)
+        assert "R-squared" not in str(table)
+        assert "R-squared Adj." not in str(table)


### PR DESCRIPTION
- [x] closes #xxxx
- [x] tests added / passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
