### PR TITLE
STY: Switch from == to is for type comparrison

### DIFF
--- a/statsmodels/base/tests/test_data.py
+++ b/statsmodels/base/tests/test_data.py
@@ -1,5 +1,8 @@
-from statsmodels.compat.pandas import assert_series_equal, assert_frame_equal,\
-    make_dataframe
+from statsmodels.compat.pandas import (
+    assert_series_equal,
+    assert_frame_equal,
+    make_dataframe,
+)
 
 import numpy as np
 from numpy.testing import assert_equal, assert_, assert_raises

--- a/statsmodels/distributions/copula/copulas.py
+++ b/statsmodels/distributions/copula/copulas.py
@@ -24,7 +24,8 @@ class CopulaDistribution:
     Parameters
     ----------
     copula : :class:`Copula` instance
-        An instance of :class:`Copula`, e.g. :class:`GaussianCopula`, :class:`FrankCopula`, etc.
+        An instance of :class:`Copula`, e.g. :class:`GaussianCopula`,
+        :class:`FrankCopula`, etc.
     marginals : list of distribution instances
         Marginal distributions.
     copargs : tuple

--- a/statsmodels/genmod/generalized_estimating_equations.py
+++ b/statsmodels/genmod/generalized_estimating_equations.py
@@ -2405,14 +2405,14 @@ class OrdinalGEE(GEE):
 
         # exog column names, including intercepts
         xnames = ["I(y>%.1f)" % v for v in endog_cuts]
-        if type(self.exog_orig) == pd.DataFrame:
+        if type(self.exog_orig) is pd.DataFrame:
             xnames.extend(self.exog_orig.columns)
         else:
             xnames.extend(["x%d" % k for k in range(1, exog.shape[1] + 1)])
         exog_out = pd.DataFrame(exog_out, columns=xnames)
 
         # Preserve the endog name if there is one
-        if type(self.endog_orig) == pd.Series:
+        if type(self.endog_orig) is pd.Series:
             endog_out = pd.Series(endog_out, name=self.endog_orig.name)
 
         return endog_out, exog_out, groups_out, time_out, offset_out

--- a/statsmodels/regression/mixed_linear_model.py
+++ b/statsmodels/regression/mixed_linear_model.py
@@ -2948,7 +2948,7 @@ def _handle_missing(data, groups, formula, re_formula, vc_formula):
 
     data = data[tokens]
     ii = pd.notnull(data).all(1)
-    if type(groups) != "str":
+    if type(groups) is not str:
         ii &= pd.notnull(groups)
 
     return data.loc[ii, :], groups[np.asarray(ii)]

