### PR TITLE
REF: Move from random_state to rng

### DIFF
--- a/statsmodels/distributions/bernstein.py
+++ b/statsmodels/distributions/bernstein.py
@@ -6,6 +6,8 @@ License: BSD-3
 
 """
 
+from statsmodels.compat.pandas import deprecate_kwarg
+
 import numpy as np
 from scipy import stats
 
@@ -178,7 +180,8 @@ class BernsteinDistribution:
         bpd_marginal = BernsteinDistribution(cdf_m)
         return bpd_marginal
 
-    def rvs(self, nobs, random_state=None):
+    @deprecate_kwarg("random_state", "rng")
+    def rvs(self, nobs, rng=None):
         """Generate random numbers from distribution.
 
         Parameters
@@ -188,7 +191,7 @@ class BernsteinDistribution:
         rng : np.random.RandomState or np.random.Generator, optional
             If not provided, uses the singleton RandomState provided by NumPy
         """
-        rng = check_random_state(random_state)
+        rng = check_random_state(rng)
         rvs_mnl = rng.multinomial(nobs, self.prob_grid.flatten())
         k_comp = self.k_dim
         rvs_m = []

--- a/statsmodels/distributions/copula/archimedean.py
+++ b/statsmodels/distributions/copula/archimedean.py
@@ -6,6 +6,8 @@ License: BSD-3
 
 """
 
+from statsmodels.compat.pandas import deprecate_kwarg
+
 import sys
 
 import numpy as np
@@ -240,8 +242,9 @@ class ClaytonCopula(ArchimedeanCopula):
                 raise ValueError("Theta must be > -1 and !=0")
         self.theta = theta
 
-    def rvs(self, nobs=1, args=(), random_state=None):
-        rng = check_random_state(random_state)
+    @deprecate_kwarg("random_state", "rng")
+    def rvs(self, nobs=1, args=(), rng=None):
+        rng = check_random_state(rng)
         (th,) = self._handle_args(args)
         x = rng.random((nobs, self.k_dim))
         v = stats.gamma(1.0 / th).rvs(size=(nobs, 1), random_state=rng)
@@ -310,8 +313,9 @@ class FrankCopula(ArchimedeanCopula):
                 raise ValueError("Theta must be !=0")
         self.theta = theta
 
-    def rvs(self, nobs=1, args=(), random_state=None):
-        rng = check_random_state(random_state)
+    @deprecate_kwarg("random_state", "rng")
+    def rvs(self, nobs=1, args=(), rng=None):
+        rng = check_random_state(rng)
         (th,) = self._handle_args(args)
         x = rng.random((nobs, self.k_dim))
         v = stats.logser.rvs(1.0 - np.exp(-th), size=(nobs, 1), random_state=rng)
@@ -437,8 +441,9 @@ class GumbelCopula(ArchimedeanCopula):
                 raise ValueError("Theta must be > 1")
         self.theta = theta
 
