### PR TITLE
Bug fix freq wasn't passed in SARIMAX class

### DIFF
--- a/statsmodels/tsa/statespace/sarimax.py
+++ b/statsmodels/tsa/statespace/sarimax.py
@@ -512,7 +512,7 @@ class SARIMAX(MLEModel):
 
         # Initialize the statespace
         super(SARIMAX, self).__init__(
-            endog, exog=exog, k_states=k_states, k_posdef=k_posdef, **kwargs
+            endog, exog=exog, k_states=k_states, k_posdef=k_posdef, freq=freq, **kwargs
         )
 
         # Set the filter to concentrate out the scale if requested


### PR DESCRIPTION
ValueWarning: No frequency information was provided, so inferred frequency D will be used. Even though freq was passed in.

``` python
import pandas as pd
import numpy as np
from statsmodels.tsa.arima.model import ARIMA
from statsmodels.tools.eval_measures import rmse

def predict_future_amounts(data, future_days=5):
    # Convert the data to a pandas DataFrame
    df = pd.DataFrame(data)
    df["dates"] = pd.to_datetime(df["dates"])

    # Prepare the data for the model
    df = df.set_index("dates")
    y = df["amounts"]

    # Train an ARIMA model
    model = ARIMA(y, order=(1, 1, 1), freq='D')
    model_fit = model.fit()

    # Predict future amounts
    y_future = model_fit.forecast(steps=future_days)
    future_dates = pd.date_range(df.index.max() + pd.Timedelta(days=1), periods=future_days)

    # Add the future dates and amounts to the original data
    future_data = {
        "dates": future_dates.strftime('%Y-%m-%d').tolist(),
        "amounts": y_future.tolist()
    }

    return future_data

data = {
    "dates": ["2023-03-01", "2023-03-02", "2023-03-03", "2023-03-04", "2023-03-05"],
    "amounts": [100, 110, 105, 120, 130],
}

future = predict_future_amounts(data)
print(future)
```
Error shown before fix
```cmd output
ValueWarning: No frequency information was provided, so inferred frequency D will be used. 
```

