### PR TITLE
BUG: Attach mlefit attributes to the results instance so they appear in dir()

### DIFF
--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -1590,7 +1590,7 @@ class LikelihoodModelResults(Results):
 
         ``(scale) * (X.T X)^(-1)[column][:,column]`` if column is 1d
         """
-        if getattr(self, "mle_settings", None) is not None and self.mle_settings["optimizer"] in [
+        if getattr(self, "mle_settings", None) and self.mle_settings["optimizer"] in [
             "l1",
             "l1_cvxopt_cp",
         ]:
@@ -2018,7 +2018,7 @@ class LikelihoodModelResults(Results):
             # let caller override J by df_constraint
             J = df_constraints
 
-        if getattr(self, "mle_settings", None) is not None and self.mle_settings["optimizer"] in [
+        if getattr(self, "mle_settings", None) and self.mle_settings["optimizer"] in [
             "l1",
             "l1_cvxopt_cp",
         ]:

--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -1590,7 +1590,7 @@ class LikelihoodModelResults(Results):
 
         ``(scale) * (X.T X)^(-1)[column][:,column]`` if column is 1d
         """
-        if hasattr(self, "mle_settings") and self.mle_settings["optimizer"] in [
+        if getattr(self, "mle_settings", None) is not None and self.mle_settings["optimizer"] in [
             "l1",
             "l1_cvxopt_cp",
         ]:
@@ -2018,7 +2018,7 @@ class LikelihoodModelResults(Results):
             # let caller override J by df_constraint
             J = df_constraints
 
-        if hasattr(self, "mle_settings") and self.mle_settings["optimizer"] in [
+        if getattr(self, "mle_settings", None) is not None and self.mle_settings["optimizer"] in [
             "l1",
             "l1_cvxopt_cp",
         ]:

--- a/statsmodels/tsa/statespace/mlemodel.py
+++ b/statsmodels/tsa/statespace/mlemodel.py
@@ -778,9 +778,11 @@ class MLEModel(tsbase.TimeSeriesModel):
                 cov_kwds=cov_kwds,
             )
 
-            res.mlefit = mlefit
-            res.mle_retvals = mlefit.mle_retvals
-            res.mle_settings = mlefit.mle_settings
+            # Attach to the underlying results instance rather than the
+            # wrapper, so these attributes also show up in dir(res).
+            res._results.mlefit = mlefit
+            res._results.mle_retvals = mlefit.mle_retvals
+            res._results.mle_settings = mlefit.mle_settings
 
             # Reset memory conservation
             if low_memory:

--- a/statsmodels/tsa/statespace/tests/test_mlemodel.py
+++ b/statsmodels/tsa/statespace/tests/test_mlemodel.py
@@ -294,6 +294,22 @@ def test_fit_misc():
     assert_almost_equal(res_params, [0, 0], 5)
 
 
+def test_fit_attrs_in_dir():
+    # GH#9271: mlefit, mle_retvals and mle_settings were attached to the
+    # results wrapper instead of the underlying results instance, so they
+    # were reachable via attribute access but did not show up in dir(res)
+    # (and therefore not in tab-completion).
+    _, res = get_dummy_mod()
+
+    for name in ["mlefit", "mle_retvals", "mle_settings"]:
+        # Reachable as before (no regression in attribute access)
+        assert hasattr(res, name)
+        # Now discoverable via dir() / tab-completion
+        assert name in dir(res)
+        # Because they now live on the underlying results instance
+        assert name in dir(res._results)
+
+
 @pytest.mark.smoke
 def test_score_misc():
     mod, res = get_dummy_mod()

--- a/statsmodels/tsa/statespace/tests/test_mlemodel.py
+++ b/statsmodels/tsa/statespace/tests/test_mlemodel.py
@@ -294,20 +294,20 @@ def test_fit_misc():
     assert_almost_equal(res_params, [0, 0], 5)
 
 
-def test_fit_attrs_in_dir():
+@pytest.mark.parametrize("name", ["mlefit", "mle_retvals", "mle_settings"])
+def test_fit_attrs_in_dir(name):
     # GH#9271: mlefit, mle_retvals and mle_settings were attached to the
     # results wrapper instead of the underlying results instance, so they
     # were reachable via attribute access but did not show up in dir(res)
     # (and therefore not in tab-completion).
     _, res = get_dummy_mod()
 
-    for name in ["mlefit", "mle_retvals", "mle_settings"]:
-        # Reachable as before (no regression in attribute access)
-        assert hasattr(res, name)
-        # Now discoverable via dir() / tab-completion
-        assert name in dir(res)
-        # Because they now live on the underlying results instance
-        assert name in dir(res._results)
+    # Reachable as before (no regression in attribute access)
+    assert hasattr(res, name)
+    # Now discoverable via dir() / tab-completion
+    assert name in dir(res)
+    # Because they now live on the underlying results instance
+    assert name in dir(res._results)
 
 
 @pytest.mark.smoke


### PR DESCRIPTION
- [x] closes #9271
- [x] tests added / passed.
- [x] code/documentation is well formatted.
- [x] properly formatted commit message.

MLEModel.fit() attached mlefit, mle_retvals and mle_settings to the
results wrapper. They were reachable through the wrapper's attribute
delegation but did not show up in dir(res), and therefore not in
tab-completion, which is misleading when exploring the API.

Following the suggestion by @josef-pkt in the issue, this attaches them
to the underlying results instance (res._results) instead. Attribute
access is unchanged and the values now appear in dir(res).

Added test_fit_attrs_in_dir in test_mlemodel.py. It fails on main
because the names are missing from dir(res), and passes with this change.
