### PR TITLE
ENH: add R-squared variants to state space results

### DIFF
--- a/docs/source/statespace.rst
+++ b/docs/source/statespace.rst
@@ -611,6 +611,8 @@ Commonly used attributes include:
   :py:meth:`mse <mlemodel.MLEResults.mse>`, and
   :py:meth:`mae <mlemodel.MLEResults.mae>` - sum of squared errors,
   mean square error, and mean absolute error
+- :py:meth:`get_rsquared <mlemodel.MLEResults.get_rsquared>` - compute
+  Harvey-style R-squared measures using an explicit baseline model
 - Information criteria, including: :py:meth:`aic <mlemodel.MLEResults.aic>`,
   :py:meth:`aicc <mlemodel.MLEResults.aicc>`,
   :py:meth:`bic <mlemodel.MLEResults.bic>`, and

--- a/examples/notebooks/statespace_sarimax_faq.ipynb
+++ b/examples/notebooks/statespace_sarimax_faq.ipynb
@@ -11,6 +11,7 @@
     "\n",
     "* Comparing trends and exogenous variables in `SARIMAX`, `ARIMA` and `AutoReg`\n",
     "* Reconstructing residuals, fitted values and forecasts in `SARIMAX` and `ARIMA`\n",
+    "* Choosing an R-squared measure for state space models\n",
     "* Initial residuals in `SARIMAX` and `ARIMA`"
    ]
   },
