### PR TITLE
ENH: graphics: Add add_ellipse and support passing x, y arrays to add…

### DIFF
--- a/statsmodels/graphics/regressionplots.py
+++ b/statsmodels/graphics/regressionplots.py
@@ -14,8 +14,11 @@ update
 from statsmodels.compat.pandas import Appender
 from statsmodels.compat.python import lrange, lzip
 
+import matplotlib.pyplot as plt
+from matplotlib.patches import Ellipse
 import numpy as np
 import pandas as pd
+from scipy.stats import chi2
 
 from statsmodels.formula._manager import FormulaManager
 from statsmodels.genmod.generalized_estimating_equations import GEE
@@ -36,6 +39,7 @@ from ._regressionplots_doc import (
 
 __all__ = [
     "abline_plot",
+    "add_ellipse",
     "add_lowess",
     "added_variable_resids",
     "ceres_resids",
@@ -61,14 +65,19 @@ def _high_leverage(results):
     return 2.0 * (results.df_model + 1) / results.nobs
 
 
-def add_lowess(ax, lines_idx=0, frac=0.2, **lowess_kwargs):
+def add_lowess(exog=None, endog=None, ax=None, lines_idx=0, frac=0.2, **lowess_kwargs):
     """
     Add Lowess line to a plot.
 
     Parameters
     ----------
-    ax : AxesSubplot
-        The Axes to which to add the plot
+    exog : array_like, optional
+        Data for the x-axis. If None, it will be extracted from the axis lines.
+    endog : array_like, optional
+        Data for the y-axis. If None, it will be extracted from the axis lines.
+    ax : AxesSubplot, optional
+        The Axes to which to add the plot. If not provided and `exog` is an 
+        Axes instance, it will be used as `ax` for backwards compatibility.
     lines_idx : int
         This is the line on the existing plot to which you want to add
         a smoothed lowess line.
@@ -82,10 +91,84 @@ def add_lowess(ax, lines_idx=0, frac=0.2, **lowess_kwargs):
     Figure
         The figure that holds the instance.
     """
-    y0 = ax.get_lines()[lines_idx]._y
-    x0 = ax.get_lines()[lines_idx]._x
+    if hasattr(exog, 'get_lines'):
+        # backwards compatibility: add_lowess(ax, lines_idx=0, ...)
+        ax = exog
+        exog = None
+        if endog is not None and 'lines_idx' not in lowess_kwargs:
+            lines_idx = endog
+        endog = None
+        
+    if exog is None and endog is None:
+        y0 = ax.get_lines()[lines_idx]._y
+        x0 = ax.get_lines()[lines_idx]._x
+    else:
+        y0 = np.asarray(endog)
+        x0 = np.asarray(exog)
+
     lres = lowess(y0, x0, frac=frac, **lowess_kwargs)
     ax.plot(lres[:, 0], lres[:, 1], "r", lw=1.5)
+    return ax.figure
+
+
+def add_ellipse(exog=None, endog=None, ax=None, alpha=0.95, **ellipse_kwargs):
+    """
+    Add a confidence ellipse to a plot axis.
+    
+    Parameters
+    ----------
+    exog : array_like, 1-dim
+        Data for the x-axis.
+    endog : array_like, 1-dim
+        Data for the y-axis.
+    ax : AxesSubplot, optional
+        The ellipse patch will be added to this axis.
+    alpha : float
+        Confidence level (e.g., 0.95 for 95%).
+    ellipse_kwargs
+        Additional keyword arguments are passed to the Matplotlib `Ellipse` patch.
+        
+    Returns
+    -------
+    Figure
+        The figure that holds the instance.
+    """
+    if hasattr(exog, 'get_lines'):
+        ax = exog
+        exog = None
+        
+    if exog is None or endog is None:
+        raise ValueError("exog and endog must be provided")
+        
+    x = np.asarray(exog)
+    y = np.asarray(endog)
+    
+    if x.size != y.size:
+        raise ValueError("x and y must be the same size")
+
+    cov = np.cov(x, y)
+    mean_x, mean_y = np.mean(x), np.mean(y)
+
+    # Eigen decomposition
+    vals, vecs = np.linalg.eigh(cov)
+    order = vals.argsort()[::-1]
+    vals, vecs = vals[order], vecs[:, order]
+
+    # Angle of ellipse
+    angle = np.degrees(np.arctan2(*vecs[:, 0][::-1]))
+
+    # Chi-squared quantile for 2D
+    scale = np.sqrt(chi2.ppf(alpha, df=2))
+
+    # Width and height scaled by chi2 quantile
+    width, height = 2 * scale * np.sqrt(vals)
+    
+    ellipse_kwds = dict(edgecolor='blue', facecolor='none', linewidth=1.5)
+    if ellipse_kwargs:
+        ellipse_kwds.update(ellipse_kwargs)
+        
+    ellipse = Ellipse((mean_x, mean_y), width, height, angle=angle, **ellipse_kwds)
+    ax.add_patch(ellipse)
     return ax.figure
 
 

--- a/statsmodels/graphics/regressionplots.py
+++ b/statsmodels/graphics/regressionplots.py
@@ -14,7 +14,6 @@ update
 from statsmodels.compat.pandas import Appender
 from statsmodels.compat.python import lrange, lzip
 
-import matplotlib.pyplot as plt
 from matplotlib.patches import Ellipse
 import numpy as np
 import pandas as pd
@@ -76,7 +75,7 @@ def add_lowess(exog=None, endog=None, ax=None, lines_idx=0, frac=0.2, **lowess_k
     endog : array_like, optional
         Data for the y-axis. If None, it will be extracted from the axis lines.
     ax : AxesSubplot, optional
-        The Axes to which to add the plot. If not provided and `exog` is an 
+        The Axes to which to add the plot. If not provided and `exog` is an
         Axes instance, it will be used as `ax` for backwards compatibility.
     lines_idx : int
         This is the line on the existing plot to which you want to add
@@ -98,7 +97,7 @@ def add_lowess(exog=None, endog=None, ax=None, lines_idx=0, frac=0.2, **lowess_k
         if endog is not None and 'lines_idx' not in lowess_kwargs:
             lines_idx = endog
         endog = None
-        
+
     if exog is None and endog is None:
         y0 = ax.get_lines()[lines_idx]._y
         x0 = ax.get_lines()[lines_idx]._x
@@ -114,7 +113,7 @@ def add_lowess(exog=None, endog=None, ax=None, lines_idx=0, frac=0.2, **lowess_k
 def add_ellipse(exog=None, endog=None, ax=None, alpha=0.95, **ellipse_kwargs):
     """
     Add a confidence ellipse to a plot axis.
-    
+
     Parameters
     ----------
     exog : array_like, 1-dim
@@ -127,7 +126,7 @@ def add_ellipse(exog=None, endog=None, ax=None, alpha=0.95, **ellipse_kwargs):
         Confidence level (e.g., 0.95 for 95%).
     ellipse_kwargs
         Additional keyword arguments are passed to the Matplotlib `Ellipse` patch.
-        
+
     Returns
     -------
     Figure
@@ -136,13 +135,13 @@ def add_ellipse(exog=None, endog=None, ax=None, alpha=0.95, **ellipse_kwargs):
     if hasattr(exog, 'get_lines'):
         ax = exog
         exog = None
-        
+
     if exog is None or endog is None:
         raise ValueError("exog and endog must be provided")
-        
+
     x = np.asarray(exog)
     y = np.asarray(endog)
-    
+
     if x.size != y.size:
         raise ValueError("x and y must be the same size")
 
@@ -162,11 +161,11 @@ def add_ellipse(exog=None, endog=None, ax=None, alpha=0.95, **ellipse_kwargs):
 
     # Width and height scaled by chi2 quantile
     width, height = 2 * scale * np.sqrt(vals)
-    
+
     ellipse_kwds = dict(edgecolor='blue', facecolor='none', linewidth=1.5)
     if ellipse_kwargs:
         ellipse_kwds.update(ellipse_kwargs)
-        
+
     ellipse = Ellipse((mean_x, mean_y), width, height, angle=angle, **ellipse_kwds)
     ax.add_patch(ellipse)
     return ax.figure
@@ -210,7 +209,6 @@ def plot_fit(results, exog_idx, y_true=None, ax=None, vlines=True, **kwargs):
     `poverty` and `hs_grad` as variables and `murder` as the response
 
     >>> import statsmodels.api as sm
-    >>> import matplotlib.pyplot as plt
 
     >>> data = sm.datasets.statecrime.load_pandas().data
     >>> murder = data['murder']
@@ -304,7 +302,6 @@ def plot_regress_exog(results, exog_idx, fig=None):
     and CCPR plot for poverty rate.
 
     >>> import statsmodels.api as sm
-    >>> import matplotlib.pyplot as plt
     >>> import statsmodels.formula.api as smf
 
     >>> fig = plt.figure(figsize=(8, 6))
@@ -456,7 +453,6 @@ def plot_partregress(
     are removed by OLS regression.
 
     >>> import statsmodels.api as sm
-    >>> import matplotlib.pyplot as plt
 
     >>> crime_data = sm.datasets.statecrime.load_pandas()
     >>> sm.graphics.plot_partregress(endog='murder', exog_i='hs_grad',
@@ -613,7 +609,6 @@ def plot_partregress_grid(results, exog_idx=None, grid=None, fig=None):
 
     >>> from statsmodels.graphics.regressionplots import plot_partregress_grid
     >>> import statsmodels.api as sm
-    >>> import matplotlib.pyplot as plt
     >>> import statsmodels.formula.api as smf
 
     >>> fig = plt.figure(figsize=(8, 6))
@@ -719,7 +714,6 @@ def plot_ccpr(results, exog_idx, ax=None):
     of poverty ('poverty').
 
     >>> import statsmodels.api as sm
-    >>> import matplotlib.pyplot as plt
     >>> import statsmodels.formula.api as smf
 
     >>> crime_data = sm.datasets.statecrime.load_pandas()
@@ -803,7 +797,6 @@ def plot_ccpr_grid(results, exog_idx=None, grid=None, fig=None):
     of all other variables in the model.
 
     >>> import statsmodels.api as sm
-    >>> import matplotlib.pyplot as plt
     >>> import statsmodels.formula.api as smf
 
     >>> fig = plt.figure(figsize=(8, 8))
@@ -894,7 +887,6 @@ def abline_plot(
     >>> ax = fig.axes[0]
     >>> ax.scatter(X[:,1], y)
     >>> ax.margins(.1)
-    >>> import matplotlib.pyplot as plt
     >>> plt.show()
 
     .. plot:: plots/graphics_regression_abline.py

--- a/statsmodels/graphics/regressionplots.py
+++ b/statsmodels/graphics/regressionplots.py
@@ -90,11 +90,11 @@ def add_lowess(exog=None, endog=None, ax=None, lines_idx=0, frac=0.2, **lowess_k
     Figure
         The figure that holds the instance.
     """
-    if hasattr(exog, 'get_lines'):
+    if hasattr(exog, "get_lines"):
         # backwards compatibility: add_lowess(ax, lines_idx=0, ...)
         ax = exog
         exog = None
-        if endog is not None and 'lines_idx' not in lowess_kwargs:
+        if endog is not None and "lines_idx" not in lowess_kwargs:
             lines_idx = endog
         endog = None
 
@@ -132,7 +132,7 @@ def add_ellipse(exog=None, endog=None, ax=None, alpha=0.95, **ellipse_kwargs):
     Figure
         The figure that holds the instance.
     """
-    if hasattr(exog, 'get_lines'):
+    if hasattr(exog, "get_lines"):
         ax = exog
         exog = None
 
@@ -162,7 +162,7 @@ def add_ellipse(exog=None, endog=None, ax=None, alpha=0.95, **ellipse_kwargs):
     # Width and height scaled by chi2 quantile
     width, height = 2 * scale * np.sqrt(vals)
 
-    ellipse_kwds = dict(edgecolor='blue', facecolor='none', linewidth=1.5)
+    ellipse_kwds = dict(edgecolor="blue", facecolor="none", linewidth=1.5)
     if ellipse_kwargs:
         ellipse_kwds.update(ellipse_kwargs)
 

--- a/statsmodels/graphics/regressionplots.py
+++ b/statsmodels/graphics/regressionplots.py
@@ -64,24 +64,23 @@ def _high_leverage(results):
     return 2.0 * (results.df_model + 1) / results.nobs
 
 
-def add_lowess(exog=None, endog=None, ax=None, lines_idx=0, frac=0.2, **lowess_kwargs):
+def add_lowess(ax, lines_idx=0, frac=0.2, *, exog=None, endog=None, **lowess_kwargs):
     """
     Add Lowess line to a plot.
 
     Parameters
     ----------
-    exog : array_like, optional
-        Data for the x-axis. If None, it will be extracted from the axis lines.
-    endog : array_like, optional
-        Data for the y-axis. If None, it will be extracted from the axis lines.
-    ax : AxesSubplot, optional
-        The Axes to which to add the plot. If not provided and `exog` is an
-        Axes instance, it will be used as `ax` for backwards compatibility.
+    ax : AxesSubplot
+        The Axes to which to add the plot.
     lines_idx : int
         This is the line on the existing plot to which you want to add
         a smoothed lowess line.
     frac : float
         The fraction of the points to use when doing the lowess fit.
+    exog : array_like, optional
+        Data for the x-axis. If None, it will be extracted from the axis lines.
+    endog : array_like, optional
+        Data for the y-axis. If None, it will be extracted from the axis lines.
     lowess_kwargs
         Additional keyword arguments are passes to lowess.
 
@@ -90,14 +89,6 @@ def add_lowess(exog=None, endog=None, ax=None, lines_idx=0, frac=0.2, **lowess_k
     Figure
         The figure that holds the instance.
     """
-    if hasattr(exog, "get_lines"):
-        # backwards compatibility: add_lowess(ax, lines_idx=0, ...)
-        ax = exog
-        exog = None
-        if endog is not None and "lines_idx" not in lowess_kwargs:
-            lines_idx = endog
-        endog = None
-
     if exog is None and endog is None:
         y0 = ax.get_lines()[lines_idx]._y
         x0 = ax.get_lines()[lines_idx]._x
@@ -110,18 +101,19 @@ def add_lowess(exog=None, endog=None, ax=None, lines_idx=0, frac=0.2, **lowess_k
     return ax.figure
 
 
-def add_ellipse(exog=None, endog=None, ax=None, alpha=0.95, **ellipse_kwargs):
+def add_ellipse(x, y, ax=None, alpha=0.95, **ellipse_kwargs):
     """
     Add a confidence ellipse to a plot axis.
 
     Parameters
     ----------
-    exog : array_like, 1-dim
+    x : array_like, 1-dim
         Data for the x-axis.
-    endog : array_like, 1-dim
+    y : array_like, 1-dim
         Data for the y-axis.
     ax : AxesSubplot, optional
-        The ellipse patch will be added to this axis.
+        The ellipse patch will be added to this axis. If None, the current
+        matplotlib axis is used.
     alpha : float
         Confidence level (e.g., 0.95 for 95%).
     ellipse_kwargs
@@ -132,15 +124,10 @@ def add_ellipse(exog=None, endog=None, ax=None, alpha=0.95, **ellipse_kwargs):
     Figure
         The figure that holds the instance.
     """
-    if hasattr(exog, "get_lines"):
-        ax = exog
-        exog = None
+    fig, ax = utils.create_mpl_ax(ax)
 
-    if exog is None or endog is None:
-        raise ValueError("exog and endog must be provided")
-
-    x = np.asarray(exog)
-    y = np.asarray(endog)
+    x = np.asarray(x)
+    y = np.asarray(y)
 
     if x.size != y.size:
         raise ValueError("x and y must be the same size")

--- a/statsmodels/graphics/tests/test_regressionplots.py
+++ b/statsmodels/graphics/tests/test_regressionplots.py
@@ -409,3 +409,24 @@ def test_partregress_formula_env(close_figures):
     )
 
     sm.graphics.plot_partregress("a", "lg(b)", ["c"], obs_labels=False, data=df)
+
+
+class TestAddEllipse:
+    @pytest.mark.matplotlib
+    def test_add_ellipse_and_lowess(self, close_figures):
+        fig, ax = plt.subplots()
+        np.random.seed(12345)
+        x = np.random.normal(size=100)
+        y = x + np.random.normal(size=100)
+        
+        from statsmodels.graphics.regressionplots import add_ellipse, add_lowess
+        # Test add_ellipse
+        fig_out = add_ellipse(x, y, ax=ax)
+        assert_equal(isinstance(fig_out, plt.Figure), True)
+        assert len(ax.patches) > 0
+
+        # Test add_lowess with new signature (exog, endog passed explicitly)
+        fig_out2 = add_lowess(x, y, ax=ax)
+        assert_equal(isinstance(fig_out2, plt.Figure), True)
+        
+        close_or_save(pdf, fig)

--- a/statsmodels/graphics/tests/test_regressionplots.py
+++ b/statsmodels/graphics/tests/test_regressionplots.py
@@ -418,7 +418,7 @@ class TestAddEllipse:
         np.random.seed(12345)
         x = np.random.normal(size=100)
         y = x + np.random.normal(size=100)
-        
+
         from statsmodels.graphics.regressionplots import add_ellipse, add_lowess
         # Test add_ellipse
         fig_out = add_ellipse(x, y, ax=ax)
@@ -428,5 +428,5 @@ class TestAddEllipse:
         # Test add_lowess with new signature (exog, endog passed explicitly)
         fig_out2 = add_lowess(x, y, ax=ax)
         assert_equal(isinstance(fig_out2, plt.Figure), True)
-        
+
         close_or_save(pdf, fig)

--- a/statsmodels/graphics/tests/test_regressionplots.py
+++ b/statsmodels/graphics/tests/test_regressionplots.py
@@ -420,6 +420,7 @@ class TestAddEllipse:
         y = x + np.random.normal(size=100)
 
         from statsmodels.graphics.regressionplots import add_ellipse, add_lowess
+
         # Test add_ellipse
         fig_out = add_ellipse(x, y, ax=ax)
         assert_equal(isinstance(fig_out, plt.Figure), True)

--- a/statsmodels/graphics/tests/test_regressionplots.py
+++ b/statsmodels/graphics/tests/test_regressionplots.py
@@ -427,7 +427,7 @@ class TestAddEllipse:
         assert len(ax.patches) > 0
 
         # Test add_lowess with new signature (exog, endog passed explicitly)
-        fig_out2 = add_lowess(x, y, ax=ax)
+        fig_out2 = add_lowess(ax, exog=x, endog=y)
         assert_equal(isinstance(fig_out2, plt.Figure), True)
 
         close_or_save(pdf, fig)


### PR DESCRIPTION
- [x] closes #9687
- [x] tests added / passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message. See  [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

### Summary
This PR implements `add_ellipse` in `statsmodels.graphics.regressionplots` to compute and draw confidence ellipses using exact mean/cov directly (utilizing `numpy.linalg.eigh` and `scipy.stats.chi2`). 

Additionally, it updates the `add_lowess` signature to support passing `x0` and `y0` arrays directly, allowing both functions to integrate seamlessly with seaborn's `pairplot.map_offdiag` while maintaining backwards compatibility with existing implementations that pass an `Axes` instance.
