### PR TITLE
BUG: Ensure ARIMA simulation is reproducable

### DIFF
--- a/statsmodels/tsa/arima/tests/test_model.py
+++ b/statsmodels/tsa/arima/tests/test_model.py
@@ -413,3 +413,22 @@ def test_hannan_rissanen_with_fixed_params(ar_order, ma_order, fixed_params):
         res = mod.fit(method='hannan_rissanen')
 
     assert_allclose(res.params, desired_p.params)
+
+
+@pytest.mark.parametrize(
+    "random_state_type", [7, np.random.RandomState, np.random.default_rng]
+)
+def test_reproducible_simulation(random_state_type):
+    x = np.random.randn(100)
+    res = ARIMA(x, order=(1, 0, 0)).fit()
+
+    def get_random_state(val):
+        if isinstance(random_state_type, int):
+            return 7
+        return random_state_type(7)
+
+    random_state = get_random_state(random_state_type)
+    sim1 = res.simulate(1, random_state=random_state)
+    random_state = get_random_state(random_state_type)
+    sim2 = res.simulate(1, random_state=random_state)
+    assert_allclose(sim1, sim2)

--- a/statsmodels/tsa/statespace/mlemodel.py
+++ b/statsmodels/tsa/statespace/mlemodel.py
@@ -3644,6 +3644,10 @@ class MLEResults(tsbase.TimeSeriesModelResults):
         if iloc > self.nobs:
             raise ValueError('Cannot anchor simulation outside of the sample.')
 
+        # GH 9162
+        from statsmodels.tsa.statespace import simulation_smoother
+        random_state = simulation_smoother.check_random_state(random_state)
+
         # Setup the initial state
         if initial_state is None:
             initial_state_moments = (
@@ -3652,7 +3656,7 @@ class MLEResults(tsbase.TimeSeriesModelResults):
 
             _repetitions = 1 if repetitions is None else repetitions
 
-            initial_state = np.random.multivariate_normal(
+            initial_state = random_state.multivariate_normal(
                 *initial_state_moments, size=_repetitions).T
 
         scale = self.scale if self.filter_results.filter_concentrated else None


### PR DESCRIPTION
Ensure rpoducability by creating random_state earlier and using consistently

- [X] closes #9162 
- [X] tests added / passed. 
- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
