### PR TITLE
DOC: Documentation cleaning pass core routines in tsa

### DIFF
--- a/statsmodels/tsa/_bds.py
+++ b/statsmodels/tsa/_bds.py
@@ -29,12 +29,14 @@ def distance_indicators(x, epsilon=None, distance=1.5):
 
     Parameters
     ----------
-    x : 1d array
+    x : array_like
         observations of time series for which heaviside distance indicators
         are calculated
-    epsilon : scalar, optional
-        the threshold distance to use in calculating the heaviside indicators
-    distance : scalar, optional
+    epsilon : float, optional
+        the threshold distance to use in calculating the heaviside
+        indicators. If not provided, computed as ``distance`` times the
+        standard deviation of ``x``
+    distance : float, optional
         if epsilon is omitted, specifies the distance multiplier to use when
         computing it
 
@@ -82,7 +84,7 @@ def correlation_sum(indicators, embedding_dim):
     -------
     corrsum : float
         Correlation sum
-    indicators_joint
+    indicators_joint : ndarray
         matrix of joint-distance-threshold indicators
     """
     if not indicators.ndim == 2:
@@ -107,7 +109,7 @@ def correlation_sums(indicators, max_dim):
 
     Parameters
     ----------
-    indicators : 2d array
+    indicators : ndarray
         matrix of distance threshold indicators
     max_dim : int
         maximum embedding dimension
@@ -140,8 +142,11 @@ def _var(indicators, max_dim):
 
     Returns
     -------
-    variances : float
-        Variance of BDS effect
+    variances : ndarray
+        Variance of the BDS effect for each embedding dimension from 2 to
+        max_dim.
+    k : float
+        Intermediate probability estimate used in the variance calculation.
     """
     nobs = len(indicators)
     corrsum_1dim, _ = correlation_sum(indicators, 1)
@@ -169,22 +174,25 @@ def bds(x, max_dim=2, epsilon=None, distance=1.5):
 
     Parameters
     ----------
-    x : ndarray
+    x : array_like
         Observations of time series for which bds statistics is calculated.
-    max_dim : int
+    max_dim : int, optional
         The maximum embedding dimension.
-    epsilon : {float, None}, optional
+    epsilon : float, optional
         The threshold distance to use in calculating the correlation sum.
+        If not provided, computed as ``distance`` times the standard
+        deviation of ``x``.
     distance : float, optional
         Specifies the distance multiplier to use when computing the test
         statistic if epsilon is omitted.
 
     Returns
     -------
-    bds_stat : float
-        The BDS statistic.
-    pvalue : float
-        The p-values associated with the BDS statistic.
+    bds_stat : float or ndarray
+        The BDS statistic. An ndarray is returned if max_dim > 2.
+    pvalue : float or ndarray
+        The p-values associated with the BDS statistic. An ndarray is
+        returned if max_dim > 2.
 
     Notes
     -----

--- a/statsmodels/tsa/adfvalues.py
+++ b/statsmodels/tsa/adfvalues.py
@@ -228,11 +228,11 @@ def mackinnonp(teststat, regression="c", N=1, lags=None):
     ----------
     teststat : float
         "T-value" from an Augmented Dickey-Fuller regression.
-    regression : str {"c", "n", "ct", "ctt"}
+    regression : {"c", "n", "ct", "ctt"}, optional
         This is the method of regression that was used.  Following MacKinnon's
         notation, this can be "c" for constant, "n" for no constant, "ct" for
         constant and trend, and "ctt" for constant, trend, and trend-squared.
-    N : int
+    N : int, optional
         The number of series believed to be I(1).  For (Augmented) Dickey-
         Fuller N = 1.
     lags : int, optional
@@ -240,7 +240,7 @@ def mackinnonp(teststat, regression="c", N=1, lags=None):
 
     Returns
     -------
-    p-value : float
+    pvalue : float
         The p-value for the ADF statistic estimated using MacKinnon 1994.
 
     Notes
@@ -416,21 +416,26 @@ def mackinnoncrit(N=1, regression="c", nobs=inf):
 
     Parameters
     ----------
-    N : int
+    N : int, optional
         The number of series of I(1) variables for which the null of
         non-cointegration is being tested.  For N > 12, the critical values
         are linearly interpolated (not yet implemented).  For the ADF test,
         N = 1.
-    regression : str {'c', 'ct', 'ctt', 'n'}
+    regression : {'c', 'ct', 'ctt', 'n'}, optional
         Following MacKinnon (1996), these stand for the type of regression run.
         'c' for constant and no trend, 'ct' for constant with a linear trend,
         'ctt' for constant with a linear and quadratic trend, and 'n' for
         no constant.  The values for the no constant case are taken from the
         1996 paper, as they were not updated for 2010 due to the unrealistic
         assumptions that would underlie such a case.
-    nobs : int or np.inf
+    nobs : int or float, optional
         This is the sample size.  If the sample size is numpy.inf, then the
         asymptotic critical values are returned.
+
+    Returns
+    -------
+    ndarray
+        The critical values at the 1%, 5%, and 10% levels.
 
     References
     ----------

--- a/statsmodels/tsa/ar_model.py
+++ b/statsmodels/tsa/ar_model.py
@@ -110,12 +110,12 @@ class AutoReg(tsa_model.TimeSeriesModel):
     ----------
     endog : array_like
         A 1-d endogenous response variable. The dependent variable.
-    lags : {None, int, list[int]}
+    lags : int, sequence of int, or None
         The number of lags to include in the model if an integer or the
         list of lag indices to include.  For example, [1, 4] will only
         include lags 1 and 4 while lags=4 will include lags 1, 2, 3, and 4.
-        None excludes all AR lags, and behave identically to 0.
-    trend : {'n', 'c', 't', 'ct', 'ctt'}
+        None excludes all AR lags, and behaves identically to 0.
+    trend : {'n', 'c', 't', 'ct', 'ctt'}, optional
         The trend to include in the model:
 
         * 'n' - No trend.
@@ -124,7 +124,7 @@ class AutoReg(tsa_model.TimeSeriesModel):
         * 'ct' - Constant and linear time trend.
         * 'ctt' - Constant and linear and quadratic time trends.
 
-    seasonal : bool
+    seasonal : bool, optional
         Flag indicating whether to include seasonal dummies in the model. If
         seasonal is True and trend includes 'c', then the first period
         is excluded from the seasonal terms.
@@ -132,7 +132,7 @@ class AutoReg(tsa_model.TimeSeriesModel):
         Exogenous variables to include in the model. Must have the same number
         of observations as endog and should be aligned so that endog[i] is
         regressed on exog[i].
-    hold_back : {None, int}
+    hold_back : int, optional
         Initial observations to exclude from the estimation sample.  If None,
         then hold_back is equal to the maximum lag in the model.  Set to a
         non-zero value to produce comparable models with different lag
@@ -140,15 +140,15 @@ class AutoReg(tsa_model.TimeSeriesModel):
         lags=1, set hold_back=3 which ensures that both models are estimated
         using observations 3,...,nobs. hold_back must be >= the maximum lag in
         the model.
-    period : {None, int}
+    period : int, optional
         The period of the data. Only used if seasonal is True. This parameter
         can be omitted if using a pandas object for endog that contains a
         recognized frequency.
-    missing : str
+    missing : str, optional
         Available options are 'none', 'drop', and 'raise'. If 'none', no nan
         checking is done. If 'drop', any observations with nans are dropped.
         If 'raise', an error is raised. Default is 'none'.
-    deterministic : DeterministicProcess
+    deterministic : DeterministicProcess, optional
         A deterministic process.  If provided, trend and seasonal are ignored.
         A warning is raised if trend is not "n" or seasonal is not False.
 
@@ -392,7 +392,7 @@ class AutoReg(tsa_model.TimeSeriesModel):
 
         Parameters
         ----------
-        cov_type : str
+        cov_type : str, optional
             The covariance estimator to use. The most common choices are listed
             below.  Supports all covariance estimators that are available
             in ``OLS.fit``.
@@ -487,7 +487,7 @@ class AutoReg(tsa_model.TimeSeriesModel):
 
         Parameters
         ----------
-        params : ndarray
+        params : array_like
             The model parameters used to compute the log-likelihood.
 
         Returns
@@ -509,7 +509,7 @@ class AutoReg(tsa_model.TimeSeriesModel):
 
         Parameters
         ----------
-        params : ndarray
+        params : array_like
             The parameters to use when evaluating the score.
 
         Returns
@@ -528,7 +528,7 @@ class AutoReg(tsa_model.TimeSeriesModel):
 
         Parameters
         ----------
-        params : ndarray
+        params : array_like
             The model parameters.
 
         Returns
@@ -546,7 +546,7 @@ class AutoReg(tsa_model.TimeSeriesModel):
 
         Parameters
         ----------
-        params : ndarray
+        params : array_like
             The parameters to use when evaluating the Hessian.
 
         Returns
@@ -616,14 +616,14 @@ class AutoReg(tsa_model.TimeSeriesModel):
             Offset relative to start at which to begin dynamic prediction.
         num_oos : int
             Number of out-of-sample observations to forecast.
-        exog : ndarray
+        exog : array_like or None
             Array containing replacement exog values.
-        exog_oos : ndarray
+        exog_oos : array_like or None
             Array containing out-of-sample exog values.
 
         Returns
         -------
-        Series
+        ndarray or Series
             The predicted values.
         """
         reg = []
@@ -708,10 +708,15 @@ class AutoReg(tsa_model.TimeSeriesModel):
         num_oos : int
             Number of out-of-sample observations, so that the returned size is
             num_oos + (end - start + 1).
-        exog : {ndarray, DataFrame}
+        exog : array_like or None
             Array containing replacement exog values
-        exog_oos : {ndarray, DataFrame}
+        exog_oos : array_like or None
             Containing forecast exog values
+
+        Returns
+        -------
+        ndarray or Series
+            The predicted values.
         """
         hold_back = self._hold_back
         nobs = self.endog.shape[0]
@@ -816,7 +821,7 @@ class AutoReg(tsa_model.TimeSeriesModel):
             the sample. Unlike standard python slices, end is inclusive so
             that all the predictions [start, start+1, ..., end-1, end] are
             returned.
-        dynamic : {bool, int, str, datetime, Timestamp}, optional
+        dynamic : bool, int, str, datetime, or Timestamp, optional
             Integer offset relative to `start` at which to begin dynamic
             prediction. Prior to this observation, true endogenous values
             will be used for prediction; starting with this observation and
@@ -824,10 +829,10 @@ class AutoReg(tsa_model.TimeSeriesModel):
             values will be used instead. Datetime-like objects are not
             interpreted as offsets. They are instead used to find the index
             location of `dynamic` which is then used to compute the offset.
-        exog : array_like
+        exog : array_like, optional
             A replacement exogenous array.  Must have the same shape as the
             exogenous data array used when the model was created.
-        exog_oos : array_like
+        exog_oos : array_like, optional
             An array containing out-of-sample values of the exogenous variable.
             Must have the same number of columns as the exog used when the
             model was created, and at least as many rows as the number of
@@ -835,7 +840,7 @@ class AutoReg(tsa_model.TimeSeriesModel):
 
         Returns
         -------
-        predictions : {ndarray, Series}
+        predictions : ndarray or Series
             Array of out of in-sample predictions and / or out-of-sample
             forecasts.
         """
@@ -936,7 +941,7 @@ class AutoRegResults(tsa_model.TimeSeriesModelResults):
         The fitted parameters from the AR Model.
     cov_params : ndarray
         The estimated covariance matrix of the model parameters.
-    normalized_cov_params : ndarray
+    normalized_cov_params : ndarray, optional
         The array inv(dot(x.T,x)) where x contains the regressors in the
         model.
     scale : float, optional
@@ -1219,11 +1224,11 @@ class AutoRegResults(tsa_model.TimeSeriesModelResults):
 
         Parameters
         ----------
-        lags : int
+        lags : int, optional
             The maximum number of lags to use in the test. Jointly tests that
             all autocorrelations up to and including lag j are zero for
             j = 1, 2, ..., lags. If None, uses min(10, nobs // 5).
-        model_df : int
+        model_df : int, optional
             The model degree of freedom to use when adjusting computing the
             test statistic to account for parameter estimation. If None, uses
             the number of AR lags included in the model.
@@ -1302,7 +1307,7 @@ class AutoRegResults(tsa_model.TimeSeriesModelResults):
 
         Parameters
         ----------
-        lags : int
+        lags : int, optional
             The maximum number of lags to use in the test. Jointly tests that
             all squared autocorrelations up to and including lag j are zero for
             j = 1, 2, ..., lags. If None, uses lag=12*(nobs/100)^{1/4}.
@@ -1426,7 +1431,7 @@ class AutoRegResults(tsa_model.TimeSeriesModelResults):
             the sample. Unlike standard python slices, end is inclusive so
             that all the predictions [start, start+1, ..., end-1, end] are
             returned.
-        dynamic : {bool, int, str, datetime, Timestamp}, optional
+        dynamic : bool, int, str, datetime, or Timestamp, optional
             Integer offset relative to `start` at which to begin dynamic
             prediction. Prior to this observation, true endogenous values
             will be used for prediction; starting with this observation and
@@ -1434,10 +1439,10 @@ class AutoRegResults(tsa_model.TimeSeriesModelResults):
             values will be used instead. Datetime-like objects are not
             interpreted as offsets. They are instead used to find the index
             location of `dynamic` which is then used to compute the offset.
-        exog : array_like
+        exog : array_like, optional
             A replacement exogenous array.  Must have the same shape as the
             exogenous data array used when the model was created.
-        exog_oos : array_like
+        exog_oos : array_like, optional
             An array containing out-of-sample values of the exogenous variable.
             Must have the same number of columns as the exog used when the
             model was created, and at least as many rows as the number of
@@ -1471,18 +1476,18 @@ class AutoRegResults(tsa_model.TimeSeriesModelResults):
 
         Parameters
         ----------
-        steps : {int, str, datetime}, default 1
+        steps : int, str, or datetime, optional
             If an integer, the number of steps to forecast from the end of the
             sample. Can also be a date string to parse or a datetime type.
             However, if the dates index does not have a fixed frequency,
-            steps must be an integer.
-        exog : {ndarray, DataFrame}
+            steps must be an integer. The default is 1.
+        exog : array_like, optional
             Exogenous values to use out-of-sample. Must have same number of
             columns as original exog data and at least `steps` rows
 
         Returns
         -------
-        array_like
+        ndarray or Series
             Array of out of in-sample predictions and / or out-of-sample
             forecasts.
 
@@ -1566,18 +1571,18 @@ class AutoRegResults(tsa_model.TimeSeriesModelResults):
 
         Parameters
         ----------\n%(predict_params)s
-        alpha : {float, None}
+        alpha : float or None, optional
             The tail probability not covered by the confidence interval. Must
             be in (0, 1). Confidence interval is constructed assuming normally
             distributed shocks. If None, figure will not show the confidence
             interval.
-        in_sample : bool
+        in_sample : bool, optional
             Flag indicating whether to include the in-sample period in the
             plot.
-        fig : Figure
+        fig : Figure, optional
             An existing figure handle. If not provided, a new figure is
             created.
-        figsize: tuple[float, float]
+        figsize : tuple of float, optional
             Tuple containing the figure size values.
 
         Returns
@@ -2083,9 +2088,9 @@ def ar_select_order(
         A 1-d endogenous response variable. The dependent variable.
     maxlag : int
         The maximum lag to consider.
-    ic : {'aic', 'hqic', 'bic'}
+    ic : {'aic', 'hqic', 'bic'}, optional
         The information criterion to use in the selection.
-    glob : bool
+    glob : bool, optional
         Flag indicating whether to use a global search across all combinations
         of lags.  In practice, this option is not computationally feasible when
         maxlag is larger than 15 (or perhaps 20) since the global search
@@ -2256,7 +2261,8 @@ class AROrderSelectionResults:
 
         Returns
         -------
-        dict[tuple, float]
+        dict
+            Mapping from lag specification to the criterion value.
         """
         return self._aic
 
@@ -2267,7 +2273,8 @@ class AROrderSelectionResults:
 
         Returns
         -------
-        dict[tuple, float]
+        dict
+            Mapping from lag specification to the criterion value.
         """
         return self._bic
 
@@ -2278,7 +2285,8 @@ class AROrderSelectionResults:
 
         Returns
         -------
-        dict[tuple, float]
+        dict
+            Mapping from lag specification to the criterion value.
         """
         return self._hqic
 

--- a/statsmodels/tsa/ardl/model.py
+++ b/statsmodels/tsa/ardl/model.py
@@ -199,31 +199,33 @@ class ARDL(AutoReg):
     ----------
     endog : array_like
         A 1-d endogenous response variable. The dependent variable.
-    lags : {int, list[int]}
+    lags : int, sequence of int, or None
         The number of lags to include in the model if an integer or the
         list of lag indices to include.  For example, [1, 4] will only
         include lags 1 and 4 while lags=4 will include lags 1, 2, 3, and 4.
-    exog : array_like
+        None excludes all AR lags, and behaves identically to 0.
+    exog : array_like, optional
         Exogenous variables to include in the model. Either a DataFrame or
         an 2-d array-like structure that can be converted to a NumPy array.
-    order : {int, sequence[int], dict}
+    order : int, sequence of int, or dict, optional
         If int, uses lags 0, 1, ..., order for all exog variables. If
-        sequence[int], uses the ``order`` for all variables. If a dict,
+        sequence of int, uses the ``order`` for all variables. If a dict,
         applies the lags series by series. If ``exog`` is anything other
         than a DataFrame, the keys are the column index of exog (e.g., 0,
         1, ...). If a DataFrame, keys are column names.
-    fixed : array_like
+    fixed : array_like, optional
         Additional fixed regressors that are not lagged.
     causal : bool, optional
         Whether to include lag 0 of exog variables.  If True, only includes
         lags 1, 2, ...
-    trend : {'n', 'c', 't', 'ct'}, optional
+    trend : {'n', 'c', 't', 'ct', 'ctt'}, optional
         The trend to include in the model:
 
         * 'n' - No trend.
         * 'c' - Constant only.
         * 't' - Time trend only.
         * 'ct' - Constant and time trend.
+        * 'ctt' - Constant, time trend, and quadratic time trend.
 
         The default is 'c'.
 
@@ -234,7 +236,7 @@ class ARDL(AutoReg):
     deterministic : DeterministicProcess, optional
         A deterministic process.  If provided, trend and seasonal are ignored.
         A warning is raised if trend is not "n" and seasonal is not False.
-    hold_back : {None, int}, optional
+    hold_back : int, optional
         Initial observations to exclude from the estimation sample.  If None,
         then hold_back is equal to the maximum lag in the model.  Set to a
         non-zero value to produce comparable models with different lag
@@ -242,11 +244,11 @@ class ARDL(AutoReg):
         lags=1, set hold_back=3 which ensures that both models are estimated
         using observations 3,...,nobs. hold_back must be >= the maximum lag in
         the model.
-    period : {None, int}, optional
+    period : int, optional
         The period of the data. Only used if seasonal is True. This parameter
         can be omitted if using a pandas object for endog that contains a
         recognized frequency.
-    missing : {"none", "drop", "raise"}, optional
+    missing : str, optional
         Available options are 'none', 'drop', and 'raise'. If 'none', no NaN
         checking is done. If 'drop', any observations with NaNs are dropped.
         If 'raise', an error is raised. Default is 'none'.
@@ -492,7 +494,7 @@ class ARDL(AutoReg):
 
         Parameters
         ----------
-        cov_type : str
+        cov_type : str, optional
             The covariance estimator to use. The most common choices are listed
             below.  Supports all covariance estimators that are available
             in ``OLS.fit``.
@@ -712,7 +714,7 @@ class ARDL(AutoReg):
             the sample. Unlike standard python slices, end is inclusive so
             that all the predictions [start, start+1, ..., end-1, end] are
             returned.
-        dynamic : {bool, int, str, datetime, Timestamp}, optional
+        dynamic : bool, int, str, datetime, or Timestamp, optional
             Integer offset relative to `start` at which to begin dynamic
             prediction. Prior to this observation, true endogenous values
             will be used for prediction; starting with this observation and
@@ -720,18 +722,18 @@ class ARDL(AutoReg):
             values will be used instead. Datetime-like objects are not
             interpreted as offsets. They are instead used to find the index
             location of `dynamic` which is then used to compute the offset.
-        exog : array_like
+        exog : array_like, optional
             A replacement exogenous array.  Must have the same shape as the
             exogenous data array used when the model was created.
-        exog_oos : array_like
+        exog_oos : array_like, optional
             An array containing out-of-sample values of the exogenous
             variables. Must have the same number of columns as the exog
             used when the model was created, and at least as many rows as
             the number of out-of-sample forecasts.
-        fixed : array_like
+        fixed : array_like, optional
             A replacement fixed array.  Must have the same shape as the
             fixed data array used when the model was created.
-        fixed_oos : array_like
+        fixed_oos : array_like, optional
             An array containing out-of-sample values of the fixed variables.
             Must have the same number of columns as the fixed used when the
             model was created, and at least as many rows as the number of
@@ -739,7 +741,7 @@ class ARDL(AutoReg):
 
         Returns
         -------
