### PR TITLE
DOC: clarify GLSAR rho argument

### DIFF
--- a/statsmodels/regression/linear_model.py
+++ b/statsmodels/regression/linear_model.py
@@ -1312,8 +1312,14 @@ class GLSAR(GLS):
     Generalized Least Squares with AR covariance structure
 
     {base._model_params_doc}
-    rho : int
-        The order of the autoregressive covariance.
+    rho : int or array_like
+        If an integer is provided, it specifies the order of the
+        autoregressive process. The AR coefficients are initialized
+        to zero and estimated during iterative fitting.
+
+        If an array is provided, it specifies initial values for the
+        autoregressive coefficients. The length of the array determines
+        the AR order.
     {base._missing_param_doc + base._extra_param_doc}
 
     Notes


### PR DESCRIPTION
Explain that an integer `rho` specifies the AR order, while an array specifies initial AR coefficients.

- [ ] closes #xxxx
- [ ] tests added / passed. 
- [ x] code/documentation is well formatted.  
- [ ] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

The current documentation of GLSAR model states that integer rho specifies the order, but does not document the alternative behavior when rho is array-like or that integer values initialize coefficients to zero.


**Notes**:

* It is essential that you add a test when making code changes. Tests are not 
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running 
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows 
  using the Windows System for Linux once `flake8` is installed in the 
  local Linux environment. While passing this test is not required, it is good practice and it help 
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.

</details>
