### PR TITLE
BUG: L-BFGS-B optimizer ignores disp=False, prints output unconditionally

### DIFF
--- a/statsmodels/base/optimizer.py
+++ b/statsmodels/base/optimizer.py
@@ -753,12 +753,12 @@ def _fit_lbfgs(
     )
     # Use unconstrained optimization by default.
     bounds = kwargs.setdefault("bounds", [(None, None)] * len(start_params))
-    kwargs.setdefault("iprint", 0)
+    kwargs.setdefault("iprint", -1 if not disp else 1)
 
     # Pass the following keyword argument names through to fmin_l_bfgs_b
     # if they are present in kwargs, otherwise use the fmin_l_bfgs_b
     # default values.
-    names = ("m", "pgtol", "factr", "maxfun", "epsilon", "approx_grad")
+    names = ("m", "pgtol", "factr", "maxfun", "epsilon", "approx_grad", "iprint")
     extra_kwargs = {x: kwargs[x] for x in names if x in kwargs}
 
     # Extract values for the options related to the gradient.

--- a/statsmodels/base/tests/test_optimize.py
+++ b/statsmodels/base/tests/test_optimize.py
@@ -190,3 +190,17 @@ def test_minimize_scipy_nm():
         disp=0,
     )
     assert_almost_equal(xopt, [2, 3.5], 4)
+
+
+def test_lbfgs_disp_false_no_output(capsys):
+    xopt, _ = _fit_lbfgs(
+        dummy_func,
+        dummy_score,
+        [1.0],
+        (),
+        {},
+        full_output=False,
+        disp=False,
+    )
+    captured = capsys.readouterr()
+    assert captured.out == ""


### PR DESCRIPTION
## Summary

`disp=False` was not silencing L-BFGS-B optimizer output because `iprint` was hardcoded to `0` (which prints a final convergence message) and was never passed through to `fmin_l_bfgs_b`.

This fix:
- Sets `iprint=-1` (fully silent) when `disp=False`, and `iprint=1` when `disp=True`
- Adds `"iprint"` to the `names` tuple so it actually gets forwarded to `fmin_l_bfgs_b`

Closes #3191

## Tests

```
python -m pytest statsmodels/base/tests/test_optimize.py::test_lbfgs_disp_false_no_output -xvs
```