### PR TITLE
MAINT: Remove iprint for SciPy 1.18+

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -379,3 +379,8 @@ exclude_also = [
 
 [tool.coverage.html]
 directory = "coverage_html_report"
+
+
+[tool.black]
+line-length = 88
+target-version = ["py310"]

--- a/statsmodels/base/optimizer.py
+++ b/statsmodels/base/optimizer.py
@@ -5,7 +5,7 @@ to untie these from LikelihoodModel so that they may be re-used generally.
 
 from __future__ import annotations
 
-from statsmodels.compat.scipy import SP_LT_15, SP_LT_17, SP_LT_115
+from statsmodels.compat.scipy import SP_LT_15, SP_LT_17, SP_LT_115, SP_LT_118
 
 from typing import TYPE_CHECKING, Any
 
@@ -548,7 +548,7 @@ def _fit_newton(
             print("         Current function value: %f" % fval)
             print("         Iterations %d" % iterations)
     if full_output:
-        (xopt, fopt, niter, gopt, hopt) = (
+        xopt, fopt, niter, gopt, hopt = (
             newparams,
             f(newparams, *fargs),
             iterations,
@@ -653,7 +653,7 @@ def _fit_bfgs(
         if not retall:
             xopt, fopt, gopt, Hinv, fcalls, gcalls, warnflag = retvals
         else:
-            (xopt, fopt, gopt, Hinv, fcalls, gcalls, warnflag, allvecs) = retvals
+            xopt, fopt, gopt, Hinv, fcalls, gcalls, warnflag, allvecs = retvals
         converged = not warnflag
         retvals = {
             "fopt": fopt,
@@ -736,29 +736,34 @@ def _fit_lbfgs(
     its gradient with respect to the parameters do not have notationally
     consistent sign.
     """
+    lbfgs_allowed = (
+        "m",
+        "pgtol",
+        "factr",
+        "maxfun",
+        "epsilon",
+        "approx_grad",
+        "bounds",
+        "loglike_and_score",
+    )
+    if SP_LT_118:
+        lbfgs_allowed += ("iprint",)
     check_kwargs(
         kwargs,
-        (
-            "m",
-            "pgtol",
-            "factr",
-            "maxfun",
-            "epsilon",
-            "approx_grad",
-            "bounds",
-            "loglike_and_score",
-            "iprint",
-        ),
-        "lbfgs",
+        allowed=lbfgs_allowed,
+        method="lbfgs",
     )
     # Use unconstrained optimization by default.
     bounds = kwargs.setdefault("bounds", [(None, None)] * len(start_params))
-    kwargs.setdefault("iprint", -1 if not disp else 1)
 
     # Pass the following keyword argument names through to fmin_l_bfgs_b
     # if they are present in kwargs, otherwise use the fmin_l_bfgs_b
     # default values.
-    names = ("m", "pgtol", "factr", "maxfun", "epsilon", "approx_grad", "iprint")
+    names = ("m", "pgtol", "factr", "maxfun", "epsilon", "approx_grad")
+    if SP_LT_118:
+        # iprint is deprecated in SciPy 1.15, error in 1.18
+        kwargs.setdefault("iprint", -1 if not disp else 1)
+        names += ("iprint",)
     extra_kwargs = {x: kwargs[x] for x in names if x in kwargs}
 
     # Extract values for the options related to the gradient.

--- a/statsmodels/compat/scipy.py
+++ b/statsmodels/compat/scipy.py
@@ -10,6 +10,7 @@ SP_LT_17 = SP_VERSION < Version("1.6.99")
 SP_LT_19 = SP_VERSION < Version("1.8.99")
 SP_LT_115 = SP_VERSION < Version("1.14.99")
 SP_LT_116 = SP_VERSION < Version("1.15.99")
+SP_LT_118 = SP_VERSION < Version("1.17.99")
 
 
 def _next_regular(target):
@@ -147,6 +148,7 @@ __all__ = [
     "SP_LT_19",
     "SP_LT_115",
     "SP_LT_116",
+    "SP_LT_118",
     "SP_VERSION",
     "apply_where",
     "multivariate_t",


### PR DESCRIPTION
iprint has been removed from scipy 1.18 for lbfgs

- [ ] closes #xxxx
- [ ] tests added / passed. 
- [ ] code/documentation is well formatted.  
- [ ] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
