### PR TITLE
ENH: More use of NamedTuple

### DIFF
--- a/docs/source/contingency_tables.rst
+++ b/docs/source/contingency_tables.rst
@@ -291,6 +291,7 @@ Module Reference
    StratifiedTable
    mcnemar
    cochrans_q
+   CochransQResult
 
 See also
 --------

--- a/docs/source/emplike.rst
+++ b/docs/source/emplike.rst
@@ -69,3 +69,5 @@ Module Reference
    descriptive.DescStat
    descriptive.DescStatUV
    descriptive.DescStatMV
+   descriptive.EmpLikeTestResult
+   elanova.ANOVAResult

--- a/docs/source/stats.rst
+++ b/docs/source/stats.rst
@@ -227,6 +227,7 @@ Non-Parametric Tests
    runstest_1samp
    runstest_2samp
    cochrans_q
+   CochransQResult
    Runs
 
 .. currentmodule:: statsmodels.stats.descriptivestats
@@ -690,6 +691,7 @@ inverse covariance or precision matrix.
    corr_nearest_factor
    corr_thresholded
    cov_nearest
+   CovNearestResult
    cov_nearest_factor_homog
    FactoredPSDMatrix
    kernel_covariance
@@ -721,6 +723,7 @@ kurtosis and cummulants.
    mvsk2mc
    mvsk2mnc
    cov2corr
+   Cov2CorrResult
    corr2cov
    se_cov
 

--- a/statsmodels/emplike/descriptive.py
+++ b/statsmodels/emplike/descriptive.py
@@ -16,6 +16,8 @@ Owen, A. (2001). "Empirical Likelihood." Chapman and Hall
 """
 
 import itertools
+from typing import NamedTuple
+import warnings
 
 import numpy as np
 from scipy import optimize
@@ -23,6 +25,46 @@ from scipy.stats import chi2, kurtosis, skew
 
 from statsmodels.base.optimizer import _fit_newton
 from statsmodels.graphics import utils
+from statsmodels.tools.validation import bool_like
+
+
+class EmpLikeTestResult(NamedTuple):
+    """
+    Result of an empirical likelihood hypothesis test.
+
+    Returned by the ``test_*`` methods of
+    :class:`~statsmodels.emplike.descriptive.DescStatUV` and
+    :class:`~statsmodels.emplike.descriptive.DescStatMV`, and by
+    :meth:`statsmodels.emplike.originregress.OriginResults.el_test`.
+
+    Parameters
+    ----------
+    llr : float
+        -2 times the log-likelihood ratio, the test statistic.
+    pvalue : float
+        The p-value of the test statistic.
+    weights : ndarray or None
+        The observation weights that maximize the likelihood under the
+        null hypothesis.
+    """
+
+    llr: float
+    pvalue: float
+    weights: np.ndarray | None
+
+
+def _warn_return_weights(name):
+    """Emit the ``return_weights`` variable-arity FutureWarning for ``name``."""
+    warnings.warn(
+        f"{name} currently returns a plain tuple whose length depends on the "
+        "return_weights argument. In release 0.16.0 or after July 2027, "
+        "whichever is later, the default behavior will switch to always "
+        "returning an EmpLikeTestResult NamedTuple. Set use_namedtuple=True "
+        "to switch now, or use_namedtuple=False to keep the current behavior "
+        "and silence this warning.",
+        FutureWarning,
+        stacklevel=3,
+    )
 
 
 def DescStat(endog):
@@ -257,7 +299,7 @@ class _OptFuncts:
             The difference between the log likelihood value of mu0 and
             a specified value.
         """
-        return self.test_mean(mu)[0] - self.r0
+        return self.test_mean(mu, use_namedtuple=True).llr - self.r0
 
     def _find_gamma(self, gamma):
         """
@@ -337,7 +379,7 @@ class _OptFuncts:
             The difference between the log likelihood ratio at var and a
             pre-specified value.
         """
-        return self.test_var(var)[0] - self.r0
+        return self.test_var(var, use_namedtuple=True).llr - self.r0
 
     def _opt_skew(self, nuis_params):
         """
@@ -460,7 +502,7 @@ class _OptFuncts:
             The difference between the log likelihood ratio at skew and a
             pre-specified value.
         """
-        return self.test_skew(skew)[0] - self.r0
+        return self.test_skew(skew, use_namedtuple=True).llr - self.r0
 
     def _ci_limits_kurt(self, kurt):
         """
@@ -478,7 +520,7 @@ class _OptFuncts:
             The difference between the log likelihood ratio at kurt and a
             pre-specified value.
         """
-        return self.test_kurt(kurt)[0] - self.r0
+        return self.test_kurt(kurt, use_namedtuple=True).llr - self.r0
 
     def _opt_correl(self, nuis_params, corr0, endog, nobs, x0, weights0):
         """
@@ -544,7 +586,7 @@ class _OptFuncts:
             The difference between the log likelihood ratio at corr and a
             pre-specified value.
         """
-        return self.test_corr(corr)[0] - self.r0
+        return self.test_corr(corr, use_namedtuple=True).llr - self.r0
 
 
 class DescStatUV(_OptFuncts):
@@ -570,7 +612,7 @@ class DescStatUV(_OptFuncts):
         self.endog = np.squeeze(endog)
         self.nobs = endog.shape[0]
 
-    def test_mean(self, mu0, return_weights=False):
+    def test_mean(self, mu0, return_weights=False, *, use_namedtuple=None):
         """
         Returns - 2 x log-likelihood ratio, p-value and weights
         for a hypothesis test of the mean.
@@ -584,12 +626,34 @@ class DescStatUV(_OptFuncts):
             If return_weights is True the function returns
             the weights of the observations under the null hypothesis.
             Default is False
+        use_namedtuple : bool, optional
+            Flag indicating whether to return the results as an
+            ``EmpLikeTestResult`` NamedTuple instead of a plain tuple. When
+            ``return_weights=True`` the NamedTuple holds the same three
+            elements as the legacy tuple, so it unpacks identically and is
+            always returned, with no warning. When ``return_weights=False``
+            the legacy two-element tuple is returned by default and a
+            ``FutureWarning`` is issued.
+
+            .. deprecated:: 0.15.0
+
+                In release 0.16.0 or after July 2027, whichever is later, the
+                default will change to always return an
+                ``EmpLikeTestResult``. Set ``use_namedtuple=True`` to opt in
+                now, or ``use_namedtuple=False`` to silence the warning and
+                keep the current return type.
 
         Returns
         -------
-        test_results : tuple
-            The log-likelihood ratio and p-value of mu0
+        EmpLikeTestResult or tuple
+            If ``use_namedtuple=True`` or ``return_weights=True``, a
+            NamedTuple with fields ``llr``, ``pvalue`` and ``weights``. See
+            :class:`~statsmodels.emplike.descriptive.EmpLikeTestResult`.
+
+            Otherwise (the deprecated default), the plain ``(llr, pvalue)``
+            tuple.
         """
+        use_namedtuple = bool_like(use_namedtuple, "use_namedtuple", optional=True)
         self.mu0 = mu0
         endog = self.endog
         nobs = self.nobs
@@ -598,10 +662,12 @@ class DescStatUV(_OptFuncts):
         eta_star = optimize.brentq(self._find_eta, eta_min, eta_max)
         new_weights = (1.0 / nobs) * 1.0 / (1.0 + eta_star * (endog - self.mu0))
         llr = -2 * np.sum(np.log(nobs * new_weights))
