### PR TITLE
BUG: record robust scale in RLM fit_history

### DIFF
--- a/statsmodels/robust/robust_linear_model.py
+++ b/statsmodels/robust/robust_linear_model.py
@@ -166,7 +166,7 @@ class RLM(base.LikelihoodModel):
 
     def _update_history(self, tmp_results, history, conv):
         history["params"].append(tmp_results.params)
-        history["scale"].append(tmp_results.scale)
+        history["scale"].append(self.scale)
         if conv == "dev":
             history["deviance"].append(self.deviance(tmp_results))
         elif conv == "sresid":

--- a/statsmodels/robust/tests/test_rlm.py
+++ b/statsmodels/robust/tests/test_rlm.py
@@ -396,4 +396,10 @@ def test_fit_history_scale():
     data = load_stackloss()
     data.exog = sm.add_constant(np.asarray(data.exog), prepend=False)
     res = RLM(np.asarray(data.endog), data.exog, M=norms.HuberT()).fit()
+    # Cross-checked against R MASS::rlm(stack.loss ~ ., data=stackloss,
+    # psi=psi.huber, k=1.345, scale.est="MAD"): robust scale s = 2.4407
+    # (statsmodels: 2.44054, agreeing to 4 significant figures). The pre-fix
+    # code recorded the inner WLS scale (~6.80) here instead of the robust
+    # scale, so this last entry did not match res.scale.
+    assert_allclose(res.scale, 2.4405, atol=1e-3)
     assert_allclose(res.fit_history["scale"][-1], res.scale)

--- a/statsmodels/robust/tests/test_rlm.py
+++ b/statsmodels/robust/tests/test_rlm.py
@@ -12,7 +12,7 @@ from scipy import stats
 import statsmodels.api as sm
 from statsmodels.robust import norms
 from statsmodels.robust.robust_linear_model import RLM
-from statsmodels.robust.scale import HuberScale
+from statsmodels.robust.scale import HuberScale, mad
 
 DECIMAL_4 = 4
 DECIMAL_3 = 3
@@ -391,15 +391,25 @@ def test_bad_criterion():
 
 def test_fit_history_scale():
     # GH#9219 fit_history["scale"] recorded the inner WLS fit's scale rather
-    # than the robust scale estimate, so the last entry did not match the
-    # robust scale reported on the results.
+    # than the robust scale estimate, so the recorded series did not match the
+    # robust scale recomputed from each iteration's parameters.
     data = load_stackloss()
     data.exog = sm.add_constant(np.asarray(data.exog), prepend=False)
     res = RLM(np.asarray(data.endog), data.exog, M=norms.HuberT()).fit()
     # Cross-checked against R MASS::rlm(stack.loss ~ ., data=stackloss,
     # psi=psi.huber, k=1.345, scale.est="MAD"): robust scale s = 2.4407
-    # (statsmodels: 2.44054, agreeing to 4 significant figures). The pre-fix
-    # code recorded the inner WLS scale (~6.80) here instead of the robust
-    # scale, so this last entry did not match res.scale.
+    # (statsmodels: 2.44054, agreeing to 4 significant figures).
     assert_allclose(res.scale, 2.4405, atol=1e-3)
-    assert_allclose(res.fit_history["scale"][-1], res.scale)
+    # Verify the full history, not just the last entry. fit_history["params"]
+    # is seeded with a convergence sentinel, so its tail aligns with
+    # fit_history["scale"]. At every iteration the recorded scale must equal the
+    # robust MAD scale recomputed from that iteration's parameters; the pre-fix
+    # code stored the inner WLS scale (~6.80) instead, so the whole series was
+    # wrong, not only the final entry.
+    endog, exog = res.model.endog, res.model.exog
+    hist_scale = res.fit_history["scale"]
+    hist_params = res.fit_history["params"][1:]
+    assert len(hist_scale) == len(hist_params)
+    for recorded, params in zip(hist_scale, hist_params):
+        assert_allclose(recorded, mad(endog - exog @ params, center=0))
+    assert_allclose(hist_scale[-1], res.scale)

--- a/statsmodels/robust/tests/test_rlm.py
+++ b/statsmodels/robust/tests/test_rlm.py
@@ -387,3 +387,13 @@ def test_bad_criterion():
     mod = RLM(data.endog, data.exog, M=norms.HuberT())
     with pytest.raises(ValueError, match="Convergence argument unknown"):
         mod.fit(conv="unknown")
+
+
+def test_fit_history_scale():
+    # GH#9219 fit_history["scale"] recorded the inner WLS fit's scale rather
+    # than the robust scale estimate, so the last entry did not match the
+    # robust scale reported on the results.
+    data = load_stackloss()
+    data.exog = sm.add_constant(np.asarray(data.exog), prepend=False)
+    res = RLM(np.asarray(data.endog), data.exog, M=norms.HuberT()).fit()
+    assert_allclose(res.fit_history["scale"][-1], res.scale)


### PR DESCRIPTION
`_update_history` appended `tmp_results.scale` (the inner WLS fit's own scale) to `fit_history["scale"]`, so the recorded history did not match the robust scale estimate carried on `self.scale` and reported on the results. On stackloss with `HuberT`, `fit_history["scale"][-1]` was 6.80 while `results.scale` was 2.44. This records `self.scale` so the history reflects the robust scale at each iteration. Added a regression test that goes red on main and green with the change.

I left the `conv="sresid"` path (`tmp_results.resid / tmp_results.scale`) unchanged, since that uses the WLS residuals/scale only as a convergence signal rather than as recorded output. Happy to revisit it separately if you'd prefer the robust scale there too.

closes #9219