### PR TITLE
Enable parallel arma parameters search

### DIFF
--- a/statsmodels/tsa/stattools.py
+++ b/statsmodels/tsa/stattools.py
@@ -1843,9 +1843,9 @@ def arma_order_select_ic(
     will be provided in the future. In the meantime, consider passing
     {method : "css"} to fit_kw.
 
-    Parallel search can be enabled. In order to use that option, `joblib` must
-    be installed. Note, that it does not always make sense to parallelise the process.
-    For small search spaces, parallelsiation will makes the search slower. Be sure
+    Parallel search can be enabled. In order to use that option, joblib must be
+    installed. Note that it does not always make sense to parallelize the process.
+    For small search spaces, parallelization will make the search slower. Be sure
     to test both options before committing to parallel search only.
 
     Examples

--- a/statsmodels/tsa/stattools.py
+++ b/statsmodels/tsa/stattools.py
@@ -1801,7 +1801,7 @@ def _safe_arma_fit(y, order, model_kw, trend, fit_kw, start_params=None):
 
 
 def arma_order_select_ic(
-    y, max_ar=4, max_ma=2, ic="bic", trend="c", model_kw=None, fit_kw=None
+    y, max_ar=4, max_ma=2, ic="bic", trend="c", model_kw=None, fit_kw=None, parallel=False
 ):
     """
     Compute information criteria for many ARMA models.
@@ -1823,6 +1823,8 @@ def arma_order_select_ic(
         Keyword arguments to be passed to the ``ARMA`` model.
     fit_kw : dict
         Keyword arguments to be passed to ``ARMA.fit``.
+    parallel : bool
+        Whether to do the parameter search in parallel. Default False.
 
     Returns
     -------
@@ -1840,6 +1842,11 @@ def arma_order_select_ic(
     therefore a little slow. An implementation using approximate estimates
     will be provided in the future. In the meantime, consider passing
     {method : "css"} to fit_kw.
+
+    Parallel search can be enabled. In order to use that option, `joblib` must
+    be installed. Note, that it does not always make sense to parallelise the process.
+    For small search spaces, parallelsiation will makes the search slower. Be sure
+    to test both options before committing to parallel search only. 
 
     Examples
     --------
@@ -1859,6 +1866,11 @@ def arma_order_select_ic(
     >>> res.aic_min_order
     >>> res.bic_min_order
     """
+    if parallel:
+        try:
+            from joblib import Parallel, delayed
+        except ModuleNotFoundError:
+            raise ModuleNotFoundError("Parallel model search was requested. Please, make sure joblib is installed.")
     max_ar = int_like(max_ar, "max_ar")
     max_ma = int_like(max_ma, "max_ma")
     trend = string_like(trend, "trend", options=("n", "c"))
@@ -1876,15 +1888,23 @@ def arma_order_select_ic(
     model_kw = {} if model_kw is None else model_kw
     fit_kw = {} if fit_kw is None else fit_kw
     y_arr = array_like(y, "y", contiguous=True)
-    for ar in ar_range:
-        for ma in ma_range:
-            mod = _safe_arma_fit(y_arr, (ar, 0, ma), model_kw, trend, fit_kw)
-            if mod is None:
-                results[:, ar, ma] = np.nan
-                continue
 
-            for i, criteria in enumerate(ic):
-                results[i, ar, ma] = getattr(mod, criteria)
+    def get_ic_for_order(ar: int, ma: int, criteria: str):
+        mod = _safe_arma_fit(y_arr, (ar, 0, ma), model_kw, trend, fit_kw)
+        if mod is None:
+            return np.nan
+        return getattr(mod, criteria)
+    
+    def fit_order(ar, ma):
+        return [get_ic_for_order(ar, ma, criteria) for criteria in ic]
+
+    if parallel:
+        results_raw = Parallel(n_jobs=-1)(delayed(fit_order)(ar, ma) for ar in ar_range for ma in ma_range)
+        results = np.array(results_raw).T.reshape(len(ic), len(ar_range), len(ma_range))
+    else:
+        for ar in ar_range:
+            for ma in ma_range:
+                results[:, ar, ma] = fit_order(ar, ma)
 
     dfs = [
         pd.DataFrame(res, columns=ma_range, index=ar_range) for res in results

--- a/statsmodels/tsa/tests/test_stattools.py
+++ b/statsmodels/tsa/tests/test_stattools.py
@@ -52,6 +52,12 @@ from statsmodels.tsa.stattools import (
     range_unit_root_test,
     zivot_andrews,
 )
+import pkgutil
+
+if pkgutil.find_loader("joblib") is not None:
+    HAS_JOBLIB = True
+else:
+    HAS_JOBLIB = False
 
 DECIMAL_8 = 8
 DECIMAL_6 = 6
@@ -1047,7 +1053,7 @@ def test_compare_acovf_vs_ccovf(demean, adjusted, fft, reset_randomstate):
 
 @pytest.mark.smoke
 @pytest.mark.slow
-@pytest.mark.parametrize("parallel", [False, True])
+@pytest.mark.parametrize("parallel", [False, True] if HAS_JOBLIB else [False])
 def test_arma_order_select_ic(parallel):
     # smoke test, assumes info-criteria are right
     from statsmodels.tsa.arima_process import arma_generate_sample

--- a/statsmodels/tsa/tests/test_stattools.py
+++ b/statsmodels/tsa/tests/test_stattools.py
@@ -1047,7 +1047,8 @@ def test_compare_acovf_vs_ccovf(demean, adjusted, fft, reset_randomstate):
 
 @pytest.mark.smoke
 @pytest.mark.slow
-def test_arma_order_select_ic():
+@pytest.mark.parametrize("parallel", [False, True])
+def test_arma_order_select_ic(parallel):
     # smoke test, assumes info-criteria are right
     from statsmodels.tsa.arima_process import arma_generate_sample
 
@@ -1058,7 +1059,7 @@ def test_arma_order_select_ic():
     nobs = 250
     np.random.seed(2014)
     y = arma_generate_sample(arparams, maparams, nobs)
-    res = arma_order_select_ic(y, ic=["aic", "bic"], trend="n")
+    res = arma_order_select_ic(y, ic=["aic", "bic"], trend="n", parallel=parallel)
     # regression tests in case we change algorithm to minic in sas
     aic_x = np.array(
         [


### PR DESCRIPTION
- [x] closes #8231
- [x] tests added, but may fail on github, see below.
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

This PR enables ARMA parameter search to be run in a parallelised way through `joblib`. This is achieved by introducing an additional flag `parallel` that is set to `False` by default. This approach proves to be faster for certain parameter ranges/dataset sizes. I can include benchmarks if needed.

Please, let me know if this is useful. If it is, I will 
1. amend the change log and it should be good to go. 
2. we need to decide what to do with `joblib` dep for github actions. We can just install it as an additional dependency for that particular action stage.
