### PR TITLE
DOC: Following NumPy-style doc for Gamma log-likelihood

### DIFF
--- a/statsmodels/genmod/families/family.py
+++ b/statsmodels/genmod/families/family.py
@@ -806,8 +806,8 @@ class Gamma(Family):
             (scale * \mu_i)) - (var\_weights_i * endog_i) /
             (scale * \mu_i)) - \ln \Gamma(var\_weights_i / scale) - \ln(\endog_i)
 
-        Note on weights parameterization
-        --------------------------------
+        **Note on weights parameterization**
+
         statsmodels follows the SPSS/SAS definition for variance weights:
         Var(endog_i) = scale * mu_i² / var_weights_i — i.e., the effective
         dispersion is scale / var_weights_i.


### PR DESCRIPTION
Getting rid of the following warning while documentation generation:

```
UserWarning: Unknown section Note On Weights Parameterization in the docstring of loglike_obs in /opt/hostedtoolcache/Python/3.14.6/x64/lib/python3.14/site-packages/statsmodels/genmod/families/family.py.
```

---

- [x] closes #xxxx - NA
- [x] tests added / passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
