### PR TITLE
Avoid random ordering in include_dirs lists

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -228,7 +228,7 @@ def update_extension(extension, requires_math=True):
     numpy_includes = [np.get_include()]
     extra_incl = pjoin(dirname(inspect.getfile(np.core)), "include")
     numpy_includes += [extra_incl]
-    numpy_includes = list(set(numpy_includes))
+    numpy_includes = sorted(set(numpy_includes))
     numpy_math_libs = {
         "include_dirs": [np.get_include()],
         "library_dirs": [os.path.join(np.get_include(), '..', 'lib')],
@@ -237,7 +237,9 @@ def update_extension(extension, requires_math=True):
 
     if not hasattr(extension, "include_dirs"):
         return
-    extension.include_dirs = list(set(extension.include_dirs + numpy_includes))
+    extension.include_dirs = sorted(
+        set(extension.include_dirs + numpy_includes)
+    )
     if requires_math:
         extension.include_dirs += numpy_math_libs["include_dirs"]
         extension.libraries += numpy_math_libs["libraries"]


### PR DESCRIPTION
I'm rebuilding RPM packages to check build reproducibility (https://docs.fedoraproject.org/en-US/reproducible-builds/), and we got the result that rebuilds of statsmodels varies in this trivial way:
│ │          "include_dirs": [
│ │ -            "statsmodels/src",
│ │              "/usr/lib64/python3.13/site-packages/numpy/core/include",
│ │ +            "statsmodels/src",
│ │              "/usr/lib64/python3.13/site-packages/numpy/core/include"
│ │          ],
(the same pattern repeats hundreds of times).

sets are hash-ordered, not insertion ordered, so the order in list(set(…)) is not reproducible. Sort the entries instead.

- [ ] closes #xxxx
- [ ] tests added / passed. 
- [ ] code/documentation is well formatted.  
- [ ] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
