### PR TITLE
fix: use log_wright_bessel to fix overflow

### DIFF
--- a/statsmodels/genmod/families/family.py
+++ b/statsmodels/genmod/families/family.py
@@ -1747,8 +1747,7 @@ class Tweedie(Family):
                     scale = scale[idx]
                 x = ((p - 1) * scale / endog) ** alpha
                 x /= (2 - p) * scale
-                wb = special.wright_bessel(-alpha, 0, x)
-                ll_obs[idx] += np.log(1/endog * wb)
+                ll_obs[idx] += np.log(1 / endog) + special.log_wright_bessel(-alpha, 0, x)
             return ll_obs
         else:
             # Equations 4 of Kaas

--- a/statsmodels/genmod/families/tests/test_family.py
+++ b/statsmodels/genmod/families/tests/test_family.py
@@ -107,3 +107,24 @@ def test_tweedie_loglike_obs(power):
         )
 
     assert_allclose(pdf(0) + integrate.quad(pdf, 0, 1e2)[0], 1, atol=1e-4)
+
+def test_tweedie_log_wright_bessel():
+    """Test the scipy log_wright_bessel function. Values taken from https://github.com/statsmodels/statsmodels/issues/9234."""
+    endog = np.array([0, 0, 0, 0, 192.85613765, 7.84301478, 182.15075391, 51.85940469, 39.49500056, 4.07506614,   2.97574021,  92.37706761])
+    mu = np.array([40.8384544, 40.8384544 , 7.26705526, 7.26705526, 192.85613765, 7.26705526, 182.15075391, 40.8384544, 40.8384544, 8.33852205, 2.97574021, 8.33852205])
+    var_weights = np.array([6.3831906 ,  0.47627479,  1.1490363 ,  5.11229578, 13.72221246, 79.00111743, 15.33762454, 29.44406732, 33.02803322, 12.84154581,6.17631048,  1.73855041])
+    scale = np.array([1.0])
+    p = 1.5
+    tweedie = Tweedie(var_power = p)
+    # results of the new loglike_obs function with the scipy log_wright_bessel function
+    loglike_results = tweedie.loglike_obs(endog, mu, var_weights=var_weights, scale=scale)
+
+    # expected results, previously loglike_obs would have had overflow issues with 'inf' values
+    expected_results = np.array([-81.58352325,  -6.08726542,  -6.19502375, -27.56291842,
+        -3.55638127,  -0.92296862,  -3.45786323,  -8.24816698,
+        -2.04396817,  -7.41592981,  -0.83535226, -58.47804978])
+    
+    assert_allclose(loglike_results, expected_results)
+
+
+


### PR DESCRIPTION
- [x] closes #9234 
- [x] tests added / passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>
Tweedie's loglike_obs function currently overflows in some cases with the scipy wright_bessel function. As of scipy version 1.14.0, log_wright_bessel has been released which fixes the overflow issues. Added a test case for the new loglike_obs function with a case where wright_bessel caused overflow to verify that the new function solves the issue. (link: https://github.com/statsmodels/statsmodels/issues/9234)


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
