### PR TITLE
BUG/DOC: doc fixes, bugs in proportion

### DIFF
--- a/statsmodels/regression/linear_model.py
+++ b/statsmodels/regression/linear_model.py
@@ -2429,7 +2429,7 @@ class RegressionResults(base.LikelihoodModelResults):
 
         - 'HAC': heteroskedasticity-autocorrelation robust covariance
 
-          ``maxlag`` :  integer, required
+          ``maxlags`` :  integer, required
             number of lags to use
 
           ``kernel`` : {callable, str}, optional
@@ -2471,7 +2471,7 @@ class RegressionResults(base.LikelihoodModelResults):
 
           ``time`` : array_like, required
             index of time periods
-          ``maxlag`` : integer, required
+          ``maxlags`` : integer, required
             number of lags to use
           ``kernel`` : {callable, str}, optional
             The available kernels are ['bartlett', 'uniform']. The default is
@@ -2495,7 +2495,7 @@ class RegressionResults(base.LikelihoodModelResults):
             indicator for groups
           ``time`` : array_like[int]
             index of time periods
-          ``maxlag`` : int, required
+          ``maxlags`` : int, required
             number of lags to use
           ``kernel`` : {callable, str}, optional
             Available kernels are ['bartlett', 'uniform'], default

--- a/statsmodels/stats/proportion.py
+++ b/statsmodels/stats/proportion.py
@@ -1543,7 +1543,6 @@ def score_test_proportions_2indep(count1, nobs1, count2, nobs2, value=None,
             prop0 = 2 * p * np.cos(a) - tmp2 / (3 * tmp3)
             prop1 = prop0 + diff
 
-        correction = True
         var = prop1 * (1 - prop1) / nobs1 + prop0 * (1 - prop0) / nobs0
         if correction:
             var *= nobs / (nobs - 1)

--- a/statsmodels/stats/proportion.py
+++ b/statsmodels/stats/proportion.py
@@ -115,11 +115,12 @@ def proportion_confint(count, nobs, alpha:float=0.05, method="normal"):
 
     Parameters
     ----------
-    count : {int, array_like}
+    count : {int or float, array_like}
         number of successes, can be pandas Series or DataFrame. Arrays
-        must contain integer values.
-    nobs : {int, array_like}
-        total number of trials.  Arrays must contain integer values.
+        must contain integer values if method is "binom_test".
+    nobs : {int or float, array_like}
+        total number of trials.  Arrays must contain integer values if method
+        is "binom_test".
     alpha : float
         Significance level, default 0.05. Must be in (0, 1)
     method : {"normal", "agresti_coull", "beta", "wilson", "binom_test"}
@@ -183,8 +184,9 @@ def proportion_confint(count, nobs, alpha:float=0.05, method="normal"):
             )
         return y
 
-    count_a = _check(np.asarray(count_a), "count")
-    nobs_a = _check(np.asarray(nobs_a), "count")
+    if method == "binom_test":
+        count_a = _check(np.asarray(count_a), "count")
+        nobs_a = _check(np.asarray(nobs_a), "count")
 
     q_ = count_a / nobs_a
     alpha_2 = 0.5 * alpha

--- a/statsmodels/stats/tests/test_proportion.py
+++ b/statsmodels/stats/tests/test_proportion.py
@@ -699,7 +699,7 @@ def test_confint_2indep_propcis():
     ci = 0.0270416, 0.3452912
     ci1 = confint_proportions_2indep(count1, nobs1, count2, nobs2,
                                      compare="diff",
-                                     method="score", correction=False)
+                                     method="score", correction=True)
     assert_allclose(ci1, ci, atol=0.002)  # lower agreement (iterative)
     # > wald2ci(7, 34, 1, 34, 0.95, adjust="AC")
     ci = 0.01161167, 0.32172166

--- a/statsmodels/stats/tests/test_proportion.py
+++ b/statsmodels/stats/tests/test_proportion.py
@@ -98,6 +98,12 @@ def test_confint_proportion_ndim(method):
                                  method=method)
     assert_allclose((ci_arr2[0][1, 2], ci_arr[1][1, 2]), ci12, rtol=1e-13)
 
+    # check floating point values
+    ci_arr2 = proportion_confint(count + 1e-4, nobs[1, 2], alpha=0.05,
+                                 method=method)
+    # should be close to values with integer values
+    assert_allclose((ci_arr2[0][1, 2], ci_arr[1][1, 2]), ci12, rtol=1e-4)
+
 
 def test_samplesize_confidenceinterval_prop():
     #consistency test for samplesize to achieve confidence_interval
@@ -966,12 +972,14 @@ def test_ci_symmetry_binom_test(nobs, count, array_like):
 
 
 def test_int_check():
+    # integer values are required only if method="binom_test"
     with pytest.raises(ValueError):
-        proportion_confint(10.5, 20)
+        proportion_confint(10.5, 20, method="binom_test")
     with pytest.raises(ValueError):
-        proportion_confint(10, 20.5)
+        proportion_confint(10, 20.5, method="binom_test")
     with pytest.raises(ValueError):
-        proportion_confint(np.array([10.3]), 20)
+        proportion_confint(np.array([10.3]), 20, method="binom_test")
+
     a = proportion_confint(21.0, 47, method="binom_test")
     b = proportion_confint(21, 47, method="binom_test")
     c = proportion_confint(21, 47.0, method="binom_test")


### PR DESCRIPTION
- reenable floats in proportion_confint except for method="binom_test"
  https://github.com/statsmodels/statsmodels/pull/7998#issuecomment-1438922706
- fix type in docstring closes #8698
- score_test_proportions_2indep hardcoded correction closes #8704
