### PR TITLE
Fix Broken Link to Citation Paper of 2010 Conference

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -64,7 +64,7 @@ Please use following citation to cite statsmodels in scientific publications:
 
 
 Seabold, Skipper, and Josef Perktold. "`statsmodels: Econometric and statistical modeling with
-python. <http://conference.scipy.org/proceedings/scipy2010/pdfs/seabold.pdf>`_" *Proceedings
+python. <https://proceedings.scipy.org/articles/proceedings-2010.pdf>`_" *Proceedings
 of the 9th Python in Science Conference.* 2010.
 
 Bibtex entry::


### PR DESCRIPTION
Fix Broken Link to Citation Paper of 2010 Conference

Before:
![image](https://github.com/user-attachments/assets/4c125956-d1a8-439b-ba07-a2bc1c39569b)

After:
![image](https://github.com/user-attachments/assets/8f472a04-876b-4ddb-b7b0-297c8359a717)

- [ ] tests added / passed. 
Not a code change. Change to a broken link in the documentation.
- [x] code/documentation is well formatted.  
- [ ] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
