### PR TITLE
REF: Remove numpy testing import from test runner

### DIFF
--- a/statsmodels/__init__.py
+++ b/statsmodels/__init__.py
@@ -33,7 +33,7 @@ def test(extra_args=None, exit=False):
     int
         The status code from the test run if exit is False.
     """
-    from .tools._testing import PytestTester
+    from .tools._test_runner import PytestTester
 
     tst = PytestTester(package_path=__file__)
     return tst(extra_args=extra_args, exit=exit)

--- a/statsmodels/base/__init__.py
+++ b/statsmodels/base/__init__.py
@@ -1,3 +1,3 @@
-from statsmodels.tools._testing import PytestTester
+from statsmodels.tools._test_runner import PytestTester
 
 test = PytestTester()

--- a/statsmodels/compat/__init__.py
+++ b/statsmodels/compat/__init__.py
@@ -1,4 +1,4 @@
-from statsmodels.tools._testing import PytestTester
+from statsmodels.tools._test_runner import PytestTester
 
 from .python import (
     PY37,

--- a/statsmodels/datasets/__init__.py
+++ b/statsmodels/datasets/__init__.py
@@ -1,7 +1,7 @@
 """
 Datasets module
 """
-from statsmodels.tools._testing import PytestTester
+from statsmodels.tools._test_runner import PytestTester
 
 from . import (
     anes96,

--- a/statsmodels/discrete/__init__.py
+++ b/statsmodels/discrete/__init__.py
@@ -1,3 +1,3 @@
-from statsmodels.tools._testing import PytestTester
+from statsmodels.tools._test_runner import PytestTester
 
 test = PytestTester()

--- a/statsmodels/distributions/__init__.py
+++ b/statsmodels/distributions/__init__.py
@@ -1,4 +1,4 @@
-from statsmodels.tools._testing import PytestTester
+from statsmodels.tools._test_runner import PytestTester
 from .empirical_distribution import (
     ECDF, ECDFDiscrete, monotone_fn_inverter, StepFunction
     )

--- a/statsmodels/duration/__init__.py
+++ b/statsmodels/duration/__init__.py
@@ -1,3 +1,3 @@
-from statsmodels.tools._testing import PytestTester
+from statsmodels.tools._test_runner import PytestTester
 
 test = PytestTester()

--- a/statsmodels/emplike/__init__.py
+++ b/statsmodels/emplike/__init__.py
@@ -1,3 +1,3 @@
-from statsmodels.tools._testing import PytestTester
+from statsmodels.tools._test_runner import PytestTester
 
 test = PytestTester()

--- a/statsmodels/formula/__init__.py
+++ b/statsmodels/formula/__init__.py
@@ -1,6 +1,6 @@
 __all__ = ['handle_formula_data', 'test']
 from .formulatools import handle_formula_data
 
-from statsmodels.tools._testing import PytestTester
+from statsmodels.tools._test_runner import PytestTester
 
 test = PytestTester()

--- a/statsmodels/gam/__init__.py
+++ b/statsmodels/gam/__init__.py
@@ -1,3 +1,3 @@
-from statsmodels.tools._testing import PytestTester
+from statsmodels.tools._test_runner import PytestTester
 
 test = PytestTester()

--- a/statsmodels/genmod/__init__.py
+++ b/statsmodels/genmod/__init__.py
@@ -1,3 +1,3 @@
-from statsmodels.tools._testing import PytestTester
+from statsmodels.tools._test_runner import PytestTester
 
 test = PytestTester()

--- a/statsmodels/genmod/families/__init__.py
+++ b/statsmodels/genmod/families/__init__.py
@@ -13,7 +13,7 @@ These families are described in
 from statsmodels.genmod.families import links
 from .family import Gaussian, Family, Poisson, Gamma, \
     InverseGaussian, Binomial, NegativeBinomial, Tweedie
-from statsmodels.tools._testing import PytestTester
+from statsmodels.tools._test_runner import PytestTester
 
 __all__ = ['test', 'links', 'Family', 'Gamma', 'Gaussian', 'Poisson',
            'InverseGaussian', 'Binomial', 'NegativeBinomial', 'Tweedie']

--- a/statsmodels/graphics/__init__.py
+++ b/statsmodels/graphics/__init__.py
@@ -1,3 +1,3 @@
-from statsmodels.tools._testing import PytestTester
+from statsmodels.tools._test_runner import PytestTester
 
 test = PytestTester()

--- a/statsmodels/imputation/__init__.py
+++ b/statsmodels/imputation/__init__.py
@@ -1,3 +1,3 @@
-from statsmodels.tools._testing import PytestTester
+from statsmodels.tools._test_runner import PytestTester
 
 test = PytestTester()

--- a/statsmodels/iolib/__init__.py
+++ b/statsmodels/iolib/__init__.py
@@ -2,7 +2,7 @@ from .foreign import savetxt
 from .table import SimpleTable, csv2st
 from .smpickle import save_pickle, load_pickle
 
-from statsmodels.tools._testing import PytestTester
+from statsmodels.tools._test_runner import PytestTester
 
 __all__ = ['test', 'csv2st', 'SimpleTable', 'savetxt',
            'save_pickle', 'load_pickle']

--- a/statsmodels/miscmodels/__init__.py
+++ b/statsmodels/miscmodels/__init__.py
@@ -1,3 +1,3 @@
-from statsmodels.tools._testing import PytestTester
+from statsmodels.tools._test_runner import PytestTester
 
 test = PytestTester()

--- a/statsmodels/multivariate/__init__.py
+++ b/statsmodels/multivariate/__init__.py
@@ -1,3 +1,3 @@
-from statsmodels.tools._testing import PytestTester
+from statsmodels.tools._test_runner import PytestTester
 
 test = PytestTester()

--- a/statsmodels/multivariate/factor_rotation/__init__.py
+++ b/statsmodels/multivariate/factor_rotation/__init__.py
@@ -24,7 +24,7 @@ References
 from ._wrappers import rotate_factors
 
 from ._analytic_rotation import target_rotation, procrustes, promax
-from statsmodels.tools._testing import PytestTester
+from statsmodels.tools._test_runner import PytestTester
 
 __all__ = ['rotate_factors', 'target_rotation', 'procrustes', 'promax',
            'test']

--- a/statsmodels/nonparametric/__init__.py
+++ b/statsmodels/nonparametric/__init__.py
@@ -4,6 +4,6 @@ Tools for nonparametric statistics, mainly density estimation and regression.
 For an overview of this module, see docs/source/nonparametric.rst
 """
 
