### PR TITLE
MAINT: Wrap pandas deprecate_kwarg

### DIFF
--- a/statsmodels/compat/pandas.py
+++ b/statsmodels/compat/pandas.py
@@ -1,5 +1,6 @@
-from typing import Optional
+from __future__ import annotations
 
+from typing import Any, Callable, Mapping, Optional, TypeVar, TYPE_CHECKING
 import numpy as np
 from packaging.version import Version, parse
 import pandas as pd
@@ -7,9 +8,18 @@ from pandas.util._decorators import (
     Appender,
     Substitution,
     cache_readonly,
-    deprecate_kwarg,
+    deprecate_kwarg as pd_deprecate_kwarg,
 )
 
+if TYPE_CHECKING:
+    try:
+        from typing import TypeAlias
+    except ImportError:
+        from typing_extensions import TypeAlias
+
+
+FuncType: TypeAlias = Callable[..., Any]
+F = TypeVar("F", bound=FuncType)
 __all__ = [
     "assert_frame_equal",
     "assert_index_equal",
@@ -188,3 +198,26 @@ MONTH_END = "M" if PD_LT_2_2_0 else "ME"
 QUARTER_END = "Q" if PD_LT_2_2_0 else "QE"
 YEAR_END = "Y" if PD_LT_2_2_0 else "YE"
 FUTURE_STACK = {} if PD_LT_2_1_0 else {"future_stack": True}
+
+
+def deprecate_kwarg(
+    old_arg_name: str,
+    new_arg_name: str | None,
+    mapping: Mapping[Any, Any] | Callable[[Any], Any] | None = None,
+    stacklevel: int = 2,
+) -> Callable[[F], F]:
+    if PD_LT_3:
+        return pd_deprecate_kwarg(
+            old_arg_name=old_arg_name,
+            new_arg_name=new_arg_name,
+            mapping=mapping,
+            stacklevel=stacklevel,
+        )
+    else:
+        return pd_deprecate_kwarg(
+            klass=FutureWarning,
+            old_arg_name=old_arg_name,
+            new_arg_name=new_arg_name,
+            mapping=mapping,
+            stacklevel=stacklevel,
+        )

--- a/statsmodels/tsa/statespace/tests/test_weights.py
+++ b/statsmodels/tsa/statespace/tests/test_weights.py
@@ -459,7 +459,7 @@ def test_smoothed_state_obs_weights_collapsed(reset_randomstate):
     actual, actual_state_intercept_weights, _ = (
         tools.compute_smoothed_state_weights(res))
 
-    assert_allclose(actual, desired, atol=1e-10)
+    assert_allclose(actual, desired, atol=1e-8)
     assert_allclose(
         actual_state_intercept_weights,
         desired_state_intercept_weights,


### PR DESCRIPTION
- [X] closes #9614 
- [X] code/documentation is well formatted.  
- [X] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
