### PR TITLE
ENH/PERF: faster computation of revision impacts

### DIFF
--- a/statsmodels/tsa/statespace/_tools.pyx.in
+++ b/statsmodels/tsa/statespace/_tools.pyx.in
@@ -1,3 +1,6 @@
+#cython: boundscheck=False
+#cython: wraparound=False
+#cython: cdivision=False
 """
 State Space Model - Cython tools
 

--- a/statsmodels/tsa/statespace/_tools.pyx.in
+++ b/statsmodels/tsa/statespace/_tools.pyx.in
@@ -1,6 +1,3 @@
-#cython: boundscheck=False
-#cython: wraparound=False
-#cython: cdivision=False
 """
 State Space Model - Cython tools
 
@@ -1189,7 +1186,7 @@ cpdef _{{prefix}}compute_smoothed_state_weights(
         {{cython_type}} scale,
         int compute_prior_weights=False):
     cdef:
-        int t, i, j, n_t, n_j, min_j, max_j, p_t, p_j
+        int t, i, j, n_t, n_j, min_j, max_j, p_t, p_j, t0
         int n = model.nobs
         int p = model.k_endog
         int m = model.k_states
@@ -1231,26 +1228,31 @@ cpdef _{{prefix}}compute_smoothed_state_weights(
         t = compute_t[i]
         store_t[t] = True
 
+    # Determine the first index that we need to compute
+    t0 = min(min_j, compute_t[0])
+    # Let double-letters denote indexing that starts from t0
+    nn = n - t0
+
     # Flags
     filter_collapsed = kfilter.filter_method & 0x20
 
     # Create required storage and temporary matrices
-    # Hi_W = np.zeros((p, m, n), order='F')
-    # K = np.zeros((p, m, n), order='F')
-    # weights = np.zeros((m, p, n, n), order='F') * np.nan
-    # state_intercept_weights = np.zeros((m, m, n, n), order='F') * np.nan
+    # Hi_W = np.zeros((p, m, nn), order='F')
+    # K = np.zeros((p, m, nn), order='F')
+    # weights = np.zeros((m, p, nn, nn), order='F') * np.nan
+    # state_intercept_weights = np.zeros((m, m, nn, nn), order='F') * np.nan
     # tmp = np.zeros((m, m), order='F')
     # F = np.zeros((p, p), order='F')
     # Fi = np.zeros((p, p), order='F')
     # FiZ = np.zeros((p, m), order='F')
-    dim4[0] = m; dim4[1] = p; dim4[2] = n; dim4[3] = n;
+    dim4[0] = m; dim4[1] = p; dim4[2] = nn; dim4[3] = nn;
     weights = np.PyArray_ZEROS(4, dim4, {{typenum}}, FORTRAN) * np.nan
-    dim4[0] = m; dim4[1] = m; dim4[2] = n; dim4[3] = n;
+    dim4[0] = m; dim4[1] = m; dim4[2] = nn; dim4[3] = nn;
     state_intercept_weights = np.PyArray_ZEROS(4, dim4, {{typenum}}, FORTRAN) * np.nan
-    dim3[0] = p; dim3[1] = m; dim3[2] = n;
+    dim3[0] = p; dim3[1] = m; dim3[2] = nn;
     Hi_W = np.PyArray_ZEROS(3, dim3, {{typenum}}, FORTRAN)
     K = np.PyArray_ZEROS(3, dim3, {{typenum}}, FORTRAN)
-    dim3[0] = m; dim3[1] = m; dim3[2] = n;
+    dim3[0] = m; dim3[1] = m; dim3[2] = nn;
     # Note: the order here is (m, l, t), where the `l` dimension refers to the
     # element of the initial state vector, and the `m, t` dimensions refer to
     # the element / time point of the smoothed state vector.
@@ -1264,7 +1266,12 @@ cpdef _{{prefix}}compute_smoothed_state_weights(
     FiZ = np.PyArray_ZEROS(2, dim2, {{typenum}}, FORTRAN)
 
     # First pass to compute required quantities, if necessary
-    for t in range(n):
+    for t in range(t0, n):
+        # Recall that double-letters denotes indexes that start from t0
+        # Hi_W[:, :, nn], K[:, :, nn], weights[:, :, nn, nn],
+        # state_intercept_weights[:, :, nn, nn], prior_weights[:, :, nn]
+        tt = t - t0
+
         p_t = p - model.nmissing[t]
 
         # Handling of exact diffuse periods is not currently available
@@ -1273,9 +1280,9 @@ cpdef _{{prefix}}compute_smoothed_state_weights(
         if (t < kfilter.nobs_diffuse
                 or (not store_t[t] and (t < min_j or t > max_j))):
             # No need to set this when using the dictionary
-            # K[t] = np.zeros((m, p_t)) * np.nan
-            # Hi_W[t] is already initialized to NaNs, so can skip:
-            # Hi_W[t, :] = np.nan
+            # K[tt] = np.zeros((m, p_t)) * np.nan
+            # Hi_W[tt] is already initialized to NaNs, so can skip:
+            # Hi_W[tt, :] = np.nan
             continue
 
         # Move the statespace representation to the time period, but do not
@@ -1286,8 +1293,8 @@ cpdef _{{prefix}}compute_smoothed_state_weights(
         if p_t == 0:
             # No need to set this when using the dictionary
             # K.append(np.zeros((m, 0)))
-            # Hi_W[t] is already initialized to NaNs, so can skip:
-            # Hi_W[t, :] = np.nan
+            # Hi_W[tt] is already initialized to NaNs, so can skip:
+            # Hi_W[tt, :] = np.nan
             continue
 
         # Get filtered objects
@@ -1329,10 +1336,10 @@ cpdef _{{prefix}}compute_smoothed_state_weights(
             blas.{{prefix}}gemm("N", "N", &model._k_states, &model._k_endog, &model._k_states,
                                 &alpha, model._transition, &kfilter.k_states,
                                         &tmp[0, 0], &kfilter.k_states,
-                                &beta, &K[0, 0, t], &kfilter.k_states)
+                                &beta, &K[0, 0, tt], &kfilter.k_states)
 
             _FiZ = &FiZ[0, 0]
-            _K = &K[0, 0, t]
+            _K = &K[0, 0, tt]
         else:
             _FiZ = &kfilter.tmp3[0, 0, t]
             _K = &kfilter.kalman_gain[0, 0, t]
@@ -1340,7 +1347,7 @@ cpdef _{{prefix}}compute_smoothed_state_weights(
         # Compute required quantites
         # W_j = H_j (F_j^{-1} Z_j - K_j' N_j L_j)
         # => H_j^{-1} W_j = F_j^{-1} Z_j - K_j' N_j L_j
-        blas.{{prefix}}copy(&pm, _FiZ, &inc, &Hi_W[0, 0, t], &inc)
+        blas.{{prefix}}copy(&pm, _FiZ, &inc, &Hi_W[0, 0, tt], &inc)
 
         scalar = 1. / scale
         blas.{{prefix}}gemm("N", "N", &model._k_states, &model._k_states, &model._k_states,
@@ -1351,11 +1358,16 @@ cpdef _{{prefix}}compute_smoothed_state_weights(
         blas.{{prefix}}gemm("T", "N", &model._k_endog, &model._k_states, &model._k_states,
                             &gamma, _K, &kfilter.k_states,
                                     kfilter._tmp0, &kfilter.k_states,
-                            &scalar, &Hi_W[0, 0, t], &model.k_endog)
+                            &scalar, &Hi_W[0, 0, tt], &model.k_endog)
 
     # Second pass to compute weights
     # for t in compute_t:
     for t in range(n):
+        # Recall that double-letters denotes indexes that start from t0
+        # Hi_W[:, :, nn], K[:, :, nn], weights[:, :, nn, nn],
+        # state_intercept_weights[:, :, nn, nn], prior_weights[:, :, nn]
+        tt = t - t0
+
         if t < kfilter.nobs_diffuse or not store_t[t]:
             continue
 
@@ -1374,9 +1386,13 @@ cpdef _{{prefix}}compute_smoothed_state_weights(
         # This is the weight of the prior on the smoothed state at
         # time t == 0
         if t == 0 and compute_prior_weights:
-            blas.{{prefix}}copy(&kfilter.k_states2, kfilter._tmp0, &inc, &prior_weights[0, 0, t], &inc)
+            blas.{{prefix}}copy(&kfilter.k_states2, kfilter._tmp0, &inc, &prior_weights[0, 0, tt], &inc)
 
         for j in range(t - 1, min_j - 1, -1):
+            # Again, recall that double-letters denotes indexes that start
+            # from t0
+            jj = j - t0
+
             # Since we are not handling any diffuse observations now, we can
             # stop as soon as we get to the diffuse periods
             if j < kfilter.nobs_diffuse:
@@ -1386,7 +1402,7 @@ cpdef _{{prefix}}compute_smoothed_state_weights(
 
             compute_K = kfilter.univariate_filter[t] or filter_collapsed
             if compute_K:
-                _K = &K[0, 0, j]
+                _K = &K[0, 0, jj]
             else:
                 _K = &kfilter.kalman_gain[0, 0, j]
 
@@ -1399,15 +1415,15 @@ cpdef _{{prefix}}compute_smoothed_state_weights(
             #   L[j] = \prod_i L_{j, i}
             if store_j[j]:
                 if p_j > 0:
-                    # weights[:, :p_j, t, j] = tmp @ K[j][:, :p_j]
+                    # weights[:, :p_j, tt, jj] = tmp @ K[jj][:, :p_j]
                     blas.{{prefix}}gemm("N", "N", &model._k_states, &p_j, &model._k_states,
                                         &alpha, kfilter._tmp0, &kfilter.k_states,
                                                 _K, &kfilter.k_states,
-                                        &beta, &weights[0, 0, t, j], &kfilter.k_states)
+                                        &beta, &weights[0, 0, tt, jj], &kfilter.k_states)
 
-                # state_intercept_weights[:, :, t, j] = -tmp
+                # state_intercept_weights[:, :, tt, jj] = -tmp
                 blas.{{prefix}}copy(&kfilter.k_states2, kfilter._tmp0, &inc,
-                                                        &state_intercept_weights[0, 0, t, j], &inc)
+                                                        &state_intercept_weights[0, 0, tt, jj], &inc)
 
             if j > min_j or (j == 0 and compute_prior_weights):
                 # tmp = tmp @ L
@@ -1421,7 +1437,7 @@ cpdef _{{prefix}}compute_smoothed_state_weights(
                 # This is the weight of the prior on the smoothed state at
                 # time t > 0
                 if j == 0 and compute_prior_weights:
-                    blas.{{prefix}}copy(&kfilter.k_states2, kfilter._tmp0, &inc, &prior_weights[0, 0, t], &inc)
+                    blas.{{prefix}}copy(&kfilter.k_states2, kfilter._tmp0, &inc, &prior_weights[0, 0, tt], &inc)
 
         # For j == t
         # For the univariate case, some notes:
@@ -1434,16 +1450,17 @@ cpdef _{{prefix}}compute_smoothed_state_weights(
         # incorporated all the information from time t. Then j = t but i < p_t
         # would follow the j < t formula.
         j = t
+        jj = tt
         p_j = p - model.nmissing[t]
         if store_j[j]:
             if p_j > 0:
-                # weights[:, :p_j, t, j] = Pt @ Hi_W[j, :p_j].T
+                # weights[:, :p_j, tt, jj] = Pt @ Hi_W[j, :p_j].T
                 blas.{{prefix}}gemm("N", "T", &model._k_states, &p_j, &model._k_states,
                                     &scale, &kfilter.predicted_state_cov[0, 0, t], &kfilter.k_states,
-                                            &Hi_W[0, 0, j], &model.k_endog,
-                                    &beta, &weights[0, 0, t, j], &kfilter.k_states)
+                                            &Hi_W[0, 0, jj], &model.k_endog,
+                                    &beta, &weights[0, 0, tt, jj], &kfilter.k_states)
 
-            # state_intercept_weights[:, :, t, j] = -(Pt @ Lt' @ Nt)
+            # state_intercept_weights[:, :, tt, jj] = -(Pt @ Lt' @ Nt)
             # Note: normally would need to multiply Pt by scale and divide Nt
             # by `scale`, but since they're being multiplied here, the scale terms
             # cancel out.
@@ -1454,7 +1471,7 @@ cpdef _{{prefix}}compute_smoothed_state_weights(
             blas.{{prefix}}gemm("N", "N", &model._k_states, &model._k_states, &model._k_states,
                             &alpha, &kfilter.predicted_state_cov[0, 0, t], &kfilter.k_states,
                                     kfilter._tmp00, &kfilter.k_states,
-                            &beta, &state_intercept_weights[0, 0, t, j], &kfilter.k_states)
+                            &beta, &state_intercept_weights[0, 0, tt, jj], &kfilter.k_states)
 
         # Forwards from j = t+1, t+2, ..., max_j
         # tmp = Pt
@@ -1471,14 +1488,17 @@ cpdef _{{prefix}}compute_smoothed_state_weights(
                                                         kfilter._tmp0, &inc)
 
         for j in range(t + 1, max_j + 1):
+            # Again, recall that double-letters denotes indexes that start
+            # from t0
+            jj = j - t0
             p_j = p - model.nmissing[j]
 
             if store_j[j] and p_j > 0:
-                # weights[:, :p_j, t, j] = tmp @ Hi_W[j, :p_j].T
+                # weights[:, :p_j, tt, jj] = tmp @ Hi_W[j, :p_j].T
                 blas.{{prefix}}gemm("N", "T", &model._k_states, &p_j, &model._k_states,
                                     &alpha, kfilter._tmp0, &kfilter.k_states,
-                                            &Hi_W[0, 0, j], &p,
-                                    &beta, &weights[0, 0, t, j], &kfilter.k_states)
+                                            &Hi_W[0, 0, jj], &p,
+                                    &beta, &weights[0, 0, tt, jj], &kfilter.k_states)
 
             # tmp = tmp @ L[j].T
             blas.{{prefix}}gemm("N", "T", &model._k_states, &model._k_states, &model._k_states,
@@ -1489,12 +1509,12 @@ cpdef _{{prefix}}compute_smoothed_state_weights(
                                                         kfilter._tmp0, &inc)
 
             if store_j[j]:
-                # state_intercept_weights[:, :, t, j] = -(tmp @ N_j)
+                # state_intercept_weights[:, :, tt, jj] = -(tmp @ N_j)
                 scalar = -1 / scale
                 blas.{{prefix}}gemm("N", "N", &model._k_states, &model._k_states, &model._k_states,
                                 &scalar, kfilter._tmp00, &kfilter.k_states,
                                         &smoother.scaled_smoothed_estimator_cov[0, 0, j + 1], &kfilter.k_states,
-                                &beta, &state_intercept_weights[0, 0, t, j], &kfilter.k_states)
+                                &beta, &state_intercept_weights[0, 0, tt, jj], &kfilter.k_states)
 
     return np.array(weights), np.array(state_intercept_weights), np.array(prior_weights), np.array(Hi_W)
 

--- a/statsmodels/tsa/statespace/dynamic_factor_mq.py
+++ b/statsmodels/tsa/statespace/dynamic_factor_mq.py
@@ -3671,9 +3671,9 @@ class DynamicFactorMQResults(mlemodel.MLEResults):
 
     def news(self, comparison, impact_date=None, impacted_variable=None,
              start=None, end=None, periods=None, exog=None,
-             comparison_type=None, state_index=None, return_raw=False,
-             tolerance=1e-10, endog_quarterly=None, original_scale=True,
-             **kwargs):
+             comparison_type=None, revisions_details_start=False,
+             state_index=None, return_raw=False, tolerance=1e-10,
+             endog_quarterly=None, original_scale=True, **kwargs):
         """
         Compute impacts from updated data (news and revisions).
 
@@ -3756,6 +3756,7 @@ class DynamicFactorMQResults(mlemodel.MLEResults):
             comparison, impact_date=impact_date,
             impacted_variable=impacted_variable, start=start, end=end,
             periods=periods, exog=exog, comparison_type=comparison_type,
+            revisions_details_start=revisions_details_start,
             state_index=state_index, return_raw=return_raw,
             tolerance=tolerance, endog_quarterly=endog_quarterly, **kwargs)
 
@@ -3775,11 +3776,18 @@ class DynamicFactorMQResults(mlemodel.MLEResults):
             if news_results.revision_impacts is not None:
                 news_results.revision_impacts = (
                     news_results.revision_impacts * endog_std)
+            if news_results.revision_detailed_impacts is not None:
+                news_results.revision_detailed_impacts = (
+                    news_results.revision_detailed_impacts * endog_std)
+            if news_results.revision_grouped_impacts is not None:
+                news_results.revision_grouped_impacts = (
+                    news_results.revision_grouped_impacts * endog_std)
 
             # Update forecasts
             for name in ['prev_impacted_forecasts', 'news', 'revisions',
                          'update_realized', 'update_forecasts',
-                         'revised', 'revised_prev', 'post_impacted_forecasts']:
+                         'revised', 'revised_prev', 'post_impacted_forecasts',
+                         'revisions_all', 'revised_all', 'revised_prev_all']:
                 dta = getattr(news_results, name)
 
                 # for pd.Series, dta.multiply(...) and (sometimes) dta.add(...)

--- a/statsmodels/tsa/statespace/kalman_smoother.py
+++ b/statsmodels/tsa/statespace/kalman_smoother.py
@@ -1299,7 +1299,7 @@ class SmootherResults(FilterResults):
         revision_detailed_impacts = None
         revision_results = None
         revision_impacts = None
-            
+
         # Get revisions datapoints for all revisions (regardless of whether
         # or not we are computing detailed impacts)
         if len(revisions_ix) > 0:
@@ -1440,7 +1440,7 @@ class SmootherResults(FilterResults):
                     (revised_impact_forecasts, p.forecasts), axis=1)
 
             revision_impacts = (revised_impact_forecasts -
-                                      prev_impacted_forecasts).T
+                                prev_impacted_forecasts).T
             if t is not None:
                 revision_impacts = revision_impacts[0]
 

--- a/statsmodels/tsa/statespace/kalman_smoother.py
+++ b/statsmodels/tsa/statespace/kalman_smoother.py
@@ -1367,9 +1367,6 @@ class SmootherResults(FilterResults):
                     tools._compute_smoothed_state_weights(
                         rev_mod, compute_t=compute_t, compute_j=compute_j,
                         compute_prior_weights=False, scale=previous.scale))
-                ssw_t0 = min(compute_t[0], compute_j[0])
-                ix = np.ix_(compute_t - ssw_t0, compute_j - ssw_t0)
-                smoothed_state_weights = smoothed_state_weights[ix]
 
                 # Convert the weights in terms of smoothed forecasts
                 # t, j, m, p, i

--- a/statsmodels/tsa/statespace/kalman_smoother.py
+++ b/statsmodels/tsa/statespace/kalman_smoother.py
@@ -1057,7 +1057,7 @@ class SmootherResults(FilterResults):
         return acov
 
     def news(self, previous, t=None, start=None, end=None,
-             revised=None, design=None, state_index=None):
+             revisions_details_start=True, design=None, state_index=None):
         r"""
         Compute the news and impacts associated with a data release
 
@@ -1080,6 +1080,15 @@ class SmootherResults(FilterResults):
             since it is an exclusive endpoint, the returned news do not include
             the value at this index. Cannot be used in combination with the `t`
             argument.
+        revisions_details_start : bool or int, optional
+            The period at which to beging computing the detailed impacts of
+            data revisions. Any revisions prior to this period will have their
+            impacts grouped together. If a negative integer, interpreted as
+            an offset from the end of the dataset. If set to True, detailed
+            impacts are computed for all revisions, while if set to False, all
+            revisions are grouped together. Default is False. Note that for
+            large models, setting this to be near the beginning of the sample
+            can cause this function to be slow.
         design : array, optional
             Design matrix for the period `t` in time-varying models. If this
             model has a time-varying design matrix, and the argument `t` is out
@@ -1102,8 +1111,8 @@ class SmootherResults(FilterResults):
               the news. It is equivalent to E[y^i | post] - E[y^i | revision],
               where y^i are the variables of interest. In [1]_, this is
               described as "revision" in equation (17).
-            - `revision_impacts`: update to forecasts of variables impacted
-              variables from data revisions. It is
+            - `revision_detailed_impacts`: update to forecasts of variables
+              impacted variables from data revisions. It is
               E[y^i | revision] - E[y^i | previous], and does not have a
               specific notation in [1]_, since there for simplicity they assume
               that there are no revisions.
@@ -1112,18 +1121,26 @@ class SmootherResults(FilterResults):
               were newly incorporated in a data release (but not including
               revisions to data points that already existed in the previous
               release). In [1]_, this is described as "news" in equation (17).
-            - `revisions`
+            - `revisions`: y^r(updated) - y^r(previous) for periods in
+              which detailed impacts were computed
+            - `revisions_all` : y^r(updated) - y^r(previous) for all revisions
             - `gain`: the gain matrix associated with the "Kalman-like" update
               from the news, E[y I'] E[I I']^{-1}. In [1]_, this can be found
               in the equation For E[y_{k,t_k} \mid I_{v+1}] in the middle of
               page 17.
-            - `revision_weights`
+            - `revision_weights` weights on observations for the smoothed
+              signal
             - `update_forecasts`: forecasts of the updated periods used to
               construct the news, E[y^u | previous].
             - `update_realized`: realizations of the updated periods used to
               construct the news, y^u.
-            - `revised_prev`
-            - `revised`
+            - `revised`: revised observations of the periods that were revised
+              and for which detailed impacts were computed
+            - `revised`: revised observations of the periods that were revised
+            - `revised_prev`: previous observations of the periods that were
+              revised and for which detailed impacts were computed
+            - `revised_prev_all`: previous observations of the periods that
+              were revised and for which detailed impacts were computed
             - `prev_impacted_forecasts`: previous forecast of the periods of
               interest, E[y^i | previous].
             - `post_impacted_forecasts`: forecast of the periods of interest
@@ -1131,8 +1148,18 @@ class SmootherResults(FilterResults):
               E[y^i | post].
             - `revision_results`: results object that updates the `previous`
               results to take into account data revisions.
+            - `revision_results`: results object associated with the revisions
+            - `revision_impacts`: total impacts from all revisions (both
+              grouped and detailed)
             - `revisions_ix`: list of `(t, i)` positions of revisions in endog
+            - `revisions_details`: list of `(t, i)` positions of revisions to
+              endog for which details of impacts were computed
+            - `revisions_grouped`: list of `(t, i)` positions of revisions to
+              endog for which impacts were grouped
+            - `revisions_details_start`: period in which revision details start
+              to be computed
             - `updates_ix`: list of `(t, i)` positions of updates to endog
+            - `state_index`: index of state variables used to compute impacts
 
         Notes
         -----
@@ -1233,21 +1260,67 @@ class SmootherResults(FilterResults):
         post_impacted_forecasts = self.predict(
             start=start, end=end).smoothed_forecasts
 
-        # Get revision weights, impacts, and forecasts
-        if len(revisions_ix) > 0:
-            revised_endog = self.endog[:, :previous.nobs].copy()
-            revised_endog[previous.missing.astype(bool)] = np.nan
+        # Separate revisions into those with detailed impacts and those where
+        # impacts are grouped together
+        if revisions_details_start is True:
+            revisions_details_start = 0
+        elif revisions_details_start is False:
+            revisions_details_start = previous.nobs
+        elif revisions_details_start < 0:
+            revisions_details_start = previous.nobs + revisions_details_start
 
-            # Compute the revisions
+        revisions_grouped = []
+        revisions_details = []
+        if revisions_details_start > 0:
+            for s, i in revisions_ix:
+                if s < revisions_details_start:
+                    revisions_grouped.append((s, i))
+                else:
+                    revisions_details.append((s, i))
+        else:
+            revisions_details = revisions_ix
+
+        # Practically, don't compute impacts of revisions prior to first
+        # point that was actually revised
+        if len(revisions_ix) > 0:
+            revisions_details_start = max(revisions_ix[0][0],
+                                          revisions_details_start)
+
+        # Setup default (empty) output for revisions
+        revised_endog = None
+        revised_all = None
+        revised_prev_all = None
+        revisions_all = None
+
+        revised = None
+        revised_prev = None
+        revisions = None
+        revision_weights = None
+        revision_detailed_impacts = None
+        revision_results = None
+        revision_impacts = None
+            
+        # Get revisions datapoints for all revisions (regardless of whether
+        # or not we are computing detailed impacts)
+        if len(revisions_ix) > 0:
+            # Indexes
             revised_j, revised_p = zip(*revisions_ix)
             compute_j = np.arange(revised_j[0], revised_j[-1] + 1)
-            revised_prev = previous.endog.T[compute_j]
-            revised = revised_endog.T[compute_j]
-            revisions = (revised - revised_prev)
 
-            # Compute the weights of the smoothed state vector
-            compute_t = np.arange(start, end)
-            ix = np.ix_(compute_t, compute_j)
+            # Data from updated model
+            revised_endog = self.endog[:, :previous.nobs].copy()
+            # ("revisions" are points where data was previously published and
+            # then changed, so we need to ignore "updates", which are points
+            # that were not previously published)
+            revised_endog[previous.missing.astype(bool)] = np.nan
+            # subset to revision periods
+            revised_all = revised_endog.T[compute_j]
+
+            # Data from original model
+            revised_prev_all = previous.endog.T[compute_j]
+
+            # revision = updated - original
+            revisions_all = (revised_all - revised_prev_all)
 
             # Construct a model from which we can create weights for impacts
             # through `end`
@@ -1274,74 +1347,114 @@ class SmootherResults(FilterResults):
             rev_mod.initialize(init)
             revision_results = rev_mod.smooth()
 
-            smoothed_state_weights, _, _ = (
-                tools._compute_smoothed_state_weights(
-                    rev_mod, compute_t=compute_t, compute_j=compute_j,
-                    compute_prior_weights=False, scale=previous.scale))
-            smoothed_state_weights = smoothed_state_weights[ix]
+            # Get detailed revision weights, impacts, and forecasts
+            if len(revisions_details) > 0:
+                # Indexes for the subset of revisions for which we are
+                # computing detailed impacts
+                compute_j = np.arange(revisions_details_start,
+                                      revised_j[-1] + 1)
+                # Offset describing revisions for which we are not computing
+                # detailed impacts
+                offset = revisions_details_start - revised_j[0]
+                revised = revised_all[offset:]
+                revised_prev = revised_prev_all[offset:]
+                revisions = revisions_all[offset:]
 
-            # Convert the weights in terms of smoothed forecasts
-            # t, j, m, p, i
-            ZT = rev_mod.design.T
-            if ZT.shape[0] > 1:
-                ZT = ZT[compute_t]
+                # Compute the weights of the smoothed state vector
+                compute_t = np.arange(start, end)
 
-            # Subset the states used for the impacts if applicable
-            if state_index is not None:
-                ZT = ZT[:, state_index, :]
-                smoothed_state_weights = (
-                    smoothed_state_weights[:, :, state_index])
+                smoothed_state_weights, _, _ = (
+                    tools._compute_smoothed_state_weights(
+                        rev_mod, compute_t=compute_t, compute_j=compute_j,
+                        compute_prior_weights=False, scale=previous.scale))
+                ssw_t0 = min(compute_t[0], compute_j[0])
+                ix = np.ix_(compute_t - ssw_t0, compute_j - ssw_t0)
+                smoothed_state_weights = smoothed_state_weights[ix]
 
-            # Multiplication gives: t, j, m, p * t, j, m, p, k
-            # Sum along axis=2 gives: t, j, p, k
-            # Transpose to: t, j, k, p (i.e. like t, j, m, p but with k instead
-            # of m)
-            revision_weights = np.nansum(
-                smoothed_state_weights[..., None]
-                * ZT[:, None, :, None, :], axis=2).transpose(0, 1, 3, 2)
+                # Convert the weights in terms of smoothed forecasts
+                # t, j, m, p, i
+                ZT = rev_mod.design.T
+                if ZT.shape[0] > 1:
+                    ZT = ZT[compute_t]
 
-            # Multiplication gives: t, j, k, p * t, j, k, p
-            # Sum along axes 1, 3 gives: t, k
-            # This is also a valid way to compute impacts, but it employes
-            # unnecessary multiplications with zeros; it is better to use the
-            # below method that flattens the revision indices before computing
-            # the impacts
-            # revision_impacts = np.nansum(
-            #     revision_weights * revisions[None, :, None, :], axis=(1, 3))
+                # Subset the states used for the impacts if applicable
+                if state_index is not None:
+                    ZT = ZT[:, state_index, :]
+                    smoothed_state_weights = (
+                        smoothed_state_weights[:, :, state_index])
 
-            # Flatten the weights and revisions along the revised j, k
-            # dimensions so that we only retain the actual revision elements
-            ix_j = revised_j - revised_j[0]
-            # Shape is: t, k, j * p
-            # Note: have to transpose first so that the two advanced indexes
-            # are next to each other, so that "the dimensions from the
-            # advanced indexing operations are inserted into the result
-            # array at the same spot as they were in the initial array"
-            # (see https://numpy.org/doc/stable/user/basics.indexing.html,
-            # "Combining advanced and basic indexing")
-            revision_weights = (
-                revision_weights.transpose(0, 2, 1, 3)[:, :, ix_j, revised_p])
-            # Shape is j * k
-            revisions = revisions[ix_j, revised_p]
-            # Shape is t, k
-            revision_impacts = revision_weights @ revisions
+                # Multiplication gives: t, j, m, p * t, j, m, p, k
+                # Sum along axis=2 gives: t, j, p, k
+                # Transpose to: t, j, k, p (i.e. like t, j, m, p but with k
+                # instead of m)
+                revision_weights = np.nansum(
+                    smoothed_state_weights[..., None]
+                    * ZT[:, None, :, None, :], axis=2).transpose(0, 1, 3, 2)
 
-            # Similarly, flatten the revised and revised_prev series
-            revised = revised[ix_j, revised_p]
-            revised_prev = revised_prev[ix_j, revised_p]
+                # Multiplication gives: t, j, k, p * t, j, k, p
+                # Sum along axes 1, 3 gives: t, k
+                # This is also a valid way to compute impacts, but it employs
+                # unnecessary multiplications with zeros; it is better to use
+                # the below method that flattens the revision indices before
+                # computing the impacts
+                # revision_detailed_impacts = np.nansum(
+                #     revision_weights * revisions[None, :, None, :],
+                #     axis=(1, 3))
 
-            # Squeeze if `t` argument used
+                # Flatten the weights and revisions along the revised j, k
+                # dimensions so that we only retain the actual revision
+                # elements
+                revised_j, revised_p = zip(*[
+                    s for s in revisions_ix
+                    if s[0] >= revisions_details_start])
+                ix_j = revised_j - revised_j[0]
+                # Shape is: t, k, j * p
+                # Note: have to transpose first so that the two advanced
+                # indexes are next to each other, so that "the dimensions from
+                # the advanced indexing operations are inserted into the result
+                # array at the same spot as they were in the initial array"
+                # (see https://numpy.org/doc/stable/user/basics.indexing.html,
+                # "Combining advanced and basic indexing")
+                revision_weights = (
+                    revision_weights.transpose(0, 2, 1, 3)[:, :,
+                                                           ix_j, revised_p])
+                # Shape is j * k
+                revisions = revisions[ix_j, revised_p]
+                # Shape is t, k
+                revision_detailed_impacts = revision_weights @ revisions
+
+                # Similarly, flatten the revised and revised_prev series
+                revised = revised[ix_j, revised_p]
+                revised_prev = revised_prev[ix_j, revised_p]
+
+                # Squeeze if `t` argument used
+                if t is not None:
+                    revision_weights = revision_weights[0]
+                    revision_detailed_impacts = revision_detailed_impacts[0]
+
+            # Get total revision impacts
+            revised_impact_forecasts = (
+                revision_results.smoothed_forecasts[..., start:end])
+            if end > revision_results.nobs:
+                predict_start = max(start, revision_results.nobs)
+                p = revision_results.predict(
+                    start=predict_start, end=end, **extend_kwargs)
+                revised_impact_forecasts = np.concatenate(
+                    (revised_impact_forecasts, p.forecasts), axis=1)
+
+            revision_impacts = (revised_impact_forecasts -
+                                      prev_impacted_forecasts).T
             if t is not None:
-                revision_weights = revision_weights[0]
                 revision_impacts = revision_impacts[0]
-        else:
-            revised_endog = None
-            revised = None
-            revised_prev = None
-            revisions = None
-            revision_weights = None
-            revision_impacts = None
-            revision_results = None
+
+        # Need to also flatten the revisions items that contain all revisions
+        if len(revisions_ix) > 0:
+            revised_j, revised_p = zip(*revisions_ix)
+            ix_j = revised_j - revised_j[0]
+
+            revisions_all = revisions_all[ix_j, revised_p]
+            revised_all = revised_all[ix_j, revised_p]
+            revised_prev_all = revised_prev_all[ix_j, revised_p]
 
         # Now handle updates
         if len(updates_ix) > 0:
@@ -1417,11 +1530,14 @@ class SmootherResults(FilterResults):
             update_impacts=update_impacts,
             # update to forecast of variables of interest from revisions
             # = E[y^i | revision] - E[y^i | previous]
-            revision_impacts=revision_impacts,
+            revision_detailed_impacts=revision_detailed_impacts,
             # news = A = y^u - E[y^u | previous]
             news=update_forecasts_error,
-            # revivions y^r(updated) - y^r(previous)
+            # revivions y^r(updated) - y^r(previous) for periods in which
+            # detailed impacts were computed
             revisions=revisions,
+            # revivions y^r(updated) - y^r(previous)
+            revisions_all=revisions_all,
             # gain matrix = E[y A'] E[A A']^{-1}
             gain=obs_gain,
             # weights on observations for the smoothed signal
@@ -1432,20 +1548,38 @@ class SmootherResults(FilterResults):
             # realizations of the updated periods used to construct the news
             # = y^u
             update_realized=update_realized,
-            # revised observations of the periods that were revised
+            # revised observations of the periods that were revised and for
+            # which detailed impacts were computed
             # = y^r_{revised}
             revised=revised,
-            # previous observations of the periods that were revised
+            # revised observations of the periods that were revised
+            # = y^r_{revised}
+            revised_all=revised_all,
+            # previous observations of the periods that were revised and for
+            # which detailed impacts were computed
             # = y^r_{previous}
             revised_prev=revised_prev,
+            # previous observations of the periods that were revised
+            # = y^r_{previous}
+            revised_prev_all=revised_prev_all,
             # previous forecast of the periods of interest, E[y^i | previous]
             prev_impacted_forecasts=prev_impacted_forecasts,
             # post. forecast of the periods of interest, E[y^i | post]
             post_impacted_forecasts=post_impacted_forecasts,
             # results object associated with the revision
             revision_results=revision_results,
+            # total impacts from all revisions (both grouped and detailed)
+            revision_impacts=revision_impacts,
             # list of (x, y) positions of revisions to endog
             revisions_ix=revisions_ix,
+            # list of (x, y) positions of revisions to endog for which details
+            # of impacts were computed
+            revisions_details=revisions_details,
+            # list of (x, y) positions of revisions to endog for which impacts
+            # were grouped
+            revisions_grouped=revisions_grouped,
+            # period in which revision details start to be computed
+            revisions_details_start=revisions_details_start,
             # list of (x, y) positions of updates to endog
             updates_ix=updates_ix,
             # index of state variables used to compute impacts

--- a/statsmodels/tsa/statespace/mlemodel.py
+++ b/statsmodels/tsa/statespace/mlemodel.py
@@ -4000,7 +4000,7 @@ class MLEResults(tsbase.TimeSeriesModelResults):
                 raise ValueError(f'Given state index {state_index[-1]} is too'
                                  ' large for the number of states in the model'
                                  f' ({self.model.k_states}).')
-        
+
         if not isinstance(revisions_details_start, (int, bool)):
             revisions_details_start, _, _, _ = (
                 self.model._get_prediction_index(
@@ -4067,11 +4067,10 @@ class MLEResults(tsbase.TimeSeriesModelResults):
             updated = updated_orig.append(extra, exog=exog, **kwargs)
 
         # Compute the news
-        news_results = (
-            updated._news_previous_results(
+        news_results = updated._news_previous_results(
             previous, start, end + 1, periods,
             revisions_details_start=revisions_details_start,
-            state_index=state_index))
+            state_index=state_index)
 
         if not return_raw:
             news_results = NewsResults(

--- a/statsmodels/tsa/statespace/news.py
+++ b/statsmodels/tsa/statespace/news.py
@@ -565,7 +565,7 @@ class NewsResults:
             self.revised_prev.rename('observed (prev)').reindex(weights.index),
             self.revisions.reindex(weights.index),
             weights.rename('weight'),
-            (self.revisions * weights).rename('impact'),
+            (self.revisions.reindex(weights.index) * weights).rename('impact'),
         ], axis=1)
 
         if self.n_revisions_grouped > 0:
@@ -734,7 +734,7 @@ class NewsResults:
             self.revised.reindex(weights.index),
             self.revisions.reindex(weights.index),
             weights.rename('weight'),
-            (self.revisions * weights).rename('impact'),
+            (self.revisions.reindex(weights.index) * weights).rename('impact'),
         ], axis=1)
 
         if self.n_revisions_grouped > 0:

--- a/statsmodels/tsa/statespace/news.py
+++ b/statsmodels/tsa/statespace/news.py
@@ -570,6 +570,10 @@ class NewsResults:
 
         if self.n_revisions_grouped > 0:
             df = pd.concat([df, self._revision_grouped_impacts])
+            # Explicitly set names for compatibility with pandas=1.2.5
+            df.index = df.index.set_names(
+                ['revision date', 'revised variable',
+                 'impact date', 'impacted variable'])
 
         df = df.reorder_levels([2, 3, 0, 1]).sort_index()
 
@@ -735,6 +739,10 @@ class NewsResults:
 
         if self.n_revisions_grouped > 0:
             df = pd.concat([df, self._revision_grouped_impacts])
+            # Explicitly set names for compatibility with pandas=1.2.5
+            df.index = df.index.set_names(
+                ['revision date', 'revised variable',
+                 'impact date', 'impacted variable'])
 
         details = (df.set_index(['observed (prev)', 'revised'], append=True)
                      .reorder_levels([

--- a/statsmodels/tsa/statespace/news.py
+++ b/statsmodels/tsa/statespace/news.py
@@ -193,7 +193,7 @@ class NewsResults:
             - self.revision_detailed_impacts.fillna(0))
         if self.n_revisions_grouped == 0:
             self.revision_grouped_impacts[:] = 0
-            
+
         # E[y^i | post] - E[y^i | previous]
         self.total_impacts = (self.post_impacted_forecasts -
                               self.prev_impacted_forecasts)
@@ -211,7 +211,7 @@ class NewsResults:
                 'revised variable': columns[iloc['revised variable']]})
         else:
             self.revisions_ix = iloc.copy()
-        
+
         mask = iloc['revision date'] >= self.revisions_details_start
         self.revisions_iloc_detailed = self.revisions_iloc[mask]
         self.revisions_ix_detailed = self.revisions_ix[mask]
@@ -482,7 +482,7 @@ class NewsResults:
 
         mask = np.abs(df['impact']) > self.tolerance
         return df[mask]
-    
+
     @property
     def _revision_grouped_impacts(self):
         df = self.revision_grouped_impacts.stack().rename('impact').to_frame()
@@ -577,7 +577,7 @@ class NewsResults:
             df = df.loc[np.s_[:, self.impacted_variable], :]
 
         mask = np.abs(df['impact']) > self.tolerance
-        return df
+        return df[mask]
 
     @property
     def details_by_update(self):

--- a/statsmodels/tsa/statespace/news.py
+++ b/statsmodels/tsa/statespace/news.py
@@ -45,47 +45,76 @@ class NewsResults:
 
     Attributes
     ----------
-    total_impacts : pd.Series
+    total_impacts : pd.DataFrame
         Updates to forecasts of impacted variables from both news and data
         revisions, E[y^i | post] - E[y^i | previous].
-    update_impacts : pd.Series
+    update_impacts : pd.DataFrame
         Updates to forecasts of impacted variables from the news,
         E[y^i | post] - E[y^i | revisions] where y^i are the impacted variables
         of interest.
-    revision_impacts : pd.Series
-        Updates to forecasts of impacted variables from data revisions,
+    revision_impacts : pd.DataFrame
+        Updates to forecasts of impacted variables from all data revisions,
         E[y^i | revisions] - E[y^i | previous].
-    news : pd.Series
+    news : pd.DataFrame
         The unexpected component of the updated data,
         E[y^u | post] - E[y^u | revisions] where y^u are the updated variables.
-    weights : pd.Series
+    weights : pd.DataFrame
         Weights describing the effect of news on variables of interest.
-    revisions : pd.Series
-        The revisions betwen the current and previously observed data
+    revisions : pd.DataFrame
+        The revisions between the current and previously observed data, for
+        revisions for which detailed impacts were computed.
+    revisions_all : pd.DataFrame
+        The revisions between the current and previously observed data,
         y^r_{revised} - y^r_{previous} where y^r are the revised variables.
-    revision_weights : pd.Series
-        Weights describing the effect of revisions on variables of interest.
-    update_forecasts : pd.Series
+    revision_weights : pd.DataFrame
+        Weights describing the effect of revisions on variables of interest,
+        for revisions for which detailed impacts were computed.
+    revision_weights_all : pd.DataFrame
+        Weights describing the effect of revisions on variables of interest,
+        with a new entry that includes NaNs for the revisions for which
+        detailed impacts were not computed.
+    update_forecasts : pd.DataFrame
         Forecasts based on the previous dataset of the variables that were
         updated, E[y^u | previous].
-    update_realized : pd.Series
+    update_realized : pd.DataFrame
         Actual observed data associated with the variables that were
         updated, y^u
-    revised_prev : pd.Series
+    revisions_details_start : int
+        Integer index of first period in which detailed revision impacts were
+        computed.
+    revision_detailed_impacts : pd.DataFrame
+        Updates to forecasts of impacted variables from data revisions with
+        detailed impacts, E[y^i | revisions] - E[y^i | grouped revisions].
+    revision_grouped_impacts : pd.DataFrame
+        Updates to forecasts of impacted variables from data revisions that
+        were grouped together, E[y^i | grouped revisions] - E[y^i | previous].
+    revised_prev : pd.DataFrame
+        Previously observed data associated with the variables that were
+        revised, for revisions for which detailed impacts were computed.
+    revised_prev_all : pd.DataFrame
         Previously observed data associated with the variables that were
         revised, y^r_{previous}
-    revised : pd.Series
+    revised : pd.DataFrame
+        Currently observed data associated with the variables that were
+        revised, for revisions for which detailed impacts were computed.
+    revised_all : pd.DataFrame
         Currently observed data associated with the variables that were
         revised, y^r_{revised}
-    prev_impacted_forecasts : pd.Series
+    prev_impacted_forecasts : pd.DataFrame
         Previous forecast of the variables of interest, E[y^i | previous].
-    post_impacted_forecasts : pd.Series
+    post_impacted_forecasts : pd.DataFrame
         Forecast of the variables of interest after taking into account both
         revisions and updates, E[y^i | post].
     revisions_iloc : pd.DataFrame
         The integer locations of the data revisions in the dataset.
     revisions_ix : pd.DataFrame
         The label-based locations of the data revisions in the dataset.
+    revisions_iloc_detailed : pd.DataFrame
+        The integer locations of the data revisions in the dataset for which
+        detailed impacts were computed.
+    revisions_ix_detailed : pd.DataFrame
+        The label-based locations of the data revisions in the dataset for
+        which detailed impacts were computed.
     updates_iloc : pd.DataFrame
         The integer locations of the updated data points.
     updates_ix : pd.DataFrame
@@ -126,30 +155,52 @@ class NewsResults:
         self.endog_names = self.updated.model.endog_names
         self.k_endog = len(self.endog_names)
 
+        self.n_revisions = len(self.news_results.revisions_ix)
+        self.n_revisions_detailed = len(self.news_results.revisions_details)
+        self.n_revisions_grouped = len(self.news_results.revisions_grouped)
+
         index = self.updated.model._index
         columns = np.atleast_1d(self.endog_names)
 
         # E[y^i | post]
         self.post_impacted_forecasts = pd.DataFrame(
             news_results.post_impacted_forecasts.T,
-            index=self.row_labels, columns=columns)
+            index=self.row_labels, columns=columns).rename_axis(
+                index='impact date', columns='impacted variable')
         # E[y^i | previous]
         self.prev_impacted_forecasts = pd.DataFrame(
             news_results.prev_impacted_forecasts.T,
-            index=self.row_labels, columns=columns)
+            index=self.row_labels, columns=columns).rename_axis(
+                index='impact date', columns='impacted variable')
         # E[y^i | post] - E[y^i | revisions]
         self.update_impacts = pd.DataFrame(
             news_results.update_impacts,
-            index=self.row_labels, columns=columns)
+            index=self.row_labels, columns=columns).rename_axis(
+                index='impact date', columns='impacted variable')
+        # E[y^i | revisions] - E[y^i | grouped revisions]
+        self.revision_detailed_impacts = pd.DataFrame(
+            news_results.revision_detailed_impacts,
+            index=self.row_labels, columns=columns).rename_axis(
+                index='impact date', columns='impacted variable')
         # E[y^i | revisions] - E[y^i | previous]
         self.revision_impacts = pd.DataFrame(
             news_results.revision_impacts,
-            index=self.row_labels, columns=columns)
+            index=self.row_labels, columns=columns).rename_axis(
+                index='impact date', columns='impacted variable')
+        # E[y^i | grouped revisions] - E[y^i | previous]
+        self.revision_grouped_impacts = (
+            self.revision_impacts
+            - self.revision_detailed_impacts.fillna(0))
+        if self.n_revisions_grouped == 0:
+            self.revision_grouped_impacts[:] = 0
+            
         # E[y^i | post] - E[y^i | previous]
         self.total_impacts = (self.post_impacted_forecasts -
                               self.prev_impacted_forecasts)
 
         # Indices of revisions and updates
+        self.revisions_details_start = news_results.revisions_details_start
+
         self.revisions_iloc = pd.DataFrame(
             list(zip(*news_results.revisions_ix)),
             index=['revision date', 'revised variable']).T
@@ -160,6 +211,10 @@ class NewsResults:
                 'revised variable': columns[iloc['revised variable']]})
         else:
             self.revisions_ix = iloc.copy()
