### PR TITLE
BUG: read the entropy integration limits from the kernel

### DIFF
--- a/statsmodels/nonparametric/kde.py
+++ b/statsmodels/nonparametric/kde.py
@@ -272,7 +272,7 @@ class KDEUnivariate:
         kern = self.kernel
 
         if kern.domain is not None:
-            a, b = self.domain
+            a, b = kern.domain
         else:
             a, b = -np.inf, np.inf
         endog = self.endog

--- a/statsmodels/nonparametric/tests/test_kde.py
+++ b/statsmodels/nonparametric/tests/test_kde.py
@@ -447,3 +447,20 @@ class TestKDECustomBandwidth:
 
         npt.assert_almost_equal(s1, kde.support, self.decimal_density)
         npt.assert_almost_equal(d1, kde.density, self.decimal_density)
+
+
+@pytest.mark.parametrize("kernel", ["epa", "tri", "uni", "cos", "biw", "triw"])
+def test_entropy_finite_domain_kernel(kernel):
+    # Kernels with a bounded domain used to read the integration limits off
+    # the KDE instead of the kernel, which has no such attribute. GH#9917
+    kde = KDE(Xi).fit(kernel=kernel, fft=False, bw="silverman")
+
+    entropy = kde.entropy
+
+    assert np.isfinite(entropy)
+
+
+def test_entropy_infinite_domain_kernel():
+    kde = KDE(Xi).fit(kernel="gau", fft=False, bw="silverman")
+
+    assert np.isfinite(kde.entropy)


### PR DESCRIPTION
## Summary

Closes #9917. `KDEUnivariate.entropy` checks `kern.domain` to decide whether the density has bounded support, then unpacks the limits from `self.domain`:

```python
if kern.domain is not None:
    a, b = self.domain      # KDEUnivariate has no `domain`
else:
    a, b = -np.inf, np.inf
```

The estimator has no `domain` attribute, so every kernel with a finite domain raised `AttributeError`. Only `gau` escaped, because an unbounded domain takes the other branch and never touches it.

The fix unpacks from `kern.domain` — the object the branch already tested.

## Verification

I could not build the extension modules on this machine, so I verified against an installed statsmodels whose `entropy` was patched to match `main` exactly (both the `kern.domain` fix and the `np.squeeze` in `entr`, which `main` has but the released 0.14.6 does not). With that, every kernel returns a finite value:

```
gau   entropy = 1.436358
epa   entropy = 0.724229
tri   entropy = 0.724180
uni   entropy = 0.724164
cos   entropy = 0.724207
biw   entropy = 0.724134
triw  entropy = 0.724090
```

Reverting only the one-line change reproduces the reported failure with exactly the right scope — the six bounded kernels fail, the gaussian still passes:

```
AttributeError: 'KDEUnivariate' object has no attribute 'domain'
6 failed, 1 passed
```

`ruff check` on both touched files is clean.

## Tests

`test_entropy_finite_domain_kernel` is parametrized over the six bounded kernels, plus `test_entropy_infinite_domain_kernel` to keep the `gau` branch pinned. They assert the result is finite rather than a fixed value, since the point is that the call completes at all.

I ran the equivalent of both tests (same bodies, sample built with the API the installed release exposes) against the patched install: **7 passed**, and 6 failed once the fix was reverted. I couldn't run the repo's own `test_kde.py` directly because `main` now calls `mixture_rvs(..., rng=...)`, which the released package predates — so CI running these on a real build is the meaningful check.

## Note for reviewers

Worth being aware of, though it is not something this PR changes: for a bounded kernel the integration runs over the *kernel's* domain (`[-1, 1]`), not the support of the estimated density. That is why the bounded kernels above all land near `0.72` while `gau` gives `1.44` — the integral is truncated to the kernel's window rather than covering the data. The existing `if kern.domain is not None` branch is clearly deliberate, so I have left the semantics alone and fixed only the crash. Happy to open a separate issue if that truncation is not intended.
