### PR TITLE
BUG: ETS multiplicative error models log-likelihood calculation

### DIFF
--- a/statsmodels/tsa/exponential_smoothing/ets.py
+++ b/statsmodels/tsa/exponential_smoothing/ets.py
@@ -1164,10 +1164,14 @@ class ETSModel(base.StateSpaceMLEModel):
             # multiplicative model is no longer well-defined. In this case
             # we overwrite the log-likelihood to be -infinity so that these
             # models are never selected.
-            if np.any(yhat <= 0):
+            # if np.any(yhat <= 0):
+            #     logL = -np.inf
+            # else:
+            #     logL -= np.sum(np.log(yhat))
+            if np.any(yhat == 0):
                 logL = -np.inf
             else:
-                logL -= np.sum(np.log(yhat))
+                logL -= np.sum(np.log(np.abs(yhat)))
         return logL
 
     @contextlib.contextmanager

--- a/statsmodels/tsa/exponential_smoothing/ets.py
+++ b/statsmodels/tsa/exponential_smoothing/ets.py
@@ -1165,8 +1165,11 @@ class ETSModel(base.StateSpaceMLEModel):
             # parameterizations, we clip negative values to very small positive
             # values so that the log-transformation yields very large negative
             # values.
-            yhat[yhat <= 0] = 1 / (1e-8 * (1 + np.abs(yhat[yhat <= 0])))
-            logL -= np.sum(np.log(yhat))
+            # yhat[yhat <= 0] = 1 / (1e-8 * (1 + np.abs(yhat[yhat <= 0])))
+            if np.any(yhat <= 0):
+                logL = -10**32
+            else:
+                logL -= np.sum(np.log(yhat))
         return logL
 
     @contextlib.contextmanager

--- a/statsmodels/tsa/exponential_smoothing/ets.py
+++ b/statsmodels/tsa/exponential_smoothing/ets.py
@@ -1165,7 +1165,7 @@ class ETSModel(base.StateSpaceMLEModel):
             # are replaced with 10^-18 (a very small number) and we take
             # the absolute of yhat to avoid computing the log of negative
             # numbers.
-            yhat[yhat == 0] = 1e-18
+            yhat[yhat == 0] = 1e-32
             logL -= np.sum(np.log(np.abs(yhat)))
         return logL
 

--- a/statsmodels/tsa/exponential_smoothing/ets.py
+++ b/statsmodels/tsa/exponential_smoothing/ets.py
@@ -1160,18 +1160,13 @@ class ETSModel(base.StateSpaceMLEModel):
         res = self._residuals(yhat, data=data)
         logL = -self.nobs / 2 * (np.log(2 * np.pi * np.mean(res ** 2)) + 1)
         if self.error == "mul":
-            # In some cases, yhat can become negative, so that a
-            # multiplicative model is no longer well-defined. In this case
-            # we overwrite the log-likelihood to be -infinity so that these
-            # models are never selected.
-            # if np.any(yhat <= 0):
-            #     logL = -np.inf
-            # else:
-            #     logL -= np.sum(np.log(yhat))
-            if np.any(yhat == 0):
-                logL = -np.inf
-            else:
-                logL -= np.sum(np.log(np.abs(yhat)))
+            # In some cases, yhat can become negative or zero, so that a
+            # multiplicative model is no longer well-defined. Zero values
+            # are replaced with 10^-18 (a very small number) and we take
+            # the absolute of yhat to avoid computing the log of negative
+            # numbers.
+            yhat[yhat == 0] = 1e-18
+            logL -= np.sum(np.log(np.abs(yhat)))
         return logL
 
     @contextlib.contextmanager

--- a/statsmodels/tsa/exponential_smoothing/ets.py
+++ b/statsmodels/tsa/exponential_smoothing/ets.py
@@ -1162,7 +1162,7 @@ class ETSModel(base.StateSpaceMLEModel):
         if self.error == "mul":
             # In some cases, yhat can become negative or zero, so that a
             # multiplicative model is no longer well-defined. Zero values
