### PR TITLE
TST: readd deleted test_package.py 

### DIFF
--- a/statsmodels/tests/test_package.py
+++ b/statsmodels/tests/test_package.py
@@ -1,0 +1,25 @@
+import subprocess
+import sys
+
+
+def test_lazy_imports():
+    # Check that when statsmodels.api is imported, matplotlib is _not_ imported
+    cmd = ("import statsmodels.api as sm; "
+           "import sys; "
+           "mods = [x for x in sys.modules if 'matplotlib.pyplot' in x]; "
+           "assert not mods, mods")
+    cmd = sys.executable + ' -c "' + cmd + '"'
+    p = subprocess.Popen(cmd, shell=True, close_fds=True)
+    p.wait()
+    rc = p.returncode
+    assert rc == 0
+
+
+def test_docstring_optimization_compat():
+    # GH#5235 check that importing with stripped docstrings does not raise
+    cmd = sys.executable + ' -OO -c "import statsmodels.api as sm"'
+    p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE,
+                         stderr=subprocess.PIPE)
+    out = p.communicate()
+    rc = p.returncode
+    assert rc == 0, out


### PR DESCRIPTION
closes #8692

unintentionally deleted test module
deleted in #8343
file at commit for history and blame https://github.com/statsmodels/statsmodels/blob/35b803767bd7803ca5f9fc35d4546aa8cb7be844/statsmodels/tests/test_package.py 