### PR TITLE
BUG: loop instead of if in SARIMAX transition init

### DIFF
--- a/statsmodels/tsa/statespace/sarimax.py
+++ b/statsmodels/tsa/statespace/sarimax.py
@@ -760,7 +760,7 @@ class SARIMAX(MLEModel):
                 transition[start:end, start:end] = seasonal_companion
 
                 # i
-                for i in range(d + 1, self._k_seasonal_diff):
+                if d < self._k_seasonal_diff - 1:
                     transition[start, end + self.seasonal_periods - 1] = 1
 
                 # \iota


### PR DESCRIPTION
**Issue**: `SARIMAX.initial_transition` method contains loop which body does not depends on loop variable `i` and can be replaced with `if` comparison (line 763).

https://github.com/statsmodels/statsmodels/blob/a948e8dee9e99a08f249f67ca2ac5df68fea835b/statsmodels/tsa/statespace/sarimax.py#L752-L767

The variable `d` in outer loop (line 755) ranges from `0` to `self._k_seasonal_diff` (not including). Inner loop (line 763) ranges from `d + 1` to `self._k_seasonal_diff` and repeats same operation `max(0, self._k_seasonal_diff - d - 1)` times. Which corresponds to condition `d < self._k_seasonal_diff - 1`.
