### PR TITLE
ENH/BUG: statespace: issue FutureWarning for unknown keyword args

### DIFF
--- a/statsmodels/regression/recursive_ls.py
+++ b/statsmodels/regression/recursive_ls.py
@@ -106,6 +106,12 @@ class RecursiveLS(MLEModel):
         # Handle coefficient initialization
         kwargs.setdefault('initialization', 'diffuse')
 
+        # Remove some formula-specific kwargs
+        formula_kwargs = ['missing', 'missing_idx', 'formula', 'design_info']
+        for name in formula_kwargs:
+            if name in kwargs:
+                del kwargs[name]
+
         # Initialize the state space representation
         super(RecursiveLS, self).__init__(
             endog, k_states=self.k_exog, exog=exog, **kwargs)
@@ -507,6 +513,7 @@ class RecursiveLSResults(MLEResults):
 
     @Appender(MLEResults.get_prediction.__doc__)
     def get_prediction(self, start=None, end=None, dynamic=False,
+                       information_set='predicted', signal_only=False,
                        index=None, **kwargs):
         # Note: need to override this, because we currently do not support
         # dynamic prediction or forecasts when there are constraints.
@@ -534,6 +541,8 @@ class RecursiveLSResults(MLEResults):
 
         # Return a new mlemodel.PredictionResults object
         res_obj = PredictionResults(self, prediction_results,
+                                    information_set=information_set,
+                                    signal_only=signal_only,
                                     row_labels=prediction_index)
         return PredictionResultsWrapper(res_obj)
 

--- a/statsmodels/tsa/statespace/dynamic_factor_mq.py
+++ b/statsmodels/tsa/statespace/dynamic_factor_mq.py
@@ -3294,8 +3294,7 @@ class DynamicFactorMQ(mlemodel.MLEModel):
             orthogonalized=orthogonalized, cumulative=cumulative,
             anchor=anchor, exog=exog, extend_model=extend_model,
             extend_kwargs=extend_kwargs, transformed=transformed,
-            includes_fixed=includes_fixed, original_scale=original_scale,
-            **kwargs)
+            includes_fixed=includes_fixed, **kwargs)
 
         # If applicable, convert predictions back to original space
         if self.standardize and original_scale:
@@ -4152,7 +4151,7 @@ class DynamicFactorMQResults(mlemodel.MLEResults):
                 self.filter_results)
             mod.ssm.initialization = init
 
-        res = self._apply(mod, refit=refit, fit_kwargs=fit_kwargs, **kwargs)
+        res = self._apply(mod, refit=refit, fit_kwargs=fit_kwargs)
 
         return res
 

--- a/statsmodels/tsa/statespace/exponential_smoothing.py
+++ b/statsmodels/tsa/statespace/exponential_smoothing.py
@@ -148,8 +148,7 @@ class ExponentialSmoothing(MLEModel):
     def __init__(self, endog, trend=False, damped_trend=False, seasonal=None,
                  initialization_method='estimated', initial_level=None,
                  initial_trend=None, initial_seasonal=None, bounds=None,
-                 concentrate_scale=True, dates=None, freq=None,
-                 missing='none'):
+                 concentrate_scale=True, dates=None, freq=None):
         # Model definition
         self.trend = bool_like(trend, 'trend')
         self.damped_trend = bool_like(damped_trend, 'damped_trend')
@@ -207,7 +206,7 @@ class ExponentialSmoothing(MLEModel):
                                       constant=[0] * k_states)
         super(ExponentialSmoothing, self).__init__(
             endog, k_states=k_states, k_posdef=k_posdef,
-            initialization=init, dates=dates, freq=freq, missing=missing)
+            initialization=init, dates=dates, freq=freq)
 
         # Concentrate the scale out of the likelihood function
         if self.concentrate_scale:
@@ -307,7 +306,7 @@ class ExponentialSmoothing(MLEModel):
         self._init_keys += ['trend', 'damped_trend', 'seasonal',
                             'initialization_method', 'initial_level',
                             'initial_trend', 'initial_seasonal', 'bounds',
-                            'concentrate_scale', 'dates', 'freq', 'missing']
+                            'concentrate_scale', 'dates', 'freq']
 
     def _get_init_kwds(self):
         kwds = super()._get_init_kwds()

