### PR TITLE
MAINT: drop removed scipy interp2d from TableDist (closes #8909)

### DIFF
--- a/statsmodels/stats/tabledist.py
+++ b/statsmodels/stats/tabledist.py
@@ -13,7 +13,7 @@ check: instead of bound checking I could use the fill-value of the
 interpolators
 """
 import numpy as np
-from scipy.interpolate import Rbf, interp1d, interp2d
+from scipy.interpolate import Rbf, interp1d
 
 from statsmodels.tools.decorators import cache_readonly
 
@@ -113,13 +113,6 @@ class TableDist:
         polyn = [interp1d(self.size, self.crit_table[:, i])
                  for i in range(self.n_alpha)]
         return polyn
-
-    @cache_readonly
-    def poly2d(self):
-        # check for monotonicity ?
-        # fix this, interp needs increasing
-        poly2d = interp2d(self.size, self.alpha, self.crit_table)
-        return poly2d
 
     @cache_readonly
     def polyrbf(self):

--- a/statsmodels/stats/tests/test_tabledist.py
+++ b/statsmodels/stats/tests/test_tabledist.py
@@ -8,6 +8,7 @@ Statistician, Vol. 40, No. 4 (Nov., 1986), pp. 294-296
 import numpy as np
 from numpy.testing import assert_allclose, assert_almost_equal
 
+from statsmodels.stats import tabledist
 from statsmodels.stats.tabledist import TableDist
 
 
@@ -99,3 +100,26 @@ def test_tabledist():
             for c in crit_lf[i, :-1]]
     vals = np.array(vals).reshape(-1, lf.n_alpha - 1)
     assert (vals > lf.alpha[:-1]).all()
+
+
+def test_no_interp2d():
+    # GH#8909: scipy.interpolate.interp2d was removed in SciPy 1.14.0. Its only
+    # usage was the unused TableDist.poly2d method, which raised
+    # NotImplementedError when called. Ensure neither the removed dependency nor
+    # the dead method is referenced anymore, while the surviving interpolation
+    # methods still work.
+    assert not hasattr(tabledist, "interp2d")
+    assert "poly2d" not in vars(TableDist)
+
+    alpha = np.array([0.2, 0.15, 0.1, 0.05, 0.01, 0.001])[::-1]
+    size = np.array([4, 5, 6, 7, 8, 9, 10], float)
+    crit = np.array([[303, 321, 346, 376, 413, 433],
+                     [289, 303, 319, 343, 397, 439],
+                     [269, 281, 297, 323, 371, 424],
+                     [252, 264, 280, 304, 351, 402],
+                     [239, 250, 265, 288, 333, 384],
+                     [227, 238, 252, 274, 317, 365],
+                     [217, 228, 241, 262, 304, 352]])[:, ::-1] / 1000.
+    lf = TableDist(alpha, size, crit)
+    assert_almost_equal(lf.crit(0.15, 5), lf.crit3(0.15, 5), decimal=3)
+    assert 0 < lf.prob(0.30, 5) < 1


### PR DESCRIPTION
Closes #8909.

`scipy.interpolate.interp2d` got removed in scipy 1.14, it just raises now:

```
NotImplementedError: `interp2d` has been removed in SciPy 1.14.0.
```

The only place we still import/use it is `TableDist.poly2d`. Like Josef already
said in #8909, that method isn't called anywhere (grep only finds its own
definition), it's not in the public api and there's no test for it. It also
looks like it was wrong to begin with - it passes `z=crit_table` with shape
`(n_size, n_alpha)` but interp2d wants `(len(y), len(x)) = (n_alpha, n_size)`,
so the axes were transposed.

So I just dropped the method and the import. Everything else on TableDist
(`prob`/`crit`/`crit3`, `_critvals`, `polyn`, `polyrbf`) goes through `interp1d`
and `Rbf` and is untouched. Added a small test in test_tabledist.py.

Ran it locally on scipy 1.17.1 / numpy 2.4.6 / pandas 3.0.3 / py3.13:
test_tabledist.py passes, and the lilliefors tests in test_diagnostic.py (the
real TableDist user) still pass.
