### PR TITLE
DOC: fix two defaults that the code does not have

### DIFF
--- a/statsmodels/base/l1_cvxopt.py
+++ b/statsmodels/base/l1_cvxopt.py
@@ -45,7 +45,7 @@ def fit_l1_cvxopt_cp(
             been zero if the solver reached the theoretical minimum.
             If 'auto', trim params using the Theory above.
             If 'size', trim params if they have very small absolute value.
-        size_trim_tol : float (default = 1e-4)
+        size_trim_tol : float
             Threshold below which a parameter is trimmed. Used when
             trim_mode == 'size'.
         auto_trim_tol : float

--- a/statsmodels/base/l1_cvxopt.py
+++ b/statsmodels/base/l1_cvxopt.py
@@ -45,7 +45,7 @@ def fit_l1_cvxopt_cp(
             been zero if the solver reached the theoretical minimum.
             If 'auto', trim params using the Theory above.
             If 'size', trim params if they have very small absolute value.
-        size_trim_tol : float or 'auto' (default = 'auto')
+        size_trim_tol : float (default = 1e-4)
             Threshold below which a parameter is trimmed. Used when
             trim_mode == 'size'.
         auto_trim_tol : float

--- a/statsmodels/base/l1_slsqp.py
+++ b/statsmodels/base/l1_slsqp.py
@@ -47,7 +47,7 @@ def fit_l1_slsqp(
             been zero if the solver reached the theoretical minimum.
             If 'auto', trim params using the Theory above.
             If 'size', trim params if they have very small absolute value.
-        size_trim_tol : float or 'auto' (default = 'auto')
+        size_trim_tol : float (default = 1e-4)
             Threshold below which a parameter is trimmed. Used when
             trim_mode == 'size'.
         auto_trim_tol : float

--- a/statsmodels/base/l1_slsqp.py
+++ b/statsmodels/base/l1_slsqp.py
@@ -47,7 +47,7 @@ def fit_l1_slsqp(
             been zero if the solver reached the theoretical minimum.
             If 'auto', trim params using the Theory above.
             If 'size', trim params if they have very small absolute value.
-        size_trim_tol : float (default = 1e-4)
+        size_trim_tol : float
             Threshold below which a parameter is trimmed. Used when
             trim_mode == 'size'.
         auto_trim_tol : float

--- a/statsmodels/base/l1_solvers_common.py
+++ b/statsmodels/base/l1_solvers_common.py
@@ -114,7 +114,7 @@ def do_trim_params(
             if the solver reached the theoretical minimum.
         If 'auto', trim params using the Theory above.
         If 'size', trim params if they have very small absolute value.
-    size_trim_tol : float or 'auto' (default = 'auto')
+    size_trim_tol : float (default = 1e-4)
         Threshold below which a parameter is trimmed. Used when
         trim_mode == 'size'.
     auto_trim_tol : float

--- a/statsmodels/base/l1_solvers_common.py
+++ b/statsmodels/base/l1_solvers_common.py
@@ -114,7 +114,7 @@ def do_trim_params(
             if the solver reached the theoretical minimum.
         If 'auto', trim params using the Theory above.
         If 'size', trim params if they have very small absolute value.
-    size_trim_tol : float (default = 1e-4)
+    size_trim_tol : float
         Threshold below which a parameter is trimmed. Used when
         trim_mode == 'size'.
     auto_trim_tol : float

--- a/statsmodels/discrete/discrete_model.py
+++ b/statsmodels/discrete/discrete_model.py
@@ -328,7 +328,7 @@ class DiscreteModel(base.LikelihoodModel):
             zero if the solver reached the theoretical minimum.
             If 'auto', trim params using the Theory above.
             If 'size', trim params if they have very small absolute value.
-        size_trim_tol : float or 'auto' (default = 'auto')
+        size_trim_tol : float (default = 1e-4)
             Tolerance used when trim_mode == 'size'.
         auto_trim_tol : float
             Tolerance used when trim_mode == 'auto'.

--- a/statsmodels/tsa/statespace/mlemodel.py
+++ b/statsmodels/tsa/statespace/mlemodel.py
@@ -5290,7 +5290,7 @@ class MLEResults(tsbase.TimeSeriesModelResults):
             endogenous variable when used in plot titles. Default is 24.
         auto_ylims : bool, optional
             If True, adjusts automatically the y-axis limits to ACF values.
-        bartlett_confint : bool, default True
+        bartlett_confint : bool, default False
             Confidence intervals for ACF values are generally placed at 2
             standard errors around r_k. The formula used for standard error
             depends upon the situation. If the autocorrelations are being used


### PR DESCRIPTION
- [ ] closes #xxxx
- [x] tests added / passed. — docstrings only, and per the template tests are not needed for doc changes
- [x] code/documentation is well formatted.
- [x] properly formatted commit message.

Two docstrings state a default the code does not have. Different files, same kind of thing, so they are together here -- say the word and I will split them.

### `size_trim_tol`, four places

Documented as `float or 'auto' (default = 'auto')` in `discrete_model.py`, `l1_solvers_common.py`, `l1_cvxopt.py` and `l1_slsqp.py`. Every signature that takes it defaults to `1e-4`, and `'auto'` is not a value it accepts: `do_trim_params` compares it against a float.

```python
elif trim_mode == "size":
    for i in range(k_params):
        if alpha[i] != 0:
            if abs(params[i]) < size_trim_tol:
```

On 0.14.6 from PyPI, following the docstring:

```
size_trim_tol=0.0001   -> ok, params [-0.002  1.5   -0.275  0.158]
size_trim_tol='auto'   -> UFuncTypeError: ufunc 'less' did not contain a loop with
                          signature matching types (Float64DType, StrDType) -> None
```

`trim_mode` right above it really does take `'auto'`, so the wording looks like it drifted one line down.

I changed the docs to match the code. If `'auto'` was meant to work here and the miss is in `do_trim_params` rather than in the docstring, that is a different patch and yours to decide -- tell me and I will drop this half.

### `bartlett_confint` in `MLEResults.plot_diagnostics`

Documented as `bool, default True`. The signature sets `False`:

```python
def plot_diagnostics(self, variable=0, lags=10, fig=None, figsize=None,
                     truncate_endog_names=24, auto_ylims=False,
                     bartlett_confint=False, acf_kwargs=None):
```

and passes it straight into `plot_acf`, whose own default is `True` -- which is where the line seems to come from. The other three places in the tree agree with their signatures, including `tsaplots.plot_diagnostics`, which also defaults to `False` and documents `False`.

Reading the current docstring, you would expect Bartlett standard errors in the correlogram and get the flat ones.
Docstrings only, no behaviour touched