### PR TITLE
BUG: divide adjusted ccovf by the overlapping count, not len(x) - k

### DIFF
--- a/statsmodels/tsa/stattools/_stattools.py
+++ b/statsmodels/tsa/stattools/_stattools.py
@@ -1078,7 +1078,8 @@ def ccovf(x, y, adjusted=True, demean=True, fft=True):
     x, y : array_like
        The time series data to use in the calculation.
     adjusted : bool, optional
-       If True, then denominators for cross-covariance are n-k, otherwise n.
+       If True, then denominators for cross-covariance are the number of
+       overlapping observations at each lag k, min(m, n-k), otherwise n.
     demean : bool, optional
         Flag indicating whether to demean x and y.
     fft : bool, default True
@@ -1100,6 +1101,7 @@ def ccovf(x, y, adjusted=True, demean=True, fft=True):
     fft = bool_like(fft, "fft", optional=False)
 
     n = len(x)
+    m = len(y)
     if demean:
         xo = x - x.mean()
         yo = y - y.mean()
@@ -1107,11 +1109,10 @@ def ccovf(x, y, adjusted=True, demean=True, fft=True):
         xo = x
         yo = y
     if adjusted:
-        d = np.arange(n, 0, -1)
+        d = np.minimum(np.arange(n, 0, -1), m)
     else:
         d = n
 
-    m = len(y)
     method = "fft" if fft else "direct"
     # When y is shorter than x, the denominator counts must follow len(y)
     # to match the actual number of overlapping observations at each lag.

--- a/statsmodels/tsa/stattools/_stattools.py
+++ b/statsmodels/tsa/stattools/_stattools.py
@@ -1497,7 +1497,8 @@ def ccovf(x, y, adjusted=True, demean=True, fft=True):
     x, y : array_like
        The time series data to use in the calculation.
     adjusted : bool, optional
-       If True, then denominators for cross-covariance are n-k, otherwise n.
+       If True, then denominators for cross-covariance are the number of
+       overlapping observations at each lag k, min(m, n-k), otherwise n.
     demean : bool, optional
         Flag indicating whether to demean x and y.
     fft : bool, default True
@@ -1519,6 +1520,7 @@ def ccovf(x, y, adjusted=True, demean=True, fft=True):
     fft = bool_like(fft, "fft", optional=False)
 
     n = len(x)
+    m = len(y)
     if demean:
         xo = x - x.mean()
         yo = y - y.mean()
@@ -1526,11 +1528,10 @@ def ccovf(x, y, adjusted=True, demean=True, fft=True):
         xo = x
         yo = y
     if adjusted:
-        d = np.arange(n, 0, -1)
+        d = np.minimum(np.arange(n, 0, -1), m)
     else:
         d = n
 
-    m = len(y)
     method = "fft" if fft else "direct"
     # When y is shorter than x, the denominator counts must follow len(y)
     # to match the actual number of overlapping observations at each lag.

--- a/statsmodels/tsa/tests/test_stattools.py
+++ b/statsmodels/tsa/tests/test_stattools.py
@@ -1098,6 +1098,23 @@ def test_ccovf_different_lengths_known_lag():
     assert np.argmax(result[:50]) == 5
 
 
+def test_ccovf_adjusted_shorter_y():
+    # GH#9565 follow-up: with len(y) < len(x), adjusted=True must divide by
+    # the number of overlapping observations, min(len(y), len(x) - k), not
+    # by len(x) - k.
+    x = np.ones(6)
+    y = np.ones(2)
+
+    # Every product is exactly 1.0, so every adjusted average must be 1.0.
+    result = ccovf(x, y, adjusted=True, demean=False)
+    assert_allclose(result, np.ones(6))
+
+    # The unadjusted path divides by len(x) throughout, by definition, so the
+    # overlap counts min(2, 6 - k) show through unscaled.
+    unadjusted = ccovf(x, y, adjusted=False, demean=False)
+    assert_allclose(unadjusted, np.array([2, 2, 2, 2, 2, 1]) / 6)
+
+
 def test_ccf_different_lengths():
     # Regression test for GH#9565 (ccf calls ccovf)
     rs = np.random.RandomState(11111)

--- a/statsmodels/tsa/tests/test_stattools.py
+++ b/statsmodels/tsa/tests/test_stattools.py
@@ -1809,6 +1809,23 @@ def test_ccovf_different_lengths_known_lag():
     assert np.argmax(result[:50]) == 5
 
 
+def test_ccovf_adjusted_shorter_y():
+    # GH#9565 follow-up: with len(y) < len(x), adjusted=True must divide by
+    # the number of overlapping observations, min(len(y), len(x) - k), not
+    # by len(x) - k.
+    x = np.ones(6)
+    y = np.ones(2)
+
+    # Every product is exactly 1.0, so every adjusted average must be 1.0.
+    result = ccovf(x, y, adjusted=True, demean=False)
+    assert_allclose(result, np.ones(6))
+
+    # The unadjusted path divides by len(x) throughout, by definition, so the
+    # overlap counts min(2, 6 - k) show through unscaled.
+    unadjusted = ccovf(x, y, adjusted=False, demean=False)
+    assert_allclose(unadjusted, np.array([2, 2, 2, 2, 2, 1]) / 6)
+
+
 def test_ccf_different_lengths():
     # Regression test for GH#9565 (ccf calls ccovf)
     rs = np.random.RandomState(11111)


