### PR TITLE
ENH: add fixed_params support to innovations_mle (Issue#6159)

### DIFF
--- a/statsmodels/tsa/arima/estimators/innovations.py
+++ b/statsmodels/tsa/arima/estimators/innovations.py
@@ -155,6 +155,19 @@ def innovations_mle(
     Note: we do not include `enforce_stationarity` as an argument, because this
     function requires stationarity.
 
+    The innovations algorithm requires the process to be stationary, and by
+    default also requires the MA polynomial to be invertible (this can be
+    relaxed with ``enforce_invertibility=False``). When `fixed_params` is
+    used, be aware that stationarity (and invertibility) are enforced by
+    transforming an unconstrained parameter vector into one that satisfies
+    the constraint, and the fixed values are substituted in after this
+    transformation. As a result, the final parameter vector is not
+    guaranteed to satisfy stationarity/invertibility. One way to avoid this:
+    fix the entire AR set or the entire MA set (rather than a partial
+    subset), so that the transformation itself only touches the block you're
+    not fixing, and stationarity/invertibility of that block is still
+    guaranteed.
+
     TODO: support concentrating out the scale (should be easy: use sigma2=1
           and then compute sigma2=np.sum(u**2 / v) / len(u); would then need to
           redo llf computation in the Cython function).

--- a/statsmodels/tsa/arima/estimators/innovations.py
+++ b/statsmodels/tsa/arima/estimators/innovations.py
@@ -12,7 +12,10 @@ from scipy.optimize import minimize
 
 from statsmodels.tools.sm_exceptions import SpecificationWarning
 from statsmodels.tools.tools import Bunch
-from statsmodels.tsa.arima.estimators.hannan_rissanen import hannan_rissanen
+from statsmodels.tsa.arima.estimators.hannan_rissanen import (
+    _validate_fixed_params,
+    hannan_rissanen,
+)
 from statsmodels.tsa.arima.params import SARIMAXParams
 from statsmodels.tsa.arima.specification import SARIMAXSpecification
 from statsmodels.tsa.innovations import arma_innovations
@@ -38,8 +41,8 @@ def innovations(endog, ma_order=0, demean=True):
     -------
     parameters : list of SARIMAXParams objects
         List elements correspond to estimates at different `ma_order`. For
-        example, parameters[0] is an `SARIMAXParams` instance corresponding to
-        `ma_order=0`.
+        example, parameters[0] is an `SARIMAXParams` instance corresponding
+        to `ma_order=0`.
     other_results : Bunch
         Includes one component, `spec`, containing the `SARIMAXSpecification`
         instance corresponding to the input arguments.
@@ -100,6 +103,7 @@ def innovations_mle(
     enforce_invertibility=True,
     start_params=None,
     minimize_kwargs=None,
+    fixed_params=None,
 ):
     """
     Estimate SARIMA parameters by MLE using innovations algorithm.
@@ -128,6 +132,11 @@ def innovations_mle(
         parameters are computed using the Hannan-Rissanen method.
     minimize_kwargs : dict, optional
         Arguments to pass to scipy.optimize.minimize.
+    fixed_params : dict, optional
+        Dictionary of parameter names and fixed values. Keys must be valid
+        AR or MA parameter names as returned by ``SARIMAXSpecification
+        .param_names`` (e.g. ``{"ar.L1": 0.5}``). ``sigma2`` may not be
+        fixed. Default is None, which fixes no parameters.
 
     Returns
     -------
@@ -150,8 +159,6 @@ def innovations_mle(
           and then compute sigma2=np.sum(u**2 / v) / len(u); would then need to
           redo llf computation in the Cython function).
 
-    TODO: add support for fixed parameters
-
     TODO: add support for secondary optimization that does not enforce
           stationarity / invertibility, starting from first step's parameters
 
@@ -168,6 +175,19 @@ def innovations_mle(
         enforce_invertibility=enforce_invertibility,
     )
     endog = spec.endog
+
+    fixed_params = _validate_fixed_params(fixed_params, spec.param_names)
+    param_names = spec.param_names
+    fixed_ix = np.array(
+        [i for i, name in enumerate(param_names) if name in fixed_params],
+        dtype=int,
+    )
+    free_ix = np.array(
+        [i for i, name in enumerate(param_names) if name not in fixed_params],
+        dtype=int,
+    )
+    fixed_vals = np.array([fixed_params[param_names[i]] for i in fixed_ix])
+
     if spec.is_integrated:
         warnings.warn(
             "Provided `endog` series has been differenced to"
@@ -247,7 +267,11 @@ def innovations_mle(
             )
 
     def obj(params):
-        p.params = spec.constrain_params(params)
+        full = np.zeros(len(param_names))
+        full[free_ix] = params
+        constrained = spec.constrain_params(full)
+        constrained[fixed_ix] = fixed_vals
+        p.params = constrained
 
         return -arma_innovations.arma_loglike(
             endog,
@@ -256,8 +280,8 @@ def innovations_mle(
             sigma2=p.sigma2,
         )
 
-    # Untransform the starting parameters
-    unconstrained_start_params = spec.unconstrain_params(start_params)
+    # Untransform the starting parameters, retaining only the free indices
+    unconstrained_start_params = spec.unconstrain_params(start_params)[free_ix]
 
     # Perform the minimization
     if minimize_kwargs is None:
@@ -270,7 +294,11 @@ def innovations_mle(
     # TODO: show warning if convergence failed.
 
     # Reverse the transformation to get the optimal parameters
-    p.params = spec.constrain_params(minimize_results.x)
+    full = np.zeros(len(param_names))
+    full[free_ix] = minimize_results.x
+    constrained = spec.constrain_params(full)
+    constrained[fixed_ix] = fixed_vals
+    p.params = constrained
 
     # Construct other results
     other_results = Bunch(

--- a/statsmodels/tsa/arima/estimators/tests/test_innovations.py
+++ b/statsmodels/tsa/arima/estimators/tests/test_innovations.py
@@ -371,3 +371,125 @@ def test_innovations_mle_invalid():
         innovations_mle(endog, order=(1, 0, 0), start_params=[1.0, 1.0])
     with pytest.raises(ValueError):
         innovations_mle(endog, order=(0, 0, 1), start_params=[1.0, 1.0])
+
+
+def test_innovations_mle_fixed_params_ar():
+    endog = lake.copy()
+    endog = endog - endog.mean()
+
+    start_params = [0.0, 0.0, np.var(endog)]
+
+    p_free, _ = innovations_mle(
+        endog, order=(1, 0, 1), demean=False, start_params=start_params
+    )
+    p_fixed, _ = innovations_mle(
+        endog,
+        order=(1, 0, 1),
+        demean=False,
+        start_params=start_params,
+        fixed_params={"ar.L1": 0.5},
+    )
+
+    assert_allclose(p_fixed.ar_params[0], 0.5)
+    assert not np.isclose(p_fixed.ma_params[0], p_free.ma_params[0])
+    assert not np.isclose(p_fixed.sigma2, p_free.sigma2)
+
+
+def test_innovations_mle_fixed_params_ma():
+    endog = lake.copy()
+    endog = endog - endog.mean()
+
+    start_params = [0.0, 0.0, np.var(endog)]
+
+    p_free, _ = innovations_mle(
+        endog, order=(1, 0, 1), demean=False, start_params=start_params
+    )
+    p_fixed, _ = innovations_mle(
+        endog,
+        order=(1, 0, 1),
+        demean=False,
+        start_params=start_params,
+        fixed_params={"ma.L1": 0.0},
+    )
+
+    assert_allclose(p_fixed.ma_params[0], 0.0)
+    assert not np.isclose(p_fixed.ar_params[0], p_free.ar_params[0])
+
+
+def test_innovations_mle_fixed_params_both():
+    endog = lake.copy()
+    endog = endog - endog.mean()
+
+    start_params = [0.0, 0.0, np.var(endog)]
+
+    p_fixed, _ = innovations_mle(
+        endog,
+        order=(1, 0, 1),
+        demean=False,
+        start_params=start_params,
+        fixed_params={"ar.L1": 0.5, "ma.L1": 0.0},
+    )
+
+    assert_allclose(p_fixed.ar_params[0], 0.5)
+    assert_allclose(p_fixed.ma_params[0], 0.0)
+    assert np.isfinite(p_fixed.sigma2) and p_fixed.sigma2 > 0
+
+
+def test_innovations_mle_fixed_params_statespace():
+    endog = lake.copy()
+    endog = endog - endog.mean()
+
+    start_params = [0.0, 0.0, np.var(endog)]
+
+    p, mleres = innovations_mle(
+        endog,
+        order=(1, 0, 1),
+        demean=False,
+        start_params=start_params,
+        fixed_params={"ar.L1": 0.5},
+    )
+
+    mod = sarimax.SARIMAX(endog, order=(1, 0, 1))
+    res = mod.filter(p.params)
+    assert_allclose(-mleres.minimize_results.fun, res.llf)
+
+
+def test_innovations_mle_fixed_params_no_fixed():
+    endog = lake.copy()
+    endog = endog - endog.mean()
+
+    start_params = [0.0, 0.0, np.var(endog)]
+
+    p_baseline, _ = innovations_mle(
+        endog, order=(1, 0, 1), demean=False, start_params=start_params
+    )
+    p_none, _ = innovations_mle(
+        endog,
+        order=(1, 0, 1),
+        demean=False,
+        start_params=start_params,
+        fixed_params=None,
+    )
+    p_empty, _ = innovations_mle(
+        endog,
+        order=(1, 0, 1),
+        demean=False,
+        start_params=start_params,
+        fixed_params={},
+    )
+
+    assert_allclose(p_none.params, p_baseline.params)
+    assert_allclose(p_empty.params, p_baseline.params)
+
+
+def test_innovations_mle_fixed_params_invalid():
+    endog = lake.copy()
+
+    with pytest.raises(ValueError, match="Invalid fixed parameter"):
+        innovations_mle(endog, order=(1, 0, 1), fixed_params={"sigma2": 1.0})
+
+    with pytest.raises(ValueError, match="Invalid fixed parameter"):
+        innovations_mle(endog, order=(1, 0, 1), fixed_params={"ar.L5": 0.5})
+
+    with pytest.raises(ValueError, match="Invalid fixed parameter"):
+        innovations_mle(endog, order=(1, 0, 1), fixed_params={"not_a_param": 0.0})


### PR DESCRIPTION
## Summary

Related to Issue #6159
The innovations_mle estimator in statsmodels/tsa/arima/estimators/innovations.py did not support fixed parameters, even though this is available in hannan_rissanen and noted as a TODO in the source. The issue is tracked in the ARIMA estimators enhancement issue.

## What was changed
**`innovations.py:`**
Added fixed_params=None parameter to innovations_mle
Imported _validate_fixed_params from hannan_rissanen (already a dependency) to reuse existing validation logic
After the spec is built, fixed_params is validated and three index structures are computed: fixed_ix, free_ix, and fixed_vals
The optimizer only receives and operates over free parameters. Inside the objective function, the full parameter vector is reconstructed by constraining the free params via spec.constrain_params, then overwriting fixed positions with user-supplied values directly — bypassing the transformation since user-supplied values are already in constrained space
The same reconstruction is applied after optimization to set the final p.params
Removed the TODO comment for fixed params

**`test_innovations.py:`**
test_innovations_mle_fixed_params_ar — AR param held exactly, free params differ from unconstrained solution
test_innovations_mle_fixed_params_ma — MA param held exactly
test_innovations_mle_fixed_params_both — both AR and MA fixed, sigma2 still optimized
test_innovations_mle_fixed_params_statespace — LLF from innovations_mle matches Kalman filter LLF at the same params
test_innovations_mle_fixed_params_no_fixed — None and {} reproduce baseline behavior
test_innovations_mle_fixed_params_invalid — sigma2, out-of-spec lag, and invalid key all raise ValueError

## Note for reviewer:
`**_validate_fixed_params**` is currently private to hannan_rissanen.py and is imported from there. If preferred, it could be moved to a shared utility module to avoid cross-importing between estimator files.
