### PR TITLE
STY: Accept 88 characters in linting

### DIFF
--- a/lint.sh
+++ b/lint.sh
@@ -17,7 +17,9 @@ if [ "$LINT" == true ]; then
     # pass _all_ flake8 checks
     echo "Linting known clean files with strict rules"
     # Default flake8 rules plus the additional rules from setup.cfg
-    flake8 --isolated --ignore=E121,E123,E126,E226,E24,E704,W503,W504,E741,E203 \
+    flake8 --isolated  \
+        --max-line-length 88 \
+        --ignore=E121,E123,E126,E226,E24,E704,W503,W504,E741,E203 \
         examples \
         setup.py \
         statsmodels/__init__.py \
@@ -377,7 +379,7 @@ if [ "$LINT" == true ]; then
     if [ -n "$NEW_FILES" ]; then
         echo "Linting newly added files with strict rules"
         echo "New files: $NEW_FILES"
-        flake8 --isolated --ignore=E121,E123,E126,E226,E24,E704,W503,W504,E741,E203 $(eval echo $NEW_FILES)
+        flake8 --isolated --max-line-length 88 --ignore=E121,E123,E126,E226,E24,E704,W503,W504,E741,E203 $(eval echo $NEW_FILES)
         if [ $? -ne "0" ]; then
             echo "New files failed linting."
             RET=1

--- a/setup.cfg
+++ b/setup.cfg
@@ -103,7 +103,8 @@ markers =
 junit_family = xunit2
 
 [flake8]
-exclude=.git,build,docs,archive
+exclude = .git,build,docs,archive
+max-line-length = 88
 ignore=
     W503,
     # W503: line break before binary operator


### PR DESCRIPTION
Move to 88 characters

closes #9347

- [X] closes #9347
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
