### PR TITLE
DOC: Update supported Python versions

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -15,7 +15,7 @@ Instructions for installing from PyPI, source or a development version are also 
 Python Support
 --------------
 
-statsmodels supports Python 3.9, 3.10, 3.11, and 3.12.
+statsmodels supports Python 3.9, 3.10, 3.11, 3.12, and 3.13.
 
 Anaconda
 --------


### PR DESCRIPTION
- [ ] code/documentation is well formatted.  
- [ ] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

This PR fixes the list of supported Python versions in `install.rst`. The original states `statsmodels supports Python 3.8, 3.9, and 3.10.` but setup.py (in the CLASSIFIERS section) states versions 3.9-3.12. The fix states `statsmodels supports Python 3.9, 3.10, 3.11, 3.12, and 3.13.`

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
