### PR TITLE
MAINT: Protect against pandas 4 changes

### DIFF
--- a/statsmodels/tsa/base/tsa_model.py
+++ b/statsmodels/tsa/base/tsa_model.py
@@ -153,7 +153,7 @@ def get_index_loc(key, index):
             # Convert the key to the appropriate date-like object
             if index_class is PeriodIndex:
                 date_key = Period(key, freq=base_index.freq)
-            elif re.fullmatch("[0-9]*Q[1-4]", key):
+            elif isinstance(key, str) and re.fullmatch("[0-9]*Q[1-4]", key):
                 # Special case dates with a format like
                 # 2026Q2
                 date_key = pd.Period(key).to_timestamp()

--- a/statsmodels/tsa/base/tsa_model.py
+++ b/statsmodels/tsa/base/tsa_model.py
@@ -8,6 +8,7 @@ from statsmodels.compat.pandas import (
 )
 
 import numbers
+import re
 import warnings
 
 import numpy as np
@@ -152,6 +153,10 @@ def get_index_loc(key, index):
             # Convert the key to the appropriate date-like object
             if index_class is PeriodIndex:
                 date_key = Period(key, freq=base_index.freq)
+            elif re.fullmatch("[0-9]*Q[1-4]", key):
+                # Special case dates with a format like
+                # 2026Q2
+                date_key = pd.Period(key).to_timestamp()
             else:
                 date_key = Timestamp(key)
 

--- a/statsmodels/tsa/tsatools.py
+++ b/statsmodels/tsa/tsatools.py
@@ -878,9 +878,9 @@ def freq_to_period(freq: str | offsets.DateOffset) -> int:
     -----
     Annual maps to 1, quarterly maps to 4, monthly to 12, weekly to 52.
     """
-    if not isinstance(freq, offsets.DateOffset):
+    if not isinstance(freq, offsets.BaseOffset):
         freq = to_offset(freq)  # go ahead and standardize
-    assert isinstance(freq, offsets.DateOffset)
+    assert isinstance(freq, offsets.BaseOffset)
     freq = freq.rule_code.upper()
 
     yearly_freqs = ("A-", "AS-", "Y-", "YS-", "YE-")


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed.
- [ ] code/documentation is well formatted.
- [ ] properly formatted commit message. See
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message).

#### AI Disclosure

Contributions must comply with the statsmodels
[AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html). Please complete
**one** of the following:

- [x] No AI tools were used to develop this pull request.
- [ ] AI tools were used. Tool(s): `<name(s), e.g. Copilot, Claude, ChatGPT>`.
      Used for: `<e.g. drafting an implementation, writing tests, debugging, editing docstrings>`.
      I have personally read, understood, and can explain every line of this diff, and
      have verified the statistical/numerical correctness of the change.

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows
  using the Windows System for Linux once `flake8` is installed in the
  local Linux environment. While passing this test is not required, it is good practice and it help
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.
* If AI tools were used to help write this PR, see the
  [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html) for what disclosure
  and review is expected of you before submitting.

</details>
