### PR TITLE
fix a typo in multicomp docstring

### DIFF
--- a/statsmodels/sandbox/stats/multicomp.py
+++ b/statsmodels/sandbox/stats/multicomp.py
@@ -921,7 +921,7 @@ class MultiComparison:
     Parameters
     ----------
     data : ndarray
-        independent data samples
+        dependent data samples
     groups : ndarray
         group labels corresponding to each data point
     group_order : list[str], optional


### PR DESCRIPTION
Hi,

I believe the input data (first argument) for `MultiComparison` must be the dependent variable, but is is mistakenly written as _independent data samples_. 

Hope this helps.