### PR TITLE
DOC fix ANOVA example link

### DIFF
--- a/docs/source/anova.rst
+++ b/docs/source/anova.rst
@@ -30,7 +30,7 @@ Examples
 
 A more detailed example for `anova_lm` can be found here:
 
-*  `ANOVA <examples/notebooks/generated/interactions_anova.ipynb>`_
+*  `ANOVA <examples/notebooks/generated/interactions_anova.html>`_
 
 Module Reference
 ----------------


### PR DESCRIPTION
Addresses statsmodels/statsmodels#9517.

Update the ANOVA documentation link to the generated HTML page. The target returns HTTP 200 on the stable documentation site.