### PR TITLE
WIP    ENH: add offset (and exposure) to discrete margeff derivatives

### DIFF
--- a/statsmodels/discrete/discrete_model.py
+++ b/statsmodels/discrete/discrete_model.py
@@ -629,7 +629,7 @@ class BinaryModel(DiscreteModel):
         if 'ex' in transform:
             margeff *= exog
         if 'ey' in transform:
-            margeff /= self.predict(params, exog)[:, None]
+            margeff /= self.predict(params, exog, offset=offset)[:, None]
 
         return self._derivative_exog_helper(margeff, params, exog,
                                             dummy_idx, count_idx, transform)
@@ -1097,7 +1097,8 @@ class CountModel(DiscreteModel):
         return dF
 
     def _derivative_exog(self, params, exog=None, transform="dydx",
-                         dummy_idx=None, count_idx=None):
+                         dummy_idx=None, count_idx=None,
+                         offset=None, exposure=None):
         """
         For computing marginal effects. These are the marginal effects
         d F(XB) / dX
@@ -1110,15 +1111,19 @@ class CountModel(DiscreteModel):
         but checks are done in the results in get_margeff.
         """
         # group 3 poisson, nbreg, zip, zinb
+
+        # compute predict before we redefine exog
+        # we need exog is None, so predict can default for offset, exposure
+        mean = self.predict(params, exog, offset=offset, exposure=exposure)
         if exog is None:
             exog = self.exog
         k_extra = getattr(self, 'k_extra', 0)
         params_exog = params if k_extra == 0 else params[:-k_extra]
-        margeff = self.predict(params, exog)[:,None] * params_exog[None,:]
+        margeff = mean[:,None] * params_exog[None,:]
         if 'ex' in transform:
             margeff *= exog
         if 'ey' in transform:
-            margeff /= self.predict(params, exog)[:,None]
+            margeff /= mean[:,None]
 
         return self._derivative_exog_helper(margeff, params, exog,
                                             dummy_idx, count_idx, transform)


### PR DESCRIPTION
#8833

trial version for adding offset and exposure to margeff derivatives.

This is not possible as a quickfix.
`get_margeff` and margeff code will need changes in addition to those in derivatives to support offset and exposure.
I had stopped then partway through refactoring an adding this.

It should be possible to use those derivatives with NonlinearDeltaCov, wald_nonlinear, or (future) get_prediction_nonlinear
Then we would be able to write unit test and examples for them.

(postponed, opening PR so I don't loose track of it)