### PR TITLE
BUG: Fix ccovf shape mismatch for different length arrays

### DIFF
--- a/statsmodels/tsa/stattools/_stattools.py
+++ b/statsmodels/tsa/stattools/_stattools.py
@@ -1111,8 +1111,9 @@ def ccovf(x, y, adjusted=True, demean=True, fft=True):
     else:
         d = n
 
+    m = len(y)
     method = "fft" if fft else "direct"
-    return correlate(xo, yo, "full", method=method)[n - 1 :] / d
+    return correlate(xo, yo, "full", method=method)[m - 1 :] / d
 
 
 @deprecate_kwarg("unbiased", "adjusted")

--- a/statsmodels/tsa/stattools/_stattools.py
+++ b/statsmodels/tsa/stattools/_stattools.py
@@ -1113,6 +1113,8 @@ def ccovf(x, y, adjusted=True, demean=True, fft=True):
 
     m = len(y)
     method = "fft" if fft else "direct"
+    # When y is shorter than x, the denominator counts must follow len(y)
+    # to match the actual number of overlapping observations at each lag.
     return correlate(xo, yo, "full", method=method)[m - 1 :] / d
 
 

--- a/statsmodels/tsa/tests/test_stattools.py
+++ b/statsmodels/tsa/tests/test_stattools.py
@@ -1063,6 +1063,51 @@ def test_compare_acovf_vs_ccovf(demean, adjusted, fft, reset_randomstate):
     assert_almost_equal(F1, F2, decimal=7)
 
 
+@pytest.mark.parametrize("adjusted", [True, False])
+@pytest.mark.parametrize("fft", [True, False])
+def test_ccovf_different_lengths(adjusted, fft):
+    # Regression test for GH#9565
+    # ccovf crashed when len(x) != len(y) and adjusted=True
+    rs = np.random.RandomState(98765)
+    x = rs.normal(size=200)
+    y = rs.normal(size=150)
+
+    result = ccovf(x, y, adjusted=adjusted, fft=fft)
+    # Output should always have length len(x)
+    assert result.shape == (200,)
+    assert np.all(np.isfinite(result))
+
+    # Also test when len(x) < len(y)
+    result2 = ccovf(y, x, adjusted=adjusted, fft=fft)
+    assert result2.shape == (150,)
+    assert np.all(np.isfinite(result2))
+
+
+def test_ccovf_different_lengths_known_lag():
+    # Verify that ccovf correctly identifies a known lag
+    # when the arrays have different lengths (GH#9565)
+    rs = np.random.RandomState(54321)
+    x = rs.normal(size=200)
+    # y is x shifted by 5 positions, but shorter
+    y = x[5:180] + rs.normal(size=175) * 0.05
+
+    result = ccovf(x, y, adjusted=False)
+    # Peak should be at lag 5
+    assert result.shape == (200,)
+    assert np.argmax(result[:50]) == 5
+
+
+def test_ccf_different_lengths():
+    # Regression test for GH#9565 (ccf calls ccovf)
+    rs = np.random.RandomState(11111)
+    x = rs.normal(size=100)
+    y = rs.normal(size=80)
+
+    result = ccf(x, y, adjusted=True, nlags=30)
+    assert result.shape == (30,)
+    assert np.all(np.isfinite(result))
+
+
 @pytest.mark.smoke
 @pytest.mark.slow
 def test_arma_order_select_ic():


### PR DESCRIPTION
- [x] closes #9565
- [x] tests added / passed.
- [x] code/documentation is well formatted.
- [x] properly formatted commit message.

## Summary

The `ccovf` function crashes with `ValueError: operands could not be broadcast together` when `adjusted=True` and the two input arrays have different lengths.

The issue is that the function slices the output of `scipy.signal.correlate(x, y, "full")` using `[n - 1:]` where `n = len(x)`. Because the full correlation has length `n + m - 1`, slicing at `n - 1` leaves `m` elements. But the function then divides by a denominator array `d` of length `n`. When `n != m`, this causes a shape mismatch.

The fix changes the slice to `[m - 1:]` where `m = len(y)`, which correctly returns `n` elements matching the length of `d`.

## Testing

Verified that:
1. The original crash from #9565 is resolved
2. Equal-length arrays produce identical results (no regressions)
3. Peak lag detection is correct when `y` is a shifted version of `x` with different length