### PR TITLE
DOC: fix typos in docstrings, comments, and messages

### DIFF
--- a/statsmodels/base/_penalized.py
+++ b/statsmodels/base/_penalized.py
@@ -44,7 +44,7 @@ class PenalizedMixin:
         super().__init__(*args, **kwds)
 
         # TODO: define pen_weight as average pen_weight? i.e. per observation
-        # I would have prefered len(self.endog) * kwds.get('pen_weight', 1)
+        # I would have preferred len(self.endog) * kwds.get('pen_weight', 1)
         # or use pen_weight_factor in signature
         if self.pen_weight is None:
             self.pen_weight = len(self.endog)

--- a/statsmodels/base/covtype.py
+++ b/statsmodels/base/covtype.py
@@ -235,7 +235,7 @@ def get_robustcov_results(self, cov_type="HC1", use_t=None, **kwds):
         # TODO: check also use_correction, do I need all combinations?
 
         if df_correction is not False:  # i.e. in [None, True]:
-            # user did not explicitely set it to False
+            # user did not explicitly set it to False
 
             adjust_df = True
     res.cov_kwds["adjust_df"] = adjust_df

--- a/statsmodels/datasets/star98/data.py
+++ b/statsmodels/datasets/star98/data.py
@@ -17,7 +17,7 @@ DESCRLONG = """
 This data is on the California education policy and outcomes (STAR program
 results for 1998.  The data measured standardized testing by the California
 Department of Education that required evaluation of 2nd - 11th grade students
-by the the Stanford 9 test on a variety of subjects.  This dataset is at
+by the Stanford 9 test on a variety of subjects.  This dataset is at
 the level of the unified school district and consists of 303 cases.  The
 binary response variable represents the number of 9th graders scoring
 over the national median value on the mathematics exam.

--- a/statsmodels/examples/ex_emplike_1.py
+++ b/statsmodels/examples/ex_emplike_1.py
@@ -28,7 +28,7 @@ print("Hypothesis test results for the mean:")
 print(eldescriptive.test_mean(0))
 
 
-# The first value is is  -2 *log-likelihood ratio, which is distributed
+# The first value is  -2 *log-likelihood ratio, which is distributed
 # chi2.  The second value is the p-value.
 
 # Let's see what the variance is:

--- a/statsmodels/examples/l1_demo/short_demo.py
+++ b/statsmodels/examples/l1_demo/short_demo.py
@@ -95,7 +95,7 @@ alphas = 1 / np.logspace(-0.5, 2, N)
 # Sweep alpha and store the coefficients
 # QC check does not always pass with the default options.
 # Use the options QC_verbose=True and disp=True
-# to to see what is happening.  It just barely does not pass, so I decreased
+# to see what is happening.  It just barely does not pass, so I decreased
 # acc and increased QC_tol to make it pass
 for n, alpha in enumerate(alphas):
     logit_res = logit_mod.fit_regularized(

--- a/statsmodels/genmod/generalized_linear_model.py
+++ b/statsmodels/genmod/generalized_linear_model.py
@@ -251,8 +251,8 @@ class GLM(base.LikelihoodModel):
     reflect the new weights.
 
     Variance weights (referred to in other packages as analytic weights) are
-    used when ``endog`` represents an an average or mean. This relies on the
-    assumption that that the inverse variance scales proportionally to the
+    used when ``endog`` represents an average or mean. This relies on the
+    assumption that the inverse variance scales proportionally to the
     weight--an observation that is deemed more credible should have less
     variance and therefore have more weight. For the ``Poisson`` family--which
     assumes that occurrences scale proportionally with time--a natural practice

--- a/statsmodels/graphics/_regressionplots_doc.py
+++ b/statsmodels/graphics/_regressionplots_doc.py
@@ -106,7 +106,7 @@ _plot_ceres_residuals_doc = """
 
     Examples
     --------
-    Using a model built from the the state crime dataset, make a CERES plot with
+    Using a model built from the state crime dataset, make a CERES plot with
     the rate of Poverty as the focus variable.
 
     >>> import statsmodels.api as sm
@@ -164,7 +164,7 @@ _plot_influence_doc = """
 
     Examples
     --------
-    Using a model built from the the state crime dataset, plot the influence in
+    Using a model built from the state crime dataset, plot the influence in
     regression.  Observations with high leverage, or large residuals will be
     labeled in the plot to show potential influence points.
 
@@ -203,7 +203,7 @@ _plot_leverage_resid2_doc = """
 
     Examples
     --------
-    Using a model built from the the state crime dataset, plot the leverage
+    Using a model built from the state crime dataset, plot the leverage
     statistics vs. normalized residuals squared.  Observations with
     Large-standardized Residuals will be labeled in the plot.
 