-from statsmodels.tools._testing import PytestTester
+from statsmodels.tools._test_runner import PytestTester
 
 test = PytestTester()

--- a/statsmodels/othermod/__init__.py
+++ b/statsmodels/othermod/__init__.py
@@ -1,3 +1,3 @@
-from statsmodels.tools._testing import PytestTester
+from statsmodels.tools._test_runner import PytestTester
 
 test = PytestTester()

--- a/statsmodels/regression/__init__.py
+++ b/statsmodels/regression/__init__.py
@@ -1,6 +1,6 @@
 from .linear_model import yule_walker
 
-from statsmodels.tools._testing import PytestTester
+from statsmodels.tools._test_runner import PytestTester
 
 __all__ = ['yule_walker', 'test']
 

--- a/statsmodels/robust/__init__.py
+++ b/statsmodels/robust/__init__.py
@@ -5,6 +5,6 @@ __all__ = ["norms", "mad", "Huber", "HuberScale", "hubers_scale", "test"]
 from . import norms
 from .scale import mad, Huber, HuberScale, hubers_scale
 
-from statsmodels.tools._testing import PytestTester
+from statsmodels.tools._test_runner import PytestTester
 
 test = PytestTester()

--- a/statsmodels/sandbox/__init__.py
+++ b/statsmodels/sandbox/__init__.py
@@ -1,6 +1,6 @@
 '''This is sandbox code
 
 '''
