### PR TITLE
fix(grouputils): unify group_sums orientation and fix group_demean

### DIFF
--- a/statsmodels/stats/sandwich_covariance.py
+++ b/statsmodels/stats/sandwich_covariance.py
@@ -580,7 +580,7 @@ def S_hac_groupsum(x, time, nlags=None, weights_func=weights_bartlett):
     """
     # needs groupsums
 
-    x_group_sums = group_sums(x, time).T  # TODO: transpose return in grou_sum
+    x_group_sums = group_sums(x, time)  # (n_groups, n_features)
 
     return S_hac_simple(x_group_sums, nlags=nlags, weights_func=weights_func)
 
@@ -606,7 +606,7 @@ def S_crosssection(x, group):
     S : ndarray, (k_vars, k_vars)
         inner covariance matrix for sandwich
     """
-    x_group_sums = group_sums(x, group).T  # TODO: why transposed
+    x_group_sums = group_sums(x, group)  # (n_groups, n_features)
 
     return S_white_simple(x_group_sums)
 

--- a/statsmodels/tools/grouputils.py
+++ b/statsmodels/tools/grouputils.py
@@ -98,7 +98,7 @@ def group_sums(x, group, use_bincount=True):
     -----
     Both code paths previously disagreed on orientation (``use_bincount``
     returned ``(n_features, n_groups)``). They now both return
