### PR TITLE
FIX: anova_lm silently returns NaN p-values when models are passed in reverse order

### DIFF
--- a/statsmodels/stats/anova.py
+++ b/statsmodels/stats/anova.py
@@ -384,6 +384,12 @@ def anova_lm(*args, **kwargs):
     table["ssr"] = [mdl.ssr for mdl in args]
     table["df_resid"] = [mdl.df_resid for mdl in args]
     table.loc[table.index[1:], "df_diff"] = -np.diff(table["df_resid"].values)
+    if np.any(table["df_diff"].dropna() < 0):
+        raise ValueError(
+            "Models must be passed in order of increasing complexity "
+            "(decreasing residual degrees of freedom). "
+            "Ensure the most restricted model is passed first."
+        )
     table["ss_diff"] = -table["ssr"].diff()
     if test == "F":
         table["F"] = table["ss_diff"] / table["df_diff"] / scale

--- a/statsmodels/stats/tests/test_anova.py
+++ b/statsmodels/stats/tests/test_anova.py
@@ -1,5 +1,7 @@
 from io import StringIO
 
+import pytest
+import pandas as pd
 import numpy as np
 from pandas import read_csv
 
@@ -470,3 +472,37 @@ class TestAnova3HC3(TestAnovaLM):
 
         np.testing.assert_almost_equal(results["F"].values, F, 4)
         np.testing.assert_almost_equal(results["PR(>F)"].values, PrF)
+
+
+def test_anova_lm_model_order_error():
+    # Models passed in decreasing order of complexity should raise,
+    # rather than silently producing NaN via negative df_diff.
+    np.random.seed(42)
+    df = pd.DataFrame({
+        "y": np.random.randn(50),
+        "x1": np.random.randn(50),
+        "x2": np.random.randn(50),
+    })
+
+    model_small = ols("y ~ x1", data=df).fit()
+    model_large = ols("y ~ x1 + x2", data=df).fit()
+
+    error_msg = "Models must be passed in order of increasing complexity"
+    with pytest.raises(ValueError, match=error_msg):
+        anova_lm(model_large, model_small)
+
+
+def test_anova_lm_model_order_correct():
+    # Correct order should not raise and should produce a real p-value.
+    np.random.seed(42)
+    df = pd.DataFrame({
+        "y": np.random.randn(50),
+        "x1": np.random.randn(50),
+        "x2": np.random.randn(50),
+    })
+
+    model_small = ols("y ~ x1", data=df).fit()
+    model_large = ols("y ~ x1 + x2", data=df).fit()
+
+    result = anova_lm(model_small, model_large)
+    assert not np.isnan(result["Pr(>F)"].iloc[-1])

--- a/statsmodels/stats/tests/test_anova.py
+++ b/statsmodels/stats/tests/test_anova.py
@@ -1,9 +1,9 @@
 from io import StringIO
 
-import pytest
-import pandas as pd
 import numpy as np
+import pandas as pd
 from pandas import read_csv
+import pytest
 
 from statsmodels.formula.api import ols
 from statsmodels.stats.anova import anova_lm


### PR DESCRIPTION
- [x] closes #9851
- [x] tests added / passed.
- [x] code/documentation is well formatted.
- [x] properly formatted commit message. See
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message).

## Description

`anova_lm` expects nested models to be passed smallest first, largest second.
If passed in the opposite order, `df_diff` becomes negative, which is silently
passed into `scipy.stats.f.sf` and returns `NaN` for `Pr(>F)` with no warning
or exception raised.

This PR adds a check that raises a clear `ValueError` when models are passed
out of order, instead of silently producing `NaN`.

## Reproduction of the original bug

```python
import numpy as np
import pandas as pd
from statsmodels.formula.api import ols
from statsmodels.stats.anova import anova_lm

np.random.seed(42)
df = pd.DataFrame({
    'y': np.random.randn(50),
    'x1': np.random.randn(50),
    'x2': np.random.randn(50)
})

model_small = ols('y ~ x1', data=df).fit()
model_large = ols('y ~ x1 + x2', data=df).fit()

anova_lm(model_large, model_small)  # silently returns NaN for Pr(>F)
```

## Changes
- `statsmodels/stats/anova.py`: raise `ValueError` when any `df_diff` is negative
- `statsmodels/stats/tests/test_anova.py`: regression tests for both the
  error case (reverse order raises) and the correct-order case (still
  produces a valid p-value)

## Testing
All existing tests in `test_anova.py` pass (17/17), including the two new ones.