--- a/statsmodels/tsa/statespace/kalman_filter.py
+++ b/statsmodels/tsa/statespace/kalman_filter.py
@@ -374,6 +374,24 @@ class KalmanFilter(Representation):
     def __init__(self, k_endog, k_states, k_posdef=None,
                  loglikelihood_burn=0, tolerance=1e-19, results_class=None,
                  kalman_filter_classes=None, **kwargs):
+        # Extract keyword arguments to-be-used later
+        keys = ['filter_method'] + KalmanFilter.filter_methods
+        filter_method_kwargs = {key: kwargs.pop(key) for key in keys
+                                if key in kwargs}
+        keys = ['inversion_method'] + KalmanFilter.inversion_methods
+        inversion_method_kwargs = {key: kwargs.pop(key) for key in keys
+                                   if key in kwargs}
+        keys = ['stability_method'] + KalmanFilter.stability_methods
+        stability_method_kwargs = {key: kwargs.pop(key) for key in keys
+                                   if key in kwargs}
+        keys = ['conserve_memory'] + KalmanFilter.memory_options
+        conserve_memory_kwargs = {key: kwargs.pop(key) for key in keys
+                                  if key in kwargs}
+        keys = ['alternate_timing'] + KalmanFilter.timing_options
+        filter_timing_kwargs = {key: kwargs.pop(key) for key in keys
+                                if key in kwargs}
+
+        # Initialize the base class
         super(KalmanFilter, self).__init__(
             k_endog, k_states, k_posdef, **kwargs
         )
@@ -392,11 +410,11 @@ class KalmanFilter(Representation):
             if kalman_filter_classes is not None
             else tools.prefix_kalman_filter_map.copy())
 
-        self.set_filter_method(**kwargs)
-        self.set_inversion_method(**kwargs)
-        self.set_stability_method(**kwargs)
-        self.set_conserve_memory(**kwargs)
-        self.set_filter_timing(**kwargs)
+        self.set_filter_method(**filter_method_kwargs)
+        self.set_inversion_method(**inversion_method_kwargs)
+        self.set_stability_method(**stability_method_kwargs)
+        self.set_conserve_memory(**conserve_memory_kwargs)
+        self.set_filter_timing(**filter_timing_kwargs)
 
         self.tolerance = tolerance
 
@@ -421,7 +439,7 @@ class KalmanFilter(Representation):
         kwargs.setdefault('inversion_method', self.inversion_method)
         kwargs.setdefault('stability_method', self.stability_method)
         kwargs.setdefault('conserve_memory', self.conserve_memory)
-        kwargs.setdefault('filter_timing', self.filter_timing)
+        kwargs.setdefault('alternate_timing', bool(self.filter_timing))
         kwargs.setdefault('tolerance', self.tolerance)
         kwargs.setdefault('loglikelihood_burn', self.loglikelihood_burn)
 

--- a/statsmodels/tsa/statespace/kalman_smoother.py
+++ b/statsmodels/tsa/statespace/kalman_smoother.py
@@ -106,6 +106,15 @@ class KalmanSmoother(KalmanFilter):
         if results_class is None:
             results_class = SmootherResults
 
+        # Extract keyword arguments to-be-used later
+        keys = ['smoother_output'] + KalmanSmoother.smoother_outputs
+        smoother_output_kwargs = {key: kwargs.pop(key) for key in keys
+                                  if key in kwargs}
+        keys = ['smooth_method'] + KalmanSmoother.smooth_methods
+        smooth_method_kwargs = {key: kwargs.pop(key) for key in keys
+                                if key in kwargs}
+
+        # Initialize the base class
         super(KalmanSmoother, self).__init__(
             k_endog, k_states, k_posdef, results_class=results_class, **kwargs
         )
@@ -120,8 +129,8 @@ class KalmanSmoother(KalmanFilter):
         self._kalman_smoothers = {}
 
         # Set the smoother options
-        self.set_smoother_output(**kwargs)
-        self.set_smooth_method(**kwargs)
+        self.set_smoother_output(**smoother_output_kwargs)
+        self.set_smooth_method(**smooth_method_kwargs)
 
     def _clone_kwargs(self, endog, **kwargs):
         # See Representation._clone_kwargs for docstring

