### PR TITLE
BUG: use the non-missing sample size for acf confint/qstat when NaNs are handled

### DIFF
--- a/statsmodels/tsa/stattools/_stattools.py
+++ b/statsmodels/tsa/stattools/_stattools.py
@@ -789,10 +789,14 @@ def acf(
         missing, "missing", options=("none", "raise", "conservative", "drop")
     )
     x = array_like(x, "x")
-    # TODO: should this shrink for missing="drop" and NaNs in x?
     nobs = x.shape[0]
     if nlags is None:
         nlags = min(int(10 * np.log10(nobs)), nobs - 1)
+    if missing in ("drop", "conservative"):
+        # "drop" removes the NaNs and "conservative" zeroes them out, and
+        # acovf uses the non-missing count as the divisor in both cases
+        # (see the missing docstring), so nobs must match.
+        nobs = int(np.sum(~np.isnan(x)))
 
     avf = acovf(x, adjusted=adjusted, demean=True, fft=fft, missing=missing)
     acf = avf[: nlags + 1] / avf[0]
@@ -805,7 +809,7 @@ def acf(
         varacf[1] = 1.0 / nobs
         varacf[2:] *= 1 + 2 * np.cumsum(acf[1:-1] ** 2)
     else:
-        varacf = 1.0 / len(x)
+        varacf = 1.0 / nobs
     interval = stats.norm.ppf(1 - _alpha / 2.0) * np.sqrt(varacf)
     confint = np.array(lzip(acf - interval, acf + interval))
     if not qstat:

--- a/statsmodels/tsa/tests/test_stattools.py
+++ b/statsmodels/tsa/tests/test_stattools.py
@@ -260,6 +260,7 @@ class TestACFMissing(CheckCorrGram):
         cls.x = np.concatenate((np.array([np.nan]), cls.x))
         cls.acf = cls.results["acvar"]  # drop and conservative
         cls.qstat = cls.results["Q1"]
+        cls.confint_res = cls.results[["acvar_lb", "acvar_ub"]].values
         cls.res_drop = acf(
             cls.x, nlags=40, qstat=True, alpha=0.05, missing="drop", fft=False
         )
@@ -301,12 +302,19 @@ class TestACFMissing(CheckCorrGram):
         # todo why is res1/qstat 1 short
         assert_almost_equal(self.res_none[2], self.qstat_none, DECIMAL_3)
 
+    def test_qstat_drop(self):
+        assert_almost_equal(self.res_drop[2][:40], self.qstat, DECIMAL_3)
 
-# FIXME: enable/xfail/skip or delete
-# how to do this test? the correct q_stat depends on whether nobs=len(x) is
-# used when x contains NaNs or whether nobs<len(x) when x contains NaNs
-#    def test_qstat_drop(self):
-#        assert_almost_equal(self.res_drop[2][:40], self.qstat, DECIMAL_3)
+    def test_qstat_conservative(self):
+        assert_almost_equal(self.res_conservative[2][:40], self.qstat, DECIMAL_3)
+
+    def test_confint_drop(self):
+        centered = self.res_drop[1] - self.res_drop[1].mean(1)[:, None]
+        assert_almost_equal(centered[1:41], self.confint_res, DECIMAL_8)
+
+    def test_confint_conservative(self):
+        centered = self.res_conservative[1] - self.res_conservative[1].mean(1)[:, None]
+        assert_almost_equal(centered[1:41], self.confint_res, DECIMAL_8)
 
 
 class TestPACF(CheckCorrGram):


### PR DESCRIPTION
BUG: use the non-missing sample size for acf confint/qstat when NaNs are handled

- [ ] closes #xxxx
- [x] tests added / passed.
- [x] code/documentation is well formatted.
- [x] properly formatted commit message.

`acf(x, missing="drop", alpha=..., qstat=True)` computes the Bartlett confidence-interval
variance and the Ljung-Box q-statistic from `nobs = len(x)`, i.e. the length of the array
*including* the NaNs that `"drop"` removes before estimating the autocovariances. The acf
point estimates already match what you'd get by dropping the NaNs yourself first and
calling `missing="none"`; the confidence interval and q-statistic do not. The same is true
for `missing="conservative"`: `acovf` keeps `x` at its original length there but zeroes the
NaN positions and divides by the non-missing count, which the `missing` docstring already
documents as the effective `n` for that branch.

#### Reproducer

```python
import numpy as np
from statsmodels.tsa.stattools import acf

rng = np.random.default_rng(0)
x_dropped = rng.standard_normal(200)
x_with_nans = np.concatenate([x_dropped, np.full(200, np.nan)])  # 400 long, half NaN

acf_drop, confint_drop, qstat_drop, pvalue_drop = acf(
    x_with_nans, nlags=10, qstat=True, alpha=0.05, missing="drop", fft=False
)
acf_ref, confint_ref, qstat_ref, pvalue_ref = acf(
    x_dropped, nlags=10, qstat=True, alpha=0.05, missing="none", fft=False
)
```

`acf_drop` matches `acf_ref` exactly, as expected. `confint_drop` and `qstat_drop` do not,
even though `"drop"` is documented to remove the NaNs and estimate as if the caller had
dropped them first:

```
confint half-width at lag 1:  drop=0.098000   reference (dropped by hand)=0.138590
qstat at lag 1:                drop=0.795745  reference=0.400857
```

The confint ratio (0.7071) is exactly `sqrt(200/400)`; the qstat ratio (1.9851) is close to
but not exactly `len(x)/n_effective` (2.0) because `q_stat`'s `(n+2)` and `(n-k)` terms make
that only an approximation. With this patch both match the reference exactly (full captured
output in `output_before.txt` / `output_after.txt`).

#### Cause

`statsmodels/tsa/stattools/_stattools.py`, `acf()`: `nobs = x.shape[0]` is used, unchanged,
for the Bartlett `varacf` and for `q_stat(acf[1:], nobs=nobs)`. `acovf()` (called right
after) uses the non-missing count as its own divisor for both `"drop"` and `"conservative"`,
so the acf point estimates are already correctly scaled -- but `acf()`'s own `nobs` never
learns about it. This was a standing, maintainer-acknowledged gap: the line was preceded by

```python
    # TODO: should this shrink for missing="drop" and NaNs in x?
    nobs = x.shape[0]
```

and the test file carried a disabled regression test for exactly the `"drop"` q_stat case:

```python
# FIXME: enable/xfail/skip or delete
# how to do this test? the correct q_stat depends on whether nobs=len(x) is
# used when x contains NaNs or whether nobs<len(x) when x contains NaNs
#    def test_qstat_drop(self):
#        assert_almost_equal(self.res_drop[2][:40], self.qstat, DECIMAL_3)
```

#### Fix

Set `nobs` to the non-missing count (`np.sum(~np.isnan(x))`) whenever `missing` is `"drop"`
or `"conservative"`, right before it's used for `varacf` and `q_stat`. No-op for `missing in
("none", "raise")`, and a no-op whenever the input has no NaNs.

#### Tests

Enabled the `test_qstat_drop` test that was committed disabled in `TestACFMissing`, added
the equivalent `test_qstat_conservative`, and added `test_confint_drop` /
`test_confint_conservative` following the same pattern `TestACF.test_confint` already uses
a few classes up in the same file. All four check against the Stata reference values
already checked into `results_corrgram.csv`. They fail on `main` and pass with this patch.

`statsmodels/tsa/tests/test_stattools.py`: 223 passed, 2 xfailed with the fix vs. 219
passed, 2 xfailed on `main` -- the four extra passes are the newly-enabled tests, nothing
regressed. Full `statsmodels/tsa/tests/`: 5269 passed vs. 5265 on `main`, same skip/xfail
counts.

---
