### PR TITLE
DOC: Standardized docstrings in stats

### DIFF
--- a/statsmodels/stats/_adnorm.py
+++ b/statsmodels/stats/_adnorm.py
@@ -20,20 +20,20 @@ def anderson_statistic(x, dist="norm", fit=True, params=(), axis=0):
     ----------
     x : array_like
         The data to test.
-    dist : {'norm', callable}
+    dist : {'norm', callable}, optional
         The assumed distribution under the null of test statistic.
-    fit : bool
+    fit : bool, optional
         If True, then the distribution parameters are estimated.
         Currently only for 1d data x, except in case dist='norm'.
-    params : tuple
+    params : tuple, optional
         The optional distribution parameters if fit is False.
-    axis : int
+    axis : int, optional
         If dist is 'norm' or fit is False, then data can be an n-dimensional
         and axis specifies the axis of a variable.
 
     Returns
     -------
-    {float, ndarray}
+    float or ndarray
         The Anderson-Darling statistic.
     """
     x = array_like(x, "x", mindim=None)
@@ -82,14 +82,14 @@ def normal_ad(x, axis=0):
     ----------
     x : array_like
         The data array.
-    axis : int
+    axis : int, optional
         The axis to perform the test along.
 
     Returns
     -------
-    ad2 : float
+    ad2 : float or ndarray
         Anderson Darling test statistic.
-    pval : float
+    pval : float or ndarray
         The pvalue for hypothesis that the data comes from a normal
         distribution with unknown mean and variance.
 

--- a/statsmodels/stats/_delta_method.py
+++ b/statsmodels/stats/_delta_method.py
@@ -38,12 +38,12 @@ class NonlinearDeltaCov:
         Parameters at which function `func` is evaluated.
     cov_params : ndarray
         Covariance matrix of the parameters `params`.
-    deriv : function or None
+    deriv : callable or None, optional
         First derivative or Jacobian of func. If deriv is None, then a
         numerical derivative will be used. If func returns a 1-D array,
         then the `deriv` should have rows corresponding to the elements
         of the return of func.
-    func_args : None
+    func_args : None, optional
         Not yet implemented.
     """
     def __init__(self, func, params, cov_params, deriv=None, func_args=None):
@@ -61,7 +61,7 @@ class NonlinearDeltaCov:
 
         Parameters
         ----------
-        params : None or ndarray
+        params : ndarray or None, optional
             Values at which gradient is evaluated. If params is None, then
             the attached params are used.
             TODO: should we drop this
@@ -169,27 +169,27 @@ class NonlinearDeltaCov:
         alpha : float, optional
             The significance level for the confidence interval.
             ie., The default `alpha` = .05 returns a 95% confidence interval.
-        use_t : boolean
+        use_t : bool, optional
             If use_t is False (default), then the normal distribution is used
             for the confidence interval, otherwise the t distribution with
             `df` degrees of freedom is used.
-        df : int or float
+        df : int or float, optional
             degrees of freedom for t distribution. Only used and required if
             use_t is True.
-        var_extra : None or array_like float
+        var_extra : array_like, optional
             Additional variance that is added to the variance based on the
             delta method. This can be used to obtain confidence intervals for
             new observations (prediction interval).
-        predicted : ndarray (float)
+        predicted : ndarray, optional
             Predicted value, can be used to avoid repeated calculations if it
             is already available.
-        se : ndarray (float)
+        se : ndarray, optional
             Standard error, can be used to avoid repeated calculations if it
             is already available.
 
         Returns
         -------
-        conf_int : array
+        conf_int : ndarray
             Each row contains [lower, upper] limits of the confidence interval
             for the corresponding parameter. The first column contains all
             lower, the second column contains all upper limits.
@@ -231,25 +231,25 @@ class NonlinearDeltaCov:
 
         Parameters
         ----------
-        xname : list of strings, optional
+        xname : list of str, optional
             Default is `c_##` for ## in p the number of regressors.
-        alpha : float
+        alpha : float, optional
             Significance level for the confidence intervals. Default is
             alpha = 0.05 which implies a confidence level of 95%.
-        title : string, optional
+        title : str, optional
             Title for the params table. If not None, then this replaces the
             default title.
-        use_t : boolean
+        use_t : bool, optional
             If use_t is False (default), then the normal distribution is used
             for the confidence interval, otherwise the t distribution with
             `df` degrees of freedom is used.
-        df : int or float
+        df : int or float, optional
             Degrees of freedom for t distribution. Only used and required if
             use_t is True.
 
         Returns
         -------
-        smry : string or Summary instance
+        smry : str or Summary instance
             This contains a parameter results table in the case of t or z
             test in the same form as the parameter results table in the
             model results summary. For F or Wald test, the return is a

--- a/statsmodels/stats/_diagnostic_other.py
+++ b/statsmodels/stats/_diagnostic_other.py
@@ -201,10 +201,10 @@ def lm_test_glm(result, exog_extra, mean_deriv=None):
     ----------
     result : GLMResults instance
         results instance with the constrained model
-    exog_extra : ndarray or None
+    exog_extra : array_like or None
         additional exogenous variables for variable addition test
         This can be set to None if mean_deriv is provided.
-    mean_deriv : None or ndarray
+    mean_deriv : None or array_like, optional
         Extra moment condition that correspond to the partial derivative of
         a mean function with respect to some parameters.
 
@@ -328,7 +328,7 @@ def cm_test_robust(resid, resid_deriv, instruments, weights=1):
     instruments : ndarray, (nobs, k_instruments)
         indicator variables of Wooldridge, multiplies the conditional moment
         restriction
-    weights : ndarray
+    weights : array_like, optional
         This is a weights function as used in WLS. The moment
         restrictions are multiplied by weights. This corresponds to the
         inverse of the variance in a heteroskedastic model.
