### PR TITLE
Add SAVI e-values for linear regression

### DIFF
--- a/docs/source/regression.rst
+++ b/docs/source/regression.rst
@@ -39,6 +39,24 @@ Detailed examples can be found here:
 * `Recursive LS <examples/notebooks/generated/recursive_ls.ipynb>`_
 * `Rolling LS <examples/notebooks/generated/rolling_ls.ipynb>`_
 
+E-Values and Sequential Inference
+---------------------------------
+
+Fitted linear regression results provide anytime-valid sequential inference
+methods based on the fitted model's existing t and F statistics. Set
+``evalues=True`` in ``RegressionResults.summary`` to replace the classical
+p-value column in the coefficient table with e-values.
+``RegressionResults.e_values`` returns e-values for parameter-wise tests by
+default, or for a joint linear restriction when a restriction matrix or formula
+is supplied. ``RegressionResults.p_values(savi=True)`` returns reciprocal
+e-values, and ``RegressionResults.conf_int(savi=True)`` returns safe
+anytime-valid confidence intervals. ``RegressionResults.sequential_p_values``
+and ``RegressionResults.confidence_sequences`` provide explicitly sequential
+names for the same anytime-valid p-values and parameter-wise confidence
+sequences. These methods use the current covariance estimator, so results refit
+or converted using robust covariance types such as ``HC1`` use the
+corresponding robust t and F statistics.
+
 Technical Documentation
 -----------------------
 

--- a/docs/source/regression.rst
+++ b/docs/source/regression.rst
@@ -57,7 +57,11 @@ confidence sequences. This includes replacing the classical model-level F-test
 p-value with the corresponding e-value. These methods use the current
 covariance estimator, so results refit or converted using robust covariance
 types such as ``HC1`` use the corresponding robust t and F statistics. These
-methods are based on Lindon et al. (2026).
+methods are based on Lindon et al. (2026). For calibration of ``g``, see
+Remark 4.8 ("Practical choice of g") in Lindon et al. (2026), which discusses
+Bayesian, frequentist minimum detectable effect, and width-optimal choices;
+larger ``g`` values lengthen the infinite-width delayed start of confidence
+sequences.
 
 Technical Documentation
 -----------------------

--- a/docs/source/regression.rst
+++ b/docs/source/regression.rst
@@ -102,8 +102,8 @@ General reference for regression models:
 
 Anytime-valid inference for linear models:
 
-* M. Lindon et al. "Anytime-Valid Linear Models and Regression Adjusted Causal
-  Inference in Randomized Experiments." Journal of the American Statistical
+* M. Lindon et al. "Anytime-Valid Inference in Linear Models with Applications
+  to Regression-Adjusted Causal Inference." Journal of the American Statistical
   Association, 2026. https://www.tandfonline.com/doi/full/10.1080/01621459.2026.2692052
 
 Econometrics references for regression models:

--- a/docs/source/regression.rst
+++ b/docs/source/regression.rst
@@ -47,8 +47,8 @@ methods based on the fitted model's existing t and F statistics.
 ``RegressionResults.e_values`` returns e-values for parameter-wise tests by
 default, or for a joint linear restriction when a restriction matrix or formula
 is supplied. ``RegressionResults.p_values(savi=True)`` returns reciprocal
-e-values, and ``RegressionResults.conf_int(savi=True)`` returns safe
-anytime-valid confidence intervals. ``RegressionResults.sequential_p_values``
+e-values clipped at one, and ``RegressionResults.conf_int(savi=True)`` returns
+safe anytime-valid confidence intervals. ``RegressionResults.sequential_p_values``
 and ``RegressionResults.confidence_sequences`` provide explicitly sequential
 names for the same anytime-valid p-values and parameter-wise confidence
 sequences. Set ``savi=True`` in ``RegressionResults.summary`` to replace

--- a/docs/source/regression.rst
+++ b/docs/source/regression.rst
@@ -56,7 +56,8 @@ classical p-values with e-values and coefficient confidence intervals with
 confidence sequences. This includes replacing the classical model-level F-test
 p-value with the corresponding e-value. These methods use the current
 covariance estimator, so results refit or converted using robust covariance
-types such as ``HC1`` use the corresponding robust t and F statistics.
+types such as ``HC1`` use the corresponding robust t and F statistics. These
+methods are based on Lindon et al. (2026).
 
 Technical Documentation
 -----------------------
@@ -98,6 +99,12 @@ References
 General reference for regression models:
 
 * D.C. Montgomery and E.A. Peck. "Introduction to Linear Regression Analysis." 2nd. Ed., Wiley, 1992.
+
+Anytime-valid inference for linear models:
+
+* M. Lindon et al. "Anytime-Valid Linear Models and Regression Adjusted Causal
+  Inference in Randomized Experiments." Journal of the American Statistical
+  Association, 2026. https://www.tandfonline.com/doi/full/10.1080/01621459.2026.2692052
 
 Econometrics references for regression models:
 

--- a/docs/source/regression.rst
+++ b/docs/source/regression.rst
@@ -43,9 +43,7 @@ E-Values and Sequential Inference
 ---------------------------------
 
 Fitted linear regression results provide anytime-valid sequential inference
-methods based on the fitted model's existing t and F statistics. Set
-``evalues=True`` in ``RegressionResults.summary`` to replace the classical
-p-value column in the coefficient table with e-values.
+methods based on the fitted model's existing t and F statistics.
 ``RegressionResults.e_values`` returns e-values for parameter-wise tests by
 default, or for a joint linear restriction when a restriction matrix or formula
 is supplied. ``RegressionResults.p_values(savi=True)`` returns reciprocal
@@ -53,9 +51,11 @@ e-values, and ``RegressionResults.conf_int(savi=True)`` returns safe
 anytime-valid confidence intervals. ``RegressionResults.sequential_p_values``
 and ``RegressionResults.confidence_sequences`` provide explicitly sequential
 names for the same anytime-valid p-values and parameter-wise confidence
-sequences. These methods use the current covariance estimator, so results refit
-or converted using robust covariance types such as ``HC1`` use the
-corresponding robust t and F statistics.
+sequences. Set ``evalues=True`` in ``RegressionResults.summary`` to replace
+the classical p-value column in the coefficient table with e-values. These
+methods use the current covariance estimator, so results refit or converted
+using robust covariance types such as ``HC1`` use the corresponding robust t
+and F statistics.
 
 Technical Documentation
 -----------------------

--- a/docs/source/regression.rst
+++ b/docs/source/regression.rst
@@ -51,11 +51,12 @@ e-values, and ``RegressionResults.conf_int(savi=True)`` returns safe
 anytime-valid confidence intervals. ``RegressionResults.sequential_p_values``
 and ``RegressionResults.confidence_sequences`` provide explicitly sequential
 names for the same anytime-valid p-values and parameter-wise confidence
-sequences. Set ``evalues=True`` in ``RegressionResults.summary`` to replace
-the classical p-value column in the coefficient table with e-values. These
-methods use the current covariance estimator, so results refit or converted
-using robust covariance types such as ``HC1`` use the corresponding robust t
-and F statistics.
+sequences. Set ``savi=True`` in ``RegressionResults.summary`` to replace
+classical p-values with e-values and coefficient confidence intervals with
+confidence sequences. This includes replacing the classical model-level F-test
+p-value with the corresponding e-value. These methods use the current
+covariance estimator, so results refit or converted using robust covariance
+types such as ``HC1`` use the corresponding robust t and F statistics.
 
 Technical Documentation
 -----------------------

--- a/statsmodels/iolib/summary.py
+++ b/statsmodels/iolib/summary.py
@@ -387,7 +387,7 @@ def summary_top(results, title=None, gleft=None, gright=None, yname=None, xname=
 
 
 def summary_params(results, yname=None, xname=None, alpha=.05, use_t=True,
-                   skip_header=False, title=None, value_header=None):
+                   skip_header=False, title=None):
     '''create a summary table for the parameters
 
     Parameters
@@ -407,10 +407,6 @@ def summary_params(results, yname=None, xname=None, alpha=.05, use_t=True,
     skip_headers : bool
         If false (default), then the header row is added. If true, then no
         header row is added.
-    value_header : str, optional
-        If provided, replaces the p-value column header and formats the column
-        using the generic numeric formatter.
-
     Returns
     -------
     params_table : SimpleTable instance
@@ -442,8 +438,6 @@ def summary_params(results, yname=None, xname=None, alpha=.05, use_t=True,
     else:
         param_header = ["coef", "std err", "z", "P>|z|",
                         "[" + str(alpha/2), str(1-alpha/2) + "]"]
-    if value_header is not None:
-        param_header[3] = value_header
 
     if skip_header:
         param_header = None
@@ -461,14 +455,10 @@ def summary_params(results, yname=None, xname=None, alpha=.05, use_t=True,
     tvalues = np.asarray(tvalues)
     pvalues = np.asarray(pvalues)
     conf_int = np.asarray(conf_int)
-    if value_header is None:
-        value_data = ["%#6.3f" % (pvalues[i]) for i in exog_idx]
-    else:
-        value_data = [forg(pvalues[i]) for i in exog_idx]
     params_data = lzip([forg(params[i], prec=4) for i in exog_idx],
                        [forg(std_err[i]) for i in exog_idx],
                        [forg(tvalues[i]) for i in exog_idx],
-                       value_data,
+                       ["%#6.3f" % (pvalues[i]) for i in exog_idx],
                        [forg(conf_int[i, 0]) for i in exog_idx],
                        [forg(conf_int[i, 1]) for i in exog_idx])
     parameter_table = SimpleTable(params_data,

--- a/statsmodels/iolib/summary.py
+++ b/statsmodels/iolib/summary.py
@@ -387,7 +387,7 @@ def summary_top(results, title=None, gleft=None, gright=None, yname=None, xname=
 
 
 def summary_params(results, yname=None, xname=None, alpha=.05, use_t=True,
-                   skip_header=False, title=None):
+                   skip_header=False, title=None, value_header=None):
     '''create a summary table for the parameters
 
     Parameters
