### PR TITLE
BUG: Fix sison-glaz confint failure for small or sparse counts

### DIFF
--- a/statsmodels/stats/proportion.py
+++ b/statsmodels/stats/proportion.py
@@ -579,10 +579,18 @@ def multinomial_proportions_confint(counts, alpha=0.05, method="goodman"):
             )
 
         # Find the value of `c` that will give us the confidence intervals
-        # (solving nu(c) <= 1 - alpha < nu(c + 1).
-        c = 1.0
-        nuc = nu(c)
-        nucp1 = nu(c + 1)
+        # (solving nu(c) <= 1 - alpha < nu(c + 1)).
+        # The coverage of the degenerate box (`c` = 0) is taken to be zero,
+        # following the reference implementation in R's MultinomialCI, so
+        # that `c` = 0 is a valid solution when nu(1) already exceeds
+        # 1 - alpha (possible for very small `n`).  Once `c` >= `n`, the box
+        # [count - c, count + c] contains the full support {0, ..., n} of
+        # every cell, so its coverage is exactly one; the Edgeworth-based
+        # approximation `nu` is not used there, as it can plateau below
+        # 1 - alpha for small or sparse counts (see GH#9587).
+        c = 0.0
+        nuc = 0.0
+        nucp1 = nu(c + 1) if c + 1 < n else 1.0
         while not (nuc <= (1 - alpha) < nucp1):
             if c > n:
                 raise Exception(
@@ -591,7 +599,7 @@ def multinomial_proportions_confint(counts, alpha=0.05, method="goodman"):
                 )
             c += 1
             nuc = nucp1
-            nucp1 = nu(c + 1)
+            nucp1 = nu(c + 1) if c + 1 < n else 1.0
 
         # Compute gamma and the corresponding confidence intervals.
         g = (1 - alpha - nuc) / (nucp1 - nuc)

--- a/statsmodels/stats/tests/test_proportion.py
+++ b/statsmodels/stats/tests/test_proportion.py
@@ -227,6 +227,31 @@ def test_confint_multinomial_proportions_sison_glaz_sparse(counts):
     assert np.all(proportions <= cis[:, 1])
 
 
+def test_confint_multinomial_proportions_sison_glaz_sparse_r_reference():
+    # GH#9587: check the fixed sison-glaz output for a sparse case against
+    # reference values computed from R's MultinomialCI (Sison-Glaz)
+    # algorithm.  For this vector nu(1) already exceeds 1 - alpha, so the
+    # search terminates at c = 0 (the branch added by the fix); R reaches
+    # the same solution by initialising pold = 0 before testing cc = 1.
+    # The counts are kept small enough that count + c never exceeds n, so
+    # the box upper bounds are not truncated and the two implementations
+    # are directly comparable.
+    ci_r = np.array(
+        [
+            0.5, 1.0,
+            0.5, 1.0,
+            0.0, 0.9655815875,
+            0.0, 0.9655815875,
+            0.0, 0.9655815875,
+            0.0, 0.9655815875,
+            0.0, 0.9655815875,
+        ]
+    ).reshape(-1, 2)
+    counts = [1, 1, 0, 0, 0, 0, 0]
+    cis = multinomial_proportions_confint(counts, 0.05, method="sison-glaz")
+    assert_allclose(cis, ci_r, atol=1e-6)
+
+
 class CheckProportionMixin:
     def test_proptest(self):
         # equality of k-samples

--- a/statsmodels/stats/tests/test_proportion.py
+++ b/statsmodels/stats/tests/test_proportion.py
@@ -203,6 +203,30 @@ def test_confint_multinomial_proportions_zeros():
     assert_allclose(ci_01, ci_0, atol=5e-4)
 
 
+@pytest.mark.parametrize(
+    "counts",
+    [
+        [6, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0],
+        [4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        [0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0],
+        [2, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0],
+    ],
+)
+def test_confint_multinomial_proportions_sison_glaz_sparse(counts):
+    # GH#9587: the search for `c` used to fail for small or sparse counts,
+    # for which the approximated coverage nu(c) either exceeds 1 - alpha
+    # already at c = 1 or plateaus below 1 - alpha.
+    counts = np.asarray(counts)
+    cis = multinomial_proportions_confint(counts, 0.05, method="sison-glaz")
+    proportions = counts / counts.sum()
+    assert cis.shape == (len(counts), 2)
+    assert np.all(cis >= 0)
+    assert np.all(cis <= 1)
+    # intervals must contain the point estimates
+    assert np.all(cis[:, 0] <= proportions)
+    assert np.all(proportions <= cis[:, 1])
+
+
 class CheckProportionMixin:
     def test_proptest(self):
         # equality of k-samples


### PR DESCRIPTION
closes #9587

`multinomial_proportions_confint(counts, method="sison-glaz")` raised `Exception: Couldn't find a value for 'c' ...` for small or sparse inputs such as `[6, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0]`. The search for `c` (solving `nu(c) <= 1 - alpha < nu(c + 1)`) failed for two reasons. First, it started at `c = 1`, so the legitimate solution `c = 0` was unreachable when `nu(1)` already exceeds `1 - alpha` (very small `n`). Second, the Edgeworth-based approximation `nu(c)` can be non-monotone and plateau below `1 - alpha` for sparse counts, even though the exact coverage is 1 once `c >= n` (the box `[count - c, count + c]` then contains the full support of every cell), so no crossing existed.

The fix starts the search at `c = 0` with `nu(0)` taken as zero — matching the reference implementation in R's MultinomialCI package — and substitutes the exact coverage of 1 for the approximation once `c + 1 >= n`. Results for all previously working inputs are unchanged (the existing tests against R MultinomialCI reference values pass unmodified); previously failing inputs now return valid intervals in [0, 1] containing the point estimates. These intervals are necessarily wide — the method's approximation is documented as needing at least 7 categories with counts of about 5 — but returning them seems preferable to raising, consistent with `goodman` handling the same inputs.

One judgment call reviewers may want to weigh: for the no-crossing case, this uses the exact saturated-box coverage rather than raising a clearer error for data outside the method's validity range. (R's own implementation silently returns invalid intervals for that case, so it was not usable as a reference there.)

A parametrized regression test covers the four vectors from the issue.

Disclosure: this patch was prepared with AI assistance and human review.
