### PR TITLE
MAINT: fix `compat.scipy.apply_where` for scipy-internal change

### DIFF
--- a/statsmodels/compat/scipy.py
+++ b/statsmodels/compat/scipy.py
@@ -126,7 +126,11 @@ def apply_where(  # type: ignore[explicit-any] # numpydoc ignore=PR01,PR02
 
     """
     try:
-        import scipy._lib.array_api_extra as xpx
+        try:
+            # From scipy >= 1.18.0
+            import scipy._external.array_api_extra as xpx
+        except (ImportError, AttributeError):
+            import scipy._lib.array_api_extra as xpx
 
         return xpx.apply_where(cond, args, f1, f2, fill_value=fill_value)
     except (ImportError, AttributeError):


### PR DESCRIPTION
- [x] tests added / passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

The move from `scipy._lib.array_api_extra` to `scipy._external.array_api_extra` will land in SciPy 1.18.0
    
This is a follow-up fix to PR gh-9543, it fixes 25 test failures with SciPy's `main` branch. This should be backported to 1.14.x as well I think.
