### PR TITLE
DOC: Documentation cleaning pass for formula, graphics and imputation

### DIFF
--- a/statsmodels/formula/_manager.py
+++ b/statsmodels/formula/_manager.py
@@ -90,7 +90,7 @@ def _check_data(data):
 
     Parameters
     ----------
-    data : {dict, list, recarray, DataFrame}
+    data : dict, list, recarray, or DataFrame
         The data used to create a formula.
 
     Notes
@@ -122,6 +122,16 @@ def _maybe_convert_data(data):
 
 
 class _FormulaOption:
+    """
+    Container for the global formula-related options.
+
+    Parameters
+    ----------
+    default_engine : {"patsy", "formulaic"}, optional
+        The initial formula engine to use. If None, the best available
+        engine is selected automatically.
+    """
+
     def __init__(self, default_engine: Literal["patsy", "formulaic"] | None = None):
         if default_engine is None:
             default_engine = DEFAULT_FORMULA_ENGINE
@@ -137,11 +147,11 @@ class _FormulaOption:
     @property
     def formula_engine(self) -> Literal["patsy", "formulaic"]:
         """
-        Get or set the formula engine
+        Get or set the formula engine.
 
         Returns
         -------
-        str: {"patsy", "formulaic"}
+        {"patsy", "formulaic"}
             The name of the formula engine.
         """
         return self._formula_engine
@@ -199,6 +209,19 @@ _NoDefault = _Default("<no default value>")
 
 
 class LinearConstraintValues(NamedTuple):
+    """
+    Container for the result of parsing a linear constraint.
+
+    Attributes
+    ----------
+    constraint_matrix : ndarray
+        The constraint coefficient matrix.
+    constraint_values : ndarray
+        The constraint constant values.
+    variable_names : list[str]
+        The names of the variables in the constraint matrix.
+    """
+
     constraint_matrix: np.ndarray
     constraint_values: np.ndarray
     variable_names: list[str]
@@ -212,14 +235,16 @@ class FormulaManager:
 
     Parameters
     ----------
-    engine : {"patsy", "formulaic"} or None
+    engine : {"patsy", "formulaic"}, optional
         The formula engine to use. If None, the default engine, which appears
-        in the attribute statsmodels.formula.formula_options.engine, is used.
+        in the attribute statsmodels.formula.options.formula_engine, is used.
 
     Raises
     ------
     ValueError
-        If the selected engine is not available.
+        If the selected engine is not "patsy" or "formulaic".
+    ImportError
+        If the selected engine is not installed.
     """
 
     def __init__(self, engine: Literal["patsy", "formulaic"] | None = None):
@@ -237,19 +262,21 @@ class FormulaManager:
 
         Parameters
         ----------
-        engine : {"patsy", "formulaic"} or None
+        engine : {"patsy", "formulaic"}, optional
             The formula engine to use. If None, the default engine, which appears
-            in the attribute statsmodels.formula.formula_options.engine, is used.
+            in the attribute statsmodels.formula.options.formula_engine, is used.
 
         Returns
         -------
         engine : {"patsy", "formulaic"}
-            The selected engine
+            The selected engine.
 
         Raises
         ------
         ValueError
-            If the selected engine is not available.
+            If the selected engine is not "patsy" or "formulaic".
+        ImportError
+            If the selected engine is not installed.
         """
         _engine: Literal["patsy", "formulaic"]
 
@@ -283,7 +310,7 @@ class FormulaManager:
     @property
     def spec(self):
         """
-        Get the model specification. Only available after calling get_arrays.
+        Get the model specification. Only available after calling get_matrices.
         """
         return self._spec
 
@@ -314,8 +341,9 @@ class FormulaManager:
 
         Returns
         -------
-        ndarray
-            A boolean array indicating if data are missing. True if missing.
+        ndarray, Series, or None
+            A boolean array or Series indicating if data are missing, True
+            if missing, or None if get_matrices has not yet been called.
         """
         return self._missing_mask
 
@@ -346,9 +374,9 @@ class FormulaManager:
 
         Returns
         -------
-        {type[ModelSpect], type[DesignInto]}
-            The model specification type of formulaic is ModelSpec.
-            patsy uses DesignInfo.
+        type[ModelSpec] or type[DesignInfo]
+            The model specification type. For formulaic this is ModelSpec;
+            for patsy it is DesignInfo.
         """
         if self._using_patsy:
             return patsy.design_info.DesignInfo
@@ -456,13 +484,13 @@ class FormulaManager:
             The formula to use.
         data : DataFrame, dict, list, recarray
             The data to use when evaluating the formula.
-        eval_env : {int, dict}
+        eval_env : int or dict, optional
             Additional context to use when evaluating the formula.
-        pandas : bool
+        pandas : bool, optional
             Return a DataFrame if true, otherwise return a numpy array.
-        na_action : {NAAction, str}
+        na_action : NAAction or str, optional
             The action to take on missing values.
-        prediction : bool
+        prediction : bool, optional
             True if using the formula for prediction. In this case, only the
             rhs is evaluated using data.
 
@@ -681,7 +709,7 @@ class FormulaManager:
 
         Returns
         -------
-        {EvalEnvironment, dict}
+        EvalEnvironment or dict
             A formula-engine-dependent empty evaluation environment.
         """
         if self._using_patsy:
@@ -716,7 +744,7 @@ class FormulaManager:
 
         Parameters
         ----------
-        spec : {ModelSpec, DesignInfo}
+        spec : ModelSpec or DesignInfo
             The model specification to check for an intercept term.
 
         Returns
@@ -733,7 +761,7 @@ class FormulaManager:
 
         Parameters
         ----------
-        spec : {ModelSpec, DesignInfo}
+        spec : ModelSpec or DesignInfo
             The model specification whose terms are searched for the intercept.
 
         Returns
@@ -752,15 +780,15 @@ class FormulaManager:
 
         Parameters
         ----------
-        action : str
+        action : str, optional
             The action to take on missing values, e.g., "drop" or "raise".
-        types : Sequence[Any]
+        types : Sequence[Any], optional
             The types of missing values to consider, e.g., "None" or "NaN".
             Only used when using patsy.
 
         Returns
         -------
-        NAAction | str
+        NAAction or str
             The formula-engine-specific NA action.
 
         Notes
@@ -784,7 +812,7 @@ class FormulaManager:
 
         Returns
         -------
-        {ModelDesc, Formula}
+        ModelDesc or Formula
             The engine-specific model specification.
         """
         if self._using_patsy:
@@ -809,7 +837,7 @@ class FormulaManager:
 
         Parameters
         ----------
-        spec_or_frame : {DataFrame, ModelSpec, DesignInfo}
+        spec_or_frame : DataFrame, ModelSpec, or DesignInfo
             The DataFrame with a model specification attached, or the model
             specification itself.
 
@@ -830,7 +858,9 @@ class FormulaManager:
 
         Parameters
         ----------
-        spec_or_frame : {DataFrame, ModelSpec, DesignInfo}
+        spec_or_frame : DataFrame, ModelSpec, or DesignInfo
+            The DataFrame with a model specification attached, or the model
+            specification itself.
 
         Returns
         -------
@@ -846,7 +876,7 @@ class FormulaManager:
 
         Parameters
         ----------
-        spec_or_frame : {DataFrame, ModelSpec, DesignInfo}
+        spec_or_frame : DataFrame, ModelSpec, or DesignInfo
             The DataFrame with a model specification attached or the model
             specification.
 
@@ -869,13 +899,14 @@ class FormulaManager:
         ----------
         frame : DataFrame
             The frame to get the model specification from.
-        optional : bool
+        optional : bool, optional
             Whether to return None if the frame does not have a model specification.
 
         Returns
         -------
-        {ModelSpec, DesignInfo}
-            The engine-specific model specification
+        ModelSpec, DesignInfo, or None
+            The engine-specific model specification, or None if optional is
+            True and frame has no attached model specification.
         """
         if self._using_patsy:
             if optional and not hasattr(frame, "design_info"):
@@ -892,7 +923,7 @@ class FormulaManager:
 
         Parameters
         ----------
-        model_spec : {ModelSpec, DesignInfo}
+        model_spec : ModelSpec or DesignInfo
             The model specification.
         term : Term
             The model term.
@@ -909,11 +940,12 @@ class FormulaManager:
 
     def get_term_name(self, term):
         """
-        Gets the string name of a term
+        Gets the string name of a term.
 
         Parameters
         ----------
         term : Term
+            The term to get the name for.
 
         Returns
         -------
@@ -931,7 +963,9 @@ class FormulaManager:
 
         Parameters
         ----------
-        spec_or_frame : {DataFrame, ModelSpec, DesignInfo}
+        spec_or_frame : DataFrame, ModelSpec, or DesignInfo
+            The DataFrame with a model specification attached, or the model
+            specification itself.
 
         Returns
         -------
