### PR TITLE
BUG: skip summary diagnostics when slim=True

### DIFF
--- a/statsmodels/regression/linear_model.py
+++ b/statsmodels/regression/linear_model.py
@@ -2895,23 +2895,8 @@ class RegressionResults(base.LikelihoodModelResults):
         alpha = float_like(alpha, "alpha", optional=False)
         slim = bool_like(slim, "slim", optional=False, strict=True)
 
-        jb, jbpv, skew, kurtosis = jarque_bera(self.wresid)
-        omni, omnipv = omni_normtest(self.wresid)
-
         eigvals = self.eigenvals
         condno = self.condition_number
-
-        # TODO: Avoid adding attributes in non-__init__
-        self.diagn = dict(
-            jb=jb,
-            jbpv=jbpv,
-            skew=skew,
-            kurtosis=kurtosis,
-            omni=omni,
-            omnipv=omnipv,
-            condno=condno,
-            mineigval=eigvals[-1],
-        )
 
         # TODO not used yet
         # diagn_left_header = ['Models stats']
@@ -2962,6 +2947,21 @@ class RegressionResults(base.LikelihoodModelResults):
             top_right = [elem for elem in top_right if elem[0] in slimlist]
             top_right = top_right + [("", [])] * (len(top_left) - len(top_right))
         else:
