### PR TITLE
Fix string formatting

### DIFF
--- a/statsmodels/graphics/gofplots.py
+++ b/statsmodels/graphics/gofplots.py
@@ -260,9 +260,7 @@ class ProbPlot:
         try:
             return self.dist.ppf(self.theoretical_percentiles)
         except TypeError:
-            msg = "%s requires more parameters to compute ppf".format(
-                self.dist.name,
-            )
+            msg = f"{self.dist.name} requires more parameters to compute ppf"
             raise TypeError(msg)
         except Exception as exc:
             msg = f"failed to compute the ppf of {self.dist.name}"

--- a/statsmodels/graphics/mosaicplot.py
+++ b/statsmodels/graphics/mosaicplot.py
@@ -40,8 +40,10 @@ def _normalize_split(proportion):
         raise ValueError("proportions should be positive,"
                           "given value: {}".format(proportion))
     if np.allclose(proportion, 0):
-        raise ValueError("at least one proportion should be "
-                          "greater than zero".format(proportion))
+        raise ValueError(
+            "at least one proportion should be greater than zero"
+            "given value: {}".format(proportion)
+        )
     # ok, data are meaningful, so go on
     if len(proportion) < 2:
         return array([0.0, 1.0])
@@ -61,7 +63,7 @@ def _split_rect(x, y, width, height, proportion, horizontal=True, gap=0.05):
     x, y, w, h = float(x), float(y), float(width), float(height)
     if (w < 0) or (h < 0):
         raise ValueError("dimension of the square less than"
-                          "zero w={} h=()".format(w, h))
+                          "zero w={} h={}".format(w, h))
     proportions = _normalize_split(proportion)
 
     # extract the starting point and the dimension of each subdivision


### PR DESCRIPTION
Fix these string formatting errors

```bash
statsmodels/graphics/gofplots.py:263:19: F523 [*] `.format` call has unused arguments at position(s): 0
statsmodels/graphics/mosaicplot.py:43:26: F523 [*] `.format` call has unused arguments at position(s): 0
statsmodels/graphics/mosaicplot.py:63:26: F523 [*] `.format` call has unused arguments at position(s): 1
Found 3 errors.
```