--- a/statsmodels/tsa/statespace/mlemodel.py
+++ b/statsmodels/tsa/statespace/mlemodel.py
@@ -3751,7 +3751,7 @@ class MLEResults(tsbase.TimeSeriesModelResults):
                 irfs = irfs.values
         return irfs
 
-    def _apply(self, mod, refit=False, fit_kwargs=None, **kwargs):
+    def _apply(self, mod, refit=False, fit_kwargs=None):
         if fit_kwargs is None:
             fit_kwargs = {}
 
@@ -4325,7 +4325,7 @@ class MLEResults(tsbase.TimeSeriesModelResults):
             kwargs.setdefault('initialization', init)
 
         mod = self.model.clone(new_endog, exog=new_exog, **kwargs)
-        res = self._apply(mod, refit=refit, fit_kwargs=fit_kwargs, **kwargs)
+        res = self._apply(mod, refit=refit, fit_kwargs=fit_kwargs)
 
         return res
 
@@ -4421,7 +4421,7 @@ class MLEResults(tsbase.TimeSeriesModelResults):
         mod.ssm.initialization = Initialization(
             mod.k_states, 'known', constant=self.predicted_state[..., -1],
             stationary_cov=self.predicted_state_cov[..., -1])
-        res = self._apply(mod, refit=False, fit_kwargs=fit_kwargs, **kwargs)
+        res = self._apply(mod, refit=False, fit_kwargs=fit_kwargs)
 
         return res
 
@@ -4514,7 +4514,7 @@ class MLEResults(tsbase.TimeSeriesModelResults):
             init = Initialization.from_results(self.filter_results)
             mod.ssm.initialization = init
 
-        res = self._apply(mod, refit=refit, fit_kwargs=fit_kwargs, **kwargs)
+        res = self._apply(mod, refit=refit, fit_kwargs=fit_kwargs)
 
         return res
 

--- a/statsmodels/tsa/statespace/representation.py
+++ b/statsmodels/tsa/statespace/representation.py
@@ -334,25 +334,25 @@ class Representation:
                                       else tools.prefix_statespace_map.copy())
 
         # State-space initialization data
-        self.initialization = kwargs.get('initialization', None)
+        self.initialization = kwargs.pop('initialization', None)
         basic_inits = ['diffuse', 'approximate_diffuse', 'stationary']
 
         if self.initialization in basic_inits:
             self.initialize(self.initialization)
         elif self.initialization == 'known':
             if 'constant' in kwargs:
-                constant = kwargs['constant']
+                constant = kwargs.pop('constant')
             elif 'initial_state' in kwargs:
                 # TODO deprecation warning
-                constant = kwargs['initial_state']
+                constant = kwargs.pop('initial_state')
             else:
                 raise ValueError('Initial state must be provided when "known"'
                                  ' is the specified initialization method.')
             if 'stationary_cov' in kwargs:
-                stationary_cov = kwargs['stationary_cov']
+                stationary_cov = kwargs.pop('stationary_cov')
             elif 'initial_state_cov' in kwargs:
                 # TODO deprecation warning
-                stationary_cov = kwargs['initial_state_cov']
+                stationary_cov = kwargs.pop('initial_state_cov')
             else:
                 raise ValueError('Initial state covariance matrix must be'
                                  ' provided when "known" is the specified'
@@ -362,6 +362,12 @@ class Representation:
         elif (not isinstance(self.initialization, Initialization) and
                 self.initialization is not None):
             raise ValueError("Invalid state space initialization method.")
+        
+        # Check for unused kwargs
+        if len(kwargs):
+            raise TypeError(f'{__class__} constructor got unexpected keyword'
+                            f' argument(s): {kwargs}.')
+
 
         # Matrix representations storage
         self._representations = {}

--- a/statsmodels/tsa/statespace/representation.py
+++ b/statsmodels/tsa/statespace/representation.py
@@ -363,7 +363,7 @@ class Representation:
         elif (not isinstance(self.initialization, Initialization) and
                 self.initialization is not None):
             raise ValueError("Invalid state space initialization method.")
-        
+
         # Check for unused kwargs
         if len(kwargs):
             # raise TypeError(f'{__class__} constructor got unexpected keyword'
@@ -372,7 +372,6 @@ class Representation:
                    'Passing unknown keyword arguments will raise a TypeError'
                    ' beginning in version 0.15.')
             warnings.warn(msg, FutureWarning)
