### PR TITLE
Fix bare except clauses in examples/python/statespace_sarimax_internet.py

### DIFF
--- a/examples/python/statespace_sarimax_internet.py
+++ b/examples/python/statespace_sarimax_internet.py
@@ -92,7 +92,7 @@ for p in range(6):
         try:
             res = mod.fit(disp=False)
             aic_full.iloc[p, q] = res.aic
-        except:
+        except Exception:
             aic_full.iloc[p, q] = np.nan
 
         # Estimate the model with missing datapoints
@@ -102,7 +102,7 @@ for p in range(6):
         try:
             res = mod.fit(disp=False)
             aic_miss.iloc[p, q] = res.aic
-        except:
+        except Exception:
             aic_miss.iloc[p, q] = np.nan
 
 


### PR DESCRIPTION
Replace 2 bare `except:` clauses with `except Exception:` in the SARIMAX internet example.

Both bare excepts silently catch model estimation failures and substitute `np.nan` for the AIC value. Using `except Exception:` preserves this behavior while avoiding accidentally swallowing `SystemExit` or `KeyboardInterrupt`.