### PR TITLE
CLN/DOC: Simplify NamedTuple and dataclasses

### DIFF
--- a/docs/source/stats.rst
+++ b/docs/source/stats.rst
@@ -602,6 +602,7 @@ functions for statistical power
 .. autosummary::
    :toctree: generated
 
+   PowerResult
    power_poisson_ratio_2indep
    PowerRatioResult
    power_equivalence_poisson_2indep

--- a/examples/notebooks/autoregressive_distributed_lag.ipynb
+++ b/examples/notebooks/autoregressive_distributed_lag.ipynb
@@ -676,9 +676,7 @@
    "id": "ba3abe46-ea62-4ee8-833a-d7a8acb57197",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "bounds_test.crit_vals"
-   ]
+   "source": "bounds_test.critical_values"
   },
   {
    "cell_type": "markdown",

--- a/examples/python/autoregressive_distributed_lag.py
+++ b/examples/python/autoregressive_distributed_lag.py
@@ -459,7 +459,7 @@ bounds_test = ecm_fit.bounds_test(case=4)
 bounds_test
 
 
-bounds_test.crit_vals
+bounds_test.critical_values
 
 
 # Case 3 also rejects the null of no levels relationship.

--- a/statsmodels/robust/covariance.py
+++ b/statsmodels/robust/covariance.py
@@ -446,11 +446,8 @@ class CovOGKResult(NamedTuple):
     ----------
     cov : ndarray
         Estimated covariance, either raw OGK or reweighted OGK.
-    loc : ndarray
-        Estimated location, either from raw OGK or reweighted OGK. Alias
-        of `mean`.
     mean : ndarray
-        Estimated location, alias of `loc`.
+        Estimated location, either from raw OGK or reweighted OGK.
     mask : ndarray or None
         Boolean mask of observations kept in the reweighting step, or None
         if `reweight` was None.
@@ -478,7 +475,6 @@ class CovOGKResult(NamedTuple):
     """
 
     cov: np.ndarray
-    loc: np.ndarray
     mean: np.ndarray
     mask: np.ndarray | None
     mahalanobis_raw: np.ndarray | None
@@ -624,10 +620,8 @@ def cov_ogk(
     if rescale_raw:
         cov_raw *= scale_factor_raw
 
-    # duplicate name loc mean center, choose consistent naming
     res = CovOGKResult(
         cov=cov,
-        loc=loc,
         mean=loc,
         mask=mask,
         mahalanobis_raw=d,

--- a/statsmodels/stats/gof.py
+++ b/statsmodels/stats/gof.py
@@ -384,7 +384,7 @@ class ChisquareResult(NamedTuple):
         Degrees of freedom of the (potentially noncentral) chisquare
         distribution used to compute ``pvalue``, equal to
         ``n_bins - 1 - ddof``.
-    distr : {"chi2", "ncx2"}
+    distribution : {"chi2", "ncx2"}
         The name of the distribution used to compute ``pvalue``: ``"chi2"``
         when ``value`` is 0, otherwise ``"ncx2"`` (the noncentral chisquare
         distribution).
@@ -393,7 +393,7 @@ class ChisquareResult(NamedTuple):
     chisq: float
     pvalue: float
     df: int
-    distr: str
+    distribution: str
 
 
 def chisquare(f_obs, f_exp=None, value=0, ddof=0, return_basic=True):
@@ -471,15 +471,17 @@ def chisquare(f_obs, f_exp=None, value=0, ddof=0, return_basic=True):
     chisq = ((f_obs - f_exp)**2 / f_exp).sum(0)
     if value == 0:
         pvalue = stats.chi2.sf(chisq, df)
-        distr = "chi2"
+        distribution = "chi2"
     else:
         pvalue = stats.ncx2.sf(chisq, df, value**2 * nobs)
-        distr = "ncx2"
+        distribution = "ncx2"
 
     if return_basic:
         return chisq, pvalue
     else:
-        return ChisquareResult(chisq=chisq, pvalue=pvalue, df=df, distr=distr)
+        return ChisquareResult(
+            chisq=chisq, pvalue=pvalue, df=df, distribution=distribution
+        )
 
 
 def chisquare_power(effect_size, nobs, n_bins, alpha=0.05, ddof=0):

--- a/statsmodels/stats/meta_analysis.py
+++ b/statsmodels/stats/meta_analysis.py
@@ -33,7 +33,7 @@ class HomogeneityTestResult(LimitedIterationMixin[float]):
     df : float
         Degrees of freedom, equal to the number of studies or samples
         minus 1.
-    distr : str
+    distribution : str
         Name of the reference distribution used for `pvalue`, ``"chi2"``.
 
     Notes
@@ -47,7 +47,7 @@ class HomogeneityTestResult(LimitedIterationMixin[float]):
     statistic: float
     pvalue: float
     df: float
-    distr: str
+    distribution: str
 
 
 class CombineResults:
@@ -227,7 +227,7 @@ class CombineResults:
         """
         pvalue = stats.chi2.sf(self.q, self.k - 1)
         res = HomogeneityTestResult(
-            statistic=self.q, pvalue=pvalue, df=self.k - 1, distr="chi2"
+            statistic=self.q, pvalue=pvalue, df=self.k - 1, distribution="chi2"
         )
         return res
 

--- a/statsmodels/stats/multivariate.py
+++ b/statsmodels/stats/multivariate.py
@@ -36,7 +36,7 @@ class HotellingResult(LimitedIterationMixin[float]):
         Numerator and denominator degrees of freedom of the F distribution.
     t2 : float
         Hotelling's T-squared statistic.
-    distr : str
+    distribution : str
         Name of the reference distribution used for `pvalue`, ``"F"``.
 
     Notes
@@ -51,7 +51,7 @@ class HotellingResult(LimitedIterationMixin[float]):
     pvalue: float
     df: tuple
     t2: float
-    distr: str
+    distribution: str
 
 
 def test_mvmean(data, mean_null=0, return_results=True):
@@ -88,7 +88,9 @@ def test_mvmean(data, mean_null=0, return_results=True):
     df = (k_vars, nobs - k_vars)
     pvalue = stats.f.sf(statistic, df[0], df[1])
     if return_results:
-        res = HotellingResult(statistic=statistic, pvalue=pvalue, df=df, t2=t2, distr="F")
+        res = HotellingResult(
+            statistic=statistic, pvalue=pvalue, df=df, t2=t2, distribution="F"
+        )
         return res
     else:
         return statistic, pvalue
@@ -132,7 +134,9 @@ def test_mvmean_2indep(data1, data2):
     statistic = t2 / factor
     df = (k_vars, nobs_t - 1 - k_vars)
     pvalue = stats.f.sf(statistic, df[0], df[1])
-    return HotellingResult(statistic=statistic, pvalue=pvalue, df=df, t2=t2, distr="F")
+    return HotellingResult(
+        statistic=statistic, pvalue=pvalue, df=df, t2=t2, distribution="F"
+    )
 
 
 def confint_mvmean(data, lin_transf=None, alpha=0.05, simult=False):
@@ -317,7 +321,7 @@ class CovTestResult(LimitedIterationMixin[float]):
         p-value based on the chi-square distribution.
     df : float
         Degrees of freedom of the chi-square distribution.
-    distr : str
+    distribution : str
         Name of the reference distribution used for `pvalue`, ``"chi2"``.
     null : str
         Short description of the null hypothesis being tested.
@@ -336,7 +340,7 @@ class CovTestResult(LimitedIterationMixin[float]):
     statistic: float
     pvalue: float
     df: float
-    distr: str
+    distribution: str
     null: str
     cov_null: np.ndarray | None = None
 
@@ -398,7 +402,7 @@ def test_cov(cov, nobs, cov_null):
         statistic=statistic,
         pvalue=pvalue,
         df=df,
-        distr="chi2",
+        distribution="chi2",
         null="equal value",
         cov_null=cov_null,
     )
