### PR TITLE
TST: Mark test as unsafe

### DIFF
--- a/statsmodels/discrete/tests/test_discrete.py
+++ b/statsmodels/discrete/tests/test_discrete.py
@@ -2667,6 +2667,9 @@ def test_issue_341():
     np.testing.assert_equal(res1.predict(x[None]).shape, (1, 7))
 
 
+@pytest.mark.thread_unsafe(
+    "Rethrowing warning can lead to spurious fails with threading"
+)
 def test_negative_binomial_default_alpha_param():
     with pytest.warns(
         UserWarning, match="Negative binomial dispersion parameter alpha not set"

--- a/tools/ci/azure/azure_template_posix.yml
+++ b/tools/ci/azure/azure_template_posix.yml
@@ -24,7 +24,7 @@ jobs:
         python_314t_latest:
           python.version: '3.14'
           python.architecture: 'x64-freethreaded'
-          PANDAS_VERSION: 3.0.0rc0
+          PANDAS_VERSION: 3
         python_312_latest:
           python.version: '3.12'
           python.architecture: 'x64'


### PR DESCRIPTION
Test with repeated warnings control can fail on free-threaded

- [ ] closes #xxxx
- [ ] tests added / passed. 
- [ ] code/documentation is well formatted.  
- [ ] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
