### PR TITLE
BUG: populate _retain_cols in out_of_sample without a prior in_sample call

### DIFF
--- a/statsmodels/tsa/deterministic.py
+++ b/statsmodels/tsa/deterministic.py
@@ -1292,7 +1292,7 @@ you can pass additional components using the additional_terms input.""")
         forecast_index: Optional[Union[Sequence[Hashable], pd.Index]] = None,
     ) -> pd.DataFrame:
         steps = required_int_like(steps, "steps")
-        if self._drop and self._retain_cols is None:
+        if self._retain_cols is None:
             self.in_sample()
         index = self._index
         if not self._deterministic_terms:

--- a/statsmodels/tsa/tests/test_deterministic.py
+++ b/statsmodels/tsa/tests/test_deterministic.py
@@ -497,6 +497,22 @@ def test_deterministic_process(
     assert isinstance(terms, pd.DataFrame)
 
 
+@pytest.mark.parametrize("drop", [True, False])
+def test_out_of_sample_without_in_sample(drop):
+    # GH: out_of_sample()/range() on a fresh DeterministicProcess used to raise
+    # a bare ``AssertionError`` when drop=False, because the lazy in_sample()
+    # call that populates _retain_cols was gated on self._drop.
+    idx = pd.RangeIndex(0, 10)
+    fresh = DeterministicProcess(idx, constant=True, order=1, drop=drop)
+    primed = DeterministicProcess(idx, constant=True, order=1, drop=drop)
+    primed.in_sample()
+    pd.testing.assert_frame_equal(
+        fresh.out_of_sample(5), primed.out_of_sample(5)
+    )
+    fresh2 = DeterministicProcess(idx, constant=True, order=1, drop=drop)
+    pd.testing.assert_frame_equal(fresh2.range(10, 15), primed.range(10, 15))
+
+
 def test_deterministic_process_errors(time_index):
     with pytest.raises(ValueError, match="seasonal and fourier"):
         DeterministicProcess(time_index, seasonal=True, fourier=2, period=5)


### PR DESCRIPTION
On a freshly constructed `DeterministicProcess`, calling `out_of_sample()` (or `range()`) before `in_sample()` raises a bare `AssertionError` — but only with the **default** `drop=False`:

```python
import pandas as pd
from statsmodels.tsa.deterministic import DeterministicProcess

dp = DeterministicProcess(pd.RangeIndex(0, 10), constant=True, order=1)
dp.out_of_sample(5)      # AssertionError: ''
```

Priming it first works, which is what every existing test happens to do:

```python
dp = DeterministicProcess(pd.RangeIndex(0, 10), constant=True, order=1)
dp.in_sample()
dp.out_of_sample(5)      # fine
```

### Cause

`out_of_sample()` lazily calls `in_sample()` to populate `self._retain_cols`, but the call is gated on `self._drop`:

```python
if self._drop and self._retain_cols is None:
    self.in_sample()
...
assert self._retain_cols is not None      # fires when drop=False
```

With `drop=False` the self-heal is skipped, `_retain_cols` stays `None`, and the assertion a few lines down fails.

### Fix

`in_sample()` always sets `_retain_cols` (to every column when `drop=False`), so the `self._drop and` conjunct is spurious — drop the guard so the self-heal runs whenever `_retain_cols` hasn't been computed yet:

```python
if self._retain_cols is None:
    self.in_sample()
```

The output is **identical** to calling `in_sample()` first (verified for both `drop` values). Fitted-model callers (`AutoReg`, `ARDL`) prime the process during `fit`, so they are unaffected.

### Tests

Added `test_out_of_sample_without_in_sample` (parametrized over `drop`). It fails on `main` (`AssertionError` at `deterministic.py:1304`, `drop=False` case) and passes here, asserting fresh output equals the primed output for both `out_of_sample` and `range`. Full `test_deterministic.py` (206), plus the `AutoReg`/`ARDL` call-site suites, pass unchanged.

---

*Disclosure: this contribution is fully AI-authored and autonomous (Claude Code, acting on this account). An AI found the bug, ran the repro, wrote the fix and the regression test, and wrote this description; the human account holder reviews every change and is accountable for it. The verification above is real and re-runnable from the diff — it was just done by the AI, not a person. If this isn't the kind of contribution you want, say so and I'll close it.*

