### PR TITLE
BUG: set k_exog_user on SVARResults so summary() works (GH#8025)

### DIFF
--- a/statsmodels/tsa/vector_ar/svar_model.py
+++ b/statsmodels/tsa/vector_ar/svar_model.py
@@ -579,6 +579,7 @@ class SVARResults(SVARProcess, VARResults):
             trendorder = None
         self.k_trend = k_trend
         self.k_exog = k_trend  # now (0.9) required by VARProcess
+        self.k_exog_user = 0
         self.trendorder = trendorder
 
         self.exog_names = util.make_lag_names(names, lag_order, k_trend)

--- a/statsmodels/tsa/vector_ar/tests/test_svar.py
+++ b/statsmodels/tsa/vector_ar/tests/test_svar.py
@@ -103,3 +103,12 @@ def test_oneparam():
 
     # regression number
     assert_allclose(results.A[0, 1], -0.075818, atol=1e-5)
+
+
+def test_summary_no_user_exog():
+    np.random.seed(0)
+    data = np.random.randn(200, 3)
+    B = np.asarray([[1, "E", "E"], [0, 1, "E"], [0, 0, 1]], dtype="U")
+    results = SVAR(data, svar_type="B", B=B).fit(maxlags=2, solver="newton")
+    assert results.k_exog_user == 0
+    results.summary()


### PR DESCRIPTION
- [x] closes #8025
- [x] tests added / passed.
- [x] code/documentation is well formatted.
- [x] properly formatted commit message.

## What

`SVARResults.summary()` raises `AttributeError: 'SVARResults' object has no attribute 'k_exog_user'`.

```python
import numpy as np
from statsmodels.tsa.vector_ar.svar_model import SVAR

data = np.random.RandomState(0).randn(200, 3)
B = np.asarray([[1, "E", "E"], [0, 1, "E"], [0, 0, 1]], dtype="U")
res = SVAR(data, svar_type="B", B=B).fit(maxlags=2, solver="newton")
res.summary()   # AttributeError
```

## Why

`SVARResults(SVARProcess, VARResults)` calls `super().__init__(...)`, which resolves via the MRO to `SVARProcess.__init__` and never chains to `VARProcess.__init__` — the only place that sets `k_exog_user` (`var_model.py`). The summary path reads it in `output.py`:

```python
dim = k * model.k_ar + model.k_trend + model.k_exog_user
```

so the attribute is missing and `summary()` crashes.

## Fix

SVAR exposes no user-supplied exog, so set `self.k_exog_user = 0` in `SVARResults.__init__`. This matches the default in `VARProcess` and the maintainer's suggestion in the issue ("`k_exog_user` could be just set to 0 in SVAR").

## Test

Added `test_summary_no_user_exog`, which fails on `main` with the `AttributeError` above and passes with this change.