### PR TITLE
Fixups

### DIFF
--- a/statsmodels/tsa/seasonal/_seasonal.py
+++ b/statsmodels/tsa/seasonal/_seasonal.py
@@ -217,7 +217,8 @@ def seasonal_decompose(
         warnings.warn(
             "`extrapolate_trend='freq'` is deprecated and will be "
             "removed in 0.16, use `extrapolate_trend='period'` instead.",
-            FutureWarning
+            FutureWarning,
+            stacklevel=2,
         )
         extrapolate_trend = "period"
 

--- a/statsmodels/tsa/stattools/_stattools.py
+++ b/statsmodels/tsa/stattools/_stattools.py
@@ -1576,7 +1576,8 @@ def ccf(
     x, y : array_like
         The time series data to use in the calculation.
     adjusted : bool
-        If True, then denominators for cross-correlation are n-k, otherwise n.
+        If True, then denominators for cross-covariance are the number of
+        overlapping observations at each lag k, min(m, n-k), otherwise n.
     fft : bool, default True
         If True, use FFT convolution.  This method should be preferred
         for long time series.

--- a/statsmodels/tsa/tests/test_stattools.py
+++ b/statsmodels/tsa/tests/test_stattools.py
@@ -1809,7 +1809,8 @@ def test_ccovf_different_lengths_known_lag():
     assert np.argmax(result[:50]) == 5
 
 
-def test_ccovf_adjusted_shorter_y():
+@pytest.mark.parametrize("fft", [True, False])
+def test_ccovf_adjusted_shorter_y(fft):
     # GH#9565 follow-up: with len(y) < len(x), adjusted=True must divide by
     # the number of overlapping observations, min(len(y), len(x) - k), not
     # by len(x) - k.
@@ -1817,12 +1818,12 @@ def test_ccovf_adjusted_shorter_y():
     y = np.ones(2)
 
     # Every product is exactly 1.0, so every adjusted average must be 1.0.
-    result = ccovf(x, y, adjusted=True, demean=False)
+    result = ccovf(x, y, adjusted=True, demean=False, fft=fft)
     assert_allclose(result, np.ones(6))
 
     # The unadjusted path divides by len(x) throughout, by definition, so the
     # overlap counts min(2, 6 - k) show through unscaled.
-    unadjusted = ccovf(x, y, adjusted=False, demean=False)
+    unadjusted = ccovf(x, y, adjusted=False, demean=False, fft=fft)
     assert_allclose(unadjusted, np.array([2, 2, 2, 2, 2, 1]) / 6)
 
 


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed.
- [ ] code/documentation is well formatted.
- [ ] properly formatted commit message. See
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message).

#### AI Disclosure

Contributions must comply with the statsmodels
[AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html). Please complete
**one** of the following:

- [x] No AI tools were used to develop this pull request.
- [ ] AI tools were used. Tool(s): `<name(s), e.g. Copilot, Claude, ChatGPT>`.
      Used for: `<e.g. drafting an implementation, writing tests, debugging, editing docstrings>`.
      I have personally read, understood, and can explain every line of this diff, and
      have verified the statistical/numerical correctness of the change.

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows
  using the Windows System for Linux once `flake8` is installed in the
  local Linux environment. While passing this test is not required, it is good practice and it help
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.
* If AI tools were used to help write this PR, see the
  [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html) for what disclosure
  and review is expected of you before submitting.

</details>
