### PR TITLE
docs: use HTTPS for MixedLM reference

### DIFF
--- a/docs/source/mixed_linear.rst
+++ b/docs/source/mixed_linear.rst
@@ -158,7 +158,7 @@ The primary reference for the implementation details is:
 
 See also this more recent document:
 
-* http://econ.ucsb.edu/~doug/245a/Papers/Mixed%20Effects%20Implement.pdf
+* https://econ.ucsb.edu/~doug/245a/Papers/Mixed%20Effects%20Implement.pdf
 
 All the likelihood, gradient, and Hessian calculations closely follow
 Lindstrom and Bates.


### PR DESCRIPTION
## Summary

- Replace the dead HTTP link in the MixedLM technical documentation with the working HTTPS URL.

Closes #8971