-            # are replaced with 10^-18 (a very small number) and we take
+            # are replaced with 10^-32 (a very small number) and we take
             # the absolute of yhat to avoid computing the log of negative
             # numbers.
             yhat[yhat == 0] = 1e-32

--- a/statsmodels/tsa/exponential_smoothing/ets.py
+++ b/statsmodels/tsa/exponential_smoothing/ets.py
@@ -1162,9 +1162,10 @@ class ETSModel(base.StateSpaceMLEModel):
         if self.error == "mul":
             # In some cases, yhat can become negative or zero, so that a
             # multiplicative model is no longer well-defined. Zero values
-            # are replaced with 10^-32 (a very small number) and we take
-            # the absolute of yhat to avoid computing the log of negative
-            # numbers.
+            # are replaced with 10^-32 (a very small number. For more
+            # information on the derivation of the log-likelihood for the
+            # multiplicative error models see: 
+            # https://openforecast.org/adam/ADAMETSEstimationLikelihood.html
             yhat[yhat == 0] = 1e-32
             logL -= np.sum(np.log(np.abs(yhat)))
         return logL

--- a/statsmodels/tsa/exponential_smoothing/ets.py
+++ b/statsmodels/tsa/exponential_smoothing/ets.py
@@ -1162,7 +1162,7 @@ class ETSModel(base.StateSpaceMLEModel):
         if self.error == "mul":
             # In some cases, yhat can become negative or zero, so that a
             # multiplicative model is no longer well-defined. Zero values
-            # are replaced with 10^-32 (a very small number. For more
+            # are replaced with 10^-32 (a very small number). For more
             # information on the derivation of the log-likelihood for the
             # multiplicative error models see:
             # https://openforecast.org/adam/ADAMETSEstimationLikelihood.html

--- a/statsmodels/tsa/exponential_smoothing/ets.py
+++ b/statsmodels/tsa/exponential_smoothing/ets.py
@@ -1160,14 +1160,12 @@ class ETSModel(base.StateSpaceMLEModel):
         res = self._residuals(yhat, data=data)
         logL = -self.nobs / 2 * (np.log(2 * np.pi * np.mean(res ** 2)) + 1)
         if self.error == "mul":
-            # GH-7331: in some cases, yhat can become negative, so that a
-            # multiplicative model is no longer well-defined. To avoid these
-            # parameterizations, we clip negative values to very small positive
-            # values so that the log-transformation yields very large negative
-            # values.
-            # yhat[yhat <= 0] = 1 / (1e-8 * (1 + np.abs(yhat[yhat <= 0])))
+            # In some cases, yhat can become negative, so that a
+            # multiplicative model is no longer well-defined. In this case
+            # we overwrite the log-likelihood to be -infinity so that these
+            # models are never selected.
             if np.any(yhat <= 0):
-                logL = -10**32
+                logL = -np.inf
             else:
                 logL -= np.sum(np.log(yhat))
         return logL

--- a/statsmodels/tsa/exponential_smoothing/ets.py
+++ b/statsmodels/tsa/exponential_smoothing/ets.py
@@ -1164,7 +1164,7 @@ class ETSModel(base.StateSpaceMLEModel):
             # multiplicative model is no longer well-defined. Zero values
             # are replaced with 10^-32 (a very small number. For more
             # information on the derivation of the log-likelihood for the
-            # multiplicative error models see: 
+            # multiplicative error models see:
             # https://openforecast.org/adam/ADAMETSEstimationLikelihood.html
             yhat[yhat == 0] = 1e-32
             logL -= np.sum(np.log(np.abs(yhat)))


### PR DESCRIPTION

Related to #7331 

**tl;dr:** This PR fixes a small issue in the likelihood calculation of ETS models with multiplicative errors, that caused them to have low ICs and unreasonable forecasts.

***

It appears that the problem raised in #7331 (ETS(MAM) giving unreasonable forecasts) is still there. The fix for the issue had the desired effect for the example time series in the issue but unfortunately the exploding forecasts can still appear for different time series like the one below:
<details><summary>Code to reproduce the plots</summary>

