### PR TITLE
DOC: Standardized docstrings in tools

### DIFF
--- a/statsmodels/tools/_test_runner.py
+++ b/statsmodels/tools/_test_runner.py
@@ -31,7 +31,7 @@ class PytestTester:
 
         Parameters
         ----------
-        extra_args : list[str], optional
+        extra_args : list of str, optional
             Command line arguments to pass to pytest. If None, defaults
             to ``["--tb=short", "--disable-pytest-warnings"]``.
         exit : bool, optional

--- a/statsmodels/tools/catadd.py
+++ b/statsmodels/tools/catadd.py
@@ -12,7 +12,7 @@ def add_indep(x, varnames, dtype=None):
     x : array_like
         Candidate columns. If `x` is a 2-dimensional ndarray, columns are
         assumed to represent variables and rows observations.
-    varnames : list[str]
+    varnames : list of str
         Names corresponding to the columns in `x`.
     dtype : dtype, optional
         dtype used to construct the output array. If omitted, uses the dtype
@@ -22,7 +22,7 @@ def add_indep(x, varnames, dtype=None):
     -------
     xout : ndarray
         Array containing only linearly independent columns.
-    varnames_new : list[str]
+    varnames_new : list of str
         Names of the retained columns.
 
     Notes

--- a/statsmodels/tools/data.py
+++ b/statsmodels/tools/data.py
@@ -71,9 +71,9 @@ def interpret_data(data, colnames=None, rownames=None):
     ----------
     data : array_like
         Data to convert.
-    colnames : sequence or None
+    colnames : sequence or None, optional
         Column names. May be part of the data structure.
-    rownames : sequence or None
+    rownames : sequence or None, optional
         Row names. May be part of the data structure.
 
     Returns

--- a/statsmodels/tools/docstring.py
+++ b/statsmodels/tools/docstring.py
@@ -16,12 +16,12 @@ def dedent_lines(lines):
 
     Parameters
     ----------
-    lines : list[str]
+    lines : list of str
         The lines to dedent.
 
     Returns
     -------
-    list[str]
+    list of str
         The dedented lines.
     """
     return textwrap.dedent("\n".join(lines)).split("\n")
@@ -33,12 +33,12 @@ def strip_blank_lines(line):
 
     Parameters
     ----------
-    line : list[str]
+    line : list of str
         The lines to strip. Modified and returned in place.
 
     Returns
     -------
-    list[str]
+    list of str
         The lines with leading and trailing blank lines removed.
     """
     while line and not line[0].strip():
@@ -55,7 +55,7 @@ class Reader:
         """
         Parameters
         ----------
-        data : str or list[str]
+        data : str or list of str
             String with lines separated by '\\n', or a list of lines.
         """
         if isinstance(data, list):
@@ -133,7 +133,7 @@ class Parameter(NamedTuple):
         The name of the parameter.
     type : str
         The type description of the parameter, as written in the docstring.
-    desc : list[str]
+    desc : list of str
         The description lines for the parameter.
     """
 
@@ -615,7 +615,7 @@ class Docstring:
 
         Parameters
         ----------
-        parameters : str, list[str]
+        parameters : str or list of str
             The names of the parameters to remove.
         """
         if self._docstring is None:
@@ -636,7 +636,7 @@ class Docstring:
 
         Parameters
         ----------
-        after : {None, str}
+        after : None or str
             If None, insert the parameters before the first parameter in the
             docstring. Otherwise, the name of the existing parameter after
             which the new parameters are inserted.
@@ -690,7 +690,7 @@ class Docstring:
 
         Parameters
         ----------
-        parameters : str, list[str]
+        parameters : str or list of str
             The names of the parameters to extract.
         indent : int, optional
             Number of spaces to indent every line of the output. Default is
@@ -738,7 +738,7 @@ def remove_parameters(docstring, parameters):
     ----------
     docstring : str
         The docstring to modify.
-    parameters : str, list[str]
+    parameters : str or list of str
         The names of the parameters to remove.
 
     Returns
@@ -759,7 +759,7 @@ def indent(text, prefix, predicate=None):
 
     Parameters
     ----------
-    text : {None, str}
+    text : None or str
         If None, function always returns ""
     prefix : str
         Prefix to add to the start of each line

--- a/statsmodels/tools/eval_measures.py
+++ b/statsmodels/tools/eval_measures.py
@@ -14,11 +14,25 @@ from statsmodels.tools.validation import array_like
 
 
 def _nan_reduction_result(arr, axis):
-    """Explicit nan with the shape a reduction of `arr` over `axis` would give.
+    """
+    Explicit nan with the shape a reduction of `arr` over `axis` would give
 
     Used for empty inputs, where the underlying numpy reduction has no
