### PR TITLE
BUG: raise on non-2x2 tables in stats.mcnemar (#9485)

### DIFF
--- a/statsmodels/stats/contingency_tables.py
+++ b/statsmodels/stats/contingency_tables.py
@@ -1365,6 +1365,11 @@ def mcnemar(table, exact=True, correction=True):
 
     table = _make_df_square(table)
     table = np.asarray(table, dtype=np.float64)
+    if table.ndim != 2:
+        raise ValueError(
+            "mcnemar requires a two-dimensional contingency table, but the input has "
+            f"shape {table.shape}."
+        )
     if table.shape != (2, 2):
         raise ValueError(
             "mcnemar requires a 2x2 contingency table, but the input has "

--- a/statsmodels/stats/contingency_tables.py
+++ b/statsmodels/stats/contingency_tables.py
@@ -1365,6 +1365,13 @@ def mcnemar(table, exact=True, correction=True):
 
     table = _make_df_square(table)
     table = np.asarray(table, dtype=np.float64)
+    if table.shape != (2, 2):
+        raise ValueError(
+            "mcnemar requires a 2x2 contingency table, but the input has "
+            f"shape {table.shape}. For a larger square table, use "
+            "SquareTable.symmetry (Bowker's test of symmetry), which "
+            "generalizes McNemar's test to k x k tables."
+        )
     n1, n2 = table[0, 1], table[1, 0]
 
     if exact:

--- a/statsmodels/stats/tests/test_contingency_tables.py
+++ b/statsmodels/stats/tests/test_contingency_tables.py
@@ -251,6 +251,10 @@ def test_mcnemar_non_2x2():
     with pytest.raises(ValueError, match="2x2"):
         ctab.mcnemar(table, exact=False)
 
+    table_3d = np.ones((2, 2, 2))
+    with pytest.raises(ValueError, match="two-dimensional"):
+        ctab.mcnemar(table_3d)
+
     # A genuine 2x2 table must still work.
     b = ctab.mcnemar(tables[0], exact=False, correction=False)
     assert np.isfinite(b.statistic)

--- a/statsmodels/stats/tests/test_contingency_tables.py
+++ b/statsmodels/stats/tests/test_contingency_tables.py
@@ -8,6 +8,7 @@ import warnings
 import numpy as np
 from numpy.testing import assert_allclose, assert_equal
 import pandas as pd
+import pytest
 
 import statsmodels.api as sm
 import statsmodels.stats.contingency_tables as ctab
@@ -239,6 +240,20 @@ def test_mcnemar():
     # Use binomial reference distribution
     b4 = ctab.mcnemar(tables[0], exact=True)
     assert_allclose(b4.pvalue, r_results.loc[0, "homog_binom_p"])
+
+
+def test_mcnemar_non_2x2():
+    # GH#9485: mcnemar only uses the [0, 1] and [1, 0] cells, so a table
+    # that is not 2x2 must raise instead of silently ignoring the rest.
+    table = np.asarray([[10, 5, 1], [3, 12, 2], [4, 6, 20]])
+    with pytest.raises(ValueError, match="2x2"):
+        ctab.mcnemar(table)
+    with pytest.raises(ValueError, match="2x2"):
+        ctab.mcnemar(table, exact=False)
+
+    # A genuine 2x2 table must still work.
+    b = ctab.mcnemar(tables[0], exact=False, correction=False)
+    assert np.isfinite(b.statistic)
 
 
 def test_from_data_stratified():


### PR DESCRIPTION
Closes #9485

### Problem

`statsmodels.stats.contingency_tables.mcnemar` reads only the `[0, 1]` and
`[1, 0]` cells of the table:

```python
table = _make_df_square(table)
table = np.asarray(table, dtype=np.float64)
n1, n2 = table[0, 1], table[1, 0]
```

There is no shape check, so passing a `k x k` table with `k > 2` silently
returns a statistic computed from just the top-left 2x2 corner and ignores
every other cell. For example:

```python
>>> from statsmodels.stats.contingency_tables import mcnemar
>>> import numpy as np
>>> mcnemar(np.array([[10, 5, 1], [3, 12, 2], [4, 6, 20]]), exact=False).statistic
0.125   # computed only from cells [0,1]=5 and [1,0]=3
```

### Root cause

McNemar's test is only defined for a 2x2 table, but the implementation never
validates the shape after squaring the input, so oversized tables produce a
misleading result instead of an error.

### Fix

After squaring the table, raise a clear `ValueError` when the shape is not
`(2, 2)`, pointing users to `SquareTable.symmetry` (Bowker's test of
symmetry), which generalizes McNemar's test to `k x k` tables. Behavior for
valid 2x2 inputs is unchanged.

### Test

Added `test_mcnemar_non_2x2` in
`statsmodels/stats/tests/test_contingency_tables.py`, which asserts that a
3x3 input raises `ValueError` (both `exact=True` and `exact=False`) and that
a genuine 2x2 table still returns a finite statistic. The full
`test_contingency_tables.py` module passes (53 passed).