### PR TITLE
MAINT/DOC: Fix more deprecations and restore doc build

### DIFF
--- a/docs/source/contingency_tables.rst
+++ b/docs/source/contingency_tables.rst
@@ -50,6 +50,7 @@ contingency table cell counts:
     import statsmodels.api as sm
 
     df = sm.datasets.get_rdataset("Arthritis", "vcd").data
+    df.fillna({"Improved":"None"}, inplace=True)
 
     tab = pd.crosstab(df['Treatment'], df['Improved'])
     tab = tab.loc[:, ["None", "Some", "Marked"]]

--- a/docs/source/plots/stl_plot.py
+++ b/docs/source/plots/stl_plot.py
@@ -1,3 +1,4 @@
+import numpy as np
 import matplotlib.pyplot as plt
 from pandas.plotting import register_matplotlib_converters
 
@@ -8,6 +9,6 @@ register_matplotlib_converters()
 data = co2.load().data
 data = data.resample('M').mean().ffill()
 
-res = STL(data).fit()
+res = STL(np.squeeze(data)).fit()
 res.plot()
 plt.show()

--- a/docs/source/treatment.rst
+++ b/docs/source/treatment.rst
@@ -1,7 +1,9 @@
 
 .. module:: statsmodels.treatment
-.. currentmodule:: statsmodels.treatment
    :synopsis: Treatment Effect
+
+.. currentmodule:: statsmodels.treatment
+
 
 
 .. _othermod:

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -1,5 +1,7 @@
 # Requirements for doc build, in addition to requirements.txt
 sphinx>=5,<6
+# Avoid warnings which break Sphinx by pinning pandas
+pandas>=2.0,<2.1
 sphinx-material
 jupyter
 notebook
@@ -14,3 +16,4 @@ theano-pymc; os_name != "nt"
 pymc3; os_name != "nt"
 arviz; os_name != "nt"
 jinja2==3.0.3
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -77,7 +77,7 @@ filterwarnings =
     error:The probit link alias is deprecated:FutureWarning:
     error:Parsing dates in:UserWarning
     error:A value is trying to be set on a copy::
-    error:Conversion of an array with ndim:DeprecationWarning:statsmodels
+    error:Conversion of an array with ndim:DeprecationWarning:
 markers =
     example: mark a test that runs example code
     matplotlib: mark a test that requires matplotlib

--- a/statsmodels/datasets/danish_data/data.py
+++ b/statsmodels/datasets/danish_data/data.py
@@ -60,6 +60,11 @@ def load():
 
 def _get_data():
     data = du.load_csv(__file__, "data.csv")
+    for i, val in enumerate(data.period):
+        parts = val.split("Q")
+        month = (int(parts[1]) - 1) * 3 + 1
+
+        data.loc[data.index[i], "period"] = f"{parts[0]}-{month:02d}-01"
     data["period"] = pd.to_datetime(data.period)
     return data.set_index("period").astype(float)
 

--- a/statsmodels/distributions/copula/archimedean.py
+++ b/statsmodels/distributions/copula/archimedean.py
@@ -21,9 +21,9 @@ def _debye(alpha):
     EPSILON = np.finfo(np.float64).eps * 100
 
     def integrand(t):
-        return t / (np.exp(t) - 1)
-
-    debye_value = integrate.quad(integrand, EPSILON, alpha)[0] / alpha
+        return np.squeeze(t / (np.exp(t) - 1))
+    _alpha = np.squeeze(alpha)
+    debye_value = integrate.quad(integrand, EPSILON, _alpha)[0] / _alpha
     return debye_value
 
 

--- a/statsmodels/emplike/originregress.py
+++ b/statsmodels/emplike/originregress.py
@@ -250,6 +250,7 @@ class OriginResults(RegressionResults):
         f = lambda b0:  self.el_test(np.array([b0]), param_num,
                                      method=method,
                                  stochastic_exog=stochastic_exog)[0] - r0
-        lowerl = optimize.brentq(f, lower_bound, self.params[param_num])
-        upperl = optimize.brentq(f, self.params[param_num], upper_bound)
+        _param = np.squeeze(self.params[param_num])
+        lowerl = optimize.brentq(f, np.squeeze(lower_bound), _param)
+        upperl = optimize.brentq(f, _param, np.squeeze(upper_bound))
         return (lowerl, upperl)

--- a/statsmodels/genmod/families/tests/test_family.py
+++ b/statsmodels/genmod/families/tests/test_family.py
@@ -100,8 +100,10 @@ def test_tweedie_loglike_obs(power):
     scale = 2.9
 
     def pdf(y):
-        return np.exp(tweedie.loglike_obs(
-                    endog=y, mu=mu, scale=scale
-        ))
+        return np.squeeze(
+            np.exp(
+                tweedie.loglike_obs(endog=y, mu=mu, scale=scale)
+            )
+        )
 
     assert_allclose(pdf(0) + integrate.quad(pdf, 0, 1e2)[0], 1, atol=1e-4)

--- a/statsmodels/sandbox/distributions/extras.py
+++ b/statsmodels/sandbox/distributions/extras.py
@@ -817,6 +817,7 @@ class TransfTwo_gen(distributions.rv_continuous):
             return 1.0 - self._cdf(x, *args, **kwargs)
 
     def _munp(self, n, *args, **kwargs):
+        args = [np.squeeze(arg) for arg in args]
         out = np.squeeze(self._mom0_sc(n, *args))
         if np.isscalar(out):
             return float(out)

--- a/statsmodels/sandbox/distributions/tests/test_transf.py
+++ b/statsmodels/sandbox/distributions/tests/test_transf.py
@@ -101,7 +101,7 @@ class Test_Transf2:
 
     def test_equivalent(self):
         xx, ppfq = self.xx, self.ppfq
-        for d1,d2 in self.dist_equivalents:
+        for j,(d1,d2) in enumerate(self.dist_equivalents):
 ##            print d1.name
             assert_almost_equal(d1.cdf(xx), d2.cdf(xx), err_msg='cdf'+d1.name)
             assert_almost_equal(d1.pdf(xx), d2.pdf(xx),
@@ -122,6 +122,8 @@ class Test_Transf2:
                 d2mom = d2.dist.moment(3, *d2.args)
             else:
                 d2mom = d2.moment(3)
+            if j==3:
+                print("now")
             assert_almost_equal(d1.moment(3), d2mom,
                                 DECIMAL,
                                 err_msg='moment '+d1.name+d2.name)


### PR DESCRIPTION
- [ ] closes #xxxx
- [X] tests added / passed. 
- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
