### PR TITLE
BUG: Pivot the QR factorization in tools.matrix_rank

### DIFF
--- a/statsmodels/tools/tests/test_tools.py
+++ b/statsmodels/tools/tests/test_tools.py
@@ -5,6 +5,7 @@ Test functions for models.tools
 from statsmodels.compat.pandas import assert_frame_equal, assert_series_equal
 from statsmodels.compat.python import lrange
 
+import itertools
 import string
 
 import numpy as np
@@ -217,6 +218,21 @@ def test_estimable():
             isestimable(np.ones((n,)), X)
     with pytest.raises(ValueError):
         isestimable(np.eye(4), X)
+
+
+@pytest.mark.parametrize("method", ["ip", "qr", "svd"])
+def test_matrix_rank_column_order(method):
+    # the rank of a matrix is a property of its column space, so it does not
+    # depend on the order the columns are given in. The regressor here is
+    # measured on a much larger scale than the intercept, which is the case
+    # that separates a tolerance taken from the leading diagonal element of
+    # the R matrix from one taken from the largest.
+    x = 1e3 * np.arange(1.0, 41.0) / 7.0
+    exog = np.column_stack((np.ones(40), x, 2.0 * x))
+
+    for cols in itertools.permutations(range(exog.shape[1])):
+        rank = tools.matrix_rank(exog[:, list(cols)], method=method)
+        assert_equal(rank, 2, err_msg=f"column order {cols}")
 
 
 def test_pandas_const_series():

--- a/statsmodels/tools/tools.py
+++ b/statsmodels/tools/tools.py
@@ -504,9 +504,9 @@ def matrix_rank(m, tol=None, method="qr"):
 
     Notes
     -----
-    When using a QR factorization, the rank is determined by the number of
-    elements on the leading diagonal of the R matrix that are above tol
-    in absolute value.
+    When using a QR factorization, the factorization is column pivoted and
+    the rank is determined by the number of elements on the leading diagonal
+    of the R matrix that are above tol in absolute value.
 
     """
     m = array_like(m, "m", ndim=2)
@@ -516,7 +516,11 @@ def matrix_rank(m, tol=None, method="qr"):
         m = m.T @ m
         return np.linalg.matrix_rank(m, tol=tol, hermitian=True)
     elif method == "qr":
-        (r,) = scipy.linalg.qr(m, mode="r")
+        # The pivoted factorization orders the diagonal of R by decreasing
+        # magnitude, which makes the number of diagonal elements above tol a
+        # rank estimate and keeps tol keyed to the largest of them. Without
+        # pivoting the count depends on the order of the columns of m.
+        r, _ = scipy.linalg.qr(m, mode="r", pivoting=True)
         abs_diag = np.abs(np.diag(r))
         if tol is None:
             tol = abs_diag[0] * m.shape[1] * np.finfo(float).eps


### PR DESCRIPTION
- [x] tests added / passed.
- [x] code/documentation is well formatted.
- [x] properly formatted commit message.

A matrix's rank is a property of its column space, so it cannot depend on the order the columns arrive in. `tools.matrix_rank` with the default `method="qr"` does depend on it.

That factorization is unpivoted, so R's diagonal follows column order rather than decreasing magnitude, and `tol` ends up keyed to whichever element happens to lead. On an exog of an intercept and a regressor measured on a much larger scale, with one column an exact multiple of another, the count of diagonal entries above `tol` changes with the permutation. Its own docstring already calls that count the rank estimate, which only holds once the diagonal is ordered.

Pivoting the factorization is a one-word change. A test asserts the same rank across all six permutations of a three-column exog under each of the three methods, and fails on `qr` without it.

`statsmodels/tools/tests/test_tools.py` is 35 passed. The regression, base and tools suites together are 1784 passed and 33 skipped, and discrete, which is the one place that asks for `method="qr"` by name, is 1104 passed.

#### AI Disclosure

Contributions must comply with the statsmodels [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html).

Please complete **one** of the following:

- [ ] No AI tools were used to develop this pull request.
- [x] AI tools were used.
      Tool(s): `Claude Code`.
      Used for: `drafting the implementation and the test`.
      I have personally read, understood, and can explain every line of this diff, and
      have verified the statistical/numerical correctness of the change.
