### PR TITLE
ENH: Add post-hoc tests to AnovaRM results #9491

### DIFF
--- a/docs/source/anova.rst
+++ b/docs/source/anova.rst
@@ -43,3 +43,22 @@ Module Reference
 
    anova_lm
    AnovaRM
+
+Post-Hoc Testing
+----------------
+
+The :class:`AnovaResults` object returned by `AnovaRM.fit` provides methods for post-hoc testing, including Tukey's HSD and general pairwise t-tests with multiple comparison correction.
+
+.. code-block:: python
+
+    # perform repeated measures anova
+    res = AnovaRM(data, 'DV', 'id', within=['A', 'B']).fit()
+
+    # perform Tukey's HSD post-hoc test
+    tukey_res = res.pairwise_tukeyhsd()
+    print(tukey_res)
+
+    # perform pairwise t-tests
+    from scipy import stats
+    ttest_res = res.allpairtest(stats.ttest_ind, method="bonf")
+    print(ttest_res[0])

--- a/docs/source/release/version0.14.4.rst
+++ b/docs/source/release/version0.14.4.rst
@@ -43,3 +43,14 @@ Merged Pull Requests
 The following Pull Requests were merged since the last release:
 
 - :pr:`9365`: Backport of #9270: add Pyodide support and CI jobs for v0.14.x
+
+The main enhancements and new features are listed below.
+
+Enhancements
+------------
+
+* Post-hoc methods (`pairwise_tukeyhsd` and `allpairtest`) can now be directly called from the results of a repeated measures ANOVA (`AnovaRM`). (:issue:`9491`)
+
+The main bug fixes are listed below.
+
+Bug Fixes

--- a/statsmodels/sandbox/stats/multicomp.py
+++ b/statsmodels/sandbox/stats/multicomp.py
@@ -76,6 +76,7 @@ import pandas as pd
 from statsmodels.graphics import utils
 from statsmodels.iolib.table import SimpleTable
 from statsmodels.tools.sm_exceptions import ValueWarning
+from statsmodels.tools.grouputils import GroupsStats
 
 try:
     # Studentized Range in SciPy 1.7+
@@ -509,105 +510,6 @@ def tiecorrect(xranks):
     ntot = float(len(xranks))
     tiecorrection = 1 - (nties**3 - nties).sum() / (ntot**3 - ntot)
     return tiecorrection
