### PR TITLE
DOC: Fix Python interpreter example backslash newlines that rendered improperly

### DIFF
--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -2103,9 +2103,9 @@ class LikelihoodModelResults(Results):
         C(Duration, Sum):C(Weight, Sum)    0.176002      0.83912310946              2        51
 
         >>> res_poi = Poisson.from_formula("Days ~ C(Weight) * C(Duration)",
-             data).fit(cov_type='HC0')
+        ...     data).fit(cov_type='HC0')
         >>> wt = res_poi.wald_test_terms(skip_single=False,
-             combine_terms=['Duration', 'Weight'])
+        ...     combine_terms=['Duration', 'Weight'])
         >>> print(wt)
                                     chi2             P>chi2  df constraint
         Intercept              15.695625  7.43960374424e-05              1

--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -2103,9 +2103,9 @@ class LikelihoodModelResults(Results):
         C(Duration, Sum):C(Weight, Sum)    0.176002      0.83912310946              2        51
 
         >>> res_poi = Poisson.from_formula("Days ~ C(Weight) * C(Duration)",
-        ...     data).fit(cov_type='HC0')
+             data).fit(cov_type='HC0')
         >>> wt = res_poi.wald_test_terms(skip_single=False,
-        ...     combine_terms=['Duration', 'Weight'])
+             combine_terms=['Duration', 'Weight'])
         >>> print(wt)
                                     chi2             P>chi2  df constraint
         Intercept              15.695625  7.43960374424e-05              1

--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -2102,10 +2102,10 @@ class LikelihoodModelResults(Results):
         C(Weight, Sum)                    12.432445  3.99943118767e-05              2        51
         C(Duration, Sum):C(Weight, Sum)    0.176002      0.83912310946              2        51
 
-        >>> res_poi = Poisson.from_formula("Days ~ C(Weight) * C(Duration)", \
-                                           data).fit(cov_type='HC0')
-        >>> wt = res_poi.wald_test_terms(skip_single=False, \
-                                         combine_terms=['Duration', 'Weight'])
+        >>> res_poi = Poisson.from_formula("Days ~ C(Weight) * C(Duration)",
+        ...     data).fit(cov_type='HC0')
+        >>> wt = res_poi.wald_test_terms(skip_single=False,
+        ...     combine_terms=['Duration', 'Weight'])
         >>> print(wt)
                                     chi2             P>chi2  df constraint
         Intercept              15.695625  7.43960374424e-05              1

--- a/statsmodels/regression/mixed_linear_model.py
+++ b/statsmodels/regression/mixed_linear_model.py
@@ -971,8 +971,8 @@ class MixedLM(base.LikelihoodModel):
         different across the schools.
 
         >>> vc = {'classroom': '0 + C(classroom)'}
-        >>> MixedLM.from_formula('test_score ~ age', vc_formula=vc, \
-                                  re_formula='1', groups='school', data=data)
+        >>> MixedLM.from_formula('test_score ~ age', vc_formula=vc,
+        ...     re_formula='1', groups='school', data=data)
 
         Now suppose we also have a previous test score called
         'pretest'.  If we want the relationship between pretest
@@ -980,17 +980,17 @@ class MixedLM(base.LikelihoodModel):
         specify a random slope for the pretest score
 
         >>> vc = {'classroom': '0 + C(classroom)', 'pretest': '0 + pretest'}
-        >>> MixedLM.from_formula('test_score ~ age + pretest', vc_formula=vc, \
-                                  re_formula='1', groups='school', data=data)
+        >>> MixedLM.from_formula('test_score ~ age + pretest', vc_formula=vc,
+        ...     re_formula='1', groups='school', data=data)
 
         The following model is almost equivalent to the previous one,
         but here the classroom random intercept and pretest slope may
         be correlated.
 
         >>> vc = {'classroom': '0 + C(classroom)'}
-        >>> MixedLM.from_formula('test_score ~ age + pretest', vc_formula=vc, \
-                                  re_formula='1 + pretest', groups='school', \
-                                  data=data)
+        >>> MixedLM.from_formula('test_score ~ age + pretest', vc_formula=vc,
+        ...     re_formula='1 + pretest', groups='school',
+        ...     data=data)
         """
 
         if "groups" not in kwargs.keys():

--- a/statsmodels/regression/mixed_linear_model.py
+++ b/statsmodels/regression/mixed_linear_model.py
@@ -972,7 +972,7 @@ class MixedLM(base.LikelihoodModel):
 
         >>> vc = {'classroom': '0 + C(classroom)'}
         >>> MixedLM.from_formula('test_score ~ age', vc_formula=vc,
-             re_formula='1', groups='school', data=data)
+        ...     re_formula='1', groups='school', data=data)
 
         Now suppose we also have a previous test score called
         'pretest'.  If we want the relationship between pretest
@@ -981,7 +981,7 @@ class MixedLM(base.LikelihoodModel):
 
         >>> vc = {'classroom': '0 + C(classroom)', 'pretest': '0 + pretest'}
         >>> MixedLM.from_formula('test_score ~ age + pretest', vc_formula=vc,
-             re_formula='1', groups='school', data=data)
+        ...     re_formula='1', groups='school', data=data)
 
         The following model is almost equivalent to the previous one,
         but here the classroom random intercept and pretest slope may
@@ -989,8 +989,7 @@ class MixedLM(base.LikelihoodModel):
 
         >>> vc = {'classroom': '0 + C(classroom)'}
         >>> MixedLM.from_formula('test_score ~ age + pretest', vc_formula=vc,
-             re_formula='1 + pretest', groups='school',
-             data=data)
+        ...     re_formula='1 + pretest', groups='school', data=data)
         """
 
         if "groups" not in kwargs.keys():

