### PR TITLE
Implement L1 solver for GLM

### DIFF
--- a/statsmodels/base/elastic_net.py
+++ b/statsmodels/base/elastic_net.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+from statsmodels.base.l1_slsqp import fit_l1_slsqp
 from statsmodels.base.model import Results
 import statsmodels.base.wrapper as wrap
 from statsmodels.tools._decorators import cache_readonly
@@ -85,88 +86,18 @@ def _gen_npfuncs(k, L1_wt, alpha, loglike_kwds, score_kwds, hess_kwds):
     return nploglike, npscore, nphess
 
 
-def fit_elasticnet(model, method="coord_descent", maxiter=100,
-                   alpha=0., L1_wt=1., start_params=None, cnvrg_tol=1e-7,
-                   zero_tol=1e-8, refit=False, check_step=True,
-                   loglike_kwds=None, score_kwds=None, hess_kwds=None):
+def _coord_descent(model, alpha, L1_wt, start_params, maxiter, cnvrg_tol,
+                   zero_tol, check_step, loglike_kwds, score_kwds,
+                   hess_kwds):
     """
-    Return an elastic net regularized fit to a regression model.
+    Minimize the penalized negative log-likelihood using coordinate
+    descent.
 
-    Parameters
-    ----------
-    model : model object
-        A statsmodels object implementing ``loglike``, ``score``, and
-        ``hessian``.
-    method : {'coord_descent'}
-        Only the coordinate descent algorithm is implemented.
-    maxiter : int
-        The maximum number of iteration cycles (an iteration cycle
-        involves running coordinate descent on all variables).
-    alpha : scalar or array_like
-        The penalty weight.  If a scalar, the same penalty weight
-        applies to all variables in the model.  If a vector, it
-        must have the same length as `params`, and contains a
-        penalty weight for each coefficient.
-    L1_wt : scalar
-        The fraction of the penalty given to the L1 penalty term.
-        Must be between 0 and 1 (inclusive).  If 0, the fit is
-        a ridge fit, if 1 it is a lasso fit.
-    start_params : array_like
-        Starting values for `params`.
-    cnvrg_tol : scalar
-        If `params` changes by less than this amount (in sup-norm)
-        in one iteration cycle, the algorithm terminates with
-        convergence.
-    zero_tol : scalar
-        Any estimated coefficient smaller than this value is
-        replaced with zero.
-    refit : bool
-        If True, the model is refit using only the variables that have
-        non-zero coefficients in the regularized fit.  The refitted
-        model is not regularized.
-    check_step : bool
-        If True, confirm that the first step is an improvement and search
-        further if it is not.
-    loglike_kwds : dict-like or None
-        Keyword arguments for the log-likelihood function.
-    score_kwds : dict-like or None
-        Keyword arguments for the score function.
-    hess_kwds : dict-like or None
-        Keyword arguments for the Hessian function.
-
-    Returns
-    -------
-    Results
-        A results object.
-
-    Notes
-    -----
-    The ``elastic net`` penalty is a combination of L1 and L2
-    penalties.
-
-    The function that is minimized is:
-
-    -loglike/n + alpha*((1-L1_wt)*|params|_2^2/2 + L1_wt*|params|_1)
-
-    where |*|_1 and |*|_2 are the L1 and L2 norms.
-
-    The computational approach used here is to obtain a quadratic
-    approximation to the smooth part of the target function:
-
-    -loglike/n + alpha*(1-L1_wt)*|params|_2^2/2
-
-    then repeatedly optimize the L1 penalized version of this function
-    along coordinate axes.
+    Helper for `fit_elasticnet`; ``alpha`` must be a vector with one
+    penalty weight per coefficient.  Returns the estimated parameters,
+    the number of iterations, and the convergence status.
     """
-
     k_exog = model.exog.shape[1]
