### PR TITLE
BUG: Ensure AutoReg summary can run after calling remove data

### DIFF
--- a/statsmodels/tsa/ar_model.py
+++ b/statsmodels/tsa/ar_model.py
@@ -1706,7 +1706,7 @@ class AutoRegResults(tsa_model.TimeSeriesModelResults):
             sample = [dates[start].strftime("%m-%d-%Y")]
             sample += ["- " + dates[-1].strftime("%m-%d-%Y")]
         else:
-            sample = [str(start), str(len(self.data.orig_endog))]
+            sample = [str(start), str(self._n_totobs)]
         model = model.__class__.__name__
         if self.model.seasonal:
             model = "Seas. " + model
@@ -1726,9 +1726,8 @@ class AutoRegResults(tsa_model.TimeSeriesModelResults):
             ("Sample:", [sample[0]]),
             ("", [sample[1]]),
         ]
-
         top_right = [
-            ("No. Observations:", [str(len(self.model.endog))]),
+            ("No. Observations:", [str(self._nobs)]),
             ("Log Likelihood", [f"{self.llf:#5.3f}"]),
             ("S.D. of innovations", [f"{self.sigma2**0.5:#5.3f}"]),
             ("AIC", [f"{self.aic:#5.3f}"]),

--- a/statsmodels/tsa/ardl/model.py
+++ b/statsmodels/tsa/ardl/model.py
@@ -86,11 +86,7 @@ Alternative: {self.alternative}
 _UECMOrder = int | dict[Hashable, int | None] | None
 
 _ARDLOrder = (
-    int
-    | _UECMOrder
-    | Sequence[int]
-    | dict[Hashable, int | Sequence[int] | None]
-    | None
+    int | _UECMOrder | Sequence[int] | dict[Hashable, int | Sequence[int] | None] | None
 )
 
 _INT_TYPES = (int, np.integer)
@@ -1248,7 +1244,7 @@ class ARDLResults(AutoRegResults):
             sample = [dates[start].strftime("%m-%d-%Y")]
             sample += ["- " + dates[-1].strftime("%m-%d-%Y")]
         else:
-            sample = [str(start), str(len(self.data.orig_endog))]
+            sample = [str(start), str(self._n_totobs)]
         model = self.model.__class__.__name__ + str(self.model.ardl_order)
         if self.model.seasonal:
             model = "Seas. " + model
@@ -1265,7 +1261,7 @@ class ARDLResults(AutoRegResults):
         ]
 
         top_right = [
-            ("No. Observations:", [str(len(self.model.endog))]),
+            ("No. Observations:", [str(self._nobs)]),
             ("Log Likelihood", [f"{self.llf:#5.3f}"]),
             ("S.D. of innovations", ["%#5.3f" % self.sigma2**0.5]),
             ("AIC", [f"{self.aic:#5.3f}"]),

--- a/statsmodels/tsa/ardl/tests/test_ardl.py
+++ b/statsmodels/tsa/ardl/tests/test_ardl.py
@@ -850,3 +850,22 @@ def test_uecm_resid():
 
     # Assert that the override fix is working
     np.testing.assert_allclose(res.resid, res.model._y - res.fittedvalues)
+
+
+@pytest.mark.parametrize("model", [ARDL, UECM])
+@pytest.mark.parametrize("lags", [0, 3])
+@pytest.mark.parametrize("pandas", [True, False])
+def test_ardl_uecm_summary_after_remove_data(model, lags, pandas):
+    """Test that UECMResults.resid is computed correctly using model._y."""
+    y = dane_data.lrm
+    x = dane_data[["lry", "ibo", "ide"]]
+    order = {"lry": 1, "ibo": 3, "ide": 2}
+    if not pandas:
+        y = np.array(y)
+        x = np.array(x)
+        order = dict(enumerate(order.values()))
+    mod = model(y, lags, x, order)
+    res = mod.fit()
+    assert isinstance(res.summary(), Summary)
+    res.remove_data()
+    assert isinstance(res.summary(), Summary)

--- a/statsmodels/tsa/tests/test_ar.py
+++ b/statsmodels/tsa/tests/test_ar.py
@@ -108,7 +108,10 @@ for param in params:
         final.append(param)
 params = final
 names = ("AR", "Seasonal", "Trend", "Exog", "Cov Type")
-ids = [", ".join([n + ": " + str(p) for n, p in zip(names, param, strict=True)]) for param in params]
+ids = [
+    ", ".join([n + ": " + str(p) for n, p in zip(names, param, strict=True)])
+    for param in params
+]
 
 
 @pytest.fixture(scope="module", params=params, ids=ids)
@@ -216,9 +219,9 @@ def test_other_tests_autoreg(ols_autoreg_result):
     a.wald_test(r, scalar=True)
 
 
-@pytest.mark.parametrize("pandas",[True, False])
-@pytest.mark.parametrize("nexog",[0, 2])
-def test_summary_after_remove_data(pandas,nexog):
+@pytest.mark.parametrize("pandas", [True, False])
+@pytest.mark.parametrize("nexog", [0, 2])
+def test_summary_after_remove_data(pandas, nexog):
     data = gen_data(250, nexog, pandas)
     # exog = {} if nexog == 0 else {"exog": data.exog}
     mod = AutoReg(data.endog, 0, trend="n", seasonal=pandas, exog=data.exog)

--- a/statsmodels/tsa/tests/test_ar.py
+++ b/statsmodels/tsa/tests/test_ar.py
@@ -216,6 +216,19 @@ def test_other_tests_autoreg(ols_autoreg_result):
     a.wald_test(r, scalar=True)
 
 
+@pytest.mark.parametrize("pandas",[True, False])
+@pytest.mark.parametrize("nexog",[0, 2])
+def test_summary_after_remove_data(pandas,nexog):
+    data = gen_data(250, nexog, pandas)
+    # exog = {} if nexog == 0 else {"exog": data.exog}
+    mod = AutoReg(data.endog, 0, trend="n", seasonal=pandas, exog=data.exog)
+    res = mod.fit()
+
+    assert isinstance(res.summary(), Summary)
+    res.remove_data()
+    assert isinstance(res.summary(), Summary)
+
+
 # TODO: test likelihood for ARX model?
 
 


### PR DESCRIPTION
Run summary, remove data, and then verify summary still works

- [ ] closes #xxxx
- [ ] tests added / passed. 
- [ ] code/documentation is well formatted.  
- [ ] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
