### PR TITLE
DOC list all GEE covariance structures

### DIFF
--- a/docs/source/gee.rst
+++ b/docs/source/gee.rst
@@ -115,10 +115,14 @@ The dependence structures currently implemented are
 
    CovStruct
    Autoregressive
+   Equivalence
    Exchangeable
    GlobalOddsRatio
    Independence
    Nested
+   NominalIndependence
+   Stationary
+   Unstructured
 
 
 Families


### PR DESCRIPTION
Addresses statsmodels/statsmodels#8741.

Add the existing `Equivalence`, `NominalIndependence`, `Stationary`, and `Unstructured` covariance structures to the GEE documentation autosummary so they appear in the public reference page.