### PR TITLE
DOC: Correct the recipr0 summary line

### DIFF
--- a/statsmodels/tools/tools.py
+++ b/statsmodels/tools/tools.py
@@ -333,7 +333,7 @@ def recipr(x):
 
 def recipr0(x):
     """
-    Reciprocal of an array with entries less than 0 set to 0
+    Reciprocal of an array with entries equal to 0 set to 0
 
     Parameters
     ----------


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed. 
- [x] code/documentation is well formatted.  
- [x] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>

`recipr0`'s summary says entries "less than 0" are set to 0, but only entries
equal to 0 are replaced — negative entries get their reciprocal:

```python
>>> recipr0(np.array([-4., 0., 2.]))
array([-0.25,  0.  ,  0.5 ])
```

`test_recipr0` already pins this behavior, so only the docstring is wrong. This
also makes the contrast with `recipr` ("less than or equal to 0") accurate.

No test added, per the note that doc changes do not need one.