### PR TITLE
BUG: fix MNLogit resid_response raising ValueError (closes #7096)

### DIFF
--- a/statsmodels/discrete/discrete_model.py
+++ b/statsmodels/discrete/discrete_model.py
@@ -6004,6 +6004,24 @@ class MultinomialResults(DiscreteResults):
         raise NotImplementedError("Use get_margeff instead")
 
     @cache_readonly
+    def resid_response(self):
+        """
+        The response residuals
+
+        Response residuals are defined to be
+
+        .. math:: y - p
+
+        where :math:`y` is the nobs x J indicator matrix of the observed
+        categories and :math:`p` are the predicted probabilities. The
+        residuals are a nobs x J array.
+        """
+        # `endog` holds the 1-dim category codes for the multinomial models,
+        # so the base class version does not conform with `predict`. `wendog`
+        # is the indicator matrix of the observed categories, which does.
+        return self.model.wendog - self.predict()
+
+    @cache_readonly
     def resid_misclassified(self):
         """
         Residuals indicating which observations are misclassified.

--- a/statsmodels/discrete/tests/test_discrete.py
+++ b/statsmodels/discrete/tests/test_discrete.py
@@ -3753,6 +3753,28 @@ def test_mlogit_t_test():
     assert_allclose(wt.statistic, 5.68660562, rtol=1e-8)
 
 
+def test_mnlogit_resid_response():
+    # GH7096, resid_response raised ValueError because the base class
+    # subtracted the nobs x J predicted probabilities from the 1-dim endog
+    data = load_anes96()
+    exog = sm.add_constant(data.exog, prepend=False)
+    res = MNLogit(data.endog, exog).fit(method="newton", disp=0)
+
+    resid = res.resid_response
+    assert_equal(resid.shape, (res.model.endog.shape[0], res.model.J))
+    assert_allclose(resid, res.model.wendog - res.predict(), rtol=1e-13)
+    # each row is an indicator vector minus a probability vector
+    assert_allclose(resid.sum(1), np.zeros(res.model.endog.shape[0]), atol=1e-10)
+
+    # with two categories this reduces to the binary response residual
+    data = load_spector()
+    exog = sm.add_constant(data.exog, prepend=False)
+    res_mnl = MNLogit(data.endog, exog).fit(method="newton", disp=0)
+    res_logit = Logit(data.endog, exog).fit(method="newton", disp=0)
+    assert_allclose(res_mnl.resid_response[:, 1], res_logit.resid_response, rtol=1e-7)
+    assert_allclose(res_mnl.resid_response[:, 0], -res_logit.resid_response, rtol=1e-7)
+
+
 def _fit_logit_for_summary():
     data = load_spector()
     data.exog = sm.add_constant(data.exog, prepend=False)


### PR DESCRIPTION
Closes #7096.

### The bug

`MultinomialResults` inherits `DiscreteResults.resid_response`:

```python
return self.model.endog - self.predict()
```

`MultinomialModel.initialize` replaces `endog` with the 1-dim array of category
codes and keeps the nobs x J indicator matrix on `wendog`, while `predict`
returns nobs x J probabilities. The subtraction cannot broadcast, so simply
reading the attribute raises:

```
>>> res = sm.MNLogit(data.endog, exog).fit(disp=0)
>>> res.resid_response
ValueError: operands could not be broadcast together with shapes (944,) (944,7)
```

`resid_pearson` is built on `resid_response`, so it raised the same error. Both
attributes are documented on the results object.

### The fix

Override `resid_response` on `MultinomialResults` to use `wendog`, the indicator
matrix that conforms with `predict`. `resid_pearson` starts working as a
consequence, with no separate change.

### Tests

`test_mnlogit_resid_response` checks the shape, agreement with
`wendog - predict()`, and that each row sums to zero, since every row is an
indicator vector minus a probability vector.

It also pins a property that would catch a wrong-but-plausible fix: with two
categories a multinomial model must reproduce `Logit`, so
`res_mnl.resid_response[:, 1]` is asserted equal to `res_logit.resid_response`
and column 0 to its negation. A fix that returned the right shape but the wrong
sign or column order would fail that.

The test fails on `main` with the `ValueError` above and passes with the change.
`statsmodels/discrete/tests/test_discrete.py`: 761 passed, 11 skipped,
42 xfailed.

### One thing worth flagging

PR #5255, opened by @josef-pkt in 2018 and last touched in 2021, is a broad
refactor of `fittedvalues` and `resid` across base, discrete, genmod and tsa.
Its diff contains `return self.model.wendog - self.fittedvalues` on the
multinomial results class, so it agrees with the approach here. It predates this
issue by two years, never references it, and has been dormant since. I have kept
this change narrow to the reported bug. If you would rather the fix land as part
of that refactor, say so and I will close this.


#### AI Disclosure

- [x] AI tools were used.
      Tool(s): `Claude (Claude Code)`.
      Used for: `diagnosing the root cause, drafting the fix and the tests, and drafting this PR description`.
      I have personally read, understood, and can explain every line of this diff, and
      have verified the statistical/numerical correctness of the change.

Apologies for missing this on the original submission; adding it now that the PR is merged.
