### PR TITLE
MAINT: Restore accidental behavior change

### DIFF
--- a/statsmodels/base/_parameter_inference.py
+++ b/statsmodels/base/_parameter_inference.py
@@ -28,10 +28,10 @@ class ScoreTestResult(LimitedIterationMixin[float]):
         p-value(s) of the test, based on `distribution`.
     distribution : {"chi2", "norm"}
         Name of the reference distribution used for `pvalue`.
-    df : int or None
-        Degrees of freedom of the chi-square distribution, equal to the
-        number of constraints. Only set for the joint hypothesis test
-        (``distribution="chi2"``), otherwise None.
+    k_constraint : int or None
+        Number of constraints tested, equal to the degrees of freedom of
+        the chi-square distribution. Only set for the joint hypothesis
+        test (``distribution="chi2"``), otherwise None.
 
     Notes
     -----
@@ -44,7 +44,7 @@ class ScoreTestResult(LimitedIterationMixin[float]):
     statistic: float
     pvalue: float
     distribution: str
-    df: int | None = None
+    k_constraint: int | None = None
 
 
 # this is a copy from stats._diagnostic_other to avoid circular imports
@@ -116,7 +116,7 @@ def _lm_robust(score, constraint_matrix, score_deriv_inv, cov_score, cov_params=
     return ScoreTestResult(
         statistic=lm_stat,
         pvalue=pval,
-        df=k_constraints,
+        k_constraint=k_constraints,
         distribution="chi2",
     )
 
@@ -132,6 +132,8 @@ def score_test(
     r_matrix=None,
     scale=None,
     observed=True,
+    *,
+    return_object: bool | None = None,
 ):
     """score test for restrictions or for omitted variables
 
@@ -200,15 +202,25 @@ def score_test(
         information matrix is used. This currently only applies to GLM where
         EIM is available.
         Warning: This option might still change.
+    return_object : bool, optional
+        No longer used. ``score_test`` always returns a ``ScoreTestResult``,
+        which unpacks as the ``(statistic, pvalue)`` tuple this function has
+        always returned, with ``k_constraint`` (and ``distribution``)
+        available as attributes.
+
+        .. deprecated:: 0.15.0
+
+            This parameter has no effect and will be removed in a future
+            release.
 
     Returns
     -------
     ScoreTestResult
         See :class:`ScoreTestResult` for a description of the attributes.
         For ``hypothesis="joint"``, `statistic` and `pvalue` are the
-        chisquare test and `df` is the number of constraints. For
+        chisquare test and `k_constraint` is the number of constraints. For
         ``hypothesis="separate"``, `statistic` and `pvalue` are arrays
-        with one z-test per constraint, and `df` is None.
+        with one z-test per constraint, and `k_constraint` is None.
 
     Notes
     -----
@@ -341,7 +353,7 @@ def score_test(
         return ScoreTestResult(
             statistic=chi2stat,
             pvalue=pval,
-            df=k_constraints,
+            k_constraint=k_constraints,
             distribution="chi2",
         )
     elif hypothesis == "separate":

--- a/statsmodels/discrete/discrete_model.py
+++ b/statsmodels/discrete/discrete_model.py
@@ -5108,6 +5108,8 @@ class DiscreteResults(base.LikelihoodModelResults):
         cov_kwds=None,
         k_constraints=None,
         observed=True,
+        *,
+        return_object: bool | None = None,
     ):
 
         res = pinfer.score_test(
@@ -5119,6 +5121,7 @@ class DiscreteResults(base.LikelihoodModelResults):
             cov_kwds=cov_kwds,
             k_constraints=k_constraints,
             observed=observed,
+            return_object=return_object,
         )
         return res
 

--- a/statsmodels/genmod/generalized_linear_model.py
+++ b/statsmodels/genmod/generalized_linear_model.py
@@ -2359,6 +2359,8 @@ class GLMResults(base.LikelihoodModelResults):
         cov_kwds=None,
         k_constraints=None,
         observed=True,
+        *,
+        return_object: bool | None = None,
     ):
 
         if self.model._has_freq_weights is True:
@@ -2390,6 +2392,7 @@ class GLMResults(base.LikelihoodModelResults):
             k_constraints=k_constraints,
             scale=None,
             observed=observed,
+            return_object=return_object,
         )
 
         self.model.df_resid = mod_df_resid

--- a/statsmodels/genmod/tests/test_score_test.py
+++ b/statsmodels/genmod/tests/test_score_test.py
@@ -28,13 +28,13 @@ class CheckScoreTest:
         wald = res_full.wald_test(restriction, scalar=True)
         # note: need to use method for res_constr for correct df_resid
         res = res_constr.score_test()
-        lm_constr = np.hstack([res.statistic, res.pvalue, res.df])
+        lm_constr = np.hstack([res.statistic, res.pvalue, res.k_constraint])
         res = score_test(res_drop, exog_extra=self.exog_extra)
-        lm_extra = np.hstack([res.statistic, res.pvalue, res.df])
+        lm_extra = np.hstack([res.statistic, res.pvalue, res.k_constraint])
         res = res_full.score_test(
             params_constrained=res_constr.params, k_constraints=res_constr.k_constr
         )
-        lm_full = np.hstack([res.statistic, res.pvalue, res.df])
+        lm_full = np.hstack([res.statistic, res.pvalue, res.k_constraint])
 
         res_wald = np.hstack([wald.statistic, wald.pvalue, [wald.df_denom]])
         assert_allclose(lm_constr, res_wald, rtol=self.rtol_ws, atol=self.atol_ws)
@@ -48,9 +48,9 @@ class CheckScoreTest:
         res_full_hc = mod_full.fit(cov_type=cov_type, start_params=res_full.params)
         wald = res_full_hc.wald_test(restriction, scalar=True)
         _res = score_test(res_constr, cov_type=cov_type)
-        lm_constr = np.hstack([_res.statistic, _res.pvalue, _res.df])
+        lm_constr = np.hstack([_res.statistic, _res.pvalue, _res.k_constraint])
         _res = score_test(res_drop, exog_extra=self.exog_extra, cov_type=cov_type)
-        lm_extra = np.hstack([_res.statistic, _res.pvalue, _res.df])
+        lm_extra = np.hstack([_res.statistic, _res.pvalue, _res.k_constraint])
 
         res_wald = np.hstack([wald.statistic, wald.pvalue, [wald.df_denom]])
         assert_allclose(lm_constr, res_wald, rtol=self.rtol_ws, atol=self.atol_ws)

--- a/statsmodels/tsa/stattools/_stattools.py
+++ b/statsmodels/tsa/stattools/_stattools.py
@@ -3368,11 +3368,9 @@ def range_unit_root_test(x, store=False, *, result_object: bool | None = None):
         the RUR statistic (default is False).
     result_object : bool, optional
         Flag indicating whether to return the results as a
-        ``RURResult`` instead of a plain tuple. When
-        ``store=True`` ``RURResult`` holds the same four
-        values as the legacy tuple, so it is always returned, with no
-        warning. When ``store=False`` the legacy three-element tuple is
-        returned by default and a ``FutureWarning`` is issued.
+        ``RURResult`` instead of a plain tuple. The legacy tuple (whose
+        length depends on `store`) is returned by default and a
+        ``FutureWarning`` is issued.
 
         .. deprecated:: 0.15.0
 
@@ -3509,7 +3507,7 @@ look-up table. The actual p-value is {direction} than the p-value returned.
     else:
         rstore = None
 
-    if result_object is None and not store:
+    if result_object is None:
         warnings.warn(
             "range_unit_root_test currently returns a plain tuple whose "
             "length depends on the store argument. In release 0.16 or "
@@ -3521,8 +3519,10 @@ look-up table. The actual p-value is {direction} than the p-value returned.
             FutureWarning,
             stacklevel=2,
         )
-    if result_object or store:
+    if result_object:
         return RURResult(rur_stat, p_value, crit_dict, rstore)
+    if store:
+        return rur_stat, p_value, crit_dict, rstore
     return rur_stat, p_value, crit_dict
 
 

--- a/statsmodels/tsa/tests/test_stattools.py
+++ b/statsmodels/tsa/tests/test_stattools.py
@@ -1714,7 +1714,7 @@ class TestRUR:
     def test_store(self):
         with pytest.warns(InterpolationWarning):
             result = range_unit_root_test(self.x, True, result_object=False)
-        store = result.resstore
+        _, _, _, store = result
 
         # assert attributes, and make sure they're correct
         assert_equal(store.nobs, len(self.x))


### PR DESCRIPTION
- [X] code/documentation is well formatted.
- [X] properly formatted commit message. See
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message).

#### AI Disclosure

Contributions must comply with the statsmodels [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html).

If using AI tools, edit the second option to explain which tool was selected and
how the tool's output was used.

Please complete **one** of the following:

- [X] No AI tools were used to develop this pull request.
- [ ] AI tools were used.
      Tool(s): `<name(s), e.g. Copilot, Claude, ChatGPT>`.
      Used for: `<e.g. drafting an implementation, writing tests, debugging, editing docstrings>`.
      I have personally read, understood, and can explain every line of this diff, and
      have verified the statistical/numerical correctness of the change.

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows
  using the Windows System for Linux once `flake8` is installed in the
  local Linux environment. While passing this test is not required, it is good practice and it help
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.
* If AI tools were used to help write this PR, see the
  [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html) for what disclosure
  and review is expected of you before submitting.

</details>
