### PR TITLE
[ENH] Add Pesaran-Timmermann directional accuracy test

### DIFF
--- a/statsmodels/stats/api.py
+++ b/statsmodels/stats/api.py
@@ -40,6 +40,7 @@ from .diagnostic import (
     linear_lm,
     linear_rainbow,
     linear_reset,
+    pesaran_timmermann,
     recursive_olsresiduals,
     spec_white,
 )
@@ -201,6 +202,7 @@ __all__ = [
     "compare_cox",
     "compare_encompassing",
     "compare_j",
+    "pesaran_timmermann",
     "confint_effectsize_oneway",
     "confint_mvmean",
     "confint_mvmean_fromstats",

--- a/statsmodels/stats/diagnostic.py
+++ b/statsmodels/stats/diagnostic.py
@@ -56,6 +56,7 @@ __all__ = [
     "anderson_statistic",
     "compare_cox",
     "compare_j",
+    "pesaran_timmermann",
     "het_arch",
     "het_breuschpagan",
     "het_goldfeldquandt",
@@ -247,6 +248,143 @@ def compare_j(results_x, results_z, store=False):
         return tstat, pval, res
 
     return tstat, pval
+
+
+def pesaran_timmermann(actual, predicted, alternative="two-sided",
+                       store=False):
+    r"""
+    Pesaran-Timmermann test of directional predictive accuracy.
+
+    Parameters
+    ----------
+    actual : array_like
+        Realized values. The direction is classified by ``actual > 0``.
+    predicted : array_like
+        Forecasted or predicted values. The direction is classified by
+        ``predicted > 0``.
+    alternative : {"two-sided", "larger", "smaller"}
+        Alternative hypothesis for the directional accuracy statistic.
+    store : bool, default False
+        If true, then the intermediate results are returned.
+
+    Returns
+    -------
+    statistic : float
+        Normal test statistic.
+    pvalue : float
+        P-value for the chosen alternative.
+    res_store : ResultsStore, optional
+        Intermediate results. Returned if ``store`` is True.
+
+    Notes
+    -----
+    The Pesaran-Timmermann test evaluates whether the realized and predicted
+    signs are independent. Let
+
+    .. math::
+
+       \hat{p} = n^{-1}\sum_{t=1}^n 1\{\operatorname{sign}(y_t)
+       = \operatorname{sign}(\hat{y}_t)\}
+
+    be the observed success rate, and let
+
+    .. math::
+
+       \hat{p}_* = \hat{p}_y \hat{p}_z +
+       (1 - \hat{p}_y)(1 - \hat{p}_z)
+
+    denote the success rate implied by independence, where
+    :math:`\hat{p}_y` and :math:`\hat{p}_z` are the sample proportions of
+    positive realizations and positive predictions. The test statistic is
+
+    .. math::
+
+       S_n = \frac{\hat{p} - \hat{p}_*}
+       {\sqrt{\hat{v} - \hat{w}}},
+
+    where
+
+    .. math::
+
+       \hat{v} = \hat{p}_* (1 - \hat{p}_*) / n
+
+    and
+
+    .. math::
+
+       \hat{w} = \left[(2\hat{p}_y - 1)^2 \hat{p}_z (1 - \hat{p}_z)
+       + (2\hat{p}_z - 1)^2 \hat{p}_y (1 - \hat{p}_y)\right] / n.
+
+    Under the null of no directional predictive ability, the statistic is
+    asymptotically standard normal.
+
+    References
+    ----------
+    .. [1] Pesaran, M. H., and Timmermann, A. "A Simple Nonparametric Test
+       of Predictive Performance." Journal of Business & Economic Statistics
+       10, no. 4 (1992): 461-465.
+    """
+    actual = array_like(actual, "actual", ndim=1)
+    predicted = array_like(predicted, "predicted", ndim=1)
+    alternative = string_like(
+        alternative,
+        "alternative",
+        options=("two-sided", "larger", "smaller"),
+    )
+    store = bool_like(store, "store")
+
+    if actual.shape[0] != predicted.shape[0]:
+        raise ValueError("actual and predicted must have the same length")
+    if actual.shape[0] < 2:
+        raise ValueError("actual and predicted must contain at least 2 values")
+    if not np.all(np.isfinite(actual)) or not np.all(np.isfinite(predicted)):
+        raise ValueError("actual and predicted must contain only finite values")
+
+    nobs = actual.shape[0]
+    realized_pos = (actual > 0).astype(float)
+    predicted_pos = (predicted > 0).astype(float)
+
+    p_y = realized_pos.mean()
+    p_z = predicted_pos.mean()
+    p_hat = np.mean(realized_pos == predicted_pos)
+    p_ind = p_y * p_z + (1 - p_y) * (1 - p_z)
+
+    v_hat = p_ind * (1 - p_ind) / nobs
+    w_hat = (((2 * p_y - 1) ** 2) * p_z * (1 - p_z) +
+             ((2 * p_z - 1) ** 2) * p_y * (1 - p_y)) / nobs
+    variance = v_hat - w_hat
+
+    if variance <= 0:
+        raise ValueError(
+            "Pesaran-Timmermann test is undefined when the estimated "
+            "variance is non-positive."
+        )
+
+    statistic = (p_hat - p_ind) / np.sqrt(variance)
+    if alternative == "two-sided":
+        pvalue = 2 * stats.norm.sf(np.abs(statistic))
+    elif alternative == "larger":
+        pvalue = stats.norm.sf(statistic)
+    else:
+        pvalue = stats.norm.cdf(statistic)
+
+    if store:
+        res = ResultsStore()
+        res.statistic = statistic
+        res.pvalue = pvalue
+        res.dist = stats.norm
+        res.alternative = alternative
+        res.nobs = nobs
+        res.p_hat = p_hat
+        res.p_ind = p_ind
+        res.p_y = p_y
+        res.p_z = p_z
+        res.v_hat = v_hat
+        res.w_hat = w_hat
+        res.variance = variance
+        return statistic, pvalue, res
+
+    return statistic, pvalue
 
 
 @deprecate_kwarg("cov_kwargs", "cov_kwds")

--- a/statsmodels/stats/tests/test_diagnostic.py
+++ b/statsmodels/stats/tests/test_diagnostic.py
@@ -62,6 +62,24 @@ def compare_to_reference(sp, sp_dict, decimal=(12, 12)):
     )
 
 
+def _pt_reference(actual, predicted):
+    actual = np.asarray(actual)
+    predicted = np.asarray(predicted)
+    realized_pos = (actual > 0).astype(float)
+    predicted_pos = (predicted > 0).astype(float)
+    nobs = actual.shape[0]
+    p_y = realized_pos.mean()
+    p_z = predicted_pos.mean()
+    p_hat = np.mean(realized_pos == predicted_pos)
+    p_ind = p_y * p_z + (1 - p_y) * (1 - p_z)
+    v_hat = p_ind * (1 - p_ind) / nobs
+    w_hat = (((2 * p_y - 1) ** 2) * p_z * (1 - p_z) +
+             ((2 * p_z - 1) ** 2) * p_y * (1 - p_y)) / nobs
+    variance = v_hat - w_hat
+    stat = (p_hat - p_ind) / np.sqrt(variance)
+    return stat, 2 * stats.norm.sf(np.abs(stat))
+
+
 def test_gq():
     d = macrodata.load().data
 
@@ -700,6 +718,63 @@ class TestDiagnosticG:
 
         _, _, store = smsdia.compare_cox(res, res2, store=True)
         assert isinstance(store, smsdia.ResultsStore)
+
+    def test_pesaran_timmermann_reference(self):
+        actual = np.r_[np.ones(50), -np.ones(50)]
+        predicted = actual.copy()
+
+        pt = smsdia.pesaran_timmermann(actual, predicted)
+        expected = (10.0, 1.5239706048321186e-23)
+        assert_allclose(pt, expected, rtol=1e-12)
+
+    def test_pesaran_timmermann_manual_formula(self):
+        actual = np.array([1.2, -0.4, 0.0, 0.9, -1.1, 0.5, -0.2, 0.3])
+        predicted = np.array([0.6, -0.2, -0.1, 1.0, 0.7, 0.2, -0.4, -0.6])
+
+        pt = smsdia.pesaran_timmermann(actual, predicted)
+        expected = _pt_reference(actual, predicted)
+        assert_allclose(pt, expected, rtol=1e-12)
+
+        pt_larger = smsdia.pesaran_timmermann(
+            actual, predicted, alternative="larger"
+        )
+        pt_smaller = smsdia.pesaran_timmermann(
+            actual, predicted, alternative="smaller"
+        )
+        assert_allclose(pt_larger[0], expected[0], rtol=1e-12)
+        assert_allclose(pt_smaller[0], expected[0], rtol=1e-12)
+        assert_allclose(
+            pt_larger[1], stats.norm.sf(expected[0]), rtol=1e-12
+        )
+        assert_allclose(
+            pt_smaller[1], stats.norm.cdf(expected[0]), rtol=1e-12
+        )
+
+    def test_pesaran_timmermann_store(self):
+        actual = np.r_[np.ones(10), -np.ones(10)]
+        predicted = actual.copy()
+
+        _, _, store = smsdia.pesaran_timmermann(actual, predicted, store=True)
+        assert isinstance(store, smsdia.ResultsStore)
+        assert store.nobs == actual.shape[0]
+        assert_allclose(store.p_hat, 1.0, rtol=1e-12)
+        assert_allclose(store.p_ind, 0.5, rtol=1e-12)
+
+    @pytest.mark.parametrize(
+        ("actual", "predicted", "kwargs", "message"),
+        [
+            ([1, -1], [1], {}, "same length"),
+            ([1], [1], {}, "at least 2 values"),
+            ([1, np.nan], [1, -1], {}, "finite"),
+            ([1, 1, 1], [1, 1, 1], {}, "variance is non-positive"),
+            ([1, -1], [1, -1], {"alternative": "bad"}, "alternative"),
+        ],
+    )
+    def test_pesaran_timmermann_invalid(
+        self, actual, predicted, kwargs, message
+    ):
+        with pytest.raises(ValueError, match=message):
+            smsdia.pesaran_timmermann(actual, predicted, **kwargs)
 
     def test_cusum_ols(self):
         # R library(strucchange)

--- a/statsmodels/stats/tests/test_diagnostic.py
+++ b/statsmodels/stats/tests/test_diagnostic.py
@@ -22,6 +22,7 @@ from numpy.testing import (
 import pandas as pd
 from pandas.testing import assert_frame_equal
 import pytest
+from scipy import stats
 
 from statsmodels.datasets import macrodata, sunspots
 from statsmodels.regression.linear_model import OLS


### PR DESCRIPTION
## Summary
- add a `pesaran_timmermann` diagnostic for directional predictive accuracy to `statsmodels.stats.diagnostic`
- export the new function through `statsmodels.stats.api`
- add focused tests for the sign-based statistic, alternatives, stored results, and invalid inputs

## Why
`statsmodels` already has several diagnostic and non-nested comparison tests, but it does not expose the Pesaran-Timmermann directional accuracy test for sign predictions. This adds a compact predictive-performance diagnostic that fits naturally in the existing `statsmodels.stats.diagnostic` module.

## Validation
- direct import checks for `statsmodels.stats.diagnostic` and `statsmodels.stats.api`
- manual pure-Python assertions covering the new Pesaran-Timmermann formulas and result storage
- neighboring diagnostic regression checks confirming `compare_cox` and `compare_j` still match their reference values

## Reference
- Pesaran, M. H., and Timmermann, A. (1992). *A Simple Nonparametric Test of Predictive Performance*. Journal of Business & Economic Statistics, 10(4), 461-465.
