### PR TITLE
DOC: Fix typo in maintainer_notes.rst (get → git)

### DIFF
--- a/docs/source/dev/maintainer_notes.rst
+++ b/docs/source/dev/maintainer_notes.rst
@@ -16,7 +16,7 @@ Grabbing Changes from Others
 If you need to push changes from others, you can link to their repository by doing::
 
     git remote add contrib-name git://github.com/contrib-name/statsmodels.git
-    get fetch contrib-name
+    git fetch contrib-name
     git branch shiny-new-feature --track contrib-name/shiny-new-feature
     git checkout shiny-new-feature
 


### PR DESCRIPTION
This pull request fixes a small typo in the documentation file maintainer_notes.rst.
Thanks !