### PR TITLE
DOC: fix typo in example notebook

### DIFF
--- a/examples/notebooks/autoregressions.ipynb
+++ b/examples/notebooks/autoregressions.ipynb
@@ -533,7 +533,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The diagnostics indicate the model captures most of the the dynamics in the data. The ACF shows a patters at the seasonal frequency and so a more complete seasonal model (`SARIMAX`) may be needed."
+    "The diagnostics indicate the model captures most of the the dynamics in the data. The ACF shows a pattern at the seasonal frequency and so a more complete seasonal model (`SARIMAX`) may be needed."
    ]
   },
   {


### PR DESCRIPTION
Fixes a small typo ("patters" -> "pattern") in autoregressions.ipynb