### PR TITLE
DOC: Add a missing minus sign in the docstring of Logit.inverse()

### DIFF
--- a/statsmodels/genmod/families/links.py
+++ b/statsmodels/genmod/families/links.py
@@ -192,7 +192,7 @@ class Logit(Link):
 
         Notes
         -----
-        g^(-1)(z) = exp(z)/(1+exp(z))
+        g^(-1)(z) = exp(z)/(1+exp(-z))
         """
         z = np.asarray(z)
         t = np.exp(-z)


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

The docstring for the inverse() method of the Logit Link class is missing a minus sign, which is added with this Pull Request

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