-    def rvs(self, nobs=1, args=(), random_state=None):
-        rng = check_random_state(random_state)
+    @deprecate_kwarg("random_state", "rng")
+    def rvs(self, nobs=1, args=(), rng=None):
+        rng = check_random_state(rng)
         (th,) = self._handle_args(args)
         x = rng.random((nobs, self.k_dim))
         v = stats.levy_stable.rvs(

--- a/statsmodels/distributions/copula/copulas.py
+++ b/statsmodels/distributions/copula/copulas.py
@@ -11,6 +11,8 @@ copulas. The Annals of Statistics, 37(5), pp.2990-3022.
 
 """
 
+from statsmodels.compat.pandas import deprecate_kwarg
+
 from abc import ABC, abstractmethod
 
 import numpy as np
@@ -47,7 +49,8 @@ class CopulaDistribution:
         self.cop_args = cop_args
         self.k_vars = len(marginals)
 
-    def rvs(self, nobs=1, cop_args=None, marg_args=None, random_state=None):
+    @deprecate_kwarg("random_state", "rng")
+    def rvs(self, nobs=1, cop_args=None, marg_args=None, rng=None):
         """Draw `n` in the half-open interval ``[0, 1)``.
 
         Sample the joint distribution.
@@ -67,7 +70,7 @@ class CopulaDistribution:
             to be a list of tuples with the same length has the number of
             marginal distributions. The list can contain empty tuples for
             marginal distributions that do not take parameter arguments.
-        random_state : {None, int, numpy.random.Generator}, optional
+        rng : {None, int, numpy.random.Generator}, optional
             If `seed` is None then the legacy singleton NumPy generator.
             This will change after 0.13 to use a fresh NumPy ``Generator``,
             so you should explicitly pass a seeded ``Generator`` if you
@@ -97,7 +100,7 @@ class CopulaDistribution:
         if marg_args is None:
             marg_args = [()] * self.k_vars
 
-        sample = self.copula.rvs(nobs=nobs, args=cop_args, random_state=random_state)
+        sample = self.copula.rvs(nobs=nobs, args=cop_args, rng=rng)
 
         for i, dist in enumerate(self.marginals):
             sample[:, i] = dist.ppf(
@@ -268,7 +271,8 @@ class Copula(ABC):
     def __init__(self, k_dim=2):
         self.k_dim = k_dim
 
-    def rvs(self, nobs=1, args=(), random_state=None):
+    @deprecate_kwarg("random_state", "rng")
+    def rvs(self, nobs=1, args=(), rng=None):
         """Draw `n` in the half-open interval ``[0, 1)``.
 
         Marginals are uniformly distributed.
@@ -280,7 +284,7 @@ class Copula(ABC):
         args : tuple
             Arguments for copula parameters. The number of arguments depends
             on the copula.
-        random_state : {None, int, numpy.random.Generator}, optional
+        rng : {None, int, numpy.random.Generator}, optional
             If `seed` is None then the legacy singleton NumPy generator.
             This will change after 0.13 to use a fresh NumPy ``Generator``,
             so you should explicitly pass a seeded ``Generator`` if you
@@ -364,7 +368,7 @@ class Copula(ABC):
             Copula cdf evaluated at points ``u``.
         """
 
-    def plot_scatter(self, sample=None, nobs=500, random_state=None, ax=None):
+    def plot_scatter(self, sample=None, nobs=500, rng=None, ax=None):
         """Sample the copula and plot.
 
         Parameters
@@ -374,12 +378,12 @@ class Copula(ABC):
             is generated.
         nobs : int, optional
             Number of samples to generate from the copula.
-        random_state : {None, int, numpy.random.Generator}, optional
-            If `seed` is None then the legacy singleton NumPy generator.
+        rng : {None, int, numpy.random.Generator}, optional
+            If `rng` is None then the legacy singleton NumPy generator.
             This will change after 0.13 to use a fresh NumPy ``Generator``,
             so you should explicitly pass a seeded ``Generator`` if you
             need reproducible results.
-            If `seed` is an int, a new ``Generator`` instance is used,
+            If `rng` is an int, a new ``Generator`` instance is used,
             seeded with `seed`.
             If `seed` is already a ``Generator`` instance then that instance is
             used.
@@ -403,7 +407,7 @@ class Copula(ABC):
             raise ValueError("Can only plot 2-dimensional Copula.")
 
         if sample is None:
-            sample = self.rvs(nobs=nobs, random_state=random_state)
+            sample = self.rvs(nobs=nobs, rng=rng)
 
         fig, ax = utils.create_mpl_ax(ax)
         ax.scatter(sample[:, 0], sample[:, 1])
@@ -476,16 +480,15 @@ class Copula(ABC):
 
         return fig
 
-    def tau_simulated(self, nobs=1024, random_state=None):
+    def tau_simulated(self, nobs=1024, rng=None):
         """Kendall's tau based on simulated samples.
 
         Returns
         -------
         tau : float
             Kendall's tau.
-
         """
-        x = self.rvs(nobs, random_state=random_state)
+        x = self.rvs(nobs, rng=rng)
         return stats.kendalltau(x[:, 0], x[:, 1])[0]
 
     def fit_corr_param(self, data):

--- a/statsmodels/distributions/copula/elliptical.py
+++ b/statsmodels/distributions/copula/elliptical.py
@@ -7,6 +7,8 @@ License: BSD-3
 
 """
 
+from statsmodels.compat.pandas import deprecate_kwarg
+
 import numpy as np
 from scipy import stats
 
@@ -40,9 +42,10 @@ class EllipticalCopula(Copula):
         else:
             return args
 
-    def rvs(self, nobs=1, args=(), random_state=None):
+    @deprecate_kwarg("random_state", "rng")
+    def rvs(self, nobs=1, args=(), rng=None):
         self._handle_args(args)
-        x = self.distr_mv.rvs(size=nobs, random_state=random_state)
+        x = self.distr_mv.rvs(size=nobs, random_state=rng)
         return self.distr_uv.cdf(x)
 
     def pdf(self, u, args=()):
@@ -52,12 +55,13 @@ class EllipticalCopula(Copula):
 
         return mv_pdf_ppf / np.prod(self.distr_uv.pdf(ppf), axis=-1)
 
-    def cdf(self, u, args=(), random_state=None):
+    @deprecate_kwarg("random_state", "rng")
+    def cdf(self, u, args=(), rng=None):
         self._handle_args(args)
         ppf = self.distr_uv.ppf(u)
         try:
             # Modern SciPy supports this and is needed to avoid global random state
-            return self.distr_mv.cdf(ppf, rng=random_state)
+            return self.distr_mv.cdf(ppf, rng=rng)
         except TypeError:
             return self.distr_mv.cdf(ppf)
 

--- a/statsmodels/distributions/copula/other_copulas.py
+++ b/statsmodels/distributions/copula/other_copulas.py
@@ -6,6 +6,8 @@ License: BSD-3
 
 """
 
+from statsmodels.compat.pandas import deprecate_kwarg
+
 import numpy as np
 from scipy import stats
 
@@ -46,9 +48,10 @@ class IndependenceCopula(Copula):
         else:
             return args
 
-    def rvs(self, nobs=1, args=(), random_state=None):
+    @deprecate_kwarg("random_state", "rng")
+    def rvs(self, nobs=1, args=(), rng=None):
         self._handle_args(args)
-        rng = check_random_state(random_state)
+        rng = check_random_state(rng)
         x = rng.random((nobs, self.k_dim))
         return x
 

--- a/statsmodels/distributions/copula/tests/test_copula.py
+++ b/statsmodels/distributions/copula/tests/test_copula.py
@@ -622,8 +622,9 @@ class CheckModernCopula(CheckCopula):
         nobs = 2000
         expected_warn = None if seed1 is not None else FutureWarning
         with pytest_warns(expected_warn):
-            rvs1 = self.copula.rvs(nobs, random_state=seed1)
-        rvs2 = self.copula.rvs(nobs, random_state=seed2)
+            rvs1 = self.copula.rvs(nobs, rng=seed1)
+        with pytest_warns(FutureWarning):
+            rvs2 = self.copula.rvs(nobs, random_state=seed2)
         assert_allclose(rvs1, rvs2)
 
 

--- a/statsmodels/distributions/discrete.py
+++ b/statsmodels/distributions/discrete.py
@@ -1,3 +1,4 @@
+from statsmodels.compat.pandas import deprecate_kwarg
 from statsmodels.compat.scipy import apply_where
 
 import numpy as np
@@ -339,12 +340,13 @@ class DiscretizedCount(rv_discrete):
             scale = 1
         return args, scale
 
-    def _rvs(self, *args, size=None, random_state=None):
+    @deprecate_kwarg("random_state", "rng")
+    def _rvs(self, *args, size=None, rng=None):
         args, scale = self._unpack_args(args)
         if size is None:
             size = getattr(self, "_size", 1)
         rv = np.trunc(
-            self.distr.rvs(*args, scale=scale, size=size, random_state=random_state)
+            self.distr.rvs(*args, scale=scale, size=size, random_state=rng)
             + self.d_offset
         )
         return rv

--- a/statsmodels/distributions/mixture_rvs.py
+++ b/statsmodels/distributions/mixture_rvs.py
@@ -1,3 +1,5 @@
+from statsmodels.compat.pandas import deprecate_kwarg
+
 import numpy as np
 
 
@@ -84,8 +86,9 @@ class MixtureDistribution:
 
     # def __init__(self, prob, size, dist, kwargs=None):
 
-    def rvs(self, prob, size, dist, kwargs=None, random_state=None):
-        return mixture_rvs(prob, size, dist, kwargs=kwargs, rng=random_state)
+    @deprecate_kwarg("random_state", "rng")
+    def rvs(self, prob, size, dist, kwargs=None, rng=None):
+        return mixture_rvs(prob, size, dist, kwargs=kwargs, rng=rng)
 
     def pdf(self, x, prob, dist, kwargs=None):
         """

--- a/statsmodels/duration/hazard_regression.py
+++ b/statsmodels/duration/hazard_regression.py
@@ -15,6 +15,8 @@ hazards model.
 http://www.mwsug.org/proceedings/2006/stats/MWSUG-2006-SD08.pdf
 """
 
+from statsmodels.compat.pandas import deprecate_kwarg
+
 import numpy as np
 
 from statsmodels.base import model
@@ -1866,7 +1868,8 @@ class rv_discrete_float:
         self.pk = pk
         self.cpk = np.cumsum(self.pk, axis=1)
 
-    def rvs(self, n=None, random_state=None):
+    @deprecate_kwarg("random_state", "rng")
+    def rvs(self, n=None, rng=None):
         """
         Returns a random sample from the discrete distribution
 
@@ -1877,7 +1880,7 @@ class rv_discrete_float:
         ----------
         n : not used
             Present for signature compatibility.
-        random_state : {None, int, array_like, BitGenerator, Generator, RandomState}, optional
+        rng : {None, int, array_like, BitGenerator, Generator, RandomState}, optional
             If an int, array_like, or BitGenerator, a new Generator is
             used with the seed provided. If a Generator or RandomState
             is provided, it is used directly. If None (or np.random),
@@ -1890,7 +1893,7 @@ class rv_discrete_float:
         """
 
         n = self.xk.shape[0]
-        rng = check_random_state(random_state, deprecated=True)
+        rng = check_random_state(rng, deprecated=True)
         u = rng.uniform(size=n)
         ix = (self.cpk < u[:, None]).sum(1)
         ii = np.arange(n, dtype=np.int32)

--- a/statsmodels/gam/gam_cross_validation/gam_cross_validation.py
+++ b/statsmodels/gam/gam_cross_validation/gam_cross_validation.py
@@ -51,9 +51,9 @@ class BaseCV(with_metaclass(ABCMeta)):
         self.exog = exog
         self.endog = endog
         # TODO: cv_iterator.split only needs nobs from endog or exog
-        self.train_test_cv_indices = self.cv_iterator.split(self.exog,
-                                                            self.endog,
-                                                            label=None)
+        self.train_test_cv_indices = self.cv_iterator.split(
+            self.exog, self.endog, label=None
+        )
 
     def fit(self, **kwargs):
         """
@@ -97,7 +97,6 @@ class BaseCV(with_metaclass(ABCMeta)):
         error : float
             prediction error evaluated on the test set
         """
-        pass
 
 
 def _split_train_test_smoothers(x, smoothers, train_index, test_index):
@@ -138,8 +137,14 @@ def _split_train_test_smoothers(x, smoothers, train_index, test_index):
 
         train_smoothers.append(
             UnivariateGenericSmoother(
-                train_x, train_basis, train_der_basis, train_der2_basis,
-                train_cov_der2, smoother.variable_name + " train"))
+                train_x,
+                train_basis,
+                train_der_basis,
+                train_der2_basis,
+                train_cov_der2,
+                smoother.variable_name + " train",
+            )
+        )
 
         test_basis = smoother.basis[test_index]
         test_der_basis = smoother.der_basis[test_index]
@@ -149,13 +154,17 @@ def _split_train_test_smoothers(x, smoothers, train_index, test_index):
 
         test_smoothers.append(
             UnivariateGenericSmoother(
-                test_x, test_basis, test_der_basis, train_der2_basis,
-                test_cov_der2, smoother.variable_name + " test"))
+                test_x,
+                test_basis,
+                test_der_basis,
+                train_der2_basis,
+                test_cov_der2,
+                smoother.variable_name + " test",
+            )
+        )
 
-    train_multivariate_smoothers = GenericSmoothers(x[train_index],
-                                                    train_smoothers)
-    test_multivariate_smoothers = GenericSmoothers(x[test_index],
-                                                   test_smoothers)
+    train_multivariate_smoothers = GenericSmoothers(x[train_index], train_smoothers)
+    test_multivariate_smoothers = GenericSmoothers(x[test_index], test_smoothers)
 
     return train_multivariate_smoothers, test_multivariate_smoothers
 
@@ -207,9 +216,7 @@ class MultivariateGAMCV(BaseCV):
         # TODO: super does not do anything with endog, exog, except get nobs
         # refactor to clean up what where `exog` and `exog_linear` is attached
         # exog is not used in super
-        super().__init__(
-            cv_iterator, endog, self.smoother.basis
-        )
+        super().__init__(cv_iterator, endog, self.smoother.basis)
 
     def _error(self, train_index, test_index, **kwargs):
         """
@@ -230,7 +237,8 @@ class MultivariateGAMCV(BaseCV):
             prediction error, evaluated with ``cost``, on the test set
         """
         train_smoother, test_smoother = _split_train_test_smoothers(
-            self.smoother.x, self.smoother, train_index, test_index)
+            self.smoother.x, self.smoother, train_index, test_index
+        )
 
         endog_train = self.endog[train_index]
         endog_test = self.endog[test_index]
@@ -241,13 +249,18 @@ class MultivariateGAMCV(BaseCV):
             exog_linear_train = None
             exog_linear_test = None
 
-        gam = self.gam(endog_train, exog=exog_linear_train,
-                       smoother=train_smoother, alpha=self.alphas)
+        gam = self.gam(
+            endog_train,
+            exog=exog_linear_train,
+            smoother=train_smoother,
+            alpha=self.alphas,
+        )
         gam_res = gam.fit(**kwargs)
         # exog_linear_test and test_smoother.basis will be column_stacked
         #     but not transformed in predict
-        endog_est = gam_res.predict(exog_linear_test, test_smoother.basis,
-                                    transform=False)
+        endog_est = gam_res.predict(
+            exog_linear_test, test_smoother.basis, transform=False
+        )
 
         return self.cost(endog_test, endog_est)
 
@@ -289,18 +302,15 @@ class BasePenaltiesPathCV(with_metaclass(ABCMeta)):
     def plot_path(self):
         """Plot the cross validation error and standard deviation over the alphas grid"""
         from statsmodels.graphics.utils import _import_mpl
+
         plt = _import_mpl()
         plt.plot(self.alphas, self.cv_error, c="black")
-        plt.plot(self.alphas, self.cv_error + 1.96 * self.cv_std,
-                 c="blue")
-        plt.plot(self.alphas, self.cv_error - 1.96 * self.cv_std,
-                 c="blue")
+        plt.plot(self.alphas, self.cv_error + 1.96 * self.cv_std, c="blue")
+        plt.plot(self.alphas, self.cv_error - 1.96 * self.cv_std, c="blue")
 
         plt.plot(self.alphas, self.cv_error, "o", c="black")
-        plt.plot(self.alphas, self.cv_error + 1.96 * self.cv_std, "o",
-                 c="blue")
-        plt.plot(self.alphas, self.cv_error - 1.96 * self.cv_std, "o",
-                 c="blue")
+        plt.plot(self.alphas, self.cv_error + 1.96 * self.cv_std, "o", c="blue")
+        plt.plot(self.alphas, self.cv_error - 1.96 * self.cv_std, "o", c="blue")
 
         # TODO add return
 
@@ -367,8 +377,20 @@ class MultivariateGAMCVPath:
         self.endog = endog
         self.exog = exog
         self.cv_iterator = cv_iterator
-        self.cv_error = np.zeros(shape=(len(self.alphas_grid, )))
-        self.cv_std = np.zeros(shape=(len(self.alphas_grid, )))
+        self.cv_error = np.zeros(
+            shape=(
+                len(
+                    self.alphas_grid,
+                )
+            )
+        )
+        self.cv_std = np.zeros(
+            shape=(
+                len(
+                    self.alphas_grid,
+                )
+            )
+        )
         self.alpha_cv = None
 
     def fit(self, **kwargs):
@@ -386,13 +408,15 @@ class MultivariateGAMCVPath:
             instance with ``cv_error``, ``cv_std`` and ``alpha_cv`` set
         """
         for i, alphas_i in enumerate(self.alphas_grid):
-            gam_cv = MultivariateGAMCV(smoother=self.smoother,
-                                       alphas=alphas_i,
-                                       gam=self.gam,
-                                       cost=self.cost,
-                                       endog=self.endog,
-                                       exog=self.exog,
-                                       cv_iterator=self.cv_iterator)
+            gam_cv = MultivariateGAMCV(
+                smoother=self.smoother,
+                alphas=alphas_i,
+                gam=self.gam,
+                cost=self.cost,
+                endog=self.endog,
+                exog=self.exog,
+                cv_iterator=self.cv_iterator,
+            )
             cv_err = gam_cv.fit(**kwargs)
             self.cv_error[i] = cv_err.mean()
             self.cv_std[i] = cv_err.std()

--- a/statsmodels/miscmodels/nonlinls.py
+++ b/statsmodels/miscmodels/nonlinls.py
@@ -3,6 +3,7 @@ Non-linear least squares
 
 Author: Josef Perktold based on scipy.optimize.curve_fit
 """
+
 import numpy as np
 from scipy import optimize
 
@@ -47,6 +48,7 @@ class Results:
 # def _weighted_general_function(params, xdata, ydata, function, weights):
 #    return weights * (function(xdata, *params) - ydata)
 #
+
 
 class NonlinearLS(Model):  # or subclass a model
     r"""
@@ -123,6 +125,7 @@ class NonlinearLS(Model):  # or subclass a model
         myres.bse
         myres.tvalues
     """
+
     # NOTE: This needs to call super for data checking
     def __init__(self, endog=None, exog=None, weights=None, sigma=None, missing="none"):
         self.endog = endog
@@ -167,7 +170,6 @@ class NonlinearLS(Model):  # or subclass a model
         params : array_like
             The parameters at which to evaluate the prediction function.
         """
-        pass
 
     def start_value(self):
         """
@@ -220,7 +222,7 @@ class NonlinearLS(Model):  # or subclass a model
         float
             The sum of squared residuals.
         """
-        return (self.geterrors(params)**2).sum()
+        return (self.geterrors(params) ** 2).sum()
 
     def fit(self, start_value=None, nparams=None, **kw):
         """
@@ -263,7 +265,7 @@ class NonlinearLS(Model):  # or subclass a model
 
         func = self.geterrors
         res = optimize.leastsq(func, p0, full_output=1, **kw)
-        (popt, pcov, infodict, errmsg, ier) = res
+        popt, pcov, infodict, errmsg, ier = res
 
         if ier not in [1, 2, 3, 4]:
             msg = "Optimal parameters not found: " + errmsg
@@ -275,12 +277,12 @@ class NonlinearLS(Model):  # or subclass a model
         if (len(ydata) > len(p0)) and pcov is not None:
             # this can use the returned errors instead of recalculating
 
-            s_sq = (err**2).sum()/(len(ydata)-len(p0))
+            s_sq = (err**2).sum() / (len(ydata) - len(p0))
             pcov = pcov * s_sq
         else:
             pcov = None
 
-        self.df_resid = len(ydata)-len(p0)
+        self.df_resid = len(ydata) - len(p0)
         self.df_model = len(p0)
         fitres = Results()
         fitres.params = popt
@@ -305,7 +307,7 @@ class NonlinearLS(Model):  # or subclass a model
             self, beta, normalized_cov_params=self.normalized_cov_params
         )
 
-        lfit.fitres = fitres   # mainly for testing
+        lfit.fitres = fitres  # mainly for testing
         self._results = lfit
         return lfit
 
@@ -362,7 +364,7 @@ class NonlinearLS(Model):  # or subclass a model
         else:
             rvs = rvs_generator(size=(ntries, nparams))
 
-        results = np.array([np.r_[self.fit_minimal(rv),  rv] for rv in rvs])
+        results = np.array([np.r_[self.fit_minimal(rv), rv] for rv in rvs])
         # selct best results and check how many solutions are within 1e-6 of best
         # not sure what leastsq returns
         return results
@@ -405,30 +407,31 @@ class Myfunc(NonlinearLS):
     def _predict(self, params):
         x = self.exog
         a, b, c = params
-        return a*np.exp(-b*x) + c
+        return a * np.exp(-b * x) + c
 
 
 if __name__ == "__main__":
+
     def func0(x, a, b, c):
-        return a*np.exp(-b*x) + c
+        return a * np.exp(-b * x) + c
 
     def func(params, x):
         a, b, c = params
-        return a*np.exp(-b*x) + c
+        return a * np.exp(-b * x) + c
 
     def error(params, x, y):
         return y - func(params, x)
 
     def error2(params, x, y):
-        return (y - func(params, x))**2
+        return (y - func(params, x)) ** 2
 
     x = np.linspace(0, 4, 50)
     params = np.array([2.5, 1.3, 0.5])
     y0 = func(params, x)
-    y = y0 + 0.2*np.random.normal(size=len(x))
+    y = y0 + 0.2 * np.random.normal(size=len(x))
 
     res = optimize.leastsq(error, params, args=(x, y), full_output=True)
-#    r, R, c = getjaccov(res[1:], 3)
+    #    r, R, c = getjaccov(res[1:], 3)
 
     mod = Myfunc(y, x)
     resmy = mod.fit(nparams=3)

--- a/statsmodels/regression/mixed_linear_model.py
+++ b/statsmodels/regression/mixed_linear_model.py
@@ -143,6 +143,8 @@ the Newton-Raphson algorithm cannot be used for model fitting.
 
 """
 
+from statsmodels.compat.pandas import deprecate_kwarg
+
 from io import StringIO
 import tokenize
 import warnings
@@ -2541,7 +2543,8 @@ class _mixedlm_distribution:
             group_idx[model.row_indices[g]] = k
         self.group_idx = group_idx
 
-    def rvs(self, n, random_state=None):
+    @deprecate_kwarg("random_state", "rng")
+    def rvs(self, n, rng=None):
         """
         Return a vector of simulated values from a mixed linear
         model
@@ -2550,10 +2553,10 @@ class _mixedlm_distribution:
         ----------
         n : int
             Ignored, but required by the interface.
-        random_state : {None, int, `numpy.random.Generator`, `numpy.random.RandomState`}, optional
-            If `random_state` is None (or `np.random`), the `numpy.random.RandomState`
-            singleton is used. If `random_state` is an int, a new ``RandomState``
-            instance is used, seeded with `random_state`. If `random_state` is already
+        rng : {None, int, `numpy.random.Generator`, `numpy.random.RandomState`}, optional
+            If `rng` is None (or `np.random`), the `numpy.random.RandomState`
+            singleton is used. If `rng` is an int, a new ``RandomState``
+            instance is used, seeded with `rng`. If `rng` is already
             a ``Generator`` or ``RandomState`` instance, that instance is used.
 
         Returns
@@ -2567,7 +2570,7 @@ class _mixedlm_distribution:
         y = np.dot(self.exog, self.fe_params)
 
         # Random effects
-        rng = check_random_state(random_state)
+        rng = check_random_state(rng)
         u = rng.normal(size=(model.n_groups, model.k_re))
         u = np.dot(u, np.linalg.cholesky(self.cov_re).T)
         y += (u[self.group_idx, :] * model.exog_re).sum(1)

--- a/statsmodels/sandbox/distributions/gof_new.py
+++ b/statsmodels/sandbox/distributions/gof_new.py
@@ -18,6 +18,7 @@ References
 
 """
 
+from statsmodels.compat.pandas import deprecate_kwarg
 from statsmodels.compat.python import lmap
 
 import numpy as np
@@ -638,12 +639,11 @@ class NewNorm:
     def cdf(self, x, args):
         return distributions.norm.cdf(x, loc=args[0], scale=args[1])
 
-    def rvs(self, args, size, random_state=None):
+    @deprecate_kwarg("random_state", "rng")
+    def rvs(self, args, size, rng=None):
         loc = args[0]
         scale = args[1]
-        return loc + scale * distributions.norm.rvs(
-            size=size, random_state=random_state
-        )
+        return loc + scale * distributions.norm.rvs(size=size, random_state=rng)
 
 
 if __name__ == "__main__":

--- a/statsmodels/sandbox/distributions/multivariate.py
+++ b/statsmodels/sandbox/distributions/multivariate.py
@@ -15,6 +15,8 @@ Genz and Bretz for formula
 
 """
 
+from statsmodels.compat.pandas import deprecate_kwarg
+
 import numpy as np
 from numpy import exp as np_exp, log as np_log
 from scipy import integrate, special, stats
@@ -105,7 +107,8 @@ def mvstdtprob(a, b, R, df, ieps=1e-5, quadkwds=None, mvstkwds=None):
 
 # written by Enzo Michelangeli, style changes by josef-pktd
 # Student's T random variable
-def multivariate_t_rvs(m, S, df=np.inf, n=1, random_state=None):
+@deprecate_kwarg("random_state", "rng")
+def multivariate_t_rvs(m, S, df=np.inf, n=1, rng=None):
     """generate random variables of multivariate t distribution
 
     Parameters
@@ -118,8 +121,14 @@ def multivariate_t_rvs(m, S, df=np.inf, n=1, random_state=None):
         degrees of freedom
     n : int
         number of observations, return random array will be (n, len(m))
-    random_state : int, np.random.RandomState or np.random.Generator, optional
-        TODO
+    rng : int, np.random.RandomState or np.random.Generator, optional
+        If `rng` is None (or `np.random`), the
+        class:``~numpy.random.RandomState`` singleton is used.
+        If `rng` is an int, a new class:``~numpy.random.RandomState``
+        instance is used, seeded with `rng`.
+        If `rng` is already a class:``~numpy.random.Generator`` or
+        class:``~numpy.random.RandomState`` instance then that instance is
+        used.
 
     Returns
     -------
@@ -129,7 +138,7 @@ def multivariate_t_rvs(m, S, df=np.inf, n=1, random_state=None):
 
 
     """
-    rng = check_random_state(random_state)
+    rng = check_random_state(rng)
     m = np.asarray(m)
     d = len(m)
     if df == np.inf:

--- a/statsmodels/sandbox/distributions/mv_normal.py
+++ b/statsmodels/sandbox/distributions/mv_normal.py
@@ -144,6 +144,8 @@ What's currently there?
 
 """
 
+from statsmodels.compat.pandas import deprecate_kwarg
+
 import numpy as np
 from scipy import special
 
@@ -843,14 +845,15 @@ class MVNormal(MVElliptical):
 
     __name__ = "Multivariate Normal Distribution"
 
-    def rvs(self, size=1, *, random_state=None):
+    @deprecate_kwarg("random_state", "rng")
+    def rvs(self, size=1, *, rng=None):
         """random variable
 
         Parameters
         ----------
         size : int or tuple
             the number and shape of random variables to draw.
-        random_state : int, np.random.RandomState, np.random.Generator, optional
+        rng : int, np.random.RandomState, np.random.Generator, optional
             The source of randomness used to produce the variates. If None,
             uses the singleton RandomState provided by NumPy.
 
@@ -866,7 +869,7 @@ class MVNormal(MVElliptical):
         uses numpy.random.multivariate_normal directly
 
         """
-        rng = check_random_state(random_state)
+        rng = check_random_state(rng)
         return rng.multivariate_normal(self.mean, self.sigma, size=size)
 
     def logpdf(self, x):
@@ -1043,19 +1046,20 @@ class MVT(MVElliptical):
         self.extra_args = ["df"]  # overwrites extra_args of super
         self.df = df
 
-    def rvs(self, size=1, random_state=None):
+    @deprecate_kwarg("random_state", "rng")
+    def rvs(self, size=1, rng=None):
         """random variables with Student T distribution
 
         Parameters
         ----------
         size : int or tuple
             the number and shape of random variables to draw.
-        random_state : {None, int, Generator, RandomState}, optional
-            If `seed` is None (or `np.random`), the
+        rng : {None, int, Generator, RandomState}, optional
+            If `rng` is None (or `np.random`), the
             class:``~numpy.random.RandomState`` singleton is used.
-            If `seed` is an int, a new class:``~numpy.random.RandomState``
-            instance is used, seeded with `seed`.
-            If `seed` is already a class:``~numpy.random.Generator`` or
+            If `rng` is an int, a new class:``~numpy.random.RandomState``
+            instance is used, seeded with `rng`.
+            If `rng` is already a class:``~numpy.random.Generator`` or
             class:``~numpy.random.RandomState`` instance then that instance is
             used.
 
@@ -1078,7 +1082,7 @@ class MVT(MVElliptical):
         from .multivariate import multivariate_t_rvs
 
         return multivariate_t_rvs(
-            self.mean, self.sigma, df=self.df, n=size, random_state=random_state
+            self.mean, self.sigma, df=self.df, n=size, random_state=rng
         )
 
     def logpdf(self, x):

--- a/statsmodels/tools/docstring_helpers.py
+++ b/statsmodels/tools/docstring_helpers.py
@@ -10,101 +10,7 @@ statsmodels' dependency on pandas private API.
 
 from __future__ import annotations
 
-from functools import wraps
 from textwrap import dedent
-from typing import Any, Callable, Mapping, TypeVar
-import warnings
-
-F = TypeVar("F", bound=Callable[..., Any])
-
-
-def deprecate_kwarg(
-    old_arg_name: str,
-    new_arg_name: str | None,
-    mapping: Mapping[Any, Any] | Callable[[Any], Any] | None = None,
-    stacklevel: int = 2,
-) -> Callable[[F], F]:
-    """
-    Decorator to deprecate a keyword argument of a function
-
-    Vendored from pandas.util._decorators to remove dependency on
-    pandas private API.
-
-    Parameters
-    ----------
-    old_arg_name : str
-        Name of argument in function to deprecate.
-    new_arg_name : str or None
-        Name of preferred argument in function. Use None to raise
-        warning that ``old_arg_name`` keyword is deprecated with
-        no replacement.
-    mapping : dict or callable, optional
-        If mapping is present, use it to translate old arguments to
-        new arguments. A callable must do its own value checking;
-        values not found in a dict will be forwarded unchanged.
-    stacklevel : int, default 2
-        Stack level for the warning.
-
-    Examples
-    --------
-    The following deprecates 'cols', using 'columns' instead:
-
-    >>> @deprecate_kwarg(old_arg_name='cols', new_arg_name='columns')
-    ... def f(columns=''):
-    ...     print(columns)
-    """
-    if mapping is not None and not hasattr(mapping, "get") and not callable(mapping):
-        raise TypeError(
-            "mapping from old to new argument values must be dict or callable!"
-        )
-
-    def _deprecate_kwarg(func: F) -> F:
-        @wraps(func)
-        def wrapper(*args, **kwargs):
-            __tracebackhide__ = True
-            old_arg_value = kwargs.pop(old_arg_name, None)
-
-            if old_arg_value is not None:
-                if new_arg_name is None:
-                    msg = (
-                        f"the {old_arg_name!r} keyword is deprecated and "
-                        "will be removed in a future version. Please take "
-                        f"steps to stop the use of {old_arg_name!r}"
-                    )
-                    warnings.warn(msg, FutureWarning, stacklevel=stacklevel)
-                    kwargs[old_arg_name] = old_arg_value
-                    return func(*args, **kwargs)
-
-                elif mapping is not None:
-                    if callable(mapping):
-                        new_arg_value = mapping(old_arg_value)
-                    else:
-                        new_arg_value = mapping.get(old_arg_value, old_arg_value)
-                    msg = (
-                        f"the {old_arg_name}={old_arg_value!r} keyword is "
-                        f"deprecated, use "
-                        f"{new_arg_name}={new_arg_value!r} instead."
-                    )
-                else:
-                    new_arg_value = old_arg_value
-                    msg = (
-                        f"the {old_arg_name!r} keyword is deprecated, "
-                        f"use {new_arg_name!r} instead."
-                    )
-
-                warnings.warn(msg, FutureWarning, stacklevel=stacklevel)
-                if kwargs.get(new_arg_name) is not None:
-                    msg = (
-                        f"Can only specify {old_arg_name!r} "
-                        f"or {new_arg_name!r}, not both."
-                    )
-                    raise TypeError(msg)
-                kwargs[new_arg_name] = new_arg_value
-            return func(*args, **kwargs)
-
-        return wrapper
-
-    return _deprecate_kwarg
 
 
 class Appender:
@@ -133,7 +39,7 @@ class Appender:
     the original docstring. An optional 'join' parameter may be supplied
     which will be used to join the docstring and addendum. e.g.
 
-    >>> add_copyright = Appender("Copyright (c) 2009", join='\n')
+    >>> add_copyright = Appender("Copyright (c) 2009", join="\n")
 
     >>> @add_copyright
     ... def my_dog(has='fleas'):

--- a/statsmodels/tools/tests/test_docstring_helpers.py
+++ b/statsmodels/tools/tests/test_docstring_helpers.py
@@ -5,11 +5,11 @@ Adapted directly from:
     pandas/tests/util/test_deprecate_kwarg.py
 """
 
+from statsmodels.compat.pandas import deprecate_kwarg
+
 import warnings
 
 import pytest
-
-from statsmodels.tools.docstring_helpers import deprecate_kwarg
 
 
 @deprecate_kwarg(old_arg_name="old", new_arg_name="new")

--- a/statsmodels/tsa/ardl/_pss_critical_values/pss-process.py
+++ b/statsmodels/tsa/ardl/_pss_critical_values/pss-process.py
@@ -79,7 +79,7 @@ if __name__ == "__main__":
         for lp in (2, 3):
             for cut in range(40, data.shape[0] - 40):
                 for log in (True, False):
-                    cv = KFold(shuffle=True, random_state=20210903)
+                    cv = KFold(shuffle=True, rng=20210903)
                     x, y = setup_regressors(data, lp, hp, cut, log)
                     k = (lp, hp, cut, log)
                     score[k] = cross_val_score(
@@ -162,7 +162,5 @@ crit_vals = {crit_vals}
     fm = FileMode(target_versions=targets, line_length=79)
     formatted_code = format_file_contents(raw_code, fast=False, mode=fm)
 
-    with open(
-            "../pss_critical_values.py", "w", newline="\n", encoding="utf-8"
-    ) as out:
+    with open("../pss_critical_values.py", "w", newline="\n", encoding="utf-8") as out:
         out.write(formatted_code)

--- a/statsmodels/tsa/arima/tests/test_model.py
+++ b/statsmodels/tsa/arima/tests/test_model.py
@@ -199,17 +199,17 @@ def test_low_memory():
     assert_equal(mod.ssm.memory_conserve, 0)
 
     # Check that low memory was actually used (just check a couple)
-    assert (res2.llf_obs is None)
-    assert (res2.predicted_state is None)
-    assert (res2.filtered_state is None)
-    assert (res2.smoothed_state is None)
+    assert res2.llf_obs is None
+    assert res2.predicted_state is None
+    assert res2.filtered_state is None
+    assert res2.smoothed_state is None
 
 
 def check_cloned(mod, endog, exog=None):
     mod_c = mod.clone(endog, exog=exog)
 
     assert_allclose(mod.nobs, mod_c.nobs)
-    assert (mod._index.equals(mod_c._index))
+    assert mod._index.equals(mod_c._index)
     assert_equal(mod.k_params, mod_c.k_params)
     assert_allclose(mod.start_params, mod_c.start_params)
     p = mod.start_params
@@ -361,8 +361,7 @@ def test_cov_type_none():
 def test_nonstationary_gls_error():
     # GH-6540
     endog = pd.read_csv(
-        io.StringIO(
-            """\
+        io.StringIO("""\
 data\n
 9.112\n9.102\n9.103\n9.099\n9.094\n9.090\n9.108\n9.088\n9.091\n9.083\n9.095\n
 9.090\n9.098\n9.093\n9.087\n9.088\n9.083\n9.095\n9.077\n9.082\n9.082\n9.081\n
@@ -382,8 +381,7 @@ data\n
 9.058\n9.074\n9.063\n9.057\n9.062\n9.058\n9.049\n9.047\n9.062\n9.052\n9.052\n
 9.044\n9.060\n9.062\n9.055\n9.058\n9.054\n9.044\n9.047\n9.050\n9.048\n9.041\n
 9.055\n9.051\n9.028\n9.030\n9.029\n9.027\n9.016\n9.023\n9.031\n9.042\n9.035\n
-"""
-        ),
+"""),
         index_col=None,
     )
     mod = ARIMA(
@@ -444,10 +442,10 @@ def test_reproducible_simulation(random_state_type):
             return 7
         return random_state_type(7)
 
-    random_state = get_random_state(random_state_type)
-    sim1 = res.simulate(1, random_state=random_state)
-    random_state = get_random_state(random_state_type)
-    sim2 = res.simulate(1, random_state=random_state)
+    rng = get_random_state(random_state_type)
+    sim1 = res.simulate(1, rng=rng)
+    rng = get_random_state(random_state_type)
+    sim2 = res.simulate(1, rng=rng)
     assert_allclose(sim1, sim2)
 
 
@@ -466,8 +464,7 @@ def test_alternative_estimators_seasonal_differencing():
         mod_hr.fit(method="hannan_rissanen")
     except Exception as exc:
         pytest.fail(
-            f"hannan_rissanen failed on seasonal-differencing-only model:"
-            f" {exc}"
+            f"hannan_rissanen failed on seasonal-differencing-only model:" f" {exc}"
         )
 
     # yule_walker: AR-only model with seasonal differencing
@@ -475,11 +472,10 @@ def test_alternative_estimators_seasonal_differencing():
     try:
         mod_yw.fit(method="yule_walker")
     except Exception as exc:
-        pytest.fail(
-            f"yule_walker failed on seasonal-differencing-only model: {exc}"
-        )
+        pytest.fail(f"yule_walker failed on seasonal-differencing-only model: {exc}")
 
     # Seasonal AR term (P=1) should still be rejected by hannan_rissanen
     with pytest.raises(ValueError, match="seasonal"):
-        ARIMA(endog, order=(1, 0, 0),
-              seasonal_order=(1, 0, 0, 12)).fit(method="hannan_rissanen")
+        ARIMA(endog, order=(1, 0, 0), seasonal_order=(1, 0, 0, 12)).fit(
+            method="hannan_rissanen"
+        )

--- a/statsmodels/tsa/exponential_smoothing/ets.py
+++ b/statsmodels/tsa/exponential_smoothing/ets.py
@@ -1768,11 +1768,21 @@ class ETSResults(base.StateSpaceMLEResults):
             eps = rng.standard_normal((nsimulations, repetitions)) * sigma
         elif isinstance(random_errors, (rv_continuous, rv_discrete)):
             params = random_errors.fit(self.resid)
-            eps = random_errors.rvs(
-                *params, size=(nsimulations, repetitions), random_state=rng
-            )
+            try:
+                eps = random_errors.rvs(
+                    *params, size=(nsimulations, repetitions), rng=rng
+                )
+            except TypeError:
+                eps = random_errors.rvs(
+                    *params, size=(nsimulations, repetitions), random_state=rng
+                )
         elif isinstance(random_errors, rv_frozen):
-            eps = random_errors.rvs(size=(nsimulations, repetitions), random_state=rng)
+            try:
+                eps = random_errors.rvs(size=(nsimulations, repetitions), rng=rng)
+            except TypeError:
+                eps = random_errors.rvs(
+                    size=(nsimulations, repetitions), random_state=rng
+                )
         else:
             raise ValueError("Argument random_errors has unexpected value!")
 

--- a/statsmodels/tsa/holtwinters/results.py
+++ b/statsmodels/tsa/holtwinters/results.py
@@ -389,17 +389,19 @@ class HoltWintersResults(Results):
 
             * ``None``: Random normally distributed values with variance
               estimated from the fit errors drawn from numpy's standard
-              RNG (can be seeded with the `random_state` argument). This is the
+              RNG (can be seeded with the `rng` argument). This is the
               default option.
             * A distribution function from ``scipy.stats``, e.g.
               ``scipy.stats.norm``: Fits the distribution function to the fit
               errors and draws from the fitted distribution.
               Note the difference between ``scipy.stats.norm`` and
               ``scipy.stats.norm()``, the latter one is a frozen distribution
-              function.
+              function. The method ``rvs`` is called on the distribution function
+              to draw the random errors.
             * A frozen distribution function from ``scipy.stats``, e.g.
               ``scipy.stats.norm(scale=2)``: Draws from the frozen distribution
-              function.
+              function. The method ``rvs`` is called on the distribution function
+              to draw the random errors.
             * A ``np.ndarray`` with shape (`nsimulations`, `repetitions`): Uses
               the given values as random errors.
             * ``"bootstrap"``: Samples the random errors from the fit errors.
@@ -648,13 +650,21 @@ class HoltWintersResults(Results):
                 eps = rng.standard_normal((nsimulations, repetitions)) * sigma
             elif isinstance(random_errors, (rv_continuous, rv_discrete)):
                 params = random_errors.fit(resid)
-                eps = random_errors.rvs(
-                    *params, size=(nsimulations, repetitions), random_state=rng
-                )
+                try:
+                    eps = random_errors.rvs(
+                        *params, size=(nsimulations, repetitions), rng=rng
+                    )
+                except TypeError:
+                    eps = random_errors.rvs(
+                        *params, size=(nsimulations, repetitions), random_state=rng
+                    )
             elif isinstance(random_errors, rv_frozen):
-                eps = random_errors.rvs(
-                    size=(nsimulations, repetitions), random_state=rng
-                )
+                try:
+                    eps = random_errors.rvs(size=(nsimulations, repetitions), rng=rng)
+                except TypeError:
+                    eps = random_errors.rvs(
+                        size=(nsimulations, repetitions), random_state=rng
+                    )
             else:
                 raise ValueError("Argument random_errors has unexpected value!")
 

--- a/statsmodels/tsa/statespace/_simulation_smoother.pxd
+++ b/statsmodels/tsa/statespace/_simulation_smoother.pxd
@@ -98,9 +98,9 @@ cdef class sSimulationSmoother(object):
     cdef readonly int pretransformed_initial_state_variates
     cdef readonly int fixed_initial_state
 
-    cpdef draw_measurement_disturbance_variates(self, random_state)
-    cpdef draw_state_disturbance_variates(self, random_state)
-    cpdef draw_initial_state_variates(self, random_state)
+    cpdef draw_measurement_disturbance_variates(self, rng)
+    cpdef draw_state_disturbance_variates(self, rng)
+    cpdef draw_initial_state_variates(self, rng)
     cpdef set_measurement_disturbance_variates(self, np.float32_t [:] variates, int pretransformed=*)
     cpdef set_state_disturbance_variates(self, np.float32_t [:] variates, int pretransformed=*)
     cpdef set_initial_state_variates(self, np.float32_t [:] variates, int pretransformed=*)
@@ -173,9 +173,9 @@ cdef class dSimulationSmoother(object):
     cdef readonly int pretransformed_initial_state_variates
     cdef readonly int fixed_initial_state
 
-    cpdef draw_measurement_disturbance_variates(self, random_state)
-    cpdef draw_state_disturbance_variates(self, random_state)
-    cpdef draw_initial_state_variates(self, random_state)
+    cpdef draw_measurement_disturbance_variates(self, rng)
+    cpdef draw_state_disturbance_variates(self, rng)
+    cpdef draw_initial_state_variates(self, rng)
     cpdef set_measurement_disturbance_variates(self, np.float64_t [:] variates, int pretransformed=*)
     cpdef set_state_disturbance_variates(self, np.float64_t [:] variates, int pretransformed=*)
     cpdef set_initial_state_variates(self, np.float64_t [:] variates, int pretransformed=*)
@@ -248,9 +248,9 @@ cdef class cSimulationSmoother(object):
     cdef readonly int pretransformed_initial_state_variates
     cdef readonly int fixed_initial_state
 
-    cpdef draw_measurement_disturbance_variates(self, random_state)
-    cpdef draw_state_disturbance_variates(self, random_state)
-    cpdef draw_initial_state_variates(self, random_state)
+    cpdef draw_measurement_disturbance_variates(self, rng)
+    cpdef draw_state_disturbance_variates(self, rng)
+    cpdef draw_initial_state_variates(self, rng)
     cpdef set_measurement_disturbance_variates(self, np.complex64_t [:] variates, int pretransformed=*)
     cpdef set_state_disturbance_variates(self, np.complex64_t [:] variates, int pretransformed=*)
     cpdef set_initial_state_variates(self, np.complex64_t [:] variates, int pretransformed=*)
@@ -323,9 +323,9 @@ cdef class zSimulationSmoother(object):
     cdef readonly int pretransformed_initial_state_variates
     cdef readonly int fixed_initial_state
 
-    cpdef draw_measurement_disturbance_variates(self, random_state)
-    cpdef draw_state_disturbance_variates(self, random_state)
-    cpdef draw_initial_state_variates(self, random_state)
+    cpdef draw_measurement_disturbance_variates(self, rng)
+    cpdef draw_state_disturbance_variates(self, rng)
+    cpdef draw_initial_state_variates(self, rng)
     cpdef set_measurement_disturbance_variates(self, np.complex128_t [:] variates, int pretransformed=*)
     cpdef set_state_disturbance_variates(self, np.complex128_t [:] variates, int pretransformed=*)
     cpdef set_initial_state_variates(self, np.complex128_t [:] variates, int pretransformed=*)

--- a/statsmodels/tsa/statespace/_simulation_smoother.pyx.in
+++ b/statsmodels/tsa/statespace/_simulation_smoother.pyx.in
@@ -284,16 +284,16 @@ cdef class {{prefix}}SimulationSmoother(object):
         self._tmp1 = &self.tmp1[0,0]
         self._tmp2 = &self.tmp2[0,0]
 
-    cpdef draw_measurement_disturbance_variates(self, random_state):
-        self.measurement_disturbance_variates = random_state.normal(size=self.n_measurement_disturbance_variates)
+    cpdef draw_measurement_disturbance_variates(self, rng):
+        self.measurement_disturbance_variates = rng.normal(size=self.n_measurement_disturbance_variates)
         self.pretransformed_measurement_disturbance_variates = False
 
-    cpdef draw_state_disturbance_variates(self, random_state):
-        self.state_disturbance_variates = random_state.normal(size=self.n_state_disturbance_variates)
+    cpdef draw_state_disturbance_variates(self, rng):
+        self.state_disturbance_variates = rng.normal(size=self.n_state_disturbance_variates)
         self.pretransformed_state_disturbance_variates = False
 
-    cpdef draw_initial_state_variates(self, random_state):
-        self.initial_state_variates = random_state.normal(size=self.n_initial_state_variates)
+    cpdef draw_initial_state_variates(self, rng):
+        self.initial_state_variates = rng.normal(size=self.n_initial_state_variates)
         self.pretransformed_initial_state_variates = False
         self.fixed_initial_state = False
 

--- a/statsmodels/tsa/statespace/kalman_filter.py
+++ b/statsmodels/tsa/statespace/kalman_filter.py
@@ -5,6 +5,8 @@ Author: Chad Fulton
 License: Simplified-BSD
 """
 
+from statsmodels.compat.pandas import deprecate_kwarg
+
 import contextlib
 from warnings import warn
 
@@ -1112,13 +1114,14 @@ class KalmanFilter(Representation):
 
         return llf_obs
 
+    @deprecate_kwarg("random_state", "rng")
     def simulate(self, nsimulations, measurement_shocks=None,
                  state_shocks=None, initial_state=None,
                  pretransformed_measurement_shocks=True,
                  pretransformed_state_shocks=True,
                  pretransformed_initial_state=True,
                  simulator=None, return_simulator=False,
-                 random_state=None):
+                 rng=None):
         r"""
         Simulate a new time series following the state space model
 
@@ -1170,7 +1173,7 @@ class KalmanFilter(Representation):
             Whether or not to return the simulator object. Typically used to
             improve performance when performing repeated sampling. Default is
             False.
-        random_state : {None, int, Generator, RandomState}, optionall
+        rng : {None, int, Generator, RandomState}, optional
             If `seed` is None (or `np.random`), the `numpy.random.RandomState`
             singleton is used.
             If `seed` is an int, a new ``RandomState`` instance is used,
@@ -1207,9 +1210,9 @@ class KalmanFilter(Representation):
             pretransformed_initial_state_variates=(
                 pretransformed_initial_state),
             simulator=simulator, return_simulator=return_simulator,
-            random_state=random_state)
+            rng=rng)
 
-    def _simulate(self, nsimulations, simulator=None, random_state=None,
+    def _simulate(self, nsimulations, simulator=None, rng=None,
                   **kwargs):
         raise NotImplementedError("Simulation only available through"
                                   " the simulation smoother.")

--- a/statsmodels/tsa/statespace/mlemodel.py
+++ b/statsmodels/tsa/statespace/mlemodel.py
@@ -6,7 +6,7 @@ License: Simplified-BSD
 """
 
 from statsmodels.compat.numpy import inplace_reshape
-from statsmodels.compat.pandas import is_int_index
+from statsmodels.compat.pandas import deprecate_kwarg, is_int_index
 
 import contextlib
 import datetime as dt
@@ -2114,6 +2114,7 @@ class MLEModel(tsbase.TimeSeriesModel):
 
         return kwargs
 
+    @deprecate_kwarg("random_state", "rng")
     def simulate(
         self,
         params,
@@ -2131,7 +2132,7 @@ class MLEModel(tsbase.TimeSeriesModel):
         pretransformed_measurement_shocks=True,
         pretransformed_state_shocks=True,
         pretransformed_initial_state=True,
-        random_state=None,
+        rng=None,
         **kwargs,
     ):
         r"""
@@ -2207,7 +2208,7 @@ class MLEModel(tsbase.TimeSeriesModel):
             assumed to contain draws from the standard Normal distribution that
             must be transformed using the `initial_state_cov` covariance
             matrix. Default is True.
-        random_state : {None, int, Generator, RandomState}, optional
+        rng : {None, int, Generator, RandomState}, optional
             If `seed` is None (or `np.random`), the
             class:``~numpy.random.RandomState`` singleton is used.
             If `seed` is an int, a new class:``~numpy.random.RandomState``
@@ -2312,7 +2313,7 @@ class MLEModel(tsbase.TimeSeriesModel):
                 pretransformed_initial_state=pretransformed_initial_state,
                 simulator=simulator,
                 return_simulator=True,
-                random_state=random_state,
+                rng=rng,
             )
 
             sim[:, :, i] = out
@@ -3959,7 +3960,7 @@ class MLEResults(tsbase.TimeSeriesModelResults):
         pretransformed_measurement_shocks=True,
         pretransformed_state_shocks=True,
         pretransformed_initial_state=True,
-        random_state=None,
+        rng=None,
         **kwargs,
     ):
         r"""
@@ -4020,7 +4021,7 @@ class MLEResults(tsbase.TimeSeriesModelResults):
             assumed to contain draws from the standard Normal distribution that
             must be transformed using the `initial_state_cov` covariance
             matrix. Default is True.
-        random_state : {None, int, Generator, RandomState}, optional
+        rng : {None, int, Generator, RandomState}, optional
             If `seed` is None (or `np.random`), the
             class:``~numpy.random.RandomState`` singleton is used.
             If `seed` is an int, a new class:``~numpy.random.RandomState``
@@ -4065,7 +4066,7 @@ class MLEResults(tsbase.TimeSeriesModelResults):
         # GH 9162
         from statsmodels.tsa.statespace import simulation_smoother
 
-        random_state = simulation_smoother.check_random_state(random_state)
+        rng = simulation_smoother.check_random_state(rng)
 
         # Setup the initial state
         if initial_state is None:
@@ -4076,7 +4077,7 @@ class MLEResults(tsbase.TimeSeriesModelResults):
 
             _repetitions = 1 if repetitions is None else repetitions
 
-            initial_state = random_state.multivariate_normal(
+            initial_state = rng.multivariate_normal(
                 *initial_state_moments, size=_repetitions
             ).T
 
@@ -4098,7 +4099,7 @@ class MLEResults(tsbase.TimeSeriesModelResults):
                 pretransformed_measurement_shocks=(pretransformed_measurement_shocks),
                 pretransformed_state_shocks=pretransformed_state_shocks,
                 pretransformed_initial_state=pretransformed_initial_state,
-                random_state=random_state,
+                rng=rng,
                 **kwargs,
             )
 

--- a/statsmodels/tsa/statespace/simulation_smoother.py
+++ b/statsmodels/tsa/statespace/simulation_smoother.py
@@ -5,6 +5,8 @@ Author: Chad Fulton
 License: Simplified-BSD
 """
 
+from statsmodels.compat.pandas import deprecate_kwarg
+
 import numbers
 import warnings
 
@@ -175,13 +177,13 @@ class SimulationSmoother(KalmanSmoother):
         self,
         nsimulations,
         simulator=None,
-        random_state=None,
+        rng=None,
         return_simulator=False,
         **kwargs,
     ):
         # Create the simulator, if necessary
         if simulator is None:
