### PR TITLE
Introducing Statsmodels Guru on Gurubase.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
   :alt: Statsmodels logo
 
 |PyPI Version| |Conda Version| |License| |Azure CI Build Status|
-|Codecov Coverage| |Coveralls Coverage| |PyPI downloads| |Conda downloads|
+|Codecov Coverage| |Coveralls Coverage| |PyPI downloads| |Conda downloads| |Gurubase|
 
 About statsmodels
 =================
@@ -107,8 +107,8 @@ Main Features
 
 * Miscellaneous models
 * Sandbox: statsmodels contains a sandbox folder with code in various stages of
-  development and testing which is not considered "production ready".  This covers
-  among others
+development and testing which is not considered "production ready".  This covers
+among others
 
   - Generalized method of moments (GMM) estimators
   - Kernel regression
@@ -205,3 +205,5 @@ https://github.com/statsmodels/statsmodels/issues
    :target: https://anaconda.org/conda-forge/statsmodels/
 .. |License| image:: https://img.shields.io/pypi/l/statsmodels.svg
    :target: https://github.com/statsmodels/statsmodels/blob/main/LICENSE.txt
+.. |Gurubase| image:: https://img.shields.io/badge/Gurubase-Ask%20Statsmodels%20Guru-006BFF
+   :target: https://gurubase.io/g/statsmodels

--- a/README.rst
+++ b/README.rst
@@ -107,8 +107,8 @@ Main Features
 
 * Miscellaneous models
 * Sandbox: statsmodels contains a sandbox folder with code in various stages of
-development and testing which is not considered "production ready".  This covers
-among others
+  development and testing which is not considered "production ready".  This covers
+  among others
 
   - Generalized method of moments (GMM) estimators
   - Kernel regression


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Statsmodels Guru](https://gurubase.io/g/statsmodels) to Gurubase. Statsmodels Guru uses the data from this repo and data from the [docs](https://www.statsmodels.org/stable/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Statsmodels Guru", which highlights that Statsmodels now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Statsmodels Guru in Gurubase, just let me know that's totally fine.