--- a/statsmodels/multivariate/factor_rotation/_gpa_rotation.py
+++ b/statsmodels/multivariate/factor_rotation/_gpa_rotation.py
@@ -226,7 +226,7 @@ def oblimin_objective(L=None, A=None, T=None, gamma=0,
                       return_gradient=True):
     r"""
     Objective function for the oblimin family for orthogonal or
-    oblique rotation wich minimizes:
+    oblique rotation which minimizes:
 
     .. math::
         \phi(L) = \frac{1}{4}(L\circ L,(I-\gamma C)(L\circ L)N),
@@ -318,7 +318,7 @@ def oblimin_objective(L=None, A=None, T=None, gamma=0,
 def orthomax_objective(L=None, A=None, T=None, gamma=0, return_gradient=True):
     r"""
     Objective function for the orthomax family for orthogonal
-    rotation wich minimizes the following objective:
+    rotation which minimizes the following objective:
 
     .. math::
         \phi(L) = -\frac{1}{4}(L\circ L,(I-\gamma C)(L\circ L)),
@@ -392,7 +392,7 @@ def CF_objective(L=None, A=None, T=None, kappa=0,
                  return_gradient=True):
     r"""
     Objective function for the Crawford-Ferguson family for orthogonal
-    and oblique rotation wich minimizes the following objective:
+    and oblique rotation which minimizes the following objective:
 
     .. math::
         \phi(L) =\frac{1-\kappa}{4} (L\circ L,(L\circ L)N)

--- a/statsmodels/regression/linear_model.py
+++ b/statsmodels/regression/linear_model.py
@@ -2679,7 +2679,7 @@ class RegressionResults(base.LikelihoodModelResults):
             df_correction = kwargs.get("df_correction", None)
             # TODO: check also use_correction, do I need all combinations?
             if df_correction is not False:  # i.e. in [None, True]:
-                # user did not explicitely set it to False
+                # user did not explicitly set it to False
                 adjust_df = True
 
         res.cov_kwds["adjust_df"] = adjust_df

--- a/statsmodels/sandbox/nonparametric/kernels.py
+++ b/statsmodels/sandbox/nonparametric/kernels.py
@@ -41,7 +41,7 @@ class NdKernel:
     mahalanobis distance defined by H.
 
     In the case of the Gaussian these are both equivalent, and the second constructiong
-    is prefered.
+    is preferred.
     """
 
     def __init__(self, n, kernels=None, H=None):

