### PR TITLE
CLN: Standardize names in new objects

### DIFF
--- a/examples/notebooks/stationarity_detrending_adf_kpss.ipynb
+++ b/examples/notebooks/stationarity_detrending_adf_kpss.ipynb
@@ -109,7 +109,7 @@
     "    print(\"Results of Dickey-Fuller Test:\")\n",
     "    dftest = adfuller(timeseries, autolag=\"AIC\", result_object=True)\n",
     "    dfoutput = pd.Series(\n",
-    "        dftest[0:4],\n",
+    "        [dftest.statistic, dftest.pvalue, dftest.lags, int(dftest.nobs)],\n",
     "        index=[\n",
     "            \"Test Statistic\",\n",
     "            \"p-value\",\n",
@@ -117,9 +117,9 @@
     "            \"Number of Observations Used\",\n",
     "        ],\n",
     "    )\n",
-    "    for key, value in dftest[4].items():\n",
+    "    for key, value in dftest.critical_values.items():\n",
     "        dfoutput[f\"Critical Value ({key})\"] = value\n",
-    "    print(dfoutput)"
+    "    print(dfoutput)\n"
    ]
   },
   {
@@ -150,9 +150,9 @@
     "    print(\"Results of KPSS Test:\")\n",
     "    kpsstest = kpss(timeseries, regression=\"c\", nlags=\"auto\", result_object=True)\n",
     "    kpss_output = pd.Series(\n",
-    "        kpsstest[0:3], index=[\"Test Statistic\", \"p-value\", \"Lags Used\"]\n",
+    "        [kpsstest.statistic, kpsstest.pvalue, kpsstest.lags], index=[\"Test Statistic\", \"p-value\", \"Lags Used\"]\n",
     "    )\n",
-    "    for key, value in kpsstest[3].items():\n",
+    "    for key, value in kpsstest.critical_values.items():\n",
     "        kpss_output[f\"Critical Value ({key})\"] = value\n",
     "    print(kpss_output)"
    ]

--- a/statsmodels/stats/tests/test_limited_iteration_mixin.py
+++ b/statsmodels/stats/tests/test_limited_iteration_mixin.py
@@ -231,7 +231,7 @@ CASES = [
         pvalue_f=0.1, df_f=(2, 30), distr_f="F",
     )),
     (ADFullerResult, dict(
-        statistic=-2.0, pvalue=0.3, usedlag=1, nobs=100,
+        statistic=-2.0, pvalue=0.3, lags=1, nobs=100,
         critical_values={"1%": -3.5, "5%": -2.9, "10%": -2.6}, icbest=None,
         resstore=None,
     )),
@@ -240,12 +240,12 @@ CASES = [
     )),
     (KPSSResult, dict(
         statistic=0.3, pvalue=0.1, lags=3,
-        crit={"10%": 0.347, "5%": 0.463, "2.5%": 0.574, "1%": 0.739},
+        critical_values={"10%": 0.347, "5%": 0.463, "2.5%": 0.574, "1%": 0.739},
         resstore=None,
     )),
     (RURResult, dict(
         statistic=1.5, pvalue=0.5,
-        crit={"10%": 1.35, "5%": 1.21, "2.5%": 1.10, "1%": 0.98},
+        critical_values={"10%": 1.35, "5%": 1.21, "2.5%": 1.10, "1%": 0.98},
         resstore=None,
     )),
 ]

--- a/statsmodels/tsa/adfvalues.py
+++ b/statsmodels/tsa/adfvalues.py
@@ -267,7 +267,7 @@ def mackinnonp(teststat, regression="c", N=1, lags=None):
     else:
         # Note: above is only for z stats
         tau_coef = _tau_largeps[regression][N-1]
-    return norm.cdf(polyval(tau_coef[::-1], teststat))
+    return float(norm.cdf(polyval(tau_coef[::-1], teststat)))
 
 
 # These are the new estimates from MacKinnon 2010

--- a/statsmodels/tsa/stattools/_stattools.py
+++ b/statsmodels/tsa/stattools/_stattools.py
@@ -184,7 +184,7 @@ class ADFullerResult(LimitedIterationMixin[float]):
         The test statistic.
     pvalue : float
         MacKinnon's approximate p-value based on MacKinnon (1994, 2010).
