### PR TITLE
BUG: describe/Description handles 0-row (empty) input gracefully (#9891)

### DIFF
--- a/statsmodels/stats/descriptivestats.py
+++ b/statsmodels/stats/descriptivestats.py
@@ -421,20 +421,8 @@ class Description:
         else:
             mode_values = df.apply(_mode).T
             if mode_values.size > 0:
-                if isinstance(mode_values, pd.DataFrame):
-                    # pandas 1.0 or later
-                    mode = np.asarray(mode_values[0], dtype=float)
-                    mode_counts = np.asarray(mode_values[1], dtype=np.int64)
-                else:
-                    # pandas before 1.0 returns a Series of 2-elem list
-                    mode = []
-                    mode_counts = []
-                    for idx in mode_values.index:
-                        val = mode_values.loc[idx]
-                        mode.append(val[0])
-                        mode_counts.append(val[1])
-                    mode = np.atleast_1d(mode)
-                    mode_counts = np.atleast_1d(mode_counts)
+                mode = np.asarray(mode_values[0], dtype=float)
+                mode_counts = np.asarray(mode_values[1], dtype=np.int64)
             else:
                 mode = mode_counts = np.empty(0)
         loc = count > 0
@@ -464,7 +452,7 @@ class Description:
                 return (np.nan,) * 4
             return jarque_bera(a)
 
-        if df.shape[0] > 0 and df.shape[1] > 0:
+        if df.size:
             jb = df.apply(
                 lambda x: list(_safe_jarque_bera(x.dropna())),
                 result_type="expand",

--- a/statsmodels/stats/descriptivestats.py
+++ b/statsmodels/stats/descriptivestats.py
@@ -412,24 +412,31 @@ class Description:
                 return [float(np.squeeze(val)) for val in mode_res]
             return np.nan, np.nan
 
-        mode_values = df.apply(_mode).T
-        if mode_values.size > 0:
-            if isinstance(mode_values, pd.DataFrame):
-                # pandas 1.0 or later
-                mode = np.asarray(mode_values[0], dtype=float)
-                mode_counts = np.asarray(mode_values[1], dtype=np.int64)
-            else:
-                # pandas before 1.0 returns a Series of 2-elem list
-                mode = []
-                mode_counts = []
-                for idx in mode_values.index:
-                    val = mode_values.loc[idx]
-                    mode.append(val[0])
-                    mode_counts.append(val[1])
-                mode = np.atleast_1d(mode)
-                mode_counts = np.atleast_1d(mode_counts)
+        if df.shape[0] == 0:
+            # No observations: the mode is undefined. Skip the apply since
+            # pandas' empty-result path mis-sizes the output, raising
+            # "Length of values (2) does not match length of index" (GH#9891).
+            mode = np.full(k, np.nan)
+            mode_counts = np.full(k, np.nan)
         else:
-            mode = mode_counts = np.empty(0)
+            mode_values = df.apply(_mode).T
+            if mode_values.size > 0:
+                if isinstance(mode_values, pd.DataFrame):
+                    # pandas 1.0 or later
+                    mode = np.asarray(mode_values[0], dtype=float)
+                    mode_counts = np.asarray(mode_values[1], dtype=np.int64)
+                else:
+                    # pandas before 1.0 returns a Series of 2-elem list
+                    mode = []
+                    mode_counts = []
+                    for idx in mode_values.index:
+                        val = mode_values.loc[idx]
+                        mode.append(val[0])
+                        mode_counts.append(val[1])
+                    mode = np.atleast_1d(mode)
+                    mode_counts = np.atleast_1d(mode_counts)
+            else:
+                mode = mode_counts = np.empty(0)
         loc = count > 0
         mode_freq = np.full(mode.shape[0], np.nan)
         mode_freq[loc] = mode_counts[loc] / count.loc[loc]
@@ -457,9 +464,17 @@ class Description:
                 return (np.nan,) * 4
             return jarque_bera(a)
 
-        jb = df.apply(
-            lambda x: list(_safe_jarque_bera(x.dropna())), result_type="expand"
-        ).T
+        if df.shape[0] > 0 and df.shape[1] > 0:
+            jb = df.apply(
+                lambda x: list(_safe_jarque_bera(x.dropna())),
+                result_type="expand",
+            ).T
+        else:
+            # No observations (or no numeric columns): Jarque-Bera is
+            # undefined. Build a NaN frame with the expected four columns so
+            # the skew/kurtosis/JB lookups below do not raise KeyError
+            # (GH#9891).
+            jb = pd.DataFrame(np.nan, index=cols, columns=range(4))
         nan_mean = mean.copy()
         nan_mean.loc[nan_mean == 0] = np.nan
         coef_var = std / nan_mean

--- a/statsmodels/stats/tests/test_descriptivestats.py
+++ b/statsmodels/stats/tests/test_descriptivestats.py
@@ -160,6 +160,38 @@ def test_empty_columns(df):
     assert dropped.shape[0] == 2
 
 
+@pytest.mark.parametrize(
+    "data",
+    [
+        pd.DataFrame({"a": pd.Series([], dtype="float64")}),
+        pd.DataFrame({"a": pd.Series([], dtype="category")}),
+        pd.DataFrame(
+            {
+                "a": pd.Series([], dtype="float64"),
+                "b": pd.Series([], dtype="category"),
+            }
+        ),
+    ],
+    ids=["numeric", "categorical", "mixed"],
+)
+def test_empty_rows(data):
+    # GH#9891: describe on a 0-row input used to raise an unhelpful error
+    # from deep inside pandas/numpy (ValueError for numeric columns, KeyError
+    # for categorical ones) instead of returning an empty/NaN summary.
+    res = describe(data)
+    assert isinstance(res, pd.DataFrame)
+    assert list(res.columns) == list(data.columns)
+    # No observations in any column
+    assert (res.loc["nobs"] == 0).all()
+    assert (res.loc["missing"] == 0).all()
+    # Undefined numeric statistics are NaN rather than raising
+    if "a" in data.select_dtypes("number").columns:
+        assert np.isnan(res.loc["mean", "a"])
+        assert np.isnan(res.loc["std", "a"])
+    # Description.frame agrees with the describe convenience wrapper
+    pd.testing.assert_frame_equal(res, Description(data).frame)
+
+
 @pytest.mark.skipif(not hasattr(pd, "NA"), reason="Must support NA")
 def test_extension_types(df):
     df["c"] = pd.Series(np.arange(100.0))


### PR DESCRIPTION
Closes #9891.

## Problem
`describe` / `Description` raised an opaque error, deep from pandas/numpy, when given a 0-row DataFrame — even though `pandas.DataFrame.describe()` handles the same input fine and returns a frame of NaNs. The message depended on the column dtype, hinting at two separate unhandled spots:

- **numeric column** → `ValueError: Length of values (2) does not match length of index (1)`
- **categorical column** → `KeyError: 2`

## Root cause
Both live in `Description.numeric` (which `describe` computes by default):

1. `df.apply(_mode)` on a 0-row frame takes pandas' *empty-result* path, which calls `_mode` on an empty column; `_mode` returns a 2-tuple, so pandas tries to fit 2 values into the 1-length column index → `ValueError`.
2. For all-categorical input the numeric frame has **no columns**, so the Jarque–Bera result `jb` has no columns and `jb[2]`/`jb[3]` (skew/kurtosis) → `KeyError: 2`.

## Fix
Short-circuit both undefined computations to NaN when there are no observations:
- when `df.shape[0] == 0`, set `mode`/`mode_counts` to NaN of the right length instead of calling `apply`;
- when there are no observations or no numeric columns, build a NaN Jarque–Bera frame with the expected four columns.

`describe` now returns an empty/NaN summary (nobs=0, missing=0, other stats NaN), matching `pandas.describe`. Non-empty inputs are completely unchanged.

## Tests
Added a parametrized `test_empty_rows` covering 0-row numeric, categorical, and mixed frames (asserts no error, correct columns, nobs/missing = 0, NaN stats, and `describe == Description(...).frame`). Full `test_descriptivestats.py` passes (18 tests).