### PR TITLE
ENH/TST: AR/MA creation with ArmaProcess.from_roots

### DIFF
--- a/statsmodels/tsa/arima_process.py
+++ b/statsmodels/tsa/arima_process.py
@@ -750,10 +750,10 @@ class ArmaProcess:
 
         Parameters
         ----------
-        maroots : array_like
+        maroots : array_like, optional
             Roots for the MA polynomial
             1 + theta_1*z + theta_2*z^2 + ..... + theta_n*z^n
-        arroots : array_like
+        arroots : array_like, optional
             Roots for the AR polynomial
             1 - phi_1*z - phi_2*z^2 - ..... - phi_n*z^n
         nobs : int, optional
@@ -775,13 +775,21 @@ class ArmaProcess:
         >>> arma_process.isinvertible
         True
         """
-        arpoly = np.polynomial.polynomial.Polynomial.fromroots(arroots)
-        mapoly = np.polynomial.polynomial.Polynomial.fromroots(maroots)
+        if arroots is not None and len(arroots):
+            arpoly = np.polynomial.polynomial.Polynomial.fromroots(arroots)
+            arcoefs = arpoly.coef[1:] / arpoly.coef[0]
+        else:
+            arcoefs = []
+
+        if maroots is not None and len(maroots):
+            mapoly = np.polynomial.polynomial.Polynomial.fromroots(maroots)
+            macoefs = mapoly.coef[1:] / mapoly.coef[0]
+        else:
+            macoefs = []
+
         # As from_coeffs will create a polynomial with constant 1/-1,(MA/AR)
         # we need to scale the polynomial coefficients accordingly
-        return cls(np.r_[1, -np.asarray(-1 * arpoly.coef[1:] / arpoly.coef[0])],
-                   np.r_[1, np.asarray(mapoly.coef[1:] / mapoly.coef[0])],
-                   nobs=nobs)
+        return cls(np.r_[1, arcoefs], np.r_[1, macoefs], nobs=nobs)
 
     @classmethod
     def from_coeffs(cls, arcoefs=None, macoefs=None, nobs=100):

--- a/statsmodels/tsa/tests/test_arima_process.py
+++ b/statsmodels/tsa/tests/test_arima_process.py
@@ -287,6 +287,39 @@ class TestArmaProcess:
         assert_almost_equal(process.isinvertible, process_direct.isinvertible)
         assert_almost_equal(process.isstationary, process_direct.isstationary)
 
+        process_direct = ArmaProcess(ar=ar_p)
+        process = ArmaProcess.from_roots(arroots=np.array(process_direct.arroots))
+
+        assert_almost_equal(process.arcoefs, process_direct.arcoefs)
+        assert_almost_equal(process.macoefs, process_direct.macoefs)
+        assert_almost_equal(process.nobs, process_direct.nobs)
+        assert_almost_equal(process.maroots, process_direct.maroots)
+        assert_almost_equal(process.arroots, process_direct.arroots)
+        assert_almost_equal(process.isinvertible, process_direct.isinvertible)
+        assert_almost_equal(process.isstationary, process_direct.isstationary)
+
+        process_direct = ArmaProcess(ma=ma_p)
+        process = ArmaProcess.from_roots(maroots=np.array(process_direct.maroots))
+
+        assert_almost_equal(process.arcoefs, process_direct.arcoefs)
+        assert_almost_equal(process.macoefs, process_direct.macoefs)
+        assert_almost_equal(process.nobs, process_direct.nobs)
+        assert_almost_equal(process.maroots, process_direct.maroots)
+        assert_almost_equal(process.arroots, process_direct.arroots)
+        assert_almost_equal(process.isinvertible, process_direct.isinvertible)
+        assert_almost_equal(process.isstationary, process_direct.isstationary)
+
+        process_direct = ArmaProcess()
+        process = ArmaProcess.from_roots()
+
+        assert_almost_equal(process.arcoefs, process_direct.arcoefs)
+        assert_almost_equal(process.macoefs, process_direct.macoefs)
+        assert_almost_equal(process.nobs, process_direct.nobs)
+        assert_almost_equal(process.maroots, process_direct.maroots)
+        assert_almost_equal(process.arroots, process_direct.arroots)
+        assert_almost_equal(process.isinvertible, process_direct.isinvertible)
+        assert_almost_equal(process.isstationary, process_direct.isstationary)
+
     def test_from_coeff(self):
         ar = [1.8, -0.9]
         ma = [0.3]


### PR DESCRIPTION
**Issue**: `ArmaProcess` can be created without AR or MA coefficient with `__init__` and `from_coeffs`. It looks like `from_roots` should also support this feature. But actually, when the method is called with empty (`None` or `[]`) `arroots` or `maroots` it throws exceptions. This is because `np.polynomial.polynomial.Polynomial.fromroots` does not work with `None` or `[]`.

This PR solves the issue and makes possible to call:
- `ArmaProcess.from_roots(arroots=[...])`
- `ArmaProcess.from_roots(maroots=[...])`
- `ArmaProcess.from_roots()`


