### PR TITLE
fix: correct parameter names in docstrings (prob_infl, bin_edges, pred_kwds, param_nums, mu1_low)

### DIFF
--- a/statsmodels/base/_prediction_inference.py
+++ b/statsmodels/base/_prediction_inference.py
@@ -534,7 +534,7 @@ def get_prediction_linear(
     row_labels : list of str or None
         If row_lables are provided, then they will replace the generated
         labels.
-    pred_kwargs :
+    pred_kwds :
         Some models can take additional keyword arguments, such as offset or
         additional exog in multi-part models.
         See the predict method of the model for the details.
@@ -610,7 +610,7 @@ def get_prediction_monotonic(
     link : instance of link function
         If no link function is provided, then the ``mmodel.family.link` is
         used.
-    pred_kwargs :
+    pred_kwds :
         Some models can take additional keyword arguments, such as offset or
         additional exog in multi-part models.
         See the predict method of the model for the details.
@@ -707,7 +707,7 @@ def get_prediction_delta(
     row_labels : list of str or None
         If row_lables are provided, then they will replace the generated
         labels.
-    pred_kwargs :
+    pred_kwds :
         Some models can take additional keyword arguments, such as offset or
         additional exog in multi-part models.
         See the predict method of the model for the details.

--- a/statsmodels/discrete/count_model.py
+++ b/statsmodels/discrete/count_model.py
@@ -782,7 +782,7 @@ class ZeroInflatedPoisson(GenericZeroInflated):
             like dispersion parameter.
         mu : array_like
             Array of mean predictions for main model.
-        prob_inlf : array_like
+        prob_infl : array_like
             Array of predicted probabilities of zero-inflation `w`.
 
         Returns
@@ -956,7 +956,7 @@ class ZeroInflatedGeneralizedPoisson(GenericZeroInflated):
             like dispersion parameter.
         mu : array_like
             Array of mean predictions for main model.
-        prob_inlf : array_like
+        prob_infl : array_like
             Array of predicted probabilities of zero-inflation `w`.
 
         Returns
@@ -1093,7 +1093,7 @@ class ZeroInflatedNegativeBinomialP(GenericZeroInflated):
             like dispersion parameter.
         mu : array_like
             Array of mean predictions for main model.
-        prob_inlf : array_like
+        prob_infl : array_like
             Array of predicted probabilities of zero-inflation `w`.
 
         Returns

--- a/statsmodels/discrete/diagnostic.py
+++ b/statsmodels/discrete/diagnostic.py
@@ -54,7 +54,7 @@ class CountDiagnostic:
 
         Parameters
         ----------
-        binedges : array_like or None
+        bin_edges : array_like or None
             This defines which counts are included in the test on frequencies
             and how counts are combined in bins.
             The default if bin_edges is None will change in future.

--- a/statsmodels/emplike/aft_el.py
+++ b/statsmodels/emplike/aft_el.py
@@ -410,7 +410,7 @@ class AFTResults(OptAFT):
         ----------
         b0_vals : list
             The value of parameters to be tested
-        param_num : list
+        param_nums : list
             Which parameters to be tested
         maxiter : int, optional
             How many iterations to use in the EM algorithm.  Default is 30

--- a/statsmodels/emplike/descriptive.py
+++ b/statsmodels/emplike/descriptive.py
@@ -1076,9 +1076,9 @@ class DescStatMV(_OptFuncts):
 
         Parameters
         ----------
-        m1_low : float
+        mu1_low : float
             Minimum value of the mean for variable 1
-        m1_upp : float
+        mu1_upp : float
             Maximum value of the mean for variable 1
         mu2_low : float
             Minimum value of the mean for variable 2

--- a/statsmodels/emplike/originregress.py
+++ b/statsmodels/emplike/originregress.py
@@ -170,7 +170,7 @@ class OriginResults(RegressionResults):
         b0_vals : 1darray
             The hypothesized value to be tested.
 
-        param_num : 1darray
+        param_nums : 1darray
             Which parameters to test.  Note this uses python
             indexing but the '0' parameter refers to the intercept term,
             which is assumed 0.  Therefore, param_num should be > 0.


### PR DESCRIPTION
## Summary

Several docstring parameter names do not match the actual function signatures, causing confusion for users reading the API docs.

### Fixes

| File | Wrong | Correct | Location |
|------|-------|---------|----------|
| `statsmodels/discrete/count_model.py` | `prob_inlf` | `prob_infl` | `ZeroInflated*._predict_var` docstring (3×) |
| `statsmodels/discrete/diagnostic.py` | `binedges` | `bin_edges` | `test_chisquare_prob` docstring |
| `statsmodels/base/_prediction_inference.py` | `pred_kwargs` | `pred_kwds` | `get_prediction_linear/monotonic/delta` docstrings (3×) |
| `statsmodels/emplike/aft_el.py` | `param_num` | `param_nums` | `AftResults.test_beta` docstring |
| `statsmodels/emplike/originregress.py` | `param_num` | `param_nums` | `OriginResults.test_beta` docstring |
| `statsmodels/emplike/descriptive.py` | `m1_low`, `m1_upp` | `mu1_low`, `mu1_upp` | `mv_mean_contour` docstring |

No logic changes - docstrings only.