@@ -950,9 +984,9 @@ class FormulaManager:
 
         Parameters
         ----------
-        factor : {EvalFactor, Factor}
+        factor : EvalFactor or Factor
             The factor to get the categories for.
-        model_spec : {ModelSpec, DesignInfo}
+        model_spec : ModelSpec or DesignInfo
             The model specification.
 
         Returns
@@ -974,14 +1008,14 @@ class FormulaManager:
         term : Term
             Either a formulaic Term or a patsy Term.
         factor : EvalFactor or Factor
-            Either a formulaic Factor or a patsy EvalFactor
-        model_spec : engine-specific model specification
+            Either a formulaic Factor or a patsy EvalFactor.
+        model_spec : ModelSpec or DesignInfo
             Either a formulaic ModelSpec or a patsy DesignInfo.
 
         Returns
         -------
         ndarray
-            The contract matrix to use for hypothesis testing.
+            The contrast matrix to use for hypothesis testing.
         """
         if self._using_patsy:
             return model_spec.term_codings[term][0].contrast_matrices[factor].matrix

--- a/statsmodels/formula/formulatools.py
+++ b/statsmodels/formula/formulatools.py
@@ -24,25 +24,25 @@ def handle_formula_data(Y, X, formula, depth=0, missing="drop"):
     X : array_like
         Either exog or None. If all the data for the formula is provided in
         Y then you must explicitly set X to None.
-    formula : str or patsy.model_desc
+    formula : str or ModelDesc
         You can pass a handler by import formula_handler and adding a
         key-value pair where the key is the formula object class and
         the value is a function that returns endog, exog, formula object.
-    depth : int
+    depth : int, optional
         The number of stack frames to go up when evaluating variables that
         are not found in Y or X.
-    missing : str
+    missing : str, optional
         The action to take on missing values, e.g., "drop" or "raise".
 
     Returns
     -------
-    result : array_like or tuple of array_like
+    result : DataFrame, ndarray, or tuple of DataFrame or ndarray
         endog and exog (or just endog if X is None), preserving the input
         type of Y, X.
-    missing_mask : ndarray or None
+    missing_mask : ndarray, Series, or None
         Boolean mask indicating observations dropped due to missing values,
         or None if no values were dropped.
-    model_spec : ModelSpec or DesignInfo or None
+    model_spec : ModelSpec, DesignInfo, or None
         The right-hand-side model specification, or None if there is no
         RHS design.
     """

--- a/statsmodels/graphics/_regressionplots_doc.py
+++ b/statsmodels/graphics/_regressionplots_doc.py
@@ -4,13 +4,13 @@ _plot_added_variable_doc = """
     Parameters
     ----------
     %(extra_params_doc)s
-    focus_exog : int or string
+    focus_exog : int or str
         The column index of exog, or a variable name, indicating the
         variable whose role in the regression is to be assessed.
-    resid_type : str
+    resid_type : str, optional
         The type of residuals to use for the dependent variable.  If
         None, uses `resid_deviance` for GLM/GEE and `resid` otherwise.
-    use_glm_weights : bool
+    use_glm_weights : bool, optional
         Only used if the model is a GLM or GEE.  If True, the
         residuals for the focus predictor are computed using WLS, with
         the weights obtained from the IRLS calculations for fitting
@@ -18,7 +18,7 @@ _plot_added_variable_doc = """
     fit_kwargs : dict, optional
         Keyword arguments to be passed to fit when refitting the
         model.
-    ax : Axes
+    ax : Axes, optional
         Matplotlib Axes instance
 
     Returns
@@ -34,10 +34,10 @@ _plot_partial_residuals_doc = """
     Parameters
     ----------
     %(extra_params_doc)s
-    focus_exog : int or string
+    focus_exog : int or str
         The column index of exog, or variable name, indicating the
         variable whose role in the regression is to be assessed.
-    ax : Axes
+    ax : Axes, optional
         Matplotlib Axes instance
 
     Returns
@@ -54,18 +54,18 @@ _plot_ceres_residuals_doc = """
     Parameters
     ----------
     %(extra_params_doc)s
-    focus_exog : {int, str}
+    focus_exog : int or str
         The column index of results.model.exog, or the variable name,
         indicating the variable whose role in the regression is to be
         assessed.
-    frac : float
+    frac : float, optional
         Lowess tuning parameter for the adjusted model used in the
         CERES analysis.  Not used if `cond_means` is provided.
     cond_means : array_like, optional
         If provided, the columns of this array span the space of the
         conditional means E[exog | focus exog], where exog ranges over
         some or all of the columns of exog (other than the focus exog).
-    ax : matplotlib.Axes instance, optional
+    ax : Axes, optional
         The axes on which to draw the plot. If not provided, a new
         axes instance is created.
 
@@ -130,20 +130,21 @@ _plot_influence_doc = """
     Parameters
     ----------
     {extra_params_doc}
-    external : bool
+    external : bool, optional
         Whether to use externally or internally studentized residuals. It is
         recommended to leave external as True.
-    alpha : float
+    alpha : float, optional
         The alpha value to identify large studentized residuals. Large means
         abs(resid_studentized) > t.ppf(1-alpha/2, dof=results.df_resid)
-    criterion : str {{'DFFITS', 'Cooks'}}
+    criterion : str {{'DFFITS', 'Cooks'}}, optional
         Which criterion to base the size of the points on. Options are
         DFFITS or Cook's D.
-    size : float
-        The range of `criterion` is mapped to 10**2 - size**2 in points.
-    plot_alpha : float
+    size : float, optional
+        The point sizes range from 8**2 to `size`**2, with `criterion`
+        mapped linearly onto this range.
+    plot_alpha : float, optional
         The `alpha` of the plotted points.
-    ax : AxesSubplot
+    ax : AxesSubplot, optional
         An instance of a matplotlib Axes.
     **kwargs
         Additional parameters passed through to `plot`.
@@ -188,10 +189,10 @@ _plot_leverage_resid2_doc = """
     Parameters
     ----------
     {extra_params_doc}
-    alpha : float
+    alpha : float, optional
         Specifies the cut-off for large-standardized residuals. Residuals
         are assumed to be distributed N(0, 1) with alpha=alpha.
-    ax : Axes
+    ax : Axes, optional
         Matplotlib Axes instance
     **kwargs
         Additional parameters passed the plot command.

