### PR TITLE
ENH: Add missing attributes from AutoReg

### DIFF
--- a/statsmodels/robust/tools.py
+++ b/statsmodels/robust/tools.py
@@ -58,7 +58,7 @@ def _var_normal(norm):
 
     """
     num = stats.norm.expect(lambda x: norm.psi(x) ** 2)
-    denom = stats.norm.expect(lambda x: norm.psi_deriv(x))**2
+    denom = stats.norm.expect(norm.psi_deriv)**2
     return num / denom
 
 
@@ -215,7 +215,7 @@ def tuning_s_estimator_mean(norm, breakdown=None):
     def func(c):
         norm_ = norm
         norm_._set_tuning_param(c, inplace=True)
-        bp = stats.norm.expect(lambda x: norm_.rho(x)) / norm_.max_rho()
+        bp = stats.norm.expect(norm_.rho) / norm_.max_rho()
         return bp
 
     res = []
@@ -223,7 +223,7 @@ def tuning_s_estimator_mean(norm, breakdown=None):
         c_bp = optimize.brentq(lambda c0, bp: func(c0) - bp, 0.1, 10, args=(bp,))
         norm._set_tuning_param(c_bp, inplace=True)  # inplace modification
         eff = 1 / _var_normal(norm)
-        b = stats.norm.expect(lambda x : norm.rho(x))
+        b = stats.norm.expect(norm.rho)
         res.append([bp, eff, c_bp, b])
 
     if np.size(bps) > 1:

--- a/statsmodels/tsa/ar_model.py
+++ b/statsmodels/tsa/ar_model.py
@@ -236,15 +236,11 @@ class AutoReg(tsa_model.TimeSeriesModel):
             self._deterministics = deterministic
             self._user_deterministic = True
         else:
-            self._deterministics = DeterministicProcess(
-                index, additional_terms=terms
-            )
+            self._deterministics = DeterministicProcess(index, additional_terms=terms)
         self._exog_names: list[str] = []
         self._k_ar = 0
         self._old_names = bool_like(old_names, "old_names", optional=False)
-        if deterministic is not None and (
-            self._trend != "n" or self._seasonal
-        ):
+        if deterministic is not None and (self._trend != "n" or self._seasonal):
             warnings.warn(
                 'When using deterministic, trend must be "n" and '
                 "seasonal must be False.",
@@ -326,9 +322,7 @@ class AutoReg(tsa_model.TimeSeriesModel):
                 np.any(_lags_arr < 1)
                 or np.unique(_lags_arr).shape[0] != _lags_arr.shape[0]
             ):
-                raise ValueError(
-                    "All values in lags must be positive and distinct."
-                )
+                raise ValueError("All values in lags must be positive and distinct.")
             self._maxlag = np.max(_lags_arr)
             _lags = [int(v) for v in _lags_arr]
         else:
@@ -355,9 +349,7 @@ class AutoReg(tsa_model.TimeSeriesModel):
         exog_names = []
         endog_names = self.endog_names
         x, y = lagmat(self.endog, maxlag, original="sep")
-        exog_names.extend(
-            [endog_names + f".L{lag}" for lag in self._lags]
-        )
+        exog_names.extend([endog_names + f".L{lag}" for lag in self._lags])
         if len(self._lags) < maxlag:
             x = x[:, np.asarray(self._lags) - 1]
         self._k_ar = x.shape[1]
@@ -405,6 +397,15 @@ class AutoReg(tsa_model.TimeSeriesModel):
                 "parameters."
             )
         self._y, self._x = y, x
+        if "c" in self._trend:
+            self.k_constant = 1
+        elif self._x.shape[1]:
+            aug_x = np.hstack((self._x, np.ones((x.shape[0], 1))))
+            rank = np.linalg.matrix_rank(aug_x)
+            self.k_constant = int(rank == self._x.shape[1])
+        else:
+            self.k_constant = 0
+
         self._exog_names = exog_names
 
     def fit(
@@ -475,9 +476,7 @@ class AutoReg(tsa_model.TimeSeriesModel):
             )
 
         ols_mod = OLS(self._y, self._x)
-        ols_res = ols_mod.fit(
-            cov_type=cov_type, cov_kwds=cov_kwds, use_t=use_t
-        )
+        ols_res = ols_mod.fit(cov_type=cov_type, cov_kwds=cov_kwds, use_t=use_t)
         cov_params = ols_res.cov_params()
         use_t = ols_res.use_t
         if cov_type == "nonrobust" and not use_t:
@@ -773,9 +772,7 @@ class AutoReg(tsa_model.TimeSeriesModel):
         return params, _exog, _exog_oos, start, end, num_oos
 
     def _parse_dynamic(self, dynamic, start):
-        if isinstance(
-            dynamic, (str, bytes, pd.Timestamp, dt.datetime, pd.Period)
-        ):
+        if isinstance(dynamic, (str, bytes, pd.Timestamp, dt.datetime, pd.Period)):
             dynamic_loc, _, _ = self._get_index_loc(dynamic)
             # Adjust since relative to start
             dynamic_loc -= start
@@ -861,18 +858,13 @@ class AutoReg(tsa_model.TimeSeriesModel):
                     "exog variable used to create the model {1}."
                 )
                 raise ValueError(msg.format(exog.shape, self.exog.shape))
-            if (
-                exog_oos is not None
-                and exog_oos.shape[1] != self.exog.shape[1]
-            ):
+            if exog_oos is not None and exog_oos.shape[1] != self.exog.shape[1]:
                 msg = (
                     "The number of columns in exog_oos ({0}) must match "
                     "the number of columns  in the exog variable used to "
                     "create the model ({1})."
                 )
-                raise ValueError(
-                    msg.format(exog_oos.shape[1], self.exog.shape[1])
-                )
+                raise ValueError(msg.format(exog_oos.shape[1], self.exog.shape[1]))
             if num_oos > 0 and exog_oos is None:
                 raise ValueError(
                     "exog_oos must be provided when producing "
@@ -888,9 +880,7 @@ class AutoReg(tsa_model.TimeSeriesModel):
 
         if (isinstance(dynamic, bool) and not dynamic) or self._maxlag == 0:
             # If model has no lags, static and dynamic are identical
-            return self._static_predict(
-                params, start, end, num_oos, exog, exog_oos
-            )
+            return self._static_predict(params, start, end, num_oos, exog, exog_oos)
         dynamic = self._parse_dynamic(dynamic, start)
 
         return self._dynamic_predict(
@@ -1122,8 +1112,7 @@ class AutoRegResults(tsa_model.TimeSeriesModelResults):
         """
         The residuals of the model.
         """
-        model = self.model
-        endog = model.endog.squeeze()
+        endog = self.model.endog.squeeze()
         return endog[self._hold_back :] - self.fittedvalues
 
     def _lag_repr(self):
@@ -1178,6 +1167,59 @@ class AutoRegResults(tsa_model.TimeSeriesModelResults):
         model is fit by `mle`.
         """
         return self.model.predict(self.params)[self._hold_back :]
