### PR TITLE
Use scientific-python-nightly-wheels

### DIFF
--- a/tools/ci/azure/install-posix.sh
+++ b/tools/ci/azure/install-posix.sh
@@ -37,5 +37,5 @@ eval $CMD
 if [[ ${USE_CVXOPT} = true ]]; then python -m pip install cvxopt; fi
 
 if [ "${PIP_PRE}" = true ]; then
-  python -m pip install -i https://pypi.anaconda.org/scipy-wheels-nightly/simple numpy pandas scipy --upgrade --use-deprecated=legacy-resolver
+  python -m pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy pandas scipy --upgrade --use-deprecated=legacy-resolver
 fi


### PR DESCRIPTION
Update to use new location for nightly builds:
- https://anaconda.org/scientific-python-nightly-wheels/

More details are available here:
- https://scientific-python.org/specs/spec-0004/

This depends on https://github.com/pandas-dev/pandas/pull/53341

How do you build and upload wheels to https://anaconda.org/scipy-wheels-nightly/ currently? There is a GH action that you may want to use (see https://scientific-python.org/specs/spec-0004/#build-nightly-wheels).