### PR TITLE
refactor code to drop constant columns

### DIFF
--- a/statsmodels/tsa/deterministic.py
+++ b/statsmodels/tsa/deterministic.py
@@ -1258,10 +1258,9 @@ you can pass additional components using the additional_terms input."""
             terms = terms.loc[:, ~all_zero]
         is_constant = terms.max(axis=0) == terms.min(axis=0)
         if np.sum(is_constant) > 1:
-            # Retain first
-            const_locs = np.where(is_constant)[0]
-            is_constant.iloc[const_locs[:1]] = False
-            terms = terms.loc[:, ~is_constant]
+            # flag surplus constant columns
+            surplus_consts = is_constant & is_constant.duplicated()
+            terms = terms.loc[:, ~surplus_consts]
         return terms
 
     @Appender(DeterministicTerm.in_sample.__doc__)


### PR DESCRIPTION
This pull request refactors a function that drops all but the first constant column from `DeterministicProcess.in_sample` object. Previously, it was raising a FutureWarning due to development in the pandas library. The change removes the need to assign to a Series based on index altogether by creating a single mask that flags surplus constant columns. For example, if columns B, C, F were constant columns (in that order), the mask flags column B as False and flags C and F as True. Therefore, if we negate this  mask, we select the desired columns.

Given the example:
```python
terms = pd.DataFrame({'A': [1, 3, 1], 'B': 2, 'C': 1.1, 'D': 20, 'E': [10, 20, 20], 'F': 10}, index=range(3))
```
`B`, `C`, `F` are constant columns. Then 
```python
is_constant = terms.max(axis=0) == terms.min(axis=0)
surplus_consts = is_constant & is_constant.duplicated()
```
returns
```
A    False
B    False
C     True
D     True
E    False
F     True
dtype: bool
```
where the all constant columns except the first one are flagged as True. This works because `.duplicated()` returns True for all re-occurring values, except the first one. 

Then negating it returns the desired dataframe:
```
terms.loc[:, ~surplus_consts]

   A  B   E
0  1  2  10
1  3  2  20
2  1  2  20
```
