### PR TITLE
BUG: honor MixedLM summary title

### DIFF
--- a/statsmodels/regression/mixed_linear_model.py
+++ b/statsmodels/regression/mixed_linear_model.py
@@ -2771,7 +2771,9 @@ class MixedLMResults(base.LikelihoodModelResults, base.ResultMixin):
         info["Log-Likelihood:"] = self.llf
         info["Converged:"] = "Yes" if self.converged else "No"
         smry.add_dict(info)
-        smry.add_title("Mixed Linear Model Regression Results")
+        if title is None:
+            title = "Mixed Linear Model Regression Results"
+        smry.add_title(title)
 
         float_fmt = "%.3f"
 

--- a/statsmodels/regression/tests/test_lme.py
+++ b/statsmodels/regression/tests/test_lme.py
@@ -797,6 +797,12 @@ class TestMixedLMSummary:
         actual = summ.tables[1].index.values  # Second table is summary of params
         assert_equal(np.asarray(actual), desired)
 
+    def test_summary_title(self):
+        # Test that the `title` argument is reflected in the summary.
+        title = "Custom MixedLM Summary"
+        summ = self.res.summary(title=title)
+        assert_equal(summ.title, title)
+
 
 # ------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- use the `title` argument passed to `MixedLMResults.summary()` instead of always rendering the default title
- add a regression test covering the custom summary title for regular and regularized MixedLM results

Closes #8051

## Tests
- `python -m pytest statsmodels/regression/tests/test_lme.py::TestMixedLMSummary statsmodels/regression/tests/test_lme.py::TestMixedLMSummaryRegularized -q`
- `python -m ruff check statsmodels/regression/mixed_linear_model.py statsmodels/regression/tests/test_lme.py`
- `python -m compileall -q statsmodels/regression/mixed_linear_model.py statsmodels/regression/tests/test_lme.py`