@@ -691,24 +691,24 @@ def conditional_moment_test_generic(
     mom_test_deriv : ndarray, 2-D, square (k_constraints, k_constraints)
         derivative of moment conditions under test with respect to the
         parameters of the model summed over observations.
-    mom_incl : ndarray, 2-D (nobs, k_params)
+    mom_incl : None or ndarray, 2-D (nobs, k_params)
         moment conditions that where use in estimation, assumed to be zero
         This is score_obs in the case of (Q)MLE
     mom_incl_deriv : ndarray, 2-D, square (k_params, k_params)
         derivative of moment conditions of estimator summed over observations
         This is the information matrix or Hessian in the case of (Q)MLE.
-    var_mom_all : None, or ndarray, 2-D, (k, k) with k = k_constraints + k_params
+    var_mom_all : None or ndarray, 2-D, (k, k) with k = k_constraints + k_params, optional
         Expected product or variance of the joint (column_stacked) moment
         conditions. The stacking should have the variance of the moment
         conditions under test in the first k_constraint rows and columns.
-        If it is not None, then it will be estimated based on cov_type.
+        If it is None, then it will be estimated based on cov_type.
         I think: This is the Hessian of the extended or alternative model
         under full MLE and score test assuming information matrix identity
         holds.
-    cov_type : str
+    cov_type : {"OPG"}, optional
         Type of covariance estimator for the joint moments. Currently only
         "OPG" (outer product of gradients) is implemented.
-    cov_kwds : dict or None
+    cov_kwds : dict, optional
         Not used yet. Reserved for keyword arguments for alternative
         covariance estimators once they are implemented.
 
@@ -817,16 +817,16 @@ def conditional_moment_test_regression(
     var_mom_all : ndarray, optional
         Not used yet. Reserved for the joint covariance of the moment
         conditions.
-    demean : bool
+    demean : bool, optional
         If True, then the columns of the combined moment conditions are
         demeaned before running the artificial regression.
-    cov_type : str
+    cov_type : str, optional
         Covariance type used in the artificial regression. If "OPG",
         then the outer-product-of-gradients regression is used and the
         test statistic is `nobs` times R-squared. Otherwise, a robust
         Wald test on the coefficients of the artificial regression is
         used.
-    cov_kwds : dict or None
+    cov_kwds : dict, optional
         Keyword arguments for the covariance estimator specified by
         `cov_type`, used only if `cov_type` is not "OPG".
 

--- a/statsmodels/stats/_inference_tools.py
+++ b/statsmodels/stats/_inference_tools.py
@@ -27,7 +27,7 @@ def _mover_confint(stat1, stat2, ci1, ci2, contrast="diff"):
         Lower and upper confidence limits for `stat1`.
     ci2 : tuple
         Lower and upper confidence limits for `stat2`.
-    contrast : {"diff", "sum", "ratio"}
+    contrast : {"diff", "sum", "ratio"}, optional
         The contrast between `stat1` and `stat2` for which the
         confidence interval is computed.
 

--- a/statsmodels/stats/_knockoff.py
+++ b/statsmodels/stats/_knockoff.py
@@ -42,10 +42,10 @@ class RegressionFDR:
     regeffects : RegressionEffects instance
         An instance of a RegressionEffects class that can compute
         effect sizes for the regression coefficients.
-    method : str
+    method : str, optional
         The approach used to assess and control FDR, currently
         must be 'knockoff'.
-    rng : {None, int, array_like[int], numpy.random.Generator, numpy.random.RandomState}, optional
+    rng : {None, int, array_like of int, numpy.random.Generator, numpy.random.RandomState}, optional
         If `rng` is None, a new ``Generator`` is created using fresh
         entropy from the operating system. If `rng` is an int or array
         of ints, a new ``Generator`` is created, seeded with `rng`. If

--- a/statsmodels/stats/_lilliefors.py
+++ b/statsmodels/stats/_lilliefors.py
@@ -94,7 +94,7 @@ def ksstat(x, cdf, alternative="two_sided", args=()):
     alternative : {'two_sided', 'less', 'greater'}, optional
         Defines the alternative hypothesis (see explanation). Default is
         'two_sided'.
-    args : tuple, sequence
+    args : tuple, optional
         Distribution parameters for call to cdf.
 
     Returns

--- a/statsmodels/stats/anova.py
+++ b/statsmodels/stats/anova.py
@@ -37,11 +37,11 @@ def anova_single(model, **kwargs):
     model : fitted linear model results instance
         A fitted linear model
     **kwargs
-        typ : int or str {1,2,3} or {"I","II","III"}
+        typ : {1, 2, 3, "I", "II", "III"}, optional
             Type of sum of squares to use.
-        test : str {"F", "Chisq", "Cp"} or None
+        test : {"F", "Chisq", "Cp", None}, optional
             Test statistics to provide. Default is "F".
-        robust : {None, "hc0", "hc1", "hc2", "hc3"}
+        robust : {None, "hc0", "hc1", "hc2", "hc3"}, optional
             Use heteroscedasticity-corrected coefficient covariance matrix.
             If robust covariance is desired, it is recommended to use `hc3`.
 
@@ -121,7 +121,7 @@ def anova1_lm_single(
         Preallocated DataFrame to be filled in with the Anova results.
     n_rows : int
         Number of rows, including the residual row, in `table`.
-    test : str {"F", "Chisq", "Cp"} or None
+    test : {"F", "Chisq", "Cp", None}
         Test statistic to provide.
     pr_test : str
         Name of the column holding the p-value for `test`, e.g., "PR(>F)".
@@ -194,7 +194,7 @@ def anova2_lm_single(model, model_spec, n_rows, test, pr_test, robust):
         The model specification describing the terms of `model`.
     n_rows : int
         Number of rows, including the residual row, in the returned table.
-    test : str {"F", "Chisq", "Cp"} or None
+    test : {"F", "Chisq", "Cp", None}
         Test statistic to provide.
     pr_test : str
         Name of the column holding the p-value for `test`, e.g., "PR(>F)".
@@ -354,14 +354,14 @@ def anova_lm(*args, **kwargs):
     ----------
     *args : fitted linear model results instance
         One or more fitted linear models
-    scale : float
+    scale : float or None, optional
         Estimate of variance, If None, will be estimated from the largest
         model. Default is None.
-    test : str {"F", "Chisq", "Cp"} or None
+    test : {"F", "Chisq", "Cp", None}, optional
         Test statistics to provide. Default is "F".
-    typ : str or int {"I","II","III"} or {1,2,3},
+    typ : {1, 2, 3, "I", "II", "III"}, optional
         The type of Anova test to perform. Default is I, more see notes.
-    robust : {None, "hc0", "hc1", "hc2", "hc3"}
+    robust : {None, "hc0", "hc1", "hc2", "hc3"}, optional
         Use heteroscedasticity-corrected coefficient covariance matrix.
         If robust covariance is desired, it is recommended to use `hc3`.
 
@@ -544,7 +544,7 @@ class AnovaRM:
         The within-subject factors
     between : list[str]
         The between-subject factors, this is not yet implemented
-    aggregate_func : {None, 'mean', callable}
+    aggregate_func : {None, 'mean', callable}, optional
         If the data set contains more than a single observation per subject
         and cell of the specified model, this function will be used to
         aggregate the data before running the Anova. `None` (the default) will

--- a/statsmodels/stats/base.py
+++ b/statsmodels/stats/base.py
@@ -134,13 +134,13 @@ class AllPairsResults:
         p-values from a pairwise comparison test
     all_pairs : list of tuples
         list of indices, one pair for each comparison
-    multitest_method : str
+    multitest_method : str, optional
         method that is used by default for p-value correction. This is used
         as default by the methods like if the multiple-testing method is not
         specified as argument.
-    levels : {list[str], None}
+    levels : list[str] or None, optional
         optional names of the levels or groups
-    n_levels : None or int
+    n_levels : None or int, optional
         If None, then the number of levels or groups is inferred from the
         other arguments. It can be explicitly specified, if the inferred
         number is incorrect.

--- a/statsmodels/stats/contingency_tables.py
+++ b/statsmodels/stats/contingency_tables.py
@@ -94,7 +94,7 @@ class Table:
     ----------
     table : array_like
         A contingency table.
-    shift_zeros : bool
+    shift_zeros : bool, optional
         If True and any cell count is zero, add 0.5 to all values
         in the table.
 
@@ -146,13 +146,14 @@ class Table:
         data : array_like
             The raw data, from which a contingency table is constructed
             using the first two columns.
-        shift_zeros : bool
+        shift_zeros : bool, optional
             If True and any cell count is zero, add 0.5 to all values
             in the table.
 
         Returns
         -------
-        A Table instance.
+        Table
+            A Table instance.
         """
 
         if isinstance(data, pd.DataFrame):
@@ -172,14 +173,15 @@ class Table:
 
         Returns
         -------
-        A bunch containing the following attributes:
+        Bunch
+            A bunch with attributes
 
-        statistic : float
-            The chi^2 test statistic.
-        df : int
-            The degrees of freedom of the reference distribution
-        pvalue : float
-            The p-value for the test.
+            * statistic : float
+                The chi^2 test statistic.
+            * df : int
+                The degrees of freedom of the reference distribution.
+            * pvalue : float
+                The p-value for the test.
         """
 
         statistic = np.asarray(self.chi2_contribs).sum()
@@ -201,27 +203,28 @@ class Table:
 
         Parameters
         ----------
-        row_scores : array_like
+        row_scores : array_like, optional
             An array of numeric row scores
-        col_scores : array_like
+        col_scores : array_like, optional
             An array of numeric column scores
 
         Returns
         -------
-        A bunch with the following attributes:
+        Bunch
+            A bunch with attributes
 
-        statistic : float
-            The test statistic.
-        null_mean : float
-            The expected value of the test statistic under the null
-            hypothesis.
-        null_sd : float
-            The standard deviation of the test statistic under the
-            null hypothesis.
-        zscore : float
-            The Z-score for the test statistic.
-        pvalue : float
-            The p-value for the test.
+            * statistic : float
+                The test statistic.
+            * null_mean : float
+                The expected value of the test statistic under the null
+                hypothesis.
+            * null_sd : float
+                The standard deviation of the test statistic under the
+                null hypothesis.
+            * zscore : float
+                The Z-score for the test statistic.
+            * pvalue : float
+                The p-value for the test.
 
         Notes
         -----
@@ -284,10 +287,12 @@ class Table:
 
         Returns
         -------
-        row : ndarray
-            Marginal row probabilities
-        col : ndarray
-            Marginal column probabilities
+        row : ndarray or Series
+            Marginal row probabilities. A Series if `table_orig` is a
+            DataFrame, otherwise an ndarray.
+        col : ndarray or Series
+            Marginal column probabilities. A Series if `table_orig` is a
+            DataFrame, otherwise an ndarray.
         """
 
         n = self.table.sum()
@@ -451,7 +456,7 @@ class SquareTable(Table):
     table : array_like
         A square contingency table, or DataFrame that is converted
         to a square form.
-    shift_zeros : bool
+    shift_zeros : bool, optional
         If True and any cell count is zero, add 0.5 to all values
         in the table.
 
@@ -487,7 +492,7 @@ class SquareTable(Table):
 
         Parameters
         ----------
-        method : str
+        method : str, optional
             The method for testing symmetry. Currently must be 'bowker'
             for Bowker's test.
 
@@ -547,7 +552,7 @@ class SquareTable(Table):
 
         Parameters
         ----------
-        method : str
+        method : str, optional
             Either 'stuart_maxwell' or 'bhapkar', leading to two different
             estimates of the covariance matrix for the estimated
             difference between the row margins and the column margins.
@@ -640,9 +645,9 @@ class SquareTable(Table):
 
         Parameters
         ----------
-        alpha : float
+        alpha : float, optional
             `1 - alpha` is the nominal coverage probability of the interval.
-        float_format : str
+        float_format : str, optional
             Used to format numeric values in the table.
         """
 
@@ -671,8 +676,8 @@ class Table2x2(SquareTable):
     ----------
     table : array_like
         A 2x2 contingency table
-    shift_zeros : bool
-        If true, 0.5 is added to all cells of the table if any cell is
+    shift_zeros : bool, optional
+        If True, 0.5 is added to all cells of the table if any cell is
         equal to zero.
 
     Notes
@@ -708,9 +713,14 @@ class Table2x2(SquareTable):
         data : array_like
             The raw data, the first column defines the rows and the
             second column defines the columns.
-        shift_zeros : bool
+        shift_zeros : bool, optional
             If True, and if there are any zeros in the contingency
             table, add 0.5 to all four cells of the table.
+
+        Returns
+        -------
+        Table2x2
+            A Table2x2 instance.
         """
 
         if isinstance(data, pd.DataFrame):
@@ -746,7 +756,7 @@ class Table2x2(SquareTable):
 
         Parameters
         ----------
-        null : float
+        null : float, optional
             The null value of the odds ratio.
         """
 
@@ -758,7 +768,7 @@ class Table2x2(SquareTable):
 
         Parameters
         ----------
-        null : float
+        null : float, optional
             The null value of the log odds ratio.
         """
 
@@ -772,10 +782,10 @@ class Table2x2(SquareTable):
 
         Parameters
         ----------
-        alpha : float
+        alpha : float, optional
             `1 - alpha` is the nominal coverage probability of the
             confidence interval.
-        method : str
+        method : str, optional
             The method for producing the confidence interval.  Currently
             must be 'normal' which uses the normal approximation.
         """
@@ -793,10 +803,10 @@ class Table2x2(SquareTable):
 
         Parameters
         ----------
-        alpha : float
+        alpha : float, optional
             `1 - alpha` is the nominal coverage probability of the
             confidence interval.
-        method : str
+        method : str, optional
             The method for producing the confidence interval.  Currently
             must be 'normal' which uses the normal approximation.
         """
@@ -835,7 +845,7 @@ class Table2x2(SquareTable):
 
         Parameters
         ----------
-        null : float
+        null : float, optional
             The null value of the risk ratio.
         """
 
@@ -847,7 +857,7 @@ class Table2x2(SquareTable):
 
         Parameters
         ----------
-        null : float
+        null : float, optional
             The null value of the log risk ratio.
         """
 
@@ -861,10 +871,10 @@ class Table2x2(SquareTable):
 
         Parameters
         ----------
-        alpha : float
+        alpha : float, optional
             `1 - alpha` is the nominal coverage probability of the
             confidence interval.
-        method : str
+        method : str, optional
             The method for producing the confidence interval.  Currently
             must be 'normal' which uses the normal approximation.
         """
@@ -881,10 +891,10 @@ class Table2x2(SquareTable):
 
         Parameters
         ----------
-        alpha : float
+        alpha : float, optional
             `1 - alpha` is the nominal coverage probability of the
             confidence interval.
-        method : str
+        method : str, optional
             The method for producing the confidence interval.  Currently
             must be 'normal' which uses the normal approximation.
         """
@@ -897,12 +907,12 @@ class Table2x2(SquareTable):
 
         Parameters
         ----------
-        alpha : float
+        alpha : float, optional
             `1 - alpha` is the nominal coverage probability of the confidence
             intervals.
-        float_format : str
+        float_format : str, optional
             Used to format the numeric values in the table.
-        method : str
+        method : str, optional
             The method for producing the confidence interval.  Currently
             must be 'normal' which uses the normal approximation.
         """
@@ -964,7 +974,7 @@ class StratifiedTable:
         Either a list containing several 2x2 contingency tables, or
         a 2x2xk ndarray in which each slice along the third axis is a
         2x2 contingency table.
-    shift_zeros : bool
+    shift_zeros : bool, optional
         If True and any cell count is zero, add 0.5 to all cells of the
         affected table(s).
 
@@ -1020,15 +1030,15 @@ class StratifiedTable:
 
         Parameters
         ----------
-        var1 : int or string
+        var1 : int or str
             The column index or name of `data` specifying the variable
             defining the rows of the contingency table.  The variable
             must have only two distinct values.
-        var2 : int or string
+        var2 : int or str
             The column index or name of `data` specifying the variable
             defining the columns of the contingency table.  The variable
             must have only two distinct values.
-        strata : int or string
+        strata : int or str
             The column index or name of `data` specifying the variable
             defining the strata.
         data : array_like
@@ -1070,7 +1080,7 @@ class StratifiedTable:
 
         Parameters
         ----------
-        correction : bool
+        correction : bool, optional
             If True, use the continuity correction when calculating the
             test statistic.
 
@@ -1160,10 +1170,10 @@ class StratifiedTable:
 
         Parameters
         ----------
-        alpha : float
+        alpha : float, optional
             `1 - alpha` is the nominal coverage probability of the
             interval.
-        method : str
+        method : str, optional
             The method for producing the confidence interval.  Currently
             must be 'normal' which uses the normal approximation.
 
@@ -1191,10 +1201,10 @@ class StratifiedTable:
 
         Parameters
         ----------
-        alpha : float
+        alpha : float, optional
             `1 - alpha` is the nominal coverage probability of the
             interval.
-        method : str
+        method : str, optional
             The method for producing the confidence interval.  Currently
             must be 'normal' which uses the normal approximation.
 
@@ -1219,18 +1229,19 @@ class StratifiedTable:
 
         Parameters
         ----------
-        adjust : bool
+        adjust : bool, optional
             Use the 'Tarone' adjustment to achieve the chi^2
             asymptotic distribution.
 
         Returns
         -------
-        A bunch containing the following attributes:
+        Bunch
+            A bunch with attributes
 
-        statistic : float
-            The chi^2 test statistic.
-        pvalue : float
-            The p-value for the test.
+            * statistic : float
+                The chi^2 test statistic.
+            * pvalue : float
+                The p-value for the test.
         """
 
         table = self.table
@@ -1275,12 +1286,12 @@ class StratifiedTable:
 
         Parameters
         ----------
-        alpha : float
+        alpha : float, optional
             `1 - alpha` is the nominal coverage probability of the
             confidence intervals.
-        float_format : str
+        float_format : str, optional
             Used for formatting numeric values in the summary.
-        method : str
+        method : str, optional
             The method for producing the confidence interval.  Currently
             must be 'normal' which uses the normal approximation.
         """
@@ -1338,27 +1349,28 @@ def mcnemar(table, exact=True, correction=True):
     Parameters
     ----------
     table : array_like
-        A square contingency table.
-    exact : bool
-        If exact is true, then the binomial distribution will be used.
-        If exact is false, then the chisquare distribution will be
+        A 2x2 contingency table.
+    exact : bool, optional
+        If exact is True, then the binomial distribution will be used.
+        If exact is False, then the chisquare distribution will be
         used, which is the approximation to the distribution of the
         test statistic for large sample sizes.
-    correction : bool
-        If true, then a continuity correction is used for the chisquare
-        distribution (if exact is false.)
+    correction : bool, optional
+        If True, then a continuity correction is used for the chisquare
+        distribution (if exact is False.)
 
     Returns
     -------
-    A bunch with attributes:
+    Bunch
+        A bunch with attributes
 
-    statistic : float or int, array
-        The test statistic is the chisquare statistic if exact is
-        false. If the exact binomial distribution is used, then this
-        contains the min(n1, n2), where n1, n2 are cases that are zero
-        in one sample but one in the other sample.
-    pvalue : float or array
-        p-value of the null hypothesis of equal marginal distributions.
+        * statistic : float
+            The test statistic is the chisquare statistic if exact is
+            False. If the exact binomial distribution is used, then this
+            contains the min(n1, n2), where n1, n2 are cases that are zero
+            in one sample but one in the other sample.
+        * pvalue : float
+            p-value of the null hypothesis of equal marginal distributions.
 
     Notes
     -----
@@ -1431,7 +1443,7 @@ def cochrans_q(x, return_object=None):
     ----------
     x : array_like, 2d (N, k)
         data with N cases and k variables
-    return_object : bool
+    return_object : bool, optional
         No longer used. ``cochrans_q`` always returns a
         ``CochransQResult``, which supports both the attribute access of the
         bunch that ``return_object=True`` used to produce and the positional

--- a/statsmodels/stats/contrast.py
+++ b/statsmodels/stats/contrast.py
@@ -122,7 +122,7 @@ class ContrastResults:
         ----------
         xname : list[str], optional
             Default is `c_##` for ## in the number of regressors.
-        alpha : float
+        alpha : float, optional
             Significance level for the confidence intervals. Default is
             alpha = 0.05 which implies a confidence level of 95%.
         title : str, optional
@@ -189,7 +189,7 @@ class ContrastResults:
         ----------
         xname : list[str], optional
             Default is `c_##` for ## in the number of regressors.
-        alpha : float
+        alpha : float, optional
             Significance level for the confidence intervals. Default is
             alpha = 0.05 which implies a confidence level of 95%.
 
@@ -555,11 +555,11 @@ def t_test_multi(
         Results of an estimated model.
     contrasts : ndarray
         Restriction matrix for t_test.
-    method : str or list of strings
+    method : str or list of str, optional
         Method for multiple testing p-value correction, default is 'hs'.
-    alpha : float
+    alpha : float, optional
         Significance level for multiple testing reject decision.
-    ci_method : None
+    ci_method : None, optional
         Not used yet, will be for multiplicity corrected confidence intervals.
     contrast_names : {list[str], None}
         If contrast_names are provided, then they are used in the index of the
@@ -634,7 +634,7 @@ def _embed_constraints(contrasts, k_params, idx_start, index=None):
         Index of the first parameter of this factor. The restrictions on the
         factor are inserted as a block in the full restriction matrix starting
         at column with index `idx_start`.
-    index : slice or ndarray
+    index : slice or ndarray, optional
         Column index if constraints do not form a block in the full restriction
         matrix, i.e., if parameters that are subject to restrictions are not
         consecutive in the list of parameters.
@@ -669,13 +669,13 @@ def _constraints_factor(
         The number of rows should be equal to the number of levels or categories
         of the factor, the number of columns should be equal to the number
         of parameters for this factor.
-    comparison : str
+    comparison : {"pairwise", "pw", "pairs"}, optional
         Currently only 'pairwise' is implemented. The restriction matrix
         can be used for testing the hypothesis that all pairwise differences
         are zero.
-    k_params : int
+    k_params : int, optional
         Number of parameters.
-    idx_start : int
+    idx_start : int, optional
         Index of the first parameter of this factor. The restrictions on the
         factor are inserted as a block in the full restriction matrix starting
         at column with index `idx_start`.
@@ -722,15 +722,15 @@ def t_test_pairwise(
         name of the term for which pairwise comparisons are computed.
         Term names for categorical effects are created by patsy and
         correspond to the main part of the exog names.
-    method : {str, list[str]}
+    method : str or list of str, optional
         multiple testing p-value correction, default is 'hs',
         see stats.multipletesting
-    alpha : float
+    alpha : float, optional
         significance level for multiple testing reject decision.
-    factor_labels : {list[str], None}
+    factor_labels : list[str], optional
         Labels for the factor levels used for pairwise labels. If not
         provided, then the labels from the formula's model_spec are used.
-    ignore : bool
+    ignore : bool, optional
         Turn off some of the exceptions raised by input checks.
 
     Returns
@@ -852,10 +852,10 @@ def wald_test_noncent(params, r_matrix, value, results, diff=None, joint=True):
     results : Results instance of a model
         The results instance is used to compute the covariance matrix of the
         linear constraints using `cov_params`.
-    diff : None or ndarray
+    diff : None or ndarray, optional
         If diff is not None, then it will be used instead of
         ``diff = r_matrix @ params - value``.
-    joint : bool
+    joint : bool, optional
         If joint is True, then the noncentrality parameter for the joint
         hypothesis will be returned.
         If joint is False, then an array of noncentrality parameters will be
@@ -905,10 +905,10 @@ def wald_test_noncent_generic(
         hypothesis. If value is None, then it will be replaced by zero.
     cov_params : ndarray
         Covariance matrix of the parameter estimates.
-    diff : None or ndarray
+    diff : None or ndarray, optional
         If diff is not None, then it will be used instead of
         ``diff = r_matrix @ params - value``.
-    joint : bool
+    joint : bool, optional
         If joint is True, then the noncentrality parameter for the joint
         hypothesis will be returned.
         If joint is False, then an array of noncentrality parameters will be

--- a/statsmodels/stats/correlation_tools.py
+++ b/statsmodels/stats/correlation_tools.py
@@ -42,16 +42,16 @@ def corr_nearest(corr, threshold=1e-15, n_fact=100):
     ----------
     corr : ndarray, (k, k)
         initial correlation matrix
-    threshold : float
+    threshold : float, optional
         clipping threshold for smallest eigenvalue, see Notes
-    n_fact : int or float
+    n_fact : int or float, optional
         factor to determine the maximum number of iterations. The maximum
         number of iterations is the integer part of the number of columns in
         the correlation matrix times n_fact.
 
     Returns
     -------
-    corr_new : ndarray, (optional)
+    corr_new : ndarray
         corrected correlation matrix
 
     See Also
@@ -112,12 +112,12 @@ def corr_clipped(corr, threshold=1e-15):
     ----------
     corr : ndarray, (k, k)
         initial correlation matrix
-    threshold : float
+    threshold : float, optional
         clipping threshold for smallest eigenvalue, see Notes
 
     Returns
     -------
-    corr_new : ndarray, (optional)
+    corr_new : ndarray
         corrected correlation matrix
 
     See Also
@@ -187,21 +187,21 @@ def cov_nearest(cov, method="clipped", threshold=1e-15, n_fact=100,
 
     Parameters
     ----------
-    cov : ndarray, (k,k)
+    cov : array_like, (k,k)
         initial covariance matrix
-    method : str
+    method : {"clipped", "nearest"}, optional
         if "clipped", then the faster but less accurate ``corr_clipped`` is
         used. If "nearest", then ``corr_nearest`` is used
-    threshold : float
+    threshold : float, optional
         clipping threshold for smallest eigen value, see Notes
-    n_fact : int or float
+    n_fact : int or float, optional
         factor to determine the maximum number of iterations in
         ``corr_nearest``. See its doc string
-    return_all : bool
+    return_all : bool, optional
         if False (default), then only the covariance matrix is returned.
         If True, then correlation matrix and standard deviation are
         additionally returned.
-    min_diag : None or float
+    min_diag : None or float, optional
         If None (default), the diagonal of ``cov`` is left unchanged. This
         function converts the covariance matrix to a correlation matrix, which
         is not defined if a diagonal element (variance) is zero or negative and
@@ -315,16 +315,16 @@ def _nmono_linesearch(
         The search direction
     obj_hist : array_like
         Objective function history (must contain at least one value)
-    M : positive int
+    M : positive int, optional
         Number of previous function points to consider (see references
         for details).
-    sig1 : real
+    sig1 : real, optional
         Tuning parameter, see references for details.
-    sig2 : real
+    sig2 : real, optional
         Tuning parameter, see references for details.
-    gam : real
+    gam : real, optional
         Tuning parameter, see references for details.
-    maxiter : int
+    maxiter : int, optional
         The maximum number of iterations; returns None for all outputs
         if convergence does not occur by this point
 
@@ -409,7 +409,7 @@ def _spg_optim(
         The gradient of the objective function
     start : array_like
         The starting point
-    project : function
+    project : callable
         In-place projection of the argument to the domain
         of func.
     maxiter : scalar, optional
@@ -677,25 +677,25 @@ def corr_nearest_factor(
 
     Parameters
     ----------
-    corr : square array
+    corr : ndarray or sparse matrix
         The target matrix (to which the nearest correlation matrix is
         sought).  Must be square, but need not be positive
         semidefinite.
     rank : int
         The rank of the factor structure of the solution, i.e., the
         number of linearly independent columns of X.
-    ctol : positive real
+    ctol : positive real, optional
         Convergence criterion.
-    lam_min : float
+    lam_min : float, optional
         Tuning parameter for spectral projected gradient optimization
         (smallest allowed step in the search direction).
-    lam_max : float
+    lam_max : float, optional
         Tuning parameter for spectral projected gradient optimization
         (largest allowed step in the search direction).
-    maxiter : int
+    maxiter : int, optional
         Maximum number of iterations in spectral projected gradient
         optimization.
-    rng : {None, int, array_like[int], numpy.random.Generator, numpy.random.RandomState}, optional
+    rng : {None, int, array_like of int, numpy.random.Generator, numpy.random.RandomState}, optional
         If `rng` is None, a new ``Generator`` is created using fresh
         entropy from the operating system. If `rng` is an int or array
         of ints, a new ``Generator`` is created, seeded with `rng`. If
@@ -841,12 +841,12 @@ def cov_nearest_factor_homog(cov, rank, *, rng=None):
 
     Parameters
     ----------
-    cov : array_like
+    cov : ndarray or sparse matrix
         The input array, must be square but need not be positive
         semidefinite
     rank : int
         The rank of the fitted factor structure
-    rng : {None, int, array_like[int], numpy.random.Generator, numpy.random.RandomState}, optional
+    rng : {None, int, array_like of int, numpy.random.Generator, numpy.random.RandomState}, optional
         If `rng` is None, a new ``Generator`` is created using fresh
         entropy from the operating system. If `rng` is an int or array
         of ints, a new ``Generator`` is created, seeded with `rng`. If
@@ -929,10 +929,10 @@ def corr_thresholded(data, minabs=None, max_elt=1e7):
 
     Parameters
     ----------
-    data : array_like
+    data : ndarray
         The data from which the row-wise thresholded correlation
         matrix is to be computed.
-    minabs : non-negative real
+    minabs : non-negative real, optional
         The threshold value; correlation coefficients smaller in
         magnitude than minabs are set to zero.  If None, defaults
         to 1 / sqrt(n), see Notes for more information.
@@ -1117,7 +1117,7 @@ def kernel_covariance(exog, loc, groups, kernel=None, bw=None):
     kernel : MultivariateKernel instance, optional
         An instance of MultivariateKernel, defaults to
         GaussianMultivariateKernel.
-    bw : array_like or scalar
+    bw : array_like or scalar, optional
         A bandwidth vector, or bandwidth multiplier.  If a 1d array, it
         contains kernel bandwidths for each component of the process, and
         must have length equal to the number of columns of exog.  If a scalar,

--- a/statsmodels/stats/covariance.py
+++ b/statsmodels/stats/covariance.py
@@ -42,15 +42,16 @@ def _term_integrate(rho):
 
 class TransformCorrNormalResult(NamedTuple):
     """
-    Result of :func:`transform_corr_normal` when the variance is returned.
+    Result of :func:`transform_corr_normal` when a NamedTuple is returned.
 
     Parameters
     ----------
     corr : ndarray
         Correlation matrix, consistent with the correlation for a
         multivariate normal distribution.
-    var : ndarray
-        Asymptotic variance of the normalized correlation.
+    var : ndarray or None
+        Asymptotic variance of the normalized correlation. ``None`` when
+        the variance was not computed, i.e. when ``return_var=False``.
     """
 
     corr: np.ndarray
@@ -68,17 +69,18 @@ def transform_corr_normal(
     corr : array_like
         correlation matrix, either Pearson, Gaussian-rank, Spearman, Kendall
         or quadrant correlation matrix
-    method : string
+    method : str
         type of covariance matrix
         supported types are 'pearson', 'gauss_rank', 'kendal', 'spearman' and
         'quadrant'
-    return_var : bool
+    return_var : bool, optional
         If true, then the asymptotic variance of the normalized correlation
         is also returned. The variance of the spearman correlation requires
         numerical integration which is calculated with scipy's odeint.
-    possdef : not implemented yet
-        Check whether resulting correlation matrix for positive semidefinite
-        and return a positive semidefinite approximation if not.
+    possdef : bool, optional
+        Not implemented yet. Check whether resulting correlation matrix for
+        positive semidefinite and return a positive semidefinite
+        approximation if not.
     result_object : bool, optional
         Flag controlling whether a ``TransformCorrNormalResult`` NamedTuple
         is returned. When ``return_var=True`` a
@@ -280,10 +282,10 @@ def corr_quadrant(data, transform=np.sign, normalize=False):
     ----------
     data : array_like
         2-D data with observations in rows and variables in columns
-    transform : callable
+    transform : callable, optional
         Function used to transform the demeaned data before computing the
         correlation. Default is ``np.sign``.
-    normalize : bool
+    normalize : bool, optional
         If True, normalize the resulting matrix by the standard deviations
         so that it is a proper correlation matrix. Default is False.
 

--- a/statsmodels/stats/descriptivestats.py
+++ b/statsmodels/stats/descriptivestats.py
@@ -142,7 +142,7 @@ def sign_test(samp, mu0=0):
     ----------
     samp : array_like
         1d array. The sample for which you want to perform the sign test.
-    mu0 : float
+    mu0 : float, optional
         See Notes for the definition of the sign test. mu0 is 0 by
         default, but it is common to set it to the median.
 
@@ -246,7 +246,7 @@ class Description:
         confidence interval, which has coverage 1 - alpha.
     use_t : bool, default False
         Use the Student's t distribution to construct confidence intervals.
-    percentiles : sequence[float]
+    percentiles : Sequence[float], optional
         A distinct sequence of floating point values all between 0 and 100.
         The default percentiles are 1, 5, 10, 25, 50, 75, 90, 95, 99.
     ntop : int, default 5
@@ -254,11 +254,11 @@ class Description:
 
     Attributes
     ----------
-    numeric_statistics
+    numeric_statistics : tuple of str
         The list of supported statistics for numeric data
-    categorical_statistics
+    categorical_statistics : tuple of str
         The list of supported statistics for categorical data
-    default_statistics
+    default_statistics : tuple of str
         The default list of statistics
 
     See Also

--- a/statsmodels/stats/diagnostic.py
+++ b/statsmodels/stats/diagnostic.py
@@ -147,10 +147,10 @@ def compare_cox(
 
     Parameters
     ----------
-    results_x : Result instance
-        result instance of first model
-    results_z : Result instance
-        result instance of second model
+    results_x : RegressionResults
+        The result instance of first model.
+    results_z : RegressionResults
+        The result instance of second model.
     store : bool, default False
         If true, then the intermediate results are returned.
     result_object : bool, optional
@@ -376,7 +376,7 @@ def pesaran_timmermann(actual, predicted, alternative="two-sided"):
     predicted : array_like
         Forecasted or predicted values. The direction is classified by
         ``predicted > 0``.
-    alternative : {"two-sided", "larger", "smaller"}
+    alternative : {"two-sided", "larger", "smaller"}, default "two-sided"
         Alternative hypothesis for the directional accuracy statistic.
 
     Returns
@@ -511,10 +511,10 @@ def compare_encompassing(results_x, results_z, cov_type="nonrobust", cov_kwds=No
 
     Parameters
     ----------
-    results_x : Result instance
-        result instance of first model
-    results_z : Result instance
-        result instance of second model
+    results_x : RegressionResults
+        The result instance of first model.
+    results_z : RegressionResults
+        The result instance of second model.
     cov_type : str, default "nonrobust"
         Covariance type. The default is "nonrobust" which uses the classic
         OLS covariance estimator. Specify one of "HC0", "HC1", "HC2", "HC3"
@@ -1007,7 +1007,7 @@ def acorr_breusch_godfrey(
 
     Parameters
     ----------
-    res : RegressionResults
+    res : Results instance
         Estimation results for which the residuals are tested for serial
         correlation.
     nlags : int, optional
@@ -1155,10 +1155,8 @@ def het_breuschpagan(resid, exog_het, robust=True):
     Parameters
     ----------
     resid : array_like
-        For the Breusch-Pagan test, this should be the residual of a
-        regression. If an array is given in exog, then the residuals are
-        calculated by the an OLS regression or resid on exog. In this case
-        resid should contain the dependent variable. Exog can be the same as x.
+        For the Breusch-Pagan test, this should be an array of residuals
+        from a fitted regression model.
     exog_het : array_like
         This contains variables suspected of being related to
         heteroscedasticity in resid.
@@ -1196,7 +1194,7 @@ def het_breuschpagan(resid, exog_het, robust=True):
 
     This is calculated using the generic formula for LM test using $R^2$
     (Greene, section 17.6) and not with the explicit formula
-    (Greene, section 11.4.3), unless `robust` is set to False.
+    (Greene, section 11.4.3), unless ``robust`` is set to False.
     The degrees of freedom for the p-value assume x is full rank.
 
     References
@@ -1325,9 +1323,8 @@ def het_goldfeldquandt(
         split+drop, where split and drop are the indices (given by rounding
         if specified as fraction). The first sample is [0:split], the
         second sample is [split+drop:]
-    alternative : {"increasing", "decreasing", "two-sided"}
-        The default is increasing. This specifies the alternative for the
-        p-value calculation.
+    alternative : {"increasing", "decreasing", "two-sided"}, default "increasing"
+        This specifies the alternative for the p-value calculation.
     store : bool, default False
         Flag indicating to return the regression results
     result_object : bool, optional
@@ -1458,7 +1455,7 @@ def linear_reset(
     ----------
     res : RegressionResults
         A results instance from a linear regression.
-    power : {int, List[int]}, default 3
+    power : {int, list[int]}, default 3
         The maximum power to include in the model, if an integer. Includes
         powers 2, 3, ..., power. If an list of integers, includes all powers
         in the list.
@@ -1770,9 +1767,9 @@ def linear_lm(resid, exog, func=None):
 
     Parameters
     ----------
-    resid : ndarray
+    resid : array_like
         residuals of a regression
-    exog : ndarray
+    exog : array_like
         exogenous variables for which linearity is tested
     func : callable, default None
         If func is None, then squares are used. func needs to take an array
@@ -2100,9 +2097,9 @@ def breaks_cusumolsresid(resid, ddof=0):
 
     Parameters
     ----------
-    resid : ndarray
+    resid : array_like
         An array of residuals from an OLS estimation.
-    ddof : int
+    ddof : int, default 0
         The number of parameters in the OLS estimation, used as degrees
         of freedom correction for error variance.
 
@@ -2115,7 +2112,7 @@ def breaks_cusumolsresid(resid, ddof=0):
         Probability of observing the data under the null hypothesis of no
         structural change, based on asymptotic distribution which is a Brownian
         Bridge
-    crit: list
+    crit : list
         The tabulated critical values, for alpha = 1%, 5% and 10%.
 
     Notes

--- a/statsmodels/stats/diagnostic_gen.py
+++ b/statsmodels/stats/diagnostic_gen.py
@@ -92,26 +92,27 @@ def test_chisquare_binning(
         If those sums are unequal and all expected values are smaller or equal
         to 1, then they are interpreted as probabilities and will be rescaled
         to match counts.
-    sort_var : array_like
+    sort_var : array_like, optional
         1-dimensional array for binning. Groups will be formed according to
         quantiles of the sorted array ``sort_var``, so that group sizes have
-        equal or approximately equal sizes.
-    bins : int
+        equal or approximately equal sizes. If None, the original order of
+        ``counts`` and ``expected`` is used for binning instead.
+    bins : int, optional
         Number of bins or groups to use for binning the data based on
         ``sort_var``. Default is 10.
-    df : int
+    df : int, optional
         Degrees of freedom of the chisquare distribution used to compute
         the p-value of the test. If None, then the degrees of freedom are
         computed from the number of groups and choices, depending on
         whether ``ordered`` is True or False.
-    ordered : bool
+    ordered : bool, optional
         If True, the degrees of freedom for the ordinal case are used when
         ``df`` is not provided. Default is False, i.e., the multinomial
         (unordered) case.
-    sort_method : str
+    sort_method : str, optional
         Sorting method used by ``numpy.argsort`` when binning by
         ``sort_var``. Default is "quicksort".
-    alpha_nc : float
+    alpha_nc : float, optional
         Significance level used in the computation of the noncentrality
         parameter confidence interval. Default is 0.05.
 

--- a/statsmodels/stats/dist_dependence_measures.py
+++ b/statsmodels/stats/dist_dependence_measures.py
@@ -27,6 +27,27 @@ from statsmodels.tools.sm_exceptions import HypothesisTestWarning
 
 
 class DistDependStat(NamedTuple):
+    """
+    Result of :func:`distance_statistics`.
+
+    Parameters
+    ----------
+    test_statistic : float
+        The "basic" test statistic (i.e., the one used when the `emp`
+        method is chosen when calling ``distance_covariance_test()``).
+    distance_correlation : float
+        The distance correlation between `x` and `y`.
+    distance_covariance : float
+        The distance covariance of `x` and `y`.
+    dvar_x : float
+        The distance variance of `x`.
+    dvar_y : float
+        The distance variance of `y`.
+    S : float
+        The mean of the euclidean distances in `x` multiplied by those
+        of `y`. Mostly used internally.
+    """
+
     test_statistic: float
     distance_correlation: float
     distance_covariance: float
@@ -57,13 +78,13 @@ def distance_covariance_test(x, y, B=None, method="auto", rng=None):
         `x`. If `y` is 2-D note that the number of columns of `y` (i.e., the
         number of components in the random vector) does not need to match
         the number of columns in `x`.
-    B : int, optional, default=`None`
+    B : int, optional
         The number of iterations to perform when evaluating the null
         distribution of the test statistic when the `emp` method is
         applied (see below). if `B` is `None` than as in [1]_ we set
         `B` to be ``B = 200 + 5000/n``, where `n` is the number of
         observations.
-    method : {'auto', 'emp', 'asym'}, optional, default=auto
+    method : {'auto', 'emp', 'asym'}, optional
         The method by which to obtain the p-value for the test.
 
         - `auto` : Default method. The number of observations will be used to
@@ -73,7 +94,7 @@ def distance_covariance_test(x, y, B=None, method="auto", rng=None):
         - `asym` : An asymptotic approximation of the distribution of the test
           statistic is used to find the p-value.
 
-    rng : {None, int, array_like[int], numpy.random.Generator, numpy.random.RandomState}, optional
+    rng : {None, int, array_like of int, numpy.random.Generator, numpy.random.RandomState}, optional
         If `rng` is None, a new ``Generator`` is created using fresh
         entropy from the operating system. If `rng` is an int or array
         of ints, a new ``Generator`` is created, seeded with `rng`. If
@@ -175,8 +196,8 @@ def _validate_and_tranform_x_and_y(x, y):
 
     Returns
     -------
-    x : array_like, 1-D or 2-D
-    y : array_like, 1-D or 2-D
+    x : ndarray, 2-D
+    y : ndarray, 2-D
 
     Raises
     ------
@@ -220,9 +241,9 @@ def _empirical_pvalue(x, y, B, n, stats, rng):
         The number of iterations when evaluating the null distribution.
     n : int
         Number of observations found in each of `x` and `y`.
-    stats : namedtuple
+    stats : DistDependStat
         The result obtained from calling ``distance_statistics(x, y)``.
-    rng : {None, int, array_like[int], numpy.random.Generator, numpy.random.RandomState}, optional
+    rng : {None, int, array_like of int, numpy.random.Generator, numpy.random.RandomState}, optional
         If `rng` is None, a new ``Generator`` is created using fresh
         entropy from the operating system. If `rng` is an int or array
         of ints, a new ``Generator`` is created, seeded with `rng`. If
@@ -253,7 +274,7 @@ def _asymptotic_pvalue(stats):
 
     Parameters
     ----------
-    stats : namedtuple
+    stats : DistDependStat
         The result obtained from calling ``distance_statistics(x, y)``.
 
     Returns
@@ -290,7 +311,7 @@ def _get_test_statistic_distribution(x, y, B, rng):
     B : int
         The number of iterations to perform when evaluating the null
         distribution.
-    rng : {None, int, array_like[int], numpy.random.Generator, numpy.random.RandomState}, optional
+    rng : {None, int, array_like of int, numpy.random.Generator, numpy.random.RandomState}, optional
         If `rng` is None, a new ``Generator`` is created using fresh
         entropy from the operating system. If `rng` is an int or array
         of ints, a new ``Generator`` is created, seeded with `rng`. If
@@ -299,7 +320,7 @@ def _get_test_statistic_distribution(x, y, B, rng):
 
     Returns
     -------
-    emp_dist : array_like
+    emp_dist : ndarray
         The empirical distribution of the test statistic.
 
     """
@@ -341,21 +362,9 @@ def distance_statistics(x, y, x_dist=None, y_dist=None):
 
     Returns
     -------
-    namedtuple
-        A named tuple of distance dependence statistics (DistDependStat) with
-        the following values:
-
-        - test_statistic : float - The "basic" test statistic (i.e., the one
-          used when the `emp` method is chosen when calling
-          ``distance_covariance_test()``
-        - distance_correlation : float - The distance correlation
-          between `x` and `y`.
-        - distance_covariance : float - The distance covariance of
-          `x` and `y`.
-        - dvar_x : float - The distance variance of `x`.
-        - dvar_y : float - The distance variance of `y`.
-        - S : float - The mean of the euclidean distances in `x` multiplied
-          by those of `y`. Mostly used internally.
+    DistDependStat
+        A named tuple of distance dependence statistics. See
+        :class:`DistDependStat` for the full list of fields.
 
     References
     ----------

--- a/statsmodels/stats/effect_size.py
+++ b/statsmodels/stats/effect_size.py
@@ -54,7 +54,7 @@ def _noncentrality_chisquare(chi2_stat, df, alpha=0.05):
         Chisquare-statistic, for example from a hypothesis test.
     df : int or float
         Degrees of freedom.
-    alpha : float in (0, 1)
+    alpha : float in (0, 1), optional
         Significance level for the confidence interval, coverage is 1 - alpha.
 
     Returns
@@ -143,7 +143,7 @@ def _noncentrality_f(f_stat, df1, df2, alpha=0.05):
         Numerator degrees of freedom.
     df2 : int or float
         Denominator degrees of freedom.
-    alpha : float in (0, 1)
+    alpha : float in (0, 1), optional
         Significance level for the confidence interval, coverage is 1 - alpha.
 
     Returns
@@ -214,7 +214,7 @@ def _noncentrality_t(t_stat, df, alpha=0.05):
         t-statistic, for example from a hypothesis test.
     df : int or float
         Degrees of freedom.
-    alpha : float in (0, 1)
+    alpha : float in (0, 1), optional
         Significance level for the confidence interval, coverage is 1 - alpha.
 
     Returns

--- a/statsmodels/stats/gof.py
+++ b/statsmodels/stats/gof.py
@@ -41,21 +41,20 @@ def powerdiscrepancy(observed, expected, lambd=0.0, axis=0, ddof=0):
 
     Parameters
     ----------
-    observed : Iterable
+    observed : array_like
         Observed values
-    expected : Iterable
+    expected : array_like
         Expected values
-    lambd : {float, str}
+    lambd : float or {'loglikeratio', 'freeman_tukey', 'pearson', 'modified_loglikeratio', 'cressie_read'}, optional
         * float : exponent `a` for power discrepancy
         * 'loglikeratio': a = 0
         * 'freeman_tukey': a = -0.5
         * 'pearson': a = 1   (standard chisquare test statistic)
         * 'modified_loglikeratio': a = -1
         * 'cressie_read': a = 2/3
-        * 'neyman' : a = -2 (Neyman-modified chisquare, reference from a book?)
-    axis : int
+    axis : int, optional
         axis for observations of one series
-    ddof : int
+    ddof : int, optional
         degrees of freedom correction,
 
     Returns
@@ -279,14 +278,14 @@ def gof_binning_discrete(rvs, distfn, arg, nsupp=20):
 
     Parameters
     ----------
-    rvs : ndarray
+    rvs : array_like
         sample data
     distfn : distribution instance
         Discrete distribution function to be tested; needs ``a``, ``b`` and
         ``cdf`` attributes/methods.
     arg : sequence
         parameters of distribution
-    nsupp : int
+    nsupp : int, optional
         number of bins. The algorithm tries to find bins with equal weights.
         depending on the distribution, the actual number of bins can be smaller.
 
@@ -415,11 +414,11 @@ def chisquare(f_obs, f_exp=None, value=0, ddof=0, return_basic=True):
     f_exp : array_like, optional
         Expected frequencies. If None, then the observed frequencies are
         assumed to follow a uniform distribution over the bins.
-    value : float
+    value : float, optional
         Value of the effect size under the null hypothesis.
-    ddof : int
+    ddof : int, optional
         Degrees of freedom correction.
-    return_basic : bool
+    return_basic : bool, optional
         If True, return only the chisquare statistic and the p-value as a
         plain tuple. If False, return a :class:`ChisquareResult` NamedTuple
         that additionally reports the degrees of freedom and the name of
@@ -435,7 +434,7 @@ def chisquare(f_obs, f_exp=None, value=0, ddof=0, return_basic=True):
 
     If ``return_basic`` is False, a :class:`ChisquareResult` NamedTuple is
     returned instead, with fields ``chisq``, ``pvalue``, ``df``, and
-    ``distr``.
+    ``distribution``.
 
     Notes
     -----
@@ -497,11 +496,11 @@ def chisquare_power(effect_size, nobs, n_bins, alpha=0.05, ddof=0):
         statistic. This follows Cohen's definition (sqrt).
     nobs : int or float
         number of observations
-    n_bins : int (or float)
+    n_bins : int or float
         number of bins, or points in the discrete distribution
-    alpha : float in (0,1)
+    alpha : float, optional
         significance level of the test, default alpha=0.05
-    ddof : int
+    ddof : int, optional
         degrees of freedom correction, default 0
 
     Returns
@@ -547,7 +546,7 @@ def chisquare_effectsize(probs0, probs1, correction=None, cohen=True, axis=0):
         and broadcast in the other dimensions
         Both probs0 and probs1 are normalized to add to one (in the ``axis``
         dimension).
-    correction : None or tuple
+    correction : None or tuple, optional
         If None, then the effect size is the chisquare statistic divide by
         the number of observations.
         If the correction is a tuple (nobs, df), then the effectsize is
@@ -555,11 +554,11 @@ def chisquare_effectsize(probs0, probs1, correction=None, cohen=True, axis=0):
         correction can make the effectsize negative. In that case, the
         effectsize is set to zero.
         Pederson and Johnson (1990) as referenced in McLaren et all. (1994)
-    cohen : bool
+    cohen : bool, optional
         If True, then the square root is returned as in the definition of the
         effect size by Cohen (1977), If False, then the original effect size
         is returned.
-    axis : int
+    axis : int, optional
         If the probability arrays broadcast to more than 1 dimension, then
         this is the axis over which the sums are taken.
 

--- a/statsmodels/stats/inter_rater.py
+++ b/statsmodels/stats/inter_rater.py
@@ -62,9 +62,9 @@ def _int_ifclose(x, dec=1, width=4):
     ----------
     x : int or float
         Value to format.
-    dec : int
+    dec : int, optional
         Number of decimals to print if x is not an integer.
-    width : int
+    width : int, optional
         Width of string.
 
     Returns
@@ -94,7 +94,7 @@ def aggregate_raters(data, n_cat=None):
     data : array_like, 2-Dim
         Data containing category assignment with subjects in rows and raters
         in columns.
-    n_cat : None or int
+    n_cat : None or int, optional
         If None, then the data is converted to integer categories,
         0,1,2,...,n_cat-1. Because of the relabeling only category levels
         with non-zero counts are included.
@@ -141,7 +141,7 @@ def to_table(data, bins=None):
     data : array_like, 2-Dim
         Data containing category assignment with subjects in rows and raters
         in columns.
-    bins : None, int or tuple of array_like
+    bins : None, int or tuple of array_like, optional
         If None, then the data is converted to integer categories,
         0,1,2,...,n_cat-1. Because of the relabeling only category levels
         with non-zero counts are included.
@@ -204,7 +204,7 @@ def fleiss_kappa(table, method="fleiss"):
         Assumes subjects in rows, and categories in columns. Convert raw
         data into this format by using
         :func:`statsmodels.stats.inter_rater.aggregate_raters`.
-    method : str
+    method : str, optional
         Method 'fleiss' returns Fleiss' kappa which uses the sample margin
         to define the chance outcome.
         Method 'randolph' or 'uniform' (only first 4 letters are needed)
@@ -281,7 +281,7 @@ def cohens_kappa(table, weights=None, return_results=True, wt=None):
     table : array_like, 2-Dim
         Square array with results of two raters, one rater in rows, second
         rater in columns.
-    weights : array_like
+    weights : array_like, optional
         The interpretation of weights depends on the wt argument.
         If both are None, then the simple kappa is computed.
         See wt for the case when wt is not None.
@@ -289,10 +289,10 @@ def cohens_kappa(table, weights=None, return_results=True, wt=None):
         matrix. For computing the variance of kappa, the maximum of the
         weights is assumed to be smaller or equal to one.
         TODO: fix conflicting definitions in the 2-Dim case for.
-    return_results : bool
+    return_results : bool, optional
         If True (default), then an instance of KappaResults is returned.
         If False, then only kappa is computed and returned.
-    wt : {None, str}
+    wt : {None, 'ca', 'linear', 'fc', 'quadratic', 'toeplitz'}, optional
         If wt and weights are None, then the simple kappa is computed.
         If wt is given, but weights is None, then the weights are set to
         be [0, 1, 2, ..., k].

--- a/statsmodels/stats/knockoff_regeffects.py
+++ b/statsmodels/stats/knockoff_regeffects.py
@@ -60,10 +60,10 @@ class ForwardEffects(RegressionEffects):
     pursuit : bool
         If True, 'basis pursuit' is used, which amounts to performing
         a full regression at each selection step to adjust the working
-        residual vector.  If False (the default), the residual is
-        adjusted by regressing out each selected variable marginally.
-        Setting pursuit=True will be considerably slower, but may give
-        better results when exog is not orthogonal.
+        residual vector.  If False, the residual is adjusted by
+        regressing out each selected variable marginally. Setting
+        pursuit=True will be considerably slower, but may give better
+        results when exog is not orthogonal.
 
     Notes
     -----
@@ -139,11 +139,11 @@ class RegModelEffects(RegressionEffects):
     model_cls : class
         Any model with appropriate fit or fit_regularized
         functions.
-    regularized : bool
+    regularized : bool, optional
         If True, use fit_regularized to fit the model.
-    model_kws : dict
+    model_kws : dict, optional
         Keywords passed to model initializer.
-    fit_kws : dict
+    fit_kws : dict, optional
         Dictionary of keyword arguments for fit or fit_regularized.
     """
 

--- a/statsmodels/stats/libqsturng/qsturng_.py
+++ b/statsmodels/stats/libqsturng/qsturng_.py
@@ -2346,15 +2346,15 @@ def qsturng(p, r, v):
 
     Parameters
     ----------
-    p : (scalar, array_like)
+    p : scalar or array_like
         The cumulative probability value
         p >= .1 and p <=.999
         (values under .5 are not recommended)
-    r : (scalar, array_like)
+    r : scalar or array_like
         The number of samples
         r >= 2 and r <= 200
         (values over 200 are permitted but not recommended)
-    v : (scalar, array_like)
+    v : scalar or array_like
         The sample degrees of freedom
         if p >= .9:
             v >=1 and v <= inf
@@ -2363,7 +2363,7 @@ def qsturng(p, r, v):
 
     Returns
     -------
-    q : (scalar, array_like)
+    q : float or ndarray
         approximation of the Studentized Range
     """
 
@@ -2437,14 +2437,14 @@ def psturng(q, r, v):
 
     Parameters
     ----------
-    q : (scalar, array_like)
+    q : scalar or array_like
         quantile value of Studentized Range
         q >= 0.
-    r : (scalar, array_like)
+    r : scalar or array_like
         The number of samples
         r >= 2 and r <= 200
         (values over 200 are permitted but not recommended)
-    v : (scalar, array_like)
+    v : scalar or array_like
         The sample degrees of freedom
         if the corresponding probability is >= .9:
             v >=1 and v <= inf
@@ -2453,7 +2453,7 @@ def psturng(q, r, v):
 
     Returns
     -------
-    p : (scalar, array_like)
+    p : float or ndarray
         1. - area from zero to q under the Studentized Range
         distribution. When v == 1, p is bound between .001
         and .1, when v > 1, p is bound between .001 and .9.

--- a/statsmodels/stats/mediation.py
+++ b/statsmodels/stats/mediation.py
@@ -44,22 +44,22 @@ class Mediation:
         and the second integer is the position of the exposure variable
         in the mediator model.  If a string is given, it must be the name
         of the exposure variable in both regression models.
-    mediator : {str, int}
+    mediator : {None, str, int}, optional
         The name or column position of the mediator variable in the
         outcome regression model.  If None, infer the name from the
         mediator model formula (if present).
-    moderators : dict
+    moderators : dict, optional
         Map from variable names or index positions to values of
         moderator variables that are held fixed when calculating
         mediation effects.  If the keys are index position they must
         be tuples `(i, j)` where `i` is the index in the outcome model
         and `j` is the index in the mediator model.  Otherwise the
         keys must be variable names.
-    outcome_fit_kwargs : dict-like
+    outcome_fit_kwargs : dict-like, optional
         Keyword arguments to use when fitting the outcome model.
-    mediator_fit_kwargs : dict-like
+    mediator_fit_kwargs : dict-like, optional
         Keyword arguments to use when fitting the mediator model.
-    outcome_predict_kwargs : dict-like
+    outcome_predict_kwargs : dict-like, optional
         Keyword arguments to use when calling predict on the outcome
         model.
 
@@ -326,11 +326,11 @@ class Mediation:
 
         Parameters
         ----------
-        method : str
+        method : str, optional
             Either 'parametric' or 'bootstrap'.
-        n_rep : int
+        n_rep : int, optional
             The number of simulation replications.
-        rng : {None, int, array_like[int], numpy.random.Generator, numpy.random.RandomState}, optional
+        rng : {None, int, array_like of int, numpy.random.Generator, numpy.random.RandomState}, optional
             If `rng` is None, a new ``Generator`` is created using fresh
             entropy from the operating system. If `rng` is an int or array
             of ints, a new ``Generator`` is created, seeded with `rng`. If
@@ -474,7 +474,7 @@ class MediationResults:
 
         Parameters
         ----------
-        alpha : float
+        alpha : float, optional
             Significance level for the confidence intervals in the
             summary table. The default produces (1 - alpha) confidence
             intervals.

--- a/statsmodels/stats/meta_analysis.py
+++ b/statsmodels/stats/meta_analysis.py
@@ -87,20 +87,20 @@ class CombineResults:
 
         Parameters
         ----------
-        alpha : float in (0, 1)
+        alpha : float in (0, 1), optional
             Significance level for confidence interval. Nominal coverage is
             ``1 - alpha``.
-        use_t : None or bool
+        use_t : None or bool, optional
             If use_t is None, then the attribute `use_t` determines whether
             normal or t-distribution is used for confidence intervals.
             Specifying use_t overrides the attribute.
             If use_t is false, then confidence intervals are based on the
             normal distribution. If it is true, then the t-distribution is
             used.
-        nobs : None or float
+        nobs : None or float, optional
             Number of observations used for degrees of freedom computation.
             Only used if use_t is true.
-        ci_func : None or callable
+        ci_func : None or callable, optional
             User provided function to compute confidence intervals.
             This is not used yet and will allow using non-standard confidence
             intervals.
@@ -165,10 +165,10 @@ class CombineResults:
 
         Parameters
         ----------
-        alpha : float in (0, 1)
+        alpha : float in (0, 1), optional
             Significance level for confidence interval. Nominal coverage is
             ``1 - alpha``.
-        use_t : None or bool
+        use_t : None or bool, optional
             If use_t is None, then the attribute `use_t` determines whether
             normal or t-distribution is used for confidence intervals.
             Specifying use_t overrides the attribute.
@@ -178,20 +178,21 @@ class CombineResults:
 
         Returns
         -------
-        ci_eff_fe : tuple of floats
-            Confidence interval for mean effects size based on fixed effects
-            model with scale=1.
-        ci_eff_re : tuple of floats
-            Confidence interval for mean effects size based on random effects
-            model with scale=1
-        ci_eff_fe_wls : tuple of floats
-            Confidence interval for mean effects size based on fixed effects
-            model with estimated scale corresponding to WLS, ie. HKSJ.
-        ci_eff_re_wls : tuple of floats
-            Confidence interval for mean effects size based on random effects
-            model with estimated scale corresponding to WLS, ie. HKSJ.
-            If random effects method is fully iterated, i.e., Paule-Mandel, then
-            the estimated scale is 1.
+        ci_eff_fe : ndarray
+            Confidence interval (lower, upper) for mean effects size based on
+            fixed effects model with scale=1.
+        ci_eff_re : ndarray
+            Confidence interval (lower, upper) for mean effects size based on
+            random effects model with scale=1
+        ci_eff_fe_wls : ndarray
+            Confidence interval (lower, upper) for mean effects size based on
+            fixed effects model with estimated scale corresponding to WLS,
+            ie. HKSJ.
+        ci_eff_re_wls : ndarray
+            Confidence interval (lower, upper) for mean effects size based on
+            random effects model with estimated scale corresponding to WLS,
+            ie. HKSJ. If random effects method is fully iterated, i.e.,
+            Paule-Mandel, then the estimated scale is 1.
         """
         if use_t is None:
             use_t = self.use_t
@@ -237,10 +238,10 @@ class CombineResults:
 
         Parameters
         ----------
-        alpha : float in (0, 1)
+        alpha : float in (0, 1), optional
             Significance level for confidence interval. Nominal coverage is
             ``1 - alpha``.
-        use_t : None or bool
+        use_t : None or bool, optional
             If use_t is None, then the attribute `use_t` determines whether
             normal or t-distribution is used for confidence intervals.
             Specifying use_t overrides the attribute.
@@ -294,10 +295,10 @@ class CombineResults:
 
         Parameters
         ----------
-        alpha : float in (0, 1)
+        alpha : float in (0, 1), optional
             Significance level for confidence interval. Nominal coverage is
             ``1 - alpha``.
-        use_t : None or bool
+        use_t : None or bool, optional
             If use_t is None, then the attribute `use_t` determines whether
             normal or t-distribution is used for confidence intervals.
             Specifying use_t overrides the attribute.
@@ -331,17 +332,17 @@ class CombineResults:
 
         Parameters
         ----------
-        alpha : float in (0, 1)
+        alpha : float in (0, 1), optional
             Significance level for confidence interval. Nominal coverage is
             ``1 - alpha``.
-        use_t : None or bool
+        use_t : None or bool, optional
             If use_t is None, then the attribute `use_t` determines whether
             normal or t-distribution is used for confidence intervals.
             Specifying use_t overrides the attribute.
             If use_t is false, then confidence intervals are based on the
             normal distribution. If it is true, then the t-distribution is
             used.
-        use_exp : bool
+        use_exp : bool, optional
             If `use_exp` is True, then the effect size and confidence limits
             will be exponentiated. This transform log-odds-ration into
             odds-ratio, and similarly for risk-ratio.
@@ -354,7 +355,8 @@ class CombineResults:
 
         Returns
         -------
-        fig : Matplotlib figure instance
+        fig : Figure
+            The forest plot.
 
         See Also
         --------
@@ -395,13 +397,13 @@ def effectsize_smd(mean1, sd1, nobs1, mean2, sd2, nobs2):
 
     Parameters
     ----------
-    mean1 : array
+    mean1 : array_like
         Mean of first sample, treatment groups.
-    sd1 : array
+    sd1 : array_like
         Standard deviation of residuals in treatment groups, within.
-    nobs1 : array
+    nobs1 : array_like
         Number of observations in treatment groups.
-    mean2, sd2, nobs2 : arrays
+    mean2, sd2, nobs2 : array_like
         Mean, standard deviation and number of observations of control
         groups.
 
@@ -452,10 +454,10 @@ def effectsize_2proportions(
     ----------
     count1, nobs1, count2, nobs2 : array_like
         Data for two samples.
-    statistic : {"diff", "odds-ratio", "risk-ratio", "arcsine"}
+    statistic : {"diff", "odds-ratio", "risk-ratio", "arcsine"}, optional
         Statistic for the comparison of two proportions.
         Effect sizes for "odds-ratio" and "risk-ratio" are in logarithm.
-    zero_correction : {None, float, "tac", "clip"}
+    zero_correction : {None, float, "tac", "clip"}, optional
         Some statistics are not finite when zero counts are in the data.
         The options to remove zeros are:
 
@@ -466,7 +468,7 @@ def effectsize_2proportions(
         * "clip" : clip proportions without adding a value to all cells
           The clip bounds can be set with zero_kwds["clip_bounds"]
 
-    zero_kwds : dict
+    zero_kwds : dict, optional
         Additional options to handle zero counts.
         "clip_bounds" tuple, default (1e-6, 1 - 1e-6) if zero_correction="clip"
         other options not yet implemented.
@@ -573,11 +575,11 @@ def combine_effects(
 
     Parameters
     ----------
-    effect : array
+    effect : array_like
         Mean of effect size measure for all samples.
-    variance : array
+    variance : array_like
         Variance of mean or effect size measure for all samples.
-    method_re : {"iterated", "chi2"}
+    method_re : {"iterated", "chi2"}, optional
         Method that is used to compute the between random effects variance.
         "iterated" or "pm" uses Paule and Mandel method to iteratively
         estimate the random effects variance. Options for the iteration can
@@ -586,12 +588,12 @@ def combine_effects(
     row_names : list of str, optional
         Names for samples or studies, will be included in results summary and
         table.
-    use_t : bool
+    use_t : bool, optional
         If use_t is False, then confidence intervals and hypothesis tests are
         based on the normal distribution. If use_t is True, then the results
         instance stores this choice as its `use_t` attribute and it is used
         when computing confidence intervals with the t-distribution.
-    alpha : float in (0, 1)
+    alpha : float in (0, 1), optional
         Significance level, default is 0.05, for the confidence intervals.
     **kwds
         Additional keyword arguments passed to the function that estimates
@@ -705,11 +707,12 @@ def _fit_tau_iterative(eff, var_eff, tau2_start=0, atol=1e-5, maxiter=50):
         Effect sizes.
     var_eff : ndarray
         Variance of effect sizes.
-    tau2_start : float
+    tau2_start : float, optional
         Starting value for iteration.
-    atol : float, default: 1e-5
+    atol : float, optional
         Convergence tolerance for absolute value of estimating equation.
-    maxiter : int
+        Default is 1e-5.
+    maxiter : int, optional
         Maximum number of iterations.
 
     Returns
@@ -790,11 +793,12 @@ def _fit_tau_iter_mm(eff, var_eff, tau2_start=0, atol=1e-5, maxiter=50):
         Effect sizes.
     var_eff : ndarray
         Variance of effect sizes.
-    tau2_start : float
+    tau2_start : float, optional
         Starting value for iteration.
-    atol : float, default: 1e-5
+    atol : float, optional
         Convergence tolerance for change in tau2 estimate between iterations.
-    maxiter : int
+        Default is 1e-5.
+    maxiter : int, optional
         Maximum number of iterations.
 
     Returns

--- a/statsmodels/stats/moment_helpers.py
+++ b/statsmodels/stats/moment_helpers.py
@@ -83,7 +83,7 @@ def mnc2mc(mnc, wmean=True):
     ----------
     mnc : array_like
         Non-central moments, with the first element equal to the mean.
-    wmean : bool
+    wmean : bool, optional
         If True (default), the first returned moment is the mean instead
         of zero.
 
@@ -371,7 +371,7 @@ def cov2corr(cov, return_std=False, *, result_object: bool | None = None):
     ----------
     cov : array_like, 2d
         Covariance matrix, see Notes.
-    return_std : bool
+    return_std : bool, optional
         If this is true then the standard deviation is also returned.
         By default only the correlation matrix is returned.
     result_object : bool, optional

--- a/statsmodels/stats/multicomp.py
+++ b/statsmodels/stats/multicomp.py
@@ -15,13 +15,13 @@ def pairwise_tukeyhsd(endog, groups, alpha=0.05, use_var="equal"):
 
     Parameters
     ----------
-    endog : ndarray, float, 1d
+    endog : array_like, 1d
         response variable
-    groups : ndarray, 1d
+    groups : array_like, 1d
         array with groups, can be string or integers
-    alpha : float
+    alpha : float, optional
         significance level for the test
-    use_var : {"unequal", "equal"}
+    use_var : {"unequal", "equal"}, optional
         If ``use_var`` is "equal", then the Tukey-hsd pvalues are returned.
         Tukey-hsd assumes that (within) variances are the same across groups.
         If ``use_var`` is "unequal", then the Games-Howell pvalues are

--- a/statsmodels/stats/multitest.py
+++ b/statsmodels/stats/multitest.py
@@ -101,9 +101,9 @@ def multipletests(
     ----------
     pvals : array_like, 1-d
         uncorrected p-values.   Must be 1-dimensional.
-    alpha : float
+    alpha : float, optional
         FWER, family-wise error rate, e.g., 0.1
-    method : str
+    method : str, optional
         Method used for testing and adjustment of pvalues. Can be either the
         full name or initial letters. Available methods are:
 
@@ -117,25 +117,26 @@ def multipletests(
         - `fdr_by` : Benjamini/Yekutieli (negative)
         - `fdr_tsbh` : two stage fdr correction (non-negative)
         - `fdr_tsbky` : two stage fdr correction (non-negative)
+        - `fdr_gbs` : adaptive step-down (Gavrilov, Benjamini, Sarkar)
         - `lfdr` : support line
 
-    maxiter : int or bool
+    maxiter : int or bool, optional
         Maximum number of iterations for two-stage fdr, `fdr_tsbh` and
         `fdr_tsbky`. It is ignored by all other methods.
         maxiter=1 (default) corresponds to the two stage method.
         maxiter=-1 corresponds to full iterations which is maxiter=len(pvals).
         maxiter=0 uses only a single stage fdr correction using a 'bh' or 'bky'
         prior fraction of assumed true hypotheses.
-    is_sorted : bool
+    is_sorted : bool, optional
         If False (default), the p_values will be sorted, but the corrected
         pvalues are in the original order. If True, then it assumed that the
         pvalues are already sorted in ascending order.
-    returnsorted : bool
+    returnsorted : bool, optional
          not tested, return sorted p-values instead of original sequence
 
     Returns
     -------
-    reject : ndarray, boolean
+    reject : ndarray, bool
         true for hypothesis that can be rejected for given alpha
     pvals_corrected : ndarray
         p-values corrected for multiple tests
@@ -345,7 +346,7 @@ def fdrcorrection(pvals, alpha=0.05, method="indep", is_sorted=False):
     -------
     rejected : ndarray, bool
         True if a hypothesis is rejected, False if not
-    pvalue-corrected : ndarray
+    pvals_corrected : ndarray
         pvalues adjusted for multiple hypothesis testing to limit FDR
 
     Notes
@@ -610,16 +611,16 @@ def fdrcorrection_twostage(
     ----------
     pvals : array_like
         set of p-values of the individual tests.
-    alpha : float
+    alpha : float, optional
         error rate
-    method : {'bky', 'bh'}
+    method : {'bky', 'bh'}, optional
         see Notes for details
 
         * 'bky' - implements the procedure in Definition 6 of Benjamini, Krieger
            and Yekutieli 2006
         * 'bh' - the two stage method of Benjamini and Hochberg
 
-    maxiter : int or bool
+    maxiter : int or bool, optional
         Maximum number of iterations.
         maxiter=1 (default) corresponds to the two stage method.
         maxiter=-1 corresponds to full iterations which is maxiter=len(pvals).
@@ -629,11 +630,11 @@ def fdrcorrection_twostage(
         deprecated ``iter`` keyword.
         maxiter=False is two-stage fdr (maxiter=1)
         maxiter=True is full iteration (maxiter=-1 or maxiter=len(pvals))
-    iter : bool
+    iter : None, optional
         Removed keyword that is kept only for backwards compatibility.
         Passing anything other than the default ``None`` raises a
         ``TypeError``; use ``maxiter`` instead.
-    is_sorted : bool
+    is_sorted : bool, optional
         If False (default), the p_values will be sorted, but the corrected
         pvalues are in the original order. If True, then it assumed that the
         pvalues are already sorted in ascending order.
@@ -642,7 +643,7 @@ def fdrcorrection_twostage(
     -------
     rejected : ndarray, bool
         True if a hypothesis is rejected, False if not
-    pvalue-corrected : ndarray
+    pvals_corrected : ndarray
         pvalues adjusted for multiple hypotheses testing to limit FDR
     m0 : int
         ntest - rej, estimated number of true (not rejected) hypotheses
@@ -748,25 +749,25 @@ def local_fdr(zscores, null_proportion=1.0, null_pdf=None, deg=7, nbins=30, alph
 
     Parameters
     ----------
-    zscores : array_like
+    zscores : ndarray
         A vector of Z-scores
-    null_proportion : float
+    null_proportion : float, optional
         The assumed proportion of true null hypotheses
-    null_pdf : function mapping reals to positive reals
+    null_pdf : callable, optional
         The density of null Z-scores; if None, use standard normal
-    deg : int
+    deg : int, optional
         The maximum exponent in the polynomial expansion of the
         density of non-null Z-scores
-    nbins : int
+    nbins : int, optional
         The number of bins for estimating the marginal density
         of Z-scores.
-    alpha : float
+    alpha : float, optional
         Use Poisson ridge regression with parameter alpha to estimate
         the density of non-null Z-scores.
 
     Returns
     -------
-    fdr : array_like
+    fdr : ndarray
         A vector of FDR values
 
     References
@@ -854,20 +855,20 @@ class NullDistribution:
 
     Parameters
     ----------
-    zscores : array_like
+    zscores : ndarray
         The observed Z-scores.
-    null_lb : float
+    null_lb : float, optional
         Z-scores between `null_lb` and `null_ub` are all considered to be
         true null hypotheses.
-    null_ub : float
+    null_ub : float, optional
         See `null_lb`.
-    estimate_mean : bool
+    estimate_mean : bool, optional
         If True, estimate the mean of the distribution.  If False, the
         mean is fixed at zero.
-    estimate_scale : bool
+    estimate_scale : bool, optional
         If True, estimate the scale of the distribution.  If False, the
         scale parameter is fixed at 1.
-    estimate_null_proportion : bool
+    estimate_null_proportion : bool, optional
         If True, estimate the proportion of true null hypotheses (i.e.
         the proportion of z-scores with expected value zero).  If False,
         this parameter is fixed at 1.
@@ -989,13 +990,13 @@ class NullDistribution:
 
         Parameters
         ----------
-        zscores : scalar or array_like
+        zscores : scalar or ndarray
             The point or points at which the density is to be
             evaluated.
 
         Returns
         -------
-        scalar or array_like
+        scalar or ndarray
             The empirical null Z-score density evaluated at the given
             points.
         """

--- a/statsmodels/stats/multivariate.py
+++ b/statsmodels/stats/multivariate.py
@@ -62,9 +62,9 @@ def test_mvmean(data, mean_null=0, return_results=True):
     ----------
     data : array_like
         data with observations in rows and variables in columns
-    mean_null : array_like
+    mean_null : array_like, optional
         mean of the multivariate data under the null hypothesis
-    return_results : bool
+    return_results : bool, optional
         If true, then a results instance is returned. If False, then only
         the test statistic and pvalue are returned.
 
@@ -149,14 +149,14 @@ def confint_mvmean(data, lin_transf=None, alpha=0.05, simult=False):
     ----------
     data : array_like
         data with observations in rows and variables in columns
-    lin_transf : array_like or None
+    lin_transf : array_like or None, optional
         The linear transformation or contrast matrix for transforming the
         vector of means. If this is None, then the identity matrix is used
         which specifies the means themselves.
-    alpha : float in (0, 1)
+    alpha : float in (0, 1), optional
         confidence level for the confidence interval, commonly used is
         alpha=0.05.
-    simult : bool
+    simult : bool, optional
         If ``simult`` is False (default), then the pointwise confidence
         interval is returned.
         Otherwise, a simultaneous confidence interval is returned.
@@ -214,20 +214,20 @@ def confint_mvmean_fromstats(
 
     Parameters
     ----------
-    mean : ndarray
+    mean : array_like
         Mean of the multivariate data.
-    cov : ndarray
+    cov : array_like
         Covariance matrix of the multivariate data.
     nobs : int
         Number of observations used in the estimation of mean and cov.
-    lin_transf : array_like or None
+    lin_transf : array_like or None, optional
         The linear transformation or contrast matrix for transforming the
         vector of means. If this is None, then the identity matrix is used
         which specifies the means themselves.
-    alpha : float in (0, 1)
+    alpha : float in (0, 1), optional
         confidence level for the confidence interval, commonly used is
         alpha=0.05.
-    simult : bool
+    simult : bool, optional
         If simult is False (default), then pointwise confidence interval is
         returned.
         Otherwise, a simultaneous confidence interval is returned.
@@ -325,7 +325,7 @@ class CovTestResult(LimitedIterationMixin[float]):
         Name of the reference distribution used for `pvalue`, ``"chi2"``.
     null : str
         Short description of the null hypothesis being tested.
-    cov_null : ndarray or None
+    cov_null : ndarray or None, optional
         Covariance matrix under the null hypothesis. Only set by
         :func:`test_cov`, otherwise None.
 
@@ -359,7 +359,7 @@ def test_cov(cov, nobs, cov_null):
         i.e., `ddof=1`.
     nobs : int
         number of observations used in the estimation of the covariance
-    cov_null : ndarray
+    cov_null : array_like
         covariance under the null hypothesis
 
     Returns
@@ -521,7 +521,7 @@ def _get_blocks(mat, block_len):
     ----------
     mat : ndarray
         Square matrix.
-    block_len : list
+    block_len : list of int
         List of length of each square diagonal block.
 
     Returns
@@ -565,7 +565,7 @@ def test_cov_blockdiagonal(cov, nobs, block_len):
         i.e., `ddof=1`.
     nobs : int
         number of observations used in the estimation of the covariance
-    block_len : list
+    block_len : list of int
         list of length of each square block
 
     Returns
@@ -682,7 +682,7 @@ def test_cov_oneway(cov_list, nobs_list):
     cov_list : list of array_like
         Covariance matrices of the sample, estimated with denominator
         ``(N - 1)``, i.e., `ddof=1`.
-    nobs_list : list
+    nobs_list : list of int
         List of the number of observations used in the estimation of the
         covariance for each sample.
 

--- a/statsmodels/stats/multivariate_tools.py
+++ b/statsmodels/stats/multivariate_tools.py
@@ -29,7 +29,8 @@ def partial_project(endog, exog):
 
     Returns
     -------
-    res : instance of Bunch with
+    res : Bunch
+        Instance of ``Bunch`` with
 
         - params : OLS parameter estimates from projection of endog on exog
         - fittedvalues : predicted values of endog given exog
@@ -58,7 +59,7 @@ def cancorr(x1, x2, demean=True, standardize=False):
 
     Parameters
     ----------
-    x1, x2 : ndarrays, 2_D
+    x1, x2 : ndarray, 2-D
         Two 2-dimensional data arrays, observations in rows, variables in
         columns.
     demean : bool, optional
@@ -70,7 +71,7 @@ def cancorr(x1, x2, demean=True, standardize=False):
 
     Returns
     -------
-    ccorr : ndarray, 1d
+    ccorr : ndarray, 1-D
         Canonical correlation coefficients, sorted from largest to smallest.
         Note, that these are the square root of the eigenvalues.
 
@@ -122,7 +123,7 @@ def cc_ranktest(x1, x2, demean=True, fullrank=False):
 
     Parameters
     ----------
-    x1, x2 : ndarrays, 2_D
+    x1, x2 : ndarray, 2-D
         Two 2-dimensional data arrays, observations in rows, variables in
         columns.
     demean : bool, optional
@@ -134,17 +135,22 @@ def cc_ranktest(x1, x2, demean=True, fullrank=False):
 
     Returns
     -------
-    value : float
-        Value of the test statistic.
-    p-value : float
-        P-value for the null hypothesis that the smallest canonical
-        correlation coefficient is zero, based on the chi-square
-        distribution.
-    df : int
+    value : float or ndarray
+        Value of the LM (Anderson canonical correlations) test statistic.
+    p-value : float or ndarray
+        P-value for the LM test statistic, for the null hypothesis that
+        the smallest canonical correlation coefficient is zero, based on
+        the chi-square distribution.
+    df : int or ndarray
         Degrees of freedom for the chi-square distribution in the
         hypothesis test.
-    ccorr : ndarray, 1d
+    ccorr : ndarray, 1-D
         All canonical correlation coefficients sorted from largest to smallest.
+    wald_value : float or ndarray
+        Value of the Wald (Cragg-Donald) test statistic.
+    wald_pvalue : float or ndarray
+        P-value for the Wald test statistic, based on the chi-square
+        distribution.
 
     Notes
     -----
@@ -188,7 +194,7 @@ def cc_stats(x1, x2, demean=True):
 
     Parameters
     ----------
-    x1, x2 : ndarrays, 2_D
+    x1, x2 : ndarray, 2-D
         Two 2-dimensional data arrays, observations in rows, variables in
         columns.
     demean : bool, optional

--- a/statsmodels/stats/nonparametric.py
+++ b/statsmodels/stats/nonparametric.py
@@ -146,17 +146,21 @@ class RankCompareResult(LimitedIterationMixin[float]):
 
     Parameters
     ----------
-    statistic : float
-        The Brunner-Munzel W statistic.
-    pvalue : float
+    statistic : float or None
+        The Brunner-Munzel W statistic. None if not computed from ranks,
+        e.g., for results returned by `rank_compare_2ordinal`.
+    pvalue : float or None
         p-value based on the t distribution if `use_t` is True, otherwise
-        based on the normal distribution.
-    s1 : float
+        based on the normal distribution. None if not computed, e.g., for
+        results returned by `rank_compare_2ordinal`.
+    s1 : float or None
         Variance-like quantity for sample 1 used in the Brunner-Munzel
-        statistic.
-    s2 : float
+        statistic. None if not computed, e.g., for results returned by
+        `rank_compare_2ordinal`.
+    s2 : float or None
         Variance-like quantity for sample 2 used in the Brunner-Munzel
-        statistic.
+        statistic. None if not computed, e.g., for results returned by
+        `rank_compare_2ordinal`.
     var1 : float
         Estimated variance contribution of sample 1 to `prob1`.
     var2 : float
@@ -171,10 +175,12 @@ class RankCompareResult(LimitedIterationMixin[float]):
         Number of observations in sample 2.
     nobs : int
         Total number of observations, ``nobs_1 + nobs_2``.
-    mean1 : float
-        Mean rank of sample 1 in the pooled sample.
-    mean2 : float
-        Mean rank of sample 2 in the pooled sample.
+    mean1 : float or None
+        Mean rank of sample 1 in the pooled sample. None if not computed
+        from ranks, e.g., for results returned by `rank_compare_2ordinal`.
+    mean2 : float or None
+        Mean rank of sample 2 in the pooled sample. None if not computed
+        from ranks, e.g., for results returned by `rank_compare_2ordinal`.
     prob1 : float
         Probability that a random draw from sample 1 is stochastically
         larger than a random draw from sample 2,
@@ -231,13 +237,13 @@ class RankCompareResult(LimitedIterationMixin[float]):
 
         Parameters
         ----------
-        value : float
+        value : float, optional
             Value, default 0, shifts the confidence interval,
             e.g., ``value=0.5`` centers the confidence interval at zero.
-        alpha : float
+        alpha : float, optional
             Significance level for the confidence interval, coverage is
             ``1-alpha``
-        alternative : str
+        alternative : {"two-sided", "larger", "smaller"}, optional
             The alternative hypothesis, H1, has to be one of the following
 
                * 'two-sided' : H1: ``prob - value`` not equal to 0.
@@ -278,9 +284,9 @@ class RankCompareResult(LimitedIterationMixin[float]):
 
         Parameters
         ----------
-        value : float
+        value : float, optional
             Value of the probability under the Null hypothesis.
-        alternative : str
+        alternative : {"two-sided", "larger", "smaller"}, optional
             The alternative hypothesis, H1, has to be one of the following
 
                * 'two-sided' : H1: ``prob - value`` not equal to 0.
@@ -394,12 +400,12 @@ class RankCompareResult(LimitedIterationMixin[float]):
 
         Parameters
         ----------
-        const, slope : float
+        const, slope : float, optional
             Constant and slope for linear (affine) transformation.
-        alpha : float
+        alpha : float, optional
             Significance level for the confidence interval, coverage is
             ``1-alpha``
-        alternative : str
+        alternative : {"two-sided", "larger", "smaller"}, optional
             The alternative hypothesis, H1, has to be one of the following
 
                * 'two-sided' : H1: ``prob - value`` not equal to 0.
@@ -440,7 +446,7 @@ class RankCompareResult(LimitedIterationMixin[float]):
 
         Parameters
         ----------
-        prob : float in (0, 1)
+        prob : float in (0, 1), optional
             Probability to be converted to Cohen's d effect size.
             If prob is None, then the ``prob1`` attribute is used.
 
@@ -460,9 +466,9 @@ class RankCompareResult(LimitedIterationMixin[float]):
 
         Parameters
         ----------
-        alpha : float
+        alpha : float, optional
             Significance level for confidence intervals. Coverage is 1 - alpha
-        xname : None or list of str
+        xname : list of str, optional
             If None, then each row has a name column with generic names.
             If xname is a list of strings, then it will be included as part
             of those names.
@@ -526,7 +532,7 @@ def rank_compare_2indep(x1, x2, use_t=True):
     ----------
     x1, x2 : array_like
         Array of samples, should be one-dimensional.
-    use_t : boolean
+    use_t : bool, optional
         If use_t is true, the t distribution with Welch-Satterthwaite type
         degrees of freedom is used for p-value and confidence interval.
         If use_t is false, then the normal distribution is used.
@@ -678,10 +684,10 @@ def rank_compare_2ordinal(count1, count2, ddof=1, use_t=True):
     count2 : array_like
         Counts of the second sample, number of categories and ordering needs
         to be the same as for sample 1.
-    ddof : scalar
+    ddof : int, optional
         Degrees of freedom correction for variance estimation. The default
         ddof=1 corresponds to `rank_compare_2indep`.
-    use_t : bool
+    use_t : bool, optional
         If use_t is true, the t distribution with Welch-Satterthwaite type
         degrees of freedom is used for p-value and confidence interval.
         If use_t is false, then the normal distribution is used.
@@ -805,7 +811,7 @@ def jonckheere_terpstra(samples, alternative="larger"):
         Sequence containing at least two one-dimensional samples of numeric,
         finite observations, in the order implied by the alternative
         hypothesis.
-    alternative : {"two-sided", "larger", "smaller"}
+    alternative : {"two-sided", "larger", "smaller"}, optional
         Defines the alternative hypothesis. The following options are
         available:
 
@@ -817,7 +823,7 @@ def jonckheere_terpstra(samples, alternative="larger"):
     -------
     res : JonckheereTerpstraResult
         A NamedTuple with the Jonckheere-Terpstra statistic, pvalue and related
-        quantities. The key fieleds are``statistic`` and ``pvalue``. See
+        quantities. The key fields are ``statistic`` and ``pvalue``. See
         :class:`JonckheereTerpstraResult` for the full list of fields.
 
     See Also

--- a/statsmodels/stats/oaxaca.py
+++ b/statsmodels/stats/oaxaca.py
@@ -66,7 +66,7 @@ class OaxacaBlinder:
     exog : array_like
         The exogenous variable(s) or the independent variable(s) that you are
         using to explain the endogenous variable.
-    bifurcate : {int, str}
+    bifurcate : int or str
         The column of the exogenous variable(s) on which to split. This would
         generally be the group that you wish to explain the two means for.
         Int of the column for a NumPy array or int/string for the name of
@@ -85,7 +85,7 @@ class OaxacaBlinder:
         See linear_model.RegressionResults.get_robustcov_results for a
         description of the required keywords for alternative covariance
         estimators.
-    rng : {None, int, array_like[int], numpy.random.Generator, numpy.random.RandomState}, optional
+    rng : {None, int, array_like of int, numpy.random.Generator, numpy.random.RandomState}, optional
         If `rng` is None, a new ``Generator`` is created using fresh
         entropy from the operating system. If `rng` is an int or array
         of ints, a new ``Generator`` is created, seeded with `rng`. If
@@ -562,10 +562,11 @@ class OaxacaResults:
 
     Attributes
     ----------
-    params
-        A list of all values for the fitted models.
-    std
-        A list of standard error calculations.
+    params : tuple of float
+        A tuple of all values for the fitted models.
+    std : tuple of float or None
+        A tuple of standard error calculations, or None if standard
+        errors were not requested.
     """
 
     def __init__(self, results, model_type, std_val=None):

--- a/statsmodels/stats/oneway.py
+++ b/statsmodels/stats/oneway.py
@@ -44,10 +44,10 @@ def effectsize_oneway(means, vars_, nobs, use_var="unequal", ddof_between=0):
         Otherwise, statistics will be weighted corresponding to nobs.
         Only relative sizes are relevant, any proportional change to nobs does
         not change the effect size.
-    use_var : {"unequal", "equal", "bf"}
+    use_var : {"unequal", "equal", "bf"}, optional
         If ``use_var`` is "unequal", then the variances can differ across
         samples and the effect size for Welch anova will be computed.
-    ddof_between : int
+    ddof_between : int, optional
         Degrees of freedom correction for the weighted between sum of squares.
         The denominator is ``nobs_total - ddof_between``
         This can be used to match differences across reference literature.
@@ -192,10 +192,10 @@ class EffectSizeFsquResult(NamedTuple):
 
     Parameters
     ----------
-    f2 : float
+    f2 : float or ndarray
         Squared Cohen's f effect size, the signal to noise ratio
         ``var_explained / var_residual``.
-    eta2 : float
+    eta2 : float or ndarray
         Squared eta effect size, the proportion of explained variance
         ``var_explained / var_total``.
     """
@@ -217,10 +217,10 @@ def convert_effectsize_fsqu(f2=None, eta2=None):
 
     Parameters
     ----------
-    f2 : None or float
+    f2 : None or array_like, optional
        Squared Cohen's F effect size. If f2 is not None, then eta2 will be
        computed.
-    eta2 : None or float
+    eta2 : None or array_like, optional
        Squared eta effect size. If f2 is None and eta2 is not None, then f2 is
        computed.
 
@@ -246,20 +246,20 @@ class FstatEffectSizeResult(NamedTuple):
 
     Parameters
     ----------
-    f2 : array_like
+    f2 : float or ndarray
         Squared Cohen's f effect size, ``f_stat * df1 / df2``.
-    eta2 : array_like
+    eta2 : float or ndarray
         Squared eta effect size, ``f2 / (f2 + 1)``.
-    omega2 : array_like
+    omega2 : float or ndarray
         Squared omega effect size, computed as
         ``(f2 - df1 / df2) / (f2 + 1 + 1 / df2)``.
-    eps2 : array_like
+    eps2 : float or ndarray
         Squared epsilon effect size, computed as
         ``(f2 - df1 / df2) / (f2 + 1)``.
-    eps2_alt : array_like
+    eps2_alt : float or ndarray
         Squared epsilon effect size, computed with the alternative
         expression ``(f_stat - 1) / (f_stat + df2 / df1)``.
-    omega2_alt : array_like
+    omega2_alt : float or ndarray
         Squared omega effect size, computed with the alternative
         expression ``(f_stat - 1) / (f_stat + (df2 + 1) / df1)``.
     """
@@ -427,9 +427,9 @@ def confint_noncentrality(f_stat, df, alpha=0.05, alternative="two-sided"):
         - df1 : numerator degrees of freedom, number of constraints
         - df2 : denominator degrees of freedom, df_resid
 
-    alpha : float, default 0.05
+    alpha : float, optional
         Significance level for the confidence interval.
-    alternative : {"two-sided"}
+    alternative : {"two-sided"}, optional
         Other alternatives have not been implemented.
 
     Returns
@@ -471,10 +471,10 @@ class ConfintEffectSizeResult(NamedTuple):
 
     Parameters
     ----------
-    f2 : float
+    f2 : ndarray
         Squared Cohen's f effect size at the confidence limits of the
         noncentrality parameter.
-    eta2 : float
+    eta2 : ndarray
         Squared eta effect size at the confidence limits of the
         noncentrality parameter.
     ci_omega2 : ndarray
@@ -517,9 +517,9 @@ def confint_effectsize_oneway(f_stat, df, alpha=0.05, nobs=None):
         - df1 : numerator degrees of freedom, number of constraints
         - df2 : denominator degrees of freedom, df_resid
 
-    alpha : float, default 0.05
+    alpha : float, optional
         Significance level for the confidence interval.
-    nobs : int, default None
+    nobs : int, optional
         Total number of observations. If None, then it is set to
         ``df1 + df2 + 1``.
 
@@ -642,28 +642,26 @@ def anova_generic(
 
     Parameters
     ----------
-    means : array_like
+    means : ndarray
         Mean of samples to be compared
     variances : float or array_like
         Residual (within) variance of each sample or pooled.
         If ``variances`` is scalar, then it is interpreted as pooled variance
         that is the same for all samples, ``use_var`` will be ignored.
         Otherwise, the variances are used depending on the ``use_var`` keyword.
-    nobs : int or array_like
-        Number of observations for the samples.
-        If nobs is scalar, then it is assumed that all samples have the same
-        number ``nobs`` of observation, i.e., a balanced sample case.
-        Otherwise, statistics will be weighted corresponding to nobs.
-        Only relative sizes are relevant, any proportional change to nobs does
-        not change the effect size.
-    use_var : {"unequal", "equal", "bf"}
+    nobs : ndarray
+        Number of observations for each sample. Statistics are weighted
+        corresponding to nobs. Only relative sizes are relevant, any
+        proportional change to nobs does not change the effect size.
+    use_var : {"unequal", "equal", "bf"}, optional
         If ``use_var`` is "unequal", then the variances can differ across
         samples and the effect size for Welch anova will be computed.
-    welch_correction : bool
+    welch_correction : bool, optional
         If this is false, then the Welch correction to the test statistic is
         not included. This allows the computation of an effect size measure
         that corresponds more closely to Cohen's f.
-    info : not used yet
+    info : optional
+        Not used yet.
 
     Returns
     -------
@@ -757,10 +755,10 @@ def anova_oneway(
         The data can be provided as a tuple or list of arrays or in long
         format with outcome observations in ``data`` and group membership in
         ``groups``.
-    groups : ndarray or Series
+    groups : ndarray or Series, optional
         If data is in long format, then groups is needed as indicator to which
         group or sample and observations belongs.
-    use_var : {"unequal", "equal" or "bf"}
+    use_var : {"unequal", "equal", "bf"}, optional
         `use_var` specified how to treat heteroscedasticity, unequal variance,
         across samples. Three approaches are available
 
@@ -776,11 +774,11 @@ def anova_oneway(
             degrees of freedom are available as additional attributes in the
             results instance, ``df_denom2`` and ``p_value2``.
 
-    welch_correction : bool
+    welch_correction : bool, optional
         If this is false, then the Welch correction to the test statistic is
         not included. This allows the computation of an effect size measure
         that corresponds more closely to Cohen's f.
-    trim_frac : float in [0, 0.5)
+    trim_frac : float in [0, 0.5), optional
         Optional trimming for Anova with trimmed mean and winsorized variances.
         With the default trim_frac equal to zero, the oneway Anova statistics
         are computed without trimming. If `trim_frac` is larger than zero,
@@ -951,9 +949,9 @@ def equivalence_oneway_generic(
         - df1 : numerator degrees of freedom, number of constraints
         - df2 : denominator degrees of freedom, df_resid
 
-    alpha : float in (0, 1)
+    alpha : float in (0, 1), optional
         Significance level for the hypothesis test.
-    margin_type : "f2" or "wellek"
+    margin_type : {"f2", "wellek"}, optional
         Type of effect size used for equivalence margin.
 
     Returns
@@ -1059,10 +1057,10 @@ def equivalence_oneway(
     equiv_margin : float
         Equivalence margin in terms of effect size. Effect size can be chosen
         with `margin_type`. default is squared Cohen's f.
-    groups : ndarray or Series
+    groups : ndarray or Series, optional
         If data is in long format, then groups is needed as indicator to which
         group or sample and observations belongs.
-    use_var : {"unequal", "equal" or "bf"}
+    use_var : {"unequal", "equal", "bf"}, optional
         `use_var` specified how to treat heteroscedasticity, unequal variance,
         across samples. Three approaches are available
 
@@ -1078,11 +1076,11 @@ def equivalence_oneway(
             degrees of freedom are available as additional attributes in the
             results instance, ``df_denom2`` and ``p_value2``.
 
-    welch_correction : bool
+    welch_correction : bool, optional
         If this is false, then the Welch correction to the test statistic is
         not included. This allows the computation of an effect size measure
         that corresponds more closely to Cohen's f.
-    trim_frac : float in [0, 0.5)
+    trim_frac : float in [0, 0.5), optional
         Optional trimming for Anova with trimmed mean and winsorized variances.
         With the default trim_frac equal to zero, the oneway Anova statistics
         are computed without trimming. If `trim_frac` is larger than zero,
@@ -1092,7 +1090,7 @@ def equivalence_oneway(
         `trim_frac` has to be smaller than 0.5, however, if the fraction is
         so large that there are not enough observations left over, then `nan`
         will be returned.
-    margin_type : "f2" or "wellek"
+    margin_type : {"f2", "wellek"}, optional
         Type of effect size used for equivalence margin, either squared
         Cohen's f or Wellek's psi. Default is "f2".
 
@@ -1151,7 +1149,7 @@ def _power_equivalence_oneway_emp(f_stat, n_groups, nobs, eps, df, alpha=0.05):
         Equivalence margin in terms of effect size given by Wellek's psi.
     df : tuple
         Degrees of freedom for F distribution.
-    alpha : float in (0, 1)
+    alpha : float in (0, 1), optional
         Significance level for the hypothesis test.
 
     Returns
@@ -1188,15 +1186,15 @@ def power_equivalence_oneway(
         with `margin_type`. default is squared Cohen's f.
     nobs_t : ndarray
         Total number of observations summed over all groups.
-    n_groups : int
+    n_groups : int, optional
         Number of groups in oneway comparison. If margin_type is "wellek",
         then either ``n_groups`` or ``df`` has to be given.
-    df : tuple
+    df : tuple, optional
         Degrees of freedom for F distribution,
         ``df = (n_groups - 1, nobs_t - n_groups)``
-    alpha : float in (0, 1)
+    alpha : float in (0, 1), optional
         Significance level for the hypothesis test.
-    margin_type : "f2" or "wellek"
+    margin_type : {"f2", "wellek"}, optional
         Type of effect size used for equivalence margin, either squared
         Cohen's f or Wellek's psi. Default is "f2".
 
@@ -1297,22 +1295,22 @@ def simulate_power_equivalence_oneway(
     equiv_margin : float
         Equivalence margin in terms of effect size. Effect size can be
         chosen with `margin_type`. default is squared Cohen's f.
-    vars_ : array_like or None
+    vars_ : array_like, optional
         Variances of the samples used to simulate the data. If None, then
         unit variance, i.e., standard deviation equal to 1, is used for all
         samples.
-    k_mc : int
+    k_mc : int, optional
         Number of Monte Carlo replications.
-    trim_frac : float in [0, 0.5)
+    trim_frac : float in [0, 0.5), optional
         Optional trimming for Anova with trimmed mean and winsorized
         variances, see `trim_frac` in `anova_oneway`.
-    options_var : list of str or None
+    options_var : list of str, optional
         List of `use_var` options that are used in the loop over Monte
         Carlo replications. If None, then
         ``["unequal", "equal", "bf"]`` is used.
-    margin_type : "f2" or "wellek"
+    margin_type : {"f2", "wellek"}, optional
         Type of effect size used for equivalence margin.
-    rng : {None, int, array_like[int], numpy.random.Generator, numpy.random.RandomState}, optional
+    rng : {None, int, array_like of int, numpy.random.Generator, numpy.random.RandomState}, optional
         If `rng` is None, a new ``Generator`` is created using fresh
         entropy from the operating system. If `rng` is an int or array
         of ints, a new ``Generator`` is created, seeded with `rng`. If
@@ -1431,7 +1429,7 @@ def test_scale_oneway(
         Data for k independent samples, with k >= 2. The data can be provided
         as a tuple or list of arrays or in long format with outcome
         observations in ``data`` and group membership in ``groups``.
-    method : {"unequal", "equal" or "bf"}
+    method : {"unequal", "equal", "bf"}, optional
         How to treat heteroscedasticity across samples. This is used as
         `use_var` option in `anova_oneway` and refers to the variance of the
         transformed data, i.e., assumption is on 4th moment if squares are used
@@ -1450,16 +1448,16 @@ def test_scale_oneway(
             results instance, ``df_denom2`` and ``p_value2``.
             This is the default.
 
-    center : "median", "mean", "trimmed" or float
+    center : {"median", "mean", "trimmed"} or float, optional
         Statistic used for centering observations. If a float, then this
         value is used to center. Default is median.
-    transform : "abs", "square" or callable
+    transform : {"abs", "square", "identity"} or callable, optional
         Transformation for the centered observations. If a callable, then this
         function is called on the centered data.
         Default is absolute value.
-    trim_frac_mean : float in [0, 0.5)
+    trim_frac_mean : float in [0, 0.5), optional
         Trim fraction for the trimmed mean when `center` is "trimmed"
-    trim_frac_anova : float in [0, 0.5)
+    trim_frac_anova : float in [0, 0.5), optional
         Optional trimming for Anova with trimmed mean and Winsorized variances.
         With the default trim_frac equal to zero, the oneway Anova statistics
         are computed without trimming. If `trim_frac` is larger than zero,
@@ -1591,7 +1589,7 @@ def equivalence_scale_oneway(
     equiv_margin : float
         Equivalence margin in terms of effect size. Effect size can be chosen
         with `margin_type`. default is squared Cohen's f.
-    method : {"unequal", "equal" or "bf"}
+    method : {"unequal", "equal", "bf"}, optional
         How to treat heteroscedasticity across samples. This is used as
         `use_var` option in `anova_oneway` and refers to the variance of the
         transformed data, i.e., assumption is on 4th moment if squares are used
@@ -1609,16 +1607,16 @@ def equivalence_scale_oneway(
             degrees of freedom are available as additional attributes in the
             results instance, ``df_denom2`` and ``p_value2``.
             This is the default.
-    center : "median", "mean", "trimmed" or float
+    center : {"median", "mean", "trimmed"} or float, optional
         Statistic used for centering observations. If a float, then this
         value is used to center. Default is median.
-    transform : "abs", "square" or callable
+    transform : {"abs", "square", "identity"} or callable, optional
         Transformation for the centered observations. If a callable, then this
         function is called on the centered data.
         Default is absolute value.
-    trim_frac_mean : float in [0, 0.5)
+    trim_frac_mean : float in [0, 0.5), optional
         Trim fraction for the trimmed mean when `center` is "trimmed"
-    trim_frac_anova : float in [0, 0.5)
+    trim_frac_anova : float in [0, 0.5), optional
         Optional trimming for Anova with trimmed mean and Winsorized variances.
         With the default trim_frac equal to zero, the oneway Anova statistics
         are computed without trimming. If `trim_frac` is larger than zero,

--- a/statsmodels/stats/outliers_influence.py
+++ b/statsmodels/stats/outliers_influence.py
@@ -35,7 +35,7 @@ def outlier_test(
     ----------
     model_results : RegressionResults
         Linear model results
-    method : str
+    method : str, optional
         - `bonferroni` : one-step correction
         - `sidak` : one-step correction
         - `holm-sidak` :
@@ -45,15 +45,15 @@ def outlier_test(
         - `fdr_bh` : Benjamini/Hochberg
         - `fdr_by` : Benjamini/Yekutieli
         See `statsmodels.stats.multitest.multipletests` for details.
-    alpha : float
+    alpha : float, optional
         familywise error rate
-    labels : None or array_like
+    labels : None or array_like, optional
         If `labels` is not None, then it will be used as index to the
         returned pandas DataFrame. See also Returns below
-    order : bool
+    order : bool, optional
         Whether or not to order the results by the absolute value of the
         studentized residuals. If labels are provided they will also be sorted.
-    cutoff : None or float in [0, 1]
+    cutoff : None or float in [0, 1], optional
         If cutoff is not None, then the return only includes observations with
         multiple testing corrected p-values strictly below the cutoff. The
         returned array or dataframe can be empty if there are no outlier
@@ -126,7 +126,7 @@ def reset_ramsey(res, degree=5):
     ----------
     res : RegressionResults instance
         Results instance from an OLS regression.
-    degree : int
+    degree : int, optional
         Maximum power to include in the RESET test.  Powers 0 and 1 are
         excluded, so that degree tests powers 2, ..., degree of the fitted
         values.
@@ -178,7 +178,7 @@ def variance_inflation_factor(exog, exog_idx, *, standardize=True):
 
     Parameters
     ----------
-    exog : {ndarray, DataFrame}
+    exog : array_like
         design matrix with all explanatory variables, as for example used in
         regression
     exog_idx : int
@@ -333,20 +333,20 @@ class _BaseInfluenceMixin:
 
         Parameters
         ----------
-        y_var : str
+        y_var : str, optional
             Name of attribute or shortcut for predefined attributes that will
             be plotted on the y-axis.
-        threshold : None or float
+        threshold : None or float, optional
             Threshold for adding annotation with observation labels.
             Observations for which the absolute value of the y_var is larger
             than the threshold will be annotated. Set to a negative number to
             label all observations or to a large number to have no annotation.
-        title : str
+        title : str, optional
             If provided, the title will replace the default "Index Plot" title.
-        ax : matplotlib axis instance
+        ax : matplotlib axis instance, optional
             The plot will be added to the `ax` if provided, otherwise a new
             figure is created.
-        idx : {None, int}
+        idx : {None, int}, optional
             Some attributes require an additional index to select the y-var.
             In dfbetas this refers to the column index.
         **kwds
@@ -413,28 +413,36 @@ class MLEInfluence(_BaseInfluenceMixin):
 
     Attributes
     ----------
-    hat_matrix_diag (hii) : This is the generalized leverage computed as the
-        local derivative of fittedvalues (predicted mean) with respect to the
+    hat_matrix_diag : ndarray or None
+        This is the generalized leverage (``hii``) computed as the local
+        derivative of fittedvalues (predicted mean) with respect to the
         observed response for each observation.
         Not available for ZeroInflated models because of nondifferentiability.
-    d_params : Change in parameters computed with one Newton step using the
+    d_params : ndarray
+        Change in parameters computed with one Newton step using the
         full Hessian corrected by division by (1 - hii).
         If hat_matrix_diag is not available, then the division by (1 - hii) is
         not included.
-    dbetas : change in parameters divided by the standard error of parameters
+    dfbetas : ndarray
+        change in parameters divided by the standard error of parameters
         from the full model results, ``bse``.
-    cooks_distance : quadratic form for change in parameters weighted by
+    cooks_distance : tuple
+        quadratic form for change in parameters weighted by
         ``cov_params`` from the full model divided by the number of variables.
         It includes p-values based on the F-distribution which are only
         approximate outside of linear Gaussian models.
-    resid_studentized : In the general MLE case resid_studentized are
+    resid_studentized : ndarray
+        In the general MLE case resid_studentized are
         computed from the score residuals scaled by hessian factor and
         leverage. This does not use ``cov_params``.
-    d_fittedvalues : local change of expected mean given the change in the
+    d_fittedvalues : ndarray
+        local change of expected mean given the change in the
         parameters as computed in ``d_params``.
-    d_fittedvalues_scaled : same as d_fittedvalues but scaled by the standard
+    d_fittedvalues_scaled : ndarray
+        same as d_fittedvalues but scaled by the standard
         errors of a predicted mean of the response.
-    params_one : is the one step parameter estimate computed as ``params``
+    params_one : ndarray
+        is the one step parameter estimate computed as ``params``
         from the full sample minus ``d_params``.
 
     Notes
@@ -655,15 +663,15 @@ class MLEInfluence(_BaseInfluenceMixin):
 
         Parameters
         ----------
-        joint : bool
+        joint : bool, optional
             If joint is true, then a quadratic form similar to score_test is
             returned for each observation.
             If joint is false, then standardized score_obs are returned. The
             returned array is two-dimensional
-        index : ndarray (optional)
+        index : ndarray, optional
             Optional index to select a subset of score_obs columns.
             By default, all columns of score_obs will be used.
-        studentize : bool
+        studentize : bool, optional
             If studentize is true, the scaled residuals are also
             studentized using the generalized leverage.
 
@@ -925,7 +933,7 @@ class OLSInfluence(_BaseInfluenceMixin):
 
         Parameters
         ----------
-        sigma : None or float
+        sigma : float, optional
             estimate of the standard deviation of the residuals. If None, then
             the estimate from the regression results is used.
 
@@ -1003,7 +1011,7 @@ class OLSInfluence(_BaseInfluenceMixin):
 
         Returns
         -------
-        dffits : float
+        dffits : ndarray
             The dffits measure for each observation, which is a measure of the
             influence of a single data point on the predicted value of a model.
         dffits_threshold : float
@@ -1132,14 +1140,14 @@ class OLSInfluence(_BaseInfluenceMixin):
         ----------
         drop_idx : int
             index of exog that is dropped from the regression
-        endog_idx : 'endog' or int
+        endog_idx : 'endog' or int, optional
             If 'endog', then the endogenous variable of the result instance
             is regressed on the exogenous variables, excluding the one at
             drop_idx. If endog_idx is an integer, then the exog with that
             index is regressed with OLS on all other exogenous variables.
             (The latter is the auxiliary regression for the variance inflation
             factor.)
-        store : bool
+        store : bool, optional
             If True, the result instance is cached for reuse.
 
         Notes
@@ -1304,7 +1312,7 @@ class OLSInfluence(_BaseInfluenceMixin):
 
         Parameters
         ----------
-        float_fmt : str
+        float_fmt : str, optional
             Format string for float values in the table.
 
         Returns
@@ -1363,7 +1371,7 @@ def summary_table(res, alpha=0.05):
     ----------
     res : RegressionResults
        Results from an OLS regression.
-    alpha : float
+    alpha : float, optional
        significance level for confidence interval
 
     Returns
@@ -1487,15 +1495,15 @@ class GLMInfluence(MLEInfluence):
 
     Attributes
     ----------
-    dbetas
+    dfbetas : ndarray
         change in parameters divided by the standard error of parameters from
         the full model results, ``bse``.
-    d_fittedvalues_scaled
+    d_fittedvalues_scaled : ndarray
         same as d_fittedvalues but scaled by the standard errors of a
         predicted mean of the response.
-    d_linpred
+    d_linpred : ndarray
         local change in linear prediction.
-    d_linpred_scale
+    d_linpred_scaled : ndarray
         local change in linear prediction scaled by the standard errors for
         the prediction based on cov_params.
 

--- a/statsmodels/stats/power.py
+++ b/statsmodels/stats/power.py
@@ -74,10 +74,10 @@ def ttest_power(effect_size, nobs, alpha, df=None, alternative="two-sided"):
     alpha : float in interval (0,1)
         Significance level, e.g., 0.05, is the probability of a type I
         error, that is wrong rejections if the Null Hypothesis is true.
-    df : int or float
+    df : int or float, optional
         Degrees of freedom. By default this is None, and ``df = nobs - 1``
         is used.
-    alternative : str, 'two-sided' (default), 'larger', 'smaller'
+    alternative : {'two-sided', 'larger', 'smaller'}, optional
         Extra argument to choose whether the power is calculated for a
         two-sided (default) or one sided test. The one-sided test can be
         either 'larger', 'smaller'.
@@ -139,11 +139,11 @@ def normal_power(effect_size, nobs, alpha, alternative="two-sided", sigma=1.0):
     alpha : float in interval (0,1)
         significance level, e.g., 0.05, is the probability of a type I
         error, that is wrong rejections if the Null Hypothesis is true.
-    alternative : string, 'two-sided' (default), 'larger', 'smaller'
+    alternative : {'two-sided', 'larger', 'smaller'}, optional
         extra argument to choose whether the power is calculated for a
         two-sided (default) or one sided test. The one-sided test can be
         either 'larger', 'smaller'.
-    sigma : float
+    sigma : float, optional
         The standard deviation used to standardize the effect size.
 
     Returns
@@ -193,13 +193,14 @@ def normal_power_het(
     alpha : float in interval (0,1)
         significance level, e.g., 0.05, is the probability of a type I
         error, that is wrong rejections if the Null Hypothesis is true.
-    std_null : float
+    std_null : float, optional
         standard deviation under the Null hypothesis without division by
         sqrt(nobs)
-    std_alternative : float
+    std_alternative : float, optional
         standard deviation under the Alternative hypothesis without division
-        by sqrt(nobs)
-    alternative : string, 'two-sided' (default), 'larger', 'smaller'
+        by sqrt(nobs). If None, ``std_alternative`` is set to the value of
+        ``std_null``.
+    alternative : {'two-sided', 'larger', 'smaller'}, optional
         extra argument to choose whether the power is calculated for a
         two-sided (default) or one sided test. The one-sided test can be
         either 'larger', 'smaller'.
@@ -259,10 +260,10 @@ def normal_sample_size_one_tail(diff, power, alpha, std_null=1.0, std_alternativ
         error, that is wrong rejections if the Null Hypothesis is true.
         Note: alpha is used for one tail. Use alpha/2 for two-sided
         alternative.
-    std_null : float
+    std_null : float, optional
         standard deviation under the Null hypothesis without division by
         sqrt(nobs)
-    std_alternative : float
+    std_alternative : float, optional
         standard deviation under the Alternative hypothesis without division
         by sqrt(nobs). Defaults to None. If None, ``std_alternative`` is set
         to the value of ``std_null``.
@@ -303,7 +304,7 @@ def ftest_anova_power(effect_size, nobs, alpha, k_groups=2, df=None):
     alpha : float in interval (0,1)
         Significance level, e.g., 0.05, is the probability of a type I
         error, that is wrong rejections if the Null Hypothesis is true.
-    k_groups : int
+    k_groups : int, optional
         Number of groups in the one-way ANOVA. Default is 2.
     df : None
         Unused. Included for compatibility; degrees of freedom are
@@ -340,7 +341,7 @@ def ftest_power(effect_size, df2, df1, alpha, ncc=1):
     alpha : float in interval (0,1)
         significance level, e.g., 0.05, is the probability of a type I
         error, that is wrong rejections if the Null Hypothesis is true.
-    ncc : int
+    ncc : int, optional
         degrees of freedom correction for non-centrality parameter.
         see Notes
 
@@ -405,7 +406,7 @@ def ftest_power_f2(effect_size, df_num, df_denom, alpha, ncc=1):
     alpha : float in interval (0,1)
         significance level, e.g., 0.05, is the probability of a type I
         error, that is wrong rejections if the Null Hypothesis is true.
-    ncc : int
+    ncc : int, optional
         degrees of freedom correction for non-centrality parameter.
         see Notes
 
@@ -700,26 +701,27 @@ class Power:
 
         Parameters
         ----------
-        dep_var : {'nobs', 'effect_size', 'alpha'}
+        dep_var : {'nobs', 'effect_size', 'alpha'}, optional
             This specifies which variable is used for the horizontal axis.
             If dep_var='nobs' (default), then one curve is created for each
             value of ``effect_size``. If dep_var='effect_size' or alpha, then
             one curve is created for each value of ``nobs``.
-        nobs : {scalar, array_like}
+        nobs : array_like, optional
             specifies the values of the number of observations in the plot
-        effect_size : {scalar, array_like}
+        effect_size : array_like, optional
             specifies the values of the effect_size in the plot
-        alpha : {float, array_like}
+        alpha : float or array_like, optional
             The significance level (type I error) used in the power
             calculation. Can only be more than a scalar, if ``dep_var='alpha'``
-        ax : None or axis instance
+        ax : AxesSubplot, optional
             If ax is None, than a matplotlib figure is created. If ax is a
             matplotlib axis instance, then it is reused, and the plot elements
             are created with it.
-        title : str
-            title for the axis. Use an empty string, ``''``, to avoid a title.
-        plt_kwds : {None, dict}
-            not used yet
+        title : str, optional
+            Title for the axis. Use an empty string, ``''``, to avoid a
+            title. If not given, the default title "Power of Test" is used.
+        plt_kwds : dict, optional
+            Not used yet.
         **kwds
             These remaining keyword arguments are used as arguments to the
             power function. Many power functions support ``alternative`` as
@@ -823,10 +825,10 @@ class TTestPower(Power):
         alpha : float in interval (0,1)
             significance level, e.g., 0.05, is the probability of a type I
             error, that is wrong rejections if the Null Hypothesis is true.
-        df : int or float
+        df : int or float, optional
             degrees of freedom. By default this is None, and the df from the
             one sample or paired ttest is used, ``df = nobs1 - 1``
-        alternative : str, 'two-sided' (default), 'larger', 'smaller'
+        alternative : {'two-sided', 'larger', 'smaller'}, optional
             extra argument to choose whether the power is calculated for a
             two-sided (default) or one sided test. The one-sided test can be
             either 'larger', 'smaller'.
@@ -866,19 +868,19 @@ class TTestPower(Power):
 
         Parameters
         ----------
-        effect_size : float
+        effect_size : None or float
             Standardized effect size, mean divided by the standard
             deviation.
-        nobs : int or float
+        nobs : None or int or float
             sample size, number of observations.
-        alpha : float in interval (0,1)
+        alpha : None or float in interval (0,1)
             significance level, e.g., 0.05, is the probability of a type I
             error, that is wrong rejections if the Null Hypothesis is true.
-        power : float in interval (0,1)
+        power : None or float in interval (0,1)
             power of the test, e.g., 0.8, is one minus the probability of a
             type II error. Power is the probability that the test correctly
             rejects the Null Hypothesis if the Alternative Hypothesis is true.
-        alternative : str, 'two-sided' (default), 'larger', 'smaller'
+        alternative : {'two-sided', 'larger', 'smaller'}, optional
             extra argument to choose whether the power is calculated for a
             two-sided (default) or one sided test. The one-sided test can be
             either 'larger', 'smaller'.
@@ -945,15 +947,13 @@ class TTestIndPower(Power):
         alpha : float in interval (0,1)
             significance level, e.g., 0.05, is the probability of a type I
             error, that is wrong rejections if the Null Hypothesis is true.
-        ratio : float
+        ratio : float, optional
             ratio of the number of observations in sample 2 relative to
             sample 1. see description of nobs1
-            The default for ratio is 1; to solve for ratio given the other
-            arguments, it has to be explicitly set to None.
-        df : int or float
+        df : int or float, optional
             degrees of freedom. By default this is None, and the df from the
             ttest with pooled variance is used, ``df = (nobs1 - 1 + nobs2 - 1)``
-        alternative : str, 'two-sided' (default), 'larger', 'smaller'
+        alternative : {'two-sided', 'larger', 'smaller'}, optional
             extra argument to choose whether the power is calculated for a
             two-sided (default) or one sided test. The one-sided test can be
             either 'larger', 'smaller'.
@@ -996,26 +996,26 @@ class TTestIndPower(Power):
 
         Parameters
         ----------
-        effect_size : float
+        effect_size : None or float
             standardized effect size, difference between the two means divided
             by the standard deviation. `effect_size` has to be positive.
-        nobs1 : int or float
+        nobs1 : None or int or float
             number of observations of sample 1. The number of observations of
             sample two is ratio times the size of sample 1,
             i.e., ``nobs2 = nobs1 * ratio``
-        alpha : float in interval (0,1)
+        alpha : None or float in interval (0,1)
             significance level, e.g., 0.05, is the probability of a type I
             error, that is wrong rejections if the Null Hypothesis is true.
-        power : float in interval (0,1)
+        power : None or float in interval (0,1)
             power of the test, e.g., 0.8, is one minus the probability of a
             type II error. Power is the probability that the test correctly
             rejects the Null Hypothesis if the Alternative Hypothesis is true.
-        ratio : float
+        ratio : None or float, optional
             ratio of the number of observations in sample 2 relative to
             sample 1. see description of nobs1
             The default for ratio is 1; to solve for ratio given the other
             arguments it has to be explicitly set to None.
-        alternative : str, 'two-sided' (default), 'larger', 'smaller'
+        alternative : {'two-sided', 'larger', 'smaller'}, optional
             extra argument to choose whether the power is calculated for a
             two-sided (default) or one sided test. The one-sided test can be
             either 'larger', 'smaller'.
@@ -1053,6 +1053,15 @@ class NormalIndPower(Power):
 
     currently only uses pooled variance
 
+    Parameters
+    ----------
+    ddof : int, optional
+        Degrees of freedom correction for the standard deviation used in
+        computing the effective sample size. Used, e.g., for a correlation
+        coefficient where ddof=3.
+    **kwds
+        Additional keyword arguments passed to the ``Power`` base class.
+
     """
 
     def __init__(self, ddof=0, **kwds):
@@ -1077,10 +1086,10 @@ class NormalIndPower(Power):
         alpha : float in interval (0,1)
             significance level, e.g., 0.05, is the probability of a type I
             error, that is wrong rejections if the Null Hypothesis is true.
-        ratio : float
+        ratio : float, optional
             ratio of the number of observations in sample 2 relative to
             sample 1. see description of nobs1
-        alternative : str, 'two-sided' (default), 'larger', 'smaller'
+        alternative : {'two-sided', 'larger', 'smaller'}, optional
             extra argument to choose whether the power is calculated for a
             two-sided (default) or one sided test. The one-sided test can be
             either 'larger', 'smaller'.
@@ -1125,30 +1134,30 @@ class NormalIndPower(Power):
 
         Parameters
         ----------
-        effect_size : float
+        effect_size : None or float
             standardized effect size, difference between the two means divided
             by the standard deviation.
             If ratio=0, then this is the standardized mean in the one sample
             test.
-        nobs1 : int or float
+        nobs1 : None or int or float
             number of observations of sample 1. The number of observations of
             sample two is ratio times the size of sample 1,
             i.e., ``nobs2 = nobs1 * ratio``
             ``ratio`` can be set to zero in order to get the power for a
             one sample test.
-        alpha : float in interval (0,1)
+        alpha : None or float in interval (0,1)
             significance level, e.g., 0.05, is the probability of a type I
             error, that is wrong rejections if the Null Hypothesis is true.
-        power : float in interval (0,1)
+        power : None or float in interval (0,1)
             power of the test, e.g., 0.8, is one minus the probability of a
             type II error. Power is the probability that the test correctly
             rejects the Null Hypothesis if the Alternative Hypothesis is true.
-        ratio : float
+        ratio : None or float, optional
             ratio of the number of observations in sample 2 relative to
             sample 1. see description of nobs1
             The default for ratio is 1; to solve for ratio given the other
             arguments it has to be explicitly set to None.
-        alternative : str, 'two-sided' (default), 'larger', 'smaller'
+        alternative : {'two-sided', 'larger', 'smaller'}, optional
             extra argument to choose whether the power is calculated for a
             two-sided (default) or one sided test. The one-sided test can be
             either 'larger', 'smaller'.
@@ -1250,7 +1259,7 @@ class FTestPower(Power):
         alpha : float in interval (0,1)
             significance level, e.g., 0.05, is the probability of a type I
             error, that is wrong rejections if the Null Hypothesis is true.
-        ncc : int
+        ncc : int, optional
             degrees of freedom correction for non-centrality parameter.
             see Notes
 
@@ -1304,26 +1313,26 @@ class FTestPower(Power):
 
         Parameters
         ----------
-        effect_size : float
+        effect_size : None or float
             Standardized effect size. The effect size is here Cohen's ``f``,
             square root of ``f2``.
-        df_num : int or float
+        df_num : None or int or float
             Warning incorrect name
             denominator degrees of freedom,
             This corresponds to the number of constraints in Wald tests.
             Sample size is given by ``nobs = df_denom + df_num + ncc``
-        df_denom : int or float
+        df_denom : None or int or float
             Warning incorrect name
             numerator degrees of freedom.
             This corresponds to the df_resid in Wald tests.
-        alpha : float in interval (0,1)
+        alpha : None or float in interval (0,1)
             significance level, e.g., 0.05, is the probability of a type I
             error, that is wrong rejections if the Null Hypothesis is true.
-        power : float in interval (0,1)
+        power : None or float in interval (0,1)
             power of the test, e.g., 0.8, is one minus the probability of a
             type II error. Power is the probability that the test correctly
             rejects the Null Hypothesis if the Alternative Hypothesis is true.
-        ncc : int
+        ncc : int, optional
             degrees of freedom correction for non-centrality parameter.
             see Notes
         **kwargs
@@ -1420,7 +1429,7 @@ class FTestPowerF2(Power):
         alpha : float in interval (0,1)
             Significance level, e.g., 0.05, is the probability of a type I
             error, that is wrong rejections if the Null Hypothesis is true.
-        ncc : int
+        ncc : int, optional
             Degrees of freedom correction for non-centrality parameter.
             see Notes
 
@@ -1470,23 +1479,23 @@ class FTestPowerF2(Power):
 
         Parameters
         ----------
-        effect_size : float
+        effect_size : None or float
             The effect size is here Cohen's ``f2``. This is equal to
             the noncentrality of an F-test divided by nobs.
-        df_num : int or float
+        df_num : None or int or float
             Numerator degrees of freedom,
             This corresponds to the number of constraints in Wald tests.
-        df_denom : int or float
+        df_denom : None or int or float
             Denominator degrees of freedom.
             This corresponds to the df_resid in Wald tests.
-        alpha : float in interval (0,1)
+        alpha : None or float in interval (0,1)
             significance level, e.g., 0.05, is the probability of a type I
             error, that is wrong rejections if the Null Hypothesis is true.
-        power : float in interval (0,1)
+        power : None or float in interval (0,1)
             power of the test, e.g., 0.8, is one minus the probability of a
             type II error. Power is the probability that the test correctly
             rejects the Null Hypothesis if the Alternative Hypothesis is true.
-        ncc : int
+        ncc : int, optional
             degrees of freedom correction for non-centrality parameter.
             see Notes
 
@@ -1572,19 +1581,19 @@ class FTestAnovaPower(Power):
 
         Parameters
         ----------
-        effect_size : float
+        effect_size : None or float
             standardized effect size, mean divided by the standard deviation.
             effect size has to be positive.
-        nobs : int or float
+        nobs : None or int or float
             sample size, number of observations.
-        alpha : float in interval (0,1)
+        alpha : None or float in interval (0,1)
             significance level, e.g., 0.05, is the probability of a type I
             error, that is wrong rejections if the Null Hypothesis is true.
-        power : float in interval (0,1)
+        power : None or float in interval (0,1)
             power of the test, e.g., 0.8, is one minus the probability of a
             type II error. Power is the probability that the test correctly
             rejects the Null Hypothesis if the Alternative Hypothesis is true.
-        k_groups : int or float
+        k_groups : int or float, optional
             number of groups in the ANOVA or k-sample comparison. Default is 2.
 
         Returns
@@ -1670,7 +1679,7 @@ class GofChisquarePower(Power):
             error, that is wrong rejections if the Null Hypothesis is true.
         n_bins : int
             number of bins or cells in the distribution.
-        ddof : int
+        ddof : int, optional
             Degrees of freedom correction for the chisquare distribution.
 
         Returns
@@ -1702,19 +1711,19 @@ class GofChisquarePower(Power):
 
         Parameters
         ----------
-        effect_size : float
+        effect_size : None or float
             standardized effect size, according to Cohen's definition.
             see :func:`statsmodels.stats.gof.chisquare_effectsize`
-        nobs : int or float
+        nobs : None or int or float
             sample size, number of observations.
-        alpha : float in interval (0,1)
+        alpha : None or float in interval (0,1)
             significance level, e.g., 0.05, is the probability of a type I
             error, that is wrong rejections if the Null Hypothesis is true.
-        power : float in interval (0,1)
+        power : None or float in interval (0,1)
             power of the test, e.g., 0.8, is one minus the probability of a
             type II error. Power is the probability that the test correctly
             rejects the Null Hypothesis if the Alternative Hypothesis is true.
-        n_bins : int
+        n_bins : int, optional
             number of bins or cells in the distribution
 
         Returns
@@ -1756,7 +1765,7 @@ class _GofChisquareIndPower(Power):
         Parameters
         ----------
         effect_size : float
-            standardize effect size, difference between the two means divided
+            standardized effect size, difference between the two means divided
             by the standard deviation. effect size has to be positive.
         nobs1 : int or float
             number of observations of sample 1. The number of observations of
@@ -1765,12 +1774,10 @@ class _GofChisquareIndPower(Power):
         alpha : float in interval (0,1)
             significance level, e.g., 0.05, is the probability of a type I
             error, that is wrong rejections if the Null Hypothesis is true.
-        ratio : float
+        ratio : float, optional
             ratio of the number of observations in sample 2 relative to
             sample 1. see description of nobs1
-            The default for ratio is 1; to solve for ratio given the other
-            arguments it has to be explicitly set to None.
-        alternative : str, 'two-sided' (default) or 'one-sided'
+        alternative : {'two-sided', 'one-sided'}, optional
             extra argument to choose whether the power is calculated for a
             two-sided (default) or one sided test.
             'one-sided' assumes we are in the relevant tail.
@@ -1802,35 +1809,35 @@ class _GofChisquareIndPower(Power):
         alternative="two-sided",
     ):
         """
-        Solve for any one parameter of the power of a two sample z-test
+        Solve for any one parameter of the power of a two sample chisquare-test
 
-        for z-test the keywords are:
+        for the chisquare-test the keywords are:
             effect_size, nobs1, alpha, power, ratio
 
         exactly one needs to be ``None``, all others need numeric values
 
         Parameters
         ----------
-        effect_size : float
-            standardize effect size, difference between the two means divided
+        effect_size : None or float
+            standardized effect size, difference between the two means divided
             by the standard deviation.
-        nobs1 : int or float
+        nobs1 : None or int or float
             number of observations of sample 1. The number of observations of
             sample two is ratio times the size of sample 1,
             i.e., ``nobs2 = nobs1 * ratio``
-        alpha : float in interval (0,1)
+        alpha : None or float in interval (0,1)
             significance level, e.g., 0.05, is the probability of a type I
             error, that is wrong rejections if the Null Hypothesis is true.
-        power : float in interval (0,1)
+        power : None or float in interval (0,1)
             power of the test, e.g., 0.8, is one minus the probability of a
             type II error. Power is the probability that the test correctly
             rejects the Null Hypothesis if the Alternative Hypothesis is true.
-        ratio : float
+        ratio : None or float, optional
             ratio of the number of observations in sample 2 relative to
             sample 1. see description of nobs1
             The default for ratio is 1; to solve for ratio given the other
             arguments it has to be explicitly set to None.
-        alternative : str, 'two-sided' (default) or 'one-sided'
+        alternative : {'two-sided', 'one-sided'}, optional
             extra argument to choose whether the power is calculated for a
             two-sided (default) or one sided test.
             'one-sided' assumes we are in the relevant tail.

--- a/statsmodels/stats/proportion.py
+++ b/statsmodels/stats/proportion.py
@@ -37,7 +37,7 @@ def _bound_proportion_confint(
         Callable function to use as the objective of the search
     qi : float
         The empirical success rate
-    lower : bool
+    lower : bool, optional
         Whether to find a lower bound for the left side of the CI
 
     Returns
@@ -76,7 +76,7 @@ def _bisection_search_conservative(
         Lower bound
     ub : float
         Upper bound
-    steps : int
+    steps : int, optional
         Number of steps to use in the bisection
 
     Returns
@@ -125,9 +125,9 @@ def proportion_confint(
     nobs : {int or float, array_like}
         total number of trials.  Arrays must contain integer values if method
         is "binom_test".
-    alpha : float
+    alpha : float, optional
         Significance level, default 0.05. Must be in (0, 1)
-    method : {"normal", "agresti_coull", "beta", "wilson", "binom_test"}
+    method : {"normal", "agresti_coull", "beta", "wilson", "jeffreys", "binom_test"}, optional
         default: "normal"
         method to use for confidence interval. Supported methods:
 
@@ -138,13 +138,13 @@ def proportion_confint(
          - `jeffreys` : Jeffreys Bayesian Interval
          - `binom_test` : Numerical inversion of binom_test
 
-    alternative : {"two-sided", "larger", "smaller"}
+    alternative : {"two-sided", "larger", "smaller"}, optional
         default: "two-sided"
         specifies whether to calculate a two-sided or one-sided confidence interval.
 
     Returns
     -------
-    ci_low, ci_upp : {float, ndarray, Series DataFrame}
+    ci_low, ci_upp : {float, ndarray, Series, DataFrame}
         larger and smaller confidence level with coverage (approximately) 1-alpha.
         When a pandas object is returned, then the index is taken from `count`.
         When side is not "two-sided", lower or upper bound is set to 0 or 1 respectively.
@@ -558,7 +558,7 @@ def multinomial_proportions_confint(counts, alpha=0.05, method="goodman"):
 
             Parameters
             ----------
-            c : int
+            c : float
                 The half-width added to and subtracted from each observed
                 count to form the per-category interval.
 
@@ -617,10 +617,10 @@ def samplesize_confint_proportion(proportion, half_length, alpha=0.05, method="n
         proportion or quantile
     half_length : float in (0, 1)
         desired half length of the confidence interval
-    alpha : float in (0, 1)
+    alpha : float in (0, 1), optional
         significance level, default 0.05,
         coverage of the two-sided interval is (approximately) ``1 - alpha``
-    method : str in ['normal']
+    method : str in ['normal'], optional
         method to use for confidence interval,
         currently only normal approximation
 
@@ -653,7 +653,7 @@ def proportion_effectsize(prop1, prop2, method="normal"):
     ----------
     prop1, prop2 : float or array_like
         The proportion value(s).
-    method : str
+    method : str, optional
         Effect size method to use, currently only 'normal' is implemented.
 
     Returns
@@ -815,7 +815,7 @@ def binom_tost_reject_interval(low, upp, nobs, alpha=0.05):
         lower and upper limit of equivalence region
     nobs : int
         the number of trials or observations.
-    alpha : float
+    alpha : float, optional
         Significance level of the test, default 0.05.
 
     Returns
@@ -840,9 +840,9 @@ def binom_test_reject_interval(value, nobs, alpha=0.05, alternative="two-sided")
         proportion under the Null hypothesis
     nobs : int
         the number of trials or observations.
-    alpha : float
+    alpha : float, optional
         Significance level of the test, default 0.05.
-    alternative : str in ['two-sided', 'smaller', 'larger']
+    alternative : str in ['two-sided', 'smaller', 'larger'], optional
         alternative hypothesis, which can be two-sided or either one of the
         one-sided tests.
 
@@ -884,7 +884,7 @@ def binom_test(count, nobs, prop=0.5, alternative="two-sided"):
     prop : float, optional
         The probability of success under the null hypothesis,
         `0 <= prop <= 1`. The default value is `prop = 0.5`
-    alternative : str in ['two-sided', 'smaller', 'larger']
+    alternative : str in ['two-sided', 'smaller', 'larger'], optional
         alternative hypothesis, which can be two-sided or either one of the
         one-sided tests.
 
@@ -923,10 +923,10 @@ def power_binom_tost(low, upp, nobs, p_alt=None, alpha=0.05):
         lower and upper limit of equivalence region
     nobs : int
         the number of trials or observations.
-    p_alt : float in (0, 1)
+    p_alt : float in (0, 1), optional
         proportion under the alternative. If p_alt is None, then the
         midpoint of the equivalence region, ``0.5 * (low + upp)``, is used.
-    alpha : float in (0, 1)
+    alpha : float in (0, 1), optional
         significance level of the test
 
     Returns
@@ -966,29 +966,29 @@ def power_ztost_prop(
         number of observations
     p_alt : float in (0,1)
         proportion under the alternative
-    alpha : float in (0,1)
+    alpha : float in (0,1), optional
         significance level of the test
-    dist : str in ['norm', 'binom']
+    dist : str in ['norm', 'binom'], optional
         This defines the distribution to evaluate the power of the test. The
         critical values of the TOST test are always based on the normal
         approximation, but the distribution for the power can be either the
         normal (default) or the binomial (exact) distribution.
-    variance_prop : None or float in (0,1)
+    variance_prop : float in (0,1), optional
         If this is None, then the variances for the two one sided tests are
         based on the proportions equal to the equivalence limits.
         If variance_prop is given, then it is used to calculate the variance
         for the TOST statistics. If this is based on an sample, then the
         estimated proportion can be used.
-    discrete : bool
+    discrete : bool, optional
         If true, then the critical values of the rejection region are converted
         to integers. If dist is "binom", this is automatically assumed.
         If discrete is false, then the TOST critical values are used as
         floating point numbers, and the power is calculated based on the
         rejection region that is not discretized.
-    continuity : bool or float
+    continuity : bool or float, optional
         adjust the rejection region for the normal power probability. This has
         an effect only if ``dist='norm'``
-    critval_continuity : bool or float
+    critval_continuity : bool or float, optional
         If this is non-zero, then the critical values of the tost rejection
         region are adjusted before converting to integers. This affects both
         distributions, ``dist='norm'`` and ``dist='binom'``.
@@ -1094,20 +1094,20 @@ def proportions_ztest(count, nobs, value=None, alternative="two-sided", prop_var
     nobs : {int, array_like}
         the number of trials or observations, with the same length as
         count.
-    value : float, array_like or None, optional
+    value : float or array_like, optional
         This is the value of the null hypothesis equal to the proportion in the
         case of a one sample test. In the case of a two-sample test, the
         null hypothesis is that prop[0] - prop[1] = value, where prop is the
         proportion in the two samples. If not provided value = 0 and the null
         is prop[0] = prop[1]
-    alternative : str in ['two-sided', 'smaller', 'larger']
+    alternative : str in ['two-sided', 'smaller', 'larger'], optional
         The alternative hypothesis can be either two-sided or one of the one-
         sided tests, smaller means that the alternative hypothesis is
         ``prop < value`` and larger means ``prop > value``. In the two sample
         test, smaller means that the alternative hypothesis is ``p1 < p2`` and
         larger means ``p1 > p2`` where ``p1`` is the proportion of the first
         sample and ``p2`` of the second one.
-    prop_var : False or float in (0, 1)
+    prop_var : False or float in (0, 1), optional
         If prop_var is false, then the variance of the proportion estimate is
         calculated based on the sample proportion. Alternatively, a proportion
         can be specified to calculate this variance. Common use case is to
@@ -1200,7 +1200,7 @@ def proportions_ztost(count, nobs, low, upp, prop_var="sample"):
         count.
     low, upp : float
         equivalence interval low < prop1 - prop2 < upp
-    prop_var : str or float in (0, 1)
+    prop_var : str or float in (0, 1), optional
         prop_var determines which proportion is used for the calculation
         of the standard deviation of the proportion estimate
         The available options for string are 'sample' (default), 'null' and
@@ -1255,7 +1255,7 @@ def proportions_chisquare(count, nobs, value=None):
     nobs : int
         the number of trials or observations, with the same length as
         count.
-    value : None or float or array_like
+    value : float or array_like, optional
         Value of the proportion under the null hypothesis. If value is
         given, then all proportions are jointly tested against this value.
         If value is not given and count and nobs are not scalar, then the
@@ -1267,7 +1267,7 @@ def proportions_chisquare(count, nobs, value=None):
         test statistic for the chisquare test
     p-value : float
         p-value for the chisquare test
-    (table, expected)
+    (table, expected) : tuple of ndarray
         table is a (k, 2) contingency table, ``expected`` is the corresponding
         table of counts that are expected under independence with given
         margins
@@ -1313,7 +1313,7 @@ def proportions_chisquare_allpairs(count, nobs, multitest_method="hs"):
         the number of successes in nobs trials.
     nobs : int
         the number of trials or observations.
-    multitest_method : str
+    multitest_method : str, optional
         This chooses the method for the multiple testing p-value correction,
         that is used as default in the results.
         It can be any method that is available in  ``multipletesting``.
@@ -1356,15 +1356,15 @@ def proportions_chisquare_pairscontrol(
         the number of successes in nobs trials.
     nobs : int
         the number of trials or observations.
-    value : None or float
+    value : None or float, optional
         Value of the proportion under the null hypothesis. Not yet
         implemented.
-    multitest_method : str
+    multitest_method : str, optional
         This chooses the method for the multiple testing p-value correction,
         that is used as default in the results.
         It can be any method that is available in  ``multipletesting``.
         The default is Holm-Sidak 'hs'.
-    alternative : str in ['two-sided', 'smaller', 'larger']
+    alternative : str in ['two-sided', 'smaller', 'larger'], optional
         alternative hypothesis, which can be two-sided or either one of the
         one-sided tests.
 
@@ -1417,7 +1417,7 @@ def confint_proportions_2indep(
         Count and sample size for first sample.
     count2, nobs2 : float
         Count and sample size for the second sample.
-    method : str
+    method : str, optional
         Method for computing confidence interval. If method is None, then a
         default method is used. The default might change as more methods are
         added.
@@ -1438,23 +1438,25 @@ def confint_proportions_2indep(
          - 'logit-adjusted' (default)
          - 'score'
 
-    compare : string in ['diff', 'ratio' 'odds-ratio']
+    compare : str in ['diff', 'ratio', 'odds-ratio'], optional
         If compare is diff, then the confidence interval is for diff = p1 - p2.
         If compare is ratio, then the confidence interval is for the risk ratio
         defined by ratio = p1 / p2.
         If compare is odds-ratio, then the confidence interval is for the
         odds-ratio defined by or = p1 / (1 - p1) / (p2 / (1 - p2).
-    alpha : float
+    alpha : float, optional
         Significance level for the confidence interval, default is 0.05.
         The nominal coverage probability is 1 - alpha.
-    correction : bool
+    correction : bool, optional
         If correction is True (default), then the Miettinen and Nurminen
         small sample correction to the variance nobs / (nobs - 1) is used.
         Applies only if method='score'.
 
     Returns
     -------
-    low, upp
+    low, upp : float
+        Lower and upper confidence limits for the chosen comparison
+        (`compare`) of the two proportions.
 
     See Also
     --------
@@ -1626,10 +1628,10 @@ def _shrink_prob(count1, nobs1, count2, nobs2, shrink_factor=2, return_corr=True
         count and sample size for first sample
     count2, nobs2 : float or int
         count and sample size for the second sample
-    shrink_factor : float
+    shrink_factor : float, optional
         This corresponds to the number of observations that are added in total
         proportional to the probabilities under independence.
-    return_corr : bool
+    return_corr : bool, optional
         If true, then only the correction term is returned
         If false, then the corrected counts, i.e., original counts plus
         correction term, are returned.
@@ -1638,7 +1640,7 @@ def _shrink_prob(count1, nobs1, count2, nobs2, shrink_factor=2, return_corr=True
     -------
     count1_corr, nobs1_corr, count2_corr, nobs2_corr : float
         correction or corrected counts
-    prob_indep :
+    prob_indep : ndarray
         TODO/Warning : this will change most likely
         probabilities under independence, only returned if return_corr is
         false.
@@ -1725,27 +1727,27 @@ def score_test_proportions_2indep(
 
     Parameters
     ----------
-    count1, nobs1 :
+    count1, nobs1 : int
         count and sample size for first sample
-    count2, nobs2 :
+    count2, nobs2 : int
         count and sample size for the second sample
-    value : float
+    value : float, optional
         diff, ratio or odds-ratio under the null hypothesis. If value is None,
         then equality of proportions under the Null is assumed,
         i.e., value=0 for 'diff' or value=1 for either rate or odds-ratio.
-    compare : string in ['diff', 'ratio' 'odds-ratio']
+    compare : str in ['diff', 'ratio', 'odds-ratio'], optional
         If compare is diff, then the confidence interval is for diff = p1 - p2.
         If compare is ratio, then the confidence interval is for the risk ratio
         defined by ratio = p1 / p2.
         If compare is odds-ratio, then the confidence interval is for the
         odds-ratio defined by or = p1 / (1 - p1) / (p2 / (1 - p2)
-    alternative : {'two-sided', 'smaller', 'larger'}
+    alternative : {'two-sided', 'smaller', 'larger'}, optional
         alternative hypothesis, which can be two-sided or either one of the
         one-sided tests.
-    correction : bool
+    correction : bool, optional
         If correction is True (default), then the Miettinen and Nurminen
         small sample correction to the variance nobs / (nobs - 1) is used.
-    return_results : bool
+    return_results : bool, optional
         If true, then a results instance with extra information is returned,
         otherwise a tuple with statistic and pvalue is returned.
 
@@ -1898,10 +1900,10 @@ class Proportions2indepTestResult(LimitedIterationMixin[float]):
     value : float
         Value of the difference, risk ratio or odds ratio under the null
         hypothesis.
-    prop1_null : float or None
+    prop1_null : float or None, optional
         Constrained estimate of the first proportion under the null
         hypothesis. Only set if ``method="score"``, otherwise None.
-    prop2_null : float or None
+    prop2_null : float or None, optional
         Constrained estimate of the second proportion under the null
         hypothesis. Only set if ``method="score"``, otherwise None.
 
@@ -1979,12 +1981,12 @@ def test_proportions_2indep(
         Count for the second sample.
     nobs2 : int
         Sample size for the second sample.
-    value : float
+    value : float, optional
         Value of the difference, risk ratio or odds ratio of 2 independent
         proportions under the null hypothesis.
         Default is equal proportions, 0 for diff and 1 for risk-ratio and for
         odds-ratio.
-    method : string
+    method : str, optional
         Method for computing the hypothesis test. If method is None, then a
         default method is used. The default might change as more methods are
         added.
@@ -2015,21 +2017,21 @@ def test_proportions_2indep(
         - 'score' if correction is True, then this uses the degrees of freedom
            correction ``nobs / (nobs - 1)`` as in Miettinen Nurminen 1985
 
-    compare : {'diff', 'ratio' 'odds-ratio'}
+    compare : {'diff', 'ratio', 'odds-ratio'}, optional
         If compare is `diff`, then the hypothesis test is for the risk
         difference diff = p1 - p2.
         If compare is `ratio`, then the hypothesis test is for the
         risk ratio defined by ratio = p1 / p2.
         If compare is `odds-ratio`, then the hypothesis test is for the
         odds-ratio defined by or = p1 / (1 - p1) / (p2 / (1 - p2)
-    alternative : {'two-sided', 'smaller', 'larger'}
+    alternative : {'two-sided', 'smaller', 'larger'}, optional
         alternative hypothesis, which can be two-sided or either one of the
         one-sided tests.
-    correction : bool
+    correction : bool, optional
         If correction is True (default), then the Miettinen and Nurminen
         small sample correction to the variance nobs / (nobs - 1) is used.
         Applies only if method='score'.
-    return_results : bool
+    return_results : bool, optional
         If true, then a results instance with extra information is returned,
         otherwise a tuple with statistic and pvalue is returned.
 
@@ -2323,13 +2325,13 @@ def tost_proportions_2indep(
 
     Parameters
     ----------
-    count1, nobs1 :
+    count1, nobs1 : int
         count and sample size for first sample
-    count2, nobs2 :
+    count2, nobs2 : int
         count and sample size for the second sample
-    low, upp :
+    low, upp : float
         equivalence margin for diff, risk ratio or odds ratio
-    method : string
+    method : str, optional
         method for computing the hypothesis test. If method is None, then a
         default method is used. The default might change as more methods are
         added.
@@ -2357,14 +2359,14 @@ def tost_proportions_2indep(
          - 'score' if correction is True, then this uses the degrees of freedom
             correction ``nobs / (nobs - 1)`` as in Miettinen Nurminen 1985
 
-    compare : string in ['diff', 'ratio' 'odds-ratio']
+    compare : str in ['diff', 'ratio', 'odds-ratio'], optional
         If compare is `diff`, then the hypothesis test is for
         diff = p1 - p2.
         If compare is `ratio`, then the hypothesis test is for the
         risk ratio defined by ratio = p1 / p2.
         If compare is `odds-ratio`, then the hypothesis test is for the
         odds-ratio defined by or = p1 / (1 - p1) / (p2 / (1 - p2).
-    correction : bool
+    correction : bool, optional
         If correction is True (default), then the Miettinen and Nurminen
         small sample correction to the variance nobs / (nobs - 1) is used.
         Applies only if method='score'.
@@ -2518,18 +2520,18 @@ def power_proportions_2indep(
         p1 = p2 + diff
     nobs1 : float or int
         number of observations in sample 1
-    ratio : float
+    ratio : float, optional
         sample size ratio, nobs2 = ratio * nobs1
-    alpha : float in interval (0,1)
+    alpha : float in interval (0,1), optional
         Significance level, e.g., 0.05, is the probability of a type I
         error, that is wrong rejections if the Null Hypothesis is true.
-    value : float
+    value : float, optional
         currently only `value=0`, i.e., equality testing, is supported
-    alternative : string, 'two-sided' (default), 'larger', 'smaller'
+    alternative : {'two-sided', 'larger', 'smaller'}, optional
         Alternative hypothesis whether the power is calculated for a
         two-sided (default) or one sided test. The one-sided test can be
         either 'larger', 'smaller'.
-    return_results : bool
+    return_results : bool, optional
         If true, then a results instance with extra information is returned,
         otherwise only the computed power is returned.
 
@@ -2595,14 +2597,14 @@ def samplesize_proportions_2indep_onetail(
         p1 = p2 + diff
     power : float
         Power for which sample size is computed.
-    ratio : float
+    ratio : float, optional
         Sample size ratio, nobs2 = ratio * nobs1
-    alpha : float in interval (0,1)
+    alpha : float in interval (0,1), optional
         Significance level, e.g., 0.05, is the probability of a type I
         error, that is wrong rejections if the Null Hypothesis is true.
-    value : float
+    value : float, optional
         Currently only `value=0`, i.e., equality testing, is supported
-    alternative : string, 'two-sided' (default), 'larger', 'smaller'
+    alternative : {'two-sided', 'larger', 'smaller'}, optional
         Alternative hypothesis whether the power is calculated for a
         two-sided (default) or one sided test. In the case of a one-sided
         alternative, it is assumed that the test is in the appropriate tail.
@@ -2636,21 +2638,21 @@ def _score_confint_inversion(
 
     Parameters
     ----------
-    count1, nobs1 :
+    count1, nobs1 : int
         Count and sample size for first sample.
-    count2, nobs2 :
+    count2, nobs2 : int
         Count and sample size for the second sample.
-    compare : string in ['diff', 'ratio' 'odds-ratio']
+    compare : str in ['diff', 'ratio', 'odds-ratio'], optional
         If compare is `diff`, then the confidence interval is for
         diff = p1 - p2.
         If compare is `ratio`, then the confidence interval is for the
         risk ratio defined by ratio = p1 / p2.
         If compare is `odds-ratio`, then the confidence interval is for the
         odds-ratio defined by or = p1 / (1 - p1) / (p2 / (1 - p2).
-    alpha : float in interval (0,1)
+    alpha : float in interval (0,1), optional
         Significance level, e.g., 0.05, is the probability of a type I
         error, that is wrong rejections if the Null Hypothesis is true.
-    correction : bool
+    correction : bool, optional
         If correction is True (default), then the Miettinen and Nurminen
         small sample correction to the variance nobs / (nobs - 1) is used.
         Applies only if method='score'.

--- a/statsmodels/stats/rates.py
+++ b/statsmodels/stats/rates.py
@@ -99,16 +99,16 @@ def test_poisson(
     nobs : array_like
         Currently this is total exposure time of the count variable.
         This will likely change.
-    value : float, array_like
+    value : float or array_like
         This is the value of poisson rate under the null hypothesis.
-    method : str
-        Method to use for confidence interval.
+    method : str, optional
+        Method to use for the hypothesis test.
         This is required, there is currently no default method.
         See Notes for available methods.
-    alternative : {'two-sided', 'smaller', 'larger'}
+    alternative : {'two-sided', 'smaller', 'larger'}, optional
         Alternative hypothesis, which can be two-sided or either one of the
         one-sided tests.
-    dispersion : float
+    dispersion : float, optional
         Dispersion scale coefficient for Poisson QMLE. Default is that the
         data follows a Poisson distribution. Dispersion different from 1
         corresponds to excess-dispersion in Poisson quasi-likelihood (GLM).
@@ -137,6 +137,7 @@ def test_poisson(
       this uses numerical inversion of the test function. not vectorized.
     - "sqrt" : based on square root transformed counts
     - "sqrt-a" based on Anscombe square root transformation of counts + 3/8.
+    - "sqrt-v" based on Vandenbroucke square root transformation of counts.
 
     See Also
     --------
@@ -248,13 +249,13 @@ def confint_poisson(count, exposure, method=None, alpha=0.05, alternative="two-s
     exposure : array_like
         Currently this is total exposure time of the count variable.
         This will likely change.
-    method : str
+    method : str, optional
         Method to use for confidence interval.
         This is required, there is currently no default method.
-    alpha : float in (0, 1)
+    alpha : float in (0, 1), optional
         Significance level, nominal coverage of the confidence interval is
         1 - alpha.
-    alternative : {"two-sided", "larger", "smaller"}
+    alternative : {"two-sided", "larger", "smaller"}, optional
         Default: "two-sided".
         Specifies whether to calculate a two-sided or one-sided confidence
         interval.
@@ -455,21 +456,21 @@ def tolerance_int_poisson(
         Observed count, number of events.
     exposure : array_like
         Currently this is total exposure time of the count variable.
-    prob : float in (0, 1)
+    prob : float in (0, 1), optional
         Probability of poisson interval, often called "content".
         With known parameters, each tail would have at most probability
         ``1 - prob / 2`` in the two-sided interval.
-    exposure_new : float
+    exposure_new : float, optional
         Exposure of the new or predicted observation.
-    method : str
+    method : str, optional
         Method to used for confidence interval of the estimate of the
         poisson rate, used in `confint_poisson`.
         This is required, there is currently no default method.
-    alpha : float in (0, 1)
+    alpha : float in (0, 1), optional
         Significance level for the confidence interval of the estimate of the
         Poisson rate. Nominal coverage of the confidence interval is
         1 - alpha.
-    alternative : {"two-sided", "larger", "smaller"}
+    alternative : {"two-sided", "larger", "smaller"}, optional
         The tolerance interval can be two-sided or one-sided.
         Alternative "larger" provides the upper bound of the confidence
         interval, larger counts are outside the interval.
@@ -546,17 +547,17 @@ def confint_quantile_poisson(
     prob : float in (0, 1)
         Probability for the quantile, e.g., 0.95 to get the upper 95% quantile.
         With known mean mu, the quantile would be poisson.ppf(prob, mu).
-    exposure_new : float
+    exposure_new : float, optional
         Exposure of the new or predicted observation.
-    method : str
+    method : str, optional
         Method to used for confidence interval of the estimate of the
         poisson rate, used in `confint_poisson`.
         This is required, there is currently no default method.
-    alpha : float in (0, 1)
+    alpha : float in (0, 1), optional
         Significance level for the confidence interval of the estimate of the
         Poisson rate. Nominal coverage of the confidence interval is
         1 - alpha.
-    alternative : {"two-sided", "larger", "smaller"}
+    alternative : {"two-sided", "larger", "smaller"}, optional
         The tolerance interval can be two-sided or one-sided.
         Alternative "larger" provides the upper bound of the confidence
         interval, larger counts are outside the interval.
@@ -614,12 +615,12 @@ def _invert_test_confint(
         Observed count, number of events.
     nobs : array_like
         Total exposure time of the count variable.
-    alpha : float in (0, 1)
+    alpha : float in (0, 1), optional
         Significance level, nominal coverage of the confidence interval is
         1 - alpha.
-    method : str
+    method : str, optional
         Method to use for the p-value in the inverted hypothesis test.
-    method_start : str
+    method_start : str, optional
         Method used to compute the starting confidence interval for the
         numerical inversion.
 
@@ -663,15 +664,15 @@ def _invert_test_confint_2indep(
         Number of events in second sample, control group.
     exposure2 : float
         Total exposure (time * subjects) in second sample.
-    alpha : float in (0, 1)
+    alpha : float in (0, 1), optional
         Significance level, nominal coverage of the confidence interval is
         1 - alpha.
-    method : str
+    method : str, optional
         Method to use for the p-value in the inverted hypothesis test.
-    compare : {'diff', 'ratio'}
+    compare : {'diff', 'ratio'}, optional
         Whether the confidence interval is for the difference or the ratio
         of the two rates.
-    method_start : str
+    method_start : str, optional
         Method used to compute the starting confidence interval for the
         numerical inversion.
 
@@ -830,10 +831,10 @@ def test_poisson_2indep(
         Number of events in second sample, control group.
     exposure2 : float
         Total exposure (time * subjects) in second sample.
-    value : float
+    value : float, optional
         Value of the ratio or difference of 2 independent rates under the null
         hypothesis. Default is equal rates, i.e., 1 for ratio and 0 for diff.
-    method : string
+    method : str, optional
         Method for the test statistic and the p-value. Defaults to `'score'`.
         see Notes.
 
@@ -857,22 +858,22 @@ def test_poisson_2indep(
         - 'wald',
         - 'waldccv'
         - 'score'
-        - 'etest-score' or 'etest: etest with score test statistic
+        - 'etest-score' or 'etest': etest with score test statistic
         - 'etest-wald': etest with wald test statistic
 
-    compare : {'diff', 'ratio'}
+    compare : {'diff', 'ratio'}, optional
         Default is "ratio".
         If compare is `ratio`, then the hypothesis test is for the
         rate ratio defined by ratio = rate1 / rate2.
         If compare is `diff`, then the hypothesis test is for
         diff = rate1 - rate2.
-    alternative : {"two-sided" (default), "larger", "smaller"}
+    alternative : {"two-sided", "larger", "smaller"}, optional
         The alternative hypothesis, H1, has to be one of the following
 
         - 'two-sided': H1: ratio, or diff, of rates is not equal to value
         - 'larger' :   H1: ratio, or diff, of rates is larger than value
         - 'smaller' :  H1: ratio, or diff, of rates is smaller than value
-    etest_kwds : dictionary
+    etest_kwds : dict, optional
         Additional optional parameters to be passed to the etest_poisson_2indep
         function, namely y_grid.
 
@@ -1093,9 +1094,9 @@ def _score_diff(y1, n1, y2, n2, value=0, return_cmle=False):
         Number of events in second sample.
     n2 : array_like
         Total exposure in second sample.
-    value : float
+    value : float, optional
         Value of the difference of the two rates under the null hypothesis.
-    return_cmle : bool
+    return_cmle : bool, optional
         If True, also return the constrained maximum likelihood estimates of
         the two rates.
 
@@ -1168,25 +1169,25 @@ def etest_poisson_2indep(
         Number of events in second sample.
     exposure2 : float
         Total exposure (time * subjects) in second sample.
-    value : float
+    value : float, optional
         Value of the ratio or diff of 2 independent rates under the null
         hypothesis. Default is equal rates, i.e., 1 for ratio and 0 for diff.
-    method : {"score", "wald"}
+    method : {"score", "wald"}, optional
         Method for the test statistic that defines the rejection region.
-    compare : {'diff', 'ratio'}
+    compare : {'diff', 'ratio'}, optional
         Default is "ratio".
         If compare is `ratio`, then the hypothesis test is for the
         rate ratio defined by ratio = rate1 / rate2.
         If compare is `diff`, then the hypothesis test is for
         diff = rate1 - rate2.
-    alternative : string
+    alternative : {"two-sided", "larger", "smaller"}, optional
         The alternative hypothesis, H1, has to be one of the following
 
         - 'two-sided': H1: ratio of rates is not equal to value (default)
         - 'larger' :   H1: ratio of rates is larger than value
         - 'smaller' :  H1: ratio of rates is smaller than value
 
-    y_grid : None or 1-D ndarray
+    y_grid : array_like, optional
         Grid values for counts of the Poisson distribution used for computing
         the pvalue. By default truncation is based on an upper tail Poisson
         quantiles.
@@ -1388,7 +1389,7 @@ def tost_poisson_2indep(
         Total exposure (time * subjects) in second sample.
     low, upp : float
         Equivalence margin for the ratio or difference of Poisson rates.
-    method : string
+    method : str, optional
         TOST uses ``test_poisson_2indep`` and has the same methods.
 
         ratio:
@@ -1414,7 +1415,7 @@ def tost_poisson_2indep(
         - 'etest-score' or 'etest': etest with score test statistic
         - 'etest-wald': etest with wald test statistic
 
-    compare : {'diff', 'ratio'}
+    compare : {'diff', 'ratio'}, optional
         Default is "ratio".
         If compare is `ratio`, then the equivalence test is for the
         rate ratio defined by ratio = rate1 / rate2.
@@ -1550,9 +1551,9 @@ def nonequivalence_poisson_2indep(
         Total exposure (time * subjects) in second sample.
     low, upp : float
         Equivalence margin for the ratio or difference of Poisson rates.
-    method : string
+    method : str, optional
         TOST uses ``test_poisson_2indep`` and has the same methods.
-    compare : {'diff', 'ratio'}
+    compare : {'diff', 'ratio'}, optional
         Default is "ratio".
         If compare is `ratio`, then the test is for the rate ratio defined
         by ratio = rate1 / rate2.
@@ -1650,7 +1651,7 @@ def confint_poisson_2indep(
         Number of events in second sample.
     exposure2 : float
         Total exposure (time * subjects) in second sample.
-    method : string
+    method : str, optional
         Method for the test statistic and the p-value. Defaults to `'score'`.
         see Notes.
 
@@ -1679,16 +1680,16 @@ def confint_poisson_2indep(
         - 'score'
         - 'mover'
 
-    compare : {'diff', 'ratio'}
+    compare : {'diff', 'ratio'}, optional
         Default is "ratio".
         If compare is `diff`, then the hypothesis test is for
         diff = rate1 - rate2.
         If compare is `ratio`, then the hypothesis test is for the
         rate ratio defined by ratio = rate1 / rate2.
-    alpha : float in (0, 1)
+    alpha : float in (0, 1), optional
         Significance level, nominal coverage of the confidence interval is
         1 - alpha.
-    method_mover : str
+    method_mover : str, optional
         Method to used for the score confidence interval of the individual
         rates in the 'mover' method.
 
@@ -1932,29 +1933,29 @@ def power_poisson_ratio_2indep(
         alternative hypothesis.
     nobs1 : float or int
         Number of observations in sample 1.
-    nobs_ratio : float
+    nobs_ratio : float, optional
         Sample size ratio, nobs2 = nobs_ratio * nobs1.
-    exposure : float
+    exposure : float, optional
         Exposure for each observation. Total exposure is nobs1 * exposure
         and nobs2 * exposure.
-    value : float
+    value : float, optional
         Rate ratio, rate1 / rate2, under the null hypothesis.
-    alpha : float in interval (0,1)
+    alpha : float in interval (0,1), optional
         Significance level, e.g., 0.05, is the probability of a type I
         error, that is wrong rejections if the Null Hypothesis is true.
-    dispersion : float
+    dispersion : float, optional
         Dispersion coefficient for quasi-Poisson. Dispersion different from
         one can capture over or under dispersion relative to Poisson
         distribution.
-    alternative : {'smaller', 'two-sided', 'larger'}
+    alternative : {'smaller', 'two-sided', 'larger'}, optional
         Alternative hypothesis whether the power is calculated for a
         one-sided or two-sided test. Default is 'smaller'.
-    method_var : {"score", "alt"}
+    method_var : {"score", "alt"}, optional
         The variance of the test statistic for the null hypothesis given the
         rates under the alternative can be either equal to the rates under the
         alternative ``method_var="alt"``, or estimated under the constrained
         of the null hypothesis, ``method_var="score"``.
-    return_results : bool
+    return_results : bool, optional
         If true, then a results instance with extra information is returned,
         otherwise only the computed power is returned.
 
@@ -2103,24 +2104,24 @@ def power_equivalence_poisson_2indep(
         Lower equivalence margin for the rate ratio, rate1 / rate2.
     upp : float
         Upper equivalence margin for the rate ratio, rate1 / rate2.
-    nobs_ratio : float
+    nobs_ratio : float, optional
         Sample size ratio, nobs2 = nobs_ratio * nobs1.
-    exposure : float
+    exposure : float, optional
         Exposure for each observation. Total exposure is nobs1 * exposure
         and nobs2 * exposure.
-    alpha : float in interval (0,1)
+    alpha : float in interval (0,1), optional
         Significance level, e.g., 0.05, is the probability of a type I
         error, that is wrong rejections if the Null Hypothesis is true.
-    dispersion : float
+    dispersion : float, optional
         Dispersion coefficient for quasi-Poisson. Dispersion different from
         one can capture over or under dispersion relative to Poisson
         distribution.
-    method_var : {"score", "alt"}
+    method_var : {"score", "alt"}, optional
         The variance of the test statistic for the null hypothesis given the
         rates under the alternative, can be either equal to the rates under
         the alternative ``method_var="alt"``, or estimated under the
         constrained of the null hypothesis, ``method_var="score"``.
-    return_results : bool
+    return_results : bool, optional
         If true, then a results instance with extra information is returned,
         otherwise only the computed power is returned.
 
@@ -2213,13 +2214,13 @@ def _power_equivalence_het_v0(
         Effect size relative to the upper equivalence margin.
     nobs : float or int
         Number of observations.
-    alpha : float in interval (0, 1)
+    alpha : float in interval (0, 1), optional
         Significance level of the test.
-    std_null_low : float
+    std_null_low : float, optional
         Standard deviation under the null hypothesis at the lower margin.
-    std_null_upp : float
+    std_null_upp : float, optional
         Standard deviation under the null hypothesis at the upper margin.
-    std_alternative : float
+    std_alternative : float, optional
         Standard deviation under the alternative hypothesis.
 
     Returns
@@ -2261,13 +2262,13 @@ def _power_equivalence_het(
         Effect size relative to the upper equivalence margin.
     nobs : float or int
         Number of observations.
-    alpha : float in interval (0, 1)
+    alpha : float in interval (0, 1), optional
         Significance level of the test.
-    std_null_low : float
+    std_null_low : float, optional
         Standard deviation under the null hypothesis at the lower margin.
-    std_null_upp : float
+    std_null_upp : float, optional
         Standard deviation under the null hypothesis at the upper margin.
-    std_alternative : float
+    std_alternative : float, optional
         Standard deviation under the alternative hypothesis.
 
     Returns
@@ -2384,23 +2385,23 @@ def power_poisson_diff_2indep(
         alternative hypothesis.
     nobs1 : float or int
         Number of observations in sample 1.
-    nobs_ratio : float
+    nobs_ratio : float, optional
         Sample size ratio, nobs2 = nobs_ratio * nobs1.
-    alpha : float in interval (0,1)
+    alpha : float in interval (0,1), optional
         Significance level, e.g., 0.05, is the probability of a type I
         error, that is wrong rejections if the Null Hypothesis is true.
-    value : float
+    value : float, optional
         Difference between rates 1 and 2 under the null hypothesis.
-    method_var : {"score", "alt"}
+    method_var : {"score", "alt"}, optional
         The variance of the test statistic for the null hypothesis given the
         rates under the alternative, can be either equal to the rates under
         the alternative ``method_var="alt"``, or estimated under the
         constrained of the null hypothesis, ``method_var="score"``.
-    alternative : {'two-sided', 'larger', 'smaller'}
+    alternative : {'two-sided', 'larger', 'smaller'}, optional
         Alternative hypothesis whether the power is calculated for a
         two-sided (default) or one sided test. The one-sided test can be
         either 'larger', 'smaller'.
-    return_results : bool
+    return_results : bool, optional
         If true, then a results instance with extra information is returned,
         otherwise only the computed power is returned.
 
@@ -2478,11 +2479,11 @@ def _var_cmle_negbin(rate1, rate2, nobs_ratio, exposure=1, value=1, dispersion=0
         Poisson or negative binomial rate for the second sample.
     nobs_ratio : float
         Sample size ratio, nobs2 = nobs_ratio * nobs1.
-    exposure : float
+    exposure : float, optional
         Exposure for each observation.
-    value : float
+    value : float, optional
         Rate ratio, rate1 / rate2, under the null hypothesis.
-    dispersion : float
+    dispersion : float, optional
         Dispersion parameter for the Negative Binomial distribution.
 
     Returns
@@ -2584,30 +2585,30 @@ def power_negbin_ratio_2indep(
         alternative hypothesis.
     nobs1 : float or int
         Number of observations in sample 1.
-    nobs_ratio : float
+    nobs_ratio : float, optional
         Sample size ratio, nobs2 = nobs_ratio * nobs1.
-    exposure : float
+    exposure : float, optional
         Exposure for each observation. Total exposure is nobs1 * exposure
         and nobs2 * exposure.
-    value : float
+    value : float, optional
         Rate ratio, rate1 / rate2, under the null hypothesis.
-    alpha : float in interval (0,1)
+    alpha : float in interval (0,1), optional
         Significance level, e.g., 0.05, is the probability of a type I
         error, that is wrong rejections if the Null Hypothesis is true.
-    dispersion : float >= 0.
+    dispersion : float >= 0., optional
         Dispersion parameter for Negative Binomial distribution.
         The Poisson limiting case corresponds to ``dispersion=0``.
-    alternative : {'two-sided', 'larger', 'smaller'}
+    alternative : {'two-sided', 'larger', 'smaller'}, optional
         Alternative hypothesis whether the power is calculated for a
         two-sided (default) or one sided test. The one-sided test can be
         either 'larger', 'smaller'.
-    method_var : {"score", "alt", "ftotal"}
+    method_var : {"score", "alt", "ftotal"}, optional
         The variance of the test statistic for the null hypothesis given the
         rates under the alternative, can be either equal to the rates under the
         alternative ``method_var="alt"``, or estimated under the constrained
         of the null hypothesis, ``method_var="score"``, or based on a moment
         constrained estimate, ``method_var="ftotal"``. see references.
-    return_results : bool
+    return_results : bool, optional
         If true, then a results instance with extra information is returned,
         otherwise only the computed power is returned.
 
@@ -2718,24 +2719,24 @@ def power_equivalence_neginb_2indep(
         Lower equivalence margin for the rate ratio, rate1 / rate2.
     upp : float
         Upper equivalence margin for the rate ratio, rate1 / rate2.
-    nobs_ratio : float
+    nobs_ratio : float, optional
         Sample size ratio, nobs2 = nobs_ratio * nobs1.
-    exposure : float
+    exposure : float, optional
         Exposure for each observation. Total exposure is nobs1 * exposure
         and nobs2 * exposure.
-    alpha : float in interval (0,1)
+    alpha : float in interval (0,1), optional
         Significance level, e.g., 0.05, is the probability of a type I
         error, that is wrong rejections if the Null Hypothesis is true.
-    dispersion : float >= 0.
+    dispersion : float >= 0., optional
         Dispersion parameter for Negative Binomial distribution.
         The Poisson limiting case corresponds to ``dispersion=0``.
-    method_var : {"score", "alt", "ftotal"}
+    method_var : {"score", "alt", "ftotal"}, optional
         The variance of the test statistic for the null hypothesis given the
         rates under the alternative, can be either equal to the rates under the
         alternative ``method_var="alt"``, or estimated under the constrained
         of the null hypothesis, ``method_var="score"``, or based on a moment
         constrained estimate, ``method_var="ftotal"``. see references.
-    return_results : bool
+    return_results : bool, optional
         If true, then a results instance with extra information is returned,
         otherwise only the computed power is returned.
 

--- a/statsmodels/stats/regularized_covariance.py
+++ b/statsmodels/stats/regularized_covariance.py
@@ -11,9 +11,9 @@ def _calc_nodewise_row(exog, idx, alpha):
 
     Parameters
     ----------
-    exog : array_like
+    exog : ndarray
         The weighted design matrix for the current partition.
-    idx : scalar
+    idx : int
         Index of the current variable.
     alpha : scalar or array_like
         The penalty weight.  If a scalar, the same penalty weight
@@ -23,8 +23,8 @@ def _calc_nodewise_row(exog, idx, alpha):
 
     Returns
     -------
-    array_like
-        An array-like object of length p-1.
+    ndarray
+        An array of length p-1.
 
     Notes
     -----
@@ -55,11 +55,11 @@ def _calc_nodewise_weight(exog, nodewise_row, idx, alpha):
 
     Parameters
     ----------
-    exog : array_like
+    exog : ndarray
         The weighted design matrix for the current partition.
     nodewise_row : array_like
         The nodewise_row values for the current variable.
-    idx : scalar
+    idx : int
         Index of the current variable.
     alpha : scalar or array_like
         The penalty weight.  If a scalar, the same penalty weight
@@ -101,13 +101,13 @@ def _calc_approx_inv_cov(nodewise_row_l, nodewise_weight_l):
         A list of array-like object where each object corresponds to
         the nodewise_row values for the corresponding variable, should
         be length p.
-    nodewise_weight_l : list
-        A list of scalars where each scalar corresponds to the nodewise_weight
+    nodewise_weight_l : ndarray
+        An array of scalars where each scalar corresponds to the nodewise_weight
         value for the corresponding variable, should be length p.
 
     Returns
     -------
-    array_like
+    ndarray
         A p x p matrix.
 
     Notes
@@ -136,12 +136,12 @@ class RegularizedInvCovariance:
 
     Parameters
     ----------
-    exog : array_like
+    exog : ndarray
         A weighted design matrix for covariance.
 
     Attributes
     ----------
-    exog : array_like
+    exog : ndarray
         A weighted design matrix for covariance.
     """
 
@@ -158,7 +158,7 @@ class RegularizedInvCovariance:
 
         Parameters
         ----------
-        alpha : scalar
+        alpha : scalar, optional
             Regularizing constant.
         """
 
@@ -187,7 +187,7 @@ class RegularizedInvCovariance:
 
         Returns
         -------
-        array_like
+        ndarray
             A p x p matrix.
         """
         return self._approx_inv_cov

--- a/statsmodels/stats/robust_compare.py
+++ b/statsmodels/stats/robust_compare.py
@@ -31,14 +31,14 @@ def trimboth(a, proportiontocut, axis=0):
         Data to trim.
     proportiontocut : float or int
         Proportion of data to trim at each end.
-    axis : int or None
+    axis : int or None, optional
         Axis along which the observations are trimmed. The default is to trim
         along axis=0. If axis is None then the array will be flattened before
         trimming.
 
     Returns
     -------
-    out : array-like
+    out : ndarray
         Trimmed version of array `a`.
 
     Examples
@@ -78,7 +78,7 @@ def trim_mean(a, proportiontocut, axis=0):
         Input array.
     proportiontocut : float
         Fraction to cut off at each tail of the sorted observations.
-    axis : int or None
+    axis : int or None, optional
         Axis along which the trimmed means are computed. The default is axis=0.
         If axis is None then the trimmed mean will be computed for the
         flattened array.
@@ -100,16 +100,16 @@ class TrimmedMean:
 
     Parameters
     ----------
-    data : array-like
+    data : array_like
         The data, observations to analyze.
     fraction : float in (0, 0.5)
         The fraction of observations to trim at each tail.
         The number of observations trimmed at each tail is
         ``int(fraction * nobs)``.
-    is_sorted : boolean
+    is_sorted : bool, optional
         Indicator if data is already sorted. By default the data is sorted
         along ``axis``.
-    axis : int
+    axis : int, optional
         The axis of reduce operations. By default axis=0, that is observations
         are along the zero dimension, i.e., rows if 2-dim.
     """
@@ -200,12 +200,12 @@ class TrimmedMean:
 
         Parameters
         ----------
-        value : float
+        value : float, optional
             Value of the mean under the Null hypothesis.
-        transform : {'trimmed', 'winsorized'}
+        transform : {'trimmed', 'winsorized'}, optional
             Specified whether the mean test is based on trimmed or winsorized
             data.
-        alternative : {'two-sided', 'larger', 'smaller'}
+        alternative : {'two-sided', 'larger', 'smaller'}, optional
             Defines the alternative hypothesis. The following options are
             available (default is 'two-sided'):
 
@@ -274,15 +274,15 @@ def scale_transform(data, center="median", transform="abs", trim_frac=0.2, axis=
     ----------
     data : array_like
         Observations for the data.
-    center : "median", "mean", "trimmed" or float
+    center : {'median', 'mean', 'trimmed'} or float, optional
         Statistic used for centering observations. If a float, then this
         value is used to center. Default is median.
-    transform : 'abs', 'square', 'identity' or a callable
+    transform : {'abs', 'square', 'identity'} or callable, optional
         The transform for the centered data.
-    trim_frac : float in [0, 0.5)
+    trim_frac : float in [0, 0.5), optional
         Fraction of observations that are trimmed on each side of the sorted
         observations. This is only used if center is `trimmed`.
-    axis : int
+    axis : int, optional
         Axis along which the data are transformed when centering.
 
     Returns

--- a/statsmodels/stats/sandwich_covariance.py
+++ b/statsmodels/stats/sandwich_covariance.py
@@ -315,7 +315,7 @@ def _get_sandwich_arrays(results, cov_type=""):
     ----------
     results : result instance or tuple
         A results instance, or a tuple of (jac, hessian_inv).
-    cov_type : str
+    cov_type : str, optional
         If "clu", then the score array is not rescaled by frequency
         weights when the model defines ``freq_weights``.
 
@@ -434,7 +434,7 @@ def _cluster_jackknife(results, group, center, hessian_inv):
     results : result instance
         need to contain regression results, uses results.model.wexog,
         results.model.wendog and results.params
-    group : ndarray
+    group : array_like of int
         Integer-valued index of clusters or groups, one entry per
         observation, already recoded to a dense range so that
         ``np.unique(group)`` visits every cluster.
@@ -579,10 +579,10 @@ def S_hac_simple(x, nlags=None, weights_func=weights_bartlett):
     ----------
     x : ndarray (nobs,) or (nobs, k_var)
         data, for HAC this is array of x_i * u_i
-    nlags : int or None
+    nlags : int or None, optional
         highest lag to include in kernel window. If None, then
         nlags = floor(4(T/100)^(2/9)) is used.
-    weights_func : callable
+    weights_func : callable, optional
         weights_func is called with nlags as argument to get the kernel
         weights. default are Bartlett weights
 
@@ -652,14 +652,14 @@ def S_hac_groupsum(x, time, nlags=None, weights_func=weights_bartlett):
 
     Parameters
     ----------
-    x : ndarray (nobs,) or (nobs, k_var)
+    x : array_like (nobs,) or (nobs, k_var)
         data, for HAC this is array of x_i * u_i
-    time : ndarray, (nobs,)
-        timeindes, assumed to be integers range(n_periods)
-    nlags : int or None
+    time : array_like of int, (nobs,)
+        time index, assumed to be integers in range(n_periods)
+    nlags : int or None, optional
         highest lag to include in kernel window. If None, then
         nlags = floor[4(T/100)^(2/9)] is used.
-    weights_func : callable
+    weights_func : callable, optional
         weights_func is called with nlags as argument to get the kernel
         weights. default are Bartlett weights
 
@@ -692,9 +692,9 @@ def S_crosssection(x, group):
 
     Parameters
     ----------
-    x : ndarray (nobs,) or (nobs, k_var)
+    x : array_like (nobs,) or (nobs, k_var)
         data, for HAC this is array of x_i * u_i
-    group : ndarray, (nobs,)
+    group : array_like of int, (nobs,)
         group or cluster indicator for each observation
 
     Returns
@@ -730,11 +730,11 @@ def cov_cluster(results, group, use_correction=True, crv_type="cluster"):
     results : result instance
        result of a regression, uses results.model.exog and results.resid
        TODO: this should use wexog instead
-    group : array_like[int] :
+    group : array_like of int
         Integer-valued index of clusters or groups.
-    use_correction : bool
+    use_correction : bool, optional
        If true (default), then the small sample correction factor is used.
-    crv_type : str
+    crv_type : {"cluster", "cluster-crv3", "cluster-jk"}, optional
        If 'cluster' (default), compute a CRV1 robust variance covariance matrix.
        If 'cluster-crv3', compute a CRV3 robust variance covariance matrix.
        If 'cluster-jk', compute a variance covariance matrix via the cluster jackknife.
@@ -811,12 +811,14 @@ def cov_cluster_2groups(
        each cluster dimension.
     group2 : ndarray, optional
        Group/cluster indicator for the second cluster dimension.
-    use_correction : bool
+    use_correction : bool, optional
        If true (default), then the small sample correction factor is used.
-    crv_type : str
-       If 'cluster' (default), compute a CRV1 robust variance covariance matrix.
-       If 'cluster-crv3', compute a CRV3 robust variance covariance matrix.
-       If 'cluster-jk', compute a variance covariance matrix via the cluster jackknife.
+    crv_type : {"cluster"}, optional
+       Only 'cluster' (default), computing the additive two-way CRV1
+       combination ``cov0 + cov1 - cov01``, is supported here. Passing
+       'cluster-crv3' or 'cluster-jk' raises ``NotImplementedError``; use
+       :func:`cov_cluster` directly with one-way clustering for those
+       options.
 
 
     Returns
@@ -895,7 +897,7 @@ def cov_white_simple(results, use_correction=True):
     results : result instance
        result of a regression, uses results.model.exog and results.resid
        TODO: this should use wexog instead
-    use_correction : bool
+    use_correction : bool, optional
        If true (default), then a small sample correction factor is used.
 
     Returns
@@ -942,13 +944,13 @@ def cov_hac_simple(results, nlags=None, weights_func=weights_bartlett,
     results : result instance
        result of a regression, uses results.model.exog and results.resid
        TODO: this should use wexog instead
-    nlags : int or None
+    nlags : int or None, optional
         highest lag to include in kernel window. If None, then
         nlags = floor[4(T/100)^(2/9)] is used.
-    weights_func : callable
+    weights_func : callable, optional
         weights_func is called with nlags as argument to get the kernel
         weights. default are Bartlett weights
-    use_correction : bool
+    use_correction : bool, optional
         If true (default), then a small sample correction factor is used.
 
     Returns
@@ -1069,22 +1071,22 @@ def cov_nw_panel(results, nlags, groupidx, weights_func=weights_bartlett,
     results : result instance
        result of a regression, uses results.model.exog and results.resid
        TODO: this should use wexog instead
-    nlags : int or None
+    nlags : int
         Highest lag to include in kernel window. Currently, no default
         because the optimal length will depend on the number of observations
         per cross-sectional unit.
     groupidx : list of tuple
         each tuple should contain the start and end index for an individual.
         (groupidx might change in future).
-    weights_func : callable
+    weights_func : callable, optional
         weights_func is called with nlags as argument to get the kernel
         weights. default are Bartlett weights
-    use_correction : 'cluster' or 'hac' or False
+    use_correction : {"hac", "cluster", False}, optional
         If False, then no small sample correction is used.
-        If 'cluster' (default), then the same correction as in cov_cluster is
+        If 'cluster', then the same correction as in cov_cluster is
         used.
-        If 'hac', then the same correction as in single time series, cov_hac
-        is used.
+        If 'hac' (default), then the same correction as in single time
+        series, cov_hac is used.
 
 
     Returns
@@ -1151,15 +1153,15 @@ def cov_nw_groupsum(
         Highest lag to include in kernel window. Currently, no default
         because the optimal length will depend on the number of observations
         per cross-sectional unit.
-    time : ndarray of int
+    time : array_like of int
         this should contain the coding for the time period of each observation.
         time periods should be integers in range(maxT) where maxT is obs of i
-    weights_func : callable
+    weights_func : callable, optional
         weights_func is called with nlags as argument to get the kernel
         weights. default are Bartlett weights
-    use_correction : 'cluster' or 'hac' or False
-        If False, then no small sample correction is used.
-        If 'hac' (default), then the same correction as in single time series, cov_hac
+    use_correction : {"hac", "cluster", False}, optional
+        If False (default), then no small sample correction is used.
+        If 'hac', then the same correction as in single time series, cov_hac
         is used.
         If 'cluster', then the same correction as in cov_cluster is
         used.

--- a/statsmodels/stats/stattools.py
+++ b/statsmodels/stats/stattools.py
@@ -26,7 +26,7 @@ def durbin_watson(resids, axis=0):
 
     Returns
     -------
-    dw : float, array_like
+    dw : float or ndarray
         The Durbin-Watson statistic.
 
     Notes
@@ -65,9 +65,9 @@ def omni_normtest(resids, axis=0):
 
     Returns
     -------
-    statistic : float or array_like
+    statistic : float or ndarray
         The Chi^2 test statistic.
-    pvalue : float or array_like
+    pvalue : float or ndarray
         The two-tailed p-value for the hypothesis test.
     """
     # TODO: change to exception in summary branch and catch in summary()
@@ -97,13 +97,13 @@ def jarque_bera(resids, axis=0):
 
     Returns
     -------
-    JB : {float, ndarray}
+    JB : float or ndarray
         The Jarque-Bera test statistic.
-    JBpv : {float, ndarray}
+    JBpv : float or ndarray
         The pvalue of the test statistic.
-    skew : {float, ndarray}
+    skew : float or ndarray
         Estimated skewness of the data.
-    kurtosis : {float, ndarray}
+    kurtosis : float or ndarray
         Estimated kurtosis of the data.
 
     Notes
@@ -303,7 +303,7 @@ def robust_kurtosis(y, axis=0, ab=(5.0, 50.0), dg=(2.5, 25.0), excess=True):
 
     Parameters
     ----------
-    y : array_like
+    y : ndarray
         Data to compute use in the estimator.
     axis : int or None, optional
         Axis along which the kurtosis are computed.  If `None`, the
@@ -463,10 +463,12 @@ def _wmedian(A, W):
 
     Parameters
     ----------
-    A : 1-d NumPy array of float
-        The numeric values for which the weighted median is to be computed.
-    W : 1-d NumPy array of int
-        The corresponding non-negative integer weights for each value in A.
+    A : ndarray
+        1-d array of the numeric values for which the weighted median is to
+        be computed.
+    W : ndarray
+        1-d array of the corresponding non-negative integer weights for each
+        value in A.
 
     Returns
     -------
@@ -512,24 +514,24 @@ def _construct_A_W(L, R, Zplus, Zminus, n_plus, eps2):
 
     Parameters
     ----------
-    L : np.ndarray
+    L : ndarray
         1-d array of left bounds.
-    R : np.ndarray
+    R : ndarray
         1-d array of right bounds.
-    Zplus : np.ndarray
+    Zplus : ndarray
         1-d array of input values.
-    Zminus :  np.ndarray
+    Zminus : ndarray
         1-d array of input values.
     n_plus : int
     eps2 : float
 
     Returns
     -------
-    A : np.ndarray
+    A : ndarray
         Array of kernel values.
-    W : np.ndarray
+    W : ndarray
         Corresponding weights.
-    valid_i : np.ndarray
+    valid_i : ndarray
         Indices used for construction.
     """
     valid_i = np.where(L <= R)[0]
@@ -555,9 +557,9 @@ def _h_kern(index_plus, index_minus, Zplus, Zminus, n_plus, eps2):
         Index of Zplus.
     index_minus : int-like
         Index of Zminus.
-    Zplus : np.ndarray
+    Zplus : ndarray
         1-d array of input values.
-    Zminus :  np.ndarray
+    Zminus : ndarray
         1-d array of input values.
     n_plus : int
     eps2 : float
@@ -582,20 +584,20 @@ def _finalize_h_kernel_sweep(L, R, Zplus, Zminus, n_plus, eps2):
 
     Parameters
     ----------
-    L : np.ndarray
+    L : ndarray
         1-d array of left indices.
-    R : np.ndarray
+    R : ndarray
         1-d array of right indices.
-    Zplus : np.ndarray
+    Zplus : ndarray
         1-d array of input values.
-    Zminus :  np.ndarray
+    Zminus : ndarray
         1-d array of input values.
     n_plus : int
     eps2 : float
 
     Returns
     -------
-    A : numpy.ndarray of float
+    A : ndarray of float
         1-d array of sorted h_kern values in descending order.
     """
 
@@ -631,8 +633,12 @@ def _medcouple_nlogn(X, eps1=2**-52, eps2=2**-1022):
 
     Parameters
     ----------
-    X : np.ndarray
+    X : ndarray
         Input 1-d array of numeric values.
+    eps1 : float, optional
+        Relative tolerance used to detect extreme values and near-ties.
+    eps2 : float, optional
+        Absolute tolerance used as a tie breaker in the H kernel.
 
     Returns
     -------
@@ -721,9 +727,9 @@ def _select_kth_h_value(Zplus, Zminus, n_plus, n_minus, k, eps1, eps2):
 
     Parameters
     ----------
-    Zplus : np.ndarray
+    Zplus : ndarray
         1-d array of input values with Zplus >= -Zeps.
-    Zminus :  np.ndarray
+    Zminus : ndarray
         1-d array of input values with Zminus <= Zeps.
     n_plus : int
     n_minus : int
@@ -815,9 +821,9 @@ def _medcouple_1d(y, use_fast=True):
 
     Parameters
     ----------
-    y : np.ndarray
+    y : ndarray
         1-d data to compute use in the estimator.
-    use_fast : bool
+    use_fast : bool, optional
         Whether to use the O(n log n) implementation. Defaults to True.
 
     Returns
@@ -843,10 +849,10 @@ def medcouple(y, axis=0, use_fast=True):
     ----------
     y : array_like
         Data to compute use in the estimator.
-    axis : {int, None}
+    axis : int or None, optional
         Axis along which the medcouple statistic is computed.  If `None`, the
         entire array is used.
-    use_fast : bool
+    use_fast : bool, optional
         Whether to use the faster O(N log N) implementation. Default is True.
         To use the legacy O(N**2) version, set to False.
 

--- a/statsmodels/stats/weightstats.py
+++ b/statsmodels/stats/weightstats.py
@@ -53,9 +53,9 @@ class DescrStatsW:
     ----------
     data : array_like, 1-D or 2-D
         dataset
-    weights : None or 1-D ndarray
+    weights : array_like, optional
         weights for each observation, with same length as zero axis of data
-    ddof : int
+    ddof : int or float, optional
         default ddof=0, degrees of freedom correction used for second moments,
         var, std, cov, corrcoef.
         However, statistical tests are independent of `ddof`, based on the
@@ -147,12 +147,12 @@ class DescrStatsW:
 
         Parameters
         ----------
-        ddof : int, float
+        ddof : int or float, optional
             degrees of freedom correction, independent of attribute ddof
 
         Returns
         -------
-        var : float, ndarray
+        var : float or ndarray
             variance with denominator ``sum_weights - ddof``
         """
         return self.sumsquares / (self.sum_weights - ddof)
@@ -163,12 +163,12 @@ class DescrStatsW:
 
         Parameters
         ----------
-        ddof : int, float
+        ddof : int or float, optional
             degrees of freedom correction, independent of attribute ddof
 
         Returns
         -------
-        std : float, ndarray
+        std : float or ndarray
             standard deviation with denominator ``sum_weights - ddof``
         """
         return np.sqrt(self.var_ddof(ddof=ddof))
@@ -234,7 +234,7 @@ class DescrStatsW:
         probs : array_like
             A vector of probability points at which to calculate the
             quantiles.  Each element of `probs` should fall in [0, 1].
-        return_pandas : bool
+        return_pandas : bool, optional
             If True, return value is a Pandas DataFrame or Series.
             Otherwise returns a ndarray.
 
@@ -330,10 +330,10 @@ class DescrStatsW:
 
         Parameters
         ----------
-        alpha : float
+        alpha : float, optional
             significance level for the confidence interval, coverage is
             ``1-alpha``
-        alternative : str
+        alternative : {"two-sided", "larger", "smaller"}, optional
             This specifies the alternative hypothesis for the test that
             corresponds to the confidence interval.
             The alternative hypothesis, H1, has to be one of the following
@@ -369,10 +369,10 @@ class DescrStatsW:
 
         Parameters
         ----------
-        alpha : float
+        alpha : float, optional
             significance level for the confidence interval, coverage is
             ``1-alpha``
-        alternative : str
+        alternative : {"two-sided", "larger", "smaller"}, optional
             This specifies the alternative hypothesis for the test that
             corresponds to the confidence interval.
             The alternative hypothesis, H1, has to be one of the following
@@ -406,9 +406,9 @@ class DescrStatsW:
 
         Parameters
         ----------
-        value : float or array
+        value : float or array_like, optional
             the hypothesized value for the mean
-        alternative : str
+        alternative : {"two-sided", "larger", "smaller"}, optional
             The alternative hypothesis, H1, has to be one of the following:
 
               - 'two-sided': H1: mean not equal to value (default)
@@ -488,9 +488,9 @@ class DescrStatsW:
 
         Parameters
         ----------
-        value : float or array
+        value : float or array_like, optional
             the hypothesized value for the mean
-        alternative : str
+        alternative : {"two-sided", "larger", "smaller"}, optional
             The alternative hypothesis, H1, has to be one of the following
 
               'two-sided': H1: mean not equal to value (default)
@@ -589,7 +589,7 @@ class DescrStatsW:
         other : array_like or instance of DescrStatsW
             If array_like then this creates an instance of DescrStatsW with
             the given weights.
-        weights : None or array
+        weights : array_like, optional
             weights are only used if other is not an instance of DescrStatsW
 
         Returns
@@ -637,14 +637,14 @@ def _tstat_generic(value1, value2, std_diff, dof, alternative, diff=0):
         Standard error of the difference value1 - value2
     dof : int or float
         Degrees of freedom
-    alternative : str
+    alternative : {"two-sided", "larger", "smaller"}
         The alternative hypothesis, H1, has to be one of the following
 
            * 'two-sided' : H1: ``value1 - value2 - diff`` not equal to 0.
            * 'larger' :   H1: ``value1 - value2 - diff > 0``
            * 'smaller' :  H1: ``value1 - value2 - diff < 0``
 
-    diff : float
+    diff : float, optional
         value of difference ``value1 - value2`` under the null hypothesis
 
     Returns
@@ -684,7 +684,7 @@ def _tconfint_generic(mean, std_mean, dof, alpha, alternative):
     alpha : float
         Significance level for the confidence interval, coverage is
         ``1-alpha``.
-    alternative : str
+    alternative : {"two-sided", "larger", "smaller"}
         The alternative hypothesis, H1, has to be one of the following
 
            * 'two-sided' : H1: ``mean`` not equal to the null value.
@@ -736,14 +736,14 @@ def _zstat_generic(value1, value2, std_diff, alternative, diff=0):
         Value, for example mean, of the second sample.
     std_diff : float or ndarray
         Standard error of the difference value1 - value2
-    alternative : str
+    alternative : {"two-sided", "larger", "smaller"}
         The alternative hypothesis, H1, has to be one of the following
 
            * 'two-sided' : H1: ``value1 - value2 - diff`` not equal to 0.
            * 'larger' :   H1: ``value1 - value2 - diff > 0``
            * 'smaller' :  H1: ``value1 - value2 - diff < 0``
 
-    diff : float
+    diff : float, optional
         value of difference ``value1 - value2`` under the null hypothesis
 
     Returns
@@ -782,7 +782,7 @@ def _zstat_generic2(value, std, alternative):
         Value of a sample statistic, for example mean.
     std : float or ndarray
         Standard error of the sample statistic value.
-    alternative : str
+    alternative : {"two-sided", "larger", "smaller"}
         The alternative hypothesis, H1, has to be one of the following
 
            * 'two-sided' : H1: ``value`` not equal to 0.
@@ -824,7 +824,7 @@ def _zconfint_generic(mean, std_mean, alpha, alternative):
     alpha : float
         Significance level for the confidence interval, coverage is
         ``1-alpha``
-    alternative : str
+    alternative : {"two-sided", "larger", "smaller"}
         The alternative hypothesis, H1, has to be one of the following
 
            * 'two-sided' : H1: ``mean`` not equal to the null value.
@@ -902,10 +902,10 @@ class CompareMeans:
         ----------
         data1, data2 : array_like, 1-D or 2-D
             compared datasets
-        weights1, weights2 : None or 1-D ndarray
+        weights1, weights2 : array_like, optional
             weights for each observation of data1 and data2 respectively,
             with same length as zero axis of corresponding dataset.
-        ddof1, ddof2 : int
+        ddof1, ddof2 : int or float, optional
             default ddof1=0, ddof2=0, degrees of freedom for data1,
             data2 respectively.
 
@@ -928,15 +928,15 @@ class CompareMeans:
         use_t : bool, optional
             if use_t is True, then t test results are returned
             if use_t is False, then z test results are returned
-        alpha : float
+        alpha : float, optional
             significance level for the confidence interval, coverage is
             ``1-alpha``
-        usevar : str, 'pooled' or 'unequal'
+        usevar : {"pooled", "unequal"}, optional
             If ``pooled``, then the standard deviation of the samples is
             assumed to be the same. If ``unequal``, then the variance of
             Welch ttest will be used, and the degrees of freedom are those
             of Satterthwaite if ``use_t`` is True.
-        value : float
+        value : float, optional
             difference between the means under the Null hypothesis.
 
         Returns
@@ -1028,17 +1028,17 @@ class CompareMeans:
 
         Parameters
         ----------
-        alternative : str
+        alternative : {"two-sided", "larger", "smaller"}, optional
             The alternative hypothesis, H1, has to be one of the following
             'two-sided': H1: difference in means not equal to value (default)
             'larger' :   H1: difference in means larger than value
             'smaller' :  H1: difference in means smaller than value
 
-        usevar : str, 'pooled' or 'unequal'
+        usevar : {"pooled", "unequal"}, optional
             If ``pooled``, then the standard deviation of the samples is assumed to be
             the same. If ``unequal``, then Welch ttest with Satterthwait degrees
             of freedom is used
-        value : float
+        value : float, optional
             difference between the means under the Null hypothesis.
 
 
@@ -1080,17 +1080,17 @@ class CompareMeans:
 
         Parameters
         ----------
-        alternative : str
+        alternative : {"two-sided", "larger", "smaller"}, optional
             The alternative hypothesis, H1, has to be one of the following
             'two-sided': H1: difference in means not equal to value (default)
             'larger' :   H1: difference in means larger than value
             'smaller' :  H1: difference in means smaller than value
 
-        usevar : str, 'pooled' or 'unequal'
+        usevar : {"pooled", "unequal"}, optional
             If ``pooled``, then the standard deviation of the samples is assumed to be
             the same. If ``unequal``, then the standard deviations of the samples may
             be different.
-        value : float
+        value : float, optional
             difference between the means under the Null hypothesis.
 
         Returns
@@ -1125,10 +1125,10 @@ class CompareMeans:
 
         Parameters
         ----------
-        alpha : float
+        alpha : float, optional
             significance level for the confidence interval, coverage is
             ``1-alpha``
-        alternative : str
+        alternative : {"two-sided", "larger", "smaller"}, optional
             This specifies the alternative hypothesis for the test that
             corresponds to the confidence interval.
             The alternative hypothesis, H1, has to be one of the following :
@@ -1137,7 +1137,7 @@ class CompareMeans:
             'larger' :   H1: difference in means larger than value
             'smaller' :  H1: difference in means smaller than value
 
-        usevar : str, 'pooled' or 'unequal'
+        usevar : {"pooled", "unequal"}, optional
             If ``pooled``, then the standard deviation of the samples is assumed to be
             the same. If ``unequal``, then Welch ttest with Satterthwait degrees
             of freedom is used
@@ -1176,10 +1176,10 @@ class CompareMeans:
 
         Parameters
         ----------
-        alpha : float
+        alpha : float, optional
             significance level for the confidence interval, coverage is
             ``1-alpha``
-        alternative : str
+        alternative : {"two-sided", "larger", "smaller"}, optional
             This specifies the alternative hypothesis for the test that
             corresponds to the confidence interval.
             The alternative hypothesis, H1, has to be one of the following :
@@ -1188,7 +1188,7 @@ class CompareMeans:
             'larger' :   H1: difference in means larger than value
             'smaller' :  H1: difference in means smaller than value
 
-        usevar : str, 'pooled' or 'unequal'
+        usevar : {"pooled", "unequal"}, optional
             If ``pooled``, then the standard deviation of the samples is assumed to be
             the same. If ``unequal``, then Welch ttest with Satterthwait degrees
             of freedom is used
@@ -1225,7 +1225,7 @@ class CompareMeans:
         ----------
         low, upp : float
             equivalence interval low < m1 - m2 < upp
-        usevar : str, 'pooled' or 'unequal'
+        usevar : {"pooled", "unequal"}, optional
             If ``pooled``, then the standard deviation of the samples is assumed to be
             the same. If ``unequal``, then Welch ttest with Satterthwait degrees
             of freedom is used
@@ -1252,7 +1252,7 @@ class CompareMeans:
         ----------
         low, upp : float
             equivalence interval low < m1 - m2 < upp
-        usevar : str, 'pooled' or 'unequal'
+        usevar : {"pooled", "unequal"}, optional
             If ``pooled``, then the standard deviation of the samples is assumed to be
             the same. If ``unequal``, then Welch ttest with Satterthwait degrees
             of freedom is used
@@ -1307,21 +1307,21 @@ def ttest_ind(
         first of the two independent samples, see notes for 2-D case
     x2 : array_like, 1-D or 2-D
         second of the two independent samples, see notes for 2-D case
-    alternative : str
+    alternative : {"two-sided", "larger", "smaller"}, optional
         The alternative hypothesis, H1, has to be one of the following
 
            * 'two-sided' (default): H1: difference in means not equal to value
            * 'larger' :   H1: difference in means larger than value
            * 'smaller' :  H1: difference in means smaller than value
 
-    usevar : str, 'pooled' or 'unequal'
+    usevar : {"pooled", "unequal"}, optional
         If ``pooled``, then the standard deviation of the samples is assumed to be
         the same. If ``unequal``, then Welch ttest with Satterthwait degrees
         of freedom is used
-    weights : tuple of None or ndarrays
+    weights : tuple of array_like, optional
         Case weights for the two samples. For details on weights see
         ``DescrStatsW``
-    value : float
+    value : float, optional
         difference between the means under the Null hypothesis.
 
     Returns
@@ -1369,14 +1369,14 @@ def ttost_ind(
         second of the two independent samples, see notes for 2-D case
     low, upp : float
         equivalence interval low < m1 - m2 < upp
-    usevar : str, 'pooled' or 'unequal'
+    usevar : {"pooled", "unequal"}, optional
         If ``pooled``, then the standard deviation of the samples is assumed to be
         the same. If ``unequal``, then Welch ttest with Satterthwait degrees
         of freedom is used
-    weights : tuple of None or ndarrays
+    weights : tuple of array_like, optional
         Case weights for the two samples. For details on weights see
         ``DescrStatsW``
-    transform : None or function
+    transform : None or callable, optional
         If None (default), then the data is not transformed. Given a function,
         sample data and thresholds are transformed. If transform is log, then
         the equivalence interval is in ratio: low < m1 / m2 < upp
@@ -1448,11 +1448,11 @@ def ttost_paired(x1, x2, low, upp, transform=None, weights=None):
         second of the two independent samples
     low, upp : float
         equivalence interval low < mean of difference < upp
-    transform : None or function
+    transform : None or callable, optional
         If None (default), then the data is not transformed. Given a function
         sample data and thresholds are transformed. If transform is log, then
         the equivalence interval is in ratio: low < x1 / x2 < upp
-    weights : None or ndarray
+    weights : array_like, optional
         case weights for the two samples. For details on weights see
         ``DescrStatsW``
 
@@ -1498,26 +1498,27 @@ def ztest(
     ----------
     x1 : array_like, 1-D or 2-D
         first of the two independent samples
-    x2 : array_like, 1-D or 2-D
-        second of the two independent samples
-    value : float
+    x2 : array_like, 1-D or 2-D, optional
+        second of the two independent samples. If None, then a one-sample
+        test is performed using `x1` only.
+    value : float, optional
         In the one sample case, value is the mean of x1 under the Null
         hypothesis.
         In the two sample case, value is the difference between mean of x1 and
         mean of x2 under the Null hypothesis. The test statistic is
         `x1_mean - x2_mean - value`.
-    alternative : str
+    alternative : {"two-sided", "larger", "smaller"}, optional
         The alternative hypothesis, H1, has to be one of the following
 
            'two-sided': H1: difference in means not equal to value (default)
            'larger' :   H1: difference in means larger than value
            'smaller' :  H1: difference in means smaller than value
 
-    usevar : str, 'pooled' or 'unequal'
+    usevar : {"pooled", "unequal"}, optional
         If ``pooled``, then the standard deviation of the samples is assumed to be
         the same. If ``unequal``, then the standard deviation of the sample is
         assumed to be different.
-    ddof : int
+    ddof : int or float, optional
         Degrees of freedom use in the calculation of the variance of the mean
         estimate. In the case of comparing means this is one, however it can
         be adjusted for testing other statistics (proportion, correlation)
@@ -1583,18 +1584,19 @@ def zconfint(
     ----------
     x1 : array_like, 1-D or 2-D
         first of the two independent samples, see notes for 2-D case
-    x2 : array_like, 1-D or 2-D
-        second of the two independent samples, see notes for 2-D case
-    value : float
+    x2 : array_like, 1-D or 2-D, optional
+        second of the two independent samples, see notes for 2-D case. If
+        None, then a one-sample test is performed using `x1` only.
+    value : float, optional
         In the one sample case, value is the mean of x1 under the Null
         hypothesis.
         In the two sample case, value is the difference between mean of x1 and
         mean of x2 under the Null hypothesis. The test statistic is
         `x1_mean - x2_mean - value`.
-    alpha : float
+    alpha : float, optional
         significance level for the confidence interval, coverage is
         ``1-alpha``
-    alternative : str
+    alternative : {"two-sided", "larger", "smaller"}, optional
         This specifies the alternative hypothesis for the test that
         corresponds to the confidence interval.
         The alternative hypothesis, H1, has to be one of the following
@@ -1603,11 +1605,11 @@ def zconfint(
            'larger' :   H1: difference in means larger than value
            'smaller' :  H1: difference in means smaller than value
 
-    usevar : str, 'pooled'
+    usevar : {"pooled"}, optional
         Currently, only 'pooled' is implemented.
         If ``pooled``, then the standard deviation of the samples is assumed to be
         the same. see CompareMeans.ztest_ind for different options.
-    ddof : int
+    ddof : int or float, optional
         Degrees of freedom use in the calculation of the variance of the mean
         estimate. In the case of comparing means this is one, however it can
         be adjusted for testing other statistics (proportion, correlation)
@@ -1664,13 +1666,14 @@ def ztost(x1, low, upp, x2=None, usevar="pooled", ddof=1.0):
         one sample or first sample for 2 independent samples
     low, upp : float
         equivalence interval low < m1 - m2 < upp
-    x2 : array_like or None
+    x2 : array_like or None, optional
         second sample for 2 independent samples test. If None, then a
         one-sample test is performed.
-    usevar : str, 'pooled'
-        If `pooled`, then the standard deviation of the samples is assumed to be
-        the same. Only `pooled` is currently implemented.
-    ddof : int
+    usevar : {"pooled", "unequal"}, optional
+        If ``pooled``, then the standard deviation of the samples is assumed to be
+        the same. If ``unequal``, then the standard deviation of the sample is
+        assumed to be different.
+    ddof : int or float, optional
         Degrees of freedom used in the calculation of the variance of the
         mean estimate. In the case of comparing means this is one, however
         it can be adjusted for testing other statistics (proportion,


### PR DESCRIPTION
- [x] code/documentation is well formatted.
- [x] properly formatted commit message. See
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message).

#### AI Disclosure

Contributions must comply with the statsmodels [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html).

If using AI tools, edit the second option to explain which tool was selected and
how the tool's output was used.

Please complete **one** of the following:

- [ ] No AI tools were used to develop this pull request.
- [x] AI tools were used.
      Tool(s): Claude
      Used for: docstting cleangin
      I have personally read, understood, and can explain every line of this diff, and
      have verified the statistical/numerical correctness of the change.

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows
  using the Windows System for Linux once `flake8` is installed in the
  local Linux environment. While passing this test is not required, it is good practice and it help
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.
* If AI tools were used to help write this PR, see the
  [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html) for what disclosure
  and review is expected of you before submitting.

</details>