-        if return_weights:
-            return llr, chi2.sf(llr, 1), new_weights
-        else:
-            return llr, chi2.sf(llr, 1)
+        pval = chi2.sf(llr, 1)
+        if use_namedtuple is None and not return_weights:
+            _warn_return_weights("DescStatUV.test_mean")
+        if use_namedtuple or return_weights:
+            return EmpLikeTestResult(llr, pval, new_weights)
+        return llr, pval
 
     def ci_mean(
         self,
@@ -691,7 +757,7 @@ class DescStatUV(_OptFuncts):
             mu_high = np.sum(weights_high * endog)
             return mu_low, mu_high
 
-    def test_var(self, sig2_0, return_weights=False):
+    def test_var(self, sig2_0, return_weights=False, *, use_namedtuple=None):
         """
         Returns  -2 x log-likelihood ratio and the p-value for the
         hypothesized variance
@@ -704,11 +770,32 @@ class DescStatUV(_OptFuncts):
         return_weights : bool
             If True, returns the weights that maximize the
             likelihood of observing sig2_0. Default is False
+        use_namedtuple : bool, optional
+            Flag indicating whether to return the results as an
+            ``EmpLikeTestResult`` NamedTuple instead of a plain tuple. When
+            ``return_weights=True`` the NamedTuple holds the same three
+            elements as the legacy tuple, so it unpacks identically and is
+            always returned, with no warning. When ``return_weights=False``
+            the legacy two-element tuple is returned by default and a
+            ``FutureWarning`` is issued.
+
+            .. deprecated:: 0.15.0
+
+                In release 0.16.0 or after July 2027, whichever is later, the
+                default will change to always return an
+                ``EmpLikeTestResult``. Set ``use_namedtuple=True`` to opt in
+                now, or ``use_namedtuple=False`` to silence the warning and
+                keep the current return type.
 
         Returns
         -------
-        test_results : tuple
-            The  log-likelihood ratio and the p_value  of sig2_0
+        EmpLikeTestResult or tuple
+            If ``use_namedtuple=True`` or ``return_weights=True``, a
+            NamedTuple with fields ``llr``, ``pvalue`` and ``weights``. See
+            :class:`~statsmodels.emplike.descriptive.EmpLikeTestResult`.
+
+            Otherwise (the deprecated default), the plain ``(llr, pvalue)``
+            tuple.
 
         Examples
         --------
@@ -716,17 +803,19 @@ class DescStatUV(_OptFuncts):
         >>> import statsmodels.api as sm
         >>> random_numbers = np.random.standard_normal(1000)*100
         >>> el_analysis = sm.emplike.DescStat(random_numbers)
-        >>> hyp_test = el_analysis.test_var(9500)
+        >>> hyp_test = el_analysis.test_var(9500, use_namedtuple=True)
         """
+        use_namedtuple = bool_like(use_namedtuple, "use_namedtuple", optional=True)
         self.sig2_0 = sig2_0
         mu_max = max(self.endog)
         mu_min = min(self.endog)
         llr = optimize.fminbound(self._opt_var, mu_min, mu_max, full_output=1)[1]
         p_val = chi2.sf(llr, 1)
-        if return_weights:
-            return llr, p_val, self.new_weights.T
-        else:
-            return llr, p_val
+        if use_namedtuple is None and not return_weights:
+            _warn_return_weights("DescStatUV.test_var")
+        if use_namedtuple or return_weights:
+            return EmpLikeTestResult(llr, p_val, self.new_weights.T)
+        return llr, p_val
 
     def ci_var(self, lower_bound=None, upper_bound=None, sig=0.05):
         """
@@ -842,7 +931,7 @@ class DescStatUV(_OptFuncts):
         ax.contour(mu_vect, var_vect, z, levels=levs)
         return fig
 
-    def test_skew(self, skew0, return_weights=False):
+    def test_skew(self, skew0, return_weights=False, *, use_namedtuple=None):
         """
         Returns  -2 x log-likelihood and p-value for the hypothesized
         skewness.
@@ -855,12 +944,34 @@ class DescStatUV(_OptFuncts):
         return_weights : bool
             If True, function also returns the weights that
             maximize the likelihood ratio. Default is False.
+        use_namedtuple : bool, optional
+            Flag indicating whether to return the results as an
+            ``EmpLikeTestResult`` NamedTuple instead of a plain tuple. When
+            ``return_weights=True`` the NamedTuple holds the same three
+            elements as the legacy tuple, so it unpacks identically and is
+            always returned, with no warning. When ``return_weights=False``
+            the legacy two-element tuple is returned by default and a
+            ``FutureWarning`` is issued.
+
+            .. deprecated:: 0.15.0
+
+                In release 0.16.0 or after July 2027, whichever is later, the
+                default will change to always return an
+                ``EmpLikeTestResult``. Set ``use_namedtuple=True`` to opt in
+                now, or ``use_namedtuple=False`` to silence the warning and
+                keep the current return type.
 
         Returns
         -------
-        test_results : tuple
-            The log-likelihood ratio and p_value of skew0
+        EmpLikeTestResult or tuple
+            If ``use_namedtuple=True`` or ``return_weights=True``, a
+            NamedTuple with fields ``llr``, ``pvalue`` and ``weights``. See
+            :class:`~statsmodels.emplike.descriptive.EmpLikeTestResult`.
+
+            Otherwise (the deprecated default), the plain ``(llr, pvalue)``
+            tuple.
         """
+        use_namedtuple = bool_like(use_namedtuple, "use_namedtuple", optional=True)
         self.skew0 = skew0
         start_nuisance = np.array([self.endog.mean(), self.endog.var()])
 
@@ -868,11 +979,13 @@ class DescStatUV(_OptFuncts):
             self._opt_skew, start_nuisance, full_output=1, disp=0
         )[1]
         p_val = chi2.sf(llr, 1)
-        if return_weights:
-            return llr, p_val, self.new_weights.T
+        if use_namedtuple is None and not return_weights:
+            _warn_return_weights("DescStatUV.test_skew")
+        if use_namedtuple or return_weights:
+            return EmpLikeTestResult(llr, p_val, self.new_weights.T)
         return llr, p_val
 
-    def test_kurt(self, kurt0, return_weights=False):
+    def test_kurt(self, kurt0, return_weights=False, *, use_namedtuple=None):
         """
         Returns -2 x log-likelihood and the p-value for the hypothesized
         kurtosis.
@@ -885,12 +998,34 @@ class DescStatUV(_OptFuncts):
         return_weights : bool
             If True, function also returns the weights that
             maximize the likelihood ratio. Default is False.
+        use_namedtuple : bool, optional
+            Flag indicating whether to return the results as an
+            ``EmpLikeTestResult`` NamedTuple instead of a plain tuple. When
+            ``return_weights=True`` the NamedTuple holds the same three
+            elements as the legacy tuple, so it unpacks identically and is
+            always returned, with no warning. When ``return_weights=False``
+            the legacy two-element tuple is returned by default and a
+            ``FutureWarning`` is issued.
+
+            .. deprecated:: 0.15.0
+
+                In release 0.16.0 or after July 2027, whichever is later, the
+                default will change to always return an
+                ``EmpLikeTestResult``. Set ``use_namedtuple=True`` to opt in
+                now, or ``use_namedtuple=False`` to silence the warning and
+                keep the current return type.
 
         Returns
         -------
-        test_results : tuple
-            The log-likelihood ratio and p-value of kurt0
+        EmpLikeTestResult or tuple
+            If ``use_namedtuple=True`` or ``return_weights=True``, a
+            NamedTuple with fields ``llr``, ``pvalue`` and ``weights``. See
+            :class:`~statsmodels.emplike.descriptive.EmpLikeTestResult`.
+
+            Otherwise (the deprecated default), the plain ``(llr, pvalue)``
+            tuple.
         """
+        use_namedtuple = bool_like(use_namedtuple, "use_namedtuple", optional=True)
         self.kurt0 = kurt0
         start_nuisance = np.array([self.endog.mean(), self.endog.var()])
 
@@ -898,11 +1033,15 @@ class DescStatUV(_OptFuncts):
             self._opt_kurt, start_nuisance, full_output=1, disp=0
         )[1]
         p_val = chi2.sf(llr, 1)
-        if return_weights:
-            return llr, p_val, self.new_weights.T
+        if use_namedtuple is None and not return_weights:
+            _warn_return_weights("DescStatUV.test_kurt")
+        if use_namedtuple or return_weights:
+            return EmpLikeTestResult(llr, p_val, self.new_weights.T)
         return llr, p_val
 
-    def test_joint_skew_kurt(self, skew0, kurt0, return_weights=False):
+    def test_joint_skew_kurt(
+        self, skew0, kurt0, return_weights=False, *, use_namedtuple=None
+    ):
         """
         Returns - 2 x log-likelihood and the p-value for the joint
         hypothesis test for skewness and kurtosis
@@ -917,12 +1056,34 @@ class DescStatUV(_OptFuncts):
         return_weights : bool
             If True, function also returns the weights that
             maximize the likelihood ratio. Default is False.
+        use_namedtuple : bool, optional
+            Flag indicating whether to return the results as an
+            ``EmpLikeTestResult`` NamedTuple instead of a plain tuple. When
+            ``return_weights=True`` the NamedTuple holds the same three
+            elements as the legacy tuple, so it unpacks identically and is
+            always returned, with no warning. When ``return_weights=False``
+            the legacy two-element tuple is returned by default and a
+            ``FutureWarning`` is issued.
+
+            .. deprecated:: 0.15.0
+
+                In release 0.16.0 or after July 2027, whichever is later, the
+                default will change to always return an
+                ``EmpLikeTestResult``. Set ``use_namedtuple=True`` to opt in
+                now, or ``use_namedtuple=False`` to silence the warning and
+                keep the current return type.
 
         Returns
         -------
-        test_results : tuple
-            The log-likelihood ratio and p-value  of the joint hypothesis test.
+        EmpLikeTestResult or tuple
+            If ``use_namedtuple=True`` or ``return_weights=True``, a
+            NamedTuple with fields ``llr``, ``pvalue`` and ``weights``. See
+            :class:`~statsmodels.emplike.descriptive.EmpLikeTestResult`.
+
+            Otherwise (the deprecated default), the plain ``(llr, pvalue)``
+            tuple.
         """
+        use_namedtuple = bool_like(use_namedtuple, "use_namedtuple", optional=True)
         self.skew0 = skew0
         self.kurt0 = kurt0
         start_nuisance = np.array([self.endog.mean(), self.endog.var()])
@@ -931,8 +1092,10 @@ class DescStatUV(_OptFuncts):
             self._opt_skew_kurt, start_nuisance, full_output=1, disp=0
         )[1]
         p_val = chi2.sf(llr, 2)
-        if return_weights:
-            return llr, p_val, self.new_weights.T
+        if use_namedtuple is None and not return_weights:
+            _warn_return_weights("DescStatUV.test_joint_skew_kurt")
+        if use_namedtuple or return_weights:
+            return EmpLikeTestResult(llr, p_val, self.new_weights.T)
         return llr, p_val
 
     def ci_skew(self, sig=0.05, upper_bound=None, lower_bound=None):
@@ -1076,7 +1239,7 @@ class DescStatMV(_OptFuncts):
         self.endog = endog
         self.nobs = endog.shape[0]
 
-    def mv_test_mean(self, mu_array, return_weights=False):
+    def mv_test_mean(self, mu_array, return_weights=False, *, use_namedtuple=None):
         """
         Returns -2 x log likelihood and the p-value
         for a multivariate hypothesis test of the mean
@@ -1090,12 +1253,34 @@ class DescStatMV(_OptFuncts):
         return_weights : bool
             If True, returns the weights that maximize the
             likelihood of mu_array. Default is False.
+        use_namedtuple : bool, optional
+            Flag indicating whether to return the results as an
+            ``EmpLikeTestResult`` NamedTuple instead of a plain tuple. When
+            ``return_weights=True`` the NamedTuple holds the same three
+            elements as the legacy tuple, so it unpacks identically and is
+            always returned, with no warning. When ``return_weights=False``
+            the legacy two-element tuple is returned by default and a
+            ``FutureWarning`` is issued.
+
+            .. deprecated:: 0.15.0
+
+                In release 0.16.0 or after July 2027, whichever is later, the
+                default will change to always return an
+                ``EmpLikeTestResult``. Set ``use_namedtuple=True`` to opt in
+                now, or ``use_namedtuple=False`` to silence the warning and
+                keep the current return type.
 
         Returns
         -------
-        test_results : tuple
-            The log-likelihood ratio and p-value for mu_array
+        EmpLikeTestResult or tuple
+            If ``use_namedtuple=True`` or ``return_weights=True``, a
+            NamedTuple with fields ``llr``, ``pvalue`` and ``weights``. See
+            :class:`~statsmodels.emplike.descriptive.EmpLikeTestResult`.
+
+            Otherwise (the deprecated default), the plain ``(llr, pvalue)``
+            tuple.
         """
+        use_namedtuple = bool_like(use_namedtuple, "use_namedtuple", optional=True)
         endog = self.endog
         nobs = self.nobs
         if len(mu_array) != endog.shape[1]:
@@ -1115,10 +1300,11 @@ class DescStatMV(_OptFuncts):
         self.new_weights = 1 / nobs * 1 / denom
         llr = -2 * np.sum(np.log(nobs * self.new_weights))
         p_val = chi2.sf(llr, mu_array.shape[1])
-        if return_weights:
-            return llr, p_val, self.new_weights.T
-        else:
-            return llr, p_val
+        if use_namedtuple is None and not return_weights:
+            _warn_return_weights("DescStatMV.mv_test_mean")
+        if use_namedtuple or return_weights:
+            return EmpLikeTestResult(llr, p_val, self.new_weights.T)
+        return llr, p_val
 
     def mv_mean_contour(
         self,
@@ -1193,7 +1379,7 @@ class DescStatMV(_OptFuncts):
         pairs = itertools.product(x, y)
         z = []
         for i in pairs:
-            z.append(self.mv_test_mean(np.asarray(i))[0])
+            z.append(self.mv_test_mean(np.asarray(i), use_namedtuple=True).llr)
         X, Y = np.meshgrid(x, y)
         z = np.asarray(z)
         z = z.reshape(X.shape[1], Y.shape[0])
@@ -1202,7 +1388,7 @@ class DescStatMV(_OptFuncts):
             ax.plot(self.endog[:, 0], self.endog[:, 1], "bo")
         return fig
 
-    def test_corr(self, corr0, return_weights=0):
+    def test_corr(self, corr0, return_weights=0, *, use_namedtuple=None):
         """
         Returns -2 x log-likelihood ratio and  p-value for the
         correlation coefficient between 2 variables
@@ -1215,12 +1401,34 @@ class DescStatMV(_OptFuncts):
         return_weights : bool
             If true, returns the weights that maximize
             the log-likelihood at the hypothesized value
+        use_namedtuple : bool, optional
+            Flag indicating whether to return the results as an
+            ``EmpLikeTestResult`` NamedTuple instead of a plain tuple. When
+            ``return_weights=True`` the NamedTuple holds the same three
+            elements as the legacy tuple, so it unpacks identically and is
+            always returned, with no warning. When ``return_weights=False``
+            the legacy two-element tuple is returned by default and a
+            ``FutureWarning`` is issued.
+
+            .. deprecated:: 0.15.0
+
+                In release 0.16.0 or after July 2027, whichever is later, the
+                default will change to always return an
+                ``EmpLikeTestResult``. Set ``use_namedtuple=True`` to opt in
+                now, or ``use_namedtuple=False`` to silence the warning and
+                keep the current return type.
 
         Returns
         -------
-        test_results : tuple
-            The log-likelihood ratio and p-value of corr0
+        EmpLikeTestResult or tuple
+            If ``use_namedtuple=True`` or ``return_weights=True``, a
+            NamedTuple with fields ``llr``, ``pvalue`` and ``weights``. See
+            :class:`~statsmodels.emplike.descriptive.EmpLikeTestResult`.
+
+            Otherwise (the deprecated default), the plain ``(llr, pvalue)``
+            tuple.
         """
+        use_namedtuple = bool_like(use_namedtuple, "use_namedtuple", optional=True)
         nobs = self.nobs
         endog = self.endog
         if endog.shape[1] != 2:
@@ -1241,8 +1449,10 @@ class DescStatMV(_OptFuncts):
             1
         ]
         p_val = chi2.sf(llr, 1)
-        if return_weights:
-            return llr, p_val, self.new_weights.T
+        if use_namedtuple is None and not return_weights:
+            _warn_return_weights("DescStatMV.test_corr")
+        if use_namedtuple or return_weights:
+            return EmpLikeTestResult(llr, p_val, self.new_weights.T)
         return llr, p_val
 
     def ci_corr(self, sig=0.05, upper_bound=None, lower_bound=None):

--- a/statsmodels/emplike/elanova.py
+++ b/statsmodels/emplike/elanova.py
@@ -10,11 +10,39 @@ References
 Owen, A. B. (2001). Empirical Likelihood. Chapman and Hall.
 """
 
+from typing import NamedTuple
+import warnings
+
 import numpy as np
 from scipy import optimize
 from scipy.stats import chi2
 
+from statsmodels.tools.validation import bool_like
+
 from .descriptive import _OptFuncts
+
+
+class ANOVAResult(NamedTuple):
+    """
+    Result of :meth:`ANOVA.compute_ANOVA`.
+
+    Parameters
+    ----------
+    llr : float
+        -2 times the log-likelihood ratio, the test statistic.
+    pvalue : float
+        The p-value of the test statistic.
+    mu : float
+        The common mean, either the value supplied by the caller or the
+        maximum empirical likelihood estimate.
+    weights : ndarray or None
+        The observation weights that maximize the likelihood.
+    """
+
+    llr: float
+    pvalue: float
+    mu: float
+    weights: np.ndarray | None
 
 
 class _ANOVAOpt(_OptFuncts):
@@ -74,7 +102,9 @@ class ANOVA(_ANOVAOpt):
         for i in self.endog:
             self.nobs = self.nobs + len(i)
 
-    def compute_ANOVA(self, mu=None, mu_start=0, return_weights=False):
+    def compute_ANOVA(
+        self, mu=None, mu_start=0, return_weights=False, *, use_namedtuple=None
+    ):
         """
         Returns -2 log likelihood, the pvalue and the maximum likelihood
         estimate for a common mean
@@ -92,27 +122,58 @@ class ANOVA(_ANOVAOpt):
         return_weights : bool
             if TRUE, returns the weights on observations that maximize the
             likelihood.  Default is FALSE.
+        use_namedtuple : bool, optional
+            Flag indicating whether to return the results as an
+            ``ANOVAResult`` NamedTuple instead of a plain tuple. When
+            ``return_weights=True`` the NamedTuple holds the same four
+            elements as the legacy tuple, so it unpacks identically and is
+            always returned, with no warning. When ``return_weights=False``
+            the legacy three-element tuple is returned by default and a
+            ``FutureWarning`` is issued.
+
+            .. deprecated:: 0.15.0
+
+                In release 0.16.0 or after July 2027, whichever is later, the
+                default will change to always return an ``ANOVAResult``. Set
+                ``use_namedtuple=True`` to opt in now, or
+                ``use_namedtuple=False`` to silence the warning and keep the
+                current return type.
 
         Returns
         -------
-        res : tuple
-            The log-likelihood, p-value and estimate for the common mean.
+        ANOVAResult or tuple
+            If ``use_namedtuple=True`` or ``return_weights=True``, a
+            NamedTuple with fields ``llr``, ``pvalue``, ``mu`` and
+            ``weights``. See
+            :class:`~statsmodels.emplike.elanova.ANOVAResult`.
+
+            Otherwise (the deprecated default), the plain
+            ``(llr, pvalue, mu)`` tuple.
         """
+        use_namedtuple = bool_like(use_namedtuple, "use_namedtuple", optional=True)
         if mu is not None:
             llr = self._opt_common_mu(mu)
-            pval = 1 - chi2.cdf(llr, self.num_groups - 1)
-            if return_weights:
-                return llr, pval, mu, self.new_weights
-            else:
-                return llr, pval, mu
+            mu_common = mu
         else:
             res = optimize.fmin_powell(
                 self._opt_common_mu, mu_start, full_output=1, disp=False
             )
             llr = res[1]
             mu_common = float(np.squeeze(res[0]))
-            pval = 1 - chi2.cdf(llr, self.num_groups - 1)
-            if return_weights:
-                return llr, pval, mu_common, self.new_weights
-            else:
-                return llr, pval, mu_common
+        pval = 1 - chi2.cdf(llr, self.num_groups - 1)
+
+        if use_namedtuple is None and not return_weights:
+            warnings.warn(
+                "ANOVA.compute_ANOVA currently returns a plain tuple whose "
+                "length depends on the return_weights argument. In release "
+                "0.16.0 or after July 2027, whichever is later, the default "
+                "behavior will switch to always returning an ANOVAResult "
+                "NamedTuple. Set use_namedtuple=True to switch now, or "
+                "use_namedtuple=False to keep the current behavior and "
+                "silence this warning.",
+                FutureWarning,
+                stacklevel=2,
+            )
+        if use_namedtuple or return_weights:
+            return ANOVAResult(llr, pval, mu_common, self.new_weights)
+        return llr, pval, mu_common

--- a/statsmodels/emplike/originregress.py
+++ b/statsmodels/emplike/originregress.py
@@ -16,14 +16,19 @@ References
 Owen, A.B. (2001). Empirical Likelihood.  Chapman and Hall. p. 82.
 
 """
+
+import warnings
+
 import numpy as np
 from scipy import optimize
 from scipy.stats import chi2
 
+from statsmodels.emplike.descriptive import EmpLikeTestResult
 from statsmodels.regression.linear_model import OLS, RegressionResults
 
 # When descriptive merged, this will be changed
 from statsmodels.tools.tools import add_constant
+from statsmodels.tools.validation import bool_like
 
 
 class ELOriginRegress:
@@ -166,7 +171,14 @@ class OriginResults(RegressionResults):
         self.llf_el = llf_el
 
     def el_test(
-        self, b0_vals, param_nums, method="nm", stochastic_exog=1, return_weights=0
+        self,
+        b0_vals,
+        param_nums,
+        method="nm",
+        stochastic_exog=1,
+        return_weights=0,
+        *,
+        use_namedtuple=None,
     ):
         """
         Returns the llr and p-value for a hypothesized parameter value
@@ -193,17 +205,44 @@ class OriginResults(RegressionResults):
         return_weights : bool
             If true, returns the weights that optimize the likelihood
             ratio at b0_vals.  Default is False.
+        use_namedtuple : bool, optional
+            Flag indicating whether to return the results as an
+            ``EmpLikeTestResult`` NamedTuple instead of a plain tuple. When
+            ``return_weights=True`` the NamedTuple holds the same three
+            elements as the legacy tuple, so it unpacks identically and is
+            always returned, with no warning. When ``return_weights=False``
+            the legacy two-element tuple is returned by default and a
+            ``FutureWarning`` is issued.
+
+            .. deprecated:: 0.15.0
+
+                In release 0.16.0 or after July 2027, whichever is later, the
+                default will change to always return an
+                ``EmpLikeTestResult``. Set ``use_namedtuple=True`` to opt in
+                now, or ``use_namedtuple=False`` to silence the warning and
+                keep the current return type.
 
         Returns
         -------
-        llr : float
-            The log likelihood ratio for the hypothesized values.
-        pval : float
-            The p-value corresponding to `llr`.
-        weights : ndarray, optional
-            The observation weights that optimize the likelihood
-            ratio.  Only returned if `return_weights` is True.
+        EmpLikeTestResult or tuple
+            If ``use_namedtuple=True`` or ``return_weights=True``, a
+            NamedTuple with fields:
+
+            llr : float
+                The log likelihood ratio for the hypothesized values.
+            pvalue : float
+                The p-value corresponding to ``llr``.
+            weights : ndarray or None
+                The observation weights that optimize the likelihood ratio.
+                ``None`` when ``return_weights`` is False, since they are
+                not computed in that case.
+
+            See :class:`~statsmodels.emplike.descriptive.EmpLikeTestResult`.
+
+            Otherwise (the deprecated default), the plain ``(llr, pvalue)``
+            tuple.
         """
+        use_namedtuple = bool_like(use_namedtuple, "use_namedtuple", optional=True)
         b0_vals = np.hstack((0, b0_vals))
         param_nums = np.hstack((0, param_nums))
         test_res = self.model.fit().el_test(
@@ -217,10 +256,25 @@ class OriginResults(RegressionResults):
         llr_test = test_res[0]
         llr_res = llr_test - self.llr
         pval = chi2.sf(llr_res, self.model.exog.shape[1] - 1)
-        if return_weights:
-            return llr_res, pval, test_res[2]
-        else:
-            return llr_res, pval
+        # The weights come from the underlying OLSResults.el_test, which only
+        # computes them when return_weights is True, so they stay None here
+        # otherwise.
+        weights = test_res[2] if return_weights else None
+        if use_namedtuple is None and not return_weights:
+            warnings.warn(
+                "OriginResults.el_test currently returns a plain tuple whose "
+                "length depends on the return_weights argument. In release "
+                "0.16.0 or after July 2027, whichever is later, the default "
+                "behavior will switch to always returning an "
+                "EmpLikeTestResult NamedTuple. Set use_namedtuple=True to "
+                "switch now, or use_namedtuple=False to keep the current "
+                "behavior and silence this warning.",
+                FutureWarning,
+                stacklevel=2,
+            )
+        if use_namedtuple or return_weights:
+            return EmpLikeTestResult(llr_res, pval, weights)
+        return llr_res, pval
 
     def conf_int_el(
         self,
@@ -275,9 +329,13 @@ class OriginResults(RegressionResults):
         def f(b0):
             b0 = np.array([b0])
             val = self.el_test(
-                b0, param_num, method=method, stochastic_exog=stochastic_exog
+                b0,
+                param_num,
+                method=method,
+                stochastic_exog=stochastic_exog,
+                use_namedtuple=True,
             )
-            return val[0] - r0
+            return val.llr - r0
 
         _param = np.squeeze(self.params[param_num])
         lowerl = optimize.brentq(f, np.squeeze(lower_bound), _param)

--- a/statsmodels/emplike/tests/test_anova.py
+++ b/statsmodels/emplike/tests/test_anova.py
@@ -1,8 +1,11 @@
+import warnings
+
 import numpy as np
-from numpy.testing import assert_almost_equal
+from numpy.testing import assert_almost_equal, assert_equal
+import pytest
 
 from statsmodels.datasets import star98
-from statsmodels.emplike.elanova import ANOVA
+from statsmodels.emplike.elanova import ANOVA, ANOVAResult
 
 from .results.el_results import ANOVAResults
 
@@ -12,8 +15,37 @@ DATA = np.asarray(star98.load().exog)[:30, 1:3]
 def test_anova():
     res1 = ANOVA([DATA[:, 0], DATA[:, 1]])
     res2 = ANOVAResults()
-    assert_almost_equal(res1.compute_ANOVA()[:2], res2.compute_ANOVA[:2], 4)
-    assert_almost_equal(res1.compute_ANOVA()[2], res2.compute_ANOVA[2], 4)
+    res = res1.compute_ANOVA(use_namedtuple=True)
+    assert_almost_equal(res[:2], res2.compute_ANOVA[:2], 4)
+    assert_almost_equal(res[2], res2.compute_ANOVA[2], 4)
     assert_almost_equal(
         res1.compute_ANOVA(return_weights=True)[3], res2.compute_ANOVA[3], 4
     )
+
+
+def test_anova_namedtuple():
+    res1 = ANOVA([DATA[:, 0], DATA[:, 1]])
+
+    # return_weights=True already yields four values, so the NamedTuple is
+    # adopted silently
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", FutureWarning)
+        full = res1.compute_ANOVA(return_weights=True)
+    assert isinstance(full, ANOVAResult)
+    assert_equal(len(full), 4)
+
+    # the three-value path still warns and still returns a plain tuple
+    with pytest.warns(FutureWarning, match="compute_ANOVA"):
+        legacy = res1.compute_ANOVA()
+    assert not isinstance(legacy, ANOVAResult)
+    assert_equal(len(legacy), 3)
+    assert_almost_equal(legacy, full[:3], 10)
+
+    # opting in or out is silent either way
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", FutureWarning)
+        opted_in = res1.compute_ANOVA(use_namedtuple=True)
+        opted_out = res1.compute_ANOVA(use_namedtuple=False)
+    assert isinstance(opted_in, ANOVAResult)
+    assert opted_in.weights is not None
+    assert_equal(len(opted_out), 3)

--- a/statsmodels/emplike/tests/test_descriptive.py
+++ b/statsmodels/emplike/tests/test_descriptive.py
@@ -1,9 +1,11 @@
+import warnings
+
 import numpy as np
 from numpy.testing import assert_almost_equal
 import pytest
 
 from statsmodels.datasets import star98
-from statsmodels.emplike.descriptive import DescStat
+from statsmodels.emplike.descriptive import DescStat, EmpLikeTestResult
 
 from .results.el_results import DescStatRes
 
@@ -30,7 +32,8 @@ class TestDescriptiveStatistics(GenRes):
         super().setup_class()
 
     def test_test_mean(self):
-        assert_almost_equal(self.res1.test_mean(14), self.res2.test_mean_14, 4)
+        res = self.res1.test_mean(14, use_namedtuple=True)
+        assert_almost_equal(res[:2], self.res2.test_mean_14, 4)
 
     def test_test_mean_weights(self):
         assert_almost_equal(
@@ -42,7 +45,8 @@ class TestDescriptiveStatistics(GenRes):
 
     @pytest.mark.thread_unsafe("calculation sets attributes and is not thread safe")
     def test_test_var(self):
-        assert_almost_equal(self.res1.test_var(3), self.res2.test_var_3, 4)
+        res = self.res1.test_var(3, use_namedtuple=True)
+        assert_almost_equal(res[:2], self.res2.test_var_3, 4)
 
     @pytest.mark.thread_unsafe("calculation sets attributes and is not thread safe")
     def test_test_var_weights(self):
@@ -56,7 +60,9 @@ class TestDescriptiveStatistics(GenRes):
 
     def test_mv_test_mean(self):
         assert_almost_equal(
-            self.mvres1.mv_test_mean(np.array([14, 56])), self.res2.mv_test_mean, 4
+            self.mvres1.mv_test_mean(np.array([14, 56]), use_namedtuple=True)[:2],
+            self.res2.mv_test_mean,
+            4,
         )
 
     def test_mv_test_mean_weights(self):
@@ -68,7 +74,8 @@ class TestDescriptiveStatistics(GenRes):
 
     @pytest.mark.thread_unsafe("calculation sets attributes and is not thread safe")
     def test_test_skew(self):
-        assert_almost_equal(self.res1.test_skew(0), self.res2.test_skew, 4)
+        res = self.res1.test_skew(0, use_namedtuple=True)
+        assert_almost_equal(res[:2], self.res2.test_skew, 4)
 
     @pytest.mark.thread_unsafe("calculation sets attributes and is not thread safe")
     def test_ci_skew(self):
@@ -81,8 +88,8 @@ class TestDescriptiveStatistics(GenRes):
         skew_ci = self.res1.ci_skew()
         lower_lim = skew_ci[0]
         upper_lim = skew_ci[1]
-        ul_pval = self.res1.test_skew(lower_lim)[1]
-        ll_pval = self.res1.test_skew(upper_lim)[1]
+        ul_pval = self.res1.test_skew(lower_lim, use_namedtuple=True).pvalue
+        ll_pval = self.res1.test_skew(upper_lim, use_namedtuple=True).pvalue
         assert_almost_equal(ul_pval, 0.050000, 4)
         assert_almost_equal(ll_pval, 0.050000, 4)
 
@@ -94,7 +101,8 @@ class TestDescriptiveStatistics(GenRes):
 
     @pytest.mark.thread_unsafe("calculation sets attributes and is not thread safe")
     def test_test_kurt(self):
-        assert_almost_equal(self.res1.test_kurt(0), self.res2.test_kurt_0, 4)
+        res = self.res1.test_kurt(0, use_namedtuple=True)
+        assert_almost_equal(res[:2], self.res2.test_kurt_0, 4)
 
     @pytest.mark.thread_unsafe("calculation sets attributes and is not thread safe")
     def test_ci_kurt(self):
@@ -102,28 +110,31 @@ class TestDescriptiveStatistics(GenRes):
         kurt_ci = self.res1.ci_kurt(upper_bound=0.5, lower_bound=-1.5)
         lower_lim = kurt_ci[0]
         upper_lim = kurt_ci[1]
-        ul_pval = self.res1.test_kurt(upper_lim)[1]
-        ll_pval = self.res1.test_kurt(lower_lim)[1]
+        ul_pval = self.res1.test_kurt(upper_lim, use_namedtuple=True).pvalue
+        ll_pval = self.res1.test_kurt(lower_lim, use_namedtuple=True).pvalue
         assert_almost_equal(ul_pval, 0.050000, 4)
         assert_almost_equal(ll_pval, 0.050000, 4)
 
     @pytest.mark.thread_unsafe("calculation sets attributes and is not thread safe")
     def test_joint_skew_kurt(self):
         assert_almost_equal(
-            self.res1.test_joint_skew_kurt(0, 0), self.res2.test_joint_skew_kurt, 4
+            self.res1.test_joint_skew_kurt(0, 0, use_namedtuple=True)[:2],
+            self.res2.test_joint_skew_kurt,
+            4,
         )
 
     @pytest.mark.thread_unsafe("calculation sets attributes and is not thread safe")
     def test_test_corr(self):
-        assert_almost_equal(self.mvres1.test_corr(0.5), self.res2.test_corr, 4)
+        res = self.mvres1.test_corr(0.5, use_namedtuple=True)
+        assert_almost_equal(res[:2], self.res2.test_corr, 4)
 
     @pytest.mark.thread_unsafe("calculation sets attributes and is not thread safe")
     def test_ci_corr(self):
         corr_ci = self.mvres1.ci_corr()
         lower_lim = corr_ci[0]
         upper_lim = corr_ci[1]
-        ul_pval = self.mvres1.test_corr(upper_lim)[1]
-        ll_pval = self.mvres1.test_corr(lower_lim)[1]
+        ul_pval = self.mvres1.test_corr(upper_lim, use_namedtuple=True).pvalue
+        ll_pval = self.mvres1.test_corr(lower_lim, use_namedtuple=True).pvalue
         assert_almost_equal(ul_pval, 0.050000, 4)
         assert_almost_equal(ll_pval, 0.050000, 4)
 
@@ -145,3 +156,67 @@ class TestDescriptiveStatistics(GenRes):
     def test_descstat_invalid_input(self, endog):
         with pytest.raises(ValueError):
             DescStat(endog)
+
+
+@pytest.mark.parametrize(
+    ("attr", "args"),
+    [
+        ("test_mean", (14,)),
+        ("test_var", (3,)),
+        ("test_skew", (0,)),
+        ("test_kurt", (0,)),
+        ("test_joint_skew_kurt", (0, 0)),
+    ],
+)
+@pytest.mark.thread_unsafe("calculation sets attributes and is not thread safe")
+def test_univariate_namedtuple(attr, args):
+    data = np.asarray(star98.load().exog)[:50, 5]
+    meth = getattr(DescStat(data), attr)
+
+    # return_weights=True already yields three values, so the NamedTuple is
+    # adopted silently
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", FutureWarning)
+        full = meth(*args, return_weights=True)
+    assert isinstance(full, EmpLikeTestResult)
+    assert len(full) == 3
+
+    # the two-value path still warns and still returns a plain tuple
+    with pytest.warns(FutureWarning, match=attr):
+        legacy = meth(*args)
+    assert not isinstance(legacy, EmpLikeTestResult)
+    assert len(legacy) == 2
+    assert_almost_equal(legacy, full[:2], 10)
+
+    # opting in or out is silent either way
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", FutureWarning)
+        opted_in = meth(*args, use_namedtuple=True)
+        opted_out = meth(*args, use_namedtuple=False)
+    assert isinstance(opted_in, EmpLikeTestResult)
+    assert opted_in.weights is not None
+    assert len(opted_out) == 2
+
+
+@pytest.mark.parametrize(
+    ("attr", "args"),
+    [
+        ("mv_test_mean", (np.array([14, 56]),)),
+        ("test_corr", (0.5,)),
+    ],
+)
+@pytest.mark.thread_unsafe("calculation sets attributes and is not thread safe")
+def test_multivariate_namedtuple(attr, args):
+    data = np.asarray(star98.load().exog)[:50, 5:7]
+    meth = getattr(DescStat(data), attr)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", FutureWarning)
+        full = meth(*args, return_weights=True)
+    assert isinstance(full, EmpLikeTestResult)
+    assert len(full) == 3
+
+    with pytest.warns(FutureWarning, match=attr):
+        legacy = meth(*args)
+    assert len(legacy) == 2
+    assert_almost_equal(legacy, full[:2], 10)

--- a/statsmodels/emplike/tests/test_origin.py
+++ b/statsmodels/emplike/tests/test_origin.py
@@ -1,7 +1,11 @@
+import warnings
+
 import numpy as np
-from numpy.testing import assert_almost_equal
+from numpy.testing import assert_almost_equal, assert_equal
+import pytest
 
 from statsmodels.datasets import cancer
+from statsmodels.emplike.descriptive import EmpLikeTestResult
 from statsmodels.emplike.originregress import ELOriginRegress
 
 from .results.el_results import OriginResults
@@ -29,8 +33,31 @@ class TestOrigin(GenRes):
         assert_almost_equal(self.res1.llf_el, self.res2.test_llf_hat, 4)
 
     def test_hypothesis_beta1(self):
-        assert_almost_equal(self.res1.el_test([.0034], [1])[0],
-                            self.res2.test_llf_hypoth, 4)
+        res = self.res1.el_test([.0034], [1], use_namedtuple=True)
+        assert_almost_equal(res.llr, self.res2.test_llf_hypoth, 4)
+
+    def test_el_test_namedtuple(self):
+        # return_weights=True already yields three values, so the NamedTuple
+        # is adopted silently
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", FutureWarning)
+            full = self.res1.el_test([.0034], [1], return_weights=1)
+        assert isinstance(full, EmpLikeTestResult)
+        assert_equal(len(full), 3)
+
+        # the two-value path still warns and still returns a plain tuple
+        with pytest.warns(FutureWarning, match="el_test"):
+            legacy = self.res1.el_test([.0034], [1])
+        assert not isinstance(legacy, EmpLikeTestResult)
+        assert_equal(len(legacy), 2)
+        assert_almost_equal(legacy, full[:2], 10)
+
+        # weights are not computed when they are not requested
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", FutureWarning)
+            opted_in = self.res1.el_test([.0034], [1], use_namedtuple=True)
+        assert isinstance(opted_in, EmpLikeTestResult)
+        assert opted_in.weights is None
 
     def test_ci_beta(self):
         ci = self.res1.conf_int_el(1)

--- a/statsmodels/graphics/regressionplots.py
+++ b/statsmodels/graphics/regressionplots.py
@@ -455,7 +455,7 @@ def plot_partregress(
         .. deprecated:: 0.15.0
 
             When ``ret_coords=False``, in release 0.16.0 or after July
-            2028, whichever is later, the default will change to return a
+            2027, whichever is later, the default will change to return a
             ``PartRegressPlotResult`` rather than a bare figure. Set
             ``use_namedtuple=True`` to opt in now, or
             ``use_namedtuple=False`` to silence the warning and keep the
@@ -619,7 +619,7 @@ def plot_partregress(
     if use_namedtuple is None and not ret_coords:
         warnings.warn(
             "plot_partregress currently returns a bare figure when "
-            "ret_coords=False. In release 0.16 or after July 2028, "
+            "ret_coords=False. In release 0.16 or after July 2027, "
             "whichever is later, the default behavior will switch to "
             "always returning a PartRegressPlotResult NamedTuple, which "
             "also carries the coordinates. Set use_namedtuple=True to "

--- a/statsmodels/nonparametric/kde.py
+++ b/statsmodels/nonparametric/kde.py
@@ -506,7 +506,7 @@ def kdensity(
     if use_namedtuple is None and not retgrid:
         warnings.warn(
             "kdensity currently returns a plain (density, bw) tuple when "
-            "retgrid=False. In release 0.16 or after July 2028, whichever "
+            "retgrid=False. In release 0.16 or after July 2027, whichever "
             "is later, the default behavior will switch to always "
             "returning a KDEResult NamedTuple, which also carries the "
             "grid. Set use_namedtuple=True to switch now, or "
@@ -715,7 +715,7 @@ def kdensityfft(
     if use_namedtuple is None and not retgrid:
         warnings.warn(
             "kdensityfft currently returns a plain (density, bw) tuple "
-            "when retgrid=False. In release 0.16 or after July 2028, "
+            "when retgrid=False. In release 0.16 or after July 2027, "
             "whichever is later, the default behavior will switch to "
             "always returning a KDEResult NamedTuple, which also carries "
             "the grid. Set use_namedtuple=True to switch now, or "

--- a/statsmodels/regression/linear_model.py
+++ b/statsmodels/regression/linear_model.py
@@ -3498,7 +3498,7 @@ class OLSResults(RegressionResults):
             warnings.warn(
                 "el_test currently returns a plain tuple whose length "
                 "depends on the return_weights and ret_params arguments. "
-                "In release 0.16 or after July 2028, whichever is later, "
+                "In release 0.16 or after July 2027, whichever is later, "
                 "the default behavior will switch to always returning an "
                 "ELTestResult NamedTuple. Set use_namedtuple=True to "
                 "switch now, or use_namedtuple=False to keep the current "

--- a/statsmodels/stats/contingency_tables.py
+++ b/statsmodels/stats/contingency_tables.py
@@ -25,6 +25,7 @@ sampled.  In general the observed units are independent and
 identically distributed.
 """
 
+from typing import NamedTuple
 import warnings
 
 import numpy as np
@@ -1400,7 +1401,26 @@ def mcnemar(table, exact=True, correction=True):
     return b
 
 
-def cochrans_q(x, return_object=True):
+class CochransQResult(NamedTuple):
+    """
+    Result of :func:`cochrans_q`.
+
+    Parameters
+    ----------
+    statistic : float
+        Test statistic.
+    pvalue : float
+        p-value from the chisquare distribution.
+    df : int
+        Degrees of freedom of the chisquare distribution.
+    """
+
+    statistic: float
+    pvalue: float
+    df: int
+
+
+def cochrans_q(x, return_object=None):
     """
     Cochran's Q test for identical binomial proportions
 
@@ -1409,17 +1429,35 @@ def cochrans_q(x, return_object=True):
     x : array_like, 2d (N, k)
         data with N cases and k variables
     return_object : bool
-        Return values as bunch instead of as individual values.
+        No longer used. ``cochrans_q`` always returns a
+        ``CochransQResult``, which supports both the attribute access of the
+        bunch that ``return_object=True`` used to produce and the positional
+        unpacking of the ``(statistic, pvalue, df)`` tuple that
+        ``return_object=False`` used to produce.
+
+        .. deprecated:: 0.15.0
+
+            ``return_object`` no longer affects the return value and will be
+            removed in statsmodels 0.16.0. Passing it raises a
+            ``FutureWarning``; simply stop passing it.
 
     Returns
     -------
-    Returns a bunch containing the following attributes, or the
-    individual values according to the value of `return_object`.
+    CochransQResult
+        A NamedTuple with fields:
 
-    statistic : float
-       test statistic
-    pvalue : float
-       pvalue from the chisquare distribution
+        statistic : float
+            test statistic
+        pvalue : float
+            pvalue from the chisquare distribution
+        df : int
+            degrees of freedom of the chisquare distribution
+
+        ``CochransQResult`` unpacks and indexes exactly like the
+        ``(statistic, pvalue, df)`` tuple that ``return_object=False``
+        returned, and exposes the same ``statistic``, ``pvalue`` and ``df``
+        attributes as the bunch that ``return_object=True`` returned. See
+        :class:`~statsmodels.stats.contingency_tables.CochransQResult`.
 
     Notes
     -----
@@ -1443,6 +1481,17 @@ def cochrans_q(x, return_object=True):
     https://en.wikipedia.org/wiki/Cochran_test
     SAS Manual for NPAR TESTS
     """
+    if return_object is not None:
+        warnings.warn(
+            "The return_object keyword of cochrans_q no longer changes the "
+            "return value and will be removed in statsmodels 0.16.0. "
+            "cochrans_q now always returns a CochransQResult, which unpacks "
+            "as (statistic, pvalue, df) and also exposes .statistic, "
+            ".pvalue and .df. Stop passing return_object to silence this "
+            "warning.",
+            FutureWarning,
+            stacklevel=2,
+        )
 
     x = np.asarray(x, dtype=np.float64)
     gruni = np.unique(x)
@@ -1469,11 +1518,8 @@ def cochrans_q(x, return_object=True):
     df = k - 1
     pvalue = stats.chi2.sf(q_stat, df)
 
-    if return_object:
-        b = _Bunch()
-        b.statistic = q_stat
-        b.df = df
-        b.pvalue = pvalue
-        return b
-
-    return q_stat, pvalue, df
+    # CochransQResult replaces both legacy return paths at once: it unpacks
+    # as the (statistic, pvalue, df) tuple that return_object=False produced
+    # and carries the same attributes as the bunch that return_object=True
+    # produced, so a single return covers every caller.
+    return CochransQResult(q_stat, pvalue, df)

--- a/statsmodels/stats/correlation_tools.py
+++ b/statsmodels/stats/correlation_tools.py
@@ -6,6 +6,7 @@ License: BSD-3
 """
 
 
+from typing import NamedTuple
 import warnings
 
 import numpy as np
@@ -20,6 +21,7 @@ from statsmodels.tools.sm_exceptions import (
     iteration_limit_doc,
 )
 from statsmodels.tools.tools import Bunch
+from statsmodels.tools.validation import bool_like
 
 
 def clip_evals(x, value=0):  # threshold=0, value=0):
@@ -153,8 +155,30 @@ def corr_clipped(corr, threshold=1e-15):
     return x_new
 
 
+class CovNearestResult(NamedTuple):
+    """
+    Result of :func:`cov_nearest` when the intermediate results are
+    returned.
+
+    Parameters
+    ----------
+    cov : ndarray
+        Corrected covariance matrix.
+    corr : ndarray
+        Corrected correlation matrix.
+    std : ndarray
+        Standard deviation taken from the diagonal of the input covariance
+        matrix.
+    """
+
+    cov: np.ndarray
+    corr: np.ndarray
+    std: np.ndarray
+
+
 def cov_nearest(cov, method="clipped", threshold=1e-15, n_fact=100,
-                return_all=False, *, min_diag=None):
+                return_all=False, *, min_diag=None,
+                use_namedtuple: bool | None = None):
     """
     Find the nearest covariance matrix that is positive (semi-) definite
 
@@ -186,15 +210,35 @@ def cov_nearest(cov, method="clipped", threshold=1e-15, n_fact=100,
         raised to ``min_diag`` before the conversion, and a ``SpecificationWarning``
         is issued. This makes it possible to correct matrices with a zero or
         negative diagonal, at the cost of changing those variances.
+    use_namedtuple : bool, optional
+        Flag controlling whether a ``CovNearestResult`` NamedTuple is
+        returned. When ``return_all=True`` a ``CovNearestResult`` is always
+        returned; it holds the same three elements as the legacy tuple, so
+        it unpacks and indexes identically. When ``return_all=False`` a bare
+        covariance matrix is returned unless ``use_namedtuple=True``, which
+        yields a ``CovNearestResult`` carrying the correlation matrix and
+        standard deviations too.
 
     Returns
     -------
-    cov_ : ndarray
-        corrected covariance matrix
-    corr_ : ndarray, (optional)
-        corrected correlation matrix
-    std_ : ndarray, (optional)
-        standard deviation
+    CovNearestResult or ndarray
+        When ``return_all=True`` (or ``use_namedtuple=True``), a NamedTuple
+        with fields:
+
+        cov : ndarray
+            corrected covariance matrix
+        corr : ndarray
+            corrected correlation matrix
+        std : ndarray
+            standard deviation
+
+        ``CovNearestResult`` has the same length and contents as the plain
+        ``(cov_, corr_, std_)`` tuple it replaces, so it unpacks and indexes
+        identically. See
+        :class:`~statsmodels.stats.correlation_tools.CovNearestResult`.
+
+        When ``return_all=False`` a bare corrected covariance matrix is
+        returned instead.
 
     See Also
     --------
@@ -218,6 +262,7 @@ def cov_nearest(cov, method="clipped", threshold=1e-15, n_fact=100,
 
     from statsmodels.stats.moment_helpers import corr2cov, cov2corr
 
+    use_namedtuple = bool_like(use_namedtuple, "use_namedtuple", optional=True)
     cov = np.asarray(cov)
     if min_diag is not None:
         diag = np.diag(cov)
@@ -240,10 +285,15 @@ def cov_nearest(cov, method="clipped", threshold=1e-15, n_fact=100,
 
     cov_ = corr2cov(corr_, std_)
 
-    if return_all:
-        return cov_, corr_, std_
-    else:
-        return cov_
+    # CovNearestResult has exactly the same length and contents as the legacy
+    # (cov_, corr_, std_) tuple, so it unpacks and indexes identically and is
+    # always used when return_all is True.  When return_all is False a bare
+    # covariance matrix is returned, as before; pass use_namedtuple=True to
+    # always get a CovNearestResult.  The correlation matrix and standard
+    # deviations are computed either way, so nothing is None-filled.
+    if use_namedtuple or return_all:
+        return CovNearestResult(cov_, corr_, std_)
+    return cov_
 
 
 def _nmono_linesearch(

--- a/statsmodels/stats/covariance.py
+++ b/statsmodels/stats/covariance.py
@@ -4,8 +4,12 @@ Author: Josef Perktold
 License: BSD-3
 """
 
+from typing import NamedTuple
+
 import numpy as np
 from scipy import integrate, stats
+
+from statsmodels.tools.validation import bool_like
 
 pi2 = np.pi**2
 pi2i = 1. / pi2
@@ -36,7 +40,26 @@ def _term_integrate(rho):
     return fact
 
 
-def transform_corr_normal(corr, method, return_var=False, possdef=True):
+class TransformCorrNormalResult(NamedTuple):
+    """
+    Result of :func:`transform_corr_normal` when the variance is returned.
+
+    Parameters
+    ----------
+    corr : ndarray
+        Correlation matrix, consistent with the correlation for a
+        multivariate normal distribution.
+    var : ndarray
+        Asymptotic variance of the normalized correlation.
+    """
+
+    corr: np.ndarray
+    var: np.ndarray
+
+
+def transform_corr_normal(
+    corr, method, return_var=False, possdef=True, *, use_namedtuple: bool | None = None
+):
     """
     Transform correlation matrix to be consistent at normal distribution
 
@@ -56,14 +79,35 @@ def transform_corr_normal(corr, method, return_var=False, possdef=True):
     possdef : not implemented yet
         Check whether resulting correlation matrix for positive semidefinite
         and return a positive semidefinite approximation if not.
+    use_namedtuple : bool, optional
+        Flag controlling whether a ``TransformCorrNormalResult`` NamedTuple
+        is returned. When ``return_var=True`` a
+        ``TransformCorrNormalResult`` is always returned; it holds the same
+        two elements as the legacy tuple, so it unpacks and indexes
+        identically. When ``return_var=False`` a bare correlation matrix is
+        returned unless ``use_namedtuple=True``, which yields a
+        ``TransformCorrNormalResult`` with ``var`` set to ``None``.
 
     Returns
     -------
-    corr : ndarray
-        correlation matrix, consistent with correlation for a multivariate
-        normal distribution
-    var : ndarray (optional)
-        asymptotic variance of the correlation if requested by `return_var`.
+    TransformCorrNormalResult or ndarray
+        When ``return_var=True`` (or ``use_namedtuple=True``), a NamedTuple
+        with fields:
+
+        corr : ndarray
+            correlation matrix, consistent with correlation for a
+            multivariate normal distribution
+        var : ndarray or None
+            asymptotic variance of the correlation. ``None`` when
+            ``return_var`` is False, since it is not computed in that case.
+
+        ``TransformCorrNormalResult`` has the same length and contents as
+        the plain ``(corr_n, var)`` tuple it replaces, so it unpacks and
+        indexes identically. See
+        :class:`~statsmodels.stats.covariance.TransformCorrNormalResult`.
+
+        When ``return_var=False`` a bare correlation matrix is returned
+        instead.
 
     Notes
     -----
@@ -88,6 +132,7 @@ def transform_corr_normal(corr, method, return_var=False, possdef=True):
        https://doi.org/10.1007/s10260-010-0142-z.
 
     """
+    use_namedtuple = bool_like(use_namedtuple, "use_namedtuple", optional=True)
     method = method.lower()
     rho = np.asarray(corr)
 
@@ -155,10 +200,15 @@ def transform_corr_normal(corr, method, return_var=False, possdef=True):
     else:
         raise ValueError("method not recognized")
 
-    if return_var:
-        return corr_n, var
-    else:
-        return corr_n
+    # TransformCorrNormalResult has exactly the same length and contents as
+    # the legacy (corr_n, var) tuple, so it unpacks and indexes identically
+    # and is always used when return_var is True.  When return_var is False a
+    # bare correlation matrix is returned, as before; pass
+    # use_namedtuple=True to always get a TransformCorrNormalResult, with
+    # var left as None since it is only computed when requested.
+    if use_namedtuple or return_var:
+        return TransformCorrNormalResult(corr_n, var)
+    return corr_n
 
 
 def corr_rank(data):

--- a/statsmodels/stats/diagnostic.py
+++ b/statsmodels/stats/diagnostic.py
@@ -234,7 +234,7 @@ def compare_cox(
         warnings.warn(
             "compare_cox currently returns a plain tuple whose length "
             "depends on the store argument. In release 0.16 or after "
-            "July 2028, whichever is later, the default behavior will "
+            "July 2027, whichever is later, the default behavior will "
             "switch to always returning a NonNestedTestResult NamedTuple. "
             "Set use_namedtuple=True to switch now, or "
             "use_namedtuple=False to keep the current behavior and "
@@ -329,7 +329,7 @@ def compare_j(results_x, results_z, store=False, *, use_namedtuple: bool | None 
         warnings.warn(
             "compare_j currently returns a plain tuple whose length "
             "depends on the store argument. In release 0.16 or after "
-            "July 2028, whichever is later, the default behavior will "
+            "July 2027, whichever is later, the default behavior will "
             "switch to always returning a NonNestedTestResult NamedTuple. "
             "Set use_namedtuple=True to switch now, or "
             "use_namedtuple=False to keep the current behavior and "
@@ -757,7 +757,7 @@ def acorr_lm(
         warnings.warn(
             "acorr_lm currently returns a plain tuple whose length "
             "depends on the store argument. In release 0.16 or after "
-            "July 2028, whichever is later, the default behavior will "
+            "July 2027, whichever is later, the default behavior will "
             "switch to always returning an LMTestResult NamedTuple. Set "
             "use_namedtuple=True to switch now, or use_namedtuple=False "
             "to keep the current behavior and silence this warning.",
@@ -945,7 +945,7 @@ def acorr_breusch_godfrey(
         warnings.warn(
             "acorr_breusch_godfrey currently returns a plain tuple whose "
             "length depends on the store argument. In release 0.16 or "
-            "after July 2028, whichever is later, the default behavior "
+            "after July 2027, whichever is later, the default behavior "
             "will switch to always returning an LMTestResult NamedTuple. "
             "Set use_namedtuple=True to switch now, or "
             "use_namedtuple=False to keep the current behavior and "
@@ -1271,7 +1271,7 @@ F-statistic ={fval:8.4f} and p-value ={fpval:8.4f}"""
         warnings.warn(
             "het_goldfeldquandt currently returns a plain tuple whose "
             "length depends on the store argument. In release 0.16 or "
-            "after July 2028, whichever is later, the default behavior "
+            "after July 2027, whichever is later, the default behavior "
             "will switch to always returning a GoldfeldQuandtResult "
             "NamedTuple. Set use_namedtuple=True to switch now, or "
             "use_namedtuple=False to keep the current behavior and "

--- a/statsmodels/stats/moment_helpers.py
+++ b/statsmodels/stats/moment_helpers.py
@@ -13,8 +13,12 @@ License: BSD-3
 
 """
 
+from typing import NamedTuple
+
 import numpy as np
 from scipy.special import comb
+
+from statsmodels.tools.validation import bool_like
 
 
 def _convert_to_multidim(x):
@@ -342,7 +346,24 @@ def mnc2mvsk(args):
 # TODO: no return, did it get lost in cut-paste?
 
 
-def cov2corr(cov, return_std=False):
+class Cov2CorrResult(NamedTuple):
+    """
+    Result of :func:`cov2corr` when the standard deviations are returned.
+
+    Parameters
+    ----------
+    corr : ndarray
+        Correlation matrix.
+    std : ndarray
+        Standard deviation taken from the diagonal of the covariance
+        matrix.
+    """
+
+    corr: np.ndarray
+    std: np.ndarray
+
+
+def cov2corr(cov, return_std=False, *, use_namedtuple: bool | None = None):
     """
     Convert covariance matrix to correlation matrix
 
@@ -353,27 +374,51 @@ def cov2corr(cov, return_std=False):
     return_std : bool
         If this is true then the standard deviation is also returned.
         By default only the correlation matrix is returned.
+    use_namedtuple : bool, optional
+        Flag controlling whether a ``Cov2CorrResult`` NamedTuple is
+        returned. When ``return_std=True`` a ``Cov2CorrResult`` is always
+        returned; it holds the same two elements as the legacy tuple, so it
+        unpacks and indexes identically. When ``return_std=False`` a bare
+        correlation matrix is returned unless ``use_namedtuple=True``, which
+        yields a ``Cov2CorrResult`` carrying the standard deviations too.
 
     Returns
     -------
-    corr : ndarray (subclass)
-        Correlation matrix.
-    std_ : ndarray
-        Standard deviation from the diagonal of cov, returned only if
-        return_std is True.
+    Cov2CorrResult or ndarray
+        When ``return_std=True`` (or ``use_namedtuple=True``), a NamedTuple
+        with fields:
+
+        corr : ndarray (subclass)
+            Correlation matrix.
+        std : ndarray
+            Standard deviation from the diagonal of cov.
+
+        ``Cov2CorrResult`` has the same length and contents as the plain
+        ``(corr, std_)`` tuple it replaces, so it unpacks and indexes
+        identically. See
+        :class:`~statsmodels.stats.moment_helpers.Cov2CorrResult`.
+
+        When ``return_std=False`` a bare correlation matrix is returned
+        instead.
 
     Notes
     -----
     This function does not convert subclasses of ndarrays. This requires that
     division is defined elementwise. np.ma.array and np.matrix are allowed.
     """
+    use_namedtuple = bool_like(use_namedtuple, "use_namedtuple", optional=True)
     cov = np.asanyarray(cov)
     std_ = np.sqrt(np.diag(cov))
     corr = cov / np.outer(std_, std_)
-    if return_std:
-        return corr, std_
-    else:
-        return corr
+    # Cov2CorrResult has exactly the same length and contents as the legacy
+    # (corr, std_) tuple, so it unpacks and indexes identically and is always
+    # used when return_std is True.  When return_std is False a bare
+    # correlation matrix is returned, as before; pass use_namedtuple=True to
+    # always get a Cov2CorrResult.  The standard deviations are computed
+    # either way, so nothing needs to be None-filled.
+    if use_namedtuple or return_std:
+        return Cov2CorrResult(corr, std_)
+    return corr
 
 
 def corr2cov(corr, std):

--- a/statsmodels/stats/tests/test_contingency_tables.py
+++ b/statsmodels/stats/tests/test_contingency_tables.py
@@ -325,7 +325,7 @@ def test_cochranq():
     ]
     table = np.asarray(table)
 
-    stat, pvalue, df = ctab.cochrans_q(table, return_object=False)
+    stat, pvalue, df = ctab.cochrans_q(table)
     assert_allclose(stat, 4.2)
     assert_allclose(df, 3)
 
@@ -342,20 +342,35 @@ def test_cochranq():
     ]
     table = np.asarray(table)
 
-    stat, pvalue, df = ctab.cochrans_q(table, return_object=False)
+    stat, pvalue, df = ctab.cochrans_q(table)
     assert_allclose(stat, 1.2174, rtol=1e-4)
     assert_allclose(df, 4)
 
     # Cochran's q and Mcnemar are equivalent for 2x2 tables
     data = table[:, 0:2]
     xtab = np.asarray(pd.crosstab(data[:, 0], data[:, 1]))
-    b1 = ctab.cochrans_q(data, return_object=True)
+    b1 = ctab.cochrans_q(data)
     b2 = ctab.mcnemar(xtab, exact=False, correction=False)
     assert_allclose(b1.statistic, b2.statistic)
     assert_allclose(b1.pvalue, b2.pvalue)
 
-    # Test for printing bunch
-    assert_equal(str(b1).startswith("df          1\npvalue      0.65"), True)
+    # The single result supports both attribute access and unpacking
+    assert isinstance(b1, ctab.CochransQResult)
+    assert_equal(len(b1), 3)
+    assert_allclose(tuple(b1), (b1.statistic, b1.pvalue, b1.df))
+    assert_equal(b1.df, 1)
+
+
+def test_cochrans_q_return_object_deprecated():
+    # return_object no longer changes the result, but still warns
+    rs = np.random.RandomState(12345)
+    data = rs.randint(0, 2, size=(30, 4))
+
+    expected = ctab.cochrans_q(data)
+    for value in (True, False):
+        with pytest.warns(FutureWarning, match="return_object"):
+            res = ctab.cochrans_q(data, return_object=value)
+        assert_equal(res, expected)
 
 
 class CheckStratifiedMixin:

--- a/statsmodels/tsa/stattools/_stattools.py
+++ b/statsmodels/tsa/stattools/_stattools.py
@@ -462,7 +462,7 @@ def adfuller(
         warnings.warn(
             "adfuller currently returns a plain tuple whose length depends "
             "on the store and autolag arguments. In release 0.16 or after "
-            "July 2028, whichever is later, the default behavior will "
+            "July 2027, whichever is later, the default behavior will "
             "switch to always returning an ADFullerResult NamedTuple. Set "
             "use_namedtuple=True to switch now, or use_namedtuple=False "
             "to keep the current behavior and silence this warning.",
@@ -1043,7 +1043,7 @@ def acf(
         warnings.warn(
             "acf currently returns a plain tuple whose length depends on "
             "the qstat and alpha arguments. In release 0.16 or after "
-            "July 2028, whichever is later, the default behavior will "
+            "July 2027, whichever is later, the default behavior will "
             "switch to always returning an AcfResult NamedTuple. Set "
             "use_namedtuple=True to switch now, or use_namedtuple=False "
             "to keep the current behavior and silence this warning.",
@@ -2959,7 +2959,7 @@ look-up table. The actual p-value is {direction} than the p-value returned.
         warnings.warn(
             "kpss currently returns a plain tuple whose length and layout "
             "depends on the store argument (and which silently drops "
-            "`lags` when store=True). In release 0.16 or after July 2028, "
+            "`lags` when store=True). In release 0.16 or after July 2027, "
             "whichever is later, the default behavior will switch to "
             "always returning a KpssResult NamedTuple. Set "
             "use_namedtuple=True to switch now, or use_namedtuple=False "
@@ -3232,7 +3232,7 @@ look-up table. The actual p-value is {direction} than the p-value returned.
         warnings.warn(
             "range_unit_root_test currently returns a plain tuple whose "
             "length depends on the store argument. In release 0.16 or "
-            "after July 2028, whichever is later, the default behavior "
+            "after July 2027, whichever is later, the default behavior "
             "will switch to always returning a RangeUnitRootTestResult "
             "NamedTuple. Set use_namedtuple=True to switch now, or "
             "use_namedtuple=False to keep the current behavior and "


### PR DESCRIPTION
Make wider use of NamedTuples to provide a path to reducing the number of function that have  variable number of returns

- [ ] closes #xxxx
- [ ] tests added / passed. 
- [ ] code/documentation is well formatted.  
- [ ] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
