### PR TITLE
docs: fix compatibility spelling in docs

### DIFF
--- a/docs/source/release/version0.13.3.rst
+++ b/docs/source/release/version0.13.3.rst
@@ -30,7 +30,7 @@ Stats
 
 The Highlights
 ==============
-This is a Python 3.11 compatability release only.  There are no significant
+This is a Python 3.11 compatibility release only.  There are no significant
 new features or bug fixes.
 
 Submodules


### PR DESCRIPTION
Changes:
- `compatability` -> `compatibility` in `docs/source/release/version0.13.3.rst` (1 occurrence(s), preserving capitalization where applicable)

Verification:
- Applied an exact spelling-only replacement against the current upstream base branch.
- Checked the repository is not archived or a fork.
- Checked open PR titles and my open PRs before opening this PR.
