### PR TITLE
DOC: add missing PoissonResults and NegativeBinomialPResults to discretemod autosummary (closes #9022)

### DIFF
--- a/docs/source/discretemod.rst
+++ b/docs/source/discretemod.rst
@@ -136,7 +136,9 @@ The specific result classes are:
    ProbitResults
    CountResults
    MultinomialResults
+   PoissonResults
    NegativeBinomialResults
+   NegativeBinomialPResults
    GeneralizedPoissonResults
 
 .. currentmodule:: statsmodels.discrete.count_model


### PR DESCRIPTION
Closes #9022 (title: "PoissonResults is not in the docs").

## What

The *"specific result classes"* autosummary block in `docs/source/discretemod.rst` lists a results class for each specific discrete model, but two were missing:

- **`PoissonResults`** — the `Poisson` model is listed in the "specific model classes" block, but `PoissonResults` was absent from the results block (this is the exact issue in the title).
- **`NegativeBinomialPResults`** — `NegativeBinomialP` is listed as a model, but its results class was likewise missing (noted in the issue body).

Both classes exist in `statsmodels.discrete.discrete_model`, so without an autosummary entry their API pages were never generated. This adds the two missing entries, ordered to mirror the model list (`Poisson`, `NegativeBinomial`, `NegativeBinomialP`).

## Scope

Deliberately limited to adding the two missing autosummary entries named by the issue. The broader discrete `Results` docstring items raised in the issue *comments* (e.g. the `_discrete_results_docs` Parameters section, the base-class list) are **not** touched here — they are a separate, larger review and are better handled on their own.

## Verification (local)

The two classes resolve under the module and their API pages are generated by the autosummary `:toctree:` after the change:

- `hasattr(statsmodels.discrete.discrete_model, "PoissonResults")` → `True`
- `hasattr(statsmodels.discrete.discrete_model, "NegativeBinomialPResults")` → `True`

Isolated Sphinx build (sphinx 7.4.7 + numpydoc 1.9.0) of the results autosummary block, before vs. after this change:

| generated page | before | after |
|---|---|---|
| `...discrete_model.PoissonResults.html` | absent | generated |
| `...discrete_model.NegativeBinomialPResults.html` | absent | generated |

The generated `NegativeBinomialPResults` page renders a real class entry (`class="py class"`), and `index` links to both new pages. This is a docs-only change (`+2/-0`, no code, no tests needed per the PR template).
