### PR TITLE
TST: Xfail test on Windows due to SciPy changes

### DIFF
--- a/statsmodels/stats/tests/test_power.py
+++ b/statsmodels/stats/tests/test_power.py
@@ -8,6 +8,8 @@ Created on Sat Mar 09 08:44:49 2013
 
 Author: Josef Perktold
 """
+from statsmodels.compat.platform import PLATFORM_WIN
+
 import copy
 import warnings
 
@@ -74,9 +76,11 @@ class CheckPowerMixin:
     def test_roots(self):
         kwds = copy.copy(self.kwds)
         kwds.update(self.kwds_extra)
-
         # kwds_extra are used as argument, but not as target for root
         for key in self.kwds:
+            if PLATFORM_WIN and isinstance(self, TestTTPowerOneS1) and key == "alpha":
+                pytest.xfail("alpha test failing on recent SciPy on Windows")
+
             # keep print to check whether tests are really executed
             # print 'testing roots', key
             value = kwds[key]


### PR DESCRIPTION
Sensitive test now fails on Windows due to upstream numerical changes

- [ ] closes #xxxx
- [ ] tests added / passed. 
- [ ] code/documentation is well formatted.  
- [ ] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