--- a/statsmodels/regression/mixed_linear_model.py
+++ b/statsmodels/regression/mixed_linear_model.py
@@ -972,7 +972,7 @@ class MixedLM(base.LikelihoodModel):
 
         >>> vc = {'classroom': '0 + C(classroom)'}
         >>> MixedLM.from_formula('test_score ~ age', vc_formula=vc,
-        ...     re_formula='1', groups='school', data=data)
+             re_formula='1', groups='school', data=data)
 
         Now suppose we also have a previous test score called
         'pretest'.  If we want the relationship between pretest
@@ -981,7 +981,7 @@ class MixedLM(base.LikelihoodModel):
 
         >>> vc = {'classroom': '0 + C(classroom)', 'pretest': '0 + pretest'}
         >>> MixedLM.from_formula('test_score ~ age + pretest', vc_formula=vc,
-        ...     re_formula='1', groups='school', data=data)
+             re_formula='1', groups='school', data=data)
 
         The following model is almost equivalent to the previous one,
         but here the classroom random intercept and pretest slope may
@@ -989,8 +989,8 @@ class MixedLM(base.LikelihoodModel):
 
         >>> vc = {'classroom': '0 + C(classroom)'}
         >>> MixedLM.from_formula('test_score ~ age + pretest', vc_formula=vc,
-        ...     re_formula='1 + pretest', groups='school',
-        ...     data=data)
+             re_formula='1 + pretest', groups='school',
+             data=data)
         """
 
         if "groups" not in kwargs.keys():

--- a/statsmodels/robust/robust_linear_model.py
+++ b/statsmodels/robust/robust_linear_model.py
@@ -85,8 +85,8 @@ class RLM(base.LikelihoodModel):
     >>> import statsmodels.api as sm
     >>> data = sm.datasets.stackloss.load()
     >>> data.exog = sm.add_constant(data.exog)
-    >>> rlm_model = sm.RLM(data.endog, data.exog, \
-                           M=sm.robust.norms.HuberT())
+    >>> rlm_model = sm.RLM(data.endog, data.exog,
+    ...     M=sm.robust.norms.HuberT())
 
     >>> rlm_results = rlm_model.fit()
     >>> rlm_results.params

--- a/statsmodels/robust/robust_linear_model.py
+++ b/statsmodels/robust/robust_linear_model.py
@@ -85,9 +85,7 @@ class RLM(base.LikelihoodModel):
     >>> import statsmodels.api as sm
     >>> data = sm.datasets.stackloss.load()
     >>> data.exog = sm.add_constant(data.exog)
-    >>> rlm_model = sm.RLM(data.endog, data.exog,
-         M=sm.robust.norms.HuberT())
-
+    >>> rlm_model = sm.RLM(data.endog, data.exog, M=sm.robust.norms.HuberT())
     >>> rlm_results = rlm_model.fit()
     >>> rlm_results.params
     array([  0.82938433,   0.92606597,  -0.12784672, -41.02649835])

--- a/statsmodels/robust/robust_linear_model.py
+++ b/statsmodels/robust/robust_linear_model.py
@@ -86,7 +86,7 @@ class RLM(base.LikelihoodModel):
     >>> data = sm.datasets.stackloss.load()
     >>> data.exog = sm.add_constant(data.exog)
     >>> rlm_model = sm.RLM(data.endog, data.exog,
-    ...     M=sm.robust.norms.HuberT())
+         M=sm.robust.norms.HuberT())
 
     >>> rlm_results = rlm_model.fit()
     >>> rlm_results.params

--- a/statsmodels/sandbox/distributions/extras.py
+++ b/statsmodels/sandbox/distributions/extras.py
@@ -1164,7 +1164,7 @@ def mvstdnormcdf(lower, upper, corrcoef, **kwds):
                         increase MAXPTS to decrease ERROR; 1.048330348e-006
     0.166666546218
     >>> print(mvstdnormcdf([-np.inf,-np.inf,-100.0],[0.0,0.0,0.0], corr,
-         maxpts=100000, abseps=1e-8))
+    ...     maxpts=100000, abseps=1e-8))
     0.166666588293
 
     """

