### PR TITLE
BUG: Forward missing kwarg from MixedLM.from_formula to superclass

### DIFF
--- a/statsmodels/regression/linear_model.py
+++ b/statsmodels/regression/linear_model.py
@@ -844,6 +844,8 @@ class WLS(RegressionModel):
             return x * np.sqrt(self.weights)
         elif x.ndim == 2:
             return np.sqrt(self.weights)[:, None] * x
+        else:
+            raise ValueError("x must be 1 or 2 dimensional")
 
     def loglike(self, params):
         r"""

--- a/statsmodels/regression/linear_model.py
+++ b/statsmodels/regression/linear_model.py
@@ -3552,6 +3552,7 @@ class OLSResults(RegressionResults):
 
         """
         result_object = bool_like(result_object, "result_object", optional=True)
+        method = string_like(method, "method", options=("nm", "powell"))
         params = np.copy(self.params)
         opt_fun_inst = _ELRegOpts()  # to store weights
         nuisance_params = None

--- a/statsmodels/regression/mixed_linear_model.py
+++ b/statsmodels/regression/mixed_linear_model.py
@@ -1131,6 +1131,7 @@ class MixedLM(base.LikelihoodModel):
         kwargs["exog_re"] = exog_re
         kwargs["exog_vc"] = exog_vc
         kwargs["groups"] = groups
+        kwargs["missing"] = missing
         advance_eval_env(kwargs)
         mod = super().from_formula(formula, data, *args, **kwargs)
 

--- a/statsmodels/regression/rolling.py
+++ b/statsmodels/regression/rolling.py
@@ -336,6 +336,9 @@ class RollingWLS:
         method = string_like(
             method, "method", options=("inv", "lstsq", "pinv")
         )
+        cov_type = string_like(
+            cov_type, "cov_type", options=("nonrobust", "HCCM", "HC0"), lower=False
+        )
         reset = int_like(reset, "reset", optional=True)
         reset = self._y.shape[0] if reset is None else reset
         if reset < 1:

--- a/statsmodels/regression/tests/test_lme.py
+++ b/statsmodels/regression/tests/test_lme.py
@@ -1057,6 +1057,40 @@ def test_handle_missing():
                 assert_equal(len(result1.fittedvalues), result1.nobs)
 
 
+def test_from_formula_missing_kwarg_forwarded():
+    # GH: MixedLM.from_formula captured its own `missing` argument but
+    # never forwarded it to Model.from_formula's **kwargs. That meant the
+    # parent class's own default ("drop") was silently used regardless of
+    # what the caller passed, which desynced the already-computed `groups`
+    # array (built from the un-dropped data) from the row-dropped
+    # exog/endog and crashed with a confusing, unrelated IndexError during
+    # fit() instead of raising a clear error about the missing data.
+    rs = np.random.RandomState(23423)
+    n = 50
+    df = pd.DataFrame(
+        {
+            "y": rs.normal(size=n),
+            "x": rs.normal(size=n),
+            "g": np.repeat(np.arange(10), 5),
+        }
+    )
+    df.loc[0, "y"] = np.nan
+
+    for kwargs in ({}, {"missing": "none"}, {"missing": "raise"}):
+        with pytest.raises(Exception) as excinfo:
+            MixedLM.from_formula("y ~ x", groups="g", data=df, **kwargs)
+        # Before the fix this raised IndexError from misaligned groups vs.
+        # exog/endog instead of a clear missing-data error.
+        assert not isinstance(excinfo.value, IndexError)
+
+    model = MixedLM.from_formula("y ~ x", groups="g", data=df, missing="drop")
+    assert model.exog.shape[0] == n - 1
+    assert model.endog.shape[0] == n - 1
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        model.fit()
+
+
 def test_summary_col():
     from statsmodels.iolib.summary2 import summary_col
 

--- a/statsmodels/regression/tests/test_regression.py
+++ b/statsmodels/regression/tests/test_regression.py
@@ -802,6 +802,11 @@ class TestWLS_CornerCases:
         with pytest.raises(ValueError):
             WLS(self.endog, self.exog, weights=weights)
 
+    def test_whiten_wrong_ndim(self):
+        mod = WLS(self.endog, self.exog, weights=1)
+        with pytest.raises(ValueError):
+            mod.whiten(np.ones((2, 2, 2)))
+
 
 class TestWLSExogWeights(CheckRegressionResults):
     # Test WLS with Greene's credit card data

--- a/statsmodels/regression/tests/test_regression.py
+++ b/statsmodels/regression/tests/test_regression.py
@@ -1031,6 +1031,15 @@ class TestCompareAndElTestNamedTuple:
             )
         assert isinstance(res_large, CompareLRTestResult)
 
+    def test_el_test_invalid_method_raises(self):
+        # An unsupported `method` used to fall through both `if` branches
+        # with no `else`, leaving `llr` unassigned and raising
+        # UnboundLocalError instead of a clear ValueError.
+        with pytest.raises(ValueError):
+            self.res_full.el_test(
+                np.array([0.0]), np.array([1]), method="unknown"
+            )
+
     def test_el_test_result_object_default_warns(self):
         with pytest.warns(FutureWarning, match="result_object"):
             res = self.res_full.el_test(np.array([0.0]), np.array([1]))

--- a/statsmodels/regression/tests/test_rolling.py
+++ b/statsmodels/regression/tests/test_rolling.py
@@ -185,6 +185,8 @@ def test_error():
         ).fit(reset=-1)
     with pytest.raises(ValueError):
         RollingWLS(y, x).fit(method="unknown")
+    with pytest.raises(ValueError):
+        RollingWLS(y, x).fit(cov_type="unknown")
     with pytest.raises(ValueError, match="min_nobs must be larger"):
         RollingWLS(y, x, min_nobs=1)
     with pytest.raises(ValueError, match="min_nobs must be larger"):


### PR DESCRIPTION
- [X] tests added / passed.
- [X] code/documentation is well formatted.
- [X] properly formatted commit message. See
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message).

#### AI Disclosure

Contributions must comply with the statsmodels [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html).

If using AI tools, edit the second option to explain which tool was selected and
how the tool's output was used.

Please complete **one** of the following:

- [ ] No AI tools were used to develop this pull request.
- [X] AI tools were used.
      Tool(s):  Claude
      Used for: Test writing
      I have personally read, understood, and can explain every line of this diff, and
      have verified the statistical/numerical correctness of the change.

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows
  using the Windows System for Linux once `flake8` is installed in the
  local Linux environment. While passing this test is not required, it is good practice and it help
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.
* If AI tools were used to help write this PR, see the
  [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html) for what disclosure
  and review is expected of you before submitting.

</details>