-    ``(n_groups, n_features)`` so indexing by group id works (#9921).
+    ``(n_groups, n_features)`` so indexing by group id works (GH9921).
     """
     x = np.asarray(x)
     group = np.asarray(group).squeeze()

--- a/statsmodels/tools/grouputils.py
+++ b/statsmodels/tools/grouputils.py
@@ -82,11 +82,16 @@ def group_sums(x, group, use_bincount=True):
     Parameters
     ----------
     x : array_like
-        Data of shape ``(nobs,)`` or ``(nobs, n_features)``.
-    group : array_like, integer
-        Group labels of shape ``(nobs,)``.
+        Data of shape ``(nobs,)`` or ``(nobs, n_features)``. Higher-dimensional
+        ``x`` is only supported when ``use_bincount=False``.
+    group : array_like of non-negative int
+        Non-negative integer group labels of shape ``(nobs,)``. For predictable
+        indexing (e.g. ``result[group]``), groups should be coded as
+        ``0, 1, ..., n_groups-1``.
     use_bincount : bool, default True
         Use ``np.bincount`` when True, otherwise a pure-Python group loop.
+        The bincount path expects non-negative, reasonably consecutive codes
+        and may re-label via ``pd.factorize`` when ``max(group)`` is large.
 
     Returns
     -------
@@ -271,7 +276,8 @@ class Group:
         sums_g = group_sums(x, self.group_int, use_bincount=use_bincount)
         # group_sums returns (n_groups, n_features)
         counts = np.bincount(self.group_int)
-        # avoid divide-by-zero for empty labels
+        # Defensive: bincount may include zero-count bins for sparse codes.
+        # group_int from combine_indices should not contain empty labels.
         counts = np.maximum(counts, 1)
         means_g = sums_g / counts[:, None]
         x_demeaned = x - means_g[self.group_int]

--- a/statsmodels/tools/grouputils.py
+++ b/statsmodels/tools/grouputils.py
@@ -77,16 +77,28 @@ def combine_indices(groups, prefix="", sep=".", return_labels=False):
 # written for and used in try_covariance_grouploop.py
 def group_sums(x, group, use_bincount=True):
     """
-    Simple bincount version, again
+    Sum ``x`` within integer groups.
 
-    group : ndarray, integer
-        assumed to be consecutive integers
+    Parameters
+    ----------
+    x : array_like
+        Data of shape ``(nobs,)`` or ``(nobs, n_features)``.
+    group : array_like, integer
+        Group labels of shape ``(nobs,)``.
+    use_bincount : bool, default True
+        Use ``np.bincount`` when True, otherwise a pure-Python group loop.
 
-    no dtype checking because I want to raise in that case
+    Returns
+    -------
+    ndarray
+        Shape ``(n_groups, n_features)``. 1-d ``x`` is treated as one feature
+        and returns shape ``(n_groups, 1)``.
 
-    uses loop over columns of x
-
-    for comparison, simple python loop
+    Notes
+    -----
+    Both code paths previously disagreed on orientation (``use_bincount``
+    returned ``(n_features, n_groups)``). They now both return
+    ``(n_groups, n_features)`` so indexing by group id works (#9921).
     """
     x = np.asarray(x)
     group = np.asarray(group).squeeze()
@@ -101,12 +113,13 @@ def group_sums(x, group, use_bincount=True):
         if np.max(group) > 2 * x.shape[0]:
             group = pd.factorize(group)[0]
 
+        # column-wise bincount yields (n_features, n_groups); transpose
         return np.array(
             [
                 np.bincount(group, weights=x[:, col])
                 for col in range(x.shape[1])
             ]
-        )
+        ).T
     else:
         uniques = np.unique(group)
         result = np.zeros([len(uniques)] + list(x.shape[1:]))
@@ -251,10 +264,20 @@ class Group:
         return group_sums(x, self.group_int, use_bincount=use_bincount)
 
     def group_demean(self, x, use_bincount=True):
-        nobs = float(len(x))
-        means_g = group_sums(x / nobs, self.group_int,
-                             use_bincount=use_bincount)
-        x_demeaned = x - means_g[self.group_int]  # check reverse_index?
+        x = np.asarray(x)
+        was_1d = x.ndim == 1
+        if was_1d:
+            x = x[:, None]
+        sums_g = group_sums(x, self.group_int, use_bincount=use_bincount)
+        # group_sums returns (n_groups, n_features)
+        counts = np.bincount(self.group_int)
+        # avoid divide-by-zero for empty labels
+        counts = np.maximum(counts, 1)
+        means_g = sums_g / counts[:, None]
+        x_demeaned = x - means_g[self.group_int]
+        if was_1d:
+            x_demeaned = x_demeaned[:, 0]
+            means_g = means_g[:, 0]
         return x_demeaned, means_g
 
 

--- a/statsmodels/tools/tests/test_grouputils.py
+++ b/statsmodels/tools/tests/test_grouputils.py
@@ -718,7 +718,7 @@ def test_group_sums():
     assert isinstance(
         group_sums(
             np.arange(len(g) * 3 * 2).reshape(len(g), 3, 2), g, use_bincount=False
-        ).T,
+        ),
         np.ndarray,
     )
     assert isinstance(
@@ -729,6 +729,27 @@ def test_group_sums():
         group_sums(np.arange(len(g) * 3 * 2).reshape(len(g), 3, 2)[:, :, 1], g),
         np.ndarray,
     )
+
+
+def test_group_sums_orientation_consistent():
+    """Both use_bincount paths return (n_groups, n_features) (#9921)."""
+    g = np.array([0, 0, 1, 2, 1, 1, 2, 0])
+    x = np.arange(len(g) * 3).reshape(len(g), 3, order="F")
+    a = group_sums(x, g, use_bincount=True)
+    b = group_sums(x, g, use_bincount=False)
+    assert a.shape == b.shape == (3, 3)  # 3 groups (0,1,2), 3 features
+    assert_allclose(a, b)
+
+
+def test_group_demean_default():
+    """group_demean works with default use_bincount and demeans by group size (#9921)."""
+    g = np.array([0, 0, 1, 1, 1, 2, 2, 2])
+    x = np.array([1.0, 3.0, 1.0, 2.0, 3.0, 10.0, 20.0, 30.0])
+    demeaned, means = Group(g).group_demean(x)
+    # group means: 0->2, 1->2, 2->20
+    expected = x - np.array([2, 2, 2, 2, 2, 20, 20, 20])
+    assert_allclose(demeaned, expected)
+    assert_allclose(means, [2.0, 2.0, 20.0])
 
 
 @pytest.mark.smoke

--- a/statsmodels/tools/tests/test_grouputils.py
+++ b/statsmodels/tools/tests/test_grouputils.py
@@ -1,7 +1,7 @@
 from statsmodels.compat.pandas import assert_frame_equal, assert_series_equal
 
 import numpy as np
-from numpy.testing import assert_equal
+from numpy.testing import assert_allclose, assert_equal
 import pandas as pd
 import pytest
 from scipy import sparse
@@ -732,7 +732,7 @@ def test_group_sums():
 
 
 def test_group_sums_orientation_consistent():
-    """Both use_bincount paths return (n_groups, n_features) (#9921)."""
+    """Both use_bincount paths return (n_groups, n_features) (GH9921)."""
     g = np.array([0, 0, 1, 2, 1, 1, 2, 0])
     x = np.arange(len(g) * 3).reshape(len(g), 3, order="F")
     a = group_sums(x, g, use_bincount=True)
@@ -742,7 +742,7 @@ def test_group_sums_orientation_consistent():
 
 
 def test_group_demean_default():
-    """group_demean works with default use_bincount and demeans by group size (#9921)."""
+    """group_demean works with default use_bincount and demeans by group size (GH9921)."""
     g = np.array([0, 0, 1, 1, 1, 2, 2, 2])
     x = np.array([1.0, 3.0, 1.0, 2.0, 3.0, 10.0, 20.0, 30.0])
     demeaned, means = Group(g).group_demean(x)


### PR DESCRIPTION
## Description

`group_sums` had two orientations depending on `use_bincount`:

- `True` (default): `(n_features, n_groups)` via stacked `bincount`
- `False`: `(n_groups, n_features)`

Callers in `sandwich_covariance` worked around the default with `.T` and `# TODO` comments. `Group.group_demean` assumed `(n_groups, n_features)` and crashed with the default (`IndexError`), or demeaned with the wrong divisor when `use_bincount=False`.

## Fix

1. Transpose the bincount path so both modes return `(n_groups, n_features)`.
2. Rewrite `group_demean` to use per-group counts (`sums / counts`).
3. Drop the compensatory `.T` in `S_hac_panel` / `S_crosssection`.

## Tests

- `test_group_sums_orientation_consistent`
- `test_group_demean_default`

Local check (PYTHONPATH): shapes match and demean means `[2, 2, 20]` for the sample in the issue discussion.

## Linked Issue

Closes #9921
