### PR TITLE
BUG: Fix added variable plots to work with OLS

### DIFF
--- a/statsmodels/graphics/regressionplots.py
+++ b/statsmodels/graphics/regressionplots.py
@@ -1274,7 +1274,8 @@ def added_variable_resids(results, focus_exog, resid_type=None,
     if fit_kwargs is not None:
         args.update(fit_kwargs)
     new_result = new_model.fit(**args)
-    if not new_result.converged:
+    cnvrg = new_result.converged if isinstance(model, (GEE, GLM)) else True
+    if not cnvrg:
         raise ValueError("fit did not converge when calculating added variable residuals")
 
     try:

--- a/statsmodels/graphics/regressionplots.py
+++ b/statsmodels/graphics/regressionplots.py
@@ -1274,8 +1274,7 @@ def added_variable_resids(results, focus_exog, resid_type=None,
     if fit_kwargs is not None:
         args.update(fit_kwargs)
     new_result = new_model.fit(**args)
-    cnvrg = new_result.converged if isinstance(model, (GEE, GLM)) else True
-    if not cnvrg:
+    if not getattr(new_result, "converged", True):
         raise ValueError("fit did not converge when calculating added variable residuals")
 
     try:

--- a/statsmodels/graphics/tests/test_regressionplots.py
+++ b/statsmodels/graphics/tests/test_regressionplots.py
@@ -230,6 +230,23 @@ class TestABLinePandas(TestABLine):
 class TestAddedVariablePlot:
 
     @pytest.mark.matplotlib
+    def test_added_variable_ols(self, close_figures):
+        np.random.seed(3446)
+        n = 100
+        p = 3
+        exog = np.random.normal(size=(n, p))
+        lin_pred = 4 + exog[:, 0] + 0.2 * exog[:, 1]**2
+        endog = lin_pred + np.random.normal(size=n)
+
+        model = sm.OLS(endog, exog)
+        results = model.fit()
+        fig = plot_added_variable(results, 0)
+        ax = fig.get_axes()[0]
+        ax.set_title("Added variable plot (OLS)")
+        close_or_save(pdf, fig)
+        close_figures()
+
+    @pytest.mark.matplotlib
     def test_added_variable_poisson(self, close_figures):
 
         np.random.seed(3446)


### PR DESCRIPTION
OLS results doesn't have (doesn't need) a converged attribute, so the added variable plot fails.