### PR TITLE
TST: Add marker for joblib

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -311,6 +311,7 @@ markers = [
     "low_precision: mark a test as low precision",
     "todo: mark a test as incomplete",
     "singleton_randomstate: mark a test as changing the singleton RandomState",
+    "joblib: mark a test as using joblib for parallel computation",
 ]
 
 [tool.isort]

--- a/statsmodels/base/tests/test_distributed_estimation.py
+++ b/statsmodels/base/tests/test_distributed_estimation.py
@@ -297,6 +297,7 @@ def test_fit_sequential():
     )
 
 
+@pytest.mark.joblib
 @pytest.mark.thread_unsafe(reason="Uses joblib")
 def test_fit_joblib():
 

--- a/statsmodels/conftest.py
+++ b/statsmodels/conftest.py
@@ -52,6 +52,12 @@ def pytest_addoption(parser):
     parser.addoption("--skip-smoke", action="store_true", help="skip smoke tests")
     parser.addoption("--only-smoke", action="store_true", help="run only smoke tests")
     parser.addoption(
+        "--skip-joblib", action="store_true", help="skip tests that use joblib"
+    )
+    parser.addoption(
+        "--only-joblib", action="store_true", help="run only tests that use joblib"
+    )
+    parser.addoption(
         "--skip-high-memory", action="store_true", help="skip high memory usage tests"
     )
     parser.addoption(
@@ -82,6 +88,12 @@ def pytest_runtest_setup(item):
 
     if "smoke" not in item.keywords and item.config.getoption("--only-smoke"):
         pytest.skip("skipping due to --only-smoke")
+
+    if "joblib" in item.keywords and item.config.getoption("--skip-joblib"):
+        pytest.skip("skipping due to --skip-joblib")
+
+    if "joblib" not in item.keywords and item.config.getoption("--only-joblib"):
+        pytest.skip("skipping due to --only-joblib")
 
     if "high_memory" in item.keywords and item.config.getoption("--skip-high-memory"):
         pytest.skip("skipping due to --skip-high-memory")

--- a/statsmodels/nonparametric/tests/test_kernel_density.py
+++ b/statsmodels/nonparametric/tests/test_kernel_density.py
@@ -411,6 +411,7 @@ class TestKDEMultivariate(KDETestBase):
         R_result = [0.54700010, 0.65907039, 0.89676865, 0.74132941, 0.25291361]
         npt.assert_allclose(sm_result, R_result, atol=1e-3)
 
+    @pytest.mark.joblib
     @pytest.mark.slow
     def test_continuous_cvls_efficient(self):
         nobs = 400
@@ -431,6 +432,7 @@ class TestKDEMultivariate(KDETestBase):
         bw = np.array([0.3404, 0.1666])
         npt.assert_allclose(bw, dens_efficient.bw, atol=0.1, rtol=0.2)
 
+    @pytest.mark.joblib
     @pytest.mark.slow
     def test_continuous_cvml_efficient(self):
         nobs = 400
@@ -452,6 +454,7 @@ class TestKDEMultivariate(KDETestBase):
         bw = np.array([0.4471, 0.2861])
         npt.assert_allclose(bw, dens_efficient.bw, atol=0.1, rtol=0.2)
 
+    @pytest.mark.joblib
     @pytest.mark.slow
     def test_efficient_notrandom(self):
         nobs = 400
@@ -628,6 +631,7 @@ class TestKDEMultivariateConditional(KDETestBase):
         expected = [0.83378885, 0.97684477, 0.90655143, 0.79393161, 0.43629083]
         npt.assert_allclose(sm_result, expected, atol=0, rtol=1e-5)
 
+    @pytest.mark.joblib
     @pytest.mark.slow
     def test_continuous_cvml_efficient(self):
         nobs = 500

--- a/statsmodels/nonparametric/tests/test_kernel_regression.py
+++ b/statsmodels/nonparametric/tests/test_kernel_regression.py
@@ -409,6 +409,7 @@ class TestKernelReg(KernelRegressionTestBase):
         npt.assert_allclose(sm_mfx[:, 0], mfx1, rtol=2e-1)
         npt.assert_allclose(sm_mfx[0:10, 1], mfx2[0:10], rtol=2e-1)
 
+    @pytest.mark.joblib
     @pytest.mark.slow
     def test_continuous_cvls_efficient(self):
         nobs = 500

--- a/statsmodels/tools/tests/test_parallel.py
+++ b/statsmodels/tools/tests/test_parallel.py
@@ -7,6 +7,7 @@ import pytest
 from statsmodels.tools.parallel import parallel_func
 
 
+@pytest.mark.joblib
 @pytest.mark.thread_unsafe(reason="uses joblib which is not thread safe")
 def test_parallel():
     x = arange(10.0)

--- a/tools/ci/azure/azure_template_posix.yml
+++ b/tools/ci/azure/azure_template_posix.yml
@@ -7,6 +7,7 @@ parameters:
   # defaults for any parameters that are not specified
   name: ''
   vmImage: ''
+  PYTEST_PATTERN: 'not slow and not joblib'
 
 
 jobs:
@@ -59,7 +60,6 @@ jobs:
           SCIPY_VERSION: 1.13.0
           CYTHON_VERSION: 3.0.12
           BLAS: "nomkl blas=*=openblas"
-          PYTEST_OPTIONS: ''
         python_313_copy_on_write:
           python.version: '3.13'
           python.architecture: 'x64'
@@ -72,7 +72,7 @@ jobs:
           python.version: '3.12'
           python.architecture: 'x64'
           SM_FORMULA_ENGINE: "formulaic"
-          PIP_UNINSTALL: "patsy matplotlib"
+          PIP_UNINSTALL: "patsy matplotlib joblib"
           USE_MATPLOTLIB: false
         python_312_no_formulaic:
           python.version: '3.12'


### PR DESCRIPTION
Add marker for joblib
Skip joblib jobs by default since meson rebuild often conflicts

- [ ] closes #xxxx
- [ ] tests added / passed. 
- [ ] code/documentation is well formatted.  
- [ ] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