-    identity element. Returns a scalar when the reduction collapses the whole
-    array, otherwise an array of nan with the remaining shape.
+    identity element. Returns a scalar when the reduction collapses the
+    whole array, otherwise an array of nan with the remaining shape.
+
+    Parameters
+    ----------
+    arr : ndarray
+        The array whose reduced shape determines the shape of the result.
+    axis : None or int
+        The axis that would be reduced over.
+
+    Returns
+    -------
+    float or ndarray
+        ``nan`` if `axis` is None or `arr` is 1d, otherwise an array of
+        ``nan`` with the shape that reducing `arr` over `axis` would give.
     """
     if axis is None or arr.ndim <= 1:
         return np.nan
@@ -35,7 +49,7 @@ def mse(x1, x2, axis=0):
     x1, x2 : array_like
        The performance measure depends on the difference between these two
        arrays.
-    axis : int
+    axis : int, optional
        axis along which the summary statistic is calculated
 
     Returns
@@ -65,7 +79,7 @@ def rmse(x1, x2, axis=0):
     x1, x2 : array_like
        The performance measure depends on the difference between these two
        arrays.
-    axis : int
+    axis : int, optional
        axis along which the summary statistic is calculated
 
     Returns
@@ -96,10 +110,10 @@ def rmspe(y, y_hat, axis=0, zeros=np.nan):
       The actual value.
     y_hat : array_like
        The predicted value.
-    axis : int
+    axis : int, optional
        Axis along which the summary statistic is calculated
-    zeros : float
-       Value to assign to error where y is zero
+    zeros : float, optional
+       Value to assign to error where y is zero. Default is nan.
 
     Returns
     -------
@@ -127,7 +141,7 @@ def maxabs(x1, x2, axis=0):
     x1, x2 : array_like
        The performance measure depends on the difference between these two
        arrays.
-    axis : int
+    axis : int, optional
        axis along which the summary statistic is calculated
 
     Returns
@@ -160,7 +174,7 @@ def meanabs(x1, x2, axis=0):
     x1, x2 : array_like
        The performance measure depends on the difference between these two
        arrays.
-    axis : int
+    axis : int, optional
        axis along which the summary statistic is calculated
 
     Returns
@@ -189,7 +203,7 @@ def medianabs(x1, x2, axis=0):
     x1, x2 : array_like
        The performance measure depends on the difference between these two
        arrays.
-    axis : int
+    axis : int, optional
        axis along which the summary statistic is calculated
 
     Returns
@@ -218,7 +232,7 @@ def bias(x1, x2, axis=0):
     x1, x2 : array_like
        The performance measure depends on the difference between these two
        arrays.
-    axis : int
+    axis : int, optional
        axis along which the summary statistic is calculated
 
     Returns
@@ -247,7 +261,7 @@ def medianbias(x1, x2, axis=0):
     x1, x2 : array_like
        The performance measure depends on the difference between these two
        arrays.
-    axis : int
+    axis : int, optional
        axis along which the summary statistic is calculated
 
     Returns
@@ -276,9 +290,9 @@ def vare(x1, x2, ddof=0, axis=0):
     x1, x2 : array_like
        The performance measure depends on the difference between these two
        arrays.
-    ddof : int
+    ddof : int, optional
        Delta degrees of freedom used in the variance calculation.
-    axis : int
+    axis : int, optional
        axis along which the summary statistic is calculated
 
     Returns
@@ -307,9 +321,9 @@ def stde(x1, x2, ddof=0, axis=0):
     x1, x2 : array_like
        The performance measure depends on the difference between these two
        arrays.
-    ddof : int
+    ddof : int, optional
        Delta degrees of freedom used in the standard deviation calculation.
-    axis : int
+    axis : int, optional
        axis along which the summary statistic is calculated
 
     Returns
@@ -339,12 +353,12 @@ def iqr(x1, x2, axis=0):
        One of the inputs into the IQR calculation.
     x2 : array_like
        The other input into the IQR calculation.
-    axis : {None, int}
+    axis : int, optional
        axis along which the summary statistic is calculated
 
     Returns
     -------
-    iqr : {float, ndarray}
+    iqr : float or ndarray of float
        Interquartile range along given axis.
 
     Notes
@@ -381,7 +395,7 @@ def aic(llf, nobs, df_modelwc):
 
     Parameters
     ----------
-    llf : {float, array_like}
+    llf : float or array_like of float
         value of the loglikelihood
     nobs : int
         number of observations
@@ -407,7 +421,7 @@ def aicc(llf, nobs, df_modelwc):
 
     Parameters
     ----------
-    llf : {float, array_like}
+    llf : float or array_like of float
         value of the loglikelihood
     nobs : int
         number of observations
@@ -442,7 +456,7 @@ def bic(llf, nobs, df_modelwc):
 
     Parameters
     ----------
-    llf : {float, array_like}
+    llf : float or array_like of float
         value of the loglikelihood
     nobs : int
         number of observations
@@ -468,7 +482,7 @@ def hqic(llf, nobs, df_modelwc):
 
     Parameters
     ----------
-    llf : {float, array_like}
+    llf : float or array_like of float
         value of the loglikelihood
     nobs : int
         number of observations
@@ -505,7 +519,7 @@ def aic_sigma(sigma2, nobs, df_modelwc, islog=False):
         number of observations
     df_modelwc : int
         number of parameters including constant
-    islog : bool
+    islog : bool, optional
         If True, `sigma2` is already log-transformed.
 
     Returns
@@ -560,7 +574,7 @@ def aicc_sigma(sigma2, nobs, df_modelwc, islog=False):
         number of observations
     df_modelwc : int
         number of parameters including constant
-    islog : bool
+    islog : bool, optional
         If True, `sigma2` is already log-transformed.
 
     Returns
@@ -598,7 +612,7 @@ def bic_sigma(sigma2, nobs, df_modelwc, islog=False):
         number of observations
     df_modelwc : int
         number of parameters including constant
-    islog : bool
+    islog : bool, optional
         If True, `sigma2` is already log-transformed.
 
     Returns
@@ -636,7 +650,7 @@ def hqic_sigma(sigma2, nobs, df_modelwc, islog=False):
         number of observations
     df_modelwc : int
         number of parameters including constant
-    islog : bool
+    islog : bool, optional
         If True, `sigma2` is already log-transformed.
 
     Returns

--- a/statsmodels/tools/grouputils.py
+++ b/statsmodels/tools/grouputils.py
@@ -46,13 +46,13 @@ def combine_indices(groups, prefix="", sep=".", return_labels=False):
         If a tuple, the elements are stacked column-wise to form a 2d
         array of groups to combine. Otherwise treated as an existing 1d
         or 2d array of group values.
-    prefix : str
+    prefix : str, optional
         Prefix prepended to each label. Only used if ``return_labels``
         is True.
-    sep : str
+    sep : str, optional
         Separator used to join the columns of a 2d group array when
         building labels. Only used if ``return_labels`` is True.
-    return_labels : bool
+    return_labels : bool, optional
         If True, also return a list of string labels for each unique
         group.
 
@@ -67,7 +67,7 @@ def combine_indices(groups, prefix="", sep=".", return_labels=False):
     uni : ndarray
         Sorted unique groups, or unique group combinations if `groups`
         was 2d or a tuple.
-    label : list[str]
+    label : list of str
         String label for each unique group in `uni`. Only returned if
         ``return_labels`` is True.
     """
