### PR TITLE
DOC: document that exog is matched by position for non-formula models

### DIFF
--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -1305,7 +1305,11 @@ class Results:
         If no formula was used, then the provided exog needs to have the
         same number of columns as the original exog in the model. No
         transformation of the data is performed except converting it to
-        a numpy array.
+        a numpy array. In this case the columns are matched by position and
+        not by name, so a DataFrame must have its columns in the same order
+        as the exog used to fit the model; its column labels are ignored.
+        This differs from the formula case above, where the variables are
+        matched by name and the column order does not matter.
 
         Row indices as in pandas data frames are supported, and added to the
         returned prediction.

--- a/statsmodels/regression/_prediction.py
+++ b/statsmodels/regression/_prediction.py
@@ -138,7 +138,10 @@ def get_prediction(self, exog=None, transform=True, weights=None,
     self : RegressionResults
         Results instance used to generate predictions.
     exog : array_like, optional
-        The values for which you want to predict.
+        The values for which you want to predict. If the model was not fit
+        using a formula, the columns are matched by position and not by name,
+        so a DataFrame must have its columns in the same order as the exog
+        used to fit the model.
     transform : bool, optional
         If the model was fit via a formula, do you want to pass
         exog through the formula. Default is True. E.g., if you fit


### PR DESCRIPTION
Addresses #9869.

#### What changed

Reworked to documentation only, per review. The runtime `ValueWarning`, the
shared helper in `tools/tools.py`, both call sites and the test have all been
dropped; this PR is now a docs change to two docstrings.

#### Why

`predict` / `get_prediction` use `exog` positionally when the model was not fit
with a formula, so reordering the columns of a prediction DataFrame silently
changes the result, while formula models match by name and are order
insensitive. That asymmetry is what surprised the reporter in #9869.

Warning about it turned out to be the wrong fix for two reasons raised in
review:

- The check cannot distinguish an accidental reorder from a deliberate one, so
  a share of the warnings would be noise on entirely valid calls.
- There are four places that convert `exog` positionally
  (`base/model.py`, `regression/_prediction.py`,
  `base/_prediction_inference.py` backing `get_prediction_glm` /
  `get_prediction_linear` / `get_prediction_monotonic` /
  `get_prediction_delta`, and `recursive_ls.py`). Covering only some of them
  would just relocate the inconsistency.

Documenting the contract fixes the surprise with no false positives, no
behaviour change and no refactor.

#### Changes

- `Results.predict`: the Notes section now states that for non-formula models
  the columns are matched by position and not by name, and contrasts that with
  the formula case.
- `regression/_prediction.py::get_prediction`: same caveat on the `exog`
  parameter.

Diff is +9 / -2 across two files, docs only.
