### PR TITLE
BUG: fix range_unit_root_test warnings and doc

### DIFF
--- a/statsmodels/tsa/stattools.py
+++ b/statsmodels/tsa/stattools.py
@@ -2152,7 +2152,7 @@ def range_unit_root_test(x, store=False):
     Range unit-root test for stationarity.
 
     Computes the Range Unit-Root (RUR) test for the null
-    hypothesis that x is stationary.
+    hypothesis that x has a single unit root.
 
     Parameters
     ----------
@@ -2254,9 +2254,9 @@ look-up table. The actual p-value is {direction} than the p-value returned.
 """
     direction = ""
     if p_value == pvals[-1]:
-        direction = "smaller"
-    elif p_value == pvals[0]:
         direction = "larger"
+    elif p_value == pvals[0]:
+        direction = "smaller"
 
     if direction:
         warnings.warn(

--- a/statsmodels/tsa/stattools.py
+++ b/statsmodels/tsa/stattools.py
@@ -2253,10 +2253,10 @@ The test statistic is outside of the range of p-values available in the
 look-up table. The actual p-value is {direction} than the p-value returned.
 """
     direction = ""
-    if p_value == pvals[-1]:
-        direction = "larger"
-    elif p_value == pvals[0]:
+    if rur_stat < inter_crit[0, 0]:
         direction = "smaller"
+    elif rur_stat > inter_crit[0, -1]:
+        direction = "larger"
 
     if direction:
         warnings.warn(

--- a/statsmodels/tsa/tests/test_stattools.py
+++ b/statsmodels/tsa/tests/test_stattools.py
@@ -970,10 +970,10 @@ class TestRUR:
         look-up table. The actual p-value is {direction} than the p-value returned.
         """
         direction = ""
-        if p_value == pvals[-1]:
-            direction = "larger"
-        elif p_value == pvals[0]:
+        if rur_stat < inter_crit[0, 0]:
             direction = "smaller"
+        elif rur_stat > inter_crit[0, -1]:
+            direction = "larger"
 
         if direction:
             warnings.warn(

--- a/statsmodels/tsa/tests/test_stattools.py
+++ b/statsmodels/tsa/tests/test_stattools.py
@@ -971,9 +971,9 @@ class TestRUR:
         """
         direction = ""
         if p_value == pvals[-1]:
-            direction = "smaller"
-        elif p_value == pvals[0]:
             direction = "larger"
+        elif p_value == pvals[0]:
+            direction = "smaller"
 
         if direction:
             warnings.warn(


### PR DESCRIPTION
- [ ] closes #8978
- [ ] tests passed. 
- [ ] code/documentation is well formatted.  
- [ ] properly formatted commit message. See [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message).

Corrects `tsa.stattools.range_unit_root_test` so that
1. the docstring correctly states the null hypothesis as _non_-stationarity of `x`;
2. `InterpolationWarning` is only emitted when the actual $p$-value is smaller than 0.01 or larger than 0.95, not whenever the returned $p$-value is 0.01 or 0.95; and
3. `InterpolationWarning` gives correct directions of differences between actual and returned $p$-values.

### Code examples
<details><summary>Documentation</summary>
<p>

The docstring now correctly states the null as a single unit root of `x`.
```
In [1]: import numpy as np
   ...: from statsmodels.tsa.stattools import range_unit_root_test
   ...: ?range_unit_root_test
Signature: range_unit_root_test(x, store=False)
Docstring:
Range unit-root test for stationarity.

Computes the Range Unit-Root (RUR) test for the null
hypothesis that x has a single unit root.
...
```
</p>
</details>

<details><summary>Stationary example</summary>
<p>

`InterpolationWarning` now correctly states that the actual $p$-value is _smaller_ than returned when the RUR statistic is smaller than the $\alpha$ = 0.01 critical value.
```
In [2]: x_constant = np.zeros(250)
   ...: rur_stat, p_value, crit = range_unit_root_test(x_constant)
   ...: print('RUR statistic: {}'.format(rur_stat))
   ...: print('p-value: {}'.format(p_value))
   ...: print('Critical values: {}'.format(crit))
<ipython-input-2-dbbe7f9c027c>:2: InterpolationWarning: The test statistic is outside of the range of p-values available in the
look-up table. The actual p-value is smaller than the p-value returned.

  rur_stat, p_value, crit = range_unit_root_test(x_constant)
RUR statistic: 0.0
p-value: 0.01
Critical values: {'10%': 1.3632, '5%': 1.2242, '2.5%': 1.1137, '1%': 0.9982}
```
</p>
</details>

<details><summary>More non-stationary example</summary>
<p>

`InterpolationWarning` now correctly states that the actual $p$-value is _larger_ than returned when the RUR statistic is larger than the $\alpha$ = 0.95 critical value.
```
In [3]: rng = np.random.default_rng(seed=1234)
   ...: x_morebias = np.cumsum(rng.uniform(-0.4, 0.6, size=250))
   ...: rur_stat, p_value, _ = range_unit_root_test(x_morebias)
   ...: print('RUR statistic: {}'.format(rur_stat))
   ...: print('p-value: {}'.format(p_value))
<ipython-input-3-25d0fd7a3141>:3: InterpolationWarning: The test statistic is outside of the range of p-values available in the
look-up table. The actual p-value is larger than the p-value returned.

  rur_stat, p_value, _ = range_unit_root_test(x_morebias)
RUR statistic: 5.502363128692981
p-value: 0.95
```
</p>
</details>

<details><summary>Less non-stationary example</summary>
<p>

A $p$-value of 0.95 is now returned without warning when the RUR statistic is between the $\alpha$ = 0.9 and $\alpha$ = 0.95 critical values.
```
In [4]: rng = np.random.default_rng(seed=1234)
   ...: x_lessbias = np.cumsum(rng.uniform(-0.45, 0.55, size=250))
   ...: rur_stat, p_value, _ = range_unit_root_test(x_lessbias)
   ...: print('RUR statistic: {}'.format(rur_stat))
   ...: print('p-value: {}'.format(p_value))
RUR statistic: 3.0990321069650117
p-value: 0.95
```
</p>
</details>

### Test output
<details>

```
(.venv) joshualiu@dhcp-10-29-180-140 statsmodels % pytest statsmodels/tsa/tests/test_stattools.py::TestRUR
=========================================== test session starts ===========================================
platform darwin -- Python 3.11.4, pytest-7.4.0, pluggy-1.2.0
Using --randomly-seed=728844893
rootdir: /Users/joshualiu/Desktop/statsmodels
configfile: setup.cfg
plugins: randomly-3.15.0, xdist-3.3.1
collected 4 items                                                                                         

statsmodels/tsa/tests/test_stattools.py ....                                                        [100%]

============================================ 4 passed in 0.40s ============================================

```
</details>