@@ -407,6 +407,9 @@ def summary_params(results, yname=None, xname=None, alpha=.05, use_t=True,
     skip_headers : bool
         If false (default), then the header row is added. If true, then no
         header row is added.
+    value_header : str, optional
+        If provided, replaces the p-value column header and formats the column
+        using the generic numeric formatter.
 
     Returns
     -------
@@ -439,6 +442,8 @@ def summary_params(results, yname=None, xname=None, alpha=.05, use_t=True,
     else:
         param_header = ["coef", "std err", "z", "P>|z|",
                         "[" + str(alpha/2), str(1-alpha/2) + "]"]
+    if value_header is not None:
+        param_header[3] = value_header
 
     if skip_header:
         param_header = None
@@ -456,10 +461,14 @@ def summary_params(results, yname=None, xname=None, alpha=.05, use_t=True,
     tvalues = np.asarray(tvalues)
     pvalues = np.asarray(pvalues)
     conf_int = np.asarray(conf_int)
+    if value_header is None:
+        value_data = ["%#6.3f" % (pvalues[i]) for i in exog_idx]
+    else:
+        value_data = [forg(pvalues[i]) for i in exog_idx]
     params_data = lzip([forg(params[i], prec=4) for i in exog_idx],
                        [forg(std_err[i]) for i in exog_idx],
                        [forg(tvalues[i]) for i in exog_idx],
-                       ["%#6.3f" % (pvalues[i]) for i in exog_idx],
+                       value_data,
                        [forg(conf_int[i, 0]) for i in exog_idx],
                        [forg(conf_int[i, 1]) for i in exog_idx])
     parameter_table = SimpleTable(params_data,

--- a/statsmodels/iolib/summary.py
+++ b/statsmodels/iolib/summary.py
@@ -407,6 +407,7 @@ def summary_params(results, yname=None, xname=None, alpha=.05, use_t=True,
     skip_headers : bool
         If false (default), then the header row is added. If true, then no
         header row is added.
+
     Returns
     -------
     params_table : SimpleTable instance

--- a/statsmodels/regression/linear_model.py
+++ b/statsmodels/regression/linear_model.py
@@ -1955,16 +1955,18 @@ class RegressionResults(base.LikelihoodModelResults):
         -------
         float or ndarray
             Classical p-values when ``savi`` is False. Reciprocal e-values
-            when ``savi`` is True, which can exceed one when the evidence
-            against the null is weak.
+            clipped at one when ``savi`` is True.
         """
         savi = bool_like(savi, "savi", optional=False, strict=True)
         if not savi:
             if r_matrix is None:
                 return self.pvalues
             return self.f_test(r_matrix, cov_p=cov_p, invcov=invcov).pvalue
-        return 1 / self.e_values(
-            r_matrix=r_matrix, g=g, cov_p=cov_p, invcov=invcov
+        return np.minimum(
+            1,
+            1 / self.e_values(
+                r_matrix=r_matrix, g=g, cov_p=cov_p, invcov=invcov
+            ),
         )
 
     def sequential_p_values(self, r_matrix=None, g=1.0, cov_p=None, invcov=None):
@@ -1988,8 +1990,7 @@ class RegressionResults(base.LikelihoodModelResults):
         Returns
         -------
         float or ndarray
-            Reciprocal of the e-value. Values can exceed one when the evidence
-            against the null is weak.
+            Reciprocal of the e-value, clipped at one.
         """
         return self.p_values(
             r_matrix=r_matrix, savi=True, g=g, cov_p=cov_p, invcov=invcov

--- a/statsmodels/regression/linear_model.py
+++ b/statsmodels/regression/linear_model.py
@@ -3237,7 +3237,7 @@ class RegressionResults(base.LikelihoodModelResults):
             title = self.model.__class__.__name__ + " " + "Regression Results"
 
         # create summary table instance
-        from statsmodels.iolib.summary import Summary, summary_params
+        from statsmodels.iolib.summary import Summary, forg, summary_params
 
         smry = Summary()
         smry.add_table_2cols(
@@ -3249,12 +3249,13 @@ class RegressionResults(base.LikelihoodModelResults):
             title=title,
         )
         if savi:
+            evalues = self.e_values(g=g)
             savi_results = (
                 self,
                 self.params,
                 self.bse,
                 self.tvalues,
-                self.e_values(g=g),
+                evalues,
                 self.conf_int(alpha, savi=True, g=g),
             )
             table = summary_params(
@@ -3263,8 +3264,11 @@ class RegressionResults(base.LikelihoodModelResults):
                 xname=xname,
                 alpha=alpha,
                 use_t=self.use_t,
-                value_header="e",
             )
+            if np.size(evalues):
+                table[0][4].data = "e"
+                for row, evalue in zip(table[1:], np.asarray(evalues).ravel()):
+                    row[4].data = forg(evalue)
             smry.tables.append(table)
         else:
             smry.add_table_params(

--- a/statsmodels/regression/linear_model.py
+++ b/statsmodels/regression/linear_model.py
@@ -2001,6 +2001,13 @@ class RegressionResults(base.LikelihoodModelResults):
         -------
         float or ndarray
             Reciprocal of the e-value, clipped at one.
+
+        Notes
+        -----
+        Classical p-values control Type I error at a fixed sample size.
+        Sequential p-values are valid under continuous monitoring:
+
+        ``P_H0(exists n such that p_n <= alpha) <= alpha``.
         """
         return self.p_values(
             r_matrix=r_matrix, savi=True, g=g, cov_p=cov_p, invcov=invcov
@@ -2023,6 +2030,13 @@ class RegressionResults(base.LikelihoodModelResults):
         array_like
             Each row contains [lower, upper] limits for the corresponding
             parameter at the current sample size.
+
+        Notes
+        -----
+        Classical confidence intervals cover the parameter at a fixed sample
+        size. Confidence sequences provide time-uniform coverage:
+
+        ``P(theta in C_n^alpha for all n) >= 1 - alpha``.
         """
         return self.conf_int(alpha=alpha, savi=True, g=g)
 

--- a/statsmodels/regression/linear_model.py
+++ b/statsmodels/regression/linear_model.py
@@ -80,19 +80,19 @@ __all__ = [
 dtrtri = get_lapack_funcs("trtri", dtype="float64", ilp64="preferred")
 
 
-def _check_sequential_g(g):
+def _check_evalue_g(g):
     g = float_like(g, "g")
     if g <= 0:
         raise ValueError("g must be positive")
     return g
 
 
-def _sequential_evalue(fvalue, df_num, df_denom, nobs, g):
+def _evalue_from_f_stat(fvalue, df_num, df_denom, nobs, g):
     fvalue = np.asarray(fvalue)
     df_num = float_like(df_num, "df_num")
     df_denom = float_like(df_denom, "df_denom")
     nobs = float_like(nobs, "nobs")
-    g = _check_sequential_g(g)
+    g = _check_evalue_g(g)
     if df_num <= 0:
         raise ValueError("df_num must be positive")
     if df_denom <= 0:
@@ -110,14 +110,14 @@ def _sequential_evalue(fvalue, df_num, df_denom, nobs, g):
     return np.exp(log_evalue)
 
 
-def _sequential_confidence_radius(alpha, g, nobs, df_num, df_denom):
+def _savi_confidence_radius(alpha, g, nobs, df_num, df_denom):
     alpha = float_like(alpha, "alpha")
     if alpha <= 0 or alpha >= 1:
         raise ValueError("alpha must be between 0 and 1")
     df_num = float_like(df_num, "df_num")
     df_denom = float_like(df_denom, "df_denom")
     nobs = float_like(nobs, "nobs")
-    g = _check_sequential_g(g)
+    g = _check_evalue_g(g)
     if df_num <= 0:
         raise ValueError("df_num must be positive")
     if df_denom <= 0:
@@ -1862,7 +1862,7 @@ class RegressionResults(base.LikelihoodModelResults):
             return ci
 
         df_denom = getattr(self, "df_resid_inference", self.df_resid)
-        radius = _sequential_confidence_radius(
+        radius = _savi_confidence_radius(
             alpha, g, self.nobs, 1.0, df_denom
         )
         q = np.sqrt(radius)
@@ -1925,7 +1925,7 @@ class RegressionResults(base.LikelihoodModelResults):
             fvalue = fres.fvalue
             df_num = fres.df_num
             df_denom = fres.df_denom
-        return _sequential_evalue(fvalue, df_num, df_denom, self.nobs, g)
+        return _evalue_from_f_stat(fvalue, df_num, df_denom, self.nobs, g)
 
     def p_values(
         self, r_matrix=None, savi=False, g=1.0, cov_p=None, invcov=None
@@ -3125,7 +3125,7 @@ class RegressionResults(base.LikelihoodModelResults):
         slim = bool_like(slim, "slim", optional=False, strict=True)
         evalues = bool_like(evalues, "evalues", optional=False, strict=True)
         if evalues:
-            g = _check_sequential_g(g)
+            g = _check_evalue_g(g)
 
         eigvals = self.eigenvals
         condno = self.condition_number

--- a/statsmodels/regression/linear_model.py
+++ b/statsmodels/regression/linear_model.py
@@ -93,12 +93,6 @@ def _evalue_from_f_stat(fvalue, df_num, df_denom, nobs, g):
     df_denom = float_like(df_denom, "df_denom")
     nobs = float_like(nobs, "nobs")
     g = _check_evalue_g(g)
-    if df_num <= 0:
-        raise ValueError("df_num must be positive")
-    if df_denom <= 0:
-        raise ValueError("df_denom must be positive")
-    if nobs <= 0:
-        raise ValueError("nobs must be positive")
 
     g_ratio = g / (g + nobs)
     stat_ratio = df_num / df_denom * fvalue
@@ -118,12 +112,6 @@ def _savi_confidence_radius(alpha, g, nobs, df_num, df_denom):
     df_denom = float_like(df_denom, "df_denom")
     nobs = float_like(nobs, "nobs")
     g = _check_evalue_g(g)
-    if df_num <= 0:
-        raise ValueError("df_num must be positive")
-    if df_denom <= 0:
-        raise ValueError("df_denom must be positive")
-    if nobs <= 0:
-        raise ValueError("nobs must be positive")
 
     g_ratio = g / (g + nobs)
     boundary = (alpha ** (2 / df_num) * g_ratio) ** (
@@ -1841,7 +1829,10 @@ class RegressionResults(base.LikelihoodModelResults):
             intervals by inverting e-values. Default is False.
         g : float, optional
             Positive tuning parameter used when ``savi`` is True. The default
-            is 1.
+            is 1. See Remark 4.8 ("Practical choice of g") in Lindon et al.
+            (2026) for Bayesian, frequentist minimum detectable effect, and
+            width-optimal calibrations; larger ``g`` values lengthen the
+            infinite-width delayed start of confidence sequences.
 
         Returns
         -------
@@ -1856,21 +1847,6 @@ class RegressionResults(base.LikelihoodModelResults):
 
         """
         savi = bool_like(savi, "savi", optional=False, strict=True)
-        if not savi:
-            # keep method for docstring for now
-            ci = super().conf_int(alpha=alpha, cols=cols)
-            return ci
-
-        df_denom = getattr(self, "df_resid_inference", self.df_resid)
-        radius = _savi_confidence_radius(
-            alpha, g, self.nobs, 1.0, df_denom
-        )
-        q = np.sqrt(radius)
-        bse = self.bse
-        err = q * bse
-        err = np.where(bse == 0, 0, err)
-        lower = self.params - err
-        upper = self.params + err
         if cols is not None:
             warnings.warn(
                 "cols is deprecated and will be removed after 0.14 is "
@@ -1882,8 +1858,25 @@ class RegressionResults(base.LikelihoodModelResults):
                 stacklevel=2,
             )
             cols = np.asarray(cols)
-            lower = lower[cols]
-            upper = upper[cols]
+        if savi:
+            ci = self._savi_conf_int(alpha=alpha, g=g)
+        else:
+            ci = super().conf_int(alpha=alpha)
+        if cols is not None:
+            ci = ci[cols]
+        return ci
+
+    def _savi_conf_int(self, alpha=0.05, g=1.0):
+        df_denom = getattr(self, "df_resid_inference", self.df_resid)
+        radius = _savi_confidence_radius(
+            alpha, g, self.nobs, 1.0, df_denom
+        )
+        q = np.sqrt(radius)
+        bse = self.bse
+        err = q * bse
+        err = np.where(bse == 0, 0, err)
+        lower = self.params - err
+        upper = self.params + err
         return np.asarray(lzip(lower, upper))
 
     def e_values(self, r_matrix=None, g=1.0, cov_p=None, invcov=None):
@@ -1896,7 +1889,11 @@ class RegressionResults(base.LikelihoodModelResults):
             Linear restriction passed to ``f_test``. If None, returns
             parameter-wise e-values using the squared t-statistics.
         g : float, optional
-            Positive tuning parameter for the mixture. The default is 1.
+            Positive tuning parameter for the mixture. The default is 1. See
+            Remark 4.8 ("Practical choice of g") in Lindon et al. (2026) for
+            Bayesian, frequentist minimum detectable effect, and width-optimal
+            calibrations; larger ``g`` values lengthen the infinite-width
+            delayed start of confidence sequences.
         cov_p : array_like, optional
             Alternative estimate for the parameter covariance matrix passed
             to ``f_test`` when ``r_matrix`` is not None.
@@ -1912,9 +1909,12 @@ class RegressionResults(base.LikelihoodModelResults):
 
         Notes
         -----
-        The calculation uses the asymptotic ``g`` expression applied to the
-        existing t or F statistic from the fitted model. If robust covariance
-        is active on the results instance, the robust covariance is used.
+        The calculation implements the ``g``-prior approximation
+        ``G_n`` in Equation (17) of Lindon et al. (2026), rather than the
+        exact ``E_n`` in Equation (9). If robust covariance is active on the
+        results instance, the same t or F statistic plug-in corresponds to
+        the heteroskedastic asymptotic e-process in Equation (22), which
+        recovers Equation (17) when ``Q_n / r`` is the usual F statistic.
 
         References
         ----------
@@ -1953,7 +1953,10 @@ class RegressionResults(base.LikelihoodModelResults):
             e-values. Default is False.
         g : float, optional
             Positive tuning parameter used when ``savi`` is True. The default
-            is 1.
+            is 1. See Remark 4.8 ("Practical choice of g") in Lindon et al.
+            (2026) for Bayesian, frequentist minimum detectable effect, and
+            width-optimal calibrations; larger ``g`` values lengthen the
+            infinite-width delayed start of confidence sequences.
         cov_p : array_like, optional
             Alternative estimate for the parameter covariance matrix passed
             to ``f_test`` or ``e_values`` when ``r_matrix`` is not None.
@@ -1989,7 +1992,11 @@ class RegressionResults(base.LikelihoodModelResults):
             Linear restriction passed to ``f_test``. If None, returns
             parameter-wise p-values using the squared t-statistics.
         g : float, optional
-            Positive tuning parameter for the mixture. The default is 1.
+            Positive tuning parameter for the mixture. The default is 1. See
+            Remark 4.8 ("Practical choice of g") in Lindon et al. (2026) for
+            Bayesian, frequentist minimum detectable effect, and width-optimal
+            calibrations; larger ``g`` values lengthen the infinite-width
+            delayed start of confidence sequences.
         cov_p : array_like, optional
             Alternative estimate for the parameter covariance matrix passed
             to ``f_test`` when ``r_matrix`` is not None.
@@ -2023,7 +2030,11 @@ class RegressionResults(base.LikelihoodModelResults):
             The significance level for the confidence sequences. The default
             `alpha` = .05 returns 95% confidence sequences.
         g : float, optional
-            Positive tuning parameter for the mixture. The default is 1.
+            Positive tuning parameter for the mixture. The default is 1. See
+            Remark 4.8 ("Practical choice of g") in Lindon et al. (2026) for
+            Bayesian, frequentist minimum detectable effect, and width-optimal
+            calibrations; larger ``g`` values lengthen the infinite-width
+            delayed start of confidence sequences.
 
         Returns
         -------
@@ -2038,7 +2049,7 @@ class RegressionResults(base.LikelihoodModelResults):
 
         ``P(theta in C_n^alpha for all n) >= 1 - alpha``.
         """
-        return self.conf_int(alpha=alpha, savi=True, g=g)
+        return self._savi_conf_int(alpha=alpha, g=g)
 
     @cache_readonly
     def nobs(self):
@@ -3119,11 +3130,14 @@ class RegressionResults(base.LikelihoodModelResults):
             Default is False.
         savi : bool, optional
             If True, replace classical p-values with e-values and coefficient
-            confidence intervals with confidence sequences computed using the
-            asymptotic ``g`` expression. Default is False.
+            confidence intervals with confidence sequences computed from the
+            fitted model's t and F statistics. Default is False.
         g : float, optional
             Positive tuning parameter used when ``savi`` is True. The default
-            is 1.
+            is 1. See Remark 4.8 ("Practical choice of g") in Lindon et al.
+            (2026) for Bayesian, frequentist minimum detectable effect, and
+            width-optimal calibrations; larger ``g`` values lengthen the
+            infinite-width delayed start of confidence sequences.
 
         Returns
         -------

--- a/statsmodels/regression/linear_model.py
+++ b/statsmodels/regression/linear_model.py
@@ -1915,6 +1915,16 @@ class RegressionResults(base.LikelihoodModelResults):
         The calculation uses the asymptotic ``g`` expression applied to the
         existing t or F statistic from the fitted model. If robust covariance
         is active on the results instance, the robust covariance is used.
+
+        References
+        ----------
+        .. [1] Lindon et al. (2026). Anytime-Valid Linear Models and
+           Regression Adjusted Causal Inference in Randomized Experiments.
+           Journal of the American Statistical Association.
+           https://www.tandfonline.com/doi/full/10.1080/01621459.2026.2692052
+
+        .. [2] Lindon, M. avlm: Anytime-Valid Linear Models. CRAN.
+           https://cran.r-project.org/web/packages/avlm/index.html
         """
         df_denom = getattr(self, "df_resid_inference", self.df_resid)
         if r_matrix is None:

--- a/statsmodels/regression/linear_model.py
+++ b/statsmodels/regression/linear_model.py
@@ -1918,8 +1918,8 @@ class RegressionResults(base.LikelihoodModelResults):
 
         References
         ----------
-        .. [1] Lindon et al. (2026). Anytime-Valid Linear Models and
-           Regression Adjusted Causal Inference in Randomized Experiments.
+        .. [1] Lindon et al. (2026). Anytime-Valid Inference in Linear Models
+           with Applications to Regression-Adjusted Causal Inference.
            Journal of the American Statistical Association.
            https://www.tandfonline.com/doi/full/10.1080/01621459.2026.2692052
 

--- a/statsmodels/regression/linear_model.py
+++ b/statsmodels/regression/linear_model.py
@@ -79,6 +79,62 @@ __all__ = [
 
 dtrtri = get_lapack_funcs("trtri", dtype="float64", ilp64="preferred")
 
+
+def _check_sequential_g(g):
+    g = float_like(g, "g")
+    if g <= 0:
+        raise ValueError("g must be positive")
+    return g
+
+
+def _sequential_evalue(fvalue, df_num, df_denom, nobs, g):
+    fvalue = np.asarray(fvalue)
+    df_num = float_like(df_num, "df_num")
+    df_denom = float_like(df_denom, "df_denom")
+    nobs = float_like(nobs, "nobs")
+    g = _check_sequential_g(g)
+    if df_num <= 0:
+        raise ValueError("df_num must be positive")
+    if df_denom <= 0:
+        raise ValueError("df_denom must be positive")
+    if nobs <= 0:
+        raise ValueError("nobs must be positive")
+
+    g_ratio = g / (g + nobs)
+    stat_ratio = df_num / df_denom * fvalue
+    log_evalue = (
+        df_num / 2 * np.log(g_ratio)
+        - (df_denom + df_num) / 2
+        * (np.log1p(g_ratio * stat_ratio) - np.log1p(stat_ratio))
+    )
+    return np.exp(log_evalue)
+
+
+def _sequential_confidence_radius(alpha, g, nobs, df_num, df_denom):
+    alpha = float_like(alpha, "alpha")
+    if alpha <= 0 or alpha >= 1:
+        raise ValueError("alpha must be between 0 and 1")
+    df_num = float_like(df_num, "df_num")
+    df_denom = float_like(df_denom, "df_denom")
+    nobs = float_like(nobs, "nobs")
+    g = _check_sequential_g(g)
+    if df_num <= 0:
+        raise ValueError("df_num must be positive")
+    if df_denom <= 0:
+        raise ValueError("df_denom must be positive")
+    if nobs <= 0:
+        raise ValueError("nobs must be positive")
+
+    g_ratio = g / (g + nobs)
+    boundary = (alpha ** (2 / df_num) * g_ratio) ** (
+        df_num / (df_denom + df_num)
+    )
+    denom = boundary - g_ratio
+    if denom <= 0:
+        return np.inf
+    return df_denom / df_num * (1 - boundary) / denom
+
+
 _fit_regularized_doc = r"""
         Return a regularized fit to a linear regression model.
 
@@ -1769,7 +1825,7 @@ class RegressionResults(base.LikelihoodModelResults):
         for key, value in kwargs.items():
             setattr(self, key, value)
 
-    def conf_int(self, alpha=0.05, cols=None):
+    def conf_int(self, alpha=0.05, cols=None, savi=False, g=1.0):
         """
         Compute the confidence interval of the fitted parameters.
 
@@ -1780,6 +1836,12 @@ class RegressionResults(base.LikelihoodModelResults):
             `alpha` = .05 returns a 95% confidence interval.
         cols : array_like, optional
             Columns to include in returned confidence intervals.
+        savi : bool, optional
+            If True, compute safe anytime-valid inference confidence
+            intervals by inverting e-values. Default is False.
+        g : float, optional
+            Positive tuning parameter used when ``savi`` is True. The default
+            is 1.
 
         Returns
         -------
@@ -1788,12 +1850,170 @@ class RegressionResults(base.LikelihoodModelResults):
 
         Notes
         -----
-        The confidence interval is based on Student's t-distribution.
+        The fixed-n confidence interval uses Student's t or normal inference
+        according to ``use_t``. If ``savi`` is True, the interval is obtained
+        by inverting e-values.
 
         """
-        # keep method for docstring for now
-        ci = super().conf_int(alpha=alpha, cols=cols)
-        return ci
+        savi = bool_like(savi, "savi", optional=False, strict=True)
+        if not savi:
+            # keep method for docstring for now
+            ci = super().conf_int(alpha=alpha, cols=cols)
+            return ci
+
+        df_denom = getattr(self, "df_resid_inference", self.df_resid)
+        radius = _sequential_confidence_radius(
+            alpha, g, self.nobs, 1.0, df_denom
+        )
+        q = np.sqrt(radius)
+        bse = self.bse
+        err = q * bse
+        err = np.where(bse == 0, 0, err)
+        lower = self.params - err
+        upper = self.params + err
+        if cols is not None:
+            warnings.warn(
+                "cols is deprecated and will be removed after 0.14 is "
+                "released. cols only works when inputs are NumPy arrays and "
+                "will fail when using pandas Series or DataFrames as input. "
+                "Subsets of confidence intervals can be selected using slices "
+                "of the full confidence interval array.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            cols = np.asarray(cols)
+            lower = lower[cols]
+            upper = upper[cols]
+        return np.asarray(lzip(lower, upper))
+
+    def e_values(self, r_matrix=None, g=1.0, cov_p=None, invcov=None):
+        """
+        Compute asymptotic e-values for linear hypotheses.
+
+        Parameters
+        ----------
+        r_matrix : {array_like, str, tuple}, optional
+            Linear restriction passed to ``f_test``. If None, returns
+            parameter-wise e-values using the squared t-statistics.
+        g : float, optional
+            Positive tuning parameter for the mixture. The default is 1.
+        cov_p : array_like, optional
+            Alternative estimate for the parameter covariance matrix passed
+            to ``f_test`` when ``r_matrix`` is not None.
+        invcov : array_like, optional
+            Inverse covariance matrix passed to ``f_test`` when ``r_matrix``
+            is not None.
+
+        Returns
+        -------
+        float or ndarray
+            E-value for the requested test. Returns one value per parameter if
+            ``r_matrix`` is None.
+
+        Notes
+        -----
+        The calculation uses the asymptotic ``g`` expression applied to the
+        existing t or F statistic from the fitted model. If robust covariance
+        is active on the results instance, the robust covariance is used.
+        """
+        df_denom = getattr(self, "df_resid_inference", self.df_resid)
+        if r_matrix is None:
+            fvalue = self.tvalues**2
+            df_num = 1.0
+        else:
+            fres = self.f_test(r_matrix, cov_p=cov_p, invcov=invcov)
+            fvalue = fres.fvalue
+            df_num = fres.df_num
+            df_denom = fres.df_denom
+        return _sequential_evalue(fvalue, df_num, df_denom, self.nobs, g)
+
+    def p_values(
+        self, r_matrix=None, savi=False, g=1.0, cov_p=None, invcov=None
+    ):
+        """
+        Compute p-values for linear hypotheses.
+
+        Parameters
+        ----------
+        r_matrix : {array_like, str, tuple}, optional
+            Linear restriction passed to ``f_test``. If None, returns
+            parameter-wise p-values.
+        savi : bool, optional
+            If True, compute safe anytime-valid p-values from reciprocal
+            e-values. Default is False.
+        g : float, optional
+            Positive tuning parameter used when ``savi`` is True. The default
+            is 1.
+        cov_p : array_like, optional
+            Alternative estimate for the parameter covariance matrix passed
+            to ``f_test`` or ``e_values`` when ``r_matrix`` is not None.
+        invcov : array_like, optional
+            Inverse covariance matrix passed to ``f_test`` or ``e_values``
+            when ``r_matrix`` is not None.
+
+        Returns
+        -------
+        float or ndarray
+            Classical p-values when ``savi`` is False. Reciprocal e-values
+            when ``savi`` is True, which can exceed one when the evidence
+            against the null is weak.
+        """
+        savi = bool_like(savi, "savi", optional=False, strict=True)
+        if not savi:
+            if r_matrix is None:
+                return self.pvalues
+            return self.f_test(r_matrix, cov_p=cov_p, invcov=invcov).pvalue
+        return 1 / self.e_values(
+            r_matrix=r_matrix, g=g, cov_p=cov_p, invcov=invcov
+        )
+
+    def sequential_p_values(self, r_matrix=None, g=1.0, cov_p=None, invcov=None):
+        """
+        Compute anytime-valid p-values from reciprocal e-values.
+
+        Parameters
+        ----------
+        r_matrix : {array_like, str, tuple}, optional
+            Linear restriction passed to ``f_test``. If None, returns
+            parameter-wise p-values using the squared t-statistics.
+        g : float, optional
+            Positive tuning parameter for the mixture. The default is 1.
+        cov_p : array_like, optional
+            Alternative estimate for the parameter covariance matrix passed
+            to ``f_test`` when ``r_matrix`` is not None.
+        invcov : array_like, optional
+            Inverse covariance matrix passed to ``f_test`` when ``r_matrix``
+            is not None.
+
+        Returns
+        -------
+        float or ndarray
+            Reciprocal of the e-value. Values can exceed one when the evidence
+            against the null is weak.
+        """
+        return self.p_values(
+            r_matrix=r_matrix, savi=True, g=g, cov_p=cov_p, invcov=invcov
+        )
+
+    def confidence_sequences(self, alpha=0.05, g=1.0):
+        """
+        Compute parameter-wise asymptotic confidence sequences.
+
+        Parameters
+        ----------
+        alpha : float, optional
+            The significance level for the confidence sequences. The default
+            `alpha` = .05 returns 95% confidence sequences.
+        g : float, optional
+            Positive tuning parameter for the mixture. The default is 1.
+
+        Returns
+        -------
+        array_like
+            Each row contains [lower, upper] limits for the corresponding
+            parameter at the current sample size.
+        """
+        return self.conf_int(alpha=alpha, savi=True, g=g)
 
     @cache_readonly
     def nobs(self):
@@ -2849,6 +3069,8 @@ class RegressionResults(base.LikelihoodModelResults):
         title: str | None = None,
         alpha: float = 0.05,
         slim: bool = False,
+        evalues: bool = False,
+        g: float = 1.0,
     ):
         """
         Summarize the Regression Results.
@@ -2869,6 +3091,13 @@ class RegressionResults(base.LikelihoodModelResults):
         slim : bool, optional
             Flag indicating to produce reduced set or diagnostic information.
             Default is False.
+        evalues : bool, optional
+            If True, replace the classical p-value column in the coefficient
+            table with e-values computed using the asymptotic ``g`` expression.
+            Default is False.
+        g : float, optional
+            Positive tuning parameter used to compute e-values. The default is
+            1.
 
         Returns
         -------
@@ -2894,6 +3123,9 @@ class RegressionResults(base.LikelihoodModelResults):
 
         alpha = float_like(alpha, "alpha", optional=False)
         slim = bool_like(slim, "slim", optional=False, strict=True)
+        evalues = bool_like(evalues, "evalues", optional=False, strict=True)
+        if evalues:
+            g = _check_sequential_g(g)
 
         eigvals = self.eigenvals
         condno = self.condition_number
@@ -2980,7 +3212,7 @@ class RegressionResults(base.LikelihoodModelResults):
             title = self.model.__class__.__name__ + " " + "Regression Results"
 
         # create summary table instance
-        from statsmodels.iolib.summary import Summary
+        from statsmodels.iolib.summary import Summary, summary_params
 
         smry = Summary()
         smry.add_table_2cols(
@@ -2991,9 +3223,28 @@ class RegressionResults(base.LikelihoodModelResults):
             xname=xname,
             title=title,
         )
-        smry.add_table_params(
-            self, yname=yname, xname=xname, alpha=alpha, use_t=self.use_t
-        )
+        if evalues:
+            evalue_results = (
+                self,
+                self.params,
+                self.bse,
+                self.tvalues,
+                self.e_values(g=g),
+                self.conf_int(alpha),
+            )
+            table = summary_params(
+                evalue_results,
+                yname=yname,
+                xname=xname,
+                alpha=alpha,
+                use_t=self.use_t,
+                value_header="e",
+            )
+            smry.tables.append(table)
+        else:
+            smry.add_table_params(
+                self, yname=yname, xname=xname, alpha=alpha, use_t=self.use_t
+            )
         if not slim:
             smry.add_table_2cols(
                 self,

--- a/statsmodels/regression/linear_model.py
+++ b/statsmodels/regression/linear_model.py
@@ -3069,7 +3069,7 @@ class RegressionResults(base.LikelihoodModelResults):
         title: str | None = None,
         alpha: float = 0.05,
         slim: bool = False,
-        evalues: bool = False,
+        savi: bool = False,
         g: float = 1.0,
     ):
         """
@@ -3087,17 +3087,18 @@ class RegressionResults(base.LikelihoodModelResults):
             Title for the top table. If not None, then this replaces the
             default title.
         alpha : float, optional
-            The significance level for the confidence intervals.
+            The significance level for the confidence intervals, or
+            confidence sequences when ``savi`` is True.
         slim : bool, optional
             Flag indicating to produce reduced set or diagnostic information.
             Default is False.
-        evalues : bool, optional
-            If True, replace the classical p-value column in the coefficient
-            table with e-values computed using the asymptotic ``g`` expression.
-            Default is False.
+        savi : bool, optional
+            If True, replace classical p-values with e-values and coefficient
+            confidence intervals with confidence sequences computed using the
+            asymptotic ``g`` expression. Default is False.
         g : float, optional
-            Positive tuning parameter used to compute e-values. The default is
-            1.
+            Positive tuning parameter used when ``savi`` is True. The default
+            is 1.
 
         Returns
         -------
@@ -3123,8 +3124,8 @@ class RegressionResults(base.LikelihoodModelResults):
 
         alpha = float_like(alpha, "alpha", optional=False)
         slim = bool_like(slim, "slim", optional=False, strict=True)
-        evalues = bool_like(evalues, "evalues", optional=False, strict=True)
-        if evalues:
+        savi = bool_like(savi, "savi", optional=False, strict=True)
+        if savi:
             g = _check_evalue_g(g)
 
         eigvals = self.eigenvals
@@ -3156,11 +3157,24 @@ class RegressionResults(base.LikelihoodModelResults):
             top_left.append(("Covariance Type:", [self.cov_type]))
 
         rsquared_type = "" if self.k_constant else " (uncentered)"
+        fvalue = self.fvalue
+        if savi:
+            if self.df_model > 0 and not np.isnan(fvalue):
+                df_denom = getattr(self, "df_resid_inference", self.df_resid)
+                f_significance = _evalue_from_f_stat(
+                    fvalue, self.df_model, df_denom, self.nobs, g
+                )
+            else:
+                f_significance = np.nan
+            f_significance_label = "e (F-statistic):"
+        else:
+            f_significance = self.f_pvalue
+            f_significance_label = "Prob (F-statistic):"
         top_right = [
             ("R-squared" + rsquared_type + ":", ["%#8.3f" % self.rsquared]),
             ("Adj. R-squared" + rsquared_type + ":", ["%#8.3f" % self.rsquared_adj]),
-            ("F-statistic:", ["%#8.4g" % self.fvalue]),
-            ("Prob (F-statistic):", ["%#6.3g" % self.f_pvalue]),
+            ("F-statistic:", ["%#8.4g" % fvalue]),
+            (f_significance_label, ["%#6.3g" % f_significance]),
             ("Log-Likelihood:", None),
             ("AIC:", ["%#8.4g" % self.aic]),
             ("BIC:", ["%#8.4g" % self.bic]),
@@ -3175,7 +3189,7 @@ class RegressionResults(base.LikelihoodModelResults):
                 "R-squared:",
                 "Adj. R-squared:",
                 "F-statistic:",
-                "Prob (F-statistic):",
+                f_significance_label,
             ]
             diagn_left = diagn_right = []
             top_left = [elem for elem in top_left if elem[0] in slimlist]
@@ -3223,17 +3237,17 @@ class RegressionResults(base.LikelihoodModelResults):
             xname=xname,
             title=title,
         )
-        if evalues:
-            evalue_results = (
+        if savi:
+            savi_results = (
                 self,
                 self.params,
                 self.bse,
                 self.tvalues,
                 self.e_values(g=g),
-                self.conf_int(alpha),
+                self.conf_int(alpha, savi=True, g=g),
             )
             table = summary_params(
-                evalue_results,
+                savi_results,
                 yname=yname,
                 xname=xname,
                 alpha=alpha,

--- a/statsmodels/regression/tests/test_regression.py
+++ b/statsmodels/regression/tests/test_regression.py
@@ -726,7 +726,7 @@ class TestEValueInference:
     def test_savi_matches_avlm_longley(self):
         data = longley.load_pandas().data
         # Expected values are from the avlm CRAN package, using R's longley
-        # data and the JASA paper's asymptotic g expression.
+        # data and the JASA paper's g-prior approximation.
         # https://cran.r-project.org/web/packages/avlm/index.html
         # https://www.tandfonline.com/doi/full/10.1080/01621459.2026.2692052
         # Scale the statsmodels copy to R's units before fitting the same
@@ -764,7 +764,7 @@ class TestEValueInference:
     def test_savi_hc0_coefficients_match_avlm_longley(self):
         data = longley.load_pandas().data
         # Expected values are from the avlm CRAN package, using R's longley
-        # data and the JASA paper's asymptotic g expression.
+        # data and the JASA paper's g-prior approximation.
         # https://cran.r-project.org/web/packages/avlm/index.html
         # https://www.tandfonline.com/doi/full/10.1080/01621459.2026.2692052
         # Scale the statsmodels copy to R's units before fitting the same

--- a/statsmodels/regression/tests/test_regression.py
+++ b/statsmodels/regression/tests/test_regression.py
@@ -649,25 +649,45 @@ class TestEValueInference:
         "res_attr, pvalue_header",
         [("res", "P>|t|"), ("res_hc1_z", "P>|z|")],
     )
-    def test_summary_evalues_replaces_pvalue_column(self, res_attr, pvalue_header):
+    def test_summary_savi_replaces_classical_inference(
+        self, res_attr, pvalue_header
+    ):
         res = getattr(self, res_attr)
-        summ = res.summary(evalues=True, g=2.5)
-        table = summ.tables[1]
-        text = table.as_text()
-        assert f" {pvalue_header} " not in text
-        assert " e " in text
+        g = 2.5
+        summ = res.summary(savi=True, g=g)
+        top_table = summ.tables[0]
+        coef_table = summ.tables[1]
+        top_text = top_table.as_text()
+        coef_text = coef_table.as_text()
+        assert "Prob (F-statistic):" not in top_text
+        assert "e (F-statistic):" in top_text
+        df_denom = getattr(res, "df_resid_inference", res.df_resid)
+        expected_f_evalue = _evalue_from_f_stat(
+            res.fvalue, res.df_model, df_denom, res.nobs, g
+        )
+        assert "%#6.3g" % expected_f_evalue in top_text
+        assert f" {pvalue_header} " not in coef_text
+        assert " e " in coef_text
         assert_allclose(
-            [float(row[4].data) for row in table[1:]],
-            res.e_values(g=2.5),
+            [float(row[4].data) for row in coef_table[1:]],
+            res.e_values(g=g),
             rtol=5e-3,
         )
+        assert_allclose(
+            [[float(row[5].data), float(row[6].data)] for row in coef_table[1:]],
+            res.conf_int(savi=True, g=g),
+            rtol=5e-3,
+            atol=5e-4,
+        )
 
-    def test_summary_evalues_does_not_change_default_summary(self):
-        assert " P>|t| " in self.res.summary().tables[1].as_text()
+    def test_summary_savi_does_not_change_default_summary(self):
+        summ = self.res.summary()
+        assert "Prob (F-statistic):" in summ.tables[0].as_text()
+        assert " P>|t| " in summ.tables[1].as_text()
 
-    def test_summary_evalues_g_validation(self):
+    def test_summary_savi_g_validation(self):
         with pytest.raises(ValueError, match="g must be positive"):
-            self.res.summary(evalues=True, g=0)
+            self.res.summary(savi=True, g=0)
 
     @pytest.mark.parametrize("alpha", [0, 1])
     def test_savi_conf_int_alpha_validation(self, alpha):

--- a/statsmodels/regression/tests/test_regression.py
+++ b/statsmodels/regression/tests/test_regression.py
@@ -697,6 +697,79 @@ class TestEValueInference:
         with pytest.raises(ValueError, match="g must be positive"):
             self.res.summary(savi=True, g=0)
 
+    def test_savi_matches_avlm_longley(self):
+        data = longley.load_pandas().data
+        # Expected values are from the avlm CRAN package, using R's longley
+        # data and the JASA paper's asymptotic g expression.
+        # https://cran.r-project.org/web/packages/avlm/index.html
+        # https://www.tandfonline.com/doi/full/10.1080/01621459.2026.2692052
+        # Scale the statsmodels copy to R's units before fitting the same
+        # model.
+        endog = data["TOTEMP"].to_numpy() / 1000
+        exog = np.column_stack(
+            (data["GNP"].to_numpy() / 1000, data["UNEMP"].to_numpy() / 10)
+        )
+        res = OLS(endog, add_constant(exog, prepend=True)).fit()
+        g = 2.5
+
+        avlm_pvalues = np.array(
+            [
+                2.3994985366968640e-06,
+                6.5452796798514853e-06,
+                1.3043518743909294e-01,
+            ]
+        )
+        avlm_conf_int = np.array(
+            [
+                [50.301901821972919038, 54.4624322783199232845],
+                [0.031635798521018964, 0.0440448555138813133],
+                [-0.012035233090925803, 0.0011637464493843685],
+            ]
+        )
+        avlm_f_pvalue = 5.3726884577847966e-06
+
+        assert_allclose(res.p_values(savi=True, g=g), avlm_pvalues)
+        assert_allclose(res.conf_int(savi=True, g=g), avlm_conf_int)
+        f_evalue = _evalue_from_f_stat(
+            res.fvalue, res.df_model, res.df_resid, res.nobs, g
+        )
+        assert_allclose(np.minimum(1, 1 / f_evalue), avlm_f_pvalue)
+
+    def test_savi_hc0_coefficients_match_avlm_longley(self):
+        data = longley.load_pandas().data
+        # Expected values are from the avlm CRAN package, using R's longley
+        # data and the JASA paper's asymptotic g expression.
+        # https://cran.r-project.org/web/packages/avlm/index.html
+        # https://www.tandfonline.com/doi/full/10.1080/01621459.2026.2692052
+        # Scale the statsmodels copy to R's units before fitting the same
+        # model.
+        endog = data["TOTEMP"].to_numpy() / 1000
+        exog = np.column_stack(
+            (data["GNP"].to_numpy() / 1000, data["UNEMP"].to_numpy() / 10)
+        )
+        res = OLS(endog, add_constant(exog, prepend=True)).fit(
+            cov_type="HC0", use_t=True
+        )
+        g = 2.5
+
+        avlm_pvalues = np.array(
+            [
+                2.3258728655056687e-06,
+                4.3782614065014952e-06,
+                4.8523079107576070e-02,
+            ]
+        )
+        avlm_conf_int = np.array(
+            [
+                [50.840615331130983634, 53.923718769161859],
+                [0.033030806719240489, 0.042649847315659788],
+                [-0.010841212821887157, -0.000030273819654277542],
+            ]
+        )
+
+        assert_allclose(res.p_values(savi=True, g=g), avlm_pvalues)
+        assert_allclose(res.conf_int(savi=True, g=g), avlm_conf_int)
+
     @pytest.mark.parametrize("alpha", [0, 1])
     def test_savi_conf_int_alpha_validation(self, alpha):
         with pytest.raises(ValueError, match="alpha must be between 0 and 1"):

--- a/statsmodels/regression/tests/test_regression.py
+++ b/statsmodels/regression/tests/test_regression.py
@@ -40,7 +40,7 @@ DECIMAL_7 = 7
 DECIMAL_0 = 0
 
 
-def _sequential_evalue(fvalue, df_num, df_denom, nobs, g):
+def _evalue_from_f_stat(fvalue, df_num, df_denom, nobs, g):
     g_ratio = g / (g + nobs)
     stat_ratio = df_num / df_denom * fvalue
     log_evalue = (
@@ -60,7 +60,7 @@ def _gaussian_evalue(qvalue, df_num, nobs, g):
     return np.exp(log_evalue)
 
 
-def _sequential_radius(alpha, g, nobs, df_num, df_denom):
+def _savi_confidence_radius(alpha, g, nobs, df_num, df_denom):
     g_ratio = g / (g + nobs)
     boundary = (alpha ** (2 / df_num) * g_ratio) ** (
         df_num / (df_denom + df_num)
@@ -564,7 +564,7 @@ class TestEValueInference:
     @pytest.mark.parametrize("g", [1.0, 2.5])
     def test_e_values_from_tvalues(self, g):
         res = self.res
-        expected = _sequential_evalue(
+        expected = _evalue_from_f_stat(
             res.tvalues**2, 1, res.df_resid, res.nobs, g
         )
         assert_allclose(res.e_values(g=g), expected)
@@ -577,7 +577,7 @@ class TestEValueInference:
         res = self.res
         r_matrix = np.eye(len(res.params))[1:3]
         ft = res.f_test(r_matrix)
-        expected = _sequential_evalue(
+        expected = _evalue_from_f_stat(
             ft.fvalue, ft.df_num, ft.df_denom, res.nobs, 2.0
         )
         assert_allclose(res.e_values(r_matrix, g=2.0), expected)
@@ -595,7 +595,7 @@ class TestEValueInference:
         nobs = 10_000_000
         df_denom = nobs - df_offset
 
-        evalue = _sequential_evalue(fvalue, df_num, df_denom, nobs, g)
+        evalue = _evalue_from_f_stat(fvalue, df_num, df_denom, nobs, g)
         gaussian_evalue = _gaussian_evalue(qvalue, df_num, nobs, g)
         assert_allclose(evalue, gaussian_evalue, rtol=1e-5)
 
@@ -606,7 +606,7 @@ class TestEValueInference:
         alpha = 0.05
         cs = res.conf_int(alpha=alpha, savi=True, g=g)
         ci = res.conf_int(alpha=alpha)
-        radius = _sequential_radius(alpha, g, res.nobs, 1, res.df_resid)
+        radius = _savi_confidence_radius(alpha, g, res.nobs, 1, res.df_resid)
         expected = np.column_stack(
             (
                 res.params - np.sqrt(radius) * res.bse,
@@ -622,7 +622,7 @@ class TestEValueInference:
         res = self.res_hc1
         r_matrix = np.eye(len(res.params))[1:3]
         ft = res.f_test(r_matrix)
-        expected = _sequential_evalue(
+        expected = _evalue_from_f_stat(
             ft.fvalue, ft.df_num, ft.df_denom, res.nobs, 1.0
         )
         assert_allclose(
@@ -631,7 +631,7 @@ class TestEValueInference:
         )
         assert_allclose(
             res.e_values(),
-            _sequential_evalue(res.tvalues**2, 1, res.df_resid, res.nobs, 1.0),
+            _evalue_from_f_stat(res.tvalues**2, 1, res.df_resid, res.nobs, 1.0),
         )
 
     @pytest.mark.parametrize(

--- a/statsmodels/regression/tests/test_regression.py
+++ b/statsmodels/regression/tests/test_regression.py
@@ -567,10 +567,12 @@ class TestEValueInference:
         expected = _evalue_from_f_stat(
             res.tvalues**2, 1, res.df_resid, res.nobs, g
         )
+        expected_pvalues = np.minimum(1, 1 / expected)
         assert_allclose(res.e_values(g=g), expected)
-        assert_allclose(res.p_values(savi=True, g=g), 1 / expected)
-        assert_allclose(res.sequential_p_values(g=g), 1 / expected)
+        assert_allclose(res.p_values(savi=True, g=g), expected_pvalues)
+        assert_allclose(res.sequential_p_values(g=g), expected_pvalues)
         assert_allclose(res.p_values(), res.pvalues)
+        assert_(np.all(res.p_values(savi=True, g=g) <= 1))
         assert_(np.all(res.sequential_p_values(g=g) >= res.pvalues))
 
     def test_e_values_from_f_test(self):
@@ -580,10 +582,16 @@ class TestEValueInference:
         expected = _evalue_from_f_stat(
             ft.fvalue, ft.df_num, ft.df_denom, res.nobs, 2.0
         )
+        expected_pvalue = np.minimum(1, 1 / expected)
         assert_allclose(res.e_values(r_matrix, g=2.0), expected)
-        assert_allclose(res.p_values(r_matrix, savi=True, g=2.0), 1 / expected)
-        assert_allclose(res.sequential_p_values(r_matrix, g=2.0), 1 / expected)
+        assert_allclose(
+            res.p_values(r_matrix, savi=True, g=2.0), expected_pvalue
+        )
+        assert_allclose(
+            res.sequential_p_values(r_matrix, g=2.0), expected_pvalue
+        )
         assert_allclose(res.p_values(r_matrix), ft.pvalue)
+        assert_(res.p_values(r_matrix, savi=True, g=2.0) <= 1)
         assert_(res.sequential_p_values(r_matrix, g=2.0) >= ft.pvalue)
 
     @pytest.mark.parametrize("df_num", [1, 3])

--- a/statsmodels/regression/tests/test_regression.py
+++ b/statsmodels/regression/tests/test_regression.py
@@ -662,11 +662,17 @@ class TestEValueInference:
     ):
         res = getattr(self, res_attr)
         g = 2.5
+        default_summ = res.summary()
         summ = res.summary(savi=True, g=g)
+        default_top_table = default_summ.tables[0]
+        default_coef_table = default_summ.tables[1]
         top_table = summ.tables[0]
         coef_table = summ.tables[1]
+        default_top_text = default_top_table.as_text()
+        default_coef_text = default_coef_table.as_text()
         top_text = top_table.as_text()
         coef_text = coef_table.as_text()
+        assert "Prob (F-statistic):" in default_top_text
         assert "Prob (F-statistic):" not in top_text
         assert "e (F-statistic):" in top_text
         df_denom = getattr(res, "df_resid_inference", res.df_resid)
@@ -674,15 +680,35 @@ class TestEValueInference:
             res.fvalue, res.df_model, df_denom, res.nobs, g
         )
         assert "%#6.3g" % expected_f_evalue in top_text
+        assert_(
+            float(default_top_table[3][3].data)
+            != float(top_table[3][3].data)
+        )
+        assert f" {pvalue_header} " in default_coef_text
         assert f" {pvalue_header} " not in coef_text
         assert " e " in coef_text
+        default_values = np.array(
+            [float(row[4].data) for row in default_coef_table[1:]]
+        )
+        savi_values = np.array([float(row[4].data) for row in coef_table[1:]])
+        assert_(not np.allclose(default_values, savi_values))
         assert_allclose(
-            [float(row[4].data) for row in coef_table[1:]],
+            savi_values,
             res.e_values(g=g),
             rtol=5e-3,
         )
+        default_intervals = np.array(
+            [
+                [float(row[5].data), float(row[6].data)]
+                for row in default_coef_table[1:]
+            ]
+        )
+        savi_intervals = np.array(
+            [[float(row[5].data), float(row[6].data)] for row in coef_table[1:]]
+        )
+        assert_(not np.allclose(default_intervals, savi_intervals))
         assert_allclose(
-            [[float(row[5].data), float(row[6].data)] for row in coef_table[1:]],
+            savi_intervals,
             res.conf_int(savi=True, g=g),
             rtol=5e-3,
             atol=5e-4,

--- a/statsmodels/regression/tests/test_regression.py
+++ b/statsmodels/regression/tests/test_regression.py
@@ -39,6 +39,38 @@ DECIMAL_1 = 1
 DECIMAL_7 = 7
 DECIMAL_0 = 0
 
+
+def _sequential_evalue(fvalue, df_num, df_denom, nobs, g):
+    g_ratio = g / (g + nobs)
+    stat_ratio = df_num / df_denom * fvalue
+    log_evalue = (
+        df_num / 2 * np.log(g_ratio)
+        - (df_denom + df_num) / 2
+        * (np.log1p(g_ratio * stat_ratio) - np.log1p(stat_ratio))
+    )
+    return np.exp(log_evalue)
+
+
+def _gaussian_evalue(qvalue, df_num, nobs, g):
+    g_ratio = g / (g + nobs)
+    log_evalue = (
+        df_num / 2 * np.log(g_ratio)
+        + 0.5 * nobs / (g + nobs) * qvalue
+    )
+    return np.exp(log_evalue)
+
+
+def _sequential_radius(alpha, g, nobs, df_num, df_denom):
+    g_ratio = g / (g + nobs)
+    boundary = (alpha ** (2 / df_num) * g_ratio) ** (
+        df_num / (df_denom + df_num)
+    )
+    denom = boundary - g_ratio
+    if denom <= 0:
+        return np.inf
+    return df_denom / df_num * (1 - boundary) / denom
+
+
 try:
     import cvxopt  # noqa:F401
 
@@ -513,6 +545,134 @@ class TestTtest2:
 
     def test_effect(self):
         assert_almost_equal(self.Ttest1.effect, -1829.2025687186533, DECIMAL_4)
+
+
+class TestEValueInference:
+    @classmethod
+    def setup_class(cls):
+        rng = np.random.default_rng(987654321)
+        nobs = 200
+        x = np.column_stack((np.ones(nobs), rng.normal(size=(nobs, 3))))
+        scale = 1 + np.abs(x[:, 1])
+        beta = np.array([1.0, 0.75, 0.0, -0.5])
+        y = x @ beta + scale * rng.standard_normal(nobs)
+        cls.res = OLS(y, x).fit()
+        cls.res_wls = WLS(y, x, weights=1 / scale**2).fit()
+        cls.res_hc1 = OLS(y, x).fit(cov_type="HC1", use_t=True)
+        cls.res_hc1_z = OLS(y, x).fit(cov_type="HC1", use_t=False)
+
+    @pytest.mark.parametrize("g", [1.0, 2.5])
+    def test_e_values_from_tvalues(self, g):
+        res = self.res
+        expected = _sequential_evalue(
+            res.tvalues**2, 1, res.df_resid, res.nobs, g
+        )
+        assert_allclose(res.e_values(g=g), expected)
+        assert_allclose(res.p_values(savi=True, g=g), 1 / expected)
+        assert_allclose(res.sequential_p_values(g=g), 1 / expected)
+        assert_allclose(res.p_values(), res.pvalues)
+        assert_(np.all(res.sequential_p_values(g=g) >= res.pvalues))
+
+    def test_e_values_from_f_test(self):
+        res = self.res
+        r_matrix = np.eye(len(res.params))[1:3]
+        ft = res.f_test(r_matrix)
+        expected = _sequential_evalue(
+            ft.fvalue, ft.df_num, ft.df_denom, res.nobs, 2.0
+        )
+        assert_allclose(res.e_values(r_matrix, g=2.0), expected)
+        assert_allclose(res.p_values(r_matrix, savi=True, g=2.0), 1 / expected)
+        assert_allclose(res.sequential_p_values(r_matrix, g=2.0), 1 / expected)
+        assert_allclose(res.p_values(r_matrix), ft.pvalue)
+        assert_(res.sequential_p_values(r_matrix, g=2.0) >= ft.pvalue)
+
+    @pytest.mark.parametrize("df_num", [1, 3])
+    def test_e_values_converge_to_gaussian_e_process(self, df_num):
+        g = 2.5
+        qvalue = 8.0
+        fvalue = qvalue / df_num
+        df_offset = 10
+        nobs = 10_000_000
+        df_denom = nobs - df_offset
+
+        evalue = _sequential_evalue(fvalue, df_num, df_denom, nobs, g)
+        gaussian_evalue = _gaussian_evalue(qvalue, df_num, nobs, g)
+        assert_allclose(evalue, gaussian_evalue, rtol=1e-5)
+
+    @pytest.mark.parametrize("res_attr", ["res", "res_wls", "res_hc1"])
+    @pytest.mark.parametrize("g", [1.0, 2.5])
+    def test_savi_conf_ints_contain_classical_conf_int(self, res_attr, g):
+        res = getattr(self, res_attr)
+        alpha = 0.05
+        cs = res.conf_int(alpha=alpha, savi=True, g=g)
+        ci = res.conf_int(alpha=alpha)
+        radius = _sequential_radius(alpha, g, res.nobs, 1, res.df_resid)
+        expected = np.column_stack(
+            (
+                res.params - np.sqrt(radius) * res.bse,
+                res.params + np.sqrt(radius) * res.bse,
+            )
+        )
+        assert_allclose(cs, expected)
+        assert_allclose(res.confidence_sequences(alpha=alpha, g=g), expected)
+        assert_(np.all(cs[:, 0] <= ci[:, 0]))
+        assert_(np.all(cs[:, 1] >= ci[:, 1]))
+
+    def test_e_values_use_robust_covariance(self):
+        res = self.res_hc1
+        r_matrix = np.eye(len(res.params))[1:3]
+        ft = res.f_test(r_matrix)
+        expected = _sequential_evalue(
+            ft.fvalue, ft.df_num, ft.df_denom, res.nobs, 1.0
+        )
+        assert_allclose(
+            res.e_values(r_matrix),
+            expected,
+        )
+        assert_allclose(
+            res.e_values(),
+            _sequential_evalue(res.tvalues**2, 1, res.df_resid, res.nobs, 1.0),
+        )
+
+    @pytest.mark.parametrize(
+        "method", ["e_values", "sequential_p_values"]
+    )
+    def test_e_value_g_validation(self, method):
+        with pytest.raises(ValueError, match="g must be positive"):
+            getattr(self.res, method)(g=0)
+
+    def test_p_values_savi_g_validation(self):
+        with pytest.raises(ValueError, match="g must be positive"):
+            self.res.p_values(savi=True, g=0)
+
+    @pytest.mark.parametrize(
+        "res_attr, pvalue_header",
+        [("res", "P>|t|"), ("res_hc1_z", "P>|z|")],
+    )
+    def test_summary_evalues_replaces_pvalue_column(self, res_attr, pvalue_header):
+        res = getattr(self, res_attr)
+        summ = res.summary(evalues=True, g=2.5)
+        table = summ.tables[1]
+        text = table.as_text()
+        assert f" {pvalue_header} " not in text
+        assert " e " in text
+        assert_allclose(
+            [float(row[4].data) for row in table[1:]],
+            res.e_values(g=2.5),
+            rtol=5e-3,
+        )
+
+    def test_summary_evalues_does_not_change_default_summary(self):
+        assert " P>|t| " in self.res.summary().tables[1].as_text()
+
+    def test_summary_evalues_g_validation(self):
+        with pytest.raises(ValueError, match="g must be positive"):
+            self.res.summary(evalues=True, g=0)
+
+    @pytest.mark.parametrize("alpha", [0, 1])
+    def test_savi_conf_int_alpha_validation(self, alpha):
+        with pytest.raises(ValueError, match="alpha must be between 0 and 1"):
+            self.res.conf_int(alpha=alpha, savi=True)
 
 
 class TestGLS:


### PR DESCRIPTION
  ## Summary

  This PR adds support for safe anytime-valid inference (SAVI) for linear regression results, based on   [Lindon et al. (2026), "Anytime-Valid Inference in Linear Models with Applications to Regression-Adjusted Causal Inference," *Journal of the American Statistical Association*
 ](https://www.tandfonline.com/doi/full/10.1080/01621459.2026.2692052)

  The implementation reuses statsmodels' existing `t` and `F` statistics, including the active covariance estimator. This keeps the implementation thin while making e-values, SAVI p-values, and confidence sequences available from fitted regression results.

  ## Motivation

  This is useful from three related perspectives.

  ### Anytime-valid inference

  Classical regression p-values and confidence intervals are fixed-sample objects. They are not generally valid under continuous monitoring or optional stopping. SAVI replaces these with e-processes and confidence
  sequences that remain valid over time, allowing users to monitor results as data accumulate while preserving time-uniform Type I error and coverage guarantees.

  See [Ramdas et al., "Game-theoretic statistics and safe anytime-valid inference"](https://arxiv.org/abs/2210.01948).

  ### Multiple testing

  E-values are useful beyond sequential monitoring. They can be combined with multiple-testing procedures such as e-BH, which provides an e-value analogue of Benjamini-Hochberg and controls FDR under arbitrary dependence
  between e-values. This makes e-values attractive for dependent regression screens, structured hypothesis tests, and exploratory workflows where many hypotheses are considered.

  See [Wang and Ramdas, "False discovery rate control with e-values"](https://arxiv.org/abs/2009.02824).

  ### Post-selection inference

  Confidence intervals obtained by inverting e-values, or e-CIs, have strong post-selection properties. They can be adjusted after arbitrary data-dependent selection while controlling false coverage rate under arbitrary
  dependence. This makes confidence sequences/e-CIs especially useful after model selection, variable screening, or exploratory regression analysis.

  See [Xu, Wang, and Ramdas, "Post-selection inference for e-value based confidence intervals"](https://arxiv.org/abs/2203.12572).

  ## API

  This PR adds:

  - `RegressionResults.e_values(..., g=...)` for parameter-wise `t` tests or joint linear restrictions via `F` tests.
  - `RegressionResults.p_values(savi=True, g=...)` for reciprocal e-values as SAVI p-values.
  - `RegressionResults.conf_int(savi=True, g=...)` for parameter-wise confidence-sequences/e-CIs.
  - `RegressionResults.summary(savi=True, g=...)` to display e-values and confidence sequences in the regression summary table, including replacing the model-level `Prob (F-statistic)` with an F-test e-value.
  - `RegressionResults.sequential_p_values(..., g=...)` and `RegressionResults.confidence_sequences(..., g=...)` as explicit aliases for users who prefer sequential-inference terminology.

  Classical behavior is unchanged unless `savi=True` is requested.

  ## Example

  The example below uses the full statsmodels Longley dataset:

  ```python
  from statsmodels.datasets import longley
  from statsmodels.regression.linear_model import OLS
  from statsmodels.tools.tools import add_constant

  data = longley.load_pandas()
  y = data.endog
  X = add_constant(data.exog, prepend=False)

  res = OLS(y, X).fit()
  print(res.summary(savi=True))
  ```

  ```text
                              OLS Regression Results
  ==============================================================================
  Dep. Variable:                 TOTEMP   R-squared:                       0.995
  Model:                            OLS   Adj. R-squared:                  0.992
  Method:                 Least Squares   F-statistic:                     330.3
  Date:                Fri, 26 Jun 2026   e (F-statistic):              2.04e+05
  Time:                        13:17:08   Log-Likelihood:                -109.62
  No. Observations:                  16   AIC:                             233.2
  Df Residuals:                       9   BIC:                             238.6
  Df Model:                           6
  Covariance Type:            nonrobust
  ==============================================================================
                   coef    std err          t          e      [0.025      0.975]
  ------------------------------------------------------------------------------
  GNPDEFL       15.0619     84.915      0.177      0.247    -312.329     342.453
  GNP           -0.0358      0.033     -1.070      0.425      -0.165       0.093
  UNEMP         -2.0202      0.488     -4.136     29.336      -3.903      -0.137
  ARMED         -1.0332      0.214     -4.822     70.649      -1.859      -0.207
  POP           -0.0511      0.226     -0.226      0.249      -0.923       0.821
  YEAR        1829.1515    455.478      4.016     24.928      73.044    3585.258
  const      -3.482e+06    8.9e+05     -3.911     21.587   -6.92e+06   -4.92e+04
  ==============================================================================
  ```

  ## Testing

  Tests cover:

  - e-values from `t` and `F` statistics,
  - SAVI p-values as reciprocal e-values,
  - confidence sequences containing classical confidence intervals,
  - robust covariance behavior,
  - `summary(savi=True)` replacing coefficient p-values, coefficient intervals, and the model-level F-test p-value,
  - validation of `g` and `alpha`,
  - convergence of the finite-sample e-process expression to the asymptotic Gaussian e-process for large `n`.
  - numerical agreement with the [`avlm` CRAN package](https://cran.r-project.org/web/packages/avlm/index.html) on the same input data, up to floating-point precision.
