### PR TITLE
DOC: Improve docstrings and css

### DIFF
--- a/docs/source/_static/stylesheets/deprecation.css
+++ b/docs/source/_static/stylesheets/deprecation.css
@@ -1,65 +1,38 @@
-span.versionmodified.deprecated {
-  color: #c00;
-  font-weight: bold;
-}
+/*
+ * Version directives -- `.. deprecated::`, `.. versionadded::` and
+ * `.. versionchanged::` -- are deliberately left to pydata-sphinx-theme's own
+ * styling so that they render the same way they do in other projects built on
+ * the theme (pandas, for example).
+ *
+ * The theme draws them as a rounded panel with a thick coloured accent bar down
+ * the left edge, a drop shadow, a FontAwesome icon in front of the "Deprecated
+ * since version X" label, and body-sized text.  Its colours come from CSS
+ * custom properties -- --pst-color-danger, --pst-color-danger-bg and
+ * --pst-color-info -- which is what lets the panels follow the light/dark theme
+ * toggle.
+ *
+ * This file previously overrode those rules with hard-coded values.  Because it
+ * is loaded after the theme stylesheet, and the selectors have the same
+ * specificity, the overrides won and the panels ended up
+ *   - at font-size 0.72rem while the surrounding page stayed at 1rem,
+ *   - with a thin 0.05rem border on all four sides, because the `border`
+ *     shorthand reset the theme's `border-left: 0.2rem` accent bar,
+ *   - with the label forced to bold, italic and #c00 rather than the theme's
+ *     upright, weight-600, inherited-colour text, and
+ *   - pinned to hard-coded colours, so `background-color: #FFFFFF` on the
+ *     shared rule stayed white in dark mode.
+ * Please do not reintroduce them; if the colours ever need to change, set the
+ * theme's custom properties instead.
+ */
 
+/*
+ * Unrelated to the version directives above: numpydoc wraps the type of each
+ * entry in a Parameters/Returns list in a `classifier` span, and this supplies
+ * the colon that separates the name from the type.
+ */
 span.classifier:before {
     font-style: normal;
     margin: 0 0.5em;
     content: ":";
     display: inline-block;
-}
-
-div.deprecated, div.versionadded, div.versionchanged {
-    background-color: #FFFFFF;
-    border: .05rem solid;
-    border-color: #459db9;
-    border-radius: .2rem;
-    /* box-shadow: 0 .2rem .5rem #d8d8d8,0 0 .0625rem #d8d8d8!important; */
-    margin: 1.5625em auto;
-    overflow: hidden;
-    padding: 0 .6rem;
-    page-break-inside: avoid;
-    position: relative;
-    transition: color .25s,background-color .25s,border-color .25s;
-    vertical-align: middle;
-    font-size: 0.72rem;
-}
-div.deprecated>p, div.versionadded>p, div.versionchanged>p {
-    margin-bottom: .6rem;
-    margin-top: .6rem;
-}
-
-div.deprecated {
-    border-color: #dc3545;
-    background-color: rgba(255, 0, 0, 0.1);
-}
-
-div.versionadded {
-    border-color: #459db9;
-    background-color: rgba(0, 191, 255, 0.1);
-}
-
-span.versionmodified {
-    font-weight: 600;
-}
-
-.versionmodified {
-    font-style: italic;
-}
-
-div.deprecated p:before {
-    background-color: #dc3545;
-}
-
-div.versionadded p:before {
-    background-color: #459db9;
-}
-
-span.versionmodified.deprecated:before {
-    color: #dc3545;
-}
-
-span.versionmodified.added {
-    color: #459db9;
 }

--- a/statsmodels/genmod/generalized_estimating_equations.py
+++ b/statsmodels/genmod/generalized_estimating_equations.py
@@ -746,10 +746,7 @@ class GEE(GLM):
             indicating the depth of the namespace to use. For example, the
             default ``eval_env=0`` uses the calling namespace.
             If you wish to use a "clean" environment set ``eval_env=-1``.
-
-        Optional arguments
-        ------------------
-        dep_data : str or array_like
+        dep_data : str or array_like, optional
             Data used for estimating the dependence structure.  See
             specific dependence structure classes (e.g. Nested) for
             details.  If `dep_data` is a string, it is interpreted as