-            simulator = self.simulator(nsimulations, random_state=random_state)
+            simulator = self.simulator(nsimulations, rng=rng)
 
         # Perform simulation smoothing
         simulator.simulate(**kwargs)
@@ -195,14 +197,15 @@ class SimulationSmoother(KalmanSmoother):
             out = out + (simulator,)
         return out
 
-    def simulator(self, nsimulations, random_state=None):
+    def simulator(self, nsimulations, rng=None):
         return self.simulation_smoother(
             simulation_output=0,
             method="kfs",
             nobs=nsimulations,
-            random_state=random_state,
+            rng=rng,
         )
 
+    @deprecate_kwarg("random_state", "rng")
     def simulation_smoother(
         self,
         simulation_output=None,
@@ -210,7 +213,7 @@ class SimulationSmoother(KalmanSmoother):
         results_class=None,
         prefix=None,
         nobs=-1,
-        random_state=None,
+        rng=None,
         **kwargs,
     ):
         r"""
@@ -239,7 +242,7 @@ class SimulationSmoother(KalmanSmoother):
             than -1, only simulation will be performed (i.e. simulation
             smoothing will not be performed), so that only the `generated_obs`
             and `generated_state` attributes will be available.
-        random_state : {None, int, Generator, RandomState}, optional
+        rng : {None, int, Generator, RandomState}, optional
             If `seed` is None (or `np.random`), the `numpy.random.RandomState`
             singleton is used.
             If `seed` is an int, a new ``numpy.random.RandomState`` instance
@@ -315,7 +318,7 @@ class SimulationSmoother(KalmanSmoother):
         )
 
         # Create results object
-        results = results_class(self, simulation_smoother, random_state=random_state)
+        results = results_class(self, simulation_smoother, rng=rng)
 
         return results
 
@@ -331,7 +334,7 @@ class SimulationSmoothResults:
         A Statespace representation
     simulation_smoother : {{prefix}}SimulationSmoother object
         The Cython simulation smoother object with which to simulation smooth.
-    random_state : {None, int, Generator, RandomState}, optional
+    rng : {None, int, Generator, RandomState}, optional
         If `seed` is None (or `np.random`), the `numpy.random.RandomState`
         singleton is used.
         If `seed` is an int, a new ``numpy.random.RandomState`` instance
@@ -375,12 +378,13 @@ class SimulationSmoothResults:
         Simulated state disturbance.
     """
 
