### PR TITLE
adjusting notation of error term in regression docs

### DIFF
--- a/docs/source/regression.rst
+++ b/docs/source/regression.rst
@@ -44,7 +44,7 @@ Technical Documentation
 
 The statistical model is assumed to be
 
- :math:`Y = X\beta + \mu`,  where :math:`\mu\sim N\left(0,\Sigma\right).`
+ :math:`Y = X\beta + \epsilon`,  where :math:`\epsilon\sim N\left(0,\Sigma\right).`
 
 Depending on the properties of :math:`\Sigma`, we have currently four classes available:
 
@@ -120,7 +120,7 @@ normalized_cov_params : array
     A `p` x `p` array equal to :math:`(X^{T}\Sigma^{-1}X)^{-1}`.
 sigma : array
     The `n` x `n` covariance matrix of the error terms:
-    :math:`\mu\sim N\left(0,\Sigma\right)`.
+    :math:`\epsilon\sim N\left(0,\Sigma\right)`.
 wexog : array
     The whitened design matrix :math:`\Psi^{T}X`.
 wendog : array


### PR DESCRIPTION
Hi all, new contributor but very much enjoy the syntax and implementations of statistical models. As a tiny first contribution, I changed the \mu to \epsilon in the OLS documentation. I think this is more standard notation in statistics, I'm not sure about other fields but since it's mostly a statistical concept it seems like this would be more straightforward. I think \mu could be confused with a mean, which is usually its meaning. 

If you don't like the change, feel free to reject it :) 

