### PR TITLE
ENH/BUG: Ensure array is owned

### DIFF
--- a/statsmodels/tsa/statespace/mlemodel.py
+++ b/statsmodels/tsa/statespace/mlemodel.py
@@ -163,8 +163,8 @@ class MLEModel(tsbase.TimeSeriesModel):
         Prepare data for use in the state space representation
         """
         endog = np.require(
-            np.array(self.data.orig_endog, order="C"), requirements="W"
-        )
+            np.array(self.data.orig_endog, copy=True), requirements="CW"
+        ).copy()
         exog = self.data.orig_exog
         if exog is not None:
             exog = np.array(exog)

--- a/statsmodels/tsa/statespace/sarimax.py
+++ b/statsmodels/tsa/statespace/sarimax.py
@@ -1027,7 +1027,10 @@ class SARIMAX(MLEModel):
         params_measurement_variance = 1 if self.measurement_error else []
 
         # We want to bound the starting variance away from zero
-        params_variance = np.atleast_1d(max(np.array(params_variance), 1e-10))
+        params_variance = np.atleast_1d(np.array(params_variance))
+        if params_variance.size:
+            # Avoid comparisons with empty arrays due to changes in NumPy 2.2
+            params_variance = np.atleast_1d(max(params_variance[0], 1e-10))
 
         # Remove state variance as parameter if scale is concentrated out
         if self.concentrate_scale:

--- a/statsmodels/tsa/statespace/tests/test_mlemodel.py
+++ b/statsmodels/tsa/statespace/tests/test_mlemodel.py
@@ -1113,7 +1113,7 @@ def test_append_extend_apply_invalid():
 
     # # Test for problems with non-date indexes
     endog3 = pd.Series(niledata.iloc[:20].values)
-    endog4 = pd.Series(niledata.iloc[:40].values)[20:]
+    endog4 = pd.Series(niledata.iloc[:40].values).iloc[20:]
     mod2 = sarimax.SARIMAX(endog3, order=(1, 0, 0), exog=endog3,
                            concentrate_scale=True)
     res2 = mod2.smooth([0.2, 0.5])


### PR DESCRIPTION
Explictly call copy() to avoid setting attributes on data not owned by the model

- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
