### PR TITLE
BUG: pass ax parameter through to dot_plot in CombineResults.plot_forest

### DIFF
--- a/statsmodels/stats/meta_analysis.py
+++ b/statsmodels/stats/meta_analysis.py
@@ -292,8 +292,6 @@ class CombineResults:
 
         Parameters
         ----------
-        ax : None or matplotlib axis instance
-            If ax is provided, then the plot will be added to it.
         alpha : float in (0, 1)
             Significance level for confidence interval. Nominal coverage is
             ``1 - alpha``.
@@ -335,6 +333,7 @@ class CombineResults:
             intervals=hw,
             lines=res_df.index,
             line_order=res_df.index,
+            ax=ax,
             **kwds,
         )
         return fig

--- a/statsmodels/stats/tests/test_meta.py
+++ b/statsmodels/stats/tests/test_meta.py
@@ -365,5 +365,9 @@ class TestMetaBinOR:
         res1.plot_forest(use_t=False)
         res1.plot_forest(use_exp=True, use_t=False)
         res1.plot_forest(alpha=0.01, use_t=False)
+        import matplotlib.pyplot as plt
+        fig, ax = plt.subplots()
+        fig_out = res1.plot_forest(ax=ax, use_t=False)
+        assert fig_out is fig
         with pytest.raises(TypeError, match="unexpected keyword"):
             res1.plot_forest(junk=5, use_t=False)

--- a/statsmodels/stats/tests/test_meta.py
+++ b/statsmodels/stats/tests/test_meta.py
@@ -8,6 +8,7 @@ License: BSD-3
 
 import io
 
+import matplotlib.pyplot as plt
 import numpy as np
 from numpy.testing import assert_allclose, assert_equal
 import pandas as pd
@@ -365,7 +366,6 @@ class TestMetaBinOR:
         res1.plot_forest(use_t=False)
         res1.plot_forest(use_exp=True, use_t=False)
         res1.plot_forest(alpha=0.01, use_t=False)
-        import matplotlib.pyplot as plt
         fig, ax = plt.subplots()
         fig_out = res1.plot_forest(ax=ax, use_t=False)
         assert fig_out is fig

--- a/statsmodels/stats/tests/test_meta.py
+++ b/statsmodels/stats/tests/test_meta.py
@@ -370,7 +370,7 @@ class TestMetaBinOR:
         fig, ax = plt.subplots()
         original_children = ax.get_children()
         fig_out = res1.plot_forest(ax=ax, use_t=False)
-        updated_children = ax.get_children(original_children)
+        updated_children = ax.get_children()
         assert len(updated_children) > len()
         assert fig_out is fig
         with pytest.raises(TypeError, match="unexpected keyword"):

--- a/statsmodels/stats/tests/test_meta.py
+++ b/statsmodels/stats/tests/test_meta.py
@@ -8,7 +8,6 @@ License: BSD-3
 
 import io
 
-import matplotlib.pyplot as plt
 import numpy as np
 from numpy.testing import assert_allclose, assert_equal
 import pandas as pd
@@ -360,6 +359,8 @@ class TestMetaBinOR:
 
     @pytest.mark.matplotlib
     def test_plot(self, close_figures):
+        import matplotlib.pyplot as plt
+
         # smoke tests
         res1 = self.res1
         # `use_t=False` avoids warning about missing nobs for use_t is true
@@ -367,7 +368,10 @@ class TestMetaBinOR:
         res1.plot_forest(use_exp=True, use_t=False)
         res1.plot_forest(alpha=0.01, use_t=False)
         fig, ax = plt.subplots()
+        original_children = ax.get_children()
         fig_out = res1.plot_forest(ax=ax, use_t=False)
+        updated_children = ax.get_children(original_children)
+        assert len(updated_children) > len()
         assert fig_out is fig
         with pytest.raises(TypeError, match="unexpected keyword"):
             res1.plot_forest(junk=5, use_t=False)


### PR DESCRIPTION
Pass the `ax` parameter through to `dot_plot` in `CombineResults.plot_forest` so that the caller's axes are reused instead of creating a new figure. Also removes the duplicate `ax` entry in the docstring and adds a regression test.

Closes #8718