### PR TITLE
ENH: Test stat for Fleiss Kappa

### DIFF
--- a/statsmodels/stats/tests/test_inter_rater.py
+++ b/statsmodels/stats/tests/test_inter_rater.py
@@ -75,10 +75,10 @@ def test_fleiss_kappa():
 
 def test_fleiss_kappa_variance():
     table = aggregate_raters(diagnoses)[0]
-    kappa, zvalue, pvalue = fleiss_kappa(table, return_stat=True)
+    results = fleiss_kappa(table, return_results=True)
     # from irr
-    assert_almost_equal(zvalue, 17.651830582991369)
-    assert_equal(pvalue, 0)
+    assert_almost_equal(results.zvalue, 17.651830582991369)
+    assert_equal(results.pvalue, 0)
 
 
 def test_fleis_randolph():


### PR DESCRIPTION
Closes #9207

- [x] closes #9207 
- [x] tests added / passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

Added the large sample variance for Fleiss' Kappa. Matches stata and irr behavior. Added test case from irr. Didn't find anything about large sample properties of Randolph's measure. I suppose you could just bootstrap in this case.