### PR TITLE
docs(stats): clarify TukeyHSD reject and pvalues access

### DIFF
--- a/statsmodels/sandbox/stats/multicomp.py
+++ b/statsmodels/sandbox/stats/multicomp.py
@@ -626,7 +626,8 @@ class TukeyHSDResults:
     std_pairs : standard deviation of pairwise mean differences
     q_crit : critical value of studentized range statistic at given alpha
     halfwidths : half widths of simultaneous confidence interval
-    pvalues : adjusted p-values from the HSD test
+    pvalues : adjusted p-values from the HSD test (numeric floats; use this
+        when you need the p-values rather than only the boolean reject flags)
 
     Notes
     -----

--- a/statsmodels/sandbox/stats/multicomp.py
+++ b/statsmodels/sandbox/stats/multicomp.py
@@ -628,7 +628,8 @@ class TukeyHSDResults:
     std_pairs : standard deviation of pairwise mean differences
     q_crit : critical value of studentized range statistic at given alpha
     halfwidths : half widths of simultaneous confidence interval
-    pvalues : adjusted p-values from the HSD test
+    pvalues : adjusted p-values from the HSD test (numeric floats; use this
+        when you need the p-values rather than only the boolean reject flags)
 
     Notes
     -----

--- a/statsmodels/sandbox/stats/multicomp.py
+++ b/statsmodels/sandbox/stats/multicomp.py
@@ -622,21 +622,45 @@ class TukeyHSDResults:
 
     Attributes
     ----------
-    reject : array of boolean, True if we reject Null for group pair
-    meandiffs : pairwise mean differences
-    confint : confidence interval for pairwise mean differences
-    std_pairs : standard deviation of pairwise mean differences
-    q_crit : critical value of studentized range statistic at given alpha
-    halfwidths : half widths of simultaneous confidence interval
-    pvalues : adjusted p-values from the HSD test (numeric floats; use this
-        when you need the p-values rather than only the boolean reject flags)
+    reject : ndarray
+        Boolean array indicating whether the null hypothesis is rejected for
+        each group pair.
+    meandiffs : ndarray
+        Pairwise mean differences.
+    confint : ndarray
+        Confidence intervals for the pairwise mean differences.
+    std_pairs : ndarray
+        Standard deviations of the pairwise mean differences.
+    q_crit : float or ndarray
+        Critical value or values of the studentized range statistic at the
+        specified significance level.
+    halfwidths : ndarray
+        Half widths of the simultaneous confidence intervals. This attribute
+        is available after calling `plot_simultaneous`.
+    pvalues : ndarray
+        Adjusted p-values from the HSD test.
+    reject2 : ndarray
+        Alternative boolean rejection decisions based on the confidence
+        intervals.
+    df_total : float or ndarray
+        Total degrees of freedom used for each pairwise comparison.
+    df_total_hsd : float
+        Total degrees of freedom used for the HSD critical value.
+    variance : float or ndarray
+        Variance estimate or estimates used in the pairwise comparisons.
+    alpha : float
+        Significance level used for the test.
+    group_t : ndarray
+        Treatment group label for each pairwise comparison.
+    group_c : ndarray
+        Control group label for each pairwise comparison.
+    data : ndarray
+        Original response data from the `MultiComparison` instance.
+    groups : ndarray
+        Original group labels from the `MultiComparison` instance.
+    groupsunique : ndarray
+        Unique group labels from the `MultiComparison` instance.
 
