### PR TITLE
ENH: Add predict methods to NominalGEE and OrdinalGEE

### DIFF
--- a/statsmodels/genmod/generalized_estimating_equations.py
+++ b/statsmodels/genmod/generalized_estimating_equations.py
@@ -59,7 +59,7 @@ from statsmodels.graphics._regressionplots_doc import (
 
 # used for wrapper:
 import statsmodels.regression.linear_model as lm
-from statsmodels.tools._decorators import cache_readonly
+from statsmodels.tools._decorators import cache_readonly, cached_data
 from statsmodels.tools.docstring_helpers import Appender
 from statsmodels.tools.sm_exceptions import (
     ConvergenceWarning,
@@ -2630,6 +2630,78 @@ class OrdinalGEE(GEE):
         result = model.fit()
         return result.params
 
+    def predict(self, params, exog=None, offset=None, which="mean"):
+        """
+        Return predicted values for a design matrix.
+
+        Parameters
+        ----------
+        params : array_like
+            Parameters / coefficients of a GEE model.
+        exog : array_like, optional
+            Design / exogenous data in the original ``(nobs, k)`` form used
+            to fit the model. If ``exog`` is None, then the original design
+            matrix ``exog_orig`` is used.
+        offset : array_like, optional
+            Offset values. If ``offset`` is None and ``exog`` is None, then
+            the model's ``offset_orig`` is used. If ``offset`` is None and
+            ``exog`` is provided, then 0 is used.
+        which : {'mean', 'linear'}, optional
+            Statistic to predict. Default is 'mean'.
+
+            - 'mean' returns the predicted probabilities for each category.
+              The returned array has shape ``(nobs, ncat)``.
+            - 'linear' returns the linear predictor for each threshold.
+              The returned array has shape ``(nobs, ncut)``.
+
+        Returns
+        -------
+        ndarray
+            See ``which``.
+
+        Notes
+        -----
+        Any ``offset`` provided here takes precedence over the ``offset``
+        used in the model fit. If ``exog`` is passed as an argument here,
+        then any ``offset`` values in the fit will be ignored.
+        """
+
+        if exog is None:
+            exog = self.exog_orig
+            if offset is None:
+                offset = self.offset_orig
+        elif offset is None:
+            offset = 0.0
+
+        exog = np.asarray(exog)
+        params = np.asarray(params)
+
+        ncut = len(self.endog_values) - 1
+
+        thresholds = params[:ncut]
+        slopes = params[ncut:]
+
+        xb = np.dot(exog, slopes)
+        lin_pred = xb[:, None] + thresholds[None, :]
+        if offset is not None:
+            offset = np.asarray(offset)
+            if offset.ndim == 1:
+                offset = offset[:, None]
+            lin_pred += offset
+
+        if which == "linear":
+            return lin_pred
+        elif which == "mean":
+            surv = self.family.link.inverse(lin_pred)
+            surv = np.concatenate(
+                (np.ones((len(surv), 1)), surv, np.zeros((len(surv), 1))),
+                axis=1,
+            )
+            probs = -np.diff(surv, axis=1)
+            return probs
+        else:
+            raise ValueError(f'The which value "{which}" is not recognized')
+
     @Appender(_gee_fit_doc)
     def fit(
         self,
@@ -2674,6 +2746,14 @@ class OrdinalGEEResults(GEEResults):
         "This class summarizes the fit of a marginal regression model"
         "for an ordinal response using GEE.\n" + _gee_results_doc
     )
+
+    @cached_data
+    def mu(self):
+        """
+        The estimated mean response on the expanded indicator scale.
+        """
+        linpred = self.model.predict(self.params, which="linear")
+        return self.model.family.link.inverse(linpred).ravel()
 
     def plot_distribution(self, ax=None, exog_values=None):
         """
@@ -2961,6 +3041,77 @@ class NominalGEE(GEE):
 
         return endog_out, exog_out, groups_out, time_out, offset_out
 
+    def predict(self, params, exog=None, offset=None, which="mean"):
+        """
+        Return predicted values for a design matrix.
+
+        Parameters
+        ----------
+        params : array_like
+            Parameters / coefficients of a GEE model.
+        exog : array_like, optional
+            Design / exogenous data in the original ``(nobs, k)`` form used
+            to fit the model. If ``exog`` is None, then the original design
+            matrix ``exog_orig`` is used.
+        offset : array_like, optional
+            Offset values. If ``offset`` is None and ``exog`` is None, then
+            the model's ``offset_orig`` is used. If ``offset`` is None and
+            ``exog`` is provided, then 0 is used.
+        which : {'mean', 'linear'}, optional
+            Statistic to predict. Default is 'mean'.
+
+            - 'mean' returns the predicted probabilities for each category.
+              The returned array has shape ``(nobs, ncat)``.
+            - 'linear' returns the linear predictor for each non-reference
+              category. The returned array has shape ``(nobs, ncut)``.
+
+        Returns
+        -------
+        ndarray
+            See ``which``.
+
+        Notes
+        -----
+        Any ``offset`` provided here takes precedence over the ``offset``
+        used in the model fit. If ``exog`` is passed as an argument here,
+        then any ``offset`` values in the fit will be ignored.
+        """
+
+        if exog is None:
+            exog = self.exog_orig
+            if offset is None:
+                offset = self.offset_orig
+        elif offset is None:
+            offset = 0.0
+
+        exog = np.asarray(exog)
+        params = np.asarray(params)
+
+        ncut = self.ncut
+        k = exog.shape[1]
+
+        params_m = params.reshape(ncut, k)
+
+        lin_pred = np.dot(exog, params_m.T)
+        if offset is not None:
+            offset = np.asarray(offset)
+            if offset.ndim == 1:
+                offset = offset[:, None]
+            lin_pred += offset
+
+        if which == "linear":
+            return lin_pred
+        elif which == "mean":
+            # Use the log-sum-exp trick for numerical stability.
+            lpr_max = np.max(lin_pred, axis=1, keepdims=True)
+            e_lpr = np.exp(lin_pred - lpr_max)
+            denom = e_lpr.sum(axis=1, keepdims=True) + np.exp(-lpr_max)
+            probs = e_lpr / denom
+            ref_prob = np.exp(-lpr_max) / denom
+            return np.concatenate((probs, ref_prob), axis=1)
+        else:
+            raise ValueError(f'The which value "{which}" is not recognized')
+
     def mean_deriv(self, exog, lin_pred):
         """
         Derivative of the expected endog with respect to the parameters.
@@ -3112,6 +3263,14 @@ class NominalGEEResults(GEEResults):
         "This class summarizes the fit of a marginal regression model"
         "for a nominal response using GEE.\n" + _gee_results_doc
     )
+
+    @cached_data
+    def mu(self):
+        """
+        The estimated mean response on the expanded indicator scale.
+        """
+        probs = self.model.predict(self.params)
+        return probs[:, :-1].ravel()
 
     def plot_distribution(self, ax=None, exog_values=None):
         """

--- a/statsmodels/genmod/generalized_estimating_equations.py
+++ b/statsmodels/genmod/generalized_estimating_equations.py
@@ -1789,7 +1789,14 @@ class GEE(GLM):
         if "ex" in transform:
             margeff *= exog
         if "ey" in transform:
-            margeff /= self.predict(params, exog)[:, None]
+            # Use the fitted mean on the modeling (expanded-indicator) scale
+            # rather than self.predict.  NominalGEE and OrdinalGEE override
+            # predict to return category probabilities on the original
+            # (nobs, ncat) scale, which is incompatible with the per-row
+            # marginal effects computed here.  family.fitted reproduces the
+            # value that predict returned before those overrides were added.
+            fitted = self.family.fitted(np.dot(exog, params))
+            margeff /= fitted[:, None]
         if count_idx is not None:
             from statsmodels.discrete.discrete_margins import (
                 _get_count_effects,
@@ -2630,7 +2637,7 @@ class OrdinalGEE(GEE):
         result = model.fit()
         return result.params
 
-    def predict(self, params, exog=None, offset=None, which="mean"):
+    def predict(self, params, exog=None, offset=None, which="mean", linear=None):
         """
         Return predicted values for a design matrix.
 
@@ -2654,6 +2661,11 @@ class OrdinalGEE(GEE):
             - 'linear' returns the linear predictor for each threshold.
               The returned array has shape ``(nobs, ncut)``.
 
+        linear : bool
+            The ``linear`` keyword is deprecated and will be removed, use
+            the ``which`` keyword instead. If True, returns the linear
+            predicted values (equivalent to ``which="linear"``).
+
         Returns
         -------
         ndarray
@@ -2664,7 +2676,20 @@ class OrdinalGEE(GEE):
         Any ``offset`` provided here takes precedence over the ``offset``
         used in the model fit. If ``exog`` is passed as an argument here,
         then any ``offset`` values in the fit will be ignored.
+
+        Because the model uses a shared slope with one intercept per
+        threshold, the category probabilities are valid for any ``exog`` as
+        long as the fitted thresholds are monotone. The thresholds are
+        estimated without an ordering constraint, so in the rare case that
+        they are not monotone some returned probabilities may be negative; a
+        warning is issued when this occurs.
         """
+
+        if linear is not None:
+            msg = 'linear keyword is deprecated, use which="linear"'
+            warnings.warn(msg, FutureWarning, stacklevel=2)
+            if linear is True:
+                which = "linear"
 
         if exog is None:
             exog = self.exog_orig
@@ -2698,9 +2723,30 @@ class OrdinalGEE(GEE):
                 axis=1,
             )
             probs = -np.diff(surv, axis=1)
+            if np.any(probs < -1e-10):
+                warnings.warn(
+                    "Some predicted probabilities are negative. This occurs "
+                    "when the fitted OrdinalGEE thresholds are not monotone, "
+                    "which indicates a degenerate fit rather than a coherent "
+                    "ordinal model.",
+                    ValueWarning,
+                    stacklevel=2,
+                )
             return probs
         else:
             raise ValueError(f'The which value "{which}" is not recognized')
+
+    def get_distribution(self, *args, **kwargs):
+        """
+        Not implemented for OrdinalGEE.
+
+        A single scipy frozen distribution cannot represent an ordinal
+        response. Use ``predict`` to obtain category probabilities.
+        """
+        raise NotImplementedError(
+            "get_distribution is not defined for OrdinalGEE; use predict to "
+            "obtain category probabilities."
+        )
 
     @Appender(_gee_fit_doc)
     def fit(
@@ -2754,6 +2800,18 @@ class OrdinalGEEResults(GEEResults):
         """
         linpred = self.model.predict(self.params, which="linear")
         return self.model.family.link.inverse(linpred).ravel()
+
+    def get_distribution(self, *args, **kwargs):
+        """
+        Not implemented for OrdinalGEE.
+
+        A single scipy frozen distribution cannot represent an ordinal
+        response. Use ``predict`` to obtain category probabilities.
+        """
+        raise NotImplementedError(
+            "get_distribution is not defined for OrdinalGEE; use predict to "
+            "obtain category probabilities."
+        )
 
     def plot_distribution(self, ax=None, exog_values=None):
         """
@@ -3041,7 +3099,7 @@ class NominalGEE(GEE):
 
         return endog_out, exog_out, groups_out, time_out, offset_out
 
-    def predict(self, params, exog=None, offset=None, which="mean"):
+    def predict(self, params, exog=None, offset=None, which="mean", linear=None):
         """
         Return predicted values for a design matrix.
 
@@ -3065,6 +3123,11 @@ class NominalGEE(GEE):
             - 'linear' returns the linear predictor for each non-reference
               category. The returned array has shape ``(nobs, ncut)``.
 
+        linear : bool
+            The ``linear`` keyword is deprecated and will be removed, use
+            the ``which`` keyword instead. If True, returns the linear
+            predicted values (equivalent to ``which="linear"``).
+
         Returns
         -------
         ndarray
@@ -3076,6 +3139,12 @@ class NominalGEE(GEE):
         used in the model fit. If ``exog`` is passed as an argument here,
         then any ``offset`` values in the fit will be ignored.
         """
+
+        if linear is not None:
+            msg = 'linear keyword is deprecated, use which="linear"'
+            warnings.warn(msg, FutureWarning, stacklevel=2)
+            if linear is True:
+                which = "linear"
 
         if exog is None:
             exog = self.exog_orig
@@ -3089,6 +3158,13 @@ class NominalGEE(GEE):
 
         ncut = self.ncut
         k = exog.shape[1]
+
+        if params.size != ncut * k:
+            raise ValueError(
+                f"params has length {params.size}, but exog with {k} columns "
+                f"requires {ncut * k} parameters ({ncut} non-reference "
+                f"categories times {k} covariates)."
+            )
 
         params_m = params.reshape(ncut, k)
 
@@ -3214,6 +3290,18 @@ class NominalGEE(GEE):
 
         return dmat
 
+    def get_distribution(self, *args, **kwargs):
+        """
+        Not implemented for NominalGEE.
+
+        A single scipy frozen distribution cannot represent a multinomial
+        response. Use ``predict`` to obtain category probabilities.
+        """
+        raise NotImplementedError(
+            "get_distribution is not defined for NominalGEE; use predict to "
+            "obtain category probabilities."
+        )
+
     @Appender(_gee_fit_doc)
     def fit(
         self,
@@ -3271,6 +3359,18 @@ class NominalGEEResults(GEEResults):
         """
         probs = self.model.predict(self.params)
         return probs[:, :-1].ravel()
+
+    def get_distribution(self, *args, **kwargs):
+        """
+        Not implemented for NominalGEE.
+
+        A single scipy frozen distribution cannot represent a multinomial
+        response. Use ``predict`` to obtain category probabilities.
+        """
+        raise NotImplementedError(
+            "get_distribution is not defined for NominalGEE; use predict to "
+            "obtain category probabilities."
+        )
 
     def plot_distribution(self, ax=None, exog_values=None):
         """

--- a/statsmodels/genmod/generalized_estimating_equations.py
+++ b/statsmodels/genmod/generalized_estimating_equations.py
@@ -495,6 +495,28 @@ def _check_args(endog, exog, groups, time, offset, exposure):
         raise ValueError("'exposure' and 'endog' should have the same size")
 
 
+class _ExpandedMeanModel:
+    """
+    Minimal adapter exposing ``predict`` as the fitted mean on the expanded
+    (modeling) scale, i.e. ``family.fitted(exog @ params)``.
+
+    Marginal effects are computed on the expanded design matrix, and the
+    discrete-margins helpers call ``model.predict(params, exog)`` expecting
+    that expanded-scale mean.  ``NominalGEE`` and ``OrdinalGEE`` override
+    ``predict`` to return original-scale category probabilities, so this
+    adapter is passed to ``_derivative_exog`` machinery in their place.  For
+    every other GEE family it reproduces the value the inherited
+    ``GLM.predict`` returns for an explicitly supplied ``exog`` (offset and
+    exposure are 0 in that case).
+    """
+
+    def __init__(self, family):
+        self.family = family
+
+    def predict(self, params, exog):
+        return self.family.fitted(np.dot(exog, params))
+
+
 class GEE(GLM):
 
     __doc__ = (
@@ -1786,24 +1808,25 @@ class GEE(GLM):
 
         margeff = self.mean_deriv_exog(exog, params, offset_exposure)
 
+        # Marginal effects operate on the expanded design and need the fitted
+        # mean on that scale.  NominalGEE and OrdinalGEE override predict to
+        # return original-scale category probabilities, which is incompatible
+        # here, so route the mean through an adapter that always returns
+        # family.fitted(exog @ params).  For every other GEE family this is
+        # exactly what self.predict returned for an explicitly supplied exog.
+        mean_model = _ExpandedMeanModel(self.family)
+
         if "ex" in transform:
             margeff *= exog
         if "ey" in transform:
-            # Use the fitted mean on the modeling (expanded-indicator) scale
-            # rather than self.predict.  NominalGEE and OrdinalGEE override
-            # predict to return category probabilities on the original
-            # (nobs, ncat) scale, which is incompatible with the per-row
-            # marginal effects computed here.  family.fitted reproduces the
-            # value that predict returned before those overrides were added.
-            fitted = self.family.fitted(np.dot(exog, params))
-            margeff /= fitted[:, None]
+            margeff /= mean_model.predict(params, exog)[:, None]
         if count_idx is not None:
             from statsmodels.discrete.discrete_margins import (
                 _get_count_effects,
             )
 
             margeff = _get_count_effects(
-                margeff, exog, count_idx, transform, self, params
+                margeff, exog, count_idx, transform, mean_model, params
             )
         if dummy_idx is not None:
             from statsmodels.discrete.discrete_margins import (
@@ -1811,7 +1834,7 @@ class GEE(GLM):
             )
 
             margeff = _get_dummy_effects(
-                margeff, exog, dummy_idx, transform, self, params
+                margeff, exog, dummy_idx, transform, mean_model, params
             )
         return margeff
 
@@ -2553,6 +2576,14 @@ class OrdinalGEE(GEE):
             constraint,
         )
 
+        # __init__ does not forward **kwargs to super (endog/exog are expanded
+        # into the indicator design first), which would otherwise drop the
+        # formula model specification passed by from_formula.  Preserve it on
+        # the model so result.predict() can transform new exog supplied as a
+        # DataFrame (predict operates on the original, pre-expansion design).
+        if kwargs.get("model_spec") is not None:
+            self.model_spec = kwargs["model_spec"]
+
     def setup_ordinal(self, endog, exog, groups, time, offset):
         """
         Restructure ordinal data as binary indicators so that they can
@@ -2637,7 +2668,10 @@ class OrdinalGEE(GEE):
         result = model.fit()
         return result.params
 
-    def predict(self, params, exog=None, offset=None, which="mean", linear=None):
+    def predict(
+        self, params, exog=None, exposure=None, offset=None, which="mean",
+        linear=None,
+    ):
         """
         Return predicted values for a design matrix.
 
@@ -2649,6 +2683,9 @@ class OrdinalGEE(GEE):
             Design / exogenous data in the original ``(nobs, k)`` form used
             to fit the model. If ``exog`` is None, then the original design
             matrix ``exog_orig`` is used.
+        exposure : array_like, optional
+            Not supported; accepted only for signature compatibility with
+            ``GLM.predict``. Passing a non-None value raises ``ValueError``.
         offset : array_like, optional
             Offset values. If ``offset`` is None and ``exog`` is None, then
             the model's ``offset_orig`` is used. If ``offset`` is None and
@@ -2657,7 +2694,9 @@ class OrdinalGEE(GEE):
             Statistic to predict. Default is 'mean'.
 
             - 'mean' returns the predicted probabilities for each category.
-              The returned array has shape ``(nobs, ncat)``.
+              The returned array has shape ``(nobs, ncat)``, with columns
+              ordered by the sorted unique response values
+              (``self.endog_values``).
             - 'linear' returns the linear predictor for each threshold.
               The returned array has shape ``(nobs, ncut)``.
 
@@ -2691,6 +2730,9 @@ class OrdinalGEE(GEE):
             if linear is True:
                 which = "linear"
 
+        if exposure is not None:
+            raise ValueError("exposure is not supported")
+
         if exog is None:
             exog = self.exog_orig
             if offset is None:
@@ -2702,6 +2744,14 @@ class OrdinalGEE(GEE):
         params = np.asarray(params)
 
         ncut = len(self.endog_values) - 1
+        k = exog.shape[1]
+
+        if params.size != ncut + k:
+            raise ValueError(
+                f"params has length {params.size}, but exog with {k} columns "
+                f"requires {ncut + k} parameters ({ncut} thresholds plus {k} "
+                f"covariate coefficients)."
+            )
 
         thresholds = params[:ncut]
         slopes = params[ncut:]
@@ -3012,6 +3062,11 @@ class NominalGEE(GEE):
             constraint,
         )
 
+        # See OrdinalGEE.__init__: preserve the formula model specification so
+        # result.predict() can transform new exog supplied as a DataFrame.
+        if kwargs.get("model_spec") is not None:
+            self.model_spec = kwargs["model_spec"]
+
     def _starting_params(self):
         exposure = getattr(self, "exposure", None)
         model = GEE(
@@ -3099,7 +3154,10 @@ class NominalGEE(GEE):
 
         return endog_out, exog_out, groups_out, time_out, offset_out
 
-    def predict(self, params, exog=None, offset=None, which="mean", linear=None):
+    def predict(
+        self, params, exog=None, exposure=None, offset=None, which="mean",
+        linear=None,
+    ):
         """
         Return predicted values for a design matrix.
 
@@ -3111,6 +3169,9 @@ class NominalGEE(GEE):
             Design / exogenous data in the original ``(nobs, k)`` form used
             to fit the model. If ``exog`` is None, then the original design
             matrix ``exog_orig`` is used.
+        exposure : array_like, optional
+            Not supported; accepted only for signature compatibility with
+            ``GLM.predict``. Passing a non-None value raises ``ValueError``.
         offset : array_like, optional
             Offset values. If ``offset`` is None and ``exog`` is None, then
             the model's ``offset_orig`` is used. If ``offset`` is None and
@@ -3119,7 +3180,10 @@ class NominalGEE(GEE):
             Statistic to predict. Default is 'mean'.
 
             - 'mean' returns the predicted probabilities for each category.
-              The returned array has shape ``(nobs, ncat)``.
+              The returned array has shape ``(nobs, ncat)``, with columns
+              ordered by the sorted unique response values
+              (``self.endog_values``); the reference category (the largest
+              value) is the last column.
             - 'linear' returns the linear predictor for each non-reference
               category. The returned array has shape ``(nobs, ncut)``.
 
@@ -3145,6 +3209,9 @@ class NominalGEE(GEE):
             warnings.warn(msg, FutureWarning, stacklevel=2)
             if linear is True:
                 which = "linear"
+
+        if exposure is not None:
+            raise ValueError("exposure is not supported")
 
         if exog is None:
             exog = self.exog_orig
@@ -3178,8 +3245,11 @@ class NominalGEE(GEE):
         if which == "linear":
             return lin_pred
         elif which == "mean":
-            # Use the log-sum-exp trick for numerical stability.
-            lpr_max = np.max(lin_pred, axis=1, keepdims=True)
+            # Use the log-sum-exp trick for numerical stability. The max
+            # includes the reference category's linear predictor (which is 0)
+            # so that np.exp(-lpr_max) cannot overflow when every
+            # non-reference linear predictor is large and negative.
+            lpr_max = np.maximum(np.max(lin_pred, axis=1, keepdims=True), 0.0)
             e_lpr = np.exp(lin_pred - lpr_max)
             denom = e_lpr.sum(axis=1, keepdims=True) + np.exp(-lpr_max)
             probs = e_lpr / denom

--- a/statsmodels/genmod/tests/test_gee.py
+++ b/statsmodels/genmod/tests/test_gee.py
@@ -321,9 +321,11 @@ class TestGEE:
         assert_equal(new_probs.shape, (5, ncat))
         assert_allclose(new_probs.sum(axis=1), 1, rtol=1e-10)
 
-        # Invalid which raises ValueError; mismatched params/exog is reported.
+        # Invalid which raises ValueError; mismatched params/exog is reported;
+        # exposure is not supported.
         assert_raises(ValueError, result.predict, which="invalid")
         assert_raises(ValueError, model.predict, result.params[:-1], exog)
+        assert_raises(ValueError, result.predict, exposure=1.0)
 
     def test_nominal_predict_offset(self):
         # Check that NominalGEE.predict handles an offset correctly.
@@ -356,9 +358,31 @@ class TestGEE:
         # The model offset is ignored once exog is supplied (GLM convention).
         probs_no_offset = result.predict(exog=new_exog)
         probs_with_offset = result.predict(exog=new_exog, offset=new_offset)
-        assert_raises(
-            AssertionError, assert_allclose, probs_no_offset, probs_with_offset
-        )
+        assert not np.allclose(probs_no_offset, probs_with_offset)
+
+    def test_nominal_predict_reference_dominant(self):
+        # Regression test for log-sum-exp overflow: when the reference category
+        # dominates (every non-reference linear predictor is large and
+        # negative), predict must return finite probabilities that sum to one,
+        # not NaN from exp(-lpr_max) overflowing.
+        endog = np.r_[0, 0, 1, 1, 2, 2]
+        exog = np.ones((6, 2))
+        exog[:, 1] = np.r_[0, 1, 0, 1, 0, 1]
+        groups = np.arange(6)
+
+        model = gee.NominalGEE(endog, exog, groups)
+        k = exog.shape[1]
+
+        # Intercept of -800 for every non-reference category drives each
+        # non-reference linear predictor to ~-800 (reference logit is 0).
+        params = np.zeros(model.ncut * k)
+        params[::k] = -800.0
+
+        probs = model.predict(params, exog=exog)
+        assert np.all(np.isfinite(probs))
+        assert_allclose(probs.sum(axis=1), 1, rtol=1e-10)
+        # The reference category (last column) carries essentially all mass.
+        assert_allclose(probs[:, -1], 1, rtol=1e-10)
 
     def test_weighted(self):
 
@@ -1206,8 +1230,9 @@ class TestGEE:
         assert_equal(new_probs.shape, (5, ncat))
         assert_allclose(new_probs.sum(axis=1), 1, rtol=1e-10)
 
-        # Invalid which raises ValueError.
+        # Invalid which raises ValueError; exposure is not supported.
         assert_raises(ValueError, rslt.predict, which="invalid")
+        assert_raises(ValueError, rslt.predict, exposure=1.0)
 
     def test_ordinal_predict_offset(self):
         # Check that OrdinalGEE.predict handles an offset correctly.
@@ -1248,15 +1273,16 @@ class TestGEE:
         # The model offset is ignored once exog is supplied (GLM convention).
         probs_no_offset = rslt.predict(exog=new_x)
         probs_with_offset = rslt.predict(exog=new_x, offset=new_offset)
-        assert_raises(
-            AssertionError, assert_allclose, probs_no_offset, probs_with_offset
-        )
+        assert not np.allclose(probs_no_offset, probs_with_offset)
 
-    def test_nominal_ordinal_margeff_elasticity(self):
+    def test_nominal_ordinal_margeff(self):
         # Regression guard: NominalGEE/OrdinalGEE override predict to return a
-        # 2-D (nobs, ncat) array, but get_margeff's elasticity transforms
-        # ("eyex"/"eydx") need the fitted mean on the expanded modeling scale.
-        # _derivative_exog must therefore not rely on the overridden predict.
+        # 2-D (nobs, ncat) array, but get_margeff computes effects on the
+        # expanded design and needs the fitted mean on that scale -- both for
+        # the elasticity transforms ("eyex"/"eydx") and for the dummy/count
+        # effect differences computed via the discrete-margins helpers.
+        # _derivative_exog must therefore route the mean through the
+        # expanded-scale adapter rather than the overridden predict.
         endog, exog, groups = load_data("gee_nominal_1.csv", icept=False)
         rn = gee.NominalGEE(
             endog, exog, groups, cov_struct=cov_struct.Independence()
@@ -1272,6 +1298,32 @@ class TestGEE:
             for method in ("dydx", "eyex", "eydx"):
                 marg = rslt.get_margeff(method=method)
                 assert np.all(np.isfinite(np.asarray(marg.margeff)))
+
+        # Dummy/count effects difference predictions on the expanded design via
+        # the discrete-margins helpers. Use at="all": the delta-method standard
+        # errors hit a separate, pre-existing GLM limitation for models that
+        # carry an offset (Nominal/OrdinalGEE always do internally). The design
+        # uses two covariates (== the number of non-reference categories) to
+        # avoid an unrelated mean_deriv_exog shape limitation when k != ncut.
+        rng = np.random.RandomState(3)
+        n = 120
+        endog = rng.randint(0, 3, n)  # 3 categories -> ncut == 2
+        groups = np.arange(n)
+        dummy_exog = np.column_stack(
+            [np.ones(n), (rng.uniform(size=n) > 0.5).astype(float)]
+        )
+        count_exog = np.column_stack(
+            [np.ones(n), rng.poisson(2, n).astype(float)]
+        )
+        for exog, kwds in (
+            (dummy_exog, dict(dummy=True)),
+            (count_exog, dict(count=True)),
+        ):
+            rd = gee.NominalGEE(
+                endog, exog, groups, cov_struct=cov_struct.Independence()
+            ).fit()
+            marg = rd.get_margeff(at="all", **kwds)
+            assert np.all(np.isfinite(np.asarray(marg.margeff)))
 
     def test_ordinal_predict_nonmonotone_warns(self):
         # OrdinalGEE is a proportional-odds model (shared slope, one intercept
@@ -1316,6 +1368,43 @@ class TestGEE:
             assert_raises(
                 NotImplementedError, rslt.model.get_distribution, rslt.params
             )
+
+    def test_nominal_ordinal_predict_formula(self):
+        # predict must work through the formula API: result.predict() on the
+        # original data, and result.predict(exog=DataFrame) on new data with
+        # the new exog transformed via the (pre-expansion) formula spec.
+        rng = np.random.RandomState(434)
+        n = 60
+        groups = np.arange(n)
+        df = pd.DataFrame({
+            "y": rng.randint(0, 3, n),
+            "x1": rng.normal(size=n),
+            "x2": rng.normal(size=n),
+        })
+        new_df = df[["x1", "x2"]].iloc[:5]
+        new_arr = np.asarray(new_df)
+
+        for Cls in (gee.OrdinalGEE, gee.NominalGEE):
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                rslt = Cls.from_formula(
+                    "y ~ 0 + x1 + x2", groups, data=df
+                ).fit()
+            ncat = len(rslt.model.endog_values)
+
+            probs = np.asarray(rslt.predict())
+            assert_equal(probs.shape, (n, ncat))
+            assert_allclose(probs.sum(axis=1), 1, rtol=1e-10)
+
+            # New data as a DataFrame is transformed via the formula and gives
+            # the same result as predicting on the equivalent array.
+            probs_df = np.asarray(rslt.predict(exog=new_df))
+            probs_arr = np.asarray(
+                rslt.predict(exog=new_arr, transform=False)
+            )
+            assert_equal(probs_df.shape, (5, ncat))
+            assert_allclose(probs_df, probs_arr, rtol=1e-10)
+            assert_allclose(probs_df, probs[:5], rtol=1e-10)
 
     @pytest.mark.smoke
     def test_ordinal_formula(self):

--- a/statsmodels/genmod/tests/test_gee.py
+++ b/statsmodels/genmod/tests/test_gee.py
@@ -19,6 +19,7 @@ from numpy.testing import (
     assert_almost_equal,
     assert_array_less,
     assert_equal,
+    assert_raises,
 )
 import pandas as pd
 import pytest
@@ -248,6 +249,68 @@ class TestGEE:
 
         assert_allclose(results.params, -logit_results.params, rtol=1e-5)
         assert_allclose(results.bse, logit_results.bse, rtol=1e-5)
+
+    def test_nominal_predict(self):
+        # Check that NominalGEE.predict returns category probabilities.
+
+        np.random.seed(34234)
+        endog = np.r_[0, 0, 0, 0, 1, 1, 1, 1]
+        exog = np.ones((8, 2))
+        exog[:, 1] = np.r_[1, 2, 1, 1, 2, 1, 2, 2]
+        groups = np.arange(8)
+
+        model = gee.NominalGEE(endog, exog, groups)
+        result = model.fit(cov_type="naive", start_params=[3.295837, -2.197225])
+
+        # Predict on the original design.
+        probs = result.predict()
+        assert_equal(probs.shape, (8, 2))
+        assert_allclose(probs.sum(axis=1), 1, rtol=1e-10)
+        assert_allclose((probs >= 0).all(axis=1), True)
+        assert_allclose((probs <= 1).all(axis=1), True)
+
+        # Linear predictor has one column per non-reference category.
+        linpred = result.predict(which="linear")
+        assert_equal(linpred.shape, (8, 1))
+
+        # The linear predictor matches a direct matrix product.
+        params_m = np.asarray(result.params).reshape(1, 2)
+        assert_allclose(linpred, np.dot(exog, params_m.T), rtol=1e-10)
+
+        # The non-reference probabilities match the model's fittedvalues.
+        assert_allclose(probs[:, :-1].ravel(), result._results.fittedvalues, rtol=1e-10)
+
+        # Predict on new data.
+        new_exog = np.array([[1, 1], [1, 2]], dtype=np.float64)
+        new_probs = result.predict(exog=new_exog)
+        assert_equal(new_probs.shape, (2, 2))
+        assert_allclose(new_probs.sum(axis=1), 1, rtol=1e-10)
+
+        # Invalid which raises ValueError.
+        assert_raises(ValueError, result.predict, which="invalid")
+
+    def test_nominal_predict_offset(self):
+        # Check that NominalGEE.predict handles an offset correctly.
+
+        np.random.seed(34234)
+        endog = np.r_[0, 0, 0, 0, 1, 1, 1, 1]
+        exog = np.ones((8, 2))
+        exog[:, 1] = np.r_[1, 2, 1, 1, 2, 1, 2, 2]
+        groups = np.arange(8)
+        offset = np.r_[0.1, -0.2, 0.0, 0.3, -0.1, 0.2, -0.3, 0.0]
+
+        model = gee.NominalGEE(endog, exog, groups, offset=offset)
+        result = model.fit(cov_type="naive", start_params=[3.295837, -2.197225])
+
+        # Predicted probabilities sum to one.
+        probs = result.predict()
+        assert_allclose(probs.sum(axis=1), 1, rtol=1e-10)
+
+        # Predictions with explicit offset on new data differ from no-offset.
+        new_exog = np.array([[1, 1], [1, 2]], dtype=np.float64)
+        probs_no_offset = result.predict(exog=new_exog)
+        probs_with_offset = result.predict(exog=new_exog, offset=np.r_[0.5, -0.5])
+        assert_raises(AssertionError, assert_allclose, probs_no_offset, probs_with_offset)
 
     def test_weighted(self):
 
@@ -1025,6 +1088,77 @@ class TestGEE:
         # Check that we get the correct results type
         assert_equal(type(rslt), gee.OrdinalGEEResultsWrapper)
         assert_equal(type(rslt._results), gee.OrdinalGEEResults)
+
+    def test_ordinal_predict(self):
+        # Check that OrdinalGEE.predict returns category probabilities.
+
+        family = families.Binomial()
+        endog, exog, groups = load_data("gee_ordinal_1.csv", icept=False)
+        va = cov_struct.GlobalOddsRatio("ordinal")
+        mod = gee.OrdinalGEE(endog, exog, groups, None, family, va)
+        rslt = mod.fit()
+
+        nobs = len(endog)
+        ncat = len(mod.endog_values)
+        ncut = ncat - 1
+
+        # Predict on the original design.
+        probs = rslt.predict()
+        assert_equal(probs.shape, (nobs, ncat))
+        assert_allclose(probs.sum(axis=1), 1, rtol=1e-10)
+        assert_allclose((probs >= 0).all(axis=1), True)
+        assert_allclose((probs <= 1).all(axis=1), True)
+
+        # Linear predictor has one column per threshold.
+        linpred = rslt.predict(which="linear")
+        assert_equal(linpred.shape, (nobs, ncut))
+
+        # The linear predictor matches a direct matrix product.
+        params_arr = np.asarray(rslt.params)
+        thresholds = params_arr[:ncut]
+        slopes = params_arr[ncut:]
+        expected = np.dot(exog, slopes)[:, None] + thresholds[None, :]
+        assert_allclose(linpred, expected, rtol=1e-10)
+
+        # The threshold survival probabilities match the model's fittedvalues.
+        surv = mod.family.link.inverse(linpred)
+        assert_allclose(surv.ravel(), rslt._results.fittedvalues, rtol=1e-10)
+
+        # Category probabilities are consistent with the survival function.
+        cumprob = np.cumsum(probs[:, :-1], axis=1)
+        assert_allclose(1 - cumprob, surv, rtol=1e-10)
+
+        # Predict on new data.
+        new_exog = exog[:5, :]
+        new_probs = rslt.predict(exog=new_exog)
+        assert_equal(new_probs.shape, (5, ncat))
+        assert_allclose(new_probs.sum(axis=1), 1, rtol=1e-10)
+
+        # Invalid which raises ValueError.
+        assert_raises(ValueError, rslt.predict, which="invalid")
+
+    def test_ordinal_predict_offset(self):
+        # Check that OrdinalGEE.predict handles an offset correctly.
+
+        np.random.seed(434)
+        n = 40
+        y = np.random.randint(0, 3, n)
+        groups = np.arange(n)
+        x = np.random.normal(size=(n, 2))
+        offset = np.random.normal(size=n)
+
+        model = gee.OrdinalGEE(y, x, groups, offset=offset)
+        rslt = model.fit()
+
+        # Predicted probabilities sum to one.
+        probs = rslt.predict()
+        assert_allclose(probs.sum(axis=1), 1, rtol=1e-10)
+
+        # Predictions with explicit offset on new data differ from no-offset.
+        new_x = x[:5, :]
+        probs_no_offset = rslt.predict(exog=new_x)
+        probs_with_offset = rslt.predict(exog=new_x, offset=np.ones(5))
+        assert_raises(AssertionError, assert_allclose, probs_no_offset, probs_with_offset)
 
     @pytest.mark.smoke
     def test_ordinal_formula(self):

--- a/statsmodels/genmod/tests/test_gee.py
+++ b/statsmodels/genmod/tests/test_gee.py
@@ -31,7 +31,7 @@ import statsmodels.discrete.discrete_model as discrete
 from statsmodels.genmod import cov_struct, families
 import statsmodels.genmod.generalized_estimating_equations as gee
 import statsmodels.regression.linear_model as lm
-from statsmodels.tools.sm_exceptions import SpecificationWarning
+from statsmodels.tools.sm_exceptions import SpecificationWarning, ValueWarning
 
 try:
     import matplotlib.pyplot as plt
@@ -251,66 +251,114 @@ class TestGEE:
         assert_allclose(results.bse, logit_results.bse, rtol=1e-5)
 
     def test_nominal_predict(self):
-        # Check that NominalGEE.predict returns category probabilities.
+        # Check that NominalGEE.predict returns category probabilities,
+        # validated against an independent multinomial-logit implementation.
+        #
+        # Under an independence working correlation the NominalGEE estimating
+        # equations coincide with the multinomial-logit score equations, so the
+        # predicted probabilities match MNLogit (and R's nnet::multinom) up to
+        # solver tolerance.  The pinned values below were confirmed with:
+        #
+        #   library(nnet)
+        #   Z <- read.csv("results/gee_nominal_1.csv", header=FALSE)
+        #   fit <- multinom(factor(Z[,2]) ~ 0 + Z[,3] + Z[,4])
+        #   round(fitted(fit)[1:5,], 8)
 
-        np.random.seed(34234)
-        endog = np.r_[0, 0, 0, 0, 1, 1, 1, 1]
-        exog = np.ones((8, 2))
-        exog[:, 1] = np.r_[1, 2, 1, 1, 2, 1, 2, 2]
-        groups = np.arange(8)
+        endog, exog, groups = load_data("gee_nominal_1.csv", icept=False)
 
-        model = gee.NominalGEE(endog, exog, groups)
-        result = model.fit(cov_type="naive", start_params=[3.295837, -2.197225])
+        model = gee.NominalGEE(endog, exog, groups,
+                               cov_struct=cov_struct.Independence())
+        result = model.fit()
 
-        # Predict on the original design.
+        ncat = len(model.endog_values)
+        ncut = model.ncut
+        nobs = len(endog)
+
         probs = result.predict()
-        assert_equal(probs.shape, (8, 2))
+        assert_equal(probs.shape, (nobs, ncat))
         assert_allclose(probs.sum(axis=1), 1, rtol=1e-10)
-        assert_allclose((probs >= 0).all(axis=1), True)
-        assert_allclose((probs <= 1).all(axis=1), True)
+        assert_array_less(-1e-12, probs)
+        assert_array_less(probs, 1 + 1e-12)
 
-        # Linear predictor has one column per non-reference category.
+        # Pinned probabilities, validated against R nnet::multinom (see above).
+        expected = np.array([
+            [0.71795494, 0.04700443, 0.23504063],
+            [0.54850664, 0.12290040, 0.32859296],
+            [0.84242458, 0.01449717, 0.14307825],
+            [0.66557818, 0.06641705, 0.26800477],
+            [0.53957468, 0.12799741, 0.33242791],
+        ])
+        assert_allclose(probs[:5], expected, rtol=1e-6, atol=1e-6)
+
+        # Independent cross-check against MNLogit (same per-category probs,
+        # regardless of which category each parameterization treats as the
+        # reference).
+        mn_probs = discrete.MNLogit(endog, exog).fit(disp=0).predict()
+        assert_allclose(probs, mn_probs, rtol=1e-5, atol=1e-7)
+
+        # Linear predictor has one column per non-reference category and
+        # matches a direct matrix product.
         linpred = result.predict(which="linear")
-        assert_equal(linpred.shape, (8, 1))
-
-        # The linear predictor matches a direct matrix product.
-        params_m = np.asarray(result.params).reshape(1, 2)
+        assert_equal(linpred.shape, (nobs, ncut))
+        params_m = np.asarray(result.params).reshape(ncut, exog.shape[1])
         assert_allclose(linpred, np.dot(exog, params_m.T), rtol=1e-10)
 
-        # The non-reference probabilities match the model's fittedvalues.
-        assert_allclose(probs[:, :-1].ravel(), result._results.fittedvalues, rtol=1e-10)
+        # Non-circular check that the expanded-scale fittedvalues are
+        # unchanged: the legacy _MultinomialLogit.inverse (used before predict
+        # was overridden) reproduces both the non-reference probabilities and
+        # fittedvalues.
+        legacy = gee._MultinomialLogit(ncut).inverse(linpred.ravel())
+        assert_allclose(legacy, probs[:, :-1].ravel(), rtol=1e-10)
+        assert_allclose(legacy, result._results.fittedvalues, rtol=1e-10)
+
+        # The deprecated linear keyword maps to which="linear".
+        with pytest.warns(FutureWarning):
+            assert_allclose(result.predict(linear=True), linpred, rtol=1e-12)
 
         # Predict on new data.
-        new_exog = np.array([[1, 1], [1, 2]], dtype=np.float64)
+        new_exog = exog[:5, :]
         new_probs = result.predict(exog=new_exog)
-        assert_equal(new_probs.shape, (2, 2))
+        assert_equal(new_probs.shape, (5, ncat))
         assert_allclose(new_probs.sum(axis=1), 1, rtol=1e-10)
 
-        # Invalid which raises ValueError.
+        # Invalid which raises ValueError; mismatched params/exog is reported.
         assert_raises(ValueError, result.predict, which="invalid")
+        assert_raises(ValueError, model.predict, result.params[:-1], exog)
 
     def test_nominal_predict_offset(self):
         # Check that NominalGEE.predict handles an offset correctly.
 
-        np.random.seed(34234)
-        endog = np.r_[0, 0, 0, 0, 1, 1, 1, 1]
-        exog = np.ones((8, 2))
-        exog[:, 1] = np.r_[1, 2, 1, 1, 2, 1, 2, 2]
-        groups = np.arange(8)
-        offset = np.r_[0.1, -0.2, 0.0, 0.3, -0.1, 0.2, -0.3, 0.0]
+        endog, exog, groups = load_data("gee_nominal_1.csv", icept=False)
+        rng = np.random.RandomState(34234)
+        offset = rng.normal(size=len(endog))
 
-        model = gee.NominalGEE(endog, exog, groups, offset=offset)
-        result = model.fit(cov_type="naive", start_params=[3.295837, -2.197225])
+        model = gee.NominalGEE(endog, exog, groups, offset=offset,
+                               cov_struct=cov_struct.Independence())
+        result = model.fit()
 
-        # Predicted probabilities sum to one.
         probs = result.predict()
         assert_allclose(probs.sum(axis=1), 1, rtol=1e-10)
 
-        # Predictions with explicit offset on new data differ from no-offset.
-        new_exog = np.array([[1, 1], [1, 2]], dtype=np.float64)
+        # An explicit offset on new data reproduces a manual recomputation of
+        # the softmax with the reference category fixed at a linear value of 0.
+        new_exog = exog[:5, :]
+        new_offset = rng.normal(size=5)
+        params_m = np.asarray(result.params).reshape(model.ncut, exog.shape[1])
+        eta = np.dot(new_exog, params_m.T) + new_offset[:, None]
+        eta = np.column_stack((eta, np.zeros(eta.shape[0])))
+        eta -= eta.max(axis=1, keepdims=True)
+        manual = np.exp(eta)
+        manual /= manual.sum(axis=1, keepdims=True)
+        assert_allclose(
+            result.predict(exog=new_exog, offset=new_offset), manual, rtol=1e-10
+        )
+
+        # The model offset is ignored once exog is supplied (GLM convention).
         probs_no_offset = result.predict(exog=new_exog)
-        probs_with_offset = result.predict(exog=new_exog, offset=np.r_[0.5, -0.5])
-        assert_raises(AssertionError, assert_allclose, probs_no_offset, probs_with_offset)
+        probs_with_offset = result.predict(exog=new_exog, offset=new_offset)
+        assert_raises(
+            AssertionError, assert_allclose, probs_no_offset, probs_with_offset
+        )
 
     def test_weighted(self):
 
@@ -1091,6 +1139,13 @@ class TestGEE:
 
     def test_ordinal_predict(self):
         # Check that OrdinalGEE.predict returns category probabilities.
+        #
+        # The category probabilities are validated by an independent
+        # reconstruction from the fitted parameters: the cumulative-logit
+        # survival probabilities P(y > c_j) = expit(x'b + threshold_j) are
+        # differenced to obtain the per-category probabilities.  The pinned
+        # values guard against regressions in the fit + predict pipeline.
+        from scipy.special import expit
 
         family = families.Binomial()
         endog, exog, groups = load_data("gee_ordinal_1.csv", icept=False)
@@ -1106,27 +1161,44 @@ class TestGEE:
         probs = rslt.predict()
         assert_equal(probs.shape, (nobs, ncat))
         assert_allclose(probs.sum(axis=1), 1, rtol=1e-10)
-        assert_allclose((probs >= 0).all(axis=1), True)
-        assert_allclose((probs <= 1).all(axis=1), True)
+        assert_array_less(-1e-12, probs)
+        assert_array_less(probs, 1 + 1e-12)
 
-        # Linear predictor has one column per threshold.
+        # Linear predictor has one column per threshold and matches a direct
+        # matrix product.
         linpred = rslt.predict(which="linear")
         assert_equal(linpred.shape, (nobs, ncut))
-
-        # The linear predictor matches a direct matrix product.
         params_arr = np.asarray(rslt.params)
         thresholds = params_arr[:ncut]
         slopes = params_arr[ncut:]
         expected = np.dot(exog, slopes)[:, None] + thresholds[None, :]
         assert_allclose(linpred, expected, rtol=1e-10)
 
-        # The threshold survival probabilities match the model's fittedvalues.
-        surv = mod.family.link.inverse(linpred)
+        # Independent reconstruction (uses scipy.expit, not the model link, and
+        # differences the survival curve by hand).
+        surv = expit(expected)
+        cat_probs = -np.diff(
+            np.column_stack((np.ones(nobs), surv, np.zeros(nobs))), axis=1
+        )
+        assert_allclose(probs, cat_probs, rtol=1e-10)
+
+        # The expanded-scale fittedvalues are the threshold survival
+        # probabilities (unchanged by the predict override).
         assert_allclose(surv.ravel(), rslt._results.fittedvalues, rtol=1e-10)
 
-        # Category probabilities are consistent with the survival function.
-        cumprob = np.cumsum(probs[:, :-1], axis=1)
-        assert_allclose(1 - cumprob, surv, rtol=1e-10)
+        # Pinned probabilities (regression guard for fit + predict).
+        expected_probs = np.array([
+            [0.55110511, 0.23064467, 0.06328116, 0.15496906],
+            [0.32155017, 0.25877266, 0.09762439, 0.32205278],
+            [0.11443507, 0.15935798, 0.09086408, 0.63534288],
+            [0.25766480, 0.24548874, 0.10340514, 0.39344132],
+            [0.00177105, 0.00337864, 0.00266891, 0.99218140],
+        ])
+        assert_allclose(probs[:5], expected_probs, rtol=1e-6, atol=1e-6)
+
+        # The deprecated linear keyword maps to which="linear".
+        with pytest.warns(FutureWarning):
+            assert_allclose(rslt.predict(linear=True), linpred, rtol=1e-12)
 
         # Predict on new data.
         new_exog = exog[:5, :]
@@ -1139,6 +1211,7 @@ class TestGEE:
 
     def test_ordinal_predict_offset(self):
         # Check that OrdinalGEE.predict handles an offset correctly.
+        from scipy.special import expit
 
         np.random.seed(434)
         n = 40
@@ -1154,11 +1227,95 @@ class TestGEE:
         probs = rslt.predict()
         assert_allclose(probs.sum(axis=1), 1, rtol=1e-10)
 
-        # Predictions with explicit offset on new data differ from no-offset.
+        # An explicit offset on new data reproduces a manual recomputation: the
+        # offset is added to every threshold's linear predictor.
         new_x = x[:5, :]
+        new_offset = np.r_[0.5, -0.5, 1.0, -1.0, 0.0]
+        params_arr = np.asarray(rslt.params)
+        ncut = len(model.endog_values) - 1
+        lin = (
+            np.dot(new_x, params_arr[ncut:])[:, None]
+            + params_arr[:ncut][None, :]
+            + new_offset[:, None]
+        )
+        surv = expit(lin)
+        manual = -np.diff(
+            np.column_stack((np.ones(5), surv, np.zeros(5))), axis=1
+        )
+        assert_allclose(rslt.predict(exog=new_x, offset=new_offset), manual,
+                        rtol=1e-10)
+
+        # The model offset is ignored once exog is supplied (GLM convention).
         probs_no_offset = rslt.predict(exog=new_x)
-        probs_with_offset = rslt.predict(exog=new_x, offset=np.ones(5))
-        assert_raises(AssertionError, assert_allclose, probs_no_offset, probs_with_offset)
+        probs_with_offset = rslt.predict(exog=new_x, offset=new_offset)
+        assert_raises(
+            AssertionError, assert_allclose, probs_no_offset, probs_with_offset
+        )
+
+    def test_nominal_ordinal_margeff_elasticity(self):
+        # Regression guard: NominalGEE/OrdinalGEE override predict to return a
+        # 2-D (nobs, ncat) array, but get_margeff's elasticity transforms
+        # ("eyex"/"eydx") need the fitted mean on the expanded modeling scale.
+        # _derivative_exog must therefore not rely on the overridden predict.
+        endog, exog, groups = load_data("gee_nominal_1.csv", icept=False)
+        rn = gee.NominalGEE(
+            endog, exog, groups, cov_struct=cov_struct.Independence()
+        ).fit()
+
+        endog, exog, groups = load_data("gee_ordinal_1.csv", icept=False)
+        ro = gee.OrdinalGEE(
+            endog, exog, groups, None, families.Binomial(),
+            cov_struct.GlobalOddsRatio("ordinal"),
+        ).fit()
+
+        for rslt in (rn, ro):
+            for method in ("dydx", "eyex", "eydx"):
+                marg = rslt.get_margeff(method=method)
+                assert np.all(np.isfinite(np.asarray(marg.margeff)))
+
+    def test_ordinal_predict_nonmonotone_warns(self):
+        # OrdinalGEE is a proportional-odds model (shared slope, one intercept
+        # per threshold), so probabilities are valid for any exog as long as
+        # the fitted thresholds are monotone.  A normal fit does not warn; a
+        # non-monotone threshold vector yields negative probabilities and a
+        # warning.
+        family = families.Binomial()
+        endog, exog, groups = load_data("gee_ordinal_1.csv", icept=False)
+        va = cov_struct.GlobalOddsRatio("ordinal")
+        mod = gee.OrdinalGEE(endog, exog, groups, None, family, va)
+        rslt = mod.fit()
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", ValueWarning)
+            probs = rslt.predict()
+        assert_array_less(-1e-12, probs)
+
+        params = np.asarray(rslt.params).copy()
+        params[0], params[1] = params[1], params[0]
+        with pytest.warns(ValueWarning, match="not monotone"):
+            bad_probs = mod.predict(params)
+        assert bad_probs.min() < 0
+
+    def test_nominal_ordinal_get_distribution_not_implemented(self):
+        # A single scipy frozen distribution cannot represent a multinomial or
+        # ordinal response, so get_distribution raises at both the model and
+        # results level (rather than erroring obscurely or returning nonsense).
+        endog, exog, groups = load_data("gee_nominal_1.csv", icept=False)
+        rn = gee.NominalGEE(
+            endog, exog, groups, cov_struct=cov_struct.Independence()
+        ).fit()
+
+        endog, exog, groups = load_data("gee_ordinal_1.csv", icept=False)
+        ro = gee.OrdinalGEE(
+            endog, exog, groups, None, families.Binomial(),
+            cov_struct.GlobalOddsRatio("ordinal"),
+        ).fit()
+
+        for rslt in (rn, ro):
+            assert_raises(NotImplementedError, rslt.get_distribution)
+            assert_raises(
+                NotImplementedError, rslt.model.get_distribution, rslt.params
+            )
 
     @pytest.mark.smoke
     def test_ordinal_formula(self):


### PR DESCRIPTION
## Summary (updated)

This PR adds model-level `predict` methods to `NominalGEE` and `OrdinalGEE` that operate on the original `(nobs, k)` design matrix and return category probabilities. The inherited GLM-style `predict` methods for these classes were removed in release 0.12.0 because they returned the expanded-indicator mean rather than per-category probabilities. This implementation restores the methods with behavior appropriate for multinomial/ordinal responses, and hardens the surrounding code paths affected by overriding `predict`.

## API

```python
result.predict(exog=None, exposure=None, offset=None, which="mean", linear=None)
```

* `which="mean"` (default): returns the full `(nobs, ncat)` category-probability matrix. Columns are ordered by the sorted unique response values (`model.endog_values`). For `NominalGEE` the reference category (the largest value) is the last column.
* `which="linear"`: returns the linear predictor — one column per non-reference category for `NominalGEE`, or per threshold for `OrdinalGEE`.
* `offset` follows the GLM convention: the model offset is used when `exog` is None; a user-provided offset overrides it.
* `linear=` is accepted as a deprecated alias for `which="linear"` (emits `FutureWarning`), matching `GLM.predict`.
* `exposure=` is accepted only for signature compatibility with `GLM.predict`. It is not meaningful for these models and raises `ValueError` if provided.
* Works through the formula API: `result.predict(exog=DataFrame)` transforms the new data via the original (pre-expansion) formula specification.

## Implementation notes

* `NominalGEE.predict` uses a numerically stable log-sum-exp softmax. The stabilizing maximum includes the reference category's linear predictor (0) so that the result stays finite and normalized even when every non-reference linear predictor is large and negative.
* `OrdinalGEE.predict` computes cumulative survival probabilities via the binomial link inverse and differences them to obtain category probabilities. Because the model uses a shared slope with one intercept per threshold (proportional odds), the category probabilities are valid for any `exog` as long as the fitted thresholds are monotone. The thresholds are estimated without an ordering constraint, so in the rare degenerate case where they are not monotone a `ValueWarning` is issued and some probabilities may be negative.
* `mu` is overridden in `NominalGEEResults` and `OrdinalGEEResults` so that the expanded-indicator-scale fitted values used by residuals, deviance, etc. remain unchanged.
* `GEE._derivative_exog` is routed through a small `_ExpandedMeanModel` adapter (which returns `family.fitted(exog @ params)`) for the elasticity and dummy/count marginal-effect paths. This decouples marginal effects from the overridden `predict`, fixing `get_margeff` for `NominalGEE`/`OrdinalGEE`, and is byte-for-byte unchanged for every other GEE family.
* `NominalGEE.predict` and `OrdinalGEE.predict` validate that the `params`/`exog` dimensions are consistent and raise a clear `ValueError` on mismatch.
* `get_distribution` raises `NotImplementedError` on both models and their results classes: a single scipy frozen distribution cannot represent a  multinomial/ordinal response (previously this errored obscurely for nominal and returned a meaningless distribution for ordinal).
* `NominalGEE.__init__`/`OrdinalGEE.__init__` preserve the formula model specification (these classes expand `endog`/`exog` before calling `super().__init__`, which would otherwise drop the spec passed by `from_formula`), enabling `predict` on new data supplied as a DataFrame.

## Tests

Added/strengthened tests in `statsmodels/genmod/tests/test_gee.py`:

* `NominalGEE.predict` validated against `MNLogit` and against R's `nnet::multinom` (pinned probabilities), using `NominalGEE(Independence)`'s reduction to multinomial logit; plus a non-circular check against the legacy `_MultinomialLogit.inverse`.
* `OrdinalGEE.predict` validated by an independent `scipy.expit` + survival-differencing reconstruction, with pinned probabilitie.
* Offset handling, the deprecated `linear=` keyword, invalid `which`, `exposure` rejection, and `params`/`exog` dimension validation.
* The `NominalGEE` reference-dominant case (no NaN/overflow) and the ordinal non-monotone-threshold warning.
* `get_margeff` elasticity and dummy/count effect paths for both classes.
* The `get_distribution` guard.
* `predict` through the formula API (`from_formula`), including new data passed as a DataFrame.

All genmod tests pass:

```bash
  python -m pytest statsmodels/genmod/tests/
  # 801 passed, 2 xfailed
```

## Known limitations (pre-existing, out of scope)

These are unrelated to the `predict` math and are flagged for separate issues:

* `get_margeff(dummy=True/count=True)` with the default `at="overall"` computes delta-method standard errors via `GLM._derivative_predict`, which raises `NotImplementedError` for any model carrying an offset. `NominalGEE`/`OrdinalGEE` always carry an internal (zeros) offset from the expanded design, so the standard-error path is unavailable for them (`at="all"`, which skips SEs, works). This predates the PR.
* `NominalGEE.mean_deriv_exog` has a shape bug when the number of covariates differs from the number of non-reference categories (`k != ncut`), which breaks `get_margeff` for such models. This predates the PR; the new marginal-effects tests use `k == ncut` designs to avoid it.

## Related issues

* Relates to #7071 (predict / margins exog support).
* Relates to #7068 (ordinal intercept / identification; the threshold parameterization used by `predict` matches the existing model).
* These predict methods were previously listed as removed in the release 0.12.0 notes.

## Open question for maintainers

The contribution guidelines ask for a release-notes entry, but there is no `docs/source/release/versionX.X.rst` file for the next release yet. Should I create `version0.15.0.rst` (or another version) and add this change there, or will the release notes be handled separately?