### PR DESCRIPTION
- [ ] closes #xxxx
- [x] tests added / passed.
- [x] code/documentation is well formatted.
- [x] properly formatted commit message.

<details>

**Notes**:

* Test added: `test_ccovf_adjusted_shorter_y`, which fails on `main` and passes here — per the note
  that a bug fix must add a test that produces the bug on `main` first.
* No `closes #xxxx`: I couldn't find an open issue for this. #9565 (the crash) and #9888 (its fix)
  are both closed; this is the denominator half that #9888's own comment describes but didn't
  implement. Happy to open an issue first if you'd prefer that order.
* `flake8` clean on both changed files.

</details>

---

`ccovf(x, y, adjusted=True)` — the default — divides by `n - k` while the numerator only sums `min(m, n - k)` products. When `y` is shorter than `x`, every value comes back shrunk by exactly `m / n`.

Follow-up to #9888 (which fixed the crash from #9565, but only the slice).

#### Reproducer

All-ones inputs, so every product is exactly 1.0 and the average is unambiguously 1.0:

```
CONTROL len(x) == len(y) (n=6, m=6):   [1. 1. 1. 1. 1. 1.]     correct
BUG     len(y) <  len(x) (n=6, m=2):   [0.333 0.4 0.5 0.667 1. 1.]
        expected                        [1. 1. 1. 1. 1. 1.]
CONTROL len(y) >  len(x) (n=2, m=6):   [1. 1.]                 correct
```

Only `m < n` breaks — a 3× error at lag 0, not float noise.

`adjusted=True` means "divide by the number of terms actually summed", so its defining property is unbiasedness. It currently fails that by exactly `m/n` (4000 draws, `n=100, m=20, σ²=4`):

```
E[lag-0 adjusted ccovf] = 0.7687
true sigma^2            = 4.0
ratio (1.0 if unbiased) = 0.1922
m/n                     = 0.2
```

#### Cause

`_stattools.py:1109` — `d = np.arange(n, 0, -1)` uses `n = len(x)`. The overlap at lag `k` is `min(m, n - k)`. `m` was only ever used for the output slice.

The comment added just above the return in 3c79a04 already says what the code should do:

> When y is shorter than x, the denominator counts must follow len(y) to match the actual number of overlapping observations at each lag.

…but `d` still follows `len(x)`. The commit is titled *"Add comment explaining the len(y) denominator fix in ccovf"* — the comment landed, the denominator change didn't.

Fix: `d = np.minimum(np.arange(n, 0, -1), m)`.

#### The docstring change, which is the one thing worth arguing about

I also changed this line, and I'd rather flag it than slip it in:

```
-   If True, then denominators for cross-covariance are n-k, otherwise n.
+   If True, then denominators for cross-covariance are the number of
+   overlapping observations at each lag k, min(m, n-k), otherwise n.
```

The `n-k` wording is only correct when `n == m`; it predates unequal-length support. The **Returns** section of the same docstring already describes the correct behaviour and explicitly contemplates unequal lengths:

> the element at index k is the covariance between {x[k], x[k+1], ..., x[n]} and {y[0], y[1], ..., y[m-k]}, **where n and m are the lengths of x and y, respectively**

A covariance of those two slices divides by their length, `min(m, n-k)`. So two of the three descriptions in the file (Returns, and the 3c79a04 comment) already agree with this patch; the `adjusted` line is the stale one. If you read it as normative instead, then the right fix is different and I'd want to know.

#### Backward compatibility

`min(m, n-k) == n-k` whenever `m >= n`, so this is a **no-op for equal-length inputs** — the overwhelmingly common case. Verified directly against a hand-computed oracle across `n ∈ {10, 50, 200} × adjusted ∈ {True, False} × fft ∈ {True, False}`: all identical.

#### Tests

Added `test_ccovf_adjusted_shorter_y`. It fails on `main` (`ACTUAL: [0.333, 0.4, 0.5, 0.667, 1., 1.]` vs `DESIRED: [1, 1, 1, 1, 1, 1]`) and passes here.

Nothing needed changing: of the three tests #9888 added, two assert only `.shape` and `np.all(np.isfinite(...))`, and the one that asserts values (`test_ccovf_different_lengths_known_lag`) uses `adjusted=False`, which bypasses the denominator. No existing test pins the adjusted values for unequal lengths.

`statsmodels/tsa/tests/test_stattools.py`: **197 passed, 2 xfailed** with the fix vs. **196 passed, 2 xfailed** on `main` — the extra one is the new test, nothing regressed.

#### Disclosure

AI-assisted, and I'd rather say so plainly. The reproducer, both controls, the Monte-Carlo unbiasedness check, the equal-length no-op sweep, the `git blame` on 3c79a04, and the `main`-vs-branch test comparison are all things I ran and read myself rather than assumed.
