### PR TITLE
fix(holtwinters): correct use_boxcox control flow in ExponentialSmoothing.fit

### DIFF
--- a/statsmodels/tsa/holtwinters/model.py
+++ b/statsmodels/tsa/holtwinters/model.py
@@ -1095,7 +1095,7 @@ class ExponentialSmoothing(TimeSeriesModel):
         data = self._data
         damped = self.damped_trend
         phi = phi if damped else 1.0
-        if self._use_boxcox is None:
+        if self._use_boxcox is not None:
             if use_boxcox == "log":
                 lamda = 0.0
                 y = boxcox(data, lamda)


### PR DESCRIPTION
Fixes a control flow bug in the fit() method of ExponentialSmoothing where Box-Cox transformation was silently skipped when use_boxcox was set at model initialization instead of being applied correctly.

The condition on line 1098 (previously line ~1098) checked 'self._use_boxcox is None' when it should have been 'is not None'. When use_boxcox=True at init, the model already transformed the data during __init__, so fit() should reuse self._y — but the inverted condition caused it to re-enter the Box-Cox block and effectively do nothing.

Fixes #9797.