-    Notes
-    -----
-    halfwidths is only available after call to `plot_simultaneous`.
-
-    Other attributes contain information about the data from the
-    MultiComparison instance: data, df_total, groups, groupsunique, variance.
     """
 
     def __init__(

--- a/statsmodels/stats/multicomp.py
+++ b/statsmodels/stats/multicomp.py
@@ -33,7 +33,16 @@ def pairwise_tukeyhsd(endog, groups, alpha=0.05, use_var="equal"):
     -------
     results : TukeyHSDResults instance
         A results class containing relevant data and some post-hoc
-        calculations, including adjusted p-value
+        calculations, including adjusted p-value.
+
+        The boolean reject decisions and numeric adjusted p-values are
+        available as attributes (and via ``summary_frame()``)::
+
+            res = pairwise_tukeyhsd(endog, groups)
+            res.reject     # boolean array: True if that pair is significant
+            res.pvalues    # adjusted p-values (float array) for each pair
+            res.summary()  # printable table (includes the reject column)
+            res.summary_frame()  # DataFrame with group_t/group_c/meandiff/p-adj/reject
 
     Notes
     -----

--- a/statsmodels/stats/multicomp.py
+++ b/statsmodels/stats/multicomp.py
@@ -38,8 +38,11 @@ def pairwise_tukeyhsd(endog, groups, alpha=0.05, use_var="equal"):
     See Also
     --------
     MultiComparison
+        Class for pairwise comparisons of multiple groups.
     tukeyhsd
+        Compute simultaneous Tukey HSD comparisons from summary data.
     statsmodels.sandbox.stats.multicomp.TukeyHSDResults
+        Results from a Tukey HSD comparison.
 
     Notes
     -----

--- a/statsmodels/stats/multicomp.py
+++ b/statsmodels/stats/multicomp.py
@@ -35,17 +35,22 @@ def pairwise_tukeyhsd(endog, groups, alpha=0.05, use_var="equal"):
         A results class containing relevant data and some post-hoc
         calculations, including adjusted p-value.
 
-        The boolean reject decisions and numeric adjusted p-values are
-        available as attributes (and via ``summary_frame()``)::
-
-            res = pairwise_tukeyhsd(endog, groups)
-            res.reject     # boolean array: True if that pair is significant
-            res.pvalues    # adjusted p-values (float array) for each pair
-            res.summary()  # printable table (includes the reject column)
-            res.summary_frame()  # DataFrame with group_t/group_c/meandiff/p-adj/reject
+    See Also
+    --------
+    MultiComparison
+    tukeyhsd
+    statsmodels.sandbox.stats.multicomp.TukeyHSDResults
 
     Notes
     -----
+    The results include the following attributes and methods:
+
+    * ``reject`` is a boolean array indicating whether each comparison is
+      statistically significant.
+    * ``pvalues`` contains the adjusted p-values for each comparison.
+    * ``summary()`` returns a printable table that includes the reject column.
+    * ``summary_frame()`` returns a DataFrame with the comparison results.
+
     This is just a wrapper around tukeyhsd method of MultiComparison.
     Tukey-hsd is not robust to heteroscedasticity, i.e., variance differ across
     groups, especially if group sizes also vary. In those cases, the actual
@@ -59,11 +64,20 @@ def pairwise_tukeyhsd(endog, groups, alpha=0.05, use_var="equal"):
 
         The `use_var` keyword and option for Games-Howell test.
 
-    See Also
+    Examples
     --------
-    MultiComparison
-    tukeyhsd
-    statsmodels.sandbox.stats.multicomp.TukeyHSDResults
+    The reject decisions and adjusted p-values can be accessed directly from
+    the results instance.
+
+    >>> import numpy as np
+    >>> endog = np.array([1, 2, 3, 4, 5, 6])
+    >>> groups = np.array(["a", "a", "b", "b", "c", "c"])
+    >>> res = pairwise_tukeyhsd(endog, groups)
+    >>> res.reject
+    array([False,  True, False])
+    >>> res.pvalues.round(3)
+    array([0.129, 0.022, 0.129])
+
     """
 
     return MultiComparison(endog, groups).tukeyhsd(alpha=alpha,

--- a/statsmodels/stats/multicomp.py
+++ b/statsmodels/stats/multicomp.py
@@ -35,17 +35,22 @@ def pairwise_tukeyhsd(endog, groups, alpha=0.05, use_var="equal"):
         A results class containing relevant data and some post-hoc
         calculations, including adjusted p-value.
 
-        The boolean reject decisions and numeric adjusted p-values are
-        available as attributes (and via ``summary_frame()``)::
-
-            res = pairwise_tukeyhsd(endog, groups)
-            res.reject     # boolean array: True if that pair is significant
-            res.pvalues    # adjusted p-values (float array) for each pair
-            res.summary()  # printable table (includes the reject column)
-            res.summary_frame()  # DataFrame with group_t/group_c/meandiff/p-adj/reject
+    See Also
+    --------
+    MultiComparison
+    tukeyhsd
+    statsmodels.sandbox.stats.multicomp.TukeyHSDResults
 
     Notes
     -----
+    The results include the following attributes and methods:
+
+    * ``reject`` is a boolean array indicating whether each comparison is
+      statistically significant.
+    * ``pvalues`` contains the adjusted p-values for each comparison.
+    * ``summary()`` returns a printable table that includes the reject column.
+    * ``summary_frame()`` returns a DataFrame with the comparison results.
+
     This is just a wrapper around tukeyhsd method of MultiComparison.
     Tukey-hsd is not robust to heteroscedasticity, i.e. variance differ across
     groups, especially if group sizes also vary. In those cases, the actual
@@ -59,11 +64,20 @@ def pairwise_tukeyhsd(endog, groups, alpha=0.05, use_var="equal"):
 
         The `use_var` keyword and option for Games-Howell test.
 
-    See Also
+    Examples
     --------
-    MultiComparison
-    tukeyhsd
-    statsmodels.sandbox.stats.multicomp.TukeyHSDResults
+    The reject decisions and adjusted p-values can be accessed directly from
+    the results instance.
+
+    >>> import numpy as np
+    >>> endog = np.array([1, 2, 3, 4, 5, 6])
+    >>> groups = np.array(["a", "a", "b", "b", "c", "c"])
+    >>> res = pairwise_tukeyhsd(endog, groups)
+    >>> res.reject
+    array([False,  True, False])
+    >>> res.pvalues.round(3)
+    array([0.129, 0.022, 0.129])
+
     """
 
     return MultiComparison(endog, groups).tukeyhsd(alpha=alpha,


### PR DESCRIPTION
## Summary

#2346 asks how to retrieve Tukey HSD reject decisions and numeric p-values. These already exist on `TukeyHSDResults` (`reject`, `pvalues`, `summary()`, `summary_frame()`), but the public wrapper docstring did not spell out the access path.

## Fix

Document attribute / table access on `pairwise_tukeyhsd` and clarify that `pvalues` are the numeric adjusted p-values.

## Verification

- The requested RST change was moved into the `Notes` section as an unordered list.
- A concrete `Examples` section accesses `reject` and rounded `pvalues`.
- The docstring doctest passes locally.
- `git diff --check` passes.
- The tracked-content secret scan reports no new findings versus `upstream/main`.

Fixes #2346

- [x] closes #2346
- [x] tests added / passed.
- [x] code/documentation is well formatted.
- [x] properly formatted commit message. See
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message).

#### AI Disclosure

Contributions must comply with the statsmodels [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html).

If using AI tools, edit the second option to explain which tool was selected and
how the tool's output was used.

Please complete **one** of the following:

- [ ] No AI tools were used to develop this pull request.
- [x] AI tools were used.
      Tool(s): `Hermes Agent`.
      Used for: investigating maintainer feedback, editing docstrings, running verification commands, and preparing signed commits.
      I have personally read, understood, and can explain every line of this diff, and
      have verified the statistical/numerical correctness of the change.

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows
  using the Windows System for Linux once `flake8` is installed in the
  local Linux environment. While passing this test is not required, it is good practice and it help
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.
* If AI tools were used to help write this PR, see the
  [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html) for what
  disclosure and review is expected of you before submitting.

</details>