### PR TITLE
MAINT: fix typos in docstrings and comments

### DIFF
--- a/statsmodels/compat/pandas.py
+++ b/statsmodels/compat/pandas.py
@@ -102,7 +102,7 @@ def infer_freq(index) -> str | None:
     with _infer_freq_returns_offset():
         freq = pd.infer_freq(index)
 
-    # new pandas versions retuns BaseOffset
+    # new pandas versions returns BaseOffset
     if not isinstance(freq, str) and freq is not None:
         return freq.freqstr
     return freq
@@ -174,7 +174,7 @@ except ImportError:
 
     def make_dataframe():
         """
-        Simple verion of pandas._testing.makeDataFrame
+        Simple version of pandas._testing.makeDataFrame
         """
         n = 30
         k = 4

--- a/statsmodels/compat/pytest.py
+++ b/statsmodels/compat/pytest.py
@@ -34,7 +34,7 @@ def pytest_warns(
     warning: type[Warning] | tuple[type[Warning], ...] | None
 ) -> WarningsChecker | NoWarningsChecker:
     """
-    Shim for pytest warn compatability
+    Shim for pytest warn compatibility
 
     Parameters
     ----------

--- a/statsmodels/conftest.py
+++ b/statsmodels/conftest.py
@@ -69,7 +69,7 @@ def pytest_runtest_setup(item):
         pytest.skip("skipping due to --skip-matplotlib")
 
     if "matplotlib" in item.keywords and not HAVE_MATPLOTLIB:
-        pytest.skip("skipping since matplotlib is not intalled")
+        pytest.skip("skipping since matplotlib is not installed")
 
     if "smoke" in item.keywords and item.config.getoption("--skip-smoke"):
         pytest.skip("skipping due to --skip-smoke")

--- a/statsmodels/discrete/diagnostic.py
+++ b/statsmodels/discrete/diagnostic.py
@@ -95,7 +95,7 @@ class CountDiagnostic:
         In this case, edges are 0, ..., 9 which defines 9 bins for
         counts 0 to 8. The last bin is dropped, so the joint test hypothesis is
         that the observed aggregated frequencies for counts 0 to 7 correspond
-        to the model prediction for those frequencies. Predicted probabilites
+        to the model prediction for those frequencies. Predicted probabilities
         Prob(y_i = k | x) are aggregated over observations ``i``.
 
         """

--- a/statsmodels/multivariate/manova.py
+++ b/statsmodels/multivariate/manova.py
@@ -86,7 +86,7 @@ class MANOVA(Model):
             If true, then testing the intercept is skipped, the model is not
             changed.
             Note: If a term has a numerically insignificant effect, then
-            an exception because of emtpy arrays may be raised. This can
+            an exception because of empty arrays may be raised. This can
             happen for the intercept if the data has been demeaned.
 
         Returns

--- a/statsmodels/multivariate/multivariate_ols.py
+++ b/statsmodels/multivariate/multivariate_ols.py
@@ -446,7 +446,7 @@ class _MultivariateOLSResults(LikelihoodModelResults):
             If true, then testing the intercept is skipped, the model is not
             changed.
             Note: If a term has a numerically insignificant effect, then
-            an exception because of emtpy arrays may be raised. This can
+            an exception because of empty arrays may be raised. This can
             happen for the intercept if the data has been demeaned.
 
         Returns
@@ -602,7 +602,7 @@ class MultivariateLSResults(LikelihoodModelResults):
             If true, then testing the intercept is skipped, the model is not
             changed.
             Note: If a term has a numerically insignificant effect, then
-            an exception because of emtpy arrays may be raised. This can
+            an exception because of empty arrays may be raised. This can
             happen for the intercept if the data has been demeaned.
 
         Returns

