### PR TITLE
fix: add informative error message when Hessian inversion fails in fit_regularized

### DIFF
--- a/statsmodels/discrete/discrete_model.py
+++ b/statsmodels/discrete/discrete_model.py
@@ -466,7 +466,18 @@ class DiscreteModel(base.LikelihoodModel):
         if nnz_params > 0:
             H_restricted = H[nz_idx[:, None], nz_idx]
             # Covariance estimate for the nonzero params
-            H_restricted_inv = np.linalg.inv(-H_restricted)
+            try:
+                H_restricted_inv = np.linalg.inv(-H_restricted)
+            except np.linalg.LinAlgError as e:
+                raise np.linalg.LinAlgError(
+                    "Hessian matrix is singular and cannot be inverted. "
+                    "This is often caused by perfect or quasi-perfect separation "
+                    "in the data, where one or more predictors perfectly predict "
+                    "the outcome, or by multicollinearity among predictors. "
+                    "Consider checking your data for separation, removing "
+                    "redundant predictors, or increasing the regularization "
+                    "penalty (alpha)."
+                ) from e
         else:
             H_restricted_inv = np.zeros(0)
 


### PR DESCRIPTION
## Summary

Fixes #2305.

When `fit_regularized` is called on discrete models (e.g., Logit, Probit, MNLogit, Poisson), the covariance parameter estimation in `cov_params_func_l1` calls `np.linalg.inv(-H_restricted)` to invert the restricted Hessian matrix. If the data has **perfect or quasi-perfect separation** — where a predictor (or combination of predictors) perfectly predicts the outcome — the Hessian becomes singular and this inversion fails with a cryptic `LinAlgError: Singular matrix` message that gives users no guidance on the root cause.

### Changes

- **File**: `statsmodels/discrete/discrete_model.py`
- **Function**: `DiscreteModel.cov_params_func_l1`
- Wrapped the `np.linalg.inv(-H_restricted)` call in a `try/except np.linalg.LinAlgError` block
- Re-raises the error with a descriptive message that:
  - Identifies the problem (singular Hessian, cannot invert)
  - Explains the likely causes (perfect separation, quasi-perfect separation, multicollinearity)
  - Suggests actionable remedies (check data for separation, remove redundant predictors, increase regularization alpha)

### Before

```
numpy.linalg.LinAlgError: Singular matrix
```

### After

```
numpy.linalg.LinAlgError: Hessian matrix is singular and cannot be inverted.
This is often caused by perfect or quasi-perfect separation in the data,
where one or more predictors perfectly predict the outcome, or by
multicollinearity among predictors. Consider checking your data for
separation, removing redundant predictors, or increasing the regularization
penalty (alpha).
```

## Test plan

- [ ] Verify the error message is raised with the new descriptive text when fitting a logit model with perfectly separated data using `fit_regularized`
- [ ] Verify that normal `fit_regularized` usage (non-singular Hessian) is unaffected
- [ ] Run existing test suite: `python -m pytest statsmodels/discrete/tests/ -x -q`