### PR TITLE
TST: Add marker for high memory tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -298,7 +298,8 @@ markers = [
     "example: mark a test that runs example code",
     "matplotlib: mark a test that requires matplotlib",
     "slow: mark a test as slow",
-    "smoke: mark a test as a smoketest",
+    "smoke: mark a test as a smoke test",
+    "high_memory: mark a test as a high memory utilization test",
     "low_precision: mark a test as low precision",
     "todo: mark a test as incomplete"
 ]

--- a/statsmodels/conftest.py
+++ b/statsmodels/conftest.py
@@ -51,6 +51,8 @@ def pytest_addoption(parser):
     )
     parser.addoption("--skip-smoke", action="store_true", help="skip smoke tests")
     parser.addoption("--only-smoke", action="store_true", help="run only smoke tests")
+    parser.addoption("--skip-high-memory", action="store_true", help="skip high memory usage tests")
+    parser.addoption("--only-high-memory", action="store_true", help="run only high memory usage tests")
 
 
 def pytest_runtest_setup(item):
@@ -74,6 +76,13 @@ def pytest_runtest_setup(item):
 
     if "smoke" not in item.keywords and item.config.getoption("--only-smoke"):
         pytest.skip("skipping due to --only-smoke")
+
+    if "high_memory" in item.keywords and item.config.getoption("--skip-high-memory"):
+        pytest.skip("skipping due to --skip-high-memory")
+
+    if "high_memory" not in item.keywords and item.config.getoption("--only-high-memory"):
+        pytest.skip("skipping due to --only-high-memory")
+
 
 
 def pytest_configure(config):

--- a/statsmodels/conftest.py
+++ b/statsmodels/conftest.py
@@ -84,7 +84,6 @@ def pytest_runtest_setup(item):
         pytest.skip("skipping due to --only-high-memory")
 
 
-
 def pytest_configure(config):
     try:
         import matplotlib as mpl

--- a/statsmodels/distributions/tests/test_bernstein.py
+++ b/statsmodels/distributions/tests/test_bernstein.py
@@ -21,7 +21,7 @@ from statsmodels.distributions.copula.api import (
     transforms as tra,
 )
 import statsmodels.distributions.tools as dt
-
+import pytest
 
 def test_bernstein_distribution_1d():
     grid = dt._Grid([501])
@@ -134,6 +134,7 @@ class TestBernsteinBeta2d:
         cls.distr = cad
         cls.bpd = BernsteinDistributionBV(cdf_g)
 
+    @pytest.mark.high_memory
     def test_basic(self):
         bpd = self.bpd
         grid = self.grid

--- a/statsmodels/distributions/tests/test_bernstein.py
+++ b/statsmodels/distributions/tests/test_bernstein.py
@@ -8,6 +8,7 @@ License: BSD-3
 
 import numpy as np
 from numpy.testing import assert_allclose, assert_array_less
+import pytest
 from scipy import stats
 
 from statsmodels.distributions.bernstein import (
@@ -21,7 +22,7 @@ from statsmodels.distributions.copula.api import (
     transforms as tra,
 )
 import statsmodels.distributions.tools as dt
-import pytest
+
 
 def test_bernstein_distribution_1d():
     grid = dt._Grid([501])

--- a/statsmodels/regression/tests/test_lme.py
+++ b/statsmodels/regression/tests/test_lme.py
@@ -97,6 +97,7 @@ class TestMixedLM:
 
     # Test analytic scores and Hessian using numeric differentiation
     @pytest.mark.slow
+    @pytest.mark.high_memory
     @pytest.mark.parametrize("use_sqrt", [False, True])
     @pytest.mark.parametrize("reml", [False, True])
     @pytest.mark.parametrize("profile_fe", [False, True])
@@ -1104,6 +1105,7 @@ def test_summary_col():
 
 
 @pytest.mark.slow
+@pytest.mark.high_memory
 def test_random_effects_getters():
     # Simulation-based test to make sure that the BLUPs and actual
     # random effects line up.

--- a/statsmodels/regression/tests/test_processreg.py
+++ b/statsmodels/regression/tests/test_processreg.py
@@ -85,6 +85,7 @@ def run_arrays(n, get_model, noise):
 
 
 @pytest.mark.slow
+@pytest.mark.high_memory
 @pytest.mark.parametrize("noise", [False, True])
 def test_arrays(noise):
 
@@ -163,6 +164,7 @@ def run_formula(n, get_model, noise):
 
 
 @pytest.mark.slow
+@pytest.mark.high_memory
 @pytest.mark.parametrize("noise", [False, True])
 def test_formulas(noise):
 

--- a/tools/ci/azure/azure_template_windows.yml
+++ b/tools/ci/azure/azure_template_windows.yml
@@ -63,7 +63,7 @@ jobs:
     displayName: "Lint"
 
   - pwsh: |
-      pytest statsmodels --skip-examples --junitxml=junit/test-results.xml -n 2 --durations=50
+      pytest statsmodels --skip-examples --skip-high-memory --junitxml=junit/test-results.xml -n 2 --durations=50
     displayName: 'Run pytest'
 
   - task: PublishTestResults@2


### PR DESCRIPTION
Add marker so high-memory tests can be skipped where needed

- [ ] closes #xxxx
- [ ] tests added / passed. 
- [ ] code/documentation is well formatted.  
- [ ] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
