### PR TITLE
BUG: Select the correct axis in drop_missing

### DIFF
--- a/statsmodels/tools/tests/test_tools.py
+++ b/statsmodels/tools/tests/test_tools.py
@@ -110,6 +110,28 @@ class TestTools:
         dfc.insert(0, "const", np.ones(3))
         assert_frame_equal(dfc, output)
 
+    def test_drop_missing(self):
+        Y = np.array([[1.0, 2.0, np.nan], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]])
+        # axis=1 looks for missing values across the columns of each row, so
+        # the row holding the nan is dropped
+        assert_almost_equal(
+            tools.drop_missing(Y, axis=1),
+            np.array([[4.0, 5.0, 6.0], [7.0, 8.0, 9.0]]),
+        )
+        # axis=0 looks across the rows of each column, so the column holding
+        # the nan is dropped instead
+        assert_almost_equal(
+            tools.drop_missing(Y, axis=0),
+            np.array([[1.0, 2.0], [4.0, 5.0], [7.0, 8.0]]),
+        )
+
+    def test_drop_missing_x(self):
+        Y = np.array([[1.0, 2.0], [3.0, np.nan], [5.0, 6.0]])
+        X = np.array([[1.0, np.nan], [1.0, 1.0], [1.0, 1.0]])
+        y, x = tools.drop_missing(Y, X, axis=0)
+        assert_almost_equal(y, np.array([[1.0], [3.0], [5.0]]))
+        assert_almost_equal(x, np.array([[1.0], [1.0], [1.0]]))
+
     def test_recipr(self):
         X = np.array([[2, 1], [-1, 0]])
         Y = tools.recipr(X)

--- a/statsmodels/tools/tests/test_tools.py
+++ b/statsmodels/tools/tests/test_tools.py
@@ -111,26 +111,34 @@ class TestTools:
         assert_frame_equal(dfc, output)
 
     def test_drop_missing(self):
-        Y = np.array([[1.0, 2.0, np.nan], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]])
+        _y = np.array([[1.0, 2.0, np.nan], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]])
         # axis=1 looks for missing values across the columns of each row, so
         # the row holding the nan is dropped
         assert_almost_equal(
-            tools.drop_missing(Y, axis=1),
+            tools.drop_missing(_y, axis=1),
             np.array([[4.0, 5.0, 6.0], [7.0, 8.0, 9.0]]),
         )
         # axis=0 looks across the rows of each column, so the column holding
         # the nan is dropped instead
         assert_almost_equal(
-            tools.drop_missing(Y, axis=0),
+            tools.drop_missing(_y, axis=0),
             np.array([[1.0, 2.0], [4.0, 5.0], [7.0, 8.0]]),
         )
 
     def test_drop_missing_x(self):
-        Y = np.array([[1.0, 2.0], [3.0, np.nan], [5.0, 6.0]])
-        X = np.array([[1.0, np.nan], [1.0, 1.0], [1.0, 1.0]])
-        y, x = tools.drop_missing(Y, X, axis=0)
+        _y = np.array([[1.0, 2.0], [3.0, np.nan], [5.0, 6.0]])
+        _x = np.array([[1.0, np.nan], [1.0, 1.0], [1.0, 1.0]])
+        y, x = tools.drop_missing(_y, _x, axis=0)
         assert_almost_equal(y, np.array([[1.0], [3.0], [5.0]]))
         assert_almost_equal(x, np.array([[1.0], [1.0], [1.0]]))
+
+        # axis=1 with two variables: a row is dropped if either _y or _x
+        # is missing anywhere in that row
+        _y = np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])
+        _x = np.array([[1.0, 1.0], [1.0, np.nan], [1.0, 1.0]])
+        y, x = tools.drop_missing(_y, _x, axis=1)
+        assert_almost_equal(y, np.array([[1.0, 2.0], [5.0, 6.0]]))
+        assert_almost_equal(x, np.array([[1.0, 1.0], [1.0, 1.0]]))
 
     def test_recipr(self):
         X = np.array([[2, 1], [-1, 0]])

--- a/statsmodels/tools/tools.py
+++ b/statsmodels/tools/tools.py
@@ -64,15 +64,21 @@ def drop_missing(Y, X=None, axis=1):
     Y = np.asarray(Y)
     if Y.ndim == 1:
         Y = Y[:, None]