--- a/statsmodels/sandbox/regression/gmm.py
+++ b/statsmodels/sandbox/regression/gmm.py
@@ -190,7 +190,7 @@ class IV2SLS(LikelihoodModel):
 
 class IVRegressionResults(RegressionResults):
     """
-    Results class for for an OLS model.
+    Results class for an OLS model.
 
     Most of the methods and attributes are inherited from RegressionResults.
     The special methods that are only available for OLS are:
@@ -609,7 +609,7 @@ class GMM(Model):
             obtained with maxiter=0 or 1. If maxiter is large, then the
             iteration will stop either at maxiter or on convergence of the
             parameters (TODO: no options for convergence criteria yet.)
-            If `maxiter == 'cue'`, the the continuously updated GMM is
+            If `maxiter == 'cue'`, the continuously updated GMM is
             calculated which updates the weight matrix during the minimization
             of the GMM objective function. The CUE estimation uses the onestep
             parameters as starting values.

--- a/statsmodels/sandbox/tsa/example_arma.py
+++ b/statsmodels/sandbox/tsa/example_arma.py
@@ -78,7 +78,7 @@ def detrend_linear(y):
 
 
 def acovf_explicit(ar, ma, nobs):
-    """add correlation of MA representation explicitely"""
+    """add correlation of MA representation explicitly"""
     ir = arma_impulse_response(ar, ma)
     acovfexpl = [np.dot(ir[: nobs - t], ir[t:nobs]) for t in range(10)]
     return acovfexpl

--- a/statsmodels/stats/libqsturng/qsturng_.py
+++ b/statsmodels/stats/libqsturng/qsturng_.py
@@ -2170,7 +2170,7 @@ def _interpolate_p(p, r, v):
 
 
 def _select_vs(v, p):
-    # This one is is about 30 times faster than
+    # This one is about 30 times faster than
     # the generic algorithm it is replacing.
     """Returns the points to use for interpolating v"""
 

--- a/statsmodels/tools/validation/validation.py
+++ b/statsmodels/tools/validation/validation.py
@@ -179,7 +179,7 @@ class PandasWrapper:
 
     Notes
     -----
-    Raises if ``orig`` is a pandas type but obj and and ``orig`` have
+    Raises if ``orig`` is a pandas type but obj and ``orig`` have
     different numbers of elements in axis 0. Also raises if the ndim of obj
     is larger than 2.
 

--- a/statsmodels/tsa/base/tests/test_tsa_indexes.py
+++ b/statsmodels/tsa/base/tests/test_tsa_indexes.py
@@ -434,7 +434,7 @@ def test_instantiation_valid():
         message = (
             "An unsupported index was provided. As a result, forecasts "
             "cannot be generated. To use the model for forecasting, use "
-            "on the the supported classes of index."
+            "on the supported classes of index."
         )
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
@@ -1103,7 +1103,7 @@ def test_custom_index():
     endog = pd.Series(rs.normal(size=5), index=["a", "b", "c", "d", "e"])
     message = (
         "An unsupported index was provided. As a result, forecasts cannot be "
-        "generated. To use the model for forecasting, use on the the "
+        "generated. To use the model for forecasting, use on the "
         "supported classes of index."
     )
     with warnings.catch_warnings(record=True) as w:

--- a/statsmodels/tsa/base/tsa_model.py
+++ b/statsmodels/tsa/base/tsa_model.py
@@ -661,7 +661,7 @@ class TimeSeriesModel(base.LikelihoodModel):
             warnings.warn(
                 "An unsupported index was provided. As a result, forecasts "
                 "cannot be generated. To use the model for forecasting, use on the "
-                "the supported classes of index.",
+                "supported classes of index.",
                 ValueWarning,
                 stacklevel=2,
             )

--- a/statsmodels/tsa/statespace/dynamic_factor.py
+++ b/statsmodels/tsa/statespace/dynamic_factor.py
@@ -427,7 +427,7 @@ class DynamicFactor(MLEModel):
         idx_diag = idx_diag[:, np.lexsort((idx_diag[1], idx_diag[0]))]
         self._idx_error_diag = (idx_diag[0], idx_diag[1])
 
-        # Finally, we want to fill the entries in in the correct order, which
+        # Finally, we want to fill the entries in the correct order, which
         # is to say we want to fill in lexicographically, first by row then by
         # column
         idx = idx[:, np.lexsort((idx[1], idx[0]))]

--- a/statsmodels/tsa/statespace/dynamic_factor_mq.py
+++ b/statsmodels/tsa/statespace/dynamic_factor_mq.py
@@ -3595,7 +3595,7 @@ class DynamicFactorMQResults(mlemodel.MLEResults):
         start : int, str, or datetime, optional
             Zero-indexed observation number at which to start forecasting,
             i.e., the first forecast is start. Can also be a date string to
-            parse or a datetime type. Default is the the zeroth observation.
+            parse or a datetime type. Default is the zeroth observation.
         end : int, str, or datetime, optional
             Zero-indexed observation number at which to end forecasting, i.e.,
             the last forecast is end. Can also be a date string to

--- a/statsmodels/tsa/statespace/initialization.py
+++ b/statsmodels/tsa/statespace/initialization.py
@@ -88,7 +88,7 @@ class Initialization:
     If a block is initialized as known, then a known (possibly degenerate)
     distribution is used; in particular, the block of states is understood to
     be distributed
-    :math:`\alpha_1^{(i)} \sim N(a^{(i)}, Q_0^{(i)})`. Here, is possible to
+    :math:`\alpha_1^{(i)} \sim N(a^{(i)}, Q_0^{(i)})`. Here, it is possible to
     set :math:`a^{(i)} = 0`, and it is also possible that
     :math:`Q_0^{(i)}` is only positive-semidefinite; i.e.
     :math:`\alpha_1^{(i)}` may be degenerate. One particular example is

--- a/statsmodels/tsa/statespace/initialization.py
+++ b/statsmodels/tsa/statespace/initialization.py
@@ -88,7 +88,7 @@ class Initialization:
     If a block is initialized as known, then a known (possibly degenerate)
     distribution is used; in particular, the block of states is understood to
     be distributed
-    :math:`\alpha_1^{(i)} \sim N(a^{(i)}, Q_0^{(i)})`. Here, is is possible to
+    :math:`\alpha_1^{(i)} \sim N(a^{(i)}, Q_0^{(i)})`. Here, is possible to
     set :math:`a^{(i)} = 0`, and it is also possible that
     :math:`Q_0^{(i)}` is only positive-semidefinite; i.e.
     :math:`\alpha_1^{(i)}` may be degenerate. One particular example is

--- a/statsmodels/tsa/statespace/mlemodel.py
+++ b/statsmodels/tsa/statespace/mlemodel.py
@@ -3659,7 +3659,7 @@ class MLEResults(tsbase.TimeSeriesModelResults):
         start : int, str, or datetime, optional
             Zero-indexed observation number at which to start forecasting,
             i.e., the first forecast is start. Can also be a date string to
-            parse or a datetime type. Default is the the zeroth observation.
+            parse or a datetime type. Default is the zeroth observation.
         end : int, str, or datetime, optional
             Zero-indexed observation number at which to end forecasting, i.e.,
             the last forecast is end. Can also be a date string to
@@ -5208,7 +5208,7 @@ class MLEResults(tsbase.TimeSeriesModelResults):
 
         if resid.shape[0] < max(d, lags):
             raise ValueError(
-                "Length of endogenous variable must be larger the the number "
+                "Length of endogenous variable must be larger the number "
                 "of lags used in the model and the number of observations "
                 "burned in the log-likelihood calculation."
             )

--- a/statsmodels/tsa/statespace/structural.py
+++ b/statsmodels/tsa/statespace/structural.py
@@ -1300,7 +1300,7 @@ class UnobservedComponentsResults(MLEResults):
     @property
     def trend(self):
         """