@@ -115,7 +115,7 @@ def group_sums(x, group, use_bincount=True):
         Non-negative integer group labels of shape ``(nobs,)``. For predictable
         indexing (e.g., ``result[group]``), groups should be coded as
         ``0, 1, ..., n_groups-1``.
-    use_bincount : bool, default True
+    use_bincount : bool, optional
         Use ``np.bincount`` when True, otherwise a pure-Python group loop.
         The bincount path expects non-negative, reasonably consecutive codes
         and may re-label via ``pd.factorize`` when ``max(group)`` is large.
@@ -249,7 +249,7 @@ class Group:
         Group labels for each observation. A tuple of arrays is combined
         into a single set of group labels representing the intersection
         of the individual groupings.
-    name : str
+    name : str, optional
         Name used as a prefix when constructing string group labels.
 
     Attributes
@@ -309,7 +309,7 @@ class Group:
 
         Returns
         -------
-        list[str]
+        list of str
             Labels built from `prefix`, `separator` and the unique group
             values in `uni`.
         """
@@ -335,10 +335,10 @@ class Group:
         drop_idx : int, optional
             Index into `uni` of a group level to drop from the returned
             matrix. Only available if ``sparse`` is False.
-        sparse : bool
+        sparse : bool, optional
             If True, return a sparse indicator matrix instead of a dense
             array.
-        dtype : type
+        dtype : dtype, optional
             The dtype of the returned dense indicator matrix.
 
         Returns
@@ -388,7 +388,7 @@ class Group:
         ----------
         x : array_like
             Data of shape ``(nobs,)`` or ``(nobs, n_features)``.
-        use_bincount : bool
+        use_bincount : bool, optional
             Use ``np.bincount`` when True, otherwise a pure-Python group
             loop. See :func:`group_sums`.
 
@@ -407,7 +407,7 @@ class Group:
         ----------
         x : array_like
             Data of shape ``(nobs,)`` or ``(nobs, n_features)``.
-        use_bincount : bool
+        use_bincount : bool, optional
             Use ``np.bincount`` when True, otherwise a pure-Python group
             loop. See :func:`group_sums`.
 
@@ -448,7 +448,7 @@ class GroupSorted(Group):
         Group labels for each observation. Must already be sorted so
         that all observations belonging to the same group are
         contiguous.
-    name : str
+    name : str, optional
         Name used as a prefix when constructing string group labels.
 
     Attributes
@@ -544,7 +544,7 @@ def _make_hierarchical_index(index, names):
     ----------
     index : array_like
         Array-like where each row is a tuple of group values.
-    names : list[str]
+    names : list of str
         Names to assign to the levels of the resulting MultiIndex.
 
     Returns
@@ -567,7 +567,7 @@ def _make_generic_names(index):
 
     Returns
     -------
-    list[str]
+    list of str
         Names of the form ``"group0"``, ``"group1"``, ... , zero-padded
         to a consistent width.
     """
@@ -732,7 +732,7 @@ class Grouping:
 
         Parameters
         ----------
-        level : int
+        level : int, optional
             Index level to group by.
 
         Notes
@@ -756,7 +756,7 @@ class Grouping:
 
         Parameters
         ----------
-        level : int
+        level : int, optional
             Index level to count.
 
         Notes
@@ -773,9 +773,9 @@ class Grouping:
 
         Parameters
         ----------
-        is_sorted : bool
+        is_sorted : bool, optional
             If True, check that `index` is sorted.
-        unique : bool
+        unique : bool, optional
             If True, check that `index` has no duplicate entries.
         index : index-like, optional
             Index to check. Defaults to `self.index`.
