### PR TITLE
ENH: Fix lowess extrapolation

### DIFF
--- a/statsmodels/nonparametric/smoothers_lowess.py
+++ b/statsmodels/nonparametric/smoothers_lowess.py
@@ -84,7 +84,9 @@ def lowess(endog, exog, frac=2.0/3.0, it=3, delta=0.0, xvals=None, is_sorted=Fal
     are less problematic. The weights downgrade the influence of
     points with large residuals. In the extreme case, points whose
     residuals are larger than 6 times the median absolute residual
-    are given weight 0.
+    are given weight 0. If during iterations, the median absolute
+    residual becomes less than 1e-7 (basically zero), iterations
+    are stopped as the algorithm becomes unstable.
 
     `delta` can be used to save computations. For each `x_i`, regressions
     are skipped for points closer than `delta`. The next regression is

--- a/statsmodels/nonparametric/tests/test_lowess.py
+++ b/statsmodels/nonparametric/tests/test_lowess.py
@@ -289,6 +289,12 @@ class TestLowess:
         with pytest.raises(ValueError):
             lowess(y, x, xvals=np.array([[5], [10]]))
 
+    def test_stop_iter(self):
+        # See GH-2108
+        expected = lowess([0] * 10 + [1] * 10, np.arange(20), it=1)
+        result = lowess([0] * 10 + [1] * 10, np.arange(20), it=2)
+        assert_equal(expected, result)
+
 
 def test_returns_inputs():
     # see 1960

--- a/statsmodels/nonparametric/tests/test_lowess.py
+++ b/statsmodels/nonparametric/tests/test_lowess.py
@@ -311,3 +311,25 @@ def test_xvals_dtype(reset_randomstate):
     # Previously raised ValueError: Buffer dtype mismatch
     results_xvals = lowess(y, x, frac=0.4, xvals=x[:5])
     assert_allclose(results_xvals, np.zeros(5), atol=1e-12)
+
+
+def test_interpolated_output():
+    # see #7337
+    y = np.arange(5, 15, dtype=float)
+    x = np.arange(5, 15, dtype=float)
+    xvals = np.arange(0, 20, dtype=float)
+
+    result = lowess(y, x, xvals=xvals, frac=0.6)
+    assert_allclose(result, xvals, atol=1e-8)
+
+    result = lowess(y, x, xvals=xvals, frac=0.5)
+    assert_allclose(result, xvals, atol=1e-8)
+
+    result = lowess(y, x, xvals=xvals, frac=0.4)
+    assert_allclose(result, xvals, atol=1e-8)
+
+    result = lowess(y, x, xvals=xvals, frac=0.3)
+    assert_allclose(result, xvals, atol=1e-8)
+
+    result = lowess(y, x, xvals=x, frac=0.5)
+    assert_allclose(result, x, atol=1e-8)

--- a/statsmodels/nonparametric/tests/test_lowess.py
+++ b/statsmodels/nonparametric/tests/test_lowess.py
@@ -296,12 +296,13 @@ class TestLowess:
         assert_equal(expected, result)
 
 
-def test_returns_inputs():
+def test_nan_regression():
     # see 1960
     y = [0] * 10 + [1] * 10
     x = np.arange(20)
     result = lowess(y, x, frac=0.4)
-    assert_almost_equal(result, np.column_stack((x, y)))
+    out = lowess([0] * 7 + [1] * 7, np.arange(14), frac=.2, it=1)[:, 1]
+    assert not np.any(np.isnan(out))
 
 
 def test_xvals_dtype(reset_randomstate):


### PR DESCRIPTION
- [x] closes #7337
- [x] tests added / passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

Really, #7337 didn't have anything to do with extrapolation per se. In most of the examples, you just get to a perfect fit and we weren't stopping so it goes off the rails. See #9220.

In the last case, where frac=.3. Since that results in 3 data points in the neighborhood, and with a radius of 2 and them being spaced like 1, 2, 3, you're only ever going to get 2 non-zero weights. Really, you only need your weights to sum to something greater than zero to do the WLS step (for better or worse), so I made that change. That revealed the test case where we have so many ties. Instead of handling this through weights counting, I added a guard for radius of zero.

Draft because this also includes #9220 until/if merged.