### PR TITLE
BUG: maxabs and iqr raise on an empty input, unlike the other eval_measures

### DIFF
--- a/statsmodels/tools/eval_measures.py
+++ b/statsmodels/tools/eval_measures.py
@@ -131,7 +131,12 @@ def maxabs(x1, x2, axis=0):
     """
     x1 = np.asanyarray(x1)
     x2 = np.asanyarray(x2)
-    return np.max(np.abs(x1 - x2), axis=axis)
+    absdiff = np.abs(x1 - x2)
+    if absdiff.size == 0:
+        # np.max has no identity element for an empty input. Return nan, as
+        # the other measures here do via np.mean / np.median.
+        return np.mean(absdiff, axis=axis)
+    return np.max(absdiff, axis=axis)
 
 
 def meanabs(x1, x2, axis=0):
@@ -336,13 +341,16 @@ def iqr(x1, x2, axis=0):
 
     """
     x1 = array_like(x1, "x1", dtype=None, ndim=None)
-    x2 = array_like(x2, "x1", dtype=None, ndim=None)
+    x2 = array_like(x2, "x2", dtype=None, ndim=None)
     if axis is None:
         x1 = x1.ravel()
         x2 = x2.ravel()
         axis = 0
     xdiff = np.sort(x1 - x2, axis=axis)
     nobs = x1.shape[axis]
+    if nobs == 0:
+        # no observations to take quantiles of; match the other measures
+        return np.mean(xdiff, axis=axis)
     idx = np.round((nobs - 1) * np.array([0.25, 0.75])).astype(int)
     sl = [slice(None)] * xdiff.ndim
     sl[axis] = idx

--- a/statsmodels/tools/eval_measures.py
+++ b/statsmodels/tools/eval_measures.py
@@ -13,6 +13,20 @@ import numpy as np
 from statsmodels.tools.validation import array_like
 
 
+
+def _nan_reduction_result(arr, axis):
+    """Explicit nan with the shape a reduction of `arr` over `axis` would give.
+
+    Used for empty inputs, where the underlying numpy reduction has no
+    identity element. Returns a scalar when the reduction collapses the whole
+    array, otherwise an array of nan with the remaining shape.
+    """
+    if axis is None or arr.ndim <= 1:
+        return np.nan
+    axis = axis % arr.ndim
+    return np.full(arr.shape[:axis] + arr.shape[axis + 1 :], np.nan)
+
+
 def mse(x1, x2, axis=0):
     """
     Mean squared error
@@ -133,9 +147,8 @@ def maxabs(x1, x2, axis=0):
     x2 = np.asanyarray(x2)
     absdiff = np.abs(x1 - x2)
     if absdiff.size == 0:
-        # np.max has no identity element for an empty input. Return nan, as
-        # the other measures here do via np.mean / np.median.
-        return np.mean(absdiff, axis=axis)
+        # np.max has no identity element for an empty input
+        return _nan_reduction_result(absdiff, axis)
     return np.max(absdiff, axis=axis)
 
 
@@ -349,8 +362,8 @@ def iqr(x1, x2, axis=0):
     xdiff = np.sort(x1 - x2, axis=axis)
     nobs = x1.shape[axis]
     if nobs == 0:
-        # no observations to take quantiles of; match the other measures
-        return np.mean(xdiff, axis=axis)
+        # no observations to take quantiles of
+        return _nan_reduction_result(xdiff, axis)
     idx = np.round((nobs - 1) * np.array([0.25, 0.75])).astype(int)
     sl = [slice(None)] * xdiff.ndim
     sl[axis] = idx

--- a/statsmodels/tools/eval_measures.py
+++ b/statsmodels/tools/eval_measures.py
@@ -13,7 +13,6 @@ import numpy as np
 from statsmodels.tools.validation import array_like
 
 
-
 def _nan_reduction_result(arr, axis):
     """Explicit nan with the shape a reduction of `arr` over `axis` would give.
 

--- a/statsmodels/tools/tests/test_eval_measures.py
+++ b/statsmodels/tools/tests/test_eval_measures.py
@@ -152,10 +152,14 @@ def test_measures_empty_input(measure):
     assert np.isnan(measure(empty, empty))
 
 