-    usedlag : int
+    lags : int
         The number of lags used.
     nobs : int
         The number of observations used for the ADF regression and
@@ -207,7 +207,7 @@ class ADFullerResult(LimitedIterationMixin[float]):
 
     statistic: float
     pvalue: float
-    usedlag: int
+    lags: int
     nobs: int
     critical_values: dict[str, float]
     icbest: float | None
@@ -220,7 +220,7 @@ class ADFullerResult(LimitedIterationMixin[float]):
 {self.__class__.__name__}
 ADF Statistic: {self.statistic:0.5f}
 P-value: {self.pvalue:0.5f}
-Used Lag: {self.usedlag}
+Used Lag: {self.lags}
 Nobs: {self.nobs}
 Critical Values: {self.critical_values}
 """
@@ -296,7 +296,7 @@ def adfuller(
     -------
     ADFullerResult
         If ``result_object=True``, a result object with fields ``statistic``,
-        ``pvalue``, ``usedlag``, ``nobs``, ``critical_values``, ``icbest``,
+        ``pvalue``, ``lags``, ``nobs``, ``critical_values``, ``icbest``,
         and ``resstore`` (``icbest``/``resstore`` are ``None`` when not
         computed). See :class:`~statsmodels.tsa.stattools.ADFullerResult`.
 
@@ -307,12 +307,12 @@ def adfuller(
         The test statistic.
     pvalue : float
         MacKinnon's approximate p-value based on MacKinnon (1994, 2010).
-    usedlag : int
+    lags : int
         The number of lags used.
     nobs : int
         The number of observations used for the ADF regression and calculation
         of the critical values.
-    critical values : dict
+    critical_values : dict
         Critical values for the test statistic at the 1 %, 5 %, and 10 %
         levels. Based on MacKinnon (2010).
     icbest : float
@@ -351,7 +351,7 @@ def adfuller(
         University, Dept of Economics, Working Papers.  Available at
         http://ideas.repec.org/p/qed/wpaper/1227.html
     """
