### PR TITLE
ENH: report the last root-finder value in the solve_power ConvergenceWarning

### DIFF
--- a/statsmodels/stats/power.py
+++ b/statsmodels/stats/power.py
@@ -501,6 +501,9 @@ class Power:
         fit_kwds = self.start_bqexp[key]
         fit_res = []
         # print vars()
+        # ensure ``val`` is bound for the warning below even if the first
+        # solver raises before assigning it and no backup solver runs
+        val = np.nan
         try:
             val, res = brentq_expanding(func, full_output=True, **fit_kwds)
             failed = False
@@ -547,11 +550,18 @@ class Power:
                 convergence_doc,
             )
 
-            warnings.warn(convergence_doc, ConvergenceWarning, stacklevel=2)
             # the root finder did not converge, so ``val`` is not a solution
             # (it is the last point the solver evaluated, e.g. a bracket
-            # bound). Returning it would masquerade as a valid answer; return
-            # nan instead to signal that no solution was found.
+            # bound). Report it in the warning for diagnostics, but return
+            # nan instead so it cannot masquerade as a valid answer.
+            warnings.warn(
+                convergence_doc
+                + f"The last value evaluated by the root finder was {val}; "
+                "returning nan instead. Solver details are stored in the "
+                "``cache_fit_res`` attribute.",
+                ConvergenceWarning,
+                stacklevel=2,
+            )
             val = np.nan
 
         # attach fit_res, for reading only, should be needed only for debugging

--- a/statsmodels/stats/tests/test_power.py
+++ b/statsmodels/stats/tests/test_power.py
@@ -931,7 +931,12 @@ def test_solve_power_no_solution_returns_nan():
     tt = smp.TTestPower()
 
     # 'smaller' alternative but a positive effect size -> impossible
-    with pytest.warns(ConvergenceWarning):
+    # the warning reports the (numeric) last value the solver evaluated,
+    # since it is no longer returned
+    with pytest.warns(
+        ConvergenceWarning,
+        match=r"last value evaluated by the root finder was \[?\d",
+    ):
         val = tt.solve_power(
             effect_size=0.5, nobs=None, alpha=0.05, power=0.8,
             alternative="smaller",


### PR DESCRIPTION
## Problem

Small follow-up to #9884, from josef-pkt's review comment. Now that `Power.solve_power` returns nan when the root finder fails to converge, the last value the solver evaluated is lost. The request was that if we don't return the latest value, it should at least be printed in the warning message.

Before (on main):

```
ConvergenceWarning:
Failed to converge on a solution.
```

After:

```
ConvergenceWarning:
Failed to converge on a solution.
The last value evaluated by the root finder was [10.]; returning nan instead. Solver details are stored in the ``cache_fit_res`` attribute.
```

## Change

- In the non-convergence branch of `Power.solve_power`, the `ConvergenceWarning` message now appends the last value the root finder evaluated and points at `cache_fit_res` for the full solver output. Return behaviour is unchanged (still nan), and converging runs are untouched.
- `val` is now pre-bound to nan before the solver chain. Without this, interpolating `val` into the message could hit an unbound name on the defensive path where `brentq_expanding` raises and no backup solver runs (`start_value` nan; not reachable with the shipped `start_ttp` defaults, but those are user-settable instance attributes).

## Tests

Extended `test_solve_power_no_solution_returns_nan` to require the warning message to contain the numeric last value (`match=r"last value evaluated by the root finder was \[?\d"`). Verified red-to-green: on main the tightened test fails with DID NOT WARN (the message is the bare generic string); with this change it passes. Full `test_power.py` passes (83 passed, 2 skipped, 2 xfailed); ruff is clean on both files.

## Notes

The value is reported in raw form, e.g. `[10.]` when the failing solver was `fsolve` (which returns a length-1 array).