--- a/statsmodels/sandbox/distributions/extras.py
+++ b/statsmodels/sandbox/distributions/extras.py
@@ -1163,8 +1163,8 @@ def mvstdnormcdf(lower, upper, corrcoef, **kwds):
     something wrong completion with ERROR > EPS and MAXPTS function values used;
                         increase MAXPTS to decrease ERROR; 1.048330348e-006
     0.166666546218
-    >>> print(mvstdnormcdf([-np.inf,-np.inf,-100.0],[0.0,0.0,0.0], corr, \
-                            maxpts=100000, abseps=1e-8))
+    >>> print(mvstdnormcdf([-np.inf,-np.inf,-100.0],[0.0,0.0,0.0], corr,
+    ...     maxpts=100000, abseps=1e-8))
     0.166666588293
 
     """

--- a/statsmodels/sandbox/distributions/extras.py
+++ b/statsmodels/sandbox/distributions/extras.py
@@ -1164,7 +1164,7 @@ def mvstdnormcdf(lower, upper, corrcoef, **kwds):
                         increase MAXPTS to decrease ERROR; 1.048330348e-006
     0.166666546218
     >>> print(mvstdnormcdf([-np.inf,-np.inf,-100.0],[0.0,0.0,0.0], corr,
-    ...     maxpts=100000, abseps=1e-8))
+         maxpts=100000, abseps=1e-8))
     0.166666588293
 
     """


### PR DESCRIPTION
In a few docstrings, there were Python interpreter examples that had newlines added using literal backslashes followed by a new line. However, when rendered into documentation, the backslashes prevented the newlines from being rendered, creating a large gap of whitespace with the rest of the code on the same line. This was confusing because if you didn't scroll to the end of the line, it was easy to miss the rest of the code. E.g. the following [docstring snippet](https://github.com/statsmodels/statsmodels/blob/main/statsmodels/regression/mixed_linear_model.py#L974)
```
        >>> MixedLM.from_formula('test_score ~ age', vc_formula=vc, \
                                  re_formula='1', groups='school', data=data)
```
was rendered as follows in [the documentation](https://www.statsmodels.org/stable/generated/statsmodels.regression.mixed_linear_model.MixedLM.from_formula.html):
```
>>> MixedLM.from_formula('test_score ~ age', vc_formula=vc,                                   re_formula='1', groups='school', data=data)
```

I searched the repo for all instances of this pattern using the regex `grep -rn '>>>.*\\$'` in the root of the repo. These are all the instances I found:
```
statsmodels/robust/robust_linear_model.py:88:    >>> rlm_model = sm.RLM(data.endog, data.exog, \
statsmodels/regression/mixed_linear_model.py:974:        >>> MixedLM.from_formula('test_score ~ age', vc_formula=vc, \
statsmodels/regression/mixed_linear_model.py:983:        >>> MixedLM.from_formula('test_score ~ age + pretest', vc_formula=vc, \
statsmodels/regression/mixed_linear_model.py:991:        >>> MixedLM.from_formula('test_score ~ age + pretest', vc_formula=vc, \
statsmodels/sandbox/tsa/movstat.py:34:>>> np.all(ndimage.filters.correlate(np.vstack([x,x]),np.array([[1,1,1],[0,0,0]]), origin = 1)[0]==\
statsmodels/sandbox/tsa/movstat.py:37:>>> np.all(ndimage.filters.correlate(np.vstack([x,x]),np.array([[0.5,0.5,0.5],[0.5,0.5,0.5]]), \
statsmodels/sandbox/distributions/extras.py:1166:    >>> print(mvstdnormcdf([-np.inf,-np.inf,-100.0],[0.0,0.0,0.0], corr, \
statsmodels/base/model.py:2105:        >>> res_poi = Poisson.from_formula("Days ~ C(Weight) * C(Duration)", \
statsmodels/base/model.py:2107:        >>> wt = res_poi.wald_test_terms(skip_single=False, \
```
and they affect these documentation pages:
https://www.statsmodels.org/stable/generated/statsmodels.robust.robust_linear_model.RLM.html
https://www.statsmodels.org/stable/generated/statsmodels.regression.mixed_linear_model.MixedLM.from_formula.html
https://www.statsmodels.org/stable/generated/statsmodels.sandbox.distributions.extras.mvstdnormcdf.html
https://www.statsmodels.org/stable/dev/generated/statsmodels.base.model.LikelihoodModelResults.wald_test_terms.html

I ignored the instances in `statsmodels/sandbox/tsa/movstat.py` because I couldn't identify a place in the documentation where they get rendered.

For the remaining instances, I went through and removed the backslashes, and on the secondary lines added `...` in the same columns as the Python interpreter `>>>`, followed by a single space separator, and then a 4 space indent. E.g. the above example is now:
```
        >>> MixedLM.from_formula('test_score ~ age', vc_formula=vc,
        ...     re_formula='1', groups='school', data=data)
```