### PR TITLE
DOC: correct typo in WLS.loglike docstring

### DIFF
--- a/statsmodels/regression/linear_model.py
+++ b/statsmodels/regression/linear_model.py
@@ -794,9 +794,10 @@ class WLS(RegressionModel):
         -----
         .. math:: -\frac{n}{2}\log SSR
                   -\frac{n}{2}\left(1+\log\left(\frac{2\pi}{n}\right)\right)
-                  -\frac{1}{2}\log\left(\left|W\right|\right)
+                  +\frac{1}{2}\log\left(\left|W\right|\right)
 
-        where :math:`W` is a diagonal weight matrix matrix and
+        where :math:`W` is a diagonal weight matrix matrix,
+        :math:`\leftW\right|` is its determinant, and
         :math:`SSR=\left(Y-\hat{Y}\right)^\prime W \left(Y-\hat{Y}\right)` is
         the sum of the squared weighted residuals.
         """

--- a/statsmodels/regression/linear_model.py
+++ b/statsmodels/regression/linear_model.py
@@ -797,7 +797,7 @@ class WLS(RegressionModel):
                   +\frac{1}{2}\log\left(\left|W\right|\right)
 
         where :math:`W` is a diagonal weight matrix matrix,
-        :math:`\leftW\right|` is its determinant, and
+        :math:`\left|W\right|` is its determinant, and
         :math:`SSR=\left(Y-\hat{Y}\right)^\prime W \left(Y-\hat{Y}\right)` is
         the sum of the squared weighted residuals.
         """


### PR DESCRIPTION
Correct the sign of the last term of the log likelihood expression.
Clarify the meaning of the (not standard) vertical bars notation.

- [ ] closes #xxxx
- [ ] tests added / passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>

There was a mismatch between the docstring and the code, and the code seems to be correct.
It took me a while to understand what |W| meant, I finally figured out it's the determinant, which simplify to the product of the diagonal terms in this case. This notation is not standard across branches of maths, so I added a comment to clarify the meaning.

</details>