--- a/statsmodels/stats/correlation_tools.py
+++ b/statsmodels/stats/correlation_tools.py
@@ -635,7 +635,7 @@ def corr_nearest_factor(corr, rank, ctol=1e-6, lam_min=1e-30,
 
     # Zero the diagonal
     corr1 = corr.copy()
-    if type(corr1) == np.ndarray:
+    if type(corr1) is np.ndarray:
         np.fill_diagonal(corr1, 0)
     elif sparse.issparse(corr1):
         corr1.setdiag(np.zeros(corr1.shape[0]))
@@ -647,7 +647,7 @@ def corr_nearest_factor(corr, rank, ctol=1e-6, lam_min=1e-30,
     # The gradient, from lemma 4.1 of BHR.
     def grad(X):
         gr = np.dot(X, np.dot(X.T, X))
-        if type(corr1) == np.ndarray:
+        if type(corr1) is np.ndarray:
             gr -= np.dot(corr1, X)
         else:
             gr -= corr1.dot(X)
@@ -657,7 +657,7 @@ def corr_nearest_factor(corr, rank, ctol=1e-6, lam_min=1e-30,
     # The objective function (sum of squared deviations between fitted
     # and observed arrays).
     def func(X):
-        if type(corr1) == np.ndarray:
+        if type(corr1) is np.ndarray:
             M = np.dot(X, X.T)
             np.fill_diagonal(M, 0)
             M -= corr1

--- a/statsmodels/tsa/base/tests/test_tsa_indexes.py
+++ b/statsmodels/tsa/base/tests/test_tsa_indexes.py
@@ -327,13 +327,13 @@ def test_instantiation_valid():
         endog.index = supported_increment_indexes[1][0]
 
         mod = tsa_model.TimeSeriesModel(endog)
-        assert_equal(type(mod._index) == pd.RangeIndex, True)
-        assert_equal(mod._index_none, False)
-        assert_equal(mod._index_dates, False)
-        assert_equal(mod._index_generated, False)
-        assert_equal(mod._index_freq, None)
-        assert_equal(mod.data.dates, None)
-        assert_equal(mod.data.freq, None)
+        assert type(mod._index) is pd.RangeIndex
+        assert not mod._index_none
+        assert not mod._index_dates
+        assert not mod._index_generated
+        assert mod._index_freq is None
+        assert mod.data.dates is None
+        assert mod.data.freq is None
 
         # Supported indexes *when a freq is given*, should not raise a warning
         with warnings.catch_warnings():
@@ -402,12 +402,12 @@ def test_instantiation_valid():
                     freq = ix.freq
                 if not isinstance(freq, str):
                     freq = freq.freqstr
-                assert_equal(type(mod._index) == pd.DatetimeIndex, True)
-                assert_equal(mod._index_none, False)
-                assert_equal(mod._index_dates, True)
-                assert_equal(mod._index_generated, False)
+                assert type(mod._index) is pd.DatetimeIndex
+                assert not mod._index_none
+                assert mod._index_dates
+                assert not mod._index_generated
                 assert_equal(mod._index.freq, mod._index_freq)
-                assert_equal(mod.data.dates.equals(mod._index), True)
+                assert mod.data.dates.equals(mod._index)
 
                 # Note: here, we need to hedge the test a little bit because
                 # inferred frequencies are not always the same as the original

--- a/statsmodels/tsa/regime_switching/markov_switching.py
+++ b/statsmodels/tsa/regime_switching/markov_switching.py
@@ -409,9 +409,9 @@ class MarkovSwitchingParams:
         elif _type is tuple:
             if not len(key) == 2:
                 raise IndexError('Invalid index')
-            if type(key[1]) == str and type(key[0]) == int:
+            if type(key[1]) is str and type(key[0]) is int:
                 return self.index_regime_purpose[key[0]][key[1]]
-            elif type(key[0]) == str and type(key[1]) == int:
+            elif type(key[0]) is str and type(key[1]) is int:
                 return self.index_regime_purpose[key[1]][key[0]]
             else:
                 raise IndexError('Invalid index')

--- a/statsmodels/tsa/statespace/kalman_filter.py
+++ b/statsmodels/tsa/statespace/kalman_filter.py
@@ -1267,7 +1267,7 @@ class KalmanFilter(Representation):
             steps += 1
 
         # Check for what kind of impulse we want
-        if type(impulse) == int:
+        if type(impulse) is int:
             if impulse >= self.k_posdef or impulse < 0:
                 raise ValueError('Invalid value for `impulse`. Must be the'
                                  ' index of one of the state innovations.')

--- a/statsmodels/tsa/statespace/mlemodel.py
+++ b/statsmodels/tsa/statespace/mlemodel.py
@@ -2231,7 +2231,7 @@ class MLEModel(tsbase.TimeSeriesModel):
 
         # Convert endog name to index
         use_pandas = isinstance(self.data, PandasData)
-        if type(impulse) == str:
+        if type(impulse) is str:
             if not use_pandas:
                 raise ValueError('Endog must be pd.DataFrame.')
             impulse = self.endog_names.index(impulse)
@@ -5030,7 +5030,7 @@ class PredictionResults(pred.PredictionResults):
 
             # Attach the endog names
             ynames = self.model.data.ynames
-            if not type(ynames) == list:
+            if type(ynames) is not list:
                 ynames = [ynames]
             names = (['lower {0}'.format(name) for name in ynames] +
                      ['upper {0}'.format(name) for name in ynames])

--- a/statsmodels/tsa/statespace/sarimax.py
+++ b/statsmodels/tsa/statespace/sarimax.py
@@ -1015,9 +1015,9 @@ class SARIMAX(MLEModel):
         if self.state_regression and self.time_varying_regression:
             # TODO how to set the initial variance parameters?
             params_exog_variance = [1] * self._k_exog
-        if (self.state_error and type(params_variance) == list and
+        if (self.state_error and type(params_variance) is list and
                 len(params_variance) == 0):
-            if not (type(params_seasonal_variance) == list and
+            if not (type(params_seasonal_variance) is list and
                     len(params_seasonal_variance) == 0):
                 params_variance = params_seasonal_variance
             elif self._k_exog > 0:

--- a/statsmodels/tsa/statespace/tests/test_tools.py
+++ b/statsmodels/tsa/statespace/tests/test_tools.py
@@ -393,7 +393,7 @@ class TestConstrainStationaryMultivariate:
         # Test that the constrained results correspond to companion matrices
         # with eigenvalues less than 1 in modulus
         for unconstrained in self.eigval_cases:
-            if type(unconstrained) == list:
+            if type(unconstrained) is list:
                 cov = np.eye(unconstrained[0].shape[0])
             else:
                 cov = np.eye(unconstrained.shape[0])
@@ -446,7 +446,7 @@ class TestStationaryMultivariate:
 
     def test_cases(self):
         for constrained in self.constrained_cases:
-            if type(constrained) == list:
+            if type(constrained) is list:
                 cov = np.eye(constrained[0].shape[0])
             else:
                 cov = np.eye(constrained.shape[0])
@@ -455,7 +455,7 @@ class TestStationaryMultivariate:
             assert_allclose(reconstrained, constrained)
 
         for unconstrained in self.unconstrained_cases:
-            if type(unconstrained) == list:
+            if type(unconstrained) is list:
                 cov = np.eye(unconstrained[0].shape[0])
             else:
                 cov = np.eye(unconstrained.shape[0])

--- a/statsmodels/tsa/statespace/tools.py
+++ b/statsmodels/tsa/statespace/tools.py
@@ -836,7 +836,7 @@ def constrain_stationary_multivariate_python(unconstrained, error_variance,
        American Statistical Association
     """
 
-    use_list = type(unconstrained) == list
+    use_list = type(unconstrained) is list
     if not use_list:
         k_endog, order = unconstrained.shape
         order //= k_endog
@@ -872,7 +872,7 @@ def constrain_stationary_multivariate(unconstrained, variance,
                                       transform_variance=False,
                                       prefix=None):
 
-    use_list = type(unconstrained) == list
+    use_list = type(unconstrained) is list
     if use_list:
         unconstrained = np.concatenate(unconstrained, axis=1)
 
@@ -1078,7 +1078,7 @@ def _compute_multivariate_acovf_from_coefficients(
 
     # Convert coefficients to a list of matrices, for use in
     # `companion_matrix`; get dimensions
-    if type(coefficients) == list:
+    if type(coefficients) is list:
         order = len(coefficients)
         k_endog = coefficients[0].shape[0]
     else:
@@ -1357,7 +1357,7 @@ def _compute_multivariate_pacf_from_coefficients(constrained, error_variance,
         y_t = A_1 y_{t-1} + \dots + A_p y_{t-p} + \varepsilon_t
     """
 
-    if type(constrained) == list:
+    if type(constrained) is list:
         order = len(constrained)
         k_endog = constrained[0].shape[0]
     else:
@@ -1414,7 +1414,7 @@ def unconstrain_stationary_multivariate(constrained, error_variance):
        to Enforce Stationarity."
        Journal of Statistical Computation and Simulation 24 (2): 99-106.
     """
-    use_list = type(constrained) == list
+    use_list = type(constrained) is list
     if not use_list:
         k_endog, order = constrained.shape
         order //= k_endog

--- a/statsmodels/tsa/vector_ar/tests/JMulTi_results/parse_jmulti_vecm_output.py
+++ b/statsmodels/tsa/vector_ar/tests/JMulTi_results/parse_jmulti_vecm_output.py
@@ -80,7 +80,7 @@ def sublists(lst, min_elmts=0, max_elmts=None):
     result = itertools.chain.from_iterable(
                 itertools.combinations(lst, sublist_len)
                 for sublist_len in range(min_elmts, max_elmts+1))
-    if type(result) != list:
+    if type(result) is not list:
         result = list(result)
     return result
 

--- a/statsmodels/tsa/vector_ar/var_model.py
+++ b/statsmodels/tsa/vector_ar/var_model.py
@@ -1962,7 +1962,7 @@ class VARResults(VARProcess):
                 "caused has to be of type string or int (or a "
                 "sequence of these types)."
             )
-        caused = [self.names[c] if type(c) == int else c for c in caused]
+        caused = [self.names[c] if type(c) is int else c for c in caused]
         caused_ind = [util.get_index(self.names, c) for c in caused]
 
         if causing is not None:
@@ -1974,7 +1974,7 @@ class VARResults(VARProcess):
                     "causing has to be of type string or int (or "
                     "a sequence of these types) or None."
                 )
-            causing = [self.names[c] if type(c) == int else c for c in causing]
+            causing = [self.names[c] if type(c) is int else c for c in causing]
             causing_ind = [util.get_index(self.names, c) for c in causing]
         else:
             causing_ind = [i for i in range(self.neqs) if i not in caused_ind]
@@ -2105,7 +2105,7 @@ class VARResults(VARProcess):
                 "causing has to be of type string or int (or a "
                 + "a sequence of these types)."
             )
-        causing = [self.names[c] if type(c) == int else c for c in causing]
+        causing = [self.names[c] if type(c) is int else c for c in causing]
         causing_ind = [util.get_index(self.names, c) for c in causing]
 
         caused_ind = [i for i in range(self.neqs) if i not in causing_ind]

--- a/statsmodels/tsa/vector_ar/vecm.py
+++ b/statsmodels/tsa/vector_ar/vecm.py
@@ -564,7 +564,7 @@ def select_coint_rank(
         )
 
     if det_order not in [-1, 0, 1]:
-        if type(det_order) == int and det_order > 1:
+        if type(det_order) is int and det_order > 1:
             raise ValueError(
                 "A det_order greather than 1 is not supported."
                 "Use a value of -1, 0, or 1."
@@ -2023,7 +2023,7 @@ class VECMResults:
                 "caused has to be of type string or int (or a "
                 "sequence of these types)."
             )
-        caused = [self.names[c] if type(c) == int else c for c in caused]
+        caused = [self.names[c] if type(c) is int else c for c in caused]
         caused_ind = [get_index(self.names, c) for c in caused]
 
         if causing is not None:
@@ -2035,7 +2035,7 @@ class VECMResults:
                     "causing has to be of type string or int (or "
                     "a sequence of these types) or None."
                 )
-            causing = [self.names[c] if type(c) == int else c for c in causing]
+            causing = [self.names[c] if type(c) is int else c for c in causing]
             causing_ind = [get_index(self.names, c) for c in causing]
 
         if causing is None:


### PR DESCRIPTION
Switch to comply with new flake8 rule E721

- [ ] closes #xxxx
- [ ] tests added / passed. 
- [ ] code/documentation is well formatted.  
- [ ] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