+    # ``axis`` is reduced when looking for missing values, so the observations
+    # that are kept must be selected along the other axis.
+    keep_axis = 1 - axis
     if X is not None:
         X = np.array(X)
         if X.ndim == 1:
             X = X[:, None]
         keepidx = np.logical_and(~np.isnan(Y).any(axis), ~np.isnan(X).any(axis))
-        return Y[keepidx], X[keepidx]
+        return (
+            np.compress(keepidx, Y, axis=keep_axis),
+            np.compress(keepidx, X, axis=keep_axis),
+        )
     else:
         keepidx = ~np.isnan(Y).any(axis)
-        return Y[keepidx]
+        return np.compress(keepidx, Y, axis=keep_axis)
 
 
 # TODO: needs to better preserve dtype and be more flexible

--- a/statsmodels/tools/tools.py
+++ b/statsmodels/tools/tools.py
@@ -31,54 +31,54 @@ def asstr2(s):
         return str(s)
 
 
-def drop_missing(Y, X=None, axis=1):
+def drop_missing(y, x=None, axis=1):
     """
-    Return views on the arrays Y and X where missing observations are dropped
+    Return views on the arrays y and x where missing observations are dropped
 
     Parameters
     ----------
-    Y : array_like
+    y : array_like
         Data with observations possibly containing NaN values.
-    X : array_like, optional
+    x : array_like, optional
         Additional data with observations possibly containing NaN
         values. If provided, an observation is dropped if it is
-        missing in either `Y` or `X`.
+        missing in either `y` or `x`.
     axis : int
         Axis along which to look for missing observations.  Default is 1, ie.,
         observations in rows.
 
     Returns
     -------
-    Y : ndarray
-        `Y` with the rows (or columns) containing missing observations
+    y : ndarray
+        `y` with the rows (or columns) containing missing observations
         removed.
-    X : ndarray
-        `X` with the rows (or columns) containing missing observations
-        removed. Only returned if `X` is not None.
+    x : ndarray
+        `x` with the rows (or columns) containing missing observations
+        removed. Only returned if `x` is not None.
 
     Notes
     -----
-    If either Y or X is 1d, it is reshaped to be 2d.
+    If either y or x is 1d, it is reshaped to be 2d.
 
     """
-    Y = np.asarray(Y)
-    if Y.ndim == 1:
-        Y = Y[:, None]
+    y = np.asarray(y)
+    if y.ndim == 1:
+        y = y[:, None]
     # ``axis`` is reduced when looking for missing values, so the observations
     # that are kept must be selected along the other axis.
     keep_axis = 1 - axis
-    if X is not None:
-        X = np.array(X)
-        if X.ndim == 1:
-            X = X[:, None]
-        keepidx = np.logical_and(~np.isnan(Y).any(axis), ~np.isnan(X).any(axis))
+    if x is not None:
+        x = np.array(x)
+        if x.ndim == 1:
+            x = x[:, None]
+        keepidx = np.logical_and(~np.isnan(y).any(axis), ~np.isnan(x).any(axis))
         return (
-            np.compress(keepidx, Y, axis=keep_axis),
-            np.compress(keepidx, X, axis=keep_axis),
+            np.compress(keepidx, y, axis=keep_axis),
+            np.compress(keepidx, x, axis=keep_axis),
         )
     else:
-        keepidx = ~np.isnan(Y).any(axis)
-        return np.compress(keepidx, Y, axis=keep_axis)
+        keepidx = ~np.isnan(y).any(axis)
+        return np.compress(keepidx, y, axis=keep_axis)
 
 
 # TODO: needs to better preserve dtype and be more flexible


### PR DESCRIPTION
- [ ] closes #xxxx
- [x] tests added / passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>

`drop_missing` reduces over `axis` to build the keep mask, but always indexes
rows with it. That is correct for the default `axis=1`, but with `axis=0` a
column mask gets applied to the rows:

```python
>>> Y = np.array([[1., 2., np.nan], [4., 5., 6.], [7., 8., 9.]])
>>> tools.drop_missing(Y, axis=0)      # should drop the column with the nan
array([[ 1.,  2., nan],
       [ 4.,  5.,  6.]])
```

The nan survives. Non-square input raises `IndexError: boolean index did not
match indexed array` instead.

Observations are now selected along the axis that was not reduced. The default
`axis=1` path is unchanged.