### PR TITLE
Dependencies consistency

### DIFF
--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -5,19 +5,19 @@ python >= 3.8
 
     www.python.org
 
-numpy >= 1.18
+numpy >= 1.22.3, < 3
 
     www.numpy.org
 
-scipy >= 1.4
+scipy >= 1.8, != 1.9.2
 
     www.scipy.org
 
-pandas >= 1.0
+pandas >= 1.4, != 2.1.0
 
     pandas.pydata.org
 
-patsy >= 0.5.2
+patsy >= 0.5.6
 
     patsy.readthedocs.org
 


### PR DESCRIPTION
Also the [statsmodels.org](https://www.statsmodels.org/stable/install.html) has a message:
```
Python Support

statsmodels supports Python 3.8, 3.9, and 3.10.
```

But if you scroll to the Dependencies section, it says that Python 3.8 is not supported:
```
Dependencies[¶](https://www.statsmodels.org/stable/install.html#dependencies)

The current minimum dependencies are:

    [Python](https://www.python.org/) >= 3.9

    [NumPy](https://www.scipy.org/) >= 1.22.3

    [SciPy](https://www.scipy.org/) >= 1.8

    [Pandas](https://pandas.pydata.org/) >= 1.4

    [Patsy](https://patsy.readthedocs.io/en/latest/) >= 0.5.6
```