### PR TITLE
[ENH] Allow ARDL model trend 'ctt'

### DIFF
--- a/statsmodels/tsa/ar_model.py
+++ b/statsmodels/tsa/ar_model.py
@@ -117,7 +117,7 @@ class AutoReg(tsa_model.TimeSeriesModel):
         * 'c' - Constant only.
         * 't' - Time trend only.
         * 'ct' - Constant and linear time trend.
-        * 'ctt' - Constant and quadratic time trend.
+        * 'ctt' - Constant and linear and quadratic time trends.
 
     seasonal : bool
         Flag indicating whether to include seasonal dummies in the model. If

--- a/statsmodels/tsa/ar_model.py
+++ b/statsmodels/tsa/ar_model.py
@@ -110,13 +110,14 @@ class AutoReg(tsa_model.TimeSeriesModel):
         list of lag indices to include.  For example, [1, 4] will only
         include lags 1 and 4 while lags=4 will include lags 1, 2, 3, and 4.
         None excludes all AR lags, and behave identically to 0.
-    trend : {'n', 'c', 't', 'ct'}
+    trend : {'n', 'c', 't', 'ct', 'ctt'}
         The trend to include in the model:
 
         * 'n' - No trend.
         * 'c' - Constant only.
         * 't' - Time trend only.
-        * 'ct' - Constant and time trend.
+        * 'ct' - Constant and linear time trend.
+        * 'ctt' - Constant and quadratic time trend.
 
     seasonal : bool
         Flag indicating whether to include seasonal dummies in the model. If
@@ -211,7 +212,7 @@ class AutoReg(tsa_model.TimeSeriesModel):
         self._trend = cast(
             Literal["n", "c", "t", "ct","ctt"],
             string_like(
-                trend, "trend", options=("n", "c", "t", "ct","ctt"), optional=False
+                trend, "trend", options=("n", "c", "t", "ct", "ctt"), optional=False
             ),
         )
         self._seasonal = bool_like(seasonal, "seasonal")

--- a/statsmodels/tsa/ar_model.py
+++ b/statsmodels/tsa/ar_model.py
@@ -210,7 +210,7 @@ class AutoReg(tsa_model.TimeSeriesModel):
     ):
         super().__init__(endog, exog, None, None, missing=missing)
         self._trend = cast(
-            Literal["n", "c", "t", "ct","ctt"],
+            Literal["n", "c", "t", "ct", "ctt"],
             string_like(
                 trend, "trend", options=("n", "c", "t", "ct", "ctt"), optional=False
             ),

--- a/statsmodels/tsa/ar_model.py
+++ b/statsmodels/tsa/ar_model.py
@@ -209,9 +209,9 @@ class AutoReg(tsa_model.TimeSeriesModel):
     ):
         super().__init__(endog, exog, None, None, missing=missing)
         self._trend = cast(
-            Literal["n", "c", "t", "ct"],
+            Literal["n", "c", "t", "ct","ctt"],
             string_like(
-                trend, "trend", options=("n", "c", "t", "ct"), optional=False
+                trend, "trend", options=("n", "c", "t", "ct","ctt"), optional=False
             ),
         )
         self._seasonal = bool_like(seasonal, "seasonal")

--- a/statsmodels/tsa/ardl/tests/test_ardl.py
+++ b/statsmodels/tsa/ardl/tests/test_ardl.py
@@ -821,3 +821,10 @@ def test_resids_ardl_uecm():
     uecm_res = uecm_mod.fit()
 
     assert_allclose(uecm_res.resid, ardl_res.resid)
+
+
+def test_ardl_trend_ctt(data):
+    """Test ARDL with trend='ctt'."""
+    res = ARDL(data.y, None, data.x, None, trend="ctt").fit()
+    assert res.params.shape[0] == 3  # Should include constant, trend, and trend^2
+    check_results(res)

--- a/statsmodels/tsa/ardl/tests/test_ardl.py
+++ b/statsmodels/tsa/ardl/tests/test_ardl.py
@@ -823,8 +823,10 @@ def test_resids_ardl_uecm():
     assert_allclose(uecm_res.resid, ardl_res.resid)
 
 
-def test_ardl_trend_ctt(data):
+@pytest.mark.parameterize("y_lags",[None, 1, 2])
+@pytest.mark.parameterize("x_lags",[None, 1, 2])
+def test_ardl_trend_ctt(data, y_lags, x_lags):
     """Test ARDL with trend='ctt'."""
     res = ARDL(data.y, None, data.x, None, trend="ctt").fit()
-    assert res.params.shape[0] == 3  # Should include constant, trend, and trend^2
+    assert res.params.shape[0] == (3 + y_lags if y_lags else 0 + x_lags if x_lags else 0)
     check_results(res)


### PR DESCRIPTION
The ARDL class constructor accepts a trend specification which must be one of 'n', 'c', 't', 'ct'.  This PR allows for one more option 'ctt' which provides for a quadratic trend. This is supported by other models and the infrastructure supports this with just a one or two line change.

Internally exogenous variables for 1, t, t**2 are generated and passed to OLS. I did not need to add code for that to take place. It was already available.
