### PR TITLE
MAINT: COrrect test on older SciPy

### DIFF
--- a/statsmodels/sandbox/distributions/tests/test_extras.py
+++ b/statsmodels/sandbox/distributions/tests/test_extras.py
@@ -4,7 +4,7 @@ Created on Sun Apr 17 22:13:36 2011
 @author: josef
 """
 
-from statsmodels.compat.scipy import SP_LT_116
+from statsmodels.compat.scipy import SP_LT_19, SP_LT_116
 
 import numpy as np
 from numpy.testing import assert_, assert_allclose, assert_almost_equal
@@ -169,7 +169,9 @@ def test_skewt():
     assert_(np.allclose(cdf_st, cdf_r, rtol=1e-13, atol=1e-25))
 
 
+@pytest.mark.singleton_randomstate
 @pytest.mark.xfail(
+    condition=not SP_LT_19,
     reason=(
         "BUG: SkewNorm_gen._rvs(self, alpha) does not accept the `size` "
         "keyword argument that scipy.stats.rv_continuous.rvs() always "
@@ -184,7 +186,9 @@ def test_skewnorm_rvs():
     skewnorm.rvs(5, size=100, random_state=np.random.RandomState(0))
 
 
+@pytest.mark.singleton_randomstate
 @pytest.mark.xfail(
+    condition=not SP_LT_19,
     reason=(
         "BUG: same root cause as test_skewnorm_rvs -- "
         "ACSkewT_gen._rvs(self, df, alpha) does not accept the `size` "
@@ -192,7 +196,7 @@ def test_skewnorm_rvs():
         "always raises TypeError."
     ),
     raises=TypeError,
-    strict=True,
+    strict=False,
 )
 def test_acskewt_rvs():
     ACSkewT_gen().rvs(5, 10, size=100, random_state=np.random.RandomState(0))


### PR DESCRIPTION
Correct test behavior for the oldest supported SciPy that does not fail but does for newer

- [ ] closes #xxxx
- [ ] tests added / passed. 
- [ ] code/documentation is well formatted.  
- [ ] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
