### PR TITLE
Added SVAR option to plot_cum_effects in irf

### DIFF
--- a/statsmodels/tsa/vector_ar/irf.py
+++ b/statsmodels/tsa/vector_ar/irf.py
@@ -172,7 +172,7 @@ class BaseIRAnalysis:
                                      stderr_type=stderr_type)
         return fig
 
-    def plot_cum_effects(self, orth=False, *, impulse=None, response=None,
+    def plot_cum_effects(self, orth=False, svar=False, *, impulse=None, response=None,
                          signif=0.05, plot_params=None, figsize=(10, 10),
                          subplot_params=None, plot_stderr=True,
                          stderr_type='asym', repl=1000, seed=None):
@@ -208,9 +208,13 @@ class BaseIRAnalysis:
         """
 
         if orth:
-            title = 'Cumulative responses responses (orthogonalized)'
+            title = 'Cumulative responses (orthogonalized)'
             cum_effects = self.orth_cum_effects
             lr_effects = self.orth_lr_effects
+        elif svar:
+            title = 'Cumulative responses (structural)'
+            cum_effects = self.svar_cum_effects
+            lr_effects = self.svar_lr_effects
         else:
             title = 'Cumulative responses'
             cum_effects = self.cum_effects
@@ -235,7 +239,6 @@ class BaseIRAnalysis:
                                      figsize=figsize,
                                      stderr_type=stderr_type)
         return fig
-
 
 class IRAnalysis(BaseIRAnalysis):
     """


### PR DESCRIPTION
plot_cum_effects function lacked SVAR check: when it was called for SVAR, it returned VAR cumulative IRFs despide them being calculated for SVAR internally. Thus one elif case has beed added to resolve this issue.

Example: 
```
data_d_reer = pd.read_csv(r'data_
[Uploading data_reer.csv…]()
reer.csv', index_col=0)
svar_model = SVAR(data_d_reer, svar_type="A", A=amat, freq='Q').fit()
svar_model.irf().plot_cum_effects();

```
Current behavior: returns VAR cumulative IR's (self.cum_effects).
Expected behavior: returns SVAR cumulative IR's (self.svar_cum_effects)