### PR TITLE
ENH: Improved performance test_eff(test_tools) 6 times faster

### DIFF
--- a/statsmodels/robust/tests/test_tools.py
+++ b/statsmodels/robust/tests/test_tools.py
@@ -49,11 +49,13 @@ results_menenez = [
 @pytest.mark.parametrize("case", results_menenez)
 def test_eff(case):
     norm, res2 = case
+    use_jump = False
 
     if norm.continuous == 2:
         var_func = _var_normal
     else:
         var_func = _var_normal_jump
+        use_jump = True
 
     res_eff = []
     for c in res2:
@@ -65,8 +67,8 @@ def test_eff(case):
     for c in res2:
         # bp = stats.norm.expect(lambda x : norm.rho(x)) / norm.rho(norm.c)
         norm._set_tuning_param(c)
-        eff = 1 / _var_normal(norm)
-        tune = _get_tuning_param(norm, eff)
+        eff = 1 / var_func(norm)
+        tune = _get_tuning_param(norm, eff, use_jump=use_jump)
         assert_allclose(tune, c, rtol=1e-6, atol=5e-4)
 
 

--- a/statsmodels/robust/tools.py
+++ b/statsmodels/robust/tools.py
@@ -155,7 +155,7 @@ def _get_tuning_param(norm, eff, kwd="c", kwargs=None, use_jump=False,
     else:
         def func(c):
             norm._set_tuning_param(c)
-            return _var_normal_jump(norm(**kwds) - 1 / eff)
+            return _var_normal_jump(norm) - 1 / eff
 
     res = optimize.brentq(func, *bracket)
     return res


### PR DESCRIPTION
- [x] tests added / passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

If you look at the performance, the slowest test is:
`113.91s call statsmodels/robust/tests/test_tools.py::test_eff[case6]`

At the same time, warnings appear:
```
Copy on Write disabled
  C:\hostedtoolcache\windows\Python\3.9.13\x64\lib\site-packages\scipy\stats\_distn_infrastructure.py:2958: IntegrationWarning: The maximum number of subdivisions (50) has been achieved.
    If increasing the limit yields no improvement it is advised to analyze 
    the integrand in order to determine the difficulties.  If the position of a 
    local difficulty can be determined (singularity, discontinuity) one will 
    probably gain from splitting up the interval and calling the integrator 
    on the subranges.  Perhaps a special-purpose integrator should be used.
    cd = integrate.quad(fun, c, d, **kwds)[0]
```
In the test_eff function, if the parameter: `norm.continuous == 2`  is not true, then `var_func = _var_normal_jump`. That is, based on the warnings, I assume that with: `norm.continuous != 2`  need to use everywhere: `_var_normal_jump`

I tried replacing `_var_normal` with `var_func` in the second loop and passing the `use_jump=use_jump` parameter to `_get_tuning_param`. Now the following error occurred:
```
line 158, in func
    return _var_normal_jump(norm(**kwds) - 1 / eff)
TypeError: RobustNorm.__call__() missing 1 required positional argument: 'z'
```
Replaced: `return _var_normal_jump(norm(**kwds) - 1 / eff) `with: `return _var_normal_jump(norm) - 1 / eff` in `_get_tuning_param`

What are the community's thoughts?

For clarity, I made tests to run directly (the tools.py module was separated into a separate file). The tools.py code is not posted due to line limitations, I am attaching it as an attachment.


<details>

<summary>test_tools - code</summary>

```
   """
Created on Mar. 12, 2024 11:10:14 a.m.

Author: Josef Perktold
License: BSD-3
"""

import pytest

import numpy as np
from numpy.testing import assert_allclose

# from scipy import stats

from statsmodels_.robust.norms import (
    AndrewWave,
    TrimmedMean,
    TukeyBiweight,
    TukeyQuartic,
    Hampel,
    HuberT,
    StudentT,
    )

from tools import (
    _var_normal,
    _var_normal_jump,
    _get_tuning_param,
    tuning_s_estimator_mean,
    )


effs = [0.9, 0.95, 0.98, 0.99]

results_menenez = [
    (HuberT(), [0.9818, 1.345, 1.7459, 2.0102]),
    (TukeyBiweight(), [3.8827, 4.6851, 5.9207, 7.0414]),
    (TukeyQuartic(), [3.1576, 3.6175, 4.2103, 4.6664]),
    (TukeyQuartic(k=2), [3.8827, 4.6851, 5.9207, 7.0414]),  # biweight
    (StudentT(df=1), [1.7249, 2.3849, 3.3962, 4.2904]),  # Cauchy
    (AndrewWave(), [1.1117, 1.338, 1.6930, 2.0170]),
    # (Hampel(), [4.4209, 5.4, 7.00609, 8.0456]),
    # rounding problem in Hampel, menenez use a as tuning parameter
    (Hampel(), [4.4208, 5.5275, 7.006, 8.0456]),
    (TrimmedMean(), [2.5003, 2.7955, 3.1365, 3.3682]),
    ]


#@pytest.mark.parametrize("case", results_menenez)
def test_eff_old(case):
    norm, res2 = case

    if norm.continuous == 2:
        var_func = _var_normal
    else:
        var_func = _var_normal_jump

    res_eff = []
    for c in res2:
        norm._set_tuning_param(c)
        res_eff.append(1 / var_func(norm))

    assert_allclose(res_eff, effs, atol=0.0005)

    for c in res2:
        # bp = stats.norm.expect(lambda x : norm.rho(x)) / norm.rho(norm.c)
        norm._set_tuning_param(c)
        eff = 1 / _var_normal(norm)
        tune = _get_tuning_param(norm, eff)
        print('tune', tune)
        assert_allclose(tune, c, rtol=1e-6, atol=5e-4)

#@pytest.mark.parametrize("case", results_menenez)
def test_eff_new(case):
    norm, res2 = case
    use_jump = False

    if norm.continuous == 2:
        var_func = _var_normal
    else:
        var_func = _var_normal_jump
        use_jump = True

    res_eff = []
    for c in res2:
        norm._set_tuning_param(c)
        res_eff.append(1 / var_func(norm))

    assert_allclose(res_eff, effs, atol=0.0005)

    for c in res2:
        # bp = stats.norm.expect(lambda x : norm.rho(x)) / norm.rho(norm.c)
        norm._set_tuning_param(c)
        eff = 1 / var_func(norm)
        tune = _get_tuning_param(norm, eff, use_jump=use_jump)
        print('tune', tune)
        assert_allclose(tune, c, rtol=1e-6, atol=5e-4)


def test_hampel_eff():
    # we cannot solve for multiple tuning parameters
    eff = 0.95
    # tuning parameters from Menezes et al 2021
    res_eff = 1 / _var_normal_jump(Hampel(a=1.35, b=2.70, c=5.40))
    assert_allclose(res_eff, eff, atol=0.005)


def test_tuning_biweight():
    # regression numbers but verified at 5 decimals
    norm = TukeyBiweight()
    res = tuning_s_estimator_mean(norm, breakdown=0.5)
    res1 = [0.28682611623149523, 1.5476449837305166, 0.1996004163055662]
    assert_allclose(res.all[1:], res1, rtol=1e-7)


@pytest.mark.parametrize("case", results_menenez)
def test_tuning_smoke(case):
    # regression numbers but verified at 5 decimals
    norm, _ = case
    # norm = Norm()
    if np.isfinite(norm.max_rho()):
        res = tuning_s_estimator_mean(norm, breakdown=0.5)
        assert res is not None


import datetime

print('start test_eff_old')
now = datetime.datetime.now()
test_eff_old(results_menenez[6])
time_old = datetime.datetime.now() - now
print('end test_eff_old')

print('start test_eff_new')
now = datetime.datetime.now()
test_eff_new(results_menenez[6])
time_new = datetime.datetime.now() - now
print('end test_eff_new')

print(f'time_old = {time_old}, time_new = {time_new}, '
          f'time_old/time_new = {time_old/time_new}')
```

</details>

[tools.py.tar.gz](https://github.com/statsmodels/statsmodels/files/15363030/tools.py.tar.gz)


<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>

