### PR TITLE
DOC: fix incorrect parameter names in deconvolve, powerdiscrepancy and VECMResults.predict docstrings

### DIFF
--- a/statsmodels/stats/gof.py
+++ b/statsmodels/stats/gof.py
@@ -37,9 +37,9 @@ def powerdiscrepancy(observed, expected, lambd=0.0, axis=0, ddof=0):
 
     Parameters
     ----------
-    o : Iterable
+    observed : Iterable
         Observed values
-    e : Iterable
+    expected : Iterable
         Expected values
     lambd : {float, str}
         * float : exponent `a` for power discrepancy

--- a/statsmodels/tsa/arima_process.py
+++ b/statsmodels/tsa/arima_process.py
@@ -617,7 +617,7 @@ def deconvolve(num, den, n=None):
     ----------
     num : array_like
         signal or lag polynomial
-    denom : array_like
+    den : array_like
         coefficients of lag polynomial (linear filter)
     n : None or int
         number of terms of quotient

--- a/statsmodels/tsa/vector_ar/vecm.py
+++ b/statsmodels/tsa/vector_ar/vecm.py
@@ -1814,7 +1814,7 @@ class VECMResults:
             If None, compute point forecast only.
             If float, compute confidence intervals too. In this case the
             argument stands for the confidence level.
-        exog : ndarray (steps x self.exog.shape[1])
+        exog_fc : ndarray (steps x self.exog.shape[1])
             If self.exog is not None, then information about the future values
             of exog have to be passed via this parameter. The ndarray may be
             larger in it's first dimension. In this case only the first steps


### PR DESCRIPTION
- [ ] closes #xxxx
- [x] tests added / passed. (N/A — documentation only; per the contributing guide, tests are not needed for doc changes)
- [x] code/documentation is well formatted.
- [x] properly formatted commit message.

## Description

Three docstrings document parameter names that do not match the actual function signatures:

- `tsa.arima_process.deconvolve(num, den, n=None)` — documented **`denom`**; corrected to **`den`**.
- `stats.gof.powerdiscrepancy(observed, expected, ...)` — documented **`o`** / **`e`**; corrected to **`observed`** / **`expected`**.
- `tsa.vector_ar.vecm.VECMResults.predict(..., exog_fc, ...)` — documented **`exog`**; corrected to **`exog_fc`**.

Documentation-only changes — no code or behaviour changes.