### PR TITLE
BUG: Reject None in array_like unless optional is True

### DIFF
--- a/statsmodels/tools/validation/tests/test_validation.py
+++ b/statsmodels/tools/validation/tests/test_validation.py
@@ -165,6 +165,12 @@ class TestArrayLike:
         a = array_like(data, "a", ndim=2)
         assert type(a[1:]) is np.ndarray
 
+    def test_none(self):
+        assert array_like(None, "a", optional=True) is None
+        # None is not array_like, and must not be converted to nan
+        with pytest.raises(TypeError, match="a must be array_like, not None"):
+            array_like(None, "a")
+
 
 def test_right_squeeze():
     x = np.empty((10, 1, 10))

--- a/statsmodels/tools/validation/validation.py
+++ b/statsmodels/tools/validation/validation.py
@@ -139,8 +139,10 @@ def array_like(
     ValueError: x is required to have shape (*, 4, 4) but has shape (4, 10, 4)
 
     """
-    if optional and obj is None:
-        return None
+    if obj is None:
+        if optional:
+            return None
+        raise TypeError(f"{name} must be array_like, not None")
     reqs = ["W"] if writeable else []
     if order == "C" or contiguous:
         reqs += ["C"]


### PR DESCRIPTION
- [ ] closes #xxxx
- [x] tests added / passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>

Follow-up to #9985, same issue in `array_like`. With the default
`optional=False`, `None` is passed through to `np.require`, which converts it
to `nan` rather than raising:

```python
>>> from statsmodels.tools.validation import array_like
>>> array_like(None, "x")
array([nan])
```

A required array argument therefore becomes a silent NaN that propagates into
the numerical code, instead of failing at validation.

This raises `TypeError` when `obj is None` and `optional` is False, matching the
other validators in the module, and adds a test that fails on `main`.

I ran the `tools`, `tsa`, `regression`, `stats` and `iolib` suites to confirm
nothing relied on the old behaviour.