### PR TITLE
BUG: sign_test raises an opaque error when all observations tie with mu0

### DIFF
--- a/statsmodels/stats/descriptivestats.py
+++ b/statsmodels/stats/descriptivestats.py
@@ -152,6 +152,12 @@ def sign_test(samp, mu0=0):
     p : float
         The p-value for the test.
 
+    Raises
+    ------
+    ValueError
+        If no observation differs from `mu0`. All values are then discarded
+        as ties and the test is not defined.
+
     Notes
     -----
     The signs test returns
@@ -173,6 +179,12 @@ def sign_test(samp, mu0=0):
     samp = np.asarray(samp)
     pos = np.sum(samp > mu0)
     neg = np.sum(samp < mu0)
+    if pos + neg == 0:
+        raise ValueError(
+            "The sign test is not defined when no observation differs from "
+            "mu0. Every value in samp is equal to mu0 (or samp is empty), and "
+            "tied values are discarded."
+        )
     M = (pos - neg) / 2.0
     try:
         p = stats.binomtest(min(pos, neg), pos + neg, 0.5).pvalue

--- a/statsmodels/stats/tests/test_descriptivestats.py
+++ b/statsmodels/stats/tests/test_descriptivestats.py
@@ -23,6 +23,19 @@ def df():
     return pd.DataFrame({"a": a, "b": b})
 
 
+def test_sign_test_no_observation_differs_from_mu0():
+    # When every observation ties with mu0 it is discarded, leaving no
+    # observations, so the test is undefined. This used to surface as an
+    # opaque "n must be an integer not less than 1" error raised from
+    # scipy's binomtest rather than explaining the cause.
+    with pytest.raises(ValueError, match="no observation differs from"):
+        sign_test([5.0, 5.0, 5.0], mu0=5.0)
+
+    # an empty sample hits the same degenerate case
+    with pytest.raises(ValueError, match="no observation differs from"):
+        sign_test([], mu0=0.0)
+
+
 def test_sign_test():
     x = [7.8, 6.6, 6.5, 7.4, 7.3, 7.0, 6.4, 7.1, 6.7, 7.6, 6.8]
     M, p = sign_test(x, mu0=6.5)


### PR DESCRIPTION
#### What / why

`sign_test` discards observations equal to `mu0` (as its Notes section documents).
When *every* observation is a tie — or `samp` is empty — nothing is left to test,
and the call reaches `scipy.stats.binomtest` with `n=0`:

```python
from statsmodels.stats.descriptivestats import sign_test
sign_test([5.0, 5.0, 5.0], mu0=5.0)
# ValueError: n must be an integer not less than 1
```

The message comes from scipy's internals and doesn't hint that the real problem
is that all observations were discarded as ties, so it's hard to trace back to
the input.

#### Change

Detect `N(+) + N(-) == 0` and raise a `ValueError` naming the cause, plus a
`Raises` section in the docstring. Samples with at least one non-tied
observation are completely unaffected.

#### Verification

- The existing `test_sign_test` reference case (checked against R's
  `SIGN.test`) is unchanged: `M = 4`, `p = 0.02148`.
- Both degenerate inputs (all ties, empty) now raise the explanatory error.
- Near-degenerate input with a single non-tied observation still works.

Happy to instead return `(0.0, 1.0)` (or `nan`) for this case if you'd prefer a
defined return value over an error — I went with the error since it doesn't
invent a statistic for an input that carries no information.
