### PR TITLE
BUG: return nan from Power.solve_power when it fails to converge

### DIFF
--- a/statsmodels/stats/power.py
+++ b/statsmodels/stats/power.py
@@ -548,6 +548,11 @@ class Power:
             )
 
             warnings.warn(convergence_doc, ConvergenceWarning, stacklevel=2)
+            # the root finder did not converge, so ``val`` is not a solution
+            # (it is the last point the solver evaluated, e.g. a bracket
+            # bound). Returning it would masquerade as a valid answer; return
+            # nan instead to signal that no solution was found.
+            val = np.nan
 
         # attach fit_res, for reading only, should be needed only for debugging
         fit_res.insert(0, success)
@@ -747,10 +752,10 @@ class TTestPower(Power):
             power of the test, e.g. 0.8, is one minus the probability of a
             type II error. Power is the probability that the test correctly
             rejects the Null Hypothesis if the Alternative Hypothesis is true.
-        alternative : str, 'two-sided' (default) or 'one-sided'
+        alternative : str, 'two-sided' (default), 'larger', 'smaller'
             extra argument to choose whether the power is calculated for a
-            two-sided (default) or one sided test.
-            'one-sided' assumes we are in the relevant tail.
+            two-sided (default) or one sided test. The one-sided test can be
+            either 'larger', 'smaller'.
 
         Returns
         -------

--- a/statsmodels/stats/tests/test_power.py
+++ b/statsmodels/stats/tests/test_power.py
@@ -919,6 +919,42 @@ def test_power_solver():
             )
 
 
+def test_solve_power_no_solution_returns_nan():
+    # GH#9378: when the power equation has no solution (e.g. a one-sided test
+    # whose effect_size points into the wrong tail) the root finder cannot
+    # converge. Previously solve_power still returned the last value the solver
+    # evaluated -- a bracket bound such as 10 -- which masqueraded as a valid
+    # sample size. It should return nan instead, while still warning that it
+    # failed to converge.
+    from statsmodels.tools.sm_exceptions import ConvergenceWarning
+
+    tt = smp.TTestPower()
+
+    # 'smaller' alternative but a positive effect size -> impossible
+    with pytest.warns(ConvergenceWarning):
+        val = tt.solve_power(
+            effect_size=0.5, nobs=None, alpha=0.05, power=0.8,
+            alternative="smaller",
+        )
+    assert np.isnan(val)
+    assert_equal(tt.cache_fit_res[0], 0)
+
+    # mirror case: 'larger' alternative but a negative effect size
+    with pytest.warns(ConvergenceWarning):
+        val = tt.solve_power(
+            effect_size=-0.5, nobs=None, alpha=0.05, power=0.8,
+            alternative="larger",
+        )
+    assert np.isnan(val)
+
+    # a solvable case is unaffected and still returns a finite sample size
+    val = tt.solve_power(
+        effect_size=0.5, nobs=None, alpha=0.05, power=0.8,
+        alternative="larger",
+    )
+    assert np.isfinite(val)
+
+
 # TODO: can something useful be made from this?
 @pytest.mark.xfail(reason="Known failure on modern SciPy >= 0.10", strict=True)
 def test_power_solver_warn():


### PR DESCRIPTION
## Problem

That `Power.solve_power` can be asked to solve a power equation that has no solution.  As a result a caller who does not treat the `ConvergenceWarning` as fatal silently gets a bogus sample size. The clearest case is a one-sided test whose `effect_size` points into the wrong tail. For example, solving for sample size with `alternative="smaller"` but a positive effect size. This was raised in #9378.

```python
from statsmodels.stats.power import TTestPower
TTestPower().solve_power(effect_size=0.5, alpha=0.05, power=0.8, alternative="smaller")
# ConvergenceWarning: Failed to converge on a solution.
# array([10.])
```

There is no `nobs` where a wrong-tail one-sided test reaches the target power, so the root finder doesn't converge and emits a `ConvergenceWarning`. But `solve_power` then returns `array([10.])` anyway. The lower bracket bound the solver last evaluated.

## Root cause

In `Power.solve_power`, when every solver attempt fails, `success` is set to 0 and a `ConvergenceWarning` is issued, but the function still runs `return val`, where `val` is the last point the solver evaluated (a bracket bound), not a root.

## Fix

When `success != 1`, set `val = np.nan` before returning. This is off the existing `success` flag, so it only affects runs that already failed to converge and already warned. No case that currently converges changes. `cache_fit_res` still records the raw solver output for debugging.

I chose `nan` over raising (both were offered in #9378) because it is the less-breaking option that composes with the `ConvergenceWarning` already emitted, and is a natural "no solution" result.

## Also

Corrects the `TTestPower.solve_power` docstring, which advertised `alternative='one-sided'`, a value the code rejects with `ValueError: alternative has to be 'two-sided', 'larger' or 'smaller'`. Its own `power` method and the sibling `TTestIndPower`/`NormalIndPower` `solve_power` docstrings already use the correct `'two-sided'`/`'larger'`/`'smaller'`.

## Tests

`test_solve_power_no_solution_returns_nan` asserts that the two sign-mismatched one-sided cases return `nan` (with a `ConvergenceWarning` and `cache_fit_res[0] == 0`), and that a solvable control case still returns a finite value. Verified red→green: the test fails on `main` (returns `array([10.])`) and passes with the fix. Full `test_power.py` and `test_gof.py` suites pass; `ruff` is clean.

## Scope

Left narrow. #9378 also asks for a general mechanism to intercept impossible cases up front via an effect-size sign check, and for a broader review of the power docstrings so those are left as follow-ups. The sign check needs per-test semantics that the maintainer flagged as uncertain, and is a larger behaviour-design change than this simple return fix.
