### PR TITLE
DOC: Standardized docstring changes

### DIFF
--- a/statsmodels/robust/norms.py
+++ b/statsmodels/robust/norms.py
@@ -174,12 +174,6 @@ class LeastSquares(RobustNorm):
         r"""
         The robust criterion function for the least squares estimator
 
-        .. math::
-
-            \rho: \mathbb{R}^n \to \mathbb{R}^n
-
-            \rho(z) = \frac{z^2}{2}
-
         Parameters
         ----------
         z : array_like
@@ -189,6 +183,10 @@ class LeastSquares(RobustNorm):
         -------
         rho : ndarray
             The value of the robust criterion function.
+
+            .. math::
+
+                \rho(z) = \frac{z^2}{2}
         """
 
         return z**2 * 0.5
@@ -197,13 +195,7 @@ class LeastSquares(RobustNorm):
         r"""
         The psi function for the least squares estimator
 
-        The analytic derivative of rho:
-
-        .. math::
-
-            \psi: \mathbb{R}^n \to \mathbb{R}^n
-
-            \psi(z) = z
+        The analytic derivative of rho.
 
         Parameters
         ----------
@@ -214,6 +206,10 @@ class LeastSquares(RobustNorm):
         -------
         psi : ndarray
             The value of the psi function.
+
+            .. math::
+
+                \psi(z) = z
         """
 
         return np.asarray(z)
@@ -224,16 +220,6 @@ class LeastSquares(RobustNorm):
 
         The psi function scaled by the input z.
 
-        .. math::
-
-            w(z) = 1
-
-        .. math::
-
-            \text{weights}: \mathbb{R}^n \to \mathbb{R}^n
-
-            \text{weights}(z) = \frac{\psi(z)}{z}
-
         Parameters
         ----------
         z : array_like
@@ -243,6 +229,10 @@ class LeastSquares(RobustNorm):
         -------
         weights : ndarray
             The value of the weighting function.
+
+            .. math::
+
+                w(z) = 1
         """
 
         z = np.asarray(z)
@@ -251,10 +241,6 @@ class LeastSquares(RobustNorm):
     def psi_deriv(self, z):
         r"""
         The derivative of the least squares psi function
-
-        .. math::
-
-            \psi'(z) = 1
 
         Parameters
         ----------
@@ -265,6 +251,10 @@ class LeastSquares(RobustNorm):
         -------
         psi_deriv : ndarray
             The value of the derivative of the psi function.
+
+            .. math::
+
+                \psi'(z) = 1
 
         Notes
         -----
@@ -348,15 +338,6 @@ class HuberT(RobustNorm):
         r"""
         The robust criterion function for Huber's t estimator
 
-        .. math::
-
-            \rho: \mathbb{R}^n \to \mathbb{R}^n
-
-            \rho(z) = \begin{cases}
-                          \frac{z^2}{2} & \text{if } \lvert z \rvert \le t \\
-                          \lvert z \rvert t - \frac{t^2}{2} & \text{if } \lvert z \rvert > t
-                      \end{cases}
-
         Parameters
         ----------
         z : array_like
@@ -366,6 +347,13 @@ class HuberT(RobustNorm):
         -------
         rho : ndarray
             The value of the robust criterion function.
+
+            .. math::
+
+                \rho(z) = \begin{cases}
+                              \frac{z^2}{2} & \text{if } \lvert z \rvert \le t \\
+                              \lvert z \rvert t - \frac{t^2}{2} & \text{if } \lvert z \rvert > t
+                          \end{cases}
         """
         z = np.asarray(z)
         test = self._subset(z)
@@ -378,15 +366,6 @@ class HuberT(RobustNorm):
 
         The analytic derivative of rho.
 
-        .. math::
-
-            \psi: \mathbb{R}^n \to \mathbb{R}^n
-
-            \psi(z) = \begin{cases}
-                          z & \text{if } \lvert z \rvert \le t \\
-                          \text{sign}(z) \cdot t & \text{if } \lvert z \rvert > t
-                      \end{cases}
-
         Parameters
         ----------
         z : array_like