+
+    @cache_readonly
+    def rsquared(self):
+        """
+        R-squared of the model.
+
+        This is defined here as 1 - `ssr`/`centered_tss` if the constant is
+        included in the model and 1 - `ssr`/`uncentered_tss` if the constant is
+        omitted.
+        """
+        if self.model.k_constant:
+            return 1 - self.ssr / self.centered_tss
+        else:
+            return 1 - self.ssr / self.uncentered_tss
+
+    @cache_readonly
+    def ssr(self):
+        """Sum of squared (whitened) residuals."""
+        resid = self.resid
+        return np.dot(resid, resid)
+
+    @cache_readonly
+    def centered_tss(self):
+        """The total (weighted) sum of squares centered about the mean."""
+        y = np.squeeze(self.model._y)
+        centered_y = y - y.mean()
+        return float(np.dot(centered_y, centered_y))
+
+    @cache_readonly
+    def uncentered_tss(self):
+        """
+        Uncentered sum of squares.
+
+        The sum of the squared values of the (whitened) endogenous response
+        variable.
+        """
+        y = np.squeeze(self.model._y)
+        return float(np.dot(y, y))
+
+    @cache_readonly
+    def ess(self):
+        """
+        The explained sum of squares.
+
+        If a constant is present, the centered total sum of squares minus the
+        sum of squared residuals. If there is no constant, the uncentered total
+        sum of squares is used.
+        """
+
+        if self.model.k_constant:
+            return self.centered_tss - self.ssr
+        else:
+            return self.uncentered_tss - self.ssr
 
     def test_serial_correlation(self, lags=None, model_df=None):
         """
@@ -1348,9 +1390,7 @@ class AutoRegResults(tsa_model.TimeSeriesModelResults):
         smry.tables.append(tab)
         smry.tables.append(spacer)
         arch_lm = self.test_heteroskedasticity()
-        values = [
-            [i + 1] + row for i, row in enumerate(arch_lm.values.tolist())
-        ]
+        values = [[i + 1] + row for i, row in enumerate(arch_lm.values.tolist())]
         data_fmts = ("%10d", "%10.3f", "%10.3f", "%10d")
         tab = SimpleTable(
             values,
@@ -1363,9 +1403,7 @@ class AutoRegResults(tsa_model.TimeSeriesModelResults):
         return smry
 
     @Appender(remove_parameters(AutoReg.predict.__doc__, "params"))
-    def predict(
-        self, start=None, end=None, dynamic=False, exog=None, exog_oos=None
-    ):
+    def predict(self, start=None, end=None, dynamic=False, exog=None, exog_oos=None):
         return self.model.predict(
             self._params,
             start=start,
@@ -1496,8 +1534,7 @@ class AutoRegResults(tsa_model.TimeSeriesModelResults):
                 mean = mean.iloc[-oos:]
         elif not in_sample:
             raise ValueError(
-                "in_sample is False but there are no"
-                "out-of-sample forecasts to plot."
+                "in_sample is False but there are no out-of-sample forecasts to plot."
             )
         ax.plot(mean, zorder=2, label="Forecast")
 
@@ -1712,9 +1749,7 @@ class AutoRegResults(tsa_model.TimeSeriesModelResults):
         ]
 
         smry = Summary()
-        smry.add_table_2cols(
-            self, gleft=top_left, gright=top_right, title=title
-        )
+        smry.add_table_2cols(self, gleft=top_left, gright=top_right, title=title)
         smry.add_table_params(self, alpha=alpha, use_t=False)
 
         # Make the roots table
@@ -1870,10 +1905,7 @@ class AutoRegResults(tsa_model.TimeSeriesModelResults):
                 "exog must be None when the original model did not contain "
                 "exog variables"
             )
-        if (
-            existing.exog is not None
-            and existing.exog.shape[1] != mod.exog.shape[1]
-        ):
+        if existing.exog is not None and existing.exog.shape[1] != mod.exog.shape[1]:
             raise ValueError(
                 "The number of exog variables passed must match the original "
                 f"number of exog values ({existing.exog.shape[1]})"
@@ -1998,8 +2030,7 @@ class AutoRegResults(tsa_model.TimeSeriesModelResults):
         if no_exog != (exog is None):
             if no_exog:
                 err = (
-                    "Original model does not contain exog data but exog data "
-                    "passed"
+                    "Original model does not contain exog data but exog data passed"
                 )
             else:
                 err = "Original model has exog data but not exog data passed"
@@ -2007,15 +2038,11 @@ class AutoRegResults(tsa_model.TimeSeriesModelResults):
         if isinstance(existing.data.orig_endog, (pd.Series, pd.DataFrame)):
             endog = _check(existing.data.orig_endog, endog, "endog")
         else:
-            endog = _check(
-                existing.endog, np.asarray(endog), "endog", use_pandas=False
-            )
+            endog = _check(existing.endog, np.asarray(endog), "endog", use_pandas=False)
         if isinstance(existing.data.orig_exog, (pd.Series, pd.DataFrame)):
             exog = _check(existing.data.orig_exog, exog, "exog")
         elif exog is not None:
-            exog = _check(
-                existing.exog, np.asarray(exog), "endog", use_pandas=False
-            )
+            exog = _check(existing.exog, np.asarray(exog), "endog", use_pandas=False)
         return self.apply(endog, exog, refit=refit, fit_kwargs=fit_kwargs)
 
 
@@ -2129,9 +2156,7 @@ def ar_select_order(
         df_model = res.df_model
         sigma2 = 1.0 / nobs * sumofsq(res.resid)
         llf = -nobs * (np.log(2 * np.pi * sigma2) + 1) / 2
-        res = SimpleNamespace(
-            nobs=nobs, df_model=df_model, sigma2=sigma2, llf=llf
-        )
+        res = SimpleNamespace(nobs=nobs, df_model=df_model, sigma2=sigma2, llf=llf)
 
         aic = call_cached_func(AutoRegResults.aic, res)
         bic = call_cached_func(AutoRegResults.bic, res)
@@ -2141,9 +2166,7 @@ def ar_select_order(
 
     def ic_no_data():
         """Fake mod and results to handle no regressor case"""
-        mod = SimpleNamespace(
-            nobs=y.shape[0], endog=y, exog=np.empty((y.shape[0], 0))
-        )
+        mod = SimpleNamespace(nobs=y.shape[0], endog=y, exog=np.empty((y.shape[0], 0)))
         llf = OLS.loglike(mod, np.empty(0))
         res = SimpleNamespace(
             resid=y, nobs=y.shape[0], llf=llf, df_model=0, k_constant=0
@@ -2167,9 +2190,7 @@ def ar_select_order(
         bits = bits.view(np.uint8)
         bits = np.unpackbits(bits).reshape(-1, 32)
         for i in range(4):
-            bits[:, 8 * i : 8 * (i + 1)] = bits[:, 8 * i : 8 * (i + 1)][
-                :, ::-1
-            ]
+            bits[:, 8 * i : 8 * (i + 1)] = bits[:, 8 * i : 8 * (i + 1)][:, ::-1]
         masks = bits[:, :maxlag]
         for mask in masks:
             sel[base_col : base_col + maxlag] = mask

--- a/statsmodels/tsa/statespace/dynamic_factor_mq.py
+++ b/statsmodels/tsa/statespace/dynamic_factor_mq.py
@@ -1769,8 +1769,7 @@ class DynamicFactorMQ(mlemodel.MLEModel):
 
         # - Factor blocks summary table --------------------------------------
         data = self.factor_block_orders.reset_index()
-        data["block"] = data["block"].map(
-            lambda factor_names: ", ".join(factor_names))
+        data["block"] = data["block"].map(", ".join)
         try:
             data[["order"]] = data[["order"]].map(str)
         except AttributeError:

--- a/statsmodels/tsa/tests/test_ar.py
+++ b/statsmodels/tsa/tests/test_ar.py
@@ -1,6 +1,7 @@
 """
 Test AR Model
 """
+
 from __future__ import annotations
 
 from statsmodels.compat.pandas import MONTH_END
@@ -102,10 +103,7 @@ for param in params:
         final.append(param)
 params = final
 names = ("AR", "Seasonal", "Trend", "Exog", "Cov Type")
-ids = [
-    ", ".join([n + ": " + str(p) for n, p in zip(names, param)])
-    for param in params
-]
+ids = [", ".join([n + ": " + str(p) for n, p in zip(names, param)]) for param in params]
 
 
 @pytest.fixture(scope="module", params=params, ids=ids)
@@ -132,6 +130,11 @@ attributes = [
     "scale",
     "tvalues",
     "use_t",
+    "ssr",
+    "ess",
+    "uncentered_tss",
+    "centered_tss",
+    "rsquared",
 ]
 
 
@@ -163,13 +166,18 @@ def fix_ols_attribute(val, attrib, res):
 @pytest.mark.parametrize("attribute", attributes)
 def test_equiv_ols_autoreg(ols_autoreg_result, attribute):
     a, o = ols_autoreg_result
+
+    assert a.model.k_constant == o.model.k_constant, (
+        a.model.k_constant,
+        o.model.k_constant,
+    )
     ols_a = getattr(o, attribute)
     ar_a = getattr(a, attribute)
     if callable(ols_a):
         ols_a = ols_a()
         ar_a = ar_a()
     ols_a = fix_ols_attribute(ols_a, attribute, o)
-    assert_allclose(ols_a, ar_a)
+    assert_allclose(ols_a, ar_a, atol=1e-12)
 
 
 def test_conf_int_ols_autoreg(ols_autoreg_result):
@@ -253,14 +261,10 @@ params = product(
 )
 params = list(params)
 params = [
-    param
-    for param in params
-    if (param[0] or param[1] != "n" or param[2] or param[3])
+    param for param in params if (param[0] or param[1] != "n" or param[2] or param[3])
 ]
 params = [
-    param
-    for param in params
-    if not param[2] or (param[2] and (param[4] or param[6]))
+    param for param in params if not param[2] or (param[2] and (param[4] or param[6]))
 ]
 param_fmt = """\
 lags: {0}, trend: {1}, seasonal: {2}, nexog: {3}, periods: {4}, \
