### PR TITLE
BUG: fix NegativeBinomial check for optional alpha

### DIFF
--- a/statsmodels/genmod/families/family.py
+++ b/statsmodels/genmod/families/family.py
@@ -1399,15 +1399,16 @@ class NegativeBinomial(Family):
         L.Log,
     ]
 
-    def __init__(self, link=None, alpha=1.0, check_link=True):
-        self.alpha = 1.0 * alpha  # make it at least float
-        if alpha is self.__init__.__defaults__[1]:  # `is` is intentional
+    def __init__(self, link=None, alpha=None, check_link=True):
+        if alpha is None:
+            alpha = 1.0
             warnings.warn(
                 "Negative binomial dispersion parameter alpha not "
                 f"set. Using default value alpha={alpha}.",
                 ValueWarning,
                 stacklevel=2,
             )
+        self.alpha = 1.0 * alpha  # make it at least float
         if link is None:
             link = L.Log()
         super().__init__(

--- a/statsmodels/includes/_complex_shim.h
+++ b/statsmodels/includes/_complex_shim.h
@@ -11,14 +11,14 @@ typedef double complex double_complex;
 
 #endif
 
-inline double sm_cabs(double_complex z){
+static inline double sm_cabs(double_complex z){
    return cabs(z);
 }
 
-inline double_complex sm_clog(double_complex z){
+static inline double_complex sm_clog(double_complex z){
    return clog(z);
 }
 
-inline double_complex sm_cexp(double_complex z){
+static inline double_complex sm_cexp(double_complex z){
    return cexp(z);
 }


### PR DESCRIPTION
- [ ] closes #xxxx
- [x] tests added / passed. 
- [ ] code/documentation is well formatted.  
- [x] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 


This PR fixes 3.14t errors in NegativeBinomial as noted in https://github.com/MacPython/statsmodels-wheels/pull/212. 
In free-threading the code constant interning behaviour is different causes the test to fail when comparing the constant from the code object. To fix it, this PR changes it to use None for the default value. 
