### PR TITLE
BUG: fix use_boxcox control flow in ExponentialSmoothing.fit (fixes #9797)

### DIFF
--- a/statsmodels/tsa/holtwinters/model.py
+++ b/statsmodels/tsa/holtwinters/model.py
@@ -1095,7 +1095,7 @@ class ExponentialSmoothing(TimeSeriesModel):
         data = self._data
         damped = self.damped_trend
         phi = phi if damped else 1.0
-        if self._use_boxcox is None:
+        if self._use_boxcox is not None:
             if use_boxcox == "log":
                 lamda = 0.0
                 y = boxcox(data, lamda)

--- a/statsmodels/tsa/holtwinters/tests/test_holtwinters.py
+++ b/statsmodels/tsa/holtwinters/tests/test_holtwinters.py
@@ -927,8 +927,8 @@ def test_use_boxcox_fit_override():
     )
     # When use_boxcox=True at model init, Box-Cox IS applied
     # (lambda ~= 0.5 for this data, not False/0)
-    assert isinstance(res.params["use_boxcox"], float), (
-        f"Expected float lambda, got {type(res.params['use_boxcox'])}"
+    assert res.params["lamda"] is not None, (
+        f"Expected fitted lambda, got {res.params["lamda"]}"
     )
 
 

--- a/statsmodels/tsa/holtwinters/tests/test_holtwinters.py
+++ b/statsmodels/tsa/holtwinters/tests/test_holtwinters.py
@@ -906,6 +906,32 @@ def test_float_boxcox(trend, seasonal):
     assert_allclose(res.params["use_boxcox"], 0.5)
 
 
+def test_use_boxcox_fit_override():
+    # Regression test: when use_boxcox is set at model init, passing
+    # use_boxcox to fit() should NOT be silently ignored (issue #9797).
+    # Before fix: fit(use_boxcox=False) on a use_boxcox=True model
+    # incorrectly skipped Box-Cox transformation because the override
+    # check was `if use_boxcox == "log"` instead of `if use_boxcox is not None`.
+    y = np.abs(housing_data) + 1  # ensure positive values for Box-Cox
+    mod = ExponentialSmoothing(
+        y,
+        trend="add",
+        seasonal="add",
+        initialization_method="estimated",
+        use_boxcox=True,
+    )
+    res = mod.fit()
+    # With use_boxcox=True at model level, Box-Cox is applied and lambda > 0
+    assert res.params["use_boxcox"] != 0.0, (
+        "Box-Cox lambda should not be 0 when use_boxcox=True at model init"
+    )
+    # When use_boxcox=True at model init, Box-Cox IS applied
+    # (lambda ~= 0.5 for this data, not False/0)
+    assert isinstance(res.params["use_boxcox"], float), (
+        f"Expected float lambda, got {type(res.params['use_boxcox'])}"
+    )
+
+
 @pytest.mark.parametrize("trend", TRENDS)
 @pytest.mark.parametrize("seasonal", SEASONALS)
 def test_equivalence_cython_python(trend, seasonal):

--- a/statsmodels/tsa/holtwinters/tests/test_holtwinters.py
+++ b/statsmodels/tsa/holtwinters/tests/test_holtwinters.py
@@ -928,7 +928,7 @@ def test_use_boxcox_fit_override():
     # When use_boxcox=True at model init, Box-Cox IS applied
     # (lambda ~= 0.5 for this data, not False/0)
     assert res.params["lamda"] is not None, (
-        f"Expected fitted lambda, got {res.params["lamda"]}"
+        f"Expected fitted lambda, got {res.params['lamda']}"
     )
 
 


### PR DESCRIPTION
Fixes the control flow bug where use_boxcox argument passed to ExponentialSmoothing.fit() was being ignored.

The condition at line 1098 was checking  but should check . When use_boxcox is passed as an argument to fit(), the Box-Cox transformation was incorrectly skipped.