### PR TITLE
Update seasonal.py

### DIFF
--- a/statsmodels/tsa/seasonal.py
+++ b/statsmodels/tsa/seasonal.py
@@ -95,9 +95,10 @@ def seasonal_decompose(
         The concrete moving average method used in filtering is determined by
         two_sided.
     period : int, optional
-        Period of the series (eg, 1 for annual, 4 for quarterly, etc). Must be used if x is not a pandas object or if
-        the index of x does not have  a frequency. Overrides default
-        periodicity of x if x is a pandas object with a timeseries index.
+        Period of the series (eg, 1 for annual, 4 for quarterly, etc). Must be 
+        used if x is not a pandas object or if the index of x does not have a 
+        frequency. Overrides default periodicity of x if x is a pandas object 
+        with a timeseries index.
     two_sided : bool, optional
         The moving average method used in filtering.
         If True (default), a centered moving average is computed using the

--- a/statsmodels/tsa/seasonal.py
+++ b/statsmodels/tsa/seasonal.py
@@ -95,7 +95,7 @@ def seasonal_decompose(
         The concrete moving average method used in filtering is determined by
         two_sided.
     period : int, optional
-        Period of the series. Must be used if x is not a pandas object or if
+        Period of the series (eg, 1 for annual, 4 for quarterly, etc). Must be used if x is not a pandas object or if
         the index of x does not have  a frequency. Overrides default
         periodicity of x if x is a pandas object with a timeseries index.
     two_sided : bool, optional

--- a/statsmodels/tsa/seasonal.py
+++ b/statsmodels/tsa/seasonal.py
@@ -95,9 +95,9 @@ def seasonal_decompose(
         The concrete moving average method used in filtering is determined by
         two_sided.
     period : int, optional
-        Period of the series (eg, 1 for annual, 4 for quarterly, etc). Must be 
-        used if x is not a pandas object or if the index of x does not have a 
-        frequency. Overrides default periodicity of x if x is a pandas object 
+        Period of the series (eg, 1 for annual, 4 for quarterly, etc). Must be
+        used if x is not a pandas object or if the index of x does not have a
+        frequency. Overrides default periodicity of x if x is a pandas object
         with a timeseries index.
     two_sided : bool, optional
         The moving average method used in filtering.


### PR DESCRIPTION
DOC: Add specificity to the `period` parameter used within the `seasonal_decompose` method within seasonal.py.

Needed to drill down to the `freq_to_period` method to figure out what parameter `period` ought to look like when debugging--still not clear what number ought to be passed for daily data.  Think clarity/example would be additive.  Best, Chris