--- a/statsmodels/nonparametric/kde.py
+++ b/statsmodels/nonparametric/kde.py
@@ -535,7 +535,7 @@ def kdensityfft(
         curve estimators`. Journal of Computational and Graphical Statistics.
         3.1, 35-56.
     Jones, M.C. and H.W. Lotwick. (1984) `Remark AS R50: A Remark on Algorithm
-        AS 176. Kernal Density Estimation Using the Fast Fourier Transform`.
+        AS 176. Kernel Density Estimation Using the Fast Fourier Transform`.
         Journal of the Royal Statistical Society. Series C. 33.1, 120-2.
     Silverman, B.W. (1982) `Algorithm AS 176. Kernel density estimation using
         the Fast Fourier Transform. Journal of the Royal Statistical Society.

--- a/statsmodels/robust/covariance.py
+++ b/statsmodels/robust/covariance.py
@@ -1607,7 +1607,7 @@ class CovDetMCD:
 
     preliminary version
 
-    reproducability:
+    reproducibility:
 
     This uses deterministic starting sets and there is no randomness in the
     estimator.
@@ -1857,11 +1857,11 @@ class CovDetS:
 
     Notes
     -----
-    Reproducability:
+    Reproducibility:
 
     This uses deterministic starting sets and there is no randomness in the
     estimator.
-    However, the estimates may not be reproducable across statsmodels versions
+    However, the estimates may not be reproducible across statsmodels versions
     when the methods for starting sets or default tuning parameters for the
     optimization change. With different starting sets, the estimate can
     converge to a different local optimum.

--- a/statsmodels/tools/rootfinding.py
+++ b/statsmodels/tools/rootfinding.py
@@ -46,7 +46,7 @@ def brentq_expanding(func, low=None, upp=None, args=(), xtol=1e-5,
         negative. If None, then it is set to -1.
     increasing : bool or None
         If None, then the function is evaluated at the initial bounds to
-        determine wether the function is increasing or not. If increasing is
+        determine whether the function is increasing or not. If increasing is
         True (False), then it is assumed that the function is monotonically
         increasing (decreasing).
     max_it : int
@@ -194,7 +194,7 @@ def brentq_expanding(func, low=None, upp=None, args=(), xtol=1e-5,
         if np.isnan(f_low) and np.isnan(f_upp):
             # can we still get here?
             raise ValueError("max_it reached"
-                             "\nthe function values at boths bounds are NaN"
+                             "\nthe function values at both bounds are NaN"
                              "\nchange the starting bounds, set bounds"
                              "or increase max_it")
 

--- a/statsmodels/tools/sequences.py
+++ b/statsmodels/tools/sequences.py
@@ -116,7 +116,7 @@ def n_primes(n):
 
     if len(primes) < n:
         big_number = 10
-        while "Not enought primes":
+        while "Not enough primes":
             primes = primes_from_2_to(big_number)[:n]
             if len(primes) == n:
                 break
@@ -173,7 +173,7 @@ def halton(dim, n_sample, bounds=None, start_index=0):
     dim : int
         Dimension of the parameter space.
     n_sample : int
-        Number of samples to generate in the parametr space.
+        Number of samples to generate in the parameter space.
     bounds : tuple or array_like ([min, k_vars], [max, k_vars])
         Desired range of transformed data. The transformation apply the bounds
         on the sample and not the theoretical space, unit cube. Thus min and

--- a/statsmodels/tools/sm_exceptions.py
+++ b/statsmodels/tools/sm_exceptions.py
@@ -6,7 +6,7 @@ only needed it standard errors, for example ValueError or TypeError, are not
 accurate descriptions of the reason for the error.
 
 Warnings should derive from either an existing warning or another custom
-warning, and should usually be accompanied by a sting using the format
+warning, and should usually be accompanied by a string using the format
 warning_name_doc that services as a generic message to use when the warning is
 raised.
 """

--- a/statsmodels/tools/tools.py
+++ b/statsmodels/tools/tools.py
@@ -461,7 +461,7 @@ class Bunch(dict):
     *args
         Arguments passed to dict constructor, tuples (key, value).
     **kwargs
-        Keyword agument passed to dict constructor, key=value.
+        Keyword argument passed to dict constructor, key=value.
 
     """
 
@@ -475,7 +475,7 @@ def _ensure_2d(x, ndarray=False):
     Parameters
     ----------
     x : ndarray, Series, DataFrame or None
-        Input to verify dimensions, and to transform as necesary
+        Input to verify dimensions, and to transform as necessary
     ndarray : bool
         Flag indicating whether to always return a NumPy array. Setting False
         will return an pandas DataFrame when the input is a Series or a


### PR DESCRIPTION
Fix spelling mistakes found with codespell in core source files. No runtime behaviour is affected.

Changes:

- `statsmodels/conftest.py`: `intalled` → `installed`
- `statsmodels/tools/sm_exceptions.py`: `sting` → `string`
- `statsmodels/tools/rootfinding.py`: `wether` → `whether`, `boths` → `both`
- `statsmodels/tools/tools.py`: `agument` → `argument`, `necesary` → `necessary`
- `statsmodels/tools/sequences.py`: `enought` → `enough`, `parametr` → `parameter`
- `statsmodels/compat/pandas.py`: `retuns` → `returns`, `verion` → `version`
- `statsmodels/compat/pytest.py`: `compatability` → `compatibility`
- `statsmodels/multivariate/manova.py`: `emtpy` → `empty`
- `statsmodels/multivariate/multivariate_ols.py`: `emtpy` → `empty` (two occurrences)
- `statsmodels/nonparametric/kde.py`: `Kernal` → `Kernel` (in a journal reference)
- `statsmodels/discrete/diagnostic.py`: `probabilites` → `probabilities`
- `statsmodels/robust/covariance.py`: `reproducability` → `reproducibility` (×3), `reproducable` → `reproducible`