### PR TITLE
BUG: Reject None in string_like unless optional is True

### DIFF
--- a/statsmodels/tools/validation/tests/test_validation.py
+++ b/statsmodels/tools/validation/tests/test_validation.py
@@ -294,6 +294,11 @@ def test_string():
         match="value must be one of: 'apple', 'banana', 'cherry'",
     ):
         string_like("date", "value", options=("apple", "banana", "cherry"))
+    # None is only allowed when optional is True
+    with pytest.raises(TypeError, match="value must be a string"):
+        string_like(None, "value")
+    with pytest.raises(TypeError, match="value must be a string"):
+        string_like(None, "value", options=("apple", "banana", "cherry"))
 
 
 def test_optional_string():

--- a/statsmodels/tools/validation/validation.py
+++ b/statsmodels/tools/validation/validation.py
@@ -437,7 +437,7 @@ def string_like(value, name, optional=False, options=None, lower=True):
         If the input is not in ``options`` when ``options`` is set.
 
     """
-    if value is None:
+    if optional and value is None:
         return None
     if not isinstance(value, str):
         extra_text = " or None" if optional else ""


### PR DESCRIPTION
- [ ] closes #xxxx
- [x] tests added / passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>

**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>

`string_like` ignores its `optional` flag and returns `None` for any `None` input:

```python
>>> from statsmodels.tools.validation import string_like
>>> string_like(None, "value")   # optional=False, the default -> returns None
```

Every other validator in the module (`bool_like`, `int_like`, `float_like`,
`dict_like`) guards this with `if optional and value is None`; `string_like` is
the only one missing the `optional and`. Its docstring also documents `optional`
as "Flag indicating whether None is allowed".

The result is that required string parameters silently accept `None` instead of
failing at validation.

This makes `string_like` match its siblings, and adds `None` cases to
`test_string` that fail on `main` and pass with the change.