### PR TITLE
ENH: Stop unstable lowess iterations

### DIFF
--- a/statsmodels/nonparametric/smoothers_lowess.py
+++ b/statsmodels/nonparametric/smoothers_lowess.py
@@ -84,7 +84,9 @@ def lowess(endog, exog, frac=2.0/3.0, it=3, delta=0.0, xvals=None, is_sorted=Fal
     are less problematic. The weights downgrade the influence of
     points with large residuals. In the extreme case, points whose
     residuals are larger than 6 times the median absolute residual
-    are given weight 0.
+    are given weight 0. If during iterations, the median absolute
+    residual becomes less than 1e-7 (basically zero), iterations
+    are stopped as the algorithm becomes unstable.
 
     `delta` can be used to save computations. For each `x_i`, regressions
     are skipped for points closer than `delta`. The next regression is

--- a/statsmodels/nonparametric/tests/test_lowess.py
+++ b/statsmodels/nonparametric/tests/test_lowess.py
@@ -289,6 +289,12 @@ class TestLowess:
         with pytest.raises(ValueError):
             lowess(y, x, xvals=np.array([[5], [10]]))
 
+    def test_stop_iter(self):
+        # See GH-2108
+        expected = lowess([0] * 10 + [1] * 10, np.arange(20), it=1)
+        result = lowess([0] * 10 + [1] * 10, np.arange(20), it=2)
+        assert_equal(expected, result)
+
 
 def test_returns_inputs():
     # see 1960

--- a/statsmodels/nonparametric/tests/test_lowess.py
+++ b/statsmodels/nonparametric/tests/test_lowess.py
@@ -296,12 +296,13 @@ class TestLowess:
         assert_equal(expected, result)
 
 
-def test_returns_inputs():
+def test_nan_regression():
     # see 1960
     y = [0] * 10 + [1] * 10
     x = np.arange(20)
     result = lowess(y, x, frac=0.4)
-    assert_almost_equal(result, np.column_stack((x, y)))
+    out = lowess([0] * 7 + [1] * 7, np.arange(14), frac=.2, it=1)[:, 1]
+    assert not np.any(np.isnan(out))
 
 
 def test_xvals_dtype(reset_randomstate):


### PR DESCRIPTION
- [x] closes #2108 
- [x] closes #2449 
- [x] tests added / passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message).

I was running into some issues trying to interpolate between a lot of 0s and 1s similar to some of the old test cases and issues. I noticed that R just bails out if the MAD gets close to zero "since the algorithm is highly unstable in that case." This seems to close a few of the open lowess issue and (partially) fix the one I was having.

I removed one of the test cases that is no longer the behavior. I guess technically this is a breaking change, but the new behavior now matches R.

This partially fixes #7337, if you consider extrapolating a good fix. Only the frac=.3 test case spits out NaNs now. I'll have to go through that part, but that's probably for a different PR.