-    x = array_like(x, "x")
+    x = array_like(x, "x", ndim=1)
     maxlag = int_like(maxlag, "maxlag", optional=True)
     regression = string_like(regression, "regression", options=("c", "ct", "ctt", "n"))
     autolag = string_like(
@@ -439,7 +439,7 @@ def adfuller(
     else:
         resols = OLS(xdshort, xdall[:, : usedlag + 1]).fit()
 
-    adfstat = resols.tvalues[0]
+    adfstat = float(resols.tvalues[0])
     #    adfstat = (resols.params[0]-1.0)/resols.bse[0]
     # the "asymptotically correct" z statistic is obtained as
     # nobs/(1-np.sum(resols.params[1:-(trendorder+1)])) (resols.params[0] - 1)
@@ -2999,7 +2999,7 @@ class KPSSResult(LimitedIterationMixin[float]):
         is, if the p-value is outside the interval (0.01, 0.1).
     lags : int
         The truncation lag parameter.
-    crit : dict[str, float]
+    critical_values : dict[str, float]
         The critical values at 10%, 5%, 2.5% and 1%. Based on Kwiatkowski
         et al. (1992).
     resstore : ResultsStore or None
@@ -3015,7 +3015,7 @@ class KPSSResult(LimitedIterationMixin[float]):
     statistic: float
     pvalue: float
     lags: int
-    crit: dict[str, float]
+    critical_values: dict[str, float]
     resstore: ResultsStore | None
 
     _iter_fields: ClassVar[tuple[str, ...]] = ("statistic", "pvalue")
@@ -3026,7 +3026,7 @@ class KPSSResult(LimitedIterationMixin[float]):
 KPSS Statistic: {self.statistic:0.5f}
 P-value: {self.pvalue:0.5f}
 Lags: {self.lags}
-Critical Values: {self.crit}
+Critical Values: {self.critical_values}
 """
 
 
@@ -3323,7 +3323,7 @@ class RURResult(LimitedIterationMixin[float]):
         in Aparicio et al. (2006), and a boundary point is returned if the
         test statistic is outside the table of critical values, that is,
         if the p-value is outside the interval (0.01, 0.1).
-    crit : dict[str, float]
+    critical_values : dict[str, float]
         The critical values at 10%, 5%, 2.5% and 1%. Based on Aparicio et
         al. (2006).
     resstore : ResultsStore or None
@@ -3338,7 +3338,7 @@ class RURResult(LimitedIterationMixin[float]):
 
     statistic: float
     pvalue: float
-    crit: dict[str, float]
+    critical_values: dict[str, float]
     resstore: ResultsStore | None
 
     _iter_fields: ClassVar[tuple[str, ...]] = ("statistic", "pvalue")
@@ -3348,7 +3348,7 @@ class RURResult(LimitedIterationMixin[float]):
 {self.__class__.__name__}
 RUR Statistic: {self.statistic:0.5f}
 P-value: {self.pvalue:0.5f}
-Critical Values: {self.crit}
+Critical Values: {self.critical_values}
 """
 
 

--- a/statsmodels/tsa/tests/test_adfuller_lag.py
+++ b/statsmodels/tsa/tests/test_adfuller_lag.py
@@ -34,7 +34,7 @@ def test_adf_autolag():
             # min-ic lag of dfgls in Stata is also 2, or 9 for maic with notrend
             assert_equal(st2.usedlag, 2)
 
-        # same result with lag fixed at usedlag of autolag
+        # same result with lag fixed at lags of autolag
         adf2 = tsast.adfuller(
             x, maxlag=2, autolag=None, regression=tr, result_object=False
         )

--- a/statsmodels/tsa/tests/test_stattools.py
+++ b/statsmodels/tsa/tests/test_stattools.py
@@ -1566,7 +1566,7 @@ class TestKPSS:
         assert res[0] == res.statistic
         assert res[1] == res.pvalue
         assert res.lags == 3
-        assert isinstance(res.crit, dict)
+        assert isinstance(res.critical_values, dict)
 
     def test_result_object_true_with_store(self):
         with pytest.warns(InterpolationWarning, match="The test statistic is"):
@@ -1728,7 +1728,7 @@ class TestRUR:
         assert res.resstore is None
         assert res[0] == res.statistic
         assert res[1] == res.pvalue
-        assert isinstance(res.crit, dict)
+        assert isinstance(res.critical_values, dict)
 
     def test_result_object_true_with_store(self):
         with pytest.warns(InterpolationWarning, match="The test statistic is"):
@@ -2414,7 +2414,7 @@ def test_adfuller_result_object_matches_legacy_values(adfuller_data):
         nt = adfuller(adfuller_data, result_object=True)
     assert_almost_equal(nt.statistic, legacy[0])
     assert_almost_equal(nt.pvalue, legacy[1])
-    assert nt.usedlag == legacy[2]
+    assert nt.lags == legacy[2]
     assert nt.nobs == legacy[3]
     assert nt.critical_values == legacy[4]
     assert_almost_equal(nt.icbest, legacy[5])


### PR DESCRIPTION
Use consistent names accross similar tests

- [X] tests added / passed.
- [X] code/documentation is well formatted.
- [X] properly formatted commit message. See
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message).

#### AI Disclosure

Contributions must comply with the statsmodels [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html).

If using AI tools, edit the second option to explain which tool was selected and
how the tool's output was used.

Please complete **one** of the following:

- [X] No AI tools were used to develop this pull request.
- [ ] AI tools were used.
      Tool(s): `<name(s), e.g. Copilot, Claude, ChatGPT>`.
      Used for: `<e.g. drafting an implementation, writing tests, debugging, editing docstrings>`.
      I have personally read, understood, and can explain every line of this diff, and
      have verified the statistical/numerical correctness of the change.

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows
  using the Windows System for Linux once `flake8` is installed in the
  local Linux environment. While passing this test is not required, it is good practice and it help
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.
* If AI tools were used to help write this PR, see the
  [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html) for what disclosure
  and review is expected of you before submitting.

</details>