@@ -456,7 +460,7 @@ def test_cov_spherical(cov, nobs):
     df = k * (k + 1) / 2 - 1
     pvalue = stats.chi2.sf(statistic, df)
     return CovTestResult(
-        statistic=statistic, pvalue=pvalue, df=df, distr="chi2", null="spherical"
+        statistic=statistic, pvalue=pvalue, df=df, distribution="chi2", null="spherical"
     )
 
 
@@ -505,7 +509,7 @@ def test_cov_diagonal(cov, nobs):
     df = k * (k - 1) / 2
     pvalue = stats.chi2.sf(statistic, df)
     return CovTestResult(
-        statistic=statistic, pvalue=pvalue, df=df, distr="chi2", null="diagonal"
+        statistic=statistic, pvalue=pvalue, df=df, distribution="chi2", null="diagonal"
     )
 
 
@@ -597,7 +601,11 @@ def test_cov_blockdiagonal(cov, nobs, block_len):
     df = a2 / 2
     pvalue = stats.chi2.sf(statistic, df)
     return CovTestResult(
-        statistic=statistic, pvalue=pvalue, df=df, distr="chi2", null="block-diagonal"
+        statistic=statistic,
+        pvalue=pvalue,
+        df=df,
+        distribution="chi2",
+        null="block-diagonal",
     )
 
 
@@ -621,7 +629,7 @@ class CovOnewayResult(LimitedIterationMixin[float]):
         p-value based on the chi-square approximation.
     df_chi2 : float
         Degrees of freedom of the chi-square approximation.
-    distr_chi2 : str
+    distribution_chi2 : str
         Name of the chi-square reference distribution, ``"chi2"``.
     statistic_f : float
         Test statistic of the F approximation, same value as `statistic`.
@@ -630,7 +638,7 @@ class CovOnewayResult(LimitedIterationMixin[float]):
     df_f : tuple
         Numerator and denominator degrees of freedom of the F
         approximation.
-    distr_f : str
+    distribution_f : str
         Name of the F reference distribution, ``"F"``.
 
     Notes
@@ -647,11 +655,11 @@ class CovOnewayResult(LimitedIterationMixin[float]):
     statistic_chi2: float
     pvalue_chi2: float
     df_chi2: float
-    distr_chi2: str
+    distribution_chi2: str
     statistic_f: float
     pvalue_f: float
     df_f: tuple
-    distr_f: str
+    distribution_f: str
 
 
 def test_cov_oneway(cov_list, nobs_list):
@@ -738,9 +746,9 @@ def test_cov_oneway(cov_list, nobs_list):
         statistic_chi2=statistic_chi2,
         pvalue_chi2=pvalue_chi2,
         df_chi2=df_chi2,
-        distr_chi2="chi2",
+        distribution_chi2="chi2",
         statistic_f=statistic_f,
         pvalue_f=pvalue_f,
         df_f=df_f,
-        distr_f="F",
+        distribution_f="F",
     )

--- a/statsmodels/stats/nonparametric.py
+++ b/statsmodels/stats/nonparametric.py
@@ -165,12 +165,12 @@ class RankCompareResult(LimitedIterationMixin[float]):
         Estimated variance of `statistic`.
     var_prob : float
         Estimated variance of `prob1` (and `prob2`).
-    nobs1 : int
+    nobs_1 : int
         Number of observations in sample 1.
-    nobs2 : int
+    nobs_2 : int
         Number of observations in sample 2.
     nobs : int
-        Total number of observations, ``nobs1 + nobs2``.
+        Total number of observations, ``nobs_1 + nobs_2``.
     mean1 : float
         Mean rank of sample 1 in the pooled sample.
     mean2 : float
@@ -209,8 +209,8 @@ class RankCompareResult(LimitedIterationMixin[float]):
     var2: float
     var: float
     var_prob: float
-    nobs1: int
-    nobs2: int
+    nobs_1: int
+    nobs_2: int
     nobs: int
     mean1: float
     mean2: float
