### PR TITLE
BUG: Fix bug in Runs.runs_test for the case of a single run yielding …

### DIFF
--- a/statsmodels/sandbox/stats/runs.py
+++ b/statsmodels/sandbox/stats/runs.py
@@ -77,18 +77,23 @@ class Runs:
             does not use any correction.
 
         pvalue based on normal distribution, with integer correction
+        if a single run is detected, pvalue is based on the Binomial distribition
 
         '''
         self.npo = npo = (self.runs_pos).sum()
         self.nne = nne = (self.runs_neg).sum()
 
-        #n_r = self.n_runs
+        n_r = self.n_runs
         n = npo + nne
+        if n_r == 1:
+            pval = 1 / (2.0 ** (min(n,1024) - 1))
+            z = -stats.norm.isf(pval)
+            return z, pval*2
         npn = npo * nne
         rmean = 2. * npn / n + 1
         rvar = 2. * npn * (2.*npn - n) / n**2. / (n-1.)
         rstd = np.sqrt(rvar)
-        rdemean = self.n_runs - rmean
+        rdemean = n_r - rmean
         if n >= 50 or not correction:
             z = rdemean
         else:

--- a/statsmodels/sandbox/stats/tests/test_runs.py
+++ b/statsmodels/sandbox/stats/tests/test_runs.py
@@ -27,3 +27,10 @@ def test_numeric_cutoff():
     expected = (-3.944254410803499, 8.004864125547193e-05)
     results = runstest_1samp(x, cutoff=cutoff, correction=False)
     assert_almost_equal(expected, results)
+
+def test_single_run():
+    x = [1] * 10
+    expected = (-2.8856349,  0.0039062)
+    results = runstest_1samp(x)
+    assert_almost_equal(expected, results)
+


### PR DESCRIPTION
…incorrect zscore and pvalue

- [ X] closes #9523
- [ X] tests added / passed. 
- [ X] code/documentation is well formatted.  
- [ X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 