@@ -859,7 +859,7 @@ class Grouping:
         function : callable
             Function applied to each group of each column via
             ``groupby(...).apply``.
-        level : int
+        level : int, optional
             Index level to group by.
         **kwargs
             Additional keyword arguments passed to `function`.
@@ -893,7 +893,7 @@ class Grouping:
             Data to transform, with `self.nobs` rows.
         function : callable
             Function applied to each group of each column.
-        level : int
+        level : int, optional
             Index level to group by.
         **kwargs
             Additional keyword arguments passed to `function`.
@@ -930,7 +930,7 @@ class Grouping:
             for each group, where `subset` is the group's rows of
             `array` and `group_idx` is the index/slice used to select
             them.
-        level : int
+        level : int, optional
             Index level to group by.
         **kwargs
             Additional keyword arguments passed to `function`.
@@ -981,7 +981,7 @@ class Grouping:
 
         Parameters
         ----------
-        level : int
+        level : int, optional
             Grouping level used to form the sparse indicator.
 
         Returns
@@ -999,7 +999,7 @@ class Grouping:
 
         Parameters
         ----------
-        level : int
+        level : int, optional
             Grouping level used to form the sparse indicator.
 
         Notes

--- a/statsmodels/tools/linalg.py
+++ b/statsmodels/tools/linalg.py
@@ -15,7 +15,7 @@ def logdet_symm(m, check_symm=False):
     ----------
     m : array_like
         2d array that is positive-definite (and symmetric)
-    check_symm : bool
+    check_symm : bool, optional
         If True, check that `m` is symmetric before factorizing.
 
     Returns
@@ -45,7 +45,7 @@ def stationary_solve(r, b):
     r : array_like
         A vector describing the coefficient matrix.  r[0] is the first
         band next to the diagonal, r[1] is the second band, etc.
-    b : array_like
+    b : ndarray
         The right-hand side for which we are solving, i.e., we solve
         Tx = b and return b, where T is the Toeplitz coefficient matrix.
 