-        predictions : {ndarray, Series}
+        predictions : ndarray or Series
             Array of out of in-sample predictions and / or out-of-sample
             forecasts.
         """
@@ -871,27 +873,28 @@ class ARDL(AutoReg):
             below.
         data : DataFrame
             DataFrame containing the variables in the formula.
-        lags : {int, list[int]}
+        lags : int, sequence of int, or None, optional
             The number of lags to include in the model if an integer or the
             list of lag indices to include.  For example, [1, 4] will only
             include lags 1 and 4 while lags=4 will include lags 1, 2, 3,
-            and 4.
-        order : {int, sequence[int], dict}
+            and 4. None excludes all AR lags, and behaves identically to 0.
+        order : int, sequence of int, or dict, optional
             If int, uses lags 0, 1, ..., order for all exog variables. If
-            sequence[int], uses the ``order`` for all variables. If a dict,
+            sequence of int, uses the ``order`` for all variables. If a dict,
             applies the lags series by series. If ``exog`` is anything other
             than a DataFrame, the keys are the column index of exog (e.g., 0,
             1, ...). If a DataFrame, keys are column names.
         causal : bool, optional
             Whether to include lag 0 of exog variables.  If True, only
             includes lags 1, 2, ...
-        trend : {'n', 'c', 't', 'ct'}, optional
+        trend : {'n', 'c', 't', 'ct', 'ctt'}, optional
             The trend to include in the model:
 
             * 'n' - No trend.
             * 'c' - Constant only.
             * 't' - Time trend only.
             * 'ct' - Constant and time trend.
+            * 'ctt' - Constant, time trend, and quadratic time trend.
 
             The default is 'n'.
 
@@ -903,7 +906,7 @@ class ARDL(AutoReg):
             A deterministic process.  If provided, trend and seasonal are
             ignored. A warning is raised if trend is not "n" and seasonal
             is not False.
-        hold_back : {None, int}, optional
+        hold_back : int, optional
             Initial observations to exclude from the estimation sample.  If
             None, then hold_back is equal to the maximum lag in the model.
             Set to a non-zero value to produce comparable models with
@@ -911,11 +914,11 @@ class ARDL(AutoReg):
             with lags=3 and lags=1, set hold_back=3 which ensures that both
             models are estimated using observations 3,...,nobs. hold_back
             must be >= the maximum lag in the model.
-        period : {None, int}, optional
+        period : int, optional
             The period of the data. Only used if seasonal is True. This
             parameter can be omitted if using a pandas object for endog
             that contains a recognized frequency.
-        missing : {"none", "drop", "raise"}, optional
+        missing : str, optional
             Available options are 'none', 'drop', and 'raise'. If 'none', no
             NaN checking is done. If 'drop', any observations with NaNs are
             dropped. If 'raise', an error is raised. Default is 'none'.
@@ -995,7 +998,7 @@ class ARDLResults(AutoRegResults):
         model.
     scale : float, optional
         An estimate of the scale of the model.
-    use_t : bool
+    use_t : bool, optional
         Whether use_t was set in fit
     """
 
@@ -1056,11 +1059,11 @@ class ARDLResults(AutoRegResults):
 
         Parameters
         ----------
-        steps : {int, str, datetime}, default 1
+        steps : int, str, or datetime, optional
             If an integer, the number of steps to forecast from the end of the
             sample. Can also be a date string to parse or a datetime type.
             However, if the dates index does not have a fixed frequency,
-            steps must be an integer.
+            steps must be an integer. The default is 1.
         exog : array_like, optional
             Exogenous values to use out-of-sample. Must have same number of
             columns as original exog data and at least `steps` rows
@@ -1070,7 +1073,7 @@ class ARDLResults(AutoRegResults):
 
         Returns
         -------
-        array_like
+        ndarray or Series
             Array of out of in-sample predictions and / or out-of-sample
             forecasts.
 
@@ -1108,19 +1111,19 @@ class ARDLResults(AutoRegResults):
         Parameters
         ----------
 
-        endog: array_like
+        endog : array_like
             New observations from the modeled time-series process.
-        exog: array_like, optional
+        exog : array_like, optional
             New observations of exogenous regressors, if applicable. It must supply the same
             un-lagged columns as the original ``exog``. The lag structure fitting the original data
             is re-applied automatically.
-        fixed: array_like, optional
+        fixed : array_like, optional
             New observations of fixed regressors, if applicable.
-        refit: bool, optional
+        refit : bool, optional
             Whether to re-fit the parameters, using the new dataset. Default is False
             (so, the parameters from the current results object are used to create the new results
             object.)
-        fit_kwargs: dict, optional
+        fit_kwargs : dict, optional
             Keyword arguments to pass to `fit` (if `refit=True`)
 
         Returns
@@ -1250,7 +1253,7 @@ class ARDLResults(AutoRegResults):
             the sample. Unlike standard python slices, end is inclusive so
             that all the predictions [start, start+1, ..., end-1, end] are
             returned.
-        dynamic : {bool, int, str, datetime, Timestamp}, optional
+        dynamic : bool, int, str, datetime, or Timestamp, optional
             Integer offset relative to `start` at which to begin dynamic
             prediction. Prior to this observation, true endogenous values
             will be used for prediction; starting with this observation and
@@ -1258,18 +1261,18 @@ class ARDLResults(AutoRegResults):
             values will be used instead. Datetime-like objects are not
             interpreted as offsets. They are instead used to find the index
             location of `dynamic` which is then used to compute the offset.
-        exog : array_like
+        exog : array_like, optional
             A replacement exogenous array.  Must have the same shape as the
             exogenous data array used when the model was created.
-        exog_oos : array_like
+        exog_oos : array_like, optional
             An array containing out-of-sample values of the exogenous variable.
             Must have the same number of columns as the exog used when the
             model was created, and at least as many rows as the number of
             out-of-sample forecasts.
-        fixed : array_like
+        fixed : array_like, optional
             A replacement fixed array.  Must have the same shape as the
             fixed data array used when the model was created.
-        fixed_oos : array_like
+        fixed_oos : array_like, optional
             An array containing out-of-sample values of the fixed variables.
             Must have the same number of columns as the fixed used when the
             model was created, and at least as many rows as the number of
@@ -1323,18 +1326,18 @@ class ARDLResults(AutoRegResults):
 
         Parameters
         ----------\n%(predict_params)s
-        alpha : {float, None}
+        alpha : float or None, optional
             The tail probability not covered by the confidence interval. Must
             be in (0, 1). Confidence interval is constructed assuming normally
             distributed shocks. If None, figure will not show the confidence
             interval.
-        in_sample : bool
+        in_sample : bool, optional
             Flag indicating whether to include the in-sample period in the
             plot.
-        fig : Figure
+        fig : Figure, optional
             An existing figure handle. If not provided, a new figure is
             created.
-        figsize: tuple[float, float]
+        figsize : tuple of int, optional
             Tuple containing the figure size values.
 
         Returns
