### PR TITLE
fix: avoid division by zero in estimate_location

### DIFF
--- a/statsmodels/robust/norms.py
+++ b/statsmodels/robust/norms.py
@@ -1516,7 +1516,7 @@ def estimate_location(a, scale, norm=None, axis=0, initial=None,
     for _ in range(maxiter):
         W = norm.weights((a-mu)/scale)
         denom = np.sum(W, axis)
-        if np.any(denom == 0):
+        if np.any(denom <= 0):
             return mu
         nmu = np.sum(W * a, axis) / denom   
         if np.all(np.less(np.abs(mu - nmu), scale * tol)):

--- a/statsmodels/robust/norms.py
+++ b/statsmodels/robust/norms.py
@@ -1515,7 +1515,10 @@ def estimate_location(a, scale, norm=None, axis=0, initial=None,
 
     for _ in range(maxiter):
         W = norm.weights((a-mu)/scale)
-        nmu = np.sum(W*a, axis) / np.sum(W, axis)
+        denom = np.sum(W, axis)
+        if np.any(denom == 0):
+            return mu
+        nmu = np.sum(W * a, axis) / denom   
         if np.all(np.less(np.abs(mu - nmu), scale * tol)):
             return nmu
         else:


### PR DESCRIPTION
Fixes a potential division by zero in estimate_location when 
the sum of weights becomes zero.

Instead of producing NaN, the function now safely returns 
the current estimate.

This improves stability in edge cases with degenerate weights.