### PR TITLE
Fix typos in test_chisquare_prob docstring

### DIFF
--- a/statsmodels/discrete/diagnostic.py
+++ b/statsmodels/discrete/diagnostic.py
@@ -53,7 +53,7 @@ class CountDiagnostic:
         """Moment test for binned probabilities using OPG.
 
         Parameters
-        ---------
+        ----------
         binedges : array_like or None
             This defines which counts are included in the test on frequencies
             and how counts are combined in bins.

--- a/statsmodels/discrete/diagnostic.py
+++ b/statsmodels/discrete/diagnostic.py
@@ -50,9 +50,9 @@ class CountDiagnostic:
         return self.results.predict(which="prob", **kwds)
 
     def test_chisquare_prob(self, bin_edges=None, method=None):
-        """Moment test for binned probabilites using OPG.
+        """Moment test for binned probabilities using OPG.
 
-        Paramters
+        Parameters
         ---------
         binedges : array_like or None
             This defines which counts are included in the test on frequencies


### PR DESCRIPTION
Fixes two typos in the `DiscreteResults.test_chisquare_prob` docstring in `statsmodels/discrete/diagnostic.py`:

- "probabilites" → "probabilities"
- "Paramters" → "Parameters" (numpydoc section header; misspelled, it wasn't being recognized as the Parameters section)

Documentation-only change.

- [x] tests added / passed. (N/A — documentation-only change)
- [x] code/documentation is well formatted.
- [x] properly formatted commit message.