@@ -759,6 +760,45 @@
    "outputs": [],
    "source": [
     "print(sarimax_res.summary())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7f58d227",
+   "metadata": {},
+   "source": [
+    "## R-squared measures\n",
+    "\n",
+    "State space models do not have a unique R-squared comparison model. `rsquared_mean` compares the model's prediction errors against deviations from a constant mean and is closest to the usual regression R-squared. `rsquared_rwdrift` instead compares against changes around an average drift, making it more informative for nonstationary series with a stochastic trend. For seasonal series, `get_rsquared` can use changes around a drift and seasonal means; the seasonal period must be supplied explicitly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3c32e6e1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "seasonal_period = 12  # For example, monthly observations\n",
+    "\n",
+    "pd.Series(\n",
+    "    {\n",
+    "        \"Mean\": sarimax_res.rsquared_mean,\n",
+    "        \"Random walk with drift\": sarimax_res.rsquared_rwdrift,\n",
+    "        \"Seasonal random walk with drift\": sarimax_res.get_rsquared(\n",
+    "            baseline=\"seasonal\", seasonal=seasonal_period\n",
+    "        ),\n",
+    "    },\n",
+    "    name=\"R-squared\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "04b80945",
+   "metadata": {},
+   "source": [
+    "The random-walk-with-drift measure is the default displayed in state space summaries when the model does not define its own R-squared. The seasonal variant should only be used when the data have a known seasonal frequency. Since each measure uses a different baseline, values should not be compared across baselines; a value can also be negative when the fitted model has larger prediction errors than its baseline."
    ]
   },
   {

--- a/examples/notebooks/statespace_sarimax_faq.ipynb
+++ b/examples/notebooks/statespace_sarimax_faq.ipynb
@@ -769,7 +769,7 @@
    "source": [
     "## R-squared measures\n",
     "\n",
-    "State space models do not have a unique R-squared comparison model. `rsquared_mean` compares the model's prediction errors against deviations from a constant mean and is closest to the usual regression R-squared. `rsquared_rwdrift` instead compares against changes around an average drift, making it more informative for nonstationary series with a stochastic trend. For seasonal series, `get_rsquared` can use changes around a drift and seasonal means; the seasonal period must be supplied explicitly."
+    "State space models do not have a unique R-squared comparison model. The measures below currently support univariate models only. `rsquared_mean` compares the model's prediction errors against deviations from a constant mean and is closest to the usual regression R-squared. `rsquared_rwdrift` instead compares against changes around an average drift, making it more informative for nonstationary series with a stochastic trend. For seasonal series, `get_rsquared` can use changes around a drift and seasonal means; the seasonal period must be supplied explicitly."
    ]
   },
   {

--- a/examples/python/statespace_sarimax_faq.py
+++ b/examples/python/statespace_sarimax_faq.py
@@ -497,6 +497,7 @@ print(sarimax_res.summary())
 # ## R-squared measures
 #
 # State space models do not have a unique R-squared comparison model.
+# The measures below currently support univariate models only.
 # `rsquared_mean` compares the model's prediction errors against deviations
 # from a constant mean and is closest to the usual regression R-squared.
 # `rsquared_rwdrift` instead compares against changes around an average

--- a/examples/python/statespace_sarimax_faq.py
+++ b/examples/python/statespace_sarimax_faq.py
@@ -17,6 +17,7 @@
 # `AutoReg`
 # * Reconstructing residuals, fitted values and forecasts in `SARIMAX` and
 # `ARIMA`
+# * Choosing an R-squared measure for state space models
 # * Initial residuals in `SARIMAX` and `ARIMA`
 
 # ## Comparing trends and exogenous variables in `SARIMAX`, `ARIMA` and
@@ -492,6 +493,39 @@ print(arx_res.summary())
 
 print(sarimax_res.summary())
 
+
+# ## R-squared measures
+#
+# State space models do not have a unique R-squared comparison model.
+# `rsquared_mean` compares the model's prediction errors against deviations
+# from a constant mean and is closest to the usual regression R-squared.
+# `rsquared_rwdrift` instead compares against changes around an average
+# drift, making it more informative for nonstationary series with a
+# stochastic trend. For seasonal series, `get_rsquared` can use changes
+# around a drift and seasonal means; the seasonal period must be supplied
+# explicitly.
+
+
+seasonal_period = 12  # For example, monthly observations
+
+pd.Series(
+    {
+        "Mean": sarimax_res.rsquared_mean,
+        "Random walk with drift": sarimax_res.rsquared_rwdrift,
+        "Seasonal random walk with drift": sarimax_res.get_rsquared(
+            baseline="seasonal", seasonal=seasonal_period
+        ),
+    },
+    name="R-squared",
+)
+
+
+# The random-walk-with-drift measure is the default displayed in state
+# space summaries when the model does not define its own R-squared. The
+# seasonal variant should only be used when the data have a known seasonal
+# frequency. Since each measure uses a different baseline, values should not
+# be compared across baselines; a value can also be negative when the fitted
+# model has larger prediction errors than its baseline.
 
 # ## Initial residuals `SARIMAX` and `ARIMA`
 #

--- a/statsmodels/tsa/statespace/mlemodel.py
+++ b/statsmodels/tsa/statespace/mlemodel.py
@@ -3393,10 +3393,13 @@ class MLEResults(tsbase.TimeSeriesModelResults):
 
         Returns
         -------
-        float or ndarray
-            The R-squared value. A float is returned for univariate models,
-            and an array with one value per endogenous variable is returned
-            for multivariate models.
+        float
+            The R-squared value.
+
+        Raises
+        ------
+        NotImplementedError
+            If the model has more than one endogenous variable.
 
         See Also
         --------
@@ -3411,6 +3414,12 @@ class MLEResults(tsbase.TimeSeriesModelResults):
         baseline = string_like(
             baseline, "baseline", options=("rwdrift", "mean", "seasonal")
         )
+
+        if self.model.k_endog > 1:
+            raise NotImplementedError(
+                "Harvey-style R-squared is currently only available for "
+                "univariate state space models."
+            )
 
         if self.standardized_forecasts_error is None:
             raise ValueError(
@@ -3472,7 +3481,7 @@ class MLEResults(tsbase.TimeSeriesModelResults):
 
         with np.errstate(divide="ignore", invalid="ignore"):
             rsquared = 1 - sse / denominator
-        return rsquared[0] if self.model.k_endog == 1 else rsquared
+        return rsquared[0]
 
     @cache_readonly
     def rsquared_mean(self):

--- a/statsmodels/tsa/statespace/mlemodel.py
+++ b/statsmodels/tsa/statespace/mlemodel.py
@@ -3398,6 +3398,11 @@ class MLEResults(tsbase.TimeSeriesModelResults):
             and an array with one value per endogenous variable is returned
             for multivariate models.
 
+        See Also
+        --------
+        rsquared_mean
+        rsquared_rwdrift
+
         Notes
         -----
         The SSE is computed from finite prediction errors following Harvey
@@ -3470,24 +3475,6 @@ class MLEResults(tsbase.TimeSeriesModelResults):
         return rsquared[0] if self.model.k_endog == 1 else rsquared
 
     @cache_readonly
-    def rsquared(self):
-        """
-        Coefficient of determination.
-
-        Raises
-        ------
-        NotImplementedError
-            Always raised. State space models do not have a unique R-squared
-            comparison model.
-        """
-        raise NotImplementedError(
-            "State space models do not have a single comparison model that is "
-            "always appropriate for R-squared computation. Use "
-            "rsquared_rwdrift, rsquared_mean, or get_rsquared with an "
-            "explicit baseline."
-        )
-
-    @cache_readonly
     def rsquared_mean(self):
         """
         R-squared relative to a constant mean model.
@@ -3497,6 +3484,11 @@ class MLEResults(tsbase.TimeSeriesModelResults):
         float or ndarray
             ``1 - SSE / SSM`` where SSM is the sum of squares around the
             sample mean.
+
+        See Also
+        --------
+        get_rsquared
+        rsquared_rwdrift
         """
         return self.get_rsquared(baseline="mean")
 
@@ -3510,23 +3502,13 @@ class MLEResults(tsbase.TimeSeriesModelResults):
         float or ndarray
             ``1 - SSE / SSDM`` where SSDM is the sum of squares of first
             differences around their mean.
+
+        See Also
+        --------
+        get_rsquared
+        rsquared_mean
         """
         return self.get_rsquared(baseline="rwdrift")
-
-    @cache_readonly
-    def rsquared_seasonal(self):
-        """
-        R-squared relative to a seasonal random walk with drift.
-
-        Raises
-        ------
-        NotImplementedError
-            Always raised. Seasonal R-squared requires a seasonal period.
-        """
-        raise NotImplementedError(
-            "Seasonal R-squared requires a seasonal period. Use "
-            'get_rsquared(baseline="seasonal", seasonal=period).'
-        )
 
     @cache_readonly
     def zvalues(self):
@@ -5516,16 +5498,19 @@ class MLEResults(tsbase.TimeSeriesModelResults):
             ("No. Observations:", [self.nobs]),
             ("Log Likelihood", ["%#5.3f" % self.llf]),
         ]
-        try:
-            r2 = self.rsquared_rwdrift
-        except (AttributeError, NotImplementedError, ValueError):
-            r2 = None
-        if r2 is not None:
-            if np.ndim(r2) == 0:
-                r2 = "%#8.3f" % r2
-            else:
-                r2 = str(["%#8.3f" % value for value in r2])
-            top_right.append(("R-squared:", [r2]))
+        if hasattr(self, "rsquared"):
+            top_right.append(("R-squared:", ["%#8.3f" % self.rsquared]))
+        else:
+            try:
+                r2 = self.rsquared_rwdrift
+            except (AttributeError, NotImplementedError, ValueError):
+                r2 = None
+            if r2 is not None:
+                if np.ndim(r2) == 0:
+                    r2 = "%#8.3f" % r2
+                else:
+                    r2 = str(["%#8.3f" % value for value in r2])
+                top_right.append(("R-squared:", [r2]))
         top_right += [
             ("AIC", ["%#5.3f" % self.aic]),
             ("BIC", ["%#5.3f" % self.bic]),

--- a/statsmodels/tsa/statespace/mlemodel.py
+++ b/statsmodels/tsa/statespace/mlemodel.py
@@ -29,6 +29,7 @@ from statsmodels.tools.numdiff import (
 )
 from statsmodels.tools.sm_exceptions import ModelWarning, PrecisionWarning, ValueWarning
 from statsmodels.tools.tools import Bunch, pinv_extended
+from statsmodels.tools.validation import int_like, string_like
 import statsmodels.tsa.base.prediction as pred
 import statsmodels.tsa.base.tsa_model as tsbase
 from statsmodels.tsa.stattools._stattools import breakvar_heteroskedasticity_test
@@ -3376,6 +3377,157 @@ class MLEResults(tsbase.TimeSeriesModelResults):
         """
         return np.sum(self.resid**2)
 
+    def get_rsquared(self, baseline="rwdrift", seasonal=None):
+        """
+        Compute a Harvey-style coefficient of determination.
+
+        Parameters
+        ----------
+        baseline : {"rwdrift", "mean", "seasonal"}, default "rwdrift"
+            The comparison model used in the denominator. "mean" compares
+            against a constant mean model, "rwdrift" compares against a random
+            walk with drift, and "seasonal" compares against a random walk with
+            drift and seasonal dummies.
+        seasonal : int, optional
+            The seasonal periodicity. Required when ``baseline="seasonal"``.
+
+        Returns
+        -------
+        float or ndarray
+            The R-squared value. A float is returned for univariate models,
+            and an array with one value per endogenous variable is returned
+            for multivariate models.
+
+        Notes
+        -----
+        The SSE is computed from finite prediction errors following Harvey
+        (1989), section 5.5.5.
+        """
+        baseline = string_like(
+            baseline, "baseline", options=("rwdrift", "mean", "seasonal")
+        )
+
+        if self.standardized_forecasts_error is None:
+            raise ValueError(
+                "Cannot compute R-squared when standardized forecast errors "
+                "have not been computed."
+            )
+        if self.forecasts_error_cov is None:
+            raise ValueError(
+                "Cannot compute R-squared when forecast error covariances "
+                "have not been computed."
+            )
+
+        d = np.maximum(self.loglikelihood_burn, self.nobs_diffuse)
+        srss = np.sum(self.standardized_forecasts_error[:, d:] ** 2, axis=1)
+        f_t = np.diagonal(self.forecasts_error_cov[:, :, -1])
+        sse = f_t * srss
+
+        endog = np.asarray(self.model.endog)
+
+        def demeaned_sumsquares(data, empty=np.nan):
+            valid = ~np.isnan(data)
+            count = valid.sum(axis=0)
+            total = np.nansum(data, axis=0)
+            mean = np.divide(
+                total, count, out=np.zeros(self.model.k_endog), where=count > 0
+            )
+            ss = np.nansum((data - mean) ** 2, axis=0)
+            ss[count == 0] = empty
+            return ss, count
+
+        if baseline == "mean":
+            denominator = demeaned_sumsquares(endog)[0]
+        else:
+            diff_endog = np.diff(endog, axis=0)
+            if baseline == "rwdrift":
+                denominator = demeaned_sumsquares(diff_endog)[0]
+            else:
+                if seasonal is None:
+                    raise ValueError(
+                        'The seasonal argument is required when '
+                        'baseline="seasonal".'
+                    )
+                seasonal = int_like(seasonal, "seasonal")
+                if seasonal < 2:
+                    raise ValueError(
+                        "seasonal must be an integer greater than 1."
+                    )
+                denominator = np.zeros(self.model.k_endog)
+                count = np.zeros(self.model.k_endog)
+                for i in range(seasonal):
+                    seasonal_diff = diff_endog[i::seasonal]
+                    if seasonal_diff.shape[0] > 0:
+                        ss_i, count_i = demeaned_sumsquares(
+                            seasonal_diff, empty=0
+                        )
+                        denominator += ss_i
+                        count += count_i
+                denominator[count == 0] = np.nan
+
+        with np.errstate(divide="ignore", invalid="ignore"):
+            rsquared = 1 - sse / denominator
+        return rsquared[0] if self.model.k_endog == 1 else rsquared
+
+    @cache_readonly
+    def rsquared(self):
+        """
+        Coefficient of determination.
+
+        Raises
+        ------
+        NotImplementedError
+            Always raised. State space models do not have a unique R-squared
+            comparison model.
+        """
+        raise NotImplementedError(
+            "State space models do not have a single comparison model that is "
+            "always appropriate for R-squared computation. Use "
+            "rsquared_rwdrift, rsquared_mean, or get_rsquared with an "
+            "explicit baseline."
+        )
+
+    @cache_readonly
+    def rsquared_mean(self):
+        """
+        R-squared relative to a constant mean model.
+
+        Returns
+        -------
+        float or ndarray
+            ``1 - SSE / SSM`` where SSM is the sum of squares around the
+            sample mean.
+        """
+        return self.get_rsquared(baseline="mean")
+
+    @cache_readonly
+    def rsquared_rwdrift(self):
+        """
+        R-squared relative to a random walk with drift.
+
+        Returns
+        -------
+        float or ndarray
+            ``1 - SSE / SSDM`` where SSDM is the sum of squares of first
+            differences around their mean.
+        """
+        return self.get_rsquared(baseline="rwdrift")
+
+    @cache_readonly
+    def rsquared_seasonal(self):
+        """
+        R-squared relative to a seasonal random walk with drift.
+
+        Raises
+        ------
+        NotImplementedError
+            Always raised. Seasonal R-squared requires a seasonal period.
+        """
+        raise NotImplementedError(
+            "Seasonal R-squared requires a seasonal period. Use "
+            'get_rsquared(baseline="seasonal", seasonal=period).'
+        )
+
     @cache_readonly
     def zvalues(self):
         """
@@ -5364,8 +5516,16 @@ class MLEResults(tsbase.TimeSeriesModelResults):
             ("No. Observations:", [self.nobs]),
             ("Log Likelihood", ["%#5.3f" % self.llf]),
         ]
-        if hasattr(self, "rsquared"):
-            top_right.append(("R-squared:", ["%#8.3f" % self.rsquared]))
+        try:
+            r2 = self.rsquared_rwdrift
+        except (AttributeError, NotImplementedError, ValueError):
+            r2 = None
+        if r2 is not None:
+            if np.ndim(r2) == 0:
+                r2 = "%#8.3f" % r2
+            else:
+                r2 = str(["%#8.3f" % value for value in r2])
+            top_right.append(("R-squared:", [r2]))
         top_right += [
             ("AIC", ["%#5.3f" % self.aic]),
             ("BIC", ["%#5.3f" % self.bic]),

--- a/statsmodels/tsa/statespace/tests/test_mlemodel.py
+++ b/statsmodels/tsa/statespace/tests/test_mlemodel.py
@@ -759,8 +759,10 @@ def test_results_rsquared_multivariate():
     mod.initialize_known([0.0], [[0.0]])
     res = mod.filter([])
 
-    assert_allclose(res.rsquared_rwdrift, _rwdrift_rsquared(res))
-    assert_equal(res.rsquared_rwdrift.shape, (2,))
+    with pytest.raises(NotImplementedError, match="only available for univariate"):
+        res.get_rsquared()
+
+    assert_equal("R-squared:" in str(res.summary()), False)
 
 
 def test_results_rsquared_missing_data():

--- a/statsmodels/tsa/statespace/tests/test_mlemodel.py
+++ b/statsmodels/tsa/statespace/tests/test_mlemodel.py
@@ -731,6 +731,20 @@ def test_results_rsquared_regression():
     assert_equal("%#8.3f" % res.rsquared_rwdrift in txt, True)
 
 
+def test_results_summary_uses_model_rsquared():
+    class ResultsWithRsquared(sarimax.SARIMAXResults):
+        @property
+        def rsquared(self):
+            return 0.123
+
+    mod = sarimax.SARIMAX(np.arange(10.0))
+    res = mod.filter([0.0, 1.0], results_class=ResultsWithRsquared)
+
+    txt = str(res.summary())
+    assert_equal("%#8.3f" % res.rsquared in txt, True)
+    assert_equal("%#8.3f" % res.rsquared_rwdrift in txt, False)
+
+
 def test_results_rsquared_multivariate():
     endog = np.array([[1.0, 2.0], [2.0, 1.0], [4.0, 3.0], [8.0, 5.0]])
     mod = MLEModel(
@@ -769,10 +783,6 @@ def test_results_rsquared_errors():
     mod = MLEModel([1.0, 2.0, 4.0, 8.0], **kwargs)
     res = mod.filter([])
 
-    with pytest.raises(NotImplementedError):
-        res.rsquared
-    with pytest.raises(NotImplementedError):
-        res.rsquared_seasonal
     with pytest.raises(ValueError, match="seasonal argument is required"):
         res.get_rsquared(baseline="seasonal")
     with pytest.raises(ValueError, match="baseline must be one of"):

--- a/statsmodels/tsa/statespace/tests/test_mlemodel.py
+++ b/statsmodels/tsa/statespace/tests/test_mlemodel.py
@@ -649,6 +649,142 @@ def test_summary():
         res.summary()
 
 
+def _finite_sse(res):
+    d = np.maximum(res.loglikelihood_burn, res.nobs_diffuse)
+    srss = np.sum(res.standardized_forecasts_error[:, d:] ** 2, axis=1)
+    f_t = np.diagonal(res.forecasts_error_cov[:, :, -1])
+    return f_t * srss
+
+
+def _demeaned_sumsquares(data, k_endog, empty=np.nan):
+    valid = ~np.isnan(data)
+    count = valid.sum(axis=0)
+    total = np.nansum(data, axis=0)
+    mean = np.divide(total, count, out=np.zeros(k_endog), where=count > 0)
+    ss = np.nansum((data - mean) ** 2, axis=0)
+    ss[count == 0] = empty
+    return ss, count
+
+
+def _mean_rsquared(res):
+    ssm = _demeaned_sumsquares(res.model.endog, res.model.k_endog)[0]
+    return 1 - _finite_sse(res) / ssm
+
+
+def _autoreg_ssr(endog, seasonal=False, period=None):
+    from statsmodels.tsa.ar_model import AutoReg
+
+    ssr = np.zeros(endog.shape[1])
+    for i in range(endog.shape[1]):
+        mod = AutoReg(
+            endog[:, i],
+            0,
+            trend="c",
+            seasonal=seasonal,
+            period=period,
+            missing="drop",
+        )
+        ssr[i] = mod.fit().ssr
+    return ssr
+
+
+def _rwdrift_rsquared(res):
+    diff_endog = np.diff(res.model.endog, axis=0)
+    ssdm = _autoreg_ssr(diff_endog)
+    return 1 - _finite_sse(res) / ssdm
+
+
+def _seasonal_rsquared(res, seasonal):
+    diff_endog = np.diff(res.model.endog, axis=0)
+    ssdsm = _autoreg_ssr(diff_endog, seasonal=True, period=seasonal)
+    return 1 - _finite_sse(res) / ssdsm
+
+
+def test_results_rsquared_regression():
+    from statsmodels.regression.linear_model import OLS
+    from statsmodels.tools.tools import add_constant
+
+    endog = np.array([1.0, 2.0, 4.0, 8.0, 16.0, 23.0])
+    exog = add_constant(np.arange(endog.shape[0]))
+    benchmark = OLS(endog, exog).fit()
+
+    mod = sarimax.SARIMAX(
+        endog,
+        exog=exog,
+        order=(0, 0, 0),
+        trend="n",
+        concentrate_scale=True,
+    )
+    res = mod.smooth(benchmark.params)
+
+    assert_allclose(res.rsquared_mean, benchmark.rsquared)
+    assert_allclose(res.get_rsquared(baseline="mean"), benchmark.rsquared)
+    assert_allclose(res.rsquared_rwdrift, _rwdrift_rsquared(res)[0])
+    assert_allclose(res.get_rsquared(), res.rsquared_rwdrift)
+    assert_allclose(
+        res.get_rsquared(baseline="seasonal", seasonal=2),
+        _seasonal_rsquared(res, 2)[0],
+    )
+
+    txt = str(res.summary())
+    assert_equal(re.search(r"R-squared:", txt) is not None, True)
+    assert_equal("%#8.3f" % res.rsquared_rwdrift in txt, True)
+
+
+def test_results_rsquared_multivariate():
+    endog = np.array([[1.0, 2.0], [2.0, 1.0], [4.0, 3.0], [8.0, 5.0]])
+    mod = MLEModel(
+        endog,
+        k_states=1,
+        design=np.zeros((2, 1)),
+        transition=np.zeros((1, 1)),
+        selection=np.zeros((1, 1)),
+        state_cov=np.zeros((1, 1)),
+        obs_cov=np.eye(2),
+    )
+    mod.initialize_known([0.0], [[0.0]])
+    res = mod.filter([])
+
+    assert_allclose(res.rsquared_rwdrift, _rwdrift_rsquared(res))
+    assert_equal(res.rsquared_rwdrift.shape, (2,))
+
+
+def test_results_rsquared_missing_data():
+    endog = np.array([1.0, 2.0, np.nan, 5.0, 8.0, 13.0])
+    mod = sarimax.SARIMAX(
+        endog, order=(0, 0, 0), trend="c", concentrate_scale=True
+    )
+    res = mod.smooth([np.nanmean(endog)])
+
+    assert_allclose(res.rsquared_mean, _mean_rsquared(res)[0])
+    assert_allclose(res.rsquared_rwdrift, _rwdrift_rsquared(res)[0])
+    assert_allclose(
+        res.get_rsquared(baseline="seasonal", seasonal=2),
+        _seasonal_rsquared(res, 2)[0],
+    )
+    assert_equal(np.isfinite(res.rsquared_rwdrift), True)
+
+
+def test_results_rsquared_errors():
+    mod = MLEModel([1.0, 2.0, 4.0, 8.0], **kwargs)
+    res = mod.filter([])
+
+    with pytest.raises(NotImplementedError):
+        res.rsquared
+    with pytest.raises(NotImplementedError):
+        res.rsquared_seasonal
+    with pytest.raises(ValueError, match="seasonal argument is required"):
+        res.get_rsquared(baseline="seasonal")
+    with pytest.raises(ValueError, match="baseline must be one of"):
+        res.get_rsquared(baseline="invalid")
+    with pytest.raises(TypeError, match="baseline must be a string"):
+        res.get_rsquared(baseline=1)
+    with pytest.raises(TypeError, match="seasonal must be integer_like"):
+        res.get_rsquared(baseline="seasonal", seasonal="month")
+    with pytest.raises(ValueError, match="integer greater than 1"):
+        res.get_rsquared(baseline="seasonal", seasonal=1)
+
+
 def check_endog(endog, nobs=2, k_endog=1, **kwargs):
     # create the model
     mod = MLEModel(endog, **kwargs)


### PR DESCRIPTION
- [x] closes #4734
- [x] tests added / passed.
- [x] code/documentation is well formatted.
- [x] properly formatted commit message. See [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message).

## Summary

This PR adds Harvey-style R-squared measures to state space model results, closing #4734.

State space models do not have a single natural R-squared baseline. Following the issue discussion and Harvey (1989), section 5.5.5, this PR adds explicit variants instead of exposing one ambiguous default interpretation.

This is a fresh implementation that incorporates review feedback from the earlier stalled PR #6620.

## Changes

- Adds `MLEResults.get_rsquared(baseline=..., seasonal=...)`
- Adds cached convenience properties:
  - `rsquared_mean`
  - `rsquared_rwdrift`
- Leaves `rsquared` explicit by raising `NotImplementedError`, since a single default baseline would be ambiguous
- Leaves `rsquared_seasonal` explicit by raising `NotImplementedError`, since the seasonal period must be supplied
- Shows the random-walk-with-drift R-squared in state space result summaries when it can be computed
- Supports both univariate and multivariate state space models
- Handles missing observations in the denominator calculations
- Documents the new method in the state space results API overview

## R-squared variants

The implementation supports the three Harvey-style variants described in #4734:

| Baseline | Formula |
| --- | --- |
| Mean | `1 - SSE / SSM` |
| Random walk with drift | `1 - SSE / SSDM` |
| Seasonal random walk with drift | `1 - SSE / SSDSM` |

The default for `get_rsquared()` is `baseline="rwdrift"`, matching the state space summary display.

For seasonal R-squared, users must call:

```python
res.get_rsquared(baseline="seasonal", seasonal=period)
```

This avoids adding an implicit or model-dependent seasonal-period guess.

## Implementation notes

The SSE is computed from finite prediction errors:

```python
d = max(loglikelihood_burn, nobs_diffuse)
srss = sum(standardized_forecasts_error[:, d:] ** 2)
sse = forecast_error_cov[:, :, -1].diagonal() * srss
```

For multivariate models, the result is returned per endogenous variable. For univariate models, the result is returned as a scalar.

Missing observations are ignored in the baseline denominator calculations, consistent with state space support for missing data.

## Validation

Tested with:

```bash
uv run --reinstall-package statsmodels --with-editable . --with pytest pytest statsmodels/tsa/statespace/tests/test_mlemodel.py
python3 -m py_compile statsmodels/tsa/statespace/mlemodel.py statsmodels/tsa/statespace/tests/test_mlemodel.py
git diff --check
```

The affected test module passes:

```text
35 passed
```

The only warning in the full affected module is an existing Kalman filter warning unrelated to this change.