### PR TITLE
DOC: add venv activation step in development setup instructions

### DIFF
--- a/docs/source/dev/test_notes.rst
+++ b/docs/source/dev/test_notes.rst
@@ -12,9 +12,12 @@ using a development install of statsmodels in a `venv` by running:
 .. code-block:: bash
 
     python -m venv .venv
+    source .venv/bin/activate
     python -m pip install -e ".[develop]"
 
-from the root directory of the git repository. The flag ``-e`` is for editable.
+from the root directory of the git repository. On Windows, replace the
+activation step with ``.venv\Scripts\activate``.
+The flag ``-e`` is for editable.
 
 This command compiles the C code and add statsmodels to your activate python
 environment by creating links from your python environment's libraries


### PR DESCRIPTION
The development setup instructions in `docs/source/dev/test_notes.rst` show how to create a venv but skip the activation step before running `pip install`. Without activation, the packages are installed into the system Python instead of the venv.

Adds `source .venv/bin/activate` between the venv creation and the pip install, with a note for Windows users.

Closes #9821