### PR TITLE
Add optional raw spec parameter for x13_arima_analysis()

### DIFF
--- a/statsmodels/tsa/tests/test_x13.py
+++ b/statsmodels/tsa/tests/test_x13.py
@@ -13,6 +13,10 @@ from statsmodels.tsa.x13 import (
     x13_arima_select_order,
 )
 
+from statsmodels.tools.sm_exceptions import (
+    X13Error,
+)
+
 x13path = _find_x12()
 
 pytestmark = pytest.mark.skipif(x13path is False, reason="X13/X12 not available")
@@ -156,3 +160,27 @@ history {
         ft.seek(0)
 
         x13_arima_analysis(dataset, rawspec=ft.name)
+
+def test_x13_arima_invalid_rawspec(dataset):
+    # bad rawspec file string ("series" misspelled, no closing "}" on "x11")
+    raw_spec_file = """
+seri es { 
+    modelspan=(,) 
+}
+x11 { 
+    seasonalma=(  msr) 
+"""
+
+    # pass rawspec as string
+    with pytest.raises(X13Error):
+
+        x13_arima_analysis(dataset, rawspec=raw_spec_file)
+
+    # pass rawspec as file path
+    with tempfile.NamedTemporaryFile(suffix='.spc') as ft:
+        ft.write(raw_spec_file.encode('utf8'))
+        ft.seek(0)
+
+        with pytest.raises(X13Error):
+
+            x13_arima_analysis(dataset, rawspec=ft.name)

--- a/statsmodels/tsa/tests/test_x13.py
+++ b/statsmodels/tsa/tests/test_x13.py
@@ -161,6 +161,83 @@ history {
 
         x13_arima_analysis(dataset, rawspec=ft.name)
 
+
+def test_x13_arima_rawspec_no_save(dataset):
+    # example rawspec file string
+    raw_spec_file = """
+series { 
+    modelspan=(,) 
+    save=(B1) 
+    span=(,) 
+    type=(flow) 
+}
+x11 { 
+    seasonalma=(  msr) 
+    appendfcst=yes 
+    mode=(mult) 
+    print=( seasadj seasonal adjustfac) 
+    savelog=(  alldiagnostics) 
+} 
+arima {model=(0 1 0)(1 0 1)} 
+transform { 
+    function=log 
+} 
+regression { 
+    savelog=(  aictest) 
+ } 
+estimate {save=mdl} 
+slidingspans { } 
+history { 
+    estimates=(sadj seasonal fcst) 
+    fixmdl=yes
+}
+"""
+
+    # pass rawspec as string
+    x13_arima_analysis(dataset, rawspec=raw_spec_file)
+
+    # pass rawspec as file path
+    with tempfile.NamedTemporaryFile(suffix='.spc') as ft:
+        ft.write(raw_spec_file.encode('utf8'))
+        ft.seek(0)
+
+        x13_arima_analysis(dataset, rawspec=ft.name)
+
+
+def test_x13_arima_rawspec_no_x11(dataset):
+    # example rawspec file string
+    raw_spec_file = """
+series { 
+    modelspan=(,) 
+    save=(B1) 
+    span=(,) 
+    type=(flow) 
+}
+arima {model=(0 1 0)(1 0 1)} 
+transform { 
+    function=log 
+} 
+regression { 
+    savelog=(  aictest) 
+ } 
+estimate {save=mdl} 
+slidingspans { } 
+history { 
+    estimates=(sadj seasonal fcst) 
+    fixmdl=yes
+}
+"""
+
+    # pass rawspec as string
+    x13_arima_analysis(dataset, rawspec=raw_spec_file)
+
+    # pass rawspec as file path
+    with tempfile.NamedTemporaryFile(suffix='.spc') as ft:
+        ft.write(raw_spec_file.encode('utf8'))
+        ft.seek(0)
+
+        x13_arima_analysis(dataset, rawspec=ft.name)
+
 def test_x13_arima_invalid_rawspec(dataset):
     # bad rawspec file string ("series" misspelled, no closing "}" on "x11")
     raw_spec_file = """

--- a/statsmodels/tsa/x13.py
+++ b/statsmodels/tsa/x13.py
@@ -491,7 +491,6 @@ def x13_arima_analysis(
     spec_obj = pandas_to_series_spec(endog)
     spec = spec_obj.create_spec()
 
-    # if specfile string (or path) is passed
     if rawspec is None:
 
         spec += f"transform{{function={_log_to_x12[log]}}}\n"
@@ -503,6 +502,7 @@ def x13_arima_analysis(
         spec += _make_forecast_options(forecast_periods)
         spec += "x11{ save=(d11 d12 d13) \n savelog=(fd8 m7 q)}"
 
+    # if specfile string (or path) is passed
     else:
 
         if ((not None) in [diff, exog, start, freq]): # or (not outlier) or trading:


### PR DESCRIPTION
- [x] tests added / passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message.

This commit adds an option to pass in a raw `.spec` file to the `x13_arima_analysis()` function, either as a path or as a string. 

We needed a way to use more advanced configuration options for x13, but adding all the specifications to the statsmodels function itself seemed like an exercise in futility. (the manual for x13 is [nearly 300 pages](https://www2.census.gov/software/x-13arima-seats/x13as/windows/documentation/docx13as.pdf)) The string substitution is hopefully not too brittle.