### PR TITLE
BUG: filter unsupported kwargs in MixedLM.fit to prevent AttributeError

### DIFF
--- a/statsmodels/regression/mixed_linear_model.py
+++ b/statsmodels/regression/mixed_linear_model.py
@@ -2209,15 +2209,16 @@ class MixedLM(base.LikelihoodModel):
             "disp",
             "maxls",
         ]
-        for x in list(fit_kwargs.keys()):
-            if x not in _allowed_kwargs:
-                warnings.warn(
-                    "Argument %s not used by MixedLM.fit" % x,
-                    RuntimeWarning,
-                    stacklevel=2,
-                )
-        fit_kwargs = {k: v for k, v in fit_kwargs.items()
-                      if k in _allowed_kwargs}
+        disallowed_kwargs = sorted(set(fit_kwargs).difference(_allowed_kwargs))
+        if disallowed_kwargs:
+            warnings.warn(
+                "Argument(s) %s not used by MixedLM.fit"
+                % ", ".join(disallowed_kwargs),
+                RuntimeWarning,
+                stacklevel=2,
+            )
+            fit_kwargs = {k: v for k, v in fit_kwargs.items()
+                          if k in _allowed_kwargs}
 
         if method is None:
             method = ["bfgs", "lbfgs", "cg"]

--- a/statsmodels/regression/mixed_linear_model.py
+++ b/statsmodels/regression/mixed_linear_model.py
@@ -2209,13 +2209,15 @@ class MixedLM(base.LikelihoodModel):
             "disp",
             "maxls",
         ]
-        for x in fit_kwargs.keys():
+        for x in list(fit_kwargs.keys()):
             if x not in _allowed_kwargs:
                 warnings.warn(
                     "Argument %s not used by MixedLM.fit" % x,
                     RuntimeWarning,
                     stacklevel=2,
                 )
+        fit_kwargs = {k: v for k, v in fit_kwargs.items()
+                      if k in _allowed_kwargs}
 
         if method is None:
             method = ["bfgs", "lbfgs", "cg"]

--- a/statsmodels/regression/tests/test_lme.py
+++ b/statsmodels/regression/tests/test_lme.py
@@ -1368,3 +1368,38 @@ def test_get_distribution():
     v += vcomp[1] * (exog_vcb**2).sum(1).mean()
     v += scale
     assert_allclose(np.var(yr - ey), v, rtol=1e-2, atol=1e-4)
+
+
+def test_fit_unsupported_kwargs_ignored():
+    # GH#9677 - passing cov_type to MixedLM.fit should warn but not crash
+    rs = np.random.RandomState(123)
+    n = 100
+    groups = np.repeat(np.arange(10), 10)
+    x = rs.normal(size=n)
+    y = x + rs.normal(size=n)
+    df = pd.DataFrame({"y": y, "x": x, "g": groups})
+
+    model = MixedLM.from_formula("y ~ x", groups="g", data=df)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        result = model.fit(cov_type="hc1")
+
+    # Should complete without AttributeError and return valid results
+    assert result.fe_params is not None
+    assert len(result.fe_params) == 2
+
+
+def test_fit_unsupported_kwargs_warns():
+    # GH#9677 - unsupported kwargs should emit RuntimeWarning
+    rs = np.random.RandomState(456)
+    n = 50
+    groups = np.repeat(np.arange(5), 10)
+    x = rs.normal(size=n)
+    y = x + rs.normal(size=n)
+    df = pd.DataFrame({"y": y, "x": x, "g": groups})
+
+    model = MixedLM.from_formula("y ~ x", groups="g", data=df)
+
+    with pytest.warns(RuntimeWarning, match="not used by MixedLM.fit"):
+        model.fit(cov_type="hc1")

--- a/statsmodels/regression/tests/test_lme.py
+++ b/statsmodels/regression/tests/test_lme.py
@@ -1401,5 +1401,10 @@ def test_fit_unsupported_kwargs_warns():
 
     model = MixedLM.from_formula("y ~ x", groups="g", data=df)
 
-    with pytest.warns(RuntimeWarning, match="not used by MixedLM.fit"):
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
         model.fit(cov_type="hc1")
+
+    runtime_warnings = [x for x in w if issubclass(x.category, RuntimeWarning)]
+    assert len(runtime_warnings) == 1
+    assert "not used by MixedLM.fit" in str(runtime_warnings[0].message)


### PR DESCRIPTION
Fixes #9677.

`MixedLM.fit()` warns about unsupported kwargs (like `cov_type`) but still passes them through to `super().fit()`. The parent class then tries to compute robust covariance, which fails with `AttributeError: 'MixedLM' object has no attribute 'wexog'`.

This PR filters out the unsupported kwargs after the warning so they never reach the parent class. The warning is still emitted so users know the argument had no effect.

Added two tests:
- verify that passing `cov_type` no longer crashes
- verify the RuntimeWarning is still raised
