### PR TITLE
MAINT: Remove oldest-supported-numpy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,14 +2,10 @@
 # These are strictly build requirements. Runtime requirements are listed in
 # INSTALL_REQUIRES in setup.py
 requires = [
-    "setuptools>=69.0.2; python_version>='3.12'",
-    "setuptools>=63.4.3",
-    "cython>=0.29.33,<4",  # Sync with CYTHON_MIN_VER in setup
-    # Workaround for oldest supported numpy using 1.21.6, but SciPy 1.9.2+ requiring 1.22.3+
-    "oldest-supported-numpy; python_version!='3.10' or platform_system!='Windows' or platform_python_implementation=='PyPy'",
-    "numpy>=1.22.3,<3",
-    "numpy<3; python_version>='3.13'",
-    "scipy>=1.7",
+    "setuptools>=69.0.2",
+    "cython>=3.0.10,<4",  # Sync with CYTHON_MIN_VER in setup
+    "numpy>=2.0.0,<3",
+    "scipy>=1.13,<2",
     "setuptools_scm[toml]>=8,<9"
 ]
 build-backend = "setuptools.build_meta"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,8 @@
 # build
-cython>=0.29.33,<4.0.0
+numpy>=2.0.0
+scipy>=1.13.0
+cython>=3.0.10,<4
 setuptools_scm[toml]~=8.0
-oldest-supported-numpy>=2022.4.18
 
 # run
 matplotlib>=3.5
@@ -11,7 +12,7 @@ joblib
 # cvxopt; os_name != "win32"
 
 # test
-pytest>=7.3.0
+pytest>=7.3.0,<8
 pytest-randomly
 pytest-xdist
 pytest-cov

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Workaround for scipy build requirements
 numpy>=1.22.3,<3  # released December 2021
-scipy>=1.7.0,!=1.9.2  # released June 2021, 1.9.2 blocked due to bug
-pandas>=1.3.0,!=2.1.0  # released July 2021, 2.1.0 blocked due to bug
+scipy>=1.8.0,!=1.9.2  # released June 2021, 1.9.2 blocked due to bug
+pandas>=1.4.0,!=2.1.0  # released July 2021, 2.1.0 blocked due to bug
 patsy>=0.5.6  # released December 2023
 packaging>=21.3  # released Nov 2021


### PR DESCRIPTION
Remove oldest supported to ensure that NumPy 2 is available when installing using requirements and --no-build-isolation

- [ ] closes #xxxx
- [ ] tests added / passed. 
- [ ] code/documentation is well formatted.  
- [ ] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
