### PR TITLE
REF: Remove unused scipy import and cell from wls.ipynb

### DIFF
--- a/examples/notebooks/wls.ipynb
+++ b/examples/notebooks/wls.ipynb
@@ -24,7 +24,6 @@
    "source": [
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
-    "from scipy import stats\n",
     "\n",
     "import statsmodels.api as sm\n",
     "from statsmodels.iolib.table import SimpleTable, default_txt_fmt\n",
@@ -144,18 +143,6 @@
    "metadata": {},
    "source": [
     "Calculate OLS prediction interval:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "covb = res_ols.cov_params()\n",
-    "prediction_var = res_ols.mse_resid + (X * np.dot(covb, X.T).T).sum(1)\n",
-    "prediction_std = np.sqrt(prediction_var)\n",
-    "tppf = stats.t.ppf(0.975, res_ols.df_resid)"
    ]
   },
   {


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed.
- [ ] code/documentation is well formatted.
- [x] properly formatted commit message. See
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message).

#### AI Disclosure

Contributions must comply with the statsmodels [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html).

If using AI tools, edit the second option to explain which tool was selected and
how the tool's output was used.

Please complete **one** of the following:

- [x] No AI tools were used to develop this pull request.
- [ ] AI tools were used.
      Tool(s): `<name(s), e.g. Copilot, Claude, ChatGPT>`.
      Used for: `<e.g. drafting an implementation, writing tests, debugging, editing docstrings>`.
      I have personally read, understood, and can explain every line of this diff, and
      have verified the statistical/numerical correctness of the change.

<details>

The calculated prediction_var, prediction_std, and tppf values are not used later in the notebook, which instead uses get_prediction().summary_frame() to obtain the prediction intervals. The now-unused scipy.stats import is removed as well.

**Notes**:

* It is essential that you add a test when making code changes. Tests are not
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows
  using the Windows System for Linux once `flake8` is installed in the
  local Linux environment. While passing this test is not required, it is good practice and it help
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.
* If AI tools were used to help write this PR, see the
  [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html) for what disclosure
  and review is expected of you before submitting.

</details>
