### PR TITLE
DOC: fix developer page linting requirements

### DIFF
--- a/docs/source/dev/index.rst
+++ b/docs/source/dev/index.rst
@@ -50,9 +50,9 @@ greatly helps the job of maintaining and releasing the software a shared effort.
     make html
 
   Check that the build output does not have *any* warnings due to your changes.
-- Follow `PEP8 <https://www.python.org/dev/peps/pep-0008/>`_ style guidelines
-  wherever possible. Compare your code to what's in main by running
-  ``git diff upstream/main -u -- "*.py" | flake8 --diff --isolated`` prior to submitting.
+- Follow `PEP8 <https://www.python.org/dev/peps/pep-0008/>`_ style guidelines wherever possible. 
+  Lint your code by running ``LINT=true ./lint.sh``. 
+- Compare your changes to what’s in main by running ``git diff upstream/main``.
 - Finally, please add your changes to the release notes. Open the
   ``docs/source/release/versionX.X.rst`` file that has the version number of the
   next release and add your changes to the appropriate section.


### PR DESCRIPTION
**Issue**: [developer page](https://www.statsmodels.org/stable/dev/index.html) suggests using a non-existent flake8 flag `--diff`. 

> Follow [PEP8](https://www.python.org/dev/peps/pep-0008/) style guidelines wherever possible. Compare your code to what’s in main by running git diff upstream/main -u -- "*.py" | flake8 --diff --isolated prior to submitting.

The option `--diff` was removed in version 6.0.0 (https://flake8.pycqa.org/en/latest/release-notes/6.0.0.html#backwards-incompatible-changes).
