### PR TITLE
DOC: Standardized docstrings in robust

### DIFF
--- a/statsmodels/robust/covariance.py
+++ b/statsmodels/robust/covariance.py
@@ -265,7 +265,7 @@ def _outlier_gy(d, distr=None, k_endog=1, trim_prob=0.975):
     ----------
     d : array_like, 1-D
         Array of squared standardized residuals or Mahalanobis distance.
-    distr : None or distribution instance, optional
+    distr : distribution instance, optional
         Reference distribution of d, needs cdf and ppf methods.
         If None, then chisquare with k_endog degrees of freedom is
         used. Otherwise, it should be a callable that provides the
@@ -349,10 +349,10 @@ def mahalanobis(data, cov=None, cov_inv=None, sqrt=False):
     data : array_like
         Multivariate data with observation in rows. Data is assumed to be
         already centered.
-    cov : None or ndarray, optional
+    cov : ndarray, optional
         Covariance matrix used in computing distance.
         This is only used if cov_inv is None.
-    cov_inv : None or ndarray, optional
+    cov_inv : ndarray, optional
         Inverse covariance matrix used in computing distance.
         One of cov and cov_inv needs to be provided.
     sqrt : bool, optional
@@ -670,7 +670,7 @@ def cov_tyler(data, start_cov=None, normalize=False, maxiter=100, eps=1e-13):
     ----------
     data : array_like
         Data array with observations in rows and variables in columns.
-    start_cov : None or ndarray, optional
+    start_cov : ndarray, optional
         Starting covariance for iterative solution.
     normalize : {False, "trace", "det", "normal", "weights"}, optional
         If normalize is False (default), then the unscaled tyler scatter matrix
