### PR TITLE
DOC: Remove five documented parameters that are not in the signature

### DIFF
--- a/statsmodels/genmod/generalized_estimating_equations.py
+++ b/statsmodels/genmod/generalized_estimating_equations.py
@@ -135,11 +135,6 @@ class ParameterConstraint:
         """
         Returns a vector that should be added to the offset vector to
         accommodate the constraint.
-
-        Parameters
-        ----------
-        exog : array_like
-           The exogenous data for the model.
         """
 
         return self._offset_increment
@@ -148,11 +143,6 @@ class ParameterConstraint:
         """
         Returns a linearly transformed exog matrix whose columns span
         the constrained model space.
-
-        Parameters
-        ----------
-        exog : array_like
-           The exogenous data for the model.
         """
         return self.exog_fulltrans[:, 0 : self.lhs0.shape[1]]
 

--- a/statsmodels/tsa/vector_ar/irf.py
+++ b/statsmodels/tsa/vector_ar/irf.py
@@ -879,8 +879,6 @@ class IRAnalysis(BaseIRAnalysis):
         ----------
         orth : bool, default False
             Compute orthogonalized impulse responses
-        svar : bool, default False
-            Use structural IRFs
         repl : int, default 1000
             Number of MC replications
         signif : float (0 < signif < 1)

--- a/statsmodels/tsa/vector_ar/var_model.py
+++ b/statsmodels/tsa/vector_ar/var_model.py
@@ -1780,8 +1780,6 @@ class VARResults(VARProcess):
             number of Monte Carlo replications to perform
         steps : int, default 10
             number of impulse response periods
-        signif : float (0 < signif <1)
-            Significance level for error bars, defaults to 95% CI
         rng : {None, int, array_like[int], numpy.random.Generator, numpy.random.RandomState}, optional
             np.random seed for replications
         seed : {None, int, array_like[int], numpy.random.Generator, numpy.random.RandomState}, optional
@@ -2089,8 +2087,6 @@ class VARResults(VARProcess):
         signif : float between 0 and 1, default 5 %
             Significance level for computing critical values for test,
             defaulting to standard 0.05 level
-        verbose : bool
-            If True, print a table with the results.
 
         Returns
         -------


### PR DESCRIPTION
- [ ] closes #xxxx
- [x] tests added / passed. — docstrings only, and per the template tests are not needed for doc changes
- [x] code/documentation is well formatted.
- [x] properly formatted commit message.

Five docstrings describe a parameter the function does not take, so the reader is told about an argument that raises `TypeError` if passed.

| Where | Documented | Actual signature |
|---|---|---|
| `ParameterConstraint.offset_increment` | `exog` | `(self)` |
| `ParameterConstraint.reduced_exog` | `exog` | `(self)` |
| `VARResults.test_inst_causality` | `verbose` | `(self, causing, signif)` |
| `VARResults.irf_resim` | `signif` | `(self, orth, repl, steps, rng, burn, cum)` |
| `IRAnalysis.cum_errband_mc` | `svar` | `(self, orth, repl, signif, rng, burn)` |

The last two look like copies from the neighbour: `irf_errband_mc`, right below `irf_resim`, really does take `signif`, and `errband_mc`, above `cum_errband_mc`, really does take `svar`. The two `ParameterConstraint` methods take no arguments at all, so their whole `Parameters` section went.

Removing the lines documents what the code does today. If any of these were meant to be real parameters rather than leftovers, that is a different change and yours to make, so say which and I will leave them alone.

## What I checked before touching anything

A sweep of the whole package reported 56 of these. Most were not real, and the two reasons are worth stating so the number is not mistaken for 56 bugs:

- **30** sit under `@deprecate_kwarg("seed", "rng")` and similar. The old name is still accepted through the decorator and the docstring documents both, marking the old one deprecated. Correct as written.
- **19** live in `archive/` and `sandbox/`.
- **2** more I looked at and left: `_lm_robust` writes `score_deriv_inv, Ainv : ndarray` in the style of the three lines around it, giving the parameter name and its symbol, and `compat/scipy.py:apply_where` carries an explicit `# numpydoc ignore=PR01,PR02`.

That leaves the five here, each read by hand.