### PR TITLE
DOC: improve doc for the ARIMA model

### DIFF
--- a/statsmodels/tsa/arima/model.py
+++ b/statsmodels/tsa/arima/model.py
@@ -51,15 +51,16 @@ class ARIMA(sarimax.SARIMAX):
     order : tuple, default: (0, 0, 0)
         The (p,d,q) order of the model for the autoregressive, differences, and
         moving average components. d is always an integer, while p and q may
-        either be integers or lists of integers. The order of differences is
-        to achieve stationnarity in the context of a sochastic trend or
-        seasonality. If your trend in deterministic, use the `trend` parameter
-        as it will provide better forecasts.
+        either be integers or lists of integers specifying exactly which lag
+        orders are included. The order of differences is to achieve
+        stationnarity in the context of a sochastic trend or seasonality. If
+        your trend in deterministic, use the `trend` parameter as it will
+        provide better forecasts.
     seasonal_order : tuple, default: (0, 0, 0, 0)
         The (P,D,Q,s) order of the seasonal component of the model for the
         AR parameters, differences, MA parameters, and periodicity. D and s
         are always integers, while P and Q may either be integers or lists
-        of positive integers.
+        of positive integers specifying exactly which lag orders are included.
     trend : str{'n','c','t','ct'} or iterable, optional
         Parameter controlling the deterministic trend. Can be specified as a
         string where 'c' indicates a constant term, 't' indicates a

--- a/statsmodels/tsa/arima/model.py
+++ b/statsmodels/tsa/arima/model.py
@@ -51,7 +51,10 @@ class ARIMA(sarimax.SARIMAX):
     order : tuple, optional
         The (p,d,q) order of the model for the autoregressive, differences, and
         moving average components. d is always an integer, while p and q may
-        either be integers or lists of integers.
+        either be integers or lists of integers. The order of differences is
+        to achieve stationnarity in the context of a sochastic trend or
+        seasonality. If your trend in deterministic, use the `trend` parameter
+        as it will provide better forecasts.
     seasonal_order : tuple, optional
         The (P,D,Q,s) order of the seasonal component of the model for the
         AR parameters, differences, MA parameters, and periodicity. Default

--- a/statsmodels/tsa/arima/model.py
+++ b/statsmodels/tsa/arima/model.py
@@ -48,18 +48,18 @@ class ARIMA(sarimax.SARIMAX):
         The observed time-series process :math:`y`.
     exog : array_like, optional
         Array of exogenous regressors.
-    order : tuple, optional
+    order : tuple, default: (0, 0, 0)
         The (p,d,q) order of the model for the autoregressive, differences, and
         moving average components. d is always an integer, while p and q may
         either be integers or lists of integers. The order of differences is
         to achieve stationnarity in the context of a sochastic trend or
         seasonality. If your trend in deterministic, use the `trend` parameter
         as it will provide better forecasts.
-    seasonal_order : tuple, optional
+    seasonal_order : tuple, default: (0, 0, 0, 0)
         The (P,D,Q,s) order of the seasonal component of the model for the
-        AR parameters, differences, MA parameters, and periodicity. Default
-        is (0, 0, 0, 0). D and s are always integers, while P and Q
-        may either be integers or lists of positive integers.
+        AR parameters, differences, MA parameters, and periodicity. D and s
+        are always integers, while P and Q may either be integers or lists
+        of positive integers.
     trend : str{'n','c','t','ct'} or iterable, optional
         Parameter controlling the deterministic trend. Can be specified as a
         string where 'c' indicates a constant term, 't' indicates a
@@ -71,18 +71,18 @@ class ARIMA(sarimax.SARIMAX):
         regressors, which differs from how trends are included in ``SARIMAX``
         models.  See the Notes section for a precise definition of the
         treatment of trend terms.
-    enforce_stationarity : bool, optional
+    enforce_stationarity : bool, default: True
         Whether or not to require the autoregressive parameters to correspond
         to a stationarity process.
-    enforce_invertibility : bool, optional
+    enforce_invertibility : bool, default: True
         Whether or not to require the moving average parameters to correspond
         to an invertible process.
-    concentrate_scale : bool, optional
+    concentrate_scale : bool, default: False
         Whether or not to concentrate the scale (variance of the error term)
         out of the likelihood. This reduces the number of parameters by one.
         This is only applicable when considering estimation by numerical
         maximum likelihood.
-    trend_offset : int, optional
+    trend_offset : int, default: 1
         The offset at which to start time trend values. Default is 1, so that
         if `trend='t'` the trend is equal to 1, 2, ..., nobs. Typically is only
         set when the model created by extending a previous dataset.
@@ -92,10 +92,10 @@ class ARIMA(sarimax.SARIMAX):
     freq : str, optional
         If no index is given by `endog` or `exog`, the frequency of the
         time-series may be specified here as a Pandas offset or offset string.
-    missing : str
+    missing : str, default: 'none'
         Available options are 'none', 'drop', and 'raise'. If 'none', no nan
         checking is done. If 'drop', any observations with nans are dropped.
-        If 'raise', an error is raised. Default is 'none'.
+        If 'raise', an error is raised.
 
     Notes
     -----

--- a/statsmodels/tsa/arima/model.py
+++ b/statsmodels/tsa/arima/model.py
@@ -44,7 +44,7 @@ class ARIMA(sarimax.SARIMAX):
 
     Parameters
     ----------
-    endog : array_like, optional
+    endog : array_like
         The observed time-series process :math:`y`.
     exog : array_like, optional
         Array of exogenous regressors.


### PR DESCRIPTION
1. the differencing order is often wrongly used. This pull request clarifies that the trend argument can be better for some cases (see https://stats.stackexchange.com/questions/630944/role-of-trend-argument-compared-to-integral-order-in-arima-model/630946#630946),
2. It also specifies the defaults values of some parameters,
3. finally, it removes the 'optional' in the `endog` param doc as it is a required parameter.

- [x] code/documentation is well formatted.  
- [x] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 