@@ -802,12 +802,12 @@ def cov_tyler_regularized(
     ----------
     data : array_like
         Data array with observations in rows and variables in columns.
-    start_cov : None or ndarray, optional
+    start_cov : ndarray, optional
         Starting covariance for iterative solution.
     normalize : bool, optional
         If True, then the scatter matrix is normalized to have trace equal
         to the number of columns in the data.
-    shrinkage_factor : None or float in [0, 1], optional
+    shrinkage_factor : float in [0, 1], optional
         Shrinkage for the scatter estimate. If it is zero, then no shrinkage
         is performed. If it is None, then the shrinkage factor will be
         determined by a plugin estimator.
@@ -916,12 +916,12 @@ def cov_tyler_pairs_regularized(
     ----------
     data_iterator : restartable iterator
         Needs to provide two elements xi and xj per iteration.
-    start_cov : None or ndarray, optional
+    start_cov : ndarray, optional
         Starting covariance for iterative solution.
     normalize : bool, optional
         If True, then the scatter matrix is normalized to have trace equal
         to the number of columns in the data.
-    shrinkage_factor : None or float in [0, 1], optional
+    shrinkage_factor : float in [0, 1], optional
         Shrinkage for the scatter estimate. If it is zero, then no shrinkage
         is performed. If it is None, then the shrinkage factor will be
         determined by a plugin estimator.
@@ -1040,13 +1040,13 @@ def cov_weighted(
         No missing value handling.
     weights : ndarray, 1-D
         Weights array with length equal to the number of observations.
-    center : None or ndarray, optional
+    center : ndarray, optional
         If None, then the weighted mean is subtracted from the data.
         If center is provided, then it is used instead of the
         weighted mean.
     weights_cov : None, ndarray or "det", optional
         If None, then the same weights as for the mean are used.
-    weights_cov_denom : None, float or "det", optional
+    weights_cov_denom : float or "det", optional
         Specifies the denominator for the weighted covariance.
         If None, then the sum of weights - ddof are used and the covariance is
         an average cross product.
@@ -1242,7 +1242,7 @@ def _cov_iter(
         Function to calculate weights from the distances and weights_args.
     weights_args : tuple, optional
         Extra arguments for the weights_func.
-    cov_init : None or ndarray, square 2-D, optional
+    cov_init : ndarray, square 2-D, optional
         Initial covariance matrix. If None, then the sample covariance of
         `data` is used.
     rescale : {"med", "none"}, optional
@@ -1576,7 +1576,7 @@ def _get_detcov_startidx(z, h, options_start=None, methods_cov="all"):
         Multivariate data with observations in rows.
     h : int
         Size of the subsets used for the starting index sets.
-    options_start : None or dict, optional
+    options_start : dict, optional
         Options for the location and scale function used to standardize
         the data before computing the starting sets. Supported keys are
         "loc_func" and "scale_func". Default is median and mad.
@@ -1693,13 +1693,13 @@ class CovM:
     data : array_like
         Multivariate data set with observation in rows and variables in
         columns.
-    norm_mean : None or norm instance, optional
+    norm_mean : norm instance, optional
         If None, then TukeyBiweight norm is used.
         (Currently no other norms are supported for calling the initial
         S-estimator)
-    norm_scatter : None or norm instance, optional
+    norm_scatter : norm instance, optional
         If norm_scatter is None, then the norm_mean will be used.
-    scale_bias : None or float, optional
+    scale_bias : float, optional
         Must currently be provided if norm_mean is not None.
     method : str, optional
         Currently only S-estimator has automatic selection of scale function.
@@ -1782,7 +1782,7 @@ class CovM:
         ----------
         maha : ndarray
             Mahalanobis distances used to estimate the scale.
-        start_scale : None or float, optional
+        start_scale : float, optional
             Starting scale. If it is None, the mad of maha is used.
         maxiter : int, optional
             Maximum iterations to compute M-scale.
@@ -1824,14 +1824,14 @@ class CovM:
 
         Parameters
         ----------
-        start_mean : None or ndarray, optional
+        start_mean : ndarray, optional
             Starting value for mean, center.
             If None, then median is used.
-        start_shape : None or 2-dim ndarray, optional
+        start_shape : 2-dim ndarray, optional
             Starting value of shape matrix, i.e., scatter matrix normalized
             to det(scatter) = 1.
             If None, then scaled covariance matrix of data is used.
-        start_scale : None or float, optional
+        start_scale : float, optional
             Starting value of scale.
         maxiter : int, optional
             Maximum number of iterations.
@@ -2069,9 +2069,9 @@ class CovDetMCD:
             Number of observations in evaluation set for cov.
         maxiter : int, optional
             Maximum number of c-steps.
-        mean : None or ndarray, optional
+        mean : ndarray, optional
             Starting value for mean. If None, the mean of ``x[idx]`` is used.
-        cov : None or ndarray, optional
+        cov : ndarray, optional
             Starting value for covariance. If None, the covariance of
             ``x[idx]`` is used.
 
@@ -2128,7 +2128,7 @@ class CovDetMCD:
         h : int
             Number of observations in evaluation set for minimizing
             determinant.
-        h_start : None or int, optional
+        h_start : int, optional
             Number of observations used in starting mean and covariance.
         mean_func, scale_func : callable or None, optional
             Mean and scale function for initial standardization.
@@ -2137,7 +2137,7 @@ class CovDetMCD:
         maxiter : int, optional
             Maximum number of iterations for the c-step of the best
             candidate solution.
-        options_start : None or dict, optional
+        options_start : dict, optional
             Options for the starting estimators.
             Currently not used.
             TODO: which options? e.g., for OGK
@@ -2242,7 +2242,7 @@ class CovDetS:
     data : array_like
         Multivariate data set with observation in rows and variables in
         columns.
-    norm : None or norm instance, optional
+    norm : norm instance, optional
         If None, then TukeyBiweight norm is used.
         (Currently no other norms are supported for calling the initial
         S-estimator)
@@ -2332,11 +2332,11 @@ class CovDetS:
 
         Parameters
         ----------
-        mean : None or ndarray, optional
+        mean : ndarray, optional
             Starting value for mean.
-        shape : None or ndarray, optional
+        shape : ndarray, optional
             Starting value for shape matrix.
-        scale : None or float, optional
+        scale : float, optional
             Starting value for scale.
         maxiter : int, optional
             Maximum number of iterations.
@@ -2379,7 +2379,7 @@ class CovDetS:
 
         Parameters
         ----------
-        h_start : None or int, optional
+        h_start : int, optional
             Number of observations used in starting mean and covariance.
         mean_func, scale_func : callable or None, optional
             Mean and scale function for initial standardization.
@@ -2388,7 +2388,7 @@ class CovDetS:
         maxiter : int, optional
             Maximum number of iterations for the c-step of the best
             candidate solution.
-        options_start : None or dict, optional
+        options_start : dict, optional
             Options for the starting estimators.
             TODO: which options? e.g., for OGK
         maxiter_step : int, optional
@@ -2476,7 +2476,7 @@ class CovDetMM:
     data : array_like
         Multivariate data set with observation in rows and variables in
         columns.
-    norm : None or norm instance, optional
+    norm : norm instance, optional
         If None, then TukeyBiweight norm is used.
         (Currently no other norms are supported for calling the initial
         S-estimator)

--- a/statsmodels/robust/covariance.py
+++ b/statsmodels/robust/covariance.py
@@ -103,7 +103,7 @@ def coef_normalize_cov_truncated(frac, k_vars):
     ----------
     frac : float in (0, 1)
         Fraction (probability) of observations that are not trimmed.
-    k_vars : integer
+    k_vars : int
         Number of variables, i.e., dimension of multivariate random variable.
 
     Returns
@@ -174,10 +174,10 @@ def _reweight(x, loc, cov, trim_frac=0.975, ddof=1):
         Location, mean or center of the data.
     cov : ndarray
         Covariance for computing Mahalanobis distance.
-    trim_frac : float in (0, 1)
+    trim_frac : float in (0, 1), optional
         This is the coverage, (1 - trim_frac) is tail probability for chi2
         distribution. (todo: change name)
-    ddof : int or float
+    ddof : int or float, optional
         Delta degrees of freedom used for trimmed Pearson covariance
         computed with `np.cov`.
 
@@ -222,13 +222,13 @@ def _rescale(x, loc, cov, prob=0.5):
 
     Parameters
     ----------
-    x : array-like
+    x : array_like
         Sample data, 2-dim with observation in rows.
     loc : ndarray
         Mean or center of data.
     cov : ndarray
         Covariance estimate.
-    prob : float
+    prob : float, optional
         Probability used to match the median of the Mahalanobis distance
         with the corresponding chi-square quantile. Currently only
         prob=0.5 is supported.
@@ -265,15 +265,15 @@ def _outlier_gy(d, distr=None, k_endog=1, trim_prob=0.975):
     ----------
     d : array_like, 1-D
         Array of squared standardized residuals or Mahalanobis distance.
-    distr : None or distribution instance
+    distr : None or distribution instance, optional
         Reference distribution of d, needs cdf and ppf methods.
         If None, then chisquare with k_endog degrees of freedom is
         used. Otherwise, it should be a callable that provides the
         cdf function.
-    k_endog : int or float
+    k_endog : int or float, optional
         Used only if distr is None. In that case, it provides the degrees
         of freedom for the chisquare distribution.
-    trim_prob : float in (0.5, 1)
+    trim_prob : float in (0.5, 1), optional
         Threshold for the tail probability at which the search for
         trimming or outlier fraction starts.
 
@@ -346,16 +346,16 @@ def mahalanobis(data, cov=None, cov_inv=None, sqrt=False):
 
     Parameters
     ----------
-    data : array-like
+    data : array_like
         Multivariate data with observation in rows. Data is assumed to be
         already centered.
-    cov : None or ndarray
+    cov : None or ndarray, optional
         Covariance matrix used in computing distance.
         This is only used if cov_inv is None.
-    cov_inv : None or ndarray
+    cov_inv : None or ndarray, optional
         Inverse covariance matrix used in computing distance.
         One of cov and cov_inv needs to be provided.
-    sqrt : bool
+    sqrt : bool, optional
         If False, then the squared distance is returned.
         If True, then the square root is returned.
 
@@ -390,7 +390,7 @@ def cov_gk1(x, y, scale_func=mad):
         Data array.
     y : ndarray
         Data array.
-    scale_func : callable
+    scale_func : callable, optional
         Scale function used in computing covariance.
         Default is median absolute deviation, MAD.
 
@@ -410,9 +410,9 @@ def cov_gk(data, scale_func=mad):
 
     Parameters
     ----------
-    data : ndarray
+    data : array_like
         Multivariate data array with observations in rows.
-    scale_func : callable
+    scale_func : callable, optional
         Scale function used in computing covariance.
         Default is median absolute deviation, MAD.
 
@@ -505,34 +505,34 @@ def cov_ogk(
 
     Parameters
     ----------
-    data : array-like
+    data : array_like
         Multivariate data set with observation in rows and variables in
         columns.
-    maxiter : int
+    maxiter : int, optional
         Number of iteration steps. According to Maronna and Zamar the
         estimate doesn't improve much after the second iteration and the
         iterations do not converge.
-    scale_func : callable
+    scale_func : callable, optional
         Scale function over axis=0 used in computing covariance.
         Default is median absolute deviation, MAD.
-    cov_func : callable
+    cov_func : callable, optional
         Bivariate covariance function. Default is GK.
-    loc_func : callable
+    loc_func : callable, optional
         Function to compute mean or center over axis=0.
-    reweight : float in (0, 1) or None
+    reweight : float in (0, 1) or None, optional
         API for this will change.
         If reweight is None, then the reweighting step is skipped.
         Otherwise, reweight is the chisquare probability beta for the
         trimming based on estimated robust distances.
         Hard-rejection is currently the only weight function.
-    rescale : bool
+    rescale : bool, optional
         If rescale is true, then reweighted covariance is rescaled to be
         consistent at normal distribution.
         This only applies if reweight is not None.
-    rescale_raw : bool
+    rescale_raw : bool, optional
         If rescale_raw is true, then the raw, non-reweighted covariance is
         rescaled to be consistent at normal distribution.
-    ddof : int
+    ddof : int, optional
         Degrees of freedom correction for the reweighted sample
         covariance.
 
@@ -668,15 +668,15 @@ def cov_tyler(data, start_cov=None, normalize=False, maxiter=100, eps=1e-13):
 
     Parameters
     ----------
-    data : array-like
+    data : array_like
         Data array with observations in rows and variables in columns.
-    start_cov : None or ndarray
+    start_cov : None or ndarray, optional
         Starting covariance for iterative solution.
-    normalize : False or string
+    normalize : {False, "trace", "det", "normal", "weights"}, optional
         If normalize is False (default), then the unscaled tyler scatter matrix
         is returned.
 
-        Three types of normalization, i.e., rescaling are available by defining
+        Four types of normalization, i.e., rescaling are available by defining
         string option:
 
         - "trace" :
@@ -692,9 +692,9 @@ def cov_tyler(data, start_cov=None, normalize=False, maxiter=100, eps=1e-13):
           The scatter matrix is rescaled by the sum of weights.
           See Ollila et al 2023.
 
-    maxiter : int
+    maxiter : int, optional
         Maximum number of iterations to find the solution.
-    eps : float
+    eps : float, optional
         Convergence criterion. The maximum absolute distance needs to be
         smaller than eps for convergence.
 
@@ -800,20 +800,20 @@ def cov_tyler_regularized(
 
     Parameters
     ----------
-    data : ndarray
+    data : array_like
         Data array with observations in rows and variables in columns.
-    start_cov : None or ndarray
+    start_cov : None or ndarray, optional
         Starting covariance for iterative solution.
-    normalize : bool
+    normalize : bool, optional
         If True, then the scatter matrix is normalized to have trace equal
         to the number of columns in the data.
-    shrinkage_factor : None or float in [0, 1]
+    shrinkage_factor : None or float in [0, 1], optional
         Shrinkage for the scatter estimate. If it is zero, then no shrinkage
         is performed. If it is None, then the shrinkage factor will be
         determined by a plugin estimator.
-    maxiter : int
+    maxiter : int, optional
         Maximum number of iterations to find the solution.
-    eps : float
+    eps : float, optional
         Convergence criterion. The maximum absolute distance needs to be
         smaller than eps for convergence.
 
@@ -916,24 +916,24 @@ def cov_tyler_pairs_regularized(
     ----------
     data_iterator : restartable iterator
         Needs to provide two elements xi and xj per iteration.
-    start_cov : None or ndarray
+    start_cov : None or ndarray, optional
         Starting covariance for iterative solution.
-    normalize : bool
+    normalize : bool, optional
         If True, then the scatter matrix is normalized to have trace equal
         to the number of columns in the data.
-    shrinkage_factor : None or float in [0, 1]
+    shrinkage_factor : None or float in [0, 1], optional
         Shrinkage for the scatter estimate. If it is zero, then no shrinkage
         is performed. If it is None, then the shrinkage factor will be
         determined by a plugin estimator.
-    nobs : int
+    nobs : int, optional
         Number of observations, needed because data_iterator does not
         provide its length.
-    k_vars : int
+    k_vars : int, optional
         Number of variables, needed because data_iterator does not provide
         the dimension of the data.
-    maxiter : int
+    maxiter : int, optional
         Maximum number of iterations to find the solution.
-    eps : float
+    eps : float, optional
         Convergence criterion. The maximum absolute distance needs to be
         smaller than eps for convergence.
 
@@ -1040,13 +1040,13 @@ def cov_weighted(
         No missing value handling.
     weights : ndarray, 1-D
         Weights array with length equal to the number of observations.
-    center : None or ndarray (optional)
+    center : None or ndarray, optional
         If None, then the weighted mean is subtracted from the data.
         If center is provided, then it is used instead of the
         weighted mean.
-    weights_cov : None, ndarray or "det" (optional)
+    weights_cov : None, ndarray or "det", optional
         If None, then the same weights as for the mean are used.
-    weights_cov_denom : None, float or "det" (optional)
+    weights_cov_denom : None, float or "det", optional
         Specifies the denominator for the weighted covariance.
         If None, then the sum of weights - ddof are used and the covariance is
         an average cross product.
@@ -1056,7 +1056,7 @@ def cov_weighted(
         without averaging or scaling (sum of squares).
         Otherwise it is used directly as denominator after subtracting
         ddof.
-    ddof : int or float
+    ddof : int or float, optional
         Covariance degrees of freedom correction, only used if
         weights_cov_denom is None or a float.
 
@@ -1161,9 +1161,9 @@ def weights_quantile(distance, frac=0.5, rescale=True):
     ----------
     distance : ndarray
         Mahalanobis distance or other measure of outlyingness.
-    frac : float in (0, 1)
+    frac : float in (0, 1), optional
         Quantile of distance used as the cutoff for the indicator weights.
-    rescale : bool
+    rescale : bool, optional
         This option is not supported.
 
     Returns
@@ -1240,22 +1240,23 @@ def _cov_iter(
         Multivariate data with observations in rows.
     weights_func : callable
         Function to calculate weights from the distances and weights_args.
-    weights_args : tuple
+    weights_args : tuple, optional
         Extra arguments for the weights_func.
-    cov_init : ndarray, square 2-D
-        Initial covariance matrix.
-    rescale : "med" or "none"
+    cov_init : None or ndarray, square 2-D, optional
+        Initial covariance matrix. If None, then the sample covariance of
+        `data` is used.
+    rescale : {"med", "none"}, optional
         If "med" then the resulting covariance matrix is normalized so it is
         approximately consistent with the normal distribution. Rescaling is
         based on the median of the distances and of the chisquare distribution.
         Other options are not yet available.
         If rescale is the string "none", then no rescaling is performed.
-    maxiter : int
+    maxiter : int, optional
         Maximum number of iterations.
-    atol : float
+    atol : float, optional
         Absolute convergence tolerance for `numpy.allclose` comparison of
         the covariance in successive iterations.
-    rtol : float
+    rtol : float, optional
         Relative convergence tolerance for `numpy.allclose` comparison of
         the covariance in successive iterations.
 
@@ -1358,16 +1359,16 @@ def _cov_starting(data, standardize=False, quantile=0.5, retransform=False):
 
     Parameters
     ----------
-    data : array-like
+    data : array_like
         Multivariate data with observations in rows (axis=0).
-    standardize : bool
+    standardize : bool, optional
         If False, then the data is only centered (by median).
         If True, then the data is standardized using median and mad-scale.
         This scaling is only intermediate, the returned covariance compensates
         for the initial scaling.
-    quantile : float in [0.5, 1]
+    quantile : float in [0.5, 1], optional
         Parameter used for `_cov_iter` estimation.
-    retransform : bool
+    retransform : bool, optional
         If standardize and retransform are both True, then the returned
         covariances are transformed back to compensate for the initial
         standardization, and the result is a list of ndarrays instead of a
@@ -1571,15 +1572,15 @@ def _get_detcov_startidx(z, h, options_start=None, methods_cov="all"):
 
     Parameters
     ----------
-    z : array-like
+    z : array_like
         Multivariate data with observations in rows.
     h : int
         Size of the subsets used for the starting index sets.
-    options_start : None or dict
+    options_start : None or dict, optional
         Options for the location and scale function used to standardize
         the data before computing the starting sets. Supported keys are
         "loc_func" and "scale_func". Default is median and mad.
-    methods_cov : "all"
+    methods_cov : {"all"}, optional
         Currently unused, only the default of using all available starting
         covariance methods is implemented.
 
@@ -1689,20 +1690,18 @@ class CovM:
 
     Parameters
     ----------
-    data : array-like
+    data : array_like
         Multivariate data set with observation in rows and variables in
         columns.
-    norm_mean : norm instance
+    norm_mean : None or norm instance, optional
         If None, then TukeyBiweight norm is used.
         (Currently no other norms are supported for calling the initial
         S-estimator)
-    norm_scatter : None or norm instance
+    norm_scatter : None or norm instance, optional
         If norm_scatter is None, then the norm_mean will be used.
-    breakdown_point : float in (0, 0.5]
-        Breakdown point for first stage S-estimator.
-    scale_bias : None or float
+    scale_bias : None or float, optional
         Must currently be provided if norm_mean is not None.
-    method : str
+    method : str, optional
         Currently only S-estimator has automatic selection of scale function.
     """
 
@@ -1783,11 +1782,11 @@ class CovM:
         ----------
         maha : ndarray
             Mahalanobis distances used to estimate the scale.
-        start_scale : None or float
+        start_scale : None or float, optional
             Starting scale. If it is None, the mad of maha is used.
-        maxiter : int
+        maxiter : int, optional
             Maximum iterations to compute M-scale.
-        rtol, atol : float
+        rtol, atol : float, optional
             Relative and absolute convergence criteria for scale used with
             allclose.
 
@@ -1825,18 +1824,18 @@ class CovM:
 
         Parameters
         ----------
-        start_mean : None or ndarray
+        start_mean : None or ndarray, optional
             Starting value for mean, center.
             If None, then median is used.
-        start_shape : None or 2-dim ndarray
+        start_shape : None or 2-dim ndarray, optional
             Starting value of shape matrix, i.e., scatter matrix normalized
             to det(scatter) = 1.
             If None, then scaled covariance matrix of data is used.
-        start_scale : None or float
+        start_scale : None or float, optional
             Starting value of scale.
-        maxiter : int
+        maxiter : int, optional
             Maximum number of iterations.
-        update_scale : bool
+        update_scale : bool, optional
             If update_scale is False, then the scale is fixed at start_scale
             and only mean and shape are updated in each iteration.
 
@@ -1971,7 +1970,7 @@ class CovDetMCD:
 
     Parameters
     ----------
-    data : array-like
+    data : array_like
         Multivariate data set with observation in rows and variables in
         columns.
 
@@ -1989,11 +1988,11 @@ class CovDetMCD:
 
     References
     ----------
-    ..[1] Hubert, Mia, Peter Rousseeuw, Dina Vanpaemel, and Tim Verdonck. 2015.
+    .. [1] Hubert, Mia, Peter Rousseeuw, Dina Vanpaemel, and Tim Verdonck. 2015.
        “The DetS and DetMM Estimators for Multivariate Location and Scatter.”
        Computational Statistics & Data Analysis 81 (January): 64-75.
        https://doi.org/10.1016/j.csda.2014.07.013.
-    ..[2] Hubert, Mia, Peter J. Rousseeuw, and Tim Verdonck. 2012. “A
+    .. [2] Hubert, Mia, Peter J. Rousseeuw, and Tim Verdonck. 2012. “A
        Deterministic Algorithm for Robust Location and Scatter.” Journal of
        Computational and Graphical Statistics 21 (3): 618-37.
        https://doi.org/10.1080/10618600.2012.672100.
@@ -2022,9 +2021,9 @@ class CovDetMCD:
             covariance at each step. This corresponds to percentile
             h / nobs; using `np.argpartition` avoids the need for an
             explicit percentile.
-        maxiter : int
+        maxiter : int, optional
             Maximum number of c-steps.
-        tol : float
+        tol : float, optional
             Convergence tolerance for the change in covariance between
             steps.
 
@@ -2068,11 +2067,11 @@ class CovDetMCD:
             Indices or mask of observation in starting set, used as ``x[idx]``.
         h : int
             Number of observations in evaluation set for cov.
-        maxiter : int
+        maxiter : int, optional
             Maximum number of c-steps.
-        mean : None or ndarray
+        mean : None or ndarray, optional
             Starting value for mean. If None, the mean of ``x[idx]`` is used.
-        cov : None or ndarray
+        cov : None or ndarray, optional
             Starting value for covariance. If None, the covariance of
             ``x[idx]`` is used.
 
@@ -2129,27 +2128,27 @@ class CovDetMCD:
         h : int
             Number of observations in evaluation set for minimizing
             determinant.
-        h_start : int
+        h_start : None or int, optional
             Number of observations used in starting mean and covariance.
-        mean_func, scale_func : callable or None
+        mean_func, scale_func : callable or None, optional
             Mean and scale function for initial standardization.
             Current defaults, if they are None, are median and mad, but
             default scale_func will likely change.
-        maxiter : int
+        maxiter : int, optional
             Maximum number of iterations for the c-step of the best
             candidate solution.
-        options_start : None or dict
+        options_start : None or dict, optional
             Options for the starting estimators.
             Currently not used.
             TODO: which options? e.g., for OGK
-        reweight : bool
+        reweight : bool, optional
             If reweight is true, then a reweighted estimator is returned. The
             reweighting is based on a chisquare trimming of Mahalanobis
             distances. The raw results are in the ``results_raw`` attribute.
-        trim_frac : float in (0, 1)
+        trim_frac : float in (0, 1), optional
             Trim fraction used if reweight is true. Used to compute quantile
             of chisquare distribution with tail probability 1 - trim_frac.
-        maxiter_step : int
+        maxiter_step : int, optional
             Number of iteration in the c-step.
             In the current implementation a small maxiter in the c-step does
             not find the optimal solution.
@@ -2240,14 +2239,14 @@ class CovDetS:
 
     Parameters
     ----------
-    data : array-like
+    data : array_like
         Multivariate data set with observation in rows and variables in
         columns.
-    norm : norm instance
+    norm : None or norm instance, optional
         If None, then TukeyBiweight norm is used.
         (Currently no other norms are supported for calling the initial
         S-estimator)
-    breakdown_point : float in (0, 0.5]
+    breakdown_point : float in (0, 0.5], optional
         Breakdown point for first stage S-estimator.
 
     Notes
@@ -2261,11 +2260,11 @@ class CovDetS:
 
     References
     ----------
-    ..[1] Hubert, Mia, Peter Rousseeuw, Dina Vanpaemel, and Tim Verdonck. 2015.
+    .. [1] Hubert, Mia, Peter Rousseeuw, Dina Vanpaemel, and Tim Verdonck. 2015.
        “The DetS and DetMM Estimators for Multivariate Location and Scatter.”
        Computational Statistics & Data Analysis 81 (January): 64-75.
        https://doi.org/10.1016/j.csda.2014.07.013.
-    ..[2] Hubert, Mia, Peter J. Rousseeuw, and Tim Verdonck. 2012. “A
+    .. [2] Hubert, Mia, Peter J. Rousseeuw, and Tim Verdonck. 2012. “A
        Deterministic Algorithm for Robust Location and Scatter.” Journal of
        Computational and Graphical Statistics 21 (3): 618-37.
        https://doi.org/10.1080/10618600.2012.672100.
@@ -2333,18 +2332,21 @@ class CovDetS:
 
         Parameters
         ----------
-        mean : None or ndarray
+        mean : None or ndarray, optional
             Starting value for mean.
-        shape : None or ndarray
+        shape : None or ndarray, optional
             Starting value for shape matrix.
-        scale : None or float
+        scale : None or float, optional
             Starting value for scale.
-        maxiter : int
+        maxiter : int, optional
             Maximum number of iterations.
 
         Returns
         -------
-        results instance with mean, shape, scale, cov and other attributes.
+        CovMResult
+            Named tuple with `mean`, `shape`, `scale`, `cov`, `converged`,
+            `n_iter`, and `mahalanobis`. See :class:`CovMResult` for
+            details.
 
         Notes
         -----
@@ -2377,21 +2379,21 @@ class CovDetS:
 
         Parameters
         ----------
-        h_start : int
+        h_start : None or int, optional
             Number of observations used in starting mean and covariance.
-        mean_func, scale_func : callable or None
+        mean_func, scale_func : callable or None, optional
             Mean and scale function for initial standardization.
             Current defaults, if they are None, are median and mad, but
             default scale_func will likely change.
-        maxiter : int
+        maxiter : int, optional
             Maximum number of iterations for the c-step of the best
             candidate solution.
-        options_start : None or dict
-           Options for the starting estimators.
-           TODO: which options? e.g., for OGK
-        maxiter_step : int
-           Number of iterations used for each starting candidate before
-           selecting the best one for further iteration.
+        options_start : None or dict, optional
+            Options for the starting estimators.
+            TODO: which options? e.g., for OGK
+        maxiter_step : int, optional
+            Number of iterations used for each starting candidate before
+            selecting the best one for further iteration.
 
         Returns
         -------
@@ -2471,19 +2473,19 @@ class CovDetMM:
 
     Parameters
     ----------
-    data : array-like
+    data : array_like
         Multivariate data set with observation in rows and variables in
         columns.
-    norm : norm instance
+    norm : None or norm instance, optional
         If None, then TukeyBiweight norm is used.
         (Currently no other norms are supported for calling the initial
         S-estimator)
         If ``norm`` is an instance of TukeyBiweight, then it will be used in
         the second stage M-estimation. The ``efficiency`` argument is ignored
         and the tuning parameter of the user provided instance is not changed.
-    breakdown_point : float in (0, 0.5]
+    breakdown_point : float in (0, 0.5], optional
         Breakdown point for first stage S-estimator.
-    efficiency : float
+    efficiency : float, optional
         Asymptotic efficiency of second stage M estimator.
 
     Notes
@@ -2499,22 +2501,22 @@ class CovDetMM:
 
     References
     ----------
-    ..[1] Hubert, Mia, Peter Rousseeuw, Dina Vanpaemel, and Tim Verdonck. 2015.
+    .. [1] Hubert, Mia, Peter Rousseeuw, Dina Vanpaemel, and Tim Verdonck. 2015.
        “The DetS and DetMM Estimators for Multivariate Location and Scatter.”
        Computational Statistics & Data Analysis 81 (January): 64-75.
        https://doi.org/10.1016/j.csda.2014.07.013.
-    ..[2] Hubert, Mia, Peter J. Rousseeuw, and Tim Verdonck. 2012. “A
+    .. [2] Hubert, Mia, Peter J. Rousseeuw, and Tim Verdonck. 2012. “A
        Deterministic Algorithm for Robust Location and Scatter.” Journal of
        Computational and Graphical Statistics 21 (3): 618-37.
        https://doi.org/10.1080/10618600.2012.672100.
-    ..[3] Lopuhaä, Hendrik P. 1989. “On the Relation between S-Estimators and
+    .. [3] Lopuhaä, Hendrik P. 1989. “On the Relation between S-Estimators and
        M-Estimators of Multivariate Location and Covariance.” The Annals of
        Statistics 17 (4): 1662-83.
-    ..[4] Salibián-Barrera, Matías, Stefan Van Aelst, and Gert Willems. 2006.
+    .. [4] Salibián-Barrera, Matías, Stefan Van Aelst, and Gert Willems. 2006.
        “Principal Components Analysis Based on Multivariate MM Estimators with
        Fast and Robust Bootstrap.” Journal of the American Statistical
        Association 101 (475): 1198-1211.
-    ..[5] Tatsuoka, Kay S., and David E. Tyler. 2000. “On the Uniqueness of
+    .. [5] Tatsuoka, Kay S., and David E. Tyler. 2000. “On the Uniqueness of
        S-Functionals and M-Functionals under Nonelliptical Distributions.” The
        Annals of Statistics 28 (4): 1219-43.
     """
@@ -2548,12 +2550,15 @@ class CovDetMM:
 
         Parameters
         ----------
-        maxiter : int
+        maxiter : int, optional
             Maximum number of iterations in the second stage M-estimation.
 
         Returns
         -------
-        Instance of a results or holder class.
+        CovMResult
+            Named tuple with `mean`, `shape`, `scale`, `cov`, `converged`,
+            `n_iter`, and `mahalanobis`. See :class:`CovMResult` for
+            details.
 
         Notes
         -----

--- a/statsmodels/robust/norms.py
+++ b/statsmodels/robust/norms.py
@@ -1236,10 +1236,10 @@ class TukeyBiweight(RobustNorm):
 
         Parameters
         ----------
-        bp : float in [0.05, 0.5] or None
+        bp : float in [0.05, 0.5] or None, optional
             Required breakdown point
             Either bp or eff has to be specified, but not both.
-        eff : float or None
+        eff : float or None, optional
             Required asymptotic efficiency.
             Either bp or eff has to be specified, but not both.
 
@@ -1927,7 +1927,7 @@ def estimate_location(a, scale, norm=None, axis=0, initial=None,
 
     Parameters
     ----------
-    a : ndarray
+    a : array_like
         Array over which the location parameter is to be estimated
     scale : ndarray
         Scale parameter to be used in M-estimator

--- a/statsmodels/robust/resistant_linear_model.py
+++ b/statsmodels/robust/resistant_linear_model.py
@@ -43,21 +43,22 @@ class RLMDetS(Model):
 
     Parameters
     ----------
-    endog : array-like, 1-dim
+    endog : array_like
         Dependent, endogenous variable.
-    exog : array-like, 1-dim
+    exog : array_like
         Independent, exogenous regressor variables.
-    norm : robust norm
+    norm : statsmodels.robust.norms.RobustNorm, optional
         Redescending robust norm used for S-estimation.
         Default is TukeyBiweight.
-    breakdown_point : float in (0, 0.5)
+    breakdown_point : float in (0, 0.5), optional
         Breakdown point of the S-estimator.
-    col_indices : None or array-like of ints
+    col_indices : array_like[int], optional
         Index of columns of exog to use in the mahalanobis distance
         computation for the starting sets of the S-estimator.
-        Default is all exog except first column (constant). Todo: will
-        change when we autodetect the constant column.
-    include_endog : bool
+        If None (default), all exog columns except the first (constant)
+        column are used. Todo: will change when we autodetect the
+        constant column.
+    include_endog : bool, optional
         If true, then the endog variable is combined with the exog
         variables to compute the mahalanobis distances for the starting
         sets of the S-estimator.
@@ -142,7 +143,31 @@ class RLMDetS(Model):
         return res
 
     def fit(self, h, maxiter=100, maxiter_step=5, start_params_extra=None):
+        """
+        Estimate the model using a deterministic S-estimator.
 
+        Parameters
+        ----------
+        h : int
+            Size of the initial sets used to compute the starting values
+            for the S-estimator.
+        maxiter : int, optional
+            Maximum number of iterations used for the final fit starting
+            from the best starting value. Default is 100.
+        maxiter_step : int, optional
+            Maximum number of iterations used when fitting each starting
+            value while searching for the best starting value. Default
+            is 5.
+        start_params_extra : list[ndarray] or None, optional
+            Additional starting parameter arrays to consider together
+            with the starting sets generated internally. Default is
+            None, which means no extra starting values are used.
+
+        Returns
+        -------
+        statsmodels.robust.robust_linear_model.RLMResults
+            Results instance corresponding to the best starting value.
+        """
         start_params_all = self._get_start_params(h)
         if start_params_extra:
             start_params_all.extend(start_params_extra)
@@ -175,23 +200,24 @@ class RLMDetSMM(RLMDetS):
 
     Parameters
     ----------
-    endog : array-like, 1-dim
+    endog : array_like
         Dependent, endogenous variable.
-    exog : array-like, 1-dim
+    exog : array_like
         Independent, exogenous regressor variables.
-    norm : robust norm
+    norm : statsmodels.robust.norms.RobustNorm, optional
         Redescending robust norm used for S- and MM-estimation.
         Default is TukeyBiweight.
-    efficiency : float in (0, 1)
+    efficiency : float in (0, 1), optional
         Asymptotic efficiency of the MM-estimator (used in second stage).
-    breakdown_point : float in (0, 0.5)
+    breakdown_point : float in (0, 0.5), optional
         Breakdown point of the preliminary S-estimator.
-    col_indices : None or array-like of ints
+    col_indices : array_like[int], optional
         Index of columns of exog to use in the mahalanobis distance computation
         for the starting sets of the S-estimator.
-        Default is all exog except first column (constant). Todo: will change
-        when we autodetect the constant column.
-    include_endog : bool
+        If None (default), all exog columns except the first (constant)
+        column are used. Todo: will change when we autodetect the
+        constant column.
+    include_endog : bool, optional
         If true, then the endog variable is combined with the exog variables
         to compute the mahalanobis distances for the starting sets of the
         S-estimator.
@@ -221,16 +247,16 @@ class RLMDetSMM(RLMDetS):
 
         Parameters
         ----------
-        h : int
+        h : int or None, optional
             The size of the initial sets for the S-estimator.
             Default is ... (todo).
-        scale_binding : bool
+        scale_binding : bool, optional
             If true, then the scale is fixed in the second stage M-estimation,
             i.e., this is the MM-estimator.
             If false, then the high breakdown point M-scale is used also in the
             second stage M-estimation if that estimated scale is smaller than
             the scale of the preliminary, first stage S-estimator.
-        start : tuple or None
+        start : tuple or None, optional
             If None, then the starting parameters and scale for the second
             stage M-estimation are taken from the first stage S-estimator.
             Alternatively, the starting parameters and starting scale can be
@@ -239,7 +265,8 @@ class RLMDetSMM(RLMDetS):
 
         Returns
         -------
-        results instance
+        statsmodels.robust.robust_linear_model.RLMResults
+            Results instance
 
         Notes
         -----

--- a/statsmodels/robust/robust_linear_model.py
+++ b/statsmodels/robust/robust_linear_model.py
@@ -44,7 +44,8 @@ class RLM(base.LikelihoodModel):
     M : statsmodels.robust.norms.RobustNorm, optional
         The robust criterion function for downweighting outliers.
         The current options are LeastSquares, HuberT, RamsayE, AndrewWave,
-        TrimmedMean, Hampel, and TukeyBiweight.  The default is HuberT().
+        TrimmedMean, Hampel, TukeyBiweight, TukeyQuartic, StudentT, and
+        MQuantileNorm.  The default is HuberT().
         See statsmodels.robust.norms for more information.
     {base._missing_param_doc}
 
@@ -199,7 +200,7 @@ class RLM(base.LikelihoodModel):
         ----------
         resid : ndarray
             The residuals used to estimate the scale.
-        scale_est : str or HuberScale()
+        scale_est : {"mad"} or callable
             The scale estimator requested in the call to `fit`.
 
         Returns
@@ -239,29 +240,29 @@ class RLM(base.LikelihoodModel):
 
         Parameters
         ----------
-        conv : str
+        conv : {"coefs", "dev", "sresid", "weights"}, optional
             Indicates the convergence criteria.
             Available options are "coefs" (the coefficients), "weights" (the
             weights in the iteration), "sresid" (the standardized residuals),
             and "dev" (the un-normalized log-likelihood for the M
             estimator).  The default is "dev".
-        cov : str, optional
-            'H1', 'H2', or 'H3'
+        cov : {"H1", "H2", "H3"}, optional
             Indicates how the covariance matrix is estimated.  Default is 'H1'.
             See rlm.RLMResults for more information.
-        maxiter : int
+        maxiter : int, optional
             The maximum number of iterations to try. Default is 50.
-        scale_est : str or HuberScale()
-            'mad' or HuberScale()
+        scale_est : {"mad"} or callable, optional
             Indicates the estimate to use for scaling the weights in the IRLS.
-            The default is 'mad' (median absolute deviation.  Other options are
-            'HuberScale' for Huber's proposal 2. Huber's proposal 2 has
-            optional keyword arguments d, tol, and maxiter for specifying the
-            tuning constant, the convergence tolerance, and the maximum number
-            of iterations. See statsmodels.robust.scale for more information.
-        tol : float
+            The default is 'mad' (median absolute deviation).  Other options
+            are a `HuberScale` instance for Huber's proposal 2, or any other
+            callable that takes the residuals and returns a scale estimate.
+            Huber's proposal 2 has optional keyword arguments d, tol, and
+            maxiter for specifying the tuning constant, the convergence
+            tolerance, and the maximum number of iterations. See
+            statsmodels.robust.scale for more information.
+        tol : float, optional
             The convergence tolerance of the estimate.  Default is 1e-8.
-        update_scale : Bool
+        update_scale : bool, optional
             If `update_scale` is False then the scale estimate for the
             weights is held constant over the iteration.  Otherwise, it
             is updated for each fit in the iteration.  Default is True.
@@ -565,9 +566,9 @@ class RLMResults(base.LikelihoodModelResults):
         title : str, optional
             Title for the top table. If not None, then this replaces the
             default title
-        alpha : float
+        alpha : float, optional
             Significance level for the confidence intervals
-        return_fmt : str
+        return_fmt : str, optional
             Unused
 
         Returns
@@ -643,9 +644,9 @@ class RLMResults(base.LikelihoodModelResults):
         title : str, optional
             Title for the top table. If not None, then this replaces the
             default title
-        alpha : float
+        alpha : float, optional
             Significance level for the confidence intervals
-        float_format : str
+        float_format : str, optional
             Print format for floats in parameters summary
 
         Returns

--- a/statsmodels/robust/scale.py
+++ b/statsmodels/robust/scale.py
@@ -43,14 +43,14 @@ def mad(a, c=GAUSSIAN_3_4, axis=0, center=np.median):
         which is approximately 0.6745.
     axis : int, optional
         The default is 0. Can also be None.
-    center : callable or float
+    center : callable or float, optional
         If a callable is provided, such as the default `np.median` then it
         is expected to be called center(a). The axis argument will be applied
         via np.apply_over_axes. Otherwise, provide a float.
 
     Returns
     -------
-    mad : float
+    float or ndarray
         `mad` = median(abs(`a` - center))/`c`
     """
     a = array_like(a, "a", mindim=None)
@@ -231,7 +231,7 @@ class Huber:
 
         Parameters
         ----------
-        a : ndarray
+        a : array_like
             1d array
         mu : float or None, optional
             If the location mu is supplied then it is not reestimated.
@@ -487,16 +487,16 @@ class MScale:
 
         Parameters
         ----------
-        data : array-like
+        data : array_like
             Data, currently assumed to be 1-dimensional.
-        start_scale : string or float
+        start_scale : str or float, optional
             Starting value of scale or method to compute the starting value.
             Default is using 'mad', no other string options are available.
-        maxiter : int
+        maxiter : int, optional
             Maximum number of iterations.
-        rtol : float
+        rtol : float, optional
             Relative convergence tolerance.
-        atol : float
+        atol : float, optional
             Absolute convergence tolerance.
 
         Returns
@@ -576,21 +576,21 @@ def scale_trimmed(data, alpha, center="median", axis=0, distr=None, distargs=Non
         observations are trimmed, and the same number of the largest
         observations are trimmed. scale estimate is base on a fraction
         (1 - 2 * alpha) of observations.
-    center : 'median', 'mean', 'tmean' or number
-        `center` defines how the trimmed sample is centered. 'median' and
-        'mean' are calculated on the full sample. `tmean` is the trimmed
-        mean, calculated with the trimmed sample. If `center` is array_like
-        then it needs to be scalar or correspond to the shape of the data
-        reduced by axis.
-    axis : int, default is 0
-        axis along which scale is estimated.
-    distr : None, 'raw' or a distribution instance
+    center : {"median", "med", "mean", "tmean"} or array_like, optional
+        `center` defines how the trimmed sample is centered. 'median' (or
+        the alias 'med') and 'mean' are calculated on the full sample.
+        `tmean` is the trimmed mean, calculated with the trimmed sample.
+        If `center` is array_like then it needs to be scalar or correspond
+        to the shape of the data reduced by axis. Default is 'median'.
+    axis : int, optional
+        Axis along which scale is estimated. The default is 0.
+    distr : None, "raw" or distribution instance, optional
         Default if distr is None is the normal distribution `scipy.stats.norm`.
         This is the reference distribution to normalize the scale.
         Note: This cannot be a frozen instance, since it does not have an
         `expect` method.
         If distr is 'raw', then the scale is not normalized.
-    distargs : tuple, optional
+    distargs : tuple or None, optional
         Arguments for the distribution.
 
     Returns
@@ -683,7 +683,7 @@ def _weight_mean(x, c):
 
     Parameters
     ----------
-    x : ndarray
+    x : array_like
         Data
     c : float
         Parameter for bisquare weights
@@ -736,27 +736,27 @@ def scale_tau(
     data : array_like, 1-D or 2-D
         If data is 2d, then the location and scale estimates
         are calculated for each column
-    cm : float
+    cm : float, optional
         constant used in call to weight_mean
-    cs : float
+    cs : float, optional
         constant used in call to weight_scale
-    weight_mean : callable
+    weight_mean : callable, optional
         function to calculate weights for weighted mean
-    weight_scale : callable
+    weight_scale : callable, optional
         function to calculate scale, "rho" function
-    normalize : bool
+    normalize : bool, optional
         rescale the scale estimate so it is consistent when the data is
         normally distributed. The computation assumes winsorized (truncated)
         variance.
-    ddof : int
+    ddof : int, optional
         Degrees of freedom used in the denominator of the variance
         computation. Default is 0.
 
     Returns
     -------
-    mean : ndarray
+    mean : float or ndarray
         robust mean
-    std : ndarray
+    std : float or ndarray
         robust estimate of scale (standard deviation)
 
     Notes
@@ -809,25 +809,25 @@ def _scale_iter(
     ----------
     data : array_like
         Data, currently assumed to be 1-dimensional.
-    scale0 : {"mad", float}
+    scale0 : {"mad", float}, optional
         Starting value of scale or method to compute the starting value.
         Default is using 'mad', no other string options are available.
-    maxiter : int
+    maxiter : int, optional
         Maximum number of iterations.
-    rtol : float
+    rtol : float, optional
         Relative convergence tolerance.
-    atol : float
+    atol : float, optional
         Absolute convergence tolerance.
-    meef_scale : callable
+    meef_scale : callable, optional
         Function that computes the moment condition (rho or weight
         function) used for estimating scale.
-    scale_bias : float
+    scale_bias : float, optional
         Factor in moment condition to obtain fisher consistency of the
         scale estimate at the normal distribution.
-    iter_method : {"rho", "weights"}
+    iter_method : {"rho", "weights"}, optional
         Method used in the iteration. "rho" uses the rho function
         directly, otherwise a weighted sum of squares is used.
-    ddof : int
+    ddof : int, optional
         Degrees of freedom used in the denominator of the variance
         computation. Default is 0.
 

--- a/statsmodels/robust/tools.py
+++ b/statsmodels/robust/tools.py
@@ -131,7 +131,7 @@ def _get_tuning_param(norm, eff, kwd="c", kwargs=None, use_jump=False,
         psi function.
         If True, then use computation then the psi function can have jump
         discontinuities.
-    bracket : None or tuple, optional
+    bracket : tuple, optional
         Bracket with lower and upper bounds to use for scipy.optimize.brentq.
         If None, than a default bracket, currently [0.1, 10], is used.
 

--- a/statsmodels/robust/tools.py
+++ b/statsmodels/robust/tools.py
@@ -122,16 +122,16 @@ def _get_tuning_param(norm, eff, kwd="c", kwargs=None, use_jump=False,
         Required asymptotic relative efficiency compared to least squares
         at the normal reference distribution. For example, ``eff=0.95`` for
         95% efficiency.
-    kwd : str
+    kwd : str, optional
         Name of keyword for tuning parameter.
-    kwargs : dict or None
+    kwargs : dict or None, optional
         Dict for other keyword parameters.
-    use_jump : bool
+    use_jump : bool, optional
         If False (default), then use computation that require continuous
         psi function.
         If True, then use computation then the psi function can have jump
         discontinuities.
-    bracket : None or tuple
+    bracket : None or tuple, optional
         Bracket with lower and upper bounds to use for scipy.optimize.brentq.
         If None, than a default bracket, currently [0.1, 10], is used.
 
@@ -197,7 +197,7 @@ def tuning_s_estimator_mean(norm, breakdown=None):
     Parameters
     ----------
     norm : instance of RobustNorm subclass
-    breakdown : float or iterable of float in (0, 0.5]
+    breakdown : float or iterable of float in (0, 0.5], optional
         Desired breakdown point between 0 and 0.5.
         Default if breakdown is None is a list of breakdown points.
 
@@ -308,7 +308,8 @@ def scale_bias_cov(norm, k_vars):
 
     Returns
     -------
-    scale_bias: float
+    scale_bias : float
+        Scale bias correction term.
     breakdown_point : float
         Breakdown point computed as scale bias divided by max rho.
     """
@@ -471,15 +472,15 @@ def tuning_m_cov_eff(norm, k_vars, efficiency=0.95, eff_mean=True, limits=()):
     norm : instance of norm class
     k_vars : int
         Number of variables in multivariate random variable, i.e., dimension.
-    efficiency : float < 1
+    efficiency : float < 1, optional
         Desired asymptotic relative efficiency of mean estimator.
         Default is 0.95.
-    eff_mean : bool
+    eff_mean : bool, optional
         If eff_mean is true (default), then tuning parameter is to achieve
         efficiency of mean estimate.
         If eff_mean is false, then tuning parameter is to achieve efficiency
         of shape estimate.
-    limits : tuple
+    limits : tuple, optional
         Limits for rootfinding with scipy.optimize.brentq.
         In some cases the interval limits for rootfinding can be too small
         and not cover the root. Current default limits are (0.5, 30).
@@ -595,7 +596,7 @@ def tukeybiweight_mvmean_eff(k, eff, eff_mean=True):
         Number of variables in multivariate random variable, i.e., dimension.
     eff : float
         Desired asymptotic relative efficiency of mean estimator.
-    eff_mean : bool
+    eff_mean : bool, optional
         If eff_mean is true (default), then tuning parameter is to achieve
         efficiency of mean estimate.
         If eff_mean is false, then tuning parameter is to achieve efficiency


### PR DESCRIPTION
- [X] code/documentation is well formatted.
- [X] properly formatted commit message. See
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message).

#### AI Disclosure

Contributions must comply with the statsmodels [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html).

If using AI tools, edit the second option to explain which tool was selected and
how the tool's output was used.

Please complete **one** of the following:

- [ ] No AI tools were used to develop this pull request.
- [X] AI tools were used.
      Tool(s): Claude
      Used for: Bulk docstring clean up
      I have personally read, understood, and can explain every line of this diff, and
      have verified the statistical/numerical correctness of the change.

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows
  using the Windows System for Linux once `flake8` is installed in the
  local Linux environment. While passing this test is not required, it is good practice and it help
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.
* If AI tools were used to help write this PR, see the
  [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html) for what disclosure
  and review is expected of you before submitting.

</details>
