### PR TITLE
MAINT: fix import sorting in test_weights

### DIFF
--- a/statsmodels/tsa/statespace/tests/test_weights.py
+++ b/statsmodels/tsa/statespace/tests/test_weights.py
@@ -5,13 +5,14 @@ Author: Chad Fulton
 License: Simplified-BSD
 """
 
+from statsmodels.compat.platform import PLATFORM_WIN
+
 import numpy as np
 from numpy.testing import assert_allclose, assert_equal
 import pandas as pd
 import pytest
 
 from statsmodels import datasets
-from statsmodels.compat.platform import PLATFORM_WIN
 from statsmodels.tsa.statespace import sarimax, tools, varmax
 from statsmodels.tsa.statespace.tests.test_impulse_responses import TVSS
 


### PR DESCRIPTION
`statsmodels/tsa/statespace/tests/test_weights.py` placed `from statsmodels.compat.platform import PLATFORM_WIN` in the first-party import group rather than the COMPAT section. `isort --check-only statsmodels` flags it, so the Windows `Lint` job currently fails on `main` (and on every open PR, since the lint runs over the whole package). This moves the import to the COMPAT section per the project's isort configuration; `isort --check-only` and `flake8` are both clean afterward.