### PR TITLE
BUG/CLN: remove dead assignment to cov_p in GLM fit

### DIFF
--- a/statsmodels/genmod/generalized_linear_model.py
+++ b/statsmodels/genmod/generalized_linear_model.py
@@ -1370,11 +1370,6 @@ class GLM(base.LikelihoodModel):
         mu = self.predict(rslt.params)
         scale = self.estimate_scale(mu)
 
-        if rslt.normalized_cov_params is None:
-            cov_p = None
-        else:
-            cov_p = rslt.normalized_cov_params / scale
-
         if cov_type.lower() == "eim":
             oim = False
             cov_type = "nonrobust"


### PR DESCRIPTION
The initial assignment to `cov_p` from `rslt.normalized_cov_params` (lines 1373-1376) is always overwritten by the hessian-based computation in the `try`/`except` block that immediately follows. The first assignment is never read before being replaced.

This removes the redundant assignment, resolving the code scanning alert.

Closes #9776