### PR TITLE
DOC: fix duplicate words in weightstats

### DIFF
--- a/statsmodels/stats/weightstats.py
+++ b/statsmodels/stats/weightstats.py
@@ -1432,8 +1432,8 @@ def ttost_paired(x1, x2, low, upp, transform=None, weights=None):
 
     where md is the mean, expected value of the difference x1 - x2
 
-    If the pvalue is smaller than a threshold,say 0.05, then we reject the
-    hypothesis that the difference between the two samples is larger than the
+    If the pvalue is smaller than a threshold, say 0.05, then we reject the
+    hypothesis that the difference between the two samples is larger than
     the thresholds given by low and upp.
 
     Parameters


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

This PR fixes a very minor issue in the documentation for `ttost_paired` function. In the original documentation, `the` was accidentally duplicated:

```[...] the the thresholds given by low and upp.``` 

This PR fixes that. I did not create an issue because it seemed to be overkill for such a minor typo to me. If you require it anyways, let me know and I'll create one 😄 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
