### PR TITLE
BUG: Report the correct accepted types in dict_like

### DIFF
--- a/statsmodels/tools/validation/tests/test_validation.py
+++ b/statsmodels/tools/validation/tests/test_validation.py
@@ -1,4 +1,5 @@
 from collections import OrderedDict
+from types import MappingProxyType
 
 import numpy as np
 import pandas as pd
@@ -279,13 +280,23 @@ def test_optional_dict_like(dict_type):
 
 
 def test_optional_dict_like_error():
+    # strict only accepts a dict, so the message must not offer a Mapping
+    match = r"value must be a dict$"
+    for value in ([], {"a"}, "a"):
+        with pytest.raises(TypeError, match=match):
+            dict_like(value, "value", optional=True)
+    # without strict any Mapping is accepted, which the message reports
     match = r"value must be a dict or dict_like \(i.e., a Mapping\)"
-    with pytest.raises(TypeError, match=match):
-        dict_like([], "value", optional=True)
-    with pytest.raises(TypeError, match=match):
-        dict_like({"a"}, "value", optional=True)
-    with pytest.raises(TypeError, match=match):
-        dict_like("a", "value", optional=True)
+    for value in ([], {"a"}, "a"):
+        with pytest.raises(TypeError, match=match):
+            dict_like(value, "value", optional=True, strict=False)
+
+
+def test_dict_like_strict_mapping():
+    proxy = MappingProxyType({"a": 1})
+    assert dict_like(proxy, "value", strict=False) is proxy
+    with pytest.raises(TypeError, match=r"value must be a dict$"):
+        dict_like(proxy, "value")
 
 
 def test_string():

--- a/statsmodels/tools/validation/validation.py
+++ b/statsmodels/tools/validation/validation.py
@@ -485,7 +485,7 @@ def dict_like(value, name, optional=False, strict=True):
         return None
     if not isinstance(value, Mapping) or (strict and not (isinstance(value, dict))):
         extra_text = "If not None, " if optional else ""
-        strict_text = " or dict_like (i.e., a Mapping)" if strict else ""
+        strict_text = "" if strict else " or dict_like (i.e., a Mapping)"
         msg = f"{extra_text}{name} must be a dict{strict_text}"
         raise TypeError(msg)
     return value


### PR DESCRIPTION
- [ ] closes #xxxx
- [x] tests added / passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>

The `strict` flag is inverted when building the `dict_like` error message, so a
strict call reports that a Mapping is acceptable when it is the one thing that
was just rejected:

```python
>>> from types import MappingProxyType
>>> dict_like(MappingProxyType({"a": 1}), "value")   # strict=True
TypeError: value must be a dict or dict_like (i.e., a Mapping)
```

Non-strict calls, which do accept a Mapping, get the shorter message instead.
The condition is now swapped so each mode reports what it actually accepts.

`test_optional_dict_like_error` asserted the previous message, so it is updated
and now covers both `strict` modes.