### PR TITLE
TST: Relax tolerance on overly tight test

### DIFF
--- a/statsmodels/robust/tests/test_covariance.py
+++ b/statsmodels/robust/tests/test_covariance.py
@@ -96,10 +96,10 @@ class TestOGKMad():
     def test(self):
         res1 = self.res1
         res2 = self.res2
-        assert_allclose(res1.cov, res2.cov, rtol=1e-13)
-        assert_allclose(res1.mean, res2.center, rtol=1e-13)
-        assert_allclose(res1.cov_raw, res2.cov_raw, rtol=1e-11)
-        assert_allclose(res1.loc_raw, res2.center_raw, rtol=1e-10)
+        assert_allclose(res1.cov, res2.cov, rtol=1e-10)
+        assert_allclose(res1.mean, res2.center, rtol=1e-10)
+        assert_allclose(res1.cov_raw, res2.cov_raw, rtol=1e-8)
+        assert_allclose(res1.loc_raw, res2.center_raw, rtol=1e-8)
 
 
 class TestOGKTau(TestOGKMad):
@@ -120,14 +120,14 @@ class TestOGKTau(TestOGKMad):
         # I did not find options to improve agreement
         res1 = self.res1
         res2 = self.res2
-        assert_allclose(res1.cov, res2.cov, atol=0.05, rtol=1e-13)
-        assert_allclose(res1.mean, res2.center, atol=0.03, rtol=1e-13)
+        assert_allclose(res1.cov, res2.cov, atol=0.05, rtol=1e-10)
+        assert_allclose(res1.mean, res2.center, atol=0.03, rtol=1e-10)
         # cov raw differs in scaling, no idea why
         # note rrcov uses C code for this case with hardoced tau scale
         # our results are "better", i.e. correct outliers same as dgp
         # rrcov has one extra outlier
         fact = 1.1356801031633883
-        assert_allclose(res1.cov_raw, res2.cov_raw * fact, rtol=1e-11)
+        assert_allclose(res1.cov_raw, res2.cov_raw * fact, rtol=1e-8)
         assert_allclose(res1.loc_raw, res2.center_raw, rtol=0.2, atol=0.1)
 
 

--- a/statsmodels/tsa/statespace/tests/test_dynamic_factor.py
+++ b/statsmodels/tsa/statespace/tests/test_dynamic_factor.py
@@ -610,7 +610,7 @@ class TestDynamicFactor_ar2_errors(CheckDynamicFactor):
                 res1.params, method='nm', maxiter=10000,
                 optim_score='approx', disp=False)
             # Added rtol to catch spurious failures on some platforms
-            assert_allclose(res.llf, self.results.llf, atol=1e-2, rtol=1e-4)
+            assert_allclose(res.llf, self.results.llf, atol=1e-2, rtol=1e-3)
 
 
 class TestDynamicFactor_scalar_error(CheckDynamicFactor):


### PR DESCRIPTION
- [X] closes #9501
- [X] tests added / passed. 
- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
