### PR TITLE
Use self._ntop instead of literal 5 for categorical frequencies in Description

### DIFF
--- a/statsmodels/stats/descriptivestats.py
+++ b/statsmodels/stats/descriptivestats.py
@@ -569,7 +569,7 @@ class Description:
         for col, single in vc.items():
             if single.shape[0] >= self._ntop:
                 top[col] = single.index[: self._ntop]
-                freq[col] = np.asarray(single.iloc[:5])
+                freq[col] = np.asarray(single.iloc[: self._ntop])
             else:
                 val = list(single.index)
                 val += [None] * (self._ntop - len(val))

--- a/statsmodels/stats/tests/test_descriptivestats.py
+++ b/statsmodels/stats/tests/test_descriptivestats.py
@@ -172,6 +172,19 @@ def test_large_ntop(df):
     assert "top_15" in res.frame.index
 
 
+def test_categorical_ntop_freq_length():
+    # The categorical `freq` rows used a hardcoded 5 instead of `ntop`, so a
+    # categorical column with at least `ntop` distinct values raised a
+    # ValueError ("Length of values (5) does not match length of index") for
+    # any ntop != 5.
+    s = pd.Series(list("aabbccddee")).astype("category")  # 5 distinct values
+    res = Description(pd.DataFrame({"x": s}), ntop=3)
+    for i in range(1, 4):
+        assert f"freq_{i}" in res.frame.index
+    # frequencies are relative; each of the 5 categories occurs 2/10 of the time
+    assert res.frame.loc["freq_1", "x"] == pytest.approx(0.2)
+
+
 def test_use_t(df):
     res = Description(df)
     res_t = Description(df, use_t=True)


### PR DESCRIPTION
## Summary

In `Description.categorical`, the frequency row for a column with at least `ntop` distinct categories is built from a hardcoded slice `single.iloc[:5]`:

```python
if single.shape[0] >= self._ntop:
    top[col] = single.index[: self._ntop]
    freq[col] = np.asarray(single.iloc[:5])          # <-- hardcoded 5
else:
    ...
index = [f"freq_{i}" for i in range(1, self._ntop + 1)]
```

The sibling `top[col]` uses `self._ntop`, the `else` branch pads to `self._ntop`, and the resulting frame is indexed to length `self._ntop`. The `5` is a leftover from the default `ntop=5`. For any `ntop != 5`, whenever a categorical column has at least `ntop` distinct values, `freq[col]` has length 5 while the index has length `ntop`, raising:

```
ValueError: Length of values (5) does not match length of index (3)
```

## Reproduction

```python
import pandas as pd
from statsmodels.stats.descriptivestats import Description

s = pd.Series(list("aabbccddee")).astype("category")   # 5 distinct values
Description(pd.DataFrame({"x": s}), ntop=3).frame
# ValueError: Length of values (5) does not match length of index (3)
```

The default `ntop=5` masks it, which is why it went unnoticed.

## Fix

```diff
-            freq[col] = np.asarray(single.iloc[:5])
+            freq[col] = np.asarray(single.iloc[: self._ntop])
```

## Tests

Added `test_categorical_ntop_freq_length`, which builds a `Description` with `ntop=3` on a 5-category column. It fails on the current code (`ValueError`) and passes with the fix. The existing `test_large_ntop` is unaffected (its column has fewer distinct values than `ntop`, so it takes the padding branch).
