### PR TITLE
BUG: Do not pass hess to L-BFGS-B and TNC in _fit_minimize

### DIFF
--- a/statsmodels/base/optimizer.py
+++ b/statsmodels/base/optimizer.py
@@ -395,7 +395,16 @@ def _fit_minimize(
     options["maxiter"] = maxiter
 
     # Use Hessian/Jacobian only if they're required by the method
-    no_hess = ["Nelder-Mead", "Powell", "CG", "BFGS", "COBYLA", "SLSQP"]
+    no_hess = [
+        "Nelder-Mead",
+        "Powell",
+        "CG",
+        "BFGS",
+        "L-BFGS-B",
+        "TNC",
+        "COBYLA",
+        "SLSQP",
+    ]
     no_jac = ["Nelder-Mead", "Powell", "COBYLA"]
     if kwargs["min_method"] in no_hess:
         hess = None

--- a/statsmodels/base/tests/test_optimize.py
+++ b/statsmodels/base/tests/test_optimize.py
@@ -1,6 +1,9 @@
 from statsmodels.compat.scipy import SP_LT_15, SP_LT_17
 
-from numpy.testing import assert_, assert_almost_equal
+import warnings
+
+import numpy as np
+from numpy.testing import assert_, assert_allclose, assert_almost_equal
 import pytest
 
 from statsmodels.base.optimizer import (
@@ -194,6 +197,30 @@ def test_minimize_scipy_nm():
         disp=0,
     )
     assert_almost_equal(xopt, [2, 3.5], 4)
+
+
+@pytest.mark.parametrize("min_method", ["L-BFGS-B", "TNC"])
+def test_minimize_no_hess_method(min_method):
+    # GH#9140: L-BFGS-B and TNC do not accept a Hessian, so `hess` must not
+    # be forwarded to scipy.optimize.minimize (warning or error depending
+    # on the scipy version).
+    from statsmodels.discrete.discrete_model import Poisson
+
+    exog = np.column_stack((np.ones(10), np.arange(10) / 10.0))
+    endog = np.array([1, 2, 1, 3, 2, 4, 3, 5, 4, 6])
+    res_default = Poisson(endog, exog).fit(disp=0)
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        res = Poisson(endog, exog).fit(
+            method="minimize", min_method=min_method, disp=0
+        )
+    hess_warnings = [
+        wrn for wrn in w if "hess" in str(wrn.message).lower()
+    ]
+    assert hess_warnings == []
+    assert res.mle_retvals["converged"]
+    assert_allclose(res.params, res_default.params, rtol=1e-4)
 
 
 def test_lbfgs_disp_false_no_output(capsys):


### PR DESCRIPTION
closes #9140

`_fit_minimize` drops the Hessian for methods that do not accept one via the `no_hess` list, but L-BFGS-B and TNC were missing from it. As a result, `fit(method="minimize", min_method="L-BFGS-B")` (or `"TNC"`) forwarded the model Hessian to `scipy.optimize.minimize`, which emits `RuntimeWarning: Method L-BFGS-B does not use Hessian information (hess)` (an error with some scipy versions). Per the scipy docs, only Newton-CG, dogleg, trust-ncg, trust-krylov, trust-exact and trust-constr accept `hess`.

This adds the two methods to `no_hess`, keeping the existing deny-list approach so that unknown or callable custom methods are unaffected. (COBYQA, added in scipy 1.14, has the same issue for both `hess` and `jac`; happy to include it here if preferred, otherwise it can be a follow-up.)

A parametrized regression test fits a small Poisson model with both methods and asserts no hess-related warning, convergence, and agreement with the default fit. The test fails on current code with the captured RuntimeWarning and passes with the fix.

Disclosure: this patch was prepared with AI assistance and human review.