@@ -137,18 +137,18 @@ def matrix_sqrt(mat, inverse=False, full=False, nullspace=False, threshold=1e-15
         There is no checking for whether the matrix is symmetric.
         A warning is issued if some singular values are negative, i.e.
         below the negative of the threshold.
-    inverse : bool
+    inverse : bool, optional
         If False (default), then the matrix square root is returned.
         If inverse is True, then the matrix square root of the inverse
         matrix is returned.
-    full : bool
+    full : bool, optional
         If full is False (default, then the square root has reduce number
         of rows if the matrix is singular, i.e., has singular values below
         the threshold.
-    nullspace : bool
+    nullspace : bool, optional
         If nullspace is true, then the matrix square root of the null space
         of the matrix is returned.
-    threshold : float
+    threshold : float, optional
         Singular values below the threshold are dropped.
 
     Returns

--- a/statsmodels/tools/numdiff.py
+++ b/statsmodels/tools/numdiff.py
@@ -59,14 +59,14 @@ _hessian_docs = """
     ----------
     x : array_like
        value at which function derivative is evaluated
-    f : function
+    f : callable
        function of one array f(x, `*args`, `**kwargs`)
     epsilon : float or array_like, optional
        Stepsize used, if None, then stepsize is automatically chosen
        according to EPS**(1/%(scale)s)*x.
-    args : tuple
+    args : tuple, optional
         Arguments for function `f`.
-    kwargs : dict
+    kwargs : dict, optional
         Keyword arguments for function `f`.
     %(extra_params)s
 
@@ -141,16 +141,16 @@ def approx_fprime(x, f, epsilon=None, args=(), kwargs=None, centered=False):
     ----------
     x : ndarray
         parameters at which the derivative is evaluated
-    f : function
+    f : callable
         `f(*((x,)+args), **kwargs)` returning either one value or 1d array
     epsilon : float, optional
         Stepsize, if None, optimal stepsize is used. This is EPS**(1/2)*x for
         `centered` == False and EPS**(1/3)*x for `centered` == True.
-    args : tuple
+    args : tuple, optional
         Tuple of additional arguments for function `f`.
-    kwargs : dict
+    kwargs : dict, optional
         Dictionary of additional keyword arguments for function `f`.
-    centered : bool
+    centered : bool, optional
         Whether central difference should be returned. If not, does forward
         differencing.
 
@@ -204,18 +204,18 @@ def _approx_fprime_scalar(x, f, epsilon=None, args=(), kwargs=None, centered=Fal
 
     Parameters
     ----------
-    x : ndarray
+    x : array_like
         Parameters at which the derivative is evaluated.
-    f : function
+    f : callable
         `f(*((x,)+args), **kwargs)` returning either one value or 1d array
     epsilon : float, optional
         Stepsize, if None, optimal stepsize is used. This is EPS**(1/2)*x for
         `centered` == False and EPS**(1/3)*x for `centered` == True.
-    args : tuple
+    args : tuple, optional
         Tuple of additional arguments for function `f`.
-    kwargs : dict
+    kwargs : dict, optional
         Dictionary of additional keyword arguments for function `f`.
-    centered : bool
+    centered : bool, optional
         Whether central difference should be returned. If not, does forward
         differencing.
 
@@ -249,14 +249,14 @@ def approx_fprime_cs(x, f, epsilon=None, args=(), kwargs=None):
     ----------
     x : ndarray
         parameters at which the derivative is evaluated
-    f : function
+    f : callable
         `f(*((x,)+args), **kwargs)` returning either one value or 1d array
     epsilon : float, optional
         Stepsize, if None, optimal stepsize is used. Optimal step-size is
         EPS*x. See note.
-    args : tuple
+    args : tuple, optional
         Tuple of additional arguments for function `f`.
-    kwargs : dict
+    kwargs : dict, optional
         Dictionary of additional keyword arguments for function `f`.
 
     Returns
@@ -298,16 +298,16 @@ def _approx_fprime_cs_scalar(x, f, epsilon=None, args=(), kwargs=None):
 
     Parameters
     ----------
-    x : ndarray
+    x : array_like
         Parameters at which the derivative is evaluated.
-    f : function
+    f : callable
         `f(*((x,)+args), **kwargs)` returning either one value or 1d array.
     epsilon : float, optional
         Stepsize, if None, optimal stepsize is used. Optimal step-size is
         EPS*x. See note.
-    args : tuple
+    args : tuple, optional
         Tuple of additional arguments for function `f`.
-    kwargs : dict
+    kwargs : dict, optional
         Dictionary of additional keyword arguments for function `f`.
 
     Returns
@@ -345,13 +345,13 @@ def approx_hess_cs(x, f, epsilon=None, args=(), kwargs=None):
     ----------
     x : array_like
        value at which function derivative is evaluated
-    f : function
+    f : callable
        function of one array f(x)
-    epsilon : float
+    epsilon : float, optional
        stepsize, if None, then stepsize is automatically chosen
-    args : tuple
+    args : tuple, optional
         Arguments for function `f`.
-    kwargs : dict
+    kwargs : dict, optional
         Keyword arguments for function `f`.
 
     Returns
@@ -394,7 +394,7 @@ def approx_hess_cs(x, f, epsilon=None, args=(), kwargs=None):
 
 @Substitution(
     scale="3",
-    extra_params="""return_grad : bool
+    extra_params="""return_grad : bool, optional
         Whether or not to also return the gradient
 """,
     extra_returns="""grad : ndarray
@@ -435,7 +435,7 @@ def approx_hess1(x, f, epsilon=None, args=(), kwargs=None, return_grad=False):
 
 @Substitution(
     scale="3",
-    extra_params="""return_grad : bool
+    extra_params="""return_grad : bool, optional
         Whether or not to also return the gradient
 """,
     extra_returns="""grad : ndarray
@@ -493,7 +493,7 @@ def approx_hess2(x, f, epsilon=None, args=(), kwargs=None, return_grad=False):
     equation="""1/(4*d_j*d_k) * ((f(x + d[j]*e[j] + d[k]*e[k]) - f(x + d[j]*e[j]
                                                      - d[k]*e[k])) -
                  (f(x - d[j]*e[j] + d[k]*e[k]) - f(x - d[j]*e[j]
-                                                     - d[k]*e[k]))""",
+                                                     - d[k]*e[k])))""",
 )
 @Appender(_hessian_docs)
 def approx_hess3(x, f, epsilon=None, args=(), kwargs=None):

--- a/statsmodels/tools/parallel.py
+++ b/statsmodels/tools/parallel.py
@@ -29,8 +29,8 @@ def parallel_func(func, n_jobs, verbose=5):
         A function
     n_jobs : int
         Number of jobs to run in parallel
-    verbose : int
-        Verbosity level
+    verbose : int, optional
+        Verbosity level. Default is 5.
 
     Returns
     -------

--- a/statsmodels/tools/print_version.py
+++ b/statsmodels/tools/print_version.py
@@ -16,10 +16,10 @@ def safe_version(module, attr="__version__", *others):
     ----------
     module : module
         The imported module to inspect.
-    attr : str or list[str]
+    attr : str or list of str, optional
         Name of the attribute (or chain of nested attribute names) to
         look up on ``module``, e.g., ``"__version__"`` or
-        ``["version", "version"]``.
+        ``["version", "version"]``. Default is ``"__version__"``.
     *others : str
         Additional attribute names to try, in order, if ``attr`` is not
         found on ``module``.
@@ -192,8 +192,8 @@ def show_versions(show_dirs=True):
 
     Parameters
     ----------
-    show_dirs : bool
-        Flag indicating to show module locations
+    show_dirs : bool, optional
+        Flag indicating to show module locations. Default is True.
 
     """
     if not show_dirs:

--- a/statsmodels/tools/rng_qrng.py
+++ b/statsmodels/tools/rng_qrng.py
@@ -10,7 +10,7 @@ def check_random_state(seed=None, deprecated=False, warn=True):
 
     Parameters
     ----------
-    seed : {None, int, array_like[int], numpy.random.Generator, numpy.random.RandomState, scipy.stats.qmc.QMCEngine}, optional
+    seed : int, array_like of int, numpy.random.Generator, numpy.random.RandomState, scipy.stats.qmc.QMCEngine, optional
         If `seed` is None fresh, unpredictable entropy will be pulled from the
         OS and `numpy.random.Generator` is used.
         If `seed` is an int or ``array_like[ints]``, a new ``Generator`` instance
@@ -26,7 +26,7 @@ def check_random_state(seed=None, deprecated=False, warn=True):
 
     Returns
     -------
-    rng : {`numpy.random.Generator`, `numpy.random.RandomState`, `scipy.stats.qmc.QMCEngine`}
+    rng : numpy.random.Generator, numpy.random.RandomState, or scipy.stats.qmc.QMCEngine
         Random number generator.
 
     Notes

--- a/statsmodels/tools/rootfinding.py
+++ b/statsmodels/tools/rootfinding.py
@@ -66,30 +66,30 @@ def brentq_expanding(func, low=None, upp=None, args=(), xtol=1e-5,
     ----------
     func : callable
         function for which we find the root ``x`` such that ``func(x) = 0``
-    low : float or None
+    low : float or None, optional
         lower bound for brentq
-    upp : float or None
+    upp : float or None, optional
         upper bound for brentq
-    args : tuple
+    args : tuple, optional
         optional additional arguments for ``func``
-    xtol : float
+    xtol : float, optional
         parameter x tolerance given to brentq
-    start_low : float (positive) or None
+    start_low : float (positive) or None, optional
         starting bound for expansion with increasing ``x``. It needs to be
         positive. If None, then it is set to 1.
-    start_upp : float (negative) or None
+    start_upp : float (negative) or None, optional
         starting bound for expansion with decreasing ``x``. It needs to be
         negative. If None, then it is set to -1.
-    increasing : bool or None
+    increasing : bool or None, optional
         If None, then the function is evaluated at the initial bounds to
         determine whether the function is increasing or not. If increasing is
         True (False), then it is assumed that the function is monotonically
         increasing (decreasing).
-    max_it : int
+    max_it : int, optional
         maximum number of expansion steps.
-    maxiter_bq : int
+    maxiter_bq : int, optional
         maximum number of iterations of brentq.
-    factor : float
+    factor : float, optional
         expansion factor for step of shifting the bounds interval, default is
         10.
     full_output : bool, optional

--- a/statsmodels/tools/sequences.py
+++ b/statsmodels/tools/sequences.py
@@ -14,10 +14,13 @@ def discrepancy(sample, bounds=None):
     ----------
     sample : array_like (n_samples, k_vars)
         The sample to compute the discrepancy from.
-    bounds : tuple or array_like ([min, k_vars], [max, k_vars])
-        Desired range of transformed data. The transformation apply the bounds
-        on the sample and not the theoretical space, unit cube. Thus min and
-        max values of the sample will coincide with the bounds.
+    bounds : ndarray, optional
+        Desired range of transformed data, of shape (2, k_vars) giving the
+        lower and upper bound for each variable. The transformation applies
+        the bounds to the sample and not the theoretical space, unit cube.
+        Thus min and max values of the sample will coincide with the
+        bounds. If None, the sample is assumed to already lie in the unit
+        hypercube.
 
     Returns
     -------
@@ -68,7 +71,7 @@ def primes_from_2_to(n):
 
     Returns
     -------
-    primes : list(int)
+    primes : ndarray
         Primes in ``2 <= p < n``.
 
     References
@@ -135,9 +138,9 @@ def van_der_corput(n_sample, base=2, start_index=0):
     ----------
     n_sample : int
         Number of element of the sequence.
-    base : int
+    base : int, optional
         Base of the sequence.
-    start_index : int
+    start_index : int, optional
         Index to start the sequence from.
 
     Returns
@@ -174,16 +177,19 @@ def halton(dim, n_sample, bounds=None, start_index=0):
         Dimension of the parameter space.
     n_sample : int
         Number of samples to generate in the parameter space.
-    bounds : tuple or array_like ([min, k_vars], [max, k_vars])
-        Desired range of transformed data. The transformation apply the bounds
-        on the sample and not the theoretical space, unit cube. Thus min and
-        max values of the sample will coincide with the bounds.
-    start_index : int
+    bounds : ndarray, optional
+        Desired range of transformed data, of shape (2, dim) giving the
+        lower and upper bound for each variable. The transformation applies
+        the bounds to the sample and not the theoretical space, unit cube.
+        Thus min and max values of the sample will coincide with the
+        bounds. If None, the sample is assumed to already lie in the unit
+        hypercube.
+    start_index : int, optional
         Index to start the sequence from.
 
     Returns
     -------
-    sequence : array_like (n_samples, k_vars)
+    sequence : ndarray of shape (n_sample, dim)
         Sequence of Halton.
 
     References

--- a/statsmodels/tools/testing.py
+++ b/statsmodels/tools/testing.py
@@ -21,7 +21,7 @@ def bunch_factory(attribute, columns):
     ----------
     attribute : str
         Attribute to access when splitting
-    columns : List[str]
+    columns : list of str
         List of names to use when splitting the columns of attribute
 
     Notes

--- a/statsmodels/tools/tools.py
+++ b/statsmodels/tools/tools.py
@@ -43,7 +43,7 @@ def drop_missing(y, x=None, axis=1):
         Additional data with observations possibly containing NaN
         values. If provided, an observation is dropped if it is
         missing in either `y` or `x`.
-    axis : int
+    axis : int, optional
         Axis along which to look for missing observations.  Default is 1, i.e.,
         observations in rows.
 
@@ -90,10 +90,10 @@ def add_constant(data, prepend=True, has_constant="skip"):
     ----------
     data : array_like
         A column-ordered design matrix.
-    prepend : bool
+    prepend : bool, optional
         If True (default), the constant is in the first column. If False, the
         constant is appended (last column).
-    has_constant : str {'raise', 'add', 'skip'}
+    has_constant : {'raise', 'add', 'skip'}, optional
         Behavior if ``data`` already has a constant. The default will return
         data without adding another constant. If 'raise', will raise an
         error if any column has a constant value. Using 'add' will add a
@@ -193,7 +193,7 @@ def pinv_extended(x, rcond=1e-15):
     ----------
     x : array_like
         The array to invert, 2d.
-    rcond : float
+    rcond : float, optional
         Singular values below ``rcond * max(singular values)`` are
         treated as zero.
 
@@ -443,7 +443,7 @@ def _ensure_2d(x, ndarray=False):
     ----------
     x : ndarray, Series, DataFrame or None
         Input to verify dimensions, and to transform as necessary
-    ndarray : bool
+    ndarray : bool, optional
         Flag indicating whether to always return a NumPy array. Setting False
         will return an pandas DataFrame when the input is a Series or a
         DataFrame.
@@ -491,7 +491,7 @@ def matrix_rank(m, tol=None, method="qr"):
     tol : float, optional
         The tolerance to use when testing the matrix rank. If not provided
         an appropriate value is selected.
-    method : {"ip", "qr", "svd"}
+    method : {"ip", "qr", "svd"}, optional
         The method used. "ip" uses the inner-product of a normalized version
         of m and then computes the rank using NumPy's matrix_rank.
         "qr" uses a QR decomposition and is the default. "svd" defers to

--- a/statsmodels/tools/transform_model.py
+++ b/statsmodels/tools/transform_model.py
@@ -17,17 +17,17 @@ class StandardizeTransform:
     ----------
     data : array_like
         data that is standardized along axis=0
-    ddof : None or int
+    ddof : int, optional
         degrees of freedom for calculation of standard deviation.
         default is 1, in contrast to numpy.std
-    const_idx : None or int
-        If None, then the presence of a constant is detected if the standard
-        deviation of a column is **equal** to zero. A constant column is
-        not transformed. If this is an integer, then the corresponding column
-        will not be transformed.
-    demean : bool, default is True
+    const_idx : int, optional
+        If None (default), then the presence of a constant is detected if
+        the standard deviation of a column is **equal** to zero. A constant
+        column is not transformed. If this is an integer, then the
+        corresponding column will not be transformed.
+    demean : bool, optional
         If demean is true, then the data will be demeaned, otherwise it will
-        only be rescaled.
+        only be rescaled. Default is True.
 
     Notes
     -----

--- a/statsmodels/tools/validation/decorators.py
+++ b/statsmodels/tools/validation/decorators.py
@@ -26,17 +26,17 @@ def array_like(
         Positional argument index to validate.
     name : str
         Argument name to use in exceptions and keyword lookup.
-    dtype : dtype
+    dtype : dtype, optional
         Required dtype.
-    ndim : int or None
+    ndim : int or None, optional
         Required number of dimensions.
-    maxdim : int or None
+    maxdim : int or None, optional
         Maximum allowed number of dimensions.
-    shape : tuple or None
+    shape : tuple or None, optional
         Required shape.
-    order : {"C", "F", None}
+    order : {"C", "F"}, optional
         Required memory order.
-    contiguous : bool
+    contiguous : bool, optional
         Whether to require contiguous memory.
 
     """

--- a/statsmodels/tools/validation/validation.py
+++ b/statsmodels/tools/validation/validation.py
@@ -62,29 +62,29 @@ def array_like(
         __array__ method returns an array, or any (nested) sequence.
     name : str
         Name of the variable to use in exceptions
-    dtype : {None, numpy.dtype, str}
+    dtype : numpy.dtype or str, optional
         Required dtype. Default is double. If None, does not change the dtype
         of obj (if present) or uses NumPy to automatically detect the dtype
-    ndim : {int, None}
+    ndim : int, optional
         Required number of dimensions of obj. If None, no check is performed.
         If the number of dimensions of obj is less than ndim, additional axes
         are inserted on the right. See examples.
-    maxdim : {int, None}
+    maxdim : int, optional
         Maximum allowed dimension.  Use ``maxdim`` instead of ``ndim`` when
         inputs are allowed to have ndim 1, 2, ..., or maxdim.
-    mindim : {int, None}
+    mindim : int, optional
         Minimum allowed dimension.  Arrays with ndim < mindim will be reshaped
         to have ndim = mindim by adding singleton dimensions on the right.
-    shape : {tuple[int], None}
+    shape : tuple of int, optional
         Required shape obj.  If None, no check is performed. Partially
         restricted shapes can be checked using None. See examples.
-    order : {'C', 'F', None}
+    order : {'C', 'F'}, optional
         Order of the array
-    contiguous : bool
+    contiguous : bool, optional
         Ensure that the array's data is contiguous with order ``order``
-    optional : bool
+    optional : bool, optional
         Flag indicating whether None is allowed
-    writeable : bool
+    writeable : bool, optional
         Whether to ensure the returned array is writeable
 
     Returns
@@ -186,7 +186,7 @@ class PandasWrapper:
 
     Parameters
     ----------
-    pandas_obj : {Series, DataFrame}
+    pandas_obj : pd.Series or pd.DataFrame
         Object to extract the index from for wrapping
 
     Notes
@@ -207,22 +207,22 @@ class PandasWrapper:
 
         Parameters
         ----------
-        obj : {array_like}
+        obj : array_like
             The value to wrap like to a pandas Series or DataFrame.
-        columns : {str, list[str]}
+        columns : str or list of str, optional
             Column names or series name, if obj is 1d.
-        append : str
+        append : str, optional
             String to append to the columns to create a new column name.
-        trim_start : int
+        trim_start : int, optional
             The number of observations to drop from the start of the index, so
             that the index applied is index[trim_start:].
-        trim_end : int
+        trim_end : int, optional
             The number of observations to drop from the end of the index , so
             that the index applied is index[:nobs - trim_end].
 
         Returns
         -------
-        array_like
+        Series, DataFrame or ndarray
             A pandas Series or DataFrame, depending on the shape of obj, if
             the object used to create the wrapper was pandas. Otherwise,
             returns `obj` converted to an ndarray, unchanged.
@@ -269,9 +269,9 @@ def bool_like(value, name, optional=False, strict=False):
         Value to verify
     name : str
         Variable name for exceptions
-    optional : bool
+    optional : bool, optional
         Flag indicating whether None is allowed
-    strict : bool
+    strict : bool, optional
         If True, then only allow bool. If False, allow types that support
         casting to bool.
 
@@ -312,9 +312,9 @@ def int_like(
         Value to verify
     name : str
         Variable name for exceptions
-    optional : bool
+    optional : bool, optional
         Flag indicating whether None is allowed
-    strict : bool
+    strict : bool, optional
         If True, then only allow int or np.integer that are not bool. If False,
         allow types that support integer division by 1 and conversion to int.
 
@@ -356,7 +356,7 @@ def required_int_like(value: Any, name: str, strict: bool = False) -> int:
         Value to verify
     name : str
         Variable name for exceptions
-    strict : bool
+    strict : bool, optional
         If True, then only allow int or np.integer that are not bool. If False,
         allow types that support integer division by 1 and conversion to int.
 
@@ -381,9 +381,9 @@ def float_like(value, name, optional=False, strict=False):
         Value to verify
     name : str
         Variable name for exceptions
-    optional : bool
+    optional : bool, optional
         Flag indicating whether None is allowed
-    strict : bool
+    strict : bool, optional
         If True, then only allow int, np.integer, float or np.inexact that are
         not bool or complex. If False, allow complex types with 0 imag part or
         any other type that is float-like in the sense that it supports
@@ -431,11 +431,11 @@ def string_like(value, name, optional=False, options=None, lower=True):
         Value to verify.
     name : str
         Variable name for exceptions.
-    optional : bool
+    optional : bool, optional
         Flag indicating whether None is allowed.
-    options : tuple[str]
+    options : tuple[str], optional
         Allowed values for input parameter `value`.
-    lower : bool
+    lower : bool, optional
         Convert all case-based characters in `value` into lowercase.
 
     Returns
@@ -476,14 +476,14 @@ def dict_like(value, name, optional=False, strict=True):
         Value to verify
     name : str
         Variable name for exceptions
-    optional : bool
+    optional : bool, optional
         Flag indicating whether None is allowed
-    strict : bool
+    strict : bool, optional
         If True, then only allow dict. If False, allow any Mapping-like object.
 
     Returns
     -------
-    converted : dict_like
+    converted : dict or Mapping
         value
 
     """

--- a/statsmodels/tools/web.py
+++ b/statsmodels/tools/web.py
@@ -13,7 +13,7 @@ def _generate_url(func, stable):
 
     Parameters
     ----------
-    func : {None, str, callable}
+    func : None, str, or callable
         Either None to get the base documentation URL, a string to search
         the documentation, or a statsmodels function to link to its
         generated API documentation.
@@ -63,9 +63,9 @@ def webdoc(func=None, stable=None):
 
     Parameters
     ----------
-    func : {str, callable}
+    func : None, str, or callable, optional
         Either a string to search the documentation or a function
-    stable : bool
+    stable : bool, optional
         Flag indicating whether to use the stable documentation (True) or
         the development documentation (False).  If not provided, opens
         the stable documentation if the current version of statsmodels is a


### PR DESCRIPTION
[skip azurepipelines]

- [X] code/documentation is well formatted.
- [X] properly formatted commit message. See
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message).

#### AI Disclosure

Contributions must comply with the statsmodels [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html).

If using AI tools, edit the second option to explain which tool was selected and
how the tool's output was used.

Please complete **one** of the following:

- [ ] No AI tools were used to develop this pull request.
- [X] AI tools were used.
      Tool(s): Claude
      Used for: Docstring cleanup
      I have personally read, understood, and can explain every line of this diff, and
      have verified the statistical/numerical correctness of the change.

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows
  using the Windows System for Linux once `flake8` is installed in the
  local Linux environment. While passing this test is not required, it is good practice and it help
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.
* If AI tools were used to help write this PR, see the
  [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html) for what disclosure
  and review is expected of you before submitting.

</details>
