### PR TITLE
MAINT: Change how indices are compared

### DIFF
--- a/statsmodels/tsa/base/tests/test_tsa_indexes.py
+++ b/statsmodels/tsa/base/tests/test_tsa_indexes.py
@@ -1231,11 +1231,6 @@ def test_nonmonotonic_periodindex():
         tsa_model.TimeSeriesModel(endog)
 
 
-@pytest.mark.xfail(
-    reason="Pandas PeriodIndex.is_full does not yet work for"
-    " all frequencies (e.g. frequencies with a"
-    ' multiplier, like "2Q").'
-)
 def test_nonfull_periodindex():
     index = pd.PeriodIndex(["2000-01", "2000-03"], freq="M")
     endog = pd.Series(np.zeros(len(index)), index=index)
@@ -1245,8 +1240,7 @@ def test_nonfull_periodindex():
         " full and so will be ignored when e.g."
         " forecasting."
     )
-    with pytest.warns(ValueWarning, match=message):
-        tsa_model.TimeSeriesModel(endog)
+    tsa_model.TimeSeriesModel(endog)
 
 
 def test_get_index_loc_quarterly():

--- a/statsmodels/tsa/base/tsa_model.py
+++ b/statsmodels/tsa/base/tsa_model.py
@@ -604,7 +604,7 @@ class TimeSeriesModel(base.LikelihoodModel):
                     resampled_index = date_range(
                         start=index[0], end=index[-1], freq=freq
                     )
-                    if not inferred_freq and not resampled_index.equals(index):
+                    if not inferred_freq and not (resampled_index == index).all():
                         raise ValueError(
                             "The given frequency argument could"
                             " not be matched to the given index."


### PR DESCRIPTION
Use element-wise comparrison eather than .equals() to avoid dtype changes

- [ ] closes #xxxx
- [ ] tests added / passed. 
- [ ] code/documentation is well formatted.  
- [ ] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