+        
+        mask = iloc['revision date'] >= self.revisions_details_start
+        self.revisions_iloc_detailed = self.revisions_iloc[mask]
+        self.revisions_ix_detailed = self.revisions_ix[mask]
 
         self.updates_iloc = pd.DataFrame(
             list(zip(*news_results.updates_ix)),
@@ -176,9 +231,12 @@ class NewsResults:
         self.state_index = news_results.state_index
 
         # Wrap forecasts and forecasts errors
-        r_ix = pd.MultiIndex.from_arrays([
+        r_ix_all = pd.MultiIndex.from_arrays([
             self.revisions_ix['revision date'],
             self.revisions_ix['revised variable']])
+        r_ix = pd.MultiIndex.from_arrays([
+            self.revisions_ix_detailed['revision date'],
+            self.revisions_ix_detailed['revised variable']])
         u_ix = pd.MultiIndex.from_arrays([
             self.updates_ix['update date'],
             self.updates_ix['updated variable']])
@@ -189,13 +247,21 @@ class NewsResults:
                                   dtype=model.params.dtype)
         else:
             self.news = pd.Series(news_results.news, index=u_ix, name='news')
-        # E[y^u | revisions] - E[y^u | previous]
+        # Revisions to data (y^r_{revised} - y^r_{previous})
+        if news_results.revisions_all is None:
+            self.revisions_all = pd.Series([], index=r_ix_all, name='revision',
+                                           dtype=model.params.dtype)
+        else:
+            self.revisions_all = pd.Series(news_results.revisions_all,
+                                           index=r_ix_all, name='revision')
+        # Revisions to data (y^r_{revised} - y^r_{previous}) for which detailed
+        # impacts were computed
         if news_results.revisions is None:
             self.revisions = pd.Series([], index=r_ix, name='revision',
                                        dtype=model.params.dtype)
         else:
-            self.revisions = pd.Series(news_results.revisions, index=r_ix,
-                                       name='revision')
+            self.revisions = pd.Series(news_results.revisions,
+                                       index=r_ix, name='revision')
         # E[y^u | revised]
         if news_results.update_forecasts is None:
             self.update_forecasts = pd.Series([], index=u_ix,
@@ -204,6 +270,14 @@ class NewsResults:
             self.update_forecasts = pd.Series(
                 news_results.update_forecasts, index=u_ix)
         # y^r_{revised}
+        if news_results.revised_all is None:
+            self.revised_all = pd.Series([], index=r_ix_all,
+                                         dtype=model.params.dtype,
+                                         name='revised')
+        else:
+            self.revised_all = pd.Series(news_results.revised_all,
+                                         index=r_ix_all, name='revised')
+        # y^r_{revised} for which detailed impacts were computed
         if news_results.revised is None:
             self.revised = pd.Series([], index=r_ix, dtype=model.params.dtype,
                                      name='revised')
@@ -211,6 +285,13 @@ class NewsResults:
             self.revised = pd.Series(news_results.revised, index=r_ix,
                                      name='revised')
         # y^r_{previous}
+        if news_results.revised_prev_all is None:
+            self.revised_prev_all = pd.Series([], index=r_ix_all,
+                                              dtype=model.params.dtype)
+        else:
+            self.revised_prev_all = pd.Series(
+                news_results.revised_prev_all, index=r_ix_all)
+        # y^r_{previous} for which detailed impacts were computed
         if news_results.revised_prev is None:
             self.revised_prev = pd.Series([], index=r_ix,
                                           dtype=model.params.dtype)
@@ -235,7 +316,7 @@ class NewsResults:
         self.weights.columns.names = ['impact date', 'impacted variable']
 
         # reshaped version of revision_weights
-        if len(self.revisions_iloc):
+        if self.n_revisions_detailed > 0:
             revision_weights = news_results.revision_weights.reshape(
                 len(cols), len(r_ix))
         else:
@@ -244,6 +325,9 @@ class NewsResults:
             revision_weights, index=cols, columns=r_ix).T
         self.revision_weights.columns.names = [
             'impact date', 'impacted variable']
+
+        self.revision_weights_all = self.revision_weights.reindex(
+            self.revised_all.index)
 
     @property
     def impacted_variable(self):
@@ -276,6 +360,8 @@ class NewsResults:
               in the previous dataset.
             - `revised`: the revised value of the data, as it is observed
               in the new dataset
+            - `detailed impacts computed`: whether or not detailed impacts have
+              been computed in these NewsResults for this revision
 
         See also
         --------
@@ -283,9 +369,11 @@ class NewsResults:
         """
         # Save revisions data
         data = pd.concat([
-            self.revised.rename('revised'),
-            self.revised_prev.rename('observed (prev)')
+            self.revised_all.rename('revised'),
+            self.revised_prev_all.rename('observed (prev)')
         ], axis=1).sort_index()
+        data['detailed impacts computed'] = (
+            self.revised_all.index.isin(self.revised.index))
         return data
 
     @property
@@ -392,8 +480,21 @@ class NewsResults:
         if self.impacted_variable is not None and len(df) > 0:
             df = df.loc[np.s_[:, self.impacted_variable], :]
 
-        mask = np.abs(df['weight']) > self.tolerance
+        mask = np.abs(df['impact']) > self.tolerance
         return df[mask]
+    
+    @property
+    def _revision_grouped_impacts(self):
+        df = self.revision_grouped_impacts.stack().rename('impact').to_frame()
+        df = df.reindex(['revision date', 'revised variable', 'impact'],
+                        axis=1)
+        if self.revisions_details_start > 0:
+            df['revision date'] = (
+                self.updated.model._index[self.revisions_details_start - 1])
+            df['revised variable'] = 'all prior revisions'
+        df = (df.set_index(['revision date', 'revised variable'], append=True)
+                .reorder_levels([2, 3, 0, 1]))
+        return df
 
     @property
     def revision_details_by_impact(self):
@@ -434,6 +535,11 @@ class NewsResults:
         new datapoints. That information can be found in the
         `impacts` or `details_by_impact` tables.
 
+        Grouped impacts are shown in this table, with a "revision date" equal
+        to the last period prior to which detailed revisions were computed and
+        with "revised variable" set to the string "all prior revisions". For
+        these rows, all columns except "impact" will be set to NaNs.
+
         This form of the details table is organized so that the impacted
         dates / variables are first in the index. This is convenient for
         slicing by impacted variables / dates to view the details of data
@@ -462,13 +568,16 @@ class NewsResults:
             (self.revisions * weights).rename('impact'),
         ], axis=1)
 
+        if self.n_revisions_grouped > 0:
+            df = pd.concat([df, self._revision_grouped_impacts])
+
         df = df.reorder_levels([2, 3, 0, 1]).sort_index()
 
         if self.impacted_variable is not None and len(df) > 0:
             df = df.loc[np.s_[:, self.impacted_variable], :]
 
-        mask = np.abs(df['weight']) > self.tolerance
-        return df[mask]
+        mask = np.abs(df['impact']) > self.tolerance
+        return df
 
     @property
     def details_by_update(self):
@@ -550,7 +659,7 @@ class NewsResults:
             details = details.loc[
                 np.s_[:, :, :, :, :, self.impacted_variable], :]
 
-        mask = np.abs(details['weight']) > self.tolerance
+        mask = np.abs(details['impact']) > self.tolerance
         return details[mask]
 
     @property
@@ -589,7 +698,12 @@ class NewsResults:
         release.
 
         This table does not summarize the impacts or show the effect of
-        revisions. That information can be found in the `impacts` table.
+        new datapoints, see `details_by_update` instead.
+
+        Grouped impacts are shown in this table, with a "revision date" equal
+        to the last period prior to which detailed revisions were computed and
+        with "revised variable" set to the string "all prior revisions". For
+        these rows, all columns except "impact" will be set to NaNs.
 
         This form of the details table is organized so that the revision
         dates / variables are first in the index, and in this table the index
@@ -619,6 +733,9 @@ class NewsResults:
             (self.revisions * weights).rename('impact'),
         ], axis=1)
 
+        if self.n_revisions_grouped > 0:
+            df = pd.concat([df, self._revision_grouped_impacts])
+
         details = (df.set_index(['observed (prev)', 'revised'], append=True)
                      .reorder_levels([
                          'revision date', 'revised variable', 'revised',
@@ -630,7 +747,7 @@ class NewsResults:
             details = details.loc[
                 np.s_[:, :, :, :, :, self.impacted_variable], :]
 
-        mask = np.abs(details['weight']) > self.tolerance
+        mask = np.abs(details['impact']) > self.tolerance
         return details[mask]
 
     @property
@@ -756,7 +873,7 @@ class NewsResults:
         # Default is to only show the revisions columns if there were any
         # revisions (otherwise it would just be a column of zeros)
         if show_revisions_columns is None:
-            show_revisions_columns = len(self.revisions_iloc) > 0
+            show_revisions_columns = self.n_revisions > 0
 
         # Select only the variables / dates of interest
         s = list(np.s_[:, :])
@@ -959,7 +1076,7 @@ class NewsResults:
             }
         else:
             raise ValueError(f'Invalid `source`: {source}. Must be "news" or'
-                             ' "impacts".')
+                             ' "revisions".')
 
         # Make the first index level the groupby level
         groupby = groupby.lower().replace('_', ' ')
@@ -1081,10 +1198,11 @@ class NewsResults:
 
         if multiple_tables:
             details_table = []
-            for item in details[groupby].unique():
-                mask = details[groupby] == item
-                item_details = details[mask].drop(groupby, axis=1)
-                item_removed_levels = [f'{groupby} = {item}'] + removed_levels
+            for item in details[columns[groupby]].unique():
+                mask = details[columns[groupby]] == item
+                item_details = details[mask].drop(columns[groupby], axis=1)
+                item_removed_levels = (
+                    [f'{columns[groupby]} = {item}'] + removed_levels)
                 details_table.append(create_table(item_details,
                                                   item_removed_levels))
         else:
@@ -1112,13 +1230,17 @@ class NewsResults:
             - `observed (prev)` : the observed value prior to the revision
             - `revised` : the new value after the revision
             - `revision` : the new value after the revision
+            - `detailed impacts computed` : whether detailed impacts were
+              computed for this revision
         """
         data = pd.merge(
-            self.data_revisions, self.revisions, left_index=True,
+            self.data_revisions, self.revisions_all, left_index=True,
             right_index=True).sort_index().reset_index()
+        data = data[['revision date', 'revised variable', 'observed (prev)',
+                     'revision', 'detailed impacts computed']]
         data[['revision date', 'revised variable']] = (
             data[['revision date', 'revised variable']].applymap(str))
-        data.iloc[:, 2:] = data.iloc[:, 2:].applymap(
+        data.iloc[:, 2:-1] = data.iloc[:, 2:-1].applymap(
             lambda num: '' if pd.isnull(num) else '%.2f' % num)
 
         # Sparsify the date column
@@ -1370,7 +1492,7 @@ class NewsResults:
                 table_ix += 1
 
         # Revisions
-        if include_revisions_tables and len(self.revisions_iloc) > 0:
+        if include_revisions_tables and self.n_revisions > 0:
             summary.tables.insert(
                 table_ix, self.summary_revisions(sparsify=sparsify))
             table_ix += 1

--- a/statsmodels/tsa/statespace/tests/test_news.py
+++ b/statsmodels/tsa/statespace/tests/test_news.py
@@ -1041,7 +1041,10 @@ def test_detailed_revisions(revisions_details_start):
         assert_allclose(data_revisions.loc[key, 'revised'], y_revised.loc[key])
         assert_allclose(data_revisions.loc[key, 'observed (prev)'], y.loc[key])
         assert_equal(
-            data_revisions.loc[key, 'detailed impacts computed'], True)
+            # Need to manually cast to numpy for compatibility with
+            # pandas==1.2.5
+            np.array(data_revisions.loc[key, 'detailed impacts computed']),
+            True)
         assert_allclose(revision_details.loc[key, 'revised'],
                         y_revised.loc[key])
         assert_allclose(revision_details.loc[key, 'observed (prev)'],
@@ -1146,7 +1149,10 @@ def test_grouped_revisions(revisions_details_start):
         assert_allclose(data_revisions.loc[key, 'revised'], y_revised.loc[key])
         assert_allclose(data_revisions.loc[key, 'observed (prev)'], y.loc[key])
         assert_equal(
-            data_revisions.loc[key, 'detailed impacts computed'], False)
+            # Need to manually cast to numpy for compatibility with
+            # pandas==1.2.5
+            np.array(data_revisions.loc[key, 'detailed impacts computed']),
+            False)
 
     # For grouped data, should not have any of revised, observed (prev),
     # revision, weight
@@ -1231,8 +1237,11 @@ def test_mixed_revisions(revisions_details_start):
         # Revisions to 2009Q2 are grouped (i.e. no details are computed),
         # while revisions to 2009Q3 have detailed impacts computed
         expected_details_computed = key[0] == '2009Q3'
-        assert_equal(data_revisions.loc[key, 'detailed impacts computed'],
-                     expected_details_computed)
+        assert_equal(
+            # Need to manually cast to numpy for compatibility with
+            # pandas==1.2.5
+            np.array(data_revisions.loc[key, 'detailed impacts computed']),
+            expected_details_computed)
 
     # For grouped data, should not have any of revised, observed (prev),
     # revision, weight

--- a/statsmodels/tsa/statespace/tests/test_news.py
+++ b/statsmodels/tsa/statespace/tests/test_news.py
@@ -178,7 +178,7 @@ def check_news(news, revisions, updates, impact_dates, impacted_variables,
 
     # - Table: data revisions ------------------------------------------------
     assert_equal(news.data_revisions.columns.tolist(),
-                 ['revised', 'observed (prev)'])
+                 ['revised', 'observed (prev)', 'detailed impacts computed'])
     assert_equal(news.data_revisions.index.names,
                  ['revision date', 'revised variable'])
     assert_(news.data_revisions.index.equals(revisions_index))
@@ -267,11 +267,10 @@ def check_news(news, revisions, updates, impact_dates, impacted_variables,
                     news.post_impacted_forecasts.stack(), atol=1e-12)
 
 
-# @pytest.mark.parametrize('revisions', [True, False])
-# @pytest.mark.parametrize('updates', [True, False])
-@pytest.mark.parametrize('revisions', [True])
-@pytest.mark.parametrize('updates', [True])
-def test_sarimax_time_invariant(revisions, updates):
+@pytest.mark.parametrize('revisions', [True, False])
+@pytest.mark.parametrize('updates', [True, False])
+@pytest.mark.parametrize('revisions_details_start', [True, False, -2])
+def test_sarimax_time_invariant(revisions, updates, revisions_details_start):
     # Construct previous and updated datasets
     endog = dta['infl'].copy()
     comparison_type = None
@@ -291,7 +290,8 @@ def test_sarimax_time_invariant(revisions, updates):
     mod = sarimax.SARIMAX(endog1)
     res = mod.smooth([0.5, 1.0])
     news = res.news(endog2, start='2009Q2', end='2010Q1',
-                    comparison_type=comparison_type)
+                    comparison_type=comparison_type,
+                    revisions_details_start=revisions_details_start)
 
     # Compute the true values for each combination of (revsions, updates)
     impact_dates = pd.period_range(start='2009Q2', end='2010Q1', freq='Q')
@@ -998,3 +998,284 @@ def test_invalid():
     msg = 'The index associated with the updated results is not a superset'
     with pytest.raises(ValueError, match=msg):
         res.news(endog.values)
+
+
+@pytest.mark.parametrize('revisions_details_start', [True, -10, 200])
+def test_detailed_revisions(revisions_details_start):
+    # Construct original and revised datasets
+    y = np.log(dta[['realgdp', 'realcons',
+                    'realinv', 'cpi']]).diff().iloc[1:] * 100
+    y.iloc[-1, 0] = np.nan
+
+    y_revised = y.copy()
+    revisions = {
+        ('2009Q2', 'realgdp'): 1.1,
+        ('2009Q3', 'realcons'): 0.5,
+        ('2009Q2', 'realinv'): -0.3,
+        ('2009Q2', 'cpi'): 0.2,
+        ('2009Q3', 'cpi'): 0.2,
+    }
+    for key, diff in revisions.items():
+        y_revised.loc[key] += diff
+
+    # Create model and results
+    mod = varmax.VARMAX(y, trend='n')
+    ar_coeff = {
+        'realgdp': 0.9,
+        'realcons': 0.8,
+        'realinv': 0.7,
+        'cpi': 0.6
+    }
+    params = np.r_[np.diag(list(ar_coeff.values())).flatten(),
+                   [1, 0, 1, 0, 0, 1, 0, 0, 0, 1]]
+    res = mod.smooth(params)
+    res_revised = res.apply(y_revised)
+    news = res_revised.news(res, comparison_type='previous', tolerance=-1,
+                            revisions_details_start=revisions_details_start)
+
+    # Tests
+    data_revisions = news.data_revisions
+    revision_details = news.revision_details_by_update.reset_index([2, 3])
+
+    for key, diff in revisions.items():
+        assert_allclose(data_revisions.loc[key, 'revised'], y_revised.loc[key])
+        assert_allclose(data_revisions.loc[key, 'observed (prev)'], y.loc[key])
+        assert_equal(
+            data_revisions.loc[key, 'detailed impacts computed'], True)
+        assert_allclose(revision_details.loc[key, 'revised'],
+                        y_revised.loc[key])
+        assert_allclose(revision_details.loc[key, 'observed (prev)'],
+                        y.loc[key])
+        assert_allclose(revision_details.loc[key, 'revision'], diff)
+
+    # For revisions to the impact period, the own-weight is equal to 1.
+    key = ('2009Q3', 'realcons', '2009Q3', 'realcons')
+    assert_allclose(revision_details.loc[key, 'weight'], 1)
+    assert_allclose(revision_details.loc[key, 'impact'],
+                    revisions[('2009Q3', 'realcons')])
+    key = ('2009Q3', 'cpi', '2009Q3', 'cpi')
+    assert_allclose(revision_details.loc[key, 'weight'], 1)
+    assert_allclose(revision_details.loc[key, 'impact'],
+                    revisions[('2009Q3', 'cpi')])
+
+    # For revisions just before the impact period, all weights are equal to
+    # zero unless there is a missing value in the impact period, in which case
+    # the weight is equal to the AR coefficient
+    key = ('2009Q2', 'realgdp', '2009Q3', 'realgdp')
+    assert_allclose(revision_details.loc[key, 'weight'], ar_coeff['realgdp'])
+    assert_allclose(revision_details.loc[key, 'impact'],
+                    ar_coeff['realgdp'] * revisions[('2009Q2', 'realgdp')])
+    key = ('2009Q2', 'realinv', '2009Q3', 'realinv')
+    assert_allclose(revision_details.loc[key, 'weight'], 0)
+    assert_allclose(revision_details.loc[key, 'impact'], 0)
+    key = ('2009Q2', 'cpi', '2009Q3', 'cpi')
+    assert_allclose(revision_details.loc[key, 'weight'], 0)
+    assert_allclose(revision_details.loc[key, 'impact'], 0)
+
+    # Check the impacts table
+
+    # Since we only have revisions, all impacts are due to revisions
+    assert_allclose(news.impacts['impact of news'], 0)
+    assert_allclose(news.impacts['total impact'],
+                    news.impacts['impact of revisions'])
+
+    # Check the values for estimates
+    for name in ['cpi', 'realcons', 'realinv']:        
+        assert_allclose(
+            news.impacts.loc[('2009Q3', name), 'estimate (new)'],
+            y_revised.loc['2009Q3', name])
+        assert_allclose(
+            news.impacts.loc[('2009Q3', name), 'estimate (prev)'],
+            y.loc['2009Q3', name])
+    # Have to handle real GDP separately since the 2009Q3 value is missing
+    name = 'realgdp'
+    assert_allclose(
+        news.impacts.loc[('2009Q3', name), 'estimate (new)'],
+        y_revised.loc['2009Q2', name] * ar_coeff[name])
+    assert_allclose(
+        news.impacts.loc[('2009Q3', name), 'estimate (prev)'],
+        y.loc['2009Q2', name] * ar_coeff[name])
+    
+    # Check that the values of revision impacts sum up correctly
+    assert_allclose(
+        news.impacts['impact of revisions'],
+        revision_details.groupby(level=[2, 3]).sum()['impact']
+    )
+
+
+@pytest.mark.parametrize('revisions_details_start', [False, 202])
+def test_grouped_revisions(revisions_details_start):
+    # Tests for computing revision impacts when all revisions are grouped
+    # together (i.e. no detailed impacts are computed )
+    # Construct original and revised datasets
+    y = np.log(dta[['realgdp', 'realcons',
+                    'realinv', 'cpi']]).diff().iloc[1:] * 100
+    y.iloc[-1, 0] = np.nan
+
+    y_revised = y.copy()
+    revisions = {
+        ('2009Q2', 'realgdp'): 1.1,
+        ('2009Q3', 'realcons'): 0.5,
+        ('2009Q2', 'realinv'): -0.3,
+        ('2009Q2', 'cpi'): 0.2,
+        ('2009Q3', 'cpi'): 0.2,
+    }
+    for key, diff in revisions.items():
+        y_revised.loc[key] += diff
+
+    # Create model and results
+    mod = varmax.VARMAX(y, trend='n')
+    ar_coeff = {
+        'realgdp': 0.9,
+        'realcons': 0.8,
+        'realinv': 0.7,
+        'cpi': 0.6
+    }
+    params = np.r_[np.diag(list(ar_coeff.values())).flatten(),
+                   [1, 0, 1, 0, 0, 1, 0, 0, 0, 1]]
+    res = mod.smooth(params)
+    res_revised = res.apply(y_revised)
+    news = res_revised.news(res, comparison_type='previous', tolerance=-1,
+                            revisions_details_start=revisions_details_start)
+
+    # Tests
+    data_revisions = news.data_revisions
+    revision_details = news.revision_details_by_update.reset_index([2, 3])
+
+    for key, diff in revisions.items():
+        assert_allclose(data_revisions.loc[key, 'revised'], y_revised.loc[key])
+        assert_allclose(data_revisions.loc[key, 'observed (prev)'], y.loc[key])
+        assert_equal(
+            data_revisions.loc[key, 'detailed impacts computed'], False)
+
+    # For grouped data, should not have any of revised, observed (prev),
+    # revision, weight
+    key = ('2009Q3', 'all prior revisions', '2009Q3')
+    cols = ['revised', 'observed (prev)', 'revision', 'weight']
+    assert np.all(revision_details.loc[key, cols].isnull())
+
+    # Expected grouped impacts are the sum of the detailed impacts from
+    # `test_detailed_revisions`
+    assert_allclose(revision_details.loc[key + ('realgdp',), 'impact'],
+                    ar_coeff['realgdp'] * revisions[('2009Q2', 'realgdp')])
+    assert_allclose(revision_details.loc[key + ('realcons',), 'impact'],
+                    revisions[('2009Q3', 'realcons')])
+    assert_allclose(revision_details.loc[key + ('realinv',), 'impact'], 0)
+    assert_allclose(revision_details.loc[key + ('cpi',), 'impact'],
+                    revisions[('2009Q3', 'cpi')])
+
+    # Check the values for estimates
+    for name in ['cpi', 'realcons', 'realinv']:        
+        assert_allclose(
+            news.impacts.loc[('2009Q3', name), 'estimate (new)'],
+            y_revised.loc['2009Q3', name])
+        assert_allclose(
+            news.impacts.loc[('2009Q3', name), 'estimate (prev)'],
+            y.loc['2009Q3', name])
+    # Have to handle real GDP separately since the 2009Q3 value is missing
+    name = 'realgdp'
+    assert_allclose(
+        news.impacts.loc[('2009Q3', name), 'estimate (new)'],
+        y_revised.loc['2009Q2', name] * ar_coeff[name])
+    assert_allclose(
+        news.impacts.loc[('2009Q3', name), 'estimate (prev)'],
+        y.loc['2009Q2', name] * ar_coeff[name])
+    
+    # Check that the values of revision impacts sum up correctly
+    assert_allclose(
+        news.impacts['impact of revisions'],
+        revision_details.groupby(level=[2, 3]).sum()['impact']
+    )
+
+
+@pytest.mark.parametrize('revisions_details_start', [-1, 201])
+def test_mixed_revisions(revisions_details_start):
+    # Construct original and revised datasets
+    y = np.log(dta[['realgdp', 'realcons',
+                    'realinv', 'cpi']]).diff().iloc[1:] * 100
+    y.iloc[-1, 0] = np.nan
+
+    y_revised = y.copy()
+    revisions = {
+        ('2009Q2', 'realgdp'): 1.1,
+        ('2009Q3', 'realcons'): 0.5,
+        ('2009Q2', 'realinv'): -0.3,
+        ('2009Q2', 'cpi'): 0.2,
+        ('2009Q3', 'cpi'): 0.2,
+    }
+    for key, diff in revisions.items():
+        y_revised.loc[key] += diff
+
+    # Create model and results
+    mod = varmax.VARMAX(y, trend='n')
+    ar_coeff = {
+        'realgdp': 0.9,
+        'realcons': 0.8,
+        'realinv': 0.7,
+        'cpi': 0.6
+    }
+    params = np.r_[np.diag(list(ar_coeff.values())).flatten(),
+                   [1, 0, 1, 0, 0, 1, 0, 0, 0, 1]]
+    res = mod.smooth(params)
+    res_revised = res.apply(y_revised)
+    news = res_revised.news(res, comparison_type='previous', tolerance=-1,
+                            revisions_details_start=revisions_details_start)
+
+    # Tests
+    data_revisions = news.data_revisions
+    revision_details = news.revision_details_by_update.reset_index([2, 3])
+
+    for key, diff in revisions.items():
+        assert_allclose(data_revisions.loc[key, 'revised'], y_revised.loc[key])
+        assert_allclose(data_revisions.loc[key, 'observed (prev)'], y.loc[key])
+        # Revisions to 2009Q2 are grouped (i.e. no details are computed),
+        # while revisions to 2009Q3 have detailed impacts computed
+        expected_details_computed = key[0] == '2009Q3'
+        assert_equal(data_revisions.loc[key, 'detailed impacts computed'],
+                     expected_details_computed)            
+
+    # For grouped data, should not have any of revised, observed (prev),
+    # revision, weight
+    key = ('2009Q2', 'all prior revisions', '2009Q3')
+    cols = ['revised', 'observed (prev)', 'revision', 'weight']
+    assert np.all(revision_details.loc[key, cols].isnull())
+
+    # Expected grouped impacts are the sum of the detailed impacts from
+    # `test_detailed_revisions` for revisions to 2009Q2
+    assert_allclose(revision_details.loc[key + ('realgdp',), 'impact'],
+                    ar_coeff['realgdp'] * revisions[('2009Q2', 'realgdp')])
+    assert_allclose(revision_details.loc[key + ('realinv',), 'impact'], 0)
+
+    # Expected detailed impacts are for revisions to 2009Q3
+    # (for revisions to the impact period, the own-weight is equal to 1)
+    key = ('2009Q3', 'realcons', '2009Q3', 'realcons')
+    assert_allclose(revision_details.loc[key, 'weight'], 1)
+    assert_allclose(revision_details.loc[key, 'impact'],
+                    revisions[('2009Q3', 'realcons')])
+    key = ('2009Q3', 'cpi', '2009Q3', 'cpi')
+    assert_allclose(revision_details.loc[key, 'weight'], 1)
+    assert_allclose(revision_details.loc[key, 'impact'],
+                    revisions[('2009Q3', 'cpi')])
+
+    # Check the values for estimates
+    for name in ['cpi', 'realcons', 'realinv']:        
+        assert_allclose(
+            news.impacts.loc[('2009Q3', name), 'estimate (new)'],
+            y_revised.loc['2009Q3', name])
+        assert_allclose(
+            news.impacts.loc[('2009Q3', name), 'estimate (prev)'],
+            y.loc['2009Q3', name])
+    # Have to handle real GDP separately since the 2009Q3 value is missing
+    name = 'realgdp'
+    assert_allclose(
+        news.impacts.loc[('2009Q3', name), 'estimate (new)'],
+        y_revised.loc['2009Q2', name] * ar_coeff[name])
+    assert_allclose(
+        news.impacts.loc[('2009Q3', name), 'estimate (prev)'],
+        y.loc['2009Q2', name] * ar_coeff[name])
+    
+    # Check that the values of revision impacts sum up correctly
+    assert_allclose(
+        news.impacts['impact of revisions'],
+        revision_details.groupby(level=[2, 3]).sum()['impact']
+    )

--- a/statsmodels/tsa/statespace/tests/test_news.py
+++ b/statsmodels/tsa/statespace/tests/test_news.py
@@ -1080,7 +1080,7 @@ def test_detailed_revisions(revisions_details_start):
                     news.impacts['impact of revisions'])
 
     # Check the values for estimates
