### PR TITLE
Maint: remove deprecated np.alltrue and np.product

### DIFF
--- a/statsmodels/distributions/bernstein.py
+++ b/statsmodels/distributions/bernstein.py
@@ -40,7 +40,7 @@ class BernsteinDistribution:
         self.cdf_grid = cdf_grid = np.asarray(cdf_grid)
         self.k_dim = cdf_grid.ndim
         self.k_grid = cdf_grid.shape
-        self.k_grid_product = np.product([i-1 for i in self.k_grid])
+        self.k_grid_product = np.prod([i-1 for i in self.k_grid])
         self._grid = _Grid(self.k_grid)
 
     @classmethod

--- a/statsmodels/distributions/copula/archimedean.py
+++ b/statsmodels/distributions/copula/archimedean.py
@@ -154,7 +154,7 @@ class ArchimedeanCopula(Copula):
 
         psi = self.transform.evaluate(u, *args).sum(axis)
 
-        pdfv = np.product(phi_d1(u, *args), axis)
+        pdfv = np.prod(phi_d1(u, *args), axis)
         pdfv *= (psi_d(psi, *args))
 
         # use abs, I'm not sure yet about where to add signs

--- a/statsmodels/distributions/tests/test_tools.py
+++ b/statsmodels/distributions/tests/test_tools.py
@@ -148,7 +148,7 @@ def test_bernstein_2d():
         x2d /= x2d.max(0)
 
         res_bp = evalbp(x2d, cd2d)
-        assert_allclose(res_bp, np.product(x2d, axis=1), atol=1e-12)
+        assert_allclose(res_bp, np.prod(x2d, axis=1), atol=1e-12)
 
         # check univariate margins
         x2d = np.column_stack((np.arange(k_x) / (k_x - 1), np.ones(k_x)))

--- a/statsmodels/distributions/tools.py
+++ b/statsmodels/distributions/tools.py
@@ -48,7 +48,7 @@ class _Grid:
         x_marginal = [np.arange(ki) / (ki - 1) for ki in k_grid]
 
         idx_flat = np.column_stack(
-                np.unravel_index(np.arange(np.product(k_grid)), k_grid)
+                np.unravel_index(np.arange(np.prod(k_grid)), k_grid)
                 ).astype(float)
         x_flat = idx_flat / idx_flat.max(0)
         if eps != 0:

--- a/statsmodels/robust/scale.py
+++ b/statsmodels/robust/scale.py
@@ -297,10 +297,10 @@ class Huber:
             nscale = np.sqrt(scale_num / scale_denom)
             nscale = tools.unsqueeze(nscale, axis, a.shape)
 
-            test1 = np.alltrue(
+            test1 = np.all(
                 np.less_equal(np.abs(scale - nscale), nscale * self.tol)
             )
-            test2 = np.alltrue(
+            test2 = np.all(
                 np.less_equal(np.abs(mu - nmu), nscale * self.tol)
             )
             if not (test1 and test2):


### PR DESCRIPTION
closes #8821
handles numpy deprecation alltrue and product, 
(not the one-element-array versus scalar problem)