-
 
         # Matrix representations storage
         self._representations = {}

--- a/statsmodels/tsa/statespace/representation.py
+++ b/statsmodels/tsa/statespace/representation.py
@@ -5,6 +5,7 @@ Author: Chad Fulton
 License: Simplified-BSD
 """
 
+import warnings
 import numpy as np
 from .tools import (
     find_best_blas_type, validate_matrix_shape, validate_vector_shape
@@ -365,8 +366,12 @@ class Representation:
         
         # Check for unused kwargs
         if len(kwargs):
-            raise TypeError(f'{__class__} constructor got unexpected keyword'
-                            f' argument(s): {kwargs}.')
+            # raise TypeError(f'{__class__} constructor got unexpected keyword'
+            #                 f' argument(s): {kwargs}.')
+            msg = (f'Unknown keyword arguments: {kwargs.keys()}.'
+                   'Passing unknown keyword arguments will raise a TypeError'
+                   ' beginning in version 0.15.')
+            warnings.warn(msg, FutureWarning)
 
 
         # Matrix representations storage

--- a/statsmodels/tsa/statespace/tests/test_fixed_params.py
+++ b/statsmodels/tsa/statespace/tests/test_fixed_params.py
@@ -459,7 +459,7 @@ def test_varmax_validate():
 
     # Now, with enforce_stationarity=False, we can fix any of the AR
     # coefficients
-    mod5 = varmax.VARMAX(endog[['cpi']], ar_order=(2, 0),
+    mod5 = varmax.VARMAX(endog[['cpi']], order=(1, 0),
                          enforce_stationarity=False)
     with mod5.fix_params({'L1.cpi.cpi': 0.6}):
         assert_(mod5._has_fixed_params)
@@ -469,7 +469,7 @@ def test_varmax_validate():
 
     # Now, with enforce_stationarity=False, we can fix any of the AR
     # coefficients
-    mod6 = varmax.VARMAX(endog, ar_order=(1, 0),
+    mod6 = varmax.VARMAX(endog, order=(1, 0),
                          enforce_stationarity=False)
     with mod6.fix_params({'L1.cpi.cpi': 0.6}):
         assert_(mod6._has_fixed_params)

--- a/statsmodels/tsa/statespace/tests/test_mlemodel.py
+++ b/statsmodels/tsa/statespace/tests/test_mlemodel.py
@@ -1225,3 +1225,11 @@ def test_states_index_rangeindex():
     cols = pd.Index(['state.0', 'state.1'])
 
     check_states_index(res.states, ix, predicted_ix, cols)
+
+
+def test_invalid_kwargs():
+    endog = [0, 0, 1.]
+    # Make sure we can create basic SARIMAX
+    sarimax.SARIMAX(endog)
+    # Now check that it raises an error if we add an invalid keyword argument
+    assert_raises(TypeError, sarimax.SARIMAX, endog, invalid_kwarg=True)

--- a/statsmodels/tsa/statespace/tests/test_mlemodel.py
+++ b/statsmodels/tsa/statespace/tests/test_mlemodel.py
@@ -1231,5 +1231,9 @@ def test_invalid_kwargs():
     endog = [0, 0, 1.]
     # Make sure we can create basic SARIMAX
     sarimax.SARIMAX(endog)
-    # Now check that it raises an error if we add an invalid keyword argument
-    assert_raises(TypeError, sarimax.SARIMAX, endog, invalid_kwarg=True)
+    # Now check that it raises a warning if we add an invalid keyword argument
+    with pytest.warns(FutureWarning):
+        sarimax.SARIMAX(endog, invalid_kwarg=True)
+    # (Note: once deprectation is completed in v0.15, switch to checking for
+    # a TypeError, as below)
+    # assert_raises(TypeError, sarimax.SARIMAX, endog, invalid_kwarg=True)


### PR DESCRIPTION
- [x] tests added / passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message.

The base state space class (`Representation`) silent swallows invalid `kwargs`. This fixes that behavior and raises a `TypeError` as usual.