### PR TITLE
DOC: correct PredictionResults.conf_int docstring

### DIFF
--- a/statsmodels/regression/_prediction.py
+++ b/statsmodels/regression/_prediction.py
@@ -78,22 +78,25 @@ class PredictionResults:
 
     def conf_int(self, obs=False, alpha=0.05):
         """
-        Returns the confidence interval of the value, `effect` of the
-        constraint.
-
-        This is currently only available for t and z tests.
+        Confidence or prediction interval for the predicted values.
 
         Parameters
         ----------
+        obs : bool, optional
+            If False (default), return the confidence interval for the mean
+            prediction, using the standard error of the mean (``se_mean``).
+            If True, return the prediction interval for a new observation,
+            using the standard error of the observation (``se_obs``), which
+            also accounts for the residual variance.
         alpha : float, optional
             The significance level for the confidence interval.
             ie., The default `alpha` = .05 returns a 95% confidence interval.
 
         Returns
         -------
-        ci : ndarray, (k_constraints, 2)
-            The array has the lower and the upper limit of the confidence
-            interval in the columns.
+        ci : ndarray, (nobs, 2)
+            The array has the lower and the upper limit of the interval
+            in the columns.
         """
 
         se = self.se_obs if obs else self.se_mean

--- a/statsmodels/regression/_prediction.py
+++ b/statsmodels/regression/_prediction.py
@@ -95,8 +95,8 @@ class PredictionResults:
         Returns
         -------
         ci : ndarray, (nobs, 2)
-            The array has the lower and the upper limit of the interval
-            in the columns.
+            The lower and upper bound of the interval for each observation.
+            Column 0 contains the lower bound, column 1 the upper bound.
         """
 
         se = self.se_obs if obs else self.se_mean


### PR DESCRIPTION
Closes #9516.

`PredictionResults.conf_int` (`statsmodels/regression/_prediction.py`) carries a docstring copied from `ContrastResults.conf_int`: it talks about the "effect of the constraint", "currently only available for t and z tests", and a `(k_constraints, 2)` return shape — none of which apply to prediction results. The `obs` parameter, which selects between the mean confidence interval and the observation prediction interval, is not documented at all (the subject of #9516).

Updated the docstring to describe the actual behaviour:

- `obs=False` (default) → confidence interval for the mean, using `se_mean = sqrt(var_pred_mean)`
- `obs=True` → prediction interval for a new observation, using `se_obs = sqrt(var_pred_mean + var_resid)`
- return shape is `(nobs, 2)`

Docstring-only change; behaviour is unchanged.