-
-    loglike_kwds = {} if loglike_kwds is None else loglike_kwds
-    score_kwds = {} if score_kwds is None else score_kwds
-    hess_kwds = {} if hess_kwds is None else hess_kwds
-
-    if np.isscalar(alpha):
-        alpha = alpha * np.ones(k_exog)
 
     # Define starting params
     if start_params is None:
@@ -237,6 +168,191 @@ def fit_elasticnet(model, method="coord_descent", maxiter=100,
 
     # Set approximate zero coefficients to be exactly zero
     params[np.abs(params) < zero_tol] = 0
+
+    return params, itr, converged
+
+
+def _l1_slsqp(model, alpha, start_params, maxiter, loglike_kwds, score_kwds,
+              trim_mode="auto", auto_trim_tol=0.01, size_trim_tol=1e-4,
+              qc_tol=0.03, qc_verbose=False, acc=1e-10):
+    """
+    Minimize the L1 penalized negative log-likelihood using slsqp.
+
+    Helper for `fit_elasticnet`; ``alpha`` must be a vector with one
+    penalty weight per coefficient.  The non-smooth L1 problem is
+    reformulated as a smooth constrained problem that is solved with
+    slsqp (an interior point style method), in contrast to the
+    coordinate descent algorithm of `_coord_descent`.  Returns the
+    estimated parameters, the number of iterations, and the
+    convergence status.
+    """
+    if np.min(alpha) < 0:
+        raise ValueError("alpha must be non-negative")
+
+    if start_params is None:
+        start_params = np.zeros(model.exog.shape[1])
+
+    nobs = model.nobs
+
+    def f(params, *args):
+        return -model.loglike(params, **loglike_kwds) / nobs
+
+    def score(params, *args):
+        return -model.score(params, **score_kwds) / nobs
+
+    # The objective function is the average (per observation) penalized
+    # negative log-likelihood, so alpha does not need to be rescaled.
+    kwargs = {
+        "alpha": alpha,
+        "alpha_rescaled": alpha,
+        "trim_mode": trim_mode,
+        "size_trim_tol": size_trim_tol,
+        "auto_trim_tol": auto_trim_tol,
+        "qc_tol": qc_tol,
+        "qc_verbose": qc_verbose,
+        "acc": acc,
+    }
+
+    params, retvals = fit_l1_slsqp(
+        f, score, start_params, args=(), kwargs=kwargs, maxiter=maxiter,
+        full_output=1)
+
+    return params, retvals["iterations"], retvals["converged"]
+
+
+def fit_elasticnet(model, method="coord_descent", maxiter=100,
+                   alpha=0., L1_wt=1., start_params=None, cnvrg_tol=1e-7,
+                   zero_tol=1e-8, refit=False, check_step=True,
+                   loglike_kwds=None, score_kwds=None, hess_kwds=None,
+                   trim_mode="auto", auto_trim_tol=0.01, size_trim_tol=1e-4,
+                   qc_tol=0.03, qc_verbose=False, acc=1e-10):
+    """
+    Return an elastic net regularized fit to a regression model.
+
+    Parameters
+    ----------
+    model : model object
+        A statsmodels object implementing ``loglike``, ``score``, and
+        ``hessian``.
+    method : {'coord_descent', 'l1_slsqp'}
+        The algorithm used to fit the model.  'coord_descent' (with
+        'elastic_net' accepted as a synonym) uses coordinate descent
+        and supports the full elastic net penalty.  'l1_slsqp' solves a
+        smooth constrained reformulation of the L1 problem with slsqp,
+        an interior point style method, and only supports the lasso
+        penalty (``L1_wt`` must be 1).
+    maxiter : int
+        The maximum number of iteration cycles (an iteration cycle
+        involves running coordinate descent on all variables).
+    alpha : scalar or array_like
+        The penalty weight.  If a scalar, the same penalty weight
+        applies to all variables in the model.  If a vector, it
+        must have the same length as `params`, and contains a
+        penalty weight for each coefficient.
+    L1_wt : scalar
+        The fraction of the penalty given to the L1 penalty term.
+        Must be between 0 and 1 (inclusive).  If 0, the fit is
+        a ridge fit, if 1 it is a lasso fit.
+    start_params : array_like
+        Starting values for `params`.
+    cnvrg_tol : scalar
+        If `params` changes by less than this amount (in sup-norm)
+        in one iteration cycle, the algorithm terminates with
+        convergence.
+    zero_tol : scalar
+        Any estimated coefficient smaller than this value is
+        replaced with zero.
+    refit : bool
+        If True, the model is refit using only the variables that have
+        non-zero coefficients in the regularized fit.  The refitted
+        model is not regularized.
+    check_step : bool
+        If True, confirm that the first step is an improvement and search
+        further if it is not.
+    loglike_kwds : dict-like or None
+        Keyword arguments for the log-likelihood function.
+    score_kwds : dict-like or None
+        Keyword arguments for the score function.
+    hess_kwds : dict-like or None
+        Keyword arguments for the Hessian function.
+    trim_mode : {'auto', 'size', 'off'}
+        (for method='l1_slsqp')
+        If not 'off', trim (set to zero) parameters that would have
+        been zero if the solver reached the theoretical minimum.  If
+        'auto', trim params using the theoretical optimality
+        conditions.  If 'size', trim params if they have very small
+        absolute value.
+    auto_trim_tol : float
+        (for method='l1_slsqp')
+        Tolerance used when trim_mode is 'auto'.
+    size_trim_tol : float
+        (for method='l1_slsqp')
+        Tolerance used when trim_mode is 'size'.
+    qc_tol : float
+        (for method='l1_slsqp')
+        Print warning and do not allow auto trim when the optimality
+        conditions are violated by this much.
+    qc_verbose : bool
+        (for method='l1_slsqp')
+        If True, print out a full QC report upon failure.
+    acc : float
+        (for method='l1_slsqp')
+        Requested accuracy for slsqp.
+
+    Returns
+    -------
+    Results
+        A results object.
+
+    Notes
+    -----
+    The ``elastic net`` penalty is a combination of L1 and L2
+    penalties.
+
+    The function that is minimized is:
+
+    -loglike/n + alpha*((1-L1_wt)*|params|_2^2/2 + L1_wt*|params|_1)
+
+    where |*|_1 and |*|_2 are the L1 and L2 norms.
+
+    When ``method`` is 'coord_descent', the computational approach
+    used is to obtain a quadratic approximation to the smooth part of
+    the target function:
+
+    -loglike/n + alpha*(1-L1_wt)*|params|_2^2/2
+
+    then repeatedly optimize the L1 penalized version of this function
+    along coordinate axes.
+
+    When ``method`` is 'l1_slsqp', the L1 penalized problem (L1_wt
+    must be 1) is reformulated as a smooth constrained problem in
+    twice as many variables that is solved with slsqp.
+    """
+
+    k_exog = model.exog.shape[1]
+
+    loglike_kwds = {} if loglike_kwds is None else loglike_kwds
+    score_kwds = {} if score_kwds is None else score_kwds
+    hess_kwds = {} if hess_kwds is None else hess_kwds
+
+    if np.isscalar(alpha):
+        alpha = alpha * np.ones(k_exog)
+
+    if method in ("coord_descent", "elastic_net"):
+        params, itr, converged = _coord_descent(
+            model, alpha, L1_wt, start_params, maxiter, cnvrg_tol,
+            zero_tol, check_step, loglike_kwds, score_kwds, hess_kwds)
+    elif method == "l1_slsqp":
+        if L1_wt != 1.:
+            raise ValueError("L1_wt must be 1 when method is 'l1_slsqp'")
+        params, itr, converged = _l1_slsqp(
+            model, alpha, start_params, maxiter, loglike_kwds, score_kwds,
+            trim_mode=trim_mode, auto_trim_tol=auto_trim_tol,
+            size_trim_tol=size_trim_tol, qc_tol=qc_tol,
+            qc_verbose=qc_verbose, acc=acc)
+    else:
+        raise ValueError(
+            "method must be 'coord_descent' or 'l1_slsqp'")
 
     if not refit:
         results = RegularizedResults(model, params)

--- a/statsmodels/genmod/generalized_linear_model.py
+++ b/statsmodels/genmod/generalized_linear_model.py
@@ -1542,8 +1542,12 @@ class GLM(base.LikelihoodModel):
 
         Parameters
         ----------
-        method : {'elastic_net'}
-            Only the `elastic_net` approach is currently implemented.
+        method : {'elastic_net', 'l1_slsqp'}
+            'elastic_net' uses coordinate descent and supports the full
+            elastic net penalty.  'l1_slsqp' solves a smooth constrained
+            reformulation of the L1 problem with slsqp, an interior
+            point style method, and only supports the lasso penalty
+            (L1_wt must be 1).
         alpha : scalar or array_like
             The penalty weight.  If a scalar, the same penalty weight
             applies to all variables in the model.  If a vector, it
@@ -1593,6 +1597,28 @@ class GLM(base.LikelihoodModel):
             one sweep through all coefficients.
         zero_tol : float
             Coefficients below this threshold are treated as zero.
+
+        The l1_slsqp method uses the following keyword arguments:
+
+        maxiter : int
+            Maximum number of iterations (default 1000).
+        trim_mode : {'auto', 'size', 'off'}
+            If not 'off', trim (set to zero) parameters that would have
+            been zero if the solver reached the theoretical minimum.
+            If 'auto', trim params using the theoretical optimality
+            conditions.  If 'size', trim params if they have very small
+            absolute value.
+        size_trim_tol : float or 'auto'
+            Tolerance used when trim_mode is 'size'.
+        auto_trim_tol : float
+            Tolerance used when trim_mode is 'auto'.
+        qc_tol : float
+            Print warning and do not allow auto trim when the
+            optimality conditions are violated by this much.
+        qc_verbose : bool
+            If True, print out a full QC report upon failure.
+        acc : float
+            Requested accuracy as used by slsqp (default 1e-10).
         """
 
         if kwargs.get("L1_wt", 1) == 0:
@@ -1600,10 +1626,22 @@ class GLM(base.LikelihoodModel):
 
         from statsmodels.base.elastic_net import fit_elasticnet
 
-        if method != "elastic_net":
-            raise ValueError("method for fit_regularized must be elastic_net")
+        if method == "elastic_net":
+            defaults = {
+                "maxiter": 50,
+                "L1_wt": 1,
+                "cnvrg_tol": 1e-10,
+                "zero_tol": 1e-10,
+            }
+        elif method == "l1_slsqp":
+            # l1_slsqp uses an interior point style method, in contrast
+            # to the coordinate descent used by elastic_net.
+            defaults = {"maxiter": 1000}
+        else:
+            raise ValueError(
+                "method for fit_regularized must be elastic_net or l1_slsqp"
+            )
 
-        defaults = {"maxiter": 50, "L1_wt": 1, "cnvrg_tol": 1e-10, "zero_tol": 1e-10}
         defaults.update(kwargs)
 
         llkw = kwargs.get("loglike_kwds", {})
@@ -1630,7 +1668,9 @@ class GLM(base.LikelihoodModel):
 
         if not result.converged:
             warnings.warn(
-                "Elastic net fitting did not converge", ConvergenceWarning, stacklevel=2
+                "Regularized fitting did not converge",
+                ConvergenceWarning,
+                stacklevel=2,
             )
 
         return result

--- a/statsmodels/genmod/generalized_linear_model.py
+++ b/statsmodels/genmod/generalized_linear_model.py
@@ -1520,8 +1520,12 @@ class GLM(base.LikelihoodModel):
 
         Parameters
         ----------
-        method : {'elastic_net'}
-            Only the `elastic_net` approach is currently implemented.
+        method : {'elastic_net', 'l1_slsqp'}
+            'elastic_net' uses coordinate descent and supports the full
+            elastic net penalty.  'l1_slsqp' solves a smooth constrained
+            reformulation of the L1 problem with slsqp, an interior
+            point style method, and only supports the lasso penalty
+            (L1_wt must be 1).
         alpha : scalar or array_like
             The penalty weight.  If a scalar, the same penalty weight
             applies to all variables in the model.  If a vector, it
@@ -1571,6 +1575,28 @@ class GLM(base.LikelihoodModel):
             one sweep through all coefficients.
         zero_tol : float
             Coefficients below this threshold are treated as zero.
+
+        The l1_slsqp method uses the following keyword arguments:
+
+        maxiter : int
+            Maximum number of iterations (default 1000).
+        trim_mode : {'auto', 'size', 'off'}
+            If not 'off', trim (set to zero) parameters that would have
+            been zero if the solver reached the theoretical minimum.
+            If 'auto', trim params using the theoretical optimality
+            conditions.  If 'size', trim params if they have very small
+            absolute value.
+        size_trim_tol : float or 'auto'
+            Tolerance used when trim_mode is 'size'.
+        auto_trim_tol : float
+            Tolerance used when trim_mode is 'auto'.
+        qc_tol : float
+            Print warning and do not allow auto trim when the
+            optimality conditions are violated by this much.
+        qc_verbose : bool
+            If True, print out a full QC report upon failure.
+        acc : float
+            Requested accuracy as used by slsqp (default 1e-10).
         """
 
         if kwargs.get("L1_wt", 1) == 0:
@@ -1578,10 +1604,22 @@ class GLM(base.LikelihoodModel):
 
         from statsmodels.base.elastic_net import fit_elasticnet
 
-        if method != "elastic_net":
-            raise ValueError("method for fit_regularized must be elastic_net")
+        if method == "elastic_net":
+            defaults = {
+                "maxiter": 50,
+                "L1_wt": 1,
+                "cnvrg_tol": 1e-10,
+                "zero_tol": 1e-10,
+            }
+        elif method == "l1_slsqp":
+            # l1_slsqp uses an interior point style method, in contrast
+            # to the coordinate descent used by elastic_net.
+            defaults = {"maxiter": 1000}
+        else:
+            raise ValueError(
+                "method for fit_regularized must be elastic_net or l1_slsqp"
+            )
 
-        defaults = {"maxiter": 50, "L1_wt": 1, "cnvrg_tol": 1e-10, "zero_tol": 1e-10}
         defaults.update(kwargs)
 
         llkw = kwargs.get("loglike_kwds", {})
@@ -1608,7 +1646,9 @@ class GLM(base.LikelihoodModel):
 
         if not result.converged:
             warnings.warn(
-                "Elastic net fitting did not converge", ConvergenceWarning, stacklevel=2
+                "Regularized fitting did not converge",
+                ConvergenceWarning,
+                stacklevel=2,
             )
 
         return result

--- a/statsmodels/genmod/tests/test_glm.py
+++ b/statsmodels/genmod/tests/test_glm.py
@@ -2823,6 +2823,133 @@ class TestRegularized:
                 llf_sm = plf(sm_result.params, model, endog, alpha, L1_wt)
                 assert_equal(np.sign(llf_sm - llf_r), 1)
 
+    @staticmethod
+    def _load_enet_data(dtype):
+        cur_dir = os.path.dirname(os.path.abspath(__file__))
+        data = np.loadtxt(
+            os.path.join(cur_dir, "results", "enet_%s.csv" % dtype),
+            delimiter=",",
+        )
+        return data[:, 0], data[:, 1:]
+
+    def test_regularized_l1_slsqp_vs_discrete(self):
+        # The l1_slsqp method uses the same solver as the L1
+        # fit_regularized of the discrete models, so the results
+        # should agree closely.  The discrete models penalize the
+        # total log-likelihood while GLM penalizes the average
+        # log-likelihood, so alpha is rescaled by nobs.
+
+        for dtype in "binomial", "poisson":
+            endog, exog = self._load_enet_data(dtype)
+            nobs = len(endog)
+
+            fam = {
+                "binomial": sm.families.Binomial,
+                "poisson": sm.families.Poisson,
+            }[dtype]
+            disc_model = {
+                "binomial": discrete.Logit,
+                "poisson": discrete.Poisson,
+            }[dtype]
+
+            for alpha in 0.01, 0.1:
+                model = GLM(endog, exog, family=fam())
+                sm_result = model.fit_regularized(
+                    method="l1_slsqp", alpha=alpha
+                )
+
+                disc_result = disc_model(endog, exog).fit_regularized(
+                    method="l1", alpha=alpha * nobs, disp=0
+                )
+
+                assert_allclose(
+                    sm_result.params, disc_result.params, atol=1e-5, rtol=1e-4
+                )
+
+    def test_regularized_l1_slsqp_vs_elastic_net(self):
+        # elastic_net with L1_wt=1 minimizes the same objective
+        # function as l1_slsqp, so the two methods should give
+        # similar results.
+
+        for dtype in "binomial", "poisson":
+            endog, exog = self._load_enet_data(dtype)
+
+            fam = {
+                "binomial": sm.families.Binomial,
+                "poisson": sm.families.Poisson,
+            }[dtype]
+
+            for alpha in 0.01, 0.1:
+                result_l1 = GLM(endog, exog, family=fam()).fit_regularized(
+                    method="l1_slsqp", alpha=alpha
+                )
+                result_enet = GLM(endog, exog, family=fam()).fit_regularized(
+                    method="elastic_net", L1_wt=1.0, alpha=alpha
+                )
+
+                assert_allclose(
+                    result_l1.params, result_enet.params, atol=1e-4, rtol=1e-3
+                )
+
+    def test_regularized_l1_slsqp_gaussian(self):
+        # Check a family where the scale parameter is estimated, using
+        # OLS as the reference, for which coordinate descent lasso is
+        # exact.
+        from statsmodels.regression.linear_model import OLS
+
+        rs = np.random.RandomState(3423)
+        n = 200
+        exog = rs.normal(size=(n, 4))
+        exog[:, 0] = 1
+        lin_pred = np.dot(exog, np.r_[1.0, 0.5, 0.0, -0.5])
+        endog = lin_pred + rs.normal(size=n)
+
+        for alpha in 0.01, 0.1:
+            result_glm = GLM(endog, exog).fit_regularized(
+                method="l1_slsqp", alpha=alpha
+            )
+            result_ols = OLS(endog, exog).fit_regularized(
+                L1_wt=1.0, alpha=alpha
+            )
+
+            assert_allclose(
+                result_glm.params, result_ols.params, atol=1e-5, rtol=1e-4
+            )
+
+    def test_regularized_l1_slsqp_refit(self):
+        # refit=True returns an unregularized fit restricted to the
+        # variables with non-zero coefficients in the regularized fit.
+        endog, exog = self._load_enet_data("binomial")
+
+        result = GLM(endog, exog, family=sm.families.Binomial()).fit_regularized(
+            method="l1_slsqp", alpha=0.1, refit=True
+        )
+        ii = np.flatnonzero(result.params)
+        assert 0 < len(ii) < exog.shape[1]
+
+        expected = GLM(
+            endog, exog[:, ii], family=sm.families.Binomial()
+        ).fit()
+        assert_allclose(result.params[ii], expected.params, rtol=1e-8)
+
+    def test_regularized_l1_slsqp_no_convergence_warns(self):
+        from statsmodels.tools.sm_exceptions import ConvergenceWarning
+
+        endog, exog = self._load_enet_data("binomial")
+
+        model = GLM(endog, exog, family=sm.families.Binomial())
+        with pytest.warns(ConvergenceWarning):
+            model.fit_regularized(method="l1_slsqp", alpha=0.1, maxiter=1)
+
+    def test_regularized_method_errors(self):
+        endog, exog = self._load_enet_data("binomial")
+
+        model = GLM(endog, exog, family=sm.families.Binomial())
+        with pytest.raises(ValueError, match="method for fit_regularized"):
+            model.fit_regularized(method="l1", alpha=0.1)
+        with pytest.raises(ValueError, match="L1_wt must be 1"):
+            model.fit_regularized(method="l1_slsqp", L1_wt=0.5, alpha=0.1)
+
 
 class TestConvergence:
     @classmethod

--- a/statsmodels/genmod/tests/test_glm.py
+++ b/statsmodels/genmod/tests/test_glm.py
@@ -2794,11 +2794,9 @@ class TestRegularized:
 
     @staticmethod
     def _load_enet_data(dtype):
-        cur_dir = os.path.dirname(os.path.abspath(__file__))
-        data = np.loadtxt(
-            os.path.join(cur_dir, "results", "enet_%s.csv" % dtype),
-            delimiter=",",
-        )
+        cur_dir = Path(__file__).resolve().parent
+        file_path = cur_dir / "results" / f"enet_{dtype}.csv"
+        data = np.loadtxt(file_path, delimiter=",")
         return data[:, 0], data[:, 1:]
 
     def test_regularized_l1_slsqp_vs_discrete(self):

--- a/statsmodels/genmod/tests/test_glm.py
+++ b/statsmodels/genmod/tests/test_glm.py
@@ -2792,6 +2792,133 @@ class TestRegularized:
                 llf_sm = plf(sm_result.params, model, endog, alpha, L1_wt)
                 assert_equal(np.sign(llf_sm - llf_r), 1)
 
+    @staticmethod
+    def _load_enet_data(dtype):
+        cur_dir = os.path.dirname(os.path.abspath(__file__))
+        data = np.loadtxt(
+            os.path.join(cur_dir, "results", "enet_%s.csv" % dtype),
+            delimiter=",",
+        )
+        return data[:, 0], data[:, 1:]
+
+    def test_regularized_l1_slsqp_vs_discrete(self):
+        # The l1_slsqp method uses the same solver as the L1
+        # fit_regularized of the discrete models, so the results
+        # should agree closely.  The discrete models penalize the
+        # total log-likelihood while GLM penalizes the average
+        # log-likelihood, so alpha is rescaled by nobs.
+
+        for dtype in "binomial", "poisson":
+            endog, exog = self._load_enet_data(dtype)
+            nobs = len(endog)
+
+            fam = {
+                "binomial": sm.families.Binomial,
+                "poisson": sm.families.Poisson,
+            }[dtype]
+            disc_model = {
+                "binomial": discrete.Logit,
+                "poisson": discrete.Poisson,
+            }[dtype]
+
+            for alpha in 0.01, 0.1:
+                model = GLM(endog, exog, family=fam())
+                sm_result = model.fit_regularized(
+                    method="l1_slsqp", alpha=alpha
+                )
+
+                disc_result = disc_model(endog, exog).fit_regularized(
+                    method="l1", alpha=alpha * nobs, disp=0
+                )
+
+                assert_allclose(
+                    sm_result.params, disc_result.params, atol=1e-5, rtol=1e-4
+                )
+
+    def test_regularized_l1_slsqp_vs_elastic_net(self):
+        # elastic_net with L1_wt=1 minimizes the same objective
+        # function as l1_slsqp, so the two methods should give
+        # similar results.
+
+        for dtype in "binomial", "poisson":
+            endog, exog = self._load_enet_data(dtype)
+
+            fam = {
+                "binomial": sm.families.Binomial,
+                "poisson": sm.families.Poisson,
+            }[dtype]
+
+            for alpha in 0.01, 0.1:
+                result_l1 = GLM(endog, exog, family=fam()).fit_regularized(
+                    method="l1_slsqp", alpha=alpha
+                )
+                result_enet = GLM(endog, exog, family=fam()).fit_regularized(
+                    method="elastic_net", L1_wt=1.0, alpha=alpha
+                )
+
+                assert_allclose(
+                    result_l1.params, result_enet.params, atol=1e-4, rtol=1e-3
+                )
+
+    def test_regularized_l1_slsqp_gaussian(self):
+        # Check a family where the scale parameter is estimated, using
+        # OLS as the reference, for which coordinate descent lasso is
+        # exact.
+        from statsmodels.regression.linear_model import OLS
+
+        rs = np.random.RandomState(3423)
+        n = 200
+        exog = rs.normal(size=(n, 4))
+        exog[:, 0] = 1
+        lin_pred = np.dot(exog, np.r_[1.0, 0.5, 0.0, -0.5])
+        endog = lin_pred + rs.normal(size=n)
+
+        for alpha in 0.01, 0.1:
+            result_glm = GLM(endog, exog).fit_regularized(
+                method="l1_slsqp", alpha=alpha
+            )
+            result_ols = OLS(endog, exog).fit_regularized(
+                L1_wt=1.0, alpha=alpha
+            )
+
+            assert_allclose(
+                result_glm.params, result_ols.params, atol=1e-5, rtol=1e-4
+            )
+
+    def test_regularized_l1_slsqp_refit(self):
+        # refit=True returns an unregularized fit restricted to the
+        # variables with non-zero coefficients in the regularized fit.
+        endog, exog = self._load_enet_data("binomial")
+
+        result = GLM(endog, exog, family=sm.families.Binomial()).fit_regularized(
+            method="l1_slsqp", alpha=0.1, refit=True
+        )
+        ii = np.flatnonzero(result.params)
+        assert 0 < len(ii) < exog.shape[1]
+
+        expected = GLM(
+            endog, exog[:, ii], family=sm.families.Binomial()
+        ).fit()
+        assert_allclose(result.params[ii], expected.params, rtol=1e-8)
+
+    def test_regularized_l1_slsqp_no_convergence_warns(self):
+        from statsmodels.tools.sm_exceptions import ConvergenceWarning
+
+        endog, exog = self._load_enet_data("binomial")
+
+        model = GLM(endog, exog, family=sm.families.Binomial())
+        with pytest.warns(ConvergenceWarning):
+            model.fit_regularized(method="l1_slsqp", alpha=0.1, maxiter=1)
+
+    def test_regularized_method_errors(self):
+        endog, exog = self._load_enet_data("binomial")
+
+        model = GLM(endog, exog, family=sm.families.Binomial())
+        with pytest.raises(ValueError, match="method for fit_regularized"):
+            model.fit_regularized(method="l1", alpha=0.1)
+        with pytest.raises(ValueError, match="L1_wt must be 1"):
+            model.fit_regularized(method="l1_slsqp", L1_wt=0.5, alpha=0.1)
+
 
 class TestConvergence:
     @classmethod


### PR DESCRIPTION
- [x] closes #9428
- [x] tests added / passed.
- [x] code/documentation is well formatted.
- [x] properly formatted commit message. See
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message).

Adds `method="l1_slsqp"` to `GLM.fit_regularized`, reusing the `fit_l1_slsqp` solver from `statsmodels.base.l1_slsqp` (the same one used by the discrete models) through a new `_l1_slsqp` helper in `statsmodels/base/elastic_net.py`. In contrast to the coordinate descent algorithm used by `elastic_net`, this solves a smooth constrained reformulation of the L1 problem (interior point style); it only supports the lasso penalty (`L1_wt = 1`).

Tests compare the results against the discrete models' L1 `fit_regularized` (`Logit`, `Poisson`), against `elastic_net` with `L1_wt=1`, and against `OLS.fit_regularized` for the Gaussian family.
