### PR TITLE
CLN: Fix lint issues

### DIFF
--- a/statsmodels/stats/multitest.py
+++ b/statsmodels/stats/multitest.py
@@ -362,25 +362,25 @@ def fdrcorrection(pvals, alpha=0.05, method="indep", is_sorted=False):
     fdr_by.
 
     **Benjamini-Hochberg procedure** (see Benjamini and Hochberg, 1995)
-    
+
     Define pvals as:
-    
-        ``pvals`` = ``pval_1`` <= ``pval_2`` <= ... ``pval_k`` ... <= ``pval_(m-1)`` <= ``pval_m``
-    
+
+        ``pvals`` = ``pval_1`` <= ``pval_2`` <= ... <= ``pval_k`` ... <= ``pval_(m-1)`` <= ``pval_m``
+
     Compute raw adjusted p-values as:
-    
-        ``raw_adj_pval_k`` = ``pval_k`` * ``m``/``k``, where
-    
+
+       ``raw_adj_pval_k`` = ``pval_k`` * ``m``/``k``, where
+
     - ``raw_adj_pval_k`` is the adjusted ``pval_k`` BEFORE a final correction,
     - ``pval_k`` is the p-value under consideration,
     - ``m`` is the total number of p-values, and
     - ``k`` is the rank of ``pval_k``.
-    
+
     Perform a final correction to make sure that adjusted p-values are monotonic:
-    
-    The final correction is to make sure that ``adj_pval_k`` is less than or equal to 
-    ``adj_pval_(k+1)``. This procedure starts at the last p-value (``raw_adj_pval_m``)
-    and proceeds until the first p-value (``raw_adj_pval_1``).
+
+    The final correction is to make sure that ``adj_pval_k`` is less than or
+    equal to ``adj_pval_(k+1)``. This procedure starts at the last p-value
+    (``raw_adj_pval_m``) and proceeds until the first p-value (``raw_adj_pval_1``).
 
     Both methods exposed via this function (Benjamini/Hochberg, Benjamini/Yekutieli)
     are also available in the function ``multipletests``, as ``method="fdr_bh"`` and


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed.
- [ ] code/documentation is well formatted.
- [ ] properly formatted commit message. See
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message).

#### AI Disclosure

Contributions must comply with the statsmodels [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html).

If using AI tools, edit the second option to explain which tool was selected and
how the tool's output was used.

Please complete **one** of the following:

- [X] No AI tools were used to develop this pull request.
- [ ] AI tools were used.
      Tool(s): `<name(s), e.g. Copilot, Claude, ChatGPT>`.
      Used for: `<e.g. drafting an implementation, writing tests, debugging, editing docstrings>`.
      I have personally read, understood, and can explain every line of this diff, and
      have verified the statistical/numerical correctness of the change.

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows
  using the Windows System for Linux once `flake8` is installed in the
  local Linux environment. While passing this test is not required, it is good practice and it help
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.
* If AI tools were used to help write this PR, see the
  [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html) for what disclosure
  and review is expected of you before submitting.

</details>