+            jb, jbpv, skew, kurtosis = jarque_bera(self.wresid)
+            omni, omnipv = omni_normtest(self.wresid)
+
+            # TODO: Avoid adding attributes in non-__init__
+            self.diagn = dict(
+                jb=jb,
+                jbpv=jbpv,
+                skew=skew,
+                kurtosis=kurtosis,
+                omni=omni,
+                omnipv=omnipv,
+                condno=condno,
+                mineigval=eigvals[-1],
+            )
+
             diagn_left = [
                 ("Omnibus:", ["%#6.3f" % omni]),
                 ("Prob(Omnibus):", ["%#6.3f" % omnipv]),

--- a/statsmodels/regression/linear_model.py
+++ b/statsmodels/regression/linear_model.py
@@ -2898,6 +2898,9 @@ class RegressionResults(base.LikelihoodModelResults):
         eigvals = self.eigenvals
         condno = self.condition_number
 
+        # TODO: Avoid adding attributes in non-__init__
+        self.diagn = dict(condno=condno, mineigval=eigvals[-1])
+
         # TODO not used yet
         # diagn_left_header = ['Models stats']
         # diagn_right_header = ['Residual stats']
@@ -2950,16 +2953,13 @@ class RegressionResults(base.LikelihoodModelResults):
             jb, jbpv, skew, kurtosis = jarque_bera(self.wresid)
             omni, omnipv = omni_normtest(self.wresid)
 
-            # TODO: Avoid adding attributes in non-__init__
-            self.diagn = dict(
+            self.diagn.update(
                 jb=jb,
                 jbpv=jbpv,
                 skew=skew,
                 kurtosis=kurtosis,
                 omni=omni,
                 omnipv=omnipv,
-                condno=condno,
-                mineigval=eigvals[-1],
             )
 
             diagn_left = [

--- a/statsmodels/regression/tests/test_regression.py
+++ b/statsmodels/regression/tests/test_regression.py
@@ -1592,3 +1592,6 @@ def test_slim_summary_skips_diagnostics(reset_randomstate):
     res = OLS(y, x).fit()
     summ = res.summary(slim=True)
     assert len(summ.tables) == 2
+    # diagn must still exist after a slim summary, populated with the
+    # always-computed condition-number diagnostics.
+    assert set(res.diagn) == {"condno", "mineigval"}

--- a/statsmodels/regression/tests/test_regression.py
+++ b/statsmodels/regression/tests/test_regression.py
@@ -1581,3 +1581,14 @@ def test_slim_summary(reset_randomstate):
     assert len(slim_summ.tables) == 2
     assert summ.tables[0].as_text() != slim_summ.tables[0].as_text()
     assert slim_summ.tables[1].as_text() == summ.tables[1].as_text()
+
+
+def test_slim_summary_skips_diagnostics(reset_randomstate):
+    # GH#9054 the slim summary omits the normality/residual diagnostics, so it
+    # should not compute them. omni_normtest raises for complex-valued data, so
+    # a slim summary must succeed there even when the full summary cannot.
+    y = np.random.standard_normal(50) + 1j * np.random.standard_normal(50)
+    x = add_constant(np.random.standard_normal((50, 2)))
+    res = OLS(y, x).fit()
+    summ = res.summary(slim=True)
+    assert len(summ.tables) == 2

--- a/statsmodels/regression/tests/test_regression.py
+++ b/statsmodels/regression/tests/test_regression.py
@@ -1587,7 +1587,7 @@ def test_slim_summary_skips_diagnostics(reset_randomstate, monkeypatch):
     # GH#9054 the slim summary omits the normality/residual diagnostics, so it
     # must not compute them. Make omni_normtest raise to prove the slim summary
     # never calls it, while the full summary still does.
-    import statsmodels.stats.stattools as stattools
+    from statsmodels.stats import stattools
 
     def _boom(*args, **kwargs):
         raise RuntimeError("diagnostics should not be computed for slim summary")

--- a/statsmodels/regression/tests/test_regression.py
+++ b/statsmodels/regression/tests/test_regression.py
@@ -1583,15 +1583,27 @@ def test_slim_summary(reset_randomstate):
     assert slim_summ.tables[1].as_text() == summ.tables[1].as_text()
 
 
-def test_slim_summary_skips_diagnostics(reset_randomstate):
+def test_slim_summary_skips_diagnostics(reset_randomstate, monkeypatch):
     # GH#9054 the slim summary omits the normality/residual diagnostics, so it
-    # should not compute them. omni_normtest raises for complex-valued data, so
-    # a slim summary must succeed there even when the full summary cannot.
-    y = np.random.standard_normal(50) + 1j * np.random.standard_normal(50)
+    # must not compute them. Make omni_normtest raise to prove the slim summary
+    # never calls it, while the full summary still does.
+    import statsmodels.stats.stattools as stattools
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("diagnostics should not be computed for slim summary")
+
+    monkeypatch.setattr(stattools, "omni_normtest", _boom)
+
+    y = np.random.standard_normal(50)
     x = add_constant(np.random.standard_normal((50, 2)))
     res = OLS(y, x).fit()
-    summ = res.summary(slim=True)
-    assert len(summ.tables) == 2
-    # diagn must still exist after a slim summary, populated with the
+
+    slim_summ = res.summary(slim=True)
+    assert len(slim_summ.tables) == 2
+    # diagn must still exist after a slim summary, populated only with the
     # always-computed condition-number diagnostics.
     assert set(res.diagn) == {"condno", "mineigval"}
+
+    # the full summary does compute the normality diagnostics
+    with pytest.raises(RuntimeError):
+        res.summary()


### PR DESCRIPTION
## Problem

`RegressionResults.summary(slim=True)` computes the normality/residual
diagnostics even though the slim summary never displays them. Besides the
wasted work, `omni_normtest` raises for some inputs (e.g. complex-valued
data), so a slim summary fails where it has nothing to report.

Fixes #9054 (see also use case #3528).

## Root cause

In `summary`, the diagnostics were computed *before* the `slim` branch:

```python
jb, jbpv, skew, kurtosis = jarque_bera(self.wresid)
omni, omnipv = omni_normtest(self.wresid)
...
self.diagn = dict(jb=jb, ..., omni=omni, omnipv=omnipv, ...)
```

`jb`, `omni`, `skew`, `kurtosis` are only consumed by the non-slim
diagnostic tables, but they were always evaluated.

## Fix

Move the `jarque_bera`/`omni_normtest` computation into the non-slim
(`else`) branch so it runs only when those values are actually rendered.

`self.diagn` is kept populated in both modes: it is initialised with the
always-computed `condno`/`mineigval` before the `slim` branch, then
`update()`d with the normality diagnostics only in the non-slim path.
This preserves `res.diagn` after a slim summary (previously the whole
dict was skipped) while avoiding the `omni_normtest` call.

After the change, `summary(slim=True)` skips the normality diagnostics and
the full summary is unchanged (still renders the diagnostics and still
populates the full `self.diagn`).

## Tests

`test_slim_summary_skips_diagnostics` monkeypatches `omni_normtest` to
raise, then asserts that:

- `summary(slim=True)` still returns its two tables and populates
  `res.diagn` with `{condno, mineigval}` — proving it never computes the
  normality diagnostics;
- `summary()` (non-slim) still calls `omni_normtest` (it raises).

This tests the behaviour directly rather than relying on scipy's
platform-dependent handling of complex input. Existing summary/slim tests
continue to pass; `flake8` is clean on both files.

## Scope

Minimal and intentionally narrow. Supporting complex residuals in the
normality tests themselves is a separate concern and out of scope here.