### PR TITLE
BUG: multipletests raises ZeroDivisionError on an empty p-value array

### DIFF
--- a/statsmodels/stats/multitest.py
+++ b/statsmodels/stats/multitest.py
@@ -169,15 +169,15 @@ def multipletests(
         pvals = np.take(pvals, sortind)
 
     ntests = len(pvals)
-    if ntests == 0:
-        # Nothing to correct. Skip the division by zero below and let the
+    if ntests > 0:
+        alphacSidak = 1 - np.power((1.0 - alphaf), 1.0 / ntests)
+        alphacBonf = alphaf / float(ntests)
+    else:
+        # Nothing to correct. Skip the division by zero above and let the
         # per-method branches operate on the empty array, which produces empty
         # results. The corrected alphas are undefined without any tests.
         alphacSidak = np.nan
         alphacBonf = np.nan
-    else:
-        alphacSidak = 1 - np.power((1.0 - alphaf), 1.0 / ntests)
-        alphacBonf = alphaf / float(ntests)
     if method.lower() in ["b", "bonf", "bonferroni"]:
         reject = pvals <= alphacBonf
         pvals_corrected = pvals * float(ntests)

--- a/statsmodels/stats/multitest.py
+++ b/statsmodels/stats/multitest.py
@@ -169,8 +169,15 @@ def multipletests(
         pvals = np.take(pvals, sortind)
 
     ntests = len(pvals)
-    alphacSidak = 1 - np.power((1.0 - alphaf), 1.0 / ntests)
-    alphacBonf = alphaf / float(ntests)
+    if ntests == 0:
+        # Nothing to correct. Skip the division by zero below and let the
+        # per-method branches operate on the empty array, which produces empty
+        # results. The corrected alphas are undefined without any tests.
+        alphacSidak = np.nan
+        alphacBonf = np.nan
+    else:
+        alphacSidak = 1 - np.power((1.0 - alphaf), 1.0 / ntests)
+        alphacBonf = alphaf / float(ntests)
     if method.lower() in ["b", "bonf", "bonferroni"]:
         reject = pvals <= alphacBonf
         pvals_corrected = pvals * float(ntests)

--- a/statsmodels/stats/tests/test_multi.py
+++ b/statsmodels/stats/tests/test_multi.py
@@ -559,4 +559,3 @@ def test_multipletests_empty(method):
     # the corrected alphas are undefined when there is nothing to correct
     assert np.isnan(alphac_sidak)
     assert np.isnan(alphac_bonf)
-

--- a/statsmodels/stats/tests/test_multi.py
+++ b/statsmodels/stats/tests/test_multi.py
@@ -543,3 +543,20 @@ def test_null_constrained(estimate_mean, estimate_scale, estimate_prob):
                     norm.pdf(np.r_[-1, 0, 1], loc=emp_null.mean,
                              scale=emp_null.sd),
                     rtol=1e-13)
+
+
+@pytest.mark.parametrize("method", sorted(multitest_methods_names))
+def test_multipletests_empty(method):
+    # An empty p-value array used to raise "float division by zero" for every
+    # method, because the corrected alphas are computed from 1 / ntests before
+    # the method is dispatched. fdrcorrection already accepted an empty input.
+    reject, pvals_corrected, alphac_sidak, alphac_bonf = multipletests(
+        [], method=method
+    )
+
+    assert reject.shape == (0,)
+    assert pvals_corrected.shape == (0,)
+    # the corrected alphas are undefined when there is nothing to correct
+    assert np.isnan(alphac_sidak)
+    assert np.isnan(alphac_bonf)
+


### PR DESCRIPTION
#### What / why

`multipletests` computes both corrected alphas from `1 / ntests` before it
dispatches on `method`:

```python
ntests = len(pvals)
alphacSidak = 1 - np.power((1.0 - alphaf), 1.0 / ntests)
alphacBonf = alphaf / float(ntests)
```

so an empty `pvals` array fails with a bare

```
ZeroDivisionError: float division by zero
```

for *every* method, including `fdr_bh` and friends that delegate to
`fdrcorrection`, which accepts an empty input and returns empty arrays. An
empty array is easy to hit in practice when the set of tests is produced by
filtering upstream.

```python
from statsmodels.stats.multitest import multipletests, fdrcorrection
fdrcorrection([])      # (array([], dtype=bool), array([], dtype=float64))
multipletests([])      # ZeroDivisionError: float division by zero
```

#### Change

Skip that computation when `ntests == 0` and let the per-method branches run on
the empty array, which produces empty results. The corrected alphas are reported
as `nan`, since they are undefined when there is nothing to correct.

Returning early instead would have skipped the `method not recognized`
validation at the end of the function, so the guard is deliberately narrow.

#### Verification

- All 10 methods in `multitest_methods_names` now return empty `reject` /
  `pvals_corrected` with `nan` alphas (added as a parametrized test).
- `multipletests([], method="nonsense")` still raises `ValueError: method not
  recognized`.
- Non-empty results are unchanged, e.g. for `[0.01, 0.04, 0.03, 0.2]`:
  bonferroni `[0.04, 0.16, 0.12, 0.8]`, holm `[0.04, 0.09, 0.09, 0.2]`,
  fdr_bh `[0.04, 0.0533, 0.0533, 0.2]`.

Happy to raise an informative error instead if you would rather an empty input
stay an error, but returning empty seemed more consistent with `fdrcorrection`.
