### PR TITLE
DOC: Generate docs for plot_ccf and plot_accf_grid

### DIFF
--- a/docs/source/dev/index.rst
+++ b/docs/source/dev/index.rst
@@ -50,6 +50,8 @@ greatly helps the job of maintaining and releasing the software a shared effort.
     make html
 
   Check that the build output does not have *any* warnings due to your changes.
+
+  Generating the docs requires additional dependencies, see ``docs/README.md`` for details.
 - Follow `PEP8 <https://www.python.org/dev/peps/pep-0008/>`_ style guidelines wherever possible. 
   Lint your code by running ``LINT=true ./lint.sh``. 
 - Compare your changes to what’s in main by running ``git diff upstream/main``.

--- a/docs/source/graphics.rst
+++ b/docs/source/graphics.rst
@@ -100,6 +100,8 @@ Time Series Plots
 
    plot_acf
    plot_pacf
+   plot_ccf
+   plot_accf_grid
    month_plot
    quarter_plot
 

--- a/statsmodels/graphics/tsaplots.py
+++ b/statsmodels/graphics/tsaplots.py
@@ -437,7 +437,7 @@ def plot_ccf(
 
     See Also
     --------
-    See notes and references for statsmodels.graphics.tsaplots.plot_acf
+    statsmodels.graphics.tsaplots.plot_acf
 
     Examples
     --------
@@ -568,7 +568,8 @@ def plot_accf_grid(
 
     See Also
     --------
-    See notes and references for statsmodels.graphics.tsaplots
+    statsmodels.graphics.tsaplots.plot_acf
+    statsmodels.graphics.tsaplots.plot_ccf
 
     Examples
     --------


### PR DESCRIPTION
Adds a reference to ``plot_ccf`` and ``plot_accf_grid`` in ``docs/source/graphics.rst`` so that the docs for the functions are included in the generated output. This was missed from #8783.

- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
