### PR TITLE
FIX: incorrect length comparison in endpoint transformation logic

### DIFF
--- a/statsmodels/base/_prediction_inference.py
+++ b/statsmodels/base/_prediction_inference.py
@@ -562,7 +562,7 @@ def get_prediction_linear(
         pred_kwds = {}
 
     k1 = exog.shape[1]
-    if len(self.params > k1):
+    if len(self.params) > k1:
         # TODO: we allow endpoint transformation only for the first link
         index = np.arange(k1)
     else:
@@ -820,7 +820,7 @@ def get_prediction(
     elif (which == "mean") and (use_endpoint is True) and (average is False):
         # endpoint transformation
         k1 = self.model.exog.shape[1]
-        if len(self.params > k1):
+        if len(self.params) > k1:
             # TODO: we allow endpoint transformation only for the first link
             index = np.arange(k1)
         else:


### PR DESCRIPTION
This PR fixes an unintentional bug where len(self.params > k1) was used instead of len(self.params) > k1. The previous code always evaluated the condition as true for non-empty parameters, leading to incorrect endpoint transformation behavior. The fix ensures the condition correctly checks whether the number of parameters exceeds the number of exogenous variables.

I can add parametrized tests if directed.
