### PR TITLE
DOC: fix discrete results parameters

### DIFF
--- a/statsmodels/discrete/discrete_model.py
+++ b/statsmodels/discrete/discrete_model.py
@@ -84,12 +84,17 @@ _discrete_results_docs = """
     Parameters
     ----------
     model : A DiscreteModel instance
-    params : array_like
-        The parameters of a fitted model.
-    hessian : array_like
-        The hessian of the fitted model.
-    scale : float
-        A scale parameter for the covariance matrix.
+        The fitted discrete model.
+    mlefit : LikelihoodModelResults instance
+        Results from fitting the model by maximum likelihood.
+    cov_type : str, optional
+        The covariance estimator used for standard errors. The default is
+        ``"nonrobust"``.
+    cov_kwds : dict, optional
+        Keywords passed to the covariance estimator.
+    use_t : bool, optional
+        If True, use the Student's t distribution for inference. If False,
+        use the normal distribution. If None, use the model default.
 
     Attributes
     ----------


### PR DESCRIPTION
- [x] closes #9290
- [x] tests added / passed. Tests are not needed for this documentation-only change; the shared docstring was parsed and checked against the `DiscreteResults.__init__` parameters.
- [x] code/documentation is well formatted.
- [x] properly formatted commit message.

Updates the shared discrete results docstring so `NegativeBinomialResults`, `LogitResults`, and the other discrete result classes document their actual constructor parameters: `model`, `mlefit`, `cov_type`, `cov_kwds`, and `use_t`.

Validation:
- Parsed the shared docstring with `numpydoc` and asserted that its parameter names exactly match the `DiscreteResults.__init__` AST signature.
- `git diff --check`.