### PR TITLE
BUG: clip wilson proportion_confint bounds to [0, 1]

### DIFF
--- a/statsmodels/stats/proportion.py
+++ b/statsmodels/stats/proportion.py
@@ -160,7 +160,9 @@ def proportion_confint(
     1 - alpha/2 in the case of "beta".
 
     The confidence intervals are clipped to be in the [0, 1] interval in the
-    case of "normal" and "agresti_coull".
+    case of "normal", "agresti_coull" and "wilson". The "wilson" interval is
+    contained in [0, 1] mathematically, but floating point error could
+    otherwise produce bounds slightly outside of it.
 
     Method "binom_test" directly inverts the binomial test in scipy.stats,
     which has discrete steps.
@@ -302,7 +304,7 @@ def proportion_confint(
         ci_upp = stats.beta.isf(alpha, count_a + 0.5, nobs_a - count_a + 0.5)
     else:
         raise NotImplementedError(f"method {method} is not available")
-    if method in ["normal", "agresti_coull"]:
+    if method in ["normal", "agresti_coull", "wilson"]:
         ci_low = np.clip(ci_low, 0, 1)
         ci_upp = np.clip(ci_upp, 0, 1)
     if is_pandas:

--- a/statsmodels/stats/tests/test_proportion.py
+++ b/statsmodels/stats/tests/test_proportion.py
@@ -106,6 +106,19 @@ def test_confint_proportion_ndim(method):
     assert_allclose((ci_arr2[0][1, 2], ci_arr[1][1, 2]), ci12, rtol=1e-4)
 
 
+def test_confint_proportion_wilson_clip():
+    # GH 7386, floating point error could push wilson bounds outside [0, 1]
+    ci_low, ci_upp = proportion_confint(38, 38, alpha=0.05, method="wilson")
+    assert 0 <= ci_low <= ci_upp <= 1
+
+    ci_low, ci_upp = proportion_confint(0, 77, alpha=0.05, method="wilson")
+    assert 0 <= ci_low <= ci_upp <= 1
+
+    # clipping must not alter bounds that are already inside [0, 1]
+    ci = proportion_confint(19, 38, alpha=0.05, method="wilson")
+    assert_allclose(ci, (0.348499283643951, 0.651500716356049), rtol=1e-12)
+
+
 def test_samplesize_confidenceinterval_prop():
     # consistency test for samplesize to achieve confidence_interval
     nobs = 20


### PR DESCRIPTION
The wilson score interval is mathematically contained in [0, 1], but floating point error can push its bounds slightly outside, e.g. `proportion_confint(38, 38, method="wilson")` returns an upper bound of `1.0000000000000002` and `proportion_confint(0, 77, method="wilson")` a lower bound of `-3.47e-18` — violating the documented [0, 1] contract (reported in #7386).

Per the discussion in the issue, normal-based symmetric intervals are the ones that need clipping, while beta/jeffreys/binom_test have the domain restriction built in. This adds `wilson` to the existing clip applied to `normal` and `agresti_coull`, updates the docstring Notes accordingly, and adds a regression test covering both reported cases plus a check that interior bounds are unchanged (verified bit-identical before/after).

Verification: full `statsmodels/stats/tests/test_proportion.py` passes locally (488 passed, 5 skipped) on an arm64 source build.

closes #7386
