### PR TITLE
BUG: Replace deprecated Pandas method

### DIFF
--- a/statsmodels/tsa/statespace/dynamic_factor_mq.py
+++ b/statsmodels/tsa/statespace/dynamic_factor_mq.py
@@ -440,8 +440,8 @@ class DynamicFactorMQStates(dict):
                           tupleize_cols=False, name='block')
             default_block_orders = pd.Series(np.ones(len(ix), dtype=int),
                                              index=ix, name='order')
-            self.factor_block_orders = (
-                self.factor_block_orders.append(default_block_orders))
+            self.factor_block_orders = pd.concat(
+                [self.factor_block_orders, default_block_orders])
             factor_names = pd.Series(
                 np.concatenate(list(self.factor_block_orders.index)))
         duplicates = factor_names.duplicated()


### PR DESCRIPTION
- [x] closes #9062 
- [x] tests added / passed. 
- [x] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

- Resolves raised error when specifying factor_orders as a dictionary
- Replace deprecated pandas.Series.append with pandas.concat
- Add test to ensure DynamicFactorMQ handles factor_orders dictionary properly

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