-from statsmodels.tools._testing import PytestTester
+from statsmodels.tools._test_runner import PytestTester
 
 test = PytestTester()

--- a/statsmodels/stats/__init__.py
+++ b/statsmodels/stats/__init__.py
@@ -1,3 +1,3 @@
-from statsmodels.tools._testing import PytestTester
+from statsmodels.tools._test_runner import PytestTester
 
 test = PytestTester()

--- a/statsmodels/stats/libqsturng/__init__.py
+++ b/statsmodels/stats/libqsturng/__init__.py
@@ -1,6 +1,6 @@
 from .qsturng_ import psturng, qsturng, p_keys, v_keys
 
-from statsmodels.tools._testing import PytestTester
+from statsmodels.tools._test_runner import PytestTester
 
 __all__ = ['p_keys', 'psturng', 'qsturng', 'v_keys', 'test']
 

--- a/statsmodels/tools/__init__.py
+++ b/statsmodels/tools/__init__.py
@@ -1,5 +1,5 @@
 from .tools import add_constant, categorical
-from statsmodels.tools._testing import PytestTester
+from statsmodels.tools._test_runner import PytestTester
 
 __all__ = ['test', 'add_constant', 'categorical']
 

--- a/statsmodels/tools/_test_runner.py
+++ b/statsmodels/tools/_test_runner.py
@@ -1,0 +1,35 @@
+"""
+Pytest runner that allows test to be run within python
+"""
+
+import os
+import sys
+from packaging.version import Version, parse
+
+
+class PytestTester:
+    def __init__(self, package_path=None):
+        f = sys._getframe(1)
+        if package_path is None:
+            package_path = f.f_locals.get("__file__", None)
+            if package_path is None:
+                raise ValueError("Unable to determine path")
+        self.package_path = os.path.dirname(package_path)
+        self.package_name = f.f_locals.get("__name__", None)
+
+    def __call__(self, extra_args=None, exit=False):
+        try:
+            import pytest
+
+            if not parse(pytest.__version__) >= Version("3.0"):
+                raise ImportError
+            if extra_args is None:
+                extra_args = ["--tb=short", "--disable-pytest-warnings"]
+            cmd = [self.package_path] + extra_args
+            print("Running pytest " + " ".join(cmd))
+            status = pytest.main(cmd)
+            if exit:
+                print(f"Exit status: {status}")
+                sys.exit(status)
+        except ImportError:
+            raise ImportError("pytest>=3 required to run the test")

