### PR TITLE
ENH/BUG: add min_diag option to cov_nearest for zero or negative diagonal

### DIFF
--- a/statsmodels/stats/correlation_tools.py
+++ b/statsmodels/stats/correlation_tools.py
@@ -153,7 +153,7 @@ def corr_clipped(corr, threshold=1e-15):
 
 
 def cov_nearest(cov, method="clipped", threshold=1e-15, n_fact=100,
-                return_all=False, min_diag=None):
+                return_all=False, *, min_diag=None):
     """
     Find the nearest covariance matrix that is positive (semi-) definite
 
@@ -222,8 +222,8 @@ def cov_nearest(cov, method="clipped", threshold=1e-15, n_fact=100,
         diag = np.diag(cov)
         if np.any(diag < min_diag):
             warnings.warn(
-                "Diagonal elements below min_diag=%r have been raised to "
-                "min_diag; the corresponding variances are changed." % min_diag,
+                f"Diagonal elements below min_diag={min_diag!r} have been "
+                "raised to min_diag; the corresponding variances are changed.",
                 SpecificationWarning,
                 stacklevel=2,
             )

--- a/statsmodels/stats/correlation_tools.py
+++ b/statsmodels/stats/correlation_tools.py
@@ -152,11 +152,13 @@ def corr_clipped(corr, threshold=1e-15):
     return x_new
 
 
-def cov_nearest(cov, method="clipped", threshold=1e-15, n_fact=100, return_all=False):
+def cov_nearest(cov, method="clipped", threshold=1e-15, n_fact=100,
+                return_all=False, min_diag=None):
     """
     Find the nearest covariance matrix that is positive (semi-) definite
 
-    This leaves the diagonal, i.e. the variance, unchanged
+    This leaves the diagonal, i.e. the variance, unchanged, unless ``min_diag``
+    is used to enforce a strictly positive diagonal (see below).
 
     Parameters
     ----------
