### PR TITLE
Fix linting error

### DIFF
--- a/statsmodels/genmod/tests/test_glm.py
+++ b/statsmodels/genmod/tests/test_glm.py
@@ -1307,7 +1307,7 @@ def test_gradient_irls():
                     mod_irls = sm.GLM(endog, exog, family=family_class(link=link()))
                 rslt_irls = mod_irls.fit(method="IRLS")
 
-                if not (family_class, link) in [(fam.Poisson, lnk.Sqrt),
+                if (family_class, link) not in [(fam.Poisson, lnk.Sqrt),
                                                 (fam.Gamma, lnk.InversePower),
                                                 (fam.InverseGaussian, lnk.Identity)
                                                 ]:

--- a/statsmodels/imputation/tests/test_mice.py
+++ b/statsmodels/imputation/tests/test_mice.py
@@ -105,7 +105,7 @@ class TestMICEData:
         )
 
         # Should make a copy
-        assert not (df is imp_data.data)
+        assert df is not imp_data.data
 
         (endog_obs, exog_obs, exog_miss,
          predict_obs_kwds, predict_miss_kwds) = imp_data.get_split_data('x3')

--- a/statsmodels/multivariate/factor_rotation/_wrappers.py
+++ b/statsmodels/multivariate/factor_rotation/_wrappers.py
@@ -223,7 +223,7 @@ def rotate_factors(A, method, *method_args, **algorithm_kwargs):
         algorithm_kwargs.pop('algorithm')
     else:
         algorithm = 'gpa'
-    assert not ('rotation_method' in algorithm_kwargs), (
+    assert 'rotation_method' not in algorithm_kwargs, (
         'rotation_method cannot be provided as keyword argument')
     L = None
     T = None

--- a/statsmodels/sandbox/panel/panelmod.py
+++ b/statsmodels/sandbox/panel/panelmod.py
@@ -31,7 +31,7 @@ def group(X):
     uniq_dict = {}
     group = np.zeros(len(X))
     for i in range(len(X)):
-        if not X[i] in uniq_dict:
+        if X[i] not in uniq_dict:
             uniq_dict.update({X[i] : len(uniq_dict)})
         group[i] = uniq_dict[X[i]]
     return group

--- a/statsmodels/sandbox/sysreg.py
+++ b/statsmodels/sandbox/sysreg.py
@@ -94,7 +94,7 @@ class SUR:
             raise ValueError("sys must be a list of pairs of endogenous and \
 exogenous variables.  Got length %s" % len(sys))
         if dfk:
-            if not dfk.lower() in ['dfk1','dfk2']:
+            if dfk.lower() not in ['dfk1','dfk2']:
                 raise ValueError("dfk option %s not understood" % (dfk))
         self._dfk = dfk
         M = len(sys[1::2])

--- a/statsmodels/tsa/statespace/structural.py
+++ b/statsmodels/tsa/statespace/structural.py
@@ -422,7 +422,7 @@ class UnobservedComponents(MLEModel):
             trend_attributes = ['irregular', 'level', 'trend',
                                 'stochastic_level', 'stochastic_trend']
             for attribute in trend_attributes:
-                if not getattr(self, attribute) is False:
+                if getattr(self, attribute) is not False:
                     warn("Value of `%s` may be overridden when the trend"
                          " component is specified using a model string."
                          % attribute, SpecificationWarning)

--- a/statsmodels/tsa/statespace/tests/results/results_structural.py
+++ b/statsmodels/tsa/statespace/tests/results/results_structural.py
@@ -270,31 +270,31 @@ lltrend_cycle_seasonal_reg_ar1_approx_diffuse = {
          'exog': True, 'mle_regression': False},
         # Verbose string specification
         {'level': 'local linear trend', 'autoregressive': 1, 'cycle': True,
-         'stochastic_cycle': True, 'seasonal': 4, 'autoregressive': 1,
+         'stochastic_cycle': True, 'seasonal': 4,
          'exog': True, 'mle_regression': False},
         # Abbreviated string specification
         {'level': 'lltrend', 'autoregressive': 1, 'cycle': True,
-         'stochastic_cycle': True, 'seasonal': 4, 'autoregressive': 1,
+         'stochastic_cycle': True, 'seasonal': 4,
          'exog': True, 'mle_regression': False},
         # Numpy exog dataset
         {'level': 'lltrend', 'autoregressive': 1, 'cycle': True,
-         'stochastic_cycle': True, 'seasonal': 4, 'autoregressive': 1,
+         'stochastic_cycle': True, 'seasonal': 4,
          'exog': 'numpy', 'mle_regression': False},
         # Annual frequency dataset
         {'level': 'lltrend', 'autoregressive': 1, 'cycle': True,
-         'stochastic_cycle': True, 'seasonal': 4, 'autoregressive': 1,
+         'stochastic_cycle': True, 'seasonal': 4,
          'exog': True, 'mle_regression': False, 'freq': 'YS'},
         # Quarterly frequency dataset
         {'level': 'lltrend', 'autoregressive': 1, 'cycle': True,
-         'stochastic_cycle': True, 'seasonal': 4, 'autoregressive': 1,
+         'stochastic_cycle': True, 'seasonal': 4,
          'exog': True, 'mle_regression': False, 'freq': 'QS'},
         # Monthly frequency dataset
         {'level': 'lltrend', 'autoregressive': 1, 'cycle': True,
-         'stochastic_cycle': True, 'seasonal': 4, 'autoregressive': 1,
+         'stochastic_cycle': True, 'seasonal': 4,
          'exog': True, 'mle_regression': False, 'freq': 'MS'},
         # Minutely frequency dataset
         {'level': 'lltrend', 'autoregressive': 1, 'cycle': True,
-         'stochastic_cycle': True, 'seasonal': 4, 'autoregressive': 1,
+         'stochastic_cycle': True, 'seasonal': 4,
          'exog': True, 'mle_regression': False, 'freq': 'min',
          'cycle_period_bounds': (1.5*12, 12*12)},
     ],

--- a/statsmodels/tsa/statespace/tools.py
+++ b/statsmodels/tsa/statespace/tools.py
@@ -1491,7 +1491,7 @@ def validate_matrix_shape(name, shape, nrows, ncols, nobs):
                          ' explicity)' % name)
 
     # Enforce time-varying array size
-    if ndim == 3 and nobs is not None and not shape[-1] in [1, nobs]:
+    if ndim == 3 and nobs is not None and shape[-1] not in [1, nobs]:
         raise ValueError('Invalid dimensions for time-varying %s'
                          ' matrix. Requires shape (*,*,%d), got %s' %
                          (name, nobs, str(shape)))
@@ -1538,7 +1538,7 @@ def validate_vector_shape(name, shape, nrows, nobs):
                          ' explicity)' % name)
 
     # Enforce time-varying array size
-    if ndim == 2 and not shape[1] in [1, nobs]:
+    if ndim == 2 and shape[1] not in [1, nobs]:
         raise ValueError('Invalid dimensions for time-varying %s'
                          ' vector. Requires shape (*,%d), got %s' %
                          (name, nobs, str(shape)))


### PR DESCRIPTION
Fix some linting errors found by `ruff`. 

Is it also a welcome change in `statsmodels` to add `ruff` as a linting tool to leverage its autofix feature? It can be added as either a GitHub Actions job, a `pre-commit` job, or part of the current `lint.sh` file

- [ ] closes #xxxx
- [ ] tests added / passed. 
- [ ] code/documentation is well formatted.  
- [ ] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
