### PR TITLE
BUG: Fix AttributeError in KDEUnivariate.entropy for bounded kernels

### DIFF
--- a/statsmodels/nonparametric/kde.py
+++ b/statsmodels/nonparametric/kde.py
@@ -272,7 +272,7 @@ class KDEUnivariate:
         kern = self.kernel
 
         if kern.domain is not None:
-            a, b = self.domain
+            a, b = kern.domain
         else:
             a, b = -np.inf, np.inf
         endog = self.endog


### PR DESCRIPTION
## Summary

Fixes #9917

When computing differential entropy for a `KDEUnivariate` fitted with a bounded kernel (e.g., Epanechnikov, Triangular, Uniform), the `entropy` property references `self.domain` which does not exist on the `KDEUnivariate` instance. The domain attribute belongs to the underlying kernel object (`kern`).

## Fix

Change `self.domain` → `kern.domain` in the `entropy` property of `KDEUnivariate`.

## Before (broken)
```python
a, b = self.domain  # AttributeError: KDEUnivariate has no attribute domain
```

## After (fixed)
```python
a, b = kern.domain  # Correctly references the kernel object's domain
```

This is a one-line fix. The Gaussian kernel path is unaffected since `kern.domain` returns `None` for unbounded kernels, which correctly skips the domain-bounded integration branch.