### PR TITLE
TST: Fix warning catching

### DIFF
--- a/statsmodels/iolib/tests/test_summary2.py
+++ b/statsmodels/iolib/tests/test_summary2.py
@@ -1,4 +1,4 @@
-from statsmodels.compat.pandas import PD_LT_3
+from statsmodels.compat.scipy import SP_LT_116
 
 import warnings
 
@@ -251,7 +251,7 @@ def test_ols_summary_rsquared_label():
     y = [6, 4, 2, 7, 4, 9, 10, 2]
     reg_with_constant = OLS(y, add_constant(x)).fit()
     r2_str = "R-squared:"
-    if PD_LT_3:
+    if SP_LT_116:
         with pytest.warns(UserWarning):
             assert r2_str in str(reg_with_constant.summary2())
         with pytest.warns(UserWarning):
@@ -262,7 +262,7 @@ def test_ols_summary_rsquared_label():
 
     reg_without_constant = OLS(y, x, hasconst=False).fit()
     r2_str = "R-squared (uncentered):"
-    if PD_LT_3:
+    if SP_LT_116:
         with pytest.warns(UserWarning):
             assert r2_str in str(reg_without_constant.summary2())
         with pytest.warns(UserWarning):

--- a/statsmodels/regression/tests/test_regression.py
+++ b/statsmodels/regression/tests/test_regression.py
@@ -2,9 +2,9 @@
 Test functions for models.regression
 """
 
-# TODO: Test for LM
-from statsmodels.compat.pandas import PD_LT_3
 from statsmodels.compat.python import lrange
+# TODO: Test for LM
+from statsmodels.compat.scipy import SP_LT_116
 
 import warnings
 
@@ -1093,7 +1093,7 @@ def test_summary_as_latex():
     x["constant"] = 1
     y = dta.endog
     res = OLS(y, x).fit()
-    if PD_LT_3:
+    if SP_LT_116:
         with pytest.warns(UserWarning):
             table = res.summary().as_latex()
     else:

--- a/statsmodels/regression/tests/test_theil.py
+++ b/statsmodels/regression/tests/test_theil.py
@@ -4,7 +4,7 @@ Created on Mon May 05 17:29:56 2014
 Author: Josef Perktold
 """
 
-from statsmodels.compat.pandas import PD_LT_3
+from statsmodels.compat.scipy import SP_LT_116
 
 import os
 
@@ -120,7 +120,7 @@ class TestTheilTextile:
 
     @pytest.mark.smoke
     def test_summary(self):
-        if PD_LT_3:
+        if SP_LT_116:
             with pytest.warns(UserWarning):
                 self.res1.summary()
         else:


### PR DESCRIPTION
Correctly reference issue relating to SciPy rather than pandas

- [ ] closes #xxxx
- [ ] tests added / passed. 
- [ ] code/documentation is well formatted.  
- [ ] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
