### PR TITLE
ENH/BUG: Use `pyodide.http` for `get_rdataset()` when running in JupyterLite

### DIFF
--- a/statsmodels/datasets/utils.py
+++ b/statsmodels/datasets/utils.py
@@ -140,9 +140,12 @@ def _in_jupyterlite() -> bool:
     if "pyodide" in sys.modules:
         import js
         return (
+            # running in a browser
+            not hasattr(js, "document") or
+            # running in JupyterLite
             hasattr(js, "_JUPYTERLAB") or
-            hasattr(js, "webpackChunk_jupyterlite_pyodide_kernel_extension") or
-            not hasattr(js, "document")
+            # using Pyodide in JupyterLite
+            hasattr(js, "webpackChunk_jupyterlite_pyodide_kernel_extension")
         )
     return False
 

--- a/statsmodels/datasets/utils.py
+++ b/statsmodels/datasets/utils.py
@@ -132,6 +132,21 @@ def _open_cache(cache_path):
         return zlib.decompress(zf.read())
 
 
+# Sourced from Holoviews:
+# https://github.com/holoviz/holoviews/blob/74fda3fb832257357c48eda1be0a73eb523966a7/holoviews/pyodide.py#L78-L81
+# License: BSD-3-Clause
+def _in_jupyterlite() -> bool:
+    import sys
+    if "pyodide" in sys.modules:
+        import js
+        return (
+            hasattr(js, "_JUPYTERLAB") or
+            hasattr(js, "webpackChunk_jupyterlite_pyodide_kernel_extension") or
+            not hasattr(js, "document")
+        )
+    return False
+
+
 def _urlopen_cached(url, cache):
     """
     Tries to load data from cache location otherwise downloads it. If it
@@ -157,7 +172,20 @@ def _urlopen_cached(url, cache):
 
     # not using the cache or did not find it in cache
     if not from_cache:
-        data = urlopen(url, timeout=3).read()
+        if _in_jupyterlite():
+            try:
+                import pyodide.http
+                stringio = pyodide.http.open_url(url)
+                data = stringio.read().encode("utf-8")
+            except Exception as e:
+                # Convert Pyodide errors to appropriate urllib errors
+                if "404" in str(e):
+                    raise HTTPError(url, 404, "Not Found", None, None)
+                else:
+                    raise URLError(str(e))
+        else:
+            data = urlopen(url, timeout=3).read()
+
         if cache is not None:  # then put it in the cache
             _cache_it(data, cache_path)
     return data, from_cache


### PR DESCRIPTION
- [ ] stemmed off from #9536
- [ ] tests added / passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>

This PR adds a check for whether code is running in JupyterLite and is using the `jupyterlite-pyodide-kernel`, and if it is, it uses [`pyodide.http` APIs](https://pyodide.org/en/stable/usage/api/python-api/http.html#pyodide.http.open_url) within `_urlopen_cached`. This public method uses the `XMLHttpRequest` JavaScript API underneath in a browser-based environment, which is a replacement for `urllib.request.urlopen`.

This change has been stemmed off from a commit in #9536 where I added it – it makes sense for them to be included separately. Once reviewed/merged, we can include this as a patch upstream and put out a Pyodide 0.27.5 micro release with it, so that this functionality of `statsmodels` works natively in the browser without having to [monkeypatch networking libraries at runtime](https://github.com/koenvo/pyodide-http).