-
-
-class GroupsStats:
-    """
-    statistics by groups (another version)
-
-    groupstats as a class with lazy evaluation (not yet - decorators are still
-    missing)
-
-    written this time as equivalent of scipy.stats.rankdata
-    gs = GroupsStats(X, useranks=True)
-    assert_almost_equal(gs.groupmeanfilter, stats.rankdata(X[:,0]), 15)
-
-    TODO: incomplete doc strings
-
-    """
-
-    def __init__(self, x, useranks=False, uni=None, intlab=None):
-        """descriptive statistics by groups
-
-        Parameters
-        ----------
-        x : ndarray, 2d
-            first column data, second column group labels
-        useranks : bool
-            if true, then use ranks as data corresponding to the
-            scipy.stats.rankdata definition (start at 1, ties get mean)
-        uni, intlab : arrays (optional)
-            to avoid call to unique, these can be given as inputs
-
-
-        """
-        self.x = np.asarray(x)
-        if intlab is None:
-            uni, intlab = np.unique(x[:, 1], return_inverse=True)
-        elif uni is None:
-            uni = np.unique(x[:, 1])
-
-        self.useranks = useranks
-
-        self.uni = uni
-        self.intlab = intlab
-        self.groupnobs = np.bincount(intlab)
-
-        # temporary until separated and made all lazy
-        self.runbasic(useranks=useranks)
-
-    def runbasic_old(self, useranks=False):
-        """runbasic_old"""
-        # check: refactoring screwed up case useranks=True
-
-        # groupxsum = np.bincount(intlab, weights=X[:,0])
-        # groupxmean = groupxsum * 1.0 / groupnobs
-        x = self.x
-        if useranks:
-            self.xx = x[:, 1].argsort().argsort() + 1  # rankraw
-        else:
-            self.xx = x[:, 0]
-        self.groupsum = groupranksum = np.bincount(self.intlab, weights=self.xx)
-        # print('groupranksum', groupranksum, groupranksum.shape, self.groupnobs.shape
-        # start at 1 for stats.rankdata :
-        self.groupmean = grouprankmean = groupranksum * 1.0 / self.groupnobs  # + 1
-        self.groupmeanfilter = grouprankmean[self.intlab]
-        # return grouprankmean[intlab]
-
-    def runbasic(self, useranks=False):
-        """runbasic"""
-        # check: refactoring screwed up case useranks=True
-
-        # groupxsum = np.bincount(intlab, weights=X[:,0])
-        # groupxmean = groupxsum * 1.0 / groupnobs
-        x = self.x
-        if useranks:
-            xuni, xintlab = np.unique(x[:, 0], return_inverse=True)
-            ranksraw = x[:, 0].argsort().argsort() + 1  # rankraw
-            self.xx = GroupsStats(
-                np.column_stack([ranksraw, xintlab]), useranks=False
-            ).groupmeanfilter
-        else:
-            self.xx = x[:, 0]
-        self.groupsum = groupranksum = np.bincount(self.intlab, weights=self.xx)
-        # print('groupranksum', groupranksum, groupranksum.shape, self.groupnobs.shape
-        # start at 1 for stats.rankdata :
-        self.groupmean = grouprankmean = groupranksum * 1.0 / self.groupnobs  # + 1
-        self.groupmeanfilter = grouprankmean[self.intlab]
-        # return grouprankmean[intlab]
-
-    def groupdemean(self):
-        """groupdemean"""
-        return self.xx - self.groupmeanfilter
-
-    def groupsswithin(self):
-        """groupsswithin"""
-        xtmp = self.groupdemean()
-        return np.bincount(self.intlab, weights=xtmp**2)
-
-    def groupvarwithin(self):
-        """groupvarwithin"""
-        return self.groupsswithin() / (self.groupnobs - 1)  # .sum()
 
 
 class TukeyHSDResults:

--- a/statsmodels/stats/anova.py
+++ b/statsmodels/stats/anova.py
@@ -8,6 +8,8 @@ from scipy import stats
 from statsmodels.formula._manager import FormulaManager
 from statsmodels.iolib import summary2
 from statsmodels.regression.linear_model import OLS
+from statsmodels.stats.multicomp import MultiComparison
+from statsmodels.tools.grouputils import GroupsStats, combine_indices
 
 
 def _get_covariance(model, robust):
@@ -327,6 +329,7 @@ def anova_lm(*args, **kwargs):
     See Also
     --------
     model_results.compare_f_test, model_results.compare_lm_test
+    statsmodels.stats.multicomp.MultiComparison.tukeyhsd
 
     Examples
     --------
@@ -523,23 +526,27 @@ class AnovaRM:
         for wi in self.within:
             factor_levels *= len(self.data[wi].unique())
 
-        cell_count = {}
-        for index in range(self.data.shape[0]):
-            key = []
-            for col in self.within:
-                key.append(self.data[col].iloc[index])
-            key = tuple(key)
-            if key in cell_count:
-                cell_count[key] = cell_count[key] + 1
-            else:
-                cell_count[key] = 1
+        # create group labels
+        groups_as_array = self.data[self.within].values
+        # combine_indices returns integer labels for unique groups
+        group_labels, _, _ = combine_indices(groups_as_array)
+
+        # use GroupsStats to get group counts
+        # The data column (first) does not affect `groupnobs`
+        d_dummy = np.arange(len(group_labels))
+        gs_input = np.column_stack([d_dummy, group_labels])
+        gs = GroupsStats(gs_input)
+
         error_message = "Data is unbalanced."
-        if len(cell_count) != factor_levels:
+        # `len(gs.groupnobs)` is number of cells that have observations
+        if len(gs.groupnobs) != factor_levels:
             raise ValueError(error_message)
-        count = cell_count[key]
-        for key in cell_count:
-            if count != cell_count[key]:
-                raise ValueError(error_message)
+
+        # check if all group counts are equal
+        if len(np.unique(gs.groupnobs)) > 1:
+            raise ValueError(error_message)
+
+        count = gs.groupnobs[0]
         if self.data.shape[0] > count * factor_levels:
             raise ValueError('There are more than 1 element in a cell! Missing'
                              ' factors?')