-        Estimates of of unobserved trend component
+        Estimates of unobserved trend component
 
         Returns
         -------

--- a/statsmodels/tsa/statespace/tests/test_news.py
+++ b/statsmodels/tsa/statespace/tests/test_news.py
@@ -811,7 +811,7 @@ def test_comparison_types():
     with pytest.raises(ValueError, match=msg):
         res.news(res)
 
-    # Test that if the the comparison type is specified, the news can be
+    # Test that if the comparison type is specified, the news can be
     # computed from data that has the same shape and number of NaNs (this can
     # happen if there are only revisions but no updates)
     news = res.news(endog, comparison_type="previous")

--- a/statsmodels/tsa/statespace/tests/test_smoothing.py
+++ b/statsmodels/tsa/statespace/tests/test_smoothing.py
@@ -1590,7 +1590,7 @@ def test_news_invalid(missing, filter_univariate, tvp):
         with pytest.raises(RuntimeError, match=msg):
             res2_smoothed.news(res, t=mod.nobs + 2)
 
-    # Test that news won't work when the calling model is is smaller
+    # Test that news won't work when the calling model is smaller
     mod, res = get_acov_model(missing, filter_univariate, tvp)
     params = [] if tvp else mod.start_params
 

--- a/statsmodels/tsa/statespace/tests/test_varmax.py
+++ b/statsmodels/tsa/statespace/tests/test_varmax.py
@@ -446,12 +446,12 @@ class TestVAR_obs_intercept(CheckLutkepohl):
         assert_allclose(bse**2, self.true["var_oim"], atol=1e-2)
 
     def test_aic(self):
-        # Since the obs_intercept is added in in an ad-hoc way here, the number
+        # Since the obs_intercept is added in an ad-hoc way here, the number
         # of parameters, and hence the aic and bic, will be off
         pass
 
     def test_bic(self):
-        # Since the obs_intercept is added in in an ad-hoc way here, the number
+        # Since the obs_intercept is added in an ad-hoc way here, the number
         # of parameters, and hence the aic and bic, will be off
         pass
 

--- a/statsmodels/tsa/vector_ar/tests/test_vecm.py
+++ b/statsmodels/tsa/vector_ar/tests/test_vecm.py
@@ -1431,7 +1431,7 @@ def test_lag_order_selection():
             # "co" is not in exog in any test case
             if "co" in deterministic:
                 deterministic_outside_exog += "co"
-            # "lo" is is in exog only in test cases with seasons>0
+            # "lo" is in exog only in test cases with seasons>0
             if "lo" in deterministic and dt[1] == 0:
                 deterministic_outside_exog += "lo"
 


### PR DESCRIPTION
Fix duplicated words (the the, is is, to to, an an, of of, in in, and and, that that, for for) and misspellings (explicitely, wich, prefered) across docstrings, code comments, and a user-facing warning message. Text-only; no behavior changes. This complements the recent docstring cleanup in #9940 by fixing the instances that were still remaining on main.

The "unsupported index" warning in tsa/base/tsa_model.py had a "the the" split across two concatenated string literals; the fix keeps that message in sync with its two assertions in tsa/base/tests/test_tsa_indexes.py (verified by concatenating and comparing the strings, so the assertions still match byte for byte).

- [ ] closes #xxxx  (no issue; small text-only cleanup)
- [x] tests added / passed.  (Doc change, so no new tests per the notes below. One existing test file is touched only to keep an assertion in sync with the corrected warning message. I could not run the full suite locally since it needs the compiled extensions, but every changed file byte-compiles.)
- [x] code/documentation is well formatted.
- [x] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>