### PR TITLE
BUG: Fix Jonckheere-Terpstra on Pyodide by casting np.repeat arg to intp size

### DIFF
--- a/statsmodels/stats/nonparametric.py
+++ b/statsmodels/stats/nonparametric.py
@@ -859,7 +859,12 @@ def jonckheere_terpstra(samples, alternative="larger"):
     if nobs < 2:
         raise ValueError("`samples` must contain at least two observations.")
 
-    group_labels = np.repeat(np.arange(n_groups, dtype=np.int64), counts)
+    # We need to cast to intp because np.repeat requires repeats to be safely
+    # castable to the platform indexing dtype, which is 32 bits on 32-bit
+    # platforms.
+    group_labels = np.repeat(
+        np.arange(n_groups, dtype=np.intp), counts.astype(np.intp, copy=False)
+    )
     pooled = np.concatenate(arrays)
     sort_idx = np.argsort(pooled, kind="mergesort")
     pooled_sorted = pooled[sort_idx]


### PR DESCRIPTION
PR #9874 introduced a failure on Pyodide builds because it introduced an implicit assumption that the index type was 64 bits. `counts` is explicitly int64 type but repeat casts its argument to intp type, see here: https://github.com/numpy/numpy/blob/6ad4b480cf53e85834721b1f7c1909d82cb29bdc/numpy/_core/src/multiarray/item_selection.c?plain=1#L908

This seems to be more or less undocumented. This adds an explicit cast to fix the TypeError.

- [x] No AI tools were used