@@ -396,6 +375,13 @@ class HuberT(RobustNorm):
         -------
         psi : ndarray
             The value of the psi function.
+
+            .. math::
+
+                \psi(z) = \begin{cases}
+                              z & \text{if } \lvert z \rvert \le t \\
+                              \text{sign}(z) \cdot t & \text{if } \lvert z \rvert > t
+                          \end{cases}
         """
         z = np.asarray(z)
         test = self._subset(z)
@@ -407,15 +393,6 @@ class HuberT(RobustNorm):
 
         The psi function scaled by z.
 
-        .. math::
-
-            \text{weights}: \mathbb{R}^n \to \mathbb{R}^n
-
-            \text{weights}(z) = \begin{cases}
-                                    1 & \text{if } \lvert z \rvert \le t \\
-                                    \frac{t}{\lvert z \rvert} & \text{if } \lvert z \rvert > t
-                                \end{cases}
-
         Parameters
         ----------
         z : array_like
@@ -425,6 +402,13 @@ class HuberT(RobustNorm):
         -------
         weights : ndarray
             The value of the weighting function.
+
+            .. math::
+
+                \text{weights}(z) = \begin{cases}
+                                        1 & \text{if } \lvert z \rvert \le t \\
+                                        \frac{t}{\lvert z \rvert} & \text{if } \lvert z \rvert > t
+                                    \end{cases}
         """
         z_isscalar = np.isscalar(z)
         z = np.atleast_1d(z)
