### PR TITLE
BUG: fix Binomial.deriv() to return 1 - 2*mu/n (missing division by n)

### DIFF
--- a/statsmodels/genmod/families/tests/test_family.py
+++ b/statsmodels/genmod/families/tests/test_family.py
@@ -146,3 +146,29 @@ def test_binomial_loglike_obs(mu, endog):
     else:
         # For our purposes, -40 is "approximately" -inf
         assert ll < -40
+
+
+def test_binomial_varfunc_deriv():
+    """Regression: Binomial.deriv should return 1 - 2*p where p = _clean(mu/n).
+
+    Prior to the fix, deriv returned 1 - 2*mu (correct only for n=1).
+    For n > 1 the formula was wrong; this test covers the general case.
+    """
+    from statsmodels.genmod.families.varfuncs import Binomial as BinomialVar
+
+    # n=10: deriv(mu) = 1 - 2*_clean(mu/10)
+    bv = BinomialVar(n=10)
+    mu_vals = np.array([1.0, 2.0, 5.0, 8.0])
+    expected = 1 - 2 * bv._clean(mu_vals / 10)
+    assert_allclose(bv.deriv(mu_vals), expected)
+
+    # n=1 (Bernoulli): old and new formula agree
+    bv1 = BinomialVar(n=1)
+    mu_01 = np.array([0.1, 0.3, 0.7, 0.9])
+    assert_allclose(bv1.deriv(mu_01), 1 - 2 * mu_01, rtol=1e-10)
+
+    # Finite-difference numerical check against V'(mu)
+    h = 1e-5
+    mu0 = 3.0
+    numerical = (bv(mu0 + h) - bv(mu0 - h)) / (2 * h)
+    assert_allclose(bv.deriv(mu0), numerical, rtol=1e-4)

--- a/statsmodels/genmod/families/varfuncs.py
+++ b/statsmodels/genmod/families/varfuncs.py
@@ -199,12 +199,13 @@ class Binomial:
     # TODO: inherit from super
     def deriv(self, mu):
         """
-        Derivative of the variance function v'(mu).
+        Derivative of the variance function V'(mu).
 
-        For the Binomial variance V(mu) = mu*(1 - mu/n), the derivative is
-        dV/dmu = 1 - 2*mu/n.
+        For the Binomial variance V(mu) = p*(1 - p)*n where p = mu/n, the
+        derivative with respect to mu is dV/dmu = 1 - 2*p.
         """
-        return 1 - 2 * mu / self.n
+        p = self._clean(mu / self.n)
+        return 1 - 2 * p
 
 
 binary = Binomial()

--- a/statsmodels/genmod/families/varfuncs.py
+++ b/statsmodels/genmod/families/varfuncs.py
@@ -199,9 +199,12 @@ class Binomial:
     # TODO: inherit from super
     def deriv(self, mu):
         """
-        Derivative of the variance function v'(mu)
+        Derivative of the variance function v'(mu).
+
+        For the Binomial variance V(mu) = mu*(1 - mu/n), the derivative is
+        dV/dmu = 1 - 2*mu/n.
         """
-        return 1 - 2*mu
+        return 1 - 2 * mu / self.n
 
 
 binary = Binomial()


### PR DESCRIPTION
## Summary

Fixes #9860.

`Binomial.deriv(mu)` in `statsmodels/genmod/families/varfuncs.py` returns the wrong derivative of the binomial variance function.

### Math

The binomial variance is:

```
V(mu) = n * p * (1 - p)   where p = mu / n
      = mu * (1 - mu/n)
```

So the derivative is:

```
dV/dmu = 1 - 2*mu/n
```

The old code returned `1 - 2*mu`, which is only correct for `n=1` (the `binary` alias). For any `n > 1` the result was wrong by a factor of `n` in the second term.

### Before / After

```python
from statsmodels.genmod.families.varfuncs import Binomial

b10 = Binomial(n=10)

# Before (wrong)
b10.deriv(5)  # => -9  (was 1 - 2*5)

# After (correct)
b10.deriv(5)  # =>  0  (= 1 - 2*5/10)
```

### Changes

- `statsmodels/genmod/families/varfuncs.py`: fix `Binomial.deriv` return value from `1 - 2*mu` to `1 - 2 * mu / self.n`; update docstring to show the formula derivation