@@ -1498,27 +1501,28 @@ def ardl_select_order(
     exog : array_like
         Exogenous variables to include in the model. Either a DataFrame or
         an 2-d array-like structure that can be converted to a NumPy array.
-    maxorder : {int, dict}
+    maxorder : int or dict
         If int, sets a common max lag length for all exog variables. If
         a dict, then sets individual lag length. They keys are column names
         if exog is a DataFrame or column indices otherwise.
-    trend : {'n', 'c', 't', 'ct'}, optional
+    trend : {'n', 'c', 't', 'ct', 'ctt'}, optional
         The trend to include in the model:
 
         * 'n' - No trend.
         * 'c' - Constant only.
         * 't' - Time trend only.
         * 'ct' - Constant and time trend.
+        * 'ctt' - Constant, time trend, and quadratic time trend.
 
         The default is 'c'.
-    fixed : array_like
+    fixed : array_like, optional
         Additional fixed regressors that are not lagged.
     causal : bool, optional
         Whether to include lag 0 of exog variables.  If True, only includes
         lags 1, 2, ...
-    ic : {"aic", "bic", "hqic"}
+    ic : {"aic", "bic", "hqic"}, optional
         The information criterion to use in model selection.
-    glob : bool
+    glob : bool, optional
         Whether to consider all possible submodels of the largest model
         or only if smaller order lags must be included if larger order
         lags are.  If ``True``, the number of model considered is of the
@@ -1534,7 +1538,7 @@ def ardl_select_order(
     deterministic : DeterministicProcess, optional
         A deterministic process.  If provided, trend and seasonal are ignored.
         A warning is raised if trend is not "n" and seasonal is not False.
-    hold_back : {None, int}, optional
+    hold_back : int, optional
         Initial observations to exclude from the estimation sample.  If None,
         then hold_back is equal to the maximum lag in the model.  Set to a
         non-zero value to produce comparable models with different lag
@@ -1542,11 +1546,11 @@ def ardl_select_order(
         lags=1, set hold_back=3 which ensures that both models are estimated
         using observations 3,...,nobs. hold_back must be >= the maximum lag in
         the model.
-    period : {None, int}, optional
+    period : int, optional
         The period of the data. Only used if seasonal is True. This parameter
         can be omitted if using a pandas object for endog that contains a
         recognized frequency.
-    missing : {"none", "drop", "raise"}, optional
+    missing : str, optional
         Available options are 'none', 'drop', and 'raise'. If 'none', no NaN
         checking is done. If 'drop', any observations with NaNs are dropped.
         If 'raise', an error is raised. Default is 'none'.
@@ -1693,7 +1697,7 @@ lags_descr = textwrap.wrap(
     "Must be at least 1.",
     71,
 )
-lags_param = Parameter(name="lags", type="int", desc=lags_descr)
+lags_param = Parameter(name="lags", type="int, optional", desc=lags_descr)
 order_descr = textwrap.wrap(
     "If int, uses lags 0, 1, ..., order for all exog variables. If a dict, "
     "applies the lags series by series. If ``exog`` is anything other than a "
@@ -1701,7 +1705,7 @@ order_descr = textwrap.wrap(
     "a DataFrame, keys are column names.",
     71,
 )
-order_param = Parameter(name="order", type="int, dict", desc=order_descr)
+order_param = Parameter(name="order", type="int or dict, optional", desc=order_descr)
 
 from_formula_doc = Docstring(ARDL.from_formula.__doc__)
 from_formula_doc.replace_block("Summary", "Construct an UECM from a formula")
@@ -1736,29 +1740,30 @@ class UECM(ARDL):
     ----------
     endog : array_like
         A 1-d endogenous response variable. The dependent variable.
-    lags : {int, list[int]}
+    lags : int or None
         The number of lags of the endogenous variable to include in the
         model. Must be at least 1.
-    exog : array_like
+    exog : array_like, optional
         Exogenous variables to include in the model. Either a DataFrame or
         an 2-d array-like structure that can be converted to a NumPy array.
-    order : {int, sequence[int], dict}
+    order : int, dict, or None, optional
         If int, uses lags 0, 1, ..., order for all exog variables. If a
         dict, applies the lags series by series. If ``exog`` is anything
         other than a DataFrame, the keys are the column index of exog
         (e.g., 0, 1, ...). If a DataFrame, keys are column names.
-    fixed : array_like
+    fixed : array_like, optional
         Additional fixed regressors that are not lagged.
     causal : bool, optional
         Whether to include lag 0 of exog variables.  If True, only includes
         lags 1, 2, ...
-    trend : {'n', 'c', 't', 'ct'}, optional
+    trend : {'n', 'c', 't', 'ct', 'ctt'}, optional
         The trend to include in the model:
 
         * 'n' - No trend.
         * 'c' - Constant only.
         * 't' - Time trend only.
         * 'ct' - Constant and time trend.
+        * 'ctt' - Constant, time trend, and quadratic time trend.
 
         The default is 'c'.
 
@@ -1769,7 +1774,7 @@ class UECM(ARDL):
     deterministic : DeterministicProcess, optional
         A deterministic process.  If provided, trend and seasonal are ignored.
         A warning is raised if trend is not "n" and seasonal is not False.
-    hold_back : {None, int}, optional
+    hold_back : int, optional
         Initial observations to exclude from the estimation sample.  If None,
         then hold_back is equal to the maximum lag in the model.  Set to a
         non-zero value to produce comparable models with different lag
@@ -1777,11 +1782,11 @@ class UECM(ARDL):
         lags=1, set hold_back=3 which ensures that both models are estimated
         using observations 3,...,nobs. hold_back must be >= the maximum lag in
         the model.
-    period : {None, int}, optional
+    period : int, optional
         The period of the data. Only used if seasonal is True. This parameter
         can be omitted if using a pandas object for endog that contains a
         recognized frequency.
-    missing : {"none", "drop", "raise"}, optional
+    missing : str, optional
         Available options are 'none', 'drop', and 'raise'. If 'none', no NaN
         checking is done. If 'drop', any observations with NaNs are dropped.
         If 'raise', an error is raised. Default is 'none'.
@@ -2049,8 +2054,11 @@ class UECM(ARDL):
         ----------
         ardl : ARDL
             The ARDL model instance
-        missing : {"none", "drop", "raise"}, default "none"
-            How to treat missing observations.
+        missing : str, optional
+            How to treat missing observations. Available options are 'none',
+            'drop', and 'raise'. If 'none', no NaN checking is done. If
+            'drop', any observations with NaNs are dropped. If 'raise', an
+            error is raised. The default is 'none'.
 
         Returns
         -------
@@ -2129,7 +2137,7 @@ class UECM(ARDL):
             the sample. Unlike standard python slices, end is inclusive so
             that all the predictions [start, start+1, ..., end-1, end] are
             returned.
-        dynamic : {bool, int, str, datetime, Timestamp}, optional
+        dynamic : bool, int, str, datetime, or Timestamp, optional
             Integer offset relative to `start` at which to begin dynamic
             prediction. Prior to this observation, true endogenous values
             will be used for prediction; starting with this observation and
@@ -2137,18 +2145,18 @@ class UECM(ARDL):
             values will be used instead. Datetime-like objects are not
             interpreted as offsets. They are instead used to find the index
             location of `dynamic` which is then used to compute the offset.
-        exog : array_like
+        exog : array_like, optional
             A replacement exogenous array.  Must have the same shape as the
             exogenous data array used when the model was created.
-        exog_oos : array_like
+        exog_oos : array_like, optional
             An array containing out-of-sample values of the exogenous
             variables. Must have the same number of columns as the exog
             used when the model was created, and at least as many rows as
             the number of out-of-sample forecasts.
-        fixed : array_like
+        fixed : array_like, optional
             A replacement fixed array.  Must have the same shape as the
             fixed data array used when the model was created.
-        fixed_oos : array_like
+        fixed_oos : array_like, optional
             An array containing out-of-sample values of the fixed variables.
             Must have the same number of columns as the fixed used when the
             model was created, and at least as many rows as the number of
@@ -2156,7 +2164,7 @@ class UECM(ARDL):
 
         Returns
         -------
-        predictions : {ndarray, Series}
+        predictions : ndarray or Series
             Array of out of in-sample predictions and / or out-of-sample
             forecasts.
         """
@@ -2386,7 +2394,7 @@ class UECMResults(ARDLResults):
         ----------
         case : {1, 2, 3, 4, 5}
             One of the cases covered in the PSS test.
-        cov_type : str
+        cov_type : str, optional
             The covariance estimator to use. The asymptotic distribution of
             the PSS test has only been established in the homoskedastic case,
             which is the default.
@@ -2416,7 +2424,7 @@ class UECMResults(ARDLResults):
         use_t : bool, optional
             A flag indicating that small-sample corrections should be applied
             to the covariance estimator.
-        asymptotic : bool
+        asymptotic : bool, optional
             Flag indicating whether to use asymptotic critical values which
             were computed by simulation (True, default) or to simulate a
             sample-size specific set of critical values. Tables are only
@@ -2424,14 +2432,14 @@ class UECMResults(ARDLResults):
             relationship, so if more variables are included then simulation
             is always used. The simulation computes the test statistic under
             an assumption that the residuals are homoskedastic.
-        nsim : int
+        nsim : int, optional
             Number of simulations to run when computing exact critical values.
             Only used if ``asymptotic`` is ``False``.
-        rng : int, array_like of int, numpy.random.Generator, numpy.random.RandomState, optional
+        rng : int, array_like of int, numpy.random.Generator, or numpy.random.RandomState, optional
             Random number generator or seed to use when simulating critical
             values. Must be provided if reproducible critical value and
             p-values are required when ``asymptotic`` is ``False``.
-        seed : {None, int, sequence[int], RandomState, Generator}, optional
+        seed : int, array_like of int, numpy.random.Generator, or numpy.random.RandomState, optional
             .. deprecated:: 0.15
 
                seed has been deprecated. In-line with SPEC-007, use

--- a/statsmodels/tsa/arima/model.py
+++ b/statsmodels/tsa/arima/model.py
@@ -58,17 +58,18 @@ class ARIMA(sarimax.SARIMAX):
         negative integer, and s is an integer strictly greater than one. P and
         Q may either be integers or lists of positive integers specifying
         exactly which lag orders are included. The default is (0, 0, 0, 0).
-    trend : str{'n','c','t','ct'} or iterable, optional
+    trend : {'n', 'c', 't', 'ct', 'ctt'} or array_like, optional
         Parameter controlling the deterministic trend. Can be specified as a
-        string where 'c' indicates a constant term, 't' indicates a
-        linear trend in time, and 'ct' includes both. Can also be specified as
-        an iterable defining a polynomial, as in `numpy.poly1d`, where
-        `[1,1,0,1]` would denote :math:`a + bt + ct^3`. Default is 'c' for
-        models without integration, and no trend for models with integration.
-        Note that all trend terms are included in the model as exogenous
-        regressors, which differs from how trends are included in ``SARIMAX``
-        models.  See the Notes section for a precise definition of the
-        treatment of trend terms.
+        string where 'n' indicates no trend, 'c' indicates a constant term,
+        't' indicates a linear trend in time, 'ct' includes both, and 'ctt'
+        includes a constant, linear trend, and squared time trend. Can also
+        be specified as an array_like defining a polynomial, as in
+        `numpy.poly1d`, where `[1,1,0,1]` would denote :math:`a + bt + ct^3`.
+        Default is 'c' for models without integration, and no trend for
+        models with integration. Note that all trend terms are included in
+        the model as exogenous regressors, which differs from how trends are
+        included in ``SARIMAX`` models.  See the Notes section for a precise
+        definition of the treatment of trend terms.
     enforce_stationarity : bool, optional
         Whether or not to require the autoregressive parameters to correspond
         to a stationarity process. Default is True.
@@ -290,7 +291,7 @@ class ARIMA(sarimax.SARIMAX):
             Default is 'opg' unless memory conservation is used to avoid
             computing the loglikelihood values for each observation, in which
             case the default is 'oim'.
-        cov_kwds : dict or None, optional
+        cov_kwds : dict, optional
             A dictionary of arguments affecting covariance matrix computation.
 
             **opg, oim, approx, robust, robust_approx**

--- a/statsmodels/tsa/arima/specification.py
+++ b/statsmodels/tsa/arima/specification.py
@@ -42,43 +42,44 @@ class SARIMAXSpecification:
         may either be integers or lists of positive integers. May not be used
         in combination with the arguments `seasonal_ar_order`, `seasonal_diff`,
         or `seasonal_ma_order`.
-    ar_order : int or list of int
+    ar_order : int or list of int, optional
         The autoregressive order of the model. May be an integer, in which case
         all autoregressive lags up to and including it will be included.
         Alternatively, may be a list of integers specifying which lag orders
         are included. May not be used in combination with `order`.
-    diff : int
+    diff : int, optional
         The order of integration of the model. May not be used in combination
         with `order`.
-    ma_order : int or list of int
+    ma_order : int or list of int, optional
         The moving average order of the model. May be an integer or
         list of integers. See the documentation for `ar_order` for details.
         May not be used in combination with `order`.
-    seasonal_ar_order : int or list of int
+    seasonal_ar_order : int or list of int, optional
         The seasonal autoregressive order of the model. May be an integer or
         list of integers. See the documentation for `ar_order` for examples.
         Note that if `seasonal_periods = 4` and `seasonal_ar_order = 2`, then
         this implies that the overall model will include lags 4 and 8.
         May not be used in combination with `seasonal_order`.
-    seasonal_diff : int
+    seasonal_diff : int, optional
         The order of seasonal integration of the model. May not be used in
         combination with `seasonal_order`.
-    seasonal_ma_order : int or list of int
+    seasonal_ma_order : int or list of int, optional
         The moving average order of the model. May be an integer or
         list of integers. See the documentation for `ar_order` and
         `seasonal_ar_order` for additional details. May not be used in
         combination with `seasonal_order`.
-    seasonal_periods : int
+    seasonal_periods : int, optional
         Number of periods in a season. May not be used in combination with
         `seasonal_order`.
-    trend : str{'n','c','t','ct'} or iterable, optional
+    trend : {'n', 'c', 't', 'ct', 'ctt'} or array_like, optional
         Parameter controlling the deterministic trend polynomial :math:`A(t)`.
-        Can be specified as a string where 'c' indicates a constant (i.e., a
-        degree zero component of the trend polynomial), 't' indicates a
-        linear trend with time, and 'ct' is both. Can also be specified as an
-        iterable defining the polynomial as in `numpy.poly1d`, where
-        `[1,1,0,1]` would denote :math:`a + bt + ct^3`. Default is to not
-        include a trend component.
+        Can be specified as a string where 'n' indicates no trend, 'c'
+        indicates a constant (i.e., a degree zero component of the trend
+        polynomial), 't' indicates a linear trend with time, 'ct' includes
+        both, and 'ctt' includes a constant, linear trend, and squared time
+        trend. Can also be specified as an array_like defining the polynomial
+        as in `numpy.poly1d`, where `[1,1,0,1]` would denote
+        :math:`a + bt + ct^3`. Default is to not include a trend component.
     enforce_stationarity : bool, optional
         Whether or not to require the autoregressive parameters to correspond
         to a stationarity process. This is only possible in estimation by
@@ -102,7 +103,7 @@ class SARIMAXSpecification:
     freq : str, optional
         If no index is given by `endog` or `exog`, the frequency of the
         time-series may be specified here as a Pandas offset or offset string.
-    missing : str
+    missing : str, optional
         Available options are 'none', 'drop', and 'raise'. If 'none', no nan
         checking is done. If 'drop', any observations with nans are dropped.
         If 'raise', an error is raised. Default is 'none'.
@@ -121,11 +122,11 @@ class SARIMAXSpecification:
 
     Attributes
     ----------
-    order : tuple, optional
+    order : tuple
         The (p,d,q) order of the model for the autoregressive, differences, and
         moving average components. d is always an integer, while p and q may
         either be integers or lists of integers.
-    seasonal_order : tuple, optional
+    seasonal_order : tuple
         The (P,D,Q,s) order of the seasonal component of the model for the
         AR parameters, differences, MA parameters, and periodicity. Default
         is (0, 0, 0, 0). D and s are always integers, while P and Q
@@ -155,14 +156,15 @@ class SARIMAXSpecification:
         `seasonal_ar_order` for additional details.
     seasonal_periods : int
         Number of periods in a season.
-    trend : str{'n','c','t','ct'} or iterable, optional
+    trend : {'n', 'c', 't', 'ct', 'ctt'} or array_like
         Parameter controlling the deterministic trend polynomial :math:`A(t)`.
-        Can be specified as a string where 'c' indicates a constant (i.e., a
-        degree zero component of the trend polynomial), 't' indicates a
-        linear trend with time, and 'ct' is both. Can also be specified as an
-        iterable defining the polynomial as in `numpy.poly1d`, where
-        `[1,1,0,1]` would denote :math:`a + bt + ct^3`. Default is to not
-        include a trend component.
+        Can be specified as a string where 'n' indicates no trend, 'c'
+        indicates a constant (i.e., a degree zero component of the trend
+        polynomial), 't' indicates a linear trend with time, 'ct' includes
+        both, and 'ctt' includes a constant, linear trend, and squared time
+        trend. Can also be specified as an array_like defining the polynomial
+        as in `numpy.poly1d`, where `[1,1,0,1]` would denote
+        :math:`a + bt + ct^3`. Default is to not include a trend component.
     ar_lags : list of int
         List of included autoregressive lags. If `ar_order` is a list, then
         `ar_lags == ar_order`. If `ar_lags = [1, 2]`, then the overall model
@@ -1054,6 +1056,25 @@ class SARIMAXSpecification:
         return self.join_params(**params)
 
     def construct_trend_data(self, nobs, offset=1):
+        """
+        Construct the trend data array implied by the trend specification
+
+        Parameters
+        ----------
+        nobs : int
+            Number of observations for which to construct trend data.
+        offset : int, optional
+            The offset at which to start time trend values. Default is 1,
+            so that if the specification includes a linear trend, the
+            trend values are 1, 2, ..., nobs.
+
+        Returns
+        -------
+        trend_data : ndarray or None
+            Array shaped ``(nobs, k_trend)`` containing the trend
+            regressors implied by `trend_poly`, or None if the
+            specification does not include a trend component.
+        """
         if self.trend_order is None:
             trend_data = None
         else:
@@ -1063,6 +1084,16 @@ class SARIMAXSpecification:
         return trend_data
 
     def construct_trend_names(self):
+        """
+        Construct names for the trend terms included in the specification
+
+        Returns
+        -------
+        names : list of str
+            Names of the included trend terms, using 'const' for a
+            constant term, 'drift' for a linear trend, and 'trend.<i>'
+            for a higher order term of degree `i`.
+        """
         names = []
         for i in self.trend_terms:
             if i == 0:

--- a/statsmodels/tsa/arima_model.py
+++ b/statsmodels/tsa/arima_model.py
@@ -60,5 +60,16 @@ class ARMAResults:
 
 
 class ARIMAResults(ARMAResults):
+    """
+    ARIMA has been deprecated in favor of the new implementation
+
+    See Also
+    --------
+    statsmodels.tsa.arima.model.ARIMA
+        ARIMA models with a variety of parameter estimators
+    statsmodels.tsa.statespace.SARIMAX
+        SARIMAX models estimated using MLE
+    """
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/statsmodels/tsa/arima_process.py
+++ b/statsmodels/tsa/arima_process.py
@@ -70,14 +70,14 @@ def arma_generate_sample(
         dimensional time series where time is indexed along the input
         variable ``axis``. All series are independent unless ``distrvs``
         generates dependent data.
-    scale : float
+    scale : float, optional
         The standard deviation of noise.
-    distrvs : function, random number generator
+    distrvs : callable, optional
         A function that generates the random numbers, and takes ``size``
         as argument. The default is np.random.standard_normal.
-    axis : int
+    axis : int, optional
         See nsample for details.
-    burnin : int
+    burnin : int, optional
         Number of observation at the beginning of the sample to drop.
         Used to reduce dependence on initial values.
 
@@ -137,9 +137,9 @@ def arma_acovf(ar, ma, nobs=10, sigma2=1, dtype=None):
         The coefficients for autoregressive lag polynomial, including zero lag.
     ma : array_like, 1d
         The coefficients for moving-average lag polynomial, including zero lag.
-    nobs : int
+    nobs : int, optional
         The number of terms (lags plus zero lag) to include in returned acovf.
-    sigma2 : float
+    sigma2 : float, optional
         Variance of the innovation term.
     dtype : str, optional
         Numpy dtype to use for the output. If None (the default), the dtype
@@ -218,7 +218,7 @@ def arma_acf(ar, ma, lags=10):
         Coefficients for autoregressive lag polynomial, including zero lag.
     ma : array_like
         Coefficients for moving-average lag polynomial, including zero lag.
-    lags : int
+    lags : int, optional
         The number of terms (lags plus zero lag) to include in returned acf.
 
     Returns
@@ -246,7 +246,7 @@ def arma_pacf(ar, ma, lags=10):
         The coefficients for autoregressive lag polynomial, including zero lag.
     ma : array_like, 1d
         The coefficients for moving-average lag polynomial, including zero lag.
-    lags : int
+    lags : int, optional
         The number of terms (lags plus zero lag) to include in returned pacf.
 
     Returns
@@ -281,12 +281,12 @@ def arma_periodogram(ar, ma, worN=None, whole=0):
         The autoregressive lag-polynomial with leading 1 and lhs sign.
     ma : array_like
         The moving average lag-polynomial with leading 1.
-    worN : {None, int}, optional
+    worN : int or array_like, optional
         An option for scipy.signal.freqz (read "w or N").
         If None, then compute at 512 frequencies around the unit circle.
         If a single integer, the compute at that many frequencies.
         Otherwise, compute the response at frequencies given in worN.
-    whole : {0,1}, optional
+    whole : bool, optional
         An option for scipy.signal.freqz.
         Normally, frequencies are computed from 0 to pi (upper-half of
         unit-circle.  If whole is non-zero compute frequencies from 0 to 2*pi.
@@ -329,13 +329,13 @@ def arma_impulse_response(ar, ma, leads=100):
         The auto regressive lag polynomial.
     ma : array_like, 1d
         The moving average lag polynomial.
-    leads : int
+    leads : int, optional
         The number of observations to calculate.
 
     Returns
     -------
     ndarray
-        The impulse response function with nobs elements.
+        The impulse response function with ``leads`` elements.
 
     Notes
     -----
@@ -384,17 +384,17 @@ def arma2ma(ar, ma, lags=100):
 
     Parameters
     ----------
-    ar : ndarray
+    ar : array_like
         The auto regressive lag polynomial.
-    ma : ndarray
+    ma : array_like
         The moving average lag polynomial.
-    lags : int
+    lags : int, optional
         The number of coefficients to calculate.
 
     Returns
     -------
     ndarray
-        The coefficients of MA lag polynomial with nobs elements.
+        The coefficients of MA lag polynomial with ``lags`` elements.
 
     Notes
     -----
@@ -413,13 +413,13 @@ def arma2ar(ar, ma, lags=100):
         The auto regressive lag polynomial.
     ma : array_like
         The moving average lag polynomial.
-    lags : int
+    lags : int, optional
         The number of coefficients to calculate.
 
     Returns
     -------
     ndarray
-        The coefficients of AR lag polynomial with nobs elements.
+        The coefficients of AR lag polynomial with ``lags`` elements.
 
     Notes
     -----
@@ -447,12 +447,12 @@ def ar2arma(ar_des, p, q, n=20, mse="ar", start=None):
         The length of desired AR lag polynomials.
     q : int
         The length of desired MA lag polynomials.
-    n : int
+    n : int, optional
         The number of terms of the impulse_response function to include in the
         objective function for the approximation.
-    mse : str, 'ar'
+    mse : str, optional
         Not used.
-    start : ndarray
+    start : array_like, optional
         Initial values to use when finding the approximation.
 
     Returns
@@ -524,14 +524,14 @@ def index2lpol(coeffs, index):
 
     Parameters
     ----------
-    coeffs : ndarray
+    coeffs : array_like
         non-zero coefficients of lag polynomial
-    index : ndarray
+    index : array_like
         index (lags) of lag polynomial with non-zero elements
 
     Returns
     -------
-    ar : array_like
+    ar : ndarray
         coefficients of lag polynomial
     """
     n = max(index)
@@ -550,7 +550,7 @@ def lpol_fima(d, n=20):
     ----------
     d : float
         fractional power
-    n : int
+    n : int, optional
         number of terms to calculate, including lag zero
 
     Returns
@@ -576,7 +576,7 @@ def lpol_fiar(d, n=20):
     ----------
     d : float
         fractional power
-    n : int
+    n : int, optional
         number of terms to calculate, including lag zero
 
     Returns
@@ -629,7 +629,7 @@ def deconvolve(num, den, n=None):
         signal or lag polynomial
     den : array_like
         coefficients of lag polynomial (linear filter)
-    n : None or int
+    n : int, optional
         number of terms of quotient
 
     Returns
@@ -680,12 +680,14 @@ class ArmaProcess:
 
     Parameters
     ----------
-    ar : array_like
+    ar : array_like, optional
         Coefficient for autoregressive lag polynomial, including zero lag.
         Must be entered using the signs from the lag polynomial representation.
-        See the notes for more information about the sign.
-    ma : array_like
+        See the notes for more information about the sign. If not provided,
+        defaults to ``[1.0]``.
+    ma : array_like, optional
         Coefficient for moving-average lag polynomial, including zero lag.
+        If not provided, defaults to ``[1.0]``.
     nobs : int, optional
         Length of simulated time series. Used, for example, if a sample is
         generated. See example.
@@ -816,12 +818,12 @@ class ArmaProcess:
 
         Parameters
         ----------
-        arcoefs : array_like
+        arcoefs : array_like, optional
             Coefficient for autoregressive lag polynomial, not including zero
             lag. The sign is inverted to conform to the usual time series
             representation of an ARMA process in statistics. See the class
             docstring for more information.
-        macoefs : array_like
+        macoefs : array_like, optional
             Coefficient for moving-average lag polynomial, excluding zero lag.
         nobs : int, optional
             Length of simulated time series. Used, for example, if a sample
@@ -982,7 +984,7 @@ class ArmaProcess:
 
         Parameters
         ----------
-        retnew : bool
+        retnew : bool, optional
             If False (default), then return the lag-polynomial as array.
             If True, then return a new instance with invertible MA-polynomial.
 
@@ -993,7 +995,7 @@ class ArmaProcess:
         wasinvertible : bool
             True if the MA lag-polynomial was already invertible, returned if
             retnew is false.
-        armaprocess : new instance of class
+        armaprocess : ArmaProcess
             If retnew is true, then return a new instance with invertible
             MA-polynomial.
         """

--- a/statsmodels/tsa/base/datetools.py
+++ b/statsmodels/tsa/base/datetools.py
@@ -124,8 +124,8 @@ def date_range_str(start, end=None, length=None):
 
     Returns
     -------
-    date_range : list
-        List of strings
+    date_range : list of str
+        List of abbreviated date strings.
     """
     flags = re.IGNORECASE | re.VERBOSE
 
@@ -175,14 +175,14 @@ def dates_from_str(dates):
 
     Parameters
     ----------
-    dates : array_like
+    dates : sequence of str
         A sequence of abbreviated dates as string. For instance,
         '1996m1' or '1996Q1'. The datetime dates are at the end of the
         period.
 
     Returns
     -------
-    date_list : list
+    date_list : list of datetime.datetime
         A list of datetime types.
     """
     return lmap(date_parser, dates)
@@ -203,7 +203,7 @@ def dates_from_range(start, end=None, length=None):
 
     Returns
     -------
-    date_list : list
+    date_list : list of datetime.datetime
         A list of datetime types.
 
     Examples

--- a/statsmodels/tsa/base/prediction.py
+++ b/statsmodels/tsa/base/prediction.py
@@ -9,19 +9,19 @@ class PredictionResults:
 
     Parameters
     ----------
-    predicted_mean : {ndarray, Series, DataFrame}
-        The predicted mean values
-    var_pred_mean : {ndarray, Series, DataFrame}
-        The variance of the predicted mean values
-    dist : {None, "norm", "t", rv_frozen}
+    predicted_mean : ndarray, Series, or DataFrame
+        The predicted mean values.
+    var_pred_mean : ndarray, Series, or DataFrame
+        The variance of the predicted mean values.
+    dist : "norm", "t", or rv_frozen, optional
         The distribution to use when constructing prediction intervals.
-        Default is normal.
+        Default is the normal distribution.
     df : int, optional
-        The degrees of freedom parameter for the t. Not used if dist is None,
-        "norm" or a callable.
-    row_labels : {Sequence[Hashable], pd.Index}
-        Row labels to use for the summary frame. If None, attempts to read the
-        index of ``predicted_mean``
+        The degrees of freedom parameter for the t distribution. Not used
+        if dist is "norm" or an rv_frozen distribution.
+    row_labels : sequence of hashable or pandas.Index, optional
+        Row labels to use for the summary frame. If None, attempts to read
+        the index of ``predicted_mean``.
     """
 
     def __init__(
@@ -105,19 +105,19 @@ class PredictionResults:
 
         Parameters
         ----------
-        value : array_like
-            value under the null hypothesis
-        alternative : str
-            'two-sided', 'larger', 'smaller'
+        value : array_like, optional
+            Value under the null hypothesis.
+        alternative : {"two-sided", "larger", "smaller"}, optional
+            The alternative hypothesis for the test.
 
         Returns
         -------
-        stat : ndarray
-            test statistic
-        pvalue : ndarray
-            p-value of the hypothesis test, the distribution is given by
-            the attribute of the instance, specified in `__init__`. Default
-            if not specified is the normal distribution.
+        stat : ndarray or Series
+            The test statistic.
+        pvalue : ndarray or Series
+            The p-value of the hypothesis test. The distribution used is
+            given by the attribute of the instance specified in `__init__`.
+            The default, if not specified, is the normal distribution.
         """
         # assumes symmetric distribution
         stat = (self.predicted_mean - value) / self.se_mean
@@ -146,7 +146,7 @@ class PredictionResults:
 
         Returns
         -------
-        pi : {ndarray, DataFrame}
+        pi : ndarray or DataFrame
             The array has the lower and the upper limit of the prediction
             interval in the columns.
         """

--- a/statsmodels/tsa/base/tsa_model.py
+++ b/statsmodels/tsa/base/tsa_model.py
@@ -337,7 +337,7 @@ def get_prediction_index(
     index_generated : bool, optional
         Whether the model's underlying index was internally generated
         rather than taken directly from `endog` / `exog`. Default is None.
-    data : statsmodels.base.data.ModelData
+    data : statsmodels.base.data.ModelData, optional
         The model's data object, used to obtain row labels and to set the
         `predict_start`, `predict_end`, and `predict_dates` attributes.
 
@@ -487,7 +487,7 @@ class TimeSeriesModel(base.LikelihoodModel):
         ----------
         dates : array_like, optional
             An array like object containing dates.
-        freq : str, tuple, datetime.timedelta, DateOffset or None, optional
+        freq : str, tuple, datetime.timedelta, or DateOffset, optional
             A frequency specification for either `dates` or the row labels from
             the endog / exog data.
 

--- a/statsmodels/tsa/coint_tables.py
+++ b/statsmodels/tsa/coint_tables.py
@@ -87,6 +87,37 @@ ejcp2 = np.array(ss_ejcp2.split(), float).reshape(-1, 3)
 
 
 def c_sja(n, p):
+    """
+    Critical values for the Johansen maximum eigenvalue statistic
+
+    Parameters
+    ----------
+    n : int
+        The dimension of the VAR system. Must be between 1 and 12,
+        inclusive.
+    p : int
+        The order of the time polynomial in the null hypothesis, -1 for no
+        deterministic part, 0 for a constant term, or 1 for a constant and
+        a linear trend.
+
+    Returns
+    -------
+    ndarray
+        Array of critical values for the maximum eigenvalue statistic at
+        the 90%, 95%, and 99% levels. NaNs are returned if ``n`` or ``p``
+        is out of range.
+
+    Notes
+    -----
+    The values returned by this function were generated using a method
+    described in MacKinnon (1996), using his FORTRAN program johdist.f.
+
+    References
+    ----------
+    MacKinnon, Haug, Michelis (1996) 'Numerical distribution functions of
+    likelihood ratio tests for cointegration', Queen's University Institute
+    for Economic Research Discussion paper.
+    """
     if ((p > 1) or (p < -1)) or ((n > 12) or (n < 1)):
         jc = np.full(3, np.nan)
     elif p == -1:
@@ -199,6 +230,36 @@ tjcp2 = np.array(ss_tjcp2.split(), float).reshape(-1, 3)
 
 
 def c_sjt(n, p):
+    """
+    Critical values for the Johansen trace statistic
+
+    Parameters
+    ----------
+    n : int
+        The dimension of the VAR system. Must be between 1 and 12,
+        inclusive.
+    p : int
+        The order of the time polynomial in the null hypothesis, -1 for no
+        deterministic part, 0 for a constant term, or 1 for a constant and
+        a linear trend.
+
+    Returns
+    -------
+    ndarray
+        Array of critical values for the trace statistic at the 90%, 95%,
+        and 99% levels. NaNs are returned if ``n`` or ``p`` is out of range.
+
+    Notes
+    -----
+    The values returned by this function were generated using a method
+    described in MacKinnon (1996), using his FORTRAN program johdist.f.
+
+    References
+    ----------
+    MacKinnon, Haug, Michelis (1996) 'Numerical distribution functions of
+    likelihood ratio tests for cointegration', Queen's University Institute
+    for Economic Research Discussion paper.
+    """
     if ((p > 1) or (p < -1)) or ((n > 12) or (n < 1)):
         jc = np.full(3, np.nan)
     elif p == -1:

--- a/statsmodels/tsa/descriptivestats.py
+++ b/statsmodels/tsa/descriptivestats.py
@@ -14,7 +14,32 @@ from . import stattools as stt
 
 # TODO: check subclassing for descriptive stats classes
 class TsaDescriptive:
-    """Collection of descriptive statistical methods for time series"""
+    """
+    Collection of descriptive statistical methods for time series
+
+    Parameters
+    ----------
+    data : array_like
+        The time series data.
+    label : str, optional
+        A label used to identify the series.
+    name : str, optional
+        A name used as the base for labeling series derived from `data`,
+        such as those produced by `filter` and `detrend`.
+
+    Attributes
+    ----------
+    data : array_like
+        The time series data.
+    label : str
+        The label identifying the series.
+    name : str
+        The base name used for derived series.
+    mod : None
+        Placeholder for the model instance created by `fit`.
+    res : None
+        Placeholder for the results instance created by `fit`.
+    """
 
     def __init__(self, data, label=None, name=""):
         self.data = data
@@ -24,16 +49,59 @@ class TsaDescriptive:
         self.res = None
 
     def filter(self, num, den):
+        """
+        Filter the time series using a linear filter.
+
+        Parameters
+        ----------
+        num : array_like
+            The numerator coefficient vector of the filter.
+        den : array_like
+            The denominator coefficient vector of the filter.
+
+        Returns
+        -------
+        TsaDescriptive
+            A new instance containing the filtered data.
+        """
         from scipy.signal import lfilter
         xfiltered = lfilter(num, den, self.data)
         return self.__class__(xfiltered, self.label, self.name + "_filtered")
 
     def detrend(self, order=1):
+        """
+        Detrend the time series.
+
+        Parameters
+        ----------
+        order : int, optional
+            The polynomial order of the trend to remove.
+
+        Returns
+        -------
+        TsaDescriptive
+            A new instance containing the detrended data.
+        """
         from . import tsatools
         xdetrended = tsatools.detrend(self.data, order=order)
         return self.__class__(xdetrended, self.label, self.name + "_detrended")
 
     def fit(self, order=(1, 0, 1), **kwds):
+        """
+        Fit an ARMA model to the time series.
+
+        Parameters
+        ----------
+        order : tuple of int, optional
+            The (p, q) order, or (p, d, q) order, of the ARMA model to fit.
+        **kwds
+            Additional keyword arguments passed to the model's `fit` method.
+
+        Returns
+        -------
+        Results
+            The results instance from fitting the model.
+        """
         from .arima_model import ARMA
         self.mod = ARMA(self.data)
         self.res = self.mod.fit(order=order, **kwds)
@@ -41,17 +109,72 @@ class TsaDescriptive:
         return self.res
 
     def acf(self, nlags=40):
+        """
+        Compute the autocorrelation function of the time series.
+
+        Parameters
+        ----------
+        nlags : int, optional
+            The number of lags to include.
+
+        Returns
+        -------
+        ndarray
+            The autocorrelation function.
+        """
         return stt.acf(self.data, nlags=nlags)
 
     def pacf(self, nlags=40):
+        """
+        Compute the partial autocorrelation function of the time series.
+
+        Parameters
+        ----------
+        nlags : int, optional
+            The number of lags to include.
+
+        Returns
+        -------
+        ndarray
+            The partial autocorrelation function.
+        """
         return stt.pacf(self.data, nlags=nlags)
 
     def periodogram(self):
+        """
+        Compute the periodogram of the time series.
+
+        Returns
+        -------
+        ndarray
+            The periodogram values.
+        """
         # does not return frequencies
         return stt.periodogram(self.data)
 
     # copied from fftarma.py
     def plot4(self, fig=None, nobs=100, nacf=20, nfreq=100):
+        """
+        Plot the series, its ACF, PACF, and power spectrum.
+
+        Parameters
+        ----------
+        fig : Figure, optional
+            An existing matplotlib figure to draw the plots in. If not
+            provided, a new figure is created.
+        nobs : int, optional
+            The number of observations to use. Not used.
+        nacf : int, optional
+            The number of lags to include in the ACF and PACF plots.
+        nfreq : int, optional
+            The number of frequencies to include in the power spectrum
+            plot.
+
+        Returns
+        -------
+        Figure
+            The figure containing the plots.
+        """
         data = self.data
         acf = self.acf(nacf)
         pacf = self.pacf(nacf)

--- a/statsmodels/tsa/deterministic.py
+++ b/statsmodels/tsa/deterministic.py
@@ -84,7 +84,7 @@ class DeterministicTerm(ABC):
         index : index_like
             An index-like object. If not an index, it is converted to an
             index.
-        forecast_index : index_like
+        forecast_index : index_like, optional
             An Index or index-like object to use for the forecasts. If
             provided must have steps elements.
 
@@ -229,9 +229,9 @@ class TimeTrend(TimeTrendDeterministicTerm):
 
     Parameters
     ----------
-    constant : bool
+    constant : bool, optional
         Flag indicating whether a constant should be included.
-    order : int
+    order : int, optional
         A non-negative int containing the powers to include (1, 2, ..., order).
 
     See Also
@@ -319,7 +319,7 @@ class Seasonality(DeterministicTerm):
     ----------
     period : int
         The length of a full cycle. Must be >= 2.
-    initial_period : int
+    initial_period : int, optional
         The seasonal index of the first observation. 1-indexed so must
         be in {1, 2, ..., period}.
 
@@ -375,7 +375,7 @@ class Seasonality(DeterministicTerm):
 
         Parameters
         ----------
-        index : {DatetimeIndex, PeriodIndex}
+        index : DatetimeIndex or PeriodIndex
             An index with its frequency (`freq`) set.
 
         Returns
@@ -466,7 +466,7 @@ class Fourier(FourierDeterministicTerm):
 
     Parameters
     ----------
-    period : int
+    period : float
         The length of a full cycle. Must be >= 2.
     order : int
         The number of Fourier components to include. Must be <= 2*period.
@@ -881,11 +881,11 @@ class CalendarTimeTrend(CalendarDeterministicTerm, TimeTrendDeterministicTerm):
     ----------
     freq : str
         A string convertible to a pandas frequency.
-    constant : bool
+    constant : bool, optional
         Flag indicating whether a constant should be included.
-    order : int
+    order : int, optional
         A non-negative int containing the powers to include (1, 2, ..., order).
-    base_period : {str, pd.Timestamp}, default None
+    base_period : str, datetime.datetime, pd.Timestamp, or numpy.datetime64, optional
         The base period to use when computing the time stamps. This value is
         treated as 1 and so all other time indices are defined as the number
         of periods since or before this time stamp. If not provided, defaults
@@ -972,7 +972,7 @@ class CalendarTimeTrend(CalendarDeterministicTerm, TimeTrendDeterministicTerm):
             * "t": Linear time trend only
             * "ct": A constant and a time trend
             * "ctt": A constant, a time trend and a quadratic time trend
-        base_period : {str, pd.Timestamp}, default None
+        base_period : str, datetime.datetime, pd.Timestamp, or numpy.datetime64, optional
             The base period to use when computing the time stamps. This value
             is treated as 1 and so all other time indices are defined as the
             number of periods since or before this time stamp. If not
@@ -1055,25 +1055,25 @@ class DeterministicProcess:
 
     Parameters
     ----------
-    index : {Sequence[Hashable], pd.Index}
+    index : index_like
         The index of the process. Should usually be the "in-sample" index when
         used in forecasting applications.
-    period : {float, int}, default None
+    period : float or int, optional
         The period of the seasonal or fourier components. Must be an int for
         seasonal dummies. If not provided, freq is read from index if
         available.
-    constant : bool, default False
+    constant : bool, optional
         Whether to include a constant.
-    order : int, default 0
+    order : int, optional
         The order of the time trend to include. For example, 2 will include
         both linear and quadratic terms. 0 excludes time trend terms.
-    seasonal : bool = False
+    seasonal : bool, optional
         Whether to include seasonal dummies
-    fourier : int = 0
+    fourier : int, optional
         The order of the fourier terms to included.
-    additional_terms : Sequence[DeterministicTerm]
+    additional_terms : sequence of DeterministicTerm, optional
         A sequence of additional deterministic terms to include in the process.
-    drop : bool, default False
+    drop : bool, optional
         A flag indicating to check for perfect collinearity and to drop any
         linearly dependent terms.
 
@@ -1396,9 +1396,9 @@ you can pass additional components using the additional_terms input.""")
 
         Parameters
         ----------
-        start : {int, str, dt.datetime, pd.Timestamp, np.datetime64}
+        start : int, str, dt.datetime, pd.Timestamp, or np.datetime64
             The first observation.
-        stop : {int, str, dt.datetime, pd.Timestamp, np.datetime64}
+        stop : int, str, dt.datetime, pd.Timestamp, or np.datetime64
             The final observation. Inclusive to match most prediction
             function in statsmodels.
 

--- a/statsmodels/tsa/exponential_smoothing/base.py
+++ b/statsmodels/tsa/exponential_smoothing/base.py
@@ -23,8 +23,28 @@ from statsmodels.tsa.statespace.tools import _safe_cond
 
 class StateSpaceMLEModel(tsbase.TimeSeriesModel):
     """
-    This is a temporary base model from ETS; here I just copy everything I need
-    from statespace.mlemodel.MLEModel
+    Temporary base model for use with the exponential smoothing models; copies
+    the functionality needed from statespace.mlemodel.MLEModel
+
+    Parameters
+    ----------
+    endog : array_like
+        The observed time-series process :math:`y`.
+    exog : array_like, optional
+        Array of exogenous regressors.
+    dates : array_like, optional
+        An array-like object of datetime objects. If a pandas object is given
+        for endog or exog, it is assumed to have a DateIndex.
+    freq : str, optional
+        The frequency of the time-series. A Pandas offset or 'B', 'D', 'W',
+        'M', 'A', or 'Q'. This is optional if dates are given.
+    missing : str, optional
+        Available options are 'none', 'drop', and 'raise'. If 'none', no nan
+        checking is done. If 'drop', any observations with nans are dropped.
+        If 'raise', an error is raised. Default is 'none'.
+    **kwargs
+        Keyword arguments used to construct the state space representation
+        of the model and stored so that the model can be recreated.
     """
 
     def __init__(
@@ -69,6 +89,7 @@ class StateSpaceMLEModel(tsbase.TimeSeriesModel):
 
     @property
     def k_params(self):
+        """The number of parameters in the model"""
         return len(self.param_names)
 
     @contextlib.contextmanager
@@ -168,7 +189,7 @@ class StateSpaceMLEModel(tsbase.TimeSeriesModel):
 
     @property
     def start_params(self):
-        """(array) Starting parameters for maximum likelihood estimation"""
+        """Starting parameters for maximum likelihood estimation"""
         if hasattr(self, "_start_params"):
             return self._start_params
         else:
@@ -176,7 +197,7 @@ class StateSpaceMLEModel(tsbase.TimeSeriesModel):
 
     @property
     def param_names(self):
-        """(list of str) List of human readable parameter names (for parameters actually included in the model)"""
+        """List of human readable parameter names (for parameters actually included in the model)"""
         if hasattr(self, "_param_names"):
             return self._param_names
         else:
@@ -298,7 +319,7 @@ class StateSpaceMLEResults(tsbase.TimeSeriesModelResults):
 
     Parameters
     ----------
-    model : MLEModel instance
+    model : Model instance
         The fitted model instance
     params : ndarray
         Fitted parameters
@@ -346,60 +367,62 @@ class StateSpaceMLEResults(tsbase.TimeSeriesModelResults):
 
     @cache_readonly
     def nobs_effective(self):
+        """The number of observations used to fit the model, after adjustments"""
         raise NotImplementedError
 
     @cache_readonly
     def df_resid(self):
+        """The residual degrees of freedom"""
         return self.nobs_effective - self.df_model
 
     @cache_readonly
     def aic(self):
-        """(float) Akaike Information Criterion"""
+        """The Akaike Information Criterion"""
         return aic(self.llf, self.nobs_effective, self.df_model)
 
     @cache_readonly
     def aicc(self):
-        """(float) Akaike Information Criterion with small sample correction"""
+        """The Akaike Information Criterion with small sample correction"""
         return aicc(self.llf, self.nobs_effective, self.df_model)
 
     @cache_readonly
     def bic(self):
-        """(float) Bayes Information Criterion"""
+        """The Bayes Information Criterion"""
         return bic(self.llf, self.nobs_effective, self.df_model)
 
     @cache_readonly
     def fittedvalues(self):
+        """The predicted values of the model"""
         # TODO
         raise NotImplementedError
 
     @cache_readonly
     def hqic(self):
-        """(float) Hannan-Quinn Information Criterion"""
+        """The Hannan-Quinn Information Criterion"""
         # return (-2 * self.llf +
         #         2 * np.log(np.log(self.nobs_effective)) * self.df_model)
         return hqic(self.llf, self.nobs_effective, self.df_model)
 
     @cache_readonly
     def llf(self):
-        """(float) The value of the log-likelihood function evaluated at `params`"""
+        """The value of the log-likelihood function evaluated at `params`"""
         raise NotImplementedError
 
     @cache_readonly
     def mae(self):
-        """(float) Mean absolute error"""
+        """The mean absolute error"""
         return np.mean(np.abs(self.resid))
 
     @cache_readonly
     def mse(self):
-        """(float) Mean squared error"""
+        """The mean squared error"""
         return self.sse / self.nobs
 
     @cache_readonly
     def pvalues(self):
         """
-        (array) The p-values associated with the z-statistics of the
-        coefficients. Note that the coefficients are assumed to have a Normal
-        distribution.
+        The p-values associated with the z-statistics of the coefficients.
+        Note that the coefficients are assumed to have a Normal distribution.
         """
         pvalues = np.zeros_like(self.zvalues) * np.nan
         mask = np.ones_like(pvalues, dtype=bool)
@@ -410,16 +433,17 @@ class StateSpaceMLEResults(tsbase.TimeSeriesModelResults):
 
     @cache_readonly
     def resid(self):
+        """The model residuals"""
         raise NotImplementedError
 
     @cache_readonly
     def sse(self):
-        """(float) Sum of squared errors"""
+        """The sum of squared errors"""
         return np.sum(self.resid ** 2)
 
     @cache_readonly
     def zvalues(self):
-        """(array) The z-statistics for the coefficients"""
+        """The z-statistics for the coefficients"""
         return self.params / self.bse
 
     def _get_prediction_start_index(self, anchor):
@@ -473,7 +497,7 @@ class StateSpaceMLEResults(tsbase.TimeSeriesModelResults):
     @cache_readonly
     def cov_params_approx(self):
         """
-        (array) The variance / covariance matrix. Computed using the numerical
+        The variance / covariance matrix, computed using the numerical
         Hessian approximated by complex step or finite differences methods.
         """
         return self._cov_params_approx(
@@ -491,7 +515,7 @@ class StateSpaceMLEResults(tsbase.TimeSeriesModelResults):
         method : {'ljungbox', 'boxpierce', None}
             The statistical test for serial correlation. If None, an attempt is
             made to select an appropriate test.
-        lags : None, int or array_like
+        lags : int, array_like of int, or None, optional
             If lags is an integer then this is taken to be the largest lag
             that is included, the test result is reported for all smaller lag
             length.
@@ -587,7 +611,7 @@ class StateSpaceMLEResults(tsbase.TimeSeriesModelResults):
             The statistical test for heteroskedasticity. Must be 'breakvar'
             for test of a break in the variance. If None, an attempt is
             made to select an appropriate test.
-        alternative : str, 'increasing', 'decreasing' or 'two-sided'
+        alternative : {'increasing', 'decreasing', 'two-sided'}, optional
             This specifies the alternative for the p-value calculation. Default
             is two-sided.
         use_f : bool, optional
@@ -766,6 +790,12 @@ class StateSpaceMLEResults(tsbase.TimeSeriesModelResults):
             Jarque-Bera normality test. If None, an attempt is made to select
             an appropriate test.
 
+        Returns
+        -------
+        output : ndarray
+            An array with `(Jarque-Bera, p-value, skew, kurtosis)` for each
+            endogenous variable, sized `(k_endog, 4)`.
+
         See Also
         --------
         statsmodels.stats.stattools.jarque_bera
@@ -828,7 +858,7 @@ class StateSpaceMLEResults(tsbase.TimeSeriesModelResults):
             Integer of the start observation. Default is 0.
         title : str, optional
             The title used for the summary table.
-        model_name : str
+        model_name : str, optional
             The name of the model used. Default is to use model class name.
         display_params : bool, optional
             Whether or not to display the parameters table. Default is True.

--- a/statsmodels/tsa/exponential_smoothing/ets.py
+++ b/statsmodels/tsa/exponential_smoothing/ets.py
@@ -216,21 +216,26 @@ class ETSModel(base.StateSpaceMLEModel):
     ----------
     endog : array_like
         The observed time-series process :math:`y`
-    error : str, optional
-        The error model. "add" (default) or "mul".
-    trend : str or None, optional
+    error : {"add", "additive", "mul", "multiplicative"}, optional
+        The error model. "add" (default) or "mul". "additive" and
+        "multiplicative" are accepted as aliases for "add" and "mul".
+    trend : {"add", "additive", "mul", "multiplicative"} or None, optional
         The trend component model. "add", "mul", or None (default).
+        "additive" and "multiplicative" are accepted as aliases for "add"
+        and "mul".
     damped_trend : bool, optional
         Whether or not an included trend component is damped. Default is
         False.
-    seasonal : str, optional
+    seasonal : {"add", "additive", "mul", "multiplicative"} or None, optional
         The seasonality model. "add", "mul", or None (default).
+        "additive" and "multiplicative" are accepted as aliases for "add"
+        and "mul".
     seasonal_periods : int, optional
         The number of periods in a complete seasonal cycle for seasonal
         (Holt-Winters) models. For example, 4 for quarterly data with an
         annual cycle or 7 for daily data with a weekly cycle. Required if
         `seasonal` is not None.
-    initialization_method : str, optional
+    initialization_method : {"estimated", "heuristic", "known"}, optional
         Method for initialization of the state space model. One of:
 
         * 'estimated' (default)
@@ -511,7 +516,7 @@ class ETSModel(base.StateSpaceMLEModel):
 
         Parameters
         ----------
-        initialization_method : str, optional
+        initialization_method : {"estimated", "heuristic", "known"}, optional
             Method for initialization of the state space model. One of:
 
             * 'estimated' (default)
@@ -963,7 +968,7 @@ class ETSModel(base.StateSpaceMLEModel):
             See LikelihoodModelResults notes section for more information.
         disp : bool, optional
             Set to True to print convergence messages.
-        callback : callable callback(xk), optional
+        callback : callable, optional
             Called after each iteration, as callback(xk), where xk is the
             current parameter vector.
         return_params : bool, optional
@@ -975,6 +980,7 @@ class ETSModel(base.StateSpaceMLEModel):
         Returns
         -------
         results : ETSResults
+            The fitted model results.
         """
 
         if start_params is None:
@@ -1078,25 +1084,25 @@ class ETSModel(base.StateSpaceMLEModel):
 
         Parameters
         ----------
-        params : array of np.float
+        params : ndarray of float
             Model parameters: (alpha, beta, gamma, phi, l[-1],
             b[-1], s[-1], ..., s[-m]). If there are no fixed values this must
             be in the format of internal parameters. Otherwise the fixed values
             are skipped.
-        yhat : array
+        yhat : ndarray
             Array of size (n,) where fitted values will be written to.
-        xhat : array
+        xhat : ndarray
             Array of size (n, _k_states_internal) where fitted states will be
             written to.
-        is_fixed : array, optional
+        is_fixed : ndarray, optional
             Boolean array indicating values which are fixed during fitting.
             This must have the full length of internal parameters.
-        fixed_values : array, optional
+        fixed_values : ndarray, optional
             Array of fixed values (arbitrary values for non-fixed parameters)
             This must have the full length of internal parameters.
-        use_beta_star : boolean
+        use_beta_star : bool
             Whether to internally use beta_star as parameter
-        use_gamma_star : boolean
+        use_gamma_star : bool
             Whether to internally use gamma_star as parameter
         """
         if np.iscomplexobj(params):
@@ -1148,7 +1154,7 @@ class ETSModel(base.StateSpaceMLEModel):
 
         Parameters
         ----------
-        params : narray of float
+        params : array_like
             Model parameters: (alpha, beta, gamma, phi, l[-1],
             b[-1], s[-1], ..., s[-m])
         **kwargs
@@ -1199,7 +1205,7 @@ class ETSModel(base.StateSpaceMLEModel):
 
         Parameters
         ----------
-        params : array_like
+        params : ndarray
             Model parameters
 
         Returns
@@ -1273,10 +1279,10 @@ class ETSModel(base.StateSpaceMLEModel):
         ----------
         params : array_like
             Array of parameters at which to evaluate the hessian.
-        approx_centered : bool
+        approx_centered : bool, optional
             Whether to use a centered scheme for finite difference
             approximation
-        approx_complex_step : bool
+        approx_complex_step : bool, optional
             Whether to use complex step differentiation for approximation
         **kwargs
             Additional keyword arguments, including ``method``, which may be
@@ -1306,6 +1312,32 @@ class ETSModel(base.StateSpaceMLEModel):
         return hessian
 
     def score(self, params, approx_centered=False, approx_complex_step=True, **kwargs):
+        r"""
+        Score vector of the likelihood function, evaluated at the given
+        parameters
+
+        Parameters
+        ----------
+        params : array_like
+            Array of parameters at which to evaluate the score.
+        approx_centered : bool, optional
+            Whether to use a centered scheme for finite difference
+            approximation
+        approx_complex_step : bool, optional
+            Whether to use complex step differentiation for approximation
+        **kwargs
+            Additional keyword arguments, including ``method``, which may be
+            used to specify the score calculation method.
+
+        Returns
+        -------
+        score : ndarray
+            Score vector evaluated at `params`
+
+        Notes
+        -----
+        This is a numerical approximation.
+        """
         method = kwargs.get("method", "approx")
 
         if method == "approx":
@@ -1583,7 +1615,7 @@ class ETSResults(base.StateSpaceMLEResults):
             `start` observation in the `predict` method.
         repetitions : int, optional
             Number of simulated paths to generate. Default is 1 simulated path.
-        random_errors : optional
+        random_errors : ndarray, rv_continuous, rv_discrete, rv_frozen, or "bootstrap", optional
             Specifies how the random errors should be obtained. Can be one of
             the following:
 
@@ -1604,7 +1636,7 @@ class ETSResults(base.StateSpaceMLEResults):
               the given values as random errors.
             * ``"bootstrap"``: Samples the random errors from the fit errors.
 
-        rng : int, array_like of int, numpy.random.Generator, numpy.random.RandomState, optional
+        rng : int, array_like of int, numpy.random.Generator, or numpy.random.RandomState, optional
             If `rng` is None, a new ``Generator`` is created using fresh
             entropy from the operating system. If `rng` is an int, a new
             ``RandomState`` instance is created, seeded with `rng`; this
@@ -2048,7 +2080,7 @@ class ETSResults(base.StateSpaceMLEResults):
             Optionally an index to associate the predicted results to. If None,
             an attempt is made to create an index for the predicted results
             from the model's index or model's row labels.
-        method : str or None, optional
+        method : {"exact", "simulated"} or None, optional
             Method to use for calculating prediction intervals. 'exact'
             (default, if available) or 'simulated'.
         simulate_repetitions : int, optional
@@ -2173,7 +2205,7 @@ class PredictionResults:
         Optionally an index to associate the predicted results to. If None,
         an attempt is made to create an index for the predicted results
         from the model's index or model's row labels.
-    method : str or None, optional
+    method : {"exact", "simulated"} or None, optional
         Method to use for calculating prediction intervals. 'exact' (default,
         if available) or 'simulated'.
     simulate_repetitions : int, optional
@@ -2295,6 +2327,14 @@ class PredictionResults:
         alpha : float, optional
             The significance level for the prediction interval. Default is
             0.05, that is, a 95% prediction interval.
+
+        Returns
+        -------
+        ndarray or DataFrame
+            The array or DataFrame of lower and upper prediction intervals,
+            with one row per forecast period. Returns a DataFrame with
+            columns labeled by `alpha` if the original data was a pandas
+            object, otherwise an ndarray.
         """
 
         if self.method == "simulated":
@@ -2323,6 +2363,26 @@ class PredictionResults:
         return pred_int
 
     def summary_frame(self, endog=0, alpha=0.05):
+        """
+        Summarize the mean prediction and prediction intervals in a DataFrame
+
+        Parameters
+        ----------
+        endog : int, optional
+            Index of the endogenous variable. Unused, since ETS models have
+            a single endogenous variable; present for compatibility with the
+            state space prediction API. Default is 0.
+        alpha : float, optional
+            The significance level for the prediction interval. Default is
+            0.05, that is, a 95% prediction interval.
+
+        Returns
+        -------
+        DataFrame
+            DataFrame containing the columns `mean`, `pi_lower`, and
+            `pi_upper`, and, when ``method='simulated'``, `mean_numerical`
+            (the average of the simulated paths).
+        """
         pred_int = np.asarray(self.pred_int(alpha=alpha))
         to_include = {}
         to_include["mean"] = self.predicted_mean

--- a/statsmodels/tsa/exponential_smoothing/initialization.py
+++ b/statsmodels/tsa/exponential_smoothing/initialization.py
@@ -6,6 +6,52 @@ import pandas as pd
 
 def _initialization_simple(endog, trend=False, seasonal=False,
                            seasonal_periods=None):
+    """
+    Compute simple initial values for level, trend, and seasonal components
+
+    Parameters
+    ----------
+    endog : array_like
+        The observed time-series process :math:`y`.
+    trend : {'add', 'mul'} or None, optional
+        The type of trend component. If not 'add' or 'mul', no initial
+        trend value is computed. Default is False, which is treated the
+        same as None.
+    seasonal : {'add', 'mul'} or None, optional
+        The type of seasonal component. If not 'add' or 'mul', the
+        non-seasonal branch is used and no initial seasonal values are
+        computed. Default is False, which is treated the same as None.
+    seasonal_periods : int, optional
+        The number of periods in a complete seasonal cycle. Required if
+        `seasonal` is 'add' or 'mul'.
+
+    Returns
+    -------
+    initial_level : float
+        The initial value for the level component.
+    initial_trend : float or None
+        The initial value for the trend component, or None if `trend` is
+        not 'add' or 'mul'.
+    initial_seasonal : ndarray or None
+        The initial values for the seasonal component, or None if
+        `seasonal` is not 'add' or 'mul'.
+
+    Raises
+    ------
+    ValueError
+        If `seasonal` is 'add' or 'mul' and `endog` does not contain at
+        least two full seasonal cycles.
+
+    Notes
+    -----
+    See Section 7.6 of Hyndman and Athanasopoulos [1]_.
+
+    References
+    ----------
+    .. [1] Hyndman, R.J., & Athanasopoulos, G. (2019) *Forecasting:
+       principles and practice*, 3rd edition, OTexts: Melbourne,
+       Australia. OTexts.com/fpp3. Accessed on April 19th 2020.
+    """
     # See Section 7.6 of Hyndman and Athanasopoulos
     nobs = len(endog)
     initial_trend = None
@@ -41,6 +87,53 @@ def _initialization_simple(endog, trend=False, seasonal=False,
 
 def _initialization_heuristic(endog, trend=False, seasonal=False,
                               seasonal_periods=None):
+    """
+    Compute heuristic initial values for level, trend, and seasonal components
+
+    Parameters
+    ----------
+    endog : ndarray
+        The observed time-series process :math:`y`.
+    trend : {'add', 'mul'} or None, optional
+        The type of trend component. If not 'add' or 'mul', no initial
+        trend value is computed. Default is False, which is treated the
+        same as None.
+    seasonal : {'add', 'mul'} or None, optional
+        The type of seasonal component. If not 'add' or 'mul', the
+        non-seasonal branch is used and no initial seasonal values are
+        computed. Default is False, which is treated the same as None.
+    seasonal_periods : int, optional
+        The number of periods in a complete seasonal cycle. Required if
+        `seasonal` is 'add' or 'mul'.
+
+    Returns
+    -------
+    initial_level : float
+        The initial value for the level component.
+    initial_trend : float or None
+        The initial value for the trend component, or None if `trend` is
+        not 'add' or 'mul'.
+    initial_seasonal : ndarray or None
+        The initial values for the seasonal component, or None if
+        `seasonal` is not 'add' or 'mul'.
+
+    Raises
+    ------
+    ValueError
+        If `endog` has fewer than 10 observations, or if `seasonal` is
+        'add' or 'mul' and `endog` does not contain enough observations
+        to compute the seasonally adjusted level.
+
+    Notes
+    -----
+    See Section 2.6 of Hyndman et al. [1]_.
+
+    References
+    ----------
+    .. [1] Hyndman, R.J., & Athanasopoulos, G. (2019) *Forecasting:
+       principles and practice*, 3rd edition, OTexts: Melbourne,
+       Australia. OTexts.com/fpp3. Accessed on April 19th 2020.
+    """
     # See Section 2.6 of Hyndman et al.
     endog = endog.copy()
     nobs = len(endog)

--- a/statsmodels/tsa/filters/bk_filter.py
+++ b/statsmodels/tsa/filters/bk_filter.py
@@ -12,14 +12,14 @@ def bkfilter(x, low=6, high=32, K=12):
     ----------
     x : array_like
         A 1 or 2d ndarray. If 2d, variables are assumed to be in columns.
-    low : float
+    low : float, optional
         Minimum period for oscillations, i.e., Baxter and King suggest that
         the Burns-Mitchell U.S. business cycle has 6 for quarterly data and
         1.5 for annual data.
-    high : float
+    high : float, optional
         Maximum period for oscillations. BK suggest that the U.S.
         business cycle has 32 for quarterly data and 8 for annual data.
-    K : int
+    K : int, optional
         Lead-lag length of the filter. Baxter and King propose a truncation
         length of 12 for quarterly data and 3 for annual data.
 
@@ -32,7 +32,7 @@ def bkfilter(x, low=6, high=32, K=12):
     --------
     statsmodels.tsa.filters.cf_filter.cffilter
         The Christiano Fitzgerald asymmetric, random walk filter.
-    statsmodels.tsa.filters.bk_filter.hpfilter
+    statsmodels.tsa.filters.hp_filter.hpfilter
         Hodrick-Prescott filter.
     statsmodels.tsa.seasonal.seasonal_decompose
         Decompose a time series using moving averages.

--- a/statsmodels/tsa/filters/cf_filter.py
+++ b/statsmodels/tsa/filters/cf_filter.py
@@ -22,15 +22,15 @@ def cffilter(x, low=6, high=32, drift=True):
     x : array_like
         The 1 or 2d array to filter. If 2d, variables are assumed to be in
         columns.
-    low : float
+    low : float, optional
         Minimum period of oscillations. Features below low periodicity are
         filtered out. Default is 6 for quarterly data, giving a 1.5 year
         periodicity.
-    high : float
+    high : float, optional
         Maximum period of oscillations. Features above high periodicity are
         filtered out. Default is 32 for quarterly data, giving an 8 year
         periodicity.
-    drift : bool
+    drift : bool, optional
         Whether or not to remove a trend from the data. The trend is estimated
         as np.arange(nobs)*(x[-1] - x[0])/(len(x)-1).
 
@@ -39,9 +39,9 @@ def cffilter(x, low=6, high=32, drift=True):
     CycleTrendResult
         A result object with fields:
 
-        cycle : array_like
+        cycle : ndarray, Series, or DataFrame
             The features of x between the periodicities low and high.
-        trend : array_like
+        trend : ndarray, Series, or DataFrame
             The trend in the data with the cycles removed.
 
     See Also

--- a/statsmodels/tsa/filters/filtertools.py
+++ b/statsmodels/tsa/filters/filtertools.py
@@ -34,12 +34,12 @@ class CycleTrendResult(NamedTuple):
 
     Parameters
     ----------
-    cycle : array_like
+    cycle : ndarray, Series, or DataFrame
         The estimated cyclical component. See the docstring of the
         function that produced this result for the precise definition
         (e.g., :func:`hamilton_filter` leaves the first ``p + h - 1``
         values as ``NaN``).
-    trend : array_like
+    trend : ndarray, Series, or DataFrame
         The estimated trend component, matching ``cycle`` in shape.
     """
 
@@ -239,7 +239,7 @@ def recursive_filter(x, ar_coeff, init=None):
 
     Returns
     -------
-    array_like
+    ndarray or Series
         Filtered array, number of columns determined by x and ar_coeff. If x
         is a pandas object than a Series is returned.
 
@@ -372,9 +372,10 @@ def miso_lfilter(ar, ma, x, useic=False):
     ar : array_like
         The coefficients of autoregressive lag polynomial including lag zero,
         ar(L) in the expression ar(L)y_t.
-    ma : array_like, same ndim as x, currently 2d
+    ma : array_like
         The coefficient of the moving average lag polynomial, ma(L) in
-        ma(L)x_t.
+        ma(L)x_t. Must have the same number of dimensions as ``x``;
+        currently only 2d is supported.
     x : array_like
         The 2-d input data series, time in rows, variables in columns.
     useic : bool, optional

--- a/statsmodels/tsa/filters/hamilton_filter.py
+++ b/statsmodels/tsa/filters/hamilton_filter.py
@@ -40,11 +40,11 @@ def hamilton_filter(x, h=8, p=4):
     CycleTrendResult
         A result object with fields:
 
-        cycle : ndarray or Series
+        cycle : ndarray, Series, or DataFrame
             Estimated cyclical component.  The first ``p + h - 1`` values
             are ``NaN`` because no regression can be formed for those
             periods.
-        trend : ndarray or Series
+        trend : ndarray, Series, or DataFrame
             Estimated trend component.  The first ``p + h - 1`` values are
             likewise ``NaN``.
 

--- a/statsmodels/tsa/filters/hp_filter.py
+++ b/statsmodels/tsa/filters/hp_filter.py
@@ -16,7 +16,7 @@ def hpfilter(x, lamb=1600):
     ----------
     x : array_like
         The time series to filter, 1-d.
-    lamb : float
+    lamb : float, optional
         The Hodrick-Prescott smoothing parameter. A value of 1600 is
         suggested for quarterly data. Ravn and Uhlig suggest using a value
         of 6.25 (1600/4**4) for annual data and 129600 (1600*3**4) for monthly
@@ -27,9 +27,9 @@ def hpfilter(x, lamb=1600):
     CycleTrendResult
         A result object with fields:
 
-        cycle : ndarray
+        cycle : ndarray or Series
             The estimated cycle in the data given lamb.
-        trend : ndarray
+        trend : ndarray or Series
             The estimated trend in the data given lamb.
 
     See Also

--- a/statsmodels/tsa/forecasting/stl.py
+++ b/statsmodels/tsa/forecasting/stl.py
@@ -36,7 +36,7 @@ ds.insert_parameters(
     "model",
     Parameter(
         "model_kwargs",
-        "dict[str, Any]",
+        "dict, optional",
         [
             (
                 "Any additional arguments needed to initialized the model using "
@@ -199,7 +199,7 @@ class STLForecast:
 
         Parameters
         ----------\n%(fit_params)s
-        fit_kwargs : dict[str, Any]
+        fit_kwargs : dict, optional
             Any additional keyword arguments to pass to ``model``'s ``fit``
             method when estimating the model on the decomposed residuals.
 
@@ -235,6 +235,8 @@ class STLForecastResults:
         The time series model used to model the non-seasonal dynamics.
     model_result : Results
         Model results instance supporting, at a minimum, ``forecast``.
+    endog : array_like
+        The original data prior to seasonal decomposition.
     """
 
     def __init__(
@@ -347,18 +349,19 @@ class STLForecastResults:
 
         Parameters
         ----------
-        start : int, str, or datetime, optional
+        start : int, str, datetime, or None
             Zero-indexed observation number at which to start forecasting,
             i.e., the first forecast is start. Can also be a date string to
-            parse or a datetime type. Default is the zeroth observation.
-        end : int, str, or datetime, optional
+            parse or a datetime type. If None, the zeroth observation is
+            used.
+        end : int, str, datetime, or None
             Zero-indexed observation number at which to end forecasting, i.e.,
             the last forecast is end. Can also be a date string to
             parse or a datetime type. However, if the dates index does not
             have a fixed frequency, end must be an integer index if you
-            want out of sample prediction. Default is the last observation in
-            the sample.
-        dynamic : bool, int, str, or datetime, optional
+            want out of sample prediction. If None, the last observation in
+            the sample is used.
+        dynamic : bool, int, str, or datetime
             Integer offset relative to `start` at which to begin dynamic
             prediction. Can also be an absolute date string to parse or a
             datetime type (these are not interpreted as offsets).
@@ -413,15 +416,15 @@ class STLForecastResults:
         ----------
         steps : int
             The number of steps required.
-        index : pd.Index
+        index : pd.Index or None
             A pandas index to use. If None, returns an ndarray.
-        offset : int
+        offset : int or None, optional
             The index of the first out-of-sample observation. If None, uses
             nobs.
 
         Returns
         -------
-        seasonal : {ndarray, Series}
+        seasonal : ndarray or Series
             The seasonal component.
         """
 
@@ -455,7 +458,7 @@ class STLForecastResults:
 
         Returns
         -------
-        forecast : {ndarray, Series}
+        forecast : ndarray or Series
             Out of sample forecasts
         """
         forecast = self._model_result.forecast(steps=steps, **kwargs)

--- a/statsmodels/tsa/forecasting/theta.py
+++ b/statsmodels/tsa/forecasting/theta.py
@@ -43,6 +43,21 @@ if TYPE_CHECKING:
 
 
 def extend_index(steps: int, index: pd.Index) -> pd.Index:
+    """
+    Extend a pandas index by a number of periods
+
+    Parameters
+    ----------
+    steps : int
+        The number of periods to extend the index by.
+    index : pd.Index
+        The index to extend.
+
+    Returns
+    -------
+    pd.Index
+        The extended index.
+    """
     return DeterministicTerm._extend_index(index, steps)
 
 
@@ -52,28 +67,27 @@ class ThetaModel:
 
     Parameters
     ----------
-    endog : array_like, 1d
-        The data to forecast.
-    period : int, default None
+    endog : array_like
+        The data to forecast, 1-d.
+    period : int, optional
         The period of the data that is used in the seasonality test and
-        adjustment. If None then the period is determined from y's index,
-        if available.
-    deseasonalize : bool, default True
-        A flag indicating whether the deseasonalize the data. If True and
-        use_test is True, the data is only deseasonalized if the null of no
-        seasonal component is rejected.
-    use_test : bool, default True
-        A flag indicating whether test the period-th autocorrelation. If this
-        test rejects using a size of 10%, then decomposition is used. Set to
+        adjustment. If None, the period is determined from y's index, if
+        available.
+    deseasonalize : bool, optional
+        Whether to deseasonalize the data. If True and use_test is True,
+        the data is only deseasonalized if the null of no seasonal
+        component is rejected.
+    use_test : bool, optional
+        Whether to test the period-th autocorrelation. If this test
+        rejects using a size of 10%, then decomposition is used. Set to
         False to skip the test.
-    method : {"auto", "additive", "multiplicative"}, default "auto"
+    method : {"auto", "additive", "multiplicative"}, optional
         The model used for the seasonal decomposition. "auto" uses a
-        multiplicative if y is non-negative and all estimated seasonal
-        components are positive. If either of these conditions is False,
-        then it uses an additive decomposition.
-    difference : bool, default False
-        A flag indicating to difference the data before testing for
-        seasonality.
+        multiplicative decomposition if y is non-negative and all
+        estimated seasonal components are positive. If either of these
+        conditions is False, then it uses an additive decomposition.
+    difference : bool, optional
+        Whether to difference the data before testing for seasonality.
 
     See Also
     --------
@@ -204,12 +218,12 @@ class ThetaModel:
 
         Parameters
         ----------
-        use_mle : bool, default False
+        use_mle : bool, optional
             Estimate the parameters using MLE by fitting an ARIMA(0,1,1) with
             a drift.  If False (the default), estimates parameters using OLS
             of a constant and a time-trend and by fitting a SES to the model
             data.
-        disp : bool, default False
+        disp : bool, optional
             Display iterative output from fitting the model.
 
         Returns
@@ -303,8 +317,10 @@ class ThetaModelResults:
         The estimated trend slope.
     alpha : float
         The estimated SES parameter.
-    sigma2 : float
-        The estimated residual variance from the SES/IMA model.
+    sigma2 : float or None
+        The estimated residual variance from the SES/IMA model. If None,
+        the variance is estimated lazily from an ARIMA(0,1,1) model when
+        first accessed.
     one_step : float
         The one-step forecast from the SES.
     seasonal : ndarray
@@ -360,9 +376,9 @@ class ThetaModelResults:
 
         Parameters
         ----------
-        steps : int
+        steps : int, optional
             The number of steps ahead to compute the forecast components.
-        theta : float
+        theta : float, optional
             The theta value to use when computing the weight to combine
             the trend and the SES forecasts.
 
@@ -427,7 +443,7 @@ class ThetaModelResults:
 
         Parameters
         ----------
-        steps : int
+        steps : int, optional
             The number of steps ahead to compute the forecast components.
 
         Returns
@@ -560,12 +576,12 @@ class ThetaModelResults:
 
         Parameters
         ----------
-        steps : int, default 1
+        steps : int, optional
             The number of steps ahead to compute the forecast components.
-        theta : float, default 2
+        theta : float, optional
             The theta value to use when computing the weight to combine
             the trend and the SES forecasts.
-        alpha : float, default 0.05
+        alpha : float, optional
             Significance level for the confidence intervals.
 
         Returns
@@ -608,23 +624,23 @@ class ThetaModelResults:
 
         Parameters
         ----------
-        steps : int, default 1
+        steps : int, optional
             The number of steps ahead to compute the forecast components.
-        theta : float, default 2
+        theta : float, optional
             The theta value to use when computing the weight to combine
             the trend and the SES forecasts.
-        alpha : {float, None}, default 0.05
+        alpha : float or None, optional
             The tail probability not covered by the confidence interval. Must
             be in (0, 1). Confidence interval is constructed assuming normally
             distributed shocks. If None, figure will not show the confidence
             interval.
-        in_sample : bool, default False
+        in_sample : bool, optional
             Flag indicating whether to include the in-sample period in the
             plot.
-        fig : Figure, default None
+        fig : Figure, optional
             An existing figure handle. If not provided, a new figure is
             created.
-        figsize : tuple[float, float], default None
+        figsize : tuple of float, optional
             Tuple containing the figure size.
 
         Returns
@@ -636,8 +652,8 @@ class ThetaModelResults:
         -----
         The variance of the h-step forecast is assumed to follow from the
         integrated Moving Average structure of the Theta model, and so is
-        :math:`\sigma^2(\alpha^2 + (h-1))`. The prediction interval assumes
-        that innovations are normally distributed.
+        :math:`\sigma^2(1 + (h-1)(1 + (\alpha-1)^2))`. The prediction interval
+        assumes that innovations are normally distributed.
         """
         from statsmodels.graphics.utils import _import_mpl, create_mpl_fig
 

--- a/statsmodels/tsa/holtwinters/model.py
+++ b/statsmodels/tsa/holtwinters/model.py
@@ -121,11 +121,11 @@ class ExponentialSmoothing(TimeSeriesModel):
     ----------
     endog : array_like
         The time series to model.
-    trend : {"add", "mul", "additive", "multiplicative", None}, optional
+    trend : {"add", "mul", "additive", "multiplicative"} or None, optional
         Type of trend component.
     damped_trend : bool, optional
         Should the trend component be damped.
-    seasonal : {"add", "mul", "additive", "multiplicative", None}, optional
+    seasonal : {"add", "mul", "additive", "multiplicative"} or None, optional
         Type of seasonal component.
     seasonal_periods : int, optional
         The number of periods in a complete seasonal cycle, e.g., 4 for
@@ -170,7 +170,7 @@ class ExponentialSmoothing(TimeSeriesModel):
     use_boxcox : {True, False, 'log', float}, optional
         Should the Box-Cox transform be applied to the data first? If 'log'
         then apply the log. If float then use the value as lambda.
-    bounds : dict[str, tuple[float, float]], optional
+    bounds : dict of str to tuple of float, optional
         A dictionary containing bounds for the parameters in the model,
         excluding the initial values if estimated. The keys of the dictionary
         are the variable names, e.g., smoothing_level or initial_slope.
@@ -184,7 +184,7 @@ class ExponentialSmoothing(TimeSeriesModel):
     freq : str, optional
         The frequency of the time-series. A Pandas offset or 'B', 'D', 'W',
         'M', 'A', or 'Q'. This is optional if dates are given.
-    missing : str
+    missing : str, optional
         Available options are 'none', 'drop', and 'raise'. If 'none', no nan
         checking is done. If 'drop', any observations with nans are dropped.
         If 'raise', an error is raised. Default is 'none'.
@@ -472,13 +472,13 @@ class ExponentialSmoothing(TimeSeriesModel):
 
         Parameters
         ----------
-        params : ndarray
+        params : dict
             The fitted model parameters.
-        start : int, str, or datetime
+        start : int, str, or datetime, optional
             Zero-indexed observation number at which to start forecasting, ie.,
             the first forecast is start. Can also be a date string to
             parse or a datetime type.
-        end : int, str, or datetime
+        end : int, str, or datetime, optional
             Zero-indexed observation number at which to end forecasting, ie.,
             the last forecast is end. Can also be a date string to
             parse or a datetime type.
@@ -960,7 +960,7 @@ class ExponentialSmoothing(TimeSeriesModel):
             "bh") and "least_squares" (also "ls"). basinhopping tries multiple
             starting values in an attempt to find a global minimizer in
             non-convex problems, and so is slower than the others.
-        minimize_kwargs : dict[str, Any]
+        minimize_kwargs : dict, optional
             A dictionary of keyword arguments passed to SciPy's minimize
             function if method is one of "L-BFGS-B", "TNC",
             "SLSQP", "Powell", or "trust-constr", or SciPy's basinhopping
@@ -1100,20 +1100,20 @@ class ExponentialSmoothing(TimeSeriesModel):
 
         Parameters
         ----------
-        initial_level : {float, None}
+        initial_level : float, optional
             The initial value used for the level component.
-        initial_trend : {float, None}
+        initial_trend : float, optional
             The initial value used for the trend component.
-        force : bool
+        force : bool, optional
             Force the calculation even if initial values exist.
 
         Returns
         -------
         initial_level : float
             The initial value used for the level component.
-        initial_trend : {float, None}
+        initial_trend : float or None
             The initial value used for the trend component.
-        initial_seasons : list
+        initial_seasons : list of float
             The initial values used for the seasonal components.
 
         Notes
@@ -1499,7 +1499,7 @@ class SimpleExpSmoothing(ExponentialSmoothing):
             the value is set then this value will be used as the value.
         optimized : bool, optional
             Estimate model parameters by maximizing the log-likelihood.
-        start_params : ndarray, optional
+        start_params : array_like, optional
             Starting values to used when optimizing the fit.  If not provided,
             starting values are determined using a combination of grid search
             and reasonable values based on the initial values of the data.
@@ -1509,13 +1509,13 @@ class SimpleExpSmoothing(ExponentialSmoothing):
         remove_bias : bool, optional
             Remove bias from forecast values and fitted values by enforcing
             that the average residual is equal to zero.
-        method : str, default "L-BFGS-B"
+        method : str, optional
             The minimizer used. Valid options are "L-BFGS-B" (default), "TNC",
             "SLSQP", "Powell", "trust-constr", "basinhopping" (also "bh") and
             "least_squares" (also "ls"). basinhopping tries multiple starting
             values in an attempt to find a global minimizer in non-convex
             problems, and so is slower than the others.
-        minimize_kwargs : dict[str, Any]
+        minimize_kwargs : dict, optional
             A dictionary of keyword arguments passed to SciPy's minimize
             function if method is one of "L-BFGS-B" (default), "TNC",
             "SLSQP", "Powell", or "trust-constr", or SciPy's basinhopping
@@ -1659,7 +1659,7 @@ class Holt(ExponentialSmoothing):
             set then this value will be used as the value.
         optimized : bool, optional
             Estimate model parameters by maximizing the log-likelihood.
-        start_params : ndarray, optional
+        start_params : array_like, optional
             Starting values to used when optimizing the fit.  If not provided,
             starting values are determined using a combination of grid search
             and reasonable values based on the initial values of the data.
@@ -1669,13 +1669,13 @@ class Holt(ExponentialSmoothing):
         remove_bias : bool, optional
             Remove bias from forecast values and fitted values by enforcing
             that the average residual is equal to zero.
-        method : str, default "L-BFGS-B"
+        method : str, optional
             The minimizer used. Valid options are "L-BFGS-B" (default), "TNC",
             "SLSQP", "Powell", "trust-constr", "basinhopping" (also "bh") and
             "least_squares" (also "ls"). basinhopping tries multiple starting
             values in an attempt to find a global minimizer in non-convex
             problems, and so is slower than the others.
-        minimize_kwargs : dict[str, Any]
+        minimize_kwargs : dict, optional
             A dictionary of keyword arguments passed to SciPy's minimize
             function if method is one of "L-BFGS-B" (default), "TNC",
             "SLSQP", "Powell", or "trust-constr", or SciPy's basinhopping

--- a/statsmodels/tsa/holtwinters/results.py
+++ b/statsmodels/tsa/holtwinters/results.py
@@ -34,9 +34,9 @@ class HoltWintersResults(Results):
         AIC with a correction for finite sample sizes.
     bic : float
         The Bayesian information criterion.
-    optimized : bool
-        Flag indicating whether the model parameters were optimized to fit
-        the data.
+    optimized : ndarray of bool
+        Flags indicating whether each parameter was optimized to fit the
+        data.
     level : ndarray
         An array of the levels values that make up the fitted values.
     trend : ndarray
@@ -58,7 +58,7 @@ class HoltWintersResults(Results):
     fcastvalues : ndarray
         An array of the forecast values forecast by the Exponential Smoothing
         model.
-    mle_retvals : {None, scipy.optimize.optimize.OptimizeResult}
+    mle_retvals : scipy.optimize.OptimizeResult or None
         Optimization results if the parameters were optimized to fit the data.
     """
 
@@ -225,7 +225,7 @@ class HoltWintersResults(Results):
 
         Parameters
         ----------
-        steps : int
+        steps : int, optional
             The number of out of sample forecasts from the end of the
             sample.
 
@@ -383,7 +383,7 @@ class HoltWintersResults(Results):
             Number of simulated paths to generate. Default is 1 simulated path.
         error : {"add", "mul", "additive", "multiplicative"}, optional
             Error model for state space formulation. Default is ``"add"``.
-        random_errors : optional
+        random_errors : ndarray, rv_continuous, rv_discrete, rv_frozen, or "bootstrap", optional
             Specifies how the random errors should be obtained. Can be one of
             the following:
 
@@ -406,7 +406,7 @@ class HoltWintersResults(Results):
               the given values as random errors.
             * ``"bootstrap"``: Samples the random errors from the fit errors.
 
-        rng : int, array_like of int, numpy.random.Generator, numpy.random.RandomState, optional
+        rng : int, array_like of int, numpy.random.Generator, or numpy.random.RandomState, optional
             If `rng` is None, a new ``Generator`` is created using fresh
             entropy from the operating system. If `rng` is an int, a new
             ``RandomState`` instance is created, seeded with `rng`; this
@@ -415,7 +415,7 @@ class HoltWintersResults(Results):
             already a ``Generator`` or ``RandomState`` instance, that
             instance is used. Only used if `random_errors` is ``None`` or
             ``"bootstrap"``.
-        rng : int, array_like of int, numpy.random.Generator, numpy.random.RandomState, optional
+
             .. deprecated:: 0.15
 
                random_state has been deprecated. In-line with SPEC-007, use

--- a/statsmodels/tsa/innovations/arma_innovations.py
+++ b/statsmodels/tsa/innovations/arma_innovations.py
@@ -20,13 +20,13 @@ def arma_innovations(endog, ar_params=None, ma_params=None, sigma2=1,
 
     Parameters
     ----------
-    endog : ndarray
+    endog : array_like
         The observed time-series process, may be univariate or multivariate.
-    ar_params : ndarray, optional
+    ar_params : array_like, optional
         Autoregressive parameters.
-    ma_params : ndarray, optional
+    ma_params : array_like, optional
         Moving average parameters.
-    sigma2 : ndarray, optional
+    sigma2 : float, optional
         The ARMA innovation variance. Default is 1.
     normalize : bool, optional
         Whether or not to normalize the returned innovations. Default is False.
@@ -114,13 +114,13 @@ def arma_loglike(endog, ar_params=None, ma_params=None, sigma2=1, prefix=None):
 
     Parameters
     ----------
-    endog : ndarray
+    endog : array_like
         The observed time-series process.
-    ar_params : ndarray, optional
+    ar_params : array_like, optional
         Autoregressive parameters.
-    ma_params : ndarray, optional
+    ma_params : array_like, optional
         Moving average parameters.
-    sigma2 : ndarray, optional
+    sigma2 : float, optional
         The ARMA innovation variance. Default is 1.
     prefix : str, optional
         The BLAS prefix associated with the datatype. Default is to find the
@@ -144,13 +144,13 @@ def arma_loglikeobs(endog, ar_params=None, ma_params=None, sigma2=1,
 
     Parameters
     ----------
-    endog : ndarray
+    endog : array_like
         The observed time-series process.
-    ar_params : ndarray, optional
+    ar_params : array_like, optional
         Autoregressive parameters.
-    ma_params : ndarray, optional
+    ma_params : array_like, optional
         Moving average parameters.
-    sigma2 : ndarray, optional
+    sigma2 : float, optional
         The ARMA innovation variance. Default is 1.
     prefix : str, optional
         The BLAS prefix associated with the datatype. Default is to find the
@@ -187,17 +187,17 @@ def arma_score(endog, ar_params=None, ma_params=None, sigma2=1,
 
     Parameters
     ----------
-    endog : ndarray
+    endog : array_like
         The observed time-series process.
-    ar_params : ndarray, optional
+    ar_params : array_like, optional
         Autoregressive coefficients, not including the zero lag.
-    ma_params : ndarray, optional
+    ma_params : array_like, optional
         Moving average coefficients, not including the zero lag, where the sign
         convention assumes the coefficients are part of the lag polynomial on
         the right-hand-side of the ARMA definition (i.e., they have the same
         sign from the usual econometrics convention in which the coefficients
         are on the right-hand-side of the ARMA definition).
-    sigma2 : ndarray, optional
+    sigma2 : float, optional
         The ARMA innovation variance. Default is 1.
     prefix : str, optional
         The BLAS prefix associated with the datatype. Default is to find the
@@ -235,17 +235,17 @@ def arma_scoreobs(endog, ar_params=None, ma_params=None, sigma2=1,
 
     Parameters
     ----------
-    endog : ndarray
+    endog : array_like
         The observed time-series process.
-    ar_params : ndarray, optional
+    ar_params : array_like, optional
         Autoregressive coefficients, not including the zero lag.
-    ma_params : ndarray, optional
+    ma_params : array_like, optional
         Moving average coefficients, not including the zero lag, where the sign
         convention assumes the coefficients are part of the lag polynomial on
         the right-hand-side of the ARMA definition (i.e., they have the same
         sign from the usual econometrics convention in which the coefficients
         are on the right-hand-side of the ARMA definition).
-    sigma2 : ndarray, optional
+    sigma2 : float, optional
         The ARMA innovation variance. Default is 1.
     prefix : str, optional
         The BLAS prefix associated with the datatype. Default is to find the

--- a/statsmodels/tsa/interp/denton.py
+++ b/statsmodels/tsa/interp/denton.py
@@ -96,11 +96,11 @@ def dentonm(indicator, benchmark, freq="aq", **kwargs):
     benchmark : array_like
         The higher frequency benchmark.  A 1d or 2d data series in columns.
         If 2d, then M series are assumed.
-    freq : str {"aq","qm", "other"}
+    freq : {"aq", "qm", "other"}, optional
         The frequency to use in the conversion.
 
         * "aq" - Benchmarking an annual series to quarterly.
-        * "mq" - Benchmarking a quarterly series to monthly.
+        * "qm" - Benchmarking a quarterly series to monthly.
         * "other" - Custom stride.  A kwarg, k, must be supplied.
     **kwargs
         Additional keyword arguments. For example:

--- a/statsmodels/tsa/seasonal/_seasonal.py
+++ b/statsmodels/tsa/seasonal/_seasonal.py
@@ -266,15 +266,15 @@ class DecomposeResult:
 
     Parameters
     ----------
-    observed : array_like
+    observed : ndarray, Series, or DataFrame
         The data series that has been decomposed.
-    seasonal : array_like
+    seasonal : ndarray, Series, or DataFrame
         The seasonal component of the data series.
-    trend : array_like
+    trend : ndarray, Series, or DataFrame
         The trend component of the data series.
-    resid : array_like
+    resid : ndarray, Series, or DataFrame
         The residual component of the data series.
-    weights : array_like, optional
+    weights : ndarray, Series, or DataFrame, optional
         The weights used to reduce outlier influence.
     """
 
@@ -332,15 +332,15 @@ class DecomposeResult:
 
         Parameters
         ----------
-        observed : bool
+        observed : bool, optional
             Include the observed series in the plot
-        seasonal : bool
+        seasonal : bool, optional
             Include the seasonal component in the plot
-        trend : bool
+        trend : bool, optional
             Include the trend component in the plot
-        resid : bool
+        resid : bool, optional
             Include the residual in the plot
-        weights : bool
+        weights : bool, optional
             Include the weights in the plot (if any)
 
         Returns

--- a/statsmodels/tsa/stattools/_arma_order_selection.py
+++ b/statsmodels/tsa/stattools/_arma_order_selection.py
@@ -52,18 +52,18 @@ def arma_order_select_ic(
     ----------
     y : array_like
         Array of time-series data.
-    max_ar : int
+    max_ar : int, optional
         Maximum number of AR lags to use. Default 4.
-    max_ma : int
+    max_ma : int, optional
         Maximum number of MA lags to use. Default 2.
-    ic : str, list
+    ic : str or sequence of str, optional
         Information criteria to report. Either a single string or a list
         of different criteria is possible.
-    trend : str
+    trend : {'n', 'c'}, optional
         The trend to use when fitting the ARMA models.
-    model_kw : dict
+    model_kw : dict, optional
         Keyword arguments to be passed to the ``ARIMA`` model.
-    fit_kw : dict
+    fit_kw : dict, optional
         Keyword arguments to be passed to ``ARIMA.fit``.
 
     Returns

--- a/statsmodels/tsa/stattools/_leybourne.py
+++ b/statsmodels/tsa/stattools/_leybourne.py
@@ -35,7 +35,7 @@ class LeybourneMcCabeStationarity:
         ----------
         stat : float
             The Leybourne-McCabe test statistic
-        model : {'c','ct'}
+        model : {'c', 'ct'}, optional
             The model used when computing the test statistic. 'c' is default.
 
         Returns
@@ -74,7 +74,7 @@ class LeybourneMcCabeStationarity:
             data series
         arlags : int
             AR(p) order
-        model : {'c','ct'}
+        model : {'c', 'ct'}
             Constant and trend order to include in regression
             * 'c'  : constant only
             * 'ct' : constant and trend
@@ -112,6 +112,7 @@ class LeybourneMcCabeStationarity:
     def _autolag(self, x):
         """
         Empirical method for Leybourne-McCabe auto AR lag detection
+
         Set number of AR lags equal to the first PACF falling within the
         95% confidence interval. Maximum number of AR lags is limited to
         the smaller of 10 or 1/2 series length. Minimum is zero lags.
@@ -144,23 +145,23 @@ class LeybourneMcCabeStationarity:
         ----------
         x : array_like
             data series
-        arlags : {None, int}, optional
+        arlags : None or int, optional
             Number of autoregressive terms to include. If None, the number
             of lags is selected using the empirical autolag procedure.
             Default is 1.
-        regression : {'c','ct'}
+        regression : {'c', 'ct'}, optional
             Constant and trend order to include in regression
 
             * 'c'  : constant only (default)
             * 'ct' : constant and trend
 
-        method : {'mle','ols'}
+        method : {'mle', 'ols'}, optional
             Method used to estimate ARIMA(p, 1, 1) filter model
 
             * 'mle' : conditional sum of squares maximum likelihood (default)
             * 'ols' : two-stage least squares
 
-        varest : {'var94','var99'}
+        varest : {'var94', 'var99'}, optional
             Method used for residual variance estimation
 
             * 'var94' : method used in original Leybourne-McCabe paper (1994)

--- a/statsmodels/tsa/stattools/_stattools.py
+++ b/statsmodels/tsa/stattools/_stattools.py
@@ -252,10 +252,10 @@ def adfuller(
     ----------
     x : array_like, 1d
         The data series to test.
-    maxlag : {None, int}
+    maxlag : int, optional
         Maximum lag which is included in test, default value of
         12*(nobs/100)^{1/4} is used when ``None``.
-    regression : {"c","ct","ctt","n"}
+    regression : {"c","ct","ctt","n"}, optional
         Constant and trend order to include in regression.
 
         * "c" : constant only (default).
@@ -263,7 +263,7 @@ def adfuller(
         * "ctt" : constant, and linear and quadratic trend.
         * "n" : no constant, no trend.
 
-    autolag : {"AIC", "BIC", "t-stat", None}
+    autolag : {"AIC", "BIC", "t-stat", None}, optional
         Method to use when automatically determining the lag length among the
         values 0, 1, ..., maxlag.
 
@@ -273,7 +273,7 @@ def adfuller(
           lag until the t-statistic on the last lag length is significant
           using a 5%-sized test.
         * If None, then the number of included lags is set to maxlag.
-    store : bool
+    store : bool, optional
         If True, then a result instance is returned additionally to
         the adf statistic. Default is False.
     regresults : bool, optional
@@ -499,24 +499,23 @@ def acovf(x, adjusted=False, demean=True, fft=True, missing="none", nlag=None):
     ----------
     x : array_like
         Time series data. Must be 1d.
-    adjusted : bool, default False
+    adjusted : bool, optional
         If True, then denominators is n-k, otherwise n.
-    demean : bool, default True
+    demean : bool, optional
         If True, then subtract the mean x from each element of x.
-    fft : bool, default True
+    fft : bool, optional
         If True, use FFT convolution.  This method should be preferred
         for long time series.
-    missing : str, default "none"
-        A string in ["none", "raise", "conservative", "drop"] specifying how
-        the NaNs are to be treated. "none" performs no checks. "raise" raises
-        an exception if NaN values are found. "drop" removes the missing
-        observations and then estimates the autocovariances treating the
-        non-missing as contiguous. "conservative" computes the autocovariance
-        using nan-ops so that nans are removed when computing the mean
-        and cross-products that are used to estimate the autocovariance.
-        When using "conservative", n is set to the number of non-missing
-        observations.
-    nlag : {int, None}, default None
+    missing : {"none", "raise", "conservative", "drop"}, optional
+        Specifies how the NaNs are to be treated. "none" performs no checks.
+        "raise" raises an exception if NaN values are found. "drop" removes
+        the missing observations and then estimates the autocovariances
+        treating the non-missing as contiguous. "conservative" computes the
+        autocovariance using nan-ops so that nans are removed when computing
+        the mean and cross-products that are used to estimate the
+        autocovariance. When using "conservative", n is set to the number of
+        non-missing observations.
+    nlag : int, optional
         Limit the number of autocovariances returned.  Size of returned
         array is nlag + 1.  Setting nlag when fft is False uses a simple,
         direct estimator of the autocovariances that only computes the first
@@ -663,7 +662,7 @@ def block_jackknife(x, statistic, n_blocks=-1):
     statistic : callable
         Function that takes an array and returns a scalar or array-valued
         estimate.
-    n_blocks : int
+    n_blocks : int, optional
         The number of blocks to use. If -1 (default), uses ``n_blocks =
         len(x)``, i.e., the classical delete-1 jackknife.
 
@@ -788,7 +787,7 @@ def q_stat(x, nobs):
     ----------
     x : array_like
         Array of autocorrelation coefficients.  Can be obtained from acf.
-    nobs : int, optional
+    nobs : int
         Number of observations in the entire sample (ie., not just the length
         of the autocorrelation function results).
 
@@ -871,23 +870,23 @@ def acf(
     ----------
     x : array_like
        The time series data.
-    adjusted : bool, default False
+    adjusted : bool, optional
        If True, then denominators for autocovariance are n-k, otherwise n.
     nlags : int, optional
         Number of lags to return autocorrelation for. If not provided,
         uses min(10 * np.log10(nobs), nobs - 1). The returned value
         includes lag 0 (ie., 1) so size of the acf vector is (nlags + 1,).
-    qstat : bool, default False
+    qstat : bool, optional
         If True, returns the Ljung-Box q statistic for each autocorrelation
         coefficient.  See q_stat for more information.
-    fft : bool, default True
+    fft : bool, optional
         If True, computes the ACF via FFT.
-    alpha : scalar, default None
+    alpha : float, optional
         If a number is given, the confidence intervals for the given level are
         returned. For instance if alpha=.05, 95 % confidence intervals are
         returned where the standard deviation is computed according to
         Bartlett's formula.
-    bartlett_confint : bool, default True
+    bartlett_confint : bool, optional
         Confidence intervals for ACF values are generally placed at 2
         standard errors around r_k. The formula used for standard error
         depends upon the situation. If the autocorrelations are being used
@@ -905,16 +904,15 @@ def acf(
         model is assumed for the data and the standard errors for the
         confidence intervals should be generated using Bartlett's formula.
         For more details on Bartlett formula result, see section 7.2 in [2].
-    missing : str, default "none"
-        A string in ["none", "raise", "conservative", "drop"] specifying how
-        the NaNs are to be treated. "none" performs no checks. "raise" raises
-        an exception if NaN values are found. "drop" removes the missing
-        observations and then estimates the autocovariances treating the
-        non-missing as contiguous. "conservative" computes the autocovariance
-        using nan-ops so that nans are removed when computing the mean
-        and cross-products that are used to estimate the autocovariance.
-        When using "conservative", n is set to the number of non-missing
-        observations.
+    missing : {"none", "raise", "conservative", "drop"}, optional
+        Specifies how the NaNs are to be treated. "none" performs no checks.
+        "raise" raises an exception if NaN values are found. "drop" removes
+        the missing observations and then estimates the autocovariances
+        treating the non-missing as contiguous. "conservative" computes the
+        autocovariance using nan-ops so that nans are removed when computing
+        the mean and cross-products that are used to estimate the
+        autocovariance. When using "conservative", n is set to the number of
+        non-missing observations.
     result_object : bool, optional
         Flag indicating whether to return the results as an ``AcfResult``
         instead of a plain tuple. ``AcfResult`` always carries all four
@@ -1084,7 +1082,7 @@ def pacf_yw(
     nlags : int, optional
         Number of lags to return autocorrelation for. If not provided,
         uses min(10 * np.log10(nobs), nobs - 1).
-    method : {"adjusted", "mle"}, default "adjusted"
+    method : {"adjusted", "mle"}, optional
         The method for the autocovariance calculations in yule walker.
 
     Returns
@@ -1353,7 +1351,7 @@ def pacf(
         Number of lags to return autocorrelation for. If not provided,
         uses min(10 * np.log10(nobs), nobs // 2 - 1). The returned value
         includes lag 0 (ie., 1) so size of the pacf vector is (nlags + 1,).
-    method : str, default "ywadjusted"
+    method : str, optional
         Specifies which method for the calculations to use.
 
         - "yw" or "ywadjusted" : Yule-Walker with sample-size adjustment in
@@ -1505,7 +1503,7 @@ def ccovf(x, y, adjusted=True, demean=True, fft=True):
        overlapping observations at each lag k, min(m, n-k), otherwise n.
     demean : bool, optional
         Flag indicating whether to demean x and y.
-    fft : bool, default True
+    fft : bool, optional
         If True, use FFT convolution.  This method should be preferred
         for long time series.
 
@@ -1579,10 +1577,10 @@ def ccf(
     ----------
     x, y : array_like
         The time series data to use in the calculation.
-    adjusted : bool
+    adjusted : bool, optional
         If True, then denominators for cross-covariance are the number of
         overlapping observations at each lag k, min(m, n-k), otherwise n.
-    fft : bool, default True
+    fft : bool, optional
         If True, use FFT convolution.  This method should be preferred
         for long time series.
     nlags : int, optional
@@ -1827,7 +1825,7 @@ def pccf(
         Number of lags to return partial cross-correlations for.
         If not provided, uses
         min(10 * np.log10(nobs), nobs // 2 - 1).
-    method : str, default "ywm"
+    method : str, optional
         Specifies which method for the calculations to use.
 
         - "ywm", "ywmle" or "yw_mle" : Yule-Walker via the
@@ -2211,11 +2209,11 @@ def breakvar_heteroskedasticity_test(
     resid : array_like
         Residuals of a time series model.
         The shape is 1d (nobs,) or 2d (nobs, nvars).
-    subset_length : {int, float}
+    subset_length : int or float, optional
         Length of the subsets to test (h in Notes below).
         If a float in 0 < subset_length < 1, it is interpreted as fraction.
         Default is 1/3.
-    alternative : {"increasing", "decreasing", "two-sided"}
+    alternative : {"increasing", "decreasing", "two-sided"}, optional
         This specifies the alternative for the p-value calculation. Default
         is two-sided.
     use_f : bool, optional
@@ -2229,9 +2227,9 @@ def breakvar_heteroskedasticity_test(
     BreakvarHeteroskedasticityResult
         A result object with fields:
 
-        stat : {float, ndarray}
+        statistic : float or ndarray
             Test statistic(s) H(h).
-        pvalue : {float, ndarray}
+        pvalue : float or ndarray
             p-value(s) of test statistic(s).
 
     Notes
@@ -2361,10 +2359,10 @@ def grangercausalitytests(x, maxlag, addconst=True):
         The data for testing whether the time series in the second column Granger
         causes the time series in the first column. Missing values are not
         supported.
-    maxlag : {int, Iterable[int]}
-        If an integer, computes the test for all lags up to maxlag. If an
-        iterable, computes the tests only for the lags in maxlag.
-    addconst : bool
+    maxlag : int or sequence of int
+        If an integer, computes the test for all lags up to maxlag. If a
+        sequence, computes the tests only for the lags in maxlag.
+    addconst : bool, optional
         Include a constant in the model.
 
     Returns
@@ -2580,18 +2578,19 @@ def coint(
         The first element in cointegrated system. Must be 1-d.
     y1 : array_like
         The remaining elements in cointegrated system.
-    trend : str {"c", "ct"}
+    trend : {"c", "ct", "ctt", "n"}, optional
         The trend term included in regression for cointegrating equation.
 
-        * "c" : constant.
+        * "c" : constant (default).
         * "ct" : constant and linear trend.
-        * also available quadratic trend "ctt", and no constant "n".
+        * "ctt" : constant and quadratic trend.
+        * "n" : no constant.
 
-    method : {"aeg"}
+    method : {"aeg"}, optional
         Only "aeg" (augmented Engle-Granger) is available.
-    maxlag : None or int
+    maxlag : int, optional
         Argument for `adfuller`, largest or given number of lags.
-    autolag : str
+    autolag : {"AIC", "BIC", "t-stat", None}, optional
         Argument for `adfuller`, lag selection criterion.
 
         * If None, then maxlag lags are used without lag search.
@@ -2600,7 +2599,7 @@ def coint(
         * "t-stat" based choice of maxlag.  Starts with maxlag and drops a
           lag until the t-statistic on the last lag length is significant
           using a 5%-sized test.
-    return_results : bool
+    return_results : bool, optional
         For future compatibility, currently only tuple available.
         If True, then a results instance is returned. Otherwise, a tuple
         with the test outcome is returned. Set `return_results=False` to
@@ -2764,7 +2763,7 @@ def diebold_mariano_test(
         provided. If not provided, ``max(horizon - 1, ceil(nobs ** (1/3)))``
         is used, so this also depends on ``horizon`` even when
         ``harvey_adj`` is False. See the Notes for details.
-    criterion : str or Callable[[array_like, array_like], array_like]
+    criterion : str or callable, optional
         The loss function used to score each forecast. Default is 'mse'.
         Implemented criteria are 'mse', 'mad' (equivalently 'mae') and
         'mape'; 'poly' selects a generalized power loss whose exponent is
@@ -2777,13 +2776,13 @@ def diebold_mariano_test(
         The exponent used to compute the loss when ``criterion='poly'``,
         i.e., the loss is ``|y - forecast| ** power``. Default is 2, which
         reproduces 'mse'. Ignored unless ``criterion='poly'``.
-    harvey_adj : bool
+    harvey_adj : bool, optional
         Indicates if the Harvey-Leybourne-Newbold (1997) correction for
         small samples should be applied. Default is False. When True, the
         test statistic is rescaled and the p-value is computed from a
         Student's t distribution with ``nobs - 1`` degrees of freedom
         instead of the standard normal.
-    horizon : int
+    horizon : int, optional
         The forecast horizon used to (1) form the default number of HAC
         lags and (2) compute the Harvey et al. (1997) adjustment when
         ``harvey_adj`` is True. Must be a positive integer. Default is 1.
@@ -3052,18 +3051,18 @@ def kpss(
     ----------
     x : array_like, 1d
         The data series to test.
-    regression : {"c", "ct"}
+    regression : {"c", "ct"}, optional
         The null hypothesis for the KPSS test.
 
         * "c" : The data is stationary around a constant (default).
         * "ct" : The data is stationary around a trend.
-    nlags : {str, int}, optional
+    nlags : {"auto", "legacy"} or int, optional
         Indicates the number of lags to be used. If "auto" (default), lags
         is calculated using the data-dependent method of Hobijn et al. (1998).
         See also Andrews (1991), Newey & West (1994), and Schwert (1989). If
         set to "legacy", uses int(12 * (n / 100)**(1 / 4)), as outlined in
         Schwert (1989).
-    store : bool
+    store : bool, optional
         If True, then a result instance is returned additionally to
         the KPSS statistic (default is False).
     result_object : bool, optional
@@ -3084,8 +3083,8 @@ def kpss(
     -------
     KPSSResult
         If ``result_object=True``, a result object with fields ``statistic``,
-        ``pvalue``, ``lags``, ``crit``, and ``resstore`` (``resstore`` is
-        ``None`` when not computed). See
+        ``pvalue``, ``lags``, ``critical_values``, and ``resstore``
+        (``resstore`` is ``None`` when not computed). See
         :class:`~statsmodels.tsa.stattools.KPSSResult`.
 
     Otherwise (the deprecated default), a plain tuple made up of:
@@ -3363,7 +3362,7 @@ def range_unit_root_test(x, store=False, *, result_object: bool | None = None):
     ----------
     x : array_like, 1d
         The data series to test.
-    store : bool
+    store : bool, optional
         If True, then a result instance is returned additionally to
         the RUR statistic (default is False).
     result_object : bool, optional
@@ -3384,8 +3383,8 @@ def range_unit_root_test(x, store=False, *, result_object: bool | None = None):
     -------
     RURResult
         If ``result_object=True``, a result object with fields
-        ``statistic``, ``pvalue``, ``crit``, and ``resstore`` (``resstore``
-        is ``None`` when not computed). See
+        ``statistic``, ``pvalue``, ``critical_values``, and ``resstore``
+        (``resstore`` is ``None`` when not computed). See
         :class:`~statsmodels.tsa.stattools.RURResult`.
 
     Otherwise (the deprecated default), a plain tuple whose length depends
@@ -3705,7 +3704,7 @@ class ZivotAndrewsUnitRoot:
         ----------
         statistic : float
             The ZA test statistic
-        model : {"c","t","ct"}
+        model : {"c","t","ct"}, optional
             The model used when computing the ZA statistic. "c" is default.
 
         Returns
@@ -3853,19 +3852,19 @@ class ZivotAndrewsUnitRoot:
         ----------
         x : array_like
             The data series to test.
-        trim : float
+        trim : float, optional
             The percentage of series at begin/end to exclude from break-period
             calculation in range [0, 0.333] (default=0.15).
-        maxlag : int
+        maxlag : int, optional
             The maximum lag which is included in test, default is
             12*(nobs/100)^{1/4} (Schwert, 1989).
-        regression : {"c","t","ct"}
+        regression : {"c","t","ct"}, optional
             Constant and trend order to include in regression.
 
             * "c" : constant only (default).
             * "t" : trend only.
             * "ct" : constant and trend.
-        autolag : {"AIC", "BIC", "t-stat", None}
+        autolag : {"AIC", "BIC", "t-stat", None}, optional
             The method to select the lag length when using automatic selection.
 
             * if None, then maxlag lags are used,

--- a/statsmodels/tsa/stl/mstl.py
+++ b/statsmodels/tsa/stl/mstl.py
@@ -48,16 +48,16 @@ class MSTL:
     ----------
     endog : array_like
         Data to be decomposed. Must be squeezable to 1-d.
-    periods : {int, array_like, None}, optional
+    periods : int, sequence of int, or None, optional
         Periodicity of the seasonal components. If None and endog is a pandas
         Series or DataFrame, attempts to determine from endog. If endog is a
         ndarray, periods must be provided.
-    windows : {int, array_like, None}, optional
+    windows : int, sequence of int, or None, optional
         Length of the seasonal smoothers for each corresponding period.
         Must be an odd integer, and should normally be >= 7 (default). If None
         then default values determined using 7 + 4 * np.arange(1, n + 1, 1)
         where n is number of seasonal components.
-    lmbda : {float, str, None}, optional
+    lmbda : float, "auto", or None, optional
         The lambda parameter for the Box-Cox transform to be applied to `endog`
         prior to decomposition. If None, no transform is applied. If "auto", a
         value will be estimated that maximizes the log-likelihood function.

--- a/statsmodels/tsa/tsatools.py
+++ b/statsmodels/tsa/tsatools.py
@@ -47,7 +47,7 @@ def add_trend(x, trend="c", prepend=False, has_constant="skip"):
     ----------
     x : array_like
         Original array of data.
-    trend : str {'n', 'c', 't', 'ct', 'ctt'}
+    trend : {'n', 'c', 't', 'ct', 'ctt'}, optional
         The trend to add.
 
         * 'n' add no trend.
@@ -55,19 +55,20 @@ def add_trend(x, trend="c", prepend=False, has_constant="skip"):
         * 't' add trend only.
         * 'ct' add constant and linear trend.
         * 'ctt' add constant and linear and quadratic trend.
-    prepend : bool
+    prepend : bool, optional
         If True, prepends the new data to the columns of X.
-    has_constant : str {'raise', 'add', 'skip'}
+    has_constant : {'raise', 'add', 'skip'}, optional
         Controls what happens when trend is 'c' and a constant column already
         exists in x. 'raise' will raise an error. 'add' will add a column of
         1s. 'skip' will return the data without change. 'skip' is the default.
 
     Returns
     -------
-    array_like
+    ndarray, Series, or DataFrame
         The original data with the additional trend columns.  If x is a
         pandas Series or DataFrame, then the trend column names are 'const',
-        'trend' and 'trend_squared'.
+        'trend' and 'trend_squared'.  A Series is only returned when
+        ``trend='n'`` and x is a Series, since no columns are added.
 
     See Also
     --------
@@ -179,14 +180,14 @@ def add_lag(x, col=None, lags=1, drop=False, insert=True):
     x : array_like
         An array or NumPy ndarray subclass. Can be either a 1d or 2d array with
         observations in columns.
-    col : int or None
+    col : int, optional
         `col` can be an int of the zero-based column index. If it's a
         1d array `col` can be None.
-    lags : int
+    lags : int, optional
         The number of lags desired.
-    drop : bool
+    drop : bool, optional
         Whether to keep the contemporaneous variable for the data.
-    insert : bool or int
+    insert : bool or int, optional
         If True, inserts the lagged values after `col`. If False, appends
         the data. If int inserts the lags at int.
 
@@ -255,13 +256,13 @@ def detrend(x, order=1, axis=0):
 
     Parameters
     ----------
-    x : array_like, 1d or 2d
-        Data, if 2d, then each row or column is independently detrended with
-        the same trendorder, but independent trend estimates.
-    order : int
+    x : ndarray
+        Data, 1d or 2d. If 2d, then each row or column is independently
+        detrended with the same trendorder, but independent trend estimates.
+    order : int, optional
         The polynomial order of the trend, zero is constant, one is
         linear trend, two is quadratic trend.
-    axis : int
+    axis : int, optional
         Axis can be either 0, observations by rows, or 1, observations by
         columns.
 
@@ -302,7 +303,7 @@ class LagmatResult(NamedTuple):
     ----------
     lags : ndarray or DataFrame
         The array with lagged observations.
-    leads : ndarray or DataFrame
+    leads : ndarray, DataFrame, or None
         The original (unlagged) array, truncated to have the same number
         of rows as ``lags``.
     """
@@ -333,14 +334,14 @@ def lagmat(
         * int : All lags from zero to maxlag are included.
         * array_like : All lags associated to the values in the array.
             Must contain non-negative integers.
-    trim : {'forward', 'backward', 'both', 'none', None}
+    trim : {'forward', 'backward', 'both', 'none', None}, optional
         The trimming method to use.
 
         * 'forward' : trim invalid observations in front.
         * 'backward' : trim invalid initial observations.
         * 'both' : trim invalid observations on both sides.
         * 'none', None : no trimming of observations.
-    original : {'ex','sep','in'}
+    original : {'ex','sep','in'}, optional
         How the original is treated.
 
         * 'ex' : drops the original array returning only the lagged values.
@@ -349,7 +350,7 @@ def lagmat(
         * 'sep' : returns a tuple (original array, lagged values). The original
                   array is truncated to have the same number of rows as
                   the returned lagmat.
-    use_pandas : bool
+    use_pandas : bool, optional
         If true, returns a DataFrame when the input is a pandas
         Series or DataFrame.  If false, return numpy ndarrays.
     result_object : bool, optional
@@ -361,20 +362,21 @@ def lagmat(
 
     Returns
     -------
-    LagmatResult or ndarray
+    LagmatResult, ndarray, or DataFrame
         When ``original="sep"`` (or ``result_object=True``), a
         :class:`LagmatResult` with fields:
 
-        lags : ndarray
+        lags : ndarray or DataFrame
             The array with lagged observations.
-        leads : ndarray or None
+        leads : ndarray, DataFrame, or None
             The original (unlagged) array, truncated to have the same
             number of rows as ``lags``. ``None`` for other values of
             ``original``, where the original series was either excluded
             ("ex") or folded into ``lags`` ("in").
 
-        For other values of ``original`` a bare array of lagged
-        observations is returned instead.
+        For other values of ``original`` a bare array (or, when
+        ``use_pandas=True`` and `x` is a pandas object, a DataFrame) of
+        lagged observations is returned instead.
 
     Notes
     -----
@@ -521,31 +523,33 @@ def lagmat2ds(x, maxlag0, maxlagex=None, dropex=0, trim="forward", use_pandas=Fa
 
     Parameters
     ----------
-    x : array_like
-        Data, 2d. Observations in rows and variables in columns.
+    x : ndarray, Series, or DataFrame
+        Data, 1d or 2d. Observations in rows and variables in columns.
     maxlag0 : int
         The first variable all lags from zero to maxlag are included.
-    maxlagex : {None, int}
+    maxlagex : int, optional
         The max lag for all other variables all lags from zero to maxlag are
-        included.
-    dropex : int
+        included. If None, defaults to maxlag0.
+    dropex : int, optional
         Exclude first dropex lags from other variables. For all variables,
         except the first, lags from dropex to maxlagex are included.
-    trim : str
+    trim : {'forward', 'backward', 'both', 'none'}, optional
         The trimming method to use.
 
         * 'forward' : trim invalid observations in front.
         * 'backward' : trim invalid initial observations.
         * 'both' : trim invalid observations on both sides.
         * 'none' : no trimming of observations.
-    use_pandas : bool
+    use_pandas : bool, optional
         If true, returns a DataFrame when the input is a pandas
         Series or DataFrame.  If false, return numpy ndarrays.
 
     Returns
     -------
-    ndarray
-        The array with lagged observations, columns ordered by variable.
+    ndarray or DataFrame
+        The array with lagged observations, columns ordered by variable. A
+        DataFrame is returned if `x` is a pandas Series or DataFrame and
+        `use_pandas` is True.
 
     Notes
     -----
@@ -595,10 +599,52 @@ def lagmat2ds(x, maxlag0, maxlagex=None, dropex=0, trim="forward", use_pandas=Fa
 
 
 def vec(mat):
+    """
+    Vectorize a matrix by stacking its columns
+
+    Parameters
+    ----------
+    mat : ndarray
+        A 2d array.
+
+    Returns
+    -------
+    ndarray
+        A 1d array containing the columns of `mat` stacked on top of
+        one another (Fortran, i.e. column-major, order).
+
+    See Also
+    --------
+    unvec
+        Inverse operation.
+    vech
+        Half-vectorization operator for symmetric matrices.
+    """
     return mat.ravel("F")
 
 
 def vech(mat):
+    """
+    Half-vectorize a symmetric matrix by stacking its lower triangle
+
+    Parameters
+    ----------
+    mat : ndarray
+        A symmetric 2d array.
+
+    Returns
+    -------
+    ndarray
+        A 1d array containing the lower-triangular elements of `mat`,
+        stacked column by column (Fortran, i.e. column-major, order).
+
+    See Also
+    --------
+    unvech
+        Inverse operation.
+    vec
+        Full vectorization operator.
+    """
     # Gets Fortran-order
     return mat.T.take(_triu_indices(len(mat)))
 
@@ -622,12 +668,51 @@ def _diag_indices(n):
 
 
 def unvec(v):
+    """
+    Reconstruct a square matrix from its vectorized (stacked-column) form
+
+    Parameters
+    ----------
+    v : ndarray
+        A 1d array whose length is a perfect square.
+
+    Returns
+    -------
+    ndarray
+        The square matrix whose columns, stacked on top of one another,
+        equal `v`.
+
+    See Also
+    --------
+    vec
+        Inverse operation.
+    """
     k = int(np.sqrt(len(v)))
     assert k * k == len(v)
     return v.reshape((k, k), order="F")
 
 
 def unvech(v):
+    """
+    Reconstruct a symmetric matrix from its half-vectorized form
+
+    Parameters
+    ----------
+    v : ndarray
+        A 1d array containing the stacked lower-triangular elements of a
+        symmetric matrix, as produced by :func:`vech`.
+
+    Returns
+    -------
+    ndarray
+        The symmetric matrix whose lower-triangular elements, stacked
+        column by column, equal `v`.
+
+    See Also
+    --------
+    vech
+        Inverse operation.
+    """
     # quadratic formula, correct fp error
     rows = 0.5 * (-1 + np.sqrt(1 + 8 * len(v)))
     rows = int(np.round(rows))
@@ -695,7 +780,8 @@ def commutation_matrix(p, q):
 
     Returns
     -------
-    K : ndarray (pq x pq)
+    K : ndarray
+        The commutation matrix, of shape `(pq, pq)`.
     """
     p = int_like(p, "p")
     q = int_like(q, "q")
@@ -711,8 +797,13 @@ def _ar_transparams(params):
 
     Parameters
     ----------
-    params : array_like
+    params : ndarray
         The AR coefficients
+
+    Returns
+    -------
+    ndarray
+        The transformed AR coefficients.
 
     References
     ----------
@@ -734,8 +825,13 @@ def _ar_invtransparams(params):
 
     Parameters
     ----------
-    params : array_like
+    params : ndarray
         The transformed AR coefficients
+
+    Returns
+    -------
+    ndarray
+        The untransformed AR coefficients.
     """
     params = params.copy()
     tmp = params.copy()
@@ -756,6 +852,11 @@ def _ma_transparams(params):
     ----------
     params : ndarray
         The ma coefficients of an (AR)MA model.
+
+    Returns
+    -------
+    ndarray
+        The transformed MA coefficients.
 
     References
     ----------
@@ -781,6 +882,11 @@ def _ma_invtransparams(macoefs):
     ----------
     macoefs : ndarray
         The transformed MA coefficients
+
+    Returns
+    -------
+    ndarray
+        The untransformed MA coefficients.
     """
     tmp = macoefs.copy()
     for j in range(len(macoefs) - 1, 0, -1):
@@ -805,7 +911,7 @@ def unintegrate_levels(x, d):
 
     Returns
     -------
-    y : array_like
+    y : ndarray
         The increasing differences from 0 to d-1 of the first d elements
         of x.
 
@@ -826,13 +932,13 @@ def unintegrate(x, levels):
     ----------
     x : array_like
         The n-th differenced series
-    levels : list
-        A list of the first-value in each differenced series, for
+    levels : sequence of float
+        The first-value in each differenced series, for
         [first-difference, second-difference, ..., n-th difference]
 
     Returns
     -------
-    y : array_like
+    y : ndarray
         The original series de-differenced
 
     Examples

--- a/statsmodels/tsa/varma_process.py
+++ b/statsmodels/tsa/varma_process.py
@@ -39,11 +39,6 @@ def varfilter(x, a):
     """
     Apply an autoregressive filter to a series x
 
-    Warning: I just found out that convolve does not work as I
-       thought, this likely does not work correctly for
-       nvars>3
-
-
     x can be 2d, a can be 1d, 2d, or 3d
 
     Parameters
@@ -56,8 +51,13 @@ def varfilter(x, a):
 
     Returns
     -------
-    y : ndarray, 2d
-        filtered array, number of columns determined by x and a
+    y : ndarray
+        filtered array, 2d, number of columns determined by x and a
+
+    Warnings
+    --------
+    convolve does not work as expected; this likely does not work
+    correctly for nvars>3.
 
     Notes
     -----
@@ -159,8 +159,9 @@ def varinversefilter(ar, nobs, version=1):
 
     Returns
     -------
-    arinv : ndarray, (nobs,nvars,nvars)
-        The inverse (MA representation) lag polynomial array.
+    arinv : ndarray
+        The inverse (MA representation) lag polynomial array, of shape
+        (nobs + 1, nvars, nvars).
     """
     nlags, nvars, nvarsex = ar.shape
     if nvars != nvarsex:
@@ -194,19 +195,22 @@ def vargenerate(ar, u, initvalues=None):
 
     Parameters
     ----------
-    ar : array (nlags,nvars,nvars)
-        matrix lagpolynomial
-    u : array (nobs,nvars)
-        exogenous variable, error term for VAR
-    initvalues : array_like, optional
+    ar : ndarray
+        Matrix lagpolynomial, of shape (nlags, nvars, nvars).
+    u : ndarray
+        Error terms (innovations) for the VAR process, of shape
+        (nobs, nvars).
+    initvalues : ndarray, optional
         Initial (presample) values for the process. If None, the initial
         values are set to zero.
 
     Returns
     -------
-    sar : array (1+nobs,nvars)
-        sample of var process, inverse filtered u
-        does not trim initial condition y_0 = 0
+    sar : ndarray
+        Sample of the VAR process, the inverse filtered `u`. Has shape
+        (nobs + max(nlags - 1, len(initvalues)), nvars); the presample
+        values, including the initial condition y_0 = 0, are not
+        trimmed.
 
     Examples
     --------
@@ -258,7 +262,7 @@ def padone(x, front=0, back=0, axis=0, fillvalue=0):
 
     Parameters
     ----------
-    x : array_like
+    x : ndarray
         Array to pad.
     front : int, optional
         Number of `fillvalue` elements to add before the array along
@@ -311,7 +315,7 @@ def trimone(x, front=0, back=0, axis=0):
 
     Parameters
     ----------
-    x : array_like
+    x : ndarray
         Array to trim.
     front : int, optional
         Number of elements to remove from the front along `axis`.
@@ -349,7 +353,20 @@ def trimone(x, front=0, back=0, axis=0):
 
 
 def ar2full(ar):
-    """Make reduced lagpolynomial into a right side lagpoly array"""
+    """
+    Make reduced lagpolynomial into a right side lagpoly array
+
+    Parameters
+    ----------
+    ar : ndarray
+        Reduced-form lag polynomial array, of shape (nlags, nvar, nvarex).
+
+    Returns
+    -------
+    ndarray
+        Full (right-hand side) lag polynomial array, of shape
+        (nlags + 1, nvar, nvarex), with an identity matrix prepended.
+    """
     nlags, nvar, nvarex = ar.shape
     return np.r_[np.eye(nvar, nvarex)[None, :, :], -ar]
 
@@ -359,6 +376,16 @@ def ar2lhs(ar):
     Convert full (rhs) lagpolynomial into a reduced, left side lagpoly array
 
     This is mainly a reminder about the definition.
+
+    Parameters
+    ----------
+    ar : ndarray
+        Full (right-hand side) lag polynomial array.
+
+    Returns
+    -------
+    ndarray
+        Reduced, left-hand side lag polynomial array.
     """
     return -ar[1:]
 
@@ -397,21 +424,23 @@ class _Var:
         Returns
         -------
         None
-            Nothing is returned, but the following are attached to the
-            instance:
-
-            arhat : array (nlags, nvar, nvar)
-                full lag polynomial array
-            arlhs : array (nlags-1, nvar, nvar)
-                reduced lag polynomial for left hand side
-            other statistics as returned by linalg.lstsq : need to be completed
+            Nothing is returned; the estimation results are attached to
+            the instance, see Notes.
 
         Notes
         -----
         This currently assumes all parameters are estimated without restrictions.
         In this case SUR is identical to OLS.
 
-        Estimation results are attached to the class instance.
+        The following are attached to the instance:
+
+        arhat : ndarray of shape (nlags, nvar, nvar)
+            Full lag polynomial array.
+        arlhs : ndarray of shape (nlags - 1, nvar, nvar)
+            Reduced lag polynomial for the left-hand side.
+        estresults
+            The full result tuple as returned by ``linalg.lstsq``; other
+            statistics still need to be completed.
         """
         self.nlags = nlags  # without current period
         nvars = self.nvars
@@ -472,15 +501,17 @@ class _Var:
 
         Parameters
         ----------
-        horiz : int (optional, default=1)
-            forecast horizon
-        u : array (horiz, nvars)
-            error term for forecast periods. If None, then u is zero.
+        horiz : int, optional
+            Forecast horizon.
+        u : ndarray, optional
+            Error term for forecast periods, of shape (horiz, nvars). If
+            None, then u is zero.
 
         Returns
         -------
-        yforecast : array (nobs+horiz, nvars)
-            this includes the sample and the forecasts
+        yforecast : ndarray
+            Forecast array, of shape (nobs + horiz, nvars); this includes
+            the sample and the forecasts.
         """
         if u is None:
             u = np.zeros((horiz, self.nvars))
@@ -490,6 +521,16 @@ class _Var:
 class VarmaPoly:
     """
     Class to keep track of Varma polynomial format
+
+    Parameters
+    ----------
+    ar : ndarray
+        The autoregressive lag polynomial array, of shape
+        (nlags, nvarall, nvars).
+    ma : ndarray, optional
+        The moving-average lag polynomial array, of shape
+        (malags, nvars, nvars). If None, no moving-average terms are
+        used and an identity matrix is used in their place.
 
     Examples
     --------
@@ -529,7 +570,22 @@ class VarmaPoly:
 
     # @property
     def vstack(self, a=None, name="ar"):
-        """Stack lagpolynomial vertically in 2d array"""
+        """
+        Stack lagpolynomial vertically in 2d array
+
+        Parameters
+        ----------
+        a : ndarray, optional
+            Lag polynomial array to stack. If None, uses ``self.ar`` or
+            ``self.ma``, selected by `name`.
+        name : {"ar", "ma"}, optional
+            Which instance lag polynomial to use when `a` is None.
+
+        Returns
+        -------
+        ndarray
+            The lag polynomial stacked vertically into a 2d array.
+        """
         if a is not None:
             _a = a
         elif name == "ar":
@@ -542,7 +598,22 @@ class VarmaPoly:
 
     # @property
     def hstack(self, a=None, name="ar"):
-        """Stack lagpolynomial horizontally in 2d array"""
+        """
+        Stack lagpolynomial horizontally in 2d array
+
+        Parameters
+        ----------
+        a : ndarray, optional
+            Lag polynomial array to stack. If None, uses ``self.ar`` or
+            ``self.ma``, selected by `name`.
+        name : {"ar", "ma"}, optional
+            Which instance lag polynomial to use when `a` is None.
+
+        Returns
+        -------
+        ndarray
+            The lag polynomial stacked horizontally into a 2d array.
+        """
         if a is not None:
             _a = a
         elif name == "ar":
@@ -555,7 +626,25 @@ class VarmaPoly:
 
     # @property
     def stacksquare(self, a=None, name="ar", orientation="vertical"):
-        """Stack lagpolynomial vertically in 2d square array with eye"""
+        """
+        Stack lagpolynomial vertically in 2d square array with eye
+
+        Parameters
+        ----------
+        a : ndarray, optional
+            Lag polynomial array to stack. If None, uses ``self.ar`` or
+            ``self.ma``, selected by `name`.
+        name : {"ar", "ma"}, optional
+            Which instance lag polynomial to use when `a` is None.
+        orientation : str, optional
+            Currently not used.
+
+        Returns
+        -------
+        ndarray
+            The lag polynomial stacked vertically into a 2d square array,
+            with an identity block appended.
+        """
         if a is not None:
             _a = a
         elif name == "ar":
@@ -590,6 +679,12 @@ class VarmaPoly:
         """
         Check whether the auto-regressive lag-polynomial is stationary
 
+        Parameters
+        ----------
+        a : ndarray, optional
+            The lag polynomial array to check. If None, uses the reduced
+            form of ``self.ar``.
+
         Returns
         -------
         isstationary : bool
@@ -619,6 +714,12 @@ class VarmaPoly:
     def getisinvertible(self, a=None):
         """
         Check whether the moving-average lag-polynomial is invertible
+
+        Parameters
+        ----------
+        a : ndarray, optional
+            The lag polynomial array to check. If None, uses the reduced
+            form of ``self.ma``.
 
         Returns
         -------
@@ -652,7 +753,22 @@ class VarmaPoly:
         return (np.abs(ev) < 1).all()
 
     def reduceform(self, apoly):
-        """This assumes no exog, todo"""
+        """
+        Convert a structural lag polynomial to reduced form
+
+        This assumes no exog, todo
+
+        Parameters
+        ----------
+        apoly : ndarray
+            3d lag polynomial array, of shape (nlags, nvars, nvars).
+
+        Returns
+        -------
+        ndarray
+            The reduced-form lag polynomial array, with the same shape as
+            `apoly`.
+        """
         if apoly.ndim != 3:
             raise ValueError("apoly needs to be 3d")
         nlags, nvarsex, nvars = apoly.shape

--- a/statsmodels/tsa/x13.py
+++ b/statsmodels/tsa/x13.py
@@ -63,14 +63,14 @@ def _find_x12(x12path=None, prefer_x13=True):
     x12path : str, optional
         The path to the x12 or x13 binary, or to the directory containing
         it. If None, the X12PATH or X13PATH environmental variable is used.
-    prefer_x13 : bool
+    prefer_x13 : bool, optional
         If True, search for x13as (and the X13PATH environmental variable)
         first. If False, search for x12a (and the X12PATH environmental
         variable) first.
 
     Returns
     -------
-    str or bool
+    Path or bool
         The full path to the located binary, or False if none was found.
     """
     _binary_names = BINARY_NAMES
@@ -125,9 +125,9 @@ def _clean_order(order):
 
     Returns
     -------
-    order : tuple
+    order : tuple of int
         The regular ARMA order.
-    sorder : tuple
+    sorder : tuple of int
         The seasonal ARMA order. (0, 0, 0) if not given in `order`.
     """
     order = re.findall(r"\([0-9 ]*?\)", order)
@@ -287,41 +287,41 @@ class SeriesSpec(Spec):
     ----------
     data : array_like
         The data to use in the spec.
-    name : str
+    name : str, optional
         The name of the series.
-    appendbcst : bool
+    appendbcst : bool, optional
         Whether or not to append the backcasts to the series.
-    appendfcst : bool
+    appendfcst : bool, optional
         Whether or not to append the forecasts to the series.
-    comptype : str
+    comptype : str, optional
         The type of composite series.
-    compwt : int
+    compwt : int, optional
         The weight for the composite series.
-    decimals : int
+    decimals : int, optional
         The number of decimals to use in the output.
-    modelspan : tuple
+    modelspan : tuple, optional
         The span of the data to use for modeling.
-    period : int
+    period : int, optional
         The period of the series, 12 for monthly, 4 for quarterly.
-    precision : int
+    precision : int, optional
         The precision to use in the output.
-    to_print : tuple
+    to_print : tuple, optional
         Optional list of tables to print.
-    to_save : tuple
+    to_save : tuple, optional
         Optional list of tables to save.
-    span : tuple
+    span : tuple, optional
         The span of the data to use.
-    start : tuple
+    start : tuple, optional
         The start date, as a (year, period) tuple.
-    title : str
+    title : str, optional
         The title of the series.
-    series_type : str
+    series_type : str, optional
         The type of the series.
-    divpower : int
+    divpower : int, optional
         The power of 10 by which the data are divided.
-    missingcode : int
+    missingcode : int, optional
         The code that identifies a missing observation.
-    missingval : int
+    missingval : int, optional
         The value substituted for missing observations.
 
     Notes
@@ -442,51 +442,51 @@ def x13_arima_analysis(
 
     Parameters
     ----------
-    endog : array_like, pandas.Series
+    endog : array_like, Series, or DataFrame
         The series to model. It is best to use a pandas object with a
         DatetimeIndex or PeriodIndex. However, you can pass an array-like
         object. If your object does not have a dates index then ``start`` and
         ``freq`` are not optional.
-    maxorder : tuple
+    maxorder : tuple of int, optional
         The maximum order of the regular and seasonal ARMA polynomials to
         examine during the model identification. The order for the regular
         polynomial must be greater than zero and no larger than 4. The
         order for the seasonal polynomial may be 1 or 2.
-    maxdiff : tuple
+    maxdiff : tuple of int, optional
         The maximum orders for regular and seasonal differencing in the
         automatic differencing procedure. Acceptable inputs for regular
         differencing are 1 and 2. The maximum order for seasonal differencing
         is 1. If ``diff`` is specified then ``maxdiff`` should be None.
         Otherwise, ``diff`` will be ignored. See also ``diff``.
-    diff : tuple
+    diff : tuple of int, optional
         Fixes the orders of differencing for the regular and seasonal
         differencing. Regular differencing may be 0, 1, or 2. Seasonal
         differencing may be 0 or 1. ``maxdiff`` must be None, otherwise
         ``diff`` is ignored.
-    exog : array_like
+    exog : Series or DataFrame, optional
         Exogenous variables.
-    log : bool or None
+    log : bool or None, optional
         If None, it is automatically determined whether to log the series or
         not. If False, logs are not taken. If True, logs are taken.
-    outlier : bool
+    outlier : bool, optional
         Whether or not outliers are tested for and corrected, if detected.
-    trading : bool
+    trading : bool, optional
         Whether or not trading day effects are tested for.
-    forecast_periods : int
-        Number of forecasts produced. The default is None.
-    retspec : bool
+    forecast_periods : int, optional
+        Number of forecasts produced.
+    retspec : bool, optional
         Whether to return the created specification file. Can be useful for
         debugging.
-    speconly : bool
+    speconly : bool, optional
         Whether to create the specification file and then return it without
         performing the analysis. Can be useful for debugging.
-    start : str, datetime
+    start : str or datetime, optional
         Must be given if ``endog`` does not have date information in its index.
         Anything accepted by pandas.DatetimeIndex for the start value.
-    freq : str
+    freq : str, optional
         Must be given if ``endog`` does not have date information in its
         index. Anything accepted by pandas.DatetimeIndex for the freq value.
-    rawspec : str or Path
+    rawspec : str or Path, optional
         As this wrapper does not provide all the available parameter
         options, users can provide a full spec file instead.
         If valid Path, will read in contents of file, otherwise string will
@@ -496,29 +496,31 @@ def x13_arima_analysis(
         are spliced into spec file before it is passed to x12/x13. Spec
         file must not contain `series{data=()}` or `series{file="" format=""}`
         parameters. See tests/x13_test.py for example test files.
-    print_stdout : bool
+    print_stdout : bool, optional
         The stdout from X12/X13 is suppressed. To print it out, set this
-        to True. Default is False.
-    x12path : str or None
+        to True.
+    x12path : str, optional
         The path to x12 or x13 binary. If None, the program will attempt
         to find x13as or x12a on the PATH or by looking at X13PATH or
         X12PATH depending on the value of prefer_x13.
-    prefer_x13 : bool
+    prefer_x13 : bool, optional
         If True, will look for x13as first and will fallback to the X13PATH
         environmental variable. If False, will look for x12a first and will
         fallback to the X12PATH environmental variable. If x12path points
         to the path for the X12/X13 binary, it does nothing.
-    log_diagnostics : bool
+    log_diagnostics : bool, optional
         If True, returns D8 F-Test, M07, and Q diagnostics from the X13
-        savelog. Set to False by default.
-    tempdir : str
+        savelog.
+    tempdir : str, optional
         The path to where temporary files are created by the function.
         If None, files are created in the default temporary file location.
 
     Returns
     -------
-    X13ArimaAnalysisResult
-        An object containing the listed attributes.
+    X13ArimaAnalysisResult or str
+        If ``speconly`` is True, the created specification file is returned
+        as a string. Otherwise, an object containing the listed attributes
+        is returned.
 
         - observed : pandas.Series
           The original ``endog`` series.
@@ -533,11 +535,10 @@ def x13_arima_analysis(
         - stdout : str
           The captured stdout produced by x12/x13.
         - spec : str, optional
-          Returned if ``retspec`` is True. The only thing returned if
-          ``speconly`` is True.
+          Returned if ``retspec`` is True.
         - x13_diagnostic : dict
           Returns F-D8, M07, and Q metrics if True. Returns dict with no
-          metrics if False
+          metrics if False.
 
     Notes
     -----
@@ -734,57 +735,57 @@ def x13_arima_select_order(
 
     Parameters
     ----------
-    endog : array_like, pandas.Series
+    endog : array_like, Series, or DataFrame
         The series to model. It is best to use a pandas object with a
         DatetimeIndex or PeriodIndex. However, you can pass an array-like
         object. If your object does not have a dates index then ``start`` and
         ``freq`` are not optional.
-    maxorder : tuple
+    maxorder : tuple of int, optional
         The maximum order of the regular and seasonal ARMA polynomials to
         examine during the model identification. The order for the regular
         polynomial must be greater than zero and no larger than 4. The
         order for the seasonal polynomial may be 1 or 2.
-    maxdiff : tuple
+    maxdiff : tuple of int, optional
         The maximum orders for regular and seasonal differencing in the
         automatic differencing procedure. Acceptable inputs for regular
         differencing are 1 and 2. The maximum order for seasonal differencing
         is 1. If ``diff`` is specified then ``maxdiff`` should be None.
         Otherwise, ``diff`` will be ignored. See also ``diff``.
-    diff : tuple
+    diff : tuple of int, optional
         Fixes the orders of differencing for the regular and seasonal
         differencing. Regular differencing may be 0, 1, or 2. Seasonal
         differencing may be 0 or 1. ``maxdiff`` must be None, otherwise
         ``diff`` is ignored.
-    exog : array_like
+    exog : Series or DataFrame, optional
         Exogenous variables.
-    log : bool or None
+    log : bool or None, optional
         If None, it is automatically determined whether to log the series or
         not. If False, logs are not taken. If True, logs are taken.
-    outlier : bool
+    outlier : bool, optional
         Whether or not outliers are tested for and corrected, if detected.
-    trading : bool
+    trading : bool, optional
         Whether or not trading day effects are tested for.
-    forecast_periods : int
-        Number of forecasts produced. The default is None.
-    start : str, datetime
+    forecast_periods : int, optional
+        Number of forecasts produced.
+    start : str or datetime, optional
         Must be given if ``endog`` does not have date information in its index.
         Anything accepted by pandas.DatetimeIndex for the start value.
-    freq : str
+    freq : str, optional
         Must be given if ``endog`` does not have date information in its
         index. Anything accepted by pandas.DatetimeIndex for the freq value.
-    print_stdout : bool
+    print_stdout : bool, optional
         The stdout from X12/X13 is suppressed. To print it out, set this
-        to True. Default is False.
-    x12path : str or None
+        to True.
+    x12path : str, optional
         The path to x12 or x13 binary. If None, the program will attempt
         to find x13as or x12a on the PATH or by looking at X13PATH or X12PATH
         depending on the value of prefer_x13.
-    prefer_x13 : bool
+    prefer_x13 : bool, optional
         If True, will look for x13as first and will fallback to the X13PATH
         environmental variable. If False, will look for x12a first and will
         fallback to the X12PATH environmental variable. If x12path points
         to the path for the X12/X13 binary, it does nothing.
-    tempdir : str
+    tempdir : str, optional
         The path to where temporary files are created by the function.
         If None, files are created in the default temporary file location.
 
@@ -793,9 +794,9 @@ def x13_arima_select_order(
     Bunch
         A bunch object containing the listed attributes.
 
-        - order : tuple
+        - order : tuple of int
           The regular order.
-        - sorder : tuple
+        - sorder : tuple of int
           The seasonal order.
         - include_mean : bool
           Whether to include a mean or not.


### PR DESCRIPTION
- [X] code/documentation is well formatted.
- [X] properly formatted commit message. See
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message).

#### AI Disclosure

Contributions must comply with the statsmodels [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html).

If using AI tools, edit the second option to explain which tool was selected and
how the tool's output was used.

Please complete **one** of the following:

- [ ] No AI tools were used to develop this pull request.
- [X] AI tools were used.
      Tool(s): Claude
      Used for: Cleanign docstrings
      I have personally read, understood, and can explain every line of this diff, and
      have verified the statistical/numerical correctness of the change.

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows
  using the Windows System for Linux once `flake8` is installed in the
  local Linux environment. While passing this test is not required, it is good practice and it help
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.
* If AI tools were used to help write this PR, see the
  [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html) for what disclosure
  and review is expected of you before submitting.

</details>
