### PR TITLE
Fix GLMInfluence.hat_matrix_diag method name

### DIFF
--- a/statsmodels/stats/outliers_influence.py
+++ b/statsmodels/stats/outliers_influence.py
@@ -1452,7 +1452,7 @@ class GLMInfluence(MLEInfluence):
         if hasattr(self, "_hat_matrix_diag"):
             return self._hat_matrix_diag
         else:
-            return self.results.get_hat_matrix()
+            return self.results.get_hat_matrix_diag()
 
     @cache_readonly
     def d_params(self):

--- a/statsmodels/stats/tests/test_influence.py
+++ b/statsmodels/stats/tests/test_influence.py
@@ -16,7 +16,7 @@ import pytest
 from statsmodels.genmod import families
 from statsmodels.genmod.generalized_linear_model import GLM
 from statsmodels.regression.linear_model import OLS
-from statsmodels.stats.outliers_influence import MLEInfluence, variance_inflation_factor
+from statsmodels.stats.outliers_influence import GLMInfluence, MLEInfluence, variance_inflation_factor
 
 cur_dir = os.path.abspath(os.path.dirname(__file__))
 
@@ -51,11 +51,8 @@ def test_influence_glm_bernoulli():
 
 
 def test_glminfluence_direct_constructor():
-    # Regression test for GH#9415: GLMInfluence constructed directly
-    # (without hat_matrix_diag) called get_hat_matrix instead of
-    # get_hat_matrix_diag, raising AttributeError.
-    from statsmodels.stats.outliers_influence import GLMInfluence
-
+    # GH#9415: GLMInfluence constructed directly raised AttributeError
+    # on cooks_distance
     df = data_bin
     res = GLM(
         df["constrict"],

--- a/statsmodels/stats/tests/test_influence.py
+++ b/statsmodels/stats/tests/test_influence.py
@@ -50,6 +50,26 @@ def test_influence_glm_bernoulli():
     assert_allclose(c_bar, results_sas[:, 9], atol=6e-5)
 
 
+def test_glminfluence_direct_constructor():
+    # Regression test for GH#9415: GLMInfluence constructed directly
+    # (without hat_matrix_diag) called get_hat_matrix instead of
+    # get_hat_matrix_diag, raising AttributeError.
+    from statsmodels.stats.outliers_influence import GLMInfluence
+
+    df = data_bin
+    res = GLM(
+        df["constrict"],
+        df[["const", "log_rate", "log_volumne"]],
+        family=families.Binomial(),
+    ).fit(attach_wls=True, atol=1e-10)
+
+    infl_direct = GLMInfluence(res)
+    infl_method = res.get_influence()
+
+    assert_allclose(infl_direct.cooks_distance[0],
+                    infl_method.cooks_distance[0], rtol=1e-12)
+
+
 class InfluenceCompareExact:
     # Mixin to compare and test two Influence instances
 


### PR DESCRIPTION
Fix typo in `GLMInfluence.hat_matrix_diag`: calls `get_hat_matrix()` (which does not exist on `GLMResults`) instead of `get_hat_matrix_diag()`.

The bug is triggered when constructing `GLMInfluence` directly rather than via `GLMResults.get_influence()`, since the latter passes `hat_matrix_diag` to the constructor.

One-line change at `outliers_influence.py:1427`.

Closes #9415