--- a/statsmodels/tools/_testing.py
+++ b/statsmodels/tools/_testing.py
@@ -9,41 +9,10 @@ The first group of functions provide consistency checks
 
 """
 
-import os
-import sys
-from packaging.version import Version, parse
-
 import numpy as np
 from numpy.testing import assert_allclose, assert_
 
 import pandas as pd
-
-
-class PytestTester:
-    def __init__(self, package_path=None):
-        f = sys._getframe(1)
-        if package_path is None:
-            package_path = f.f_locals.get('__file__', None)
-            if package_path is None:
-                raise ValueError('Unable to determine path')
-        self.package_path = os.path.dirname(package_path)
-        self.package_name = f.f_locals.get('__name__', None)
-
-    def __call__(self, extra_args=None, exit=False):
-        try:
-            import pytest
-            if not parse(pytest.__version__) >= Version('3.0'):
-                raise ImportError
-            if extra_args is None:
-                extra_args = ['--tb=short', '--disable-pytest-warnings']
-            cmd = [self.package_path] + extra_args
-            print('Running pytest ' + ' '.join(cmd))
-            status = pytest.main(cmd)
-            if exit:
-                print(f"Exit status: {status}")
-                sys.exit(status)
-        except ImportError:
-            raise ImportError('pytest>=3 required to run the test')
 
 
 def check_ttest_tvalues(results):
@@ -60,16 +29,17 @@ def check_ttest_tvalues(results):
     assert_allclose(tt.conf_int(), res.conf_int(), rtol=1e-10)
 
     # test params table frame returned by t_test
-    table_res = np.column_stack((res.params, res.bse, res.tvalues,
-                                 res.pvalues, res.conf_int()))
+    table_res = np.column_stack(
+        (res.params, res.bse, res.tvalues, res.pvalues, res.conf_int())
+    )
     table2 = tt.summary_frame().values
     assert_allclose(table2, table_res, rtol=1e-12)
 
     # TODO: move this to test_attributes ?
-    assert_(hasattr(res, 'use_t'))
+    assert_(hasattr(res, "use_t"))
 
     tt = res.t_test(mat[0])
-    tt.summary()   # smoke test for #1323
+    tt.summary()  # smoke test for #1323
     pvalues = np.asarray(res.pvalues)
     assert_allclose(tt.pvalue, pvalues[0], rtol=5e-10)
     # TODO: Adapt more of test_generic_methods.test_ttest_values here?
@@ -95,18 +65,22 @@ def check_ftest_pvalues(results):
     use_t = res.use_t
     k_vars = len(res.params)
     # check default use_t
-    pvals = [res.wald_test(np.eye(k_vars)[k], use_f=use_t, scalar=True).pvalue
-             for k in range(k_vars)]
+    pvals = [
+        res.wald_test(np.eye(k_vars)[k], use_f=use_t, scalar=True).pvalue
+        for k in range(k_vars)
+    ]
     assert_allclose(pvals, res.pvalues, rtol=5e-10, atol=1e-25)
 
     # automatic use_f based on results class use_t
-    pvals = [res.wald_test(np.eye(k_vars)[k], scalar=True).pvalue
-             for k in range(k_vars)]
+    pvals = [
+        res.wald_test(np.eye(k_vars)[k], scalar=True).pvalue
+        for k in range(k_vars)
+    ]
     assert_allclose(pvals, res.pvalues, rtol=5e-10, atol=1e-25)
 
     # TODO: Separate these out into summary/summary2 tests?
     # label for pvalues in summary
-    string_use_t = 'P>|z|' if use_t is False else 'P>|t|'
+    string_use_t = "P>|z|" if use_t is False else "P>|t|"
     summ = str(res.summary())
     assert_(string_use_t in summ)
 
@@ -127,10 +101,10 @@ def check_fitted(results):
     from statsmodels.discrete.discrete_model import DiscreteResults
 
     # possibly unwrap -- GEE has no wrapper
-    results = getattr(results, '_results', results)
+    results = getattr(results, "_results", results)
 
     if isinstance(results, (GLMResults, DiscreteResults)):
-        pytest.skip(f'Not supported for {type(results)}')
+        pytest.skip(f"Not supported for {type(results)}")
 
     res = results
     fitted = res.fittedvalues
@@ -158,10 +132,13 @@ def check_predict_types(results):
     # ignore wrapper for isinstance check
     from statsmodels.genmod.generalized_linear_model import GLMResults
     from statsmodels.discrete.discrete_model import DiscreteResults
-    from statsmodels.compat.pandas import assert_frame_equal, assert_series_equal
+    from statsmodels.compat.pandas import (
+        assert_frame_equal,
+        assert_series_equal,
+    )
 
     # possibly unwrap -- GEE has no wrapper
-    results = getattr(results, '_results', results)
+    results = getattr(results, "_results", results)
 
     if isinstance(results, (GLMResults, DiscreteResults)):
         # SMOKE test only  TODO: mark this somehow
@@ -172,13 +149,14 @@ def check_predict_types(results):
         fitted = res.fittedvalues[:2]
         assert_allclose(fitted, res.predict(p_exog), rtol=1e-12)
         # this needs reshape to column-vector:
-        assert_allclose(fitted, res.predict(np.squeeze(p_exog).tolist()),
-                        rtol=1e-12)
+        assert_allclose(
+            fitted, res.predict(np.squeeze(p_exog).tolist()), rtol=1e-12
+        )
         # only one prediction:
-        assert_allclose(fitted[:1], res.predict(p_exog[0].tolist()),
-                        rtol=1e-12)
-        assert_allclose(fitted[:1], res.predict(p_exog[0]),
-                        rtol=1e-12)
+        assert_allclose(
+            fitted[:1], res.predict(p_exog[0].tolist()), rtol=1e-12
+        )
+        assert_allclose(fitted[:1], res.predict(p_exog[0]), rtol=1e-12)
 
         # Check that pandas wrapping works as expected
         exog_index = range(len(p_exog))

--- a/statsmodels/tsa/__init__.py
+++ b/statsmodels/tsa/__init__.py
@@ -1,3 +1,3 @@
-from statsmodels.tools._testing import PytestTester
+from statsmodels.tools._test_runner import PytestTester
 
 test = PytestTester()

--- a/statsmodels/tsa/base/__init__.py
+++ b/statsmodels/tsa/base/__init__.py
@@ -1,3 +1,3 @@
-from statsmodels.tools._testing import PytestTester
+from statsmodels.tools._test_runner import PytestTester
 
 test = PytestTester()

--- a/statsmodels/tsa/filters/__init__.py
+++ b/statsmodels/tsa/filters/__init__.py
@@ -1,3 +1,3 @@
-from statsmodels.tools._testing import PytestTester
+from statsmodels.tools._test_runner import PytestTester
 
 test = PytestTester()

--- a/statsmodels/tsa/innovations/__init__.py
+++ b/statsmodels/tsa/innovations/__init__.py
@@ -1,3 +1,3 @@
-from statsmodels.tools._testing import PytestTester
+from statsmodels.tools._test_runner import PytestTester
 
 test = PytestTester()

--- a/statsmodels/tsa/interp/__init__.py
+++ b/statsmodels/tsa/interp/__init__.py
@@ -1,5 +1,5 @@
 __all__ = ['dentonm', 'test']
 from .denton import dentonm
-from statsmodels.tools._testing import PytestTester
+from statsmodels.tools._test_runner import PytestTester
 
 test = PytestTester()

--- a/statsmodels/tsa/regime_switching/__init__.py
+++ b/statsmodels/tsa/regime_switching/__init__.py
@@ -1,3 +1,3 @@
-from statsmodels.tools._testing import PytestTester
+from statsmodels.tools._test_runner import PytestTester
 
 test = PytestTester()

--- a/statsmodels/tsa/statespace/__init__.py
+++ b/statsmodels/tsa/statespace/__init__.py
@@ -1,3 +1,3 @@
-from statsmodels.tools._testing import PytestTester
+from statsmodels.tools._test_runner import PytestTester
 
 test = PytestTester()

--- a/statsmodels/tsa/stl/__init__.py
+++ b/statsmodels/tsa/stl/__init__.py
@@ -1,3 +1,3 @@
-from statsmodels.tools._testing import PytestTester
+from statsmodels.tools._test_runner import PytestTester
 
 test = PytestTester()

--- a/statsmodels/tsa/vector_ar/__init__.py
+++ b/statsmodels/tsa/vector_ar/__init__.py
@@ -1,3 +1,3 @@
-from statsmodels.tools._testing import PytestTester
+from statsmodels.tools._test_runner import PytestTester
 
 test = PytestTester()


### PR DESCRIPTION
Refactor to avoid importing functions from numpy testing when importing statsmodels

- [X] closes #9289 
- [X] tests added / passed. 
- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
