### PR TITLE
ENH: Add option to select stats to display under coefs in `summary2.summary_col`

### DIFF
--- a/statsmodels/iolib/summary2.py
+++ b/statsmodels/iolib/summary2.py
@@ -1,10 +1,12 @@
+from statsmodels.base.wrapper import ResultsWrapper
 from statsmodels.compat.pandas import FUTURE_STACK
 from statsmodels.compat.python import lzip
 
 import datetime
-from functools import reduce
 import re
 import textwrap
+from functools import reduce
+from typing import Callable
 
 import numpy as np
 import pandas as pd
@@ -396,7 +398,12 @@ def summary_params(results, yname=None, xname=None, alpha=.05, use_t=True,
 
 
 # Vertical summary instance for multiple models
-def _col_params(result, float_format='%.4f', stars=True, include_r2=False):
+def _col_params(
+    result: ResultsWrapper,
+    float_format: str = '%.4f',
+    stars: bool = True,
+    include_r2: bool = False
+):
     """Stack coefficients and standard errors in single column
     """
 
@@ -469,9 +476,16 @@ def _make_unique(list_of_names):
     return header
 
 
-def summary_col(results, float_format='%.4f', model_names=(), stars=False,
-                info_dict=None, regressor_order=(), drop_omitted=False,
-                include_r2=True):
+def summary_col(
+    results: ResultsWrapper | list[ResultsWrapper],
+    float_format: str = '%.4f',
+    model_names: list[str] | None = None,
+    stars: bool = False,
+    info_dict: dict[str, Callable | dict] | None = None,
+    regressor_order: list[str] | None = None,
+    drop_omitted: bool = False,
+    include_r2: bool = True
+):
     """
     Summarize multiple results instances side-by-side (coefs and SEs)
 
@@ -513,7 +527,7 @@ def summary_col(results, float_format='%.4f', model_names=(), stars=False,
                         include_r2=include_r2) for x in results]
 
     # Unique column names (pandas has problems merging otherwise)
-    if model_names:
+    if model_names is not None:
         colnames = _make_unique(model_names)
     else:
         colnames = _make_unique([x.columns[0] for x in cols])
@@ -537,7 +551,7 @@ def summary_col(results, float_format='%.4f', model_names=(), stars=False,
     summ = reduce(merg, cols)
     summ = summ.reindex(index)
 
-    if regressor_order:
+    if regressor_order is not None:
         varnames = summ.index.get_level_values(0).tolist()
         vc = pd.Series(varnames).value_counts()
         varnames = vc.loc[vc == 2].index.tolist()

--- a/statsmodels/iolib/summary2.py
+++ b/statsmodels/iolib/summary2.py
@@ -6,7 +6,7 @@ import datetime
 import re
 import textwrap
 from functools import reduce
-from typing import Callable
+from typing import Callable, Literal
 
 import numpy as np
 import pandas as pd
@@ -397,23 +397,32 @@ def summary_params(results, yname=None, xname=None, alpha=.05, use_t=True,
     return data
 
 
+_CoefficientStats = Literal["std_error", "t_stat", "z_stat", ""]
+
+
 # Vertical summary instance for multiple models
 def _col_params(
     result: ResultsWrapper,
     float_format: str = '%.4f',
     stars: bool = True,
-    include_r2: bool = False
+    include_r2: bool = False,
+    coef_stats: _CoefficientStats | None = 'std_error'
 ):
     """Stack coefficients and standard errors in single column
     """
-
     # Extract parameters
-    res = summary_params(result)
+    res = summary_params(result, use_t=coef_stats == 't_stat')
+
+    coef_column_index = 0
+    stat_column_index = 1 if coef_stats == 'std_error' else 2
     # Format float
-    for col in res.columns[:2]:
+    for col in res.columns[[coef_column_index, stat_column_index]]:
         res[col] = res[col].apply(lambda x: float_format % x)
-    # Std.Errors in parentheses
-    res.iloc[:, 1] = '(' + res.iloc[:, 1] + ')'
+    # Coefficient stats in parentheses
+    if coef_stats:
+        res.iloc[:, stat_column_index] = (
+            "(" + res.iloc[:, stat_column_index] + ")"
+        )
     # Significance stars
     if stars:
         idx = res.iloc[:, 3] < .1
@@ -422,8 +431,9 @@ def _col_params(
         res.loc[idx, res.columns[0]] = res.loc[idx, res.columns[0]] + '*'
         idx = res.iloc[:, 3] < .01
         res.loc[idx, res.columns[0]] = res.loc[idx, res.columns[0]] + '*'
-    # Stack Coefs and Std.Errors
-    res = res.iloc[:, :2]
+    # Keep coefs and stats only, and stack them
+    res = (res.iloc[:, [coef_column_index, stat_column_index]] if coef_stats
+           else res.iloc[:, [coef_column_index]])
     res = res.stack(**FUTURE_STACK)
 
     # Add R-squared
@@ -484,7 +494,8 @@ def summary_col(
     info_dict: dict[str, Callable | dict] | None = None,
     regressor_order: list[str] | None = None,
     drop_omitted: bool = False,
-    include_r2: bool = True
+    include_r2: bool = True,
+    coef_stats: _CoefficientStats = 'std_error'
 ):
     """
     Summarize multiple results instances side-by-side (coefs and SEs)
@@ -518,13 +529,24 @@ def summary_col(
         If True, only regressors in regressor_order will be included.
     include_r2 : bool, optional
         Includes R2 and adjusted R2 in the summary table.
+    coef_stats: str, optional
+        Specifies the type of statistics to show under the coefficients. Must
+        be one of 'std_error', 't_stat', or 'z_stat'. If None or an empty
+        string, no additional statistics are shown.
+        Default : 'std_error'
     """
 
     if not isinstance(results, list):
         results = [results]
 
+    if coef_stats not in ('std_error', 't_stat', 'z_stat', '', None):
+        raise ValueError("coef_stats must be one of 'std_error', 't_stat', "
+                         "'z_stat', or an empty string. "
+                         f"Got {coef_stats!r} instead.")
+
     cols = [_col_params(x, stars=stars, float_format=float_format,
-                        include_r2=include_r2) for x in results]
+                        include_r2=include_r2, coef_stats=coef_stats)
+            for x in results]
 
     # Unique column names (pandas has problems merging otherwise)
     if model_names is not None:
@@ -598,7 +620,14 @@ def summary_col(
     smry = Summary()
     smry._merge_latex = True
     smry.add_df(summ, header=True, align='l')
-    smry.add_text('Standard errors in parentheses.')
+
+    if coef_stats:
+        coef_stats_names = {
+            'std_error': 'Standard errors',
+            't_stat': 't-statistics',
+            'z_stat': 'z-statistics',
+        }
+        smry.add_text(f"{coef_stats_names.get(coef_stats)} in parentheses.")
     if stars:
         smry.add_text('* p<.1, ** p<.05, ***p<.01')
 

--- a/statsmodels/iolib/tests/test_summary2.py
+++ b/statsmodels/iolib/tests/test_summary2.py
@@ -198,13 +198,13 @@ class TestSummaryLabels:
         x = add_constant([1, 2, 3, 4] * 4)
         cls.mod = OLS(endog=y, exog=x).fit()
 
-    def test_summary_col_r2(self,):
+    def test_summary_col_r2(self):
         # GH 6578
         table = summary_col(results=self.mod, include_r2=True)
         assert "R-squared  " in str(table)
         assert "R-squared Adj." in str(table)
 
-    def test_absence_of_r2(self,):
+    def test_absence_of_r2(self):
         table = summary_col(results=self.mod, include_r2=False)
         assert "R-squared" not in str(table)
         assert "R-squared Adj." not in str(table)

--- a/statsmodels/iolib/tests/test_summary2.py
+++ b/statsmodels/iolib/tests/test_summary2.py
@@ -1,3 +1,4 @@
+import re
 import warnings
 
 import numpy as np
@@ -6,8 +7,8 @@ import pytest
 from numpy.testing import assert_equal
 
 from statsmodels.iolib.summary2 import summary_col
-from statsmodels.tools.tools import add_constant
 from statsmodels.regression.linear_model import OLS
+from statsmodels.tools.tools import add_constant
 
 
 class TestSummaryLatex:
@@ -208,3 +209,78 @@ class TestSummaryLabels:
         table = summary_col(results=self.mod, include_r2=False)
         assert "R-squared" not in str(table)
         assert "R-squared Adj." not in str(table)
+
+    @pytest.mark.parametrize(
+        "coef_stat, expected_constant_stat, expected_x1_stat",
+        [
+            (None, 0.670820, 0.244949),  # default behavior
+            ("std_error", 0.670820, 0.244949),
+            ("t_stat", 0.745356, 2.449490),
+            ("z_stat", 0.745356, 2.449490),
+        ]
+    )
+    def test_coef_stats_parameter_return_correct_value(
+        self, coef_stat, expected_constant_stat, expected_x1_stat
+    ):
+        if coef_stat is None:
+            # Test the default behavior.
+            # N.B.: we don't pass None to the coef_stats parameter
+            table = summary_col(
+                results=self.mod,
+                float_format="%.5f",  # to avoid rounding errors
+            )
+        else:
+            table = summary_col(
+                results=self.mod,
+                float_format="%.5f",  # to avoid rounding errors
+                coef_stats=coef_stat
+            )
+
+        constant_stat = table.tables[0].iloc[1, 0]
+        # check that the stat is in parentheses
+        assert re.match(r"\(.*\)", constant_stat)
+        constant_stat_value = float(constant_stat.strip("()"))
+        assert np.isclose(constant_stat_value, expected_constant_stat)
+
+        x1_stat = table.tables[0].iloc[3, 0]
+        # check that the stat is in parentheses
+        assert re.match(r"\(.*\)", x1_stat)
+        x1_stat_value = float(x1_stat.strip("()"))
+        assert np.isclose(x1_stat_value, expected_x1_stat)
+
+    @pytest.mark.parametrize(
+        "coef_stat, expected_footer",
+        [
+            ("std_error", "Standard errors in parentheses."),
+            ("t_stat", "t-statistics in parentheses."),
+            ("z_stat", "z-statistics in parentheses."),
+        ]
+    )
+    def test_coef_stats_parameter_adds_correct_footer(
+        self, coef_stat, expected_footer
+    ):
+        table = summary_col(results=self.mod, coef_stats=coef_stat)
+        assert expected_footer in table.extra_txt
+
+    @pytest.mark.parametrize(
+        "coef_stat",
+        ["", None]
+    )
+    def test_no_coef_stats_parameter_deletes_stats(self, coef_stat):
+        table = summary_col(results=self.mod, coef_stats=coef_stat)
+        # ensure the table has no stats index
+        # stat index would be an empty string after 'const' and after 'x1'
+        assert all(table.tables[0].index == [
+            "const", "x1", "R-squared", "R-squared Adj."
+        ])
+        # ensure that the footer is not present
+        assert "in parentheses." not in str(table)
+        print(table)
+
+    @pytest.mark.parametrize(
+        "coef_stat",
+        ["invalid", 42, True]
+    )
+    def test_invalid_coef_stats_parameter_raises_error(self, coef_stat):
+        with pytest.raises(ValueError):
+            summary_col(results=self.mod, coef_stats=coef_stat)


### PR DESCRIPTION
- [X] Linked to #8996 
- [x] tests added 
- [ ] tests passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>

This PR introduces a new optional argument to [`statsmodels.iolib.summary2.summary_col`](https://github.com/statsmodels/statsmodels/blob/v0.14.0/statsmodels/iolib/summary2.py#L471), which allows choosing which stat to display under the coefficients:

```diff
  def summary_col(
      results,
      float_format: str ='%.4f',
      model_names=(),
      stars=False,
      info_dict=None,
      regressor_order=(),
      drop_omitted=False,
      include_r2=True,
+     coef_stats: str="std_error",
  ):
```

Example:

* `std_error` (default, current behaviour):
```
=======================
                  y    
-----------------------
const          0.5000  
               (0.6708)
x1             0.6000  
               (0.2449)
R-squared      0.3000  
R-squared Adj. 0.2500  
=======================
Standard errors in
parentheses.
```
* `t_stat`:
```

=======================
                  y    
-----------------------
const          0.5000  
               (0.7454)
x1             0.6000  
               (2.4495)
R-squared      0.3000  
R-squared Adj. 0.2500  
=======================
t-statistics in
parentheses.
```
* `z_stat`:
```
=======================
                  y    
-----------------------
const          0.5000  
               (0.7454)
x1             0.6000  
               (2.4495)
R-squared      0.3000  
R-squared Adj. 0.2500  
=======================
z-statistics in
parentheses.
```
* `""` or `None`:
```
=====================
                 y   
---------------------
const          0.5000
x1             0.6000
R-squared      0.3000
R-squared Adj. 0.2500
=====================
```
* "foobar":
```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/ebosi/perso/statsmodels/statsmodels/iolib/summary2.py", line 543, in summary_col
    raise ValueError("coef_stats must be one of 'std_error', 't_stat', "
ValueError: coef_stats must be one of 'std_error', 't_stat', 'z_stat', or an empty string. Got 'foobar' instead.
```