### PR TITLE
DOC: Add numpydoc parameters sections to NamedTuple result classes

### DIFF
--- a/statsmodels/stats/diagnostic.py
+++ b/statsmodels/stats/diagnostic.py
@@ -22,6 +22,7 @@ missing:
   - breaks_ap, more recent breaks tests
   - specification tests against nonparametric alternatives
 """
+
 from __future__ import annotations
 
 from collections.abc import Iterable
@@ -135,8 +136,9 @@ class NonNestedTestResult(NamedTuple):
     res_store: ResultsStore | None
 
 
-def compare_cox(results_x, results_z, store=False, *,
-                use_namedtuple: bool | None = None):
+def compare_cox(
+    results_x, results_z, store=False, *, use_namedtuple: bool | None = None
+):
     """
     Compute the Cox test for non-nested models
 
@@ -210,8 +212,8 @@ def compare_cox(results_x, results_z, store=False, *,
     err_xzx = res_xzx.resid
 
     sigma2_zx = sigma2_x + np.dot(err_zx.T, err_zx) / nobs
-    c01 = nobs / 2. * (np.log(sigma2_z) - np.log(sigma2_zx))
-    v01 = sigma2_x * np.dot(err_xzx.T, err_xzx) / sigma2_zx ** 2
+    c01 = nobs / 2.0 * (np.log(sigma2_z) - np.log(sigma2_zx))
+    v01 = sigma2_x * np.dot(err_xzx.T, err_xzx) / sigma2_zx**2
     q = c01 / np.sqrt(v01)
     pval = 2 * stats.norm.sf(np.abs(q))
 
@@ -246,8 +248,7 @@ def compare_cox(results_x, results_z, store=False, *,
     return q, pval
 
 
-def compare_j(results_x, results_z, store=False, *,
-             use_namedtuple: bool | None = None):
+def compare_j(results_x, results_z, store=False, *, use_namedtuple: bool | None = None):
     """
     Compute the J-test for non-nested models
 
@@ -343,8 +344,7 @@ def compare_j(results_x, results_z, store=False, *,
     return tstat, pval
 
 
-def compare_encompassing(results_x, results_z, cov_type="nonrobust",
-                         cov_kwds=None):
+def compare_encompassing(results_x, results_z, cov_type="nonrobust", cov_kwds=None):
     r"""
     Davidson-MacKinnon encompassing test for comparing non-nested models
 
@@ -425,13 +425,22 @@ def compare_encompassing(results_x, results_z, cov_type="nonrobust",
 
     x_nested = _test_nested(y, x, z, cov_type, cov_kwds)
     z_nested = _test_nested(y, z, x, cov_type, cov_kwds)
-    return pd.DataFrame([x_nested, z_nested],
-                        index=["x", "z"],
-                        columns=["stat", "pvalue", "df_num", "df_denom"])
+    return pd.DataFrame(
+        [x_nested, z_nested],
+        index=["x", "z"],
+        columns=["stat", "pvalue", "df_num", "df_denom"],
+    )
 
 
-def acorr_ljungbox(x, lags=None, boxpierce=False, model_df=0, period=None,
-                   return_df=True, auto_lag=False):
+def acorr_ljungbox(
+    x,
+    lags=None,
+    boxpierce=False,
+    model_df=0,
+    period=None,
+    return_df=True,
+    auto_lag=False,
+):
     """
     Ljung-Box test of autocorrelation in residuals
 
@@ -520,6 +529,7 @@ def acorr_ljungbox(x, lags=None, boxpierce=False, model_df=0, period=None,
     """
     # Avoid cyclic import
     from statsmodels.tsa.stattools._stattools import acf
+
     x = array_like(x, "x")
     period = int_like(period, "period", optional=True)
     model_df = int_like(model_df, "model_df", optional=False)
@@ -535,11 +545,15 @@ def acorr_ljungbox(x, lags=None, boxpierce=False, model_df=0, period=None,
         sacf = acf(x, nlags=maxlag, fft=False)
 
         if not boxpierce:
-            q_sacf = (nobs * (nobs + 2) *
-                      np.cumsum(sacf[1:maxlag + 1] ** 2
-                                / (nobs - np.arange(1, maxlag + 1))))
+            q_sacf = (
+                nobs
+                * (nobs + 2)
+                * np.cumsum(
+                    sacf[1 : maxlag + 1] ** 2 / (nobs - np.arange(1, maxlag + 1))
+                )
+            )
         else:
-            q_sacf = nobs * np.cumsum(sacf[1:maxlag + 1] ** 2)
+            q_sacf = nobs * np.cumsum(sacf[1 : maxlag + 1] ** 2)
 
         # obtain thresholds
         q = 2.4
@@ -547,7 +561,7 @@ def acorr_ljungbox(x, lags=None, boxpierce=False, model_df=0, period=None,
         threshold_metric = np.abs(sacf).max() * np.sqrt(nobs)
 
         # compute penalized sum of squared autocorrelations
-        if (threshold_metric <= threshold):
+        if threshold_metric <= threshold:
             q_sacf = q_sacf - (np.arange(1, nobs) * np.log(nobs))
         else:
             q_sacf = q_sacf - (2 * np.arange(1, nobs))
@@ -570,7 +584,7 @@ def acorr_ljungbox(x, lags=None, boxpierce=False, model_df=0, period=None,
     # normalize by nobs not (nobs-nlags)
     # SS: unbiased=False is default now
     sacf = acf(x, nlags=maxlag, fft=False)
-    sacf2 = sacf[1:maxlag + 1] ** 2 / (nobs - np.arange(1, maxlag + 1))
+    sacf2 = sacf[1 : maxlag + 1] ** 2 / (nobs - np.arange(1, maxlag + 1))
     qljungbox = nobs * (nobs + 2) * np.cumsum(sacf2)[lags - 1]
     adj_lags = lags - model_df
     pval = np.full_like(qljungbox, np.nan)
@@ -578,15 +592,20 @@ def acorr_ljungbox(x, lags=None, boxpierce=False, model_df=0, period=None,
     pval[loc] = stats.chi2.sf(qljungbox[loc], adj_lags[loc])
 
     if not boxpierce:
-        return pd.DataFrame({"lb_stat": qljungbox, "lb_pvalue": pval},
-                            index=lags)
+        return pd.DataFrame({"lb_stat": qljungbox, "lb_pvalue": pval}, index=lags)
 
-    qboxpierce = nobs * np.cumsum(sacf[1:maxlag + 1] ** 2)[lags - 1]
+    qboxpierce = nobs * np.cumsum(sacf[1 : maxlag + 1] ** 2)[lags - 1]
     pvalbp = np.full_like(qljungbox, np.nan)
     pvalbp[loc] = stats.chi2.sf(qboxpierce[loc], adj_lags[loc])
-    return pd.DataFrame({"lb_stat": qljungbox, "lb_pvalue": pval,
-                         "bp_stat": qboxpierce, "bp_pvalue": pvalbp},
-                        index=lags)
+    return pd.DataFrame(
+        {
+            "lb_stat": qljungbox,
+            "lb_pvalue": pval,
+            "bp_stat": qboxpierce,
+            "bp_pvalue": pvalbp,
+        },
+        index=lags,
+    )
 
 
 class LMTestResult(NamedTuple):
@@ -600,9 +619,17 @@ class LMTestResult(NamedTuple):
     res_store: ResultsStore | None
 
 
-def acorr_lm(resid, nlags=None, store=False, *, period=None,
-             ddof=0, cov_type="nonrobust", cov_kwds=None,
-             use_namedtuple: bool | None = None):
+def acorr_lm(
+    resid,
+    nlags=None,
+    store=False,
+    *,
+    period=None,
+    ddof=0,
+    cov_type="nonrobust",
+    cov_kwds=None,
+    use_namedtuple: bool | None = None,
+):
     """
     Lagrange Multiplier tests for autocorrelation
 
@@ -705,8 +732,9 @@ def acorr_lm(resid, nlags=None, store=False, *, period=None,
     res_store = ResultsStore()
     usedlag = maxlag
 
-    resols = OLS(xshort, xdall[:, :usedlag + 1]).fit(cov_type=cov_type,
-                                                     cov_kwds=cov_kwds)
+    resols = OLS(xshort, xdall[:, : usedlag + 1]).fit(
+        cov_type=cov_type, cov_kwds=cov_kwds
+    )
     fval = float(resols.fvalue)
     fpval = float(resols.f_pvalue)
     if cov_type == "nonrobust":
@@ -743,8 +771,9 @@ def acorr_lm(resid, nlags=None, store=False, *, period=None,
     return lm, lmpval, fval, fpval
 
 
-def het_arch(resid, nlags=None, store=False, ddof=0, *,
-            use_namedtuple: bool | None = None):
+def het_arch(
+    resid, nlags=None, store=False, ddof=0, *, use_namedtuple: bool | None = None
+):
     """
     Engle's Test for Autoregressive Conditional Heteroscedasticity (ARCH)
 
@@ -801,12 +830,14 @@ def het_arch(resid, nlags=None, store=False, ddof=0, *,
     -----
     verified against R:FinTS::ArchTest
     """
-    return acorr_lm(resid ** 2, nlags=nlags, store=store, ddof=ddof,
-                    use_namedtuple=use_namedtuple)
+    return acorr_lm(
+        resid**2, nlags=nlags, store=store, ddof=ddof, use_namedtuple=use_namedtuple
+    )
 
 
-def acorr_breusch_godfrey(res, nlags=None, store=False, *,
-                          use_namedtuple: bool | None = None):
+def acorr_breusch_godfrey(
+    res, nlags=None, store=False, *, use_namedtuple: bool | None = None
+):
     """
     Breusch-Godfrey Lagrange Multiplier tests for residual autocorrelation
 
@@ -871,8 +902,9 @@ def acorr_breusch_godfrey(res, nlags=None, store=False, *,
     use_namedtuple = bool_like(use_namedtuple, "use_namedtuple", optional=True)
     x = np.asarray(res.resid).squeeze()
     if x.ndim != 1:
-        raise ValueError("Model resid must be a 1d array. Cannot be used on"
-                         " multivariate models.")
+        raise ValueError(
+            "Model resid must be a 1d array. Cannot be used on" " multivariate models."
+        )
     exog_old = res.model.exog
     nobs = x.shape[0]
     if nlags is None:
@@ -938,10 +970,7 @@ def _check_het_test(x: np.ndarray, test_name: str) -> None:
         The test name for the exception
     """
     x_max = x.max(axis=0)
-    if (
-        not np.any(((x_max - x.min(axis=0)) == 0) & (x_max != 0))
-        or x.shape[1] < 2
-    ):
+    if not np.any(((x_max - x.min(axis=0)) == 0) & (x_max != 0)) or x.shape[1] < 2:
         raise ValueError(
             f"{test_name} test requires exog to have at least "
             "two columns where one is a constant."
@@ -1077,7 +1106,7 @@ def het_white(resid, exog, interaction_terms=True):
         i0, i1 = np.triu_indices(nvars0)
         exog = x[:, i0] * x[:, i1]
         nobs, nvars = exog.shape
-    resols = OLS(y ** 2, exog).fit()
+    resols = OLS(y**2, exog).fit()
     fval = resols.fvalue
     fpval = resols.f_pvalue
     lm = nobs * resols.rsquared
@@ -1094,9 +1123,17 @@ class GoldfeldQuandtResult(NamedTuple):
     res_store: ResultsStore | None
 
 
-def het_goldfeldquandt(y, x, idx=None, split=None, drop=None,
-                       alternative="increasing", store=False, *,
-                       use_namedtuple: bool | None = None):
+def het_goldfeldquandt(
+    y,
+    x,
+    idx=None,
+    split=None,
+    drop=None,
+    alternative="increasing",
+    store=False,
+    *,
+    use_namedtuple: bool | None = None,
+):
     """
     Goldfeld-Quandt homoskedasticity test
 
@@ -1179,12 +1216,12 @@ def het_goldfeldquandt(y, x, idx=None, split=None, drop=None,
     nobs, nvars = x.shape
     if split is None:
         split = nobs // 2
-    elif (0 < split < 1):
+    elif 0 < split < 1:
         split = int(nobs * split)
 
     if drop is None:
         start2 = split
-    elif (0 < drop < 1):
+    elif 0 < drop < 1:
         start2 = split + int(nobs * drop)
     else:
         start2 = split + drop
@@ -1202,7 +1239,7 @@ def het_goldfeldquandt(y, x, idx=None, split=None, drop=None,
         fpval = stats.f.sf(fval, resols1.df_resid, resols2.df_resid)
         ordering = "increasing"
     elif alternative.lower() in ["d", "dec", "decreasing"]:
-        fpval = stats.f.sf(1. / fval, resols2.df_resid, resols1.df_resid)
+        fpval = stats.f.sf(1.0 / fval, resols2.df_resid, resols1.df_resid)
         ordering = "decreasing"
     elif alternative.lower() in ["2", "2-sided", "two-sided"]:
         fpval_sm = stats.f.cdf(fval, resols2.df_resid, resols1.df_resid)
@@ -1248,8 +1285,9 @@ F-statistic ={fval:8.4f} and p-value ={fpval:8.4f}"""
     return fval, fpval, ordering
 
 
-def linear_reset(res, power=3, test_type="fitted", use_f=False,
-                 cov_type="nonrobust", cov_kwds=None):
+def linear_reset(
+    res, power=3, test_type="fitted", use_f=False, cov_type="nonrobust", cov_kwds=None
+):
     r"""
     Ramsey's RESET test for neglected nonlinearity
 
@@ -1312,11 +1350,14 @@ def linear_reset(res, power=3, test_type="fitted", use_f=False,
     if not isinstance(res, RegressionResultsWrapper):
         raise TypeError("result must come from a linear regression model")
     if bool(res.model.k_constant) and res.model.exog.shape[1] == 1:
-        raise ValueError("exog contains only a constant column. The RESET "
-                         "test requires exog to have at least 1 "
-                         "non-constant column.")
-    test_type = string_like(test_type, "test_type",
-                            options=("fitted", "exog", "princomp"))
+        raise ValueError(
+            "exog contains only a constant column. The RESET "
+            "test requires exog to have at least 1 "
+            "non-constant column."
+        )
+    test_type = string_like(
+        test_type, "test_type", options=("fitted", "exog", "princomp")
+    )
     cov_kwds = dict_like(cov_kwds, "cov_kwds", optional=True)
     use_f = bool_like(use_f, "use_f")
     if isinstance(power, int):
@@ -1328,8 +1369,7 @@ def linear_reset(res, power=3, test_type="fitted", use_f=False,
             power = np.array(power, dtype=int)
         except Exception as exc:
             raise ValueError("power must be an integer or list of integers") from exc
-        if power.ndim != 1 or len(set(power)) != power.shape[0] or \
-                (power < 2).any():
+        if power.ndim != 1 or len(set(power)) != power.shape[0] or (power < 2).any():
             raise ValueError("power must contains distinct integers all >= 2")
     exog = res.model.exog
     if test_type == "fitted":
@@ -1337,29 +1377,35 @@ def linear_reset(res, power=3, test_type="fitted", use_f=False,
     elif test_type == "exog":
         # Remove constant and binary
         aug = res.model.exog
-        binary = ((exog == exog.max(axis=0)) | (exog == exog.min(axis=0)))
+        binary = (exog == exog.max(axis=0)) | (exog == exog.min(axis=0))
         binary = binary.all(axis=0)
         if binary.all():
             raise ValueError("Model contains only constant or binary data")
         aug = aug[:, ~binary]
     else:
         from statsmodels.multivariate.pca import PCA
+
         aug = exog
         if res.k_constant:
             retain = np.arange(aug.shape[1]).tolist()
             retain.pop(int(res.model.data.const_idx))
             aug = aug[:, retain]
-        pca = PCA(aug, ncomp=1, standardize=bool(res.k_constant),
-                  demean=bool(res.k_constant), method="nipals")
+        pca = PCA(
+            aug,
+            ncomp=1,
+            standardize=bool(res.k_constant),
+            demean=bool(res.k_constant),
+            method="nipals",
+        )
         aug = pca.factors[:, :1]
-    aug_exog = np.hstack([exog] + [aug ** p for p in power])
+    aug_exog = np.hstack([exog] + [aug**p for p in power])
     mod_class = res.model.__class__
     mod = mod_class(res.model.data.endog, aug_exog)
     cov_kwds = {} if cov_kwds is None else cov_kwds
     res = mod.fit(cov_type=cov_type, cov_kwds=cov_kwds)
     nrestr = aug_exog.shape[1] - exog.shape[1]
     nparams = aug_exog.shape[1]
-    r_mat = np.eye(nrestr, nparams, k=nparams-nrestr)
+    r_mat = np.eye(nrestr, nparams, k=nparams - nrestr)
     return res.wald_test(r_mat, use_f=use_f, scalar=True)
 
 
@@ -1406,8 +1452,7 @@ def linear_harvey_collier(res, order_by=None, skip=None):
     return stats.ttest_1samp(rr[3][3:], 0)
 
 
-def linear_rainbow(res, frac=0.5, order_by=None, use_distance=False,
-                   center=None):
+def linear_rainbow(res, frac=0.5, order_by=None, use_distance=False, center=None):
     """
     Rainbow test for linearity
 
@@ -1455,8 +1500,7 @@ def linear_rainbow(res, frac=0.5, order_by=None, use_distance=False,
     endog = res.model.endog
     exog = res.model.exog
     if order_by is not None and use_distance:
-        raise ValueError("order_by and use_distance cannot be simultaneously"
-                         "used.")
+        raise ValueError("order_by and use_distance cannot be simultaneously" "used.")
     if order_by is not None:
         if isinstance(order_by, np.ndarray):
             order_by = array_like(order_by, "order_by", ndim=1, dtype="int")
@@ -1466,9 +1510,11 @@ def linear_rainbow(res, frac=0.5, order_by=None, use_distance=False,
             try:
                 cols = res.model.data.orig_exog[order_by].copy()
             except (IndexError, KeyError) as exc:
-                raise TypeError("order_by must contain valid column names "
-                                "from the exog data used to construct res,"
-                                "and exog must be a pandas DataFrame.") from exc
+                raise TypeError(
+                    "order_by must contain valid column names "
+                    "from the exog data used to construct res,"
+                    "and exog must be a pandas DataFrame."
+                ) from exc
             name = "__index__"
             while name in cols:
                 name += "_"
@@ -1482,13 +1528,14 @@ def linear_rainbow(res, frac=0.5, order_by=None, use_distance=False,
         if isinstance(center, float):
             if not 0.0 <= center <= 1.0:
                 raise ValueError("center must be in (0, 1) when a float.")
-            center = int(center * (nobs-1))
+            center = int(center * (nobs - 1))
         else:
             center = int_like(center, "center")
             if not 0 < center < nobs - 1:
                 raise ValueError("center must be in [0, nobs) when an int.")
-        center_obs = exog[center:center+1]
+        center_obs = exog[center : center + 1]
         from scipy.spatial.distance import cdist
+
         try:
             err = exog - center_obs
             vi = np.linalg.inv(err.T @ err / nobs)
@@ -1503,9 +1550,11 @@ def linear_rainbow(res, frac=0.5, order_by=None, use_distance=False,
     lowidx = np.ceil(0.5 * (1 - frac) * nobs).astype(int)
     uppidx = np.floor(lowidx + frac * nobs).astype(int)
     if uppidx - lowidx < exog.shape[1]:
-        raise ValueError("frac is too small to perform test. frac * nobs"
-                         "must be greater than the number of exogenous"
-                         "variables in the model.")
+        raise ValueError(
+            "frac is too small to perform test. frac * nobs"
+            "must be greater than the number of exogenous"
+            "variables in the model."
+        )
     mi_sl = slice(lowidx, uppidx)
     res_mi = OLS(endog[mi_sl], exog[mi_sl]).fit()
     nobs_mi = res_mi.model.endog.shape[0]
@@ -1552,8 +1601,10 @@ def linear_lm(resid, exog, func=None):
     correct.
     """
     if func is None:
+
         def func(x):
             return np.power(x, 2)
+
     exog = np.asarray(exog)
     exog_aux = np.column_stack((exog, func(exog[:, 1:])))
 
@@ -1618,8 +1669,10 @@ def spec_white(resid, exog):
     x = array_like(exog, "exog", ndim=2)
     e = array_like(resid, "resid", ndim=1)
     if x.shape[1] < 2 or not np.any(np.ptp(x, 0) == 0.0):
-        raise ValueError("White's specification test requires at least two"
-                         "columns where one is a constant.")
+        raise ValueError(
+            "White's specification test requires at least two"
+            "columns where one is a constant."
+        )
 
     # add interaction terms
     i0, i1 = np.triu_indices(x.shape[1])
@@ -1648,8 +1701,7 @@ def spec_white(resid, exog):
     return stat, pval, dof
 
 
-def recursive_olsresiduals(res, skip=None, lamda=0.0, alpha=0.95,
-                           order_by=None):
+def recursive_olsresiduals(res, skip=None, lamda=0.0, alpha=0.95, order_by=None):
     """
     Calculate recursive ols with residuals and Cusum test statistic
 
@@ -1712,8 +1764,9 @@ def recursive_olsresiduals(res, skip=None, lamda=0.0, alpha=0.95,
         raise TypeError("res a regression results instance")
     y = res.model.endog
     x = res.model.exog
-    order_by = array_like(order_by, "order_by", dtype="int", optional=True,
-                          ndim=1, shape=(y.shape[0],))
+    order_by = array_like(
+        order_by, "order_by", dtype="int", optional=True, ndim=1, shape=(y.shape[0],)
+    )
     # intialize with skip observations
     if order_by is not None:
         x = x[order_by]
@@ -1745,7 +1798,7 @@ skip large enough to ensure that the first OLS estimator is well-defined.
     rresid[skip - 1] = y[skip - 1] - yipred
     rvarraw[skip - 1] = 1 + np.dot(x[skip - 1], np.dot(xtxi, x[skip - 1]))
     for i in range(skip, nobs):
-        xi = x[i:i + 1, :]
+        xi = x[i : i + 1, :]
         yi = y[i]
 
         # get prediction error with previous beta
@@ -1771,7 +1824,7 @@ skip large enough to ensure that the first OLS estimator is well-defined.
     # Gretl uses: by reverse engineering matching their numbers
     sigma2 = rresid_scaled[skip:].var(ddof=1)
     rresid_standardized = rresid_scaled / np.sqrt(sigma2)  # N(0,1) distributed
-    rcusum = rresid_standardized[skip - 1:].cumsum()
+    rcusum = rresid_standardized[skip - 1 :].cumsum()
     # confidence interval points in Greene p136 looks strange. Cleared up
     # this assumes sum of independent standard normal, which does not take into
     # account that we make many tests at the same time
@@ -1786,10 +1839,18 @@ skip large enough to ensure that the first OLS estimator is well-defined.
 
     # following taken from Ploberger,
     # crit = a * np.sqrt(nrr)
-    rcusumci = (a * np.sqrt(nrr) + 2 * a * np.arange(0, nobs - skip) / np.sqrt(
-        nrr)) * np.array([[-1.], [+1.]])
-    return (rresid, rparams, rypred, rresid_standardized, rresid_scaled,
-            rcusum, rcusumci)
+    rcusumci = (
+        a * np.sqrt(nrr) + 2 * a * np.arange(0, nobs - skip) / np.sqrt(nrr)
+    ) * np.array([[-1.0], [+1.0]])
+    return (
+        rresid,
+        rparams,
+        rypred,
+        rresid_standardized,
+        rresid_scaled,
+        rcusum,
+        rcusumci,
+    )
 
 
 def breaks_hansen(olsresults):
@@ -1825,14 +1886,16 @@ def breaks_hansen(olsresults):
     x = olsresults.model.exog
     resid = array_like(olsresults.resid, "resid", ndim=1, shape=(x.shape[0],))
     nobs, nvars = x.shape
-    resid2 = resid ** 2
+    resid2 = resid**2
     ft = np.c_[x * resid[:, None], (resid2 - resid2.mean())]
     score = ft.cumsum(0)
     f = nobs * (ft[:, :, None] * ft[:, None, :]).sum(0)
     s = (score[:, :, None] * score[:, None, :]).sum(0)
     h = np.trace(np.dot(np.linalg.inv(f), s))
-    crit95 = np.array([(2, 1.01), (6, 1.9), (15, 3.75), (19, 4.52)],
-                      dtype=[("nobs", int), ("crit", float)])
+    crit95 = np.array(
+        [(2, 1.01), (6, 1.9), (15, 3.75), (19, 4.52)],
+        dtype=[("nobs", int), ("crit", float)],
+    )
     # TODO: get critical values from Bruce Hansen's 1992 paper
     return h, crit95
 
@@ -1881,7 +1944,7 @@ def breaks_cusumolsresid(resid, ddof=0):
     """
     resid = np.asarray(resid).ravel()
     nobs = len(resid)
-    nobssigma2 = (resid ** 2).sum()
+    nobssigma2 = (resid**2).sum()
     if ddof > 0:
         nobssigma2 = nobssigma2 / (nobs - ddof) * nobs
     # b is asymptotically a Brownian Bridge
@@ -1895,6 +1958,7 @@ def breaks_cusumolsresid(resid, ddof=0):
     # array([ 1.62762361,  1.35809864,  1.22384787])
     pval = stats.kstwobign.sf(sup_b)
     return sup_b, pval, crit
+
 
 # def breaks_cusum(recolsresid):
 #    """renormalized cusum test for parameter stability based on recursive

--- a/statsmodels/tsa/ar_model.py
+++ b/statsmodels/tsa/ar_model.py
@@ -55,9 +55,22 @@ __all__ = ["AR", "AutoReg", "InformationCriteria"]
 
 
 class InformationCriteria(NamedTuple):
-    """Result of order-selection information-criteria computations, shared
+    """
+    Result of order-selection information-criteria computations, shared
     between :func:`ar_select_order` and
-    :func:`~statsmodels.tsa.ardl.model.ardl_select_order`."""
+    :func:`~statsmodels.tsa.ardl.model.ardl_select_order`.
+
+    Parameters
+    ----------
+    aic : float
+        The Akaike information criterion for the candidate model order.
+    bic : float
+        The Bayesian (Schwarz) information criterion for the candidate
+        model order.
+    hqic : float
+        The Hannan-Quinn information criterion for the candidate model
+        order.
+    """
 
     aic: float
     bic: float

--- a/statsmodels/tsa/arima/estimators/_base.py
+++ b/statsmodels/tsa/arima/estimators/_base.py
@@ -9,7 +9,8 @@ from typing import NamedTuple
 
 
 class ARMAEstimationResult(NamedTuple):
-    """Result of an ARIMA parameter estimator.
+    """
+    Result of an ARIMA parameter estimator.
 
     Common to :func:`~statsmodels.tsa.arima.estimators.burg.burg`,
     :func:`~statsmodels.tsa.arima.estimators.gls.gls`,
@@ -19,6 +20,19 @@ class ARMAEstimationResult(NamedTuple):
     :func:`~statsmodels.tsa.arima.estimators.yule_walker.yule_walker`,
     :func:`~statsmodels.tsa.arima.estimators.durbin_levinson.durbin_levinson`,
     and :func:`~statsmodels.tsa.arima.estimators.statespace.statespace`.
+
+    Parameters
+    ----------
+    parameters : SARIMAXParams or list of SARIMAXParams
+        Contains the parameter estimates from the final iteration. A list
+        of ``SARIMAXParams`` objects for :func:`innovations` and
+        :func:`durbin_levinson`, which estimate at multiple orders; a
+        single ``SARIMAXParams`` object for all other estimators.
+    other_results : Bunch
+        Estimator-specific ancillary results, always including at least
+        ``spec``, the ``SARIMAXSpecification`` instance corresponding to
+        the input arguments. See the individual estimator's docstring for
+        the full set of components.
     """
 
     parameters: object

--- a/statsmodels/tsa/filters/filtertools.py
+++ b/statsmodels/tsa/filters/filtertools.py
@@ -28,8 +28,20 @@ if TYPE_CHECKING:
 
 
 class CycleTrendResult(NamedTuple):
-    """Result of :func:`cffilter`, :func:`hamilton_filter`, and
-    :func:`hpfilter`: a cycle/trend decomposition."""
+    """
+    Result of :func:`cffilter`, :func:`hamilton_filter`, and
+    :func:`hpfilter`: a cycle/trend decomposition.
+
+    Parameters
+    ----------
+    cycle : array_like
+        The estimated cyclical component. See the docstring of the
+        function that produced this result for the precise definition
+        (e.g. :func:`hamilton_filter` leaves the first ``p + h - 1``
+        values as ``NaN``).
+    trend : array_like
+        The estimated trend component, matching ``cycle`` in shape.
+    """
 
     cycle: ArrayLike1D | ArrayLike2D
     trend: ArrayLike1D | ArrayLike2D

--- a/statsmodels/tsa/stattools/_stattools.py
+++ b/statsmodels/tsa/stattools/_stattools.py
@@ -172,7 +172,30 @@ def _autolag(
 
 
 class ADFullerResult(NamedTuple):
-    """Result of :func:`adfuller` when ``use_namedtuple=True``."""
+    """
+    Result of :func:`adfuller` when ``use_namedtuple=True``.
+
+    Parameters
+    ----------
+    adf : float
+        The test statistic.
+    pvalue : float
+        MacKinnon's approximate p-value based on MacKinnon (1994, 2010).
+    usedlag : int
+        The number of lags used.
+    nobs : int
+        The number of observations used for the ADF regression and
+        calculation of the critical values.
+    critical_values : dict[str, float]
+        Critical values for the test statistic at the 1 %, 5 %, and 10 %
+        levels. Based on MacKinnon (2010).
+    icbest : float or None
+        The maximized information criterion if autolag is not None,
+        otherwise None.
+    resstore : ResultsStore or None
+        A dummy class with results attached as attributes, if ``store`` was
+        True, otherwise None.
+    """
 
     adf: float
     pvalue: float
@@ -599,7 +622,16 @@ def acovf(x, adjusted=False, demean=True, fft=True, missing="none", nlag=None):
 
 
 class JackknifeResult(NamedTuple):
-    """Result of :func:`block_jackknife`."""
+    """
+    Result of :func:`block_jackknife`.
+
+    Parameters
+    ----------
+    theta_jack : float or ndarray
+        The bias-corrected jackknife point estimate.
+    se : float or ndarray
+        The jackknife standard error estimate.
+    """
 
     theta_jack: float | np.ndarray
     se: float | np.ndarray
@@ -723,7 +755,16 @@ def block_jackknife(x, statistic, n_blocks=-1):
 
 
 class QStatResult(NamedTuple):
-    """Result of :func:`q_stat`."""
+    """
+    Result of :func:`q_stat`.
+
+    Parameters
+    ----------
+    qstat : ndarray
+        Ljung-Box Q-statistic for autocorrelation parameters.
+    pvalue : ndarray
+        P-value of the Q statistic.
+    """
 
     qstat: np.ndarray
     pvalue: np.ndarray
@@ -776,8 +817,25 @@ def q_stat(x, nobs):
 # see for example
 # http://www.itl.nist.gov/div898/handbook/eda/section3/autocopl.htm
 class AcfResult(NamedTuple):
-    """Result of :func:`acf` when ``qstat`` or ``alpha`` is set and
-    ``use_namedtuple=True``."""
+    """
+    Result of :func:`acf` when ``qstat`` or ``alpha`` is set and
+    ``use_namedtuple=True``.
+
+    Parameters
+    ----------
+    acf : ndarray
+        The autocorrelation function for lags 0, 1, ..., nlags. Shape
+        (nlags+1,).
+    confint : ndarray or None
+        Confidence intervals for the ACF at lags 0, 1, ..., nlags. Shape
+        (nlags + 1, 2). ``None`` unless ``alpha`` was not None.
+    qstat : ndarray or None
+        The Ljung-Box Q-statistic for autocorrelation parameters. ``None``
+        unless ``qstat`` was True.
+    pvalues : ndarray or None
+        The p-values associated with the Q-statistics of the Ljung-Box
+        autocorrelation test. ``None`` unless ``qstat`` was True.
+    """
 
     acf: np.ndarray
     confint: np.ndarray | None
@@ -1038,7 +1096,17 @@ def pacf_yw(
 
 
 class PacfBurgResult(NamedTuple):
-    """Result of :func:`pacf_burg`."""
+    """
+    Result of :func:`pacf_burg`.
+
+    Parameters
+    ----------
+    pacf : ndarray
+        Partial autocorrelations for lags 0, 1, ..., nlag.
+    sigma2 : ndarray
+        Residual variance estimates where the value in position m is the
+        residual variance in an AR model that includes m lags.
+    """
 
     pacf: np.ndarray
     sigma2: np.ndarray
@@ -1208,8 +1276,18 @@ def pacf_ols(
 
 
 class PacfResult(NamedTuple):
-    """Result of :func:`pacf` when ``alpha`` is not None and
-    ``use_namedtuple=True``."""
+    """
+    Result of :func:`pacf` when ``alpha`` is not None and
+    ``use_namedtuple=True``.
+
+    Parameters
+    ----------
+    pacf : ndarray
+        Partial autocorrelations for lags 0, 1, ..., nlags.
+    confint : ndarray
+        Confidence intervals for the PACF at lags 0, 1, ..., nlags. Shape
+        (nlags + 1, 2).
+    """
 
     pacf: np.ndarray
     confint: np.ndarray
@@ -1451,8 +1529,21 @@ def ccovf(x, y, adjusted=True, demean=True, fft=True):
 
 
 class CcfResult(NamedTuple):
-    """Result of :func:`ccf` when ``alpha`` is not None and
-    ``use_namedtuple=True``."""
+    """
+    Result of :func:`ccf` when ``alpha`` is not None and
+    ``use_namedtuple=True``.
+
+    Parameters
+    ----------
+    ccf : ndarray
+        The cross-correlation function of x and y: the element at index k
+        is the correlation between {x[k], x[k+1], ..., x[n]} and
+        {y[0], y[1], ..., y[m-k]}, where n and m are the lengths of x and
+        y, respectively.
+    confint : ndarray
+        Confidence intervals for the CCF at lags 0, 1, ..., nlags-1. Shape
+        (nlags, 2).
+    """
 
     ccf: np.ndarray
     confint: np.ndarray
@@ -1682,8 +1773,18 @@ def _pccf_ols(x, y, nlags):
 
 
 class PccfResult(NamedTuple):
-    """Result of :func:`pccf` when ``alpha`` is not None and
-    ``use_namedtuple=True``."""
+    """
+    Result of :func:`pccf` when ``alpha`` is not None and
+    ``use_namedtuple=True``.
+
+    Parameters
+    ----------
+    pccf : ndarray
+        The partial cross-correlation function for lags 1, 2, ..., nlags.
+    confint : ndarray
+        Confidence intervals for the PCCF at lags 1, 2, ..., nlags. Shape
+        (nlags, 2).
+    """
 
     pccf: np.ndarray
     confint: np.ndarray
@@ -1912,7 +2013,25 @@ def pccf(
 # moved from sandbox.tsa.examples.try_ld_nitime, via nitime
 # TODO: check what to return, for testing and trying out returns everything
 class LevinsonDurbinResult(NamedTuple):
-    """Result of :func:`levinson_durbin`."""
+    """
+    Result of :func:`levinson_durbin`.
+
+    Parameters
+    ----------
+    sigma_v : float
+        The estimate of the error variance.
+    arcoefs : ndarray
+        The estimate of the autoregressive coefficients for a model
+        including nlags.
+    pacf : ndarray
+        The partial autocorrelation function.
+    sigma : ndarray
+        The entire sigma array from intermediate result, last value is
+        sigma_v.
+    phi : ndarray
+        The entire phi array from intermediate result, last column
+        contains autoregressive coefficients for AR(nlags).
+    """
 
     sigma_v: float
     arcoefs: np.ndarray
@@ -1995,7 +2114,17 @@ def levinson_durbin(s, nlags=10, isacov=False):
 
 
 class LevinsonDurbinPacfResult(NamedTuple):
-    """Result of :func:`levinson_durbin_pacf`."""
+    """
+    Result of :func:`levinson_durbin_pacf`.
+
+    Parameters
+    ----------
+    arcoefs : ndarray
+        AR coefficients computed from the partial autocorrelations.
+    acf : ndarray
+        The acf computed from the partial autocorrelations. Contains the
+        autocorrelations corresponding to lags 0, 1, ..., p.
+    """
 
     arcoefs: np.ndarray
     acf: np.ndarray
@@ -2062,7 +2191,16 @@ def levinson_durbin_pacf(pacf, nlags=None):
 
 
 class BreakvarHeteroskedasticityResult(NamedTuple):
-    """Result of :func:`breakvar_heteroskedasticity_test`."""
+    """
+    Result of :func:`breakvar_heteroskedasticity_test`.
+
+    Parameters
+    ----------
+    test_statistic : float or ndarray
+        Test statistic(s) H(h).
+    p_value : float or ndarray
+        p-value(s) of test statistic(s).
+    """
 
     test_statistic: float | np.ndarray
     p_value: float | np.ndarray
@@ -2403,7 +2541,21 @@ def grangercausalitytests(x, maxlag, addconst=True):
 
 
 class CointResult(NamedTuple):
-    """Result of :func:`coint`."""
+    """
+    Result of :func:`coint`.
+
+    Parameters
+    ----------
+    coint_t : float
+        The t-statistic of unit-root test on residuals.
+    pvalue : float
+        MacKinnon's approximate, asymptotic p-value based on MacKinnon
+        (1994).
+    crit_value : ndarray
+        Critical values for the test statistic at the 1 %, 5 %, and 10 %
+        levels based on regression curve. This depends on the number of
+        observations.
+    """
 
     coint_t: float
     pvalue: float
@@ -2576,7 +2728,27 @@ def has_missing(data):
 
 
 class KpssResult(NamedTuple):
-    """Result of :func:`kpss` when ``use_namedtuple=True``."""
+    """
+    Result of :func:`kpss` when ``use_namedtuple=True``.
+
+    Parameters
+    ----------
+    kpss_stat : float
+        The KPSS test statistic.
+    p_value : float
+        The p-value of the test. The p-value is interpolated from Table 1
+        in Kwiatkowski et al. (1992), and a boundary point is returned if
+        the test statistic is outside the table of critical values, that
+        is, if the p-value is outside the interval (0.01, 0.1).
+    lags : int
+        The truncation lag parameter.
+    crit : dict[str, float]
+        The critical values at 10%, 5%, 2.5% and 1%. Based on Kwiatkowski
+        et al. (1992).
+    resstore : ResultsStore or None
+        An instance of a dummy class with results attached as attributes,
+        if ``store`` was True, otherwise None.
+    """
 
     kpss_stat: float
     p_value: float
@@ -2870,7 +3042,25 @@ def _kpss_autolag(resids, nobs):
 
 
 class RangeUnitRootTestResult(NamedTuple):
-    """Result of :func:`range_unit_root_test` when ``use_namedtuple=True``."""
+    """
+    Result of :func:`range_unit_root_test` when ``use_namedtuple=True``.
+
+    Parameters
+    ----------
+    rur_stat : float
+        The RUR test statistic.
+    p_value : float
+        The p-value of the test. The p-value is interpolated from Table 1
+        in Aparicio et al. (2006), and a boundary point is returned if the
+        test statistic is outside the table of critical values, that is,
+        if the p-value is outside the interval (0.01, 0.1).
+    crit : dict[str, float]
+        The critical values at 10%, 5%, 2.5% and 1%. Based on Aparicio et
+        al. (2006).
+    resstore : ResultsStore or None
+        An instance of a dummy class with results attached as attributes,
+        if ``store`` was True, otherwise None.
+    """
 
     rur_stat: float
     p_value: float

--- a/statsmodels/tsa/tsatools.py
+++ b/statsmodels/tsa/tsatools.py
@@ -295,8 +295,18 @@ def detrend(x, order=1, axis=0):
 
 
 class LagmatResult(NamedTuple):
-    """Result of :func:`lagmat` when ``original="sep"`` and
-    ``use_namedtuple=True``."""
+    """
+    Result of :func:`lagmat` when ``original="sep"`` and
+    ``use_namedtuple=True``.
+
+    Parameters
+    ----------
+    lags : ndarray or DataFrame
+        The array with lagged observations.
+    leads : ndarray or DataFrame
+        The original (unlagged) array, truncated to have the same number
+        of rows as ``lags``.
+    """
 
     lags: NDArray | DataFrame
     leads: NDArray | DataFrame

--- a/statsmodels/tsa/vector_ar/hypothesis_test_results.py
+++ b/statsmodels/tsa/vector_ar/hypothesis_test_results.py
@@ -6,8 +6,20 @@ from statsmodels.iolib.table import SimpleTable
 
 
 class ForecastInterval(NamedTuple):
-    """Result of the module-level :func:`~statsmodels.tsa.vector_ar.var_model.forecast_interval`
-    and :meth:`~statsmodels.tsa.vector_ar.var_model.VARProcess.forecast_interval`."""
+    """
+    Result of the module-level
+    :func:`~statsmodels.tsa.vector_ar.var_model.forecast_interval` and
+    :meth:`~statsmodels.tsa.vector_ar.var_model.VARProcess.forecast_interval`.
+
+    Parameters
+    ----------
+    point_forecast : ndarray
+        Mean value of forecast.
+    forc_lower : ndarray
+        Lower bound of confidence interval.
+    forc_upper : ndarray
+        Upper bound of confidence interval.
+    """
 
     point_forecast: np.ndarray
     forc_lower: np.ndarray
@@ -15,13 +27,22 @@ class ForecastInterval(NamedTuple):
 
 
 class ErrorBand(NamedTuple):
-    """Impulse-response error band, shared by
+    """
+    Impulse-response error band, shared by
     :meth:`~statsmodels.tsa.vector_ar.irf.IRAnalysis.err_band_sz1`,
     :meth:`~statsmodels.tsa.vector_ar.irf.IRAnalysis.err_band_sz2`,
     :meth:`~statsmodels.tsa.vector_ar.irf.IRAnalysis.err_band_sz3`,
     :meth:`~statsmodels.tsa.vector_ar.irf.IRAnalysis.errband_mc`,
     :meth:`~statsmodels.tsa.vector_ar.svar_model.SVARResults.sirf_errband_mc`,
-    and :meth:`~statsmodels.tsa.vector_ar.var_model.VARResults.irf_errband_mc`."""
+    and :meth:`~statsmodels.tsa.vector_ar.var_model.VARResults.irf_errband_mc`.
+
+    Parameters
+    ----------
+    lower : ndarray
+        Lower error band for the impulse responses.
+    upper : ndarray
+        Upper error band for the impulse responses.
+    """
 
     lower: np.ndarray
     upper: np.ndarray


### PR DESCRIPTION
Every NamedTuple result class added by the ongoing return-type migration (tsa.stattools, tsatools.lagmat, filters.filtertools, ar_model, vector_ar.hypothesis_test_results, arima.estimators._base) previously had only a one-line docstring, so their fields rendered with no description on the generated docs page. Add a numpydoc "Parameters" section to each, describing every field, sourced from the owning function's own Returns section so the class docstring is self-contained.

- [ ] closes #xxxx
- [ ] tests added / passed. 
- [ ] code/documentation is well formatted.  
- [ ] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
