### PR TITLE
Fix test_knockoff.py::test_sim failures and link

### DIFF
--- a/statsmodels/stats/_knockoff.py
+++ b/statsmodels/stats/_knockoff.py
@@ -20,7 +20,7 @@ Reference
 ---------
 Rina Foygel Barber, Emmanuel Candes (2015).  Controlling the False
 Discovery Rate via Knockoffs.  Annals of Statistics 43:5.
-http://statweb.stanford.edu/~candes/papers/FDR_regression.pdf
+https://candes.su.domains/publications/downloads/FDR_regression.pdf
 """
 
 import numpy as np

--- a/statsmodels/stats/tests/test_knockoff.py
+++ b/statsmodels/stats/tests/test_knockoff.py
@@ -154,4 +154,4 @@ def test_sim(method, tester, n, p, es):
     assert_array_equal(power > 0.6, True)
 
     # Check that we are close to the target FDR
-    assert_array_equal(fdr < target_fdr + 0.05, True)
+    assert_array_equal(fdr < target_fdr + 0.1, True)


### PR DESCRIPTION
(sorry, I seem to have submitted that unfinished by accident, the title is supposed to be "Fix test_knockoff.py::test_sim failures and link")

Ubuntu's statsmodels [failed test_knockoff.py::test_sim on some (unusual) hardware](https://launchpadlibrarian.net/650184054/buildlog_ubuntu-lunar-s390x.statsmodels_0.13.5+dfsg-6_BUILDING.txt.gz).

This is probably because a fixed random seed only gives fixed results within a hardware type, and the threshold is strict enough that random failures are expected.  (It [can](https://salsa.debian.org/science-team/statsmodels/-/jobs/3944557/raw) also [fail](
https://salsa.debian.org/science-team/statsmodels/-/jobs/3944556/raw) on x86 if the random seed is changed.)  A rough estimate is that it fails when negativebinomial(6\*10,p=0.5)>0.05\*30\*10, or ~10% of the time.

This increases the tolerance to avoid this.  (Alternatively, we could instead skip this test on non-x86 hardware.)

It also fixes a broken link.