### PR TITLE
MAINT: Remove panding deprecation matrix usage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -162,7 +162,8 @@ filterwarnings = [
     "error:random_state is deprecated:FutureWarning",
     "error:seed is deprecated:FutureWarning",
     "error:get_state is deprecated:FutureWarning",
-    "error:Conversion of an array with ndim:DeprecationWarning:arch"
+    "error:Conversion of an array with ndim:DeprecationWarning:",
+    "error:the matrix subclass is not the recommended::",
     # Strict checks disabled
     # "error:overflow encountered in square:RuntimeWarning",
     # "error:invalid value encountered in cos:RuntimeWarning",

--- a/statsmodels/tools/tests/test_grouputils.py
+++ b/statsmodels/tools/tests/test_grouputils.py
@@ -316,8 +316,8 @@ def test_dummy_sparse():
     g = np.array([0, 0, 2, 1, 1, 2, 0])
     indi = dummy_sparse(g)
     assert isinstance(indi, sparse.csr_matrix)
-    result = indi.todense()
-    expected = np.matrix([[1, 0, 0],
+    result = indi.toarray()
+    expected = np.array([[1, 0, 0],
                          [1, 0, 0],
                          [0, 0, 1],
                          [0, 1, 0],
@@ -329,8 +329,8 @@ def test_dummy_sparse():
     # current behavior with missing groups
     g = np.array([0, 0, 2, 0, 2, 0])
     indi = dummy_sparse(g)
-    result = indi.todense()
-    expected = np.matrix([[1, 0, 0],
+    result = indi.toarray()
+    expected = np.array([[1, 0, 0],
                          [1, 0, 0],
                          [0, 0, 1],
                          [1, 0, 0],

--- a/statsmodels/tsa/vector_ar/vecm.py
+++ b/statsmodels/tsa/vector_ar/vecm.py
@@ -1513,7 +1513,7 @@ class VECMResults:
         omega12 = b_y.dot(self._delta_x.T)
         omega21 = omega12.T
         omega22 = self._delta_x.dot(self._delta_x.T)
-        omega = np.bmat([[omega11, omega12], [omega21, omega22]]).A
+        omega = np.block([[omega11, omega12], [omega21, omega22]])
 
         mat1 = b_id.dot(inv(omega)).dot(b_id.T)
         return np.kron(mat1, self.sigma_u)


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed. 
- [ ] code/documentation is well formatted.  
- [ ] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
