### PR TITLE
MAINT: Simplify and standardize setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,9 +21,6 @@ import sys
 import numpy as np
 from packaging.version import parse
 
-SETUP_DIR = Path(__file__).parent.resolve()
-
-
 try:
     # SM_FORCE_C is a testing shim to force setup to use C source files
     FORCE_C = int(os.environ.get("SM_FORCE_C", 0))
@@ -36,9 +33,11 @@ try:
     HAS_CYTHON = True
     CYTHON_3 = parse(cython_version) >= parse("3.0")
 except ImportError:
-    from setuptools.command.build_ext import build_ext
+    from setuptools.command.build_ext import build_ext  # noqa: F401
 
     HAS_CYTHON = CYTHON_3 = False
+
+SETUP_DIR = Path(__file__).parent.resolve()
 
 ###############################################################################
 # Key Values that Change Each Release

--- a/tools/ci/azure/azure_template_posix.yml
+++ b/tools/ci/azure/azure_template_posix.yml
@@ -72,6 +72,9 @@ jobs:
           python.version: '3.11'
         python312_macos_latest:
           python.version: '3.12'
+        python312_macos_latest_install:
+          python.version: '3.12'
+          test.install: true
     maxParallel: 10
 
   steps:


### PR DESCRIPTION
Simplify setup since NumPy wikk always be installed when using pip install.
Standardize library usage

xref #9333

- [ ] closes #xxxx
- [ ] tests added / passed. 
- [ ] code/documentation is well formatted.  
- [ ] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