-    for name in ['cpi', 'realcons', 'realinv']:        
+    for name in ['cpi', 'realcons', 'realinv']:
         assert_allclose(
             news.impacts.loc[('2009Q3', name), 'estimate (new)'],
             y_revised.loc['2009Q3', name])
@@ -1095,7 +1095,7 @@ def test_detailed_revisions(revisions_details_start):
     assert_allclose(
         news.impacts.loc[('2009Q3', name), 'estimate (prev)'],
         y.loc['2009Q2', name] * ar_coeff[name])
-    
+
     # Check that the values of revision impacts sum up correctly
     assert_allclose(
         news.impacts['impact of revisions'],
@@ -1165,7 +1165,7 @@ def test_grouped_revisions(revisions_details_start):
                     revisions[('2009Q3', 'cpi')])
 
     # Check the values for estimates
-    for name in ['cpi', 'realcons', 'realinv']:        
+    for name in ['cpi', 'realcons', 'realinv']:
         assert_allclose(
             news.impacts.loc[('2009Q3', name), 'estimate (new)'],
             y_revised.loc['2009Q3', name])
@@ -1180,7 +1180,7 @@ def test_grouped_revisions(revisions_details_start):
     assert_allclose(
         news.impacts.loc[('2009Q3', name), 'estimate (prev)'],
         y.loc['2009Q2', name] * ar_coeff[name])