@@ -609,7 +616,8 @@ class AnovaRM:
                 anova_table.loc[term, 'Den DF'] = df2
                 anova_table.loc[term, 'Pr > F'] = p
 
-        return AnovaResults(anova_table)
+        return AnovaResults(anova_table, self.data, self.depvar, self.within,
+                            self.subject)
 
 
 class AnovaResults:
@@ -620,8 +628,13 @@ class AnovaResults:
     ----------
     anova_table : DataFrame
     """
-    def __init__(self, anova_table):
+    def __init__(self, anova_table, data=None, depvar=None, within=None,
+                 subject=None):
         self.anova_table = anova_table
+        self.data = data
+        self.depvar = depvar
+        self.within = within
+        self.subject = subject
 
     def __str__(self):
         return self.summary().__str__()
@@ -638,6 +651,78 @@ class AnovaResults:
         summ.add_df(self.anova_table)
 
         return summ
+
+    def pairwise_tukeyhsd(self, alpha=0.05, use_var='equal'):
+        """
+        Tukey's range test to compare means of all pairs of groups.
+
+        Parameters
+        ----------
+        alpha : float, optional
+            Value of FWER at which to calculate HSD.
+        use_var : {"unequal", "equal"}
+            If ``use_var`` is "equal", then the Tukey-hsd pvalues are returned.
+            Tukey-hsd assumes that (within) variances are the same across groups.
+            If ``use_var`` is "unequal", then the Games-Howell pvalues are
+            returned. This uses Welch's t-test for unequal variances with
+            Satterthwait's corrected degrees of freedom for each pairwise
+            comparison.
+
+        Returns
+        -------
+        results : TukeyHSDResults instance
+            A results class containing relevant data and some post-hoc
+            calculations
+
+        Notes
+        -----
+        See Also
+        --------
+        statsmodels.stats.multicomp.MultiComparison.tukeyhsd
+        """
+        # Create a MultiComparison object
+        mc = MultiComparison(self.data[self.depvar], self.data[self.within[0]])
+        # Perform Tukey's HSD test
+        result = mc.tukeyhsd(alpha=alpha, use_var=use_var)
+        return result
+
+    def allpairtest(self, testfunc, alpha=0.05, method="bonf", pvalidx=1):
+        """
+        Run a pairwise test on all pairs with multiple test correction.
+
+        The statistical test given in testfunc is calculated for all pairs
+        and the p-values are adjusted by methods in multipletests. The p-value
+        correction is generic and based only on the p-values, and does not
+        take any special structure of the hypotheses into account.
+
+        Parameters
+        ----------
+        testfunc : function
+            A test function for two (independent) samples. It is assumed that
+            the return value on position pvalidx is the p-value.
+        alpha : float
+            familywise error rate
+        method : str
+            This specifies the method for the p-value correction. Any method
+            of multipletests is possible.
+        pvalidx : int (default: 1)
+            position of the p-value in the return of testfunc
+
+        Returns
+        -------
+        sumtab : SimpleTable instance
+            summary table for printing
+
+        See Also
+        --------
+        statsmodels.stats.multicomp.MultiComparison.allpairtest
+        """
+        # Create a MultiComparison object
+        mc = MultiComparison(self.data[self.depvar], self.data[self.within[0]])
+        # Perform all-pairs test
+        result = mc.allpairtest(testfunc, alpha=alpha, method=method,
+                                pvalidx=pvalidx)
+        return result
 
 
 if __name__ == "__main__":

--- a/statsmodels/tools/grouputils.py
+++ b/statsmodels/tools/grouputils.py
@@ -550,3 +550,103 @@ class Grouping:
         """
         indi = dummy_sparse(self.labels[level])
         self._dummies = indi
