### PR TITLE
Fix redundant heading in docs/README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-# Documentation Documentation
+# Documentation
 
 We use a combination of sphinx and Jupyter notebooks for the documentation.
 Jupyter notebooks should be used for longer, self-contained examples demonstrating


### PR DESCRIPTION
This PR removes the duplicate "Documentation" heading in readme and ensures the file starts with a single, clear # Documentation heading. 