-def test_maxabs_empty_keeps_axis_shape():
-    # the reduced axis is dropped and the remaining shape is kept, as it is
-    # for the measures built on np.mean
+@pytest.mark.parametrize(
+    "measure",
+    [bias, iqr, maxabs, meanabs, medianabs, medianbias, mse, rmse, rmspe, vare],
+)
+def test_measures_empty_input_keeps_axis_shape(measure):
+    # reducing over an empty axis drops that axis and keeps the rest, so a
+    # (0, 3) input reduces to three nans rather than a scalar
     empty = np.empty((0, 3))
 
-    assert_equal(maxabs(empty, empty), np.full(3, np.nan))
+    assert_equal(measure(empty, empty), np.full(3, np.nan))
 

--- a/statsmodels/tools/tests/test_eval_measures.py
+++ b/statsmodels/tools/tests/test_eval_measures.py
@@ -137,3 +137,25 @@ def test_iqr_axis():
     assert_almost_equal(ax_1, np.array(ax_1_direct))
 
     assert any(ax_0 != ax_1)
+
+
+@pytest.mark.parametrize(
+    "measure",
+    [bias, iqr, maxabs, meanabs, medianabs, medianbias, mse, rmse, rmspe, vare],
+)
+def test_measures_empty_input(measure):
+    # maxabs and iqr used to raise on an empty input, np.max because it has no
+    # identity element and iqr because it indexes into the sorted differences,
+    # while every other measure here returned nan.
+    empty = np.empty(0)
+
+    assert np.isnan(measure(empty, empty))
+
+
+def test_maxabs_empty_keeps_axis_shape():
+    # the reduced axis is dropped and the remaining shape is kept, as it is
+    # for the measures built on np.mean
+    empty = np.empty((0, 3))
+
+    assert_equal(maxabs(empty, empty), np.full(3, np.nan))
+

--- a/statsmodels/tools/tests/test_eval_measures.py
+++ b/statsmodels/tools/tests/test_eval_measures.py
@@ -162,4 +162,3 @@ def test_measures_empty_input_keeps_axis_shape(measure):
     empty = np.empty((0, 3))
 
     assert_equal(measure(empty, empty), np.full(3, np.nan))
-


### PR DESCRIPTION
#### What / why

The comparison measures in `statsmodels.tools.eval_measures` share the same
`(x1, x2, axis)` signature, but they disagree on an empty input. `mse`, `rmse`,
`meanabs`, `medianabs`, `bias`, `medianbias`, `rmspe` and `vare` all return `nan`,
because they are built on `np.mean` / `np.median`. The two that are not raise
instead:

```python
>>> import numpy as np
>>> from statsmodels.tools.eval_measures import mse, maxabs, iqr
>>> empty = np.empty(0)
>>> mse(empty, empty)
nan
>>> maxabs(empty, empty)
ValueError: zero-size array to reduction operation maximum which has no identity
>>> iqr(empty, empty)
IndexError: index 0 is out of bounds for axis 0 with size 0
```

Neither message points at the empty input as the cause, and iterating over the
measures to build a comparison table fails on exactly two of them.

#### Changes

- `maxabs`: return `nan` when the input is empty, since `np.max` has no identity
  element there. The reduced axis is dropped and the remaining shape is kept,
  matching the `np.mean`-based measures, so `maxabs` on a `(0, 3)` input returns
  `[nan, nan, nan]`.
- `iqr`: return `nan` when there are no observations, instead of indexing into
  the empty sorted differences.
- `iqr` also passed `"x1"` as the name for `x2` in its `array_like` call, so a
  validation failure on `x2` would report the wrong argument. Corrected to
  `"x2"`.

#### Verification

- All ten measures return `nan` on an empty input (added as a parametrized test).
- Non-empty results are unchanged, e.g. for `x1 = [1, 2, 3, 10]`,
  `x2 = [1.5, 1, 4, 6]`: `mse` 4.5625, `maxabs` 4.0, `meanabs` 1.625,
  `medianabs` 1.0, `iqr` 1.5.