-    def __init__(self, model, simulation_smoother, random_state=None):
+    @deprecate_kwarg("random_state", "rng")
+    def __init__(self, model, simulation_smoother, rng=None):
         self.model = model
         self.prefix = model.prefix
         self.dtype = model.dtype
         self._simulation_smoother = simulation_smoother
-        self.random_state = check_random_state(random_state)
+        self.rng = check_random_state(rng)
 
         # Output
         self._generated_measurement_disturbance = None
@@ -575,6 +579,7 @@ class SimulationSmoothResults:
             )
         return self._simulated_state_disturbance
 
+    @deprecate_kwarg("random_state", "rng")
     def simulate(
         self,
         simulation_output=-1,
@@ -586,7 +591,7 @@ class SimulationSmoothResults:
         pretransformed_measurement_disturbance_variates=None,
         pretransformed_state_disturbance_variates=None,
         pretransformed_initial_state_variates=False,
-        random_state=None,
+        rng=None,
     ):
         r"""
         Perform simulation smoothing
@@ -638,7 +643,7 @@ class SimulationSmoothResults:
             then it is assumed to contain draws from the standard Normal
             distribution that must be transformed using the `initial_state_cov`
             covariance matrix. Default is False.
-        random_state : {None, int, Generator, RandomState}, optional
+        rng : {None, int, Generator, RandomState}, optional
             If `seed` is None (or `np.random`), the `numpy.random.RandomState`
             singleton is used.
             If `seed` is an int, a new ``numpy.random.RandomState`` instance
@@ -722,10 +727,10 @@ class SimulationSmoothResults:
         self._simulated_state_disturbance = None
 
         # Handle the random state
-        if random_state is None:
-            random_state = self.random_state
+        if rng is None:
+            rng = self.rng
         else:
-            random_state = check_random_state(random_state)
+            rng = check_random_state(rng)
 
         # Re-initialize the _statespace representation
         prefix, dtype, create_smoother, create_filter, create_statespace = (
@@ -750,9 +755,7 @@ class SimulationSmoothResults:
                 pretransformed=pretransformed_measurement_disturbance_variates,
             )
         else:
-            self._simulation_smoother.draw_measurement_disturbance_variates(
-                random_state
-            )
+            self._simulation_smoother.draw_measurement_disturbance_variates(rng)
 
         # Draw the (independent) random variates for disturbances in the
         # simulation
@@ -762,7 +765,7 @@ class SimulationSmoothResults:
                 pretransformed=pretransformed_state_disturbance_variates,
             )
         else:
-            self._simulation_smoother.draw_state_disturbance_variates(random_state)
+            self._simulation_smoother.draw_state_disturbance_variates(rng)
 
         # Draw the (independent) random variates for the initial states in the
         # simulation
@@ -782,7 +785,7 @@ class SimulationSmoothResults:
             # initial state cov, but still adds the initial state mean. It's
             # not clear when this would be useful...
         else:
-            self._simulation_smoother.draw_initial_state_variates(random_state)
+            self._simulation_smoother.draw_initial_state_variates(rng)
 
         # Perform simulation smoothing
         self._simulation_smoother.simulate(simulation_output)

--- a/statsmodels/tsa/statespace/tests/test_dynamic_factor_mq_monte_carlo.py
+++ b/statsmodels/tsa/statespace/tests/test_dynamic_factor_mq_monte_carlo.py
@@ -35,7 +35,7 @@ def simulate_k_factor1(nobs=1000, rng=None):
         [0.0] * mod_sim.k_endog,
     ]
     ix = pd.period_range(start="1935-01", periods=nobs, freq="M")
-    endog = pd.DataFrame(mod_sim.simulate(p, nobs, random_state=rng), index=ix)
+    endog = pd.DataFrame(mod_sim.simulate(p, nobs, rng=rng), index=ix)
 
     true = pd.Series(p, index=mod_sim.param_names)
 

--- a/statsmodels/tsa/statespace/tests/test_multivariate_switch_univariate.py
+++ b/statsmodels/tsa/statespace/tests/test_multivariate_switch_univariate.py
@@ -435,13 +435,13 @@ def test_simulation_smoothing(missing):
     sim_uv = mod_uv.simulation_smoother()
 
     # Test for basic simulationg of a new observed series
-    simulate_switch = mod_switch.simulate([], 10, random_state=1234)
-    simulate_uv = mod_uv.simulate([], 10, random_state=1234)
+    simulate_switch = mod_switch.simulate([], 10, rng=1234)
+    simulate_uv = mod_uv.simulate([], 10, rng=1234)
     assert_allclose(simulate_switch, simulate_uv)
 
     # Perform simulation smoothing
-    sim_switch.simulate(random_state=1234)
-    sim_uv.simulate(random_state=1234)
+    sim_switch.simulate(rng=1234)
+    sim_uv.simulate(rng=1234)
 
     # Make sure that switching happened in the first model but not the second
     kfilter = sim_switch._simulation_smoother.simulated_kfilter

--- a/statsmodels/tsa/statespace/tests/test_simulation_smoothing.py
+++ b/statsmodels/tsa/statespace/tests/test_simulation_smoothing.py
@@ -681,7 +681,7 @@ def test_misc():
     n_disturbance_variates = mod.nobs * (mod.k_endog + mod.k_states)
     variates = rs.normal(size=n_disturbance_variates)
     rs = np.random.RandomState(1234)
-    sim.simulate(random_state=rs)
+    sim.simulate(rng=rs)
     assert_allclose(sim.generated_measurement_disturbance[:, 0], variates[: mod.nobs])
     assert_allclose(sim.generated_state_disturbance[:, 0], variates[mod.nobs :])
 
@@ -917,7 +917,7 @@ def test_nan():
     res = mod.smooth([0, 0.5, 1.0])
 
     rs = np.random.RandomState(1234)
-    sim = mod.simulation_smoother(random_state=rs)
+    sim = mod.simulation_smoother(rng=rs)
 
     n = 1000000
     out = np.zeros((n, mod.nobs))


### PR DESCRIPTION
In line with SPEC 007 consistently use rng rather than random_state as arguments for passing entropy

- [ ] closes #xxxx
- [ ] tests added / passed. 
- [ ] code/documentation is well formatted.  
- [ ] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
