### PR TITLE
Add hamilton_filter: regression-based trend-cycle decomposition (Hamilton 2018)

### DIFF
--- a/statsmodels/tsa/filters/api.py
+++ b/statsmodels/tsa/filters/api.py
@@ -2,6 +2,7 @@ __all__ = [
            "bkfilter",
            "cffilter",
            "convolution_filter",
+           "hamilton_filter",
            "hpfilter",
            "miso_lfilter",
            "recursive_filter",
@@ -9,4 +10,5 @@ __all__ = [
 from .bk_filter import bkfilter
 from .cf_filter import cffilter
 from .filtertools import convolution_filter, miso_lfilter, recursive_filter
+from .hamilton_filter import hamilton_filter
 from .hp_filter import hpfilter

--- a/statsmodels/tsa/filters/hamilton_filter.py
+++ b/statsmodels/tsa/filters/hamilton_filter.py
@@ -1,0 +1,126 @@
+"""
+Hamilton (2018) filter — regression-based trend-cycle decomposition.
+
+Reference
+---------
+Hamilton, J. D. (2018). Why You Should Never Use the Hodrick-Prescott Filter.
+*Review of Economics and Statistics*, 100(5), 831-843.
+"""
+
+import numpy as np
+
+from statsmodels.tools.validation import PandasWrapper, array_like
+
+
+def hamilton_filter(x, h=8, p=4):
+    r"""
+    Hamilton (2018) regression-based trend-cycle decomposition.
+
+    Decomposes a time series into trend and cycle components by projecting
+    ``h``-period-ahead values on the ``p`` most recent lags and a constant:
+
+    .. math::
+
+        y_{t+h} = \alpha_0 + \alpha_1 y_t + \alpha_2 y_{t-1}
+                  + \cdots + \alpha_p y_{t-p+1} + v_{t+h}
+
+    The cycle at time ``t + h`` is the residual :math:`\hat{v}_{t+h}` from
+    this OLS regression.  The trend is the corresponding fitted value.
+
+    Parameters
+    ----------
+    x : array_like
+        The time series to decompose, 1-d with at least ``p + h`` observations.
+    h : int, optional
+        Forecast horizon used in the projection.  Hamilton recommends:
+
+        * **8** for quarterly data (two years ahead, default)
+        * **24** for monthly data (two years ahead)
+        * **2** for annual data
+
+    p : int, optional
+        Number of lagged values of ``x`` to include as regressors.
+        Hamilton recommends **4** for quarterly data (one year of lags) and
+        **12** for monthly data.
+
+    Returns
+    -------
+    cycle : ndarray or Series
+        Estimated cyclical component.  The first ``p + h - 1`` values are
+        ``NaN`` because no regression can be formed for those periods.
+    trend : ndarray or Series
+        Estimated trend component.  The first ``p + h - 1`` values are
+        likewise ``NaN``.
+
+    See Also
+    --------
+    statsmodels.tsa.filters.hp_filter.hpfilter
+        Hodrick-Prescott filter.
+    statsmodels.tsa.filters.bk_filter.bkfilter
+        Baxter-King bandpass filter.
+    statsmodels.tsa.filters.cf_filter.cffilter
+        Christiano-Fitzgerald asymmetric filter.
+
+    Notes
+    -----
+    Unlike the HP filter, the Hamilton filter uses only lagged information and
+    produces stationary residuals when the underlying series is I(1) or I(2).
+    Hamilton (2018) shows that the HP filter introduces spurious cyclical
+    dynamics; the regression-based filter avoids this by construction.
+
+    The regression is estimated once on all available observations (i.e. this
+    is *not* a rolling regression).  With ``h = 8`` and ``p = 4`` (the
+    quarterly defaults), the first ``11`` observations of the output are
+    ``NaN``.
+
+    References
+    ----------
+    Hamilton, J. D. (2018). Why You Should Never Use the Hodrick-Prescott
+    Filter. *Review of Economics and Statistics*, 100(5), 831-843.
+
+    Examples
+    --------
+    >>> import statsmodels.api as sm
+    >>> import pandas as pd
+    >>> dta = sm.datasets.macrodata.load_pandas().data
+    >>> index = pd.period_range('1959Q1', '2009Q3', freq='Q')
+    >>> dta.set_index(index, inplace=True)
+    >>> cycle, trend = sm.tsa.filters.hamilton_filter(dta['realgdp'], h=8, p=4)
+    """
+    pw = PandasWrapper(x)
+    x = array_like(x, "x", ndim=1)
+    T = len(x)
+
+    if h < 1:
+        raise ValueError("h must be a positive integer.")
+    if p < 1:
+        raise ValueError("p must be a positive integer.")
+    if T < p + h:
+        raise ValueError(
+            f"x must have at least p + h = {p + h} observations; "
+            f"got {T}."
+        )
+
+    n_obs = T - p - h + 1
+
+    # Dependent variable: y_{t+h} for t = p-1, p, ..., T-h-1
+    Y = x[p + h - 1:]          # shape (n_obs,)
+
+    # Regressors: [y_t, y_{t-1}, ..., y_{t-p+1}, 1]
+    cols = [x[p - 1 - j : T - h - j] for j in range(p)]
+    cols.append(np.ones(n_obs))
+    X = np.column_stack(cols)   # shape (n_obs, p+1)
+
+    # OLS estimate
+    params, _, _, _ = np.linalg.lstsq(X, Y, rcond=None)
+
+    fitted = X @ params         # trend values at t+h
+    resid = Y - fitted          # cycle values at t+h
+
+    # Place results at the correct positions in output arrays
+    trend = np.full(T, np.nan)
+    cycle = np.full(T, np.nan)
+    trend[p + h - 1:] = fitted
+    cycle[p + h - 1:] = resid
+
+    return pw.wrap(cycle, append="cycle"), pw.wrap(trend, append="trend")

--- a/statsmodels/tsa/filters/tests/test_hamilton_filter.py
+++ b/statsmodels/tsa/filters/tests/test_hamilton_filter.py
@@ -1,0 +1,245 @@
+"""Tests for the Hamilton (2018) regression-based trend-cycle filter.
+
+Reference
+---------
+Hamilton, J. D. (2018). Why You Should Never Use the Hodrick-Prescott Filter.
+Review of Economics and Statistics, 100(5), 831-843.
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+from numpy.testing import assert_allclose
+
+from statsmodels.tsa.filters.hamilton_filter import hamilton_filter
+
+
+# ---------------------------------------------------------------------------
+# DGP helpers
+# ---------------------------------------------------------------------------
+
+RNG = np.random.default_rng(0)
+_QUARTERLY = RNG.standard_normal(200)  # 200 quarters
+_SHORT = RNG.standard_normal(15)
+
+
+# ---------------------------------------------------------------------------
+# Output shapes and NaN locations
+# ---------------------------------------------------------------------------
+
+
+def test_output_shapes_default():
+    x = np.ones(50)
+    cycle, trend = hamilton_filter(x)
+    assert cycle.shape == (50,)
+    assert trend.shape == (50,)
+
+
+def test_output_shapes_custom_h_p():
+    T = 80
+    x = RNG.standard_normal(T)
+    cycle, trend = hamilton_filter(x, h=12, p=6)
+    assert cycle.shape == (T,)
+    assert trend.shape == (T,)
+
+
+def test_nan_prefix_default():
+    """First p+h-1 = 4+8-1 = 11 values must be NaN (default h=8, p=4)."""
+    cycle, trend = hamilton_filter(_QUARTERLY)
+    assert np.all(np.isnan(cycle[:11]))
+    assert np.all(np.isnan(trend[:11]))
+
+
+def test_nan_prefix_custom():
+    """First p+h-1 values NaN for custom h, p."""
+    h, p = 3, 2
+    T = 30
+    x = RNG.standard_normal(T)
+    cycle, trend = hamilton_filter(x, h=h, p=p)
+    prefix = p + h - 1  # = 4
+    assert np.all(np.isnan(cycle[:prefix]))
+    assert np.all(np.isnan(trend[:prefix]))
+
+
+def test_finite_after_nan_prefix():
+    cycle, trend = hamilton_filter(_QUARTERLY)
+    assert np.all(np.isfinite(cycle[11:]))
+    assert np.all(np.isfinite(trend[11:]))
+
+
+# ---------------------------------------------------------------------------
+# Mathematical identities
+# ---------------------------------------------------------------------------
+
+
+def test_trend_plus_cycle_equals_x():
+    """Trend + cycle must equal x wherever both are defined."""
+    x = _QUARTERLY
+    cycle, trend = hamilton_filter(x)
+    assert_allclose(trend[11:] + cycle[11:], x[11:], atol=1e-10)
+
+
+def test_trend_plus_cycle_equals_x_custom():
+    h, p = 5, 3
+    x = RNG.standard_normal(60)
+    cycle, trend = hamilton_filter(x, h=h, p=p)
+    start = p + h - 1
+    assert_allclose(trend[start:] + cycle[start:], x[start:], atol=1e-10)
+
+
+def test_cycle_mean_near_zero():
+    """OLS residuals have mean zero (constant included in regressors)."""
+    cycle, _ = hamilton_filter(_QUARTERLY)
+    assert_allclose(np.nanmean(cycle), 0.0, atol=1e-10)
+
+
+def test_n_finite_obs():
+    """Number of finite observations equals T - p - h + 1."""
+    T, h, p = 100, 8, 4
+    x = RNG.standard_normal(T)
+    cycle, _ = hamilton_filter(x, h=h, p=p)
+    n_finite = np.sum(np.isfinite(cycle))
+    assert n_finite == T - p - h + 1
+
+
+# ---------------------------------------------------------------------------
+# Correctness against direct OLS
+# ---------------------------------------------------------------------------
+
+
+def test_matches_direct_ols():
+    """Hamilton filter should match explicit OLS regression."""
+    x = _QUARTERLY
+    h, p = 8, 4
+    T = len(x)
+    n_obs = T - p - h + 1
+
+    Y = x[p + h - 1:]
+    cols = [x[p - 1 - j : T - h - j] for j in range(p)]
+    cols.append(np.ones(n_obs))
+    X = np.column_stack(cols)
+    params, _, _, _ = np.linalg.lstsq(X, Y, rcond=None)
+    ols_cycle = Y - X @ params
+
+    _, cycle, _ = (None, *hamilton_filter(x, h=h, p=p))
+    # hamilton_filter returns (cycle, trend)
+    ham_cycle, _ = hamilton_filter(x, h=h, p=p)
+    assert_allclose(ham_cycle[p + h - 1:], ols_cycle, atol=1e-10)
+
+
+# ---------------------------------------------------------------------------
+# Pandas integration
+# ---------------------------------------------------------------------------
+
+
+def test_pandas_series_input():
+    s = pd.Series(_QUARTERLY, name="gdp")
+    cycle, trend = hamilton_filter(s)
+    assert isinstance(cycle, pd.Series)
+    assert isinstance(trend, pd.Series)
+
+
+def test_pandas_name_suffix():
+    s = pd.Series(_QUARTERLY, name="gdp")
+    cycle, trend = hamilton_filter(s)
+    assert cycle.name == "gdp_cycle"
+    assert trend.name == "gdp_trend"
+
+
+def test_pandas_index_preserved():
+    idx = pd.date_range("2000Q1", periods=len(_QUARTERLY), freq="QE")
+    s = pd.Series(_QUARTERLY, index=idx, name="gdp")
+    cycle, _ = hamilton_filter(s)
+    assert (cycle.index == idx).all()
+
+
+def test_pandas_dataframe_column():
+    df = pd.DataFrame({"gdp": _QUARTERLY, "cpi": _QUARTERLY * 0.5})
+    cycle, trend = hamilton_filter(df["gdp"])
+    assert isinstance(cycle, pd.Series)
+
+
+# ---------------------------------------------------------------------------
+# Parameter validation
+# ---------------------------------------------------------------------------
+
+
+def test_raises_h_zero():
+    with pytest.raises(ValueError, match="h must be a positive integer"):
+        hamilton_filter(_QUARTERLY, h=0)
+
+
+def test_raises_p_zero():
+    with pytest.raises(ValueError, match="p must be a positive integer"):
+        hamilton_filter(_QUARTERLY, p=0)
+
+
+def test_raises_too_short():
+    with pytest.raises(ValueError, match="at least p \\+ h"):
+        hamilton_filter(np.ones(5), h=8, p=4)  # 5 < 4+8
+
+
+def test_minimum_length_works():
+    """Exactly p+h observations — one valid data point."""
+    h, p = 3, 2
+    x = RNG.standard_normal(p + h)  # = 5 obs
+    cycle, trend = hamilton_filter(x, h=h, p=p)
+    assert np.sum(np.isfinite(cycle)) == 1
+
+
+# ---------------------------------------------------------------------------
+# Monthly and annual recommended settings
+# ---------------------------------------------------------------------------
+
+
+def test_monthly_settings():
+    """Monthly defaults: h=24, p=12 (two years ahead, one year lags)."""
+    T = 120  # 10 years monthly
+    x = RNG.standard_normal(T)
+    cycle, trend = hamilton_filter(x, h=24, p=12)
+    assert cycle.shape == (T,)
+    start = 24 + 12 - 1  # = 35
+    assert np.all(np.isnan(cycle[:start]))
+    assert np.all(np.isfinite(cycle[start:]))
+
+
+def test_annual_settings():
+    """Annual example: h=2, p=4."""
+    T = 50
+    x = RNG.standard_normal(T)
+    cycle, trend = hamilton_filter(x, h=2, p=4)
+    start = 5
+    assert np.all(np.isnan(cycle[:start]))
+    assert np.all(np.isfinite(cycle[start:]))
+
+
+# ---------------------------------------------------------------------------
+# Integration with statsmodels filters API
+# ---------------------------------------------------------------------------
+
+
+def test_accessible_via_tsa_filters():
+    from statsmodels.tsa.filters.hamilton_filter import hamilton_filter as hf
+    assert callable(hf)
+
+
+def test_importable_from_api():
+    from statsmodels.tsa.filters.api import hamilton_filter as hf
+    assert callable(hf)
+
+
+# ---------------------------------------------------------------------------
+# Stationarity property (I(1) input → stationary cycle)
+# ---------------------------------------------------------------------------
+
+
+def test_stationary_cycle_from_random_walk():
+    """Hamilton filter produces stationary cycle from a random walk."""
+    T = 500
+    rw = np.cumsum(RNG.standard_normal(T))
+    cycle, _ = hamilton_filter(rw)
+    c = cycle[~np.isnan(cycle)]
+    # Rough stationarity check: variance of first half ≈ variance of second half
+    n = len(c) // 2
+    ratio = np.var(c[:n]) / np.var(c[n:])
+    assert 0.3 < ratio < 3.0  # generous: just not trending wildly


### PR DESCRIPTION
## Summary

Adds `hamilton_filter` to `statsmodels.tsa.filters`, implementing the regression-based trend-cycle decomposition from Hamilton (2018, *Review of Economics and Statistics*).

### Motivation

Hamilton (2018) shows that the HP filter has three pathological properties regardless of the smoothing parameter:

1. It induces spurious cyclical dynamics even in white noise
2. The spurious cycles it identifies are exactly the ones that would be predicted by many business cycle models
3. It produces inconsistent estimates near the endpoints of the sample

The Hamilton filter avoids these problems by using only lagged information and producing stationary residuals when the underlying series is integrated.

### Algorithm

For a time series `x` of length `T`, with step `h` and lag order `p`, estimate by OLS:

```
y_{t+h} = α₀ + α₁ y_t + α₂ y_{t-1} + ⋯ + αₚ y_{t-p+1} + v_{t+h}
```

- **Trend** at `t+h`: fitted values `ŷ_{t+h}`
- **Cycle** at `t+h`: residuals `v̂_{t+h} = y_{t+h} − ŷ_{t+h}`
- **NaN prefix**: first `p + h − 1` observations cannot be estimated (set to `NaN`)

### Recommended parameters (Table 1, Hamilton 2018)

| Frequency | `h` | `p` |
|-----------|-----|-----|
| Quarterly | 8 (default) | 4 (default) |
| Monthly | 24 | 12 |
| Annual | 2 | 4 |

### API

Matches the existing `hpfilter` / `bkfilter` conventions exactly — supports both NumPy arrays and pandas Series (with index and name preservation):

```python
import statsmodels.api as sm

dta = sm.datasets.macrodata.load_pandas().data
gdp = dta['realgdp']

# Using default quarterly parameters
cycle, trend = sm.tsa.filters.hamilton_filter(gdp, h=8, p=4)

# Monthly data
cycle_m, trend_m = sm.tsa.filters.hamilton_filter(monthly_series, h=24, p=12)
```

## Files changed

- `statsmodels/tsa/filters/hamilton_filter.py` — new implementation (~130 lines, zero new dependencies)
- `statsmodels/tsa/filters/api.py` — exports `hamilton_filter`
- `statsmodels/tsa/filters/tests/test_hamilton_filter.py` — 23 tests

## Test plan

- [x] **23/23 new tests pass** — shapes, NaN prefix, `trend + cycle == x`, OLS identity, pandas integration, parameter validation, monthly/annual settings, stationarity property
- [x] **14/14 existing filter tests pass** (zero regressions in `test_filters.py`)
- [x] `trend + cycle == x` exact to 1e-10 everywhere (algebraic identity from OLS)
- [x] Cycle mean = 0 exactly (OLS includes constant)
- [x] n_finite = T − p − h + 1 verified (correct number of estimable observations)
- [x] Stationary cycle from random-walk input verified

## Reference

Hamilton, J. D. (2018). Why You Should Never Use the Hodrick-Prescott Filter. *Review of Economics and Statistics*, 100(5), 831–843.

🤖 Generated with [Claude Code](https://claude.com/claude-code)