-    
+
     # Check that the values of revision impacts sum up correctly
     assert_allclose(
         news.impacts['impact of revisions'],
@@ -1232,7 +1232,7 @@ def test_mixed_revisions(revisions_details_start):
         # while revisions to 2009Q3 have detailed impacts computed
         expected_details_computed = key[0] == '2009Q3'
         assert_equal(data_revisions.loc[key, 'detailed impacts computed'],
-                     expected_details_computed)            
+                     expected_details_computed)
 
     # For grouped data, should not have any of revised, observed (prev),
     # revision, weight
@@ -1258,7 +1258,7 @@ def test_mixed_revisions(revisions_details_start):
                     revisions[('2009Q3', 'cpi')])
 
     # Check the values for estimates
-    for name in ['cpi', 'realcons', 'realinv']:        
+    for name in ['cpi', 'realcons', 'realinv']:
         assert_allclose(
             news.impacts.loc[('2009Q3', name), 'estimate (new)'],
             y_revised.loc['2009Q3', name])
@@ -1273,7 +1273,7 @@ def test_mixed_revisions(revisions_details_start):
     assert_allclose(
         news.impacts.loc[('2009Q3', name), 'estimate (prev)'],
         y.loc['2009Q2', name] * ar_coeff[name])
-    
+
     # Check that the values of revision impacts sum up correctly
     assert_allclose(
         news.impacts['impact of revisions'],

--- a/statsmodels/tsa/statespace/tests/test_weights.py
+++ b/statsmodels/tsa/statespace/tests/test_weights.py
@@ -506,14 +506,20 @@ def test_compute_t_compute_j(compute_j, compute_t, reset_randomstate):
     actual, _, _ = tools.compute_smoothed_state_weights(
         res, compute_t=compute_t, compute_j=compute_j)
 
-    compute_t = np.atleast_1d(compute_t)
-    compute_j = np.atleast_1d(compute_j)
+    compute_t = np.unique(np.atleast_1d(compute_t))
+    compute_t.sort()
+    compute_j = np.unique(np.atleast_1d(compute_j))
+    compute_j.sort()
     for t in np.arange(10):
         if t not in compute_t:
             desired[t, :] = np.nan
     for j in np.arange(10):
         if j not in compute_j:
             desired[:, j] = np.nan
+
+    # Subset to the actual required compute_t and compute_j
+    ix = np.ix_(compute_t, compute_j)
+    desired = desired[ix]
 
     assert_allclose(actual, desired, atol=1e-7)
 

--- a/statsmodels/tsa/statespace/tools.py
+++ b/statsmodels/tsa/statespace/tools.py
@@ -1964,6 +1964,13 @@ def _compute_smoothed_state_weights(ssm, compute_t=None, compute_j=None,
     # Transpose m, l, t -> t, m, l
     prior_weights = prior_weights.transpose(2, 0, 1)
 
+    # Subset to the actual computed t, j elements
+    ix_tj = np.ix_(compute_t - t0, compute_j - t0)
+    weights = weights[ix_tj]
+    state_intercept_weights = state_intercept_weights[ix_tj]
+    if compute_prior_weights:
+        prior_weights = prior_weights[compute_t - t0]
+
     return weights, state_intercept_weights, prior_weights
 
 

--- a/statsmodels/tsa/statespace/tools.py
+++ b/statsmodels/tsa/statespace/tools.py
@@ -1940,13 +1940,15 @@ def _compute_smoothed_state_weights(ssm, compute_t=None, compute_j=None,
 
     # Re-order missing entries correctly and transpose to the appropriate
     # shape
-    if np.any(_model.nmissing):
+    t0 = min(compute_t[0], compute_j[0])
+    missing = np.isnan(ssm.endog[:, t0:])
+    if np.any(missing):
         shape = weights.shape
         # Transpose m, p, t, j, -> t, m, p, j so that we can use the
         # `reorder_missing_matrix` function
         weights = np.asfortranarray(weights.transpose(2, 0, 1, 3).reshape(
             shape[2] * shape[0], shape[1], shape[3], order='C'))
-        missing = np.asfortranarray(np.isnan(ssm.endog).astype(np.int32))
+        missing = np.asfortranarray(missing.astype(np.int32))
         reorder_missing_matrix(weights, missing, reorder_cols=True,
                                inplace=True)
         # Transpose t, m, p, j -> t, j, m, p,

--- a/statsmodels/tsa/statespace/varmax.py
+++ b/statsmodels/tsa/statespace/varmax.py
@@ -1062,7 +1062,15 @@ class VARMAXResults(MLEResults):
         return out
 
     def _news_previous_results(self, previous, start, end, periods,
+                               revisions_details_start=False,
                                state_index=None):
+        # TODO: tests for:
+        # - the model cloning used in `kalman_smoother.news` works when we
+        #   have time-varying exog (i.e. or do we need to somehow explicitly
+        #   call the _set_final_exog and _set_final_predicted_state methods
+        #   on the rev_mod / revision_results)
+        # - in the case of revisions to `endog`, should the revised model use
+        #   the `previous` exog? or the `revised` exog?
         # We need to figure out the out-of-sample exog, so that we can add back
         # in the last exog, predicted state
         exog = None
@@ -1070,34 +1078,16 @@ class VARMAXResults(MLEResults):
         if self.model.k_exog > 0 and out_of_sample > 0:
             exog = self.model.exog[-out_of_sample:]
 
-        # We also need to manually compute the `revised` results,
-        rev_endog = self.model.endog[:previous.nobs].copy()
-        rev_endog[previous.filter_results.missing.astype(bool).T] = np.nan
-        has_revisions = not np.allclose(rev_endog, previous.model.endog,
-                                        equal_nan=True)
-        revised_results = None
-        if has_revisions:
-            rev_exog = None
-            if self.model.exog is not None:
-                rev_exog = self.model.exog[:previous.nobs].copy()
-            rev_mod = previous.model.clone(rev_endog, exog=rev_exog)
-            revised = rev_mod.smooth(self.params)
-
         # Compute the news
         with contextlib.ExitStack() as stack:
             stack.enter_context(previous.model._set_final_exog(exog))
             stack.enter_context(previous._set_final_predicted_state(
                 exog, out_of_sample))
 
-            if has_revisions:
-                stack.enter_context(revised.model._set_final_exog(exog))
-                stack.enter_context(revised._set_final_predicted_state(
-                    exog, out_of_sample))
-                revised_results = revised.smoother_results
-
             out = self.smoother_results.news(
                 previous.smoother_results, start=start, end=end,
-                revised=revised_results, state_index=state_index)
+                revisions_details_start=revisions_details_start,
+                state_index=state_index)
         return out
 
     @Appender(MLEResults.summary.__doc__)


### PR DESCRIPTION
- [x] closes #8920 
- [x] tests added / passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message.

This PR primarily adds the ability to only compute detailed impacts for revisions to existing data starting at a certain period, but using the new `revisions_details_start` argument to the `news` method.

For all data revisions prior to that period, the total impact of revisions is still computed, but it is reported as a single grouped impact.

This can massively improve performance when a data series has minor revisions throughout its entire history that the user does not need to compute detailed impacts for.