@@ -650,7 +650,7 @@ def rank_compare_2indep(x1, x2, use_t=True):
     return RankCompareResult(statistic=wbfn, pvalue=pvalue, s1=S1, s2=S2,
                              var1=var1, var2=var2, var=var,
                              var_prob=var_prob,
-                             nobs1=nobs1, nobs2=nobs2, nobs=nobs,
+                             nobs_1=nobs1, nobs_2=nobs2, nobs=nobs,
                              mean1=meanr1, mean2=meanr2,
                              prob1=prob1, prob2=prob2,
                              somersd1=prob1 * 2 - 1, somersd2=prob2 * 2 - 1,
@@ -732,7 +732,7 @@ def rank_compare_2ordinal(count1, count2, ddof=1, use_t=True):
     res = RankCompareResult(statistic=None, pvalue=None, s1=None, s2=None,
                             var1=var1, var2=var2, var=var,
                             var_prob=var_prob,
-                            nobs1=nobs1, nobs2=nobs2, nobs=nobs,
+                            nobs_1=nobs1, nobs_2=nobs2, nobs=nobs,
                             mean1=None, mean2=None,
                             prob1=prob1, prob2=prob2,
                             somersd1=prob1 * 2 - 1, somersd2=prob2 * 2 - 1,
@@ -760,7 +760,7 @@ class JonckheereTerpstraResult(NamedTuple):
         The alternative hypothesis that was tested.
     nobs : int
         Total number of observations across all samples.
-    k_groups : int
+    n_groups : int
         Number of samples, i.e., the number of ordered groups.
     counts : ndarray
         Number of observations in each sample.
@@ -782,7 +782,7 @@ class JonckheereTerpstraResult(NamedTuple):
     distribution: str
     alternative: str
     nobs: int
-    k_groups: int
+    n_groups: int
     counts: np.ndarray
     mean_null: float
     var_null: float
@@ -960,7 +960,7 @@ def jonckheere_terpstra(samples, alternative="larger"):
         distribution="normal",
         alternative=alternative,
         nobs=nobs,
-        k_groups=n_groups,
+        n_groups=n_groups,
         counts=counts,
         mean_null=mean_null,
         var_null=var_s / 4.0,
@@ -1050,9 +1050,9 @@ class RankPlacementsResult(NamedTuple):
 
     Parameters
     ----------
-    n_1 : int
+    nobs_1 : int
         Number of observations in the first sample.
-    n_2 : int
+    nobs_2 : int
         Number of observations in the second sample.
     overall_ranks_pooled : ndarray
         Ranks of the pooled sample.
@@ -1070,8 +1070,8 @@ class RankPlacementsResult(NamedTuple):
         Placements of the second sample in the pooled sample.
     """
 
-    n_1: int
-    n_2: int
+    nobs_1: int
+    nobs_2: int
     overall_ranks_pooled: np.ndarray
     overall_ranks_1: np.ndarray
     overall_ranks_2: np.ndarray
@@ -1115,15 +1115,15 @@ def _compute_rank_placements(x1, x2) -> RankPlacementsResult:
     thought of as measures of the degree of overlap or
     separation between two samples.
     """
-    n_1 = len(x1)
-    n_2 = len(x2)
+    nobs_1 = len(x1)
+    nobs_2 = len(x2)
 
     # Overall ranks for each obs among combined sample
     overall_ranks_pooled = rankdata(
         np.r_[x1, x2], method="average"
     )
-    overall_ranks_1 = overall_ranks_pooled[:n_1]
-    overall_ranks_2 = overall_ranks_pooled[n_1:]
+    overall_ranks_1 = overall_ranks_pooled[:nobs_1]
+    overall_ranks_2 = overall_ranks_pooled[nobs_1:]
     # Within group ranks for each obs
     within_group_ranks_1 = rankdata(x1, method="average")
     within_group_ranks_2 = rankdata(x2, method="average")
@@ -1132,8 +1132,8 @@ def _compute_rank_placements(x1, x2) -> RankPlacementsResult:
     placements_2 = overall_ranks_2 - within_group_ranks_2
 
     return RankPlacementsResult(
-        n_1=n_1,
-        n_2=n_2,
+        nobs_1=nobs_1,
+        nobs_2=nobs_2,
         overall_ranks_pooled=overall_ranks_pooled,
         overall_ranks_1=overall_ranks_1,
         overall_ranks_2=overall_ranks_2,
@@ -1313,8 +1313,8 @@ def samplesize_rank_compare_onetail(
         reference_sample,
     )
     # Extra few bytes of name binding for explicitness & readability
-    n_syn = rank_place.n_1
-    n_ref = rank_place.n_2
+    n_syn = rank_place.nobs_1
+    n_ref = rank_place.nobs_2
     overall_ranks_pooled = rank_place.overall_ranks_pooled
     placements_syn = rank_place.placements_1
     placements_ref = rank_place.placements_2

--- a/statsmodels/stats/oneway.py
+++ b/statsmodels/stats/oneway.py
@@ -256,10 +256,10 @@ class FstatEffectSizeResult(NamedTuple):
     eps2 : array_like
         Squared epsilon effect size, computed as
         ``(f2 - df1 / df2) / (f2 + 1)``.
-    eps2_ : array_like
+    eps2_alt : array_like
         Squared epsilon effect size, computed with the alternative
         expression ``(f_stat - 1) / (f_stat + df2 / df1)``.
-    omega2_ : array_like
+    omega2_alt : array_like
         Squared omega effect size, computed with the alternative
         expression ``(f_stat - 1) / (f_stat + (df2 + 1) / df1)``.
     """
@@ -268,8 +268,8 @@ class FstatEffectSizeResult(NamedTuple):
     eta2: np.ndarray
     omega2: np.ndarray
     eps2: np.ndarray
-    eps2_: np.ndarray
-    omega2_: np.ndarray
+    eps2_alt: np.ndarray
+    omega2_alt: np.ndarray
 
 
 def _fstat2effectsize(f_stat, df):
@@ -316,12 +316,17 @@ def _fstat2effectsize(f_stat, df):
     df1, df2 = df
     f2 = f_stat * df1 / df2
     eta2 = f2 / (f2 + 1)
-    omega2_ = (f_stat - 1) / (f_stat + (df2 + 1) / df1)
+    omega2_alt = (f_stat - 1) / (f_stat + (df2 + 1) / df1)
     omega2 = (f2 - df1 / df2) / (f2 + 1 + 1 / df2)  # rewrite
-    eps2_ = (f_stat - 1) / (f_stat + df2 / df1)
+    eps2_alt = (f_stat - 1) / (f_stat + df2 / df1)
     eps2 = (f2 - df1 / df2) / (f2 + 1)  # rewrite
     return FstatEffectSizeResult(
-        f2=f2, eta2=eta2, omega2=omega2, eps2=eps2, eps2_=eps2_, omega2_=omega2_
+        f2=f2,
+        eta2=eta2,
+        omega2=omega2,
+        eps2=eps2,
+        eps2_alt=eps2_alt,
+        omega2_alt=omega2_alt,
     )
 
 
@@ -560,7 +565,7 @@ def confint_effectsize_oneway(f_stat, df, alpha=0.05, nobs=None):
     return ci_res
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, slots=True, kw_only=True)
 class AnovaResult(LimitedIterationMixin[float]):
     """
     Result of :func:`anova_generic` and :func:`anova_oneway`.
@@ -580,7 +585,7 @@ class AnovaResult(LimitedIterationMixin[float]):
         Numerator degrees of freedom.
     df_denom : float
         Denominator degrees of freedom used for `pvalue`.
-    nobs_t : float
+    nobs_total : float
         Total number of observations across all samples.
     n_groups : int
         Number of samples being compared.
@@ -617,7 +622,7 @@ class AnovaResult(LimitedIterationMixin[float]):
     df: tuple
     df_num: float
     df_denom: float
-    nobs_t: float
+    nobs_total: float
     n_groups: int
     means: np.ndarray
     nobs: np.ndarray
@@ -726,7 +731,7 @@ def anova_generic(
         df=(df_num, df_denom),
         df_num=df_num,
         df_denom=df_denom,
-        nobs_t=nobs_t,
+        nobs_total=nobs_t,
         n_groups=n_groups,
         means=means,
         nobs=nobs,
@@ -1115,7 +1120,7 @@ def equivalence_oneway(
     res = equivalence_oneway_generic(
         f_stat,
         res0.n_groups,
-        res0.nobs_t,
+        res0.nobs_total,
         equiv_margin,
         res0.df,
         alpha=0.05,
@@ -1379,54 +1384,22 @@ def simulate_power_equivalence_oneway(
     return res
 
 
-@dataclass(frozen=True, slots=True)
-class ScaleAnovaResult(LimitedIterationMixin[float]):
+@dataclass(frozen=True, slots=True, kw_only=True)
+class ScaleAnovaResult(AnovaResult):
     """
     Result of :func:`test_scale_oneway`.
 
-    Has the same attributes as :class:`AnovaResult`, computed on the
-    transformed data, plus `data_transformed`.
+    Extends :class:`AnovaResult`, computed on the transformed data, with
+    one additional field.
 
     Parameters
     ----------
-    statistic : float
-        Test statistic for k-sample mean comparison which is approximately
-        F-distributed.
-    pvalue : float
-        If ``method="bf"``, then the p-value is based on corrected degrees
-        of freedom following Mehrotra 1997.
-    df : tuple
-        Degrees of freedom ``(df_num, df_denom)`` for the F-distribution
-        used for `pvalue`.
-    df_num : float
-        Numerator degrees of freedom.
-    df_denom : float
-        Denominator degrees of freedom used for `pvalue`.
-    nobs_t : float
-        Total number of observations across all samples.
-    n_groups : int
-        Number of samples being compared.
-    means : ndarray
-        Mean of each sample of the transformed data.
-    nobs : ndarray
-        Number of observations in each sample.
-    vars_ : ndarray
-        Residual (within) variance of each sample of the transformed data.
-    use_var : {"unequal", "equal", "bf"}
-        The `method` option that was used to compute the test.
-    welch_correction : bool
-        Whether the Welch correction was included in the test statistic.
     data_transformed : list of ndarray
         The centered and transformed data used to compute the test.
-    df2 : tuple or None
-        Degrees of freedom ``(df_num2, df_denom)`` for the Brown-Forsythe
-        1974 p-value. Only set if ``method="bf"``, otherwise None.
-    df_num2 : float or None
-        Numerator degrees of freedom for the Brown-Forsythe 1974 p-value.
-        Only set if ``method="bf"``, otherwise None.
-    pvalue2 : float or None
-        p-value based on degrees of freedom as in Brown-Forsythe 1974.
-        Only set if ``method="bf"``, otherwise None.
+
+    See Also
+    --------
+    AnovaResult
 
     Notes
     -----
@@ -1434,24 +1407,7 @@ class ScaleAnovaResult(LimitedIterationMixin[float]):
     accessible using attributes.
     """
 
-    _iter_fields: ClassVar[tuple[str, ...]] = ("statistic", "pvalue")
-
-    statistic: float
-    pvalue: float
-    df: tuple
-    df_num: float
-    df_denom: float
-    nobs_t: float
-    n_groups: int
-    means: np.ndarray
-    nobs: np.ndarray
-    vars_: np.ndarray
-    use_var: str
-    welch_correction: bool
     data_transformed: list
-    df2: tuple | None = None
-    df_num2: float | None = None
-    pvalue2: float | None = None
 
 
 def test_scale_oneway(

--- a/statsmodels/stats/rates.py
+++ b/statsmodels/stats/rates.py
@@ -1817,10 +1817,10 @@ def confint_poisson_2indep(
     return ci
 
 
-@dataclass(frozen=True, slots=True)
-class PowerRatioResult(LimitedIterationMixin[float]):
+@dataclass(frozen=True, slots=True, kw_only=True)
+class PowerResult(LimitedIterationMixin[float]):
     """
-    Result of :func:`power_poisson_ratio_2indep`.
+    Common base for the power-computation result classes in this module.
 
     Behaves like the scalar `power` when converted to an array, e.g., with
     ``np.asarray`` or in ``numpy.testing.assert_allclose``, so that it can
@@ -1830,20 +1830,15 @@ class PowerRatioResult(LimitedIterationMixin[float]):
     ----------
     power : float
         Power of the test.
-    p_pooled : None
-        Not currently computed, reserved for future use.
-    std_null : float
-        Standard error of the test statistic under the null hypothesis
-        (without ``sqrt(nobs1)``).
     std_alt : float
         Standard error of the test statistic under the alternative
-        hypothesis (without ``sqrt(nobs1)``).
-    nobs1 : float or int
+        hypothesis (without ``sqrt(nobs_1)``).
+    nobs_1 : float or int
         Number of observations in sample 1.
-    nobs2 : float or int
+    nobs_2 : float or int
         Number of observations in sample 2.
     nobs_ratio : float
-        Sample size ratio, ``nobs2 = nobs_ratio * nobs1``.
+        Sample size ratio, ``nobs_2 = nobs_ratio * nobs_1``.
     alpha : float
         Significance level used for the power computation.
 
@@ -1856,16 +1851,56 @@ class PowerRatioResult(LimitedIterationMixin[float]):
     _iter_fields: ClassVar[tuple[str, ...]] = ("power",)
 
     power: float
-    p_pooled: None
-    std_null: float
     std_alt: float
-    nobs1: float
-    nobs2: float
+    nobs_1: float
+    nobs_2: float
     nobs_ratio: float
     alpha: float
 
     def __array__(self, dtype=None, copy=None):
         return np.asarray(self.power, dtype=dtype)
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class PowerRatioResult(PowerResult):
+    """
+    Result of :func:`power_poisson_ratio_2indep`.
+
+    Extends :class:`PowerResult` with `p_pooled` and `std_null`.
+
+    Parameters
+    ----------
+    power : float
+        Power of the test.
+    p_pooled : float or None
+        Not currently computed, reserved for future use.
+    std_null : float
+        Standard error of the test statistic under the null hypothesis
+        (without ``sqrt(nobs_1)``).
+    std_alt : float
+        Standard error of the test statistic under the alternative
+        hypothesis (without ``sqrt(nobs_1)``).
+    nobs_1 : float or int
+        Number of observations in sample 1.
+    nobs_2 : float or int
+        Number of observations in sample 2.
+    nobs_ratio : float
+        Sample size ratio, ``nobs_2 = nobs_ratio * nobs_1``.
+    alpha : float
+        Significance level used for the power computation.
+
+    See Also
+    --------
+    PowerResult
+
+    Notes
+    -----
+    Unpacks as a length-1 sequence, ``(power,) = result``. Other values are
+    only accessible using attributes.
+    """
+
+    p_pooled: float | None
+    std_null: float
 
 
 def power_poisson_ratio_2indep(
@@ -1980,8 +2015,8 @@ def power_poisson_ratio_2indep(
             p_pooled=p_pooled,
             std_null=std_null,
             std_alt=std_alt,
-            nobs1=nobs1,
-            nobs2=nobs2,
+            nobs_1=nobs1,
+            nobs_2=nobs2,
             nobs_ratio=nobs_ratio,
             alpha=alpha,
         )
@@ -1990,15 +2025,14 @@ def power_poisson_ratio_2indep(
     return pow_
 
 
-@dataclass(frozen=True, slots=True)
-class PowerEquivalenceResult(LimitedIterationMixin[float]):
+@dataclass(frozen=True, slots=True, kw_only=True)
+class PowerEquivalenceResult(PowerResult):
     """
     Result of :func:`power_equivalence_poisson_2indep` and
     :func:`power_equivalence_neginb_2indep`.
 
-    Behaves like the scalar `power` when converted to an array, e.g., with
-    ``np.asarray`` or in ``numpy.testing.assert_allclose``, so that it can
-    be compared directly against a plain power value.
+    Extends :class:`PowerResult` with `power_margins`, `std_null_low` and
+    `std_null_upp`.
 
     Parameters
     ----------
@@ -2015,14 +2049,18 @@ class PowerEquivalenceResult(LimitedIterationMixin[float]):
     std_alt : float
         Standard error of the test statistic under the alternative
         hypothesis.
-    nobs1 : float or int
+    nobs_1 : float or int
         Number of observations in sample 1.
-    nobs2 : float or int
+    nobs_2 : float or int
         Number of observations in sample 2.
     nobs_ratio : float
-        Sample size ratio, ``nobs2 = nobs_ratio * nobs1``.
+        Sample size ratio, ``nobs_2 = nobs_ratio * nobs_1``.
     alpha : float
         Significance level used for the power computation.
+
+    See Also
+    --------
+    PowerResult
 
     Notes
     -----
@@ -2030,20 +2068,9 @@ class PowerEquivalenceResult(LimitedIterationMixin[float]):
     only accessible using attributes.
     """
 
-    _iter_fields: ClassVar[tuple[str, ...]] = ("power",)
-
-    power: float
     power_margins: np.ndarray
     std_null_low: float
     std_null_upp: float
-    std_alt: float
-    nobs1: float
-    nobs2: float
-    nobs_ratio: float
-    alpha: float
-
-    def __array__(self, dtype=None, copy=None):
-        return np.asarray(self.power, dtype=dtype)
 
 
 def power_equivalence_poisson_2indep(
@@ -2156,8 +2183,8 @@ def power_equivalence_poisson_2indep(
             std_null_low=std_null_low,
             std_null_upp=std_null_upp,
             std_alt=std_alternative,
-            nobs1=nobs1,
-            nobs2=nobs2,
+            nobs_1=nobs1,
+            nobs_2=nobs2,
             nobs_ratio=nobs_ratio,
             alpha=alpha,
         )
@@ -2291,14 +2318,12 @@ def _std_2poisson_power(
     return rates_pooled, np.sqrt(v0), np.sqrt(v1)
 
 
-@dataclass(frozen=True, slots=True)
-class PowerDiffResult(LimitedIterationMixin[float]):
+@dataclass(frozen=True, slots=True, kw_only=True)
+class PowerDiffResult(PowerResult):
     """
     Result of :func:`power_poisson_diff_2indep`.
 
-    Behaves like the scalar `power` when converted to an array, e.g., with
-    ``np.asarray`` or in ``numpy.testing.assert_allclose``, so that it can
-    be compared directly against a plain power value.
+    Extends :class:`PowerResult` with `rates_alt` and `std_null`.
 
     Parameters
     ----------
@@ -2308,18 +2333,22 @@ class PowerDiffResult(LimitedIterationMixin[float]):
         The two rates under the alternative hypothesis, ``(rate1, rate2)``.
     std_null : float
         Standard error of the test statistic under the null hypothesis
-        (without ``sqrt(nobs1)``).
+        (without ``sqrt(nobs_1)``).
     std_alt : float
         Standard error of the test statistic under the alternative
-        hypothesis (without ``sqrt(nobs1)``).
-    nobs1 : float or int
+        hypothesis (without ``sqrt(nobs_1)``).
+    nobs_1 : float or int
         Number of observations in sample 1.
-    nobs2 : float or int
+    nobs_2 : float or int
         Number of observations in sample 2.
     nobs_ratio : float
-        Sample size ratio, ``nobs2 = nobs_ratio * nobs1``.
+        Sample size ratio, ``nobs_2 = nobs_ratio * nobs_1``.
     alpha : float
         Significance level used for the power computation.
+
+    See Also
+    --------
+    PowerResult
 
     Notes
     -----
@@ -2327,19 +2356,8 @@ class PowerDiffResult(LimitedIterationMixin[float]):
     only accessible using attributes.
     """
 
-    _iter_fields: ClassVar[tuple[str, ...]] = ("power",)
-
-    power: float
     rates_alt: tuple
     std_null: float
-    std_alt: float
-    nobs1: float
-    nobs2: float
-    nobs_ratio: float
-    alpha: float
-
-    def __array__(self, dtype=None, copy=None):
-        return np.asarray(self.power, dtype=dtype)
 
 
 def power_poisson_diff_2indep(
@@ -2434,8 +2452,8 @@ def power_poisson_diff_2indep(
             rates_alt=(rate2 + diff, rate2),
             std_null=std_null,
             std_alt=std_alt,
-            nobs1=nobs1,
-            nobs2=nobs_ratio * nobs1,
+            nobs_1=nobs1,
+            nobs_2=nobs_ratio * nobs1,
             nobs_ratio=nobs_ratio,
             alpha=alpha,
         )
@@ -2501,14 +2519,12 @@ def _var_cmle_negbin(rate1, rate2, nobs_ratio, exposure=1, value=1, dispersion=0
     return v * nobs_ratio, r1, r2
 
 
-@dataclass(frozen=True, slots=True)
-class PowerNegbinRatioResult(LimitedIterationMixin[float]):
+@dataclass(frozen=True, slots=True, kw_only=True)
+class PowerNegbinRatioResult(PowerResult):
     """
     Result of :func:`power_negbin_ratio_2indep`.
 
-    Behaves like the scalar `power` when converted to an array, e.g., with
-    ``np.asarray`` or in ``numpy.testing.assert_allclose``, so that it can
-    be compared directly against a plain power value.
+    Extends :class:`PowerResult` with `std_null`.
 
     Parameters
     ----------
@@ -2516,18 +2532,22 @@ class PowerNegbinRatioResult(LimitedIterationMixin[float]):
         Power of the test.
     std_null : float
         Standard error of the test statistic under the null hypothesis
-        (without ``sqrt(nobs1)``).
+        (without ``sqrt(nobs_1)``).
     std_alt : float
         Standard error of the test statistic under the alternative
-        hypothesis (without ``sqrt(nobs1)``).
-    nobs1 : float or int
+        hypothesis (without ``sqrt(nobs_1)``).
+    nobs_1 : float or int
         Number of observations in sample 1.
-    nobs2 : float or int
+    nobs_2 : float or int
         Number of observations in sample 2.
     nobs_ratio : float
-        Sample size ratio, ``nobs2 = nobs_ratio * nobs1``.
+        Sample size ratio, ``nobs_2 = nobs_ratio * nobs_1``.
     alpha : float
         Significance level used for the power computation.
+
+    See Also
+    --------
+    PowerResult
 
     Notes
     -----
@@ -2535,18 +2555,7 @@ class PowerNegbinRatioResult(LimitedIterationMixin[float]):
     only accessible using attributes.
     """
 
-    _iter_fields: ClassVar[tuple[str, ...]] = ("power",)
-
-    power: float
     std_null: float
-    std_alt: float
-    nobs1: float
-    nobs2: float
-    nobs_ratio: float
-    alpha: float
-
-    def __array__(self, dtype=None, copy=None):
-        return np.asarray(self.power, dtype=dtype)
 
 
 def power_negbin_ratio_2indep(
@@ -2669,8 +2678,8 @@ def power_negbin_ratio_2indep(
             power=pow_,
             std_null=std_null,
             std_alt=std_alt,
-            nobs1=nobs1,
-            nobs2=nobs2,
+            nobs_1=nobs1,
+            nobs_2=nobs2,
             nobs_ratio=nobs_ratio,
             alpha=alpha,
         )
@@ -2812,8 +2821,8 @@ def power_equivalence_neginb_2indep(
             std_null_low=std_null_low,
             std_null_upp=std_null_upp,
             std_alt=std_alternative,
-            nobs1=nobs1,
-            nobs2=nobs2,
+            nobs_1=nobs1,
+            nobs_2=nobs2,
             nobs_ratio=nobs_ratio,
             alpha=alpha,
         )

--- a/statsmodels/stats/tests/test_limited_iteration_mixin.py
+++ b/statsmodels/stats/tests/test_limited_iteration_mixin.py
@@ -128,7 +128,9 @@ CASES = [
         statistic=1.0, pvalue=0.1, pvalue_smaller=0.2, pvalue_larger=0.8,
         chi2=1.0, pvalue_chi2=0.1, df_chi2=1, distribution="normal",
     )),
-    (HomogeneityTestResult, dict(statistic=1.0, pvalue=0.1, df=2.0, distr="chi2")),
+    (HomogeneityTestResult, dict(
+        statistic=1.0, pvalue=0.1, df=2.0, distribution="chi2",
+    )),
     (PoissonTestResult, dict(
         statistic=1.0, pvalue=0.1, distribution="normal", method="score",
         alternative="two-sided", rate=0.5, nobs=20.0,
@@ -148,20 +150,20 @@ CASES = [
         results_smaller=_p2i, title="nonequiv",
     )),
     (PowerRatioResult, dict(
-        power=0.8, p_pooled=None, std_null=0.1, std_alt=0.1, nobs1=20.0,
-        nobs2=20.0, nobs_ratio=1.0, alpha=0.05,
+        power=0.8, p_pooled=None, std_null=0.1, std_alt=0.1, nobs_1=20.0,
+        nobs_2=20.0, nobs_ratio=1.0, alpha=0.05,
     )),
     (PowerEquivalenceResult, dict(
         power=0.8, power_margins=np.array([0.1, 0.2]), std_null_low=0.1,
-        std_null_upp=0.1, std_alt=0.1, nobs1=20.0, nobs2=20.0,
+        std_null_upp=0.1, std_alt=0.1, nobs_1=20.0, nobs_2=20.0,
         nobs_ratio=1.0, alpha=0.05,
     )),
     (PowerDiffResult, dict(
         power=0.8, rates_alt=(2.0, 1.5), std_null=0.1, std_alt=0.1,
-        nobs1=20.0, nobs2=20.0, nobs_ratio=1.0, alpha=0.05,
+        nobs_1=20.0, nobs_2=20.0, nobs_ratio=1.0, alpha=0.05,
     )),
     (PowerNegbinRatioResult, dict(
-        power=0.8, std_null=0.1, std_alt=0.1, nobs1=20.0, nobs2=20.0,
+        power=0.8, std_null=0.1, std_alt=0.1, nobs_1=20.0, nobs_2=20.0,
         nobs_ratio=1.0, alpha=0.05,
     )),
     (ScoreTestProportionsResult, dict(
@@ -179,7 +181,7 @@ CASES = [
     )),
     (AnovaResult, dict(
         statistic=1.0, pvalue=0.1, df=(2.0, 30.0), df_num=2.0, df_denom=30.0,
-        nobs_t=33.0, n_groups=3, means=np.array([1.0, 2.0, 3.0]),
+        nobs_total=33.0, n_groups=3, means=np.array([1.0, 2.0, 3.0]),
         nobs=np.array([10, 11, 12]), vars_=np.array([1.0, 1.0, 1.0]),
         use_var="unequal", welch_correction=True,
     )),
@@ -190,7 +192,7 @@ CASES = [
     )),
     (ScaleAnovaResult, dict(
         statistic=1.0, pvalue=0.1, df=(2.0, 30.0), df_num=2.0, df_denom=30.0,
-        nobs_t=33.0, n_groups=3, means=np.array([1.0, 2.0, 3.0]),
+        nobs_total=33.0, n_groups=3, means=np.array([1.0, 2.0, 3.0]),
         nobs=np.array([10, 11, 12]), vars_=np.array([1.0, 1.0, 1.0]),
         use_var="unequal", welch_correction=True, data_transformed=[1, 2, 3],
     )),
@@ -208,7 +210,7 @@ CASES = [
     )),
     (RankCompareResult, dict(
         statistic=1.0, pvalue=0.1, s1=1.0, s2=1.0, var1=1.0, var2=1.0,
-        var=1.0, var_prob=1.0, nobs1=10, nobs2=10, nobs=20, mean1=1.0,
+        var=1.0, var_prob=1.0, nobs_1=10, nobs_2=10, nobs=20, mean1=1.0,
         mean2=1.0, prob1=0.5, prob2=0.5, somersd1=0.0, somersd2=0.0,
         df=None, use_t=False,
     )),
@@ -219,16 +221,16 @@ CASES = [
         chi2_stat_groups=np.array([0.5, 0.5]), indices=[[0], [1]],
     )),
     (HotellingResult, dict(
-        statistic=1.0, pvalue=0.1, df=(3, 47), t2=4.0, distr="F",
+        statistic=1.0, pvalue=0.1, df=(3, 47), t2=4.0, distribution="F",
     )),
     (CovTestResult, dict(
-        statistic=1.0, pvalue=0.1, df=6.0, distr="chi2", null="equal value",
-        cov_null=None,
+        statistic=1.0, pvalue=0.1, df=6.0, distribution="chi2",
+        null="equal value", cov_null=None,
     )),
     (CovOnewayResult, dict(
         statistic=1.0, pvalue=0.1, statistic_base=1.0, statistic_chi2=1.0,
-        pvalue_chi2=0.1, df_chi2=2.0, distr_chi2="chi2", statistic_f=1.0,
-        pvalue_f=0.1, df_f=(2, 30), distr_f="F",
+        pvalue_chi2=0.1, df_chi2=2.0, distribution_chi2="chi2",
+        statistic_f=1.0, pvalue_f=0.1, df_f=(2, 30), distribution_f="F",
     )),
     (ADFullerResult, dict(
         statistic=-2.0, pvalue=0.3, lags=1, nobs=100,

--- a/statsmodels/stats/tests/test_nonparametric.py
+++ b/statsmodels/stats/tests/test_nonparametric.py
@@ -673,7 +673,7 @@ def test_jonckheere_terpstra_many_unequal_groups():
         alternative="two-sided",
     )
 
-    assert res.k_groups == len(samples)
+    assert res.n_groups == len(samples)
     assert res.nobs == sum(sizes)
     assert_allclose(res.statistic, expected_stat, rtol=1e-13)
     expected_statistic = expected.correlation if SP_LT_110 else expected.statistic
@@ -717,8 +717,8 @@ cases_continuous = [
         np.array([6.6, 7.7, 8.8, 9.9, 10.1]),
         # Expected ranks and placements
         Holder(
-            n_1=5,
-            n_2=5,
+            nobs_1=5,
+            nobs_2=5,
             overall_ranks_pooled=np.arange(1, 11),
             overall_ranks_1=np.arange(1, 6),
             overall_ranks_2=np.arange(6, 11),
@@ -736,8 +736,8 @@ cases_ordinal = [
         np.array([4, 5, 6, 7, 8]),
         # Expected ranks and placements
         Holder(
-            n_1=5,
-            n_2=5,
+            nobs_1=5,
+            nobs_2=5,
             # First two ties are (1+2)/2=1.5, next two are (3+4)/2=3.5
             overall_ranks_pooled=np.array([1.5, 1.5, 3.5, 3.5, 5, 6, 7, 8, 9, 10]),
             overall_ranks_1=np.array([1.5, 1.5, 3.5, 3.5, 5]),
@@ -754,8 +754,8 @@ cases_ordinal = [
         np.array([4, 5, 6, 7, 8]),
         # Expected ranks and placements
         Holder(
-            n_1=5,
-            n_2=5,
+            nobs_1=5,
+            nobs_2=5,
             # Ties at (2+3)/2=2.5, (4+5)/2=4.5, (6+7)/2=6.5
             # So 2 -> 2.5, 4 -> 4.5, 5 -> 6.5
             overall_ranks_pooled=np.array(
@@ -787,8 +787,8 @@ def test_compute_rank_placements(test_cases):
     """
     x1, x2, expected_holder = test_cases
     res = _compute_rank_placements(x1, x2)
-    assert_allclose(res.n_1, expected_holder.n_1)
-    assert_allclose(res.n_2, expected_holder.n_2)
+    assert_allclose(res.nobs_1, expected_holder.nobs_1)
+    assert_allclose(res.nobs_2, expected_holder.nobs_2)
     assert_allclose(res.overall_ranks_pooled, expected_holder.overall_ranks_pooled)
     assert_allclose(res.overall_ranks_1, expected_holder.overall_ranks_1)
     assert_allclose(res.overall_ranks_2, expected_holder.overall_ranks_2)

--- a/statsmodels/tsa/ardl/model.py
+++ b/statsmodels/tsa/ardl/model.py
@@ -75,10 +75,10 @@ class BoundsTestResult(NamedTuple):
     ----------
     statistic : float
         The F-type test statistic favored in PSS.
-    crit_vals : DataFrame
+    critical_values : DataFrame
         The critical values for the test statistic, with columns "lower"
         and "upper" indexed by percentile.
-    p_values : Series
+    pvalue : Series
         The p-values corresponding to the "lower" and "upper" bounds of
         the test statistic.
     null : str
@@ -88,8 +88,8 @@ class BoundsTestResult(NamedTuple):
     """
 
     statistic: float
-    crit_vals: pd.DataFrame
-    p_values: pd.Series
+    critical_values: pd.DataFrame
+    pvalue: pd.Series
     null: str
     alternative: str
 
@@ -97,8 +97,8 @@ class BoundsTestResult(NamedTuple):
         return f"""\
 {self.__class__.__name__}
 Stat: {self.statistic:0.5f}
-Upper P-value: {self.p_values["upper"]:0.3g}
-Lower P-value: {self.p_values["lower"]:0.3g}
+Upper P-value: {self.pvalue["upper"]:0.3g}
+Lower P-value: {self.pvalue["lower"]:0.3g}
 Null: {self.null}
 Alternative: {self.alternative}
 """
@@ -2441,9 +2441,9 @@ class UECMResults(ARDLResults):
         Returns
         -------
         BoundsTestResult
-            Named tuple containing ``statistic``, ``crit_vals``, ``p_values``,
-            ``null`` and ``alternative``. The statistic is the F-type
-            test statistic favored in PSS.
+            Named tuple containing ``statistic``, ``critical_values``,
+            ``pvalue``, ``null`` and ``alternative``. The statistic is the
+            F-type test statistic favored in PSS.
 
         Notes
         -----

--- a/statsmodels/tsa/ardl/tests/test_ardl.py
+++ b/statsmodels/tsa/ardl/tests/test_ardl.py
@@ -832,9 +832,9 @@ def test_bounds_test_simulation(case):
     bounds_result = res.bounds_test(
         case=case, asymptotic=False, rng=[1, 2, 3, 4], nsim=10_000
     )
-    assert (bounds_result.p_values >= 0.0).all()
-    assert (bounds_result.p_values <= 1.0).all()
-    assert (bounds_result.crit_vals > 0.0).all().all()
+    assert (bounds_result.pvalue >= 0.0).all()
+    assert (bounds_result.pvalue <= 1.0).all()
+    assert (bounds_result.critical_values > 0.0).all().all()
 
 
 @pytest.mark.parametrize(
@@ -850,9 +850,9 @@ def test_bounds_test_rng(rng):
     )
     res = mod.fit()
     bounds_result = res.bounds_test(case=3, asymptotic=False, rng=rng, nsim=10_000)
-    assert (bounds_result.p_values >= 0.0).all()
-    assert (bounds_result.p_values <= 1.0).all()
-    assert (bounds_result.crit_vals > 0.0).all().all()
+    assert (bounds_result.pvalue >= 0.0).all()
+    assert (bounds_result.pvalue <= 1.0).all()
+    assert (bounds_result.critical_values > 0.0).all().all()
 
 
 def test_bounds_test_simulate_order():
@@ -867,7 +867,7 @@ def test_bounds_test_simulate_order():
     assert "BoundsTestResult" in str(bounds_result)
     bounds_result_sim = res.bounds_test(3, asymptotic=False, nsim=10_000, rng=[1, 2, 3])
     assert_allclose(bounds_result.statistic, bounds_result_sim.statistic)
-    assert (bounds_result_sim.p_values > bounds_result.p_values).all()
+    assert (bounds_result_sim.pvalue > bounds_result.pvalue).all()
 
 
 def test_resids_ardl_uecm():

--- a/statsmodels/tsa/statespace/mlemodel.py
+++ b/statsmodels/tsa/statespace/mlemodel.py
@@ -1325,7 +1325,7 @@ class MLEModel(tsbase.TimeSeriesModel):
         References
         ----------
         .. [Harvey1989] Harvey, Andrew C. 1989. Forecasting, Structural Time Series Models
-        and the Kalman Filter. Cambridge University Press.
+           and the Kalman Filter. Cambridge University Press.
         """
         params = np.array(params, ndmin=1)
 

--- a/statsmodels/tsa/stattools/_stattools.py
+++ b/statsmodels/tsa/stattools/_stattools.py
@@ -2540,7 +2540,7 @@ class CointResult(NamedTuple):
     pvalue : float
         MacKinnon's approximate, asymptotic p-value based on MacKinnon
         (1994).
-    crit_value : ndarray
+    critical_values : ndarray
         Critical values for the test statistic at the 1 %, 5 %, and 10 %
         levels based on regression curve. This depends on the number of
         observations.
@@ -2548,7 +2548,7 @@ class CointResult(NamedTuple):
 
     coint_t: float
     pvalue: float
-    crit_value: np.ndarray
+    critical_values: np.ndarray
 
 
 def coint(
@@ -2616,7 +2616,7 @@ def coint(
         pvalue : float
             MacKinnon's approximate, asymptotic p-value based on MacKinnon
             (1994).
-        crit_value : ndarray
+        critical_values : ndarray
             Critical values for the test statistic at the 1 %, 5 %, and
             10 % levels based on regression curve. This depends on the
             number of observations.

--- a/statsmodels/tsa/tests/test_stattools.py
+++ b/statsmodels/tsa/tests/test_stattools.py
@@ -1316,12 +1316,12 @@ def test_coint():
 
             assert_allclose(res1[i].coint_t, res[i][0], rtol=1e-11)
             r2 = res[i][1:]
-            r1 = res1[i].crit_value
+            r1 = res1[i].critical_values
             assert_allclose(r1, r2, rtol=0, atol=6e-7)
 
     # use default autolag #4490
     res1_0 = coint(y[:, 0], y[:, 1], trend="ct", maxlag=4)
-    assert_allclose(res1_0.crit_value, res_egranger["ct"][0][1:], rtol=0, atol=6e-7)
+    assert_allclose(res1_0.critical_values, res_egranger["ct"][0][1:], rtol=0, atol=6e-7)
     # the following is just a regression test
     assert_allclose(
         [res1_0.coint_t, res1_0.pvalue],
@@ -2760,4 +2760,4 @@ def test_stattools_fixed_arity_result_objects():
     assert isinstance(res, CointResult)
     assert res[0] == res.coint_t
     assert res[1] == res.pvalue
-    assert res[2] is res.crit_value
+    assert res[2] is res.critical_values


### PR DESCRIPTION
Improve structure
Normalie new names

- [X] code/documentation is well formatted.
- [X] properly formatted commit message. See
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message).

#### AI Disclosure

Contributions must comply with the statsmodels [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html).

If using AI tools, edit the second option to explain which tool was selected and
how the tool's output was used.

Please complete **one** of the following:

- [ ] No AI tools were used to develop this pull request.
- [X] AI tools were used.
      Tool(s): Claude
      Used for: Copy docstrings
      I have personally read, understood, and can explain every line of this diff, and
      have verified the statistical/numerical correctness of the change.

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows
  using the Windows System for Linux once `flake8` is installed in the
  local Linux environment. While passing this test is not required, it is good practice and it help
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.
* If AI tools were used to help write this PR, see the
  [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html) for what disclosure
  and review is expected of you before submitting.

</details>