```python
from statsmodels.tsa.exponential_smoothing.ets import ETSModel
import numpy as np
from matplotlib import pyplot as plt

data = np.array([
    214307.1, 331110.3, 324617.4, 230818.8, 275551.5, 232633.5,
    281989.2, 245336.4, 296976. , 207572.7, 252719.4, 210795. ,
    142705.8, 146742.3, 261613.5, 276959.1, 365010. ,  48734.7,
    308919.9, 319401. , 150199.2, 103010.1, 109861.8,  89486.1,
    393645. , 421279.5, 347387.4, 269928. , 171278.7, 158568.9,
    280526.4, 195104.4, 230998.2, 226602.9, 267526.8, 258632.7
])

plt.plot(data)
plt.title("Original time series")
plt.show()

res = ETSModel(
    endog=data,
    seasonal_periods=12,
    error="mul",
    seasonal="mul",
    trend="add",
).fit()
pred = res.forecast(steps=12)
pred_fill = np.zeros_like(data)
pred_fill[:] = np.nan
plt.plot(data, label="endog")
plt.plot(np.concatenate([pred_fill, pred]), label="forecast")
plt.legend()
plt.title("ETS(MAM) forecast - statsmodels (main)")
plt.show()
```

</details>

![image](https://github.com/statsmodels/statsmodels/assets/64217214/5db70668-bb07-4609-bc25-d72c248a11d2)
![image](https://github.com/statsmodels/statsmodels/assets/64217214/cb60deba-733f-404b-b438-25e82fc4ee83)



Moreover, the log-likelihood of the unreasonable forecasts is unreasonably high making the AutoETS implementations (e.g. [sktime](https://github.com/sktime/sktime/blob/main/sktime/forecasting/ets.py), [aeon](https://github.com/aeon-toolkit/aeon/blob/main/aeon/forecasting/ets.py)) that are based on ETS model selection using information criteria (e.g. AIC) select the unreasonable forecasts.
&nbsp;
The problem comes from the Log-Likelihood calculation for ETS models with multiplicative errors, and more specifically the fail-safe mechanism for negative or zero yhat values here:
https://github.com/statsmodels/statsmodels/blob/23faea30e30ff759c3c9d3f1d57864b2aa68c827/statsmodels/tsa/exponential_smoothing/ets.py#L1162-L1169
&nbsp;
This way is not consistent with the literature (see screenshot below):
![image](https://github.com/statsmodels/statsmodels/assets/64217214/5bbbdda3-076f-4ba9-95b1-8885952ba59b)
*screenshot from the [online version](https://www.openforecast.org/adam/ADAMETSEstimationLikelihood.html) of Svetunkov, I. (2023). Forecasting and Analytics with the Augmented Dynamic Adaptive Model (ADAM) (1st ed.). Chapman and Hall/CRC. https://doi.org/10.1201/9781003452652*
&nbsp;

In addition, it's not consistent with any other ETS implementations, where they all seem to follow the formula above for the last term of the log-likelihood, namely log(| yhat |). Below is the relevant code from the other OSS implementations I checked:
* [forecast](https://github.com/robjhyndman/forecast/blob/7d5a856e3ed6579bbd673234807e045c267f4521/src/etscalc.c#L106)
* [smooth](https://github.com/config-i1/smooth/blob/6ead0a2a3115075686b9cfe6240da63ee5db4418/R/adam.R#L2529)
* [nixtla - statsforecast](https://github.com/Nixtla/statsforecast/blob/9d75d22d21bec23063bc1df912cf7d415fd93fd6/statsforecast/ets.py#L96)

All the implementations listed above give similar Log-Likelihood values and AIC as well as reasonable forecasts. The AIC for ETS and this time series is best for the EST(ANN) model hence all the automatic model selection methods from the packages above select this one. Below are the forecasts from these different packages for ETS(MAM) for the same time "problematic" series:

<details><summary>(R) forecast </summary>

```R
library(forecast)
library(ggplot2)

data = ts(
  c(
    214307.1, 331110.3, 324617.4, 230818.8, 275551.5, 232633.5,
    281989.2, 245336.4, 296976. , 207572.7, 252719.4, 210795. ,
    142705.8, 146742.3, 261613.5, 276959.1, 365010. ,  48734.7,
    308919.9, 319401. , 150199.2, 103010.1, 109861.8,  89486.1,
    393645. , 421279.5, 347387.4, 269928. , 171278.7, 158568.9,
    280526.4, 195104.4, 230998.2, 226602.9, 267526.8, 258632.7
  ),
  freq=12
)

fcast_ets_mam = forecast::ets(data, model="MAM", ic="aic") %>% forecast(h=12)
autoplot(fcast_ets_mam)
summary(fcast_ets_mam)
```

</details>

![image](https://github.com/statsmodels/statsmodels/assets/64217214/5de65f19-056c-41c1-a794-74feac46bb85)



<details><summary> (R) smooth </summary>

```R
library(smooth)
library(ggplot2)

data = ts(
  c(
    214307.1, 331110.3, 324617.4, 230818.8, 275551.5, 232633.5,
    281989.2, 245336.4, 296976. , 207572.7, 252719.4, 210795. ,
    142705.8, 146742.3, 261613.5, 276959.1, 365010. ,  48734.7,
    308919.9, 319401. , 150199.2, 103010.1, 109861.8,  89486.1,
    393645. , 421279.5, 347387.4, 269928. , 171278.7, 158568.9,
    280526.4, 195104.4, 230998.2, 226602.9, 267526.8, 258632.7
  ),
  freq=12
)

smooth_es_fit = smooth::es(data, model="MAM")
summary(smooth_es_fit)
smooth_es_fit %>% forecast(h=12) |> plot(main="Smooth ETS(MAM)")
```

</details>

![image](https://github.com/statsmodels/statsmodels/assets/64217214/133df913-6f31-40b4-9d2a-b265c0e1a502)


<details><summary>(Python) nixtla - statsforecast</summary>

```python
from statsforecast.models import AutoETS as StatsforecastETS
import numpy as np
from matplotlib import pyplot as plt

data = np.array([
    214307.1, 331110.3, 324617.4, 230818.8, 275551.5, 232633.5,
    281989.2, 245336.4, 296976. , 207572.7, 252719.4, 210795. ,
    142705.8, 146742.3, 261613.5, 276959.1, 365010. ,  48734.7,
    308919.9, 319401. , 150199.2, 103010.1, 109861.8,  89486.1,
    393645. , 421279.5, 347387.4, 269928. , 171278.7, 158568.9,
    280526.4, 195104.4, 230998.2, 226602.9, 267526.8, 258632.7
])
s_fcaster = StatsforecastETS(model="MAM", season_length=12)
s_fcaster.fit(data)
pred = s_fcaster.predict(h=12)["mean"]
pred_fill = np.empty_like(data)
pred_fill[:] = np.nan
pred = np.concatenate([pred_fill, pred])
plt.plot(data, label="endog")
plt.plot(pred, label="forecast")
plt.title("Nixtla/statsforecast - ETS(MAM)")
plt.show()
print(s_fcaster.__dict__)
```

</details>

![image](https://github.com/statsmodels/statsmodels/assets/64217214/0eb7f320-ffc6-4fc0-8e1b-f2746997db42)


&nbsp;

This PR changes the code for the log-likelihood for multiplicative error models so that it's consistent with the literature and the other ETS implementations. This results in similar forecasts like above:

![image](https://github.com/statsmodels/statsmodels/assets/64217214/fb4d3b80-de25-4e93-8582-a10e83353ab2)


Here are the values for each the log-likelihood and the AIC for ETS(MAM) and that series for each implementation, including the change in statsmodels proposed in this PR.
| ETS Implementation  | Log-Likelihood | AIC |
| ------------- | ------------- | ------------- |
| **statsmodels - main**  | -79.417 | 194.835  |
| **(R) forecast**  | -470.094 |  974.188 |
| **(R) smooth**  | -453.326 |  936.652 |
| **nixtla - statsforecast**  | -467.193  |  968.386 |
| **statsmodels - this PR** | -453.251 |  942.503 |

***

**PS:** Many many many thanks to @config-i1 for helping me to figure this one out! 🙏