### PR TITLE
more reliable casting of pandas data

### DIFF
--- a/statsmodels/base/data.py
+++ b/statsmodels/base/data.py
@@ -504,7 +504,7 @@ class PandasData(ModelData):
     def _convert_endog_exog(self, endog, exog=None):
         #TODO: remove this when we handle dtype systematically
         endog = np.asarray(endog)
-        exog = exog if exog is None else np.asarray(exog)
+        exog = exog if exog is None else np.asarray(exog, dtype=float)
         if endog.dtype == object or exog is not None and exog.dtype == object:
             raise ValueError("Pandas data cast to numpy dtype of object. "
                              "Check input data with np.asarray(data).")


### PR DESCRIPTION
- [ ] quick fix to #9205 
- [ ] tests added / passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

Note: Only one test fails, in a particular code path that avoids data casting.
```python
    def test_dtype_object():
        # see GH#880
    
        X = np.random.random((40, 2))
        df = pd.DataFrame(X)
        df[2] = np.random.randint(2, size=40).astype('object')
        df['constant'] = 1
    
        y = pd.Series(np.random.randint(2, size=40))
    
>       np.testing.assert_raises(ValueError, sm_data.handle_data, y, df)
```

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