--- a/statsmodels/graphics/regressionplots.py
+++ b/statsmodels/graphics/regressionplots.py
@@ -446,11 +446,11 @@ def plot_partregress(
         defining endog or exog.
     use_namedtuple : bool, optional
         Flag controlling whether a ``PartRegressPlotResult`` NamedTuple is
-        returned. If ``None`` (the default), a ``PartRegressPlotResult``
-        is returned when ``ret_coords`` is True and a bare figure
-        otherwise. Set to True to always receive a
-        ``PartRegressPlotResult``. Set to False to always receive the
-        legacy bare figure or ``(fig, coords)`` tuple.
+        returned. When ``ret_coords`` is True a ``PartRegressPlotResult``
+        is always returned; it holds the same two elements as the legacy
+        ``(fig, coords)`` tuple, so it unpacks and indexes identically.
+        Otherwise a bare figure is returned unless
+        ``use_namedtuple=True``.
 
         .. deprecated:: 0.15.0
 
@@ -628,8 +628,11 @@ def plot_partregress(
             FutureWarning,
             stacklevel=2,
         )
-    if use_namedtuple is False:
-        return (fig, coords) if ret_coords else fig
+    # PartRegressPlotResult has exactly the same length and contents as the
+    # legacy (fig, coords) tuple, so it unpacks and indexes identically and
+    # is always used when ret_coords=True.  Otherwise a bare figure is
+    # returned, as before; pass use_namedtuple=True to always get a
+    # PartRegressPlotResult.
     if use_namedtuple or ret_coords:
         return PartRegressPlotResult(fig, coords)
     return fig

--- a/statsmodels/graphics/tests/test_regressionplots.py
+++ b/statsmodels/graphics/tests/test_regressionplots.py
@@ -441,13 +441,19 @@ def test_plot_partregress_use_namedtuple(close_figures):
     assert res.coords is not None
     assert len(res.coords) == 2
 
+    # The NamedTuple is used whenever it unpacks identically, so
+    # use_namedtuple=False cannot opt out of it here.
     with warnings.catch_warnings():
         warnings.filterwarnings("error", category=FutureWarning)
         res = plot_partregress(
             y, x1, x2[:, None], ret_coords=True, use_namedtuple=False
         )
-    assert type(res) is tuple
+    assert isinstance(res, PartRegressPlotResult)
     assert len(res) == 2
+    # ...and it still unpacks like the legacy (fig, coords) tuple
+    fig, coords = res
+    assert fig is res.fig
+    assert coords is res.coords
 
 
 @pytest.mark.matplotlib

--- a/statsmodels/nonparametric/kde.py
+++ b/statsmodels/nonparametric/kde.py
@@ -398,10 +398,11 @@ def kdensity(
         Whether or not to return the grid over which the density is estimated.
     use_namedtuple : bool, optional
         Flag controlling whether a ``KDEResult`` NamedTuple is returned.
-        If ``None`` (the default), a ``KDEResult`` is returned when
-        ``retgrid`` is True (the default) and the legacy
-        ``(density, bw)`` tuple otherwise. Set to True to always receive a
-        ``KDEResult``. Set to False to always receive the legacy tuple.
+        When ``retgrid`` is True (the default) a ``KDEResult`` is always
+        returned; it holds the same three elements as the legacy
+        ``(density, grid, bw)`` tuple, so it unpacks and indexes
+        identically. When ``retgrid=False`` the legacy ``(density, bw)``
+        tuple is returned unless ``use_namedtuple=True``.
 
         .. deprecated:: 0.15.0
 
@@ -410,7 +411,7 @@ def kdensity(
             ``KDEResult`` rather than a ``(density, bw)`` tuple. Set
             ``use_namedtuple=True`` to opt in now, or
             ``use_namedtuple=False`` to silence the warning and keep the
-            current return type. ``KDEResult`` will be manadatory in 0.17
+            current return type. ``KDEResult`` will be mandatory in 0.17
             or after July 2028, whichever is later.
 
     Returns
@@ -589,10 +590,11 @@ def kdensityfft(
         Whether or not to return the grid over which the density is estimated.
     use_namedtuple : bool, optional
         Flag controlling whether a ``KDEResult`` NamedTuple is returned.
-        If ``None`` (the default), a ``KDEResult`` is returned when
-        ``retgrid`` is True (the default) and the legacy
-        ``(density, bw)`` tuple otherwise. Set to True to always receive a
-        ``KDEResult``. Set to False to always receive the legacy tuple.
+        When ``retgrid`` is True (the default) a ``KDEResult`` is always
+        returned; it holds the same three elements as the legacy
+        ``(density, grid, bw)`` tuple, so it unpacks and indexes
+        identically. When ``retgrid=False`` the legacy ``(density, bw)``
+        tuple is returned unless ``use_namedtuple=True``.
 
         .. deprecated:: 0.15.0
 
@@ -601,7 +603,7 @@ def kdensityfft(
             ``KDEResult`` rather than a ``(density, bw)`` tuple. Set
             ``use_namedtuple=True`` to opt in now, or
             ``use_namedtuple=False`` to silence the warning and keep the
-            current return type. ``KDEResult`` will be manadatory in 0.17
+            current return type. ``KDEResult`` will be mandatory in 0.17
             or after July 2028, whichever is later.
 
     Returns
@@ -722,8 +724,6 @@ def kdensityfft(
             FutureWarning,
             stacklevel=2,
         )
-    if use_namedtuple is False:
-        return (f, grid, bw) if retgrid else (f, bw)
     if use_namedtuple or retgrid:
         # `grid` is always computed, so it is returned even when
         # retgrid=False rather than being None-filled.

--- a/statsmodels/nonparametric/kde.py
+++ b/statsmodels/nonparametric/kde.py
@@ -405,12 +405,13 @@ def kdensity(
 
         .. deprecated:: 0.15.0
 
-            When ``retgrid=False``, in release 0.16.0 or after July 2028,
+            When ``retgrid=False``, in release 0.16.0 or after July 2027,
             whichever is later, the default will change to return a
             ``KDEResult`` rather than a ``(density, bw)`` tuple. Set
             ``use_namedtuple=True`` to opt in now, or
             ``use_namedtuple=False`` to silence the warning and keep the
-            current return type.
+            current return type. ``KDEResult`` will be manadatory in 0.17
+            or after July 2028, whichever is later.
 
     Returns
     -------
@@ -513,8 +514,6 @@ def kdensity(
             FutureWarning,
             stacklevel=2,
         )
-    if use_namedtuple is False:
-        return (dens, grid, bw) if retgrid else (dens, bw)
     if use_namedtuple or retgrid:
         # `grid` is always computed, so it is returned even when
         # retgrid=False rather than being None-filled.
@@ -597,12 +596,13 @@ def kdensityfft(
 
         .. deprecated:: 0.15.0
 
-            When ``retgrid=False``, in release 0.16.0 or after July 2028,
+            When ``retgrid=False``, in release 0.16.0 or after July 2027,
             whichever is later, the default will change to return a
             ``KDEResult`` rather than a ``(density, bw)`` tuple. Set
             ``use_namedtuple=True`` to opt in now, or
             ``use_namedtuple=False`` to silence the warning and keep the
-            current return type.
+            current return type. ``KDEResult`` will be manadatory in 0.17
+            or after July 2028, whichever is later.
 
     Returns
     -------

--- a/statsmodels/regression/linear_model.py
+++ b/statsmodels/regression/linear_model.py
@@ -1519,15 +1519,17 @@ def yule_walker(x, order=1, method="adjusted", df=None, inv=False, demean=True, 
         Flag indicating whether to return the results as a
         ``YuleWalkerResult`` NamedTuple instead of a plain tuple. If
         ``None`` (the default), the current tuple-returning behavior is
-        used and a ``FutureWarning`` is issued.
+        used and a ``FutureWarning`` is issued. If ``inv`` is True,
+        a ``YuleWalkerResult`` is always returned.
 
         .. deprecated:: 0.15.0
 
-            In release 0.16.0 or after July 2028, whichever is later, the
-            default will change to always return a ``YuleWalkerResult``.
+            In release 0.16.0 or after July 2027, whichever is later, the
+            default will change to returning a ``YuleWalkerResult``.
             Set ``use_namedtuple=True`` to opt in now, or
             ``use_namedtuple=False`` to silence the warning and keep the
-            current return type.
+            current return type. ``YuleWalkerResult`` will become mandatory
+            in release 0.17.0 or after July 2028, whichever is later.
 
     Returns
     -------
@@ -1543,7 +1545,7 @@ def yule_walker(x, order=1, method="adjusted", df=None, inv=False, demean=True, 
     sigma : float
         The estimate of the residual standard deviation.
     Rinv : ndarray, optional
-        The inverse of R. Only returned if `inv` is True.
+        The inverse of R. Only returned if ``inv`` is True, otherwise ``None``.
 
     See Also
     --------
@@ -1614,21 +1616,19 @@ def yule_walker(x, order=1, method="adjusted", df=None, inv=False, demean=True, 
         sigma = np.nan
     Rinv = np.linalg.inv(R) if inv else None
 
-    if use_namedtuple is None:
+    if use_namedtuple is None and not inv:
         warnings.warn(
             "yule_walker currently returns a plain tuple whose length "
             "depends on the inv argument. In release 0.16 or after July "
             "2028, whichever is later, the default behavior will switch "
-            "to always returning a YuleWalkerResult NamedTuple. Set "
+            "to returning a YuleWalkerResult NamedTuple. Set "
             "use_namedtuple=True to switch now, or use_namedtuple=False "
             "to keep the current behavior and silence this warning.",
             FutureWarning,
             stacklevel=2,
         )
-    if use_namedtuple:
+    if use_namedtuple or inv:
         return YuleWalkerResult(rho, sigma, Rinv)
-    if inv:
-        return rho, sigma, Rinv
     return rho, sigma
 
 
@@ -3376,11 +3376,12 @@ class OLSResults(RegressionResults):
 
             .. deprecated:: 0.15.0
 
-                In release 0.16.0 or after July 2028, whichever is later,
-                the default will change to always return an
-                ``ELTestResult``. Set ``use_namedtuple=True`` to opt in
-                now, or ``use_namedtuple=False`` to silence the warning and
-                keep the current return type.
+                In release 0.16.0 or after July 2027, whichever is later,
+                the default will change to returning an ``ELTestResult``.
+                Set ``use_namedtuple=True`` to opt in now, or
+                ``use_namedtuple=False`` to silence the warning and keep the
+                current return type.  ``ELTestResult`` will become mandatory
+                in release 0.17.0 or after July 2028, whichever is later.
 
         Returns
         -------

--- a/statsmodels/regression/linear_model.py
+++ b/statsmodels/regression/linear_model.py
@@ -3370,9 +3370,13 @@ class OLSResults(RegressionResults):
             regressors. The default is True.
         use_namedtuple : bool, optional
             Flag indicating whether to return the results as an
-            ``ELTestResult`` NamedTuple instead of a plain tuple. If
-            ``None`` (the default), the current tuple-returning behavior is
-            used and a ``FutureWarning`` is issued.
+            ``ELTestResult`` NamedTuple instead of a plain tuple. When the
+            nuisance parameters are produced -- ``ret_params`` is True and
+            ``len(param_nums) < len(params)`` -- the NamedTuple holds the
+            same four elements as the legacy tuple, so it unpacks
+            identically and is always returned, with no warning. Every
+            other combination returns the shorter legacy tuple by default
+            and issues a ``FutureWarning``.
 
             .. deprecated:: 0.15.0
 
@@ -3386,12 +3390,19 @@ class OLSResults(RegressionResults):
         Returns
         -------
         ELTestResult
-            If ``use_namedtuple=True``, a NamedTuple with fields ``llr``,
-            ``pval``, ``weights``, and ``nuisance_params`` (``weights`` is
-            ``None`` unless ``return_weights`` or ``ret_params`` is True;
+            A NamedTuple with fields ``llr``, ``pval``, ``weights`` and
+            ``nuisance_params`` (``weights`` is ``None`` unless
+            ``return_weights`` or ``ret_params`` is True;
             ``nuisance_params`` is ``None`` unless ``ret_params`` is True
             and ``len(param_nums) < len(params)``). See
             :class:`~statsmodels.regression.linear_model.ELTestResult`.
+
+            This is returned whenever ``use_namedtuple=True``. It is also
+            returned by default when the nuisance parameters were
+            produced -- that is, when ``ret_params`` is True and
+            ``len(param_nums) < len(params)`` -- because the NamedTuple
+            then has exactly the same four elements as the legacy tuple
+            and so unpacks identically; that case is adopted silently.
 
         Otherwise (the deprecated default), a plain tuple whose length
         depends on `return_weights` and `ret_params`, made up of a subset
@@ -3479,7 +3490,11 @@ class OLSResults(RegressionResults):
             else:
                 weights = None
 
-        if use_namedtuple is None:
+        # ELTestResult always carries all four fields, so it unpacks
+        # identically to the legacy tuple only when the nuisance parameters
+        # were produced as well; in that case it is adopted silently.
+        unpacks_unchanged = nuisance_params is not None
+        if use_namedtuple is None and not unpacks_unchanged:
             warnings.warn(
                 "el_test currently returns a plain tuple whose length "
                 "depends on the return_weights and ret_params arguments. "
@@ -3491,10 +3506,8 @@ class OLSResults(RegressionResults):
                 FutureWarning,
                 stacklevel=2,
             )
-        if use_namedtuple:
+        if use_namedtuple or unpacks_unchanged:
             return ELTestResult(llr, pval, weights, nuisance_params)
-        if nuisance_params is not None:
-            return llr, pval, weights, nuisance_params
         if weights is not None:
             return llr, pval, weights
         return llr, pval

--- a/statsmodels/stats/diagnostic.py
+++ b/statsmodels/stats/diagnostic.py
@@ -152,9 +152,10 @@ def compare_cox(
         If true, then the intermediate results are returned.
     use_namedtuple : bool, optional
         Flag indicating whether to return the results as a
-        ``NonNestedTestResult`` NamedTuple instead of a plain tuple. If
-        ``None`` (the default), the current tuple-returning behavior is
-        used and a ``FutureWarning`` is issued.
+        ``NonNestedTestResult`` NamedTuple instead of a plain tuple. When
+        ``store=True`` the NamedTuple holds the same three elements as the
+        legacy tuple, so it unpacks identically and is always returned, with no warning. When ``store=False`` the legacy two-element tuple
+        is returned by default and a ``FutureWarning`` is issued.
 
         .. deprecated:: 0.15.0
 
@@ -260,9 +261,10 @@ def compare_j(results_x, results_z, store=False, *, use_namedtuple: bool | None 
         If true, then the intermediate results are returned.
     use_namedtuple : bool, optional
         Flag indicating whether to return the results as a
-        ``NonNestedTestResult`` NamedTuple instead of a plain tuple. If
-        ``None`` (the default), the current tuple-returning behavior is
-        used and a ``FutureWarning`` is issued.
+        ``NonNestedTestResult`` NamedTuple instead of a plain tuple. When
+        ``store=True`` the NamedTuple holds the same three elements as the
+        legacy tuple, so it unpacks identically and is always returned, with no warning. When ``store=False`` the legacy two-element tuple
+        is returned by default and a ``FutureWarning`` is issued.
 
         .. deprecated:: 0.15.0
 
@@ -659,9 +661,11 @@ def acorr_lm(
         more details.
     use_namedtuple : bool, optional
         Flag indicating whether to return the results as an ``LMTestResult``
-        NamedTuple instead of a plain tuple. If ``None`` (the default), the
-        current tuple-returning behavior is used and a ``FutureWarning`` is
-        issued.
+        NamedTuple instead of a plain tuple. When ``store=True`` the
+        NamedTuple holds the same five elements as the legacy tuple, so it
+        unpacks identically and is always returned, with no warning.
+        When ``store=False`` the legacy four-element tuple is returned by
+        default and a ``FutureWarning`` is issued.
 
         .. deprecated:: 0.15.0
 
@@ -786,9 +790,11 @@ def het_arch(
         ARMA(p,q).
     use_namedtuple : bool, optional
         Flag indicating whether to return the results as an ``LMTestResult``
-        NamedTuple instead of a plain tuple. If ``None`` (the default), the
-        current tuple-returning behavior is used and a ``FutureWarning`` is
-        issued.
+        NamedTuple instead of a plain tuple. When ``store=True`` the
+        NamedTuple holds the same five elements as the legacy tuple, so it
+        unpacks identically and is always returned, with no warning.
+        When ``store=False`` the legacy four-element tuple is returned by
+        default and a ``FutureWarning`` is issued.
 
         .. deprecated:: 0.15.0
 
@@ -848,9 +854,11 @@ def acorr_breusch_godfrey(
         intermediate results is returned.
     use_namedtuple : bool, optional
         Flag indicating whether to return the results as an ``LMTestResult``
-        NamedTuple instead of a plain tuple. If ``None`` (the default), the
-        current tuple-returning behavior is used and a ``FutureWarning`` is
-        issued.
+        NamedTuple instead of a plain tuple. When ``store=True`` the
+        NamedTuple holds the same five elements as the legacy tuple, so it
+        unpacks identically and is always returned, with no warning.
+        When ``store=False`` the legacy four-element tuple is returned by
+        default and a ``FutureWarning`` is issued.
 
         .. deprecated:: 0.15.0
 
@@ -1160,9 +1168,10 @@ def het_goldfeldquandt(
         Flag indicating to return the regression results
     use_namedtuple : bool, optional
         Flag indicating whether to return the results as a
-        ``GoldfeldQuandtResult`` NamedTuple instead of a plain tuple. If
-        ``None`` (the default), the current tuple-returning behavior is
-        used and a ``FutureWarning`` is issued.
+        ``GoldfeldQuandtResult`` NamedTuple instead of a plain tuple. When
+        ``store=True`` the NamedTuple holds the same four elements as the
+        legacy tuple, so it unpacks identically and is always returned, with no warning. When ``store=False`` the legacy three-element
+        tuple is returned by default and a ``FutureWarning`` is issued.
 
         .. deprecated:: 0.15.0
 

--- a/statsmodels/stats/diagnostic.py
+++ b/statsmodels/stats/diagnostic.py
@@ -158,7 +158,7 @@ def compare_cox(
 
         .. deprecated:: 0.15.0
 
-            In release 0.16.0 or after July 2028, whichever is later, the
+            In release 0.16.0 or after July 2027, whichever is later, the
             default will change to always return a
             ``NonNestedTestResult``. Set ``use_namedtuple=True`` to opt in
             now, or ``use_namedtuple=False`` to silence the warning and
@@ -229,7 +229,7 @@ def compare_cox(
     else:
         res = None
 
-    if use_namedtuple is None:
+    if use_namedtuple is None and not store:
         warnings.warn(
             "compare_cox currently returns a plain tuple whose length "
             "depends on the store argument. In release 0.16 or after "
@@ -241,10 +241,8 @@ def compare_cox(
             FutureWarning,
             stacklevel=2,
         )
-    if use_namedtuple:
+    if use_namedtuple or store:
         return NonNestedTestResult(q, pval, res)
-    if store:
-        return q, pval, res
     return q, pval
 
 
@@ -268,7 +266,7 @@ def compare_j(results_x, results_z, store=False, *, use_namedtuple: bool | None 
 
         .. deprecated:: 0.15.0
 
-            In release 0.16.0 or after July 2028, whichever is later, the
+            In release 0.16.0 or after July 2027, whichever is later, the
             default will change to always return a
             ``NonNestedTestResult``. Set ``use_namedtuple=True`` to opt in
             now, or ``use_namedtuple=False`` to silence the warning and
@@ -325,7 +323,7 @@ def compare_j(results_x, results_z, store=False, *, use_namedtuple: bool | None 
     else:
         res = None
 
-    if use_namedtuple is None:
+    if use_namedtuple is None and not store:
         warnings.warn(
             "compare_j currently returns a plain tuple whose length "
             "depends on the store argument. In release 0.16 or after "
@@ -337,10 +335,8 @@ def compare_j(results_x, results_z, store=False, *, use_namedtuple: bool | None 
             FutureWarning,
             stacklevel=2,
         )
-    if use_namedtuple:
+    if use_namedtuple or store:
         return NonNestedTestResult(tstat, pval, res)
-    if store:
-        return tstat, pval, res
     return tstat, pval
 
 
@@ -669,7 +665,7 @@ def acorr_lm(
 
         .. deprecated:: 0.15.0
 
-            In release 0.16.0 or after July 2028, whichever is later, the
+            In release 0.16.0 or after July 2027, whichever is later, the
             default will change to always return an ``LMTestResult``. Set
             ``use_namedtuple=True`` to opt in now, or
             ``use_namedtuple=False`` to silence the warning and keep the
@@ -753,7 +749,7 @@ def acorr_lm(
     else:
         res_store = None
 
-    if use_namedtuple is None:
+    if use_namedtuple is None and not store:
         warnings.warn(
             "acorr_lm currently returns a plain tuple whose length "
             "depends on the store argument. In release 0.16 or after "
@@ -764,10 +760,8 @@ def acorr_lm(
             FutureWarning,
             stacklevel=2,
         )
-    if use_namedtuple:
+    if use_namedtuple or store:
         return LMTestResult(lm, lmpval, fval, fpval, res_store)
-    if store:
-        return lm, lmpval, fval, fpval, res_store
     return lm, lmpval, fval, fpval
 
 
@@ -798,7 +792,7 @@ def het_arch(
 
         .. deprecated:: 0.15.0
 
-            In release 0.16.0 or after July 2028, whichever is later, the
+            In release 0.16.0 or after July 2027, whichever is later, the
             default will change to always return an ``LMTestResult``. Set
             ``use_namedtuple=True`` to opt in now, or
             ``use_namedtuple=False`` to silence the warning and keep the
@@ -860,7 +854,7 @@ def acorr_breusch_godfrey(
 
         .. deprecated:: 0.15.0
 
-            In release 0.16.0 or after July 2028, whichever is later, the
+            In release 0.16.0 or after July 2027, whichever is later, the
             default will change to always return an ``LMTestResult``. Set
             ``use_namedtuple=True`` to opt in now, or
             ``use_namedtuple=False`` to silence the warning and keep the
@@ -939,7 +933,7 @@ def acorr_breusch_godfrey(
     else:
         res_store = None
 
-    if use_namedtuple is None:
+    if use_namedtuple is None and not store:
         warnings.warn(
             "acorr_breusch_godfrey currently returns a plain tuple whose "
             "length depends on the store argument. In release 0.16 or "
@@ -951,10 +945,8 @@ def acorr_breusch_godfrey(
             FutureWarning,
             stacklevel=2,
         )
-    if use_namedtuple:
+    if use_namedtuple or store:
         return LMTestResult(lm, lmpval, fval, fpval, res_store)
-    if store:
-        return lm, lmpval, fval, fpval, res_store
     return lm, lmpval, fval, fpval
 
 
@@ -1174,7 +1166,7 @@ def het_goldfeldquandt(
 
         .. deprecated:: 0.15.0
 
-            In release 0.16.0 or after July 2028, whichever is later, the
+            In release 0.16.0 or after July 2027, whichever is later, the
             default will change to always return a
             ``GoldfeldQuandtResult``. Set ``use_namedtuple=True`` to opt
             in now, or ``use_namedtuple=False`` to silence the warning and
@@ -1266,7 +1258,7 @@ F-statistic ={fval:8.4f} and p-value ={fpval:8.4f}"""
     else:
         res = None
 
-    if use_namedtuple is None:
+    if use_namedtuple is None and not store:
         warnings.warn(
             "het_goldfeldquandt currently returns a plain tuple whose "
             "length depends on the store argument. In release 0.16 or "
@@ -1278,10 +1270,8 @@ F-statistic ={fval:8.4f} and p-value ={fpval:8.4f}"""
             FutureWarning,
             stacklevel=2,
         )
-    if use_namedtuple:
+    if use_namedtuple or store:
         return GoldfeldQuandtResult(fval, fpval, ordering, res)
-    if store:
-        return fval, fpval, ordering, res
     return fval, fpval, ordering
 
 

--- a/statsmodels/tsa/stattools/_stattools.py
+++ b/statsmodels/tsa/stattools/_stattools.py
@@ -276,7 +276,7 @@ def adfuller(
 
         .. deprecated:: 0.15.0
 
-            In release 0.16.0 or after July 2028, whichever is later, the
+            In release 0.16.0 or after July 2027, whichever is later, the
             default will change to always return an ``ADFullerResult``.
             Set ``use_namedtuple=True`` to opt in now, or
             ``use_namedtuple=False`` to silence the warning and keep the
@@ -918,7 +918,7 @@ def acf(
 
         .. deprecated:: 0.15.0
 
-            In release 0.16.0 or after July 2028, whichever is later, the
+            In release 0.16.0 or after July 2027, whichever is later, the
             default will change to always return an ``AcfResult`` when
             ``qstat`` is True or ``alpha`` is not None. Set
             ``use_namedtuple=True`` to opt in now, or
@@ -1035,15 +1035,13 @@ def acf(
             FutureWarning,
             stacklevel=2,
         )
-    if use_namedtuple:
+    if use_namedtuple or alpha is not None:
         return AcfResult(acf, confint, qstat_vals, pvalue)
 
     if not (qstat or alpha):
         return acf
-    if not qstat:
+    elif not qstat:
         return acf, confint
-    if alpha is not None:
-        return acf, confint, qstat_vals, pvalue
     return acf, qstat_vals, pvalue
 
 
@@ -2794,7 +2792,7 @@ def kpss(
 
         .. deprecated:: 0.15.0
 
-            In release 0.16.0 or after July 2028, whichever is later, the
+            In release 0.16.0 or after July 2027, whichever is later, the
             default will change to always return a ``KpssResult``. Set
             ``use_namedtuple=True`` to opt in now, or
             ``use_namedtuple=False`` to silence the warning and keep the
@@ -3086,7 +3084,7 @@ def range_unit_root_test(x, store=False, *, use_namedtuple: bool | None = None):
 
         .. deprecated:: 0.15.0
 
-            In release 0.16.0 or after July 2028, whichever is later, the
+            In release 0.16.0 or after July 2027, whichever is later, the
             default will change to always return a
             ``RangeUnitRootTestResult``. Set ``use_namedtuple=True`` to opt
             in now, or ``use_namedtuple=False`` to silence the warning and
@@ -3219,7 +3217,7 @@ look-up table. The actual p-value is {direction} than the p-value returned.
     else:
         rstore = None
 
-    if use_namedtuple is None:
+    if use_namedtuple is None and not store:
         warnings.warn(
             "range_unit_root_test currently returns a plain tuple whose "
             "length depends on the store argument. In release 0.16 or "
@@ -3231,12 +3229,9 @@ look-up table. The actual p-value is {direction} than the p-value returned.
             FutureWarning,
             stacklevel=2,
         )
-    if use_namedtuple:
+    if use_namedtuple or store:
         return RangeUnitRootTestResult(rur_stat, p_value, crit_dict, rstore)
-    if store:
-        return rur_stat, p_value, crit_dict, rstore
-    else:
-        return rur_stat, p_value, crit_dict
+    return rur_stat, p_value, crit_dict
 
 
 class ZivotAndrewsUnitRoot:

--- a/statsmodels/tsa/stattools/_stattools.py
+++ b/statsmodels/tsa/stattools/_stattools.py
@@ -907,20 +907,21 @@ def acf(
         When using "conservative", n is set to the number of non-missing
         observations.
     use_namedtuple : bool, optional
-        Only relevant when ``qstat`` is True or ``alpha`` is not None,
-        where the return value's arity depends on this flag. Flag
-        indicating whether to return the results as an ``AcfResult``
-        NamedTuple instead of a plain tuple. If ``None`` (the default),
-        the current tuple-returning behavior is used and a
-        ``FutureWarning`` is issued. Ignored when ``qstat`` is False and
-        ``alpha`` is None, since ``acf`` always returns a single array in
-        that case.
+        Flag indicating whether to return the results as an ``AcfResult``
+        NamedTuple instead of a plain tuple. ``AcfResult`` always carries
+        all four fields, so it unpacks identically to the legacy tuple
+        only when both ``qstat`` is True and ``alpha`` is not None; that
+        combination is always returned, with no warning. Requesting
+        only one of ``qstat`` or ``alpha`` still returns the shorter
+        legacy tuple by default and issues a ``FutureWarning``, because
+        the NamedTuple would change how many values are unpacked. Ignored
+        when ``qstat`` is False and ``alpha`` is None, since ``acf``
+        returns a single array in that case.
 
         .. deprecated:: 0.15.0
 
             In release 0.16.0 or after July 2027, whichever is later, the
-            default will change to always return an ``AcfResult`` when
-            ``qstat`` is True or ``alpha`` is not None. Set
+            default will change to always return an ``AcfResult``. Set
             ``use_namedtuple=True`` to opt in now, or
             ``use_namedtuple=False`` to silence the warning and keep the
             current return type.
@@ -932,11 +933,17 @@ def acf(
         (nlags+1,). Returned directly (not part of a tuple) unless
         ``qstat`` is True or ``alpha`` is not None.
     AcfResult
-        If (``qstat`` is True or ``alpha`` is not None) and
-        ``use_namedtuple=True``, a NamedTuple with fields ``acf``,
-        ``confint``, ``qstat``, and ``pvalues`` instead of the plain
-        tuple below (``confint``/``qstat``/``pvalues`` are ``None`` when
-        not computed). See :class:`~statsmodels.tsa.stattools.AcfResult`.
+        A NamedTuple with fields ``acf``, ``confint``, ``qstat`` and
+        ``pvalues`` (each of the latter three is ``None`` when it was not
+        computed). See :class:`~statsmodels.tsa.stattools.AcfResult`.
+
+        This is returned whenever ``use_namedtuple=True``. It is also
+        returned by default when both ``qstat`` is True and ``alpha`` is
+        not None, because the NamedTuple then has exactly the same four
+        elements as the legacy tuple and so unpacks identically; that
+        case is adopted silently. Requesting only one of ``qstat`` or
+        ``alpha`` still returns the shorter legacy tuple below and warns,
+        since the NamedTuple would change how many values are unpacked.
     confint : ndarray, optional
         Confidence intervals for the ACF at lags 0, 1, ..., nlags. Shape
         (nlags + 1, 2). Returned (as part of a plain tuple, the
@@ -1021,10 +1028,18 @@ def acf(
     if qstat:
         qstat_vals, pvalue = q_stat(acf[1:], nobs=nobs)  # drop lag 0
 
-    # Only the qstat/alpha paths return more than one value today, so those
-    # are the only ones whose result shape is at stake.  Warning on the
-    # single-output path would fire for every internal use of acf.
-    if use_namedtuple is None and (qstat or alpha is not None):
+    # AcfResult always carries all four fields, so it unpacks identically to
+    # the legacy tuple only when both qstat and alpha were requested; in that
+    # case it is adopted silently.  Requesting just one of the two still
+    # returns the shorter legacy tuple and warns.  Only the qstat/alpha paths
+    # return more than one value today, so the single-output path stays quiet
+    # -- warning there would fire for every internal use of acf.
+    unpacks_unchanged = qstat and alpha is not None
+    if (
+        use_namedtuple is None
+        and (qstat or alpha is not None)
+        and not unpacks_unchanged
+    ):
         warnings.warn(
             "acf currently returns a plain tuple whose length depends on "
             "the qstat and alpha arguments. In release 0.16 or after "
@@ -1035,7 +1050,7 @@ def acf(
             FutureWarning,
             stacklevel=2,
         )
-    if use_namedtuple or alpha is not None:
+    if use_namedtuple or unpacks_unchanged:
         return AcfResult(acf, confint, qstat_vals, pvalue)
 
     if not (qstat or alpha):
@@ -1354,11 +1369,11 @@ def pacf(
         1/sqrt(len(x)).
     use_namedtuple : bool, optional
         Flag controlling whether a ``PacfResult`` NamedTuple is returned.
-        If ``None`` (the default), a ``PacfResult`` is returned when
-        ``alpha`` is not None and a bare array otherwise. Set to True to
-        always receive a ``PacfResult``, with ``confint`` set to ``None``
-        when ``alpha`` is None. Set to False to always receive the legacy
-        plain tuple or bare array.
+        When ``alpha`` is not None a ``PacfResult`` is always returned; it
+        holds the same two elements as the legacy tuple, so it unpacks
+        and indexes identically. When ``alpha`` is None a bare array is
+        returned unless ``use_namedtuple=True``, which additionally
+        yields a ``PacfResult`` with ``confint`` set to ``None``.
 
     Returns
     -------
@@ -1466,12 +1481,10 @@ def pacf(
         confint[0] = ret[0]  # fix confidence interval for lag 0 to varpacf=0
 
     # PacfResult has exactly the same length and contents as the legacy
-    # (pacf, confint) tuple, so it unpacks and indexes identically and can
-    # be adopted with no deprecation.  When alpha is None a bare array is
-    # returned, as before; pass use_namedtuple=True to always get a
+    # (pacf, confint) tuple, so it unpacks and indexes identically and is
+    # always used when alpha is not None.  When alpha is None a bare array
+    # is returned, as before; pass use_namedtuple=True to always get a
     # PacfResult.
-    if use_namedtuple is False:
-        return (ret, confint) if alpha is not None else ret
     if use_namedtuple or alpha is not None:
         return PacfResult(ret, confint)
     return ret
@@ -1579,11 +1592,11 @@ def ccf(
         1/sqrt(len(x)).
     use_namedtuple : bool, optional
         Flag controlling whether a ``CcfResult`` NamedTuple is returned.
-        If ``None`` (the default), a ``CcfResult`` is returned when
-        ``alpha`` is not None and a bare array otherwise. Set to True to
-        always receive a ``CcfResult``, with ``confint`` set to ``None``
-        when ``alpha`` is None. Set to False to always receive the legacy
-        plain tuple or bare array.
+        When ``alpha`` is not None a ``CcfResult`` is always returned; it
+        holds the same two elements as the legacy tuple, so it unpacks
+        and indexes identically. When ``alpha`` is None a bare array is
+        returned unless ``use_namedtuple=True``, which additionally
+        yields a ``CcfResult`` with ``confint`` set to ``None``.
 
     Returns
     -------
@@ -1645,12 +1658,10 @@ def ccf(
         confint = ret.reshape(-1, 1) + interval * np.array([-1, 1])
 
     # CcfResult has exactly the same length and contents as the legacy
-    # (ccf, confint) tuple, so it unpacks and indexes identically and can be
-    # adopted with no deprecation.  When alpha is None a bare array is
-    # returned, as before; pass use_namedtuple=True to always get a
+    # (ccf, confint) tuple, so it unpacks and indexes identically and is
+    # always used when alpha is not None.  When alpha is None a bare array
+    # is returned, as before; pass use_namedtuple=True to always get a
     # CcfResult.
-    if use_namedtuple is False:
-        return (ret, confint) if alpha is not None else ret
     if use_namedtuple or alpha is not None:
         return CcfResult(ret, confint)
     return ret
@@ -1836,11 +1847,11 @@ def pccf(
         deviation is 1/sqrt(n).
     use_namedtuple : bool, optional
         Flag controlling whether a ``PccfResult`` NamedTuple is returned.
-        If ``None`` (the default), a ``PccfResult`` is returned when
-        ``alpha`` is not None and a bare array otherwise. Set to True to
-        always receive a ``PccfResult``, with ``confint`` set to ``None``
-        when ``alpha`` is None. Set to False to always receive the legacy
-        plain tuple or bare array.
+        When ``alpha`` is not None a ``PccfResult`` is always returned; it
+        holds the same two elements as the legacy tuple, so it unpacks
+        and indexes identically. When ``alpha`` is None a bare array is
+        returned unless ``use_namedtuple=True``, which additionally
+        yields a ``PccfResult`` with ``confint`` set to ``None``.
 
     Returns
     -------
@@ -1985,12 +1996,10 @@ def pccf(
         confint = ret.reshape(-1, 1) + interval * np.array([-1, 1])
 
     # PccfResult has exactly the same length and contents as the legacy
-    # (pccf, confint) tuple, so it unpacks and indexes identically and can
-    # be adopted with no deprecation.  When alpha is None a bare array is
-    # returned, as before; pass use_namedtuple=True to always get a
+    # (pccf, confint) tuple, so it unpacks and indexes identically and is
+    # always used when alpha is not None.  When alpha is None a bare array
+    # is returned, as before; pass use_namedtuple=True to always get a
     # PccfResult.
-    if use_namedtuple is False:
-        return (ret, confint) if alpha is not None else ret
     if use_namedtuple or alpha is not None:
         return PccfResult(ret, confint)
     return ret
@@ -3079,8 +3088,10 @@ def range_unit_root_test(x, store=False, *, use_namedtuple: bool | None = None):
     use_namedtuple : bool, optional
         Flag indicating whether to return the results as a
         ``RangeUnitRootTestResult`` NamedTuple instead of a plain tuple.
-        If ``None`` (the default), the current tuple-returning behavior is
-        used and a ``FutureWarning`` is issued.
+        When ``store=True`` the NamedTuple holds the same four elements as
+        the legacy tuple, so it unpacks identically and is always returned, with no warning. When ``store=False`` the legacy
+        three-element tuple is returned by default and a ``FutureWarning``
+        is issued.
 
         .. deprecated:: 0.15.0
 

--- a/statsmodels/tsa/tests/test_stattools.py
+++ b/statsmodels/tsa/tests/test_stattools.py
@@ -310,7 +310,7 @@ class TestACF(CheckCorrGram):
 
     def test_default_warns(self):
         with pytest.warns(FutureWarning, match="use_namedtuple"):
-            res = acf(self.x, nlags=40, qstat=True, alpha=0.05, fft=False)
+            res = acf(self.x, nlags=40, qstat=True, fft=False)
         assert isinstance(res, tuple)
         assert not isinstance(res, AcfResult)
 

--- a/statsmodels/tsa/tests/test_stattools.py
+++ b/statsmodels/tsa/tests/test_stattools.py
@@ -329,6 +329,44 @@ class TestACF(CheckCorrGram):
         assert res_nt.qstat is None
         assert res_nt.pvalues is None
 
+    @pytest.mark.parametrize(
+        "kwargs, expected",
+        [
+            ({"alpha": 0.05}, 2),
+            ({"qstat": True}, 3),
+            ({"qstat": True, "alpha": 0.05}, 4),
+        ],
+    )
+    def test_legacy_unpacking_preserved(self, kwargs, expected):
+        # AcfResult always carries four fields, so it may only be adopted by
+        # default where that matches the legacy arity.  Returning it for
+        # alpha-only or qstat-only would raise "too many values to unpack"
+        # in existing user code.
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            res = acf(self.x, nlags=40, fft=False, **kwargs)
+            opted_out = acf(
+                self.x, nlags=40, fft=False, use_namedtuple=False, **kwargs
+            )
+        assert len(res) == expected
+        assert len(opted_out) == expected
+        # unpacking with exactly `expected` names must not raise
+        _ = [*res]
+        assert len([*res]) == expected
+
+    def test_only_full_request_adopts_namedtuple_silently(self):
+        # Both qstat and alpha -> the four-field NamedTuple unpacks exactly
+        # like the legacy 4-tuple, so it is adopted with no warning.
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            res = acf(self.x, nlags=40, fft=False, qstat=True, alpha=0.05)
+        assert isinstance(res, AcfResult)
+        # Requesting only one of them still warns and keeps the short tuple.
+        for kwargs in ({"alpha": 0.05}, {"qstat": True}):
+            with pytest.warns(FutureWarning, match="use_namedtuple"):
+                short = acf(self.x, nlags=40, fft=False, **kwargs)
+            assert not isinstance(short, AcfResult)
+
 
 class TestACF_FFT(CheckCorrGram):
     # Test Autocorrelation Function using FFT
@@ -459,14 +497,18 @@ class TestPACF(CheckCorrGram):
             res = pacf(self.x, nlags=40, alpha=0.05, method="ols")
         assert isinstance(res, PacfResult)
         assert len(res) == 2
+        # The NamedTuple is used whenever it unpacks identically, so
+        # use_namedtuple=False cannot opt out of it here.
         with warnings.catch_warnings():
             warnings.simplefilter("error")
-            legacy = pacf(
+            opted_out = pacf(
                 self.x, nlags=40, alpha=0.05, method="ols", use_namedtuple=False
             )
-        assert type(legacy) is tuple
-        assert_allclose(res.pacf, legacy[0])
-        assert_allclose(res.confint, legacy[1])
+        assert isinstance(opted_out, PacfResult)
+        # ...and it still unpacks like the legacy 2-tuple
+        vals, confint = res
+        assert_allclose(vals, res.pacf)
+        assert_allclose(confint, res.confint)
 
     def test_alpha_use_namedtuple_true(self):
         with warnings.catch_warnings():
@@ -571,14 +613,18 @@ class TestCCF:
             res = ccf(self.x, self.y, nlags=self.nlags, alpha=0.05)
         assert isinstance(res, CcfResult)
         assert len(res) == 2
+        # The NamedTuple is used whenever it unpacks identically, so
+        # use_namedtuple=False cannot opt out of it here.
         with warnings.catch_warnings():
             warnings.simplefilter("error")
-            legacy = ccf(
+            opted_out = ccf(
                 self.x, self.y, nlags=self.nlags, alpha=0.05, use_namedtuple=False
             )
-        assert type(legacy) is tuple
-        assert_allclose(res.ccf, legacy[0])
-        assert_allclose(res.confint, legacy[1])
+        assert isinstance(opted_out, CcfResult)
+        # ...and it still unpacks like the legacy 2-tuple
+        vals, confint = res
+        assert_allclose(vals, res.ccf)
+        assert_allclose(confint, res.confint)
 
     def test_alpha_use_namedtuple_true(self):
         with warnings.catch_warnings():
@@ -660,9 +706,11 @@ class TestPCCF:
             res = pccf(self.x, self.y, nlags=self.nlags, method="ols", alpha=0.05)
         assert isinstance(res, PccfResult)
         assert len(res) == 2
+        # The NamedTuple is used whenever it unpacks identically, so
+        # use_namedtuple=False cannot opt out of it here.
         with warnings.catch_warnings():
             warnings.simplefilter("error")
-            legacy = pccf(
+            opted_out = pccf(
                 self.x,
                 self.y,
                 nlags=self.nlags,
@@ -670,9 +718,11 @@ class TestPCCF:
                 alpha=0.05,
                 use_namedtuple=False,
             )
-        assert type(legacy) is tuple
-        assert_allclose(res.pccf, legacy[0])
-        assert_allclose(res.confint, legacy[1])
+        assert isinstance(opted_out, PccfResult)
+        # ...and it still unpacks like the legacy 2-tuple
+        vals, confint = res
+        assert_allclose(vals, res.pccf)
+        assert_allclose(confint, res.confint)
 
     def test_alpha_use_namedtuple_true(self):
         with warnings.catch_warnings():

--- a/statsmodels/tsa/tests/test_tsa_tools.py
+++ b/statsmodels/tsa/tests/test_tsa_tools.py
@@ -220,16 +220,19 @@ class TestLagmat:
         with warnings.catch_warnings():
             warnings.simplefilter("error")
             res = stattools.lagmat(data, 3, trim="none", original="sep")
-            legacy = stattools.lagmat(
+            # The NamedTuple is used whenever it unpacks identically, so
+            # use_namedtuple=False cannot opt out of it here.
+            opted_out = stattools.lagmat(
                 data, 3, trim="none", original="sep", use_namedtuple=False
             )
         assert isinstance(res, LagmatResult)
+        assert isinstance(opted_out, LagmatResult)
         assert len(res) == 2
+        # ...and it still unpacks like the legacy 2-tuple
         lags, leads = res
         assert isinstance(lags, np.ndarray)
-        assert type(legacy) is tuple
-        assert_array_almost_equal(res.lags, legacy[0])
-        assert_array_almost_equal(res.leads, legacy[1])
+        assert_array_almost_equal(lags, res.lags)
+        assert_array_almost_equal(leads, res.leads)
 
     def test_sep_return_use_namedtuple_true(self):
         data = self.random_data

--- a/statsmodels/tsa/tsatools.py
+++ b/statsmodels/tsa/tsatools.py
@@ -355,11 +355,12 @@ def lagmat(
         Series or DataFrame.  If false, return numpy ndarrays.
     use_namedtuple : bool, optional
         Flag controlling whether a ``LagmatResult`` NamedTuple is
-        returned. If ``None`` (the default), a ``LagmatResult`` is
-        returned when ``original="sep"`` and a bare array otherwise. Set
-        to True to always receive a ``LagmatResult``, with ``leads`` set
-        to ``None`` for other values of ``original``. Set to False to
-        always receive the legacy plain tuple or bare array.
+        returned. When ``original="sep"`` a ``LagmatResult`` is always
+        returned; it holds the same two elements as the legacy tuple, so
+        it unpacks and indexes identically. For other values of
+        ``original`` a bare array is returned unless
+        ``use_namedtuple=True``, which additionally yields a
+        ``LagmatResult`` with ``leads`` set to ``None``.
 
     Returns
     -------
@@ -512,13 +513,12 @@ def lagmat(
             leads = lm[startobs:stopobs, :dropidx]
 
     # LagmatResult has exactly the same length and contents as the legacy
-    # (lags, leads) tuple, so it unpacks and indexes identically and can be
-    # adopted with no deprecation.  For other values of `original` a bare
-    # array is returned, as before; pass use_namedtuple=True to always get
-    # a LagmatResult.  `leads` is only meaningful for "sep" -- for "ex" the
-    # caller asked for it to be excluded and for "in" it is part of `lags`.
-    if use_namedtuple is False:
-        return (lags, leads) if original == "sep" else lags
+    # (lags, leads) tuple, so it unpacks and indexes identically and is
+    # always used when original="sep".  For other values of `original` a
+    # bare array is returned, as before; pass use_namedtuple=True to always
+    # get a LagmatResult.  `leads` is only meaningful for "sep" -- for "ex"
+    # the caller asked for it to be excluded and for "in" it is part of
+    # `lags`.
     if use_namedtuple or original == "sep":
         return LagmatResult(lags, leads if original == "sep" else None)
     return lags


### PR DESCRIPTION
Improve the docstrings of the methods that now return NamedTuples
Fix css deprecation boxes and related objects in the docs.- [ ] closes #xxxx
- [ ] tests added / passed. 
- [ ] code/documentation is well formatted.  
- [ ] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