+
+
+# from multicomp
+class GroupsStats:
+    """
+    statistics by groups (another version)
+
+    groupstats as a class with lazy evaluation (not yet - decorators are still
+    missing)
+
+    written this time as equivalent of scipy.stats.rankdata
+    gs = GroupsStats(X, useranks=True)
+    assert_almost_equal(gs.groupmeanfilter, stats.rankdata(X[:,0]), 15)
+
+    TODO: incomplete doc strings
+
+    """
+
+    def __init__(self, x, useranks=False, uni=None, intlab=None):
+        """descriptive statistics by groups
+
+        Parameters
+        ----------
+        x : ndarray, 2d
+            first column data, second column group labels
+        useranks : bool
+            if true, then use ranks as data corresponding to the
+            scipy.stats.rankdata definition (start at 1, ties get mean)
+        uni, intlab : arrays (optional)
+            to avoid call to unique, these can be given as inputs
+
+
+        """
+        self.x = np.asarray(x)
+        if intlab is None:
+            uni, intlab = np.unique(x[:, 1], return_inverse=True)
+        elif uni is None:
+            uni = np.unique(x[:, 1])
+
+        self.useranks = useranks
+
+        self.uni = uni
+        self.intlab = intlab
+        self.groupnobs = np.bincount(intlab)
+
+        # temporary until separated and made all lazy
+        self.runbasic(useranks=useranks)
+
+    def runbasic_old(self, useranks=False):
+        """runbasic_old"""
+        # check: refactoring screwed up case useranks=True
+
+        # groupxsum = np.bincount(intlab, weights=X[:,0])
+        # groupxmean = groupxsum * 1.0 / groupnobs
+        x = self.x
+        if useranks:
+            self.xx = x[:, 1].argsort().argsort() + 1  # rankraw
+        else:
+            self.xx = x[:, 0]
+        self.groupsum = groupranksum = np.bincount(self.intlab, weights=self.xx)
+        # print('groupranksum', groupranksum, groupranksum.shape, self.groupnobs.shape
+        # start at 1 for stats.rankdata :
+        self.groupmean = grouprankmean = groupranksum * 1.0 / self.groupnobs  # + 1
+        self.groupmeanfilter = grouprankmean[self.intlab]
+        # return grouprankmean[intlab]
+
+    def runbasic(self, useranks=False):
+        """runbasic"""
+        # check: refactoring screwed up case useranks=True
+
+        # groupxsum = np.bincount(intlab, weights=X[:,0])
+        # groupxmean = groupxsum * 1.0 / groupnobs
+        x = self.x
+        if useranks:
+            xuni, xintlab = np.unique(x[:, 0], return_inverse=True)
+            ranksraw = x[:, 0].argsort().argsort() + 1  # rankraw
+            self.xx = GroupsStats(
+                np.column_stack([ranksraw, xintlab]), useranks=False
+            ).groupmeanfilter
+        else:
+            self.xx = x[:, 0]
+        self.groupsum = groupranksum = np.bincount(self.intlab, weights=self.xx)
+        # print('groupranksum', groupranksum, groupranksum.shape, self.groupnobs.shape
+        # start at 1 for stats.rankdata :
+        self.groupmean = grouprankmean = groupranksum * 1.0 / self.groupnobs  # + 1
+        self.groupmeanfilter = grouprankmean[self.intlab]
+        # return grouprankmean[intlab]
+
+    def groupdemean(self):
+        """groupdemean"""
+        return self.xx - self.groupmeanfilter
+
+    def groupsswithin(self):
+        """groupsswithin"""
+        xtmp = self.groupdemean()
+        return np.bincount(self.intlab, weights=xtmp**2)
+
+    def groupvarwithin(self):
+        """groupvarwithin"""
+        return self.groupsswithin() / (self.groupnobs - 1)  # .sum()


### PR DESCRIPTION
Adds pairwise_tukeyhsd and allpairtest methods to the AnovaResults class. This allows for direct post-hoc analysis following a repeated measures ANOVA, simplifying the user workflow.

This change also refactors the GroupsStats class out of the sandbox and into the central 	tools.grouputils module. The _check_data_balanced method in AnovaRM is updated to use this new utility.

Unit tests are added for the new post-hoc methods and for the refactored GroupsStats class to ensure correctness and reliability.

- [x] closes https://github.com/statsmodels/statsmodels/issues/9491 
- [x] tests added / passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