@@ -274,9 +278,7 @@ def gen_data(nobs, nexog, pandas, seed=92874765):
     endog = rs.standard_normal(nobs)
     exog = rs.standard_normal((nobs, nexog)) if nexog else None
     if pandas:
-        index = pd.date_range(
-            dt.datetime(1999, 12, 31), periods=nobs, freq=MONTH_END
-        )
+        index = pd.date_range(dt.datetime(1999, 12, 31), periods=nobs, freq=MONTH_END)
         endog = pd.Series(endog, name="endog", index=index)
         if nexog:
             cols = [f"exog.{i}" for i in range(exog.shape[1])]
@@ -329,14 +331,10 @@ params = product(
 )
 params = list(params)
 params = [
-    param
-    for param in params
-    if (param[0] or param[1] != "n" or param[2] or param[3])
+    param for param in params if (param[0] or param[1] != "n" or param[2] or param[3])
 ]
 params = [
-    param
-    for param in params
-    if not param[2] or (param[2] and (param[4] or param[6]))
+    param for param in params if not param[2] or (param[2] and (param[4] or param[6]))
 ]
 param_fmt = """\
 lags: {0}, trend: {1}, seasonal: {2}, nexog: {3}, periods: {4}, \
@@ -402,6 +400,8 @@ def test_autoreg_predict_smoke(ar_data):
         missing=ar_data.missing,
     )
     res = mod.fit()
+    summary = res.summary()
+    assert isinstance(summary, Summary)
     exog_oos = None
     if ar_data.exog is not None:
         exog_oos = np.empty((1, ar_data.exog.shape[1]))
@@ -724,9 +724,7 @@ def test_ar_order_select():
     y = arma_generate_sample([1, -0.75, 0.3], [1], 100)
     ts = Series(
         y,
-        index=date_range(
-            start=dt.datetime(1990, 1, 1), periods=100, freq=MONTH_END
-        ),
+        index=date_range(start=dt.datetime(1990, 1, 1), periods=100, freq=MONTH_END),
     )
     res = ar_select_order(ts, maxlag=12, ic="aic")
     assert tuple(res.ar_lags) == (1, 2)
@@ -805,7 +803,7 @@ def test_autoreg_roots():
 def test_equiv_dynamic(reset_randomstate):
     e = np.random.standard_normal(1001)
     y = np.empty(1001)
-    y[0] = e[0] * np.sqrt(1.0 / (1 - 0.9 ** 2))
+    y[0] = e[0] * np.sqrt(1.0 / (1 - 0.9**2))
     for i in range(1, 1001):
         y[i] = 0.9 * y[i - 1] + e[i]
     mod = AutoReg(y, 1)
@@ -829,7 +827,7 @@ def test_dynamic_against_sarimax():
     rs = np.random.RandomState(12345678)
     e = rs.standard_normal(1001)
     y = np.empty(1001)
-    y[0] = e[0] * np.sqrt(1.0 / (1 - 0.9 ** 2))
+    y[0] = e[0] * np.sqrt(1.0 / (1 - 0.9**2))
     for i in range(1, 1001):
         y[i] = 0.9 * y[i - 1] + e[i]
     smod = SARIMAX(y, order=(1, 0, 0), trend="c")
@@ -852,15 +850,13 @@ def test_predict_seasonal():
     rs = np.random.RandomState(12345678)
     e = rs.standard_normal(1001)
     y = np.empty(1001)
-    y[0] = e[0] * np.sqrt(1.0 / (1 - 0.9 ** 2))
+    y[0] = e[0] * np.sqrt(1.0 / (1 - 0.9**2))
     effects = 10 * np.cos(np.arange(12) / 11 * 2 * np.pi)
     for i in range(1, 1001):
         y[i] = 10 + 0.9 * y[i - 1] + e[i] + effects[i % 12]
     ys = pd.Series(
         y,
-        index=pd.date_range(
-            dt.datetime(1950, 1, 1), periods=1001, freq=MONTH_END
-        ),
+        index=pd.date_range(dt.datetime(1950, 1, 1), periods=1001, freq=MONTH_END),
     )
 
     mod = AutoReg(ys, 1, seasonal=True)
@@ -892,14 +888,12 @@ def test_predict_exog():
     e = rs.standard_normal(1001)
     y = np.empty(1001)
     x = rs.standard_normal((1001, 2))
-    y[:3] = e[:3] * np.sqrt(1.0 / (1 - 0.9 ** 2)) + x[:3].sum(1)
+    y[:3] = e[:3] * np.sqrt(1.0 / (1 - 0.9**2)) + x[:3].sum(1)
     for i in range(3, 1001):
         y[i] = 10 + 0.9 * y[i - 1] - 0.5 * y[i - 3] + e[i] + x[i].sum()
     ys = pd.Series(
         y,
-        index=pd.date_range(
-            dt.datetime(1950, 1, 1), periods=1001, freq=MONTH_END
-        ),
+        index=pd.date_range(dt.datetime(1950, 1, 1), periods=1001, freq=MONTH_END),
     )
     xdf = pd.DataFrame(x, columns=["x0", "x1"], index=ys.index)
     mod = AutoReg(ys, [1, 3], trend="c", exog=xdf)
@@ -943,14 +937,11 @@ def test_predict_irregular_ar():
     rs = np.random.RandomState(12345678)
     e = rs.standard_normal(1001)
     y = np.empty(1001)
-    y[:3] = e[:3] * np.sqrt(1.0 / (1 - 0.9 ** 2))
+    y[:3] = e[:3] * np.sqrt(1.0 / (1 - 0.9**2))
     for i in range(3, 1001):
         y[i] = 10 + 0.9 * y[i - 1] - 0.5 * y[i - 3] + e[i]
     ys = pd.Series(
-        y,
-        index=pd.date_range(
-            dt.datetime(1950, 1, 1), periods=1001, freq=MONTH_END
-        )
+        y, index=pd.date_range(dt.datetime(1950, 1, 1), periods=1001, freq=MONTH_END)
     )
     mod = AutoReg(ys, [1, 3], trend="ct")
     res = mod.fit()
@@ -964,21 +955,14 @@ def test_predict_irregular_ar():
     direct[1] = c + t * 902 + ar[0] * direct[0] + ar[1] * y[898]
     direct[2] = c + t * 903 + ar[0] * direct[1] + ar[1] * y[899]
     for i in range(3, 201):
-        direct[i] = (
-            c + t * (901 + i) + ar[0] * direct[i - 1] + ar[1] * direct[i - 3]
-        )
+        direct[i] = c + t * (901 + i) + ar[0] * direct[i - 1] + ar[1] * direct[i - 3]
     direct = pd.Series(
         direct, index=pd.date_range(ys.index[900], periods=201, freq=MONTH_END)
     )
     assert_series_equal(pred, direct)
 
     pred = res.predict(900)
-    direct = (
-        c
-        + t * np.arange(901, 901 + 101)
-        + ar[0] * y[899:-1]
-        + ar[1] * y[897:-3]
-    )
+    direct = c + t * np.arange(901, 901 + 101) + ar[0] * y[899:-1] + ar[1] * y[897:-3]
     idx = pd.date_range(ys.index[900], periods=101, freq=MONTH_END)
     direct = pd.Series(direct, index=idx)
     assert_series_equal(pred, direct)
@@ -989,25 +973,17 @@ def test_forecast_start_end_equiv(dynamic):
     rs = np.random.RandomState(12345678)
     e = rs.standard_normal(1001)
     y = np.empty(1001)
-    y[0] = e[0] * np.sqrt(1.0 / (1 - 0.9 ** 2))
+    y[0] = e[0] * np.sqrt(1.0 / (1 - 0.9**2))
     effects = 10 * np.cos(np.arange(12) / 11 * 2 * np.pi)
     for i in range(1, 1001):
         y[i] = 10 + 0.9 * y[i - 1] + e[i] + effects[i % 12]
     ys = pd.Series(
-        y, index=pd.date_range(
-            dt.datetime(1950, 1, 1),
-            periods=1001,
-            freq=MONTH_END
-        )
+        y, index=pd.date_range(dt.datetime(1950, 1, 1), periods=1001, freq=MONTH_END)
     )
     mod = AutoReg(ys, 1, seasonal=True)
     res = mod.fit()
     pred_int = res.predict(1000, 1020, dynamic=dynamic)
-    dates = pd.date_range(
-        dt.datetime(1950, 1, 1),
-        periods=1021,
-        freq=MONTH_END
-    )
+    dates = pd.date_range(dt.datetime(1950, 1, 1), periods=1021, freq=MONTH_END)
     pred_dates = res.predict(dates[1000], dates[1020], dynamic=dynamic)
     assert_series_equal(pred_int, pred_dates)
 
@@ -1031,9 +1007,7 @@ def test_deterministic(reset_randomstate):
     m2 = AutoReg(y, trend="ct", seasonal=True, lags=2, period=12)
     res2 = m2.fit()
     assert_almost_equal(np.asarray(res.params), np.asarray(res2.params))
-    with pytest.warns(
-        SpecificationWarning, match="When using deterministic, trend"
-    ):
+    with pytest.warns(SpecificationWarning, match="When using deterministic, trend"):
         AutoReg(y, trend="ct", seasonal=False, lags=2, deterministic=dp)
     with pytest.raises(TypeError, match="deterministic must be"):
         AutoReg(y, 2, deterministic="ct")
@@ -1127,9 +1101,7 @@ def test_dynamic_predictions_oos(ar2):
     d25_end = res.predict(dynamic=25, end=61)
     s10_d15_end = res.predict(start=10, dynamic=15, end=61)
     end = ar2.index[-1] + 12 * (ar2.index[-1] - ar2.index[-2])
-    sd_index_end = res.predict(
-        start=ar2.index[10], dynamic=ar2.index[25], end=end
-    )
+    sd_index_end = res.predict(start=ar2.index[10], dynamic=ar2.index[25], end=end)
     assert_allclose(s10_d15_end, sd_index_end)
     assert_allclose(d25_end[25:], sd_index_end[15:])
 
@@ -1325,9 +1297,7 @@ def test_autoreg_append(append_data, use_pandas, lags, trend, seasonal):
         y_both = np.asarray(y_both)
         x_both = np.asarray(x_both)
 
-    res = AutoReg(
-        y, lags=lags, trend=trend, seasonal=seasonal, period=period
-    ).fit()
+    res = AutoReg(y, lags=lags, trend=trend, seasonal=seasonal, period=period).fit()
     res_append = res.append(y_oos, refit=True)
     res_direct = AutoReg(
         y_both, lags=lags, trend=trend, seasonal=seasonal, period=period


### PR DESCRIPTION
Add attributes like ssr and rsquared that are common for OLS but were missing from AutoReg

- [ ] closes #xxxx
- [ ] tests added / passed. 
- [ ] code/documentation is well formatted.  
- [ ] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
