### PR TITLE
BUG: make Binomial family more robust to corner case mu=0 , endog=0

### DIFF
--- a/statsmodels/genmod/families/family.py
+++ b/statsmodels/genmod/families/family.py
@@ -1053,7 +1053,7 @@ class Binomial(Family):
         # note that mu is still in (0,1), i.e. not converted back
         return (
             special.gammaln(n + 1) - special.gammaln(y + 1) -
-            special.gammaln(n - y + 1) + y * np.log(mu / (1 - mu + 1e-20)) +
+            special.gammaln(n - y + 1) + y * np.log((mu + 1e-20) / (1 - mu + 1e-20)) +
             n * np.log(1 - mu + 1e-20)) * var_weights
 
     def resid_anscombe(self, endog, mu, var_weights=1., scale=1.):

--- a/statsmodels/genmod/families/tests/test_family.py
+++ b/statsmodels/genmod/families/tests/test_family.py
@@ -6,7 +6,7 @@ import warnings
 import pytest
 
 import numpy as np
-from numpy.testing import assert_allclose
+from numpy.testing import assert_allclose, assert_almost_equal
 
 from scipy import integrate
 
@@ -15,7 +15,7 @@ from statsmodels.tools.sm_exceptions import (
     ValueWarning,
     )
 import statsmodels.genmod.families as F
-from statsmodels.genmod.families.family import Tweedie
+from statsmodels.genmod.families.family import Tweedie, Binomial
 import statsmodels.genmod.families.links as L
 
 all_links = {
@@ -107,3 +107,15 @@ def test_tweedie_loglike_obs(power):
         )
 
     assert_allclose(pdf(0) + integrate.quad(pdf, 0, 1e2)[0], 1, atol=1e-4)
+
+
+@pytest.mark.parametrize("mu", [0,1])
+@pytest.mark.parametrize("endog", [0,1])
+def test_binomial_loglike_obs(mu, endog):
+    """Test Binomial loglike with extreme values"""
+    ll = Binomial().loglike_obs(endog=endog, mu=mu)
+    if mu == endog:
+        assert_almost_equal(ll, 0)
+    else:
+        # For our purposes, -40 is "approximately" -inf
+        assert ll < -40


### PR DESCRIPTION
This fixes #9580

- [ ] closes #xxxx
- [ ] tests added / passed. 
- [ ] code/documentation is well formatted.  
- [ ] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