@@ -174,6 +176,15 @@ def cov_nearest(cov, method="clipped", threshold=1e-15, n_fact=100, return_all=F
         if False (default), then only the covariance matrix is returned.
         If True, then correlation matrix and standard deviation are
         additionally returned.
+    min_diag : None or float
+        If None (default), the diagonal of ``cov`` is left unchanged. This
+        function converts the covariance matrix to a correlation matrix, which
+        is not defined if a diagonal element (variance) is zero or negative and
+        results in a matrix that contains ``nan``. If ``min_diag`` is a positive
+        float, then diagonal elements that are smaller than ``min_diag`` are
+        raised to ``min_diag`` before the conversion, and a ``SpecificationWarning``
+        is issued. This makes it possible to correct matrices with a zero or
+        negative diagonal, at the cost of changing those variances.
 
     Returns
     -------
@@ -205,6 +216,19 @@ def cov_nearest(cov, method="clipped", threshold=1e-15, n_fact=100, return_all=F
     """
 
     from statsmodels.stats.moment_helpers import corr2cov, cov2corr
+
+    cov = np.asarray(cov)
+    if min_diag is not None:
+        diag = np.diag(cov)
+        if np.any(diag < min_diag):
+            warnings.warn(
+                "Diagonal elements below min_diag=%r have been raised to "
+                "min_diag; the corresponding variances are changed." % min_diag,
+                SpecificationWarning,
+            )
+            cov = cov.copy()
+            k = cov.shape[0]
+            cov[np.arange(k), np.arange(k)] = np.maximum(diag, min_diag)
 
     cov_, std_ = cov2corr(cov, return_std=True)
     if method == "clipped":

--- a/statsmodels/stats/correlation_tools.py
+++ b/statsmodels/stats/correlation_tools.py
@@ -225,6 +225,7 @@ def cov_nearest(cov, method="clipped", threshold=1e-15, n_fact=100,
                 "Diagonal elements below min_diag=%r have been raised to "
                 "min_diag; the corresponding variances are changed." % min_diag,
                 SpecificationWarning,
+                stacklevel=2,
             )
             cov = cov.copy()
             k = cov.shape[0]

--- a/statsmodels/stats/tests/test_corrpsd.py
+++ b/statsmodels/stats/tests/test_corrpsd.py
@@ -179,6 +179,45 @@ def test_corr_psd():
     assert_almost_equal(x2, y, decimal=14)
 
 
+@pytest.mark.parametrize("method", ["clipped", "nearest"])
+def test_cov_nearest_min_diag(method):
+    # GH#9675 cov_nearest returns nan for a zero or negative diagonal because
+    # the conversion to a correlation matrix divides by a zero standard
+    # deviation. min_diag raises such diagonal elements to a positive floor.
+    from statsmodels.tools.sm_exceptions import SpecificationWarning
+
+    # default behavior is unchanged: a zero on the diagonal still yields nan
+    mat = np.array([[2.0, 0.0], [0.0, 0.0]])
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        res_default = cov_nearest(mat, method=method)
+    assert np.isnan(res_default).any()
+
+    # min_diag clips the zero diagonal element and warns
+    with pytest.warns(SpecificationWarning):
+        res = cov_nearest(mat, method=method, min_diag=1e-8)
+    assert not np.isnan(res).any()
+    assert_allclose(res, [[2.0, 0.0], [0.0, 1e-8]], atol=1e-12)
+    # result is positive semi-definite and the input is not modified
+    assert np.linalg.eigvalsh(res).min() >= -1e-12
+    assert_allclose(mat, [[2.0, 0.0], [0.0, 0.0]])
+
+    # a negative diagonal element is also corrected
+    neg = np.array([[2.0, 0.0], [0.0, -1e-8]])
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        res_neg = cov_nearest(neg, method=method, min_diag=1e-8)
+    assert not np.isnan(res_neg).any()
+    assert np.diag(res_neg).min() >= 1e-8 - 1e-20
+
+    # no warning and no change when the diagonal is already above min_diag
+    good = np.array([[2.0, 0.1], [0.1, 1.0]])
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", SpecificationWarning)
+        res_good = cov_nearest(good, method=method, min_diag=1e-8)
+    assert not np.isnan(res_good).any()
+
+
 class CheckCorrPSDMixin:
 
     def test_nearest(self):


### PR DESCRIPTION
## Summary

Closes #9675. `cov_nearest` returns a matrix full of `nan` when the input covariance has a zero (or negative) element on the diagonal:

```python
>>> cov_nearest(np.array([[2.0, 0.0], [0.0, 0.0]]))
[[ 2. nan]
 [nan nan]]
```

The cause is the conversion to a correlation matrix (`cov2corr`), which divides by `std = sqrt(diag(cov))`; a zero variance divides by zero and a negative variance takes `sqrt` of a negative number, so the result is `nan` and every downstream step propagates it.

This adds an opt-in `min_diag` parameter, following the approach @josef-pkt outlined in the issue: when `min_diag` is a positive float, diagonal elements below it are raised to `min_diag` before the correlation conversion, and a `SpecificationWarning` is issued. This fixes both zero and negative diagonals:

```python
>>> cov_nearest(np.array([[2.0, 0.0], [0.0, 0.0]]), min_diag=1e-8)
[[2.e+00 0.e+00]
 [0.e+00 1.e-08]]
```

which matches the magnitude of R's `Matrix::nearPD` on the same input.

**Default behavior is unchanged** (`min_diag=None`), so existing callers are unaffected — the `nan` result is only corrected when the caller opts in. I kept it opt-in rather than picking a non-`None` default; happy to change the default or the `1e-8` example value if you'd prefer a specific one.

## Testing

- Added `test_cov_nearest_min_diag`, parametrized over both `method="clipped"` and `method="nearest"`, asserting: default still returns `nan` (no behavior change), `min_diag` removes the `nan`, the result equals `[[2, 0], [0, 1e-8]]` and is PSD, a negative diagonal is corrected, the input array is not mutated, and no warning fires when the diagonal is already above `min_diag`.
- Full `statsmodels/stats/tests/test_corrpsd.py` passes (22 passed, 3 skipped) on Python 3.13 / macOS arm64.
- flake8 clean on both changed files.