@@ -517,12 +501,6 @@ class RamsayE(RobustNorm):
         r"""
         The robust criterion function for Ramsay's Ea
 
-        .. math::
-
-            \rho: \mathbb{R}^n \to \mathbb{R}^n
-
-            \rho(z) = a^{-2} \cdot (1 - \exp(-a \lvert z \rvert ) \cdot (1 + a \lvert z \rvert))
-
         Parameters
         ----------
         z : array_like
@@ -532,6 +510,10 @@ class RamsayE(RobustNorm):
         -------
         rho : ndarray
             The value of the robust criterion function.
+
+            .. math::
+
+                \rho(z) = a^{-2} \cdot (1 - \exp(-a \lvert z \rvert ) \cdot (1 + a \lvert z \rvert))
         """
         z = np.asarray(z)
         return (1 - np.exp(-self.a * np.abs(z)) *
@@ -543,12 +525,6 @@ class RamsayE(RobustNorm):
 
         The analytic derivative of rho.
 
-        .. math::
-
-            \psi: \mathbb{R}^n \to \mathbb{R}^n
-
-            \psi(z) = z \cdot \exp(-a \cdot \lvert z \rvert)
-
         Parameters
         ----------
         z : array_like
@@ -558,6 +534,10 @@ class RamsayE(RobustNorm):
         -------
         psi : ndarray
             The value of the psi function.
+
+            .. math::
+
+                \psi(z) = z \cdot \exp(-a \cdot \lvert z \rvert)
         """
         z = np.asarray(z)
         return z * np.exp(-self.a * np.abs(z))
@@ -568,12 +548,6 @@ class RamsayE(RobustNorm):
 
         The psi function scaled by z.
 
-        .. math::
-
-            \text{weights}: \mathbb{R}^n \to \mathbb{R}^n
-
-            \text{weights}(z) = \exp(-a \cdot \lvert z \rvert)
-
         Parameters
         ----------
         z : array_like
@@ -583,6 +557,10 @@ class RamsayE(RobustNorm):
         -------
         weights : ndarray
             The value of the weighting function.
+
+            .. math::
+
+                \text{weights}(z) = \exp(-a \cdot \lvert z \rvert)
         """
 
         z = np.asarray(z)
@@ -688,15 +666,6 @@ class AndrewWave(RobustNorm):
         r"""
         The robust criterion function for Andrew's wave
 
-        .. math::
-
-            \rho: \mathbb{R}^n \to \mathbb{R}^n
-
-            \rho(z) = \begin{cases}
-                          a^2 \cdot (1 - \cos(\frac{z}{a})) & \text{if } \lvert z \rvert \le a\pi \\
-                          2a^2 & \text{if } \lvert z \rvert > a\pi
-                      \end{cases}
-
         Parameters
         ----------
         z : array_like
@@ -706,6 +675,13 @@ class AndrewWave(RobustNorm):
         -------
         rho : ndarray
             The value of the robust criterion function.
+
+            .. math::
+
+                \rho(z) = \begin{cases}
+                              a^2 \cdot (1 - \cos(\frac{z}{a})) & \text{if } \lvert z \rvert \le a\pi \\
+                              2a^2 & \text{if } \lvert z \rvert > a\pi
+                          \end{cases}
         """
 
         a = self.a
@@ -720,15 +696,6 @@ class AndrewWave(RobustNorm):
 
         The analytic derivative of rho.
 
-        .. math::
-
-            \psi: \mathbb{R}^n \to \mathbb{R}^n
-
-            \psi(z) = \begin{cases}
-                          a \cdot \sin(\frac{z}{a}) & \text{if } \lvert z \rvert \le a\pi \\
-                          0 & \text{if } \lvert z \rvert > a\pi
-                      \end{cases}
-
         Parameters
         ----------
         z : array_like
@@ -738,6 +705,13 @@ class AndrewWave(RobustNorm):
         -------
         psi : ndarray
             The value of the psi function.
+
+            .. math::
+
+                \psi(z) = \begin{cases}
+                              a \cdot \sin(\frac{z}{a}) & \text{if } \lvert z \rvert \le a\pi \\
+                              0 & \text{if } \lvert z \rvert > a\pi
+                          \end{cases}
         """
 
         a = self.a
@@ -751,15 +725,6 @@ class AndrewWave(RobustNorm):
 
         The psi function scaled by z.
 
-        .. math::
-
-            \text{weights}: \mathbb{R}^n \to \mathbb{R}^n
-
-            \text{weights}(z) = \begin{cases}
-                                    \frac{a}{z} \cdot \sin(\frac{z}{a}) & \text{if } \lvert z \rvert \le a\pi \\
-                                    0 & \text{if } \lvert z \rvert > a\pi
-                                \end{cases}
-
         Parameters
         ----------
         z : array_like
@@ -769,6 +734,13 @@ class AndrewWave(RobustNorm):
         -------
         weights : ndarray
             The value of the weighting function.
+
+            .. math::
+
+                \text{weights}(z) = \begin{cases}
+                                        \frac{a}{z} \cdot \sin(\frac{z}{a}) & \text{if } \lvert z \rvert \le a\pi \\
+                                        0 & \text{if } \lvert z \rvert > a\pi
+                                    \end{cases}
         """
         a = self.a
         z = np.asarray(z)
@@ -882,15 +854,6 @@ class TrimmedMean(RobustNorm):
         r"""
         The robust criterion function for least trimmed mean
 
-        .. math::
-
-            \rho: \mathbb{R}^n \to \mathbb{R}^n
-
-            \rho(z) = \begin{cases}
-                          \frac{z^2}{2} & \text{if } \lvert z \rvert \le c \\
-                          \frac{c^2}{2} & \text{if } \lvert z \rvert > c
-                      \end{cases}
-
         Parameters
         ----------
         z : array_like
@@ -900,6 +863,13 @@ class TrimmedMean(RobustNorm):
         -------
         rho : ndarray
             The value of the robust criterion function.
+
+            .. math::
+
+                \rho(z) = \begin{cases}
+                              \frac{z^2}{2} & \text{if } \lvert z \rvert \le c \\
+                              \frac{c^2}{2} & \text{if } \lvert z \rvert > c
+                          \end{cases}
         """
 
         z = np.asarray(z)
@@ -912,15 +882,6 @@ class TrimmedMean(RobustNorm):
 
         The analytic derivative of rho.
 
-        .. math::
-
-            \psi: \mathbb{R}^n \to \mathbb{R}^n
-
-            \psi(z) = \begin{cases}
-                          z & \text{if } \lvert z \rvert \le c \\
-                          0 & \text{if } \lvert z \rvert > c
-                      \end{cases}
-
         Parameters
         ----------
         z : array_like
@@ -930,6 +891,13 @@ class TrimmedMean(RobustNorm):
         -------
         psi : ndarray
             The value of the psi function.
+
+            .. math::
+
+                \psi(z) = \begin{cases}
+                              z & \text{if } \lvert z \rvert \le c \\
+                              0 & \text{if } \lvert z \rvert > c
+                          \end{cases}
         """
         z = np.asarray(z)
         test = self._subset(z)
@@ -941,15 +909,6 @@ class TrimmedMean(RobustNorm):
 
         The psi function scaled by z.
 
-        .. math::
-
-            \text{weights}: \mathbb{R}^n \to \mathbb{R}^n
-
-            \text{weights}(z) = \begin{cases}
-                                    1 & \text{if } \lvert z \rvert \le c \\
-                                    0 & \text{if } \lvert z \rvert > c
-                                \end{cases}
-
         Parameters
         ----------
         z : array_like
@@ -959,6 +918,13 @@ class TrimmedMean(RobustNorm):
         -------
         weights : ndarray
             The value of the weighting function.
+
+            .. math::
+
+                \text{weights}(z) = \begin{cases}
+                                        1 & \text{if } \lvert z \rvert \le c \\
+                                        0 & \text{if } \lvert z \rvert > c
+                                    \end{cases}
         """
         z = np.asarray(z)
         test = self._subset(z)
@@ -1073,17 +1039,6 @@ class Hampel(RobustNorm):
         r"""
         The robust criterion function for Hampel's estimator
 
-        .. math::
-
-            \rho: \mathbb{R}^n \to \mathbb{R}^n
-
-            \rho(z) = \begin{cases}
-                          \frac{z^2}{2} & \text{if } \lvert z \rvert \le a \\
-                          a \lvert z \rvert - \frac{a^2}{2} & \text{if } a < \lvert z \rvert \le b \\
-                          \frac{a}{2}(b + c - a) - \frac{a}{2(c - b)}(c - \lvert z \rvert)^2  & \text{if } b < \lvert z \rvert \le c \\
-                          \frac{a}{2} \cdot (b + c - a) & \text{if } \lvert z \rvert > c
-                      \end{cases}
-
         Parameters
         ----------
         z : array_like
@@ -1093,6 +1048,15 @@ class Hampel(RobustNorm):
         -------
         rho : ndarray
             The value of the robust criterion function.
+
+            .. math::
+
+                \rho(z) = \begin{cases}
+                              \frac{z^2}{2} & \text{if } \lvert z \rvert \le a \\
+                              a \lvert z \rvert - \frac{a^2}{2} & \text{if } a < \lvert z \rvert \le b \\
+                              \frac{a}{2}(b + c - a) - \frac{a}{2(c - b)}(c - \lvert z \rvert)^2  & \text{if } b < \lvert z \rvert \le c \\
+                              \frac{a}{2} \cdot (b + c - a) & \text{if } \lvert z \rvert > c
+                          \end{cases}
         """
         a, b, c = self.a, self.b, self.c
 
@@ -1121,17 +1085,6 @@ class Hampel(RobustNorm):
 
         The analytic derivative of rho.
 
-        .. math::
-
-            \psi: \mathbb{R}^n \to \mathbb{R}^n
-
-            \psi(z) = \begin{cases}
-                          z & \text{if } \lvert z \rvert \le a \\
-                          a \cdot \text{sign}(z) & \text{if } a < \lvert z \rvert \le b \\
-                          \frac{a}{c - b} \cdot \text{sign}(z) \cdot (c - \lvert z \rvert) & \text{if } b < \lvert z \rvert \le c \\
-                          0 & \text{if } \lvert z \rvert > c \\
-                      \end{cases}
-
         Parameters
         ----------
         z : array_like
@@ -1141,6 +1094,15 @@ class Hampel(RobustNorm):
         -------
         psi : ndarray
             The value of the psi function.
+
+            .. math::
+
+                \psi(z) = \begin{cases}
+                              z & \text{if } \lvert z \rvert \le a \\
+                              a \cdot \text{sign}(z) & \text{if } a < \lvert z \rvert \le b \\
+                              \frac{a}{c - b} \cdot \text{sign}(z) \cdot (c - \lvert z \rvert) & \text{if } b < \lvert z \rvert \le c \\
+                              0 & \text{if } \lvert z \rvert > c \\
+                          \end{cases}
         """
         a, b, c = self.a, self.b, self.c
 
@@ -1167,17 +1129,6 @@ class Hampel(RobustNorm):
 
         The psi function scaled by z.
 
-        .. math::
-
-            \text{weights}: \mathbb{R}^n \to \mathbb{R}^n
-
-            \text{weights}(z) = \begin{cases}
-                                    1 & \text{if } \lvert z \rvert \le a \\
-                                    \frac{a}{\lvert z \rvert} & \text{if } a < \lvert z \rvert \le b \\
-                                    \frac{a}{\lvert z \rvert (c - b)} \cdot (c - \lvert z \rvert) & \text{if } b < \lvert z \rvert \le c \\
-                                    0 & \text{if } \lvert z \rvert > c \\
-                                \end{cases}
-
         Parameters
         ----------
         z : array_like
@@ -1187,6 +1138,15 @@ class Hampel(RobustNorm):
         -------
         weights : ndarray
             The value of the weighting function.
+
+            .. math::
+
+                \text{weights}(z) = \begin{cases}
+                                        1 & \text{if } \lvert z \rvert \le a \\
+                                        \frac{a}{\lvert z \rvert} & \text{if } a < \lvert z \rvert \le b \\
+                                        \frac{a}{\lvert z \rvert (c - b)} \cdot (c - \lvert z \rvert) & \text{if } b < \lvert z \rvert \le c \\
+                                        0 & \text{if } \lvert z \rvert > c \\
+                                    \end{cases}
         """
         a, b, c = self.a, self.b, self.c
 
@@ -1351,15 +1311,6 @@ class TukeyBiweight(RobustNorm):
         r"""
         The robust criterion function for Tukey's biweight estimator
 
-        .. math::
-
-            \rho: \mathbb{R}^n \to \mathbb{R}^n
-
-            \rho(z) = \begin{cases}
-                          \frac{c^2}{6}\left(1 - \left(1 - (\frac{z}{c})^2\right)^3\right) & \text{if } \lvert z \rvert \le c \\
-                          \frac{c^2}{6} & \text{if } \lvert z \rvert > c
-                      \end{cases}
-
         Parameters
         ----------
         z : array_like
@@ -1368,9 +1319,14 @@ class TukeyBiweight(RobustNorm):
         Returns
         -------
         rho : ndarray
-            rho(z) = (c**2 / 6) * (1 - (1 - (z/c)**2)**3)   for \|z\| <= c
+            The value of the robust criterion function.
 
-            rho(z) = c**2 / 6                               for \|z\| > c
+            .. math::
+
+                \rho(z) = \begin{cases}
+                              \frac{c^2}{6}\left(1 - \left(1 - (\frac{z}{c})^2\right)^3\right) & \text{if } \lvert z \rvert \le c \\
+                              \frac{c^2}{6} & \text{if } \lvert z \rvert > c
+                          \end{cases}
         """
         subset = self._subset(z)
         factor = self.c**2 / 6.
@@ -1380,16 +1336,7 @@ class TukeyBiweight(RobustNorm):
         r"""
         The psi function for Tukey's biweight estimator
 
-        The analytic derivative of rho
-
-        .. math::
-
-            \psi: \mathbb{R}^n \to \mathbb{R}^n
-
-            \psi(z) = \begin{cases}
-                          z \cdot (1 - (\frac{z}{c})^2)^2 & \text{if } \lvert z \rvert \le c \\
-                          0 & \text{if } \lvert z \rvert > c
-                      \end{cases}
+        The analytic derivative of rho.
 
         Parameters
         ----------
@@ -1399,9 +1346,14 @@ class TukeyBiweight(RobustNorm):
         Returns
         -------
         psi : ndarray
-            psi(z) = z*(1 - (z/c)**2)**2        for \|z\| <= c
+            The value of the psi function.
 
-            psi(z) = 0                           for \|z\| > c
+            .. math::
+
+                \psi(z) = \begin{cases}
+                              z \cdot (1 - (\frac{z}{c})^2)^2 & \text{if } \lvert z \rvert \le c \\
+                              0 & \text{if } \lvert z \rvert > c
+                          \end{cases}
         """
 
         z = np.asarray(z)
@@ -1412,16 +1364,7 @@ class TukeyBiweight(RobustNorm):
         r"""
         Tukey's biweight weighting function for the IRLS algorithm
 
-        The psi function scaled by z
-
-        .. math::
-
-            \text{weights}: \mathbb{R}^n \to \mathbb{R}^n
-
-            \text{weights}(z) = \begin{cases}
-                                    (1 - (\frac{z}{c})^2)^2 & \text{if } \lvert z \rvert \le c \\
-                                    0 & \text{if } \lvert z \rvert > c
-                                \end{cases}
+        The psi function scaled by z.
 
         Parameters
         ----------
@@ -1431,9 +1374,14 @@ class TukeyBiweight(RobustNorm):
         Returns
         -------
         weights : ndarray
-            weights(z) = (1 - (z/c)**2)**2          for \|z\| <= c
+            The value of the weighting function.
 
-            weights(z) = 0                          for \|z\| > c
+            .. math::
+
+                \text{weights}(z) = \begin{cases}
+                                        (1 - (\frac{z}{c})^2)^2 & \text{if } \lvert z \rvert \le c \\
+                                        0 & \text{if } \lvert z \rvert > c
+                                    \end{cases}
         """
         z = np.asarray(z)
         subset = self._subset(z)
@@ -1543,15 +1491,6 @@ class TukeyQuartic(RobustNorm):
         r"""
         The robust criterion function for TukeyQuartic norm
 
-        .. math::
-
-            \rho(z) = \begin{cases}
-            \frac{1}{2} z^2 \left(1 - \frac{4}{k + 2} x^k + \frac{1}{k + 1} x^{2k}\right) & \text{for } |z| \le c \\
-            \rho(c) & \text{for } | z | > c
-            \end{cases}
-
-        where :math:`x = z / c`.
-
         Parameters
         ----------
         z : array_like
@@ -1561,6 +1500,15 @@ class TukeyQuartic(RobustNorm):
         -------
         rho : ndarray
             The value of the robust criterion function.
+
+            .. math::
+
+                \rho(z) = \begin{cases}
+                              \frac{1}{2} z^2 \left(1 - \frac{4}{k + 2} x^k + \frac{1}{k + 1} x^{2k}\right) & \text{if } \lvert z \rvert \le c \\
+                              \rho(c) & \text{if } \lvert z \rvert > c
+                          \end{cases}
+
+            where :math:`x = z / c`.
         """
         c = self.c
         k = self.k


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed.
- [ ] code/documentation is well formatted.
- [ ] properly formatted commit message. See
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message).

#### AI Disclosure

Contributions must comply with the statsmodels [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html).

If using AI tools, edit the second option to explain which tool was selected and
how the tool's output was used.

Please complete **one** of the following:

- [ ] No AI tools were used to develop this pull request.
- [ ] AI tools were used.
      Tool(s): `<name(s), e.g. Copilot, Claude, ChatGPT>`.
      Used for: `<e.g. drafting an implementation, writing tests, debugging, editing docstrings>`.
      I have personally read, understood, and can explain every line of this diff, and
      have verified the statistical/numerical correctness of the change.

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows
  using the Windows System for Linux once `flake8` is installed in the
  local Linux environment. While passing this test is not required, it is good practice and it help
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.
* If AI tools were used to help write this PR, see the
  [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html) for what disclosure
  and review is expected of you before submitting.

</details>
