### PR TITLE
ENH: vectorize loo function for local_constant estimator

### DIFF
--- a/statsmodels/nonparametric/_kernel_base.py
+++ b/statsmodels/nonparametric/_kernel_base.py
@@ -5,7 +5,7 @@ regression, plus some utilities.
 import copy
 
 import numpy as np
-from scipy import optimize
+from scipy import optimize, spatial
 from scipy.stats.mstats import mquantiles
 
 try:
@@ -516,3 +516,64 @@ def gpke(bw, data, data_predict, var_type, ckertype='gaussian',
         return dens.sum(axis=0)
     else:
         return dens
+
+
+def pairwise_product_kernel(bw, data, var_type, ckertype='gaussian',
+         okertype='wangryzin', ukertype='aitchisonaitken'):
+    r"""
+    Returns the pairwise product kernel function for each pair of data points
+    in `data` as a 2-D array. Summing row-wise or col-wise gives the `gpke`
+    evaluated at each data point in `data`.
+
+    Parameters
+    ----------
+    bw : 1-D ndarray, shape (k_vars,)
+        Bandwidth parameters for the kernel functions.
+    data : 2-D ndarray, shape (nobs, k_vars)
+        Points at which the kernel function is evaluated.
+    var_type : str
+        The type of the variables, one character per variable:
+
+            - c: continuous
+            - u: unordered (discrete)
+            - o: ordered (discrete)
+            
+    ckertype : TYPE, optional
+        The kernel used for the continuous variables. The default is
+        'gaussian'.
+    okertype : TYPE, optional
+        The kernel used for the ordered discrete variables. The default is
+        'wangryzin'.
+    ukertype : TYPE, optional
+        The kernel used for the unordered discrete variables. The default is
+        'aitchisonaitken'.
+
+    Returns
+    -------
+    K : 2-D ndarray, shape (nobs, nobs)
+        A 2-D array.where the (i, j) component is K(x_i, x_j) where K
+        is the product kernel function.
+
+    """
+    nobs, k_vars = np.shape(data)
+    # full vectorization only for continuous gaussian kernel
+    if (ckertype == 'gaussian') and (set(var_type) == set('c')):
+        VI = np.diag(1 / bw) ** 2
+        D = spatial.distance.squareform(
+            spatial.distance.pdist(data, metric='mahalanobis', VI=VI)
+            ) ** 2
+        K = np.exp(-0.5 * D) * (1. / np.sqrt(2 * np.pi)) ** k_vars
+        K = K / np.prod(bw)
+    else:
+        K = np.empty((nobs, nobs))
+        for ii in range(nobs):
+            ker_ii = gpke(bw, data=data, data_predict=data[ii, :],
+                          var_type=var_type,
+                          ckertype=ckertype,
+                          ukertype=ukertype,
+                          okertype=okertype,
+                          tosum=False)
+            
+            K[:, ii] = ker_ii
+    
+    return K


### PR DESCRIPTION
- [ ] closes #4187 (dealt with performance issues for leave one out estimation of bandwidth for local constant estimator)
- [x] tests passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

This is a performance improvement for bandwidth estimation using leave one out cross-validation for local constant estimators. A method `cv_loo_fast` is added which is only used when `reg_type` is 'lc'. The idea is to calculate the leave-on-out estimations by using matrix multiplication instead of using a loop. In general, I see a 2~2.5 times of speed up for <=1000 rows of data. When using only continuous gaussian kernel, the speed up is more than 6 times due to a further vectorization in calculating the product kernel function.

**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
