### PR TITLE
MAINT: Add _NoValue sentinel and initialize OLS conditional attributes (GH#9880)

### DIFF
--- a/statsmodels/regression/linear_model.py
+++ b/statsmodels/regression/linear_model.py
@@ -50,6 +50,7 @@ from statsmodels.emplike.elregress import _ELRegOpts
 # need import in module instead of lazily to copy `__doc__`
 from statsmodels.regression._prediction import PredictionResults
 from statsmodels.tools._decorators import cache_readonly, cache_writable
+from statsmodels.tools._no_value import _NoValue
 from statsmodels.tools.docstring_helpers import Appender
 from statsmodels.tools.sm_exceptions import (
     InvalidTestWarning,
@@ -999,6 +1000,13 @@ class OLS(WLS):
 
         if type(self) is OLS:
             self._check_kwargs(kwargs, ["offset"])
+        # offset is attached by Model._handle_data only when passed
+        if "offset" not in kwargs:
+            self.offset = _NoValue
+        # score/hessian intermediates, computed lazily by _setup_score_hess
+        self._wendog_xprod = _NoValue
+        self._wexog_xprod = _NoValue
+        self._wexog_x_wendog = _NoValue
 
     def loglike(self, params, scale=None):
         """
@@ -1022,7 +1030,7 @@ class OLS(WLS):
         nobs2 = self.nobs / 2.0
         nobs = float(self.nobs)
         resid = self.endog - np.dot(self.exog, params)
-        if hasattr(self, "offset"):
+        if self.offset is not _NoValue:
             resid -= self.offset
         ssr = np.sum(resid**2)
         if scale is None:
@@ -1078,7 +1086,7 @@ class OLS(WLS):
             The score vector.
 
         """
-        if not hasattr(self, "_wexog_xprod"):
+        if self._wexog_xprod is _NoValue:
             self._setup_score_hess()
 
         xtxb = np.dot(self._wexog_xprod, params)
@@ -1093,7 +1101,7 @@ class OLS(WLS):
 
     def _setup_score_hess(self):
         y = self.wendog
-        if hasattr(self, "offset"):
+        if self.offset is not _NoValue:
             y = y - self.offset
         self._wendog_xprod = np.sum(y * y)
         self._wexog_xprod = np.dot(self.wexog.T, self.wexog)
@@ -1118,7 +1126,7 @@ class OLS(WLS):
             The Hessian matrix.
 
         """
-        if not hasattr(self, "_wexog_xprod"):
+        if self._wexog_xprod is _NoValue:
             self._setup_score_hess()
 
         xtxb = np.dot(self._wexog_xprod, params)

--- a/statsmodels/regression/tests/test_regression.py
+++ b/statsmodels/regression/tests/test_regression.py
@@ -7,6 +7,7 @@ from statsmodels.compat.python import lrange
 from statsmodels.compat.scipy import SP_LT_116
 
 from pathlib import Path
+import pickle
 import warnings
 
 import numpy as np
@@ -31,6 +32,7 @@ from statsmodels.regression.linear_model import (
     burg,
     yule_walker,
 )
+from statsmodels.tools._no_value import _NoValue
 from statsmodels.tools.tools import add_constant
 
 DECIMAL_4 = 4
@@ -1666,3 +1668,47 @@ def test_summary_after_remove_data(fit_func):
     assert isinstance(res.summary(), Summary)
     res.remove_data()
     assert isinstance(res.summary(), Summary)
+
+
+def test_ols_offset_novalue_sentinel():
+    # GH#9880: attributes that are only set on some paths are initialized
+    # to the _NoValue sentinel instead of being left missing
+    rs = np.random.RandomState(3132)
+    x = rs.normal(size=(50, 3))
+    y = x.sum(1) + rs.normal(size=50)
+
+    model = OLS(y, x)
+    assert model.offset is _NoValue
+    assert model._wexog_xprod is _NoValue
+
+    # default behavior is unchanged: loglike/score/hessian without offset
+    params = model.fit().params
+    assert np.isfinite(model.loglike(params))
+    assert_allclose(model.score(params), np.zeros(3), atol=1e-6)
+    assert model._wexog_xprod is not _NoValue
+    assert np.all(np.isfinite(model.hessian(params)))
+
+    # explicit offset still enters loglike/score/hessian
+    shifted = OLS(y, x, offset=1.0)
+    assert shifted.offset == 1.0
+    equiv = OLS(y - 1.0, x)
+    assert_allclose(shifted.loglike(params), equiv.loglike(params))
+    assert_allclose(shifted.score(params), equiv.score(params))
+    assert_allclose(shifted.hessian(params), equiv.hessian(params))
+
+    # the distinction the sentinel exists for: offset=None is a value that
+    # was passed, not a missing attribute
+    assert OLS(y, x, offset=None).offset is None
+
+
+def test_ols_novalue_pickle():
+    # sentinel attributes must survive a pickle round-trip with identity
+    # intact so `is _NoValue` checks still work on unpickled models
+    rs = np.random.RandomState(3132)
+    x = rs.normal(size=(50, 3))
+    y = x.sum(1) + rs.normal(size=50)
+
+    res = OLS(y, x).fit()
+    loaded = pickle.loads(pickle.dumps(res))
+    assert loaded.model.offset is _NoValue
+    assert_allclose(loaded.model.loglike(res.params), res.model.loglike(res.params))

--- a/statsmodels/tools/_no_value.py
+++ b/statsmodels/tools/_no_value.py
@@ -1,0 +1,58 @@
+"""
+Module defining the singleton sentinel used to mark instance attributes
+that have not been set.
+
+Modelled on ``numpy._NoValue`` (``numpy/_globals.py``).  Attributes that
+are only computed on some code paths should be initialized to ``_NoValue``
+in ``__init__`` and tested with ``attr is _NoValue`` instead of probing the
+instance with ``hasattr``/``getattr(..., default)``.  Unlike ``None``,
+``_NoValue`` cannot collide with a legitimate attribute value.
+
+This module raises a RuntimeError if an attempt to reload it is made, so
+the identity of ``_NoValue`` is fixed even if statsmodels is reloaded and
+``is`` comparisons remain valid.
+
+See GH#9880.
+"""
+
+__all__ = ["_NoValue"]
+
+# Disallow reloading this module so as to preserve the identity of _NoValue.
+if "_is_loaded" in globals():
+    raise RuntimeError("Reloading statsmodels.tools._no_value is not allowed")
+_is_loaded = True
+
+
+class _NoValueType:
+    """Special value indicating an attribute has not been set.
+
+    Use the ``_NoValue`` singleton instance of this class, and test with
+    ``is``::
+
+        self.attr = _NoValue
+        ...
+        if self.attr is not _NoValue:
+            ...
+
+    Do not rely on truthiness; ``_NoValue`` is truthy like any plain
+    object.
+    """
+
+    __instance = None
+
+    def __new__(cls):
+        # ensure that only one instance exists
+        if not cls.__instance:
+            cls.__instance = super().__new__(cls)
+        return cls.__instance
+
+    def __reduce__(self):
+        # preserve singleton identity across pickle round-trips for every
+        # protocol, so `is` checks hold on unpickled results objects
+        return (self.__class__, ())
+
+    def __repr__(self):
+        return "<no value>"
+
+
+_NoValue = _NoValueType()

--- a/statsmodels/tools/tests/test_no_value.py
+++ b/statsmodels/tools/tests/test_no_value.py
@@ -1,0 +1,31 @@
+"""
+Test functions for tools._no_value
+"""
+import pickle
+
+import pytest
+
+from statsmodels.tools._no_value import _NoValue, _NoValueType
+
+
+def test_singleton():
+    assert _NoValueType() is _NoValue
+    assert _NoValueType() is _NoValueType()
+
+
+def test_distinct_from_none():
+    # the reason the sentinel exists: it must never be mistaken for a
+    # legitimate attribute value such as None
+    assert _NoValue is not None
+    assert _NoValue != None  # noqa: E711
+
+
+def test_repr():
+    assert repr(_NoValue) == "<no value>"
+
+
+@pytest.mark.parametrize("protocol", range(pickle.HIGHEST_PROTOCOL + 1))
+def test_pickle_preserves_identity(protocol):
+    # results objects holding _NoValue are pickled by save/load, so
+    # `is` checks must hold after a round-trip under every protocol
+    assert pickle.loads(pickle.dumps(_NoValue, protocol)) is _NoValue


### PR DESCRIPTION
First slice of #9880, following the suggestion there to use a `_NoValue` sentinel rather than `None`. I kept it to one module so the pattern can be reviewed before sweeping the rest of the codebase.

**Infrastructure**: `statsmodels/tools/_no_value.py` defines a `_NoValue` singleton modelled on `numpy._NoValue` (`numpy/_globals.py`): singleton `__new__`, a reload guard, and `__reduce__` so identity survives pickle round-trips under every protocol. Results objects are pickled by `save`/`load`, so `attr is _NoValue` must still hold after loading.

**Application** (`regression.linear_model`): OLS now always initializes its conditionally-set attributes - `offset` and the score/hessian intermediates `_wendog_xprod`, `_wexog_xprod`, `_wexog_x_wendog` - to `_NoValue`, and the four `hasattr` probes in `loglike`, `score`, `hessian` and `_setup_score_hess` become `is _NoValue` checks. Behavior is unchanged, including `OLS(y, x, offset=None)`, which still attaches `None` (a passed value, distinguishable from an unset attribute - the distinction the sentinel exists for).

I deliberately left the remaining `hasattr`/`getattr` sites in the module, since a sentinel on `self` cannot fix them:

- `hasattr(model, "wexog_singular_values")` in `RegressionResults.__init__`: `model` is duck-typed - GLM, GAM and IV2SLS instances also pass through here, so this site needs those modules converted first.
- the `cov_type` guards: `cov_type` is always set by `RegressionResults.__init__`, but subclasses in sandbox/emplike/quantile construct results in ways I did not want to audit in this PR; removing those guards is a separate cleanup.
- `getattr(restricted, ...)` in `compare_f_test`/`compare_lr_test`: `restricted` is a caller-supplied results object.
- `hasattr(self, "resid")` in `resid_pearson`: probes whether a cached property can still be computed after `remove_data`, not a conditionally-set attribute.
- `hasattr(groups, ...)`: duck-typing of user input.

**Tests**: `tools/tests/test_no_value.py` covers singleton identity, repr and pickle identity under every protocol. Two new tests in `regression/tests/test_regression.py` cover sentinel initialization, unchanged loglike/score/hessian with and without offset, the offset=None distinction, and a pickle round-trip. `pytest statsmodels/regression/ statsmodels/tools/ statsmodels/emplike/` passes locally: 1374 passed, 16 skipped. flake8 is clean on the touched files.

If this shape looks right I will convert the remaining modules (discrete, base, tsa, genmod, ...) in follow-up PRs of similar size.

- [x] references #9880 (first module, does not close it)
- [x] tests added / passed
- [x] code/documentation is well formatted
- [x] properly formatted commit message
