### PR TITLE
ENH: make `tsa/statespace` Cython usage compatible with SciPy ILP64 builds

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -21,8 +21,10 @@ scipy_has_blas_int = cy.compiles(
 _blas_int_conf = configuration_data()
 if scipy_has_blas_int
   _blas_int_conf.set('BLAS_INT_DEF', 'from scipy.linalg.cython_blas cimport blas_int')
+  _blas_int_conf.set('BLAS_BINT_DEF', 'from scipy.linalg.cython_blas cimport blas_bint')
 else
   _blas_int_conf.set('BLAS_INT_DEF', 'ctypedef int blas_int')
+  _blas_int_conf.set('BLAS_BINT_DEF', 'ctypedef bint blas_bint')
 endif
 
 if not cy.version().version_compare('>=3.0.10')

--- a/meson.build
+++ b/meson.build
@@ -12,6 +12,19 @@ cy = meson.get_compiler('cython')
 cython = find_program(cy.cmd_array()[0])
 tempita = find_program('statsmodels/_build/tempita.py')
 
+# Check if scipy's cython_blas exports blas_int (ILP64 support).
+scipy_has_blas_int = cy.compiles(
+  'from scipy.linalg.cython_blas cimport blas_int',
+  name: 'scipy cython_blas blas_int'
+)
+
+_blas_int_conf = configuration_data()
+if scipy_has_blas_int
+  _blas_int_conf.set('BLAS_INT_DEF', 'from scipy.linalg.cython_blas cimport blas_int')
+else
+  _blas_int_conf.set('BLAS_INT_DEF', 'ctypedef int blas_int')
+endif
+
 if not cy.version().version_compare('>=3.0.10')
   error('statsmodels requires Cython >= 3.0.10')
 endif

--- a/statsmodels/tsa/statespace/_blas_int.pxi.in
+++ b/statsmodels/tsa/statespace/_blas_int.pxi.in
@@ -1,0 +1,3 @@
+# This will be a plain `int` if scipy.linalg.cython_blas doesn't have `blas_int`, and
+# `blas_int` if it does. See `meson.build` in this directory for the compile-time check.
+@BLAS_INT_DEF@

--- a/statsmodels/tsa/statespace/_blas_int.pxi.in
+++ b/statsmodels/tsa/statespace/_blas_int.pxi.in
@@ -1,3 +1,4 @@
 # This will be a plain `int` if scipy.linalg.cython_blas doesn't have `blas_int`, and
 # `blas_int` if it does. See `meson.build` in this directory for the compile-time check.
 @BLAS_INT_DEF@
+@BLAS_BINT_DEF@

--- a/statsmodels/tsa/statespace/_cfa_simulation_smoother.pyx.in
+++ b/statsmodels/tsa/statespace/_cfa_simulation_smoother.pyx.in
@@ -47,6 +47,7 @@ np.import_array()
 
 cimport scipy.linalg.cython_blas as blas
 cimport scipy.linalg.cython_lapack as lapack
+include "statsmodels/tsa/statespace/_blas_int.pxi"
 cimport statsmodels.tsa.statespace._tools as tools
 
 cdef int FORTRAN = 1
@@ -82,7 +83,7 @@ cdef class {{prefix}}CFASimulationSmoother(object):
     """
 
     def __init__(self, {{prefix}}Statespace model):
-        cdef int inc = 1
+        cdef blas_int inc = 1
         cdef:
             np.npy_intp dim1[1]
             np.npy_intp dim2[2]
@@ -203,12 +204,18 @@ cdef class {{prefix}}CFASimulationSmoother(object):
         # "lower diagonal ordered form" - see e.g. Scipy's documentation page
         # for linalg.cholesky_banded for details of the storage format
         cdef:
-            int t, i, j, rows, ld, info
+            int t, i, j
+            blas_int rows, ld, info
             int reset_missing = 0
-            int inc = 1
+            blas_int inc = 1
             {{cython_type}} alpha = 1.0
             {{cython_type}} beta = 0.0
             {{cython_type}} gamma = -1.0
+            blas_int k_states = self.k_states
+            blas_int k_states2 = self.k_states2
+            blas_int _k_endog = self.model._k_endog
+            blas_int _k_endog2 = self.model._k_endog2
+            blas_int _k_endogstates = self.model._k_endogstates
             int time_varying_obs_intercept = self.model.obs_intercept.shape[1] > 1
             int time_varying_design = self.model.design.shape[2] > 1
             int time_varying_obs_cov = self.model.obs_cov.shape[2] > 1
@@ -225,13 +232,13 @@ cdef class {{prefix}}CFASimulationSmoother(object):
         if self.model.initialized_diffuse:
             self.initial_state_cov_inv[:] = 0.
         else:
-            blas.{{prefix}}copy(&self.k_states2, self.model._initial_state_cov, &inc, self._initial_state_cov_inv, &inc)
-            lapack.{{prefix}}potrf("L", &self.k_states, self._initial_state_cov_inv, &self.k_states, &info)
+            blas.{{prefix}}copy(&k_states2, self.model._initial_state_cov, &inc, self._initial_state_cov_inv, &inc)
+            lapack.{{prefix}}potrf("L", &k_states, self._initial_state_cov_inv, &k_states, &info)
             if info > 0:
                 raise np.linalg.LinAlgError('Non-positive-definite initial state covariance matrix.')
             elif info < 0:
                 raise np.linalg.LinAlgError('Invalid value in initial state covariance matrix.')
-            lapack.{{prefix}}potri("L", &self.k_states, self._initial_state_cov_inv, &self.k_states, &info)
+            lapack.{{prefix}}potri("L", &k_states, self._initial_state_cov_inv, &k_states, &info)
 
         # Iterate over periods
         j = 0  # this will be a column counter
@@ -248,59 +255,64 @@ cdef class {{prefix}}CFASimulationSmoother(object):
             # Invert selected_state_cov
             # (again, we actually need the inverse itself)
             if t == 0 or time_varying_selected_state_cov:
-                blas.{{prefix}}copy(&self.k_states2, self.model._selected_state_cov, &inc, self._selected_state_cov_inv, &inc)
-                lapack.{{prefix}}potrf("L", &self.k_states, self._selected_state_cov_inv, &self.k_states, &info)
+                blas.{{prefix}}copy(&k_states2, self.model._selected_state_cov, &inc, self._selected_state_cov_inv, &inc)
+                lapack.{{prefix}}potrf("L", &k_states, self._selected_state_cov_inv, &k_states, &info)
                 if info > 0:
                     raise np.linalg.LinAlgError('Non-positive-definite selected state covariance matrix encountered at period %d' % t)
                 elif info < 0:
                     raise np.linalg.LinAlgError('Invalid value in selected state covariance matrix encountered at period %d' % t)
-                lapack.{{prefix}}potri("L", &self.k_states, self._selected_state_cov_inv, &self.k_states, &info)
+                lapack.{{prefix}}potri("L", &k_states, self._selected_state_cov_inv, &k_states, &info)
 
             # T(RQRi)T + (RQRi)
             if (t == 0 or time_varying_transition or
                     time_varying_selected_state_cov):
                 # QiT = (RQRi) @ T
-                blas.{{prefix}}symm("L", "L", &self.k_states, &self.k_states,
-                                    &alpha, self._selected_state_cov_inv, &self.k_states,
-                                        self.model._transition, &self.k_states,
-                                    &beta, self._QiT, &self.k_states)
+                blas.{{prefix}}symm("L", "L", &k_states, &k_states,
+                                    &alpha, self._selected_state_cov_inv, &k_states,
+                                        self.model._transition, &k_states,
+                                    &beta, self._QiT, &k_states)
 
                 # TQiT = T.T @ QiT
-                blas.{{prefix}}gemm("T", "N", &self.k_states, &self.k_states, &self.k_states,
-                                    &alpha, self.model._transition, &self.k_states,
-                                        self._QiT, &self.k_states,
-                                    &beta, self._TQiT, &self.k_states)
+                blas.{{prefix}}gemm("T", "N", &k_states, &k_states, &k_states,
+                                    &alpha, self.model._transition, &k_states,
+                                        self._QiT, &k_states,
+                                    &beta, self._TQiT, &k_states)
 
                 # TQiTpQ = TQiT + RQRi
                 # Note: there will not be correct entries in the upper triangle, because
                 # selected_state_cov was only set in the lower triangle. However, that's
                 # okay because we only reference the lower triangle, below
-                blas.{{prefix}}copy(&self.k_states2, self._selected_state_cov_inv, &inc, self._TQiTpQ, &inc)
-                blas.{{prefix}}axpy(&self.k_states2, &alpha, self._TQiT, &inc, self._TQiTpQ, &inc)
+                blas.{{prefix}}copy(&k_states2, self._selected_state_cov_inv, &inc, self._TQiTpQ, &inc)
+                blas.{{prefix}}axpy(&k_states2, &alpha, self._TQiT, &inc, self._TQiTpQ, &inc)
 
             # Z (Hi) Z
             if t == 0 or reset_missing or time_varying_design or time_varying_obs_cov:
 
                 # Cholesky of obs_cov
                 if t == 0 or reset_missing or time_varying_obs_cov:
-                    blas.{{prefix}}copy(&self.model._k_endog2, self.model._obs_cov, &inc, self._obs_cov_fac, &inc)
-                    lapack.{{prefix}}potrf("L", &self.model._k_endog, self._obs_cov_fac, &self.model._k_endog, &info)
+                    _k_endog = self.model._k_endog
+                    _k_endog2 = self.model._k_endog2
+                    _k_endogstates = self.model._k_endogstates
+                    blas.{{prefix}}copy(&_k_endog2, self.model._obs_cov, &inc, self._obs_cov_fac, &inc)
+                    lapack.{{prefix}}potrf("L", &_k_endog, self._obs_cov_fac, &_k_endog, &info)
                     if info > 0:
                         raise np.linalg.LinAlgError('Non-positive-definite observation covariance matrix encountered at period %d' % t)
                     elif info < 0:
                         raise np.linalg.LinAlgError('Invalid value in observation covariance matrix encountered at period %d' % t)
 
                 # HiZ = Hi Z
-                blas.{{prefix}}copy(&self.model._k_endogstates, self.model._design, &inc, self._HiZ, &inc)
-                lapack.{{prefix}}potrs("L", &self.model._k_endog, &self.k_states,
-                                       self._obs_cov_fac, &self.model._k_endog,
-                                       self._HiZ, &self.model._k_endog, &info)
+                _k_endog = self.model._k_endog
+                _k_endogstates = self.model._k_endogstates
+                blas.{{prefix}}copy(&_k_endogstates, self.model._design, &inc, self._HiZ, &inc)
+                lapack.{{prefix}}potrs("L", &_k_endog, &k_states,
+                                       self._obs_cov_fac, &_k_endog,
+                                       self._HiZ, &_k_endog, &info)
 
                 # ZHiZ = Z.T @ HiZ
-                blas.{{prefix}}gemm("T", "N", &self.k_states, &self.k_states, &self.model._k_endog,
-                                    &alpha, self.model._design, &self.model._k_endog,
-                                        self._HiZ, &self.model._k_endog,
-                                    &beta, self._ZHiZ, &self.k_states)
+                blas.{{prefix}}gemm("T", "N", &k_states, &k_states, &_k_endog,
+                                    &alpha, self.model._design, &_k_endog,
+                                        self._HiZ, &_k_endog,
+                                    &beta, self._ZHiZ, &k_states)
 
             # Fill in K and posterior_cov_inv_chol (which is right now just
             # going to contain posterior_cov_inv, and then we will take the
@@ -324,10 +336,10 @@ cdef class {{prefix}}CFASimulationSmoother(object):
                     blas.{{prefix}}axpy(&rows, &alpha, &self.ZHiZ[i, i], &inc,
                                                         &self.posterior_cov_inv_chol[0, j], &inc)
                     # K[q - i:q + q - i, col] = -QiT[:q, i]
-                    blas.{{prefix}}copy(&self.k_states, &self.QiT[0, i], &inc, &self.K[rows, j], &inc)
-                    blas.{{prefix}}scal(&self.k_states, &gamma, &self.K[rows, j], &inc)
+                    blas.{{prefix}}copy(&k_states, &self.QiT[0, i], &inc, &self.K[rows, j], &inc)
+                    blas.{{prefix}}scal(&k_states, &gamma, &self.K[rows, j], &inc)
                     # P[q - i:q + q - i, col] = -QiT[:q, i]
-                    blas.{{prefix}}copy(&self.k_states, &self.K[rows, j], &inc,
+                    blas.{{prefix}}copy(&k_states, &self.K[rows, j], &inc,
                                                                &self.posterior_cov_inv_chol[rows, j], &inc)
 
                 # Last period is different
@@ -346,12 +358,12 @@ cdef class {{prefix}}CFASimulationSmoother(object):
             # Prior mean
             if t == 0:
                 # prior_mean[:, 0] = initial_state
-                blas.{{prefix}}copy(&self.k_states, self.model._initial_state, &inc, &self.prior_mean[0, 0], &inc)
+                blas.{{prefix}}copy(&k_states, self.model._initial_state, &inc, &self.prior_mean[0, 0], &inc)
             else:
                 # prior_mean[:, t] = c[:, t] + T @ prior_mean[:, t-1]
-                blas.{{prefix}}copy(&self.k_states, self.model._state_intercept, &inc, &self.prior_mean[0, t], &inc)
-                blas.{{prefix}}gemv("N", &self.k_states, &self.k_states,
-                                    &alpha, self.model._transition, &self.k_states,
+                blas.{{prefix}}copy(&k_states, self.model._state_intercept, &inc, &self.prior_mean[0, t], &inc)
+                blas.{{prefix}}gemv("N", &k_states, &k_states,
+                                    &alpha, self.model._transition, &k_states,
                                             &self.prior_mean[0, t - 1], &inc,
                                     &alpha, &self.prior_mean[0, t], &inc)
 
@@ -359,19 +371,21 @@ cdef class {{prefix}}CFASimulationSmoother(object):
             if self.model.nmissing[t] == self.model.k_endog:
                 self.posterior_mean[:, t] = 0
             else:
-                blas.{{prefix}}copy(&self.model._k_endog, self.model._obs, &inc, &self.ymd[0], &inc)
-                blas.{{prefix}}axpy(&self.model._k_endog, &gamma, self.model._obs_intercept, &inc, &self.ymd[0], &inc)
-                blas.{{prefix}}gemv("T", &self.model._k_endog, &self.k_states,
-                                         &alpha, self._HiZ, &self.model._k_endog,
+                _k_endog = self.model._k_endog
+                blas.{{prefix}}copy(&_k_endog, self.model._obs, &inc, &self.ymd[0], &inc)
+                blas.{{prefix}}axpy(&_k_endog, &gamma, self.model._obs_intercept, &inc, &self.ymd[0], &inc)
+                blas.{{prefix}}gemv("T", &_k_endog, &k_states,
+                                         &alpha, self._HiZ, &_k_endog,
                                                 &self.ymd[0], &inc,
                                          &beta, &self.posterior_mean[0, t], &inc)
 
         # Orders of sparse matrices
-        order = self.model.nobs * self.k_states
+        cdef blas_int blas_order = self.order
+        cdef blas_int blas_lower_bandwidth = self.lower_bandwidth
         ld = self.lower_bandwidth + 1
 
         # Compute the sparse Cholesky factor of posterior cov
-        lapack.{{prefix}}pbtrf("L", &self.order, &self.lower_bandwidth,
+        lapack.{{prefix}}pbtrf("L", &blas_order, &blas_lower_bandwidth,
                                &self.posterior_cov_inv_chol[0, 0], &ld,
                                &info)
         if info > 0:
@@ -381,17 +395,19 @@ cdef class {{prefix}}CFASimulationSmoother(object):
 
         # Compute the posterior mean
         # posterior_mean = P^{-1} (K prior_mean + ZHimd)
-        blas.{{prefix}}{{if combined_prefix == 'd'}}s{{else}}h{{endif}}bmv("L", &self.order, &self.lower_bandwidth,
+        blas.{{prefix}}{{if combined_prefix == 'd'}}s{{else}}h{{endif}}bmv("L", &blas_order, &blas_lower_bandwidth,
                             &alpha, self._K, &ld,
                                     &self.prior_mean[0, 0], &inc,
                             &alpha, &self.posterior_mean[0, 0], &inc)
-        lapack.{{prefix}}pbtrs("L", &self.order, &self.lower_bandwidth, &inc,
+        lapack.{{prefix}}pbtrs("L", &blas_order, &blas_lower_bandwidth, &inc,
                                &self.posterior_cov_inv_chol[0, 0], &ld,
-                               &self.posterior_mean[0, 0], &self.order, &info)
+                               &self.posterior_mean[0, 0], &blas_order, &info)
 
     cpdef simulate(self, variates=None):
-        cdef int inc = 1
-        cdef int ld = self.lower_bandwidth + 1
+        cdef blas_int inc = 1
+        cdef blas_int ld = self.lower_bandwidth + 1
+        cdef blas_int blas_order = self.order
+        cdef blas_int blas_lower_bandwidth = self.lower_bandwidth
         cdef {{cython_type}} alpha = 1.0
         cdef {{cython_type}} [:] u
 
@@ -406,12 +422,12 @@ cdef class {{prefix}}CFASimulationSmoother(object):
 
         # Solve L' x = u to get x \sim N(0, P^{-1})
         # (L = posterior_cov_inv_chol is lower triangular)
-        blas.{{prefix}}tbsv("L", "T", "N", &self.order, &self.lower_bandwidth,
+        blas.{{prefix}}tbsv("L", "T", "N", &blas_order, &blas_lower_bandwidth,
                             &self.posterior_cov_inv_chol[0, 0], &ld,
                             &u[0], &inc)
 
         # Add in the posterior mean
-        blas.{{prefix}}axpy(&self.order, &alpha, &self.posterior_mean[0, 0], &inc, &u[0], &inc)
+        blas.{{prefix}}axpy(&blas_order, &alpha, &self.posterior_mean[0, 0], &inc, &u[0], &inc)
 
         return np.array(u).reshape(self.model.nobs, self.k_states).T
 

--- a/statsmodels/tsa/statespace/_filters/_conventional.pyx.in
+++ b/statsmodels/tsa/statespace/_filters/_conventional.pyx.in
@@ -25,6 +25,7 @@ cimport numpy as np
 from statsmodels.includes.math cimport *
 cimport scipy.linalg.cython_blas as blas
 cimport scipy.linalg.cython_lapack as lapack
+include "statsmodels/tsa/statespace/_blas_int.pxi"
 
 from statsmodels.tsa.statespace._kalman_filter cimport (
     MEMORY_NO_FORECAST_COV, FILTER_CONCENTRATED, FILTER_CHANDRASEKHAR)
@@ -53,7 +54,8 @@ if prefix == 's':
 
 cdef int {{prefix}}forecast_missing_conventional({{prefix}}KalmanFilter kfilter, {{prefix}}Statespace model):
     cdef int i, j
-    cdef int inc = 1, design_t = 0
+    cdef blas_int inc = 1
+    cdef int design_t = 0
     cdef {{cython_type}} alpha = 1
 
     # #### Forecast for time t
@@ -78,13 +80,15 @@ cdef int {{prefix}}forecast_missing_conventional({{prefix}}KalmanFilter kfilter,
             kfilter._forecast_error_cov[j + i*kfilter.k_endog] = 0
 
 cdef int {{prefix}}updating_missing_conventional({{prefix}}KalmanFilter kfilter, {{prefix}}Statespace model):
-    cdef int inc = 1
+    cdef blas_int inc = 1
+    cdef blas_int k_states = kfilter.k_states
+    cdef blas_int k_states2 = kfilter.k_states2
 
     # Simply copy over the input arrays ($a_t, P_t$) to the filtered arrays
     # ($a_{t|t}, P_{t|t}$)
     # Note: use kfilter dimensions since we just want to copy whole arrays;
-    blas.{{prefix}}copy(&kfilter.k_states, kfilter._input_state, &inc, kfilter._filtered_state, &inc)
-    blas.{{prefix}}copy(&kfilter.k_states2, kfilter._input_state_cov, &inc, kfilter._filtered_state_cov, &inc)
+    blas.{{prefix}}copy(&k_states, kfilter._input_state, &inc, kfilter._filtered_state, &inc)
+    blas.{{prefix}}copy(&k_states2, kfilter._input_state_cov, &inc, kfilter._filtered_state_cov, &inc)
 
 cdef {{cython_type}} {{prefix}}inverse_missing_conventional({{prefix}}KalmanFilter kfilter, {{prefix}}Statespace model, {{cython_type}} determinant)  except *:
     # Since the inverse of the forecast error covariance matrix is not
@@ -109,7 +113,12 @@ cdef int {{prefix}}forecast_conventional({{prefix}}KalmanFilter kfilter, {{prefi
 
     # Constants
     cdef:
-        int inc = 1, ld, i, j
+        int i, j
+        blas_int inc = 1
+        blas_int k_states = kfilter.k_states
+        blas_int k_endog = kfilter.k_endog
+        blas_int _k_states = model._k_states
+        blas_int _k_endog = model._k_endog
         {{cython_type}} alpha = 1.0
         {{cython_type}} beta = 0.0
         {{cython_type}} gamma = -1.0
@@ -121,11 +130,11 @@ cdef int {{prefix}}forecast_conventional({{prefix}}KalmanFilter kfilter, {{prefi
     # from the previous iteration of the filter (for $t > 0$).
 
     # $\\# = d_t$
-    blas.{{prefix}}copy(&model._k_endog, model._obs_intercept, &inc, kfilter._forecast, &inc)
+    blas.{{prefix}}copy(&_k_endog, model._obs_intercept, &inc, kfilter._forecast, &inc)
     # `forecast` $= 1.0 * Z_t a_t + 1.0 * \\#$
     # $(p \times 1) = (p \times m) (m \times 1) + (p \times 1)$
-    blas.{{prefix}}gemv("N", &model._k_endog, &model._k_states,
-          &alpha, model._design, &model._k_endog,
+    blas.{{prefix}}gemv("N", &_k_endog, &_k_states,
+          &alpha, model._design, &_k_endog,
                   kfilter._input_state, &inc,
           &alpha, kfilter._forecast, &inc)
 
@@ -133,19 +142,19 @@ cdef int {{prefix}}forecast_conventional({{prefix}}KalmanFilter kfilter, {{prefi
     # `forecast_error` $\equiv v_t = y_t -$ `forecast`
 
     # $\\# = y_t$
-    blas.{{prefix}}copy(&model._k_endog, model._obs, &inc, kfilter._forecast_error, &inc)
+    blas.{{prefix}}copy(&_k_endog, model._obs, &inc, kfilter._forecast_error, &inc)
     # $v_t = -1.0 * $ `forecast` $ + \\#$
     # $(p \times 1) = (p \times 1) + (p \times 1)$
-    blas.{{prefix}}axpy(&model._k_endog, &gamma, kfilter._forecast, &inc, kfilter._forecast_error, &inc)
+    blas.{{prefix}}axpy(&_k_endog, &gamma, kfilter._forecast, &inc, kfilter._forecast_error, &inc)
 
     # *Intermediate calculation* (used just below and then once more)
     # `tmp1` array used here, dimension $(m \times p)$
     # $\\#_1 = P_t Z_t'$
     # $(m \times p) = (m \times m) (p \times m)'$
-    blas.{{prefix}}gemm("N", "T", &model._k_states, &model._k_endog, &model._k_states,
-          &alpha, kfilter._input_state_cov, &kfilter.k_states,
-                  model._design, &model._k_endog,
-          &beta, kfilter._tmp1, &kfilter.k_states)
+    blas.{{prefix}}gemm("N", "T", &_k_states, &_k_endog, &_k_states,
+          &alpha, kfilter._input_state_cov, &k_states,
+                  model._design, &_k_endog,
+          &beta, kfilter._tmp1, &k_states)
 
     # #### Forecast error covariance matrix for time t
     # $F_t \equiv Z_t P_t Z_t' + H_t$
@@ -161,19 +170,27 @@ cdef int {{prefix}}forecast_conventional({{prefix}}KalmanFilter kfilter, {{prefi
                 kfilter._forecast_error_cov[j + i*kfilter.k_endog] = model._obs_cov[j + i*model._k_endog]
 
         # $F_t = 1.0 * Z_t \\#_1 + 1.0 * \\#$
-        blas.{{prefix}}gemm("N", "N", &model._k_endog, &model._k_endog, &model._k_states,
-              &alpha, model._design, &model._k_endog,
-                     kfilter._tmp1, &kfilter.k_states,
-              &alpha, kfilter._forecast_error_cov, &kfilter.k_endog)
+        blas.{{prefix}}gemm("N", "N", &_k_endog, &_k_endog, &_k_states,
+              &alpha, model._design, &_k_endog,
+                     kfilter._tmp1, &k_states,
+              &alpha, kfilter._forecast_error_cov, &k_endog)
 
     return 0
 
 cdef int {{prefix}}chandrasekhar_recursion({{prefix}}KalmanFilter kfilter, {{prefix}}Statespace model):
     # Constants
     cdef:
-        int info
-        int inc = 1
+        blas_int info
+        blas_int inc = 1
         int j, k
+        blas_int k_states = kfilter.k_states
+        blas_int k_endog = kfilter.k_endog
+        blas_int _k_states = model._k_states
+        blas_int _k_endog = model._k_endog
+        blas_int _k_endog2 = model._k_endog2
+        blas_int _k_states2 = model._k_states2
+        blas_int _k_endogstates = model._k_endogstates
+        blas_int ldwork = kfilter.ldwork
         {{cython_type}} alpha = 1.0
         {{cython_type}} beta = 0.0
         {{cython_type}} gamma = -1.0
@@ -182,77 +199,83 @@ cdef int {{prefix}}chandrasekhar_recursion({{prefix}}KalmanFilter kfilter, {{pre
     # Initialization of the recursions
     if kfilter.t == 0:
         # Initialize M
-        blas.{{prefix}}copy(&model._k_endog2, kfilter._forecast_error_cov, &inc, &kfilter.CM[0, 0], &inc)
-        lapack.{{prefix}}getrf(&model._k_endog, &model._k_endog,
-                        &kfilter.CM[0, 0], &kfilter.k_endog,
+        blas.{{prefix}}copy(&_k_endog2, kfilter._forecast_error_cov, &inc, &kfilter.CM[0, 0], &inc)
+        lapack.{{prefix}}getrf(&_k_endog, &_k_endog,
+                        &kfilter.CM[0, 0], &k_endog,
                         kfilter._forecast_error_ipiv, &info)
-        lapack.{{prefix}}getri(&model._k_endog, &kfilter.CM[0, 0], &kfilter.k_endog,
-               kfilter._forecast_error_ipiv, kfilter._forecast_error_work, &kfilter.ldwork, &info)
-        blas.{{prefix}}scal(&model._k_endog2, &gamma, &kfilter.CM[0, 0], &inc)
+        lapack.{{prefix}}getri(&_k_endog, &kfilter.CM[0, 0], &k_endog,
+               kfilter._forecast_error_ipiv, kfilter._forecast_error_work, &ldwork, &info)
+        blas.{{prefix}}scal(&_k_endog2, &gamma, &kfilter.CM[0, 0], &inc)
 
         # Initialize W
         # Our Kalman gain is T P Z' F^{-1} but we need to initialize
         # W = T P Z', so we need to multiply by F
         # (not particularly efficient way to do this, but it's only
         # done for one time step so it's probably okay)
-        blas.{{prefix}}gemm("N", "N", &model._k_states, &model._k_endog, &model._k_endog,
-          &alpha, kfilter._kalman_gain, &kfilter.k_states,
-                  kfilter._forecast_error_cov, &kfilter.k_endog,
-          &beta, &kfilter.CW[0, 0], &kfilter.k_states)
+        blas.{{prefix}}gemm("N", "N", &_k_states, &_k_endog, &_k_endog,
+          &alpha, kfilter._kalman_gain, &k_states,
+                  kfilter._forecast_error_cov, &k_endog,
+          &beta, &kfilter.CW[0, 0], &k_states)
     else:
         # Compute M = M + M @ W.T @ Z.T @ Fi_prev @ Z @ W @ M
         #           = M + (M @ W.T) @ Z.T @ (Fi_prev @ Z) @ (W @ M)
 
         # M @ W.T: (p x p) (p x m) -> (p x m)
-        blas.{{prefix}}gemm("N", "T", &model._k_endog, &model._k_states, &model._k_endog,
-          &alpha, &kfilter.CM[0, 0], &kfilter.k_endog,
-                  &kfilter.CW[0, 0], &kfilter.k_states,
-          &beta, &kfilter.CMW[0, 0], &kfilter.k_endog)
+        blas.{{prefix}}gemm("N", "T", &_k_endog, &_k_states, &_k_endog,
+          &alpha, &kfilter.CM[0, 0], &k_endog,
+                  &kfilter.CW[0, 0], &k_states,
+          &beta, &kfilter.CMW[0, 0], &k_endog)
 
         # (Fi_prev @ Z) @ (W @ M): (p x m) (m x p) -> (p x p)
-        blas.{{prefix}}gemm("N", "T", &model._k_endog, &model._k_endog, &model._k_states,
-          &alpha, &kfilter.CprevFiZ[0, 0], &kfilter.k_endog,
-                  &kfilter.CMW[0, 0], &kfilter.k_endog,
-          &beta, &kfilter.CtmpM[0, 0], &kfilter.k_endog)
+        blas.{{prefix}}gemm("N", "T", &_k_endog, &_k_endog, &_k_states,
+          &alpha, &kfilter.CprevFiZ[0, 0], &k_endog,
+                  &kfilter.CMW[0, 0], &k_endog,
+          &beta, &kfilter.CtmpM[0, 0], &k_endog)
 
         # (M @ W.T) @ Z.T: (p x m) (m x p) -> (p x p)
-        blas.{{prefix}}gemm("N", "T", &model._k_endog, &model._k_endog, &model._k_states,
-          &alpha, &kfilter.CMW[0, 0], &kfilter.k_endog,
-                  model._design, &model._k_endog,
-          &beta, &kfilter.CMWZ[0, 0], &kfilter.k_endog)
+        blas.{{prefix}}gemm("N", "T", &_k_endog, &_k_endog, &_k_states,
+          &alpha, &kfilter.CMW[0, 0], &k_endog,
+                  model._design, &_k_endog,
+          &beta, &kfilter.CMWZ[0, 0], &k_endog)
 
         # M + (M @ W.T @ Z.T) (Fi_prev @ Z @ W @ M) : (p x p) (p x p) -> (p x p)
-        blas.{{prefix}}gemm("N", "N", &model._k_endog, &model._k_endog, &model._k_endog,
-          &alpha, &kfilter.CMWZ[0, 0], &kfilter.k_endog,
-                  &kfilter.CtmpM[0, 0], &model._k_endog,
-          &alpha, &kfilter.CM[0, 0], &kfilter.k_endog)
+        blas.{{prefix}}gemm("N", "N", &_k_endog, &_k_endog, &_k_endog,
+          &alpha, &kfilter.CMWZ[0, 0], &k_endog,
+                  &kfilter.CtmpM[0, 0], &_k_endog,
+          &alpha, &kfilter.CM[0, 0], &k_endog)
 
         # Compute W = (T - Kg @ Z) @ W
         # W -> tmpW
-        blas.{{prefix}}copy(&model._k_endogstates, &kfilter.CW[0, 0], &inc, &kfilter.CtmpW[0, 0], &inc)
+        blas.{{prefix}}copy(&_k_endogstates, &kfilter.CW[0, 0], &inc, &kfilter.CtmpW[0, 0], &inc)
 
         # T -> tmp00
-        blas.{{prefix}}copy(&model._k_states2, model._transition, &inc, kfilter._tmp00, &inc)
+        blas.{{prefix}}copy(&_k_states2, model._transition, &inc, kfilter._tmp00, &inc)
 
         # T - K @ Z: (m x p) (p x m) -> (m x m)
-        blas.{{prefix}}gemm("N", "N", &model._k_states, &model._k_states, &model._k_endog,
-            &gamma, kfilter._kalman_gain, &kfilter.k_states,
-                    model._design, &model._k_endog,
-            &alpha, kfilter._tmp00, &kfilter.k_states)
+        blas.{{prefix}}gemm("N", "N", &_k_states, &_k_states, &_k_endog,
+            &gamma, kfilter._kalman_gain, &k_states,
+                    model._design, &_k_endog,
+            &alpha, kfilter._tmp00, &k_states)
 
         # (T - T @ K @ Z[i]) @ tmpW -> W
-        blas.{{prefix}}gemm("N", "N", &model._k_states, &model._k_endog, &model._k_states,
-              &alpha, kfilter._tmp00, &kfilter.k_states,
-                      &kfilter.CtmpW[0, 0], &kfilter.k_states,
-              &beta, &kfilter.CW[0, 0], &kfilter.k_states)
+        blas.{{prefix}}gemm("N", "N", &_k_states, &_k_endog, &_k_states,
+              &alpha, kfilter._tmp00, &k_states,
+                      &kfilter.CtmpW[0, 0], &k_states,
+              &beta, &kfilter.CW[0, 0], &k_states)
 
     # Save F^{-1} Z (this period's value used in next iteration)
-    blas.{{prefix}}copy(&model._k_endogstates, kfilter._tmp3, &inc, &kfilter.CprevFiZ[0, 0], &inc)
+    blas.{{prefix}}copy(&_k_endogstates, kfilter._tmp3, &inc, &kfilter.CprevFiZ[0, 0], &inc)
 
 cdef int {{prefix}}updating_conventional({{prefix}}KalmanFilter kfilter, {{prefix}}Statespace model):
     # Constants
     cdef:
-        int inc = 1
+        blas_int inc = 1
+        blas_int k_states = kfilter.k_states
+        blas_int k_states2 = kfilter.k_states2
+        blas_int k_endog = kfilter.k_endog
+        blas_int _k_states = model._k_states
+        blas_int _k_endog = model._k_endog
+        blas_int _k_endogstates = model._k_endogstates
         {{cython_type}} alpha = 1.0
         {{cython_type}} beta = 0.0
         {{cython_type}} gamma = -1.0
@@ -260,9 +283,9 @@ cdef int {{prefix}}updating_conventional({{prefix}}KalmanFilter kfilter, {{prefi
     # #### Filtered state for time t
     # $a_{t|t} = a_t + P_t Z_t' F_t^{-1} v_t$
     # $a_{t|t} = 1.0 * \\#_1 \\#_2 + 1.0 a_t$
-    blas.{{prefix}}copy(&kfilter.k_states, kfilter._input_state, &inc, kfilter._filtered_state, &inc)
-    blas.{{prefix}}gemv("N", &model._k_states, &model._k_endog,
-          &alpha, kfilter._tmp1, &kfilter.k_states,
+    blas.{{prefix}}copy(&k_states, kfilter._input_state, &inc, kfilter._filtered_state, &inc)
+    blas.{{prefix}}gemv("N", &_k_states, &_k_endog,
+          &alpha, kfilter._tmp1, &k_states,
                   kfilter._tmp2, &inc,
           &alpha, kfilter._filtered_state, &inc)
 
@@ -271,10 +294,10 @@ cdef int {{prefix}}updating_conventional({{prefix}}KalmanFilter kfilter, {{prefi
     if not kfilter.converged:
         # P_t Z_t' F_t^{-1}
         # $(m \times p) = (m \times m) (m \times p)$
-        blas.{{prefix}}gemm("N", "T", &model._k_states, &model._k_endog, &model._k_states,
-              &alpha, kfilter._input_state_cov, &kfilter.k_states,
-                      kfilter._tmp3, &kfilter.k_endog,
-              &beta, &kfilter.CtmpW[0, 0], &kfilter.k_states)
+        blas.{{prefix}}gemm("N", "T", &_k_states, &_k_endog, &_k_states,
+              &alpha, kfilter._input_state_cov, &k_states,
+                      kfilter._tmp3, &k_endog,
+              &beta, &kfilter.CtmpW[0, 0], &k_states)
 
     # $P_{t|t} = P_t - P_t Z_t' F_t^{-1} Z_t P_t$
     # $P_{t|t} = P_t - \\#_1 \\#_3 P_t$
@@ -282,14 +305,14 @@ cdef int {{prefix}}updating_conventional({{prefix}}KalmanFilter kfilter, {{prefi
     # *Note*: this and does nothing at all to `filtered_state_cov` if
     # converged == True
     if not kfilter.converged:
-        blas.{{prefix}}copy(&kfilter.k_states2, kfilter._input_state_cov, &inc, kfilter._filtered_state_cov, &inc)
+        blas.{{prefix}}copy(&k_states2, kfilter._input_state_cov, &inc, kfilter._filtered_state_cov, &inc)
 
         # $P_{t|t} = - 1.0 * \\# P_t + 1.0 * P_t$
         # $(m \times m) = (m \times p) (p \times m) + (m \times m)$
-        blas.{{prefix}}gemm("N", "T", &model._k_states, &model._k_states, &model._k_endog,
-              &gamma, &kfilter.CtmpW[0, 0], &kfilter.k_states,
-                      kfilter._tmp1, &kfilter.k_states,
-              &alpha, kfilter._filtered_state_cov, &kfilter.k_states)
+        blas.{{prefix}}gemm("N", "T", &_k_states, &_k_states, &_k_endog,
+              &gamma, &kfilter.CtmpW[0, 0], &k_states,
+                      kfilter._tmp1, &k_states,
+              &alpha, kfilter._filtered_state_cov, &k_states)
 
     # #### Kalman gain for time t
     # $K_t = T_t P_t Z_t' F_t^{-1}$
@@ -302,12 +325,12 @@ cdef int {{prefix}}updating_conventional({{prefix}}KalmanFilter kfilter, {{prefi
         # T_t P_t Z_t' F_t^{-1}
         # $(m \times p) = (m \times m) (m \times p)$
         if model.identity_transition:
-            blas.{{prefix}}copy(&model._k_endogstates, &kfilter.CtmpW[0, 0], &inc, kfilter._kalman_gain, &inc)
+            blas.{{prefix}}copy(&_k_endogstates, &kfilter.CtmpW[0, 0], &inc, kfilter._kalman_gain, &inc)
         else:
-            blas.{{prefix}}gemm("N", "N", &model._k_states, &model._k_endog, &model._k_states,
-                &alpha, model._transition, &kfilter.k_states,
-                        &kfilter.CtmpW[0, 0], &kfilter.k_states,
-                &beta, kfilter._kalman_gain, &kfilter.k_states)
+            blas.{{prefix}}gemm("N", "N", &_k_states, &_k_endog, &_k_states,
+                &alpha, model._transition, &k_states,
+                        &kfilter.CtmpW[0, 0], &k_states,
+                &beta, kfilter._kalman_gain, &k_states)
 
     return 0
 
@@ -315,8 +338,13 @@ cdef int {{prefix}}prediction_conventional({{prefix}}KalmanFilter kfilter, {{pre
 
     # Constants
     cdef:
-        int inc = 1
+        blas_int inc = 1
         int forecast_cov_t = kfilter.t
+        blas_int k_states = kfilter.k_states
+        blas_int k_endog = kfilter.k_endog
+        blas_int _k_states = model._k_states
+        blas_int _k_states2 = model._k_states2
+        blas_int _k_endog = model._k_endog
         {{cython_type}} alpha = 1.0
         {{cython_type}} beta = 0.0
         {{cython_type}} gamma = -1.0
@@ -326,12 +354,12 @@ cdef int {{prefix}}prediction_conventional({{prefix}}KalmanFilter kfilter, {{pre
 
     # #### Predicted state for time t+1
     # $a_{t+1} = T_t a_{t|t} + c_t$
-    blas.{{prefix}}copy(&model._k_states, model._state_intercept, &inc, kfilter._predicted_state, &inc)
+    blas.{{prefix}}copy(&_k_states, model._state_intercept, &inc, kfilter._predicted_state, &inc)
     if model.identity_transition:
-        blas.{{prefix}}axpy(&model._k_states, &alpha, kfilter._filtered_state, &inc, kfilter._predicted_state, &inc)
+        blas.{{prefix}}axpy(&_k_states, &alpha, kfilter._filtered_state, &inc, kfilter._predicted_state, &inc)
     else:
-        blas.{{prefix}}gemv("N", &model._k_states, &model._k_states,
-            &alpha, model._transition, &model._k_states,
+        blas.{{prefix}}gemv("N", &_k_states, &_k_states,
+            &alpha, model._transition, &_k_states,
                     kfilter._filtered_state, &inc,
             &alpha, kfilter._predicted_state, &inc)
 
@@ -341,7 +369,7 @@ cdef int {{prefix}}prediction_conventional({{prefix}}KalmanFilter kfilter, {{pre
     # *Note*: this and does nothing at all to `predicted_state_cov` if
     # converged == True
     if not kfilter.converged:
-        blas.{{prefix}}copy(&model._k_states2, model._selected_state_cov, &inc, kfilter._predicted_state_cov, &inc)
+        blas.{{prefix}}copy(&_k_states2, model._selected_state_cov, &inc, kfilter._predicted_state_cov, &inc)
         # `tmp0` array used here, dimension $(m \times m)$
 
         if kfilter.filter_method & FILTER_CHANDRASEKHAR:
@@ -349,35 +377,35 @@ cdef int {{prefix}}prediction_conventional({{prefix}}KalmanFilter kfilter, {{pre
             {{prefix}}chandrasekhar_recursion(kfilter, model)
 
             # Chandrasekhar-based prediction step
-            blas.{{prefix}}copy(&model._k_states2, kfilter._input_state_cov, &inc, kfilter._predicted_state_cov, &inc)
+            blas.{{prefix}}copy(&_k_states2, kfilter._input_state_cov, &inc, kfilter._predicted_state_cov, &inc)
             # M @ W.T. (p x p) (p x m)
-            blas.{{prefix}}gemm("N", "T", &model._k_endog, &model._k_states, &model._k_endog,
-              &alpha, &kfilter.CM[0, 0], &kfilter.k_endog,
-                      &kfilter.CW[0, 0], &kfilter.k_states,
-              &beta, &kfilter.CMW[0, 0], &kfilter.k_endog)
+            blas.{{prefix}}gemm("N", "T", &_k_endog, &_k_states, &_k_endog,
+              &alpha, &kfilter.CM[0, 0], &k_endog,
+                      &kfilter.CW[0, 0], &k_states,
+              &beta, &kfilter.CMW[0, 0], &k_endog)
             # P = P + W M W.T
-            blas.{{prefix}}gemm("N", "N", &model._k_states, &model._k_states, &model._k_endog,
-              &alpha, &kfilter.CW[0, 0], &kfilter.k_states,
-                      &kfilter.CMW[0, 0], &kfilter.k_endog,
-              &alpha, kfilter._predicted_state_cov, &kfilter.k_states)
+            blas.{{prefix}}gemm("N", "N", &_k_states, &_k_states, &_k_endog,
+              &alpha, &kfilter.CW[0, 0], &k_states,
+                      &kfilter.CMW[0, 0], &k_endog,
+              &alpha, kfilter._predicted_state_cov, &k_states)
         else:
             # Kalman filter prediction step
             # $\\#_0 = T_t P_{t|t} $
 
             if model.identity_transition:
-                blas.{{prefix}}axpy(&model._k_states2, &alpha, kfilter._filtered_state_cov, &inc, kfilter._predicted_state_cov, &inc)
+                blas.{{prefix}}axpy(&_k_states2, &alpha, kfilter._filtered_state_cov, &inc, kfilter._predicted_state_cov, &inc)
             else:
                 # $(m \times m) = (m \times m) (m \times m)$
-                blas.{{prefix}}gemm("N", "N", &model._k_states, &model._k_states, &model._k_states,
-                    &alpha, model._transition, &model._k_states,
-                            kfilter._filtered_state_cov, &kfilter.k_states,
-                    &beta, kfilter._tmp0, &kfilter.k_states)
+                blas.{{prefix}}gemm("N", "N", &_k_states, &_k_states, &_k_states,
+                    &alpha, model._transition, &_k_states,
+                            kfilter._filtered_state_cov, &k_states,
+                    &beta, kfilter._tmp0, &k_states)
                 # $P_{t+1} = 1.0 \\#_0 T_t' + 1.0 \\#$
                 # $(m \times m) = (m \times m) (m \times m) + (m \times m)$
-                blas.{{prefix}}gemm("N", "T", &model._k_states, &model._k_states, &model._k_states,
-                    &alpha, kfilter._tmp0, &kfilter.k_states,
-                            model._transition, &model._k_states,
-                    &alpha, kfilter._predicted_state_cov, &kfilter.k_states)
+                blas.{{prefix}}gemm("N", "T", &_k_states, &_k_states, &_k_states,
+                    &alpha, kfilter._tmp0, &k_states,
+                            model._transition, &_k_states,
+                    &alpha, kfilter._predicted_state_cov, &k_states)
 
     return 0
 
@@ -386,7 +414,8 @@ cdef {{cython_type}} {{prefix}}loglikelihood_conventional({{prefix}}KalmanFilter
     # Constants
     cdef:
         {{cython_type}} loglikelihood
-        int inc = 1
+        blas_int inc = 1
+        blas_int _k_endog = model._k_endog
         {{cython_type}} alpha = 1.0
         {{cython_type}} beta = 0.0
 
@@ -394,9 +423,9 @@ cdef {{cython_type}} {{prefix}}loglikelihood_conventional({{prefix}}KalmanFilter
 
     if not kfilter.filter_method & FILTER_CONCENTRATED:
         {{if combined_prefix == 'd'}}
-        loglikelihood = loglikelihood - 0.5*blas.{{prefix}}dot(&model._k_endog, kfilter._forecast_error, &inc, kfilter._tmp2, &inc)
+        loglikelihood = loglikelihood - 0.5*blas.{{prefix}}dot(&_k_endog, kfilter._forecast_error, &inc, kfilter._tmp2, &inc)
         {{else}}
-        blas.{{prefix}}gemv("N", &inc, &model._k_endog,
+        blas.{{prefix}}gemv("N", &inc, &_k_endog,
                        &alpha, kfilter._forecast_error, &inc,
                                kfilter._tmp2, &inc,
                        &beta, kfilter._tmp0, &inc)
@@ -409,14 +438,15 @@ cdef {{cython_type}} {{prefix}}scale_conventional({{prefix}}KalmanFilter kfilter
     # Constants
     cdef:
         {{cython_type}} scale
-        int inc = 1
+        blas_int inc = 1
+        blas_int _k_endog = model._k_endog
         {{cython_type}} alpha = 1.0
         {{cython_type}} beta = 0.0
 
     {{if combined_prefix == 'd'}}
-    scale = blas.{{prefix}}dot(&model._k_endog, kfilter._forecast_error, &inc, kfilter._tmp2, &inc)
+    scale = blas.{{prefix}}dot(&_k_endog, kfilter._forecast_error, &inc, kfilter._tmp2, &inc)
     {{else}}
-    blas.{{prefix}}gemv("N", &inc, &model._k_endog,
+    blas.{{prefix}}gemv("N", &inc, &_k_endog,
                    &alpha, kfilter._forecast_error, &inc,
                            kfilter._tmp2, &inc,
                    &beta, kfilter._tmp0, &inc)

--- a/statsmodels/tsa/statespace/_filters/_inversions.pyx.in
+++ b/statsmodels/tsa/statespace/_filters/_inversions.pyx.in
@@ -25,6 +25,7 @@ import numpy as np
 from statsmodels.includes.math cimport *
 cimport scipy.linalg.cython_blas as blas
 cimport scipy.linalg.cython_lapack as lapack
+include "statsmodels/tsa/statespace/_blas_int.pxi"
 
 from statsmodels.tsa.statespace._kalman_filter cimport (
     MEMORY_NO_SMOOTHING, MEMORY_NO_STD_FORECAST)
@@ -63,7 +64,8 @@ cdef {{cython_type}} {{prefix}}inverse_univariate({{prefix}}KalmanFilter kfilter
 
     # #### Intermediate values
     cdef:
-        int inc = 1
+        blas_int inc = 1
+        blas_int _k_endogstates = model._k_endogstates
         {{cython_type}} scalar
 
     # Take the inverse of the forecast error covariance matrix
@@ -81,8 +83,8 @@ cdef {{cython_type}} {{prefix}}inverse_univariate({{prefix}}KalmanFilter kfilter
                                     ' covariance matrix encountered at'
                                     ' period %d' % kfilter.t)
     kfilter._tmp2[0] = scalar * kfilter._forecast_error[0]
-    blas.{{prefix}}copy(&model._k_endogstates, model._design, &inc, kfilter._tmp3, &inc)
-    blas.{{prefix}}scal(&model._k_endogstates, &scalar, kfilter._tmp3, &inc)
+    blas.{{prefix}}copy(&_k_endogstates, model._design, &inc, kfilter._tmp3, &inc)
+    blas.{{prefix}}scal(&_k_endogstates, &scalar, kfilter._tmp3, &inc)
 
     if not (kfilter.conserve_memory & MEMORY_NO_STD_FORECAST > 0):
         kfilter._standardized_forecast_error[0] = kfilter._forecast_error[0] * scalar**0.5
@@ -105,13 +107,16 @@ cdef {{cython_type}} {{prefix}}factorize_cholesky({{prefix}}KalmanFilter kfilter
     returns the determinant that was passed in.
     """
     cdef:
-        int inc = 1
-        int info
+        blas_int inc = 1
+        blas_int info
         int i
+        blas_int k_endog2 = kfilter.k_endog2
+        blas_int k_endog = kfilter.k_endog
+        blas_int _k_endog = model._k_endog
 
     if not kfilter.converged or not (kfilter.conserve_memory & MEMORY_NO_STD_FORECAST > 0):
-        blas.{{prefix}}copy(&kfilter.k_endog2, kfilter._forecast_error_cov, &inc, kfilter._forecast_error_fac, &inc)
-        lapack.{{prefix}}potrf("U", &model._k_endog, kfilter._forecast_error_fac, &kfilter.k_endog, &info)
+        blas.{{prefix}}copy(&k_endog2, kfilter._forecast_error_cov, &inc, kfilter._forecast_error_fac, &inc)
+        lapack.{{prefix}}potrf("U", &_k_endog, kfilter._forecast_error_fac, &k_endog, &info)
 
         if info < 0:
             raise np.linalg.LinAlgError('Illegal value in forecast error'
@@ -144,16 +149,19 @@ cdef {{cython_type}} {{prefix}}factorize_lu({{prefix}}KalmanFilter kfilter, {{pr
     returns the determinant that was passed in.
     """
     cdef:
-        int inc = 1
-        int info
+        blas_int inc = 1
+        blas_int info
         int i
+        blas_int k_endog2 = kfilter.k_endog2
+        blas_int k_endog = kfilter.k_endog
+        blas_int _k_endog = model._k_endog
 
     if not kfilter.converged:
         # Perform LU decomposition into `forecast_error_fac`
-        blas.{{prefix}}copy(&kfilter.k_endog2, kfilter._forecast_error_cov, &inc, kfilter._forecast_error_fac, &inc)
+        blas.{{prefix}}copy(&k_endog2, kfilter._forecast_error_cov, &inc, kfilter._forecast_error_fac, &inc)
 
-        lapack.{{prefix}}getrf(&model._k_endog, &model._k_endog,
-                        kfilter._forecast_error_fac, &kfilter.k_endog,
+        lapack.{{prefix}}getrf(&_k_endog, &_k_endog,
+                        kfilter._forecast_error_fac, &k_endog,
                         kfilter._forecast_error_ipiv, &info)
 
         if info < 0:
@@ -185,9 +193,12 @@ cdef {{cython_type}} {{prefix}}inverse_cholesky({{prefix}}KalmanFilter kfilter, 
     returns the determinant that was passed in.
     """
     cdef:
-        int info
-        int inc = 1
+        blas_int info
+        blas_int inc = 1
         int i, j
+        blas_int k_endog = kfilter.k_endog
+        blas_int _k_endog = model._k_endog
+        blas_int _k_states = model._k_states
         {{cython_type}} alpha = 1.0
         {{cython_type}} beta = 0.0
 
@@ -199,10 +210,10 @@ cdef {{cython_type}} {{prefix}}inverse_cholesky({{prefix}}KalmanFilter kfilter, 
         # (in the notation of DK, kfilter._forecast_error_fac holds L_t', and
         # we want to solve the equation L_t' v_t^s = v_t)
         if not (kfilter.conserve_memory & MEMORY_NO_STD_FORECAST > 0):
-            blas.{{prefix}}copy(&kfilter.k_endog, kfilter._forecast_error, &inc, kfilter._standardized_forecast_error, &inc)
-            lapack.{{prefix}}trtrs("U", "T", "N", &model._k_endog, &inc,
-                                   kfilter._forecast_error_fac, &kfilter.k_endog,
-                                   kfilter._standardized_forecast_error, &kfilter.k_endog, &info)
+            blas.{{prefix}}copy(&k_endog, kfilter._forecast_error, &inc, kfilter._standardized_forecast_error, &inc)
+            lapack.{{prefix}}trtrs("U", "T", "N", &_k_endog, &inc,
+                                   kfilter._forecast_error_fac, &k_endog,
+                                   kfilter._standardized_forecast_error, &k_endog, &info)
 
             if info != 0:
                 raise np.linalg.LinAlgError('Error computing standardized'
@@ -210,7 +221,7 @@ cdef {{cython_type}} {{prefix}}inverse_cholesky({{prefix}}KalmanFilter kfilter, 
                                             % kfilter.t)
 
         # Continue taking the inverse
-        lapack.{{prefix}}potri("U", &model._k_endog, kfilter._forecast_error_fac, &kfilter.k_endog, &info)
+        lapack.{{prefix}}potri("U", &_k_endog, kfilter._forecast_error_fac, &k_endog, &info)
 
         # ?potri only fills in the upper triangle of the symmetric array, and
         # since the ?symm and ?symv routines are not available as of scipy
@@ -227,33 +238,33 @@ cdef {{cython_type}} {{prefix}}inverse_cholesky({{prefix}}KalmanFilter kfilter, 
     # $\\#_2 = F_t^{-1} v_t$
     #blas.{{prefix}}symv("U", &model._k_endog, &alpha, kfilter._forecast_error_fac, &kfilter.k_endog,
     #               kfilter._forecast_error, &inc, &beta, kfilter._tmp2, &inc)
-    blas.{{prefix}}gemv("N", &model._k_endog, &model._k_endog,
-                   &alpha, kfilter._forecast_error_fac, &kfilter.k_endog,
+    blas.{{prefix}}gemv("N", &_k_endog, &_k_endog,
+                   &alpha, kfilter._forecast_error_fac, &k_endog,
                            kfilter._forecast_error, &inc,
                    &beta, kfilter._tmp2, &inc)
 
     # `tmp3` array used here, dimension $(p \times m)$
     # $\\#_3 = F_t^{-1} Z_t$
-    #blas.{{prefix}}symm("L", "U", &kfilter.k_endog, &kfilter.k_states,
-    #               &alpha, kfilter._forecast_error_fac, &kfilter.k_endog,
-    #                       kfilter._design, &kfilter.k_endog,
-    #               &beta, kfilter._tmp3, &kfilter.k_endog)
-    blas.{{prefix}}gemm("N", "N", &model._k_endog, &model._k_states, &model._k_endog,
-                   &alpha, kfilter._forecast_error_fac, &kfilter.k_endog,
-                           model._design, &model._k_endog,
-                   &beta, kfilter._tmp3, &kfilter.k_endog)
+    #blas.{{prefix}}symm("L", "U", &k_endog, &kfilter.k_states,
+    #               &alpha, kfilter._forecast_error_fac, &k_endog,
+    #                       kfilter._design, &k_endog,
+    #               &beta, kfilter._tmp3, &k_endog)
+    blas.{{prefix}}gemm("N", "N", &_k_endog, &_k_states, &_k_endog,
+                   &alpha, kfilter._forecast_error_fac, &k_endog,
+                           model._design, &_k_endog,
+                   &beta, kfilter._tmp3, &k_endog)
 
     if not (kfilter.conserve_memory & MEMORY_NO_SMOOTHING > 0):
         # `tmp4` array used here, dimension $(p \times p)$
         # $\\#_4 = F_t^{-1} H_t$
-        #blas.{{prefix}}symm("L", "U", &kfilter.k_endog, &kfilter.k_endog,
-        #               &alpha, kfilter._forecast_error_fac, &kfilter.k_endog,
-        #                       kfilter._obs_cov, &kfilter.k_endog,
-        #               &beta, kfilter._tmp4, &kfilter.k_endog)
-        blas.{{prefix}}gemm("N", "N", &model._k_endog, &model._k_endog, &model._k_endog,
-                       &alpha, kfilter._forecast_error_fac, &kfilter.k_endog,
-                               model._obs_cov, &model._k_endog,
-                       &beta, kfilter._tmp4, &kfilter.k_endog)
+        #blas.{{prefix}}symm("L", "U", &k_endog, &k_endog,
+        #               &alpha, kfilter._forecast_error_fac, &k_endog,
+        #                       kfilter._obs_cov, &k_endog,
+        #               &beta, kfilter._tmp4, &k_endog)
+        blas.{{prefix}}gemm("N", "N", &_k_endog, &_k_endog, &_k_endog,
+                       &alpha, kfilter._forecast_error_fac, &k_endog,
+                               model._obs_cov, &_k_endog,
+                       &beta, kfilter._tmp4, &k_endog)
 
     return determinant
 
@@ -265,8 +276,12 @@ cdef {{cython_type}} {{prefix}}inverse_lu({{prefix}}KalmanFilter kfilter, {{pref
     returns the determinant that was passed in.
     """
     cdef:
-        int info
-        int inc = 1
+        blas_int info
+        blas_int inc = 1
+        blas_int k_endog = kfilter.k_endog
+        blas_int _k_endog = model._k_endog
+        blas_int _k_states = model._k_states
+        blas_int ldwork = kfilter.ldwork
         {{cython_type}} alpha = 1.0
         {{cython_type}} beta = 0.0
 
@@ -275,32 +290,32 @@ cdef {{cython_type}} {{prefix}}inverse_lu({{prefix}}KalmanFilter kfilter, {{pref
         determinant = {{prefix}}factorize_lu(kfilter, model, determinant)
 
         # Continue taking the inverse
-        lapack.{{prefix}}getri(&model._k_endog, kfilter._forecast_error_fac, &kfilter.k_endog,
-               kfilter._forecast_error_ipiv, kfilter._forecast_error_work, &kfilter.ldwork, &info)
+        lapack.{{prefix}}getri(&_k_endog, kfilter._forecast_error_fac, &k_endog,
+               kfilter._forecast_error_ipiv, kfilter._forecast_error_work, &ldwork, &info)
 
     # Get `tmp2` and `tmp3` via matrix multiplications
 
     # `tmp2` array used here, dimension $(p \times 1)$
     # $\\#_2 = F_t^{-1} v_t$
-    blas.{{prefix}}gemv("N", &model._k_endog, &model._k_endog,
-                   &alpha, kfilter._forecast_error_fac, &kfilter.k_endog,
+    blas.{{prefix}}gemv("N", &_k_endog, &_k_endog,
+                   &alpha, kfilter._forecast_error_fac, &k_endog,
                            kfilter._forecast_error, &inc,
                    &beta, kfilter._tmp2, &inc)
 
     # `tmp3` array used here, dimension $(p \times m)$
     # $\\#_3 = F_t^{-1} Z_t$
-    blas.{{prefix}}gemm("N", "N", &model._k_endog, &model._k_states, &model._k_endog,
-                   &alpha, kfilter._forecast_error_fac, &kfilter.k_endog,
-                           model._design, &model._k_endog,
-                   &beta, kfilter._tmp3, &kfilter.k_endog)
+    blas.{{prefix}}gemm("N", "N", &_k_endog, &_k_states, &_k_endog,
+                   &alpha, kfilter._forecast_error_fac, &k_endog,
+                           model._design, &_k_endog,
+                   &beta, kfilter._tmp3, &k_endog)
 
     if not (kfilter.conserve_memory & MEMORY_NO_SMOOTHING > 0):
         # `tmp4` array used here, dimension $(p \times p)$
         # $\\#_4 = F_t^{-1} H_t$
-        blas.{{prefix}}gemm("N", "N", &model._k_endog, &model._k_endog, &model._k_endog,
-                       &alpha, kfilter._forecast_error_fac, &kfilter.k_endog,
-                               model._obs_cov, &model._k_endog,
-                       &beta, kfilter._tmp4, &kfilter.k_endog)
+        blas.{{prefix}}gemm("N", "N", &_k_endog, &_k_endog, &_k_endog,
+                       &alpha, kfilter._forecast_error_fac, &k_endog,
+                               model._obs_cov, &_k_endog,
+                       &beta, kfilter._tmp4, &k_endog)
 
     return determinant
 
@@ -312,8 +327,14 @@ cdef {{cython_type}} {{prefix}}solve_cholesky({{prefix}}KalmanFilter kfilter, {{
     returns the determinant that was passed in.
     """
     cdef:
-        int info, i, j
-        int inc = 1
+        blas_int info
+        int i, j
+        blas_int inc = 1
+        blas_int k_endog = kfilter.k_endog
+        blas_int k_endog2 = kfilter.k_endog2
+        blas_int k_endogstates = kfilter.k_endogstates
+        blas_int _k_endog = model._k_endog
+        blas_int _k_states = model._k_states
 
     if not kfilter.converged:
         # Perform the Cholesky decomposition and get the determinant
@@ -323,10 +344,10 @@ cdef {{cython_type}} {{prefix}}solve_cholesky({{prefix}}KalmanFilter kfilter, {{
     # (in the notation of DK, kfilter._forecast_error_fac holds L_t', and
     # we want to solve the equation L_t' v_t^s = v_t)
     if not (kfilter.conserve_memory & MEMORY_NO_STD_FORECAST > 0):
-        blas.{{prefix}}copy(&kfilter.k_endog, kfilter._forecast_error, &inc, kfilter._standardized_forecast_error, &inc)
-        lapack.{{prefix}}trtrs("U", "T", "N", &model._k_endog, &inc,
-                               kfilter._forecast_error_fac, &kfilter.k_endog,
-                               kfilter._standardized_forecast_error, &kfilter.k_endog, &info)
+        blas.{{prefix}}copy(&k_endog, kfilter._forecast_error, &inc, kfilter._standardized_forecast_error, &inc)
+        lapack.{{prefix}}trtrs("U", "T", "N", &_k_endog, &inc,
+                               kfilter._forecast_error_fac, &k_endog,
+                               kfilter._standardized_forecast_error, &k_endog, &info)
 
         if info != 0:
                 raise np.linalg.LinAlgError('Error computing standardized'
@@ -336,29 +357,29 @@ cdef {{cython_type}} {{prefix}}solve_cholesky({{prefix}}KalmanFilter kfilter, {{
     # Solve the linear systems
     # `tmp2` array used here, dimension $(p \times 1)$
     # $F_t \\#_2 = v_t$
-    blas.{{prefix}}copy(&kfilter.k_endog, kfilter._forecast_error, &inc, kfilter._tmp2, &inc)
-    lapack.{{prefix}}potrs("U", &model._k_endog, &inc, kfilter._forecast_error_fac, &kfilter.k_endog, kfilter._tmp2, &kfilter.k_endog, &info)
+    blas.{{prefix}}copy(&k_endog, kfilter._forecast_error, &inc, kfilter._tmp2, &inc)
+    lapack.{{prefix}}potrs("U", &_k_endog, &inc, kfilter._forecast_error_fac, &k_endog, kfilter._tmp2, &k_endog, &info)
 
     # `tmp3` array used here, dimension $(p \times m)$
     # $F_t \\#_3 = Z_t$
     if model._k_states == model.k_states and model._k_endog == model.k_endog:
-        blas.{{prefix}}copy(&kfilter.k_endogstates, model._design, &inc, kfilter._tmp3, &inc)
+        blas.{{prefix}}copy(&k_endogstates, model._design, &inc, kfilter._tmp3, &inc)
     else:
         for i in range(model._k_states): # columns
             for j in range(model._k_endog): # rows
                 kfilter._tmp3[j + i*kfilter.k_endog] = model._design[j + i*model._k_endog]
-    lapack.{{prefix}}potrs("U", &model._k_endog, &model._k_states, kfilter._forecast_error_fac, &kfilter.k_endog, kfilter._tmp3, &kfilter.k_endog, &info)
+    lapack.{{prefix}}potrs("U", &_k_endog, &_k_states, kfilter._forecast_error_fac, &k_endog, kfilter._tmp3, &k_endog, &info)
 
     if not (kfilter.conserve_memory & MEMORY_NO_SMOOTHING > 0):
         # `tmp4` array used here, dimension $(p \times p)$
         # $F_t \\#_4 = H_t$
         if model._k_states == model.k_states and model._k_endog == model.k_endog:
-            blas.{{prefix}}copy(&kfilter.k_endog2, model._obs_cov, &inc, kfilter._tmp4, &inc)
+            blas.{{prefix}}copy(&k_endog2, model._obs_cov, &inc, kfilter._tmp4, &inc)
         else:
             for i in range(model._k_endog): # columns
                 for j in range(model._k_endog): # rows
                     kfilter._tmp4[j + i*kfilter.k_endog] = model._obs_cov[j + i*model._k_endog]
-        lapack.{{prefix}}potrs("U", &model._k_endog, &model._k_endog, kfilter._forecast_error_fac, &kfilter.k_endog, kfilter._tmp4, &kfilter.k_endog, &info)
+        lapack.{{prefix}}potrs("U", &_k_endog, &_k_endog, kfilter._forecast_error_fac, &k_endog, kfilter._tmp4, &k_endog, &info)
 
     return determinant
 
@@ -370,8 +391,13 @@ cdef {{cython_type}} {{prefix}}solve_lu({{prefix}}KalmanFilter kfilter, {{prefix
     returns the determinant that was passed in.
     """
     cdef:
-        int info
-        int inc = 1
+        blas_int info
+        blas_int inc = 1
+        blas_int k_endog = kfilter.k_endog
+        blas_int k_endog2 = kfilter.k_endog2
+        blas_int k_endogstates = kfilter.k_endogstates
+        blas_int _k_endog = model._k_endog
+        blas_int _k_states = model._k_states
         {{cython_type}} alpha = 1.0
         {{cython_type}} beta = 0.0
 
@@ -382,32 +408,32 @@ cdef {{cython_type}} {{prefix}}solve_lu({{prefix}}KalmanFilter kfilter, {{prefix
     # Solve the linear systems
     # `tmp2` array used here, dimension $(p \times 1)$
     # $F_t \\#_2 = v_t$
-    blas.{{prefix}}copy(&kfilter.k_endog, kfilter._forecast_error, &inc, kfilter._tmp2, &inc)
-    lapack.{{prefix}}getrs("N", &model._k_endog, &inc, kfilter._forecast_error_fac, &kfilter.k_endog,
-                    kfilter._forecast_error_ipiv, kfilter._tmp2, &kfilter.k_endog, &info)
+    blas.{{prefix}}copy(&k_endog, kfilter._forecast_error, &inc, kfilter._tmp2, &inc)
+    lapack.{{prefix}}getrs("N", &_k_endog, &inc, kfilter._forecast_error_fac, &k_endog,
+                    kfilter._forecast_error_ipiv, kfilter._tmp2, &k_endog, &info)
 
     # `tmp3` array used here, dimension $(p \times m)$
     # $F_t \\#_3 = Z_t$
     if model._k_states == model.k_states and model._k_endog == model.k_endog:
-        blas.{{prefix}}copy(&kfilter.k_endogstates, model._design, &inc, kfilter._tmp3, &inc)
+        blas.{{prefix}}copy(&k_endogstates, model._design, &inc, kfilter._tmp3, &inc)
     else:
         for i in range(model._k_states): # columns
             for j in range(model._k_endog): # rows
                 kfilter._tmp3[j + i*kfilter.k_endog] = model._design[j + i*model._k_endog]
-    lapack.{{prefix}}getrs("N", &model._k_endog, &model._k_states, kfilter._forecast_error_fac, &kfilter.k_endog,
-                    kfilter._forecast_error_ipiv, kfilter._tmp3, &kfilter.k_endog, &info)
+    lapack.{{prefix}}getrs("N", &_k_endog, &_k_states, kfilter._forecast_error_fac, &k_endog,
+                    kfilter._forecast_error_ipiv, kfilter._tmp3, &k_endog, &info)
 
     if not (kfilter.conserve_memory & MEMORY_NO_SMOOTHING > 0):
         # `tmp4` array used here, dimension $(p \times p)$
         # $F_t \\#_4 = H_t$
         if model._k_states == model.k_states and model._k_endog == model.k_endog:
-            blas.{{prefix}}copy(&kfilter.k_endog2, model._obs_cov, &inc, kfilter._tmp4, &inc)
+            blas.{{prefix}}copy(&k_endog2, model._obs_cov, &inc, kfilter._tmp4, &inc)
         else:
             for i in range(model._k_endog): # columns
                 for j in range(model._k_endog): # rows
                     kfilter._tmp4[j + i*kfilter.k_endog] = model._obs_cov[j + i*model._k_endog]
-        lapack.{{prefix}}getrs("N", &model._k_endog, &model._k_endog, kfilter._forecast_error_fac, &kfilter.k_endog,
-                        kfilter._forecast_error_ipiv, kfilter._tmp4, &kfilter.k_endog, &info)
+        lapack.{{prefix}}getrs("N", &_k_endog, &_k_endog, kfilter._forecast_error_fac, &k_endog,
+                        kfilter._forecast_error_ipiv, kfilter._tmp4, &k_endog, &info)
 
     return determinant
 

--- a/statsmodels/tsa/statespace/_filters/_univariate.pyx.in
+++ b/statsmodels/tsa/statespace/_filters/_univariate.pyx.in
@@ -27,6 +27,7 @@ import numpy as np
 from statsmodels.includes.math cimport *
 cimport scipy.linalg.cython_blas as blas
 cimport scipy.linalg.cython_lapack as lapack
+include "statsmodels/tsa/statespace/_blas_int.pxi"
 
 from statsmodels.tsa.statespace._kalman_filter cimport (
     MEMORY_NO_LIKELIHOOD, MEMORY_NO_FORECAST_COV, MEMORY_NO_STD_FORECAST,
@@ -59,7 +60,7 @@ cdef int {{prefix}}forecast_univariate({{prefix}}KalmanFilter kfilter, {{prefix}
     # Constants
     cdef:
         int i, j, k
-        int inc = 1
+        blas_int inc = 1
         int forecast_cov_t = kfilter.t
         int check
         {{cython_type}} forecast_error_cov
@@ -144,11 +145,13 @@ cdef int {{prefix}}forecast_univariate({{prefix}}KalmanFilter kfilter, {{prefix}
     return 0
 
 cdef void {{prefix}}initialize_filtered({{prefix}}KalmanFilter kfilter, {{prefix}}Statespace model):
-    cdef int inc = 1
-    blas.{{prefix}}copy(&kfilter.k_states, kfilter._input_state, &inc,
+    cdef blas_int inc = 1
+    cdef blas_int k_states = kfilter.k_states
+    cdef blas_int k_states2 = kfilter.k_states2
+    blas.{{prefix}}copy(&k_states, kfilter._input_state, &inc,
                                            kfilter._filtered_state, &inc)
     if not kfilter.converged:
-        blas.{{prefix}}copy(&kfilter.k_states2, kfilter._input_state_cov, &inc,
+        blas.{{prefix}}copy(&k_states2, kfilter._input_state_cov, &inc,
                                                 kfilter._filtered_state_cov, &inc)
 
 cdef int {{prefix}}check1({{prefix}}KalmanFilter kfilter, {{cython_type}} forecast_error_cov):
@@ -185,10 +188,11 @@ cdef void {{prefix}}symmetry({{prefix}}KalmanFilter kfilter, {{prefix}}Statespac
 
 cdef void {{prefix}}forecast_error({{prefix}}KalmanFilter kfilter, {{prefix}}Statespace model, int i):
     cdef:
-        int inc = 1
+        blas_int inc = 1
         {{cython_type}} alpha = 1
         {{cython_type}} beta = 0
-        int k_states = model._k_states
+        blas_int k_states = model._k_states
+        blas_int _k_endog = model._k_endog
     # Adjust for a VAR transition (i.e. design = [#, 0], where the zeros
     # correspond to all states except the first k_posdef states)
     if model.subset_design:
@@ -198,13 +202,13 @@ cdef void {{prefix}}forecast_error({{prefix}}KalmanFilter kfilter, {{prefix}}Sta
     {{if combined_prefix == 'd'}}
     kfilter._forecast[i] = (
         model._obs_intercept[i] +
-        blas.{{prefix}}dot(&k_states, &model._design[i], &model._k_endog,
+        blas.{{prefix}}dot(&k_states, &model._design[i], &_k_endog,
                                       kfilter._filtered_state, &inc)
     )
     {{else}}
     blas.{{prefix}}gemv("N", &inc, &k_states,
                    &alpha, kfilter._filtered_state, &inc,
-                           &model._design[i], &model._k_endog,
+                           &model._design[i], &_k_endog,
                    &beta, kfilter._tmp0, &inc)
     kfilter._forecast[i] = model._obs_intercept[i] + kfilter._tmp0[0]
     {{endif}}
@@ -214,11 +218,14 @@ cdef void {{prefix}}forecast_error({{prefix}}KalmanFilter kfilter, {{prefix}}Sta
 
 cdef {{cython_type}} {{prefix}}forecast_error_cov({{prefix}}KalmanFilter kfilter, {{prefix}}Statespace model, int i):
     cdef:
-        int inc = 1
+        blas_int inc = 1
         {{cython_type}} alpha = 1
         {{cython_type}} beta = 0
         {{cython_type}} forecast_error_cov
-        int k_states = model._k_states
+        blas_int k_states = model._k_states
+        blas_int _k_states = model._k_states
+        blas_int _k_endog = model._k_endog
+        blas_int kf_k_states = kfilter.k_states
 
     # Adjust for a VAR transition (i.e. design = [#, 0], where the zeros
     # correspond to all states except the first k_posdef states)
@@ -235,25 +242,25 @@ cdef {{cython_type}} {{prefix}}forecast_error_cov({{prefix}}KalmanFilter kfilter
 
     # $F_{t,i} \equiv Z_{t,i} P_{t,i} Z_{t,i}' + H_{t,i}$
     {{if combined_prefix == 'd'}}
-    blas.{{prefix}}symv("L", &model._k_states,
-          &alpha, kfilter._filtered_state_cov, &kfilter.k_states,
-                  &model._design[i], &model._k_endog,
+    blas.{{prefix}}symv("L", &_k_states,
+          &alpha, kfilter._filtered_state_cov, &kf_k_states,
+                  &model._design[i], &_k_endog,
           &beta, &kfilter._M[i*kfilter.k_states], &inc)
 
     forecast_error_cov = (
         model._obs_cov[i + i*model._k_endog] +
-        blas.{{prefix}}dot(&k_states, &model._design[i], &model._k_endog,
+        blas.{{prefix}}dot(&k_states, &model._design[i], &_k_endog,
                                       &kfilter._M[i*kfilter.k_states], &inc)
     )
     {{else}}
-    blas.{{prefix}}symm("R", "L", &inc, &model._k_states,
-          &alpha, kfilter._filtered_state_cov, &kfilter.k_states,
-                  &model._design[i], &model._k_endog,
+    blas.{{prefix}}symm("R", "L", &inc, &_k_states,
+          &alpha, kfilter._filtered_state_cov, &kf_k_states,
+                  &model._design[i], &_k_endog,
           &beta, &kfilter._M[i*kfilter.k_states], &inc)
 
     blas.{{prefix}}gemv("N", &inc, &k_states,
                    &alpha, &kfilter._M[i*kfilter.k_states], &inc,
-                           &model._design[i], &model._k_endog,
+                           &model._design[i], &_k_endog,
                    &beta, kfilter._tmp0, &inc)
     forecast_error_cov = model._obs_cov[i + i*model._k_endog] + kfilter._tmp0[0]
     {{endif}}
@@ -262,7 +269,9 @@ cdef {{cython_type}} {{prefix}}forecast_error_cov({{prefix}}KalmanFilter kfilter
 
 cdef void {{prefix}}temp_arrays({{prefix}}KalmanFilter kfilter, {{prefix}}Statespace model, int i, {{cython_type}} forecast_error_cov_inv):
     cdef:
-        int k_states = model._k_states
+        blas_int k_states = model._k_states
+        blas_int _k_endog = model._k_endog
+        blas_int k_endog = kfilter.k_endog
         tmp_1 = 0
 
     # Adjust for a VAR transition (i.e. design = [#, 0], where the zeros
@@ -276,9 +285,9 @@ cdef void {{prefix}}temp_arrays({{prefix}}KalmanFilter kfilter, {{prefix}}States
     # $\\#_3 = Z_{t,i} / F_{t,i}$
     # $\\#_4 = H_{t,i} / F_{t,i}$
     if not kfilter.converged:
-        blas.{{prefix}}copy(&k_states, &model._design[i], &model._k_endog,
-                                       &kfilter._tmp3[i], &kfilter.k_endog)
-        blas.{{prefix}}scal(&k_states, &forecast_error_cov_inv, &kfilter._tmp3[i], &kfilter.k_endog)
+        blas.{{prefix}}copy(&k_states, &model._design[i], &_k_endog,
+                                       &kfilter._tmp3[i], &k_endog)
+        blas.{{prefix}}scal(&k_states, &forecast_error_cov_inv, &kfilter._tmp3[i], &k_endog)
 
         kfilter._tmp4[i + i*kfilter.k_endog] = model._obs_cov[i + i*model._k_endog] * forecast_error_cov_inv
     elif kfilter.conserve_memory & MEMORY_NO_SMOOTHING > 0:
@@ -288,8 +297,8 @@ cdef void {{prefix}}temp_arrays({{prefix}}KalmanFilter kfilter, {{prefix}}States
     else:
         # If we're converged and we are storing these arrays, then we
         # just need to copy them from the previous iteration
-        blas.{{prefix}}copy(&k_states, &kfilter.tmp3[i, 0, kfilter.t - 1], &kfilter.k_endog,
-                                       &kfilter._tmp3[i], &kfilter.k_endog)
+        blas.{{prefix}}copy(&k_states, &kfilter.tmp3[i, 0, kfilter.t - 1], &k_endog,
+                                       &kfilter._tmp3[i], &k_endog)
         kfilter._tmp4[i + i*kfilter.k_endog] = kfilter.tmp4[i, i, kfilter.t - 1]
 
 cdef void {{prefix}}filtered_state({{prefix}}KalmanFilter kfilter, {{prefix}}Statespace model, int i, {{cython_type}} forecast_error_cov_inv):
@@ -305,12 +314,14 @@ cdef void {{prefix}}filtered_state({{prefix}}KalmanFilter kfilter, {{prefix}}Sta
 
 cdef void {{prefix}}filtered_state_cov({{prefix}}KalmanFilter kfilter, {{prefix}}Statespace model, int i, {{cython_type}} forecast_error_cov_inv):
     cdef:
-        int inc = 1, j, k
+        blas_int inc = 1
+        int j, k
         {{cython_type}} scalar = -1.0 * forecast_error_cov_inv
         {{cython_type}} alpha = 1.0
         {{cython_type}} gamma = -1.0
-        int k_states = model._k_states
-        int k_states1 = model._k_states
+        blas_int k_states = model._k_states
+        blas_int k_states1 = model._k_states
+        blas_int kf_k_states = kfilter.k_states
 
     # Adjust for a VAR transition (i.e. design = [#, 0], where the zeros
     # correspond to all states except the first k_posdef states)
@@ -327,21 +338,27 @@ cdef void {{prefix}}filtered_state_cov({{prefix}}KalmanFilter kfilter, {{prefix}
     # )
 
     {{if combined_prefix == 'd'}}
-    blas.{{prefix}}syr("L", &model._k_states,
+    blas.{{prefix}}syr("L", &k_states,
         &scalar, &kfilter._M[i*kfilter.k_states], &inc,
-                 kfilter._filtered_state_cov, &kfilter.k_states
+                 kfilter._filtered_state_cov, &kf_k_states
     )
     {{else}}
-    blas.{{prefix}}syrk("L", "N", &model._k_states, &inc,
-        &scalar, &kfilter._M[i*kfilter.k_states], &kfilter.k_states,
-        &alpha, kfilter._filtered_state_cov, &kfilter.k_states)
+    blas.{{prefix}}syrk("L", "N", &k_states, &inc,
+        &scalar, &kfilter._M[i*kfilter.k_states], &kf_k_states,
+        &alpha, kfilter._filtered_state_cov, &kf_k_states)
     {{endif}}
 
 cdef void {{prefix}}chandrasekhar_recursion({{prefix}}KalmanFilter kfilter, {{prefix}}Statespace model, int i, {{cython_type}} forecast_error_cov, {{cython_type}} forecast_error_cov_inv, {{cython_type}} forecast_error_cov_inv_prev):
     # Constants
     cdef:
-        int inc = 1
+        blas_int inc = 1
         int j, k
+        blas_int k_states = kfilter.k_states
+        blas_int k_endog = kfilter.k_endog
+        blas_int _k_states = model._k_states
+        blas_int _k_states2 = model._k_states2
+        blas_int _k_endog = model._k_endog
+        blas_int _k_endogstates = model._k_endogstates
         {{cython_type}} alpha = 1.0
         {{cython_type}} beta = 0.0
         {{cython_type}} gamma = -1.0
@@ -355,8 +372,8 @@ cdef void {{prefix}}chandrasekhar_recursion({{prefix}}KalmanFilter kfilter, {{pr
         # W[:, i:i+1] = T @ K @ F[i, i]
         # Note: we scale by forecast error cov here b/c kalman_gain was
         # computed above as K = P @ Z[i].T @ (1 / F[i, i])
-        blas.{{prefix}}gemv("N", &model._k_states, &model._k_states,
-          &forecast_error_cov, model._transition, &model._k_states,
+        blas.{{prefix}}gemv("N", &_k_states, &_k_states,
+          &forecast_error_cov, model._transition, &_k_states,
                   &kfilter._kalman_gain[i * kfilter.k_states], &inc,
           &beta, &kfilter.CW[0, i], &inc)
         # M[i, i] = Finv[i, i]
@@ -364,26 +381,26 @@ cdef void {{prefix}}chandrasekhar_recursion({{prefix}}KalmanFilter kfilter, {{pr
     # Updating
     else:
         # M.T @ W.T. (p x p) (p x m)
-        blas.{{prefix}}gemm("T", "T", &model._k_endog, &model._k_states, &model._k_endog,
-          &alpha, &kfilter.CM[0, 0], &kfilter.k_endog,
-                  &kfilter.CW[0, 0], &kfilter.k_states,
-          &beta, &kfilter.CMW[0, 0], &kfilter.k_endog)
+        blas.{{prefix}}gemm("T", "T", &_k_endog, &_k_states, &_k_endog,
+          &alpha, &kfilter.CM[0, 0], &k_endog,
+                  &kfilter.CW[0, 0], &k_states,
+          &beta, &kfilter.CMW[0, 0], &k_endog)
         # MW @ Z[i].T (p x m) (m x 1) -> (p x 1)
-        blas.{{prefix}}gemv("N", &model._k_endog, &model._k_states,
-          &alpha, &kfilter.CMW[0, 0], &kfilter.k_endog,
-                  &model._design[i], &model._k_endog,
+        blas.{{prefix}}gemv("N", &_k_endog, &_k_states,
+          &alpha, &kfilter.CMW[0, 0], &k_endog,
+                  &model._design[i], &_k_endog,
           &beta, &kfilter.CMWZ[0, 0], &inc)
 
         # M = M + MWZ @ MWZ.T / F_prev[i, i]
         # Note: syr / syrk only fills in lower triangle here
         {{if combined_prefix == 'd'}}
-        blas.{{prefix}}syr("L", &model._k_endog,
+        blas.{{prefix}}syr("L", &_k_endog,
             &forecast_error_cov_inv_prev, &kfilter.CMWZ[0, 0], &inc,
-                     &kfilter.CM[0, 0], &kfilter.k_endog)
+                     &kfilter.CM[0, 0], &k_endog)
         {{else}}
-        blas.{{prefix}}syrk("L", "N", &model._k_endog, &inc,
-            &forecast_error_cov_inv_prev, &kfilter.CMWZ[0, 0], &kfilter.k_endog,
-            &alpha, &kfilter.CM[0, 0], &kfilter.k_endog)
+        blas.{{prefix}}syrk("L", "N", &_k_endog, &inc,
+            &forecast_error_cov_inv_prev, &kfilter.CMWZ[0, 0], &k_endog,
+            &alpha, &kfilter.CM[0, 0], &k_endog)
         {{endif}}
 
         # Fill in the upper triangle
@@ -394,44 +411,44 @@ cdef void {{prefix}}chandrasekhar_recursion({{prefix}}KalmanFilter kfilter, {{pr
 
         # Compute W
         # W -> tmpW
-        blas.{{prefix}}copy(&model._k_endogstates, &kfilter.CW[0, 0], &inc, &kfilter.CtmpW[0, 0], &inc)
+        blas.{{prefix}}copy(&_k_endogstates, &kfilter.CW[0, 0], &inc, &kfilter.CtmpW[0, 0], &inc)
 
         if i == model.k_endog - 1:
             # W = (T - T @ K @ Z[i]) @ W
 
             # Compute T @ K: (m x m) (m x 1) -> (m x 1)
             # Note: we previously copied CW -> CtmpW, so overwriting CW is okay
-            blas.{{prefix}}gemv("N", &model._k_states, &model._k_states,
-              &alpha, model._transition, &model._k_states,
+            blas.{{prefix}}gemv("N", &_k_states, &_k_states,
+              &alpha, model._transition, &_k_states,
                       &kfilter._kalman_gain[i*kfilter.k_states], &inc,
               &beta, &kfilter.CW[0, 0], &inc)
             # T -> tmp00
-            blas.{{prefix}}copy(&model._k_states2, model._transition, &inc, kfilter._tmp00, &inc)
+            blas.{{prefix}}copy(&_k_states2, model._transition, &inc, kfilter._tmp00, &inc)
             # T - (T @ K) @ Z[i]: (m x 1) (1 x m) -> (m x m)
-            blas.{{prefix}}ger{{combined_suffix}}(&model._k_states, &model._k_states,
+            blas.{{prefix}}ger{{combined_suffix}}(&_k_states, &_k_states,
                 &gamma, &kfilter.CW[0, 0], &inc,
-                       &model._design[i], &model._k_endog,
-                kfilter._tmp00, &kfilter.k_states)
+                       &model._design[i], &_k_endog,
+                kfilter._tmp00, &k_states)
 
             # (T - T @ K @ Z[i]) @ tmpW -> W
-            blas.{{prefix}}gemm("N", "N", &model._k_states, &model._k_endog, &model._k_states,
-                  &alpha, kfilter._tmp00, &kfilter.k_states,
-                          &kfilter.CtmpW[0, 0], &kfilter.k_states,
-                  &beta, &kfilter.CW[0, 0], &kfilter.k_states)
+            blas.{{prefix}}gemm("N", "N", &_k_states, &_k_endog, &_k_states,
+                  &alpha, kfilter._tmp00, &k_states,
+                          &kfilter.CtmpW[0, 0], &k_states,
+                  &beta, &kfilter.CW[0, 0], &k_states)
         else:
             # W = (I - I @ K @ Z[i]) @ W
             # K @ Z[i] (m x 1) (1 x m) -> (m x m)
             kfilter.tmp0[:] = 0
-            blas.{{prefix}}ger{{combined_suffix}}(&model._k_states, &model._k_states,
+            blas.{{prefix}}ger{{combined_suffix}}(&_k_states, &_k_states,
                 &alpha, &kfilter._kalman_gain[i*kfilter.k_states], &inc,
-                        &model._design[i], &model._k_endog,
-                kfilter._tmp0, &kfilter.k_states)
+                        &model._design[i], &_k_endog,
+                kfilter._tmp0, &k_states)
 
             # W = - K @ Z[i] @ W + W
-            blas.{{prefix}}gemm("N", "N", &model._k_states, &model._k_endog, &model._k_states,
-                  &gamma, kfilter._tmp0, &kfilter.k_states,
-                          &kfilter.CtmpW[0, 0], &kfilter.k_states,
-                  &alpha, &kfilter.CW[0, 0], &kfilter.k_states)
+            blas.{{prefix}}gemm("N", "N", &_k_states, &_k_endog, &_k_states,
+                  &gamma, kfilter._tmp0, &k_states,
+                          &kfilter.CtmpW[0, 0], &k_states,
+                  &alpha, &kfilter.CW[0, 0], &k_states)
 
 
 cdef void {{prefix}}loglikelihood({{prefix}}KalmanFilter kfilter, {{prefix}}Statespace model, int i, {{cython_type}} forecast_error_cov, {{cython_type}} forecast_error_cov_inv):
@@ -452,7 +469,7 @@ cdef int {{prefix}}updating_univariate({{prefix}}KalmanFilter kfilter, {{prefix}
 cdef int {{prefix}}prediction_univariate({{prefix}}KalmanFilter kfilter, {{prefix}}Statespace model):
     # Constants
     cdef:
-        int inc = 1
+        blas_int inc = 1
         int i, j
         {{cython_type}} alpha = 1.0
         {{cython_type}} beta = 0.0
@@ -485,72 +502,83 @@ cdef int {{prefix}}prediction_univariate({{prefix}}KalmanFilter kfilter, {{prefi
 
 cdef void {{prefix}}predicted_state({{prefix}}KalmanFilter kfilter, {{prefix}}Statespace model):
     cdef:
-        int inc = 1
+        blas_int inc = 1
+        blas_int _k_states = model._k_states
         {{cython_type}} alpha = 1.0
 
     # $a_{t+1} = T_t a_{t,n} + c_t$
-    blas.{{prefix}}copy(&model._k_states, model._state_intercept, &inc, kfilter._predicted_state, &inc)
-    blas.{{prefix}}gemv("N", &model._k_states, &model._k_states,
-          &alpha, model._transition, &model._k_states,
+    blas.{{prefix}}copy(&_k_states, model._state_intercept, &inc, kfilter._predicted_state, &inc)
+    blas.{{prefix}}gemv("N", &_k_states, &_k_states,
+          &alpha, model._transition, &_k_states,
                   kfilter._filtered_state, &inc,
           &alpha, kfilter._predicted_state, &inc)
 
 cdef void {{prefix}}predicted_state_cov({{prefix}}KalmanFilter kfilter, {{prefix}}Statespace model):
     cdef:
-        int inc = 1
+        blas_int inc = 1
+        blas_int _k_states = model._k_states
+        blas_int _k_states2 = model._k_states2
+        blas_int k_states = kfilter.k_states
         {{cython_type}} alpha = 1.0
         {{cython_type}} beta = 0.0
 
     # $P_{t+1} = T_t P_{t,n} T_t' + Q_t^*$
-    blas.{{prefix}}copy(&model._k_states2, model._selected_state_cov, &inc, kfilter._predicted_state_cov, &inc)
+    blas.{{prefix}}copy(&_k_states2, model._selected_state_cov, &inc, kfilter._predicted_state_cov, &inc)
     # `tmp0` array used here, dimension $(m \times m)$
 
     # $\\#_0 = T_t P_{t|t} $
 
     # $(m \times m) = (m \times m) (m \times m)$
-    # blas.{{prefix}}gemm("N", "N", &model._k_states, &model._k_states, &model._k_states,
-    #       &alpha, model._transition, &model._k_states,
-    #               kfilter._filtered_state_cov, &kfilter.k_states,
-    #       &beta, kfilter._tmp0, &kfilter.k_states)
-    blas.{{prefix}}symm("R", "L", &model._k_states, &model._k_states,
-          &alpha, kfilter._filtered_state_cov, &kfilter.k_states,
-                  model._transition, &model._k_states,
-          &beta, kfilter._tmp0, &kfilter.k_states)
+    # blas.{{prefix}}gemm("N", "N", &_k_states, &_k_states, &_k_states,
+    #       &alpha, model._transition, &_k_states,
+    #               kfilter._filtered_state_cov, &k_states,
+    #       &beta, kfilter._tmp0, &k_states)
+    blas.{{prefix}}symm("R", "L", &_k_states, &_k_states,
+          &alpha, kfilter._filtered_state_cov, &k_states,
+                  model._transition, &_k_states,
+          &beta, kfilter._tmp0, &k_states)
     # $P_{t+1} = 1.0 \\#_0 T_t' + 1.0 \\#$
     # $(m \times m) = (m \times m) (m \times m) + (m \times m)$
-    blas.{{prefix}}gemm("N", "T", &model._k_states, &model._k_states, &model._k_states,
-          &alpha, kfilter._tmp0, &kfilter.k_states,
-                  model._transition, &model._k_states,
-          &alpha, kfilter._predicted_state_cov, &kfilter.k_states)
+    blas.{{prefix}}gemm("N", "T", &_k_states, &_k_states, &_k_states,
+          &alpha, kfilter._tmp0, &k_states,
+                  model._transition, &_k_states,
+          &alpha, kfilter._predicted_state_cov, &k_states)
 
 cdef void {{prefix}}predicted_state_cov_chandrasekhar({{prefix}}KalmanFilter kfilter, {{prefix}}Statespace model):
     # Constants
     cdef:
-        int inc = 1
+        blas_int inc = 1
+        blas_int _k_states = model._k_states
+        blas_int _k_states2 = model._k_states2
+        blas_int _k_endog = model._k_endog
+        blas_int k_states = kfilter.k_states
+        blas_int k_endog = kfilter.k_endog
         {{cython_type}} alpha = 1.0
         {{cython_type}} beta = 0.0
-    blas.{{prefix}}copy(&model._k_states2, kfilter._input_state_cov, &inc, kfilter._predicted_state_cov, &inc)
+    blas.{{prefix}}copy(&_k_states2, kfilter._input_state_cov, &inc, kfilter._predicted_state_cov, &inc)
     # M @ W.T. (p x p) (p x m)
-    blas.{{prefix}}gemm("N", "T", &model._k_endog, &model._k_states, &model._k_endog,
-      &alpha, &kfilter.CM[0, 0], &kfilter.k_endog,
-              &kfilter.CW[0, 0], &kfilter.k_states,
-      &beta, &kfilter.CMW[0, 0], &kfilter.k_endog)
+    blas.{{prefix}}gemm("N", "T", &_k_endog, &_k_states, &_k_endog,
+      &alpha, &kfilter.CM[0, 0], &k_endog,
+              &kfilter.CW[0, 0], &k_states,
+      &beta, &kfilter.CMW[0, 0], &k_endog)
     # P = P + W M W.T
-    blas.{{prefix}}gemm("N", "N", &model._k_states, &model._k_states, &model._k_endog,
-      &alpha, &kfilter.CW[0, 0], &kfilter.k_states,
-              &kfilter.CMW[0, 0], &kfilter.k_endog,
-      &alpha, kfilter._predicted_state_cov, &kfilter.k_states)
+    blas.{{prefix}}gemm("N", "N", &_k_states, &_k_states, &_k_endog,
+      &alpha, &kfilter.CW[0, 0], &k_states,
+              &kfilter.CMW[0, 0], &k_endog,
+      &alpha, kfilter._predicted_state_cov, &k_states)
 
 cdef void {{prefix}}companion_predicted_state({{prefix}}KalmanFilter kfilter, {{prefix}}Statespace model):
     cdef:
         int i
-        int inc = 1
+        blas_int inc = 1
+        blas_int _k_states = model._k_states
+        blas_int _k_posdef = model._k_posdef
         {{cython_type}} alpha = 1.0
 
     # $a_{t+1} = T_t a_{t,n} + c_t$
-    blas.{{prefix}}copy(&model._k_states, model._state_intercept, &inc, kfilter._predicted_state, &inc)
-    blas.{{prefix}}gemv("N", &model._k_posdef, &model._k_states,
-          &alpha, model._transition, &model._k_states,
+    blas.{{prefix}}copy(&_k_states, model._state_intercept, &inc, kfilter._predicted_state, &inc)
+    blas.{{prefix}}gemv("N", &_k_posdef, &_k_states,
+          &alpha, model._transition, &_k_states,
                   kfilter._filtered_state, &inc,
           &alpha, kfilter._predicted_state, &inc)
 
@@ -560,7 +588,10 @@ cdef void {{prefix}}companion_predicted_state({{prefix}}KalmanFilter kfilter, {{
 cdef void {{prefix}}companion_predicted_state_cov({{prefix}}KalmanFilter kfilter, {{prefix}}Statespace model):
     cdef:
         int i, j, idx
-        int inc = 1
+        blas_int inc = 1
+        blas_int _k_states = model._k_states
+        blas_int _k_posdef = model._k_posdef
+        blas_int k_states = kfilter.k_states
         {{cython_type}} alpha = 1.0
         {{cython_type}} beta = 0.0
         {{cython_type}} tmp
@@ -572,17 +603,17 @@ cdef void {{prefix}}companion_predicted_state_cov({{prefix}}KalmanFilter kfilter
 
     # $(p \times m) = (p \times m) (m \times m)$
     # TODO: symm?
-    blas.{{prefix}}gemm("N", "N", &model._k_posdef, &model._k_states, &model._k_states,
-          &alpha, model._transition, &model._k_states,
-                  kfilter._filtered_state_cov, &kfilter.k_states,
-          &beta, kfilter._tmp0, &kfilter.k_states)
+    blas.{{prefix}}gemm("N", "N", &_k_posdef, &_k_states, &_k_states,
+          &alpha, model._transition, &_k_states,
+                  kfilter._filtered_state_cov, &k_states,
+          &beta, kfilter._tmp0, &k_states)
 
     # $P_{t+1} = 1.0 \\#_0 \phi_t' + 1.0 \\#$
     # $(m \times m) = (p \times m) (m \times p) + (m \times m)$
-    blas.{{prefix}}gemm("N", "T", &model._k_posdef, &model._k_posdef, &model._k_states,
-          &alpha, kfilter._tmp0, &kfilter.k_states,
-                  model._transition, &model._k_states,
-          &beta, kfilter._predicted_state_cov, &kfilter.k_states)
+    blas.{{prefix}}gemm("N", "T", &_k_posdef, &_k_posdef, &_k_states,
+          &alpha, kfilter._tmp0, &k_states,
+                  model._transition, &_k_states,
+          &beta, kfilter._predicted_state_cov, &k_states)
 
     # Fill in the basic matrix blocks
     for i in range(kfilter.k_states):      # columns

--- a/statsmodels/tsa/statespace/_filters/_univariate_diffuse.pyx.in
+++ b/statsmodels/tsa/statespace/_filters/_univariate_diffuse.pyx.in
@@ -27,6 +27,7 @@ import numpy as np
 from statsmodels.includes.math cimport *
 cimport scipy.linalg.cython_blas as blas
 cimport scipy.linalg.cython_lapack as lapack
+include "statsmodels/tsa/statespace/_blas_int.pxi"
 
 from statsmodels.tsa.statespace._kalman_filter cimport (
     FILTER_CONCENTRATED, MEMORY_NO_LIKELIHOOD, MEMORY_NO_STD_FORECAST)
@@ -61,18 +62,22 @@ cdef int {{prefix}}forecast_univariate_diffuse({{prefix}}KalmanFilter kfilter, {
     # Constants
     cdef:
         int i, j, k
-        int inc = 1
+        blas_int inc = 1
+        blas_int k_states = kfilter.k_states
+        blas_int k_states2 = kfilter.k_states2
+        blas_int _k_states = model._k_states
+        blas_int _k_endog = model._k_endog
         {{cython_type}} forecast_error_cov, forecast_error_cov_inv, forecast_error_diffuse_cov, forecast_error_diffuse_cov_inv, F1, F12
         {{cython_type}} alpha = 1.0
         {{cython_type}} beta = 0.0
         {{cython_type}} gamma = -1.0
 
     # Initialize the filtered states
-    blas.{{prefix}}copy(&kfilter.k_states, kfilter._input_state, &inc,
+    blas.{{prefix}}copy(&k_states, kfilter._input_state, &inc,
                                            kfilter._filtered_state, &inc)
-    blas.{{prefix}}copy(&kfilter.k_states2, kfilter._input_state_cov, &inc,
+    blas.{{prefix}}copy(&k_states2, kfilter._input_state_cov, &inc,
                                             kfilter._filtered_state_cov, &inc)
-    blas.{{prefix}}copy(&kfilter.k_states2, kfilter._input_diffuse_state_cov, &inc,
+    blas.{{prefix}}copy(&k_states2, kfilter._input_diffuse_state_cov, &inc,
                                             kfilter._predicted_diffuse_state_cov, &inc)
 
     # Iterate over endogenous variables
@@ -107,42 +112,42 @@ cdef int {{prefix}}forecast_univariate_diffuse({{prefix}}KalmanFilter kfilter, {
             F12 = -forecast_error_cov * forecast_error_diffuse_cov_inv
 
             # K0 = M_inf[:, i:i+1] * F1
-            blas.{{prefix}}copy(&kfilter.k_states, &kfilter._M_inf[i * kfilter.k_states], &inc, kfilter._tmpK0, &inc)
-            blas.{{prefix}}scal(&kfilter.k_states, &F1, kfilter._tmpK0, &inc)
+            blas.{{prefix}}copy(&k_states, &kfilter._M_inf[i * kfilter.k_states], &inc, kfilter._tmpK0, &inc)
+            blas.{{prefix}}scal(&k_states, &F1, kfilter._tmpK0, &inc)
             # K1 = M[:, i:i+1] * F1 + M_inf[:, i:i+1] * F2
             # K1 = M[:, i:i+1] * F1 + K0 * F12
-            blas.{{prefix}}copy(&kfilter.k_states, &kfilter._M[i*kfilter.k_states], &inc, kfilter._tmpK1, &inc)
-            blas.{{prefix}}scal(&kfilter.k_states, &F1, kfilter._tmpK1, &inc)
-            blas.{{prefix}}axpy(&kfilter.k_states, &F12, kfilter._tmpK0, &inc, kfilter._tmpK1, &inc)
+            blas.{{prefix}}copy(&k_states, &kfilter._M[i*kfilter.k_states], &inc, kfilter._tmpK1, &inc)
+            blas.{{prefix}}scal(&k_states, &F1, kfilter._tmpK1, &inc)
+            blas.{{prefix}}axpy(&k_states, &F12, kfilter._tmpK0, &inc, kfilter._tmpK1, &inc)
             # L0 = np.eye(m) - np.dot(K0, Zi)
             kfilter.tmpL0[:] = 0
-            blas.{{prefix}}ger{{combined_suffix}}(&model._k_states, &model._k_states, &gamma, kfilter._tmpK0, &inc, &model._design[i], &model._k_endog, kfilter._tmpL0, &kfilter.k_states)
+            blas.{{prefix}}ger{{combined_suffix}}(&_k_states, &_k_states, &gamma, kfilter._tmpK0, &inc, &model._design[i], &_k_endog, kfilter._tmpL0, &k_states)
             for j in range(kfilter.k_states):
                 kfilter._tmpL0[j + j*kfilter.k_states] = kfilter._tmpL0[j + j*kfilter.k_states] + 1
             # L1 = -np.dot(K1, Zi)
             kfilter.tmpL1[:] = 0
-            blas.{{prefix}}ger{{combined_suffix}}(&model._k_states, &model._k_states, &gamma, kfilter._tmpK1, &inc, &model._design[i], &model._k_endog, kfilter._tmpL1, &kfilter.k_states)
+            blas.{{prefix}}ger{{combined_suffix}}(&_k_states, &_k_states, &gamma, kfilter._tmpK1, &inc, &model._design[i], &_k_endog, kfilter._tmpL1, &k_states)
 
             # a_t = a_t + K0[:, 0] * v[i]
-            blas.{{prefix}}axpy(&kfilter.k_states, &kfilter._forecast_error[i], kfilter._tmpK0, &inc, kfilter._filtered_state, &inc)
+            blas.{{prefix}}axpy(&k_states, &kfilter._forecast_error[i], kfilter._tmpK0, &inc, kfilter._filtered_state, &inc)
 
             # P_t = np.dot(P_t_inf, L1.T) + np.dot(P_t, L0.T)
             # `tmp0` array used here, dimension $(m \times m)$
-            blas.{{prefix}}copy(&kfilter.k_states2, kfilter._filtered_state_cov, &inc, kfilter._tmp0, &inc)
-            blas.{{prefix}}gemm("N", "T", &model._k_states, &model._k_states, &model._k_states,
-              &alpha, kfilter._tmp0, &kfilter.k_states,
-                      kfilter._tmpL0, &kfilter.k_states,
-              &beta, kfilter._filtered_state_cov, &kfilter.k_states)
-            blas.{{prefix}}gemm("N", "T", &model._k_states, &model._k_states, &model._k_states,
-              &alpha, kfilter._predicted_diffuse_state_cov, &kfilter.k_states,
-                      kfilter._tmpL1, &kfilter.k_states,
-              &alpha, kfilter._filtered_state_cov, &kfilter.k_states)
+            blas.{{prefix}}copy(&k_states2, kfilter._filtered_state_cov, &inc, kfilter._tmp0, &inc)
+            blas.{{prefix}}gemm("N", "T", &_k_states, &_k_states, &_k_states,
+              &alpha, kfilter._tmp0, &k_states,
+                      kfilter._tmpL0, &k_states,
+              &beta, kfilter._filtered_state_cov, &k_states)
+            blas.{{prefix}}gemm("N", "T", &_k_states, &_k_states, &_k_states,
+              &alpha, kfilter._predicted_diffuse_state_cov, &k_states,
+                      kfilter._tmpL1, &k_states,
+              &alpha, kfilter._filtered_state_cov, &k_states)
             # P_t_inf = np.dot(P_t_inf, L0.T)
-            blas.{{prefix}}copy(&kfilter.k_states2, kfilter._predicted_diffuse_state_cov, &inc, kfilter._tmp0, &inc)
-            blas.{{prefix}}gemm("N", "T", &model._k_states, &model._k_states, &model._k_states,
-              &alpha, kfilter._tmp0, &kfilter.k_states,
-                      kfilter._tmpL0, &kfilter.k_states,
-              &beta, kfilter._predicted_diffuse_state_cov, &kfilter.k_states)
+            blas.{{prefix}}copy(&k_states2, kfilter._predicted_diffuse_state_cov, &inc, kfilter._tmp0, &inc)
+            blas.{{prefix}}gemm("N", "T", &_k_states, &_k_states, &_k_states,
+              &alpha, kfilter._tmp0, &k_states,
+                      kfilter._tmpL0, &k_states,
+              &beta, kfilter._predicted_diffuse_state_cov, &k_states)
 
             # Loglikelihood
             kfilter._loglikelihood[0] = (
@@ -158,23 +163,23 @@ cdef int {{prefix}}forecast_univariate_diffuse({{prefix}}KalmanFilter kfilter, {
                     kfilter._forecast_error[i] * forecast_error_cov_inv**0.5)
 
             # K0 = M[:, i:i+1] / F[i, i]
-            blas.{{prefix}}copy(&kfilter.k_states, &kfilter._M[i*kfilter.k_states], &inc, kfilter._tmpK0, &inc)
-            blas.{{prefix}}scal(&kfilter.k_states, &forecast_error_cov_inv, kfilter._tmpK0, &inc)
+            blas.{{prefix}}copy(&k_states, &kfilter._M[i*kfilter.k_states], &inc, kfilter._tmpK0, &inc)
+            blas.{{prefix}}scal(&k_states, &forecast_error_cov_inv, kfilter._tmpK0, &inc)
 
             # L0 = np.eye(m) - np.dot(K0, Zi)
             kfilter.tmpL0[:] = 0
-            blas.{{prefix}}ger{{combined_suffix}}(&model._k_states, &model._k_states, &gamma, kfilter._tmpK0, &inc, &model._design[i], &model._k_endog, kfilter._tmpL0, &kfilter.k_states)
+            blas.{{prefix}}ger{{combined_suffix}}(&_k_states, &_k_states, &gamma, kfilter._tmpK0, &inc, &model._design[i], &_k_endog, kfilter._tmpL0, &k_states)
             for j in range(kfilter.k_states):
                 kfilter._tmpL0[j + j*kfilter.k_states] = kfilter._tmpL0[j + j*kfilter.k_states] + 1
 
             # a_t = a_t + K0[:, 0] * v[i]
-            blas.{{prefix}}axpy(&kfilter.k_states, &kfilter._forecast_error[i], kfilter._tmpK0, &inc, kfilter._filtered_state, &inc)
+            blas.{{prefix}}axpy(&k_states, &kfilter._forecast_error[i], kfilter._tmpK0, &inc, kfilter._filtered_state, &inc)
             # P_t = np.dot(P_t, L0)
-            blas.{{prefix}}copy(&kfilter.k_states2, kfilter._filtered_state_cov, &inc, kfilter._tmp0, &inc)
-            blas.{{prefix}}gemm("N", "T", &model._k_states, &model._k_states, &model._k_states,
-              &alpha, kfilter._tmp0, &kfilter.k_states,
-                      kfilter._tmpL0, &kfilter.k_states,
-              &beta, kfilter._filtered_state_cov, &kfilter.k_states)
+            blas.{{prefix}}copy(&k_states2, kfilter._filtered_state_cov, &inc, kfilter._tmp0, &inc)
+            blas.{{prefix}}gemm("N", "T", &_k_states, &_k_states, &_k_states,
+              &alpha, kfilter._tmp0, &k_states,
+                      kfilter._tmpL0, &k_states,
+              &beta, kfilter._filtered_state_cov, &k_states)
             # P_t_inf = P_t_inf
             # (noop)
 
@@ -190,7 +195,7 @@ cdef int {{prefix}}forecast_univariate_diffuse({{prefix}}KalmanFilter kfilter, {
                     kfilter._loglikelihood[0] = kfilter._loglikelihood[0] - 0.5 * (kfilter._forecast_error[i]**2 * forecast_error_cov_inv)
 
         # Kalman gain
-        blas.{{prefix}}copy(&kfilter.k_states, kfilter._tmpK0, &inc, &kfilter._kalman_gain[i * kfilter.k_states], &inc)
+        blas.{{prefix}}copy(&k_states, kfilter._tmpK0, &inc, &kfilter._kalman_gain[i * kfilter.k_states], &inc)
 
         # Prediction (done below)
         # a_t1[:] = np.dot(T, a_tt)
@@ -202,11 +207,14 @@ cdef int {{prefix}}forecast_univariate_diffuse({{prefix}}KalmanFilter kfilter, {
 
 cdef {{cython_type}} {{prefix}}forecast_error_diffuse_cov({{prefix}}KalmanFilter kfilter, {{prefix}}Statespace model, int i):
     cdef:
-        int inc = 1
+        blas_int inc = 1
         {{cython_type}} alpha = 1
         {{cython_type}} beta = 0
         {{cython_type}} forecast_error_diffuse_cov
-        int k_states = model._k_states
+        blas_int k_states = model._k_states
+        blas_int _k_states = model._k_states
+        blas_int _k_endog = model._k_endog
+        blas_int kf_k_states = kfilter.k_states
 
     # Adjust for a VAR transition (i.e. design = [#, 0], where the zeros
     # correspond to all states except the first k_posdef states)
@@ -217,31 +225,31 @@ cdef {{cython_type}} {{prefix}}forecast_error_diffuse_cov({{prefix}}KalmanFilter
     # `M_inf` array used here, dimension $(m \times 1)$
     # $M_{i, \infty} = P_{t,i,\infty} Z_{t,i}'$
     # $(m \times 1) = (m \times m) (1 \times m)'$
-    blas.{{prefix}}gemv("N", &model._k_states, &model._k_states,
-          &alpha, kfilter._predicted_diffuse_state_cov, &kfilter.k_states,
-                  &model._design[i], &model._k_endog,
+    blas.{{prefix}}gemv("N", &_k_states, &_k_states,
+          &alpha, kfilter._predicted_diffuse_state_cov, &kf_k_states,
+                  &model._design[i], &_k_endog,
           &beta, &kfilter._M_inf[i * kfilter.k_states], &inc)
 
     # $F_{t,i,\infty} \equiv Z_{t,i} P_{t,i,\infty} Z_{t,i}'$
     {{if combined_prefix == 'd'}}
-    # blas.{{prefix}}symv("U", &model._k_states,
-    #       &alpha, kfilter._filtered_state_cov, &kfilter.k_states,
-    #               &model._design[i], &model._k_endog,
+    # blas.{{prefix}}symv("U", &_k_states,
+    #       &alpha, kfilter._filtered_state_cov, &kf_k_states,
+    #               &model._design[i], &_k_endog,
     #       &beta, &kfilter._M_inf[i * kfilter.k_states], &inc)
 
     forecast_error_diffuse_cov = (
-        blas.{{prefix}}dot(&k_states, &model._design[i], &model._k_endog,
+        blas.{{prefix}}dot(&k_states, &model._design[i], &_k_endog,
                                       &kfilter._M_inf[i * kfilter.k_states], &inc)
     )
     {{else}}
-    # blas.{{prefix}}gemv("N", &model._k_states, &k_states,
-    #       &alpha, kfilter._filtered_state_cov, &kfilter.k_states,
-    #               &model._design[i], &model._k_endog,
+    # blas.{{prefix}}gemv("N", &_k_states, &k_states,
+    #       &alpha, kfilter._filtered_state_cov, &kf_k_states,
+    #               &model._design[i], &_k_endog,
     #       &beta, &kfilter._M_inf[i * kfilter.k_states], &inc)
 
     blas.{{prefix}}gemv("N", &inc, &k_states,
                    &alpha, &kfilter._M_inf[i * kfilter.k_states], &inc,
-                           &model._design[i], &model._k_endog,
+                           &model._design[i], &_k_endog,
                    &beta, kfilter._tmp0, &inc)
     forecast_error_diffuse_cov = kfilter._tmp0[0]
     {{endif}}
@@ -252,7 +260,7 @@ cdef {{cython_type}} {{prefix}}forecast_error_diffuse_cov({{prefix}}KalmanFilter
 cdef int {{prefix}}prediction_univariate_diffuse({{prefix}}KalmanFilter kfilter, {{prefix}}Statespace model):
     # Constants
     cdef:
-        int inc = 1
+        blas_int inc = 1
         int i, j
         {{cython_type}} alpha = 1.0
         {{cython_type}} beta = 0.0
@@ -267,7 +275,10 @@ cdef int {{prefix}}prediction_univariate_diffuse({{prefix}}KalmanFilter kfilter,
 
 cdef void {{prefix}}predicted_diffuse_state_cov({{prefix}}KalmanFilter kfilter, {{prefix}}Statespace model):
     cdef:
-        int inc = 1
+        blas_int inc = 1
+        blas_int k_states2 = kfilter.k_states2
+        blas_int k_states = kfilter.k_states
+        blas_int _k_states = model._k_states
         {{cython_type}} alpha = 1.0
         {{cython_type}} beta = 0.0
 
@@ -275,20 +286,20 @@ cdef void {{prefix}}predicted_diffuse_state_cov({{prefix}}KalmanFilter kfilter, 
     # conventional Kalman filter routines are used in this case and they do not
     # copy over the predicted diffuse state cov
     if model._nmissing == model.k_endog:
-        blas.{{prefix}}copy(&kfilter.k_states2, kfilter._input_diffuse_state_cov, &inc,
+        blas.{{prefix}}copy(&k_states2, kfilter._input_diffuse_state_cov, &inc,
                                                 kfilter._predicted_diffuse_state_cov, &inc)
 
     # P_t1_inf[:] = np.dot(np.dot(T, P_t_inf), T.T)
-    blas.{{prefix}}gemm("N", "N", &model._k_states, &model._k_states, &model._k_states,
-          &alpha, model._transition, &model._k_states,
-                  kfilter._predicted_diffuse_state_cov, &kfilter.k_states,
-          &beta, kfilter._tmp0, &kfilter.k_states)
+    blas.{{prefix}}gemm("N", "N", &_k_states, &_k_states, &_k_states,
+          &alpha, model._transition, &_k_states,
+                  kfilter._predicted_diffuse_state_cov, &k_states,
+          &beta, kfilter._tmp0, &k_states)
     # $P_{t+1} = 1.0 \\#_0 T_t' + 1.0 \\#$
     # $(m \times m) = (m \times m) (m \times m) + (m \times m)$
-    blas.{{prefix}}gemm("N", "T", &model._k_states, &model._k_states, &model._k_states,
-          &alpha, kfilter._tmp0, &kfilter.k_states,
-                  model._transition, &model._k_states,
-          &beta, kfilter._predicted_diffuse_state_cov, &kfilter.k_states)
+    blas.{{prefix}}gemm("N", "T", &_k_states, &_k_states, &_k_states,
+          &alpha, kfilter._tmp0, &k_states,
+                  model._transition, &_k_states,
+          &beta, kfilter._predicted_diffuse_state_cov, &k_states)
 
 
 # Note: updating, inverse, loglikelihood are all performed in prior steps

--- a/statsmodels/tsa/statespace/_initialization.pyx.in
+++ b/statsmodels/tsa/statespace/_initialization.pyx.in
@@ -30,6 +30,7 @@ np.import_array()
 from statsmodels.includes.math cimport *
 cimport scipy.linalg.cython_blas as blas
 cimport scipy.linalg.cython_lapack as lapack
+include "statsmodels/tsa/statespace/_blas_int.pxi"
 cimport statsmodels.tsa.statespace._tools as tools
 
 {{for prefix, types in TYPES.items()}}
@@ -132,18 +133,21 @@ cdef class {{prefix}}Initialization(object):
 
     cdef int initialize_known_constant(self, int offset,
                                         {{cython_type}} [:] initial_state_mean) except 1:
-        cdef int inc = 1
-        blas.{{prefix}}copy(&self.k_states, &self.constant[0], &inc,
+        cdef blas_int inc = 1
+        cdef blas_int k_states = self.k_states
+        blas.{{prefix}}copy(&k_states, &self.constant[0], &inc,
                                      &initial_state_mean[offset], &inc)
 
         return 0
 
     cdef int initialize_known_stationary_cov(self, int offset,
                                               {{cython_type}} [::1, :] initial_stationary_state_cov) except 1:
-        cdef int i, inc = 1
+        cdef int i
+        cdef blas_int inc = 1
+        cdef blas_int k_states = self.k_states
         # Copy columns
         for i in range(self.k_states):
-            blas.{{prefix}}copy(&self.k_states, &self.stationary_cov[0, i], &inc,
+            blas.{{prefix}}copy(&k_states, &self.stationary_cov[0, i], &inc,
                                          &initial_stationary_state_cov[offset, offset + i], &inc)
 
         return 0
@@ -170,11 +174,14 @@ cdef class {{prefix}}Initialization(object):
 
         cdef:
             np.npy_intp dim2[2]
-            int i, info, inc = 1
-            int k_states2 = self.k_states**2
+            int i
+            blas_int info, inc = 1
+            blas_int k_states = self.k_states
+            blas_int k_states2 = self.k_states**2
+            blas_int model_k_states = model.k_states
             np.float64_t asum, tol = 1e-9
             cdef {{cython_type}} scalar
-            cdef int [::1,:] ipiv
+            cdef blas_int [::1,:] ipiv
 
         # Clear the unconditional mean (for this block)
         initial_state_mean[offset:offset + self.k_states] = 0
@@ -182,23 +189,26 @@ cdef class {{prefix}}Initialization(object):
         # Check if the state intercept is all zeros; if it is, then the
         # unconditional mean is also all zeros
         {{if combined_prefix == 'd'}}
-        asum = blas.{{prefix}}asum(&model.k_states, &model.state_intercept[0, 0], &inc)
+        asum = blas.{{prefix}}asum(&model_k_states, &model.state_intercept[0, 0], &inc)
         {{elif prefix == 'c'}}
-        asum = blas.scasum(&model.k_states, &model.state_intercept[0, 0], &inc)
+        asum = blas.scasum(&model_k_states, &model.state_intercept[0, 0], &inc)
         {{else}}
-        asum = blas.dzasum(&model.k_states, &model.state_intercept[0, 0], &inc)
+        asum = blas.dzasum(&model_k_states, &model.state_intercept[0, 0], &inc)
         {{endif}}
 
         # If the state intercept is non-zero, compute the mean
         if asum > tol:
             dim2[0] = self.k_states
             dim2[1] = self.k_states
-            ipiv = np.PyArray_ZEROS(2, dim2, np.NPY_INT32, FORTRAN)
+            if sizeof(blas_int) == 4:
+                ipiv = np.PyArray_ZEROS(2, dim2, np.NPY_INT32, FORTRAN)
+            else:
+                ipiv = np.PyArray_ZEROS(2, dim2, np.NPY_INT64, FORTRAN)
 
             # Create T - I
             # (copy colummns)
             for i in range(self.k_states):
-                blas.{{prefix}}copy(&self.k_states, &model.transition[offset,offset + i,0], &inc,
+                blas.{{prefix}}copy(&k_states, &model.transition[offset,offset + i,0], &inc,
                                                     &self._tmp_transition[0,i], &inc)
                 self._tmp_transition[i, i] = self._tmp_transition[i, i] - 1
             # Multiply by -1 to get I - T
@@ -206,14 +216,14 @@ cdef class {{prefix}}Initialization(object):
             blas.{{prefix}}scal(&k_states2, &scalar, &self._tmp_transition[0, 0], &inc)
 
             # c
-            blas.{{prefix}}copy(&self.k_states, &model.state_intercept[offset,0], &inc,
+            blas.{{prefix}}copy(&k_states, &model.state_intercept[offset,0], &inc,
                                                 &initial_state_mean[offset], &inc)
 
             # Solve (I - T) x = c
-            lapack.{{prefix}}getrf(&self.k_states, &self.k_states, &self._tmp_transition[0, 0], &self.k_states,
+            lapack.{{prefix}}getrf(&k_states, &k_states, &self._tmp_transition[0, 0], &k_states,
                                    &ipiv[0, 0], &info)
-            lapack.{{prefix}}getrs('N', &self.k_states, &inc, &self._tmp_transition[0, 0], &self.k_states,
-                                   &ipiv[0, 0], &initial_state_mean[offset], &self.k_states, &info)
+            lapack.{{prefix}}getrs('N', &k_states, &inc, &self._tmp_transition[0, 0], &k_states,
+                                   &ipiv[0, 0], &initial_state_mean[offset], &k_states, &info)
 
         return 0
 
@@ -221,8 +231,10 @@ cdef class {{prefix}}Initialization(object):
                                         {{cython_type}} [::1, :] initial_stationary_state_cov,
                                         int complex_step=False) except 1:
         cdef:
-            int i, inc = 1
-            int k_states2 = self.k_states**2
+            int i
+            blas_int inc = 1
+            blas_int k_states = self.k_states
+            blas_int k_states2 = self.k_states**2
 
         # Create selected state covariance matrix
         tools._{{prefix}}select_cov(self.k_states, model.k_posdef, model.k_states,
@@ -234,7 +246,7 @@ cdef class {{prefix}}Initialization(object):
         # Create a copy of the transition matrix
         # (copy colummns)
         for i in range(self.k_states):
-            blas.{{prefix}}copy(&self.k_states, &model.transition[offset,offset + i,0], &inc,
+            blas.{{prefix}}copy(&k_states, &model.transition[offset,offset + i,0], &inc,
                                                 &self._tmp_transition[0,i], &inc)
 
         # Solve the discrete Lyapunov equation to the get initial state
@@ -245,7 +257,7 @@ cdef class {{prefix}}Initialization(object):
         # Copy into initial_stationary_state_cov
         # (copy colummns)
         for i in range(self.k_states):
-            blas.{{prefix}}copy(&self.k_states, &self._tmp_selected_state_cov[0,i], &inc,
+            blas.{{prefix}}copy(&k_states, &self._tmp_selected_state_cov[0,i], &inc,
                                                 &initial_stationary_state_cov[offset,offset + i], &inc)
 
         return 0

--- a/statsmodels/tsa/statespace/_kalman_filter.pxd
+++ b/statsmodels/tsa/statespace/_kalman_filter.pxd
@@ -8,6 +8,8 @@ Author: Chad Fulton
 License: Simplified-BSD
 """
 
+include "statsmodels/tsa/statespace/_blas_int.pxi"
+
 # ## Constants
 
 # ### Filters
@@ -107,7 +109,7 @@ cdef class sKalmanFilter(object):
 
     # ### Temporary arrays
     cdef readonly np.float32_t [::1,:] forecast_error_fac
-    cdef readonly int [:] forecast_error_ipiv
+    cdef readonly blas_int [:] forecast_error_ipiv
     cdef readonly np.float32_t [::1,:] forecast_error_work
     cdef readonly np.float32_t [::1,:] tmp0, tmp00
     cdef readonly np.float32_t [::1,:] tmp2
@@ -162,7 +164,7 @@ cdef class sKalmanFilter(object):
     cdef np.float32_t * _converged_M
 
     cdef np.float32_t * _forecast_error_fac
-    cdef int * _forecast_error_ipiv
+    cdef blas_int * _forecast_error_ipiv
     cdef np.float32_t * _forecast_error_work
 
     cdef np.float32_t * _tmp0
@@ -262,7 +264,7 @@ cdef class dKalmanFilter(object):
 
     # ### Temporary arrays
     cdef readonly np.float64_t [::1,:] forecast_error_fac
-    cdef readonly int [:] forecast_error_ipiv
+    cdef readonly blas_int [:] forecast_error_ipiv
     cdef readonly np.float64_t [::1,:] forecast_error_work
     cdef readonly np.float64_t [::1,:] tmp0, tmp00
     cdef readonly np.float64_t [::1,:] tmp2
@@ -316,7 +318,7 @@ cdef class dKalmanFilter(object):
     cdef np.float64_t * _converged_M
 
     cdef np.float64_t * _forecast_error_fac
-    cdef int * _forecast_error_ipiv
+    cdef blas_int * _forecast_error_ipiv
     cdef np.float64_t * _forecast_error_work
 
     cdef np.float64_t * _tmp0
@@ -416,7 +418,7 @@ cdef class cKalmanFilter(object):
 
     # ### Temporary arrays
     cdef readonly np.complex64_t [::1,:] forecast_error_fac
-    cdef readonly int [:] forecast_error_ipiv
+    cdef readonly blas_int [:] forecast_error_ipiv
     cdef readonly np.complex64_t [::1,:] forecast_error_work
     cdef readonly np.complex64_t [::1,:] tmp0, tmp00
     cdef readonly np.complex64_t [::1,:] tmp2
@@ -471,7 +473,7 @@ cdef class cKalmanFilter(object):
     cdef np.complex64_t * _converged_M
 
     cdef np.complex64_t * _forecast_error_fac
-    cdef int * _forecast_error_ipiv
+    cdef blas_int * _forecast_error_ipiv
     cdef np.complex64_t * _forecast_error_work
 
     cdef np.complex64_t * _tmp0
@@ -571,7 +573,7 @@ cdef class zKalmanFilter(object):
 
     # ### Temporary arrays
     cdef readonly np.complex128_t [::1,:] forecast_error_fac
-    cdef readonly int [:] forecast_error_ipiv
+    cdef readonly blas_int [:] forecast_error_ipiv
     cdef readonly np.complex128_t [::1,:] forecast_error_work
     cdef readonly np.complex128_t [::1,:] tmp0, tmp00
     cdef readonly np.complex128_t [::1,:] tmp2
@@ -626,7 +628,7 @@ cdef class zKalmanFilter(object):
     cdef np.complex128_t * _converged_M
 
     cdef np.complex128_t * _forecast_error_fac
-    cdef int * _forecast_error_ipiv
+    cdef blas_int * _forecast_error_ipiv
     cdef np.complex128_t * _forecast_error_work
 
     cdef np.complex128_t * _tmp0

--- a/statsmodels/tsa/statespace/_kalman_filter.pyx.in
+++ b/statsmodels/tsa/statespace/_kalman_filter.pyx.in
@@ -86,6 +86,7 @@ np.import_array()
 from statsmodels.includes.math cimport *
 cimport scipy.linalg.cython_blas as blas
 cimport scipy.linalg.cython_lapack as lapack
+include "statsmodels/tsa/statespace/_blas_int.pxi"
 cimport statsmodels.tsa.statespace._tools as tools
 
 {{for prefix, types in TYPES.items()}}
@@ -649,7 +650,10 @@ cdef class {{prefix}}KalmanFilter(object):
         self.forecast_error_work = np.PyArray_ZEROS(2, dim2, {{typenum}}, FORTRAN)
         self._forecast_error_work = &self.forecast_error_work[0,0]
         dim1[0] = self.k_endog;
-        self.forecast_error_ipiv = np.PyArray_ZEROS(1, dim1, np.NPY_INT, FORTRAN)
+        if sizeof(blas_int) == 4:
+            self.forecast_error_ipiv = np.PyArray_ZEROS(1, dim1, np.NPY_INT32, FORTRAN)
+        else:
+            self.forecast_error_ipiv = np.PyArray_ZEROS(1, dim1, np.NPY_INT64, FORTRAN)
         self._forecast_error_ipiv = &self.forecast_error_ipiv[0]
 
         # Holds arrays of dimension $(m \times m)$ and $(m \times r)$
@@ -1056,7 +1060,9 @@ cdef class {{prefix}}KalmanFilter(object):
     cdef void initialize_filter_object_pointers(self):
         cdef:
             int t = self.t
-            int inc = 1
+            blas_int inc = 1
+            blas_int _k_states = self.model._k_states
+            blas_int _k_states2 = self.model._k_states2
         # Indices for arrays that may or may not be stored completely
         cdef:
             int forecast_mean_t = t
@@ -1111,9 +1117,9 @@ cdef class {{prefix}}KalmanFilter(object):
             # This means that the zeroth entry in the time-dimension can hold the
             # input array (even though it is no different than what is held in the
             # initial_state_* arrays).
-            blas.{{prefix}}copy(&self.model._k_states, self.model._initial_state, &inc, self._input_state, &inc)
-            blas.{{prefix}}copy(&self.model._k_states2, self.model._initial_state_cov, &inc, self._input_state_cov, &inc)
-            blas.{{prefix}}copy(&self.model._k_states2, self.model._initial_diffuse_state_cov, &inc, self._input_diffuse_state_cov, &inc)
+            blas.{{prefix}}copy(&_k_states, self.model._initial_state, &inc, self._input_state, &inc)
+            blas.{{prefix}}copy(&_k_states2, self.model._initial_state_cov, &inc, self._input_state_cov, &inc)
+            blas.{{prefix}}copy(&_k_states2, self.model._initial_diffuse_state_cov, &inc, self._input_diffuse_state_cov, &inc)
 
         # Now we can check if we are in a diffuse period. If we are but we are
         # not using the univariate method, then we may need to perform the
@@ -1223,29 +1229,34 @@ cdef class {{prefix}}KalmanFilter(object):
     cdef void post_convergence(self):
         # Constants
         cdef:
-            int inc = 1
+            blas_int inc = 1
+            blas_int k_endog2 = self.k_endog2
+            blas_int k_states2 = self.k_states2
+            blas_int k_endogstates = self.k_endogstates
 
         if self.converged:
             # $F_t$
-            blas.{{prefix}}copy(&self.k_endog2, self._converged_forecast_error_cov, &inc, self._forecast_error_cov, &inc)
+            blas.{{prefix}}copy(&k_endog2, self._converged_forecast_error_cov, &inc, self._forecast_error_cov, &inc)
             # $P_{t|t}$
-            blas.{{prefix}}copy(&self.k_states2, self._converged_filtered_state_cov, &inc, self._filtered_state_cov, &inc)
+            blas.{{prefix}}copy(&k_states2, self._converged_filtered_state_cov, &inc, self._filtered_state_cov, &inc)
             # $P_t$
-            blas.{{prefix}}copy(&self.k_states2, self._converged_predicted_state_cov, &inc, self._predicted_state_cov, &inc)
+            blas.{{prefix}}copy(&k_states2, self._converged_predicted_state_cov, &inc, self._predicted_state_cov, &inc)
             # $K_t$
-            blas.{{prefix}}copy(&self.k_endogstates, self._converged_kalman_gain, &inc, self._kalman_gain, &inc)
+            blas.{{prefix}}copy(&k_endogstates, self._converged_kalman_gain, &inc, self._kalman_gain, &inc)
             # $|F_t|$
             self.determinant = self.converged_determinant
             # $M_t$
-            blas.{{prefix}}copy(&self.k_endogstates, self._converged_M, &inc, self._M, &inc)
+            blas.{{prefix}}copy(&k_endogstates, self._converged_M, &inc, self._M, &inc)
 
     cdef void numerical_stability(self):
-        cdef int inc = 1
-        cdef int k_states
+        cdef blas_int inc = 1
+        cdef blas_int k_states
         cdef int i, j
         cdef int predicted_cov_t = self.t
         cdef {{cython_type}} alpha = 1.0
         cdef {{cython_type}} scalar = 0.5
+        cdef blas_int blas_k_states = self.k_states
+        cdef blas_int k_states2 = self.k_states2
 
         if self.conserve_memory & MEMORY_NO_PREDICTED_COV:
             predicted_cov_t = 1
@@ -1259,25 +1270,26 @@ cdef class {{prefix}}KalmanFilter(object):
             # See Grewal (2001), Section 6.3.1.1
             for i in range(self.k_states):
                 k_states = self.k_states - i
-                blas.{{prefix}}axpy(&k_states, &alpha, &self.predicted_state_cov[i, i, predicted_cov_t], &self.k_states,
+                blas.{{prefix}}axpy(&k_states, &alpha, &self.predicted_state_cov[i, i, predicted_cov_t], &blas_k_states,
                                                        &self.predicted_state_cov[i, i, predicted_cov_t], &inc)
                 blas.{{prefix}}copy(&k_states, &self.predicted_state_cov[i, i, predicted_cov_t], &inc,
-                                               &self.predicted_state_cov[i, i, predicted_cov_t], &self.k_states)
-            blas.{{prefix}}scal(&self.k_states2, &scalar, &self.predicted_state_cov[0, 0, predicted_cov_t], &inc)
+                                               &self.predicted_state_cov[i, i, predicted_cov_t], &blas_k_states)
+            blas.{{prefix}}scal(&k_states2, &scalar, &self.predicted_state_cov[0, 0, predicted_cov_t], &inc)
 
     cdef int check_diffuse(self):
         cdef:
-            int inc = 1
+            blas_int inc = 1
+            blas_int k_states2 = self.k_states2
             {{cython_type}} alpha = 1.0
             {{cython_type}} beta = 0.0
             {{cython_type}} scalar
 
         if self.t == self.nobs_diffuse:
             {{if combined_prefix == 'd'}}
-            if blas.{{prefix}}dot(&self.k_states2, self._input_diffuse_state_cov, &inc, self._input_diffuse_state_cov, &inc) > self.tolerance_diffuse:
+            if blas.{{prefix}}dot(&k_states2, self._input_diffuse_state_cov, &inc, self._input_diffuse_state_cov, &inc) > self.tolerance_diffuse:
                 self.nobs_diffuse = self.nobs_diffuse + 1
             {{else}}
-            blas.{{prefix}}gemv("N", &inc, &self.k_states2, &alpha, self._input_diffuse_state_cov, &inc, self._input_diffuse_state_cov, &inc, &beta, self._tmp00, &inc)
+            blas.{{prefix}}gemv("N", &inc, &k_states2, &alpha, self._input_diffuse_state_cov, &inc, self._input_diffuse_state_cov, &inc, &beta, self._tmp00, &inc)
             if {{combined_prefix}}abs(self._tmp00[0]) > self.tolerance_diffuse:
                 self.nobs_diffuse = self.nobs_diffuse + 1
             {{endif}}
@@ -1287,10 +1299,14 @@ cdef class {{prefix}}KalmanFilter(object):
     cdef void check_convergence(self):
         # Constants
         cdef:
-            int inc = 1, missing_flag = 0
+            blas_int inc = 1
+            int missing_flag = 0
             {{cython_type}} alpha = 1.0
             {{cython_type}} beta = 0.0
             {{cython_type}} gamma = -1.0
+            blas_int k_states2 = self.k_states2
+            blas_int k_endog2 = self.k_endog2
+            blas_int k_endogstates = self.k_endogstates
         # Indices for arrays that may or may not be stored completely
         cdef:
             int forecast_cov_t = self.t
@@ -1316,22 +1332,22 @@ cdef class {{prefix}}KalmanFilter(object):
             # `tmp0` array used here, dimension $(m \times m)$
             # `tmp00` array used here, dimension $(1 \times 1)$
             if self.filter_timing == TIMING_INIT_PREDICTED:
-                blas.{{prefix}}copy(&self.k_states2, self._input_state_cov, &inc, self._tmp0, &inc)
-                blas.{{prefix}}axpy(&self.k_states2, &gamma, self._predicted_state_cov, &inc, self._tmp0, &inc)
+                blas.{{prefix}}copy(&k_states2, self._input_state_cov, &inc, self._tmp0, &inc)
+                blas.{{prefix}}axpy(&k_states2, &gamma, self._predicted_state_cov, &inc, self._tmp0, &inc)
             elif self.t > 0:
-                blas.{{prefix}}copy(&self.k_states2, &self.predicted_state_cov[0,0,predicted_cov_t], &inc, self._tmp0, &inc)
-                blas.{{prefix}}axpy(&self.k_states2, &gamma, &self.predicted_state_cov[0,0,predicted_cov_t-1], &inc, self._tmp0, &inc)
+                blas.{{prefix}}copy(&k_states2, &self.predicted_state_cov[0,0,predicted_cov_t], &inc, self._tmp0, &inc)
+                blas.{{prefix}}axpy(&k_states2, &gamma, &self.predicted_state_cov[0,0,predicted_cov_t-1], &inc, self._tmp0, &inc)
             else:
                 return
 
 
             {{if combined_prefix == 'd'}}
-            if blas.{{prefix}}dot(&self.k_states2, self._tmp0, &inc, self._tmp0, &inc) < self.tolerance:
+            if blas.{{prefix}}dot(&k_states2, self._tmp0, &inc, self._tmp0, &inc) < self.tolerance:
                 self.converged = 1
                 self.period_converged = self.t
 
             {{else}}
-            blas.{{prefix}}gemv("N", &inc, &self.k_states2, &alpha, self._tmp0, &inc, self._tmp0, &inc, &beta, self._tmp00, &inc)
+            blas.{{prefix}}gemv("N", &inc, &k_states2, &alpha, self._tmp0, &inc, self._tmp0, &inc, &beta, self._tmp00, &inc)
             if {{combined_prefix}}abs(self._tmp00[0]) < self.tolerance:
                 self.converged = 1
                 self.period_converged = self.t
@@ -1341,55 +1357,59 @@ cdef class {{prefix}}KalmanFilter(object):
             # converged storage
             if self.converged == 1:
                 # $F_t$
-                blas.{{prefix}}copy(&self.k_endog2, &self.forecast_error_cov[0, 0, forecast_cov_t], &inc, self._converged_forecast_error_cov, &inc)
+                blas.{{prefix}}copy(&k_endog2, &self.forecast_error_cov[0, 0, forecast_cov_t], &inc, self._converged_forecast_error_cov, &inc)
                 # $P_{t|t}$
-                blas.{{prefix}}copy(&self.k_states2, &self.filtered_state_cov[0, 0, filtered_cov_t], &inc, self._converged_filtered_state_cov, &inc)
+                blas.{{prefix}}copy(&k_states2, &self.filtered_state_cov[0, 0, filtered_cov_t], &inc, self._converged_filtered_state_cov, &inc)
                 # $P_t$
-                blas.{{prefix}}copy(&self.k_states2, &self.predicted_state_cov[0, 0, predicted_cov_t], &inc, self._converged_predicted_state_cov, &inc)
+                blas.{{prefix}}copy(&k_states2, &self.predicted_state_cov[0, 0, predicted_cov_t], &inc, self._converged_predicted_state_cov, &inc)
                 # $|F_t|$
                 self.converged_determinant = self.determinant
                 # $K_t$
-                blas.{{prefix}}copy(&self.k_endogstates, &self.kalman_gain[0, 0, gain_t], &inc, self._converged_kalman_gain, &inc)
+                blas.{{prefix}}copy(&k_endogstates, &self.kalman_gain[0, 0, gain_t], &inc, self._converged_kalman_gain, &inc)
                 # $M_t$
-                blas.{{prefix}}copy(&self.k_endogstates, &self.M[0, 0, predicted_cov_t], &inc, self._converged_M, &inc)
+                blas.{{prefix}}copy(&k_endogstates, &self.M[0, 0, predicted_cov_t], &inc, self._converged_M, &inc)
 
     cdef void migrate_storage(self):
         cdef:
-            int inc = 1
+            blas_int inc = 1
             int diffuse = self.check_diffuse()
+            blas_int k_endog = self.k_endog
+            blas_int k_endog2 = self.k_endog2
+            blas_int k_states = self.k_states
+            blas_int k_states2 = self.k_states2
 
 
         # Forecast: 1 -> 0
         if self.conserve_memory & MEMORY_NO_FORECAST_MEAN > 0:
-            blas.{{prefix}}copy(&self.k_endog, &self.forecast[0, 1], &inc, &self.forecast[0, 0], &inc)
-            blas.{{prefix}}copy(&self.k_endog, &self.forecast_error[0, 1], &inc, &self.forecast_error[0, 0], &inc)
+            blas.{{prefix}}copy(&k_endog, &self.forecast[0, 1], &inc, &self.forecast[0, 0], &inc)
+            blas.{{prefix}}copy(&k_endog, &self.forecast_error[0, 1], &inc, &self.forecast_error[0, 0], &inc)
         if self.conserve_memory & MEMORY_NO_FORECAST_COV > 0:
-            blas.{{prefix}}copy(&self.k_endog2, &self.forecast_error_cov[0, 0, 1], &inc, &self.forecast_error_cov[0, 0, 0], &inc)
+            blas.{{prefix}}copy(&k_endog2, &self.forecast_error_cov[0, 0, 1], &inc, &self.forecast_error_cov[0, 0, 0], &inc)
 
         # Filtered: 1 -> 0
         if self.conserve_memory & MEMORY_NO_FILTERED_MEAN > 0:
-            blas.{{prefix}}copy(&self.k_states, &self.filtered_state[0, 1], &inc, &self.filtered_state[0, 0], &inc)
+            blas.{{prefix}}copy(&k_states, &self.filtered_state[0, 1], &inc, &self.filtered_state[0, 0], &inc)
         if self.conserve_memory & MEMORY_NO_FILTERED_COV > 0:
-            blas.{{prefix}}copy(&self.k_states2, &self.filtered_state_cov[0, 0, 1], &inc, &self.filtered_state_cov[0, 0, 0], &inc)
+            blas.{{prefix}}copy(&k_states2, &self.filtered_state_cov[0, 0, 1], &inc, &self.filtered_state_cov[0, 0, 0], &inc)
 
         if self.conserve_memory & MEMORY_NO_PREDICTED_MEAN > 0:
             # Predicted: 1 -> 0
-            blas.{{prefix}}copy(&self.k_states, &self.predicted_state[0, 1], &inc, &self.predicted_state[0, 0], &inc)
+            blas.{{prefix}}copy(&k_states, &self.predicted_state[0, 1], &inc, &self.predicted_state[0, 0], &inc)
             # Predicted: 2 -> 1
             if self.filter_timing == TIMING_INIT_PREDICTED:
-                blas.{{prefix}}copy(&self.k_states, &self.predicted_state[0, 2], &inc, &self.predicted_state[0, 1], &inc)
+                blas.{{prefix}}copy(&k_states, &self.predicted_state[0, 2], &inc, &self.predicted_state[0, 1], &inc)
 
         if self.conserve_memory & MEMORY_NO_PREDICTED_COV > 0:
             # Predicted: 1 -> 0
-            blas.{{prefix}}copy(&self.k_states2, &self.predicted_state_cov[0, 0, 1], &inc, &self.predicted_state_cov[0, 0, 0], &inc)
+            blas.{{prefix}}copy(&k_states2, &self.predicted_state_cov[0, 0, 1], &inc, &self.predicted_state_cov[0, 0, 0], &inc)
             if diffuse:
-                blas.{{prefix}}copy(&self.k_states2, &self.predicted_diffuse_state_cov[0, 0, 1], &inc, &self.predicted_diffuse_state_cov[0, 0, 0], &inc)
+                blas.{{prefix}}copy(&k_states2, &self.predicted_diffuse_state_cov[0, 0, 1], &inc, &self.predicted_diffuse_state_cov[0, 0, 0], &inc)
 
             # Predicted: 2 -> 1
             if self.filter_timing == TIMING_INIT_PREDICTED:
-                blas.{{prefix}}copy(&self.k_states2, &self.predicted_state_cov[0, 0, 2], &inc, &self.predicted_state_cov[0, 0, 1], &inc)
+                blas.{{prefix}}copy(&k_states2, &self.predicted_state_cov[0, 0, 2], &inc, &self.predicted_state_cov[0, 0, 1], &inc)
                 if diffuse:
-                    blas.{{prefix}}copy(&self.k_states2, &self.predicted_diffuse_state_cov[0, 0, 2], &inc, &self.predicted_diffuse_state_cov[0, 0, 1], &inc)
+                    blas.{{prefix}}copy(&k_states2, &self.predicted_diffuse_state_cov[0, 0, 2], &inc, &self.predicted_diffuse_state_cov[0, 0, 1], &inc)
 
 
 {{endfor}}

--- a/statsmodels/tsa/statespace/_kalman_filter.pyx.in
+++ b/statsmodels/tsa/statespace/_kalman_filter.pyx.in
@@ -86,7 +86,6 @@ np.import_array()
 from statsmodels.includes.math cimport *
 cimport scipy.linalg.cython_blas as blas
 cimport scipy.linalg.cython_lapack as lapack
-include "statsmodels/tsa/statespace/_blas_int.pxi"
 cimport statsmodels.tsa.statespace._tools as tools
 
 {{for prefix, types in TYPES.items()}}

--- a/statsmodels/tsa/statespace/_kalman_smoother.pyx.in
+++ b/statsmodels/tsa/statespace/_kalman_smoother.pyx.in
@@ -52,6 +52,7 @@ cimport cython
 np.import_array()
 
 cimport scipy.linalg.cython_blas as blas
+include "statsmodels/tsa/statespace/_blas_int.pxi"
 
 cdef int FORTRAN = 1
 
@@ -518,7 +519,9 @@ cdef class {{prefix}}KalmanSmoother(object):
         """
         Perform an iteration of the Kalman smoother
         """
-        cdef int t, inc = 1
+        cdef int t
+        cdef blas_int inc = 1
+        cdef blas_int k_states2 = self.kfilter.k_states2
         cdef int diffuse = self.t < self.kfilter.nobs_diffuse
 
         # Get time subscript, and stop the iterator if at the end
@@ -578,9 +581,9 @@ cdef class {{prefix}}KalmanSmoother(object):
 
         # Smoothed state autocovariance matrix
         if diffuse:
-            blas.{{prefix}}copy(&self.kfilter.k_states2, self.kfilter._tmpL0, &inc, self._innovations_transition, &inc)
+            blas.{{prefix}}copy(&k_states2, self.kfilter._tmpL0, &inc, self._innovations_transition, &inc)
         else:
-            blas.{{prefix}}copy(&self.kfilter.k_states2, self._tmpL, &inc, self._innovations_transition, &inc)
+            blas.{{prefix}}copy(&k_states2, self._tmpL, &inc, self._innovations_transition, &inc)
         if self.smoother_output & SMOOTHER_STATE_AUTOCOV:
             if diffuse:
                 {{prefix}}smoothed_state_autocov_univariate_diffuse(self, self.kfilter, self.model)

--- a/statsmodels/tsa/statespace/_representation.pyx.in
+++ b/statsmodels/tsa/statespace/_representation.pyx.in
@@ -30,6 +30,7 @@ np.import_array()
 from statsmodels.includes.math cimport *
 cimport scipy.linalg.cython_blas as blas
 cimport scipy.linalg.cython_lapack as lapack
+include "statsmodels/tsa/statespace/_blas_int.pxi"
 cimport statsmodels.tsa.statespace._tools as tools
 
 {{for prefix, types in TYPES.items()}}
@@ -448,11 +449,13 @@ cdef class {{prefix}}Statespace(object):
         """
         cdef np.npy_intp dim1[1]
         cdef np.npy_intp dim2[2]
-        cdef int i, info, inc = 1
-        cdef int k_states2 = self.k_states**2
+        cdef int i
+        cdef blas_int info, inc = 1
+        cdef blas_int k_states = self.k_states
+        cdef blas_int k_states2 = self.k_states**2
         cdef np.float64_t asum, tol = 1e-9
         cdef {{cython_type}} scalar
-        cdef int [::1,:] ipiv
+        cdef blas_int [::1,:] ipiv
 
         # Create selected state covariance matrix
         {{prefix}}select_cov(self.k_states, self.k_posdef,
@@ -463,11 +466,11 @@ cdef class {{prefix}}Statespace(object):
 
         # Initial state mean
         {{if combined_prefix == 'd'}}
-        asum = blas.{{prefix}}asum(&self.k_states, &self.state_intercept[0, 0], &inc)
+        asum = blas.{{prefix}}asum(&k_states, &self.state_intercept[0, 0], &inc)
         {{elif prefix == 'c'}}
-        asum = blas.scasum(&self.k_states, &self.state_intercept[0, 0], &inc)
+        asum = blas.scasum(&k_states, &self.state_intercept[0, 0], &inc)
         {{else}}
-        asum = blas.dzasum(&self.k_states, &self.state_intercept[0, 0], &inc)
+        asum = blas.dzasum(&k_states, &self.state_intercept[0, 0], &inc)
         {{endif}}
 
         dim1[0] = self.k_states
@@ -475,7 +478,10 @@ cdef class {{prefix}}Statespace(object):
         if asum > tol:
             dim2[0] = self.k_states
             dim2[1] = self.k_states
-            ipiv = np.PyArray_ZEROS(2, dim2, np.NPY_INT32, FORTRAN)
+            if sizeof(blas_int) == 4:
+                ipiv = np.PyArray_ZEROS(2, dim2, np.NPY_INT32, FORTRAN)
+            else:
+                ipiv = np.PyArray_ZEROS(2, dim2, np.NPY_INT64, FORTRAN)
 
             # I - T
             blas.{{prefix}}copy(&k_states2, &self.transition[0,0,0], &inc,
@@ -486,14 +492,14 @@ cdef class {{prefix}}Statespace(object):
                 self.tmp[i, i] = self.tmp[i, i] + 1
 
             # c
-            blas.{{prefix}}copy(&self.k_states, &self.state_intercept[0,0], &inc,
+            blas.{{prefix}}copy(&k_states, &self.state_intercept[0,0], &inc,
                                                 &self.initial_state[0], &inc)
 
             # Solve (I - T) x = c
-            lapack.{{prefix}}getrf(&self.k_states, &self.k_states, &self.tmp[0, 0], &self.k_states,
+            lapack.{{prefix}}getrf(&k_states, &k_states, &self.tmp[0, 0], &k_states,
                                    &ipiv[0, 0], &info)
-            lapack.{{prefix}}getrs('N', &self.k_states, &inc, &self.tmp[0, 0], &self.k_states,
-                                   &ipiv[0, 0], &self.initial_state[0], &self.k_states, &info)
+            lapack.{{prefix}}getrs('N', &k_states, &inc, &self.tmp[0, 0], &k_states,
+                                   &ipiv[0, 0], &self.initial_state[0], &k_states, &info)
 
         dim2[0] = self.k_states; dim2[1] = self.k_states;
         self.initial_state_cov = np.PyArray_ZEROS(2, dim2, {{typenum}}, FORTRAN)
@@ -657,10 +663,13 @@ cdef class {{prefix}}Statespace(object):
     cdef void _select_missing_partial_obs(self, unsigned int t):
         cdef:
             int i, j, k, l
-            int inc = 1
+            blas_int inc = 1
             int design_t = 0
             int obs_cov_t = 0
             int k_endog = self.k_endog - self._nmissing
+            blas_int blas_k_states = self.k_states
+            blas_int blas_k_endog = k_endog
+            blas_int blas_k_endog_orig = self.k_endog
 
         k = 0
         for i in range(self.k_endog):
@@ -670,9 +679,9 @@ cdef class {{prefix}}Statespace(object):
                 self.selected_obs_intercept[k] = self._obs_intercept[i]
 
                 # i is rows, k is rows
-                blas.{{prefix}}copy(&self.k_states,
-                      &self._design[i], &self.k_endog,
-                      &self.selected_design[k], &k_endog)
+                blas.{{prefix}}copy(&blas_k_states,
+                      &self._design[i], &blas_k_endog_orig,
+                      &self.selected_design[k], &blas_k_endog)
 
                 # i, k is columns, j, l is rows
                 l = 0
@@ -703,9 +712,14 @@ cdef class {{prefix}}Statespace(object):
         # TODO need unit tests, especially for the missing case
         # TODO need to also transform observation intercept
         cdef:
-            int i, j, inc=1
+            int i, j
+            blas_int inc = 1
+            blas_int info
+            blas_int _k_endog = self._k_endog
+            blas_int _k_endog2 = self._k_endog2
+            blas_int _k_states = self._k_states
+            blas_int _k_endogstates = self._k_endogstates
             int obs_cov_t = 0
-            int info
             int reset_missing
             int diagonal_obs_cov
             {{cython_type}} * _transform_obs_cov = &self.transform_obs_cov[0, 0]
@@ -747,7 +761,7 @@ cdef class {{prefix}}Statespace(object):
         # decomposition of *self._obs_cov
         if t == 0 or self.obs_cov.shape[2] > 1 or reset_missing or reset:
             # LDL decomposition
-            blas.{{prefix}}copy(&self._k_endog2, self._obs_cov, &inc, _transform_cholesky, &inc)
+            blas.{{prefix}}copy(&_k_endog2, self._obs_cov, &inc, _transform_cholesky, &inc)
             info = tools._{{prefix}}ldl(_transform_cholesky, self._k_endog)
 
             # Check for errors
@@ -779,10 +793,10 @@ cdef class {{prefix}}Statespace(object):
         if not self._nmissing == self.k_endog:
             # If we have some missing elements, selected_obs is already populated
             if self._nmissing == 0:
-                blas.{{prefix}}copy(&self._k_endog, &self.obs[0,t], &inc, &self.selected_obs[0], &inc)
-            lapack.{{prefix}}trtrs("L", "N", "U", &self._k_endog, &inc,
-                        _transform_cholesky, &self.k_endog,
-                        &self.selected_obs[0], &self._k_endog, &info)
+                blas.{{prefix}}copy(&_k_endog, &self.obs[0,t], &inc, &self.selected_obs[0], &inc)
+            lapack.{{prefix}}trtrs("L", "N", "U", &_k_endog, &inc,
+                        _transform_cholesky, &_k_endog,
+                        &self.selected_obs[0], &_k_endog, &info)
 
             # Check for errors
             if info > 0:
@@ -795,18 +809,18 @@ cdef class {{prefix}}Statespace(object):
 
         # Solve for d_t^*, if necessary
         if t == 0 or self.obs_intercept.shape[1] > 1 or reset_missing or reset:
-            blas.{{prefix}}copy(&self._k_endog, self._obs_intercept, &inc, &self.transform_obs_intercept[0], &inc)
-            lapack.{{prefix}}trtrs("L", "N", "U", &self._k_endog, &inc,
-                        _transform_cholesky, &self.k_endog,
-                        &self.transform_obs_intercept[0], &self._k_endog,
+            blas.{{prefix}}copy(&_k_endog, self._obs_intercept, &inc, &self.transform_obs_intercept[0], &inc)
+            lapack.{{prefix}}trtrs("L", "N", "U", &_k_endog, &inc,
+                        _transform_cholesky, &_k_endog,
+                        &self.transform_obs_intercept[0], &_k_endog,
                         &info)
 
         # Solve for Z_t^*, if necessary
         if t == 0 or self.design.shape[2] > 1 or reset_missing or reset:
-            blas.{{prefix}}copy(&self._k_endogstates, self._design, &inc, &self.transform_design[0,0], &inc)
-            lapack.{{prefix}}trtrs("L", "N", "U", &self._k_endog, &self._k_states,
-                        _transform_cholesky, &self.k_endog,
-                        &self.transform_design[0,0], &self._k_endog,
+            blas.{{prefix}}copy(&_k_endogstates, self._design, &inc, &self.transform_design[0,0], &inc)
+            lapack.{{prefix}}trtrs("L", "N", "U", &_k_endog, &_k_states,
+                        _transform_cholesky, &_k_endog,
+                        &self.transform_design[0,0], &_k_endog,
                         &info)
 
             # Check for errors
@@ -825,16 +839,20 @@ cdef class {{prefix}}Statespace(object):
         # Note: this assumes that select_missing has *already* been done
         # TODO need unit tests, especially for the missing case
         cdef:
-            int i, j, k, l, inc=1
+            int i, j, k, l
+            blas_int inc = 1
+            blas_int info
             int obs_cov_t, design_t
-            int info
             int reset_missing
             {{cython_type}} alpha = 1.0
             {{cython_type}} beta = 0.0
             {{cython_type}} gamma = -1.0
-            int k_states = self._k_states
-            int k_states2 = self._k_states2
-            int k_endogstates = self._k_endogstates
+            blas_int k_states = self._k_states
+            blas_int k_states2 = self._k_states2
+            blas_int k_endogstates = self._k_endogstates
+            blas_int _k_endog = self._k_endog
+            blas_int _k_endog2 = self._k_endog2
+            blas_int blas_k_endog = self.k_endog
 
         # $y_t^* = \bar A^* y_t = C_t Z_t' H_t^{-1} y_t$
         # $Z_t^* = C_t^{-1}$
@@ -875,8 +893,8 @@ cdef class {{prefix}}Statespace(object):
         # Perform the Cholesky decomposition of H_t, if necessary
         if t == 0 or self.obs_cov.shape[2] > 1 or reset_missing or reset:
             # Cholesky decomposition: $H = L L'$
-            blas.{{prefix}}copy(&self._k_endog2, self._obs_cov, &inc, &self.transform_cholesky[0,0], &inc)
-            lapack.{{prefix}}potrf("L", &self._k_endog, &self.transform_cholesky[0,0], &self._k_endog, &info)
+            blas.{{prefix}}copy(&_k_endog2, self._obs_cov, &inc, &self.transform_cholesky[0,0], &inc)
+            lapack.{{prefix}}potrf("L", &_k_endog, &self.transform_cholesky[0,0], &_k_endog, &info)
 
             # Check for errors
             if info > 0:
@@ -898,10 +916,10 @@ cdef class {{prefix}}Statespace(object):
         # Get $Z_t \equiv C^{-1}$, if necessary
         if t == 0 or self.obs_cov.shape[2] > 1 or self.design.shape[2] > 1 or reset_missing or reset:
             # Calculate $H_t^{-1} Z_t \equiv (Z_t' H_t^{-1})'$ via Cholesky solver
-            blas.{{prefix}}copy(&self._k_endogstates, self._design, &inc, &self.transform_design[0,0], &inc)
-            lapack.{{prefix}}potrs("L", &self._k_endog, &k_states,
-                            &self.transform_cholesky[0,0], &self._k_endog,
-                            &self.transform_design[0,0], &self._k_endog,
+            blas.{{prefix}}copy(&k_endogstates, self._design, &inc, &self.transform_design[0,0], &inc)
+            lapack.{{prefix}}potrs("L", &_k_endog, &k_states,
+                            &self.transform_cholesky[0,0], &_k_endog,
+                            &self.transform_design[0,0], &_k_endog,
                             &info)
 
             # Check for errors
@@ -910,22 +928,22 @@ cdef class {{prefix}}Statespace(object):
 
             # Calculate $(H_t^{-1} Z_t)' Z_t$
             # $(m \times m) = (m \times p) (p \times p) (p \times m)$
-            blas.{{prefix}}gemm("T", "N", &k_states, &k_states, &self._k_endog,
-                   &alpha, self._design, &self._k_endog,
-                           &self.transform_design[0,0], &self._k_endog,
-                   &beta, &self.collapse_cholesky[0,0], &self._k_states)
+            blas.{{prefix}}gemm("T", "N", &k_states, &k_states, &_k_endog,
+                   &alpha, self._design, &_k_endog,
+                           &self.transform_design[0,0], &_k_endog,
+                   &beta, &self.collapse_cholesky[0,0], &k_states)
 
             # Calculate $(Z_t' H_t^{-1} Z_t)^{-1}$ via Cholesky inversion
-            lapack.{{prefix}}potrf("U", &k_states, &self.collapse_cholesky[0,0], &self.k_states, &info)
+            lapack.{{prefix}}potrf("U", &k_states, &self.collapse_cholesky[0,0], &k_states, &info)
             # Check for errors
             if info > 0:
                 raise np.linalg.LinAlgError('Non-positive-definite ZHZ matrix encountered at period %d' % t)
             elif info < 0:
                 raise np.linalg.LinAlgError('Invalid value in ZHZ matrix encountered at period %d' % t)
-            lapack.{{prefix}}potri("U", &k_states, &self.collapse_cholesky[0,0], &self.k_states, &info)
+            lapack.{{prefix}}potri("U", &k_states, &self.collapse_cholesky[0,0], &k_states, &info)
 
             # Calculate $C_t$ (the upper triangular cholesky decomposition of $(Z_t' H_t^{-1} Z_t)^{-1}$)
-            lapack.{{prefix}}potrf("U", &k_states, &self.collapse_cholesky[0,0], &self.k_states, &info)
+            lapack.{{prefix}}potrf("U", &k_states, &self.collapse_cholesky[0,0], &k_states, &info)
 
             # Check for errors
             if info > 0:
@@ -936,10 +954,10 @@ cdef class {{prefix}}Statespace(object):
             # Calculate $C_t'^{-1} \equiv Z_t$
             # Do so by solving the system: $C_t' x = I$
             # (Recall that collapse_obs_cov is an identity matrix)
-            blas.{{prefix}}copy(&self._k_states2, &self.collapse_obs_cov[0,0], &inc, &self.collapse_design[0,0], &inc)
+            blas.{{prefix}}copy(&k_states2, &self.collapse_obs_cov[0,0], &inc, &self.collapse_design[0,0], &inc)
             lapack.{{prefix}}trtrs("U", "T", "N", &k_states, &k_states,
-                        &self.collapse_cholesky[0,0], &self._k_states,
-                        &self.collapse_design[0,0], &self._k_states,
+                        &self.collapse_cholesky[0,0], &k_states,
+                        &self.collapse_design[0,0], &k_states,
                         &info)
 
         # Calculate $\bar y_t^* = \bar A_t^* y_t = C_t Z_t' H_t^{-1} y_t$
@@ -948,15 +966,15 @@ cdef class {{prefix}}Statespace(object):
         if not self._nmissing == self.k_endog:
             # If we have some missing elements, selected_obs is already populated
             if self._nmissing == 0:
-                blas.{{prefix}}copy(&self.k_endog, &self.obs[0,t], &inc, &self.selected_obs[0], &inc)
+                blas.{{prefix}}copy(&blas_k_endog, &self.obs[0,t], &inc, &self.selected_obs[0], &inc)
             # $\\# = Z_t' H_t^{-1} y_t$
-            blas.{{prefix}}gemv("T", &self._k_endog, &k_states,
-                  &alpha, &self.transform_design[0,0], &self._k_endog,
+            blas.{{prefix}}gemv("T", &_k_endog, &k_states,
+                  &alpha, &self.transform_design[0,0], &_k_endog,
                           &self.selected_obs[0], &inc,
                   &beta, &self.collapse_obs[0], &inc)
             # $y_t^* = C_t \\#$
             blas.{{prefix}}trmv("U", "N", "N", &k_states,
-                                &self.collapse_cholesky[0,0], &self._k_states,
+                                &self.collapse_cholesky[0,0], &k_states,
                                 &self.collapse_obs[0], &inc)
 
             # Get residuals for loglikelihood calculation
@@ -971,12 +989,12 @@ cdef class {{prefix}}Statespace(object):
             # $ \\# = C_t' y_t^*$
             blas.{{prefix}}copy(&k_states, &self.collapse_obs[0], &inc, &self.collapse_obs_tmp[0], &inc)
             blas.{{prefix}}trmv("U", "T", "N", &k_states,
-                                &self.collapse_cholesky[0,0], &self._k_states,
+                                &self.collapse_cholesky[0,0], &k_states,
                                 &self.collapse_obs_tmp[0], &inc)
 
             # $e_t = - Z_t C_t' y_t^* + y_t$
-            blas.{{prefix}}gemv("N", &self._k_endog, &k_states,
-                  &gamma, self._design, &self._k_endog,
+            blas.{{prefix}}gemv("N", &_k_endog, &k_states,
+                  &gamma, self._design, &_k_endog,
                           &self.collapse_obs_tmp[0], &inc,
                   &alpha, &self.selected_obs[0], &inc)
 
@@ -985,9 +1003,9 @@ cdef class {{prefix}}Statespace(object):
             # So we want $e_t' L^{-1}' L^{-1} e_t = (L^{-1} e_t)' L^{-1} e_t$
             # We have $L$ in `transform_cholesky`, so we want to do a linear
             # solve of $L x = e_t$  where L is lower triangular
-            lapack.{{prefix}}trtrs("L", "N", "N", &self._k_endog, &inc,
-                        &self.transform_cholesky[0,0], &self._k_endog,
-                        &self.selected_obs[0], &self._k_endog,
+            lapack.{{prefix}}trtrs("L", "N", "N", &_k_endog, &inc,
+                        &self.transform_cholesky[0,0], &_k_endog,
+                        &self.selected_obs[0], &_k_endog,
                         &info)
 
             # Calculate loglikelihood contribution of this observation
@@ -1024,6 +1042,8 @@ cdef int {{prefix}}select_cov(int k, int k_posdef,
     cdef:
         {{cython_type}} alpha = 1.0
         {{cython_type}} beta = 0.0
+        blas_int blas_k = k
+        blas_int blas_k_posdef = k_posdef
 
     # Only need to do something if there is a covariance matrix
     # (i.e k_posdof == 0)
@@ -1043,15 +1063,15 @@ cdef int {{prefix}}select_cov(int k, int k_posdef,
 
         # $\\#_0 = 1.0 * R_t Q_t$
         # $(m \times r) = (m \times r) (r \times r)$
-        blas.{{prefix}}gemm("N", "N", &k, &k_posdef, &k_posdef,
-              &alpha, selection, &k,
-                      cov, &k_posdef,
-              &beta, tmp, &k)
+        blas.{{prefix}}gemm("N", "N", &blas_k, &blas_k_posdef, &blas_k_posdef,
+              &alpha, selection, &blas_k,
+                      cov, &blas_k_posdef,
+              &beta, tmp, &blas_k)
         # $Q_t^* = 1.0 * \\#_0 R_t'$
         # $(m \times m) = (m \times r) (m \times r)'$
-        blas.{{prefix}}gemm("N", "T", &k, &k, &k_posdef,
-              &alpha, tmp, &k,
-                      selection, &k,
-              &beta, selected_cov, &k)
+        blas.{{prefix}}gemm("N", "T", &blas_k, &blas_k, &blas_k_posdef,
+              &alpha, tmp, &blas_k,
+                      selection, &blas_k,
+              &beta, selected_cov, &blas_k)
 
 {{endfor}}

--- a/statsmodels/tsa/statespace/_simulation_smoother.pyx.in
+++ b/statsmodels/tsa/statespace/_simulation_smoother.pyx.in
@@ -50,6 +50,7 @@ np.import_array()
 
 cimport scipy.linalg.cython_blas as blas
 cimport scipy.linalg.cython_lapack as lapack
+include "statsmodels/tsa/statespace/_blas_int.pxi"
 cimport statsmodels.tsa.statespace._tools as tools
 
 cdef int FORTRAN = 1
@@ -80,7 +81,7 @@ cdef class {{prefix}}SimulationSmoother(object):
                  int smoother_output=SMOOTHER_ALL,
                  int simulation_output=SIMULATE_ALL,
                  int nobs=-1):
-        cdef int inc = 1
+        cdef blas_int inc = 1
         # If nobs != 1, then we are only simulating a new series (i.e. we are
         # not simulation smoothing)
         self.simulate_only = (nobs != -1)
@@ -89,7 +90,7 @@ cdef class {{prefix}}SimulationSmoother(object):
             np.npy_intp dim2[2]
         cdef {{cython_type}} [::1,:] obs
         cdef {{cython_type}} [::1,:] secondary_obs
-        cdef int nobs_endog
+        cdef blas_int nobs_endog
 
         # Use model nobs by default
         if nobs == -1:
@@ -339,18 +340,18 @@ cdef class {{prefix}}SimulationSmoother(object):
         Draw a simulation
         """
         cdef:
-            int inc = 1
-            int info
+            blas_int inc = 1
+            blas_int info
             int measurement_idx, state_idx, t
-            int k_endog = self.model.k_endog
-            int k_states = self.model.k_states
-            int k_states2 = self.model.k_states**2
-            int k_posdef = self.model.k_posdef
-            int k_posdef2 = self.model.k_posdef**2
-            int nobs_endog = self.nobs * self.model.k_endog
-            int nobs_kstates = self.nobs * self.model.k_states
-            int nobs1_kstates = (self.nobs+1) * self.model.k_states
-            int nobs_posdef = self.nobs * self.model.k_posdef
+            blas_int k_endog = self.model.k_endog
+            blas_int k_states = self.model.k_states
+            blas_int k_states2 = self.model.k_states**2
+            blas_int k_posdef = self.model.k_posdef
+            blas_int k_posdef2 = self.model.k_posdef**2
+            blas_int nobs_endog = self.nobs * self.model.k_endog
+            blas_int nobs_kstates = self.nobs * self.model.k_states
+            blas_int nobs1_kstates = (self.nobs+1) * self.model.k_states
+            blas_int nobs_posdef = self.nobs * self.model.k_posdef
         cdef:
             {{cython_type}} alpha = 1.0
             {{cython_type}} gamma = -1.0
@@ -562,9 +563,9 @@ cdef class {{prefix}}SimulationSmoother(object):
 
     cdef {{cython_type}} generate_obs(self, int t, {{cython_type}} * obs, {{cython_type}} * state, {{cython_type}} * variates):
         cdef:
-            int inc = 1
-            int k_endog = self.model.k_endog
-            int k_states = self.model.k_states
+            blas_int inc = 1
+            blas_int k_endog = self.model.k_endog
+            blas_int k_states = self.model.k_states
             int design_t = 0
             int obs_intercept_t = 0
         cdef:
@@ -595,9 +596,9 @@ cdef class {{prefix}}SimulationSmoother(object):
 
     cdef {{cython_type}} generate_state(self, int t, {{cython_type}} * state, {{cython_type}} * input_state, {{cython_type}} * variates):
         cdef:
-            int inc = 1
-            int k_states = self.model.k_states
-            int k_posdef = self.model.k_posdef
+            blas_int inc = 1
+            blas_int k_states = self.model.k_states
+            blas_int k_posdef = self.model.k_posdef
             int state_intercept_t = 0
             int transition_t = 0
             int selection_t = 0
@@ -628,24 +629,26 @@ cdef class {{prefix}}SimulationSmoother(object):
 
     cdef void cholesky(self, {{cython_type}} * source, {{cython_type}} * destination, int n):
         cdef:
-            int inc = 1
-            int n2 = n**2
-            int info
+            blas_int inc = 1
+            blas_int n2 = n**2
+            blas_int info
+            blas_int blas_n = n
         if n == 1:
             destination[0] = source[0]**0.5
         else:
             blas.{{prefix}}copy(&n2, source, &inc, destination, &inc)
-            lapack.{{prefix}}potrf("L", &n, destination, &n, &info)
+            lapack.{{prefix}}potrf("L", &blas_n, destination, &blas_n, &info)
 
     cdef void transform_variates(self, {{cython_type}} * variates, {{cython_type}} * cholesky_factor, int n):
         cdef:
-            int inc = 1
+            blas_int inc = 1
+            blas_int blas_n = n
 
         # Overwrites variate
         if n == 1:
             variates[0] = cholesky_factor[0] * variates[0]
         else:
-            blas.{{prefix}}trmv("L", "N", "N", &n, cholesky_factor, &n,
+            blas.{{prefix}}trmv("L", "N", "N", &blas_n, cholesky_factor, &blas_n,
                                                    variates, &inc)
 
 {{endfor}}

--- a/statsmodels/tsa/statespace/_smoothers/_alternative.pyx.in
+++ b/statsmodels/tsa/statespace/_smoothers/_alternative.pyx.in
@@ -24,6 +24,7 @@ import numpy as np
 cimport numpy as np
 from statsmodels.includes.math cimport *
 cimport scipy.linalg.cython_blas as blas
+include "statsmodels/tsa/statespace/_blas_int.pxi"
 
 from statsmodels.tsa.statespace._kalman_smoother cimport (
     SMOOTHER_STATE, SMOOTHER_STATE_COV, SMOOTHER_DISTURBANCE,
@@ -53,25 +54,30 @@ if prefix == 's':
 cdef int {{prefix}}smoothed_estimators_measurement_alternative({{prefix}}KalmanSmoother smoother, {{prefix}}KalmanFilter kfilter, {{prefix}}Statespace model) except *:
     cdef:
         int i
-        int inc = 1
+        blas_int inc = 1
+        blas_int kf_k_endog = kfilter.k_endog
+        blas_int m_k_endog = model._k_endog
+        blas_int m_k_states = model._k_states
+        blas_int m_k_states2 = model._k_states2
+        blas_int kf_k_states = kfilter.k_states
         {{cython_type}} alpha = 1.0
         {{cython_type}} beta = 0.0
         {{cython_type}} gamma = -1.0
 
     if model._nmissing == model.k_endog:
         # $L_t = T_t$
-        blas.{{prefix}}copy(&model._k_states2, model._transition, &inc, smoother._tmpL, &inc)
+        blas.{{prefix}}copy(&m_k_states2, model._transition, &inc, smoother._tmpL, &inc)
         return 1
 
     # $C_t = (I - P_t Z_t' F_t^{-1} Z_t)$
     # $C_t = (I - \\#_1 \\#_3)$
     # $(m \times m) = (m \times m) + (m \times p) (p \times m)$
     # (this is required for any type of smoothing)
-    blas.{{prefix}}copy(&model._k_states2, model._transition, &inc, smoother._tmpL, &inc)
-    blas.{{prefix}}gemm("N", "N", &model._k_states, &model._k_states, &model._k_endog,
-              &gamma, kfilter._tmp1, &kfilter.k_states,
-                      kfilter._tmp3, &kfilter.k_endog,
-              &beta, smoother._tmpL, &kfilter.k_states)
+    blas.{{prefix}}copy(&m_k_states2, model._transition, &inc, smoother._tmpL, &inc)
+    blas.{{prefix}}gemm("N", "N", &m_k_states, &m_k_states, &m_k_endog,
+              &gamma, kfilter._tmp1, &kf_k_states,
+                      kfilter._tmp3, &kf_k_endog,
+              &beta, smoother._tmpL, &kf_k_states)
     for i in range(model._k_states):
         smoother.tmpL[i,i] = smoother.tmpL[i,i] + 1
 
@@ -80,15 +86,15 @@ cdef int {{prefix}}smoothed_estimators_measurement_alternative({{prefix}}KalmanS
     # $\tilde r_{t} = \\#_3' v_n + C_t' \hat r_n$
     # $(m \times 1) = (m \times p) (p \times 1) + (m \times m) (m \times 1)$
     if smoother.smoother_output & (SMOOTHER_STATE | SMOOTHER_DISTURBANCE):
-        blas.{{prefix}}gemv("T", &model._k_states, &model._k_states,
-                  &alpha, smoother._tmpL, &kfilter.k_states,
+        blas.{{prefix}}gemv("T", &m_k_states, &m_k_states,
+                  &alpha, smoother._tmpL, &kf_k_states,
                           smoother._input_scaled_smoothed_estimator, &inc,
                   &beta, smoother._tmp0, &inc)
 
-        blas.{{prefix}}copy(&model._k_states, smoother._tmp0, &inc,
+        blas.{{prefix}}copy(&m_k_states, smoother._tmp0, &inc,
                                               smoother._input_scaled_smoothed_estimator, &inc)
-        blas.{{prefix}}gemv("T", &model._k_endog, &model._k_states,
-                  &alpha, kfilter._tmp3, &kfilter.k_endog,
+        blas.{{prefix}}gemv("T", &m_k_endog, &m_k_states,
+                  &alpha, kfilter._tmp3, &kf_k_endog,
                           &kfilter.forecast_error[0, smoother.t], &inc,
                   &alpha, smoother._input_scaled_smoothed_estimator, &inc)
 
@@ -97,42 +103,44 @@ cdef int {{prefix}}smoothed_estimators_measurement_alternative({{prefix}}KalmanS
     # $\tilde N_{t} = Z_t' \\#_3 + C_t' \hat N_t C_t$
     # $(m \times m) = (m \times p) (p \times m) + (m \times m) (m \times m) (m \times m)$
     if smoother.smoother_output & (SMOOTHER_STATE_COV | SMOOTHER_DISTURBANCE_COV):
-        blas.{{prefix}}gemm("N", "N", &model._k_states, &model._k_states, &model._k_states,
-                  &alpha, smoother._input_scaled_smoothed_estimator_cov, &kfilter.k_states,
-                          smoother._tmpL, &kfilter.k_states,
-                  &beta, smoother._tmp0, &kfilter.k_states)
-        blas.{{prefix}}gemm("T", "N", &model._k_states, &model._k_states, &model._k_states,
-                  &alpha, smoother._tmpL, &kfilter.k_states,
-                          smoother._tmp0, &kfilter.k_states,
-                  &beta, smoother._input_scaled_smoothed_estimator_cov, &kfilter.k_states)
-        blas.{{prefix}}gemm("T", "N", &model._k_states, &model._k_states, &model._k_endog,
-                  &alpha, model._design, &model._k_endog,
-                          kfilter._tmp3, &kfilter.k_endog,
-                  &alpha, smoother._input_scaled_smoothed_estimator_cov, &kfilter.k_states)
+        blas.{{prefix}}gemm("N", "N", &m_k_states, &m_k_states, &m_k_states,
+                  &alpha, smoother._input_scaled_smoothed_estimator_cov, &kf_k_states,
+                          smoother._tmpL, &kf_k_states,
+                  &beta, smoother._tmp0, &kf_k_states)
+        blas.{{prefix}}gemm("T", "N", &m_k_states, &m_k_states, &m_k_states,
+                  &alpha, smoother._tmpL, &kf_k_states,
+                          smoother._tmp0, &kf_k_states,
+                  &beta, smoother._input_scaled_smoothed_estimator_cov, &kf_k_states)
+        blas.{{prefix}}gemm("T", "N", &m_k_states, &m_k_states, &m_k_endog,
+                  &alpha, model._design, &m_k_endog,
+                          kfilter._tmp3, &kf_k_endog,
+                  &alpha, smoother._input_scaled_smoothed_estimator_cov, &kf_k_states)
 
     # $L_t = T_t C_t$
     # $(m \times m) = (m \times m) (m \times m)$
-    blas.{{prefix}}copy(&model._k_states2, smoother._tmpL, &inc, smoother._tmp0, &inc)
-    blas.{{prefix}}gemm("N", "N", &model._k_states, &model._k_states, &model._k_states,
-              &alpha, model._transition, &kfilter.k_states,
-                      smoother._tmp0, &kfilter.k_states,
-              &beta, smoother._tmpL, &kfilter.k_states)
+    blas.{{prefix}}copy(&m_k_states2, smoother._tmpL, &inc, smoother._tmp0, &inc)
+    blas.{{prefix}}gemm("N", "N", &m_k_states, &m_k_states, &m_k_states,
+              &alpha, model._transition, &kf_k_states,
+                      smoother._tmp0, &kf_k_states,
+              &beta, smoother._tmpL, &kf_k_states)
 
     # Smoothing error
     # $u_t = \\#_2 - K_t' \tilde r_{t+1}$
     # $(p \times 1) = (p \times 1) - (p \times m) (m \times 1)$
     if smoother.smoother_output & (SMOOTHER_DISTURBANCE):
-        blas.{{prefix}}copy(&kfilter.k_endog, kfilter._tmp2, &inc, smoother._smoothing_error, &inc)
+        blas.{{prefix}}copy(&kf_k_endog, kfilter._tmp2, &inc, smoother._smoothing_error, &inc)
         if smoother.t < model.nobs - 1:
-            blas.{{prefix}}gemv("T", &model._k_states, &model._k_endog,
-                      &gamma, kfilter._kalman_gain, &kfilter.k_states,
+            blas.{{prefix}}gemv("T", &m_k_states, &m_k_endog,
+                      &gamma, kfilter._kalman_gain, &kf_k_states,
                               &smoother.scaled_smoothed_estimator[0, smoother.t+1], &inc,
                       &alpha, smoother._smoothing_error, &inc)
 
 cdef int {{prefix}}smoothed_estimators_time_alternative({{prefix}}KalmanSmoother smoother, {{prefix}}KalmanFilter kfilter, {{prefix}}Statespace model):
     cdef:
         int i
-        int inc = 1
+        blas_int inc = 1
+        blas_int m_k_states = model._k_states
+        blas_int kf_k_states = kfilter.k_states
         {{cython_type}} alpha = 1.0
         {{cython_type}} beta = 0.0
         {{cython_type}} gamma = -1.0
@@ -144,8 +152,8 @@ cdef int {{prefix}}smoothed_estimators_time_alternative({{prefix}}KalmanSmoother
     # $\hat r_{t-1} = T_t' \tilde r_t$
     # $(m \times 1) = (m \times m) (m \times 1)
     if smoother.smoother_output & (SMOOTHER_STATE | SMOOTHER_DISTURBANCE):
-        blas.{{prefix}}gemv("T", &model._k_states, &model._k_states,
-                  &alpha, model._transition, &kfilter.k_states,
+        blas.{{prefix}}gemv("T", &m_k_states, &m_k_states,
+                  &alpha, model._transition, &kf_k_states,
                           smoother._input_scaled_smoothed_estimator, &inc,
                   &beta, smoother._scaled_smoothed_estimator, &inc)
 
@@ -153,19 +161,21 @@ cdef int {{prefix}}smoothed_estimators_time_alternative({{prefix}}KalmanSmoother
     # $\hat N_{t-1} = T_t' \tilde N_t T_t$
     # $(m \times m) = (m \times p) (m \times m) (m \times m)$
     if smoother.smoother_output & (SMOOTHER_STATE_COV | SMOOTHER_DISTURBANCE_COV):
-        blas.{{prefix}}gemm("T", "N", &model._k_states, &model._k_states, &model._k_states,
-                  &alpha, model._transition, &kfilter.k_states,
-                          smoother._input_scaled_smoothed_estimator_cov, &kfilter.k_states,
-                  &beta, smoother._tmp0, &kfilter.k_states)
-        blas.{{prefix}}gemm("N", "N", &model._k_states, &model._k_states, &model._k_states,
-                  &alpha, smoother._tmp0, &kfilter.k_states,
-                          model._transition, &kfilter.k_states,
-                  &beta, smoother._scaled_smoothed_estimator_cov, &kfilter.k_states)
+        blas.{{prefix}}gemm("T", "N", &m_k_states, &m_k_states, &m_k_states,
+                  &alpha, model._transition, &kf_k_states,
+                          smoother._input_scaled_smoothed_estimator_cov, &kf_k_states,
+                  &beta, smoother._tmp0, &kf_k_states)
+        blas.{{prefix}}gemm("N", "N", &m_k_states, &m_k_states, &m_k_states,
+                  &alpha, smoother._tmp0, &kf_k_states,
+                          model._transition, &kf_k_states,
+                  &beta, smoother._scaled_smoothed_estimator_cov, &kf_k_states)
 
 cdef int {{prefix}}smoothed_state_alternative({{prefix}}KalmanSmoother smoother, {{prefix}}KalmanFilter kfilter, {{prefix}}Statespace model):
     cdef int i, j
     cdef:
-        int inc = 1
+        blas_int inc = 1
+        blas_int kf_k_states = kfilter.k_states
+        blas_int m_k_states = model._k_states
         {{cython_type}} alpha = 1.0
         {{cython_type}} beta = 0.0
         {{cython_type}} gamma = -1.0
@@ -180,10 +190,10 @@ cdef int {{prefix}}smoothed_state_alternative({{prefix}}KalmanSmoother smoother,
     if smoother.smoother_output & SMOOTHER_STATE:
         # $\hat \alpha_t = a_t|t + P_t|t \hat r_t$
         # $(m \times 1) = (m \times 1) + (m \times m) (m \times 1)$
-        blas.{{prefix}}copy(&kfilter.k_states, &kfilter.filtered_state[0,smoother.t], &inc, smoother._smoothed_state, &inc)
+        blas.{{prefix}}copy(&kf_k_states, &kfilter.filtered_state[0,smoother.t], &inc, smoother._smoothed_state, &inc)
 
-        blas.{{prefix}}gemv("N", &model._k_states, &model._k_states,
-                  &alpha, &kfilter.filtered_state_cov[0, 0, smoother.t], &kfilter.k_states,
+        blas.{{prefix}}gemv("N", &m_k_states, &m_k_states,
+                  &alpha, &kfilter.filtered_state_cov[0, 0, smoother.t], &kf_k_states,
                           smoother._input_scaled_smoothed_estimator, &inc,
                   &alpha, smoother._smoothed_state, &inc)
 
@@ -191,21 +201,28 @@ cdef int {{prefix}}smoothed_state_alternative({{prefix}}KalmanSmoother smoother,
     if smoother.smoother_output & SMOOTHER_STATE_COV:
         # $V_t = P_t|t [I - \hat N_t P_t|t]$
         # $(m \times m) = (m \times m) [(m \times m) - (m \times m) (m \times m)]$
-        blas.{{prefix}}gemm("N", "N", &model._k_states, &model._k_states, &model._k_states,
-              &gamma, smoother._input_scaled_smoothed_estimator_cov, &kfilter.k_states,
-                      &kfilter.filtered_state_cov[0, 0, smoother.t], &kfilter.k_states,
-              &beta, smoother._tmp0, &kfilter.k_states)
+        blas.{{prefix}}gemm("N", "N", &m_k_states, &m_k_states, &m_k_states,
+              &gamma, smoother._input_scaled_smoothed_estimator_cov, &kf_k_states,
+                      &kfilter.filtered_state_cov[0, 0, smoother.t], &kf_k_states,
+              &beta, smoother._tmp0, &kf_k_states)
         for i in range(kfilter.k_states):
             smoother.tmp0[i,i] = 1 + smoother.tmp0[i,i]
-        blas.{{prefix}}gemm("N", "N", &model._k_states, &model._k_states, &model._k_states,
-              &alpha, &kfilter.filtered_state_cov[0,0,smoother.t], &kfilter.k_states,
-                      smoother._tmp0, &kfilter.k_states,
-              &beta, smoother._smoothed_state_cov, &kfilter.k_states)
+        blas.{{prefix}}gemm("N", "N", &m_k_states, &m_k_states, &m_k_states,
+              &alpha, &kfilter.filtered_state_cov[0,0,smoother.t], &kf_k_states,
+                      smoother._tmp0, &kf_k_states,
+              &beta, smoother._smoothed_state_cov, &kf_k_states)
 
 cdef int {{prefix}}smoothed_disturbances_alternative({{prefix}}KalmanSmoother smoother, {{prefix}}KalmanFilter kfilter, {{prefix}}Statespace model):
     cdef int i, j
     cdef:
-        int inc = 1
+        blas_int inc = 1
+        blas_int kf_k_endog = kfilter.k_endog
+        blas_int kf_k_posdef = kfilter.k_posdef
+        blas_int kf_k_states = kfilter.k_states
+        blas_int m_k_endog = model._k_endog
+        blas_int m_k_posdef = model._k_posdef
+        blas_int m_k_posdef2 = model._k_posdef2
+        blas_int m_k_states = model._k_states
         {{cython_type}} alpha = 1.0
         {{cython_type}} beta = 0.0
         {{cython_type}} gamma = -1.0
@@ -219,53 +236,53 @@ cdef int {{prefix}}smoothed_disturbances_alternative({{prefix}}KalmanSmoother sm
     # $\\#_0 = R_t Q_t$
     # $(m \times r) = (m \times r) (r \times r)$
     if smoother.smoother_output & (SMOOTHER_DISTURBANCE | SMOOTHER_DISTURBANCE_COV):
-        blas.{{prefix}}gemm("N", "N", &model._k_states, &model._k_posdef, &model._k_posdef,
-                  &alpha, model._selection, &model._k_states,
-                          model._state_cov, &model._k_posdef,
-                  &beta, smoother._tmp0, &kfilter.k_states)
+        blas.{{prefix}}gemm("N", "N", &m_k_states, &m_k_posdef, &m_k_posdef,
+                  &alpha, model._selection, &m_k_states,
+                          model._state_cov, &m_k_posdef,
+                  &beta, smoother._tmp0, &kf_k_states)
 
     if smoother.smoother_output & SMOOTHER_DISTURBANCE:
         # Smoothed measurement disturbance
         # $\hat \varepsilon_t = H_t u_t$
         # $(p \times 1) = (p \times p) (p \times 1)$
-        blas.{{prefix}}gemv("N", &model._k_endog, &model._k_endog,
-                      &alpha, model._obs_cov, &model._k_endog,
+        blas.{{prefix}}gemv("N", &m_k_endog, &m_k_endog,
+                      &alpha, model._obs_cov, &m_k_endog,
                               smoother._smoothing_error, &inc,
                       &beta, smoother._smoothed_measurement_disturbance, &inc)
 
         # Smoothed state disturbance
         # $\hat \eta_t = \\#_0' \tilde r_{t+1}$
         # $(r \times 1) = (r \times m) (m \times 1)$
-        blas.{{prefix}}gemv("T", &model._k_states, &model._k_posdef,
-                      &alpha, smoother._tmp0, &kfilter.k_states,
+        blas.{{prefix}}gemv("T", &m_k_states, &m_k_posdef,
+                      &alpha, smoother._tmp0, &kf_k_states,
                               &smoother.scaled_smoothed_estimator[0, smoother.t+1], &inc,
                       &beta, smoother._smoothed_state_disturbance, &inc)
 
     if smoother.smoother_output & SMOOTHER_DISTURBANCE_COV:
         # $\\#_00 = K_t H_t$
         # $(m \times p) = (m \times p) (p \times p)$
-        blas.{{prefix}}gemm("N", "N", &model._k_states, &model._k_endog, &model._k_endog,
-                  &alpha, kfilter._kalman_gain, &kfilter.k_states,
-                          model._obs_cov, &model._k_endog,
-                  &beta, smoother._tmp00, &kfilter.k_states)
+        blas.{{prefix}}gemm("N", "N", &m_k_states, &m_k_endog, &m_k_endog,
+                  &alpha, kfilter._kalman_gain, &kf_k_states,
+                          model._obs_cov, &m_k_endog,
+                  &beta, smoother._tmp00, &kf_k_states)
 
         # Smoothed measurement disturbance covariance matrix
         # $Var(\varepsilon_t | Y_n) = H_t - H_t \\#_4 - \\#_00' \tilde N_t \\#_00$
         # $(p \times p) = (p \times p) - (p \times p) (p \times p) - (p \times m) (m \times m) (m \times p)$
-        blas.{{prefix}}gemm("N", "N", &model._k_endog, &model._k_endog, &model._k_endog,
-                  &gamma, model._obs_cov, &model._k_endog,
-                          kfilter._tmp4, &kfilter.k_endog,
-                  &beta, smoother._smoothed_measurement_disturbance_cov, &kfilter.k_endog)
+        blas.{{prefix}}gemm("N", "N", &m_k_endog, &m_k_endog, &m_k_endog,
+                  &gamma, model._obs_cov, &m_k_endog,
+                          kfilter._tmp4, &kf_k_endog,
+                  &beta, smoother._smoothed_measurement_disturbance_cov, &kf_k_endog)
 
-        blas.{{prefix}}gemm("N", "N", &model._k_states, &model._k_endog, &model._k_states,
-                  &alpha, &smoother.scaled_smoothed_estimator_cov[0, 0, smoother.t+1], &kfilter.k_states,
-                          smoother._tmp00, &kfilter.k_states,
-                  &beta, smoother._tmp000, &kfilter.k_states)
+        blas.{{prefix}}gemm("N", "N", &m_k_states, &m_k_endog, &m_k_states,
+                  &alpha, &smoother.scaled_smoothed_estimator_cov[0, 0, smoother.t+1], &kf_k_states,
+                          smoother._tmp00, &kf_k_states,
+                  &beta, smoother._tmp000, &kf_k_states)
 
-        blas.{{prefix}}gemm("T", "N", &model._k_endog, &model._k_endog, &model._k_states,
-                  &gamma, smoother._tmp00, &kfilter.k_states,
-                          smoother._tmp000, &kfilter.k_states,
-                  &alpha, smoother._smoothed_measurement_disturbance_cov, &kfilter.k_endog)
+        blas.{{prefix}}gemm("T", "N", &m_k_endog, &m_k_endog, &m_k_states,
+                  &gamma, smoother._tmp00, &kf_k_states,
+                          smoother._tmp000, &kf_k_states,
+                  &alpha, smoother._smoothed_measurement_disturbance_cov, &kf_k_endog)
 
         # blas.{{prefix}}axpy(&model._k_endog2, &alpha,
         #        model._obs_cov, &inc,
@@ -279,15 +296,15 @@ cdef int {{prefix}}smoothed_disturbances_alternative({{prefix}}KalmanSmoother sm
         # Smoothed state disturbance covariance matrix
         # $Var(\eta_t | Y_n) = Q_t - \\#_0' \tilde N_t \\#_0$
         # $(r \times r) = (r \times r) - (r \times m) (m \times m) (m \times r)$
-        blas.{{prefix}}gemm("N", "N", &model._k_states, &model._k_posdef, &model._k_states,
-                  &alpha, &smoother.scaled_smoothed_estimator_cov[0, 0, smoother.t+1], &kfilter.k_states,
-                          smoother._tmp0, &kfilter.k_states,
-                  &beta, smoother._tmpL, &kfilter.k_states)
+        blas.{{prefix}}gemm("N", "N", &m_k_states, &m_k_posdef, &m_k_states,
+                  &alpha, &smoother.scaled_smoothed_estimator_cov[0, 0, smoother.t+1], &kf_k_states,
+                          smoother._tmp0, &kf_k_states,
+                  &beta, smoother._tmpL, &kf_k_states)
 
-        blas.{{prefix}}copy(&model._k_posdef2, model._state_cov, &inc, smoother._smoothed_state_disturbance_cov, &inc)
-        blas.{{prefix}}gemm("T", "N", &model._k_posdef, &model._k_posdef, &model._k_states,
-                  &gamma, smoother._tmp0, &kfilter.k_states,
-                          smoother._tmpL, &kfilter.k_states,
-                  &alpha, smoother._smoothed_state_disturbance_cov, &kfilter.k_posdef)
+        blas.{{prefix}}copy(&m_k_posdef2, model._state_cov, &inc, smoother._smoothed_state_disturbance_cov, &inc)
+        blas.{{prefix}}gemm("T", "N", &m_k_posdef, &m_k_posdef, &m_k_states,
+                  &gamma, smoother._tmp0, &kf_k_states,
+                          smoother._tmpL, &kf_k_states,
+                  &alpha, smoother._smoothed_state_disturbance_cov, &kf_k_posdef)
 
 {{endfor}}

--- a/statsmodels/tsa/statespace/_smoothers/_classical.pyx.in
+++ b/statsmodels/tsa/statespace/_smoothers/_classical.pyx.in
@@ -63,6 +63,7 @@ cimport numpy as np
 from statsmodels.includes.math cimport *
 cimport scipy.linalg.cython_blas as blas
 cimport scipy.linalg.cython_lapack as lapack
+include "statsmodels/tsa/statespace/_blas_int.pxi"
 
 from statsmodels.tsa.statespace._kalman_smoother cimport (
     SMOOTHER_STATE, SMOOTHER_STATE_COV, SMOOTHER_DISTURBANCE,
@@ -91,17 +92,24 @@ if prefix == 's':
 
 cdef int {{prefix}}smoothed_estimators_measurement_classical({{prefix}}KalmanSmoother smoother, {{prefix}}KalmanFilter kfilter, {{prefix}}Statespace model) except *:
     cdef:
-        int i, j, info
-        int inc = 1
+        int i, j
+        blas_int info
+        blas_int inc = 1
+        blas_int kf_k_endog = kfilter.k_endog
+        blas_int kf_k_states = kfilter.k_states
+        blas_int kf_k_states2 = kfilter.k_states2
+        blas_int m_k_endog = model._k_endog
+        blas_int m_k_states = model._k_states
+        blas_int m_k_states2 = model._k_states2
         {{cython_type}} alpha = 1.0
         {{cython_type}} beta = 0.0
         {{cython_type}} gamma = -1.0
         {{cython_type}} tmp
 
     # Factorize the predicted state covariance matrix
-    blas.{{prefix}}copy(&kfilter.k_states2, &kfilter.predicted_state_cov[0,0,smoother.t+1], &inc,
+    blas.{{prefix}}copy(&kf_k_states2, &kfilter.predicted_state_cov[0,0,smoother.t+1], &inc,
                                             smoother._tmpL, &inc)
-    lapack.{{prefix}}potrf("L", &kfilter.k_states, smoother._tmpL, &kfilter.k_states, &info)
+    lapack.{{prefix}}potrf("L", &kf_k_states, smoother._tmpL, &kf_k_states, &info)
 
     if info < 0:
         raise np.linalg.LinAlgError('Illegal value in predicted state'
@@ -118,13 +126,13 @@ cdef int {{prefix}}smoothed_estimators_measurement_classical({{prefix}}KalmanSmo
     # Note: save $r_t$ as _input_scaled_smoothed_estimator not as
     # _scaled_smoothed_estimator
     if smoother.t < model.nobs-1 and smoother.smoother_output & (SMOOTHER_STATE | SMOOTHER_DISTURBANCE):
-        blas.{{prefix}}copy(&kfilter.k_states, &smoother.smoothed_state[0, smoother.t+1], &inc,
+        blas.{{prefix}}copy(&kf_k_states, &smoother.smoothed_state[0, smoother.t+1], &inc,
                                                smoother._input_scaled_smoothed_estimator, &inc)
-        blas.{{prefix}}axpy(&kfilter.k_states, &gamma, &kfilter.predicted_state[0,smoother.t+1], &inc,
+        blas.{{prefix}}axpy(&kf_k_states, &gamma, &kfilter.predicted_state[0,smoother.t+1], &inc,
                                                        smoother._input_scaled_smoothed_estimator, &inc)
 
-        lapack.{{prefix}}potrs("L", &kfilter.k_states, &inc, smoother._tmpL, &kfilter.k_states,
-                                                             smoother._input_scaled_smoothed_estimator, &kfilter.k_states, &info)
+        lapack.{{prefix}}potrs("L", &kf_k_states, &inc, smoother._tmpL, &kf_k_states,
+                                                             smoother._input_scaled_smoothed_estimator, &kf_k_states, &info)
 
         if info < 0:
             raise np.linalg.LinAlgError('Illegal value in predicted state'
@@ -137,13 +145,13 @@ cdef int {{prefix}}smoothed_estimators_measurement_classical({{prefix}}KalmanSmo
     # Note: save $N_t$ as _input_scaled_smoothed_estimator_cov not as
     # _scaled_smoothed_estimator_cov
     if smoother.t < model.nobs-1 and smoother.smoother_output & (SMOOTHER_STATE_COV | SMOOTHER_DISTURBANCE_COV):
-        blas.{{prefix}}copy(&kfilter.k_states2, &kfilter.predicted_state_cov[0, 0, smoother.t+1], &inc,
+        blas.{{prefix}}copy(&kf_k_states2, &kfilter.predicted_state_cov[0, 0, smoother.t+1], &inc,
                                                 smoother._input_scaled_smoothed_estimator_cov, &inc)
-        blas.{{prefix}}axpy(&kfilter.k_states2, &gamma, &smoother.smoothed_state_cov[0, 0, smoother.t+1], &inc,
+        blas.{{prefix}}axpy(&kf_k_states2, &gamma, &smoother.smoothed_state_cov[0, 0, smoother.t+1], &inc,
                                                         smoother._input_scaled_smoothed_estimator_cov, &inc)
 
-        lapack.{{prefix}}potrs("L", &kfilter.k_states, &kfilter.k_states, smoother._tmpL, &kfilter.k_states,
-                                                             smoother._input_scaled_smoothed_estimator_cov, &kfilter.k_states, &info)
+        lapack.{{prefix}}potrs("L", &kf_k_states, &kf_k_states, smoother._tmpL, &kf_k_states,
+                                                             smoother._input_scaled_smoothed_estimator_cov, &kf_k_states, &info)
 
         if info < 0:
             raise np.linalg.LinAlgError('Illegal value in predicted state'
@@ -159,8 +167,8 @@ cdef int {{prefix}}smoothed_estimators_measurement_classical({{prefix}}KalmanSmo
                 smoother.scaled_smoothed_estimator_cov[i,j,smoother.t+1] = smoother.scaled_smoothed_estimator_cov[j,i,smoother.t+1]
                 smoother.scaled_smoothed_estimator_cov[j,i,smoother.t+1] = tmp
 
-        lapack.{{prefix}}potrs("L", &kfilter.k_states, &kfilter.k_states, smoother._tmpL, &kfilter.k_states,
-                                                             smoother._input_scaled_smoothed_estimator_cov, &kfilter.k_states, &info)
+        lapack.{{prefix}}potrs("L", &kf_k_states, &kf_k_states, smoother._tmpL, &kf_k_states,
+                                                             smoother._input_scaled_smoothed_estimator_cov, &kf_k_states, &info)
 
         if info < 0:
             raise np.linalg.LinAlgError('Illegal value in predicted state'
@@ -172,20 +180,20 @@ cdef int {{prefix}}smoothed_estimators_measurement_classical({{prefix}}KalmanSmo
     # $(p \times 1) = (p \times 1) - (p \times m) (m \times 1)$
     if smoother.smoother_output & (SMOOTHER_DISTURBANCE):
         if not model._nmissing == model.k_endog:
-            blas.{{prefix}}copy(&kfilter.k_endog, kfilter._tmp2, &inc, smoother._smoothing_error, &inc)
-        blas.{{prefix}}gemv("T", &model._k_states, &model._k_endog,
-                  &gamma, kfilter._kalman_gain, &kfilter.k_states,
+            blas.{{prefix}}copy(&kf_k_endog, kfilter._tmp2, &inc, smoother._smoothing_error, &inc)
+        blas.{{prefix}}gemv("T", &m_k_states, &m_k_endog,
+                  &gamma, kfilter._kalman_gain, &kf_k_states,
                           smoother._input_scaled_smoothed_estimator, &inc,
                   &alpha, smoother._smoothing_error, &inc)
 
     # $L_t = (T_t - K_t Z_t)$
     # $(m \times m) = (m \times m) + (m \times p) (p \times m)$
     # (this is required for any type of smoothing)
-    blas.{{prefix}}copy(&model._k_states2, model._transition, &inc, smoother._tmpL, &inc)
-    blas.{{prefix}}gemm("N", "N", &model._k_states, &model._k_states, &model._k_endog,
-              &gamma, kfilter._kalman_gain, &kfilter.k_states,
-                      model._design, &model._k_endog,
-              &alpha, smoother._tmpL, &kfilter.k_states)
+    blas.{{prefix}}copy(&m_k_states2, model._transition, &inc, smoother._tmpL, &inc)
+    blas.{{prefix}}gemm("N", "N", &m_k_states, &m_k_states, &m_k_endog,
+              &gamma, kfilter._kalman_gain, &kf_k_states,
+                      model._design, &m_k_endog,
+              &alpha, smoother._tmpL, &kf_k_states)
 
 cdef int {{prefix}}smoothed_estimators_time_classical({{prefix}}KalmanSmoother smoother, {{prefix}}KalmanFilter kfilter, {{prefix}}Statespace model):
   pass
@@ -193,25 +201,27 @@ cdef int {{prefix}}smoothed_estimators_time_classical({{prefix}}KalmanSmoother s
 cdef int {{prefix}}smoothed_state_classical({{prefix}}KalmanSmoother smoother, {{prefix}}KalmanFilter kfilter, {{prefix}}Statespace model):
     cdef int i, j
     cdef:
-        int inc = 1
+        blas_int inc = 1
+        blas_int kf_k_states = kfilter.k_states
+        blas_int m_k_states = model._k_states
         {{cython_type}} alpha = 1.0
         {{cython_type}} beta = 0.0
         {{cython_type}} gamma = -1.0
 
     if (smoother.smoother_output & SMOOTHER_STATE) or (smoother.smoother_output & SMOOTHER_STATE_COV):
-        blas.{{prefix}}gemm("N", "T", &model._k_states, &model._k_states, &model._k_states,
-                  &alpha, &kfilter.filtered_state_cov[0, 0, smoother.t], &kfilter.k_states,
-                          model._transition, &kfilter.k_states,
-                  &beta, smoother._tmp0, &kfilter.k_states)
+        blas.{{prefix}}gemm("N", "T", &m_k_states, &m_k_states, &m_k_states,
+                  &alpha, &kfilter.filtered_state_cov[0, 0, smoother.t], &kf_k_states,
+                          model._transition, &kf_k_states,
+                  &beta, smoother._tmp0, &kf_k_states)
 
     # Smoothed state
     if smoother.smoother_output & SMOOTHER_STATE:
         # $\hat \alpha_t = a_t|t + P_t|t T_t' r_t$
         # $(m \times 1) = (m \times 1) + (m \times m) (m \times 1)$
-        blas.{{prefix}}copy(&kfilter.k_states, &kfilter.filtered_state[0,smoother.t], &inc, smoother._smoothed_state, &inc)
+        blas.{{prefix}}copy(&kf_k_states, &kfilter.filtered_state[0,smoother.t], &inc, smoother._smoothed_state, &inc)
 
-        blas.{{prefix}}gemv("N", &model._k_states, &model._k_states,
-                  &alpha, smoother._tmp0, &kfilter.k_states,
+        blas.{{prefix}}gemv("N", &m_k_states, &m_k_states,
+                  &alpha, smoother._tmp0, &kf_k_states,
                           smoother._input_scaled_smoothed_estimator, &inc,
                   &alpha, smoother._smoothed_state, &inc)
 
@@ -219,19 +229,19 @@ cdef int {{prefix}}smoothed_state_classical({{prefix}}KalmanSmoother smoother, {
     if smoother.smoother_output & SMOOTHER_STATE_COV:
         # $V_t = P_t|t [I - T_t' N_t T_t P_t|t]$
         # $(m \times m) = (m \times m) [(m \times m) - (m \times m) (m \times m)]$
-        blas.{{prefix}}gemm("N", "T", &model._k_states, &model._k_states, &model._k_states,
-              &alpha, smoother._input_scaled_smoothed_estimator_cov, &kfilter.k_states,
-                      smoother._tmp0, &kfilter.k_states,
-              &beta, smoother._tmpL2, &kfilter.k_states)
-        blas.{{prefix}}gemm("T", "N", &model._k_states, &model._k_states, &model._k_states,
-              &gamma, model._transition, &kfilter.k_states,
-                      smoother._tmpL2, &kfilter.k_states,
-              &beta, smoother._tmp0, &kfilter.k_states)
+        blas.{{prefix}}gemm("N", "T", &m_k_states, &m_k_states, &m_k_states,
+              &alpha, smoother._input_scaled_smoothed_estimator_cov, &kf_k_states,
+                      smoother._tmp0, &kf_k_states,
+              &beta, smoother._tmpL2, &kf_k_states)
+        blas.{{prefix}}gemm("T", "N", &m_k_states, &m_k_states, &m_k_states,
+              &gamma, model._transition, &kf_k_states,
+                      smoother._tmpL2, &kf_k_states,
+              &beta, smoother._tmp0, &kf_k_states)
         for i in range(kfilter.k_states):
             smoother.tmp0[i,i] = 1 + smoother.tmp0[i,i]
-        blas.{{prefix}}gemm("N", "N", &model._k_states, &model._k_states, &model._k_states,
-              &alpha, &kfilter.filtered_state_cov[0,0,smoother.t], &kfilter.k_states,
-                      smoother._tmp0, &kfilter.k_states,
-              &beta, smoother._smoothed_state_cov, &kfilter.k_states)
+        blas.{{prefix}}gemm("N", "N", &m_k_states, &m_k_states, &m_k_states,
+              &alpha, &kfilter.filtered_state_cov[0,0,smoother.t], &kf_k_states,
+                      smoother._tmp0, &kf_k_states,
+              &beta, smoother._smoothed_state_cov, &kf_k_states)
 
 {{endfor}}

--- a/statsmodels/tsa/statespace/_smoothers/_conventional.pyx.in
+++ b/statsmodels/tsa/statespace/_smoothers/_conventional.pyx.in
@@ -62,6 +62,7 @@ import numpy as np
 cimport numpy as np
 from statsmodels.includes.math cimport *
 cimport scipy.linalg.cython_blas as blas
+include "statsmodels/tsa/statespace/_blas_int.pxi"
 
 from statsmodels.tsa.statespace._kalman_smoother cimport (
     SMOOTHER_STATE, SMOOTHER_STATE_COV, SMOOTHER_DISTURBANCE,
@@ -90,7 +91,11 @@ if prefix == 's':
 
 cdef int {{prefix}}smoothed_estimators_missing_conventional({{prefix}}KalmanSmoother smoother, {{prefix}}KalmanFilter kfilter, {{prefix}}Statespace model) except *:
     cdef:
-        int inc = 1
+        blas_int inc = 1
+        blas_int kf_k_states = kfilter.k_states
+        blas_int m_k_endog = model._k_endog
+        blas_int m_k_states = model._k_states
+        blas_int m_k_states2 = model._k_states2
         {{cython_type}} alpha = 1.0
         {{cython_type}} beta = 0.0
         {{cython_type}} gamma = -1.0
@@ -103,10 +108,10 @@ cdef int {{prefix}}smoothed_estimators_missing_conventional({{prefix}}KalmanSmoo
     # T+1 of them (r_{T-1} to r_{-1} -> r_T to r_0)
     if smoother.smoother_output & (SMOOTHER_STATE | SMOOTHER_DISTURBANCE):
         if model.identity_transition:
-            blas.{{prefix}}copy(&model._k_states, smoother._input_scaled_smoothed_estimator, &inc, smoother._scaled_smoothed_estimator, &inc)
+            blas.{{prefix}}copy(&m_k_states, smoother._input_scaled_smoothed_estimator, &inc, smoother._scaled_smoothed_estimator, &inc)
         else:
-            blas.{{prefix}}gemv("T", &model._k_states, &model._k_states,
-                    &alpha, model._transition, &model._k_states,
+            blas.{{prefix}}gemv("T", &m_k_states, &m_k_states,
+                    &alpha, model._transition, &m_k_states,
                             smoother._input_scaled_smoothed_estimator, &inc,
                     &beta, smoother._scaled_smoothed_estimator, &inc)
 
@@ -118,19 +123,19 @@ cdef int {{prefix}}smoothed_estimators_missing_conventional({{prefix}}KalmanSmoo
     # need to store T+1 of them (N_{T-1} to N_{-1} -> N_T to N_0)
     if smoother.smoother_output & (SMOOTHER_STATE_COV | SMOOTHER_DISTURBANCE_COV):
         if model.identity_transition:
-            blas.{{prefix}}copy(&model._k_states2, smoother._input_scaled_smoothed_estimator_cov, &inc, smoother._scaled_smoothed_estimator_cov, &inc)
+            blas.{{prefix}}copy(&m_k_states2, smoother._input_scaled_smoothed_estimator_cov, &inc, smoother._scaled_smoothed_estimator_cov, &inc)
         else:
-            blas.{{prefix}}gemm("N", "N", &model._k_states, &model._k_states, &model._k_states,
-                      &alpha, smoother._input_scaled_smoothed_estimator_cov, &kfilter.k_states,
-                              model._transition, &model._k_states,
-                      &beta, smoother._tmp0, &kfilter.k_states)
-            blas.{{prefix}}gemm("T", "N", &kfilter.k_states, &kfilter.k_states, &kfilter.k_states,
-                      &alpha, model._transition, &model._k_states,
-                              smoother._tmp0, &kfilter.k_states,
-                      &beta, smoother._scaled_smoothed_estimator_cov, &kfilter.k_states)
+            blas.{{prefix}}gemm("N", "N", &m_k_states, &m_k_states, &m_k_states,
+                      &alpha, smoother._input_scaled_smoothed_estimator_cov, &kf_k_states,
+                              model._transition, &m_k_states,
+                      &beta, smoother._tmp0, &kf_k_states)
+            blas.{{prefix}}gemm("T", "N", &kf_k_states, &kf_k_states, &kf_k_states,
+                      &alpha, model._transition, &m_k_states,
+                              smoother._tmp0, &kf_k_states,
+                      &beta, smoother._scaled_smoothed_estimator_cov, &kf_k_states)
 
     # $L_t = T_t$
-    blas.{{prefix}}copy(&model._k_states2, model._transition, &inc, smoother._tmpL, &inc)
+    blas.{{prefix}}copy(&m_k_states2, model._transition, &inc, smoother._tmpL, &inc)
 
     # Smoothing error
     # It is undefined here, since F_t^{-1} is nan
@@ -143,14 +148,21 @@ cdef int {{prefix}}smoothed_estimators_missing_conventional({{prefix}}KalmanSmoo
     # TODO in the missing case, I think K_t is defined to be zeros, so this
     # would be unnecessary
     if smoother.smoother_output & (SMOOTHER_DISTURBANCE):
-        blas.{{prefix}}gemv("T", &model._k_states, &model._k_endog,
-                  &gamma, kfilter._kalman_gain, &kfilter.k_states,
+        blas.{{prefix}}gemv("T", &m_k_states, &m_k_endog,
+                  &gamma, kfilter._kalman_gain, &kf_k_states,
                           smoother._input_scaled_smoothed_estimator, &inc,
                   &beta, smoother._smoothing_error, &inc)
 
 cdef int {{prefix}}smoothed_disturbances_missing_conventional({{prefix}}KalmanSmoother smoother, {{prefix}}KalmanFilter kfilter, {{prefix}}Statespace model):
     cdef:
-        int inc = 1
+        blas_int inc = 1
+        blas_int kf_k_posdef = kfilter.k_posdef
+        blas_int kf_k_states = kfilter.k_states
+        blas_int m_k_endog = model._k_endog
+        blas_int m_k_endog2 = model._k_endog2
+        blas_int m_k_posdef = model._k_posdef
+        blas_int m_k_posdef2 = model._k_posdef2
+        blas_int m_k_states = model._k_states
         {{cython_type}} alpha = 1.0
         {{cython_type}} beta = 0.0
         {{cython_type}} gamma = -1.0
@@ -160,17 +172,17 @@ cdef int {{prefix}}smoothed_disturbances_missing_conventional({{prefix}}KalmanSm
     # $\\#_0 = R_t Q_t$
     # $(m \times r) = (m \times r) (r \times r)$
     if smoother.smoother_output & (SMOOTHER_DISTURBANCE | SMOOTHER_DISTURBANCE_COV):
-        blas.{{prefix}}gemm("N", "N", &model._k_states, &model._k_posdef, &model._k_posdef,
-                  &alpha, model._selection, &model._k_states,
-                          model._state_cov, &model._k_posdef,
-                  &beta, smoother._tmp0, &kfilter.k_states)
+        blas.{{prefix}}gemm("N", "N", &m_k_states, &m_k_posdef, &m_k_posdef,
+                  &alpha, model._selection, &m_k_states,
+                          model._state_cov, &m_k_posdef,
+                  &beta, smoother._tmp0, &kf_k_states)
 
     if smoother.smoother_output & SMOOTHER_DISTURBANCE:
         # Smoothed state disturbance
         # $\hat \eta_t = \\#_0' r_t$
         # $(r \times 1) = (r \times m) (m \times 1)$
-        blas.{{prefix}}gemv("T", &kfilter.k_states, &kfilter.k_posdef,
-                      &alpha, smoother._tmp0, &kfilter.k_states,
+        blas.{{prefix}}gemv("T", &kf_k_states, &kf_k_posdef,
+                      &alpha, smoother._tmp0, &kf_k_states,
                               smoother._input_scaled_smoothed_estimator, &inc,
                       &beta, smoother._smoothed_state_disturbance, &inc)
 
@@ -178,15 +190,15 @@ cdef int {{prefix}}smoothed_disturbances_missing_conventional({{prefix}}KalmanSm
       # Smoothed state disturbance covariance matrix
         # $Var(\eta_t | Y_n) = Q_t - \\#_0' N_t \\#_0$
         # $(r \times r) = (r \times r) - (r \times m) (m \times m) (m \times r)$
-        blas.{{prefix}}gemm("N", "N", &model._k_states, &model._k_posdef, &model._k_states,
-                  &alpha, smoother._input_scaled_smoothed_estimator_cov, &kfilter.k_states,
-                          smoother._tmp0, &kfilter.k_states,
-                  &beta, smoother._tmpL, &kfilter.k_states)
-        blas.{{prefix}}copy(&model._k_posdef2, model._state_cov, &inc, smoother._smoothed_state_disturbance_cov, &inc)
-        blas.{{prefix}}gemm("T", "N", &model._k_posdef, &model._k_posdef, &model._k_states,
-                  &gamma, smoother._tmp0, &kfilter.k_states,
-                          smoother._tmpL, &kfilter.k_states,
-                  &alpha, smoother._smoothed_state_disturbance_cov, &kfilter.k_posdef)
+        blas.{{prefix}}gemm("N", "N", &m_k_states, &m_k_posdef, &m_k_states,
+                  &alpha, smoother._input_scaled_smoothed_estimator_cov, &kf_k_states,
+                          smoother._tmp0, &kf_k_states,
+                  &beta, smoother._tmpL, &kf_k_states)
+        blas.{{prefix}}copy(&m_k_posdef2, model._state_cov, &inc, smoother._smoothed_state_disturbance_cov, &inc)
+        blas.{{prefix}}gemm("T", "N", &m_k_posdef, &m_k_posdef, &m_k_states,
+                  &gamma, smoother._tmp0, &kf_k_states,
+                          smoother._tmpL, &kf_k_states,
+                  &alpha, smoother._smoothed_state_disturbance_cov, &kf_k_posdef)
 
 
     # Just return the unconditional distribution for the measurement
@@ -201,7 +213,7 @@ cdef int {{prefix}}smoothed_disturbances_missing_conventional({{prefix}}KalmanSm
 
     # Smoothed measurement and state disturbances have unconditional covariance
     # matrix of $H_t, Q_t$, respectively
-    blas.{{prefix}}copy(&model._k_endog2, model._obs_cov, &inc, smoother._smoothed_measurement_disturbance_cov, &inc)
+    blas.{{prefix}}copy(&m_k_endog2, model._obs_cov, &inc, smoother._smoothed_measurement_disturbance_cov, &inc)
 
 
 # ### Conventional Kalman smoother
@@ -214,7 +226,12 @@ cdef int {{prefix}}smoothed_disturbances_missing_conventional({{prefix}}KalmanSm
 cdef int {{prefix}}smoothed_estimators_measurement_conventional({{prefix}}KalmanSmoother smoother, {{prefix}}KalmanFilter kfilter, {{prefix}}Statespace model) except *:
     cdef:
         int i
-        int inc = 1
+        blas_int inc = 1
+        blas_int m_k_endog = model._k_endog
+        blas_int m_k_states = model._k_states
+        blas_int m_k_states2 = model._k_states2
+        blas_int kf_k_endog = kfilter.k_endog
+        blas_int kf_k_states = kfilter.k_states
         {{cython_type}} alpha = 1.0
         {{cython_type}} beta = 0.0
         {{cython_type}} gamma = -1.0
@@ -223,20 +240,20 @@ cdef int {{prefix}}smoothed_estimators_measurement_conventional({{prefix}}Kalman
     # $u_t = \\#_2 - K_t' r_t$
     # $(p \times 1) = (p \times 1) - (p \times m) (m \times 1)$
     if smoother.smoother_output & (SMOOTHER_DISTURBANCE):
-        blas.{{prefix}}copy(&model._k_endog, kfilter._tmp2, &inc, smoother._smoothing_error, &inc)
-        blas.{{prefix}}gemv("T", &model._k_states, &model._k_endog,
-                  &gamma, kfilter._kalman_gain, &kfilter.k_states,
+        blas.{{prefix}}copy(&m_k_endog, kfilter._tmp2, &inc, smoother._smoothing_error, &inc)
+        blas.{{prefix}}gemv("T", &m_k_states, &m_k_endog,
+                  &gamma, kfilter._kalman_gain, &kf_k_states,
                           smoother._input_scaled_smoothed_estimator, &inc,
                   &alpha, smoother._smoothing_error, &inc)
 
     # $L_t = (T_t - K_t Z_t)$  = (T_t - T_t P_t Z_t' F_t^{-1} Z_t)
     # $(m \times m) = (m \times m) + (m \times p) (p \times m)$
     # (this is required for any type of smoothing)
-    blas.{{prefix}}copy(&model._k_states2, model._transition, &inc, smoother._tmpL, &inc)
-    blas.{{prefix}}gemm("N", "N", &model._k_states, &model._k_states, &model._k_endog,
-              &gamma, kfilter._kalman_gain, &kfilter.k_states,
-                      model._design, &model._k_endog,
-              &alpha, smoother._tmpL, &kfilter.k_states)
+    blas.{{prefix}}copy(&m_k_states2, model._transition, &inc, smoother._tmpL, &inc)
+    blas.{{prefix}}gemm("N", "N", &m_k_states, &m_k_states, &m_k_endog,
+              &gamma, kfilter._kalman_gain, &kf_k_states,
+                      model._design, &m_k_endog,
+              &alpha, smoother._tmpL, &kf_k_states)
 
     # Scaled smoothed estimator
     # $r_{t-1} = Z_t' \\#_2 + L_t' r_t$
@@ -245,13 +262,13 @@ cdef int {{prefix}}smoothed_estimators_measurement_conventional({{prefix}}Kalman
     # as scaled_smoothed_estimator[t-1] because we actually need to store
     # T+1 of them (r_{T-1} to r_{-1} -> r_T to r_0)
     if smoother.smoother_output & (SMOOTHER_STATE | SMOOTHER_DISTURBANCE):
-        blas.{{prefix}}gemv("T", &model._k_states, &model._k_states,
-                  &alpha, smoother._tmpL, &kfilter.k_states,
+        blas.{{prefix}}gemv("T", &m_k_states, &m_k_states,
+                  &alpha, smoother._tmpL, &kf_k_states,
                           smoother._input_scaled_smoothed_estimator, &inc,
                   &beta, smoother._scaled_smoothed_estimator, &inc)
 
-        blas.{{prefix}}gemv("T", &model._k_endog, &model._k_states,
-                  &alpha, model._design, &model._k_endog,
+        blas.{{prefix}}gemv("T", &m_k_endog, &m_k_states,
+                  &alpha, model._design, &m_k_endog,
                           kfilter._tmp2, &inc,
                   &alpha, smoother._scaled_smoothed_estimator, &inc)
 
@@ -262,18 +279,18 @@ cdef int {{prefix}}smoothed_estimators_measurement_conventional({{prefix}}Kalman
     # than as scaled_smoothed_estimator_cov[t-1] because we actually
     # need to store T+1 of them (N_{T-1} to N_{-1} -> N_T to N_0)
     if smoother.smoother_output & (SMOOTHER_STATE_COV | SMOOTHER_DISTURBANCE_COV):
-        blas.{{prefix}}gemm("N", "N", &model._k_states, &model._k_states, &model._k_states,
-                  &alpha, smoother._input_scaled_smoothed_estimator_cov, &kfilter.k_states,
-                          smoother._tmpL, &kfilter.k_states,
-                  &beta, smoother._tmp0, &kfilter.k_states)
-        blas.{{prefix}}gemm("T", "N", &model._k_states, &model._k_states, &model._k_states,
-                  &alpha, smoother._tmpL, &kfilter.k_states,
-                          smoother._tmp0, &kfilter.k_states,
-                  &beta, smoother._scaled_smoothed_estimator_cov, &kfilter.k_states)
-        blas.{{prefix}}gemm("T", "N", &model._k_states, &model._k_states, &model._k_endog,
-                  &alpha, model._design, &model._k_endog,
-                          kfilter._tmp3, &kfilter.k_endog,
-                  &alpha, smoother._scaled_smoothed_estimator_cov, &kfilter.k_states)
+        blas.{{prefix}}gemm("N", "N", &m_k_states, &m_k_states, &m_k_states,
+                  &alpha, smoother._input_scaled_smoothed_estimator_cov, &kf_k_states,
+                          smoother._tmpL, &kf_k_states,
+                  &beta, smoother._tmp0, &kf_k_states)
+        blas.{{prefix}}gemm("T", "N", &m_k_states, &m_k_states, &m_k_states,
+                  &alpha, smoother._tmpL, &kf_k_states,
+                          smoother._tmp0, &kf_k_states,
+                  &beta, smoother._scaled_smoothed_estimator_cov, &kf_k_states)
+        blas.{{prefix}}gemm("T", "N", &m_k_states, &m_k_states, &m_k_endog,
+                  &alpha, model._design, &m_k_endog,
+                          kfilter._tmp3, &kf_k_endog,
+                  &alpha, smoother._scaled_smoothed_estimator_cov, &kf_k_states)
 
 cdef int {{prefix}}smoothed_estimators_time_conventional({{prefix}}KalmanSmoother smoother, {{prefix}}KalmanFilter kfilter, {{prefix}}Statespace model):
   pass
@@ -281,7 +298,9 @@ cdef int {{prefix}}smoothed_estimators_time_conventional({{prefix}}KalmanSmoothe
 cdef int {{prefix}}smoothed_state_conventional({{prefix}}KalmanSmoother smoother, {{prefix}}KalmanFilter kfilter, {{prefix}}Statespace model):
     cdef int i, j
     cdef:
-        int inc = 1
+        blas_int inc = 1
+        blas_int kf_k_states = kfilter.k_states
+        blas_int m_k_states = model._k_states
         {{cython_type}} alpha = 1.0
         {{cython_type}} beta = 0.0
         {{cython_type}} gamma = -1.0
@@ -290,9 +309,9 @@ cdef int {{prefix}}smoothed_state_conventional({{prefix}}KalmanSmoother smoother
     if smoother.smoother_output & SMOOTHER_STATE:
         # $\hat \alpha_t = a_t + P_t r_{t-1}$
         # $(m \times 1) = (m \times 1) + (m \times m) (m \times 1)$
-        blas.{{prefix}}copy(&kfilter.k_states, &kfilter.predicted_state[0,smoother.t], &inc, smoother._smoothed_state, &inc)
-        blas.{{prefix}}gemv("N", &model._k_states, &model._k_states,
-                  &alpha, &kfilter.predicted_state_cov[0,0,smoother.t], &kfilter.k_states,
+        blas.{{prefix}}copy(&kf_k_states, &kfilter.predicted_state[0,smoother.t], &inc, smoother._smoothed_state, &inc)
+        blas.{{prefix}}gemv("N", &m_k_states, &m_k_states,
+                  &alpha, &kfilter.predicted_state_cov[0,0,smoother.t], &kf_k_states,
                           smoother._scaled_smoothed_estimator, &inc,
                   &alpha, smoother._smoothed_state, &inc)
 
@@ -300,22 +319,24 @@ cdef int {{prefix}}smoothed_state_conventional({{prefix}}KalmanSmoother smoother
     if smoother.smoother_output & SMOOTHER_STATE_COV:
         # $V_t = P_t [I - N_{t-1} P_t]$
         # $(m \times m) = (m \times m) [(m \times m) - (m \times m) (m \times m)]$
-        blas.{{prefix}}gemm("N", "N", &model._k_states, &model._k_states, &model._k_states,
-              &gamma, smoother._scaled_smoothed_estimator_cov, &kfilter.k_states,
-                      &kfilter.predicted_state_cov[0,0,smoother.t], &kfilter.k_states,
-              &beta, smoother._tmp0, &kfilter.k_states)
+        blas.{{prefix}}gemm("N", "N", &m_k_states, &m_k_states, &m_k_states,
+              &gamma, smoother._scaled_smoothed_estimator_cov, &kf_k_states,
+                      &kfilter.predicted_state_cov[0,0,smoother.t], &kf_k_states,
+              &beta, smoother._tmp0, &kf_k_states)
         for i in range(kfilter.k_states):
             smoother.tmp0[i,i] = 1 + smoother.tmp0[i,i]
-        blas.{{prefix}}gemm("N", "N", &model._k_states, &model._k_states, &model._k_states,
-              &alpha, &kfilter.predicted_state_cov[0,0,smoother.t], &kfilter.k_states,
-                      smoother._tmp0, &kfilter.k_states,
-              &beta, smoother._smoothed_state_cov, &kfilter.k_states)
+        blas.{{prefix}}gemm("N", "N", &m_k_states, &m_k_states, &m_k_states,
+              &alpha, &kfilter.predicted_state_cov[0,0,smoother.t], &kf_k_states,
+                      smoother._tmp0, &kf_k_states,
+              &beta, smoother._smoothed_state_cov, &kf_k_states)
 
 
 cdef int {{prefix}}smoothed_state_autocov_conventional({{prefix}}KalmanSmoother smoother, {{prefix}}KalmanFilter kfilter, {{prefix}}Statespace model):
     cdef:
         int i
-        int inc = 1
+        blas_int inc = 1
+        blas_int kf_k_states = kfilter.k_states
+        blas_int mod_k_states = model.k_states
         {{cython_type}} alpha = 1.0
         {{cython_type}} beta = 0.0
         {{cython_type}} gamma = -1.0
@@ -323,27 +344,34 @@ cdef int {{prefix}}smoothed_state_autocov_conventional({{prefix}}KalmanSmoother 
     # From Durbin and Koopman, 2012, Chapter 4.7
     # Cov(alpha_{t+1}, alpha_t) = (I - P_{t+1} N_{t}) L_t P_t
 
-    blas.{{prefix}}gemm("N", "N", &model.k_states, &model.k_states, &model.k_states,
-                  &gamma, &kfilter.predicted_state_cov[0,0,smoother.t+1], &kfilter.k_states,
-                          smoother._input_scaled_smoothed_estimator_cov, &kfilter.k_states,
-                  &beta, smoother._tmp0, &kfilter.k_states)
+    blas.{{prefix}}gemm("N", "N", &mod_k_states, &mod_k_states, &mod_k_states,
+                  &gamma, &kfilter.predicted_state_cov[0,0,smoother.t+1], &kf_k_states,
+                          smoother._input_scaled_smoothed_estimator_cov, &kf_k_states,
+                  &beta, smoother._tmp0, &kf_k_states)
     for i in range(kfilter.k_states):
         smoother.tmp0[i,i] = 1 + smoother.tmp0[i,i]
 
-    blas.{{prefix}}gemm("N", "N", &model.k_states, &model.k_states, &model.k_states,
-                  &alpha, smoother._tmpL, &kfilter.k_states,
-                          &kfilter.predicted_state_cov[0,0,smoother.t], &kfilter.k_states,
-                  &beta, smoother._tmp_autocov, &kfilter.k_states)
+    blas.{{prefix}}gemm("N", "N", &mod_k_states, &mod_k_states, &mod_k_states,
+                  &alpha, smoother._tmpL, &kf_k_states,
+                          &kfilter.predicted_state_cov[0,0,smoother.t], &kf_k_states,
+                  &beta, smoother._tmp_autocov, &kf_k_states)
 
-    blas.{{prefix}}gemm("N", "N", &model.k_states, &model.k_states, &model.k_states,
-                  &alpha, smoother._tmp0, &kfilter.k_states,
-                          smoother._tmp_autocov, &kfilter.k_states,
-                  &beta, smoother._smoothed_state_autocov, &kfilter.k_states)
+    blas.{{prefix}}gemm("N", "N", &mod_k_states, &mod_k_states, &mod_k_states,
+                  &alpha, smoother._tmp0, &kf_k_states,
+                          smoother._tmp_autocov, &kf_k_states,
+                  &beta, smoother._smoothed_state_autocov, &kf_k_states)
 
 cdef int {{prefix}}smoothed_disturbances_conventional({{prefix}}KalmanSmoother smoother, {{prefix}}KalmanFilter kfilter, {{prefix}}Statespace model):
     cdef int i, j
     cdef:
-        int inc = 1
+        blas_int inc = 1
+        blas_int kf_k_endog = kfilter.k_endog
+        blas_int kf_k_posdef = kfilter.k_posdef
+        blas_int kf_k_states = kfilter.k_states
+        blas_int m_k_endog = model._k_endog
+        blas_int m_k_posdef = model._k_posdef
+        blas_int m_k_posdef2 = model._k_posdef2
+        blas_int m_k_states = model._k_states
         {{cython_type}} alpha = 1.0
         {{cython_type}} beta = 0.0
         {{cython_type}} gamma = -1.0
@@ -353,53 +381,53 @@ cdef int {{prefix}}smoothed_disturbances_conventional({{prefix}}KalmanSmoother s
     # $\\#_0 = R_t Q_t$
     # $(m \times r) = (m \times r) (r \times r)$
     if smoother.smoother_output & (SMOOTHER_DISTURBANCE | SMOOTHER_DISTURBANCE_COV):
-        blas.{{prefix}}gemm("N", "N", &model._k_states, &model._k_posdef, &model._k_posdef,
-                  &alpha, model._selection, &model._k_states,
-                          model._state_cov, &model._k_posdef,
-                  &beta, smoother._tmp0, &kfilter.k_states)
+        blas.{{prefix}}gemm("N", "N", &m_k_states, &m_k_posdef, &m_k_posdef,
+                  &alpha, model._selection, &m_k_states,
+                          model._state_cov, &m_k_posdef,
+                  &beta, smoother._tmp0, &kf_k_states)
 
     if smoother.smoother_output & SMOOTHER_DISTURBANCE:
         # Smoothed measurement disturbance
         # $\hat \varepsilon_t = H_t u_t$
         # $(p \times 1) = (p \times p) (p \times 1)$
-        blas.{{prefix}}gemv("N", &model._k_endog, &model._k_endog,
-                      &alpha, model._obs_cov, &model._k_endog,
+        blas.{{prefix}}gemv("N", &m_k_endog, &m_k_endog,
+                      &alpha, model._obs_cov, &m_k_endog,
                               smoother._smoothing_error, &inc,
                       &beta, smoother._smoothed_measurement_disturbance, &inc)
 
         # Smoothed state disturbance
         # $\hat \eta_t = \\#_0' r_t$
         # $(r \times 1) = (r \times m) (m \times 1)$
-        blas.{{prefix}}gemv("T", &model._k_states, &model._k_posdef,
-                      &alpha, smoother._tmp0, &kfilter.k_states,
+        blas.{{prefix}}gemv("T", &m_k_states, &m_k_posdef,
+                      &alpha, smoother._tmp0, &kf_k_states,
                               smoother._input_scaled_smoothed_estimator, &inc,
                       &beta, smoother._smoothed_state_disturbance, &inc)
 
     if smoother.smoother_output & SMOOTHER_DISTURBANCE_COV:
         # $\\#_00 = K_t H_t$
         # $(m \times p) = (m \times p) (p \times p)$
-        blas.{{prefix}}gemm("N", "N", &model._k_states, &model._k_endog, &model._k_endog,
-                  &alpha, kfilter._kalman_gain, &kfilter.k_states,
-                          model._obs_cov, &model._k_endog,
-                  &beta, smoother._tmp00, &kfilter.k_states)
+        blas.{{prefix}}gemm("N", "N", &m_k_states, &m_k_endog, &m_k_endog,
+                  &alpha, kfilter._kalman_gain, &kf_k_states,
+                          model._obs_cov, &m_k_endog,
+                  &beta, smoother._tmp00, &kf_k_states)
 
         # Smoothed measurement disturbance covariance matrix
         # $Var(\varepsilon_t | Y_n) = H_t - H_t \\#_4 - \\#_00' N_t \\#_00$
         # $(p \times p) = (p \times p) - (p \times p) (p \times p) - (p \times m) (m \times m) (m \times p)$
-        blas.{{prefix}}gemm("N", "N", &model._k_endog, &model._k_endog, &model._k_endog,
-                  &gamma, model._obs_cov, &model._k_endog,
-                          kfilter._tmp4, &kfilter.k_endog,
-                  &beta, smoother._smoothed_measurement_disturbance_cov, &kfilter.k_endog)
+        blas.{{prefix}}gemm("N", "N", &m_k_endog, &m_k_endog, &m_k_endog,
+                  &gamma, model._obs_cov, &m_k_endog,
+                          kfilter._tmp4, &kf_k_endog,
+                  &beta, smoother._smoothed_measurement_disturbance_cov, &kf_k_endog)
 
-        blas.{{prefix}}gemm("N", "N", &model._k_states, &model._k_endog, &model._k_states,
-                  &alpha, smoother._input_scaled_smoothed_estimator_cov, &kfilter.k_states,
-                          smoother._tmp00, &kfilter.k_states,
-                  &beta, smoother._tmp000, &kfilter.k_states)
+        blas.{{prefix}}gemm("N", "N", &m_k_states, &m_k_endog, &m_k_states,
+                  &alpha, smoother._input_scaled_smoothed_estimator_cov, &kf_k_states,
+                          smoother._tmp00, &kf_k_states,
+                  &beta, smoother._tmp000, &kf_k_states)
 
-        blas.{{prefix}}gemm("T", "N", &model._k_endog, &model._k_endog, &model._k_states,
-                  &gamma, smoother._tmp00, &kfilter.k_states,
-                          smoother._tmp000, &kfilter.k_states,
-                  &alpha, smoother._smoothed_measurement_disturbance_cov, &kfilter.k_endog)
+        blas.{{prefix}}gemm("T", "N", &m_k_endog, &m_k_endog, &m_k_states,
+                  &gamma, smoother._tmp00, &kf_k_states,
+                          smoother._tmp000, &kf_k_states,
+                  &alpha, smoother._smoothed_measurement_disturbance_cov, &kf_k_endog)
 
         # blas.{{prefix}}axpy(&model._k_endog2, &alpha,
         #        model._obs_cov, &inc,
@@ -413,15 +441,15 @@ cdef int {{prefix}}smoothed_disturbances_conventional({{prefix}}KalmanSmoother s
         # Smoothed state disturbance covariance matrix
         # $Var(\eta_t | Y_n) = Q_t - \\#_0' N_t \\#_0$
         # $(r \times r) = (r \times r) - (r \times m) (m \times m) (m \times r)$
-        blas.{{prefix}}gemm("N", "N", &model._k_states, &model._k_posdef, &model._k_states,
-                  &alpha, smoother._input_scaled_smoothed_estimator_cov, &kfilter.k_states,
-                          smoother._tmp0, &kfilter.k_states,
-                  &beta, smoother._tmpL, &kfilter.k_states)
+        blas.{{prefix}}gemm("N", "N", &m_k_states, &m_k_posdef, &m_k_states,
+                  &alpha, smoother._input_scaled_smoothed_estimator_cov, &kf_k_states,
+                          smoother._tmp0, &kf_k_states,
+                  &beta, smoother._tmpL, &kf_k_states)
 
-        blas.{{prefix}}copy(&model._k_posdef2, model._state_cov, &inc, smoother._smoothed_state_disturbance_cov, &inc)
-        blas.{{prefix}}gemm("T", "N", &model._k_posdef, &model._k_posdef, &model._k_states,
-                  &gamma, smoother._tmp0, &kfilter.k_states,
-                          smoother._tmpL, &kfilter.k_states,
-                  &alpha, smoother._smoothed_state_disturbance_cov, &kfilter.k_posdef)
+        blas.{{prefix}}copy(&m_k_posdef2, model._state_cov, &inc, smoother._smoothed_state_disturbance_cov, &inc)
+        blas.{{prefix}}gemm("T", "N", &m_k_posdef, &m_k_posdef, &m_k_states,
+                  &gamma, smoother._tmp0, &kf_k_states,
+                          smoother._tmpL, &kf_k_states,
+                  &alpha, smoother._smoothed_state_disturbance_cov, &kf_k_posdef)
 
 {{endfor}}

--- a/statsmodels/tsa/statespace/_smoothers/_univariate.pyx.in
+++ b/statsmodels/tsa/statespace/_smoothers/_univariate.pyx.in
@@ -44,6 +44,7 @@ import numpy as np
 cimport numpy as np
 from statsmodels.includes.math cimport *
 cimport scipy.linalg.cython_blas as blas
+include "statsmodels/tsa/statespace/_blas_int.pxi"
 
 from statsmodels.tsa.statespace._kalman_smoother cimport (
     SMOOTHER_STATE, SMOOTHER_STATE_COV, SMOOTHER_STATE_AUTOCOV,
@@ -78,12 +79,17 @@ if combined_prefix == 'z':
 
 cdef int {{prefix}}smoothed_estimators_measurement_univariate({{prefix}}KalmanSmoother smoother, {{prefix}}KalmanFilter kfilter, {{prefix}}Statespace model) except *:
     cdef:
-        int i, j, k, inc = 1
+        int i, j
+        blas_int k
+        blas_int inc = 1
         {{cython_type}} alpha = 1.0
         {{cython_type}} beta = 0.0
         {{cython_type}} gamma = -1.0
         {{cython_type}} scalar
-        int k_states = model._k_states
+        blas_int k_states = model._k_states
+        blas_int kf_k_states2 = kfilter.k_states2
+        blas_int m_k_states = model._k_states
+        blas_int kf_k_states = kfilter.k_states
         # {{cython_type}} [::1, :] tmpL
         # {{cython_type}} * _tmpL
 
@@ -115,11 +121,11 @@ cdef int {{prefix}}smoothed_estimators_measurement_univariate({{prefix}}KalmanSm
             # Note: zdot and cdot are broken, so have to use gemv for those
             {{if combined_prefix == 'd'}}
             smoother._smoothed_measurement_disturbance[i] = (
-                blas.{{prefix}}dot(&model._k_states, &kfilter._kalman_gain[i*kfilter.k_states], &inc,
+                blas.{{prefix}}dot(&m_k_states, &kfilter._kalman_gain[i*kfilter.k_states], &inc,
                                                        smoother._scaled_smoothed_estimator, &inc)
             )
             {{else}}
-            blas.{{prefix}}gemv("N", &inc, &model._k_states,
+            blas.{{prefix}}gemv("N", &inc, &m_k_states,
                            &alpha, smoother._scaled_smoothed_estimator, &inc,
                                    &kfilter._kalman_gain[i*kfilter.k_states], &inc,
                            &beta, &smoother._smoothed_measurement_disturbance[i], &inc)
@@ -133,18 +139,18 @@ cdef int {{prefix}}smoothed_estimators_measurement_univariate({{prefix}}KalmanSm
             #                          &alpha, smoother._scaled_smoothed_estimator_cov, &kfilter.k_states,
             #                                  &kfilter._kalman_gain[i*kfilter.k_states], &inc,
             #                          &beta, smoother._tmp0, &inc)
-            blas.{{prefix}}{{if combined_prefix == 'z'}}he{{else}}sy{{endif}}mv("U", &model._k_states,
-                                     &alpha, smoother._scaled_smoothed_estimator_cov, &kfilter.k_states,
+            blas.{{prefix}}{{if combined_prefix == 'z'}}he{{else}}sy{{endif}}mv("U", &m_k_states,
+                                     &alpha, smoother._scaled_smoothed_estimator_cov, &kf_k_states,
                                              &kfilter._kalman_gain[i*kfilter.k_states], &inc,
                                      &beta, smoother._tmp0, &inc)
             # Note: zdot and cdot are broken, so have to use gemv for those
             {{if combined_prefix == 'd'}}
             smoother._smoothed_measurement_disturbance_cov[i + i*kfilter.k_endog] = (
-                blas.{{prefix}}dot(&model._k_states, &kfilter._kalman_gain[i*kfilter.k_states], &inc,
+                blas.{{prefix}}dot(&m_k_states, &kfilter._kalman_gain[i*kfilter.k_states], &inc,
                                                       smoother._tmp0, &inc)
             )
             {{else}}
-            blas.{{prefix}}gemv("N", &inc, &model._k_states,
+            blas.{{prefix}}gemv("N", &inc, &m_k_states,
                            &alpha, smoother._tmp0, &inc,
                                    &kfilter._kalman_gain[i*kfilter.k_states], &inc,
                            &beta, &smoother._smoothed_measurement_disturbance_cov[i*kfilter.k_endog + i], &inc)
@@ -163,13 +169,13 @@ cdef int {{prefix}}smoothed_estimators_measurement_univariate({{prefix}}KalmanSm
             {{prefix}}precise_iter_smoothed_estimators_measurement_univariate(smoother, kfilter, model, i, k_states)
 
     # Transition for L
-    blas.{{prefix}}copy(&kfilter.k_states2, smoother._tmpL, &inc, smoother._tmpL2, &inc)
-    blas.{{prefix}}gemm("N", "N", &model._k_states, &model._k_states, &model._k_states,
-                      &alpha, model._transition, &kfilter.k_states,
-                              smoother._tmpL2, &kfilter.k_states,
-                      &beta, smoother._tmpL, &kfilter.k_states)
+    blas.{{prefix}}copy(&kf_k_states2, smoother._tmpL, &inc, smoother._tmpL2, &inc)
+    blas.{{prefix}}gemm("N", "N", &m_k_states, &m_k_states, &m_k_states,
+                      &alpha, model._transition, &kf_k_states,
+                              smoother._tmpL2, &kf_k_states,
+                      &beta, smoother._tmpL, &kf_k_states)
 
-cdef int {{prefix}}fast_iter_smoothed_estimators_measurement_univariate({{prefix}}KalmanSmoother smoother, {{prefix}}KalmanFilter kfilter, {{prefix}}Statespace model, int i, int k_states):
+cdef int {{prefix}}fast_iter_smoothed_estimators_measurement_univariate({{prefix}}KalmanSmoother smoother, {{prefix}}KalmanFilter kfilter, {{prefix}}Statespace model, int i, blas_int k_states):
     """
     Faster version of univariate smoother iteration
 
@@ -204,12 +210,17 @@ cdef int {{prefix}}fast_iter_smoothed_estimators_measurement_univariate({{prefix
     $$
     """
     cdef:
-        int j, k, inc = 1
+        int j
+        blas_int k
+        blas_int inc = 1
         {{cython_type}} alpha = 1.0
         {{cython_type}} beta = 0.0
         {{cython_type}} gamma = -1.0
         {{cython_type}} scalar
 
+        blas_int kf_k_states = kfilter.k_states
+        blas_int m_k_endog = model._k_endog
+        blas_int m_k_states = model._k_states
     # Accumulate L_{t,i} so that at the end of the iteration we have L_t
     # L_{t}^n = L_{t,n}
     if i == kfilter.k_endog - 1:
@@ -218,10 +229,10 @@ cdef int {{prefix}}fast_iter_smoothed_estimators_measurement_univariate({{prefix
         # blas.{{prefix}}scal(&kfilter.k_states2, &beta, smoother._tmpL, &inc)
         # Create the K_{t,i} Z_{t,i} component
         # (m x p) (m x 1) x (1 x p)
-        blas.{{prefix}}ger{{combined_suffix}}(&model._k_states, &k_states,
+        blas.{{prefix}}ger{{combined_suffix}}(&m_k_states, &k_states,
                   &gamma, &kfilter._kalman_gain[i*kfilter.k_states], &inc,
-                          &model._design[i], &model._k_endog,
-                          smoother._tmpL, &kfilter.k_states)
+                          &model._design[i], &m_k_endog,
+                          smoother._tmpL, &kf_k_states)
         # Add the identity matrix
         for j in range(k_states):
             smoother._tmpL[j + j*kfilter.k_states] = smoother._tmpL[j + j*kfilter.k_states] + 1
@@ -229,8 +240,8 @@ cdef int {{prefix}}fast_iter_smoothed_estimators_measurement_univariate({{prefix
     else:
         # blas.{{prefix}}copy(&kfilter.k_states2, smoother._tmpL, &inc, smoother._tmp0, &inc)
         # L_t^i K_{t,i} -> tmpL2  (m x m) (m x 1)
-        blas.{{prefix}}gemv("N", &model._k_states, &model._k_states,
-                  &alpha, smoother._tmpL, &kfilter.k_states,
+        blas.{{prefix}}gemv("N", &m_k_states, &m_k_states,
+                  &alpha, smoother._tmpL, &kf_k_states,
                           &kfilter._kalman_gain[i*kfilter.k_states], &inc,
                   &beta, smoother._tmpL2, &inc)
         # L_t^i - (L_t^i K_{t,i}) Z_{t,i} -> tmpL  (m x 1) (1 x m)
@@ -238,10 +249,10 @@ cdef int {{prefix}}fast_iter_smoothed_estimators_measurement_univariate({{prefix
         #           &gamma, smoother._tmpL2, &kfilter.k_states,
         #                   &model._design[i], &model._k_endog,
         #           &alpha, smoother._tmpL, &kfilter.k_states)
-        blas.{{prefix}}ger{{combined_suffix}}(&model._k_states, &model._k_states,
+        blas.{{prefix}}ger{{combined_suffix}}(&m_k_states, &m_k_states,
                   &gamma, smoother._tmpL2, &inc,
-                          &model._design[i], &model._k_endog,
-                  smoother._tmpL, &kfilter.k_states)
+                          &model._design[i], &m_k_endog,
+                  smoother._tmpL, &kf_k_states)
 
     # Scaled smoothed estimator
     # $r_{t,i-1} = Z_{t,i}' v_{t,i} / F_{t,i} + L_{t,i}' r_{t,i}$
@@ -252,7 +263,7 @@ cdef int {{prefix}}fast_iter_smoothed_estimators_measurement_univariate({{prefix
     # T+1 of them (r_{T-1} to r_{-1} -> r_T to r_0)
     if smoother.smoother_output & (SMOOTHER_STATE | SMOOTHER_DISTURBANCE):
         scalar = kfilter._tmp2[i] - smoother._smoothed_measurement_disturbance[i]
-        blas.{{prefix}}axpy(&k_states, &scalar, &model._design[i], &model._k_endog,
+        blas.{{prefix}}axpy(&k_states, &scalar, &model._design[i], &m_k_endog,
                                        smoother._scaled_smoothed_estimator, &inc)
 
     if smoother.smoother_output & (SMOOTHER_STATE_COV | SMOOTHER_DISTURBANCE_COV):
@@ -268,10 +279,10 @@ cdef int {{prefix}}fast_iter_smoothed_estimators_measurement_univariate({{prefix
         smoother.tmpL2[:] = 0
 
         # (N_{t,i} K_{t,i} Z_{t,i})
-        blas.{{prefix}}ger{{combined_suffix}}(&model._k_states, &model._k_states,
+        blas.{{prefix}}ger{{combined_suffix}}(&m_k_states, &m_k_states,
             &alpha, smoother._tmp0, &inc,
-                    &model._design[i], &model._k_endog,
-            smoother._tmpL2, &kfilter.k_states)
+                    &model._design[i], &m_k_endog,
+            smoother._tmpL2, &kf_k_states)
 
         # (N_{t,i} K_{t,i} Z_{t,i}) + (N_{t,i} K_{t,i} Z_{t,i})'
         # for j in range(kfilter.k_states):
@@ -289,10 +300,10 @@ cdef int {{prefix}}fast_iter_smoothed_estimators_measurement_univariate({{prefix
             k = kfilter.k_states - j
             blas.{{prefix}}axpy(&k, &gamma, &smoother.tmpL2[j, j], &inc,
                                             &smoother._scaled_smoothed_estimator_cov[j+j*kfilter.k_states], &inc)
-            blas.{{prefix}}axpy(&k, &gamma, &smoother.tmpL2[j, j], &kfilter.k_states,
+            blas.{{prefix}}axpy(&k, &gamma, &smoother.tmpL2[j, j], &kf_k_states,
                                             &smoother._scaled_smoothed_estimator_cov[j+j*kfilter.k_states], &inc)
             blas.{{prefix}}copy(&k, &smoother._scaled_smoothed_estimator_cov[j+j*kfilter.k_states], &inc,
-                                    &smoother._scaled_smoothed_estimator_cov[j+j*kfilter.k_states], &kfilter.k_states)
+                                    &smoother._scaled_smoothed_estimator_cov[j+j*kfilter.k_states], &kf_k_states)
 
         # N_{t,i-1}
         scalar = smoother._smoothed_measurement_disturbance_cov[i*kfilter.k_endog + i]
@@ -300,10 +311,10 @@ cdef int {{prefix}}fast_iter_smoothed_estimators_measurement_univariate({{prefix
             scalar = scalar + 1 / kfilter._forecast_error_cov[i*kfilter.k_endog + i]
 
         # TODO: replace with syr + fill in upper triangle?
-        blas.{{prefix}}ger{{combined_suffix}}(&model._k_states, &model._k_states,
-            &scalar, &model._design[i], &model._k_endog,
-                    &model._design[i], &model._k_endog,
-            smoother._scaled_smoothed_estimator_cov, &kfilter.k_states)
+        blas.{{prefix}}ger{{combined_suffix}}(&m_k_states, &m_k_states,
+            &scalar, &model._design[i], &m_k_endog,
+                    &model._design[i], &m_k_endog,
+            smoother._scaled_smoothed_estimator_cov, &kf_k_states)
         # {{if combined_prefix == 'd'}}
         # blas.{{prefix}}syr("L", &model._k_states,
         #     &scalar, &model._design[i], &model._k_endog,
@@ -320,13 +331,20 @@ cdef int {{prefix}}fast_iter_smoothed_estimators_measurement_univariate({{prefix
         #             smoother._scaled_smoothed_estimator_cov[j + k*kfilter.k_states] = smoother._scaled_smoothed_estimator_cov[k + j*kfilter.k_states]
 
 
-cdef int {{prefix}}precise_iter_smoothed_estimators_measurement_univariate({{prefix}}KalmanSmoother smoother, {{prefix}}KalmanFilter kfilter, {{prefix}}Statespace model, int i, int k_states):
+cdef int {{prefix}}precise_iter_smoothed_estimators_measurement_univariate({{prefix}}KalmanSmoother smoother, {{prefix}}KalmanFilter kfilter, {{prefix}}Statespace model, int i, blas_int k_states):
     cdef:
-        int j, k, inc = 1
+        int j
+        blas_int k
+        blas_int inc = 1
         {{cython_type}} alpha = 1.0
         {{cython_type}} beta = 0.0
         {{cython_type}} gamma = -1.0
         {{cython_type}} scalar
+        blas_int kf_k_endog = kfilter.k_endog
+        blas_int kf_k_states = kfilter.k_states
+        blas_int kf_k_states2 = kfilter.k_states2
+        blas_int m_k_endog = model._k_endog
+        blas_int m_k_states = model._k_states
 
     # $L_{t,i} = (I_m - K_{t,i} Z_{t,i})$
     # $(m \times m) = (m \times m) - (m \times 1) (1 \times m)$
@@ -339,23 +357,23 @@ cdef int {{prefix}}precise_iter_smoothed_estimators_measurement_univariate({{pre
     smoother.tmpL2[:,:k_states] = 0
     # Create the K_{t,i} Z_{t,i} component
     # (m x p) (m x 1) x (1 x p)
-    blas.{{prefix}}ger{{combined_suffix}}(&model._k_states, &k_states,
+    blas.{{prefix}}ger{{combined_suffix}}(&m_k_states, &k_states,
               &gamma, &kfilter._kalman_gain[i*kfilter.k_states], &inc,
-                      &model._design[i], &model._k_endog,
-                      smoother._tmpL2, &kfilter.k_states)
+                      &model._design[i], &m_k_endog,
+                      smoother._tmpL2, &kf_k_states)
     # Add the identity matrix
     for j in range(k_states):
         smoother._tmpL2[j + j*kfilter.k_states] = smoother._tmpL2[j + j*kfilter.k_states] + 1
 
     # Accumulate L_{t,i} into L_{t} = L_{t,n} L_{t,n-1} ... L_{t,1}
     if i == kfilter.k_endog-1:
-        blas.{{prefix}}copy(&kfilter.k_states2, smoother._tmpL2, &inc, smoother._tmpL, &inc)
+        blas.{{prefix}}copy(&kf_k_states2, smoother._tmpL2, &inc, smoother._tmpL, &inc)
     else:
-        blas.{{prefix}}copy(&kfilter.k_states2, smoother._tmpL, &inc, smoother._tmp0, &inc)
-        blas.{{prefix}}gemm("N", "N", &model._k_states, &model._k_states, &model._k_states,
-                  &alpha, smoother._tmp0, &kfilter.k_states,
-                          smoother._tmpL2, &kfilter.k_states,
-                  &beta, smoother._tmpL, &kfilter.k_states)
+        blas.{{prefix}}copy(&kf_k_states2, smoother._tmpL, &inc, smoother._tmp0, &inc)
+        blas.{{prefix}}gemm("N", "N", &m_k_states, &m_k_states, &m_k_states,
+                  &alpha, smoother._tmp0, &kf_k_states,
+                          smoother._tmpL2, &kf_k_states,
+                  &beta, smoother._tmpL, &kf_k_states)
 
     # Scaled smoothed estimator
     # $r_{t,i-1} = Z_{t,i}' v_{t,i} / F_{t,i} + L_{t,i}' r_{t,i}$
@@ -366,13 +384,13 @@ cdef int {{prefix}}precise_iter_smoothed_estimators_measurement_univariate({{pre
     if smoother.smoother_output & (SMOOTHER_STATE | SMOOTHER_DISTURBANCE):
         #blas.{{prefix}}scal(&kfilter.k_states, &beta, smoother._tmp0, &inc)
 
-        blas.{{prefix}}gemv("T", &model._k_states, &k_states,
-                  &alpha, smoother._tmpL2, &kfilter.k_states,
+        blas.{{prefix}}gemv("T", &m_k_states, &k_states,
+                  &alpha, smoother._tmpL2, &kf_k_states,
                           smoother._scaled_smoothed_estimator, &inc,
                   &beta, smoother._tmp0, &inc)
         blas.{{prefix}}swap(&k_states, smoother._tmp0, &inc,
                                        smoother._scaled_smoothed_estimator, &inc)
-        blas.{{prefix}}axpy(&k_states, &kfilter._tmp2[i], &model._design[i], &model._k_endog,
+        blas.{{prefix}}axpy(&k_states, &kfilter._tmp2[i], &model._design[i], &m_k_endog,
                                                           smoother._scaled_smoothed_estimator, &inc)
 
     if smoother.smoother_output & (SMOOTHER_STATE_COV | SMOOTHER_DISTURBANCE_COV):
@@ -382,29 +400,33 @@ cdef int {{prefix}}precise_iter_smoothed_estimators_measurement_univariate({{pre
         # Note: save $N_{t-1}$ as scaled_smoothed_estimator_cov[t] rather
         # than as scaled_smoothed_estimator_cov[t-1] because we actually
         # need to store T+1 of them (N_{T-1} to N_{-1} -> N_T to N_0)
-        blas.{{prefix}}gemm("N", "N", &model._k_states, &model._k_states, &model._k_states,
-                  &alpha, smoother._scaled_smoothed_estimator_cov, &kfilter.k_states,
-                          smoother._tmpL2, &kfilter.k_states,
-                  &beta, smoother._tmp0, &kfilter.k_states)
-        blas.{{prefix}}gemm("T", "N", &model._k_states, &model._k_states, &model._k_states,
-                  &alpha, smoother._tmpL2, &kfilter.k_states,
-                          smoother._tmp0, &kfilter.k_states,
-                  &beta, smoother._scaled_smoothed_estimator_cov, &kfilter.k_states)
-        blas.{{prefix}}ger{{combined_suffix}}(&model._k_states, &model._k_states,
-            &alpha, &model._design[i], &model._k_endog,
-                    &kfilter._tmp3[i], &kfilter.k_endog,
-            smoother._scaled_smoothed_estimator_cov, &kfilter.k_states)
+        blas.{{prefix}}gemm("N", "N", &m_k_states, &m_k_states, &m_k_states,
+                  &alpha, smoother._scaled_smoothed_estimator_cov, &kf_k_states,
+                          smoother._tmpL2, &kf_k_states,
+                  &beta, smoother._tmp0, &kf_k_states)
+        blas.{{prefix}}gemm("T", "N", &m_k_states, &m_k_states, &m_k_states,
+                  &alpha, smoother._tmpL2, &kf_k_states,
+                          smoother._tmp0, &kf_k_states,
+                  &beta, smoother._scaled_smoothed_estimator_cov, &kf_k_states)
+        blas.{{prefix}}ger{{combined_suffix}}(&m_k_states, &m_k_states,
+            &alpha, &model._design[i], &m_k_endog,
+                    &kfilter._tmp3[i], &kf_k_endog,
+            smoother._scaled_smoothed_estimator_cov, &kf_k_states)
 
 
 cdef int {{prefix}}smoothed_estimators_time_univariate({{prefix}}KalmanSmoother smoother, {{prefix}}KalmanFilter kfilter, {{prefix}}Statespace model):
     cdef:
-        int i, j, inc = 1
+        int i, j
+        blas_int inc = 1
         {{cython_type}} alpha = 1.0
         {{cython_type}} beta = 0.0
         {{cython_type}} gamma = -1.0
         {{cython_type}} scalar
-        int k_states = model._k_states
+        blas_int k_states = model._k_states
         {{cython_type}} * _transition
+        blas_int kf_k_states = kfilter.k_states
+        blas_int kf_k_states2 = kfilter.k_states2
+        blas_int m_k_states = model._k_states
 
     if smoother.t == 0:
         return 1
@@ -415,22 +437,22 @@ cdef int {{prefix}}smoothed_estimators_time_univariate({{prefix}}KalmanSmoother 
     else:
         _transition = &model.transition[0, 0, 0]
     if smoother.smoother_output & (SMOOTHER_STATE | SMOOTHER_DISTURBANCE):
-        blas.{{prefix}}gemv("T", &model._k_states, &model._k_states,
-                                 &alpha, _transition, &model._k_states,
+        blas.{{prefix}}gemv("T", &m_k_states, &m_k_states,
+                                 &alpha, _transition, &m_k_states,
                                          smoother._scaled_smoothed_estimator, &inc,
                                  &beta, &smoother.scaled_smoothed_estimator[0, smoother.t-1], &inc)
     # N_{t-1,p} = T_{t-1}' N_{t,0} T_{t-1}
     if smoother.smoother_output & (SMOOTHER_STATE_COV | SMOOTHER_DISTURBANCE_COV):
-        blas.{{prefix}}copy(&kfilter.k_states2, smoother._scaled_smoothed_estimator_cov, &inc,
+        blas.{{prefix}}copy(&kf_k_states2, smoother._scaled_smoothed_estimator_cov, &inc,
                                                  &smoother.scaled_smoothed_estimator_cov[0, 0, smoother.t-1], &inc)
-        blas.{{prefix}}gemm("T", "N", &model._k_states, &model._k_states, &model._k_states,
-                                      &alpha, _transition, &model._k_states,
-                                              smoother._scaled_smoothed_estimator_cov, &kfilter.k_states,
-                                      &beta, smoother._tmp0, &kfilter.k_states)
-        blas.{{prefix}}gemm("N", "N", &model._k_states, &model._k_states, &model._k_states,
-                                      &alpha, smoother._tmp0, &kfilter.k_states,
-                                              _transition, &model._k_states,
-                                      &beta, &smoother.scaled_smoothed_estimator_cov[0, 0, smoother.t-1], &kfilter.k_states)
+        blas.{{prefix}}gemm("T", "N", &m_k_states, &m_k_states, &m_k_states,
+                                      &alpha, _transition, &m_k_states,
+                                              smoother._scaled_smoothed_estimator_cov, &kf_k_states,
+                                      &beta, smoother._tmp0, &kf_k_states)
+        blas.{{prefix}}gemm("N", "N", &m_k_states, &m_k_states, &m_k_states,
+                                      &alpha, smoother._tmp0, &kf_k_states,
+                                              _transition, &m_k_states,
+                                      &beta, &smoother.scaled_smoothed_estimator_cov[0, 0, smoother.t-1], &kf_k_states)
 
 
 cdef int {{prefix}}smoothed_disturbances_univariate({{prefix}}KalmanSmoother smoother, {{prefix}}KalmanFilter kfilter, {{prefix}}Statespace model):
@@ -438,7 +460,12 @@ cdef int {{prefix}}smoothed_disturbances_univariate({{prefix}}KalmanSmoother smo
     # definition of the smoothed measurement disturbance and cov
     cdef int i, j
     cdef:
-        int inc = 1
+        blas_int inc = 1
+        blas_int kf_k_posdef = kfilter.k_posdef
+        blas_int kf_k_states = kfilter.k_states
+        blas_int m_k_posdef = model._k_posdef
+        blas_int m_k_posdef2 = model._k_posdef2
+        blas_int m_k_states = model._k_states
         {{cython_type}} alpha = 1.0
         {{cython_type}} beta = 0.0
         {{cython_type}} gamma = -1.0
@@ -447,10 +474,10 @@ cdef int {{prefix}}smoothed_disturbances_univariate({{prefix}}KalmanSmoother smo
 
     # $\\#_0 = R_t Q_t$
     # $(m \times r) = (m \times r) (r \times r)$
-    blas.{{prefix}}gemm("N", "N", &model._k_states, &model._k_posdef, &model._k_posdef,
-              &alpha, model._selection, &model._k_states,
-                      model._state_cov, &model._k_posdef,
-              &beta, smoother._tmp0, &kfilter.k_states)
+    blas.{{prefix}}gemm("N", "N", &m_k_states, &m_k_posdef, &m_k_posdef,
+              &alpha, model._selection, &m_k_states,
+                      model._state_cov, &m_k_posdef,
+              &beta, smoother._tmp0, &kf_k_states)
 
     if smoother.smoother_output & SMOOTHER_DISTURBANCE:
         for i in range(model._k_endog):
@@ -471,8 +498,8 @@ cdef int {{prefix}}smoothed_disturbances_univariate({{prefix}}KalmanSmoother smo
         # Smoothed state disturbance
         # $\hat \eta_t = \\#_0' r_t$
         # $(r \times 1) = (r \times m) (m \times 1)$
-        blas.{{prefix}}gemv("T", &model._k_states, &model._k_posdef,
-                      &alpha, smoother._tmp0, &kfilter.k_states,
+        blas.{{prefix}}gemv("T", &m_k_states, &m_k_posdef,
+                      &alpha, smoother._tmp0, &kf_k_states,
                               smoother._input_scaled_smoothed_estimator, &inc,
                       &beta, smoother._smoothed_state_disturbance, &inc)
 
@@ -495,14 +522,14 @@ cdef int {{prefix}}smoothed_disturbances_univariate({{prefix}}KalmanSmoother smo
         # Smoothed state disturbance covariance matrix
         # $Var(\eta_t | Y_n) = Q_t - \\#_0' N_t \\#_0$
         # $(r \times r) = (r \times r) - (r \times m) (m \times m) (m \times r)$
-        blas.{{prefix}}gemm("N", "N", &model._k_states, &model._k_posdef, &model._k_states,
-                  &alpha, smoother._input_scaled_smoothed_estimator_cov, &kfilter.k_states,
-                          smoother._tmp0, &kfilter.k_states,
-                  &beta, smoother._tmpL, &kfilter.k_states)
-        blas.{{prefix}}copy(&model._k_posdef2, model._state_cov, &inc, smoother._smoothed_state_disturbance_cov, &inc)
-        blas.{{prefix}}gemm("T", "N", &kfilter.k_posdef, &kfilter.k_posdef, &kfilter.k_states,
-                  &gamma, smoother._tmp0, &kfilter.k_states,
-                          smoother._tmpL, &kfilter.k_states,
-                  &alpha, smoother._smoothed_state_disturbance_cov, &kfilter.k_posdef)
+        blas.{{prefix}}gemm("N", "N", &m_k_states, &m_k_posdef, &m_k_states,
+                  &alpha, smoother._input_scaled_smoothed_estimator_cov, &kf_k_states,
+                          smoother._tmp0, &kf_k_states,
+                  &beta, smoother._tmpL, &kf_k_states)
+        blas.{{prefix}}copy(&m_k_posdef2, model._state_cov, &inc, smoother._smoothed_state_disturbance_cov, &inc)
+        blas.{{prefix}}gemm("T", "N", &kf_k_posdef, &kf_k_posdef, &kf_k_states,
+                  &gamma, smoother._tmp0, &kf_k_states,
+                          smoother._tmpL, &kf_k_states,
+                  &alpha, smoother._smoothed_state_disturbance_cov, &kf_k_posdef)
 
 {{endfor}}

--- a/statsmodels/tsa/statespace/_smoothers/_univariate_diffuse.pyx.in
+++ b/statsmodels/tsa/statespace/_smoothers/_univariate_diffuse.pyx.in
@@ -49,6 +49,7 @@ import numpy as np
 cimport numpy as np
 from statsmodels.includes.math cimport *
 cimport scipy.linalg.cython_blas as blas
+include "statsmodels/tsa/statespace/_blas_int.pxi"
 
 from statsmodels.tsa.statespace._kalman_smoother cimport (
     SMOOTHER_STATE, SMOOTHER_STATE_COV, SMOOTHER_STATE_AUTOCOV,
@@ -77,7 +78,8 @@ if combined_prefix == 'z':
 
 cdef int {{prefix}}smoothed_estimators_measurement_univariate_diffuse({{prefix}}KalmanSmoother smoother, {{prefix}}KalmanFilter kfilter, {{prefix}}Statespace model) except *:
     cdef:
-        int i, j, inc = 1
+        int i, j
+        blas_int inc = 1
         {{cython_type}} alpha = 1.0
         {{cython_type}} beta = 0.0
         {{cython_type}} gamma = -1.0
@@ -85,6 +87,11 @@ cdef int {{prefix}}smoothed_estimators_measurement_univariate_diffuse({{prefix}}
         int k_states = model._k_states
         {{cython_type}} forecast_error_cov, forecast_error_cov_inv, forecast_error_diffuse_cov, forecast_error_diffuse_cov_inv, F1, F12, F2
 
+        blas_int kf_k_states = kfilter.k_states
+        blas_int kf_k_states2 = kfilter.k_states2
+        blas_int m_k_endog = model._k_endog
+        blas_int m_k_states = model._k_states
+        blas_int m_k_states2 = model._k_states2
     # Adjust for a VAR transition (i.e. design = [#, 0], where the zeros
     # correspond to all states except the first k_posdef states)
     if model.subset_design:
@@ -133,31 +140,31 @@ cdef int {{prefix}}smoothed_estimators_measurement_univariate_diffuse({{prefix}}
             F2 = F12 * forecast_error_diffuse_cov_inv
 
             # K0 = M_inf[:, i:i+1] * F1
-            blas.{{prefix}}copy(&kfilter.k_states, &kfilter._M_inf[i * kfilter.k_states], &inc, kfilter._tmpK0, &inc)
-            blas.{{prefix}}scal(&kfilter.k_states, &F1, kfilter._tmpK0, &inc)
+            blas.{{prefix}}copy(&kf_k_states, &kfilter._M_inf[i * kfilter.k_states], &inc, kfilter._tmpK0, &inc)
+            blas.{{prefix}}scal(&kf_k_states, &F1, kfilter._tmpK0, &inc)
             # K1 = M[:, i:i+1] * F1 + M_inf[:, i:i+1] * F2
             # K1 = M[:, i:i+1] * F1 + K0 * F12
-            blas.{{prefix}}copy(&kfilter.k_states, &kfilter._M[i*kfilter.k_states], &inc, kfilter._tmpK1, &inc)
-            blas.{{prefix}}scal(&kfilter.k_states, &F1, kfilter._tmpK1, &inc)
-            blas.{{prefix}}axpy(&kfilter.k_states, &F12, kfilter._tmpK0, &inc, kfilter._tmpK1, &inc)
+            blas.{{prefix}}copy(&kf_k_states, &kfilter._M[i*kfilter.k_states], &inc, kfilter._tmpK1, &inc)
+            blas.{{prefix}}scal(&kf_k_states, &F1, kfilter._tmpK1, &inc)
+            blas.{{prefix}}axpy(&kf_k_states, &F12, kfilter._tmpK0, &inc, kfilter._tmpK1, &inc)
             # L0 = np.eye(m) - np.dot(K0, Zi)
             kfilter.tmpL0[:] = 0
-            blas.{{prefix}}ger{{combined_suffix}}(&model._k_states, &model._k_states, &gamma, kfilter._tmpK0, &inc, &model._design[i], &model._k_endog, kfilter._tmpL0, &kfilter.k_states)
+            blas.{{prefix}}ger{{combined_suffix}}(&m_k_states, &m_k_states, &gamma, kfilter._tmpK0, &inc, &model._design[i], &m_k_endog, kfilter._tmpL0, &kf_k_states)
             for j in range(kfilter.k_states):
                 kfilter._tmpL0[j + j*kfilter.k_states] = kfilter._tmpL0[j + j*kfilter.k_states] + 1
             # L1 = -np.dot(K1, Zi)
             kfilter.tmpL1[:] = 0
-            blas.{{prefix}}ger{{combined_suffix}}(&model._k_states, &model._k_states, &gamma, kfilter._tmpK1, &inc, &model._design[i], &model._k_endog, kfilter._tmpL1, &kfilter.k_states)
+            blas.{{prefix}}ger{{combined_suffix}}(&m_k_states, &m_k_states, &gamma, kfilter._tmpK1, &inc, &model._design[i], &m_k_endog, kfilter._tmpL1, &kf_k_states)
         elif not forecast_error_cov == 0:
             forecast_error_cov_inv = 1.0 / forecast_error_cov
 
             # K0 = M[:, i:i+1] / F[i, i]
-            blas.{{prefix}}copy(&kfilter.k_states, &kfilter._M[i*kfilter.k_states], &inc, kfilter._tmpK0, &inc)
-            blas.{{prefix}}scal(&kfilter.k_states, &forecast_error_cov_inv, kfilter._tmpK0, &inc)
+            blas.{{prefix}}copy(&kf_k_states, &kfilter._M[i*kfilter.k_states], &inc, kfilter._tmpK0, &inc)
+            blas.{{prefix}}scal(&kf_k_states, &forecast_error_cov_inv, kfilter._tmpK0, &inc)
 
             # L0 = np.eye(m) - np.dot(K0, Zi)
             kfilter.tmpL0[:] = 0
-            blas.{{prefix}}ger{{combined_suffix}}(&model._k_states, &model._k_states, &gamma, kfilter._tmpK0, &inc, &model._design[i], &model._k_endog, kfilter._tmpL0, &kfilter.k_states)
+            blas.{{prefix}}ger{{combined_suffix}}(&m_k_states, &m_k_states, &gamma, kfilter._tmpK0, &inc, &model._design[i], &m_k_endog, kfilter._tmpL0, &kf_k_states)
             for j in range(kfilter.k_states):
                 kfilter._tmpL0[j + j*kfilter.k_states] = kfilter._tmpL0[j + j*kfilter.k_states] + 1
         else:
@@ -167,17 +174,17 @@ cdef int {{prefix}}smoothed_estimators_measurement_univariate_diffuse({{prefix}}
                 kfilter._tmpL0[j + j*kfilter.k_states] = 1
 
         # Cumulate L0 and L1
-        blas.{{prefix}}copy(&kfilter.k_states2, smoother._tmpL, &inc, smoother._tmp0, &inc)
-        blas.{{prefix}}gemm("N", "N", &model._k_states, &model._k_states, &model._k_states,
-                  &alpha, smoother._tmp0, &kfilter.k_states,
-                          kfilter._tmpL0, &kfilter.k_states,
-                  &beta, smoother._tmpL, &kfilter.k_states)
+        blas.{{prefix}}copy(&kf_k_states2, smoother._tmpL, &inc, smoother._tmp0, &inc)
+        blas.{{prefix}}gemm("N", "N", &m_k_states, &m_k_states, &m_k_states,
+                  &alpha, smoother._tmp0, &kf_k_states,
+                          kfilter._tmpL0, &kf_k_states,
+                  &beta, smoother._tmpL, &kf_k_states)
         if {{combined_prefix}}abs(forecast_error_diffuse_cov) > kfilter.tolerance_diffuse:
-            blas.{{prefix}}copy(&kfilter.k_states2, smoother._tmpL2, &inc, smoother._tmp0, &inc)
-            blas.{{prefix}}gemm("N", "N", &model._k_states, &model._k_states, &model._k_states,
-                      &alpha, smoother._tmp0, &kfilter.k_states,
-                              kfilter._tmpL1, &kfilter.k_states,
-                      &beta, smoother._tmpL2, &kfilter.k_states)
+            blas.{{prefix}}copy(&kf_k_states2, smoother._tmpL2, &inc, smoother._tmp0, &inc)
+            blas.{{prefix}}gemm("N", "N", &m_k_states, &m_k_states, &m_k_states,
+                      &alpha, smoother._tmp0, &kf_k_states,
+                              kfilter._tmpL1, &kf_k_states,
+                      &beta, smoother._tmpL2, &kf_k_states)
 
         # Store values for measurement disturbance smoothing
         # np.dot(K0.T, rt)
@@ -185,11 +192,11 @@ cdef int {{prefix}}smoothed_estimators_measurement_univariate_diffuse({{prefix}}
             # Note: zdot and cdot are broken, so have to use gemv for those
             {{if combined_prefix == 'd'}}
             smoother._smoothed_measurement_disturbance[i] = (
-                blas.{{prefix}}dot(&model._k_states, kfilter._tmpK0, &inc,
+                blas.{{prefix}}dot(&m_k_states, kfilter._tmpK0, &inc,
                                                      smoother._scaled_smoothed_estimator, &inc)
             )
             {{else}}
-            blas.{{prefix}}gemv("N", &inc, &model._k_states,
+            blas.{{prefix}}gemv("N", &inc, &m_k_states,
                            &alpha, smoother._scaled_smoothed_estimator, &inc,
                                    kfilter._tmpK0, &inc,
                            &beta, &smoother._smoothed_measurement_disturbance[i], &inc)
@@ -198,18 +205,18 @@ cdef int {{prefix}}smoothed_estimators_measurement_univariate_diffuse({{prefix}}
         # Store values for measurement disturbance covariance smoothing
         # np.dot(np.dot(K0.T, Nt), K0)
         if smoother.smoother_output & SMOOTHER_DISTURBANCE_COV:
-            blas.{{prefix}}gemv("N", &model._k_states, &model._k_states,
-                                     &alpha, smoother._scaled_smoothed_estimator_cov, &kfilter.k_states,
+            blas.{{prefix}}gemv("N", &m_k_states, &m_k_states,
+                                     &alpha, smoother._scaled_smoothed_estimator_cov, &kf_k_states,
                                              kfilter._tmpK0, &inc,
                                      &beta, smoother._tmp0, &inc)
             # Note: zdot and cdot are broken, so have to use gemv for those
             {{if combined_prefix == 'd'}}
             smoother._smoothed_measurement_disturbance_cov[i + i*kfilter.k_endog] = (
-                blas.{{prefix}}dot(&model._k_states, kfilter._tmpK0, &inc,
+                blas.{{prefix}}dot(&m_k_states, kfilter._tmpK0, &inc,
                                                       smoother._tmp0, &inc)
             )
             {{else}}
-            blas.{{prefix}}gemv("N", &inc, &model._k_states,
+            blas.{{prefix}}gemv("N", &inc, &m_k_states,
                            &alpha, smoother._tmp0, &inc,
                                    kfilter._tmpK0, &inc,
                            &beta, &smoother._smoothed_measurement_disturbance_cov[i*kfilter.k_endog + i], &inc)
@@ -219,91 +226,91 @@ cdef int {{prefix}}smoothed_estimators_measurement_univariate_diffuse({{prefix}}
         if {{combined_prefix}}abs(forecast_error_diffuse_cov) > kfilter.tolerance_diffuse:
             # Update
             # rt_inf[:] = Zi.T[:, 0] * v[i] * F1 + np.dot(L0.T, rt_inf) + np.dot(L1.T, rt)
-            blas.{{prefix}}copy(&model._k_states, smoother._scaled_smoothed_diffuse_estimator, &inc, smoother._tmp0, &inc)
-            blas.{{prefix}}copy(&model._k_states, &model._design[i], &model._k_endog, smoother._scaled_smoothed_diffuse_estimator, &inc)
+            blas.{{prefix}}copy(&m_k_states, smoother._scaled_smoothed_diffuse_estimator, &inc, smoother._tmp0, &inc)
+            blas.{{prefix}}copy(&m_k_states, &model._design[i], &m_k_endog, smoother._scaled_smoothed_diffuse_estimator, &inc)
             scalar = F1 * kfilter._forecast_error[i]
-            blas.{{prefix}}gemv("T", &model._k_states, &model._k_states,
-                &alpha, kfilter._tmpL0, &kfilter.k_states,
+            blas.{{prefix}}gemv("T", &m_k_states, &m_k_states,
+                &alpha, kfilter._tmpL0, &kf_k_states,
                     smoother._tmp0, &inc,
                 &scalar, smoother._scaled_smoothed_diffuse_estimator, &inc)
 
-            blas.{{prefix}}gemv("T", &model._k_states, &model._k_states,
-                &alpha, kfilter._tmpL1, &kfilter.k_states,
+            blas.{{prefix}}gemv("T", &m_k_states, &m_k_states,
+                &alpha, kfilter._tmpL1, &kf_k_states,
                     smoother._scaled_smoothed_estimator, &inc,
                 &alpha, smoother._scaled_smoothed_diffuse_estimator, &inc)
 
             # rt[:] = np.dot(L0.T, rt)
-            blas.{{prefix}}copy(&model._k_states, smoother._scaled_smoothed_estimator, &inc, smoother._tmp0, &inc)
-            blas.{{prefix}}gemv("T", &model._k_states, &model._k_states,
-                &alpha, kfilter._tmpL0, &kfilter.k_states,
+            blas.{{prefix}}copy(&m_k_states, smoother._scaled_smoothed_estimator, &inc, smoother._tmp0, &inc)
+            blas.{{prefix}}gemv("T", &m_k_states, &m_k_states,
+                &alpha, kfilter._tmpL0, &kf_k_states,
                     smoother._tmp0, &inc,
                 &beta, smoother._scaled_smoothed_estimator, &inc)
 
             # Nt_inf2[:] = ZiTZi * F2 + np.dot(np.dot(L0.T, Nt_inf2), L0) + np.dot(np.dot(L0.T, Nt_inf1), L1) + np.dot(np.dot(L1.T, Nt_inf1.T), L0) + np.dot(np.dot(L1.T, Nt), L1)
             # Nt_inf2[:] = ZiTZi * F2 + np.dot(np.dot(L0.T, Nt_inf2), L0) + np.dot(np.dot(L0.T, Nt_inf1), L1) + np.dot(np.dot(L1.T, Nt_inf1.T), L0) + np.dot(np.dot(L1.T, Nt), L1)
             #  : np.dot(L0.T, Nt_inf2) -> tmp0
-            blas.{{prefix}}gemm("T", "N", &model._k_states, &model._k_states, &model._k_states,
-                      &alpha, kfilter._tmpL0, &kfilter.k_states,
-                              smoother._scaled_smoothed_diffuse2_estimator_cov, &kfilter.k_states,
-                      &beta, smoother._tmp0, &kfilter.k_states)
+            blas.{{prefix}}gemm("T", "N", &m_k_states, &m_k_states, &m_k_states,
+                      &alpha, kfilter._tmpL0, &kf_k_states,
+                              smoother._scaled_smoothed_diffuse2_estimator_cov, &kf_k_states,
+                      &beta, smoother._tmp0, &kf_k_states)
             #  : np.dot(tmp0, L0) -> scaled_smoothed_diffuse2_estimator_cov
-            blas.{{prefix}}gemm("N", "N", &model._k_states, &model._k_states, &model._k_states,
-                      &alpha, smoother._tmp0, &kfilter.k_states,
-                              kfilter._tmpL0, &kfilter.k_states,
-                      &beta, smoother._scaled_smoothed_diffuse2_estimator_cov, &kfilter.k_states)
+            blas.{{prefix}}gemm("N", "N", &m_k_states, &m_k_states, &m_k_states,
+                      &alpha, smoother._tmp0, &kf_k_states,
+                              kfilter._tmpL0, &kf_k_states,
+                      &beta, smoother._scaled_smoothed_diffuse2_estimator_cov, &kf_k_states)
             #  : np.dot(L0.T, Nt_inf1) -> tmp0
-            blas.{{prefix}}gemm("T", "N", &model._k_states, &model._k_states, &model._k_states,
-                      &alpha, kfilter._tmpL0, &kfilter.k_states,
-                              smoother._scaled_smoothed_diffuse1_estimator_cov, &kfilter.k_states,
-                      &beta, smoother._tmp0, &kfilter.k_states)
+            blas.{{prefix}}gemm("T", "N", &m_k_states, &m_k_states, &m_k_states,
+                      &alpha, kfilter._tmpL0, &kf_k_states,
+                              smoother._scaled_smoothed_diffuse1_estimator_cov, &kf_k_states,
+                      &beta, smoother._tmp0, &kf_k_states)
             #  : np.dot(tmp0, L1) -> scaled_smoothed_diffuse2_estimator_cov
-            blas.{{prefix}}gemm("N", "N", &model._k_states, &model._k_states, &model._k_states,
-                      &alpha, smoother._tmp0, &kfilter.k_states,
-                              kfilter._tmpL1, &kfilter.k_states,
-                      &alpha, smoother._scaled_smoothed_diffuse2_estimator_cov, &kfilter.k_states)
+            blas.{{prefix}}gemm("N", "N", &m_k_states, &m_k_states, &m_k_states,
+                      &alpha, smoother._tmp0, &kf_k_states,
+                              kfilter._tmpL1, &kf_k_states,
+                      &alpha, smoother._scaled_smoothed_diffuse2_estimator_cov, &kf_k_states)
             #  : np.dot(L1.T, Nt_inf1.T) -> tmp0
-            blas.{{prefix}}gemm("T", "T", &model._k_states, &model._k_states, &model._k_states,
-                      &alpha, kfilter._tmpL1, &kfilter.k_states,
-                              smoother._scaled_smoothed_diffuse1_estimator_cov, &kfilter.k_states,
-                      &beta, smoother._tmp0, &kfilter.k_states)
+            blas.{{prefix}}gemm("T", "T", &m_k_states, &m_k_states, &m_k_states,
+                      &alpha, kfilter._tmpL1, &kf_k_states,
+                              smoother._scaled_smoothed_diffuse1_estimator_cov, &kf_k_states,
+                      &beta, smoother._tmp0, &kf_k_states)
             #  : np.dot(tmp0, L0) -> scaled_smoothed_diffuse2_estimator_cov
-            blas.{{prefix}}gemm("N", "N", &model._k_states, &model._k_states, &model._k_states,
-                      &alpha, smoother._tmp0, &kfilter.k_states,
-                              kfilter._tmpL0, &kfilter.k_states,
-                      &alpha, smoother._scaled_smoothed_diffuse2_estimator_cov, &kfilter.k_states)
+            blas.{{prefix}}gemm("N", "N", &m_k_states, &m_k_states, &m_k_states,
+                      &alpha, smoother._tmp0, &kf_k_states,
+                              kfilter._tmpL0, &kf_k_states,
+                      &alpha, smoother._scaled_smoothed_diffuse2_estimator_cov, &kf_k_states)
             #  : np.dot(L1.T, Nt) -> tmp0
-            blas.{{prefix}}gemm("T", "N", &model._k_states, &model._k_states, &model._k_states,
-                      &alpha, kfilter._tmpL1, &kfilter.k_states,
-                              smoother._scaled_smoothed_estimator_cov, &kfilter.k_states,
-                      &beta, smoother._tmp0, &kfilter.k_states)
+            blas.{{prefix}}gemm("T", "N", &m_k_states, &m_k_states, &m_k_states,
+                      &alpha, kfilter._tmpL1, &kf_k_states,
+                              smoother._scaled_smoothed_estimator_cov, &kf_k_states,
+                      &beta, smoother._tmp0, &kf_k_states)
             #  : np.dot(tmp0, L1) -> scaled_smoothed_diffuse2_estimator_cov
-            blas.{{prefix}}gemm("N", "N", &model._k_states, &model._k_states, &model._k_states,
-                      &alpha, smoother._tmp0, &kfilter.k_states,
-                              kfilter._tmpL1, &kfilter.k_states,
-                      &alpha, smoother._scaled_smoothed_diffuse2_estimator_cov, &kfilter.k_states)
+            blas.{{prefix}}gemm("N", "N", &m_k_states, &m_k_states, &m_k_states,
+                      &alpha, smoother._tmp0, &kf_k_states,
+                              kfilter._tmpL1, &kf_k_states,
+                      &alpha, smoother._scaled_smoothed_diffuse2_estimator_cov, &kf_k_states)
             # Note: still need to add ZiTZi * F2 to Nt_inf2, which is done below.
 
             # Nt_inf1[:] = ZiTZi * F1 + np.dot(np.dot(L0.T, Nt_inf1), L0) + np.dot(np.dot(L1.T, Nt), L0)
             #  : np.dot(L0.T, Nt_inf1) -> tmp0
-            blas.{{prefix}}gemm("T", "N", &model._k_states, &model._k_states, &model._k_states,
-                      &alpha, kfilter._tmpL0, &kfilter.k_states,
-                              smoother._scaled_smoothed_diffuse1_estimator_cov, &kfilter.k_states,
-                      &beta, smoother._tmp0, &kfilter.k_states)
+            blas.{{prefix}}gemm("T", "N", &m_k_states, &m_k_states, &m_k_states,
+                      &alpha, kfilter._tmpL0, &kf_k_states,
+                              smoother._scaled_smoothed_diffuse1_estimator_cov, &kf_k_states,
+                      &beta, smoother._tmp0, &kf_k_states)
             #  : np.dot(tmp0, L0) -> scaled_smoothed_diffuse2_estimator_cov
-            blas.{{prefix}}gemm("N", "N", &model._k_states, &model._k_states, &model._k_states,
-                      &alpha, smoother._tmp0, &kfilter.k_states,
-                              kfilter._tmpL0, &kfilter.k_states,
-                      &beta, smoother._scaled_smoothed_diffuse1_estimator_cov, &kfilter.k_states)
+            blas.{{prefix}}gemm("N", "N", &m_k_states, &m_k_states, &m_k_states,
+                      &alpha, smoother._tmp0, &kf_k_states,
+                              kfilter._tmpL0, &kf_k_states,
+                      &beta, smoother._scaled_smoothed_diffuse1_estimator_cov, &kf_k_states)
             #  : np.dot(L1.T, Nt) -> tmp0
-            blas.{{prefix}}gemm("T", "N", &model._k_states, &model._k_states, &model._k_states,
-                      &alpha, kfilter._tmpL1, &kfilter.k_states,
-                              smoother._scaled_smoothed_estimator_cov, &kfilter.k_states,
-                      &beta, smoother._tmp0, &kfilter.k_states)
+            blas.{{prefix}}gemm("T", "N", &m_k_states, &m_k_states, &m_k_states,
+                      &alpha, kfilter._tmpL1, &kf_k_states,
+                              smoother._scaled_smoothed_estimator_cov, &kf_k_states,
+                      &beta, smoother._tmp0, &kf_k_states)
             #  : np.dot(tmp0, L0) -> scaled_smoothed_diffuse2_estimator_cov
-            blas.{{prefix}}gemm("N", "N", &model._k_states, &model._k_states, &model._k_states,
-                      &alpha, smoother._tmp0, &kfilter.k_states,
-                              kfilter._tmpL0, &kfilter.k_states,
-                      &alpha, smoother._scaled_smoothed_diffuse1_estimator_cov, &kfilter.k_states)
+            blas.{{prefix}}gemm("N", "N", &m_k_states, &m_k_states, &m_k_states,
+                      &alpha, smoother._tmp0, &kf_k_states,
+                              kfilter._tmpL0, &kf_k_states,
+                      &alpha, smoother._scaled_smoothed_diffuse1_estimator_cov, &kf_k_states)
             # #  : np.dot(L0.T, Nt) -> tmp0
             # blas.{{prefix}}gemm("T", "N", &model._k_states, &model._k_states, &model._k_states,
             #           &alpha, kfilter._tmpL0, &kfilter.k_states,
@@ -319,24 +326,24 @@ cdef int {{prefix}}smoothed_estimators_measurement_univariate_diffuse({{prefix}}
             # Now add in ZiTZi
             # ZiTZi
             smoother.tmp0[:] = 0
-            blas.{{prefix}}ger{{combined_suffix}}(&model._k_states, &model._k_states, &alpha, &model._design[i], &model._k_endog, &model._design[i], &model._k_endog, smoother._tmp0, &kfilter.k_states)
+            blas.{{prefix}}ger{{combined_suffix}}(&m_k_states, &m_k_states, &alpha, &model._design[i], &m_k_endog, &model._design[i], &m_k_endog, smoother._tmp0, &kf_k_states)
 
             # : Nt_inf2 += ZiTZi * F2
-            blas.{{prefix}}axpy(&kfilter.k_states2, &F2, smoother._tmp0, &inc, smoother._scaled_smoothed_diffuse2_estimator_cov, &inc)
+            blas.{{prefix}}axpy(&kf_k_states2, &F2, smoother._tmp0, &inc, smoother._scaled_smoothed_diffuse2_estimator_cov, &inc)
             # : Nt_inf1 += ZiTZi * F1
-            blas.{{prefix}}axpy(&kfilter.k_states2, &F1, smoother._tmp0, &inc, smoother._scaled_smoothed_diffuse1_estimator_cov, &inc)
+            blas.{{prefix}}axpy(&kf_k_states2, &F1, smoother._tmp0, &inc, smoother._scaled_smoothed_diffuse1_estimator_cov, &inc)
 
             # Nt[:] = np.dot(np.dot(L0.T, Nt), L0)
             #  : np.dot(L0.T, Nt) -> tmp0
-            blas.{{prefix}}gemm("T", "N", &model._k_states, &model._k_states, &model._k_states,
-                      &alpha, kfilter._tmpL0, &kfilter.k_states,
-                              smoother._scaled_smoothed_estimator_cov, &kfilter.k_states,
-                      &beta, smoother._tmp0, &kfilter.k_states)
+            blas.{{prefix}}gemm("T", "N", &m_k_states, &m_k_states, &m_k_states,
+                      &alpha, kfilter._tmpL0, &kf_k_states,
+                              smoother._scaled_smoothed_estimator_cov, &kf_k_states,
+                      &beta, smoother._tmp0, &kf_k_states)
             #  : np.dot(tmp0, L0) -> scaled_smoothed_estimator_cov
-            blas.{{prefix}}gemm("N", "N", &model._k_states, &model._k_states, &model._k_states,
-                      &alpha, smoother._tmp0, &kfilter.k_states,
-                              kfilter._tmpL0, &kfilter.k_states,
-                      &beta, smoother._scaled_smoothed_estimator_cov, &kfilter.k_states)
+            blas.{{prefix}}gemm("N", "N", &m_k_states, &m_k_states, &m_k_states,
+                      &alpha, smoother._tmp0, &kf_k_states,
+                              kfilter._tmpL0, &kf_k_states,
+                      &beta, smoother._scaled_smoothed_estimator_cov, &kf_k_states)
 
         # F_{\infty, i, i, t} = 0
         elif not forecast_error_cov == 0:
@@ -347,57 +354,61 @@ cdef int {{prefix}}smoothed_estimators_measurement_univariate_diffuse({{prefix}}
             # version is consistent with the definition of the smoothing
             # recursion in the book.
             # rt[:] = Zi.T[:, 0] * v[i] / F[i, i] + np.dot(L0.T, rt)
-            blas.{{prefix}}copy(&model._k_states, smoother._scaled_smoothed_estimator, &inc, smoother._tmp0, &inc)
-            blas.{{prefix}}copy(&model._k_states, &model._design[i], &model._k_endog, smoother._scaled_smoothed_estimator, &inc)
+            blas.{{prefix}}copy(&m_k_states, smoother._scaled_smoothed_estimator, &inc, smoother._tmp0, &inc)
+            blas.{{prefix}}copy(&m_k_states, &model._design[i], &m_k_endog, smoother._scaled_smoothed_estimator, &inc)
             scalar = forecast_error_cov_inv * kfilter._forecast_error[i]
-            blas.{{prefix}}gemv("T", &model._k_states, &model._k_states,
-                &alpha, kfilter._tmpL0, &kfilter.k_states,
+            blas.{{prefix}}gemv("T", &m_k_states, &m_k_states,
+                &alpha, kfilter._tmpL0, &kf_k_states,
                     smoother._tmp0, &inc,
                 &scalar, smoother._scaled_smoothed_estimator, &inc)
             # rt_inf[:] = rt_inf[:]
 
             # Nt[:] = ZiTZi / F[i, i] + np.dot(np.dot(L0.T, Nt), L0)
             #  : np.dot(L0.T, Nt) -> tmp0
-            blas.{{prefix}}gemm("T", "N", &model._k_states, &model._k_states, &model._k_states,
-                      &alpha, kfilter._tmpL0, &kfilter.k_states,
-                              smoother._scaled_smoothed_estimator_cov, &kfilter.k_states,
-                      &beta, smoother._tmp0, &kfilter.k_states)
+            blas.{{prefix}}gemm("T", "N", &m_k_states, &m_k_states, &m_k_states,
+                      &alpha, kfilter._tmpL0, &kf_k_states,
+                              smoother._scaled_smoothed_estimator_cov, &kf_k_states,
+                      &beta, smoother._tmp0, &kf_k_states)
             #  : np.dot(tmp0, L0) -> scaled_smoothed_diffuse2_estimator_cov
-            blas.{{prefix}}gemm("N", "N", &model._k_states, &model._k_states, &model._k_states,
-                      &alpha, smoother._tmp0, &kfilter.k_states,
-                              kfilter._tmpL0, &kfilter.k_states,
-                      &beta, smoother._scaled_smoothed_estimator_cov, &kfilter.k_states)
-            blas.{{prefix}}ger{{combined_suffix}}(&model._k_states, &model._k_states, &forecast_error_cov_inv, &model._design[i], &model._k_endog, &model._design[i], &model._k_endog, smoother._scaled_smoothed_estimator_cov, &kfilter.k_states)
+            blas.{{prefix}}gemm("N", "N", &m_k_states, &m_k_states, &m_k_states,
+                      &alpha, smoother._tmp0, &kf_k_states,
+                              kfilter._tmpL0, &kf_k_states,
+                      &beta, smoother._scaled_smoothed_estimator_cov, &kf_k_states)
+            blas.{{prefix}}ger{{combined_suffix}}(&m_k_states, &m_k_states, &forecast_error_cov_inv, &model._design[i], &m_k_endog, &model._design[i], &m_k_endog, smoother._scaled_smoothed_estimator_cov, &kf_k_states)
             # Nt_inf1[:] = np.dot(Nt_inf1, L0)
-            blas.{{prefix}}copy(&model._k_states2, smoother._scaled_smoothed_diffuse1_estimator_cov, &inc, smoother._tmp0, &inc)
-            blas.{{prefix}}gemm("N", "N", &model._k_states, &model._k_states, &model._k_states,
-                      &alpha, smoother._tmp0, &kfilter.k_states,
-                              kfilter._tmpL0, &kfilter.k_states,
-                      &beta, smoother._scaled_smoothed_diffuse1_estimator_cov, &kfilter.k_states)
+            blas.{{prefix}}copy(&m_k_states2, smoother._scaled_smoothed_diffuse1_estimator_cov, &inc, smoother._tmp0, &inc)
+            blas.{{prefix}}gemm("N", "N", &m_k_states, &m_k_states, &m_k_states,
+                      &alpha, smoother._tmp0, &kf_k_states,
+                              kfilter._tmpL0, &kf_k_states,
+                      &beta, smoother._scaled_smoothed_diffuse1_estimator_cov, &kf_k_states)
             # Nt_inf2[:] = Nt_inf2
 
     # Finalize the cumulated L0 and L1 by premultiplying by T
     # (and put them into kfilter.tmpL0 and kfilter.tmpL1)
-    blas.{{prefix}}copy(&kfilter.k_states2, smoother._tmpL, &inc, smoother._tmp0, &inc)
-    blas.{{prefix}}gemm("N", "N", &model._k_states, &model._k_states, &model._k_states,
-                      &alpha, model._transition, &kfilter.k_states,
-                              smoother._tmp0, &kfilter.k_states,
-                      &beta, kfilter._tmpL0, &kfilter.k_states)
-    blas.{{prefix}}copy(&kfilter.k_states2, smoother._tmpL2, &inc, smoother._tmp0, &inc)
-    blas.{{prefix}}gemm("N", "N", &model._k_states, &model._k_states, &model._k_states,
-                      &alpha, model._transition, &kfilter.k_states,
-                              smoother._tmp0, &kfilter.k_states,
-                      &beta, kfilter._tmpL1, &kfilter.k_states)
+    blas.{{prefix}}copy(&kf_k_states2, smoother._tmpL, &inc, smoother._tmp0, &inc)
+    blas.{{prefix}}gemm("N", "N", &m_k_states, &m_k_states, &m_k_states,
+                      &alpha, model._transition, &kf_k_states,
+                              smoother._tmp0, &kf_k_states,
+                      &beta, kfilter._tmpL0, &kf_k_states)
+    blas.{{prefix}}copy(&kf_k_states2, smoother._tmpL2, &inc, smoother._tmp0, &inc)
+    blas.{{prefix}}gemm("N", "N", &m_k_states, &m_k_states, &m_k_states,
+                      &alpha, model._transition, &kf_k_states,
+                              smoother._tmp0, &kf_k_states,
+                      &beta, kfilter._tmpL1, &kf_k_states)
 
 
 cdef int {{prefix}}smoothed_estimators_time_univariate_diffuse({{prefix}}KalmanSmoother smoother, {{prefix}}KalmanFilter kfilter, {{prefix}}Statespace model):
     cdef:
-        int i, j, inc = 1
+        int i, j
+        blas_int inc = 1
         {{cython_type}} alpha = 1.0
         {{cython_type}} beta = 0.0
         {{cython_type}} gamma = -1.0
         {{cython_type}} scalar
         int k_states = model._k_states
+        blas_int kf_k_states = kfilter.k_states
+        blas_int kf_k_states2 = kfilter.k_states2
+        blas_int m_k_states = model._k_states
 
     if smoother.t == 0:
         return 1
@@ -405,69 +416,72 @@ cdef int {{prefix}}smoothed_estimators_time_univariate_diffuse({{prefix}}KalmanS
     # TODO check that this is the right transition matrix to use in the case
     # of time-varying matrices
     # rt1[:] = np.dot(T1.T, rt)
-    blas.{{prefix}}gemv("T", &model._k_states, &model._k_states,
-                             &alpha, model._transition, &model._k_states,
+    blas.{{prefix}}gemv("T", &m_k_states, &m_k_states,
+                             &alpha, model._transition, &m_k_states,
                                      smoother._scaled_smoothed_estimator, &inc,
                              &beta, &smoother.scaled_smoothed_estimator[0, smoother.t-1], &inc)
     # rt1_inf[:] = np.dot(T1.T, rt_inf)
-    blas.{{prefix}}gemv("T", &model._k_states, &model._k_states,
-                             &alpha, model._transition, &model._k_states,
+    blas.{{prefix}}gemv("T", &m_k_states, &m_k_states,
+                             &alpha, model._transition, &m_k_states,
                                      smoother._scaled_smoothed_diffuse_estimator, &inc,
                              &beta, &smoother.scaled_smoothed_diffuse_estimator[0, smoother.t-1], &inc)
 
     # Nt1 = np.dot(np.dot(T1.T, Nt1), T1)
-    blas.{{prefix}}copy(&kfilter.k_states2, smoother._scaled_smoothed_estimator_cov, &inc,
+    blas.{{prefix}}copy(&kf_k_states2, smoother._scaled_smoothed_estimator_cov, &inc,
                                              &smoother.scaled_smoothed_estimator_cov[0, 0, smoother.t-1], &inc)
-    blas.{{prefix}}gemm("T", "N", &model._k_states, &model._k_states, &model._k_states,
-                                  &alpha, model._transition, &model._k_states,
-                                          smoother._scaled_smoothed_estimator_cov, &kfilter.k_states,
-                                  &beta, smoother._tmp0, &kfilter.k_states)
-    blas.{{prefix}}gemm("N", "N", &model._k_states, &model._k_states, &model._k_states,
-                                  &alpha, smoother._tmp0, &kfilter.k_states,
-                                          model._transition, &model._k_states,
-                                  &beta, &smoother.scaled_smoothed_estimator_cov[0, 0, smoother.t-1], &kfilter.k_states)
+    blas.{{prefix}}gemm("T", "N", &m_k_states, &m_k_states, &m_k_states,
+                                  &alpha, model._transition, &m_k_states,
+                                          smoother._scaled_smoothed_estimator_cov, &kf_k_states,
+                                  &beta, smoother._tmp0, &kf_k_states)
+    blas.{{prefix}}gemm("N", "N", &m_k_states, &m_k_states, &m_k_states,
+                                  &alpha, smoother._tmp0, &kf_k_states,
+                                          model._transition, &m_k_states,
+                                  &beta, &smoother.scaled_smoothed_estimator_cov[0, 0, smoother.t-1], &kf_k_states)
     # Nt1_inf1 = np.dot(np.dot(T1.T, Nt1_inf1), T1)
-    blas.{{prefix}}copy(&kfilter.k_states2, smoother._scaled_smoothed_diffuse1_estimator_cov, &inc,
+    blas.{{prefix}}copy(&kf_k_states2, smoother._scaled_smoothed_diffuse1_estimator_cov, &inc,
                                              &smoother.scaled_smoothed_diffuse1_estimator_cov[0, 0, smoother.t-1], &inc)
-    blas.{{prefix}}gemm("T", "N", &model._k_states, &model._k_states, &model._k_states,
-                                  &alpha, model._transition, &model._k_states,
-                                          smoother._scaled_smoothed_diffuse1_estimator_cov, &kfilter.k_states,
-                                  &beta, smoother._tmp0, &kfilter.k_states)
-    blas.{{prefix}}gemm("N", "N", &model._k_states, &model._k_states, &model._k_states,
-                                  &alpha, smoother._tmp0, &kfilter.k_states,
-                                          model._transition, &model._k_states,
-                                  &beta, &smoother.scaled_smoothed_diffuse1_estimator_cov[0, 0, smoother.t-1], &kfilter.k_states)
+    blas.{{prefix}}gemm("T", "N", &m_k_states, &m_k_states, &m_k_states,
+                                  &alpha, model._transition, &m_k_states,
+                                          smoother._scaled_smoothed_diffuse1_estimator_cov, &kf_k_states,
+                                  &beta, smoother._tmp0, &kf_k_states)
+    blas.{{prefix}}gemm("N", "N", &m_k_states, &m_k_states, &m_k_states,
+                                  &alpha, smoother._tmp0, &kf_k_states,
+                                          model._transition, &m_k_states,
+                                  &beta, &smoother.scaled_smoothed_diffuse1_estimator_cov[0, 0, smoother.t-1], &kf_k_states)
     # Nt1_inf2 = np.dot(np.dot(T1.T, Nt1_inf2), T1)
-    blas.{{prefix}}copy(&kfilter.k_states2, smoother._scaled_smoothed_diffuse2_estimator_cov, &inc,
+    blas.{{prefix}}copy(&kf_k_states2, smoother._scaled_smoothed_diffuse2_estimator_cov, &inc,
                                              &smoother.scaled_smoothed_diffuse2_estimator_cov[0, 0, smoother.t-1], &inc)
-    blas.{{prefix}}gemm("T", "N", &model._k_states, &model._k_states, &model._k_states,
-                                  &alpha, model._transition, &model._k_states,
-                                          smoother._scaled_smoothed_diffuse2_estimator_cov, &kfilter.k_states,
-                                  &beta, smoother._tmp0, &kfilter.k_states)
-    blas.{{prefix}}gemm("N", "N", &model._k_states, &model._k_states, &model._k_states,
-                                  &alpha, smoother._tmp0, &kfilter.k_states,
-                                          model._transition, &model._k_states,
-                                  &beta, &smoother.scaled_smoothed_diffuse2_estimator_cov[0, 0, smoother.t-1], &kfilter.k_states)
+    blas.{{prefix}}gemm("T", "N", &m_k_states, &m_k_states, &m_k_states,
+                                  &alpha, model._transition, &m_k_states,
+                                          smoother._scaled_smoothed_diffuse2_estimator_cov, &kf_k_states,
+                                  &beta, smoother._tmp0, &kf_k_states)
+    blas.{{prefix}}gemm("N", "N", &m_k_states, &m_k_states, &m_k_states,
+                                  &alpha, smoother._tmp0, &kf_k_states,
+                                          model._transition, &m_k_states,
+                                  &beta, &smoother.scaled_smoothed_diffuse2_estimator_cov[0, 0, smoother.t-1], &kf_k_states)
 
 cdef int {{prefix}}smoothed_state_univariate_diffuse({{prefix}}KalmanSmoother smoother, {{prefix}}KalmanFilter kfilter, {{prefix}}Statespace model):
     cdef:
-        int i, j, inc = 1
+        int i, j
+        blas_int inc = 1
         {{cython_type}} alpha = 1.0
         {{cython_type}} beta = 0.0
         {{cython_type}} gamma = -1.0
         {{cython_type}} scalar
         int k_states = model._k_states
+        blas_int kf_k_states = kfilter.k_states
+        blas_int m_k_states = model._k_states
 
     # Smoothed state
     if smoother.smoother_output & SMOOTHER_STATE:
         # alpha_hat[:] = a_t + np.dot(P_t, rt) + np.dot(P_t_inf, rt_inf)
-        blas.{{prefix}}copy(&kfilter.k_states, &kfilter.predicted_state[0,smoother.t], &inc, smoother._smoothed_state, &inc)
-        blas.{{prefix}}gemv("N", &model._k_states, &model._k_states,
-                  &alpha, &kfilter.predicted_state_cov[0,0,smoother.t], &kfilter.k_states,
+        blas.{{prefix}}copy(&kf_k_states, &kfilter.predicted_state[0,smoother.t], &inc, smoother._smoothed_state, &inc)
+        blas.{{prefix}}gemv("N", &m_k_states, &m_k_states,
+                  &alpha, &kfilter.predicted_state_cov[0,0,smoother.t], &kf_k_states,
                           smoother._scaled_smoothed_estimator, &inc,
                   &alpha, smoother._smoothed_state, &inc)
-        blas.{{prefix}}gemv("N", &model._k_states, &model._k_states,
-                  &alpha, &kfilter.predicted_diffuse_state_cov[0,0,smoother.t], &kfilter.k_states,
+        blas.{{prefix}}gemv("N", &m_k_states, &m_k_states,
+                  &alpha, &kfilter.predicted_diffuse_state_cov[0,0,smoother.t], &kf_k_states,
                           smoother._scaled_smoothed_diffuse_estimator, &inc,
                   &alpha, smoother._smoothed_state, &inc)
 
@@ -475,54 +489,59 @@ cdef int {{prefix}}smoothed_state_univariate_diffuse({{prefix}}KalmanSmoother sm
     if smoother.smoother_output & SMOOTHER_STATE_COV:
         # V[:] = P_t - np.dot(np.dot(P_t, Nt), P_t) - np.dot(np.dot(P_t, Nt_inf1), P_t_inf) - np.dot(np.dot(P_t_inf, Nt_inf1), P_t).T - np.dot(np.dot(P_t_inf, Nt_inf2), P_t_inf)
         # : P_t [ I - N_t P_t]
-        blas.{{prefix}}gemm("N", "N", &model._k_states, &model._k_states, &model._k_states,
-              &gamma, smoother._scaled_smoothed_estimator_cov, &kfilter.k_states,
-                      &kfilter.predicted_state_cov[0,0,smoother.t], &kfilter.k_states,
-              &beta, smoother._tmp0, &kfilter.k_states)
+        blas.{{prefix}}gemm("N", "N", &m_k_states, &m_k_states, &m_k_states,
+              &gamma, smoother._scaled_smoothed_estimator_cov, &kf_k_states,
+                      &kfilter.predicted_state_cov[0,0,smoother.t], &kf_k_states,
+              &beta, smoother._tmp0, &kf_k_states)
         for i in range(kfilter.k_states):
             smoother.tmp0[i,i] = 1 + smoother.tmp0[i,i]
-        blas.{{prefix}}gemm("N", "N", &model._k_states, &model._k_states, &model._k_states,
-              &alpha, &kfilter.predicted_state_cov[0,0,smoother.t], &kfilter.k_states,
-                      smoother._tmp0, &kfilter.k_states,
-              &beta, smoother._smoothed_state_cov, &kfilter.k_states)
+        blas.{{prefix}}gemm("N", "N", &m_k_states, &m_k_states, &m_k_states,
+              &alpha, &kfilter.predicted_state_cov[0,0,smoother.t], &kf_k_states,
+                      smoother._tmp0, &kf_k_states,
+              &beta, smoother._smoothed_state_cov, &kf_k_states)
         # : - np.dot(np.dot(P_t_inf, Nt_inf1), P_t)
-        blas.{{prefix}}gemm("N", "N", &model._k_states, &model._k_states, &model._k_states,
-                  &alpha, &kfilter.predicted_diffuse_state_cov[0,0,smoother.t], &kfilter.k_states,
-                          smoother._scaled_smoothed_diffuse1_estimator_cov, &kfilter.k_states,
-                  &beta, smoother._tmp0, &kfilter.k_states)
-        blas.{{prefix}}gemm("N", "N", &model._k_states, &model._k_states, &model._k_states,
-                  &gamma, smoother._tmp0, &kfilter.k_states,
-                          &kfilter.predicted_state_cov[0,0,smoother.t], &kfilter.k_states,
-                  &alpha, smoother._smoothed_state_cov, &kfilter.k_states)
+        blas.{{prefix}}gemm("N", "N", &m_k_states, &m_k_states, &m_k_states,
+                  &alpha, &kfilter.predicted_diffuse_state_cov[0,0,smoother.t], &kf_k_states,
+                          smoother._scaled_smoothed_diffuse1_estimator_cov, &kf_k_states,
+                  &beta, smoother._tmp0, &kf_k_states)
+        blas.{{prefix}}gemm("N", "N", &m_k_states, &m_k_states, &m_k_states,
+                  &gamma, smoother._tmp0, &kf_k_states,
+                          &kfilter.predicted_state_cov[0,0,smoother.t], &kf_k_states,
+                  &alpha, smoother._smoothed_state_cov, &kf_k_states)
 
         # : - np.dot(np.dot(P_t_inf, Nt_inf1), P_t).T
         # [or]
         # : - np.dot(np.dot(P_t, Nt_inf1.T), P_t_inf)
-        blas.{{prefix}}gemm("N", "T", &model._k_states, &model._k_states, &model._k_states,
-                  &alpha, &kfilter.predicted_state_cov[0,0,smoother.t], &kfilter.k_states,
-                          smoother._scaled_smoothed_diffuse1_estimator_cov, &kfilter.k_states,
-                  &beta, smoother._tmp0, &kfilter.k_states)
-        blas.{{prefix}}gemm("N", "N", &model._k_states, &model._k_states, &model._k_states,
-                  &gamma, smoother._tmp0, &kfilter.k_states,
-                          &kfilter.predicted_diffuse_state_cov[0,0,smoother.t], &kfilter.k_states,
-                  &alpha, smoother._smoothed_state_cov, &kfilter.k_states)
+        blas.{{prefix}}gemm("N", "T", &m_k_states, &m_k_states, &m_k_states,
+                  &alpha, &kfilter.predicted_state_cov[0,0,smoother.t], &kf_k_states,
+                          smoother._scaled_smoothed_diffuse1_estimator_cov, &kf_k_states,
+                  &beta, smoother._tmp0, &kf_k_states)
+        blas.{{prefix}}gemm("N", "N", &m_k_states, &m_k_states, &m_k_states,
+                  &gamma, smoother._tmp0, &kf_k_states,
+                          &kfilter.predicted_diffuse_state_cov[0,0,smoother.t], &kf_k_states,
+                  &alpha, smoother._smoothed_state_cov, &kf_k_states)
 
         # - np.dot(np.dot(P_t_inf, Nt_inf2), P_t_inf)
-        blas.{{prefix}}gemm("N", "N", &model._k_states, &model._k_states, &model._k_states,
-                  &alpha, &kfilter.predicted_diffuse_state_cov[0,0,smoother.t], &kfilter.k_states,
-                          smoother._scaled_smoothed_diffuse2_estimator_cov, &kfilter.k_states,
-                  &beta, smoother._tmp0, &kfilter.k_states)
-        blas.{{prefix}}gemm("N", "N", &model._k_states, &model._k_states, &model._k_states,
-                  &gamma, smoother._tmp0, &kfilter.k_states,
-                          &kfilter.predicted_diffuse_state_cov[0,0,smoother.t], &kfilter.k_states,
-                  &alpha, smoother._smoothed_state_cov, &kfilter.k_states)
+        blas.{{prefix}}gemm("N", "N", &m_k_states, &m_k_states, &m_k_states,
+                  &alpha, &kfilter.predicted_diffuse_state_cov[0,0,smoother.t], &kf_k_states,
+                          smoother._scaled_smoothed_diffuse2_estimator_cov, &kf_k_states,
+                  &beta, smoother._tmp0, &kf_k_states)
+        blas.{{prefix}}gemm("N", "N", &m_k_states, &m_k_states, &m_k_states,
+                  &gamma, smoother._tmp0, &kf_k_states,
+                          &kfilter.predicted_diffuse_state_cov[0,0,smoother.t], &kf_k_states,
+                  &alpha, smoother._smoothed_state_cov, &kf_k_states)
 
 cdef int {{prefix}}smoothed_disturbances_univariate_diffuse({{prefix}}KalmanSmoother smoother, {{prefix}}KalmanFilter kfilter, {{prefix}}Statespace model):
     # Note: this only differs from the conventional version in the
     # definition of the smoothed measurement disturbance and cov
     cdef int i, j
     cdef:
-        int inc = 1
+        blas_int inc = 1
+        blas_int kf_k_posdef = kfilter.k_posdef
+        blas_int kf_k_states = kfilter.k_states
+        blas_int m_k_posdef = model._k_posdef
+        blas_int m_k_posdef2 = model._k_posdef2
+        blas_int m_k_states = model._k_states
         {{cython_type}} alpha = 1.0
         {{cython_type}} beta = 0.0
         {{cython_type}} gamma = -1.0
@@ -532,10 +551,10 @@ cdef int {{prefix}}smoothed_disturbances_univariate_diffuse({{prefix}}KalmanSmoo
 
     # $\\#_0 = R_t Q_t$
     # $(m \times r) = (m \times r) (r \times r)$
-    blas.{{prefix}}gemm("N", "N", &model._k_states, &model._k_posdef, &model._k_posdef,
-              &alpha, model._selection, &model._k_states,
-                      model._state_cov, &model._k_posdef,
-              &beta, smoother._tmp0, &kfilter.k_states)
+    blas.{{prefix}}gemm("N", "N", &m_k_states, &m_k_posdef, &m_k_posdef,
+              &alpha, model._selection, &m_k_states,
+                      model._state_cov, &m_k_posdef,
+              &beta, smoother._tmp0, &kf_k_states)
 
     for i in range(model._k_endog):
         forecast_error_cov = kfilter._forecast_error_cov[i + i*kfilter.k_endog]
@@ -565,27 +584,30 @@ cdef int {{prefix}}smoothed_disturbances_univariate_diffuse({{prefix}}KalmanSmoo
 
     # Smoothed state disturbance
     if smoother.smoother_output & SMOOTHER_DISTURBANCE:
-        blas.{{prefix}}gemv("T", &model._k_states, &model._k_posdef,
-                      &alpha, smoother._tmp0, &kfilter.k_states,
+        blas.{{prefix}}gemv("T", &m_k_states, &m_k_posdef,
+                      &alpha, smoother._tmp0, &kf_k_states,
                               smoother._input_scaled_smoothed_estimator, &inc,
                       &beta, smoother._smoothed_state_disturbance, &inc)
 
     # Smoothed state disturbance covariance matrix
     if smoother.smoother_output & SMOOTHER_DISTURBANCE_COV:
-        blas.{{prefix}}gemm("N", "N", &model._k_states, &model._k_posdef, &model._k_states,
-                  &alpha, smoother._input_scaled_smoothed_estimator_cov, &kfilter.k_states,
-                          smoother._tmp0, &kfilter.k_states,
-                  &beta, smoother._tmpL, &kfilter.k_states)
-        blas.{{prefix}}copy(&model._k_posdef2, model._state_cov, &inc, smoother._smoothed_state_disturbance_cov, &inc)
-        blas.{{prefix}}gemm("T", "N", &kfilter.k_posdef, &kfilter.k_posdef, &kfilter.k_states,
-                  &gamma, smoother._tmp0, &kfilter.k_states,
-                          smoother._tmpL, &kfilter.k_states,
-                  &alpha, smoother._smoothed_state_disturbance_cov, &kfilter.k_posdef)
+        blas.{{prefix}}gemm("N", "N", &m_k_states, &m_k_posdef, &m_k_states,
+                  &alpha, smoother._input_scaled_smoothed_estimator_cov, &kf_k_states,
+                          smoother._tmp0, &kf_k_states,
+                  &beta, smoother._tmpL, &kf_k_states)
+        blas.{{prefix}}copy(&m_k_posdef2, model._state_cov, &inc, smoother._smoothed_state_disturbance_cov, &inc)
+        blas.{{prefix}}gemm("T", "N", &kf_k_posdef, &kf_k_posdef, &kf_k_states,
+                  &gamma, smoother._tmp0, &kf_k_states,
+                          smoother._tmpL, &kf_k_states,
+                  &alpha, smoother._smoothed_state_disturbance_cov, &kf_k_posdef)
 
 cdef int {{prefix}}smoothed_state_autocov_univariate_diffuse({{prefix}}KalmanSmoother smoother, {{prefix}}KalmanFilter kfilter, {{prefix}}Statespace model):
     cdef:
         int i
-        int inc = 1
+        blas_int inc = 1
+        blas_int kf_k_states = kfilter.k_states
+        blas_int kf_k_states2 = kfilter.k_states2
+        blas_int mod_k_states = model.k_states
         {{cython_type}} alpha = 1.0
         {{cython_type}} beta = 0.0
         {{cython_type}} gamma = -1.0
@@ -596,71 +618,71 @@ cdef int {{prefix}}smoothed_state_autocov_univariate_diffuse({{prefix}}KalmanSmo
     return 0
 
     # -P_t1 N0t -> tmp0
-    blas.{{prefix}}gemm("N", "N", &model.k_states, &model.k_states, &model.k_states,
-                  &gamma, &kfilter.predicted_state_cov[0,0,smoother.t+1], &kfilter.k_states,
-                          smoother._input_scaled_smoothed_estimator_cov, &kfilter.k_states,
-                  &beta, smoother._tmp0, &kfilter.k_states)
+    blas.{{prefix}}gemm("N", "N", &mod_k_states, &mod_k_states, &mod_k_states,
+                  &gamma, &kfilter.predicted_state_cov[0,0,smoother.t+1], &kf_k_states,
+                          smoother._input_scaled_smoothed_estimator_cov, &kf_k_states,
+                  &beta, smoother._tmp0, &kf_k_states)
 
     # - P_t1_inf N2t - P_t1 N0t -> tmpL
-    blas.{{prefix}}copy(&kfilter.k_states2, smoother._tmp0, &inc, smoother._tmpL, &inc)
-    blas.{{prefix}}gemm("N", "N", &model.k_states, &model.k_states, &model.k_states,
-                  &gamma, &kfilter.predicted_diffuse_state_cov[0,0,smoother.t+1], &kfilter.k_states,
-                          smoother._input_scaled_smoothed_diffuse2_estimator_cov, &kfilter.k_states,
-                  &alpha, smoother._tmpL, &kfilter.k_states)
+    blas.{{prefix}}copy(&kf_k_states2, smoother._tmp0, &inc, smoother._tmpL, &inc)
+    blas.{{prefix}}gemm("N", "N", &mod_k_states, &mod_k_states, &mod_k_states,
+                  &gamma, &kfilter.predicted_diffuse_state_cov[0,0,smoother.t+1], &kf_k_states,
+                          smoother._input_scaled_smoothed_diffuse2_estimator_cov, &kf_k_states,
+                  &alpha, smoother._tmpL, &kf_k_states)
 
     # I - P_t1_inf N1t - P_t1 N0t -> tmp0
-    blas.{{prefix}}gemm("N", "N", &model.k_states, &model.k_states, &model.k_states,
-                  &gamma, &kfilter.predicted_diffuse_state_cov[0,0,smoother.t+1], &kfilter.k_states,
-                          smoother._input_scaled_smoothed_diffuse1_estimator_cov, &kfilter.k_states,
-                  &alpha, smoother._tmp0, &kfilter.k_states)
+    blas.{{prefix}}gemm("N", "N", &mod_k_states, &mod_k_states, &mod_k_states,
+                  &gamma, &kfilter.predicted_diffuse_state_cov[0,0,smoother.t+1], &kf_k_states,
+                          smoother._input_scaled_smoothed_diffuse1_estimator_cov, &kf_k_states,
+                  &alpha, smoother._tmp0, &kf_k_states)
     for i in range(kfilter.k_states):
         smoother.tmp0[i,i] = 1 + smoother.tmp0[i,i]
 
     # L0t P_t -> tmpL2
-    blas.{{prefix}}gemm("N", "N", &model.k_states, &model.k_states, &model.k_states,
-                  &alpha, kfilter._tmpL0, &kfilter.k_states,
-                          &kfilter.predicted_state_cov[0, 0, smoother.t], &kfilter.k_states,
-                  &beta, smoother._tmpL2, &kfilter.k_states)
+    blas.{{prefix}}gemm("N", "N", &mod_k_states, &mod_k_states, &mod_k_states,
+                  &alpha, kfilter._tmpL0, &kf_k_states,
+                          &kfilter.predicted_state_cov[0, 0, smoother.t], &kf_k_states,
+                  &beta, smoother._tmpL2, &kf_k_states)
     # L0t P_t + L1t P_t_inf -> tmpL2
-    blas.{{prefix}}gemm("N", "N", &model.k_states, &model.k_states, &model.k_states,
-                  &alpha, kfilter._tmpL1, &kfilter.k_states,
-                          &kfilter.predicted_diffuse_state_cov[0, 0, smoother.t], &kfilter.k_states,
-                  &alpha, smoother._tmpL2, &kfilter.k_states)
+    blas.{{prefix}}gemm("N", "N", &mod_k_states, &mod_k_states, &mod_k_states,
+                  &alpha, kfilter._tmpL1, &kf_k_states,
+                          &kfilter.predicted_diffuse_state_cov[0, 0, smoother.t], &kf_k_states,
+                  &alpha, smoother._tmpL2, &kf_k_states)
 
     # [I - P_t1_inf N1t - P_t1 N0t] (L1t P_t_inf + L0t P_t) -> smoothed_state_autocov
-    blas.{{prefix}}gemm("N", "N", &model.k_states, &model.k_states, &model.k_states,
-                  &alpha, smoother._tmp0, &kfilter.k_states,
-                          smoother._tmpL2, &kfilter.k_states,
-                  &beta, smoother._smoothed_state_autocov, &kfilter.k_states)
+    blas.{{prefix}}gemm("N", "N", &mod_k_states, &mod_k_states, &mod_k_states,
+                  &alpha, smoother._tmp0, &kf_k_states,
+                          smoother._tmpL2, &kf_k_states,
+                  &beta, smoother._smoothed_state_autocov, &kf_k_states)
 
     # L0t P_t_inf -> tmp0
-    blas.{{prefix}}gemm("N", "N", &model.k_states, &model.k_states, &model.k_states,
-                  &alpha, kfilter._tmpL0, &kfilter.k_states,
-                          &kfilter.predicted_diffuse_state_cov[0, 0, smoother.t], &kfilter.k_states,
-                  &beta, smoother._tmp0, &kfilter.k_states)
+    blas.{{prefix}}gemm("N", "N", &mod_k_states, &mod_k_states, &mod_k_states,
+                  &alpha, kfilter._tmpL0, &kf_k_states,
+                          &kfilter.predicted_diffuse_state_cov[0, 0, smoother.t], &kf_k_states,
+                  &beta, smoother._tmp0, &kf_k_states)
 
     # [- P_t1_inf N2t - P_t1 N0t] L0t P_t_inf +-> smoothed_state_autocov
-    blas.{{prefix}}gemm("N", "N", &model.k_states, &model.k_states, &model.k_states,
-                  &alpha, smoother._tmpL, &kfilter.k_states,
-                          smoother._tmp0, &kfilter.k_states,
-                  &alpha, smoother._smoothed_state_autocov, &kfilter.k_states)
+    blas.{{prefix}}gemm("N", "N", &mod_k_states, &mod_k_states, &mod_k_states,
+                  &alpha, smoother._tmpL, &kf_k_states,
+                          smoother._tmp0, &kf_k_states,
+                  &alpha, smoother._smoothed_state_autocov, &kf_k_states)
 
     # [- P_t1_inf N0t ] -> tmpL
-    blas.{{prefix}}gemm("N", "N", &model.k_states, &model.k_states, &model.k_states,
-                  &gamma, &kfilter.predicted_diffuse_state_cov[0,0,smoother.t+1], &kfilter.k_states,
-                          smoother._input_scaled_smoothed_estimator_cov, &kfilter.k_states,
-                  &beta, smoother._tmpL, &kfilter.k_states)
+    blas.{{prefix}}gemm("N", "N", &mod_k_states, &mod_k_states, &mod_k_states,
+                  &gamma, &kfilter.predicted_diffuse_state_cov[0,0,smoother.t+1], &kf_k_states,
+                          smoother._input_scaled_smoothed_estimator_cov, &kf_k_states,
+                  &beta, smoother._tmpL, &kf_k_states)
 
     # L1t P_t -> tmp0
-    blas.{{prefix}}gemm("N", "N", &model.k_states, &model.k_states, &model.k_states,
-                  &alpha, kfilter._tmpL1, &kfilter.k_states,
-                          &kfilter.predicted_state_cov[0, 0, smoother.t], &kfilter.k_states,
-                  &beta, smoother._tmp0, &kfilter.k_states)
+    blas.{{prefix}}gemm("N", "N", &mod_k_states, &mod_k_states, &mod_k_states,
+                  &alpha, kfilter._tmpL1, &kf_k_states,
+                          &kfilter.predicted_state_cov[0, 0, smoother.t], &kf_k_states,
+                  &beta, smoother._tmp0, &kf_k_states)
 
     # [- P_t1_inf N0t ] L1t P_t +-> smoothed_state_autocov
-    blas.{{prefix}}gemm("N", "N", &model.k_states, &model.k_states, &model.k_states,
-                  &alpha, smoother._tmpL, &kfilter.k_states,
-                          smoother._tmp0, &kfilter.k_states,
-                  &alpha, smoother._smoothed_state_autocov, &kfilter.k_states)
+    blas.{{prefix}}gemm("N", "N", &mod_k_states, &mod_k_states, &mod_k_states,
+                  &alpha, smoother._tmpL, &kf_k_states,
+                          smoother._tmp0, &kf_k_states,
+                  &alpha, smoother._smoothed_state_autocov, &kf_k_states)
 
 {{endfor}}

--- a/statsmodels/tsa/statespace/_tools.pyx.in
+++ b/statsmodels/tsa/statespace/_tools.pyx.in
@@ -19,6 +19,8 @@ from statsmodels.includes.math cimport *
 cimport scipy.linalg.cython_blas as blas
 cimport scipy.linalg.cython_lapack as lapack
 
+include "statsmodels/tsa/statespace/_blas_int.pxi"
+
 cdef FORTRAN = 1
 
 ctypedef fused sm_type_t:
@@ -55,8 +57,8 @@ cdef validate_vector_shape(str name, Py_ssize_t *shape, int nrows, nobs = None):
 # ------------------------------------------------------------------------
 # Blas Wrapping
 
-cdef inline copy(int size, sm_type_t* src_arr, sm_type_t* target,
-                 int incx=1, int incy=1):
+cdef inline copy(blas_int size, sm_type_t* src_arr, sm_type_t* target,
+                 blas_int incx=1, blas_int incy=1):
     """
     Parameters
     ----------
@@ -85,8 +87,8 @@ cdef inline copy(int size, sm_type_t* src_arr, sm_type_t* target,
         blas.zcopy(&size, src_arr, &incx, target, &incy)
 
 
-cdef inline swap(int size, sm_type_t* src_arr, sm_type_t* target,
-                 int incx=1, int incy=1):
+cdef inline swap(blas_int size, sm_type_t* src_arr, sm_type_t* target,
+                 blas_int incx=1, blas_int incy=1):
     """
     Parameters
     ----------
@@ -158,9 +160,10 @@ cdef int _{{prefix}}solve_discrete_lyapunov({{cython_type}} * a, {{cython_type}}
     # q: input / output
     cdef:
         int i, j
-        int info
-        int inc = 1
-        int n2 = n**2
+        blas_int info
+        blas_int inc = 1
+        blas_int n_ = n
+        blas_int n2 = n**2
         {{if prefix == 's' or prefix == 'c'}}
         np.float32_t scale = 0.0
         {{else}}
@@ -173,13 +176,13 @@ cdef int _{{prefix}}solve_discrete_lyapunov({{cython_type}} * a, {{cython_type}}
         char trans
     cdef np.npy_intp dim[2]
     cdef {{cython_type}} [::1,:] apI, capI, u, v
-    cdef int [::1,:] ipiv
+    cdef blas_int [::1,:] ipiv
     # Dummy selection function, will not actually be referenced since we do not
     # need to order the eigenvalues in the ?gees call.
     cdef:
-        int sdim
-        int lwork = 3*n
-        bint bwork
+        blas_int sdim
+        blas_int lwork = 3*n
+        blas_int bwork
     cdef np.npy_intp dim1[1]
     cdef {{cython_type}} [::1,:] work
     cdef {{cython_type}} [:] wr
@@ -195,7 +198,10 @@ cdef int _{{prefix}}solve_discrete_lyapunov({{cython_type}} * a, {{cython_type}}
     capI = np.PyArray_ZEROS(2, dim, {{typenum}}, FORTRAN)
     u = np.PyArray_ZEROS(2, dim, {{typenum}}, FORTRAN)
     v = np.PyArray_ZEROS(2, dim, {{typenum}}, FORTRAN)
-    ipiv = np.PyArray_ZEROS(2, dim, np.NPY_INT32, FORTRAN)
+    if sizeof(blas_int) == 4:
+        ipiv = np.PyArray_ZEROS(2, dim, np.NPY_INT32, FORTRAN)
+    else:
+        ipiv = np.PyArray_ZEROS(2, dim, np.NPY_INT64, FORTRAN)
 
     dim1[0] = n;
     wr = np.PyArray_ZEROS(1, dim1, {{typenum}}, FORTRAN)
@@ -239,13 +245,13 @@ cdef int _{{prefix}}solve_discrete_lyapunov({{cython_type}} * a, {{cython_type}}
     # where b = (a^H - eye) (a^H + eye)^{-1}
     # or b^H = (a + eye)^{-1} (a - eye)
     # or (a + eye) b^H = (a - eye)
-    lapack.{{prefix}}getrf(&n, &n, &capI[0,0], &n, &ipiv[0,0], &info)
+    lapack.{{prefix}}getrf(&n_, &n_, &capI[0,0], &n_, &ipiv[0,0], &info)
 
     if not info == 0:
         raise np.linalg.LinAlgError('LU decomposition error.')
 
-    lapack.{{prefix}}getrs("N", &n, &n, &capI[0,0], &n, &ipiv[0,0],
-                               a, &n, &info)
+    lapack.{{prefix}}getrs("N", &n_, &n_, &capI[0,0], &n_, &ipiv[0,0],
+                               a, &n_, &info)
 
     if not info == 0:
         raise np.linalg.LinAlgError('LU solver error.')
@@ -270,8 +276,8 @@ cdef int _{{prefix}}solve_discrete_lyapunov({{cython_type}} * a, {{cython_type}}
 
     # Solve [conj(a) + I] tmp' = q (result stored in q)
     # For: y = q (a^H + eye)^{-1} => (a + eye) y^H = q
-    lapack.{{prefix}}getrs("N", &n, &n, &capI[0,0], &n, &ipiv[0,0],
-                                        q, &n, &info)
+    lapack.{{prefix}}getrs("N", &n_, &n_, &capI[0,0], &n_, &ipiv[0,0],
+                                        q, &n_, &info)
 
     if not info == 0:
         raise np.linalg.LinAlgError('LU solver error.')
@@ -289,8 +295,8 @@ cdef int _{{prefix}}solve_discrete_lyapunov({{cython_type}} * a, {{cython_type}}
             q[i] = q[i] - q[i].imag * 2.0j
     {{endif}}
 
-    lapack.{{prefix}}getrs("N", &n, &n, &capI[0,0], &n, &ipiv[0,0],
-                                        q, &n, &info)
+    lapack.{{prefix}}getrs("N", &n_, &n_, &capI[0,0], &n_, &ipiv[0,0],
+                                        q, &n_, &info)
 
     if not info == 0:
         raise np.linalg.LinAlgError('LU solver error.')
@@ -317,19 +323,19 @@ cdef int _{{prefix}}solve_discrete_lyapunov({{cython_type}} * a, {{cython_type}}
     # In the complex-step case, we will instead have:
     # r = s.conj()
     # u = v.conj()
-    lapack.{{prefix}}gees("V", "N", <lapack.{{prefix}}select2 *> &_{{prefix}}select2, &n,
-                          a, &n,
+    lapack.{{prefix}}gees("V", "N", <lapack.{{prefix}}select2 *> &_{{prefix}}select2, &n_,
+                          a, &n_,
                           &sdim,
                           &wr[0], &wi[0],
-                          &u[0,0], &n,
+                          &u[0,0], &n_,
                           &work[0,0], &lwork,
                           &bwork, &info)
     {{else}}
-    lapack.{{prefix}}gees("V", "N", <lapack.{{prefix}}select1 *> &_{{prefix}}select1, &n,
-                          a, &n,
+    lapack.{{prefix}}gees("V", "N", <lapack.{{prefix}}select1 *> &_{{prefix}}select1, &n_,
+                          a, &n_,
                           &sdim,
                           &wr[0],
-                          &u[0,0], &n,
+                          &u[0,0], &n_,
                           &work[0,0], &lwork,
                           &wi[0],
                           &bwork, &info)
@@ -351,14 +357,14 @@ cdef int _{{prefix}}solve_discrete_lyapunov({{cython_type}} * a, {{cython_type}}
     # Construct f = u^H*q*u (result overwrites q)
     # In the usual case, v = u
     # In the complex step case, v = u.conj()
-    blas.{{prefix}}gemm("N", "N", &n, &n, &n,
-                        &alpha, q, &n,
-                                &v[0,0], &n,
-                        &beta, &capI[0,0], &n)
-    blas.{{prefix}}gemm("C", "N", &n, &n, &n,
-                        &alpha, &u[0,0], &n,
-                                &capI[0,0], &n,
-                        &beta, q, &n)
+    blas.{{prefix}}gemm("N", "N", &n_, &n_, &n_,
+                        &alpha, q, &n_,
+                                &v[0,0], &n_,
+                        &beta, &capI[0,0], &n_)
+    blas.{{prefix}}gemm("C", "N", &n_, &n_, &n_,
+                        &alpha, &u[0,0], &n_,
+                                &capI[0,0], &n_,
+                        &beta, q, &n_)
 
     # DTRYSL Solve op(A)*X + X*op(B) = scale*C which is here:
     # r*X + X*r = scale*q
@@ -370,10 +376,10 @@ cdef int _{{prefix}}solve_discrete_lyapunov({{cython_type}} * a, {{cython_type}}
             for j in range(n):
                 apI[j,i] = apI[j,i] - apI[j,i].imag * 2.0j
     {{endif}}
-    lapack.{{prefix}}trsyl("N", "C", &inc, &n, &n,
-                           a, &n,
-                           &apI[0,0], &n,
-                           q, &n,
+    lapack.{{prefix}}trsyl("N", "C", &inc, &n_, &n_,
+                           a, &n_,
+                           &apI[0,0], &n_,
+                           q, &n_,
                            &scale, &info)
 
     # Scale q by scale
@@ -383,14 +389,14 @@ cdef int _{{prefix}}solve_discrete_lyapunov({{cython_type}} * a, {{cython_type}}
     # Calculate the solution: u * q * v^H (results overwrite q)
     # In the usual case, v = u
     # In the complex step case, v = u.conj()
-    blas.{{prefix}}gemm("N", "C", &n, &n, &n,
-                        &alpha, q, &n,
-                                &v[0,0], &n,
-                        &beta, &capI[0,0], &n)
-    blas.{{prefix}}gemm("N", "N", &n, &n, &n,
-                        &alpha, &u[0,0], &n,
-                                &capI[0,0], &n,
-                        &beta, q, &n)
+    blas.{{prefix}}gemm("N", "C", &n_, &n_, &n_,
+                        &alpha, q, &n_,
+                                &v[0,0], &n_,
+                        &beta, &capI[0,0], &n_)
+    blas.{{prefix}}gemm("N", "N", &n_, &n_, &n_,
+                        &alpha, &u[0,0], &n_,
+                                &capI[0,0], &n_,
+                        &beta, q, &n_)
 
 
 cpdef _{{prefix}}compute_coefficients_from_multivariate_pacf({{cython_type}} [::1,:] partial_autocorrelations,
@@ -413,6 +419,9 @@ cpdef _{{prefix}}compute_coefficients_from_multivariate_pacf({{cython_type}} [::
         int k_endog_order = k_endog * order
         int k_endog_order1 = k_endog * (order+1)
         int info, s, k
+        blas_int k_endog_ = k_endog
+        blas_int k_endog2_ = k_endog2
+        blas_int info_
     # Local variables
     cdef:
         np.npy_intp dim2[2]
@@ -479,8 +488,8 @@ cpdef _{{prefix}}compute_coefficients_from_multivariate_pacf({{cython_type}} [::
 
     # error_variance_factor = linalg.cholesky(error_variance, lower=True)
     copy(k_endog2, &error_variance[0, 0], &forward_factors[0,0])
-    lapack.{{prefix}}potrf("L", &k_endog, &forward_factors[0,0], &k_endog, &info)
-    copy(k_endog2, &forward_factors[0, 0], &backward_factors[0, 0])
+    lapack.{{prefix}}potrf("L", &k_endog_, &forward_factors[0,0], &k_endog_, &info_)
+    copy(k_endog2_, &forward_factors[0, 0], &backward_factors[0, 0])
 
     # We fill in the entries as follows:
     # [1,1]
@@ -515,15 +524,15 @@ cpdef _{{prefix}}compute_coefficients_from_multivariate_pacf({{cython_type}} [::
         # )
         for k in range(k_endog):
             copy(k_endog, &partial_autocorrelations[k, s*k_endog], &tmp[0, k], k_endog)
-        lapack.{{prefix}}trtrs("L", "T", "N", &k_endog, &k_endog, &backward_factors[0,0], &k_endog,
-                                                           &tmp[0, 0], &k_endog, &info)
+        lapack.{{prefix}}trtrs("L", "T", "N", &k_endog_, &k_endog_, &backward_factors[0,0], &k_endog_,
+                                                           &tmp[0, 0], &k_endog_, &info_)
         # {{prefix}}gemm("N", "T", &k_endog, &k_endog, &k_endog,
         #   &alpha, &forward_factors[0,0], &k_endog,
         #           &tmp[0, 0], &k_endog,
         #   &beta, &forwards[s*k_endog2], &k_endog)
-        blas.{{prefix}}trmm("R", "L", "T", "N", &k_endog, &k_endog,
-          &alpha, &forward_factors[0,0], &k_endog,
-                  &tmp[0, 0], &k_endog)
+        blas.{{prefix}}trmm("R", "L", "T", "N", &k_endog_, &k_endog_,
+          &alpha, &forward_factors[0,0], &k_endog_,
+                  &tmp[0, 0], &k_endog_)
         for k in range(k_endog):
             copy(k_endog, &tmp[k, 0], &forwards[s*k_endog2 + k*k_endog], k_endog)
 
@@ -537,15 +546,15 @@ cpdef _{{prefix}}compute_coefficients_from_multivariate_pacf({{cython_type}} [::
         #         lower=True, trans='T').T
         # )
         copy(k_endog2, &partial_autocorrelations[0, s*k_endog], &tmp[0, 0])
-        lapack.{{prefix}}trtrs("L", "T", "N", &k_endog, &k_endog, &forward_factors[0, 0], &k_endog,
-                                                           &tmp[0, 0], &k_endog, &info)
+        lapack.{{prefix}}trtrs("L", "T", "N", &k_endog_, &k_endog_, &forward_factors[0, 0], &k_endog_,
+                                                           &tmp[0, 0], &k_endog_, &info_)
         # {{prefix}}gemm("N", "T", &k_endog, &k_endog, &k_endog,
         #   &alpha, &backward_factors[0, 0], &k_endog,
         #           &tmp[0, 0], &k_endog,
         #   &beta, &backwards[s * k_endog2], &k_endog)
-        blas.{{prefix}}trmm("R", "L", "T", "N", &k_endog, &k_endog,
-          &alpha, &backward_factors[0,0], &k_endog,
-                  &tmp[0, 0], &k_endog)
+        blas.{{prefix}}trmm("R", "L", "T", "N", &k_endog_, &k_endog_,
+          &alpha, &backward_factors[0,0], &k_endog_,
+                  &tmp[0, 0], &k_endog_)
         for k in range(k_endog):
             copy(k_endog, &tmp[k, 0], &backwards[s*k_endog2 + k*k_endog], k_endog)
 
@@ -555,10 +564,10 @@ cpdef _{{prefix}}compute_coefficients_from_multivariate_pacf({{cython_type}} [::
         # Also, this calculation will be re-used in the forward variance
         # tmp = np.dot(forwards[:, s*k_endog:(s+1)*k_endog], backward_variance)
         # tmpT = np.dot(backward_variance.T, forwards[:, s*k_endog:(s+1)*k_endog].T)
-        blas.{{prefix}}gemm("T", "T", &k_endog, &k_endog, &k_endog,
-          &alpha, &backward_variance[0, 0], &k_endog,
-                  &forwards[s * k_endog2], &k_endog,
-          &beta, &tmp[0, 0], &k_endog)
+        blas.{{prefix}}gemm("T", "T", &k_endog_, &k_endog_, &k_endog_,
+          &alpha, &backward_variance[0, 0], &k_endog_,
+                  &forwards[s * k_endog2], &k_endog_,
+          &beta, &tmp[0, 0], &k_endog_)
         # autocovariances[:, (s+1)*k_endog:(s+2)*k_endog] = tmp.copy().T
         copy(k_endog2, &tmp[0, 0], &autocovariances[0, (s+1)*k_endog])
 
@@ -573,10 +582,10 @@ cpdef _{{prefix}}compute_coefficients_from_multivariate_pacf({{cython_type}} [::
             #     )
             # )
             copy(k_endog2, &prev_forwards[k * k_endog2], &forwards[k * k_endog2])
-            blas.{{prefix}}gemm("N", "N", &k_endog, &k_endog, &k_endog,
-              &gamma, &forwards[s * k_endog2], &k_endog,
-                      &prev_backwards[(s - k - 1) * k_endog2], &k_endog,
-              &alpha, &forwards[k * k_endog2], &k_endog)
+            blas.{{prefix}}gemm("N", "N", &k_endog_, &k_endog_, &k_endog_,
+              &gamma, &forwards[s * k_endog2], &k_endog_,
+                      &prev_backwards[(s - k - 1) * k_endog2], &k_endog_,
+              &alpha, &forwards[k * k_endog2], &k_endog_)
 
             # backwards[:, k*k_endog:(k+1)*k_endog] = (
             #     prev_backwards[:, k*k_endog:(k+1)*k_endog] -
@@ -586,19 +595,19 @@ cpdef _{{prefix}}compute_coefficients_from_multivariate_pacf({{cython_type}} [::
             #     )
             # )
             copy(k_endog2, &prev_backwards[k * k_endog2], &backwards[k * k_endog2])
-            blas.{{prefix}}gemm("N", "N", &k_endog, &k_endog, &k_endog,
-              &gamma, &backwards[s * k_endog2], &k_endog,
-                      &prev_forwards[(s - k - 1) * k_endog2], &k_endog,
-              &alpha, &backwards[k * k_endog2], &k_endog)
+            blas.{{prefix}}gemm("N", "N", &k_endog_, &k_endog_, &k_endog_,
+              &gamma, &backwards[s * k_endog2], &k_endog_,
+                      &prev_forwards[(s - k - 1) * k_endog2], &k_endog_,
+              &alpha, &backwards[k * k_endog2], &k_endog_)
 
             # autocovariances[:, (s+1)*k_endog:(s+2)*k_endog] += np.dot(
             #     autocovariances[:, (k+1)*k_endog:(k+2)*k_endog],
             #     prev_forwards[:, (s-k-1)*k_endog:(s-k)*k_endog].T
             # )
-            blas.{{prefix}}gemm("N", "T", &k_endog, &k_endog, &k_endog,
-              &alpha, &autocovariances[0, (k+1)*k_endog], &k_endog,
-                      &prev_forwards[(s - k - 1) * k_endog2], &k_endog,
-              &alpha, &autocovariances[0, (s+1)*k_endog], &k_endog)
+            blas.{{prefix}}gemm("N", "T", &k_endog_, &k_endog_, &k_endog_,
+              &alpha, &autocovariances[0, (k+1)*k_endog], &k_endog_,
+                      &prev_forwards[(s - k - 1) * k_endog2], &k_endog_,
+              &alpha, &autocovariances[0, (s+1)*k_endog], &k_endog_)
 
         # Create forward and backwards variances
         # backward_variance = (
@@ -608,14 +617,14 @@ cpdef _{{prefix}}compute_coefficients_from_multivariate_pacf({{cython_type}} [::
         #         backwards[:, s*k_endog:(s+1)*k_endog].T
         #     )
         # )
-        blas.{{prefix}}gemm("N", "N", &k_endog, &k_endog, &k_endog,
-          &alpha, &backwards[s * k_endog2], &k_endog,
-                  &forward_variance[0, 0], &k_endog,
-          &beta, &tmp2[0, 0], &k_endog)
-        blas.{{prefix}}gemm("N", "T", &k_endog, &k_endog, &k_endog,
-          &gamma, &tmp2[0, 0], &k_endog,
-                  &backwards[s * k_endog2], &k_endog,
-          &alpha, &backward_variance[0, 0], &k_endog)
+        blas.{{prefix}}gemm("N", "N", &k_endog_, &k_endog_, &k_endog_,
+          &alpha, &backwards[s * k_endog2], &k_endog_,
+                  &forward_variance[0, 0], &k_endog_,
+          &beta, &tmp2[0, 0], &k_endog_)
+        blas.{{prefix}}gemm("N", "T", &k_endog_, &k_endog_, &k_endog_,
+          &gamma, &tmp2[0, 0], &k_endog_,
+                  &backwards[s * k_endog2], &k_endog_,
+          &alpha, &backward_variance[0, 0], &k_endog_)
         # forward_variance = (
         #     forward_variance -
         #     np.dot(tmp, forwards[:, s*k_endog:(s+1)*k_endog].T)
@@ -624,18 +633,18 @@ cpdef _{{prefix}}compute_coefficients_from_multivariate_pacf({{cython_type}} [::
         #     forward_variance -
         #     np.dot(tmpT.T, forwards[:, s*k_endog:(s+1)*k_endog].T)
         # )
-        blas.{{prefix}}gemm("T", "T", &k_endog, &k_endog, &k_endog,
-          &gamma, &tmp[0, 0], &k_endog,
-                  &forwards[s * k_endog2], &k_endog,
-          &alpha, &forward_variance[0, 0], &k_endog)
+        blas.{{prefix}}gemm("T", "T", &k_endog_, &k_endog_, &k_endog_,
+          &gamma, &tmp[0, 0], &k_endog_,
+                  &forwards[s * k_endog2], &k_endog_,
+          &alpha, &forward_variance[0, 0], &k_endog_)
 
         # Cholesky factors
         # forward_factors = linalg.cholesky(forward_variance, lower=True)
         # backward_factors =  linalg.cholesky(backward_variance, lower=True)
-        copy(k_endog2, &forward_variance[0, 0], &forward_factors[0, 0])
-        lapack.{{prefix}}potrf("L", &k_endog, &forward_factors[0,0], &k_endog, &info)
-        copy(k_endog2, &backward_variance[0, 0], &backward_factors[0, 0])
-        lapack.{{prefix}}potrf("L", &k_endog, &backward_factors[0,0], &k_endog, &info)
+        copy(k_endog2_, &forward_variance[0, 0], &forward_factors[0, 0])
+        lapack.{{prefix}}potrf("L", &k_endog_, &forward_factors[0,0], &k_endog_, &info_)
+        copy(k_endog2_, &backward_variance[0, 0], &backward_factors[0, 0])
+        lapack.{{prefix}}potrf("L", &k_endog_, &backward_factors[0,0], &k_endog_, &info_)
 
 
     # If we do not want to use the transformed variance, we need to
@@ -655,12 +664,12 @@ cpdef _{{prefix}}compute_coefficients_from_multivariate_pacf({{cython_type}} [::
         # => L M^{-1} = T
         # initial_variance_factor = np.linalg.cholesky(initial_variance)
         # L'
-        lapack.{{prefix}}potrf("U", &k_endog, &initial_variance[0,0], &k_endog, &info)
+        lapack.{{prefix}}potrf("U", &k_endog_, &initial_variance[0,0], &k_endog_, &info_)
         # transformed_variance_factor = np.linalg.cholesky(variance)
         # M'
-        copy(k_endog2, &forward_variance[0, 0], &tmp[0, 0])
-        lapack.{{prefix}}potrf("U", &k_endog, &tmp[0,0], &k_endog, &info)
-        # {{prefix}}potri("L", &k_endog, &tmp[0,0], &k_endog, &info)
+        copy(k_endog2_, &forward_variance[0, 0], &tmp[0, 0])
+        lapack.{{prefix}}potrf("U", &k_endog_, &tmp[0,0], &k_endog_, &info_)
+        # {{prefix}}potri("L", &k_endog_, &tmp[0,0], &k_endog_, &info_)
 
         # We need to zero out the lower triangle of L', because ?trtrs only
         # knows that M' is upper triangular
@@ -673,8 +682,8 @@ cpdef _{{prefix}}compute_coefficients_from_multivariate_pacf({{cython_type}} [::
         # M' T' = L'
         # transform = np.dot(initial_variance_factor,
         #                    np.linalg.inv(transformed_variance_factor))
-        lapack.{{prefix}}trtrs("U", "N", "N", &k_endog, &k_endog, &tmp[0,0], &k_endog,
-                                                           &initial_variance[0, 0], &k_endog, &info)
+        lapack.{{prefix}}trtrs("U", "N", "N", &k_endog_, &k_endog_, &tmp[0,0], &k_endog_,
+                                                           &initial_variance[0, 0], &k_endog_, &info_)
         # Now:
         # initial_variance = T'
 
@@ -691,14 +700,14 @@ cpdef _{{prefix}}compute_coefficients_from_multivariate_pacf({{cython_type}} [::
 
             # Get TF
             copy(k_endog2, &forwards[s * k_endog2], &tmp2[0, 0])
-            blas.{{prefix}}trmm("L", "U", "T", "N", &k_endog, &k_endog,
-              &alpha, &initial_variance[0, 0], &k_endog,
-                      &tmp2[0, 0], &k_endog)
+            blas.{{prefix}}trmm("L", "U", "T", "N", &k_endog_, &k_endog_,
+              &alpha, &initial_variance[0, 0], &k_endog_,
+                      &tmp2[0, 0], &k_endog_)
             for k in range(k_endog):
                 copy(k_endog, &tmp2[k, 0], &tmp[0, k], k_endog)
             # Get x'
-            lapack.{{prefix}}trtrs("U", "N", "N", &k_endog, &k_endog, &initial_variance[0,0], &k_endog,
-                                                               &tmp[0, 0], &k_endog, &info)
+            lapack.{{prefix}}trtrs("U", "N", "N", &k_endog_, &k_endog_, &initial_variance[0,0], &k_endog_,
+                                                               &tmp[0, 0], &k_endog_, &info_)
             # Get x
             for k in range(k_endog):
                 copy(k_endog, &tmp[k, 0], &forwards[s * k_endog2 + k*k_endog], k_endog)
@@ -722,6 +731,9 @@ cpdef _{{prefix}}constrain_sv_less_than_one({{cython_type}} [::1,:] unconstraine
         {{cython_type}} alpha = 1.0
         int k_endog2 = k_endog**2
         int info, i
+        blas_int k_endog_ = k_endog
+        blas_int k_endog2_ = k_endog2
+        blas_int info_
     # Local variables
     cdef:
         np.npy_intp dim2[2]
@@ -738,16 +750,16 @@ cpdef _{{prefix}}constrain_sv_less_than_one({{cython_type}} [::1,:] unconstraine
     eye = np.asfortranarray(np.eye(k_endog, dtype={{dtype}}))
     for i in range(order):
         copy(k_endog2, &eye[0, 0], &tmp[0, 0])
-        blas.{{prefix}}gemm("N", "T", &k_endog, &k_endog, &k_endog,
-          &alpha, &unconstrained[0, i*k_endog], &k_endog,
-                  &unconstrained[0, i*k_endog], &k_endog,
-          &alpha, &tmp[0, 0], &k_endog)
-        lapack.{{prefix}}potrf("L", &k_endog, &tmp[0, 0], &k_endog, &info)
+        blas.{{prefix}}gemm("N", "T", &k_endog_, &k_endog_, &k_endog_,
+          &alpha, &unconstrained[0, i*k_endog], &k_endog_,
+                  &unconstrained[0, i*k_endog], &k_endog_,
+          &alpha, &tmp[0, 0], &k_endog_)
+        lapack.{{prefix}}potrf("L", &k_endog_, &tmp[0, 0], &k_endog_, &info_)
 
-        copy(k_endog2, &unconstrained[0, i*k_endog], &constrained[0, i*k_endog])
+        copy(k_endog2_, &unconstrained[0, i*k_endog], &constrained[0, i*k_endog])
         # constrained.append(linalg.solve_triangular(B, A, lower=lower))
-        lapack.{{prefix}}trtrs("L", "N", "N", &k_endog, &k_endog, &tmp[0, 0], &k_endog,
-                                                           &constrained[0, i*k_endog], &k_endog, &info)
+        lapack.{{prefix}}trtrs("L", "N", "N", &k_endog_, &k_endog_, &tmp[0, 0], &k_endog_,
+                                                           &constrained[0, i*k_endog], &k_endog_, &info_)
     return constrained
 
 cdef int _{{prefix}}ldl({{cython_type}} * A, int n) except *:
@@ -1149,6 +1161,9 @@ cdef int _{{prefix}}select_cov(int k_states, int k_posdef, int k_states_total,
         int i, k_states2 = k_states**2
         {{cython_type}} alpha = 1.0
         {{cython_type}} beta = 0.0
+        blas_int k_states_ = k_states
+        blas_int k_posdef_ = k_posdef
+        blas_int k_states_total_ = k_states_total
 
     # Only need to do something if there is a covariance matrix
     # (i.e k_posdof == 0)
@@ -1165,16 +1180,16 @@ cdef int _{{prefix}}select_cov(int k_states, int k_posdef, int k_states_total,
 
         # $\\#_0 = 1.0 * R_t Q_t$
         # $(m \times r) = (m \times r) (r \times r)$
-        blas.{{prefix}}gemm("N", "N", &k_states, &k_posdef, &k_posdef,
-              &alpha, selection, &k_states_total,
-                      cov, &k_posdef,
-              &beta, tmp, &k_states)
+        blas.{{prefix}}gemm("N", "N", &k_states_, &k_posdef_, &k_posdef_,
+              &alpha, selection, &k_states_total_,
+                      cov, &k_posdef_,
+              &beta, tmp, &k_states_)
         # $Q_t^* = 1.0 * \\#_0 R_t'$
         # $(m \times m) = (m \times r) (m \times r)'$
-        blas.{{prefix}}gemm("N", "T", &k_states, &k_states, &k_posdef,
-              &alpha, tmp, &k_states,
-                      selection, &k_states_total,
-              &beta, selected_cov, &k_states)
+        blas.{{prefix}}gemm("N", "T", &k_states_, &k_states_, &k_posdef_,
+              &alpha, tmp, &k_states_,
+                      selection, &k_states_total_,
+              &beta, selected_cov, &k_states_)
     else:
         for i in range(k_states2):
             selected_cov[i] = 0
@@ -1197,6 +1212,15 @@ cpdef _{{prefix}}compute_smoothed_state_weights(
         int filter_collapsed, compute_K
         int inc = 1
         int compute
+        blas_int inc_ = 1
+        blas_int pm_ = pm
+        blas_int p_ = p
+        blas_int p_j_
+        blas_int _k_endog_ = model._k_endog
+        blas_int _k_states_ = model._k_states
+        blas_int k_endog_ = model.k_endog
+        blas_int k_states_ = kfilter.k_states
+        blas_int k_states2_ = kfilter.k_states2
         np.int32_t [:] store_t, store_j
         np.npy_intp dim1[1]
         np.npy_intp dim2[2]
@@ -1291,6 +1315,12 @@ cpdef _{{prefix}}compute_smoothed_state_weights(
         # Move the statespace representation to the time period, but do not
         # apply the collapse (first zero) or diagonalization (second zero)
         model.seek(t, 0, 0, True)
+        # Update blas_int copies after seek (model dimensions may change)
+        _k_endog_ = model._k_endog
+        _k_states_ = model._k_states
+        k_endog_ = model.k_endog
+        k_states_ = kfilter.k_states
+        k_states2_ = kfilter.k_states2
 
         # Get statespace objects
         if p_t == 0:
@@ -1309,37 +1339,37 @@ cpdef _{{prefix}}compute_smoothed_state_weights(
             # F = Z @ P @ Z.T + H
             # Note: here use Fi as a temporary array for the moment
             # Z @ P
-            blas.{{prefix}}gemm("N", "N", &model._k_endog, &model._k_states, &model._k_states,
-                                &alpha, model._design, &model._k_endog,
-                                        &kfilter.predicted_state_cov[0, 0, t], &kfilter.k_states,
-                                &beta, &FiZ[0, 0], &model.k_endog)
+            blas.{{prefix}}gemm("N", "N", &_k_endog_, &_k_states_, &_k_states_,
+                                &alpha, model._design, &_k_endog_,
+                                        &kfilter.predicted_state_cov[0, 0, t], &k_states_,
+                                &beta, &FiZ[0, 0], &k_endog_)
             for i in range(model._k_endog): # columns
                 for j in range(model._k_endog): # rows
                     F[j, i] = model._obs_cov[j + i*model._k_endog]
-            blas.{{prefix}}gemm("N", "T", &model._k_endog, &model._k_endog, &model._k_states,
-                                &alpha, &FiZ[0, 0], &model.k_endog,
-                                        model._design, &model._k_endog,
-                                &alpha, &F[0, 0], &model.k_endog)
+            blas.{{prefix}}gemm("N", "T", &_k_endog_, &_k_endog_, &_k_states_,
+                                &alpha, &FiZ[0, 0], &k_endog_,
+                                        model._design, &_k_endog_,
+                                &alpha, &F[0, 0], &k_endog_)
             # Note: pinv is required for the cases in which F is singular
             # Note: use T to make the array Fortran contiguous
             Fi = np.linalg.pinv(F[:p_t, :p_t]).T
-            blas.{{prefix}}gemm("N", "N", &model._k_endog, &model._k_states, &model._k_endog,
-                                &alpha, &Fi[0, 0], &model._k_endog,
-                                        model._design, &model._k_endog,
-                                &beta, &FiZ[0, 0], &model.k_endog)
+            blas.{{prefix}}gemm("N", "N", &_k_endog_, &_k_states_, &_k_endog_,
+                                &alpha, &Fi[0, 0], &_k_endog_,
+                                        model._design, &_k_endog_,
+                                &beta, &FiZ[0, 0], &k_endog_)
 
             # P_t Z_t' F_t^{-1}
             # $(m \times p) = (m \times m) (m \times p)$
-            blas.{{prefix}}gemm("N", "T", &model._k_states, &model._k_endog, &model._k_states,
-                                &alpha, &kfilter.predicted_state_cov[0, 0, t], &kfilter.k_states,
-                                        &FiZ[0, 0], &model.k_endog,
-                                &beta, &tmp[0, 0], &kfilter.k_states)
+            blas.{{prefix}}gemm("N", "T", &_k_states_, &_k_endog_, &_k_states_,
+                                &alpha, &kfilter.predicted_state_cov[0, 0, t], &k_states_,
+                                        &FiZ[0, 0], &k_endog_,
+                                &beta, &tmp[0, 0], &k_states_)
             # T_t P_t Z_t' F_t^{-1}
             # $(m \times p) = (m \times m) (m \times p)$
-            blas.{{prefix}}gemm("N", "N", &model._k_states, &model._k_endog, &model._k_states,
-                                &alpha, model._transition, &kfilter.k_states,
-                                        &tmp[0, 0], &kfilter.k_states,
-                                &beta, &K[0, 0, tt], &kfilter.k_states)
+            blas.{{prefix}}gemm("N", "N", &_k_states_, &_k_endog_, &_k_states_,
+                                &alpha, model._transition, &k_states_,
+                                        &tmp[0, 0], &k_states_,
+                                &beta, &K[0, 0, tt], &k_states_)
 
             _FiZ = &FiZ[0, 0]
             _K = &K[0, 0, tt]
@@ -1350,18 +1380,18 @@ cpdef _{{prefix}}compute_smoothed_state_weights(
         # Compute required quantites
         # W_j = H_j (F_j^{-1} Z_j - K_j' N_j L_j)
         # => H_j^{-1} W_j = F_j^{-1} Z_j - K_j' N_j L_j
-        blas.{{prefix}}copy(&pm, _FiZ, &inc, &Hi_W[0, 0, tt], &inc)
+        blas.{{prefix}}copy(&pm_, _FiZ, &inc_, &Hi_W[0, 0, tt], &inc_)
 
         scalar = 1. / scale
-        blas.{{prefix}}gemm("N", "N", &model._k_states, &model._k_states, &model._k_states,
-                            &scalar, &smoother.scaled_smoothed_estimator_cov[0, 0, t + 1], &kfilter.k_states,
-                                    &smoother.innovations_transition[0, 0, t], &kfilter.k_states,
-                            &beta, kfilter._tmp0, &kfilter.k_states)
+        blas.{{prefix}}gemm("N", "N", &_k_states_, &_k_states_, &_k_states_,
+                            &scalar, &smoother.scaled_smoothed_estimator_cov[0, 0, t + 1], &k_states_,
+                                    &smoother.innovations_transition[0, 0, t], &k_states_,
+                            &beta, kfilter._tmp0, &k_states_)
 
-        blas.{{prefix}}gemm("T", "N", &model._k_endog, &model._k_states, &model._k_states,
-                            &gamma, _K, &kfilter.k_states,
-                                    kfilter._tmp0, &kfilter.k_states,
-                            &scalar, &Hi_W[0, 0, tt], &model.k_endog)
+        blas.{{prefix}}gemm("T", "N", &_k_endog_, &_k_states_, &_k_states_,
+                            &gamma, _K, &k_states_,
+                                    kfilter._tmp0, &k_states_,
+                            &scalar, &Hi_W[0, 0, tt], &k_endog_)
 
     # Second pass to compute weights
     # for t in compute_t:
@@ -1379,17 +1409,17 @@ cpdef _{{prefix}}compute_smoothed_state_weights(
         # Note: normally would need to multiply Pt by scale and divide N[t+1]
         # by `scale`, but since they're being multiplied here, the scale terms
         # cancel out.
-        blas.{{prefix}}gemm("N", "N", &model._k_states, &model._k_states, &model._k_states,
-                            &gamma, &kfilter.predicted_state_cov[0, 0, t], &kfilter.k_states,
-                                    &smoother.scaled_smoothed_estimator_cov[0, 0, t], &kfilter.k_states,
-                            &beta, kfilter._tmp0, &kfilter.k_states)
+        blas.{{prefix}}gemm("N", "N", &_k_states_, &_k_states_, &_k_states_,
+                            &gamma, &kfilter.predicted_state_cov[0, 0, t], &k_states_,
+                                    &smoother.scaled_smoothed_estimator_cov[0, 0, t], &k_states_,
+                            &beta, kfilter._tmp0, &k_states_)
         for i in range(m):
             kfilter.tmp0[i, i] = kfilter.tmp0[i, i] + 1
 
         # This is the weight of the prior on the smoothed state at
         # time t == 0
         if t == 0 and compute_prior_weights:
-            blas.{{prefix}}copy(&kfilter.k_states2, kfilter._tmp0, &inc, &prior_weights[0, 0, tt], &inc)
+            blas.{{prefix}}copy(&k_states2_, kfilter._tmp0, &inc_, &prior_weights[0, 0, tt], &inc_)
 
         for j in range(t - 1, min_j - 1, -1):
             # Again, recall that double-letters denotes indexes that start
@@ -1418,29 +1448,30 @@ cpdef _{{prefix}}compute_smoothed_state_weights(
             #   L[j] = \prod_i L_{j, i}
             if store_j[j]:
                 if p_j > 0:
+                    p_j_ = p_j
                     # weights[:, :p_j, tt, jj] = tmp @ K[jj][:, :p_j]
-                    blas.{{prefix}}gemm("N", "N", &model._k_states, &p_j, &model._k_states,
-                                        &alpha, kfilter._tmp0, &kfilter.k_states,
-                                                _K, &kfilter.k_states,
-                                        &beta, &weights[0, 0, tt, jj], &kfilter.k_states)
+                    blas.{{prefix}}gemm("N", "N", &_k_states_, &p_j_, &_k_states_,
+                                        &alpha, kfilter._tmp0, &k_states_,
+                                                _K, &k_states_,
+                                        &beta, &weights[0, 0, tt, jj], &k_states_)
 
                 # state_intercept_weights[:, :, tt, jj] = -tmp
-                blas.{{prefix}}copy(&kfilter.k_states2, kfilter._tmp0, &inc,
-                                                        &state_intercept_weights[0, 0, tt, jj], &inc)
+                blas.{{prefix}}copy(&k_states2_, kfilter._tmp0, &inc_,
+                                                        &state_intercept_weights[0, 0, tt, jj], &inc_)
 
             if j > min_j or (j == 0 and compute_prior_weights):
                 # tmp = tmp @ L
-                blas.{{prefix}}gemm("N", "N", &model._k_states, &model._k_states, &model._k_states,
-                            &alpha, kfilter._tmp0, &kfilter.k_states,
-                                    &smoother.innovations_transition[0, 0, j], &kfilter.k_states,
-                            &beta, kfilter._tmp00, &kfilter.k_states)
-                blas.{{prefix}}copy(&kfilter.k_states2, kfilter._tmp00, &inc,
-                                                        kfilter._tmp0, &inc)
+                blas.{{prefix}}gemm("N", "N", &_k_states_, &_k_states_, &_k_states_,
+                            &alpha, kfilter._tmp0, &k_states_,
+                                    &smoother.innovations_transition[0, 0, j], &k_states_,
+                            &beta, kfilter._tmp00, &k_states_)
+                blas.{{prefix}}copy(&k_states2_, kfilter._tmp00, &inc_,
+                                                        kfilter._tmp0, &inc_)
 
                 # This is the weight of the prior on the smoothed state at
                 # time t > 0
                 if j == 0 and compute_prior_weights:
-                    blas.{{prefix}}copy(&kfilter.k_states2, kfilter._tmp0, &inc, &prior_weights[0, 0, tt], &inc)
+                    blas.{{prefix}}copy(&k_states2_, kfilter._tmp0, &inc_, &prior_weights[0, 0, tt], &inc_)
 
         # For j == t
         # For the univariate case, some notes:
@@ -1457,38 +1488,39 @@ cpdef _{{prefix}}compute_smoothed_state_weights(
         p_j = p - model.nmissing[t]
         if store_j[j]:
             if p_j > 0:
+                p_j_ = p_j
                 # weights[:, :p_j, tt, jj] = Pt @ Hi_W[j, :p_j].T
-                blas.{{prefix}}gemm("N", "T", &model._k_states, &p_j, &model._k_states,
-                                    &scale, &kfilter.predicted_state_cov[0, 0, t], &kfilter.k_states,
-                                            &Hi_W[0, 0, jj], &model.k_endog,
-                                    &beta, &weights[0, 0, tt, jj], &kfilter.k_states)
+                blas.{{prefix}}gemm("N", "T", &_k_states_, &p_j_, &_k_states_,
+                                    &scale, &kfilter.predicted_state_cov[0, 0, t], &k_states_,
+                                            &Hi_W[0, 0, jj], &k_endog_,
+                                    &beta, &weights[0, 0, tt, jj], &k_states_)
 
             # state_intercept_weights[:, :, tt, jj] = -(Pt @ Lt' @ Nt)
             # Note: normally would need to multiply Pt by scale and divide Nt
             # by `scale`, but since they're being multiplied here, the scale terms
             # cancel out.
-            blas.{{prefix}}gemm("T", "N", &model._k_states, &model._k_states, &model._k_states,
-                            &gamma, &smoother.innovations_transition[0, 0, t], &kfilter.k_states,
-                                    &smoother.scaled_smoothed_estimator_cov[0, 0, t + 1], &kfilter.k_states,
-                            &beta, kfilter._tmp00, &kfilter.k_states)
-            blas.{{prefix}}gemm("N", "N", &model._k_states, &model._k_states, &model._k_states,
-                            &alpha, &kfilter.predicted_state_cov[0, 0, t], &kfilter.k_states,
-                                    kfilter._tmp00, &kfilter.k_states,
-                            &beta, &state_intercept_weights[0, 0, tt, jj], &kfilter.k_states)
+            blas.{{prefix}}gemm("T", "N", &_k_states_, &_k_states_, &_k_states_,
+                            &gamma, &smoother.innovations_transition[0, 0, t], &k_states_,
+                                    &smoother.scaled_smoothed_estimator_cov[0, 0, t + 1], &k_states_,
+                            &beta, kfilter._tmp00, &k_states_)
+            blas.{{prefix}}gemm("N", "N", &_k_states_, &_k_states_, &_k_states_,
+                            &alpha, &kfilter.predicted_state_cov[0, 0, t], &k_states_,
+                                    kfilter._tmp00, &k_states_,
+                            &beta, &state_intercept_weights[0, 0, tt, jj], &k_states_)
 
         # Forwards from j = t+1, t+2, ..., max_j
         # tmp = Pt
-        blas.{{prefix}}copy(&kfilter.k_states2, &kfilter.predicted_state_cov[0, 0, t], &inc, kfilter._tmp0, &inc)
+        blas.{{prefix}}copy(&k_states2_, &kfilter.predicted_state_cov[0, 0, t], &inc_, kfilter._tmp0, &inc_)
         if scale != 1:
-            blas.{{prefix}}scal(&kfilter.k_states2, &scale, kfilter._tmp0, &inc)
+            blas.{{prefix}}scal(&k_states2_, &scale, kfilter._tmp0, &inc_)
         if max_j > t:
             # tmp = tmp @ L[t].T
-            blas.{{prefix}}gemm("N", "T", &model._k_states, &model._k_states, &model._k_states,
-                                &alpha, kfilter._tmp0, &kfilter.k_states,
-                                        &smoother.innovations_transition[0, 0, t], &kfilter.k_states,
-                                &beta, kfilter._tmp00, &kfilter.k_states)
-            blas.{{prefix}}copy(&kfilter.k_states2, kfilter._tmp00, &inc,
-                                                        kfilter._tmp0, &inc)
+            blas.{{prefix}}gemm("N", "T", &_k_states_, &_k_states_, &_k_states_,
+                                &alpha, kfilter._tmp0, &k_states_,
+                                        &smoother.innovations_transition[0, 0, t], &k_states_,
+                                &beta, kfilter._tmp00, &k_states_)
+            blas.{{prefix}}copy(&k_states2_, kfilter._tmp00, &inc_,
+                                                        kfilter._tmp0, &inc_)
 
         for j in range(t + 1, max_j + 1):
             # Again, recall that double-letters denotes indexes that start
@@ -1497,27 +1529,28 @@ cpdef _{{prefix}}compute_smoothed_state_weights(
             p_j = p - model.nmissing[j]
 
             if store_j[j] and p_j > 0:
+                p_j_ = p_j
                 # weights[:, :p_j, tt, jj] = tmp @ Hi_W[j, :p_j].T
-                blas.{{prefix}}gemm("N", "T", &model._k_states, &p_j, &model._k_states,
-                                    &alpha, kfilter._tmp0, &kfilter.k_states,
-                                            &Hi_W[0, 0, jj], &p,
-                                    &beta, &weights[0, 0, tt, jj], &kfilter.k_states)
+                blas.{{prefix}}gemm("N", "T", &_k_states_, &p_j_, &_k_states_,
+                                    &alpha, kfilter._tmp0, &k_states_,
+                                            &Hi_W[0, 0, jj], &p_,
+                                    &beta, &weights[0, 0, tt, jj], &k_states_)
 
             # tmp = tmp @ L[j].T
-            blas.{{prefix}}gemm("N", "T", &model._k_states, &model._k_states, &model._k_states,
-                                &alpha, kfilter._tmp0, &kfilter.k_states,
-                                        &smoother.innovations_transition[0, 0, j], &kfilter.k_states,
-                                &beta, kfilter._tmp00, &kfilter.k_states)
-            blas.{{prefix}}copy(&kfilter.k_states2, kfilter._tmp00, &inc,
-                                                        kfilter._tmp0, &inc)
+            blas.{{prefix}}gemm("N", "T", &_k_states_, &_k_states_, &_k_states_,
+                                &alpha, kfilter._tmp0, &k_states_,
+                                        &smoother.innovations_transition[0, 0, j], &k_states_,
+                                &beta, kfilter._tmp00, &k_states_)
+            blas.{{prefix}}copy(&k_states2_, kfilter._tmp00, &inc_,
+                                                        kfilter._tmp0, &inc_)
 
             if store_j[j]:
                 # state_intercept_weights[:, :, tt, jj] = -(tmp @ N_j)
                 scalar = -1 / scale
-                blas.{{prefix}}gemm("N", "N", &model._k_states, &model._k_states, &model._k_states,
-                                &scalar, kfilter._tmp00, &kfilter.k_states,
-                                        &smoother.scaled_smoothed_estimator_cov[0, 0, j + 1], &kfilter.k_states,
-                                &beta, &state_intercept_weights[0, 0, tt, jj], &kfilter.k_states)
+                blas.{{prefix}}gemm("N", "N", &_k_states_, &_k_states_, &_k_states_,
+                                &scalar, kfilter._tmp00, &k_states_,
+                                        &smoother.scaled_smoothed_estimator_cov[0, 0, j + 1], &k_states_,
+                                &beta, &state_intercept_weights[0, 0, tt, jj], &k_states_)
 
     return np.array(weights), np.array(state_intercept_weights), np.array(prior_weights), np.array(Hi_W)
 

--- a/statsmodels/tsa/statespace/_tools.pyx.in
+++ b/statsmodels/tsa/statespace/_tools.pyx.in
@@ -145,10 +145,10 @@ if prefix == 's':
 }}
 
 
-cdef bint _{{prefix}}select1({{cython_type}} * a):
+cdef blas_bint _{{prefix}}select1({{cython_type}} * a):
     return 0
 
-cdef bint _{{prefix}}select2({{cython_type}} * a, {{cython_type}} * b):
+cdef blas_bint _{{prefix}}select2({{cython_type}} * a, {{cython_type}} * b):
     return 0
 
 cdef int _{{prefix}}solve_discrete_lyapunov({{cython_type}} * a, {{cython_type}} * q, int n, int complex_step=False) except *:
@@ -182,7 +182,7 @@ cdef int _{{prefix}}solve_discrete_lyapunov({{cython_type}} * a, {{cython_type}}
     cdef:
         blas_int sdim
         blas_int lwork = 3*n
-        blas_int bwork
+        blas_bint bwork
     cdef np.npy_intp dim1[1]
     cdef {{cython_type}} [::1,:] work
     cdef {{cython_type}} [:] wr

--- a/statsmodels/tsa/statespace/meson.build
+++ b/statsmodels/tsa/statespace/meson.build
@@ -9,6 +9,12 @@ _statspece_tree = _tsa_tree + [
     fs.copyfile('_tools.pxd')
 ]
 
+_blas_int_pxi = configure_file(
+  input: '_blas_int.pxi.in',
+  output: '_blas_int.pxi',
+  configuration: _blas_int_conf,
+)
+
 subdir('_filters')
 subdir('_smoothers')
 


### PR DESCRIPTION
The upcoming SciPy version 1.18 will support two BLAS/LAPACK modes: LP64 (32-bit integers, C `int`) and ILP64 (64-bit integers, C `int64_t`). Depending on how scipy is built, `cython_{blas,lapack}` ABI can be either LP64 or ILP64. 
The wheel builds will be LP64-only, but from-source builds may feature both options: 64-bit integers in internal LAPACK and `cython_lapack` signatures, and 64-bit integers in internal LAPACK and 32-bit integers in `cython_lapack`.

This PR makes statsmodels's `cython_lapack` usage compatible with all these scenarios. The python side of the SciPy's ILP64 option is already covered by https://github.com/statsmodels/statsmodels/pull/9767

Starting from SciPy 1.18, `cython_lapack` signatures will use the `blas_int` type which resolves to either `int` or `int64_t`, depending on the scipy build details.

There are three main pieces:
- build-time detection of whether `blas_int` type can be cimported from `scipy.linalg.cython_lapack`.  If it cannot, it means we're on an older scipy, and cython LAPACK ABI is LP64, thus we typedef it. 
- `cython_lapack` calls use this `blas_int` type for integer variables (`n`, `lda`, `info`). This part is simple if repetetive: we cast cython variables to `blas_int` just before calling LAPACK functions. 
- integer arrays (pivots, `ipiv`) need to be allocated with the right size/dtype; in cython, buffers use numpy arrays with the typecode which depends on `sizeof(blas_int)`:   `NPY_INT32 if sizeof(blas_int) == 4 else NPY_INT64`. 

Essentially, this PR follows the simpler option (2) of https://github.com/scipy/scipy/pull/25025. As a comparison, `scikit-learn` takes a more complicated option of routing BLAS/LAPACK calls through an internal shim (cf  https://github.com/scikit-learn/scikit-learn/pull/33784). Given the statsmodels usage, it is simpler to just change the integer type usage, as this PR does.

The patch here is written by @rgommers, with some Claude usage for repetetive tasks.


- [ ] closes #xxxx
- [ ] tests added / passed. 
- [ ] code/documentation is well formatted.  
- [ ] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
