### PR TITLE
BUG: Treat empty docstrings as None in Docstring class

### DIFF
--- a/statsmodels/tools/docstring.py
+++ b/statsmodels/tools/docstring.py
@@ -570,7 +570,8 @@ class Docstring:
     def __init__(self, docstring):
         self._ds = None
         self._docstring = docstring
-        if docstring is None:
+        if docstring is None or not docstring.strip():
+            self._docstring = None
             return
         self._ds = NumpyDocString(docstring)
 

--- a/statsmodels/tools/tests/test_docstring.py
+++ b/statsmodels/tools/tests/test_docstring.py
@@ -165,6 +165,19 @@ def test_empty_ds():
     assert str(ds) == "None"
 
 
+@pytest.mark.parametrize("docstring", ["", "   ", "\n"])
+def test_empty_string_ds(docstring):
+    # GH#9765: Nuitka sets __doc__ to "" instead of None.
+    # Empty or whitespace-only docstrings should behave like None.
+    ds = Docstring(docstring)
+    assert ds._docstring is None
+    ds.replace_block("summary", ["New summary."])
+    ds.remove_parameters("x")
+    new = Parameter("w", "ndarray", ["An array input."])
+    ds.insert_parameters("y", new)
+    assert str(ds) == "None"
+
+
 def test_yield_return():
     with pytest.raises(ValueError):
         Docstring(bad_yields)


### PR DESCRIPTION
## Summary

Fixes `ValueError` in `Docstring.remove_parameters()` when statsmodels is compiled with [Nuitka](https://github.com/Nuitka/Nuitka), which sets `__doc__` to `""` instead of `None`.

The existing guard in `Docstring.__init__` only checked `if docstring is None`, so empty strings passed through to `NumpyDocString`, which returned empty parameter lists. This caused `remove_parameters` to raise `ValueError` because `0 + len(parameters) != 0`.

**Fix:** Treat empty and whitespace-only docstrings identically to `None` by also checking `not docstring.strip()`. This aligns with the existing `-oo` protection already present in `remove_parameters`, `insert_parameters`, `replace_block`, and `extract_parameters`.

**Test:** Parametrized test covering `""`, `"   "`, and `"\n"` inputs — verifies all `Docstring` methods remain safe.

Closes #9765