--- a/statsmodels/graphics/agreement.py
+++ b/statsmodels/graphics/agreement.py
@@ -35,7 +35,7 @@ def mean_diff_plot(
         A 1-d array.
     m2 : array_like
         A 1-d array.
-    sd_limit : float
+    sd_limit : float, optional
         The limit of agreements expressed in terms of the standard deviation of
         the differences. If `md` is the mean of the differences, and `sd` is
         the standard deviation of those differences, then the limits of

--- a/statsmodels/graphics/boxplots.py
+++ b/statsmodels/graphics/boxplots.py
@@ -309,7 +309,7 @@ def beanplot(
           - 'jitter_marker_size', int.  Marker size.  Default is 4.
           - 'jitter_fc', MPL color.  Jitter marker face color.  Default is None.
           - 'bean_legend_text', str.  If given, add a legend with given text.
-    rng : int, array_like of int, numpy.random.Generator, numpy.random.RandomState, optional
+    rng : int, array_like of int, numpy.random.Generator, or numpy.random.RandomState, optional
         If `rng` is None, a new ``Generator`` is created using fresh
         entropy from the operating system. If `rng` is an int or array
         of ints, a new ``Generator`` is created, seeded with `rng`. If

--- a/statsmodels/graphics/dotplots.py
+++ b/statsmodels/graphics/dotplots.py
@@ -20,75 +20,75 @@ def dot_plot(points, intervals=None, lines=None, sections=None,
     ----------
     points : array_like
         The quantitative values to be plotted as markers.
-    intervals : array_like
+    intervals : array_like, optional
         The intervals to be plotted around the points.  The elements
         of `intervals` are either scalars or sequences of length 2.  A
         scalar indicates the half width of a symmetric interval.  A
         sequence of length 2 contains the left and right half-widths
         (respectively) of a nonsymmetric interval.  If None, no
         intervals are drawn.
-    lines : array_like
+    lines : array_like, optional
         A grouping variable indicating which points/intervals are
         drawn on a common line.  If None, each point/interval appears
         on its own line.
-    sections : array_like
+    sections : array_like, optional
         A grouping variable indicating which lines are grouped into
         sections.  If None, everything is drawn in a single section.
-    styles : array_like
+    styles : array_like, optional
         A grouping label defining the plotting style of the markers
         and intervals.
-    marker_props : dict
+    marker_props : dict, optional
         A dictionary mapping style codes (the values in `styles`) to
         dictionaries defining key/value pairs to be passed as keyword
         arguments to `plot` when plotting markers.  Useful keyword
         arguments are "color", "marker", and "ms" (marker size).
-    line_props : dict
+    line_props : dict, optional
         A dictionary mapping style codes (the values in `styles`) to
         dictionaries defining key/value pairs to be passed as keyword
         arguments to `plot` when plotting interval lines.  Useful
         keyword arguments are "color", "linestyle", "solid_capstyle",
         and "linewidth".
-    split_names : str
+    split_names : str, optional
         If not None, this is used to split the values of `lines` into
         substrings that are drawn in the left and right margins,
         respectively.  If None, the values of `lines` are drawn in the
         left margin.
-    section_order : array_like
+    section_order : array_like, optional
         The section labels in the order in which they appear in the
         dotplot.
-    line_order : array_like
+    line_order : array_like, optional
         The line labels in the order in which they appear in the
         dotplot.
-    stacked : bool
+    stacked : bool, optional
         If True, when multiple points or intervals are drawn on the
         same line, they are offset from each other.
-    styles_order : array_like
+    styles_order : array_like, optional
         If stacked=True, this is the order in which the point styles
         on a given line are drawn from top to bottom (if horizontal
         is True) or from left to right (if horizontal is False).  If
         None (default), the order is lexical.
-    striped : bool
+    striped : bool, optional
         If True, every other line is enclosed in a shaded box.
-    horizontal : bool
+    horizontal : bool, optional
         If True (default), the lines are drawn horizontally, otherwise
         they are drawn vertically.
-    show_names : str
+    show_names : {'both', 'left', 'right'}, optional
         Determines whether labels (names) are shown in the left and/or
         right margins (top/bottom margins if `horizontal` is True).
         If `both`, labels are drawn in both margins, if 'left', labels
         are drawn in the left or top margin.  If `right`, labels are
         drawn in the right or bottom margin.
-    fmt_left_name : callable
+    fmt_left_name : callable, optional
         The left/top margin names are passed through this function
         before drawing on the plot.
-    fmt_right_name : callable
+    fmt_right_name : callable, optional
         The right/bottom margin names are passed through this function
         before drawing on the plot.
-    show_section_titles : bool or None
+    show_section_titles : bool or None, optional
         If None, section titles are drawn only if there is more than
         one section.  If False/True, section titles are never/always
         drawn, respectively.
-    ax : matplotlib.axes
+    ax : AxesSubplot, optional
         The axes on which the dotplot is drawn.  If None, a new axes
         is created.
 

--- a/statsmodels/graphics/factorplots.py
+++ b/statsmodels/graphics/factorplots.py
@@ -44,7 +44,7 @@ def interaction_plot(
     func : str or callable, optional
         Anything accepted by `pandas.DataFrame.aggregate`. This is applied to
         the response variable grouped by the trace levels.
-    ax : axes, optional
+    ax : AxesSubplot, optional
         Matplotlib axes instance
     plottype : {'b', 'both', 'l', 'line', 's', 'scatter'}, optional
         The type of plot to return. Can be 'l', 's', or 'b'
@@ -60,9 +60,9 @@ def interaction_plot(
         If given, must have length == number of levels in trace
     linestyles : list, optional
         If given, must have length == number of levels in trace.
-    legendloc : {None, str, int}, optional
+    legendloc : str or int, optional
         Location passed to the legend command.
-    legendtitle : {None, str}, optional
+    legendtitle : str, optional
         Title of the legend.
     **kwargs
         These will be passed to the plot command used either plot or scatter.
@@ -198,9 +198,10 @@ def _recode(x, levels):
 
     Parameters
     ----------
-    x : array_like
-        Array-like object of categorically coded data, supporting numpy
-        array methods.
+    x : ndarray or Series
+        Categorically coded data.  If a `Series`, its values are extracted
+        before recoding; otherwise `x` must already be an `ndarray` (it is
+        accessed via ``x.dtype``).
     levels : dict
         Mapping of labels to integer codings.
 

--- a/statsmodels/graphics/functional.py
+++ b/statsmodels/graphics/functional.py
@@ -49,12 +49,10 @@ def _inverse_transform(pca, data):
     ----------
     pca : statsmodels Principal Component Analysis instance
         The PCA object to use.
-    data : sequence of ndarrays or 2-D ndarray
-        The vectors of functions to create a functional boxplot from.  If a
-        sequence of 1-D arrays, these should all be the same size.
-        The first axis is the function index, the second axis the one along
-        which the function is defined.  So ``data[0, :]`` is the first
-        functional curve.
+    data : ndarray
+        Points in the reduced (PCA factor) space to inverse transform back
+        to the original curve space.  Reshaped internally to
+        ``(-1, ncomp)`` before being assigned to `pca.factors`.
 
     Returns
     -------
@@ -77,7 +75,7 @@ def _curve_constrained(x, idx, sign, band, pca, ks_gaussian):
 
     Parameters
     ----------
-    x : float
+    x : ndarray
         Curve in reduced space.
     idx : int
         Index value of the components to compute.
@@ -112,8 +110,8 @@ def _min_max_band(args):
 
     Parameters
     ----------
-    args : list
-        It is a list of an idx and other arguments as a tuple:
+    args : tuple
+        It is a tuple of an idx and other arguments as a tuple:
             idx : int
                 Index value of the components to compute
         The tuple contains:
@@ -129,7 +127,7 @@ def _min_max_band(args):
             use_brute : bool
                 Use the brute force optimizer instead of the default
                 differential evolution to find the curves.
-            rng : int, array_like of int, numpy.random.Generator, numpy.random.RandomState, optional
+            rng : int, numpy.random.Generator, or numpy.random.RandomState, optional
                 Value to pass to scipy.optimize.differential_evolution as
                 its `seed` argument.
 
@@ -219,7 +217,7 @@ def hdrboxplot(
             - cv_ml: cross validation maximum likelihood
             - cv_ls: cross validation least squares
 
-    xdata : ndarray, optional
+    xdata : array_like, optional
         The independent variable for the data. If not given, it is assumed to
         be an array of integers 0..N-1 with N the length of the vectors in
         `data`.
@@ -229,21 +227,21 @@ def hdrboxplot(
     ax : AxesSubplot, optional
         If given, this subplot is used to plot in instead of a new figure being
         created.
-    use_brute : bool
+    use_brute : bool, optional
         Use the brute force optimizer instead of the default differential
         evolution to find the curves. Default is False.
-    rng : int, array_like of int, numpy.random.Generator, numpy.random.RandomState, optional
+    rng : int, numpy.random.Generator, or numpy.random.RandomState, optional
         Value to pass to scipy.optimize.differential_evolution as its `seed`
-        argument. If an int, a new Generator seeded with that value is used
+        argument. If an int, a new RandomState seeded with that value is used
         by scipy. If a Generator or RandomState instance, that instance is
         used directly. If None, then the default RandomState provided by
         np.random is used.
-    seed : {None, int, numpy.random.Generator, numpy.random.RandomState}, optional
+    seed : int, numpy.random.Generator, or numpy.random.RandomState, optional
         .. deprecated:: 0.15
 
            seed has been deprecated. In-line with SPEC-007, use
            rng for passing a random number generator or seed.
-    kernel_rng : int, array_like of int, numpy.random.Generator, numpy.random.RandomState, optional
+    kernel_rng : int, array_like of int, numpy.random.Generator, or numpy.random.RandomState, optional
         A random number generator or seed to use for the kernel density. If
         None, will use the global RandomState.
 
@@ -252,7 +250,7 @@ def hdrboxplot(
             In release 0.17.0 or after January 2028, whichever comes sooner,
             using None will initialize a new numpy.random.default_rng using
             system entropy.
-    kernel_seed : int, array_like of int, numpy.random.Generator, numpy.random.RandomState, optional
+    kernel_seed : int, array_like of int, numpy.random.Generator, or numpy.random.RandomState, optional
         .. deprecated:: 0.15
 
            kernel_seed has been deprecated. In-line with SPEC-007, use
@@ -266,13 +264,15 @@ def hdrboxplot(
     hdr_res : HdrResults instance
         An `HdrResults` instance with the following attributes:
 
-         - 'median', array. Median curve.
-         - 'hdr_50', array. 50% quantile band. [sup, inf] curves
-         - 'hdr_90', list of array. 90% quantile band. [sup, inf]
+         - 'median', ndarray. Median curve.
+         - 'hdr_50', list of tuple of float. 50% quantile band. [sup, inf]
             curves.
-         - 'extra_quantiles', list of array. Extra quantile band.
+         - 'hdr_90', list of tuple of float. 90% quantile band. [sup, inf]
+            curves.
+         - 'extra_quantiles', list of tuple of float. Extra quantile band.
             [sup, inf] curves.
          - 'outliers', ndarray. Outlier curves.
+         - 'outliers_idx', ndarray. Indices of the outlier curves in `data`.
 
     See Also
     --------
@@ -426,12 +426,12 @@ def hdrboxplot(
         ----------
         band : array_like
             alpha values ``(max_alpha, min_alpha)`` ex: ``[0.9, 0.5]``
-        use_brute : bool
+        use_brute : bool, optional
             Use the brute force optimizer instead of the default differential
             evolution to find the curves. Default is False.
-        rng : int, array_like of int, numpy.random.Generator, numpy.random.RandomState, optional
+        rng : int, numpy.random.Generator, or numpy.random.RandomState, optional
             Value to pass to scipy.optimize.differential_evolution as its
-            `seed` argument. If an int, a new Generator seeded with that
+            `seed` argument. If an int, a new RandomState seeded with that
             value is used by scipy. If a Generator or RandomState instance,
             that instance is used directly. If None, then the default
             RandomState provided by numpy.random is used.
@@ -566,7 +566,7 @@ def fboxplot(
         The first axis is the function index, the second axis the one along
         which the function is defined.  So ``data[0, :]`` is the first
         functional curve.
-    xdata : ndarray, optional
+    xdata : array_like, optional
         The independent variable for the data.  If not given, it is assumed to
         be an array of integers 0..N-1 with N the length of the vectors in
         `data`.
@@ -767,7 +767,7 @@ def rainbowplot(data, xdata=None, depth=None, method="MBD", ax=None, cmap=None):
         The first axis is the function index, the second axis the one along
         which the function is defined.  So ``data[0, :]`` is the first
         functional curve.
-    xdata : ndarray, optional
+    xdata : array_like, optional
         The independent variable for the data.  If not given, it is assumed to
         be an array of integers 0..N-1 with N the length of the vectors in
         `data`.

--- a/statsmodels/graphics/gofplots.py
+++ b/statsmodels/graphics/gofplots.py
@@ -318,10 +318,10 @@ class ProbPlot:
 
         Parameters
         ----------
-        xlabel : str or None, optional
+        xlabel : str, optional
             User-provided labels for the x-axis. If None (default),
             other values are used depending on the status of the kwarg `other`.
-        ylabel : str or None, optional
+        ylabel : str, optional
             User-provided labels for the y-axis. If None (default),
             other values are used depending on the status of the kwarg `other`.
         line : {None, "45", "s", "r", "q"}, optional
@@ -411,10 +411,10 @@ class ProbPlot:
 
         Parameters
         ----------
-        xlabel : {None, str}, optional
+        xlabel : str, optional
             User-provided labels for the x-axis. If None (default),
             other values are used depending on the status of the kwarg `other`.
-        ylabel : {None, str}, optional
+        ylabel : str, optional
             User-provided labels for the y-axis. If None (default),
             other values are used depending on the status of the kwarg `other`.
         line : {None, "45", "s", "r", "q"}, optional
@@ -428,7 +428,7 @@ class ProbPlot:
             - "q" - A line is fit through the quartiles.
             - None - by default no reference line is added to the plot.
 
-        other : {ProbPlot, array_like, None}, optional
+        other : ProbPlot, array_like, or None, optional
             If provided, the sample quantiles of this `ProbPlot` instance are
             plotted against the sample quantiles of the `other` `ProbPlot`
             instance. Sample size of `other` must be equal or larger than
@@ -517,11 +517,11 @@ class ProbPlot:
 
         Parameters
         ----------
-        xlabel : {None, str}, optional
+        xlabel : str, optional
             User-provided labels for the x-axis. If None (default),
             "Non-exceedance Probability (%)" or "Probability of Exceedance
             (%)" is used, depending on `exceed`.
-        ylabel : {None, str}, optional
+        ylabel : str, optional
             User-provided labels for the y-axis. If None (default),
             "Sample Quantiles" is used.
         line : {None, "45", "s", "r", "q"}, optional
@@ -714,17 +714,17 @@ def qqplot_2samples(
 
     Parameters
     ----------
-    data1 : {array_like, ProbPlot}
+    data1 : array_like or ProbPlot
         Data to plot along x axis. If the sample sizes are unequal, the longer
         series is always plotted along the x-axis.
-    data2 : {array_like, ProbPlot}
+    data2 : array_like or ProbPlot
         Data to plot along y axis. Does not need to have the same number of
         observations as data 1. If the sample sizes are unequal, the longer
         series is always plotted along the x-axis.
-    xlabel : {None, str}, optional
+    xlabel : str, optional
         User-provided labels for the x-axis. If None (default),
         other values are used.
-    ylabel : {None, str}, optional
+    ylabel : str, optional
         User-provided labels for the y-axis. If None (default),
         other values are used.
     line : {None, "45", "s", "r", "q"}, optional
@@ -809,7 +809,7 @@ def qqline(ax, line, x=None, y=None, dist=None, fmt="r-", **lineoptions):
 
     Parameters
     ----------
-    ax : matplotlib axes instance
+    ax : AxesSubplot
         The axes on which to plot the line
     line : {"45", "r", "s", "q"}
         Options for the reference line to which the data is compared:
@@ -821,9 +821,9 @@ def qqline(ax, line, x=None, y=None, dist=None, fmt="r-", **lineoptions):
         - "r"  - A regression line is fit
         - "q"  - A line is fit through the quartiles.
 
-    x : ndarray, optional
+    x : array_like, optional
         X data for plot. Not needed if line is "45".
-    y : ndarray, optional
+    y : array_like, optional
         Y data for plot. Not needed if line is "45".
     dist : scipy.stats.distribution, optional
         A scipy.stats distribution, needed if line is "q".
@@ -939,10 +939,10 @@ def plotting_pos(nobs, a=0.0, b=None):
     ----------
     nobs : int
         Number of probability points to plot
-    a : float, default 0.0
+    a : float, optional
         alpha parameter for the plotting position of an expected order
         statistic
-    b : float, default None
+    b : float, optional
         beta parameter for the plotting position of an expected order
         statistic. If None, then b is set to a.
 
@@ -977,7 +977,7 @@ def _fmt_probplot_axis(ax, dist, nobs):
     dist : scipy.stats.distribution
         A scipy.stats distribution sufficiently specified to implement its
         ppf() method.
-    nobs : scalar
+    nobs : int
         Number of observations in the sample.
 
     Notes
@@ -1016,9 +1016,9 @@ def _do_plot(x, y, dist=None, line=None, ax=None, fmt="b", step=False, **kwargs)
         X-axis data to be plotted
     y : array_like
         Y-axis data to be plotted
-    dist : scipy.stats.distribution
+    dist : scipy.stats.distribution, optional
         A scipy.stats distribution, needed if `line` is "q".
-    line : {"45", "s", "r", "q", None}, default None
+    line : {None, "45", "s", "r", "q"}, optional
         Options for the reference line to which the data is compared.
     ax : AxesSubplot, optional
         If given, this subplot is used to plot in instead of a new figure being

--- a/statsmodels/graphics/mosaicplot.py
+++ b/statsmodels/graphics/mosaicplot.py
@@ -284,7 +284,7 @@ def _hierarchical_split(count_dict, horizontal=True, gap=0.05):
     horizontal : bool, optional
         The starting direction of the split (by default along
         the horizontal axis)
-    gap : float or array of floats, optional
+    gap : float or array_like of float, optional
         The list of gaps to be applied on each subdivision.
         If the length of the given array is less of the number
         of subcategories (or if it's a single number) it will extend
@@ -449,9 +449,9 @@ def _normalize_data(data, index):
 
     Parameters
     ----------
-    data : {dict, Series, ndarray, DataFrame}
+    data : dict, Series, ndarray, or DataFrame
         The contingency table to normalize.
-    index : list, optional
+    index : list or None
         The preferred order for the category ordering. If None, the
         order in which the keys were found is used.
 
@@ -539,7 +539,7 @@ def _statistical_coloring(data):
 
     Parameters
     ----------
-    data : {dict, Series, ndarray, DataFrame}
+    data : dict, Series, ndarray, or DataFrame
         The contingency table to color.
 
     Returns
@@ -724,7 +724,7 @@ def mosaic(data, index=None, ax=None, horizontal=True, gap=0.005,
 
     Parameters
     ----------
-    data : {dict, Series, ndarray, DataFrame}
+    data : dict, Series, ndarray, or DataFrame
         The contingency table that contains the data.
         Each category should contain a non-negative number
         with a tuple as index.  It expects that all the combination
@@ -746,7 +746,7 @@ def mosaic(data, index=None, ax=None, horizontal=True, gap=0.005,
     horizontal : bool, optional
         The starting direction of the split (by default along
         the horizontal axis)
-    gap : {float, sequence[float]}, optional
+    gap : float or sequence[float], optional
         The list of gaps to be applied on each subdivision.
         If the length of the given array is less of the number
         of subcategories (or if it's a single number) it will extend
@@ -775,7 +775,7 @@ def mosaic(data, index=None, ax=None, horizontal=True, gap=0.005,
     axes_label : bool, optional
         Show the name of each value of each category
         on the axis (default) or hide them.
-    label_rotation : {float, list[float]}, optional
+    label_rotation : float or list[float], optional
         The rotation of the axis label (if present). If a list is given
         each axis can have a different rotation
 

--- a/statsmodels/graphics/plottools.py
+++ b/statsmodels/graphics/plottools.py
@@ -12,7 +12,7 @@ def rainbow(n):
 
     Returns
     -------
-    R : (n,3) array
+    R : ndarray of shape (n, 3)
         An array of rows of RGB color values
 
     Notes

--- a/statsmodels/graphics/regressionplots.py
+++ b/statsmodels/graphics/regressionplots.py
@@ -79,10 +79,10 @@ def add_lowess(ax, lines_idx=0, frac=0.2, *, exog=None, endog=None, **lowess_kwa
     ----------
     ax : AxesSubplot
         The Axes to which to add the plot.
-    lines_idx : int
+    lines_idx : int, optional
         This is the line on the existing plot to which you want to add
         a smoothed lowess line.
-    frac : float
+    frac : float, optional
         The fraction of the points to use when doing the lowess fit.
     exog : array_like, optional
         Data for the x-axis. If None, it will be extracted from the axis lines.
@@ -121,7 +121,7 @@ def add_ellipse(x, y, ax=None, alpha=0.95, **ellipse_kwargs):
     ax : AxesSubplot, optional
         The ellipse patch will be added to this axis. If None, the current
         matplotlib axis is used.
-    alpha : float
+    alpha : float, optional
         Confidence level (e.g., 0.95 for 95%).
     ellipse_kwargs
         Additional keyword arguments are passed to the Matplotlib `Ellipse` patch.
@@ -179,7 +179,7 @@ def plot_fit(results, exog_idx, y_true=None, ax=None, vlines=True, **kwargs):
     results : Results
         A result instance with resid, model.endog and model.exog as
         attributes.
-    exog_idx : {int, str}
+    exog_idx : int or str
         Name or index of regressor in exog matrix.
     y_true : array_like, optional
         If this is not None, then the array is added to the plot.
@@ -410,38 +410,39 @@ def plot_partregress(
 
     Parameters
     ----------
-    endog : {ndarray, str}
+    endog : array_like or str
         The endogenous or response variable. If string is given, you can use
         arbitrary translations as with a formula.
-    exog_i : {ndarray, str}
+    exog_i : array_like or str
         The exogenous, explanatory variable. If string is given, you can use
         arbitrary translations as with a formula.
-    exog_others : {ndarray, list[str]}
-        Any other exogenous, explanatory variables. If a list of strings is
-        given, each item is a term in formula. You can use arbitrary
-        translations as with a formula. The effect of these variables will be
-        removed by OLS regression.
-    data : {DataFrame, dict}
+    exog_others : array_like, str, or list[str]
+        Any other exogenous, explanatory variables. If a string is given, it
+        is used directly as the right-hand side of a formula. If a list of
+        strings is given, each item is a term in formula. You can use
+        arbitrary translations as with a formula. The effect of these
+        variables will be removed by OLS regression.
+    data : DataFrame or dict, optional
         Some kind of data structure with names if the other variables are
         given as strings.
-    title_kwargs : dict
+    title_kwargs : dict, optional
         Keyword arguments to pass on for the title. The key to control the
         fonts is fontdict.
-    obs_labels : {bool, array_like}
+    obs_labels : bool or array_like, optional
         Whether or not to annotate the plot points with their observation
         labels. If obs_labels is a boolean, the point labels will try to do
         the right thing. First it will try to use the index of data, then
         fall back to the index of exog_i. Alternatively, you may give an
         array-like object corresponding to the observation numbers.
-    label_kwargs : dict
+    label_kwargs : dict, optional
         Keyword arguments that control annotate for the observation labels.
     ax : AxesSubplot, optional
         If given, this subplot is used to plot in instead of a new figure being
         created.
-    ret_coords : bool
+    ret_coords : bool, optional
         If True will return the coordinates of the points in the plot. You
         can use this to add your own annotations.
-    eval_env : int
+    eval_env : int, optional
         Patsy eval environment if user functions and formulas are used in
         defining endog or exog.
     result_object : bool, optional
@@ -647,10 +648,10 @@ def plot_partregress_grid(results, exog_idx=None, grid=None, fig=None):
     ----------
     results : Results instance
         A regression model results instance.
-    exog_idx : {None, list[int], list[str]}
+    exog_idx : list[int] or list[str], optional
         The indices or column names of the exog used in the plot, default is
         all.
-    grid : {None, tuple[int]}
+    grid : tuple[int], optional
         If grid is given, then it is used for the arrangement of the subplots.
         The format of grid is  (nrows, ncols). If grid is None, then ncol is
         one, if there are only 2 subplots, and the number of columns is two
@@ -754,7 +755,7 @@ def plot_ccpr(results, exog_idx, ax=None):
     ----------
     results : result instance
         A regression results instance.
-    exog_idx : {int, str}
+    exog_idx : int or str
         Exogenous, explanatory variable. If string is given, it should
         be the variable name that you want to use, and you can use arbitrary
         translations as with a formula.
@@ -837,12 +838,13 @@ def plot_ccpr_grid(results, exog_idx=None, grid=None, fig=None):
     ----------
     results : result instance
         A results instance with exog and params.
-    exog_idx : None or list of int
+    exog_idx : list[int] or list[str], optional
         The indices or column names of the exog used in the plot.
-    grid : None or tuple of int (nrows, ncols)
+    grid : tuple[int], optional
         If grid is given, then it is used for the arrangement of the subplots.
-        If grid is None, then ncol is one, if there are only 2 subplots, and
-        the number of columns is two otherwise.
+        The format of grid is (nrows, ncols). If grid is None, then ncol is
+        one, if there are only 2 subplots, and the number of columns is two
+        otherwise.
     fig : Figure, optional
         If given, this figure is simply returned.  Otherwise a new figure is
         created.
@@ -934,18 +936,18 @@ def abline_plot(
 
     Parameters
     ----------
-    intercept : float
+    intercept : float, optional
         The intercept of the line.
-    slope : float
+    slope : float, optional
         The slope of the line.
-    horiz : float or array_like
+    horiz : float or array_like, optional
         Data for horizontal lines on the y-axis.
-    vert : float or array_like
+    vert : float or array_like, optional
         Data for vertical lines on the x-axis.
-    model_results : statsmodels results instance
+    model_results : statsmodels results instance, optional
         Any object that has a two-value `params` attribute. Assumed that it
         is (intercept, slope).
-    ax : axes, optional
+    ax : AxesSubplot, optional
         Matplotlib axes instance.
     **kwargs
         Options passed to matplotlib.pyplot.plt.
@@ -1313,7 +1315,7 @@ def ceres_resids(results, focus_exog, frac=0.66, cond_means=None):
     ----------
     results : model results instance
         The fitted model for which the CERES residuals are calculated.
-    focus_exog : {int, str}
+    focus_exog : int or str
         The column index of results.model.exog, or the variable name,
         used as the 'focus variable'.
     frac : float, optional
@@ -1406,7 +1408,7 @@ def partial_resids(results, focus_exog):
     ----------
     results : results instance
         A fitted regression model.
-    focus_exog : {int, str}
+    focus_exog : int or str
         The column index of model.exog, or the variable name, with
         respect to which the partial residuals are calculated.
 
@@ -1458,13 +1460,13 @@ def added_variable_resids(
     results : regression results instance
         A fitted model including the focus exog and all other
         predictors of interest.
-    focus_exog : {int, str}
+    focus_exog : int or str
         The column of results.model.exog or a variable name that is
         to be residualized against the other predictors.
-    resid_type : str
+    resid_type : str, optional
         The type of residuals to use for the dependent variable.  If
         None, uses `resid_deviance` for GLM/GEE and `resid` otherwise.
-    use_glm_weights : bool
+    use_glm_weights : bool, optional
         Only used if the model is a GLM or GEE.  If True, the
         residuals for the focus predictor are computed using WLS, with
         the weights obtained from the IRLS calculations for fitting
@@ -1475,9 +1477,9 @@ def added_variable_resids(
 
     Returns
     -------
-    endog_resid : array_like
+    endog_resid : ndarray
         The residuals for the original exog
-    focus_exog_resid : array_like
+    focus_exog_resid : ndarray
         The residuals for the focus predictor
 
     Notes

--- a/statsmodels/graphics/tsaplots.py
+++ b/statsmodels/graphics/tsaplots.py
@@ -22,7 +22,7 @@ def _prepare_data_corr_plot(x, lags, zero):
     ----------
     x : array_like
         Array of time-series values.
-    lags : {int, array_like, None}
+    lags : int, array_like, or None
         An int or array of lag values, or None to use a sensible default
         based on the number of observations in `x`.
     zero : bool
@@ -175,11 +175,11 @@ def plot_acf(
     ax : AxesSubplot, optional
         If given, this subplot is used to plot in instead of a new figure being
         created.
-    lags : {int, array_like}, optional
+    lags : int or array_like, optional
         An int or array of lag values, used on horizontal axis. Uses
         np.arange(lags) when lags is an int.  If not provided,
         ``lags=np.arange(len(corr))`` is used.
-    alpha : scalar, optional
+    alpha : float or None, optional
         If a number is given, the confidence intervals for the given level are
         returned. For instance if alpha=.05, 95 % confidence intervals are
         returned where the standard deviation is computed according to
@@ -204,16 +204,16 @@ def plot_acf(
         Default is True.
     auto_ylims : bool, optional
         If True, adjusts automatically the y-axis limits to ACF values.
-    bartlett_confint : bool, default True
+    bartlett_confint : bool, optional
         Confidence intervals for ACF values are generally placed at 2
         standard errors around r_k. The formula used for standard error
         depends upon the situation. If the autocorrelations are being used
         to test for randomness of residuals as part of the ARIMA routine,
         the standard errors are determined assuming the residuals are white
         noise. The approximate formula for any lag is that standard error
-        of each r_k = 1/sqrt(N). See section 9.4 of [1] for more details on
+        of each r_k = 1/sqrt(N). See section 9.4 of [1]_ for more details on
         the 1/sqrt(N) result. For more elementary discussion, see section
-        5.3.2 in [2].
+        5.3.2 in [2]_.
         For the ACF of raw data, the standard error at a lag k is
         found as if the right model was an MA(k-1). This allows the
         possible interpretation that if all autocorrelations past a
@@ -222,10 +222,10 @@ def plot_acf(
         case, a moving average model is assumed for the data and the
         standard errors for the confidence intervals should be
         generated using Bartlett's formula. For more details on
-        Bartlett formula result, see section 7.2 in [1].
+        Bartlett formula result, see section 7.2 in [1]_.
     vlines_kwargs : dict, optional
         Optional dictionary of keyword arguments that are passed to vlines.
-    **kwargs : kwargs, optional
+    **kwargs
         Optional keyword arguments that are directly passed on to the
         Matplotlib ``plot`` and ``axhline`` functions.
 
@@ -257,9 +257,9 @@ def plot_acf(
 
     References
     ----------
-    [1] Brockwell and Davis, 1987. Time Series Theory and Methods
-    [2] Brockwell and Davis, 2010. Introduction to Time Series and
-    Forecasting, 2nd edition.
+    .. [1] Brockwell and Davis, 1987. Time Series Theory and Methods
+    .. [2] Brockwell and Davis, 2010. Introduction to Time Series and
+       Forecasting, 2nd edition.
 
     Examples
     --------
@@ -332,15 +332,15 @@ def plot_pacf(
     ax : AxesSubplot, optional
         If given, this subplot is used to plot in instead of a new figure being
         created.
-    lags : {int, array_like}, optional
+    lags : int or array_like, optional
         An int or array of lag values, used on horizontal axis. Uses
         np.arange(lags) when lags is an int.  If not provided,
         ``lags=np.arange(len(corr))`` is used.
-    alpha : float, optional
+    alpha : float or None, optional
         If a number is given, the confidence intervals for the given level are
         returned. For instance if alpha=.05, 95 % confidence intervals are
         returned where the standard deviation is computed according to
-        1/sqrt(len(x))
+        1/sqrt(len(x)). If None, no confidence intervals are plotted.
     method : str, optional
         Specifies which method for the calculations to use:
 
@@ -356,6 +356,7 @@ def plot_pacf(
           correction.
         - "ldb" or "ldbiased" : Levinson-Durbin recursion without bias
           correction.
+        - "burg" : Burg's partial autocorrelation estimator.
 
     use_vlines : bool, optional
         If True, vertical lines and markers are plotted.
@@ -368,7 +369,7 @@ def plot_pacf(
         Default is True.
     vlines_kwargs : dict, optional
         Optional dictionary of keyword arguments that are passed to vlines.
-    **kwargs : kwargs, optional
+    **kwargs
         Optional keyword arguments that are directly passed on to the
         Matplotlib ``plot`` and ``axhline`` functions.
 
@@ -470,13 +471,13 @@ def plot_ccf(
     ax : AxesSubplot, optional
         If given, this subplot is used to plot in, otherwise a new figure with
         one subplot is created.
-    lags : {int, array_like}, optional
+    lags : int or array_like, optional
         An int or array of lag values, used on the horizontal axis. Uses
         ``np.arange(lags)`` when lags is an int.  If not provided,
         ``lags=np.arange(len(corr))`` is used.
     negative_lags : bool, optional
         If True, negative lags are shown on the horizontal axis.
-    alpha : scalar, optional
+    alpha : float or None, optional
         If a number is given, the confidence intervals for the given level are
         plotted, e.g., if alpha=.05, 95 % confidence intervals are shown.
         If None, confidence intervals are not shown on the plot.
@@ -494,7 +495,7 @@ def plot_ccf(
         If True, adjusts automatically the vertical axis limits to CCF values.
     vlines_kwargs : dict, optional
         Optional dictionary of keyword arguments that are passed to vlines.
-    **kwargs : kwargs, optional
+    **kwargs
         Optional keyword arguments that are directly passed on to the
         Matplotlib ``plot`` and ``axhline`` functions.
 
@@ -588,11 +589,11 @@ def plot_pccf(
     ax : AxesSubplot, optional
         If given, this subplot is used to plot in, otherwise a new
         figure with one subplot is created.
-    lags : {int, array_like}, optional
+    lags : int or array_like, optional
         An int or array of lag values, used on the horizontal axis.
         Uses ``np.arange(lags)`` when lags is an int.  If not
         provided, ``lags=np.arange(len(corr))`` is used.
-    method : str, default "ywm"
+    method : str, optional
         Specifies which method for the calculations to use.
 
         - "ywm", "ywmle" or "yw_mle" : Yule-Walker via the
@@ -603,7 +604,7 @@ def plot_pccf(
           sample-size adjustment in the autocovariance denominator.
         - "ols" : OLS regression of x_t and y_{t+h} on all
           intervening observations.
-    alpha : scalar, optional
+    alpha : float or None, optional
         If a number is given, the confidence intervals for the
         given level are plotted, e.g., if alpha=.05, 95 %
         confidence intervals are shown.
@@ -622,7 +623,7 @@ def plot_pccf(
     vlines_kwargs : dict, optional
         Optional dictionary of keyword arguments that are passed
         to vlines.
-    **kwargs : kwargs, optional
+    **kwargs
         Optional keyword arguments that are directly passed on to
         the Matplotlib ``plot`` and ``axhline`` functions.
 
@@ -724,17 +725,17 @@ def plot_accf_grid(
         and ``varnames`` is provided, it overrides the column names
         of the dataframe. If ``varnames`` is not provided and ``x`` is not
         a dataframe, variable names ``x[0]``, ``x[1]``, etc. are generated.
-    fig : Matplotlib figure instance, optional
+    fig : Figure, optional
         If given, this figure is used to plot in, otherwise a new figure
         is created.
-    lags : {int, array_like}, optional
+    lags : int or array_like, optional
         An int or array of lag values, used on horizontal axes. Uses
         ``np.arange(lags)`` when lags is an int.  If not provided,
         ``lags=np.arange(len(corr))`` is used.
     negative_lags : bool, optional
         If True, negative lags are shown on the horizontal axes of plots
         below the main diagonal.
-    alpha : scalar, optional
+    alpha : float or None, optional
         If a number is given, the confidence intervals for the given level are
         plotted, e.g., if alpha=.05, 95 % confidence intervals are shown.
         If None, confidence intervals are not shown on the plot.
@@ -755,13 +756,13 @@ def plot_accf_grid(
     auto_ylims : bool, optional
         If True, adjusts automatically the vertical axis limits
         to correlation values.
-    bartlett_confint : bool, default False
+    bartlett_confint : bool, optional
         If True, use Bartlett's formula to calculate confidence intervals
         in auto-correlation plots. See the description of ``plot_acf`` for
         details. This argument does not affect cross-correlation plots.
     vlines_kwargs : dict, optional
         Optional dictionary of keyword arguments that are passed to vlines.
-    **kwargs : kwargs, optional
+    **kwargs
         Optional keyword arguments that are directly passed on to the
         Matplotlib ``plot`` and ``axhline`` functions.
 
@@ -1034,7 +1035,7 @@ def plot_predict(
         prediction; starting with this observation and continuing through
         the end of prediction, forecasted endogenous values will be used
         instead.
-    alpha : {float, None}, optional
+    alpha : float or None, optional
         The tail probability not covered by the confidence interval. Must
         be in (0, 1). Confidence interval is constructed assuming normally
         distributed shocks. If None, figure will not show the confidence
@@ -1096,13 +1097,13 @@ def seasonal_diagnostic_plot(x, period, subplots=None, labels=None, nrows=1, **k
     period : int
         The length of the period. Should match the `period` parameter used to
         decompose the series.
-    subplots : int or array of int, optional
+    subplots : int, list of int, or ndarray of int, optional
         If `period` is large, `subplots` can be used to specify how many should
         be plotted. If `subplots` is an `int`, the periods are selected evenly
-        from `range(period)`. If `subplots` is an array of `int`, the periods
-        with those indices will be selected for the subplots. By default,
-        `subplots=period`.
-    labels : array of str, optional
+        from `range(period)`. If `subplots` is a list or ndarray of `int`, the
+        periods with those indices will be selected for the subplots. By
+        default, `subplots=period`.
+    labels : sequence of str, optional
         Labels for the displayed period subplots.
     nrows : int, optional
         The number of rows on which to display the plots.

--- a/statsmodels/graphics/utils.py
+++ b/statsmodels/graphics/utils.py
@@ -150,7 +150,7 @@ def maybe_name_or_idx(idx, model):
 
     Parameters
     ----------
-    idx : {None, int, str, list, tuple}
+    idx : int, str, list, tuple, or None
         The column(s) to look up in `model`.  If None, all columns of
         ``model.exog`` are used.  If an int, it is treated as an integer
         location.  If a str, it is treated as a column name.  If a list or
@@ -162,9 +162,9 @@ def maybe_name_or_idx(idx, model):
 
     Returns
     -------
-    exog_name : {str, list[str]}
+    exog_name : str or list[str]
         The name(s) of the column(s) corresponding to `idx`.
-    exog_idx : {int, list[int]}
+    exog_idx : int or list[int]
         The integer location(s) of the column(s) corresponding to `idx`.
     """
     if idx is None:
@@ -193,13 +193,13 @@ def get_data_names(series_or_dataframe):
 
     Parameters
     ----------
-    series_or_dataframe : {array_like, Series, DataFrame}
+    series_or_dataframe : array_like, Series, or DataFrame
         Input can be an array or pandas-like.  Will handle 1d array-like but
         not 2d.
 
     Returns
     -------
-    {str, list[str]}
+    str or list[str]
         A str for 1d data or a list of strings for 2d data.
     """
     names = getattr(series_or_dataframe, "name", None)

--- a/statsmodels/imputation/bayes_mi.py
+++ b/statsmodels/imputation/bayes_mi.py
@@ -20,21 +20,21 @@ class BayesGaussMI:
 
     Parameters
     ----------
-    data : ndarray
+    data : array_like
         The array of data to be imputed.  Values in the array equal to
         NaN are imputed.
-    mean_prior : ndarray, optional
+    mean_prior : array_like, optional
         The covariance matrix of the Gaussian prior distribution for
         the mean vector.  If not provided, the identity matrix is
         used.
-    cov_prior : ndarray, optional
+    cov_prior : array_like, optional
         The center matrix for the inverse Wishart prior distribution
         for the covariance matrix.  If not provided, the identity
         matrix is used.
     cov_prior_df : positive float, optional
         The degrees of freedom of the inverse Wishart prior
         distribution for the covariance matrix.  Defaults to 1.
-    rng : int, array_like of int, numpy.random.Generator, numpy.random.RandomState, optional
+    rng : int, array_like of int, numpy.random.Generator, or numpy.random.RandomState, optional
         If `rng` is None, a new ``Generator`` is created using fresh
         entropy from the operating system. If `rng` is an int or array
         of ints, a new ``Generator`` is created, seeded with `rng`. If
@@ -203,29 +203,31 @@ class MI:
         An imputer class, such as BayesGaussMI.
     model : model class
         Any statsmodels model class.
-    model_args_fn : function
+    model_args_fn : callable, optional
         A function taking an imputed dataset as input and returning
         endog, exog.  If the model is fit using a formula, returns
         a DataFrame used to build the model.  Optional when a formula
         is used.
-    model_kwds_fn : function, optional
+    model_kwds_fn : callable, optional
         A function taking an imputed dataset as input and returning
         a dictionary of model keyword arguments.
     formula : str, optional
         If provided, the model is constructed using the `from_formula`
         class method, otherwise the `__init__` method is used.
-    fit_args : list-like, optional
-        List of arguments to be passed to the fit method
-    fit_kwds : dict-like, optional
-        Keyword arguments to be passed to the fit method
-    xfunc : function mapping ndarray to ndarray
+    fit_args : callable, optional
+        A function taking an imputed dataset as input and returning a
+        list of arguments to be passed to the fit method.
+    fit_kwds : callable, optional
+        A function taking an imputed dataset as input and returning a
+        dictionary of keyword arguments to be passed to the fit method.
+    xfunc : callable, optional
         A function that is applied to the complete data matrix
         prior to fitting the model
-    burn : int
+    burn : int, optional
         Number of burn-in iterations
-    nrep : int
+    nrep : int, optional
         Number of imputed data sets to use in the analysis
-    skip : int
+    skip : int, optional
         Number of Gibbs iterations to skip between successive
         multiple imputation fits.
 
@@ -311,7 +313,7 @@ class MI:
 
         Parameters
         ----------
-        results_cb : function, optional
+        results_cb : callable, optional
             If provided, each results instance r is passed through `results_cb`,
             then appended to the `results` attribute of the MIResults object.
             To save complete results, use `results_cb=lambda x: x`.  The default
@@ -402,7 +404,7 @@ class MIResults(LikelihoodModelResults):
         and data values are not used.
     params : array_like
         The overall multiple imputation parameter estimates.
-    normalized_cov_params : array_like (2d)
+    normalized_cov_params : ndarray
         The overall variance covariance matrix of the estimates.
     """
 

--- a/statsmodels/imputation/mice.py
+++ b/statsmodels/imputation/mice.py
@@ -146,19 +146,19 @@ class MICEData:
 
     Parameters
     ----------
-    data : Pandas data frame
+    data : DataFrame
         The data set, which is copied internally.
     perturbation_method : str, optional
         The default perturbation method
     k_pmm : int, optional
         The number of nearest neighbors to use during predictive mean
-        matching.  Can also be specified in `fit`.
-    history_callback : function, optional
+        matching.  Can also be specified in `set_imputer`.
+    history_callback : callable, optional
         A function that is called after each complete imputation
         cycle.  The return value is appended to `history`.  The
         MICEData object is passed as the sole argument to
         `history_callback`.
-    rng : int, array_like or int, numpy.random.Generator, numpy.random.RandomState, optional
+    rng : int, array_like of int, numpy.random.Generator, or numpy.random.RandomState, optional
         If `rng` is None, a new ``Generator`` is created using fresh
         entropy from the operating system. If `rng` is an int or array
         of ints, a new ``Generator`` is created, seeded with `rng`. If
@@ -272,7 +272,7 @@ class MICEData:
 
         Returns
         -------
-        data : array_like
+        data : DataFrame
             An imputed dataset from the MICE chain.
 
         Notes
@@ -350,7 +350,7 @@ class MICEData:
             Determines number of neighboring observations from which
             to randomly sample when using predictive mean matching.
         perturbation_method : str, optional
-            Either 'gaussian' or 'bootstrap'. Determines the method
+            Either 'gaussian' or 'boot'. Determines the method
             for perturbing parameters in the imputation model.  If
             None, uses the default specified at class initialization.
         regularized : bool, optional
@@ -447,20 +447,20 @@ class MICEData:
 
         Returns
         -------
-        endog_obs : DataFrame
+        endog_obs : ndarray
             Observed values of the variable to be imputed.
-        exog_obs : DataFrame
+        exog_obs : ndarray
             Current values of the predictors where the variable to be
             imputed is observed.
-        exog_miss : DataFrame
+        exog_miss : ndarray
             Current values of the predictors where the variable to be
             imputed is missing.
-        init_kwds : dict-like
-            The init keyword arguments for `vname`, processed through Patsy
-            as required.
-        fit_kwds : dict-like
-            The fit keyword arguments for `vname`, processed through Patsy
-            as required.
+        predict_obs_kwds : dict-like
+            The predict keyword arguments for `vname` associated with
+            the observed cases, processed through Patsy as required.
+        predict_miss_kwds : dict-like
+            The predict keyword arguments for `vname` associated with
+            the missing cases, processed through Patsy as required.
         """
 
         formula = self.conditional_formula[vname]
@@ -519,9 +519,9 @@ class MICEData:
 
         Returns
         -------
-        endog : DataFrame
+        endog : ndarray
             Observed values of `vname`.
-        exog : DataFrame
+        exog : ndarray
             Regression design matrix for imputing `vname`.
         init_kwds : dict-like
             The init keyword arguments for `vname`, processed through Patsy
@@ -673,7 +673,7 @@ class MICEData:
             The variable to be plotted on the horizontal axis.
         col2_name : str
             The variable to be plotted on the vertical axis.
-        lowess_args : dictionary, optional
+        lowess_args : dict, optional
             A dictionary of dictionaries, keys are 'ii', 'io', 'oi'
             and 'oo', where 'o' denotes 'observed' and 'i' denotes
             imputed.  See Notes for details.
@@ -1028,6 +1028,18 @@ class MICEData:
         self.params[vname] = self.rng.multivariate_normal(mean=mu, cov=cov)
 
     def perturb_params(self, vname):
+        """
+        Perturb the parameters of the imputation model for one variable
+
+        The parameters are set using the perturbation method (either
+        'gaussian' or 'boot') assigned to `vname`.
+
+        Parameters
+        ----------
+        vname : str
+            The name of the variable whose imputation model
+            parameters are to be perturbed.
+        """
 
         if self.perturbation_method[vname] == "gaussian":
             self._perturb_gaussian(vname)
@@ -1037,6 +1049,14 @@ class MICEData:
             raise ValueError("unknown perturbation method")
 
     def impute(self, vname):
+        """
+        Impute missing values for a single variable
+
+        Parameters
+        ----------
+        vname : str
+            The name of the variable to be imputed.
+        """
         # Wrap this in case we later add additional imputation
         # methods.
         self.impute_pmm(vname)
@@ -1072,6 +1092,11 @@ class MICEData:
     def impute_pmm(self, vname):
         """
         Use predictive mean matching to impute missing values
+
+        Parameters
+        ----------
+        vname : str
+            The name of the variable to be imputed.
 
         Notes
         -----
@@ -1344,6 +1369,43 @@ class MICE:
 
 
 class MICEResults(LikelihoodModelResults):
+    """
+    Results of a MICE analysis
+
+    Holds the parameter estimates and covariance matrix obtained by
+    pooling the results of an analysis model fit to each of a
+    sequence of multiply imputed data sets, along with the fraction
+    of missing information for each parameter.  Instances are
+    returned by `MICE.fit` and `MICE.combine`.
+
+    Attributes
+    ----------
+    params : ndarray
+        The pooled parameter estimates, averaged across the analysis
+        models fit to the imputed data sets.
+    normalized_cov_params : ndarray
+        The pooled covariance matrix of the parameter estimates,
+        normalized by `scale`.
+    scale : float
+        The average scale parameter across the analysis models fit
+        to the imputed data sets.
+    frac_miss_info : ndarray
+        The fraction of missing information for each parameter.
+    exog_names : list of str
+        The names of the explanatory variables in the analysis
+        model.
+    endog_names : list of str
+        The names of the dependent variable(s) in the analysis
+        model.
+    model_class : statsmodels model
+        The model class used to fit the analysis model to each
+        imputed data set.
+
+    See Also
+    --------
+    MICE.fit
+    MICE.combine
+    """
 
     def __init__(self, model, params, normalized_cov_params):
 
@@ -1358,12 +1420,12 @@ class MICEResults(LikelihoodModelResults):
         title : str, optional
             Title for the top table. If not None, then this replaces
             the default title
-        alpha : float
+        alpha : float, optional
             Significance level for the confidence intervals
 
         Returns
         -------
-        smry : Summary instance
+        Summary
             This holds the summary tables and text, which can be
             printed or converted to various output formats.
         """

--- a/statsmodels/imputation/ros.py
+++ b/statsmodels/imputation/ros.py
@@ -44,7 +44,7 @@ def _ros_sort(df, observations, censorship, warn=False):
         observation is left-censored. (i.e., True -> censored,
         False -> uncensored)
 
-    warn : bool
+    warn : bool, optional
         Whether to warn when censored observations larger than the
         maximum uncensored observation are dropped.
 
@@ -269,8 +269,8 @@ def _ros_group_rank(df, dl_idx, censorship):
 
     Returns
     -------
-    ranks : ndarray
-        Array of ranks for the dataset.
+    ranks : Series
+        Series of ranks for the dataset.
     """
 
     # (editted for pandas 0.14 compatibility; see commit 63f162e
@@ -292,7 +292,7 @@ def _ros_plot_pos(row, censorship, cohn):
 
     Parameters
     ----------
-    row : {Series, dict}
+    row : Series or dict
         Full observation (row) from a censored dataset. Requires a
         'rank', 'det_limit_index', and `censorship` column.
 
@@ -338,7 +338,8 @@ def _norm_plot_pos(observations):
 
     Returns
     -------
-    plotting_position : array of floats
+    plotting_position : ndarray
+        Array of standard normal plotting positions.
     """
     ppos, sorted_res = stats.probplot(observations, fit=False)
     return stats.norm.cdf(ppos)
@@ -365,7 +366,8 @@ def plotting_positions(df, censorship, cohn):
 
     Returns
     -------
-    plotting_position : array of float
+    plotting_position : Series
+        Series of plotting positions.
 
     See Also
     --------
@@ -514,10 +516,10 @@ def impute_ros(
 
     Parameters
     ----------
-    observations : str or array-like
+    observations : str or array_like
         Label of the column or the float array of censored observations
 
-    censorship : str
+    censorship : str or array_like
         Label of the column or the bool array of the censorship
         status of the observations.
 
@@ -528,36 +530,40 @@ def impute_ros(
         If `observations` and `censorship` are labels, this is the
         DataFrame that contains those columns.
 
-    min_uncensored : int (default is 2)
+    min_uncensored : int, optional
         The minimum number of uncensored values required before ROS
         can be used to impute the censored observations. When this
         criterion is not met, simple substitution is used instead.
+        Default is 2.
 
-    max_fraction_censored : float (default is 0.8)
+    max_fraction_censored : float, optional
         The maximum fraction of censored data below which ROS can be
         used to impute the censored observations. When this fraction is
-        exceeded, simple substituion is used instead.
+        exceeded, simple substituion is used instead. Default is 0.8.
 
-    substitution_fraction : float (default is 0.5)
+    substitution_fraction : float, optional
         The fraction of the detection limit to be used during simple
-        substitution of the censored values.
+        substitution of the censored values. Default is 0.5.
 
-    transform_in : callable (default is np.log)
+    transform_in : callable, optional
         Transformation to be applied to the values prior to fitting a
-        line to the plotting positions vs. uncensored values.
+        line to the plotting positions vs. uncensored values. Default
+        is ``np.log``.
 
-    transform_out : callable (default is np.exp)
+    transform_out : callable, optional
         Transformation to be applied to the imputed censored values
-        estimated from the previously computed best-fit line.
+        estimated from the previously computed best-fit line. Default
+        is ``np.exp``.
 
-    as_array : bool (default is True)
+    as_array : bool, optional
         When True, a numpy array of the imputed observations is
         returned. Otherwise, a modified copy of the original dataframe
-        with all of the intermediate calculations is returned.
+        with all of the intermediate calculations is returned. Default
+        is True.
 
     Returns
     -------
-    imputed : {ndarray, DataFrame}
+    imputed : ndarray or DataFrame
         The final observations where the censored values have either been
         imputed through ROS or substituted as a fraction of the
         detection limit.


### PR DESCRIPTION
- [X ] code/documentation is well formatted.
- [X] properly formatted commit message. See
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message).

#### AI Disclosure

Contributions must comply with the statsmodels [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html).

If using AI tools, edit the second option to explain which tool was selected and
how the tool's output was used.

Please complete **one** of the following:

- [ ] No AI tools were used to develop this pull request.
- [X ] AI tools were used.
      Tool(s): Claude
      Used for: Docstring cleaning
      I have personally read, understood, and can explain every line of this diff, and
      have verified the statistical/numerical correctness of the change.

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows
  using the Windows System for Linux once `flake8` is installed in the
  local Linux environment. While passing this test is not required, it is good practice and it help
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.
* If AI tools were used to help write this PR, see the
  [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html) for what disclosure
  and review is expected of you before submitting.

</details>
