### PR TITLE
MAINT: adapt to upcoming change in pd.freq

### DIFF
--- a/statsmodels/compat/pandas.py
+++ b/statsmodels/compat/pandas.py
@@ -93,7 +93,8 @@ def infer_freq(index) -> str | None:
         # in older versions the option is not available and a str is returned
         freq = pd.infer_freq(index)
 
-    if not isinstance(freq, (str, None)):
+    # new pandas versions retuns BaseOffset
+    if not isinstance(freq, str) and freq is not None:
         return freq.freqstr
     return freq
 

--- a/statsmodels/compat/pandas.py
+++ b/statsmodels/compat/pandas.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from contextlib import contextmanager
 
 from typing import TYPE_CHECKING, Any, Callable, Mapping, Optional, TypeVar
 
@@ -83,14 +84,21 @@ assert_index_equal = testing.assert_index_equal
 assert_series_equal = testing.assert_series_equal
 
 
-def infer_freq(index) -> str | None:
+@contextmanager
+def _infer_freq_returns_offset():
 
     # pandas 3.1 changes the return value of infer_freq
     try:
         with pd.option_context("future.infer_freq_returns_offset", True):
-            freq = pd.infer_freq(index)
+            yield
     except pd.errors.OptionError:
         # in older versions the option is not available and a str is returned
+        yield
+
+def infer_freq(index) -> str | None:
+
+    # pandas 3.1 changes the return value of infer_freq
+    with _infer_freq_returns_offset():
         freq = pd.infer_freq(index)
 
     # new pandas versions retuns BaseOffset

--- a/statsmodels/compat/pandas.py
+++ b/statsmodels/compat/pandas.py
@@ -89,10 +89,13 @@ def infer_freq(index) -> str | None:
     try:
         with pd.option_context("future.infer_freq_returns_offset", True):
             freq = pd.infer_freq(index)
-            return freq.freqstr
     except pd.errors.OptionError:
         # in older versions the option is not available and a str is returned
-        return pd.infer_freq(index)
+        freq = pd.infer_freq(index)
+
+    if not isinstance(freq, str | None):
+        return freq.freqstr
+    return freq
 
 
 def is_int_index(index: pd.Index) -> bool:

--- a/statsmodels/compat/pandas.py
+++ b/statsmodels/compat/pandas.py
@@ -12,12 +12,6 @@ from pandas.util._decorators import (
 
 from statsmodels.tools.docstring_helpers import Appender, Substitution
 
-try:
-    pd.set_option("future.infer_freq_returns_offset", True)
-except pd.errors.OptionError:
-    # Do nothing if key doesn't exist
-    pass
-
 if TYPE_CHECKING:
     try:
         from typing import TypeAlias
@@ -87,6 +81,17 @@ except ImportError:
 assert_frame_equal = testing.assert_frame_equal
 assert_index_equal = testing.assert_index_equal
 assert_series_equal = testing.assert_series_equal
+
+def infer_freq(index) -> str | None:
+
+    # pandas 3.1 changes the return value of infer_freq
+    try:
+        with pd.option_context("future.infer_freq_returns_offset", True):
+            freq = pd.infer_freq(index)
+            return freq.freqstr
+    except pd.errors.OptionError:
+        freq = pd.infer_freq(index)
+
 
 
 def is_int_index(index: pd.Index) -> bool:

--- a/statsmodels/compat/pandas.py
+++ b/statsmodels/compat/pandas.py
@@ -93,7 +93,7 @@ def infer_freq(index) -> str | None:
         # in older versions the option is not available and a str is returned
         freq = pd.infer_freq(index)
 
-    if not isinstance(freq, str | None):
+    if not isinstance(freq, (str, None)):
         return freq.freqstr
     return freq
 

--- a/statsmodels/compat/pandas.py
+++ b/statsmodels/compat/pandas.py
@@ -82,6 +82,7 @@ assert_frame_equal = testing.assert_frame_equal
 assert_index_equal = testing.assert_index_equal
 assert_series_equal = testing.assert_series_equal
 
+
 def infer_freq(index) -> str | None:
 
     # pandas 3.1 changes the return value of infer_freq
@@ -90,8 +91,8 @@ def infer_freq(index) -> str | None:
             freq = pd.infer_freq(index)
             return freq.freqstr
     except pd.errors.OptionError:
-        freq = pd.infer_freq(index)
-
+        # in older versions the option is not available and a str is returned
+        return pd.infer_freq(index)
 
 
 def is_int_index(index: pd.Index) -> bool:

--- a/statsmodels/compat/pandas.py
+++ b/statsmodels/compat/pandas.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
-from contextlib import contextmanager
 
+from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any, Callable, Mapping, Optional, TypeVar
 
 import numpy as np
@@ -94,6 +94,7 @@ def _infer_freq_returns_offset():
     except pd.errors.OptionError:
         # in older versions the option is not available and a str is returned
         yield
+
 
 def infer_freq(index) -> str | None:
 

--- a/statsmodels/tools/data.py
+++ b/statsmodels/tools/data.py
@@ -1,6 +1,7 @@
 """Compatibility tools for various data structure inputs."""
 
 from statsmodels.compat.numpy import NP_LT_2
+from statsmodels.compat.pandas import infer_freq
 
 import numpy as np
 import pandas as pd
@@ -15,7 +16,7 @@ def _check_period_index(x, freq="M"):
     if x.index.freq is not None:
         inferred_freq = x.index.freqstr
     else:
-        inferred_freq = pd.infer_freq(x.index)
+        inferred_freq = infer_freq(x.index)
         if isinstance(inferred_freq, pd.tseries.offsets.BaseOffset):
             inferred_freq = inferred_freq.freqstr
     if not inferred_freq.startswith(freq):

--- a/statsmodels/tsa/base/tsa_model.py
+++ b/statsmodels/tsa/base/tsa_model.py
@@ -4,6 +4,7 @@ from statsmodels.compat.pandas import (
     is_float_index,
     is_int_index,
     is_numeric_dtype,
+    _infer_freq_returns_offset,
 )
 
 import numbers
@@ -568,7 +569,8 @@ class TimeSeriesModel(base.LikelihoodModel):
             if isinstance(index, (DatetimeIndex, PeriodIndex)):
                 # If no frequency, try to get an inferred frequency
                 if freq is None and index.freq is None:
-                    freq = index.inferred_freq
+                    with _infer_freq_returns_offset():
+                        freq = index.inferred_freq
                     # If we got an inferred frequncy, alert the user
                     if freq is not None:
                         inferred_freq = True

--- a/statsmodels/tsa/base/tsa_model.py
+++ b/statsmodels/tsa/base/tsa_model.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 from statsmodels.compat.pandas import (
+    _infer_freq_returns_offset,
     is_float_index,
     is_int_index,
     is_numeric_dtype,
-    _infer_freq_returns_offset,
 )
 
 import numbers

--- a/statsmodels/tsa/deterministic.py
+++ b/statsmodels/tsa/deterministic.py
@@ -24,6 +24,7 @@ from statsmodels.tools.validation import (
     string_like,
 )
 from statsmodels.tsa.tsatools import freq_to_period
+from statsmodels.compat.pandas import _infer_freq_returns_offset
 
 if TYPE_CHECKING:
     from collections.abc import Hashable, Sequence
@@ -392,7 +393,8 @@ class Seasonality(DeterministicTerm):
         if isinstance(index, pd.PeriodIndex):
             freq = index.freq
         elif isinstance(index, pd.DatetimeIndex):
-            freq = index.freq if index.freq else index.inferred_freq
+            with _infer_freq_returns_offset():
+                freq = index.freq if index.freq else index.inferred_freq
         else:
             raise TypeError("index must be a DatetimeIndex or PeriodIndex")
         if freq is None:
@@ -1438,7 +1440,8 @@ differences can be extended when producing out-of-sample forecasts.
             self._index_freq = self._index.freq
             self._extendable = True
         elif isinstance(self._index, pd.DatetimeIndex):
-            self._index_freq = self._index.freq or self._index.inferred_freq
+            with _infer_freq_returns_offset():
+                self._index_freq = self._index.freq or self._index.inferred_freq
             self._extendable = self._index_freq is not None
         elif isinstance(self._index, pd.RangeIndex):
             self._extendable = True

--- a/statsmodels/tsa/deterministic.py
+++ b/statsmodels/tsa/deterministic.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from statsmodels.compat.pandas import (
     PD_LT_2_2_0,
     PD_LT_3_1_0,
+    _infer_freq_returns_offset,
     is_int_index,
     to_numpy,
 )
@@ -24,7 +25,6 @@ from statsmodels.tools.validation import (
     string_like,
 )
 from statsmodels.tsa.tsatools import freq_to_period
-from statsmodels.compat.pandas import _infer_freq_returns_offset
 
 if TYPE_CHECKING:
     from collections.abc import Hashable, Sequence

--- a/statsmodels/tsa/filters/_utils.py
+++ b/statsmodels/tsa/filters/_utils.py
@@ -2,7 +2,7 @@ from functools import wraps
 
 from statsmodels.tools.data import _is_using_pandas
 from statsmodels.tsa.tsatools import freq_to_period
-
+from statsmodels.compat.pandas import _infer_freq_returns_offset
 
 def _get_pandas_wrapper(X, trim_head=None, trim_tail=None, names=None):
     index = X.index
@@ -83,7 +83,8 @@ def pandas_wrapper_freq(func, trim_head=None, trim_tail=None,
         wrapper_func = _get_pandas_wrapper(X, trim_head, trim_tail,
                                            columns)
         index = X.index
-        freq = index.inferred_freq
+        with _infer_freq_returns_offset():
+            freq = index.inferred_freq
         kwargs.update({freq_kw : freq_to_period(freq)})
         ret = func(X, *args, **kwargs)
         ret = wrapper_func(ret)

--- a/statsmodels/tsa/filters/_utils.py
+++ b/statsmodels/tsa/filters/_utils.py
@@ -1,8 +1,10 @@
+from statsmodels.compat.pandas import _infer_freq_returns_offset
+
 from functools import wraps
 
 from statsmodels.tools.data import _is_using_pandas
 from statsmodels.tsa.tsatools import freq_to_period
-from statsmodels.compat.pandas import _infer_freq_returns_offset
+
 
 def _get_pandas_wrapper(X, trim_head=None, trim_tail=None, names=None):
     index = X.index

--- a/statsmodels/tsa/holtwinters/tests/test_holtwinters.py
+++ b/statsmodels/tsa/holtwinters/tests/test_holtwinters.py
@@ -3,9 +3,8 @@ Author: Terence L van Zyl
 Modified: Kevin Sheppard
 """
 
-from statsmodels.compat.pandas import MONTH_END
+from statsmodels.compat.pandas import MONTH_END, infer_freq
 from statsmodels.compat.pytest import pytest_warns
-from statsmodels.compat.pandas import infer_freq
 
 import os
 import re

--- a/statsmodels/tsa/holtwinters/tests/test_holtwinters.py
+++ b/statsmodels/tsa/holtwinters/tests/test_holtwinters.py
@@ -34,6 +34,9 @@ from statsmodels.tsa.holtwinters._smoothers import (
     to_unrestricted,
 )
 
+# suppress pandas warning from pd.infer_freq
+pytest.mark.filterwarnings("ignore:A future version of pandas will return a BaseOffset")
+
 base, _ = os.path.split(os.path.abspath(__file__))
 housing_data = pd.read_csv(
     os.path.join(base, "results", "housing-data.csv"),

--- a/statsmodels/tsa/holtwinters/tests/test_holtwinters.py
+++ b/statsmodels/tsa/holtwinters/tests/test_holtwinters.py
@@ -35,7 +35,9 @@ from statsmodels.tsa.holtwinters._smoothers import (
 )
 
 # pandas 3.1 changes the return type of infer_freq - suppress its deprecation warning
-pytest.mark.filterwarnings("ignore:A future version of pandas will return a BaseOffset")
+pytestmark = [
+    pytest.mark.filterwarnings("ignore:A future version of pandas will return a BaseOffset")
+]
 
 base, _ = os.path.split(os.path.abspath(__file__))
 housing_data = pd.read_csv(

--- a/statsmodels/tsa/holtwinters/tests/test_holtwinters.py
+++ b/statsmodels/tsa/holtwinters/tests/test_holtwinters.py
@@ -5,6 +5,7 @@ Modified: Kevin Sheppard
 
 from statsmodels.compat.pandas import MONTH_END
 from statsmodels.compat.pytest import pytest_warns
+from statsmodels.compat.pandas import infer_freq
 
 import os
 import re
@@ -33,11 +34,6 @@ from statsmodels.tsa.holtwinters._smoothers import (
     to_restricted,
     to_unrestricted,
 )
-
-# pandas 3.1 changes the return type of infer_freq - suppress its deprecation warning
-pytestmark = [
-    pytest.mark.filterwarnings("ignore:A future version of pandas will return a BaseOffset")
-]
 
 base, _ = os.path.split(os.path.abspath(__file__))
 housing_data = pd.read_csv(
@@ -104,7 +100,7 @@ index = [
     "2010-12-01 00:00:00",
 ]
 idx = pd.to_datetime(index)
-aust = pd.Series(data, index=pd.DatetimeIndex(idx, freq=pd.infer_freq(idx)))
+aust = pd.Series(data, index=pd.DatetimeIndex(idx, freq=infer_freq(idx)))
 
 
 @pytest.fixture(scope="module")
@@ -182,7 +178,7 @@ class TestHoltWinters:
         ]
         oildata_oil = pd.Series(data, index)
         oildata_oil.index = pd.DatetimeIndex(
-            oildata_oil.index, freq=pd.infer_freq(oildata_oil.index)
+            oildata_oil.index, freq=infer_freq(oildata_oil.index)
         )
         cls.oildata_oil = oildata_oil
 
@@ -224,7 +220,7 @@ class TestHoltWinters:
         ]
         air_ausair = pd.Series(data, index)
         air_ausair.index = pd.DatetimeIndex(
-            air_ausair.index, freq=pd.infer_freq(air_ausair.index)
+            air_ausair.index, freq=infer_freq(air_ausair.index)
         )
         cls.air_ausair = air_ausair
 
@@ -299,7 +295,7 @@ class TestHoltWinters:
         livestock2_livestock = pd.Series(data, index)
         livestock2_livestock.index = pd.DatetimeIndex(
             livestock2_livestock.index,
-            freq=pd.infer_freq(livestock2_livestock.index),
+            freq=infer_freq(livestock2_livestock.index),
         )
         cls.livestock2_livestock = livestock2_livestock
 

--- a/statsmodels/tsa/holtwinters/tests/test_holtwinters.py
+++ b/statsmodels/tsa/holtwinters/tests/test_holtwinters.py
@@ -34,7 +34,7 @@ from statsmodels.tsa.holtwinters._smoothers import (
     to_unrestricted,
 )
 
-# suppress pandas warning from pd.infer_freq
+# pandas 3.1 changes the return type of infer_freq - suppress its deprecation warning
 pytest.mark.filterwarnings("ignore:A future version of pandas will return a BaseOffset")
 
 base, _ = os.path.split(os.path.abspath(__file__))

--- a/statsmodels/tsa/stl/_stl.pyx
+++ b/statsmodels/tsa/stl/_stl.pyx
@@ -86,10 +86,11 @@ import pandas as pd
 
 from libc.math cimport NAN, fabs, isnan, sqrt
 
+from statsmodels.compat.pandas import _infer_freq_returns_offset
+
 from statsmodels.tools.validation import array_like
 from statsmodels.tsa.seasonal._seasonal import DecomposeResult
 from statsmodels.tsa.tsatools import freq_to_period
-from statsmodels.compat.pandas import _infer_freq_returns_offset
 
 
 def _is_pos_int(x, odd):

--- a/statsmodels/tsa/stl/_stl.pyx
+++ b/statsmodels/tsa/stl/_stl.pyx
@@ -89,6 +89,7 @@ from libc.math cimport NAN, fabs, isnan, sqrt
 from statsmodels.tools.validation import array_like
 from statsmodels.tsa.seasonal._seasonal import DecomposeResult
 from statsmodels.tsa.tsatools import freq_to_period
+from statsmodels.compat.pandas import _infer_freq_returns_offset
 
 
 def _is_pos_int(x, odd):
@@ -219,7 +220,8 @@ cdef class STL(object):
         if period is None:
             freq = None
             if isinstance(endog, (pd.Series, pd.DataFrame)):
-                freq = getattr(endog.index, 'inferred_freq', None)
+                with _infer_freq_returns_offset():
+                    freq = getattr(endog.index, 'inferred_freq', None)
             if freq is None:
                 raise ValueError('Unable to determine period from endog')
             period = freq_to_period(freq)

--- a/statsmodels/tsa/vector_ar/tests/test_var.py
+++ b/statsmodels/tsa/vector_ar/tests/test_var.py
@@ -2,7 +2,7 @@
 Test VAR Model
 """
 
-from statsmodels.compat.pandas import QUARTER_END, assert_index_equal
+from statsmodels.compat.pandas import QUARTER_END, assert_index_equal, _infer_freq_returns_offset
 from statsmodels.compat.python import lrange
 
 from io import BytesIO
@@ -953,7 +953,8 @@ def test_correct_nobs():
     mdata = mdata[["realgdp", "realcons", "realinv"]]
     mdata.index = pd.DatetimeIndex(quarterly)
     data = np.log(mdata).diff().dropna()
-    data.index.freq = data.index.inferred_freq
+    with _infer_freq_returns_offset():
+        data.index.freq = data.index.inferred_freq
     data_exog = pd.DataFrame(index=data.index)
     rs = np.random.RandomState(238971)
     data_exog["exovar1"] = rs.normal(size=data_exog.shape[0])

--- a/statsmodels/tsa/vector_ar/tests/test_var.py
+++ b/statsmodels/tsa/vector_ar/tests/test_var.py
@@ -2,7 +2,11 @@
 Test VAR Model
 """
 
-from statsmodels.compat.pandas import QUARTER_END, assert_index_equal, _infer_freq_returns_offset
+from statsmodels.compat.pandas import (
+    QUARTER_END,
+    _infer_freq_returns_offset,
+    assert_index_equal,
+)
 from statsmodels.compat.python import lrange
 
 from io import BytesIO

--- a/statsmodels/tsa/x13.py
+++ b/statsmodels/tsa/x13.py
@@ -328,7 +328,7 @@ def pandas_to_series_spec(x):
     try:
         period = _freq_to_period[x.index.freqstr]
     except (AttributeError, ValueError):
-        from pandas.tseries.api import infer_freq
+        from statsmodels.compat.pandas import infer_freq
 
         period = _freq_to_period[infer_freq(x.index)]
     start_date = x.index[0]


### PR DESCRIPTION
- [x] closes #9882
- [ ] tests added / passed. 
- [ ] code/documentation is well formatted.  
- [ ] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

One approach to fix #9882 which a compat function for `pd.infer_freq`.

- this is ugly - a `with` in a `try` block but I think a `contextmanager` of `if` block would not be any better...
- i think for the tests it's better to suppress the error messages instead of fixing the usage
- no AI


<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
