### PR TITLE
DOC: Clean docstrings in discrete, duration gam and genmod

### DIFF
--- a/statsmodels/discrete/_diagnostics_count.py
+++ b/statsmodels/discrete/_diagnostics_count.py
@@ -27,14 +27,14 @@ def _combine_bins(edge_index, x):
 
     Parameters
     ----------
-    edge_index : array_like
+    edge_index : sequence of int
          This defines the (zero-based) indices for the columns that are to be
          combined. Each index in `edge_index` except the last is the starting
          index for a bin. The largest index in a bin is the next
          ``edge_index - 1``.
-    x : 1d or 2d array
-        Array for which columns are combined. If x is 1-dimensional, then it
-        will be treated as a 2-d row vector.
+    x : array_like
+        1-d or 2-d array for which columns are combined. If x is
+        1-dimensional, then it will be treated as a 2-d row vector.
 
     Returns
     -------
@@ -85,19 +85,19 @@ def plot_probs(freq, probs_predicted, label="predicted", upp_xlim=None, fig=None
 
     Parameters
     ----------
-    freq, probs_predicted : ndarrays
+    freq, probs_predicted : array_like
         Two arrays of probabilities, this can be any probabilities for
         the same events, default is designed for comparing predicted
         and observed probabilities.
-    label : str or tuple
+    label : str or tuple, optional
         If string, then it will be used as the label for probs_predicted and
         "freq" is used for the other probabilities.
         If label is a tuple of strings, then its two elements are used as
         labels for both probabilities.
-    upp_xlim : None or int
+    upp_xlim : int, optional
         If it is not None, then the xlim of the first two plots are set to
         (0, upp_xlim), otherwise the matplotlib default is used.
-    fig : None or matplotlib figure instance
+    fig : matplotlib.figure.Figure, optional
         If fig is provided, then the axes will be added to it in a (3,1)
         subplot grid, otherwise a matplotlib figure instance is created.
 
@@ -190,7 +190,7 @@ def test_chisquare_prob(results, probs, bin_edges=None):
     probs : ndarray
         Array of predicted probabilities with observations
         in rows and event counts in columns
-    bin_edges : None or array
+    bin_edges : array_like, optional
         intervals to combine several counts into cells
         see _combine_bins
 
@@ -331,15 +331,15 @@ def test_poisson_dispersion(results, method="all"):
     results : Poisson results instance
         This can be a results instance for either a discrete Poisson or a GLM
         with family Poisson.
-    method : str
+    method : str, optional
         Not used yet. Currently results for all methods are returned.
 
     Returns
     -------
-    res : instance
-        The instance of DispersionResults has the hypothesis test results,
-        statistic, pvalue, method, alternative, as main attributes and a
-        summary_frame method that returns the results as pandas DataFrame.
+    DispersionResults
+        See :class:`DispersionResults` for a description of the attributes.
+        The instance also has a `summary_frame` method that returns the
+        results as a pandas DataFrame.
 
     """
 
@@ -444,20 +444,20 @@ def _test_poisson_dispersion_generic(
         Additional control variables that are added to the variance
         function together with `exog_new_test`, but whose coefficients
         are not tested.
-    include_score : bool
+    include_score : bool, optional
         If True, then the score of the mean model is added as an
         additional control variable.
-    use_endog : bool
+    use_endog : bool, optional
         If True, then the variance function is specified in terms of the
         squared residuals based on `endog`. If False, then it is based on
         the fitted mean instead of `endog`.
-    cov_type : str
+    cov_type : str, optional
         Covariance type for the auxiliary OLS regression used in the
         test. Default is "HC3".
     cov_kwds : dict, optional
         Keywords for the specified covariance type of the auxiliary OLS
         regression.
-    use_t : bool
+    use_t : bool, optional
         If True, then the t-distribution is used for the auxiliary OLS
         regression.
 
@@ -568,7 +568,7 @@ def test_poisson_zeroinflation_jh(results_poisson, exog_infl=None):
     results_poisson : results instance
         The test is only valid if the results instance is a Poisson
         model.
-    exog_infl : ndarray
+    exog_infl : ndarray, optional
         Explanatory variables for the zero-inflated or zero-modified
         alternative. If exog_infl is None, then the inflation
         probability is assumed to be constant.

--- a/statsmodels/discrete/conditional_models.py
+++ b/statsmodels/discrete/conditional_models.py
@@ -103,6 +103,20 @@ class _ConditionalModel(base.LikelihoodModel):
             self._n1.append(np.sum(self._endog_grp[g]))
 
     def hessian(self, params):
+        """
+        Returns numerical approximation to the Hessian.
+
+        Parameters
+        ----------
+        params : array_like
+            The model parameters.
+
+        Returns
+        -------
+        ndarray
+            The Hessian matrix, approximated numerically from the
+            score function.
+        """
 
         from statsmodels.tools.numdiff import approx_fprime
 
@@ -123,6 +137,44 @@ class _ConditionalModel(base.LikelihoodModel):
         skip_hessian=False,
         **kwargs,
     ):
+        """
+        Fit the conditional model.
+
+        Parameters
+        ----------
+        start_params : array_like, optional
+            Initial guess of the solution for the loglikelihood
+            maximization. The default is an array of zeros.
+        method : str, optional
+            The `method` determines which solver from `scipy.optimize`
+            is used, see `LikelihoodModel.fit` for more information.
+        maxiter : int, optional
+            The maximum number of iterations to perform.
+        full_output : bool, optional
+            Set to True to have all available output in the Results
+            object's mle_retvals attribute.
+        disp : bool, optional
+            Set to True to print convergence messages.
+        fargs : tuple, optional
+            Extra arguments passed to the likelihood function.
+        callback : callable, optional
+            Called after each iteration, as callback(xk), where xk is
+            the current parameter vector.
+        retall : bool, optional
+            Set to True to return list of solutions at each iteration.
+        skip_hessian : bool, optional
+            If False, the covariance matrix is calculated using the
+            numerical Hessian after the optimization.  If True, the
+            Hessian is not calculated and the returned results have
+            no covariance matrix.
+        **kwargs
+            Additional keyword arguments used by the solver.
+
+        Returns
+        -------
+        ConditionalResultsWrapper
+            The fitted model results.
+        """
 
         rslt = super().fit(
             start_params=start_params,
@@ -158,16 +210,16 @@ class _ConditionalModel(base.LikelihoodModel):
 
         Parameters
         ----------
-        method : {'elastic_net'}
+        method : {'elastic_net'}, optional
             Only the `elastic_net` approach is currently implemented.
-        alpha : scalar or array_like
+        alpha : scalar or array_like, optional
             The penalty weight.  If a scalar, the same penalty weight
             applies to all variables in the model.  If a vector, it
             must have the same length as `params`, and contains a
             penalty weight for each coefficient.
-        start_params : array_like
+        start_params : array_like, optional
             Starting values for `params`.
-        refit : bool
+        refit : bool, optional
             If True, the model is refit using only the variables that
             have non-zero coefficients in the regularized fit.  The
             refitted model is not regularized.
@@ -240,10 +292,9 @@ class ConditionalLogit(_ConditionalModel):
         in this array.
     groups : array_like
         Codes defining the groups. This is a required keyword parameter.
-    missing : str
-        Available options are 'none', 'drop', and 'raise'. If 'none', no nan
-        checking is done. If 'drop', any observations with nans are dropped.
-        If 'raise', an error is raised.
+    missing : {'none', 'drop', 'raise'}, optional
+        If 'none', no nan checking is done. If 'drop', any observations
+        with nans are dropped. If 'raise', an error is raised.
     """
 
     def __init__(self, endog, exog, missing="none", **kwargs):
@@ -258,6 +309,20 @@ class ConditionalLogit(_ConditionalModel):
         # i.e., self.k_params, for compatibility with MNLogit
 
     def loglike(self, params):
+        """
+        Log-likelihood of the conditional logistic model.
+
+        Parameters
+        ----------
+        params : array_like
+            The parameters of the model.
+
+        Returns
+        -------
+        float
+            The log-likelihood value at `params`, summed over all
+            groups.
+        """
 
         ll = 0
         for g in range(len(self._endog_grp)):
@@ -266,6 +331,19 @@ class ConditionalLogit(_ConditionalModel):
         return ll
 
     def score(self, params):
+        """
+        Score vector of the conditional logistic model.
+
+        Parameters
+        ----------
+        params : array_like
+            The parameters of the model.
+
+        Returns
+        -------
+        ndarray
+            The score vector at `params`, summed over all groups.
+        """
 
         score = 0
         for g in range(self._n_groups):
@@ -380,13 +458,26 @@ class ConditionalPoisson(_ConditionalModel):
         The covariates
     groups : array_like
         Codes defining the groups. This is a required keyword parameter.
-    missing : str
-        Available options are 'none', 'drop', and 'raise'. If 'none', no nan
-        checking is done. If 'drop', any observations with nans are dropped.
-        If 'raise', an error is raised.
+    missing : {'none', 'drop', 'raise'}, optional
+        If 'none', no nan checking is done. If 'drop', any observations
+        with nans are dropped. If 'raise', an error is raised.
     """
 
     def loglike(self, params):
+        """
+        Log-likelihood of the conditional Poisson model.
+
+        Parameters
+        ----------
+        params : array_like
+            The parameters of the model.
+
+        Returns
+        -------
+        float
+            The log-likelihood value at `params`, summed over all
+            groups.
+        """
 
         ofs = None
         if hasattr(self, "offset"):
@@ -408,6 +499,19 @@ class ConditionalPoisson(_ConditionalModel):
         return ll
 
     def score(self, params):
+        """
+        Score vector of the conditional Poisson model.
+
+        Parameters
+        ----------
+        params : array_like
+            The parameters of the model.
+
+        Returns
+        -------
+        ndarray
+            The score vector at `params`, summed over all groups.
+        """
 
         ofs = None
         if hasattr(self, "offset"):
@@ -445,13 +549,13 @@ class ConditionalResults(base.LikelihoodModelResults):
         ----------
         yname : str, optional
             Default is `y`
-        xname : list[str], optional
+        xname : list of str, optional
             Names for the exogenous variables, default is "var_xx".
             Must match the number of parameters in the model
         title : str, optional
             Title for the top table. If not None, then this replaces the
             default title
-        alpha : float
+        alpha : float, optional
             Significance level for the confidence intervals
 
         Returns
@@ -519,10 +623,9 @@ class ConditionalMNLogit(_ConditionalModel):
         The independent variables.
     groups : array_like
         Codes defining the groups. This is a required keyword parameter.
-    missing : str
-        Available options are 'none', 'drop', and 'raise'. If 'none', no nan
-        checking is done. If 'drop', any observations with nans are dropped.
-        If 'raise', an error is raised.
+    missing : {'none', 'drop', 'raise'}, optional
+        If 'none', no nan checking is done. If 'drop', any observations
+        with nans are dropped. If 'raise', an error is raised.
 
     Notes
     -----
@@ -573,6 +676,49 @@ class ConditionalMNLogit(_ConditionalModel):
         generator=None,
         **kwargs,
     ):
+        """
+        Fit the conditional multinomial logit model.
+
+        Parameters
+        ----------
+        start_params : array_like, optional
+            Initial guess of the solution for the loglikelihood
+            maximization.  If None, random values are drawn using
+            `generator`.
+        method : str, optional
+            The `method` determines which solver from `scipy.optimize`
+            is used, see `LikelihoodModel.fit` for more information.
+        maxiter : int, optional
+            The maximum number of iterations to perform.
+        full_output : bool, optional
+            Set to True to have all available output in the Results
+            object's mle_retvals attribute.
+        disp : bool, optional
+            Set to True to print convergence messages.
+        fargs : tuple, optional
+            Extra arguments passed to the likelihood function.
+        callback : callable, optional
+            Called after each iteration, as callback(xk), where xk is
+            the current parameter vector.
+        retall : bool, optional
+            Set to True to return list of solutions at each iteration.
+        skip_hessian : bool, optional
+            If False, the covariance matrix is calculated using the
+            numerical Hessian after the optimization.  If True, the
+            Hessian is not calculated and the returned results have
+            no covariance matrix.
+        generator : numpy.random.Generator or numpy.random.RandomState, optional
+            Used to draw random starting values for `start_params` when
+            `start_params` is None.  If not provided, the global
+            ``numpy.random`` state is used.
+        **kwargs
+            Additional keyword arguments used by the solver.
+
+        Returns
+        -------
+        MultinomialResultsWrapper
+            The fitted model results.
+        """
 
         if start_params is None:
             q = self.exog.shape[1]
@@ -604,6 +750,21 @@ class ConditionalMNLogit(_ConditionalModel):
         return MultinomialResultsWrapper(rslt)
 
     def loglike(self, params):
+        """
+        Log-likelihood of the conditional multinomial logit model.
+
+        Parameters
+        ----------
+        params : ndarray
+            The flattened parameter array, of length
+            ``exog.shape[1] * (k_cat - 1)``.
+
+        Returns
+        -------
+        float
+            The log-likelihood value at `params`, summed over all
+            groups.
+        """
 
         q = self.exog.shape[1]
         c = self.k_cat - 1
@@ -626,6 +787,21 @@ class ConditionalMNLogit(_ConditionalModel):
         return ll
 
     def score(self, params):
+        """
+        Score vector of the conditional multinomial logit model.
+
+        Parameters
+        ----------
+        params : ndarray
+            The flattened parameter array, of length
+            ``exog.shape[1] * (k_cat - 1)``.
+
+        Returns
+        -------
+        ndarray
+            The flattened score vector at `params`, summed over all
+            groups.
+        """
 
         q = self.exog.shape[1]
         c = self.k_cat - 1

--- a/statsmodels/discrete/count_model.py
+++ b/statsmodels/discrete/count_model.py
@@ -32,15 +32,15 @@ from statsmodels.tools.numdiff import approx_fprime, approx_hess
 from statsmodels.tools.sm_exceptions import ConvergenceWarning
 
 _doc_zi_params = """
-    exog_infl : array_like or None
+    exog_infl : array_like or None, optional
         Explanatory variables for the binary inflation model, i.e., for
         mixing probability model. If None, then a constant is used.
-    offset : array_like
+    offset : array_like, optional
         Offset is added to the linear prediction with coefficient equal to 1.
-    exposure : array_like
+    exposure : array_like, optional
         Log(exposure) is added to the linear prediction with coefficient
         equal to 1.
-    inflation : {'logit', 'probit'}
+    inflation : {'logit', 'probit'}, optional
         The model for zero inflation, either Logit (default) or Probit.
     """
 
@@ -346,6 +346,20 @@ class GenericZeroInflated(CountModel):
         return np.hstack((dldw, dldp))
 
     def score(self, params):
+        """
+        Generic Zero-Inflated model score (gradient) vector of the log-likelihood.
+
+        Parameters
+        ----------
+        params : array_like
+            The parameters of the model
+
+        Returns
+        -------
+        score : ndarray, 1-D
+            The score vector of the model, i.e., the first derivative of the
+            log-likelihood function, evaluated at `params`
+        """
         return self.score_obs(params).sum(0)
 
     def _hessian_main(self, params):
@@ -425,9 +439,6 @@ class GenericZeroInflated(CountModel):
         hess : ndarray, (k_vars, k_vars)
             The Hessian, second derivative of the log-likelihood function,
             evaluated at `params`
-
-        Notes
-        -----
         """
         hess_arr_main = self._hessian_main(params)
         hess_arr_infl = self._hessian_inflate(params)
@@ -456,19 +467,19 @@ class GenericZeroInflated(CountModel):
         ----------
         params : array_like
             The parameters of the model.
-        exog : ndarray, optional
+        exog : array_like, optional
             Explanatory variables for the main count model.
             If ``exog`` is None, then the data from the model will be used.
-        exog_infl : ndarray, optional
+        exog_infl : array_like, optional
             Explanatory variables for the zero-inflation model.
             ``exog_infl`` has to be provided if ``exog`` was provided unless
             ``exog_infl`` in the model is only a constant.
-        offset : ndarray, optional
+        offset : array_like, optional
             Offset is added to the linear predictor of the mean function with
             coefficient equal to 1.
             Default is zero if exog is not None, and the model offset if exog
             is None.
-        exposure : ndarray, optional
+        exposure : array_like, optional
             Log(exposure) is added to the linear predictor with coefficient
             equal to 1. If exposure is specified, then it will be logged by
             the method. The user does not need to log it first.
@@ -492,9 +503,14 @@ class GenericZeroInflated(CountModel):
               for y_values if those are provided. This is a multivariate
               return (2-dim when predicting for several observations).
 
-        y_values : array_like
+        y_values : array_like, optional
             Values of the random variable endog at which pmf is evaluated.
             Only used if ``which="prob"``
+
+        Returns
+        -------
+        ndarray
+            The predicted values, whose interpretation depends on `which`.
         """
         no_exog = False
         if exog is None:
@@ -597,13 +613,14 @@ class GenericZeroInflated(CountModel):
 
         Parameters
         ----------
-        params : ndarray
+        params : array_like
             parameter at which score is evaluated
 
         Returns
         -------
-        The value of the derivative of the expected endog with respect
-        to the parameter vector.
+        ndarray
+            The value of the derivative of the expected endog with respect
+            to the parameter vector.
         """
         params_infl = params[:self.k_inflate]
         params_main = params[self.k_inflate:]
@@ -627,12 +644,12 @@ class GenericZeroInflated(CountModel):
 
         Parameters
         ----------
-        params : ndarray
+        params : array_like
             parameter at which score is evaluated
 
         Returns
         -------
-        derivative : ndarray_2d
+        derivative : ndarray, 2-D
             The derivative of the score_obs with respect to endog.
         """
         raise NotImplementedError
@@ -780,7 +797,8 @@ class ZeroInflatedPoisson(GenericZeroInflated):
 
         Returns
         -------
-        Predicted conditional variance.
+        ndarray
+            Predicted conditional variance.
         """
         w = prob_infl
         var_ = (1 - w) * mu * (1 + w * mu)
@@ -803,19 +821,19 @@ class ZeroInflatedPoisson(GenericZeroInflated):
         ----------
         params : array_like
             The parameters of the model.
-        exog : ndarray, optional
+        exog : array_like, optional
             Explanatory variables for the main count model.
             If ``exog`` is None, then the data from the model will be used.
-        exog_infl : ndarray, optional
+        exog_infl : array_like, optional
             Explanatory variables for the zero-inflation model.
             ``exog_infl`` has to be provided if ``exog`` was provided unless
             ``exog_infl`` in the model is only a constant.
-        offset : ndarray, optional
+        offset : array_like, optional
             Offset is added to the linear predictor of the mean function with
             coefficient equal to 1.
             Default is zero if exog is not None, and the model offset if exog
             is None.
-        exposure : ndarray, optional
+        exposure : array_like, optional
             Log(exposure) is added to the linear predictor of the mean
             function with coefficient equal to 1. If exposure is specified,
             then it will be logged by the method. The user does not need to
@@ -825,7 +843,9 @@ class ZeroInflatedPoisson(GenericZeroInflated):
 
         Returns
         -------
-        Instance of frozen scipy distribution subclass.
+        scipy.stats.distributions.rv_frozen
+            Frozen random variable instance representing the distribution
+            implied by the model and the given parameters.
         """
         mu = self.predict(
             params,
@@ -864,14 +884,12 @@ class ZeroInflatedGeneralizedPoisson(GenericZeroInflated):
         A reference to the exogenous design.
     exog_infl : ndarray
         A reference to the zero-inflated exogenous design.
-    p : scalar
-        P denotes parameterizations for ZIGP regression.
     """.format(
         params=base._model_params_doc,
         extra_params=_doc_zi_params
-        + """p : float
-        dispersion power parameter for the GeneralizedPoisson model.  p=1 for
-        ZIGP-1 and p=2 for ZIGP-2. Default is p=2
+        + """p : int, optional
+        Dispersion power parameter for the GeneralizedPoisson model. p=1
+        for ZIGP-1 and p=2 for ZIGP-2. Default is p=2.
     """
         + base._missing_param_doc,
     )
@@ -956,7 +974,8 @@ class ZeroInflatedGeneralizedPoisson(GenericZeroInflated):
 
         Returns
         -------
-        Predicted conditional variance.
+        ndarray
+            Predicted conditional variance.
         """
         alpha = params[-1]
         w = prob_infl
@@ -1004,15 +1023,12 @@ class ZeroInflatedNegativeBinomialP(GenericZeroInflated):
         A reference to the exogenous design.
     exog_infl : ndarray
         A reference to the zero-inflated exogenous design.
-    p : scalar
-        P denotes parameterizations for ZINB regression. p=1 for ZINB-1 and
-        p=2 for ZINB-2. Default is p=2
     """.format(
         params=base._model_params_doc,
         extra_params=_doc_zi_params
-        + """p : float
-        dispersion power parameter for the NegativeBinomialP model.  p=1 for
-        ZINB-1 and p=2 for ZINB-2. Default is p=2
+        + """p : int, optional
+        Dispersion power parameter for the NegativeBinomialP model. p=1
+        for ZINB-1 and p=2 for ZINB-2. Default is p=2.
     """
         + base._missing_param_doc,
     )
@@ -1094,7 +1110,8 @@ class ZeroInflatedNegativeBinomialP(GenericZeroInflated):
 
         Returns
         -------
-        Predicted conditional variance.
+        ndarray
+            Predicted conditional variance.
         """
         alpha = params[-1]
         w = prob_infl
@@ -1130,7 +1147,56 @@ class ZeroInflatedResults(CountResults):
                        offset=None, which="mean", average=False,
                        agg_weights=None, y_values=None,
                        transform=True, row_labels=None):
+        """
+        Compute prediction results for zero-inflated model.
 
+        Parameters
+        ----------
+        exog : array_like, optional
+            The values for which you want to predict.
+        exog_infl : array_like, optional
+            Explanatory variables for the zero-inflation model.
+        exposure : array_like, optional
+            Log(exposure) is added to the linear predictor of the mean
+            function with coefficient equal to 1.
+        offset : array_like, optional
+            Offset is added to the linear predictor of the mean function
+            with coefficient equal to 1.
+        which : str, optional
+            Which statistic is to be predicted. Default is "mean".
+            The available statistics and options depend on the model.
+            See the model.predict docstring.
+        average : bool, optional
+            If average is True, then the mean prediction is computed, that
+            is, predictions are computed for individual exog and then the
+            average over observation is used.
+            If average is False, then the results are the predictions for
+            all observations, i.e., same length as ``exog``.
+        agg_weights : ndarray, optional
+            Aggregation weights, only used if average is True.
+            The weights are not normalized.
+        y_values : array_like, optional
+            Values of the random variable endog at which pmf is evaluated.
+            Only used if ``which="prob"``.
+        transform : bool, optional
+            If the model was fit via a formula, do you want to pass
+            exog through the formula. Default is True. E.g., if you fit
+            a model y ~ log(x1) + log(x2), and transform is True, then
+            you can pass a data structure that contains x1 and x2 in
+            their original form. Otherwise, you'd need to log the data
+            first.
+        row_labels : list of str, optional
+            If row_labels are provided, then they will replace the
+            generated labels.
+
+        Returns
+        -------
+        PredictionResultsDelta
+            The prediction results instance contains prediction and
+            prediction variance and can on demand calculate confidence
+            intervals and summary tables for the prediction of the mean
+            and of new observations.
+        """
         import statsmodels.base._prediction_inference as pred
 
         pred_kwds = {

--- a/statsmodels/discrete/diagnostic.py
+++ b/statsmodels/discrete/diagnostic.py
@@ -31,8 +31,9 @@ class CountDiagnostic:
 
     Parameters
     ----------
-    results : Results instance of a count model.
-    y_max : int
+    results : Results instance
+        Results instance of a fitted count model.
+    y_max : int, optional
         Largest count to include when computing predicted probabilities for
         counts. Default is the largest observed count.
 
@@ -56,12 +57,12 @@ class CountDiagnostic:
 
         Parameters
         ----------
-        bin_edges : array_like or None
+        bin_edges : array_like, optional
             This defines which counts are included in the test on frequencies
             and how counts are combined in bins.
             The default if bin_edges is None will change in future.
             See Notes and Example sections below.
-        method : str
+        method : str, optional
             Currently only `method = "opg"` is available.
             If method is None, the OPG will be used, but the default might
             change in future versions.
@@ -69,7 +70,9 @@ class CountDiagnostic:
 
         Returns
         -------
-        test result
+        ChisquareProbResult
+            See :class:`~statsmodels.discrete._diagnostics_count.ChisquareProbResult`
+            for a description of the attributes.
 
         Notes
         -----
@@ -112,7 +115,26 @@ class CountDiagnostic:
         return res
 
     def plot_probs(self, label="predicted", upp_xlim=None, fig=None):
-        """Plot observed versus predicted frequencies for entire sample"""
+        """
+        Plot observed versus predicted frequencies for entire sample
+
+        Parameters
+        ----------
+        label : str, optional
+            Label used for the predicted frequencies in the plot legend.
+        upp_xlim : int, optional
+            If provided, the xlim of the first two subplots is set to
+            (0, upp_xlim), otherwise the matplotlib default is used.
+        fig : matplotlib.figure.Figure, optional
+            If provided, then the axes will be added to it in a (3, 1)
+            subplot grid, otherwise a matplotlib figure instance is created.
+
+        Returns
+        -------
+        Figure
+            The figure contains 3 subplots with probabilities, cumulative
+            probabilities and a PP-plot.
+        """
         probs_predicted = self.probs_predicted.sum(0)
         k_probs = len(probs_predicted)
         freq = np.bincount(self.results.model.endog.astype(int), minlength=k_probs)[
@@ -143,7 +165,9 @@ class PoissonDiagnostic(CountDiagnostic):
 
         Returns
         -------
-        dispersion results
+        DispersionResults
+            See :class:`~statsmodels.discrete._diagnostics_count.DispersionResults`
+            for a description of the attributes.
         """
         res = test_poisson_dispersion(self.results)
         return res
@@ -154,20 +178,26 @@ class PoissonDiagnostic(CountDiagnostic):
 
         Parameters
         ----------
-        method : str
+        method : str, optional
             Three methods are available for the test:
 
              - "prob" : moment test for the probability of zeros
              - "broek" : score test against zero inflation with or without
                 explanatory variables for inflation
 
-        exog_infl : array_like or None
+        exog_infl : array_like, optional
             Optional explanatory variables under the alternative of zero
             inflation, or deflation. Only used if method is "broek".
 
         Returns
         -------
-        results
+        ZeroModificationTestResult or ZeroinflationJHResult
+            The test result. A
+            :class:`~statsmodels.discrete._diagnostics_count.ZeroModificationTestResult`
+            is returned if `method` is "prob", or if `method` is "broek" and
+            `exog_infl` is not provided. Otherwise, a
+            :class:`~statsmodels.discrete._diagnostics_count.ZeroinflationJHResult`
+            is returned.
 
         Notes
         -----
@@ -228,6 +258,38 @@ class PoissonDiagnostic(CountDiagnostic):
         The observations are split into approximately equal sized groups
         of observations sorted according to ``sort_var``.
 
+        Parameters
+        ----------
+        sort_var : array_like, optional
+            1-dimensional array used for sorting observations into bins.
+            If None, the linear predictor, ``results.predict(which="lin")``,
+            is used.
+        bins : int, optional
+            Number of bins used for the Hosmer-Lemeshow type grouping.
+        k_max : int, optional
+            Largest count included before the upper tail is truncated into
+            a single bin. If None, it is chosen so that approximately
+            `frac_upp` of the observations fall in the truncated upper bin.
+        df : int, optional
+            Degrees of freedom of the chi-square distribution used for the
+            test. If None, it is computed from the number of bins and
+            counts.
+        sort_method : str, optional
+            Sorting method used by :func:`numpy.argsort` when binning by
+            `sort_var`.
+        frac_upp : float, optional
+            Fraction of observations used to determine the truncation point
+            of the upper tail when `k_max` is None.
+        alpha_nc : float, optional
+            Significance level used in the computation of the noncentrality
+            parameter confidence interval.
+
+        Returns
+        -------
+        ChisquareBinningResult
+            See
+            :class:`~statsmodels.stats.diagnostic_gen.ChisquareBinningResult`
+            for a description of the attributes.
         """
 
         if sort_var is None:

--- a/statsmodels/discrete/discrete_margins.py
+++ b/statsmodels/discrete/discrete_margins.py
@@ -15,6 +15,20 @@ from statsmodels.tools._decorators import cache_readonly
 def _check_margeff_args(at, method):
     """
     Checks valid options for margeff
+
+    Parameters
+    ----------
+    at : str
+        Value of the `at` option for marginal effects. See `get_margeff`
+        for the allowed values.
+    method : str
+        Value of the `method` option for marginal effects. See
+        `get_margeff` for the allowed values.
+
+    Raises
+    ------
+    ValueError
+        If `at` or `method` is not one of the allowed values.
     """
     if at not in ["overall", "mean", "median", "zero", "all"]:
         raise ValueError(f"{at} not a valid option for `at`.")
@@ -25,6 +39,21 @@ def _check_margeff_args(at, method):
 def _check_discrete_args(at, method):
     """
     Checks the arguments for margeff if the exogenous variables are discrete.
+
+    Parameters
+    ----------
+    at : str
+        Value of the `at` option for marginal effects. See `get_margeff`
+        for the allowed values.
+    method : str
+        Value of the `method` option for marginal effects. See
+        `get_margeff` for the allowed values.
+
+    Raises
+    ------
+    ValueError
+        If `method` is "dyex" or "eyex", or if `at` is "median" or "zero",
+        none of which are valid for discrete variables.
     """
     if method in ["dyex", "eyex"]:
         raise ValueError(f"{method} not allowed for discrete variables")
@@ -35,7 +64,21 @@ def _check_discrete_args(at, method):
 def _get_const_index(exog):
     """
     Returns a boolean array of non-constant column indices in exog and
-    an scalar array of where the constant is or None
+    a scalar array of where the constant is or None
+
+    Parameters
+    ----------
+    exog : ndarray
+        Two-dimensional array of exogenous regressors.
+
+    Returns
+    -------
+    effects_idx : ndarray
+        Boolean array that is True for columns of `exog` that are not
+        constant.
+    const_idx : ndarray or None
+        Array containing the column index of the constant column, or None
+        if `exog` does not contain a constant column.
     """
     effects_idx = exog.var(0) != 0
     if np.any(~effects_idx):
@@ -75,6 +118,25 @@ def _isdummy(X):
 
 
 def _get_dummy_index(X, const_idx):
+    """
+    Returns the column indices of dummy variables in `X`.
+
+    Parameters
+    ----------
+    X : array_like
+        A 1d or 2d array of numbers.
+    const_idx : ndarray or None
+        Unused. Present for a consistent signature with
+        `_get_count_index`.
+
+    Returns
+    -------
+    dummy_ind : ndarray or None
+        Column indices of the dummy variables in `X`, or None if `X`
+        contains no dummy variables.
+    dummy : bool
+        True if `X` contains at least one dummy variable.
+    """
     dummy_ind = _isdummy(X)
     dummy = True
 
@@ -114,6 +176,25 @@ def _iscount(X):
 
 
 def _get_count_index(X, const_idx):
+    """
+    Returns the column indices of count variables in `X`.
+
+    Parameters
+    ----------
+    X : array_like
+        A 1d or 2d array of numbers.
+    const_idx : ndarray or None
+        Unused. Present for a consistent signature with
+        `_get_dummy_index`.
+
+    Returns
+    -------
+    count_ind : ndarray or None
+        Column indices of the count variables in `X`, or None if `X`
+        contains no count variables.
+    count : bool
+        True if `X` contains at least one count variable.
+    """
     count_ind = _iscount(X)
     count = True
 
@@ -124,6 +205,32 @@ def _get_count_index(X, const_idx):
 
 
 def _get_margeff_exog(exog, at, atexog, ind):
+    """
+    Builds the exog array at which marginal effects are evaluated.
+
+    Parameters
+    ----------
+    exog : ndarray
+        Exogenous regressors as a 2-dimensional array.
+    at : str
+        One of "overall", "mean", "median", "zero", or "all". See
+        `get_margeff` for details. Only "mean", "median", and "zero" have
+        an effect here.
+    atexog : dict or ndarray, optional
+        User-supplied values to substitute into `exog` before applying
+        `at`. If a dict, keys are the zero-indexed columns of `exog` and
+        values are the replacement values. If an ndarray, it replaces
+        `exog` outright.
+    ind : ndarray
+        Boolean array that is True for the non-constant columns of
+        `exog`. Used when `at` is "zero" to leave the constant column
+        equal to one.
+
+    Returns
+    -------
+    exog : ndarray
+        The exogenous regressors evaluated at the requested `at` option.
+    """
     if atexog is not None:  # user supplied
         if isinstance(atexog, dict):
             # assumes values are singular or of len(exog)
@@ -157,6 +264,29 @@ def _get_count_effects(effects, exog, count_ind, method, model, params):
     """
     If there's a count variable, the predicted difference is taken by
     subtracting one and adding one to exog then averaging the difference
+
+    Parameters
+    ----------
+    effects : ndarray
+        Marginal effects to be updated in place for the count columns.
+    exog : ndarray
+        Exogenous regressors at which the effects are evaluated.
+    count_ind : array_like of int
+        Column indices of `exog` that are count variables.
+    method : str
+        One of "dydx", "eyex", "dyex", or "eydx". See `get_margeff` for
+        details.
+    model : model instance
+        The fitted model whose `predict` method is used to compute the
+        effect.
+    params : ndarray
+        Estimated model parameters.
+
+    Returns
+    -------
+    effects : ndarray
+        The `effects` array with the columns in `count_ind` replaced by
+        the count marginal effects.
     """
     # this is the index for the effect and the index for count col in exog
     for i in count_ind:
@@ -178,6 +308,29 @@ def _get_dummy_effects(effects, exog, dummy_ind, method, model, params):
     """
     If there's a dummy variable, the predicted difference is taken at
     0 and 1
+
+    Parameters
+    ----------
+    effects : ndarray
+        Marginal effects to be updated in place for the dummy columns.
+    exog : ndarray
+        Exogenous regressors at which the effects are evaluated.
+    dummy_ind : array_like of int
+        Column indices of `exog` that are dummy variables.
+    method : str
+        One of "dydx", "eyex", "dyex", or "eydx". See `get_margeff` for
+        details.
+    model : model instance
+        The fitted model whose `predict` method is used to compute the
+        effect.
+    params : ndarray
+        Estimated model parameters.
+
+    Returns
+    -------
+    effects : ndarray
+        The `effects` array with the columns in `dummy_ind` replaced by
+        the dummy marginal effects.
     """
     # this is the index for the effect and the index for dummy col in exog
     for i in dummy_ind:
@@ -195,6 +348,23 @@ def _get_dummy_effects(effects, exog, dummy_ind, method, model, params):
 
 
 def _effects_at(effects, at):
+    """
+    Reduces `effects` according to the `at` option.
+
+    Parameters
+    ----------
+    effects : ndarray
+        Marginal effects with observations in rows.
+    at : str
+        One of "overall", "mean", "median", "zero", or "all". See
+        `get_margeff` for details.
+
+    Returns
+    -------
+    ndarray
+        `effects` unchanged if `at` is "all", averaged over observations
+        if `at` is "overall", or the single row of `effects` otherwise.
+    """
     if at == "all":
         return effects
     elif at == "overall":
@@ -216,6 +386,33 @@ def _margeff_cov_params_dummy(model, cov_margins, params, exog, dummy_ind, metho
     f(XB)*X | d = 1 - f(XB)*X | d = 0
 
     Where F is the default prediction of the model.
+
+    Parameters
+    ----------
+    model : model instance
+        The model that returned the fitted results. Its
+        `_derivative_predict` method is used to compute the Jacobian.
+    cov_margins : ndarray
+        Jacobian of the marginal effects with respect to the parameters,
+        updated in place for the columns in `dummy_ind`.
+    params : ndarray
+        Estimated model parameters.
+    exog : ndarray
+        Exogenous regressors at which the Jacobian is evaluated.
+    dummy_ind : array_like of int
+        Column indices of `exog` that are dummy variables.
+    method : str
+        One of "dydx", "eyex", "dyex", or "eydx". See `get_margeff` for
+        details.
+    J : int
+        The number of response categories of the model. This is 1 except
+        for multinomial models.
+
+    Returns
+    -------
+    cov_margins : ndarray
+        The `cov_margins` array with the rows for `dummy_ind` replaced by
+        the Jacobian for the dummy variables.
     """
     for i in dummy_ind:
         exog0 = exog.copy()
@@ -249,6 +446,33 @@ def _margeff_cov_params_count(model, cov_margins, params, exog, count_ind, metho
     (f(XB)*X | d += 1 - f(XB)*X | d -= 1) / 2
 
     where F is the default prediction for the model.
+
+    Parameters
+    ----------
+    model : model instance
+        The model that returned the fitted results. Its
+        `_derivative_predict` method is used to compute the Jacobian.
+    cov_margins : ndarray
+        Jacobian of the marginal effects with respect to the parameters,
+        updated in place for the columns in `count_ind`.
+    params : ndarray
+        Estimated model parameters.
+    exog : ndarray
+        Exogenous regressors at which the Jacobian is evaluated.
+    count_ind : array_like of int
+        Column indices of `exog` that are count variables.
+    method : str
+        One of "dydx", "eyex", "dyex", or "eydx". See `get_margeff` for
+        details.
+    J : int
+        The number of response categories of the model. This is 1 except
+        for multinomial models.
+
+    Returns
+    -------
+    cov_margins : ndarray
+        The `cov_margins` array with the rows for `count_ind` replaced by
+        the Jacobian for the count variables.
     """
     for i in count_ind:
         exog0 = exog.copy()
@@ -298,8 +522,8 @@ def margeff_cov_params(
 
         Only overall has any effect here.
 
-    derivative : function or array_like
-        If a function, it returns the marginal effects of the model with
+    derivative : callable or array_like
+        If callable, it returns the marginal effects of the model with
         respect to the exogenous variables evaluated at exog. Expected to be
         called derivative(params, exog). This will be numerically
         differentiated. Otherwise, it can be the Jacobian of the marginal
@@ -363,6 +587,14 @@ def margeff_cov_with_se(
 
     Same function but returns both the covariance of the marginal effects
     and their standard errors.
+
+    Returns
+    -------
+    cov_me : ndarray
+        The covariance of the marginal effects.
+    se : ndarray
+        The standard errors of the marginal effects, the square root of
+        the diagonal of `cov_me`.
     """
     cov_me = margeff_cov_params(
         model, params, exog, cov_params, at, derivative, dummy_ind, count_ind, method, J
@@ -375,6 +607,20 @@ def margeff():
 
 
 def _check_at_is_all(method):
+    """
+    Raises if the marginal effects were computed with `at="all"`.
+
+    Parameters
+    ----------
+    method : dict
+        The `margeff_options` dict of the `DiscreteMargins` instance,
+        which contains the `at` option used to compute the effects.
+
+    Raises
+    ------
+    ValueError
+        If ``method["at"]`` is "all".
+    """
     if method["at"] == "all":
         raise ValueError(
             "Only margeff are available when `at` is "
@@ -447,7 +693,7 @@ class DiscreteMargins:
     args : tuple
         Args are passed to `get_margeff`. This is the same as
         results.get_margeff. See there for more information.
-    kwargs : dict
+    kwargs : dict, optional
         Keyword args are passed to `get_margeff`. This is the same as
         results.get_margeff. See there for more information.
     """
@@ -472,7 +718,7 @@ class DiscreteMargins:
 
         Parameters
         ----------
-        alpha : float
+        alpha : float, optional
             Number between 0 and 1. The confidence intervals have the
             probability 1-alpha.
 
@@ -554,7 +800,7 @@ class DiscreteMargins:
 
         Parameters
         ----------
-        alpha : float
+        alpha : float, optional
             Number between 0 and 1. The confidence intervals have the
             probability 1-alpha.
 
@@ -577,7 +823,7 @@ class DiscreteMargins:
 
         Parameters
         ----------
-        alpha : float
+        alpha : float, optional
             Number between 0 and 1. The confidence intervals have the
             probability 1-alpha.
 

--- a/statsmodels/discrete/discrete_model.py
+++ b/statsmodels/discrete/discrete_model.py
@@ -307,35 +307,36 @@ class DiscreteModel(base.LikelihoodModel):
         start_params : array_like, optional
             Initial guess of the solution for the log-likelihood maximization.
             The default is an array of zeros.
-        method : 'l1' or 'l1_cvxopt_cp'
+        method : {'l1', 'l1_cvxopt_cp'}, optional
             See notes for details.
-        maxiter : {int, 'defined_by_method'}
+        maxiter : int or 'defined_by_method', optional
             Maximum number of iterations to perform.
             If 'defined_by_method', then use method defaults (see notes).
-        full_output : bool
+        full_output : bool, optional
             Set to True to have all available output in the Results object's
             mle_retvals attribute. The output is dependent on the solver.
             See LikelihoodModelResults notes section for more information.
-        disp : bool
+        disp : bool, optional
             Set to True to print convergence messages.
-        callback : callable callback(xk)
+        callback : callable, optional
             Called after each iteration, as callback(xk), where xk is the
             current parameter vector.
-        alpha : non-negative scalar or numpy array (same size as parameters)
-            The weight multiplying the l1 penalty term.
-        trim_mode : 'auto, 'size', or 'off'
+        alpha : float or array_like, optional
+            Non-negative. The weight multiplying the l1 penalty term. If an
+            array, it must be the same size as the parameters.
+        trim_mode : {'auto', 'size', 'off'}, optional
             If not 'off', trim (set to zero) parameters that would have been
             zero if the solver reached the theoretical minimum.
             If 'auto', trim params using the Theory above.
             If 'size', trim params if they have very small absolute value.
-        size_trim_tol : float (default = 1e-4)
+        size_trim_tol : float, optional
             Tolerance used when trim_mode == 'size'.
-        auto_trim_tol : float
+        auto_trim_tol : float, optional
             Tolerance used when trim_mode == 'auto'.
-        qc_tol : float
+        qc_tol : float, optional
             Print warning and do not allow auto trim when (ii) (above) is
             violated by this much.
-        qc_verbose : bool
+        qc_verbose : bool, optional
             If true, print out a full QC report upon failure.
         **kwargs
             Additional keyword arguments used when fitting the model.
@@ -691,13 +692,14 @@ class BinaryModel(DiscreteModel):
 
         Parameters
         ----------
-        params : ndarray
+        params : array_like
             parameter at which score is evaluated
 
         Returns
         -------
-        The value of the derivative of the expected endog with respect
-        to the parameter vector.
+        ndarray
+            The value of the derivative of the expected endog with respect
+            to the parameter vector.
         """
         link = self.link
         lin_pred = self.predict(params, which="linear")
@@ -713,10 +715,10 @@ class BinaryModel(DiscreteModel):
         ----------
         params : array_like
             The parameters of the model.
-        exog : ndarray, optional
+        exog : array_like, optional
             Explanatory variables for the main count model.
             If ``exog`` is None, then the data from the model will be used.
-        offset : ndarray, optional
+        offset : array_like, optional
             Offset is added to the linear predictor of the mean function with
             coefficient equal to 1.
             Default is zero if exog is not None, and the model offset if exog
@@ -724,7 +726,9 @@ class BinaryModel(DiscreteModel):
 
         Returns
         -------
-        Instance of frozen scipy distribution.
+        scipy.stats.distributions.rv_frozen
+            Frozen random variable instance representing the distribution
+            implied by the model and the given parameters.
         """
         mu = self.predict(params, exog=exog, offset=offset)
         # distr = stats.bernoulli(mu[:, None])
@@ -1092,7 +1096,7 @@ class CountModel(DiscreteModel):
             equal to 1. If offset is not provided and exog
             is None, uses the model's offset if present.  If not, uses
             0 as the default value.
-        which : 'mean', 'linear', 'var', 'prob' (optional)
+        which : {'mean', 'linear', 'var', 'prob'}, optional
             Statistic to predict. Default is 'mean'.
 
             - 'mean' returns the conditional expectation of endog E(y | x),
@@ -1188,13 +1192,14 @@ class CountModel(DiscreteModel):
 
         Parameters
         ----------
-        params : ndarray
+        params : array_like
             parameter at which score is evaluated
 
         Returns
         -------
-        The value of the derivative of the expected endog with respect
-        to the parameter vector.
+        ndarray
+            The value of the derivative of the expected endog with respect
+            to the parameter vector.
         """
         from statsmodels.genmod.families import links
 
@@ -1286,9 +1291,9 @@ class Poisson(CountModel):
         A reference to the exogenous design.
     """.format(
         params=base._model_params_doc,
-        extra_params="""offset : array_like
+        extra_params="""offset : array_like, optional
         Offset is added to the linear prediction with coefficient equal to 1.
-    exposure : array_like
+    exposure : array_like, optional
         Log(exposure) is added to the linear prediction with coefficient
         equal to 1.
         """ + base._missing_param_doc + _check_rank_doc,
@@ -1311,7 +1316,8 @@ class Poisson(CountModel):
 
         Returns
         -------
-        The value of the Poisson CDF at each point.
+        ndarray
+            The value of the Poisson CDF at each point.
 
         Notes
         -----
@@ -1398,7 +1404,7 @@ class Poisson(CountModel):
 
         Returns
         -------
-        loglike : array_like
+        loglike : ndarray
             The log likelihood for each observation of the model evaluated
             at `params`. See Notes
 
@@ -1514,7 +1520,7 @@ class Poisson(CountModel):
             Otherwise, the constraints can be given as strings or list of
             strings.
             see t_test for details
-        start_params : None or array_like
+        start_params : array_like, optional
             starting values for the optimization. `start_params` needs to be
             given in the original parameter space and are internally
             transformed.
@@ -1610,7 +1616,7 @@ class Poisson(CountModel):
 
         Returns
         -------
-        score : array_like
+        score : ndarray
             The score vector (nobs, k_vars) of the model evaluated at `params`
 
         Notes
@@ -1640,7 +1646,7 @@ class Poisson(CountModel):
 
         Returns
         -------
-        score : array_like
+        score : ndarray
             The score factor (nobs, ) of the model evaluated at `params`
 
         Notes
@@ -1723,7 +1729,7 @@ class Poisson(CountModel):
 
         Parameters
         ----------
-        params : ndarray
+        params : array_like
             parameter at which score is evaluated
         scale : None or float
             If scale is None, then the default scale will be calculated.
@@ -1732,7 +1738,7 @@ class Poisson(CountModel):
 
         Returns
         -------
-        derivative : ndarray_2d
+        derivative : ndarray
             The derivative of the score_obs with respect to endog. This
             can is given by `score_factor0[:, None] * exog` where
             `score_factor0` is the score_factor without the residual.
@@ -1772,7 +1778,7 @@ class Poisson(CountModel):
             equal to 1.
             Default is one if exog is not None, and is the model exposure
             if exog is None.
-        which : 'mean', 'linear', 'var', 'prob' (optional)
+        which : {'mean', 'linear', 'var', 'prob'}, optional
             Statistic to predict. Default is 'mean'.
 
             - 'mean' returns the conditional expectation of endog E(y | x),
@@ -1783,9 +1789,14 @@ class Poisson(CountModel):
             - 'prob' return probabilities for counts from 0 to max(endog) or
               for y_values if those are provided.
 
-        y_values : array_like
+        y_values : array_like, optional
             Values of the random variable endog at which pmf is evaluated.
             Only used if ``which="prob"``
+
+        Returns
+        -------
+        array
+            Fitted values at exog.
         """
         # Note docstring is reused by other count models
 
@@ -1849,15 +1860,15 @@ class Poisson(CountModel):
         ----------
         params : array_like
             The parameters of the model.
-        exog : ndarray, optional
+        exog : array_like, optional
             Explanatory variables for the main count model.
             If ``exog`` is None, then the data from the model will be used.
-        offset : ndarray, optional
+        offset : array_like, optional
             Offset is added to the linear predictor of the mean function with
             coefficient equal to 1.
             Default is zero if exog is not None, and the model offset if exog
             is None.
-        exposure : ndarray, optional
+        exposure : array_like, optional
             Log(exposure) is added to the linear predictor of the mean
             function with coefficient equal to 1. If exposure is specified,
             then it will be logged by the method. The user does not need to
@@ -1867,7 +1878,9 @@ class Poisson(CountModel):
 
         Returns
         -------
-        Instance of frozen scipy distribution subclass.
+        scipy.stats.distributions.rv_frozen
+            Frozen random variable instance representing the distribution
+            implied by the model and the given parameters.
         """
         mu = self.predict(params, exog=exog, exposure=exposure, offset=offset)
         distr = stats.poisson(mu)
@@ -1890,12 +1903,12 @@ class GeneralizedPoisson(CountModel):
     """.format(
         params=base._model_params_doc,
         extra_params="""
-    p : scalar
+    p : int, optional
         P denotes parameterizations for GP regression. p=1 for GP-1 and
         p=2 for GP-2. Default is p=1.
-    offset : array_like
+    offset : array_like, optional
         Offset is added to the linear prediction with coefficient equal to 1.
-    exposure : array_like
+    exposure : array_like, optional
         Log(exposure) is added to the linear prediction with coefficient
         equal to 1.""" + base._missing_param_doc + _check_rank_doc,
     )
@@ -2253,7 +2266,7 @@ class GeneralizedPoisson(CountModel):
         -------
         dldp : float
             dldp is the first derivative of the log-likelihood function,
-        evaluated at `p-parameter`.
+            evaluated at `p-parameter`.
         """
         if self._transparams:
             alpha = np.exp(params[-1])
@@ -2366,7 +2379,7 @@ class GeneralizedPoisson(CountModel):
 
         Parameters
         ----------
-        params : array-like
+        params : array_like
             The parameters of the model
 
         Returns
@@ -2484,12 +2497,12 @@ class GeneralizedPoisson(CountModel):
 
         Parameters
         ----------
-        params : ndarray
+        params : array_like
             parameter at which score is evaluated
 
         Returns
         -------
-        derivative : ndarray_2d
+        derivative : ndarray
             The derivative of the score_obs with respect to endog.
         """
         # code duplication with NegativeBinomialP
@@ -2546,7 +2559,7 @@ class Logit(BinaryModel):
     Logit Model
 
     {base._model_params_doc}
-    offset : array_like
+    offset : array_like, optional
         Offset is added to the linear prediction with coefficient equal to 1.
     {base._missing_param_doc + _check_rank_doc}
 
@@ -2578,7 +2591,8 @@ class Logit(BinaryModel):
 
         Returns
         -------
-        1/(1 + exp(-X))
+        ndarray
+            1 / (1 + exp(-X))
 
         Notes
         -----
@@ -2717,7 +2731,7 @@ class Logit(BinaryModel):
 
         Returns
         -------
-        jac : array_like
+        jac : ndarray
             The derivative of the log-likelihood for each observation evaluated
             at `params`.
 
@@ -2744,7 +2758,7 @@ class Logit(BinaryModel):
 
         Returns
         -------
-        score_factor : array_like
+        score_factor : ndarray
             The derivative of the log-likelihood for each observation evaluated
             at `params`.
 
@@ -2833,12 +2847,12 @@ class Logit(BinaryModel):
 
         Parameters
         ----------
-        params : ndarray
+        params : array_like
             parameter at which score is evaluated
 
         Returns
         -------
-        derivative : ndarray_2d
+        derivative : ndarray
             The derivative of the score_obs with respect to endog. This
             can is given by `score_factor0[:, None] * exog` where
             `score_factor0` is the score_factor without the residual.
@@ -2851,7 +2865,7 @@ class Probit(BinaryModel):
     Probit Model
 
     {base._model_params_doc}
-    offset : array_like
+    offset : array_like, optional
         Offset is added to the linear prediction with coefficient equal to 1.
     {base._missing_param_doc + _check_rank_doc}
 
@@ -2949,7 +2963,7 @@ class Probit(BinaryModel):
 
         Returns
         -------
-        loglike : array_like
+        loglike : ndarray
             The log likelihood for each observation of the model evaluated
             at `params`. See Notes
 
@@ -3008,7 +3022,7 @@ class Probit(BinaryModel):
 
         Returns
         -------
-        jac : array_like
+        jac : ndarray
             The derivative of the log-likelihood for each observation evaluated
             at `params`.
 
@@ -3035,12 +3049,12 @@ class Probit(BinaryModel):
 
         Parameters
         ----------
-        params : array-like
+        params : array_like
             The parameters of the model
 
         Returns
         -------
-        score_factor : array_like (nobs,)
+        score_factor : ndarray, (nobs,)
             The derivative of the log-likelihood function for each observation
             with respect to linear predictor evaluated at `params`
 
@@ -3097,7 +3111,7 @@ class Probit(BinaryModel):
 
         Parameters
         ----------
-        params : array-like
+        params : array_like
             The parameters of the model
 
         Returns
@@ -3150,12 +3164,12 @@ class Probit(BinaryModel):
 
         Parameters
         ----------
-        params : ndarray
+        params : array_like
             parameter at which score is evaluated
 
         Returns
         -------
-        derivative : ndarray_2d
+        derivative : ndarray
             The derivative of the score_obs with respect to endog. This
             can is given by `score_factor0[:, None] * exog` where
             `score_factor0` is the score_factor without the residual.
@@ -3239,7 +3253,7 @@ class MNLogit(MultinomialModel):
 
         Parameters
         ----------
-        X : ndarray
+        X : array_like
             The linear predictor of the model XB.
 
         Returns
@@ -3298,7 +3312,7 @@ class MNLogit(MultinomialModel):
 
         Returns
         -------
-        loglike : array_like
+        loglike : ndarray
             The log likelihood for each observation of the model evaluated
             at `params`. See Notes
 
@@ -3327,7 +3341,7 @@ class MNLogit(MultinomialModel):
 
         Parameters
         ----------
-        params : ndarray
+        params : array_like
             The parameters of the multinomial logit model.
 
         Returns
@@ -3371,12 +3385,12 @@ class MNLogit(MultinomialModel):
 
         Parameters
         ----------
-        params : ndarray
+        params : array_like
             The parameters of the multinomial logit model.
 
         Returns
         -------
-        jac : array_like
+        jac : ndarray
             The derivative of the log-likelihood for each observation evaluated
             at `params` .
 
@@ -3532,17 +3546,17 @@ class NegativeBinomial(CountModel):
         Press.
     """.format(
         params=base._model_params_doc,
-        extra_params="""loglike_method : str
-        Log-likelihood type. 'nb2','nb1', or 'geometric'.
+        extra_params="""loglike_method : {'nb2', 'nb1', 'geometric'}, optional
+        Log-likelihood type.
         Fitted value :math:`\\mu`
         Heterogeneity parameter :math:`\\alpha`
 
         - nb2: Variance equal to :math:`\\mu + \\alpha\\mu^2` (most common)
         - nb1: Variance equal to :math:`\\mu + \\alpha\\mu`
         - geometric: Variance equal to :math:`\\mu + \\mu^2`
-    offset : array_like
+    offset : array_like, optional
         Offset is added to the linear prediction with coefficient equal to 1.
-    exposure : array_like
+    exposure : array_like, optional
         Log(exposure) is added to the linear prediction with coefficient
         equal to 1.
     """ + base._missing_param_doc + _check_rank_doc,
@@ -4155,17 +4169,14 @@ class NegativeBinomialP(CountModel):
         A reference to the endogenous response variable
     exog : ndarray
         A reference to the exogenous design.
-    p : scalar
-        P denotes parameterizations for NB-P regression. p=1 for NB-1 and
-        p=2 for NB-2. Default is p=1.
     """.format(
         params=base._model_params_doc,
-        extra_params="""p : scalar
+        extra_params="""p : int, optional
         P denotes parameterizations for NB regression. p=1 for NB-1 and
         p=2 for NB-2. Default is p=2.
-    offset : array_like
+    offset : array_like, optional
         Offset is added to the linear prediction with coefficient equal to 1.
-    exposure : array_like
+    exposure : array_like, optional
         Log(exposure) is added to the linear prediction with coefficient
         equal to 1.
         """ + base._missing_param_doc + _check_rank_doc,
@@ -4330,7 +4341,7 @@ class NegativeBinomialP(CountModel):
 
         Parameters
         ----------
-        params : array-like
+        params : array_like
             The parameters of the model
         endog : array_like, optional
             Endogenous variable to use in place of the model's `endog`.
@@ -4466,7 +4477,7 @@ class NegativeBinomialP(CountModel):
 
         Parameters
         ----------
-        params : array-like
+        params : array_like
             The parameters of the model
 
         Returns
@@ -4788,12 +4799,12 @@ class NegativeBinomialP(CountModel):
 
         Parameters
         ----------
-        params : ndarray
+        params : array_like
             parameter at which score is evaluated
 
         Returns
         -------
-        derivative : ndarray_2d
+        derivative : ndarray
             The derivative of the score_obs with respect to endog.
         """
         from statsmodels.tools.numdiff import _approx_fprime_cs_scalar
@@ -4927,10 +4938,10 @@ class DiscreteResults(base.LikelihoodModelResults):
 
         Parameters
         ----------
-        llnull : {None, float}
+        llnull : None or float
             If llnull is not None, then the value will be directly assigned to
             the cached attribute "llnull".
-        attach_results : bool
+        attach_results : bool, optional
             Sets an internal flag whether the results instance of the null
             model should be attached. By default without calling this method,
             the null model results are not attached and only the log-likelihood
@@ -5063,15 +5074,16 @@ class DiscreteResults(base.LikelihoodModelResults):
 
         Parameters
         ----------
-        crit : string
-            One of 'aic', 'bic', 'tic' or 'gbic'.
-        dk_params : int or float
+        crit : {'aic', 'bic', 'tic', 'gbic'}
+            The information criterion to compute.
+        dk_params : int or float, optional
             Correction to the number of parameters used in the information
             criterion.
 
         Returns
         -------
-        Value of information criterion.
+        float
+            Value of information criterion.
 
         Notes
         -----
@@ -5152,14 +5164,14 @@ class DiscreteResults(base.LikelihoodModelResults):
             you can pass a data structure that contains x1 and x2 in
             their original form. Otherwise, you'd need to log the data
             first.
-        which : str
+        which : str, optional
             Which statistic is to be predicted. Default is "mean".
             The available statistics and options depend on the model.
             see the model.predict docstring
-        row_labels : list of str or None
+        row_labels : list of str, optional
             If row_labels are provided, then they will replace the generated
             labels.
-        average : bool
+        average : bool, optional
             If average is True, then the mean prediction is computed, that is,
             predictions are computed for individual exog and then the average
             over observation is used.
@@ -5168,7 +5180,7 @@ class DiscreteResults(base.LikelihoodModelResults):
         agg_weights : ndarray, optional
             Aggregation weights, only used if average is True.
             The weights are not normalized.
-        y_values : None or nd_array
+        y_values : array_like, optional
             Some predictive statistics like which="prob" are computed at
             values of the response variable. If y_values is not None, then
             it will be used instead of the default set of y_values.
@@ -5333,15 +5345,15 @@ class DiscreteResults(base.LikelihoodModelResults):
         ----------
         yname : str, optional
             The name of the endog variable in the tables. The default is `y`.
-        xname : list[str], optional
+        xname : list of str, optional
             The names for the exogenous variables, default is "var_xx".
             Must match the number of parameters in the model.
         title : str, optional
             Title for the top table. If not None, then this replaces the
             default title.
-        alpha : float
+        alpha : float, optional
             The significance level for the confidence intervals.
-        yname_list : list[str], optional
+        yname_list : list of str, optional
             Names for the endogenous variables, used for the parameter
             table. If None, the names are taken from `yname`.
 
@@ -5417,17 +5429,17 @@ class DiscreteResults(base.LikelihoodModelResults):
 
         Parameters
         ----------
-        yname : str
-            Name of the dependent variable (optional).
-        xname : list[str], optional
+        yname : str, optional
+            Name of the dependent variable.
+        xname : list of str, optional
             List of strings of length equal to the number of parameters
-            Names of the independent variables (optional).
+            Names of the independent variables.
         title : str, optional
             Title for the top table. If not None, then this replaces the
             default title.
-        alpha : float
+        alpha : float, optional
             The significance level for the confidence intervals.
-        float_format : str
+        float_format : str, optional
             The print format for floats in parameters summary.
 
         Returns
@@ -5741,7 +5753,7 @@ class BinaryResults(DiscreteResults):
 
         Parameters
         ----------
-        threshold : scalar
+        threshold : float, optional
             Number between 0 and 1. Threshold above which a prediction is
             considered 1 and below which a prediction is considered 0.
 
@@ -6049,9 +6061,9 @@ class MultinomialResults(DiscreteResults):
 
         Parameters
         ----------
-        alpha : float
+        alpha : float, optional
             significance level for the confidence intervals
-        float_format : str
+        float_format : str, optional
             print format for floats in parameters summary
 
         Returns

--- a/statsmodels/discrete/truncated_model.py
+++ b/statsmodels/discrete/truncated_model.py
@@ -42,18 +42,18 @@ class TruncatedLFGeneric(CountModel):
 
     Attributes
     ----------
-    endog : array
+    endog : ndarray
         A reference to the endogenous response variable
-    exog : array
+    exog : ndarray
         A reference to the exogenous design.
-    truncation : int, optional
+    truncation : int
         Truncation parameter that specifies the truncation point out of
         the support of the distribution. pmf(k) = 0 for k <= truncation
     """.format(
            params=base._model_params_doc,
-           extra_params="""offset : array_like
+           extra_params="""offset : array_like, optional
         Offset is added to the linear prediction with coefficient equal to 1.
-    exposure : array_like
+    exposure : array_like, optional
         Log(exposure) is added to the linear prediction with coefficient
         equal to 1.
 
@@ -90,18 +90,13 @@ class TruncatedLFGeneric(CountModel):
 
         Parameters
         ----------
-        params : array-like
+        params : array_like
             The parameters of the model.
 
         Returns
         -------
         loglike : float
             The log-likelihood function of the model evaluated at `params`.
-            See notes.
-
-        Notes
-        -----
-
         """
         return np.sum(self.loglikeobs(params))
 
@@ -111,18 +106,14 @@ class TruncatedLFGeneric(CountModel):
 
         Parameters
         ----------
-        params : array-like
+        params : array_like
             The parameters of the model.
 
         Returns
         -------
         loglike : ndarray (nobs,)
             The log likelihood for each observation of the model evaluated
-            at `params`. See Notes
-
-        Notes
-        -----
-
+            at `params`.
         """
         llf_main = self.model_main.loglikeobs(params)
 
@@ -157,7 +148,7 @@ class TruncatedLFGeneric(CountModel):
 
         Parameters
         ----------
-        params : array-like
+        params : array_like
             The parameters of the model
 
         Returns
@@ -192,7 +183,7 @@ class TruncatedLFGeneric(CountModel):
 
         Parameters
         ----------
-        params : array-like
+        params : array_like
             The parameters of the model
 
         Returns
@@ -287,7 +278,7 @@ class TruncatedLFGeneric(CountModel):
 
         Parameters
         ----------
-        params : array-like
+        params : array_like
             The parameters of the model
 
         Returns
@@ -295,9 +286,6 @@ class TruncatedLFGeneric(CountModel):
         hess : ndarray, (k_vars, k_vars)
             The Hessian, second derivative of the log-likelihood function,
             evaluated at `params`
-
-        Notes
-        -----
         """
         return approx_hess(params, self.loglike)
 
@@ -310,15 +298,15 @@ class TruncatedLFGeneric(CountModel):
         ----------
         params : array_like
             The parameters of the model.
-        exog : ndarray, optional
+        exog : array_like, optional
             Explanatory variables for the main count model.
             If ``exog`` is None, then the data from the model will be used.
-        offset : ndarray, optional
+        offset : array_like, optional
             Offset is added to the linear predictor of the mean function with
             coefficient equal to 1.
             Default is zero if exog is not None, and the model offset if exog
             is None.
-        exposure : ndarray, optional
+        exposure : array_like, optional
             Log(exposure) is added to the linear predictor with coefficient
             equal to 1. If exposure is specified, then it will be logged by
             the method. The user does not need to log it first.
@@ -343,13 +331,14 @@ class TruncatedLFGeneric(CountModel):
               return (2-dim when predicting for several observations).
 
 
-        y_values : array_like
+        y_values : array_like, optional
             Values of the random variable endog at which pmf is evaluated.
             Only used if ``which="prob"``
 
         Returns
         -------
-        predicted values
+        ndarray
+            The predicted values, whose interpretation depends on `which`.
 
         Notes
         -----
@@ -447,18 +436,18 @@ class TruncatedLFPoisson(TruncatedLFGeneric):
 
     Attributes
     ----------
-    endog : array
+    endog : ndarray
         A reference to the endogenous response variable
-    exog : array
+    exog : ndarray
         A reference to the exogenous design.
-    truncation : int, optional
+    truncation : int
         Truncation parameter that specifies the truncation point out of
         the support of the distribution. pmf(k) = 0 for k <= truncation
     """.format(
            params=base._model_params_doc,
-           extra_params="""offset : array_like
+           extra_params="""offset : array_like, optional
         Offset is added to the linear prediction with coefficient equal to 1.
-    exposure : array_like
+    exposure : array_like, optional
         Log(exposure) is added to the linear prediction with coefficient
         equal to 1.
 
@@ -525,20 +514,23 @@ class TruncatedLFNegativeBinomialP(TruncatedLFGeneric):
 
     Attributes
     ----------
-    endog : array
+    endog : ndarray
         A reference to the endogenous response variable
-    exog : array
+    exog : ndarray
         A reference to the exogenous design.
-    truncation : int, optional
+    truncation : int
         Truncation parameter that specifies the truncation point out of
         the support of the distribution. pmf(k) = 0 for k <= truncation
     """.format(
            params=base._model_params_doc,
-           extra_params="""offset : array_like
+           extra_params="""offset : array_like, optional
         Offset is added to the linear prediction with coefficient equal to 1.
-    exposure : array_like
+    exposure : array_like, optional
         Log(exposure) is added to the linear prediction with coefficient
         equal to 1.
+    p : int, optional
+        P denotes parameterizations for NB regression. p=1 for NB-1 and
+        p=2 for NB-2. Default is p=2.
 
     """ + base._missing_param_doc,
        )
@@ -616,20 +608,23 @@ class TruncatedLFGeneralizedPoisson(TruncatedLFGeneric):
 
     Attributes
     ----------
-    endog : array
+    endog : ndarray
         A reference to the endogenous response variable
-    exog : array
+    exog : ndarray
         A reference to the exogenous design.
-    truncation : int, optional
+    truncation : int
         Truncation parameter that specifies the truncation point out of
         the support of the distribution. pmf(k) = 0 for k <= truncation
     """.format(
            params=base._model_params_doc,
-           extra_params="""offset : array_like
+           extra_params="""offset : array_like, optional
         Offset is added to the linear prediction with coefficient equal to 1.
-    exposure : array_like
+    exposure : array_like, optional
         Log(exposure) is added to the linear prediction with coefficient
         equal to 1.
+    p : int, optional
+        Dispersion power parameter for the GeneralizedPoisson model. p=1
+        for GP-1 and p=2 for GP-2. Default is p=2.
 
     """ + base._missing_param_doc,
        )
@@ -671,15 +666,15 @@ class _RCensoredGeneric(CountModel):
 
     Attributes
     ----------
-    endog : array
+    endog : ndarray
         A reference to the endogenous response variable
-    exog : array
+    exog : ndarray
         A reference to the exogenous design.
     """.format(
            params=base._model_params_doc,
-           extra_params="""offset : array_like
+           extra_params="""offset : array_like, optional
         Offset is added to the linear prediction with coefficient equal to 1.
-    exposure : array_like
+    exposure : array_like, optional
         Log(exposure) is added to the linear prediction with coefficient
         equal to 1.
 
@@ -705,18 +700,13 @@ class _RCensoredGeneric(CountModel):
 
         Parameters
         ----------
-        params : array-like
+        params : array_like
             The parameters of the model.
 
         Returns
         -------
         loglike : float
             The log-likelihood function of the model evaluated at `params`.
-            See notes.
-
-        Notes
-        -----
-
         """
         return np.sum(self.loglikeobs(params))
 
@@ -726,18 +716,14 @@ class _RCensoredGeneric(CountModel):
 
         Parameters
         ----------
-        params : array-like
+        params : array_like
             The parameters of the model.
 
         Returns
         -------
         loglike : ndarray (nobs,)
             The log likelihood for each observation of the model evaluated
-            at `params`. See Notes
-
-        Notes
-        -----
-
+            at `params`.
         """
         llf_main = self.model_main.loglikeobs(params)
 
@@ -754,7 +740,7 @@ class _RCensoredGeneric(CountModel):
 
         Parameters
         ----------
-        params : array-like
+        params : array_like
             The parameters of the model
 
         Returns
@@ -781,7 +767,7 @@ class _RCensoredGeneric(CountModel):
 
         Parameters
         ----------
-        params : array-like
+        params : array_like
             The parameters of the model
 
         Returns
@@ -871,7 +857,7 @@ class _RCensoredGeneric(CountModel):
 
         Parameters
         ----------
-        params : array-like
+        params : array_like
             The parameters of the model
 
         Returns
@@ -879,9 +865,6 @@ class _RCensoredGeneric(CountModel):
         hess : ndarray, (k_vars, k_vars)
             The Hessian, second derivative of the log-likelihood function,
             evaluated at `params`
-
-        Notes
-        -----
         """
         return approx_hess(params, self.loglike)
 
@@ -895,15 +878,15 @@ class _RCensoredPoisson(_RCensoredGeneric):
 
     Attributes
     ----------
-    endog : array
+    endog : ndarray
         A reference to the endogenous response variable
-    exog : array
+    exog : ndarray
         A reference to the exogenous design.
     """.format(
            params=base._model_params_doc,
-           extra_params="""offset : array_like
+           extra_params="""offset : array_like, optional
         Offset is added to the linear prediction with coefficient equal to 1.
-    exposure : array_like
+    exposure : array_like, optional
         Log(exposure) is added to the linear prediction with coefficient
         equal to 1.
 
@@ -932,15 +915,15 @@ class _RCensoredGeneralizedPoisson(_RCensoredGeneric):
 
     Attributes
     ----------
-    endog : array
+    endog : ndarray
         A reference to the endogenous response variable
-    exog : array
+    exog : ndarray
         A reference to the exogenous design.
     """.format(
            params=base._model_params_doc,
-           extra_params="""offset : array_like
+           extra_params="""offset : array_like, optional
         Offset is added to the linear prediction with coefficient equal to 1.
-    exposure : array_like
+    exposure : array_like, optional
         Log(exposure) is added to the linear prediction with coefficient
         equal to 1.
 
@@ -971,15 +954,15 @@ class _RCensoredNegativeBinomialP(_RCensoredGeneric):
 
     Attributes
     ----------
-    endog : array
+    endog : ndarray
         A reference to the endogenous response variable
-    exog : array
+    exog : ndarray
         A reference to the exogenous design.
     """.format(
            params=base._model_params_doc,
-           extra_params="""offset : array_like
+           extra_params="""offset : array_like, optional
         Offset is added to the linear prediction with coefficient equal to 1.
-    exposure : array_like
+    exposure : array_like, optional
         Log(exposure) is added to the linear prediction with coefficient
         equal to 1.
 
@@ -1016,15 +999,15 @@ class _RCensored(_RCensoredGeneric):
 
     Attributes
     ----------
-    endog : array
+    endog : ndarray
         A reference to the endogenous response variable
-    exog : array
+    exog : ndarray
         A reference to the exogenous design.
     """.format(
            params=base._model_params_doc,
-           extra_params="""offset : array_like
+           extra_params="""offset : array_like, optional
         Offset is added to the linear prediction with coefficient equal to 1.
-    exposure : array_like
+    exposure : array_like, optional
         Log(exposure) is added to the linear prediction with coefficient
         equal to 1.
 
@@ -1075,20 +1058,10 @@ class HurdleCountModel(CountModel):
 
     Attributes
     ----------
-    endog : array
+    endog : ndarray
         A reference to the endogenous response variable
-    exog : array
+    exog : ndarray
         A reference to the exogenous design.
-    dist : string
-        Log-likelihood type of count model family. 'poisson' or 'negbin'
-    zerodist : string
-        Log-likelihood type of zero hurdle model family. 'poisson', 'negbin'
-    p : scalar
-        Define parameterization for count model.
-        Used when dist='negbin'.
-    pzero : scalar
-        Define parameterization parameter zero hurdle model family.
-        Used when zerodist='negbin'.
 
     Notes
     -----
@@ -1102,9 +1075,20 @@ class HurdleCountModel(CountModel):
     not yet
     """.format(
            params=base._model_params_doc,
-           extra_params="""offset : array_like
+           extra_params="""offset : array_like, optional
         Offset is added to the linear prediction with coefficient equal to 1.
-    exposure : array_like
+    dist : {'poisson', 'negbin'}, optional
+        Log-likelihood type of count model family. Default is 'poisson'.
+    zerodist : {'poisson', 'negbin'}, optional
+        Log-likelihood type of zero hurdle model family. Default is
+        'poisson'.
+    p : int, optional
+        Dispersion power parameter for the NegativeBinomialP count model.
+        Used when dist='negbin'. Default is 2.
+    pzero : int, optional
+        Dispersion power parameter for the NegativeBinomialP zero hurdle
+        model. Used when zerodist='negbin'. Default is 2.
+    exposure : array_like, optional
         Log(exposure) is added to the linear prediction with coefficient
         equal to 1.
 
@@ -1162,18 +1146,13 @@ class HurdleCountModel(CountModel):
 
         Parameters
         ----------
-        params : array-like
+        params : array_like
             The parameters of the model.
 
         Returns
         -------
         loglike : float
             The log-likelihood function of the model evaluated at `params`.
-            See notes.
-
-        Notes
-        -----
-
         """
         k = int((len(params) - self.k_extra1 - self.k_extra2) / 2
                 ) + self.k_extra1
@@ -1245,15 +1224,15 @@ class HurdleCountModel(CountModel):
         ----------
         params : array_like
             The parameters of the model.
-        exog : ndarray, optional
+        exog : array_like, optional
             Explanatory variables for the main count model.
             If ``exog`` is None, then the data from the model will be used.
-        offset : ndarray, optional
+        offset : array_like, optional
             Offset is added to the linear predictor of the mean function with
             coefficient equal to 1.
             Default is zero if exog is not None, and the model offset if exog
             is None.
-        exposure : ndarray, optional
+        exposure : array_like, optional
             Log(exposure) is added to the linear predictor with coefficient
             equal to 1. If exposure is specified, then it will be logged by
             the method. The user does not need to log it first.
@@ -1281,13 +1260,14 @@ class HurdleCountModel(CountModel):
               for y_values if those are provided. This is a multivariate
               return (2-dim when predicting for several observations).
 
-        y_values : array_like
+        y_values : array_like, optional
             Values of the random variable endog at which pmf is evaluated.
             Only used if ``which="prob"``
 
         Returns
         -------
-        predicted values
+        ndarray
+            The predicted values, whose interpretation depends on `which`.
 
         Notes
         -----

--- a/statsmodels/duration/_kernel_estimates.py
+++ b/statsmodels/duration/_kernel_estimates.py
@@ -18,11 +18,11 @@ def _kernel_cumincidence(time, status, exog, kfunc, freq_weights,
     exog : array_like
         Covariates such that censoring becomes independent of
         outcome times conditioned on the covariate values.
-    kfunc : function
+    kfunc : callable
         A kernel function
     freq_weights : array_like
         Optional frequency weights
-    dimred : bool
+    dimred : bool, optional
         If True, proportional hazards regression models are used to
         reduce exog to two columns by predicting overall events and
         censoring in two separate models.  If False, exog is used
@@ -31,10 +31,10 @@ def _kernel_cumincidence(time, status, exog, kfunc, freq_weights,
 
     Returns
     -------
-    utime : array_like
+    utime : ndarray
         The unique times at which the cumulative incidence functions
         are estimated.
-    ip : list of arrays
+    ip : list of ndarray
         ip[k-1] contains the estimated cumulative incidence rates
         for outcome k=1, 2, ...
     """
@@ -140,16 +140,16 @@ def _kernel_survfunc(time, status, exog, kfunc, freq_weights):
     exog : array_like
         Covariates such that censoring is independent conditional on
         exog
-    kfunc : function
+    kfunc : callable
         Kernel function
     freq_weights : array_like
         Optional frequency weights
 
     Returns
     -------
-    probs : array_like
+    probs : ndarray
         The estimated survival probabilities
-    times : array_like
+    times : ndarray
         The times at which the survival probabilities are estimated
 
     References

--- a/statsmodels/duration/hazard_regression.py
+++ b/statsmodels/duration/hazard_regression.py
@@ -33,26 +33,26 @@ _predict_docstring = """
 
     Parameters
     ----------%(params_doc)s
-    exog : array_like
+    exog : array_like, optional
         Data to use as `exog` in forming predictions.  If not
         provided, the `exog` values from the model used to fit the
         data are used.%(cov_params_doc)s
-    endog : array_like
+    endog : array_like, optional
         Duration (time) values at which the predictions are made.
         Only used if pred_type is either 'cumhaz' or 'surv'.  If
         using model `exog`, defaults to model `endog` (time), but
         may be provided explicitly to make predictions at
         alternative times.
-    strata : array_like
+    strata : array_like, optional
         A vector of stratum values used to form the predictions.
         Not used (may be 'None') if pred_type is 'lhr' or 'hr'.
         If `exog` is None, the model stratum values are used.  If
         `exog` is not None and pred_type is 'surv' or 'cumhaz',
         stratum values must be provided (unless there is only one
         stratum).
-    offset : array_like
+    offset : array_like, optional
         Offset values used to create the predicted values.
-    pred_type : str
+    pred_type : {'lhr', 'hr', 'surv', 'cumhaz'}, optional
         If 'lhr', returns log hazard ratios, if 'hr' returns
         hazard ratios, if 'surv' returns the survival function, if
         'cumhaz' returns the cumulative hazard function.%(extra_params_doc)s
@@ -77,19 +77,19 @@ _predict_params_doc = """
         The proportional hazards model parameters."""
 
 _predict_cov_params_docstring = """
-    cov_params : array_like
+    cov_params : array_like, optional
         The covariance matrix of the estimated `params` vector,
         used to obtain prediction errors if pred_type='lhr',
         otherwise optional."""
 
 _predict_pred_only_docstring = """
-    pred_only : bool
+    pred_only : bool, optional
         If True, returns only an array of predicted values.  Otherwise
         returns a bunch containing the predicted values and standard
         errors."""
 
 _predict_transform_docstring = """
-    transform : bool
+    transform : bool, optional
         If the model was fit via a formula, whether to pass `exog`
         through the formula before forming the prediction."""
 
@@ -103,26 +103,26 @@ class PHSurvivalTime:
 
         Parameters
         ----------
-        time : array_like
+        time : ndarray
             The times at which either the event (failure) occurs or
             the observation is censored.
-        status : array_like
+        status : ndarray
             Indicates whether the event (failure) occurs at `time`
             (`status` is 1), or if `time` is a censoring time (`status`
             is 0).
-        exog : array_like
+        exog : 2D ndarray
             The exogeneous (covariate) data matrix, cases are rows and
             variables are columns.
-        strata : array_like
+        strata : array_like, optional
             Grouping variable defining the strata.  If None, all
             observations are in a single stratum.
-        entry : array_like
+        entry : ndarray, optional
             Entry (left truncation) times.  The observation is not
             part of the risk set for times before the entry time.  If
             None, the entry time is treated as being zero, which
             gives no left truncation.  The entry time must be less
             than or equal to `time`.
-        offset : array_like
+        offset : ndarray, optional
             An optional array of offsets
         """
 
@@ -290,22 +290,21 @@ class PHReg(model.LikelihoodModel):
         The observed times (event or censoring)
     exog : 2D array_like
         The covariates or exogeneous variables
-    status : array_like
+    status : array_like, optional
         The censoring status values; status=1 indicates that an
         event occurred (e.g., failure or death), status=0 indicates
         that the observation was right censored. If None, defaults
         to status=1 for all cases.
-    entry : array_like
+    entry : array_like, optional
         The entry times, if left truncation occurs
-    strata : array_like
+    strata : array_like, optional
         Stratum labels.  If None, all observations are taken to be
         in a single stratum.
-    ties : str
-        The method used to handle tied times, must be either 'breslow'
-        or 'efron'.
-    offset : array_like
+    ties : {'breslow', 'efron'}, optional
+        The method used to handle tied times.
+    offset : array_like, optional
         Array of offset values
-    missing : str
+    missing : str, optional
         The method used to handle missing data
 
     Notes
@@ -400,26 +399,25 @@ class PHReg(model.LikelihoodModel):
             The formula specifying the model
         data : array_like
             The data for the model. See Notes.
-        status : array_like
+        status : array_like, optional
             The censoring status values; status=1 indicates that an
             event occurred (e.g., failure or death), status=0 indicates
             that the observation was right censored. If None, defaults
             to status=1 for all cases.
-        entry : array_like
+        entry : array_like, optional
             The entry times, if left truncation occurs
-        strata : array_like
+        strata : array_like, optional
             Stratum labels.  If None, all observations are taken to be
             in a single stratum.
-        offset : array_like
+        offset : array_like, optional
             Array of offset values
-        subset : array_like
+        subset : array_like, optional
             An array-like object of booleans, integers, or index
             values that indicate the subset of df to use in the
             model. Assumes df is a `pandas.DataFrame`
-        ties : str
-            The method used to handle tied times, must be either 'breslow'
-            or 'efron'.
-        missing : str
+        ties : {'breslow', 'efron'}, optional
+            The method used to handle tied times.
+        missing : str, optional
             The method used to handle missing data
         args : extra arguments
             These are passed to the model
@@ -434,6 +432,12 @@ class PHReg(model.LikelihoodModel):
         Returns
         -------
         model : PHReg model instance
+
+        Notes
+        -----
+        data must define __getitem__ with the keys in the formula terms
+        args and kwargs are passed on to the model instantiation. E.g.,
+        a numpy structured or rec array, a dictionary, or a pandas DataFrame.
         """
 
         # Allow array arguments to be passed by column name.
@@ -483,7 +487,7 @@ class PHReg(model.LikelihoodModel):
 
         Parameters
         ----------
-        groups : array_like
+        groups : array_like, optional
             Labels indicating groups of observations that may be
             dependent.  If present, the standard errors account for
             this dependence. Does not affect fitted values.
@@ -525,16 +529,16 @@ class PHReg(model.LikelihoodModel):
 
         Parameters
         ----------
-        method : {'elastic_net'}
+        method : {'elastic_net'}, optional
             Only the `elastic_net` approach is currently implemented.
-        alpha : scalar or array_like
+        alpha : scalar or array_like, optional
             The penalty weight.  If a scalar, the same penalty weight
             applies to all variables in the model.  If a vector, it
             must have the same length as `params`, and contains a
             penalty weight for each coefficient.
-        start_params : array_like
+        start_params : array_like, optional
             Starting values for `params`.
-        refit : bool
+        refit : bool, optional
             If True, the model is refit using only the variables that
             have non-zero coefficients in the regularized fit.  The
             refitted model is not regularized.
@@ -1188,7 +1192,7 @@ class PHReg(model.LikelihoodModel):
 
         Returns
         -------
-        averages : list of ndarrays
+        averages : list of ndarray
             averages[stx][i,:] is a row vector containing the weighted
             average values (for all the covariates) of at-risk
             subjects at the i^th largest observed failure time in
@@ -1454,9 +1458,9 @@ class PHReg(model.LikelihoodModel):
         ----------
         params : array_like
             The proportional hazards model parameters.
-        scale : float
+        scale : float, optional
             Present for compatibility, not used.
-        exog : array_like
+        exog : ndarray, optional
             A design matrix, defaults to model.exog.
 
         Returns
@@ -1761,14 +1765,14 @@ class PHRegResults(base.LikelihoodModelResults):
         ----------
         yname : str, optional
             Default is `y`
-        xname : list[str], optional
+        xname : list of str, optional
             Names for the exogenous variables, default is `x#` for # in
             the number of regressors. Must match the number of parameters
             in the model
         title : str, optional
             Title for the top table. If not None, then this replaces
             the default title
-        alpha : float
+        alpha : float, optional
             significance level for the confidence intervals
 
         Returns
@@ -1854,10 +1858,10 @@ class rv_discrete_float:
 
     Parameters
     ----------
-    xk : 2d array_like
+    xk : 2D ndarray
         The support points, should be non-decreasing within each
         row.
-    pk : 2d array_like
+    pk : 2D ndarray
         The probabilities, should sum to one within each row.
 
     Notes
@@ -1894,7 +1898,7 @@ class rv_discrete_float:
         ----------
         n : not used
             Present for signature compatibility.
-        rng : int, array_like of int, numpy.random.Generator, numpy.random.RandomState, optional
+        rng : int, array_like of int, numpy.random.Generator, or numpy.random.RandomState, optional
             If `rng` is None, a new ``Generator`` is created using fresh
             entropy from the operating system. If `rng` is an int, a new
             ``RandomState`` instance is created, seeded with `rng`; this
@@ -1902,7 +1906,7 @@ class rv_discrete_float:
             creating a ``Generator`` in a future release. If `rng` is
             already a ``Generator`` or ``RandomState`` instance, that
             instance is used.
-        rng : int, array_like of int, numpy.random.Generator, numpy.random.RandomState, optional
+        rng : int, array_like of int, numpy.random.Generator, or numpy.random.RandomState, optional
             .. deprecated:: 0.15
 
                random_state has been deprecated. In-line with SPEC-007, use

--- a/statsmodels/duration/survfunc.py
+++ b/statsmodels/duration/survfunc.py
@@ -26,29 +26,29 @@ def _calc_survfunc_right(time, status, weights=None, entry=None, compress=True,
     entry : array_like, optional
         An array of entry times for handling left truncation (the
         subject is not in the risk set on or before the entry time)
-    compress : bool
+    compress : bool, optional
         If True, only times at which an event occurred are retained
         in the returned arrays.
-    retall : bool
+    retall : bool, optional
         If True, all computed results (including the standard
         error) are returned.  If False, only `sp`, `utime`, `rtime`,
         `n`, and `d` are returned.
 
     Returns
     -------
-    sp : array_like
+    sp : ndarray
         The estimated survival probabilities
-    se : array_like
+    se : ndarray
         The standard errors for the values in `sp`.  Only returned
         if `retall` is True.
-    utime : array_like
+    utime : ndarray
         The unique times at which the survival function is estimated
-    rtime : array_like
+    rtime : ndarray
         The rank (0, 1, 2, ...) of each observed time among the
         unique times
-    n : array_like
+    n : ndarray
         The size of the risk set just prior to each time in `utime`
-    d : array_like
+    d : ndarray
         The number of events at each time in `utime`
     """
 
@@ -140,13 +140,13 @@ def _calc_incidence_right(time, status, weights=None):
 
     Returns
     -------
-    ip : list of arrays
+    ip : list of ndarray
         ip[k-1] contains the estimated cumulative incidence rates
         for outcome k=1, 2, ...
-    se : list of arrays or None
+    se : list of ndarray or None
         The standard errors for the values in `ip`.  None if
         `weights` is provided.
-    utime : array_like
+    utime : ndarray
         The unique times at which the incidence rates are estimated
     """
 
@@ -238,17 +238,17 @@ class CumIncidenceRight:
     status : array_like
         If status >= 1 indicates which event occurred at time t.  If
         status = 0, the subject was censored at time t.
-    title : str
+    title : str, optional
         Optional title used for plots and summary output.
-    freq_weights : array_like
+    freq_weights : array_like, optional
         Optional frequency weights
-    exog : array_like
+    exog : array_like, optional
         Optional, if present used to account for violation of
         independent censoring.
-    bw_factor : float
+    bw_factor : float, optional
         Band-width multiplier for kernel-based estimation.  Only
         used if exog is provided.
-    dimred : bool
+    dimred : bool, optional
         If True, proportional hazards regression models are used to
         reduce exog to two columns by predicting overall events and
         censoring in two separate models.  If False, exog is used
@@ -257,12 +257,12 @@ class CumIncidenceRight:
 
     Attributes
     ----------
-    times : array_like
+    times : ndarray
         The distinct times at which the incidence rates are estimated
-    cinc : list of arrays
+    cinc : list of ndarray
         cinc[k-1] contains the estimated cumulative incidence rates
         for outcome k=1,2,...
-    cinc_se : list of arrays
+    cinc_se : list of ndarray or None
         The standard errors for the values in `cinc`.  Not available when
         exog and/or frequency weights are provided.
 
@@ -348,31 +348,31 @@ class SurvfuncRight:
     entry : array_like, optional
         An array of entry times for handling left truncation (the
         subject is not in the risk set on or before the entry time)
-    title : str
+    title : str, optional
         Optional title used for plots and summary output.
-    freq_weights : array_like
+    freq_weights : array_like, optional
         Optional frequency weights
-    exog : array_like
+    exog : array_like, optional
         Optional, if present used to account for violation of
         independent censoring.
-    bw_factor : float
+    bw_factor : float, optional
         Band-width multiplier for kernel-based estimation.  Only used
         if exog is provided.
 
     Attributes
     ----------
-    surv_prob : array_like
+    surv_prob : ndarray
         The estimated value of the survivor function at each time
         point in `surv_times`.
-    surv_prob_se : array_like
+    surv_prob_se : ndarray
         The standard errors for the values in `surv_prob`.  Not available
         if exog is provided.
-    surv_times : array_like
+    surv_times : ndarray
         The points where the survival function changes.
-    n_risk : array_like
+    n_risk : ndarray
         The number of subjects at risk just before each time value in
         `surv_times`.  Not available if exog is provided.
-    n_events : array_like
+    n_events : ndarray
         The number of events (e.g., deaths) that occur at each point
         in `surv_times`.  Not available if exog is provided.
 
@@ -508,12 +508,11 @@ class SurvfuncRight:
         p : float
             The probability point for which a confidence interval is
             determined.
-        alpha : float
+        alpha : float, optional
             The confidence interval has nominal coverage probability
             1 - `alpha`.
-        method : str
-            Function to use for g-transformation, must be one of
-            "cloglog", "linear", "log", "logit", or "asinsqrt".
+        method : {"cloglog", "linear", "log", "logit", "asinsqrt"}, optional
+            Function to use for g-transformation.
 
         Returns
         -------
@@ -619,26 +618,25 @@ class SurvfuncRight:
 
         Parameters
         ----------
-        alpha : float
+        alpha : float, optional
             `1 - alpha` is the desired simultaneous coverage
             probability for the confidence region.  Currently alpha
             must be set to 0.05, giving 95% simultaneous intervals.
-        method : str
+        method : {"hw"}, optional
             The method used to produce the simultaneous confidence
             band.  Only the Hall-Wellner (hw) method is currently
             implemented.
-        transform : str
+        transform : {"log", "arcsin"}, optional
             The transform used to produce the interval (note that
             the returned interval is on the survival probability
-            scale regardless of which transform is used).  Only
-            `log` and `arcsin` are implemented.
+            scale regardless of which transform is used).
 
         Returns
         -------
-        lcb : array_like
+        lcb : ndarray
             The lower confidence limits corresponding to the points
             in `surv_times`.
-        ucb : array_like
+        ucb : ndarray
             The upper confidence limits corresponding to the points
             in `surv_times`.
         """
@@ -701,9 +699,9 @@ def survdiff(time, status, group, weight_type=None, strata=None,
         - gb : Gehan-Breslow, weights by the number at risk
         - tw : Tarone-Ware, weights by the square root of the number at risk
 
-    strata : array_like
+    strata : array_like, optional
         Optional stratum indicators for a stratified test
-    entry : array_like
+    entry : array_like, optional
         Entry times to handle left truncation. The subject is not in
         the risk set on or before the entry time.
 
@@ -856,7 +854,7 @@ def plot_survfunc(survfuncs, ax=None):
 
     Parameters
     ----------
-    survfuncs : object or array_like
+    survfuncs : SurvfuncRight or list of SurvfuncRight
         A single SurvfuncRight object, or a list of SurvfuncRight
         objects that are plotted together.
     ax : AxesSubplot, optional

--- a/statsmodels/gam/gam_cross_validation/cross_validators.py
+++ b/statsmodels/gam/gam_cross_validation/cross_validators.py
@@ -40,10 +40,10 @@ class KFold(BaseCrossValidator):
     ----------
     k_folds : int
         Number of folds.
-    shuffle : bool
+    shuffle : bool, optional
         If true, then the index is shuffled before splitting into train and
         test indices.
-    rng : int, array_like of int, numpy.random.Generator, numpy.random.RandomState, optional
+    rng : int, array_like of int, numpy.random.Generator, or numpy.random.RandomState, optional
         If `rng` is None, a new ``Generator`` is created using fresh
         entropy from the operating system. If `rng` is an int or array
         of ints, a new ``Generator`` is created, seeded with `rng`. If

--- a/statsmodels/gam/gam_cross_validation/gam_cross_validation.py
+++ b/statsmodels/gam/gam_cross_validation/gam_cross_validation.py
@@ -181,7 +181,7 @@ class MultivariateGAMCV(BaseCV):
         penalty weights, one for each smooth term
     gam : model class
         model class for creating a model with the training data
-    cost : function
+    cost : callable
         cost function used to compute the prediction error
     endog : ndarray
         dependent (response) variable of the model
@@ -192,7 +192,7 @@ class MultivariateGAMCV(BaseCV):
 
     Attributes
     ----------
-    cost : function
+    cost : callable
         cost function used to compute the prediction error
     gam : model class
         model class for creating a model with the training data
@@ -323,12 +323,12 @@ class MultivariateGAMCVPath:
     ----------
     smoother : additive smoother instance
         smoother providing the basis for the smooth terms of the model
-    alphas : list of iterables
+    alphas : list of iterable
         list of alpha for smooths. The product space will be used as alpha
         grid for cross-validation
     gam : model class
         model class for creating a model with k-fold training data
-    cost : function
+    cost : callable
         cost function for the prediction error
     endog : ndarray
         dependent (response) variable of the model
@@ -339,15 +339,15 @@ class MultivariateGAMCVPath:
 
     Attributes
     ----------
-    cost : function
+    cost : callable
         cost function for the prediction error
     smoother : additive smoother instance
         smoother providing the basis for the smooth terms of the model
     gam : model class
         model class for creating a model with k-fold training data
-    alphas : list of iterables
+    alphas : list of iterable
         list of alpha for smooths
-    alphas_grid : list of tuples
+    alphas_grid : list of tuple
         product space of ``alphas`` searched during cross-validation
     endog : ndarray
         dependent (response) variable of the model

--- a/statsmodels/gam/gam_penalties.py
+++ b/statsmodels/gam/gam_penalties.py
@@ -21,9 +21,9 @@ class UnivariateGamPenalty(Penalty):
     ----------
     univariate_smoother : instance
         instance of univariate smoother or spline class
-    alpha : float
+    alpha : float, optional
         default penalty weight, alpha can be provided to each method
-    weights : array_like
+    weights : array_like, optional
         Not used and not verified, might be removed.
 
     Attributes
@@ -55,7 +55,7 @@ class UnivariateGamPenalty(Penalty):
         ----------
         params : ndarray
             coefficients for the spline basis in the regression model
-        alpha : float
+        alpha : float, optional
             default penalty weight
 
         Returns
@@ -77,7 +77,7 @@ class UnivariateGamPenalty(Penalty):
         ----------
         params : ndarray
             coefficients for the spline basis in the regression model
-        alpha : float
+        alpha : float, optional
             default penalty weight
 
         Returns
@@ -100,7 +100,7 @@ class UnivariateGamPenalty(Penalty):
         ----------
         params : ndarray
             coefficients for the spline basis in the regression model
-        alpha : float
+        alpha : float, optional
             default penalty weight
 
         Returns
@@ -121,8 +121,8 @@ class UnivariateGamPenalty(Penalty):
 
         Parameters
         ----------
-        alpha : list of floats or None
-            penalty weights
+        alpha : float, optional
+            penalty weight
 
         Returns
         -------
@@ -149,12 +149,12 @@ class MultivariateGamPenalty(Penalty):
     alpha : list of float
         default penalty weight, list with length equal to the number of smooth
         terms. ``alpha`` can also be provided to each method.
-    weights : array_like
+    weights : array_like, optional
         currently not used
         is a list of doubles of the same length as alpha or a list
         of ndarrays where each component has the length equal to the number
         of columns in that component
-    start_idx : int
+    start_idx : int, optional
         number of parameters that come before the smooth terms. If the model
         has a linear component, then the parameters for the smooth components
         start at ``start_index``.
@@ -236,7 +236,7 @@ class MultivariateGamPenalty(Penalty):
         ----------
         params : ndarray
             coefficients in the regression model
-        alpha : float or list of floats
+        alpha : list of float, optional
             penalty weights
 
         Returns
@@ -262,7 +262,7 @@ class MultivariateGamPenalty(Penalty):
         ----------
         params : ndarray
             coefficients in the regression model
-        alpha : list of floats or None
+        alpha : list of float, optional
             penalty weights
 
         Returns
@@ -288,7 +288,7 @@ class MultivariateGamPenalty(Penalty):
         ----------
         params : ndarray
             coefficients in the regression model
-        alpha : list of floats or None
+        alpha : list of float, optional
             penalty weights
 
         Returns
@@ -312,7 +312,7 @@ class MultivariateGamPenalty(Penalty):
 
         Parameters
         ----------
-        alpha : list of floats or None
+        alpha : list of float, optional
             penalty weights
 
         Returns

--- a/statsmodels/gam/generalized_additive_model.py
+++ b/statsmodels/gam/generalized_additive_model.py
@@ -176,7 +176,7 @@ class GLMGamResults(GLMResults):
         ----------
         exog : array_like, optional
             The values for the linear explanatory variables.
-        exog_smooth : array_like
+        exog_smooth : array_like, optional
             values for the variables in the smooth terms
         transform : bool, optional
             If transform is False, then ``exog`` is returned unchanged and
@@ -230,7 +230,7 @@ class GLMGamResults(GLMResults):
         ----------
         exog : array_like, optional
             The values for the linear explanatory variables
-        exog_smooth : array_like
+        exog_smooth : array_like, optional
             values for the variables in the smooth terms
         transform : bool, optional
             If transform is True, then the basis representation of the smooth
@@ -295,7 +295,7 @@ class GLMGamResults(GLMResults):
         ----------
         exog : array_like, optional
             The values for which you want to predict.
-        exog_smooth : array_like
+        exog_smooth : array_like, optional
             values for the variables in the smooth terms
         transform : bool, optional
             If transform is True, then the basis representation of the smooth
@@ -325,7 +325,7 @@ class GLMGamResults(GLMResults):
         ----------
         smooth_index : int
             index of the smooth term within list of smooth terms
-        include_constant : bool
+        include_constant : bool, optional
             If true, then the estimated intercept is added to the prediction
             and its standard errors. This avoids that the confidence interval
             has zero width at the imposed identification constraint, e.g.
@@ -379,19 +379,20 @@ class GLMGamResults(GLMResults):
         ----------
         smooth_index : int
             index of the smooth term within list of smooth terms
-        plot_se : bool
+        plot_se : bool, optional
             If plot_se is true, then the confidence interval for the linear
             prediction will be added to the plot.
-        cpr : bool
+        cpr : bool, optional
             If cpr (component plus residual) is true, then a scatter plot of
             the partial working residuals will be added to the plot.
-        include_constant : bool
+        include_constant : bool, optional
             If true, then the estimated intercept is added to the prediction
             and its standard errors. This avoids that the confidence interval
             has zero width at the imposed identification constraint, e.g.
             either at a reference point or at the mean.
-        ax : None or matplotlib axis instance
-           If ax is not None, then the plot will be added to it.
+        ax : AxesSubplot, optional
+            An axes on which to draw the graph. If None, new figure and
+            axes objects are created.
 
         Returns
         -------
@@ -468,14 +469,14 @@ class GLMGamResults(GLMResults):
 
         Parameters
         ----------
-        observed : bool
+        observed : bool, optional
             If true, then observed hessian is used in the hat matrix
             computation. If false, then the expected hessian is used.
             In the case of a canonical link function both are the same.
             This is only relevant for models that implement both observed
             and expected Hessian, which is currently only GLM. Other
             models only use the observed Hessian.
-        _axis : int
+        _axis : int, optional
             This is mainly for internal use. By default it returns the usual
             diagonal of the hat matrix. If _axis is zero, then the result
             corresponds to the effective degrees of freedom, ``edf`` for each
@@ -547,21 +548,22 @@ class GLMGam(PenalizedMixin, GLM):
     ----------
     endog : array_like
         The response variable.
-    exog : array_like or None
+    exog : array_like, optional
         These explanatory variables are treated as linear. The model in
-        this case is a partial linear model.
+        this case is a partial linear model. If None, the model does not
+        include a linear part.
     smoother : instance of additive smoother class
         Examples of smoother instances include Bsplines or CyclicCubicSplines.
     alpha : float or list of floats
         Penalization weights for smooth terms. The length of the list needs
         to be the same as the number of smooth terms in the ``smoother``.
-    family : instance of GLM family
+    family : family class instance, optional
         See GLM.
-    offset : None or array_like
+    offset : array_like, optional
         See GLM.
-    exposure : None or array_like
+    exposure : array_like, optional
         See GLM.
-    missing : str
+    missing : str, optional
         Missing value handling is not supported in this class, and the
         value must be 'none'.
     **kwargs
@@ -722,22 +724,22 @@ class GLMGam(PenalizedMixin, GLM):
             through to the underlying optimizer.
         maxiter : int, optional
             Maximum number of iterations. Default is 1000.
-        method : str
+        method : str, optional
             The special optimization method is "pirls" which uses a
             penalized version of IRLS. This is the default. Other methods
             are gradient optimizers as used in
             base.model.LikelihoodModel.fit that are called on the
             penalized log-likelihood.
-        tol : float
+        tol : float, optional
             Convergence tolerance for "pirls". Default is 1e-8.
         scale : str or float, optional
             `scale` can be 'X2', 'dev', or a float. See GLM.fit for details.
-        cov_type : str
+        cov_type : str, optional
             The type of parameter estimate covariance matrix to compute.
-        cov_kwds : dict-like
+        cov_kwds : dict-like, optional
             Extra arguments for calculating the covariance of the parameter
             estimates.
-        use_t : bool
+        use_t : bool, optional
             If True, the Student t-distribution is used for inference.
         full_output : bool, optional
             Set to True to have all available output in the Results
@@ -745,7 +747,7 @@ class GLMGam(PenalizedMixin, GLM):
         disp : bool, optional
             Set to True to print convergence messages. Not used if method
             is "pirls".
-        max_start_irls : int
+        max_start_irls : int, optional
             The number of PIRLS iterations used to obtain starting values
             for gradient optimization. Only relevant if `method` is set to
             something other than "pirls".
@@ -835,17 +837,17 @@ class GLMGam(PenalizedMixin, GLM):
             specific ``starting_mu`` is used to initialize the fit.
         maxiter : int, optional
             Maximum number of PIRLS iterations. Default is 100.
-        tol : float
+        tol : float, optional
             Convergence tolerance. Default is 1e-8.
         scale : str or float, optional
             `scale` can be 'X2', 'dev', or a float. See GLM.fit for
             details.
-        cov_type : str
+        cov_type : str, optional
             The type of parameter estimate covariance matrix to compute.
-        cov_kwds : dict-like
+        cov_kwds : dict-like, optional
             Extra arguments for calculating the covariance of the
             parameter estimates.
-        use_t : bool
+        use_t : bool, optional
             If True, the Student t-distribution is used for inference.
         weights : array_like, optional
             Case weights to be used in the WLS updates. If None, then
@@ -978,16 +980,16 @@ class GLMGam(PenalizedMixin, GLM):
 
         Parameters
         ----------
-        criterion : str
+        criterion : str, optional
             name of results attribute to be minimized.
             Default is 'aic', other options are 'gcv', 'cv' or 'bic'.
-        start_params : None or array
+        start_params : array_like, optional
             starting parameters for alpha in the penalization weight
             minimization. The parameters are internally exponentiated and
             the minimization is with respect to ``exp(alpha)``
-        start_model_params : None or array
+        start_model_params : array_like, optional
             starting parameter for the ``model._fit_pirls``.
-        method : 'basinhopping', 'nm' or 'minimize'
+        method : 'basinhopping', 'nm' or 'minimize', optional
             'basinhopping' and 'nm' directly use the underlying scipy.optimize
             functions `basinhopping` and `fmin`. 'minimize' provides access
             to the high level interface, `scipy.optimize.minimize`.
@@ -1094,23 +1096,23 @@ class GLMGam(PenalizedMixin, GLM):
 
         Parameters
         ----------
-        alphas : None or list of arrays
+        alphas : list of array_like, optional
             Grid of alpha values to search over, one array per smooth
             term. If None, a default grid is constructed, see Notes.
-        cv_iterator : instance
+        cv_iterator : instance, optional
             instance of a cross-validation iterator, by default this is a
             KFold instance
-        cost : function
+        cost : callable, optional
             default is mean squared error. The cost function to evaluate the
             prediction error for the left out sample. This should take two
             arrays as argument and return one float.
-        k_folds : int
+        k_folds : int, optional
             number of folds if default Kfold iterator is used.
             This is ignored if ``cv_iterator`` is not None.
-        k_grid : int
+        k_grid : int, optional
             number of points in the default grid of alpha values for each
             smooth term. This is ignored if ``alphas`` is not None.
-        rng : int, array_like of int, numpy.random.Generator, numpy.random.RandomState, optional
+        rng : int, array_like of int, numpy.random.Generator, or numpy.random.RandomState, optional
             If `rng` is None, a new ``Generator`` is created using fresh
             entropy from the operating system. If `rng` is an int or array
             of ints, a new ``Generator`` is created, seeded with `rng`. If

--- a/statsmodels/gam/smooth_basis.py
+++ b/statsmodels/gam/smooth_basis.py
@@ -85,10 +85,10 @@ def _eval_bspline_basis(x, knots, degree, deriv="all", include_intercept=True):
         duplicate copies of the boundary knots should already be included.
     degree : int
         Degree of the spline.
-    deriv : {"all", 0, 1, 2}
+    deriv : {"all", 0, 1, 2}, optional
         Which derivative of the basis to return. If "all", a tuple with
         the basis and its first and second derivatives is returned.
-    include_intercept : bool
+    include_intercept : bool, optional
         If False, the first basis column (the constant) is dropped.
 
     Returns
@@ -201,7 +201,27 @@ def compute_all_knots(x, df, degree):
 
 
 def make_bsplines_basis(x, df, degree):
-    """Make a spline basis for x."""
+    """
+    Make a spline basis for x
+
+    Parameters
+    ----------
+    x : array_like
+        Underlying explanatory variable used to place the interior knots.
+    df : int
+        Number of basis functions or degrees of freedom.
+    degree : int
+        Degree of the spline.
+
+    Returns
+    -------
+    basis : ndarray
+        Design matrix for the spline basis.
+    der_basis : ndarray
+        First derivative of `basis`.
+    der2_basis : ndarray
+        Second derivative of `basis`.
+    """
 
     all_knots, _, _, _ = compute_all_knots(x, df, degree)
     basis, der_basis, der2_basis = _eval_bspline_basis(x, all_knots, degree)
@@ -234,9 +254,9 @@ def get_knots_bsplines(x=None, df=None, knots=None, degree=3,
     knots : array_like, optional
         Interior knots. If provided, these are used directly instead of
         being computed from `x`.
-    degree : int
+    degree : int, optional
         Degree of the spline.
-    spacing : {"quantile", "equal"}
+    spacing : {"quantile", "equal"}, optional
         Method used to compute interior knots when `knots` is not
         provided: quantiles of `x`, or equally spaced over its range.
     lower_bound : float, optional
@@ -335,7 +355,7 @@ def _get_integration_points(knots, k_points=3):
     ----------
     knots : array_like
         1-D array of knots.
-    k_points : int
+    k_points : int, optional
         Number of points to insert between each pair of consecutive
         knots.
 
@@ -368,17 +388,17 @@ def get_covder2(smoother, k_points=3, integration_points=None,
         Smoother for which the penalty matrix based on the second
         derivative is computed. Needs a ``knots`` attribute and a
         ``transform`` method.
-    k_points : int
+    k_points : int, optional
         Number of points to insert between each pair of consecutive knots
         when `integration_points` is not provided.
     integration_points : array_like, optional
         Points at which to evaluate the second derivative. If not
         provided, points are generated from `smoother.knots` using
         `k_points`.
-    skip_ctransf : bool
+    skip_ctransf : bool, optional
         Whether to skip the constraint transform when evaluating the
         smoother's derivative.
-    deriv : int
+    deriv : int, optional
         Derivative of the smoother basis used to compute the penalty
         matrix.
 
@@ -412,7 +432,7 @@ def make_poly_basis(x, degree, intercept=True):
         1-D array of the underlying explanatory variable.
     degree : int
         Highest power included in the polynomial basis.
-    intercept : bool
+    intercept : bool, optional
         If False, the constant column is dropped from the basis and its
         derivatives.
 
@@ -469,11 +489,11 @@ class UnivariateGamSmoother(with_metaclass(ABCMeta)):
     ----------
     x : ndarray, 1-D
         Underlying explanatory variable for the smooth term.
-    constraints : {None, str, array_like}
+    constraints : None, str, or ndarray, optional
         Constraints are used to transform the basis functions to satisfy
         those constraints. ``constraints = 'center'`` applies a linear
         transform to remove the constant and center the basis functions.
-    variable_name : str
+    variable_name : str, optional
         The name for the underlying explanatory variable, x, used for
         creating the column and parameter names for the basis functions.
     """
@@ -533,7 +553,7 @@ class UnivariateGenericSmoother(UnivariateGamSmoother):
         Second derivative of `basis`.
     cov_der2 : ndarray
         Penalty matrix based on the second derivative.
-    variable_name : str
+    variable_name : str, optional
         The name for the underlying explanatory variable, x, used for
         creating the column and parameter names for the basis functions.
     """
@@ -561,7 +581,7 @@ class UnivariatePolynomialSmoother(UnivariateGamSmoother):
         Underlying explanatory variable for the smooth term.
     degree : int
         Highest power included in the polynomial basis.
-    variable_name : str
+    variable_name : str, optional
         The name for the underlying explanatory variable, x, used for
         creating the column and parameter names for the basis functions.
     """
@@ -607,24 +627,24 @@ class UnivariateBSplines(UnivariateGamSmoother):
         underlying explanatory variable for smooth terms.
     df : int
         number of basis functions or degrees of freedom
-    degree : int
+    degree : int, optional
         degree of the spline
-    include_intercept : bool
+    include_intercept : bool, optional
         If False, then the basis functions are transformed so that they
         do not include a constant. This avoids perfect collinearity if
         a constant or several components are included in the model.
-    constraints : {None, str, array}
+    constraints : None, str, or ndarray, optional
         Constraints are used to transform the basis functions to satisfy
         those constraints.
         `constraints = 'center'` applies a linear transform to remove the
         constant and center the basis functions.
-    variable_name : {None, str}
+    variable_name : str, optional
         The name for the underlying explanatory variable, x, used in for
         creating the column and parameter names for the basis functions.
-    covder2_kwds : {None, dict}
+    covder2_kwds : dict, optional
         options for computing the penalty matrix from the second derivative
         of the spline.
-    knot_kwds : {None, list[dict]}
+    **knot_kwds
         option for the knot selection.
         By default knots are selected in the same way as in patsy, however the
         number of knots is independent of keeping or removing the constant.
@@ -633,16 +653,16 @@ class UnivariateBSplines(UnivariateGamSmoother):
         range.
         The available options used with `get_knots_bsplines` are
 
-        - knots : None or array
+        - knots : array_like, optional
           interior knots
         - spacing : 'quantile' or 'equal'
-        - lower_bound : None or float
+        - lower_bound : float, optional
           location of lower boundary knots, all boundary knots are at the same
           point
-        - upper_bound : None or float
+        - upper_bound : float, optional
           location of upper boundary knots, all boundary knots are at the same
           point
-        - all_knots : None or array
+        - all_knots : array_like, optional
           If all knots are provided, then those will be taken as given and
           all other options will be ignored.
     """
@@ -680,10 +700,10 @@ class UnivariateBSplines(UnivariateGamSmoother):
         ----------
         x_new : ndarray
             observations of the underlying explanatory variable
-        deriv : int
+        deriv : int, optional
             which derivative of the spline basis to compute
             This is an option for internal computation.
-        skip_ctransf : bool
+        skip_ctransf : bool, optional
             whether to skip the constraint transform
             This is an option for internal computation.
 
@@ -718,16 +738,16 @@ class UnivariateCubicSplines(UnivariateGamSmoother):
         Underlying explanatory variable for the smooth term.
     df : int
         Number of basis functions or degrees of freedom.
-    constraints : {None, str, array_like}
+    constraints : None, str, or ndarray, optional
         Constraints are used to transform the basis functions to satisfy
         those constraints. ``constraints = 'no-const'`` drops the
         constant column from the basis.
-    transform : {None, "domain", tuple}
+    transform : None, "domain", or tuple, optional
         Rescaling applied to `x` before computing the basis. If
         ``"domain"``, `x` is rescaled to the unit interval using its own
         minimum and maximum. If a tuple ``(low, upp)``, `x` is rescaled
         to the unit interval using those bounds instead.
-    variable_name : str
+    variable_name : str, optional
         The name for the underlying explanatory variable, x, used for
         creating the column and parameter names for the basis functions.
     """
@@ -752,7 +772,7 @@ class UnivariateCubicSplines(UnivariateGamSmoother):
         ----------
         x : ndarray
             Observations of the underlying explanatory variable.
-        initialize : bool
+        initialize : bool, optional
             If True, the rescaling bounds (`domain_low`, `domain_upp`,
             `domain_diff`) are computed from `x` (or from the tuple
             passed to `transform` at instance construction) and stored
@@ -891,12 +911,12 @@ class UnivariateCubicCyclicSplines(UnivariateGamSmoother):
         underlying explanatory variable for smooth terms.
     df : int
         number of basis functions or degrees of freedom
-    constraints : {None, str, array}
+    constraints : None, str, or ndarray, optional
         Constraints are used to transform the basis functions to satisfy
         those constraints.
         `constraints = 'center'` applies a linear transform to remove the
         constant and center the basis functions.
-    variable_name : None or str
+    variable_name : str, optional
         The name for the underlying explanatory variable, x, used in for
         creating the column and parameter names for the basis functions.
     """
@@ -1036,11 +1056,11 @@ class AdditiveGamSmoother(with_metaclass(ABCMeta)):
         Underlying explanatory variable(s) for the smooth terms. If
         2-dimensional, observations are in rows and explanatory
         variables in columns.
-    variable_names : {list[str], None}
+    variable_names : list of str, optional
         Names for the underlying explanatory variables. If None and
         `x` is a pandas object, the names are taken from it, otherwise
         generic names are generated.
-    include_intercept : bool or list[bool]
+    include_intercept : bool or list of bool, optional
         If False, then the basis functions of each smooth term are
         transformed so that they do not include a constant. Can be a
         single bool applied to all smooth terms, or a list with one
@@ -1112,7 +1132,7 @@ class AdditiveGamSmoother(with_metaclass(ABCMeta)):
 
         Parameters
         ----------
-        x_new: ndarray
+        x_new : ndarray
             observations of the underlying explanatory variable
 
         Returns
@@ -1161,10 +1181,10 @@ class PolynomialSmoother(AdditiveGamSmoother):
         Underlying explanatory variable(s) for the smooth terms. If
         2-dimensional, observations are in rows and explanatory
         variables in columns.
-    degrees : array_like of int
+    degrees : sequence of int
         Highest power included in the polynomial basis for each
         explanatory variable in `x`.
-    variable_names : {list[str], None}
+    variable_names : list of str, optional
         The names for the underlying explanatory variables, used for
         creating the column and parameter names for the basis functions.
         If ``x`` is a pandas object, then the names will be taken from it.
@@ -1197,27 +1217,27 @@ class BSplines(AdditiveGamSmoother):
         underlying explanatory variable for smooth terms.
         If 2-dimensional, then observations should be in rows and
         explanatory variables in columns.
-    df :  int or array_like of int
+    df : int or sequence of int
         number of basis functions or degrees of freedom; should be equal
         in length to the number of columns of `x`; may be an integer if
         `x` has one column or is 1-D.
-    degree : int or array_like of int
+    degree : int or sequence of int
         degree(s) of the spline; the same length and type rules apply as
         to `df`
-    include_intercept : bool
+    include_intercept : bool, optional
         If False, then the basis functions are transformed so that they
         do not include a constant. This avoids perfect collinearity if
         a constant or several components are included in the model.
-    constraints : {None, str, array}
+    constraints : None, str, or ndarray, optional
         Constraints are used to transform the basis functions to satisfy
         those constraints.
         `constraints = 'center'` applies a linear transform to remove the
         constant and center the basis functions.
-    variable_names : {list[str], None}
+    variable_names : list of str, optional
         The names for the underlying explanatory variables, x used in for
         creating the column and parameter names for the basis functions.
         If ``x`` is a pandas object, then the names will be taken from it.
-    knot_kwds : None or list of dict
+    knot_kwds : list of dict, optional
         option for the knot selection.
         By default knots are selected in the same way as in patsy, however the
         number of knots is independent of keeping or removing the constant.
@@ -1226,16 +1246,16 @@ class BSplines(AdditiveGamSmoother):
         range.
         The available options used with `get_knots_bsplines` are
 
-        - knots : None or array
+        - knots : array_like, optional
           interior knots
         - spacing : 'quantile' or 'equal'
-        - lower_bound : None or float
+        - lower_bound : float, optional
           location of lower boundary knots, all boundary knots are at the same
           point
-        - upper_bound : None or float
+        - upper_bound : float, optional
           location of upper boundary knots, all boundary knots are at the same
           point
-        - all_knots : None or array
+        - all_knots : array_like, optional
           If all knots are provided, then those will be taken as given and
           all other options will be ignored.
 
@@ -1243,11 +1263,17 @@ class BSplines(AdditiveGamSmoother):
     Attributes
     ----------
     smoothers : list of univariate smooth component instances
-    basis : design matrix, array of spline bases columns for all components
-    penalty_matrices : list of penalty matrices, one for each smooth term
-    dim_basis : number of columns in the basis
-    k_variables : number of smooth components
-    col_names : created names for the basis columns
+        The individual smooth components making up the additive model.
+    basis : ndarray
+        Design matrix of spline basis columns for all components.
+    penalty_matrices : list of ndarray
+        Penalty matrices, one for each smooth term.
+    dim_basis : int
+        Number of columns in the basis.
+    k_variables : int
+        Number of smooth components.
+    col_names : list of str
+        Names created for the basis columns.
 
     There are additional attributes about the specification of the splines
     and some attributes mainly for internal use.
@@ -1313,18 +1339,18 @@ class CubicSplines(AdditiveGamSmoother):
         underlying explanatory variable for smooth terms.
         If 2-dimensional, then observations should be in rows and
         explanatory variables in columns.
-    df :  array_like of int
+    df : sequence of int
         number of basis functions or degrees of freedom; should be equal
         in length to the number of columns of `x`.
-    constraints : {None, str, array}
+    constraints : None, str, or ndarray, optional
         Constraints are used to transform the basis functions to satisfy
         those constraints.
         `constraints = 'center'` applies a linear transform to remove the
         constant and center the basis functions.
-    transform : {None, "domain", tuple}
+    transform : None, "domain", or tuple, optional
         Rescaling applied to each column of `x` before computing the
         basis. See `UnivariateCubicSplines` for details.
-    variable_names : {list[str], None}
+    variable_names : list of str, optional
         The names for the underlying explanatory variables, x used in for
         creating the column and parameter names for the basis functions.
         If ``x`` is a pandas object, then the names will be taken from it.
@@ -1364,12 +1390,12 @@ class CyclicCubicSplines(AdditiveGamSmoother):
         underlying explanatory variable for smooth terms.
         If 2-dimensional, then observations should be in rows and
         explanatory variables in columns.
-    df :  int
+    df : sequence of int
         number of basis functions or degrees of freedom
-    constraints : {None, str, array}
+    constraints : None, str, or ndarray, optional
         Constraints are used to transform the basis functions to satisfy
         those constraints.
-    variable_names : {list[str], None}
+    variable_names : list of str, optional
         The names for the underlying explanatory variables, x used in for
         creating the column and parameter names for the basis functions.
         If ``x`` is a pandas object, then the names will be taken from it.

--- a/statsmodels/genmod/bayes_mixed_glm.py
+++ b/statsmodels/genmod/bayes_mixed_glm.py
@@ -94,7 +94,7 @@ _init_doc = r"""
         Array of covariates for the random part of the model.  A
         scipy.sparse array may be provided, or else the passed
         array will be converted to sparse internally.
-    ident : array_like
+    ident : array_like of int
         Array of integer labels showing which random terms (columns
         of `exog_vc`) have a common variance.
     vcp_p : float
@@ -103,16 +103,14 @@ _init_doc = r"""
         the standard deviation of a random effect).
     fe_p : float
         Prior standard deviation for fixed effects parameters.
-    family : statsmodels.genmod.families instance
-        The GLM family.
-    fep_names : list[str]
+    fep_names : list of str, optional
         The names of the fixed effects parameters (corresponding to
         columns of exog).  If None, default names are constructed.
-    vcp_names : list[str]
+    vcp_names : list of str, optional
         The names of the variance component parameters (corresponding
         to distinct labels in ident).  If None, default names are
         constructed.
-    vc_names : list[str]
+    vc_names : list of str, optional
         The names of the random effect realizations.
 
     Returns
@@ -418,20 +416,20 @@ class _BayesMixedGLM(base.Model):
         formula : str
             Formula for the endog and fixed effects terms (use ~ to
             separate dependent and independent expressions).
-        vc_formulas : dictionary
+        vc_formulas : dict
             vc_formulas[name] is a one-sided formula that creates one
             collection of random effects with a common variance
             parameter.  If using categorical (factor) variables to
             produce variance components, note that generally `0 + ...`
             should be used so that an intercept is not included.
-        data : data frame
+        data : DataFrame
             The data to which the formulas are applied.
-        family : genmod.families instance
+        family : statsmodels.genmod.families instance, optional
             A GLM family.
-        vcp_p : float
+        vcp_p : float, optional
             The prior standard deviation for the logarithms of the standard
             deviations of the random effects.
-        fe_p : float
+        fe_p : float, optional
             The prior standard deviation for the fixed effects parameters.
         """
 
@@ -482,16 +480,16 @@ class _BayesMixedGLM(base.Model):
 
         Parameters
         ----------
-        method : str
+        method : str, optional
             Optimization method for finding the posterior mode.
-        minim_opts : dict
+        minim_opts : dict, optional
             Options passed to scipy.minimize.
-        scale_fe : bool
+        scale_fe : bool, optional
             If True, the columns of the fixed effects design matrix
             are centered and scaled to unit variance before fitting
             the model.  The results are back-transformed so that the
             results are presented on the original scale.
-        rng : int, array_like of int, numpy.random.Generator, numpy.random.RandomState, optional
+        rng : int, array_like of int, numpy.random.Generator, or numpy.random.RandomState, optional
             If `rng` is None, a new ``Generator`` is created using fresh
             entropy from the operating system. If `rng` is an int or array
             of ints, a new ``Generator`` is created, seeded with `rng`. If
@@ -551,10 +549,10 @@ class _BayesMixedGLM(base.Model):
         params : array_like
             The parameter vector, may be the full parameter vector, or may
             be truncated to include only the mean parameters.
-        exog : array_like
+        exog : array_like, optional
             The design matrix for the mean structure.  If omitted, use the
             model's design matrix.
-        linear : bool
+        linear : bool, optional
             If True, return the linear predictor without passing through the
             link function.
 
@@ -608,8 +606,9 @@ class _VariationalBayesMixedGLM:
 
         Parameters
         ----------
-        h : function mapping 1d vector to 1d vector
-            The contribution of the model to the ELBO function can be
+        h : callable
+            A function mapping a 1d vector to a 1d vector.  The
+            contribution of the model to the ELBO function can be
             expressed as y_i*lp_i + Eh_i(z), where y_i and lp_i are
             the response and linear predictor for observation i, and z
             is a standard normal random variable.  This formulation
@@ -629,6 +628,11 @@ class _VariationalBayesMixedGLM:
             Standard deviation of the variance component parameters.
         vc_sd : array_like
             Standard deviation of the random effects realizations.
+
+        Returns
+        -------
+        float
+            The evidence lower bound value.
         """
 
         # p(y | vc) contributions
@@ -728,23 +732,23 @@ class _VariationalBayesMixedGLM:
 
         Parameters
         ----------
-        mean : array_like
+        mean : array_like, optional
             Starting value for VB mean vector
-        sd : array_like
+        sd : array_like, optional
             Starting value for VB standard deviation vector
-        fit_method : str
+        fit_method : str, optional
             Algorithm for scipy.minimize
-        minim_opts : dict
+        minim_opts : dict, optional
             Options passed to scipy.minimize
-        scale_fe : bool
+        scale_fe : bool, optional
             If true, the columns of the fixed effects design matrix
             are centered and scaled to unit variance before fitting
             the model.  The results are back-transformed so that the
             results are presented on the original scale.
-        verbose : bool
+        verbose : bool, optional
             If True, print the gradient norm to the screen each time
             it is calculated.
-        rng : int, array_like of int, numpy.random.Generator, numpy.random.RandomState, optional
+        rng : int, array_like of int, numpy.random.Generator, or numpy.random.RandomState, optional
             If `rng` is None, a new ``Generator`` is created using fresh
             entropy from the operating system. If `rng` is an int or array
             of ints, a new ``Generator`` is created, seeded with `rng`. If
@@ -898,20 +902,30 @@ class BayesMixedGLMResults:
 
     Attributes
     ----------
-    fe_mean : array_like
+    model : _BayesMixedGLM
+        The model instance used to obtain this result.
+    params : ndarray
+        The full vector of posterior parameter estimates (fixed
+        effects, variance component parameters, and random effect
+        realizations, in that order).
+    fe_mean : ndarray
         Posterior mean of the fixed effects coefficients.
-    fe_sd : array_like
+    fe_sd : ndarray
         Posterior standard deviation of the fixed effects coefficients
-    vcp_mean : array_like
+    vcp_mean : ndarray
         Posterior mean of the logged variance component standard
         deviations.
-    vcp_sd : array_like
+    vcp_sd : ndarray
         Posterior standard deviation of the logged variance component
         standard deviations.
-    vc_mean : array_like
+    vc_mean : ndarray
         Posterior mean of the random coefficients
-    vc_sd : array_like
+    vc_sd : ndarray
         Posterior standard deviation of the random coefficients
+    optim_retvals : optional
+        The return value of the numerical optimization routine used
+        to obtain the fit (e.g. the ``OptimizeResult`` from
+        ``scipy.optimize.minimize``), if available.
     """
 
     def __init__(self, model, params, cov_params, optim_retvals=None):
@@ -933,6 +947,20 @@ class BayesMixedGLMResults:
         self.vc_sd = np.sqrt(self.vc_sd)
 
     def cov_params(self):
+        """
+        Return the covariance matrix of the posterior parameter estimates.
+
+        Returns
+        -------
+        DataFrame, Series, or ndarray
+            If the model data was fit using a formula (or otherwise has
+            named parameters), a DataFrame (2-dimensional covariance
+            matrix) or Series (1-dimensional variances only, as
+            produced by variational Bayes fitting) is returned, with
+            index and, if applicable, columns given by the parameter
+            names.  Otherwise, the covariance matrix or variance
+            vector is returned as an ndarray.
+        """
 
         if hasattr(self.model.data, "frame"):
             # Return the covariance matrix as a dataframe or series
@@ -946,6 +974,16 @@ class BayesMixedGLMResults:
         return self._cov_params
 
     def summary(self):
+        """
+        Summarize the posterior parameter estimates.
+
+        Returns
+        -------
+        Summary
+            A summary instance with tables of the mean structure and
+            variance structure parameter estimates, which can be
+            printed or converted to various output formats.
+        """
 
         df = pd.DataFrame()
         m = self.model.k_fep + self.model.k_vcp
@@ -991,7 +1029,7 @@ class BayesMixedGLMResults:
 
         Parameters
         ----------
-        term : int or None
+        term : int or None, optional
             If None, results for all random effects are returned.  If
             an integer, returns results for a given set of random
             effects.  The value of `term` refers to an element of the
@@ -1028,10 +1066,10 @@ class BayesMixedGLMResults:
 
         Parameters
         ----------
-        exog : array_like
+        exog : array_like, optional
             The design matrix for the mean structure.  If None,
             use the model's design matrix.
-        linear : bool
+        linear : bool, optional
             If True, returns the linear predictor, otherwise
             transform the linear predictor using the link function.
 
@@ -1087,18 +1125,18 @@ class BinomialBayesMixedGLM(_VariationalBayesMixedGLM, _BayesMixedGLM):
         formula : str
             Formula for the endog and fixed effects terms (use ~ to
             separate dependent and independent expressions).
-        vc_formulas : dictionary
+        vc_formulas : dict
             vc_formulas[name] is a one-sided formula that creates one
             collection of random effects with a common variance
             parameter.  If using categorical (factor) variables to
             produce variance components, note that generally `0 + ...`
             should be used so that an intercept is not included.
-        data : data frame
+        data : DataFrame
             The data to which the formulas are applied.
-        vcp_p : float
+        vcp_p : float, optional
             The prior standard deviation for the logarithms of the standard
             deviations of the random effects.
-        fe_p : float
+        fe_p : float, optional
             The prior standard deviation for the fixed effects parameters.
 
         Returns
@@ -1130,6 +1168,21 @@ class BinomialBayesMixedGLM(_VariationalBayesMixedGLM, _BayesMixedGLM):
     def vb_elbo(self, vb_mean, vb_sd):
         """
         Returns the evidence lower bound (ELBO) for the model.
+
+        Parameters
+        ----------
+        vb_mean : ndarray
+            The mean vector of the variational approximation, packed
+            as fixed effects parameters, then variance component
+            parameters, then random effect realizations.
+        vb_sd : ndarray
+            The standard deviation vector of the variational
+            approximation, packed in the same order as `vb_mean`.
+
+        Returns
+        -------
+        float
+            The evidence lower bound value.
         """
 
         fep_mean, vcp_mean, vc_mean = self._unpack(vb_mean)
@@ -1146,6 +1199,23 @@ class BinomialBayesMixedGLM(_VariationalBayesMixedGLM, _BayesMixedGLM):
     def vb_elbo_grad(self, vb_mean, vb_sd):
         """
         Returns the gradient of the model's evidence lower bound (ELBO).
+
+        Parameters
+        ----------
+        vb_mean : ndarray
+            The mean vector of the variational approximation, packed
+            as fixed effects parameters, then variance component
+            parameters, then random effect realizations.
+        vb_sd : ndarray
+            The standard deviation vector of the variational
+            approximation, packed in the same order as `vb_mean`.
+
+        Returns
+        -------
+        mean_grad : ndarray
+            The gradient of the ELBO with respect to `vb_mean`.
+        sd_grad : ndarray
+            The gradient of the ELBO with respect to `vb_sd`.
         """
 
         fep_mean, vcp_mean, vc_mean = self._unpack(vb_mean)
@@ -1210,22 +1280,22 @@ class PoissonBayesMixedGLM(_VariationalBayesMixedGLM, _BayesMixedGLM):
         formula : str
             Formula for the endog and fixed effects terms (use ~ to
             separate dependent and independent expressions).
-        vc_formulas : dictionary
+        vc_formulas : dict
             vc_formulas[name] is a one-sided formula that creates one
             collection of random effects with a common variance
             parameter.  If using categorical (factor) variables to
             produce variance components, note that generally `0 + ...`
             should be used so that an intercept is not included.
-        data : data frame
+        data : DataFrame
             The data to which the formulas are applied.
-        vcp_p : float
+        vcp_p : float, optional
             The prior standard deviation for the logarithms of the standard
             deviations of the random effects.
-        fe_p : float
+        fe_p : float, optional
             The prior standard deviation for the fixed effects parameters.
-        vcp_names : list[str]
+        vcp_names : list of str, optional
             The names of the variance component parameters.
-        vc_names : list[str]
+        vc_names : list of str, optional
             The names of the random effect realizations.
 
         Returns
@@ -1257,6 +1327,21 @@ class PoissonBayesMixedGLM(_VariationalBayesMixedGLM, _BayesMixedGLM):
     def vb_elbo(self, vb_mean, vb_sd):
         """
         Returns the evidence lower bound (ELBO) for the model.
+
+        Parameters
+        ----------
+        vb_mean : ndarray
+            The mean vector of the variational approximation, packed
+            as fixed effects parameters, then variance component
+            parameters, then random effect realizations.
+        vb_sd : ndarray
+            The standard deviation vector of the variational
+            approximation, packed in the same order as `vb_mean`.
+
+        Returns
+        -------
+        float
+            The evidence lower bound value.
         """
 
         fep_mean, vcp_mean, vc_mean = self._unpack(vb_mean)
@@ -1273,6 +1358,23 @@ class PoissonBayesMixedGLM(_VariationalBayesMixedGLM, _BayesMixedGLM):
     def vb_elbo_grad(self, vb_mean, vb_sd):
         """
         Returns the gradient of the model's evidence lower bound (ELBO).
+
+        Parameters
+        ----------
+        vb_mean : ndarray
+            The mean vector of the variational approximation, packed
+            as fixed effects parameters, then variance component
+            parameters, then random effect realizations.
+        vb_sd : ndarray
+            The standard deviation vector of the variational
+            approximation, packed in the same order as `vb_mean`.
+
+        Returns
+        -------
+        mean_grad : ndarray
+            The gradient of the ELBO with respect to `vb_mean`.
+        sd_grad : ndarray
+            The gradient of the ELBO with respect to `vb_sd`.
         """
 
         fep_mean, vcp_mean, vc_mean = self._unpack(vb_mean)

--- a/statsmodels/genmod/cov_struct.py
+++ b/statsmodels/genmod/cov_struct.py
@@ -40,6 +40,13 @@ class CovStruct:
 
     The default state of a newly-created instance should always be
     the identity correlation matrix.
+
+    Parameters
+    ----------
+    cov_nearest_method : {"clipped", "nearest"}, optional
+        Method for projecting a covariance matrix that is not positive
+        semidefinite to the nearest such matrix. See `cov_nearest` in
+        statsmodels.stats.correlation_tools for more information.
     """
 
     def __init__(self, cov_nearest_method="clipped"):
@@ -74,7 +81,7 @@ class CovStruct:
 
         Parameters
         ----------
-        params : array_like
+        params : sequence of float
             Working values for the regression parameters.
         """
         raise NotImplementedError
@@ -95,7 +102,7 @@ class CovStruct:
 
         Returns
         -------
-        M : matrix
+        M : ndarray
             The covariance or correlation matrix of endog
         is_cor : bool
             True if M is a correlation matrix, False if M is a
@@ -119,13 +126,13 @@ class CovStruct:
         stdev : array_like
             The standard deviation of endog for each observation in
             the group.
-        rhs : list/tuple of array_like
+        rhs : sequence of ndarray
             A set of right-hand sides; each defines a matrix equation
             to be solved.
 
         Returns
         -------
-        soln : list/tuple of array_like
+        soln : list of ndarray
             The solutions to the matrix equations.
 
         Notes
@@ -237,6 +244,13 @@ class Unstructured(CovStruct):
     time argument must be of integer dtype, and indicates
     which position in a complete data vector is occupied
     by each observed value.
+
+    Parameters
+    ----------
+    cov_nearest_method : {"clipped", "nearest"}, optional
+        Method for projecting a covariance matrix that is not positive
+        semidefinite to the nearest such matrix. See `cov_nearest` in
+        statsmodels.stats.correlation_tools for more information.
     """
 
     def __init__(self, cov_nearest_method="clipped"):
@@ -452,6 +466,11 @@ class Nested(CovStruct):
         `designx` is a matrix, with each row containing dummy
         variables indicating which variance components are associated
         with the corresponding element of QY.
+
+        Parameters
+        ----------
+        model : GEE class
+            A reference to the parent GEE class instance.
         """
 
         super().initialize(model)
@@ -570,8 +589,14 @@ class Nested(CovStruct):
 
     def summary(self):
         """
-        Returns a summary string describing the state of the
-        dependence structure.
+        Returns a summary of the state of the dependence structure.
+
+        Returns
+        -------
+        DataFrame
+            A DataFrame with one row per variance component
+            (including the residual), containing the estimated
+            variance of each component.
         """
 
         dep_names = ["Groups"]
@@ -603,12 +628,15 @@ class Stationary(CovStruct):
 
     Parameters
     ----------
-    max_lag : float
+    max_lag : int, optional
         The largest distance that is included in the covariance model.
-    grid : bool
+    grid : None or bool, optional
         If True, the index positions in the data (after dropping missing
         values) are used to define distances, and the `time` variable is
-        ignored.
+        ignored. If False, the `time` variable is used to determine
+        distances. If None (the default), behaves as False and a
+        ``FutureWarning`` is issued because the default will change to
+        True in a future version.
     """
 
     def __init__(self, max_lag=1, grid=None):
@@ -787,13 +815,17 @@ class Autoregressive(CovStruct):
 
     Parameters
     ----------
-    dist_func : function from R^k x R^k to R^+, optional
+    dist_func : callable, optional
         A function that computes the distance between the two
-        observations based on their `time` values.
-    grid : bool, optional
+        observations based on their `time` values. Takes two
+        array_like arguments of length `k` and returns a
+        non-negative float.
+    grid : None or bool, optional
         If True, use the grid-based implementation for equally spaced data.
         If False, estimate the dependence parameter using all available
-        pairs of observations.
+        pairs of observations. If None (the default), behaves as False
+        and a ``FutureWarning`` is issued because the default will
+        change to True in a future version.
 
     References
     ----------
@@ -1026,7 +1058,7 @@ class CategoricalCovStruct(CovStruct):
     ----------
     nlevel : int
         The number of distinct levels for the outcome variable.
-    ibd : list
+    ibd : list of ndarray
         A list whose i^th element ibd[i] is an array whose rows
         contain integer pairs (a,b), where endog_li[i][a:b] is the
         subvector of binary indicators derived from the same ordinal
@@ -1057,6 +1089,11 @@ class GlobalOddsRatio(CategoricalCovStruct):
     """
     Estimate the global odds ratio for a GEE with ordinal or nominal
     data.
+
+    Parameters
+    ----------
+    endog_type : {"ordinal", "nominal"}
+        Whether the endog variable is ordinal or nominal.
 
     Notes
     -----
@@ -1354,7 +1391,7 @@ class Equivalence(CovStruct):
 
     Parameters
     ----------
-    pairs : dict-like
+    pairs : dict-like, optional
       A dictionary of dictionaries, where `pairs[group][label]`
       provides the indices of all pairs of observations in the group
       that have the same covariance value.  Specifically,
@@ -1364,14 +1401,14 @@ class Equivalence(CovStruct):
       one triangle of each covariance matrix should be included.
       Positions where j1 and j2 have the same value are variance
       parameters.
-    labels : array_like
+    labels : array_like, optional
       An array of labels such that every distinct pair of labels
       defines an equivalence class.  Either `labels` or `pairs` must
       be provided.  When the two labels in a pair are equal two
       equivalence classes are defined: one for the diagonal elements
       (corresponding to variances) and one for the off-diagonal
       elements (corresponding to covariances).
-    return_cov : bool
+    return_cov : bool, optional
       If True, `covariance_matrix` returns an estimate of the
       covariance matrix, otherwise returns an estimate of the
       correlation matrix.
@@ -1400,11 +1437,11 @@ class Equivalence(CovStruct):
     groups, equal variance for all observations, and constant
     covariance for all pairs of observations within each group.
 
-    >> pairs = {0: {}, 1: {}}
-    >> pairs[0][0] = (np.r_[0, 1, 2], np.r_[0, 1, 2])
-    >> pairs[0][1] = np.tril_indices(3, -1)
-    >> pairs[1][0] = (np.r_[3, 4, 5], np.r_[3, 4, 5])
-    >> pairs[1][2] = 3 + np.tril_indices(3, -1)
+    >>> pairs = {0: {}, 1: {}}
+    >>> pairs[0][0] = (np.r_[0, 1, 2], np.r_[0, 1, 2])
+    >>> pairs[0][1] = np.tril_indices(3, -1)
+    >>> pairs[1][0] = (np.r_[3, 4, 5], np.r_[3, 4, 5])
+    >>> pairs[1][2] = 3 + np.tril_indices(3, -1)
     """
 
     def __init__(self, pairs=None, labels=None, return_cov=False):
@@ -1518,7 +1555,7 @@ class Equivalence(CovStruct):
         ----------
         model : GEE class
             A reference to the parent GEE class instance.
-        rng : int, array_like of int, numpy.random.Generator, numpy.random.RandomState, optional
+        rng : int, array_like of int, numpy.random.Generator, or numpy.random.RandomState, optional
             If `rng` is None, a new ``Generator`` is created using fresh
             entropy from the operating system. If `rng` is an int or array
             of ints, a new ``Generator`` is created, seeded with `rng`. If

--- a/statsmodels/genmod/families/family.py
+++ b/statsmodels/genmod/families/family.py
@@ -33,8 +33,8 @@ class Family:
     variance : a variance function
         Measures the variance as a function of the mean probabilities.
         See the individual families for the default variance function.
-    check_link : bool
-        If True (default), then and exception is raised if the link is invalid
+    check_link : bool, optional
+        If True (default), then an exception is raised if the link is invalid
         for the family.
         If False, then the link is not checked.
 
@@ -154,16 +154,16 @@ class Family:
             The endogenous response variable
         mu : array_like
             The inverse of the link function at the linear predicted values.
-        var_weights : array_like
+        var_weights : array_like, optional
             1d array of variance (analytic) weights. The default is 1.
-        freq_weights : array_like
+        freq_weights : array_like, optional
             1d array of frequency weights. The default is 1.
         scale : float, optional
             An optional scale argument. The default is 1.
 
         Returns
         -------
-        Deviance : ndarray
+        Deviance : float
             The value of deviance function defined below.
 
         Notes
@@ -196,14 +196,14 @@ class Family:
             The endogenous response variable
         mu : array_like
             The inverse of the link function at the linear predicted values.
-        var_weights : array_like
+        var_weights : array_like, optional
             1d array of variance (analytic) weights. The default is 1.
         scale : float, optional
             An optional scale argument. The default is 1.
 
         Returns
         -------
-        resid_dev : float
+        resid_dev : ndarray
             Deviance residuals as defined below.
 
         Notes
@@ -247,7 +247,7 @@ class Family:
 
         Parameters
         ----------
-        mu : ndarray
+        mu : array_like
             The mean response variables
 
         Returns
@@ -265,18 +265,18 @@ class Family:
 
         Parameters
         ----------
-        endog : ndarray
+        endog : array_like
             Usually the endogenous response variable.
-        mu : ndarray
+        mu : array_like
             Usually but not always the fitted mean response variable.
-        var_weights : array_like
+        var_weights : array_like, optional
             1d array of variance (analytic) weights. The default is 1.
-        scale : float
+        scale : float, optional
             The scale parameter. The default is 1.
 
         Returns
         -------
-        ll_i : float
+        ll_i : ndarray
             The value of the log-likelihood evaluated at
             (endog, mu, var_weights, scale) as defined below.
 
@@ -295,15 +295,15 @@ class Family:
 
         Parameters
         ----------
-        endog : ndarray
+        endog : array_like
             Usually the endogenous response variable.
-        mu : ndarray
+        mu : array_like
             Usually but not always the fitted mean response variable.
-        var_weights : array_like
+        var_weights : array_like, optional
             1d array of variance (analytic) weights. The default is 1.
-        freq_weights : array_like
+        freq_weights : array_like, optional
             1d array of frequency weights. The default is 1.
-        scale : float
+        scale : float, optional
             The scale parameter. The default is 1.
 
         Returns
@@ -333,11 +333,11 @@ class Family:
 
         Parameters
         ----------
-        endog : ndarray
+        endog : array_like
             The endogenous response variable
-        mu : ndarray
+        mu : array_like
             The inverse of the link function at the linear predicted values.
-        var_weights : array_like
+        var_weights : array_like, optional
             1d array of variance (analytic) weights. The default is 1.
         scale : float, optional
             An optional argument to divide the residuals by sqrt(scale).
@@ -386,8 +386,8 @@ class Poisson(Family):
         The default link for the Poisson family is the log link. Available
         links are log, identity, and sqrt. See statsmodels.families.links for
         more information.
-    check_link : bool
-        If True (default), then and exception is raised if the link is invalid
+    check_link : bool, optional
+        If True (default), then an exception is raised if the link is invalid
         for the family.
         If False, then the link is not checked.
 
@@ -423,14 +423,14 @@ class Poisson(Family):
 
         Parameters
         ----------
-        endog : ndarray
+        endog : array_like
             The endogenous response variable.
-        mu : ndarray
+        mu : array_like
             The inverse of the link function at the linear predicted values.
 
         Returns
         -------
-        resid_dev : float
+        resid_dev : ndarray
             Deviance residuals as defined below.
 
         Notes
@@ -451,18 +451,18 @@ class Poisson(Family):
 
         Parameters
         ----------
-        endog : ndarray
+        endog : array_like
             Usually the endogenous response variable.
-        mu : ndarray
+        mu : array_like
             Usually but not always the fitted mean response variable.
-        var_weights : array_like
+        var_weights : array_like, optional
             1d array of variance (analytic) weights. The default is 1.
-        scale : float
+        scale : float, optional
             The scale parameter. The default is 1.
 
         Returns
         -------
-        ll_i : float
+        ll_i : ndarray
             The value of the log-likelihood evaluated at
             (endog, mu, var_weights, scale) as defined below.
 
@@ -482,11 +482,11 @@ class Poisson(Family):
 
         Parameters
         ----------
-        endog : ndarray
+        endog : array_like
             The endogenous response variable
-        mu : ndarray
+        mu : array_like
             The inverse of the link function at the linear predicted values.
-        var_weights : array_like
+        var_weights : array_like, optional
             1d array of variance (analytic) weights. The default is 1.
         scale : float, optional
             An optional argument to divide the residuals by sqrt(scale).
@@ -518,11 +518,11 @@ class Poisson(Family):
 
         Parameters
         ----------
-        mu : ndarray
+        mu : array_like
             Usually but not always the fitted mean response variable.
-        scale : float
+        scale : float, optional
             The scale parameter is ignored.
-        var_weights : array_like
+        var_weights : array_like, optional
             1d array of variance (analytic) weights. The default is 1.
             var_weights are ignored for Poisson.
 
@@ -545,8 +545,8 @@ class Gaussian(Family):
         The default link for the Gaussian family is the identity link.
         Available links are log, identity, and inverse.
         See statsmodels.genmod.families.links for more information.
-    check_link : bool
-        If True (default), then and exception is raised if the link is invalid
+    check_link : bool, optional
+        If True (default), then an exception is raised if the link is invalid
         for the family.
         If False, then the link is not checked.
 
@@ -579,14 +579,14 @@ class Gaussian(Family):
 
         Parameters
         ----------
-        endog : ndarray
+        endog : array_like
             The endogenous response variable.
-        mu : ndarray
+        mu : array_like
             The inverse of the link function at the linear predicted values.
 
         Returns
         -------
-        resid_dev : float
+        resid_dev : ndarray
             Deviance residuals as defined below.
 
         Notes
@@ -604,18 +604,18 @@ class Gaussian(Family):
 
         Parameters
         ----------
-        endog : ndarray
+        endog : array_like
             Usually the endogenous response variable.
-        mu : ndarray
+        mu : array_like
             Usually but not always the fitted mean response variable.
-        var_weights : array_like
+        var_weights : array_like, optional
             1d array of variance (analytic) weights. The default is 1.
-        scale : float
+        scale : float, optional
             The scale parameter. The default is 1.
 
         Returns
         -------
-        ll_i : float
+        ll_i : ndarray
             The value of the log-likelihood evaluated at
             (endog, mu, var_weights, scale) as defined below.
 
@@ -653,11 +653,11 @@ class Gaussian(Family):
 
         Parameters
         ----------
-        endog : ndarray
+        endog : array_like
             The endogenous response variable
-        mu : ndarray
+        mu : array_like
             The inverse of the link function at the linear predicted values.
-        var_weights : array_like
+        var_weights : array_like, optional
             1d array of variance (analytic) weights. The default is 1.
         scale : float, optional
             An optional argument to divide the residuals by sqrt(scale).
@@ -688,11 +688,11 @@ class Gaussian(Family):
 
         Parameters
         ----------
-        mu : ndarray
+        mu : array_like
             Usually but not always the fitted mean response variable.
         scale : float
             The scale parameter is required argument for get_distribution.
-        var_weights : array_like
+        var_weights : array_like, optional
             1d array of variance (analytic) weights. The default is 1.
 
         Returns
@@ -715,8 +715,8 @@ class Gamma(Family):
         The default link for the Gamma family is the inverse link.
         Available links are log, identity, and inverse.
         See statsmodels.genmod.families.links for more information.
-    check_link : bool
-        If True (default), then and exception is raised if the link is invalid
+    check_link : bool, optional
+        If True (default), then an exception is raised if the link is invalid
         for the family.
         If False, then the link is not checked.
 
@@ -751,14 +751,14 @@ class Gamma(Family):
 
         Parameters
         ----------
-        endog : ndarray
+        endog : array_like
             The endogenous response variable.
-        mu : ndarray
+        mu : array_like
             The inverse of the link function at the linear predicted values.
 
         Returns
         -------
-        resid_dev : float
+        resid_dev : ndarray
             Deviance residuals as defined below.
 
         Notes
@@ -779,18 +779,18 @@ class Gamma(Family):
 
         Parameters
         ----------
-        endog : ndarray
+        endog : array_like
             Usually the endogenous response variable.
-        mu : ndarray
+        mu : array_like
             Usually but not always the fitted mean response variable.
-        var_weights : array_like
+        var_weights : array_like, optional
             1d array of variance (analytic) weights. The default is 1.
-        scale : float
+        scale : float, optional
             The scale parameter. The default is 1.
 
         Returns
         -------
-        ll_i : float
+        ll_i : ndarray
             The value of the log-likelihood evaluated at
             (endog, mu, var_weights, scale) as defined below.
 
@@ -837,11 +837,11 @@ class Gamma(Family):
 
         Parameters
         ----------
-        endog : ndarray
+        endog : array_like
             The endogenous response variable
-        mu : ndarray
+        mu : array_like
             The inverse of the link function at the linear predicted values.
-        var_weights : array_like
+        var_weights : array_like, optional
             1d array of variance (analytic) weights. The default is 1.
         scale : float, optional
             An optional argument to divide the residuals by sqrt(scale).
@@ -871,11 +871,11 @@ class Gamma(Family):
 
         Parameters
         ----------
-        mu : ndarray
+        mu : array_like
             Usually but not always the fitted mean response variable.
         scale : float
             The scale parameter is required argument for get_distribution.
-        var_weights : array_like
+        var_weights : array_like, optional
             1d array of variance (analytic) weights. The default is 1.
 
         Returns
@@ -900,8 +900,8 @@ class Binomial(Family):
         The default link for the Binomial family is the logit link.
         Available links are logit, probit, cauchy, log, loglog, and cloglog.
         See statsmodels.genmod.families.links for more information.
-    check_link : bool
-        If True (default), then and exception is raised if the link is invalid
+    check_link : bool, optional
+        If True (default), then an exception is raised if the link is invalid
         for the family.
         If False, then the link is not checked.
 
@@ -1007,14 +1007,14 @@ class Binomial(Family):
 
         Parameters
         ----------
-        endog : ndarray
+        endog : array_like
             The endogenous response variable.
-        mu : ndarray
+        mu : array_like
             The inverse of the link function at the linear predicted values.
 
         Returns
         -------
-        resid_dev : float
+        resid_dev : ndarray
             Deviance residuals as defined below.
 
         Notes
@@ -1036,18 +1036,18 @@ class Binomial(Family):
 
         Parameters
         ----------
-        endog : ndarray
+        endog : array_like
             Usually the endogenous response variable.
-        mu : ndarray
+        mu : array_like
             Usually but not always the fitted mean response variable.
-        var_weights : array_like
+        var_weights : array_like, optional
             1d array of variance (analytic) weights. The default is 1.
-        scale : float
+        scale : float, optional
             The scale parameter. The default is 1.
 
         Returns
         -------
-        ll_i : float
+        ll_i : ndarray
             The value of the log-likelihood evaluated at
             (endog, mu, var_weights, scale) as defined below.
 
@@ -1090,11 +1090,11 @@ class Binomial(Family):
 
         Parameters
         ----------
-        endog : ndarray
+        endog : array_like
             The endogenous response variable
-        mu : ndarray
+        mu : array_like
             The inverse of the link function at the linear predicted values.
-        var_weights : array_like
+        var_weights : array_like, optional
             1d array of variance (analytic) weights. The default is 1.
         scale : float, optional
             An optional argument to divide the residuals by sqrt(scale).
@@ -1155,14 +1155,14 @@ class Binomial(Family):
 
         Parameters
         ----------
-        mu : ndarray
+        mu : array_like
             Usually but not always the fitted mean response variable.
-        scale : float
+        scale : float, optional
             The scale parameter is ignored.
-        var_weights : array_like
+        var_weights : array_like, optional
             1d array of variance (analytic) weights. The default is 1.
             var_weights are ignored for Poisson.
-        n_trials : int
+        n_trials : int, optional
             Number of trials for the binomial distribution. The default is 1
             which corresponds to a Bernoulli random variable.
 
@@ -1186,8 +1186,8 @@ class InverseGaussian(Family):
         inverse squared link.
         Available links are InverseSquared, Inverse, Log, and Identity.
         See statsmodels.genmod.families.links for more information.
-    check_link : bool
-        If True (default), then and exception is raised if the link is invalid
+    check_link : bool, optional
+        If True (default), then an exception is raised if the link is invalid
         for the family.
         If False, then the link is not checked.
 
@@ -1230,14 +1230,14 @@ class InverseGaussian(Family):
 
         Parameters
         ----------
-        endog : ndarray
+        endog : array_like
             The endogenous response variable.
-        mu : ndarray
+        mu : array_like
             The inverse of the link function at the linear predicted values.
 
         Returns
         -------
-        resid_dev : float
+        resid_dev : ndarray
             Deviance residuals as defined below.
 
         Notes
@@ -1255,18 +1255,18 @@ class InverseGaussian(Family):
 
         Parameters
         ----------
-        endog : ndarray
+        endog : array_like
             Usually the endogenous response variable.
-        mu : ndarray
+        mu : array_like
             Usually but not always the fitted mean response variable.
-        var_weights : array_like
+        var_weights : array_like, optional
             1d array of variance (analytic) weights. The default is 1.
-        scale : float
+        scale : float, optional
             The scale parameter. The default is 1.
 
         Returns
         -------
-        ll_i : float
+        ll_i : ndarray
             The value of the log-likelihood evaluated at
             (endog, mu, var_weights, scale) as defined below.
 
@@ -1289,11 +1289,11 @@ class InverseGaussian(Family):
 
         Parameters
         ----------
-        endog : ndarray
+        endog : array_like
             The endogenous response variable
-        mu : ndarray
+        mu : array_like
             The inverse of the link function at the linear predicted values.
-        var_weights : array_like
+        var_weights : array_like, optional
             1d array of variance (analytic) weights. The default is 1.
         scale : float, optional
             An optional argument to divide the residuals by sqrt(scale).
@@ -1322,11 +1322,11 @@ class InverseGaussian(Family):
 
         Parameters
         ----------
-        mu : ndarray
+        mu : array_like
             Usually but not always the fitted mean response variable.
         scale : float
             The scale parameter is required argument for get_distribution.
-        var_weights : array_like
+        var_weights : array_like, optional
             1d array of variance (analytic) weights. The default is 1.
 
         Returns
@@ -1354,8 +1354,8 @@ class NegativeBinomial(Family):
         The ancillary parameter for the negative binomial distribution.
         For now ``alpha`` is assumed to be nonstochastic.  The default value
         is 1.  Permissible values are usually assumed to be between .01 and 2.
-    check_link : bool
-        If True (default), then and exception is raised if the link is invalid
+    check_link : bool, optional
+        If True (default), then an exception is raised if the link is invalid
         for the family.
         If False, then the link is not checked.
 
@@ -1419,14 +1419,14 @@ class NegativeBinomial(Family):
 
         Parameters
         ----------
-        endog : ndarray
+        endog : array_like
             The endogenous response variable.
-        mu : ndarray
+        mu : array_like
             The inverse of the link function at the linear predicted values.
 
         Returns
         -------
-        resid_dev : float
+        resid_dev : ndarray
             Deviance residuals as defined below.
 
         Notes
@@ -1451,18 +1451,18 @@ class NegativeBinomial(Family):
 
         Parameters
         ----------
-        endog : ndarray
+        endog : array_like
             Usually the endogenous response variable.
-        mu : ndarray
+        mu : array_like
             Usually but not always the fitted mean response variable.
-        var_weights : array_like
+        var_weights : array_like, optional
             1d array of variance (analytic) weights. The default is 1.
-        scale : float
+        scale : float, optional
             The scale parameter. The default is 1.
 
         Returns
         -------
-        ll_i : float
+        ll_i : ndarray
             The value of the log-likelihood evaluated at
             (endog, mu, var_weights, scale) as defined below.
 
@@ -1502,11 +1502,11 @@ class NegativeBinomial(Family):
 
         Parameters
         ----------
-        endog : ndarray
+        endog : array_like
             The endogenous response variable
-        mu : ndarray
+        mu : array_like
             The inverse of the link function at the linear predicted values.
-        var_weights : array_like
+        var_weights : array_like, optional
             1d array of variance (analytic) weights. The default is 1.
         scale : float, optional
             An optional argument to divide the residuals by sqrt(scale).
@@ -1555,11 +1555,11 @@ class NegativeBinomial(Family):
 
         Parameters
         ----------
-        mu : ndarray
+        mu : array_like
             Usually but not always the fitted mean response variable.
-        scale : float
+        scale : float, optional
             The scale parameter is ignored.
-        var_weights : array_like
+        var_weights : array_like, optional
             1d array of variance (analytic) weights. The default is 1.
             var_weights are ignored for NegativeBinomial.
 
@@ -1585,13 +1585,13 @@ class Tweedie(Family):
         See statsmodels.genmod.families.links for more information.
     var_power : float, optional
         The variance power. The default is 1.
-    eql : bool
+    eql : bool, optional
         If True, the Extended Quasi-Likelihood is used, else the
         likelihood is used.
         In both cases, for likelihood computations the var_power
         must be between 1 and 2.
-    check_link : bool
-        If True (default), then and exception is raised if the link is invalid
+    check_link : bool, optional
+        If True (default), then an exception is raised if the link is invalid
         for the family.
         If False, then the link is not checked.
 
@@ -1641,14 +1641,14 @@ class Tweedie(Family):
 
         Parameters
         ----------
-        endog : ndarray
+        endog : array_like
             The endogenous response variable.
-        mu : ndarray
+        mu : array_like
             The inverse of the link function at the linear predicted values.
 
         Returns
         -------
-        resid_dev : float
+        resid_dev : ndarray
             Deviance residuals as defined below.
 
         Notes
@@ -1708,18 +1708,18 @@ class Tweedie(Family):
 
         Parameters
         ----------
-        endog : ndarray
+        endog : array_like
             Usually the endogenous response variable.
-        mu : ndarray
+        mu : array_like
             Usually but not always the fitted mean response variable.
-        var_weights : array_like
+        var_weights : array_like, optional
             1d array of variance (analytic) weights. The default is 1.
-        scale : float
+        scale : float, optional
             The scale parameter. The default is 1.
 
         Returns
         -------
-        ll_i : float
+        ll_i : ndarray
             The value of the log-likelihood evaluated at
             (endog, mu, var_weights, scale) as defined below.
 
@@ -1804,11 +1804,11 @@ class Tweedie(Family):
 
         Parameters
         ----------
-        endog : ndarray
+        endog : array_like
             The endogenous response variable
-        mu : ndarray
+        mu : array_like
             The inverse of the link function at the linear predicted values.
-        var_weights : array_like
+        var_weights : array_like, optional
             1d array of variance (analytic) weights. The default is 1.
         scale : float, optional
             An optional argument to divide the residuals by sqrt(scale).

--- a/statsmodels/genmod/families/links.py
+++ b/statsmodels/genmod/families/links.py
@@ -67,6 +67,7 @@ class Link:
         Parameters
         ----------
         p : array_like
+            Probabilities
 
         Returns
         -------
@@ -267,13 +268,13 @@ class Power(Link):
 
     Parameters
     ----------
-    power : float
+    power : float, optional
         The exponent of the power transform
 
     Notes
     -----
     Aliases of Power:
-    Inverse = Power(power=-1)
+    InversePower = Power(power=-1)
     Sqrt = Power(power=.5)
     InverseSquared = Power(power=-2.)
     Identity = Power(power=1.)
@@ -427,7 +428,7 @@ class InversePower(Power):
     -----
     g(p) = 1/p
 
-    Alias of statsmodels.family.links.Power(power=-1.)
+    Alias of statsmodels.genmod.families.links.Power(power=-1.)
     """
 
     def __init__(self):
@@ -442,7 +443,7 @@ class Sqrt(Power):
     -----
     g(`p`) = sqrt(`p`)
 
-    Alias of statsmodels.family.links.Power(power=.5)
+    Alias of statsmodels.genmod.families.links.Power(power=.5)
     """
 
     def __init__(self):
@@ -457,7 +458,7 @@ class InverseSquared(Power):
     -----
     g(`p`) = 1/(`p`\*\*2)
 
-    Alias of statsmodels.family.links.Power(power=2.)
+    Alias of statsmodels.genmod.families.links.Power(power=2.)
     """
 
     def __init__(self):
@@ -472,7 +473,7 @@ class Identity(Power):
     -----
     g(`p`) = `p`
 
-    Alias of statsmodels.family.links.Power(power=1.)
+    Alias of statsmodels.genmod.families.links.Power(power=1.)
     """
 
     def __init__(self):
@@ -519,7 +520,7 @@ class Log(Link):
 
         Parameters
         ----------
-        z : ndarray
+        z : array_like
             The inverse of the link function at `p`
 
         Returns
@@ -581,7 +582,7 @@ class Log(Link):
 
         Parameters
         ----------
-        z : ndarray
+        z : array_like
             The inverse of the link function at `p`
 
         Returns
@@ -633,7 +634,7 @@ class LogC(Link):
 
         Parameters
         ----------
-        z : ndarray
+        z : array_like
             The inverse of the link function at `p`
 
         Returns
@@ -696,7 +697,7 @@ class LogC(Link):
 
         Parameters
         ----------
-        z : ndarray
+        z : array_like
             The inverse of the link function at `p`
 
         Returns
@@ -735,7 +736,7 @@ class CDFLink(Logit):
 
     Parameters
     ----------
-    dbn : scipy.stats distribution
+    dbn : scipy.stats distribution, optional
         Default is dbn=scipy.stats.norm
 
     Notes
@@ -836,7 +837,7 @@ class CDFLink(Logit):
 
         Parameters
         ----------
-        z : ndarray
+        z : array_like
             The inverse of the link function at `p`
 
         Returns
@@ -891,8 +892,20 @@ class Probit(CDFLink):
         """
         Second derivative of the inverse link function
 
-        This is the derivative of the pdf in a CDFLink
+        Parameters
+        ----------
+        z : array_like
+            `z` is usually the linear predictor for a GLM or GEE model.
 
+        Returns
+        -------
+        g^(-1)''(z) : ndarray
+            The value of the second derivative of the inverse of the
+            probit link function
+
+        Notes
+        -----
+        This is the derivative of the pdf in a CDFLink
         """
         return -z * self.dbn.pdf(z)
 
@@ -900,6 +913,16 @@ class Probit(CDFLink):
         """
         Second derivative of the link function g''(p)
 
+        Parameters
+        ----------
+        p : array_like
+            Probabilities
+
+        Returns
+        -------
+        g''(p) : ndarray
+            The value of the second derivative of the probit link
+            function
         """
         p = self._clean(p)
         linpred = self.dbn.ppf(p)
@@ -940,6 +963,20 @@ class Cauchy(CDFLink):
         return d2
 
     def inverse_deriv2(self, z):
+        """
+        Second derivative of the inverse of the Cauchy transform
+
+        Parameters
+        ----------
+        z : array_like
+            `z` is usually the linear predictor for a GLM or GEE model.
+
+        Returns
+        -------
+        g^(-1)''(z) : ndarray
+            The value of the second derivative of the inverse of the
+            Cauchy link function
+        """
         return -2 * z / (np.pi * (z**2 + 1) ** 2)
 
 
@@ -961,7 +998,7 @@ class CLogLog(Logit):
 
         Parameters
         ----------
-        p : ndarray
+        p : array_like
             Mean parameters
 
         Returns
@@ -1069,7 +1106,7 @@ class LogLog(Logit):
 
         Parameters
         ----------
-        p : ndarray
+        p : array_like
             Mean parameters
 
         Returns

--- a/statsmodels/genmod/families/varfuncs.py
+++ b/statsmodels/genmod/families/varfuncs.py
@@ -47,6 +47,16 @@ class VarianceFunction:
     def deriv(self, mu):
         """
         Derivative of the variance function v'(mu)
+
+        Parameters
+        ----------
+        mu : array_like
+            mean parameters
+
+        Returns
+        -------
+        v' : ndarray
+            zeros(mu.shape)
         """
         return np.zeros_like(mu)
 
@@ -66,7 +76,7 @@ class Power:
 
     Parameters
     ----------
-    power : float
+    power : float, optional
         exponent used in power variance function
 
     Methods
@@ -109,6 +119,16 @@ class Power:
         Derivative of the variance function v'(mu)
 
         May be undefined at zero.
+
+        Parameters
+        ----------
+        mu : array_like
+            mean parameters
+
+        Returns
+        -------
+        v' : ndarray
+            The value of the derivative of the power variance function
         """
 
         der = self.power * np.fabs(mu) ** (self.power - 1)
@@ -203,6 +223,16 @@ class Binomial:
 
         For the Binomial variance V(mu) = p*(1 - p)*n where p = mu/n, the
         derivative with respect to mu is dV/dmu = 1 - 2*p.
+
+        Parameters
+        ----------
+        mu : array_like
+            mean parameters
+
+        Returns
+        -------
+        V' : ndarray
+            The value of the derivative of the binomial variance function
         """
         p = self._clean(mu / self.n)
         return 1 - 2 * p
@@ -224,7 +254,7 @@ class NegativeBinomial:
 
     Parameters
     ----------
-    alpha : float
+    alpha : float, optional
         The ancillary parameter for the negative binomial variance function.
         `alpha` is assumed to be nonstochastic.  The default is 1.
 
@@ -272,6 +302,17 @@ class NegativeBinomial:
     def deriv(self, mu):
         """
         Derivative of the negative binomial variance function.
+
+        Parameters
+        ----------
+        mu : array_like
+            mean parameters
+
+        Returns
+        -------
+        V' : ndarray
+            The value of the derivative of the negative binomial variance
+            function
         """
 
         p = self._clean(mu)

--- a/statsmodels/genmod/generalized_estimating_equations.py
+++ b/statsmodels/genmod/generalized_estimating_equations.py
@@ -191,33 +191,33 @@ _gee_init_doc = """
         `statsmodels.tools.add_constant`.
     groups : array_like
         A 1d array of length `nobs` containing the group labels.
-    time : array_like
+    time : array_like, optional
         A 2d array of time (or other index) values, used by some
         dependence structures to define similarity relationships among
         observations within a cluster.
-    family : family class instance
+    family : family class instance, optional
 %(family_doc)s
-    cov_struct : CovStruct class instance
+    cov_struct : CovStruct class instance, optional
         The default is Independence.  To specify an exchangeable
         structure use cov_struct = Exchangeable().  See
         statsmodels.genmod.cov_struct.CovStruct for more
         information.
-    offset : array_like
+    offset : array_like, optional
         An offset to be included in the fit.  If provided, must be
         an array whose length is the number of rows in exog.
-    dep_data : array_like
+    dep_data : array_like, optional
         Additional data passed to the dependence structure.
-    constraint : (ndarray, ndarray)
+    constraint : tuple of ndarray, optional
         If provided, the constraint is a tuple (L, R) such that the
         model parameters are estimated under the constraint L *
         param = R, where L is a q x p matrix and R is a
         q-dimensional vector.  If constraint is provided, a score
         test is performed to compare the constrained model to the
         unconstrained model.
-    update_dep : bool
+    update_dep : bool, optional
         If true, the dependence parameters are optimized, otherwise
         they are held fixed at their starting values.
-    weights : array_like
+    weights : array_like, optional
         An array of case weights to use in the analysis.
     %(extra_params)s
 
@@ -290,30 +290,30 @@ _gee_fit_doc = """
 
     Parameters
     ----------
-    maxiter : int
+    maxiter : int, optional
         The maximum number of iterations
-    ctol : float
+    ctol : float, optional
         The convergence criterion for stopping the Gauss-Seidel
         iterations
-    start_params : array_like
+    start_params : array_like, optional
         A vector of starting values for the regression
         coefficients.  If None, a default is chosen.
-    params_niter : int
+    params_niter : int, optional
         The number of Gauss-Seidel updates of the mean structure
         parameters that take place prior to each update of the
         dependence structure.
-    first_dep_update : int
+    first_dep_update : int, optional
         No dependence structure updates occur before this
         iteration number.
-    cov_type : str
+    cov_type : str, optional
         One of "robust", "naive", or "bias_reduced".
-    ddof_scale : scalar or None
+    ddof_scale : int, optional
         The scale parameter is estimated as the sum of squared
         Pearson residuals divided by `N - ddof_scale`, where N
         is the total sample size.  If `ddof_scale` is None, the
         number of covariates (including an intercept if present)
         is used.
-    scaling_factor : scalar
+    scaling_factor : float, optional
         The estimated covariance of the parameter estimates is
         scaled by this value.  Default is 1, Stata uses N / (N - g),
         where N is the total sample size and g is the average group
@@ -327,7 +327,8 @@ _gee_fit_doc = """
 
     Returns
     -------
-    An instance of the GEEResults class or subclass
+    results : GEEResultsWrapper
+        An instance of the GEEResults class or subclass.
 
     Notes
     -----
@@ -711,25 +712,25 @@ class GEE(GLM):
         ----------
         formula : str or generic Formula object
             The formula specifying the model
-        groups : array_like or string
+        groups : array_like or str
             Array of grouping labels.  If a string, this is the name
             of a variable in `data` that contains the grouping labels.
         data : array_like
             The data for the model.
-        subset : array_like
+        subset : array_like, optional
             An array-like object of booleans, integers, or index
             values that indicate the subset of the data to used when
             fitting the model.
-        time : array_like or string
+        time : array_like or str, optional
             The time values, used for dependence structures involving
             distances between observations.  If a string, this is the
             name of a variable in `data` that contains the time
             values.
-        offset : array_like or string
+        offset : array_like or str, optional
             The offset values, added to the linear predictor.  If a
             string, this is the name of a variable in `data` that
             contains the offset values.
-        exposure : array_like or string
+        exposure : array_like or str, optional
             The exposure values, only used if the link function is the
             logarithm function, in which case the log of `exposure`
             is added to the offset (if any).  If a string, this is the
@@ -1081,10 +1082,10 @@ class GEE(GLM):
         """
         Returns
         -------
-        update : array_like
+        update : ndarray
             The update vector such that params + update is the next
             iterate when solving the score equations.
-        score : array_like
+        score : ndarray
             The current value of the score equations, not
             incorporating the scale parameter.  If desired,
             multiply this vector by the scale parameter to
@@ -1169,15 +1170,15 @@ class GEE(GLM):
 
         Returns
         -------
-        cov_robust : array_like
+        cov_robust : ndarray
            The robust, or sandwich estimate of the covariance, which
            is meaningful even if the working covariance structure is
            incorrectly specified.
-        cov_naive : array_like
+        cov_naive : ndarray
            The model-based estimate of the covariance, which is
            meaningful if the covariance structure is correctly
            specified.
-        cmat : array_like
+        cmat : ndarray
            The center matrix of the sandwich expression, used in
            obtaining score test results.
         """
@@ -1553,27 +1554,27 @@ class GEE(GLM):
         ----------
         pen_wt : float
             The penalty weight (a non-negative scalar).
-        scad_param : float
+        scad_param : float, optional
             Non-negative scalar determining the shape of the Scad
             penalty.
-        maxiter : int
+        maxiter : int, optional
             The maximum number of iterations.
-        ddof_scale : int
+        ddof_scale : int, optional
             Value to subtract from `nobs` when calculating the
             denominator degrees of freedom for t-statistics, defaults
             to the number of columns in `exog`.
-        update_assoc : int
+        update_assoc : int, optional
             The dependence parameters are updated every `update_assoc`
             iterations of the mean structure parameter updates.
-        ctol : float
+        ctol : float, optional
             Convergence criterion, default is one order of magnitude
             smaller than proposed in section 3.1 of Wang et al.
-        ztol : float
+        ztol : float, optional
             Coefficients smaller than this value are treated as
             being zero, default is based on section 5 of Wang et al.
-        eps : non-negative scalar
-            Numerical constant, see section 3.2 of Wang et al.
-        scale : float or string
+        eps : float, optional
+            Non-negative numerical constant, see section 3.2 of Wang et al.
+        scale : float or str, optional
             If a float, this value is used as the scale parameter.
             If "X2", the scale parameter is always estimated using
             Pearson's chi-square method (e.g., as in a quasi-Poisson
@@ -1673,10 +1674,10 @@ class GEE(GLM):
 
         Returns
         -------
-        mean_params : array_like
+        mean_params : ndarray
             The input parameter vector mean_params, expanded to the
             coordinate system of the full model
-        bcov : array_like
+        bcov : ndarray
             The input covariance matrix bcov, expanded to the
             coordinate system of the full model
         """
@@ -1802,24 +1803,24 @@ class GEE(GLM):
         ----------
         params : array_like
             The GEE estimates of the regression parameters.
-        scale : scalar
+        scale : float
             Estimated scale parameter
         cov_params : array_like
             An estimate of the covariance matrix for the
             model parameters.  Conventionally this is the robust
             covariance matrix.
-        n_step : integer
+        n_step : int, optional
             The number of points in the trapezoidal approximation
             to the quasi-likelihood function.
 
         Returns
         -------
-        ql : scalar
+        ql : float
             The quasi-likelihood value
-        qic : scalar
+        qic : float
             A QIC that can be used to compare the mean and covariance
             structures of the model.
-        qicu : scalar
+        qicu : float
             A simplified QIC that can be used to compare mean structures
             but not covariance structures
 
@@ -1951,7 +1952,7 @@ class GEEResults(GLMResults):
 
         Parameters
         ----------
-        cov_type : str
+        cov_type : str, optional
             One of "robust", "naive", or "bias_reduced".  Determines
             the covariance used to compute standard errors.  Defaults
             to "robust".
@@ -2127,7 +2128,7 @@ class GEEResults(GLMResults):
         alpha : float, optional
              The `alpha` level for the confidence interval.  i.e., The
              default `alpha` = .05 returns a 95% confidence interval.
-        cov_type : str
+        cov_type : str, optional
              The covariance type used for computing standard errors;
              must be one of 'robust', 'naive', and 'bias reduced'.
              See `GEE` for details.
@@ -2159,14 +2160,14 @@ class GEEResults(GLMResults):
         ----------
         yname : str, optional
             Default is `y`
-        xname : list[str], optional
+        xname : list of str, optional
             Names for the exogenous variables, default is `var_#` for ## in
             the number of regressors. Must match the number of parameters in
             the model
         title : str, optional
             Title for the top table. If not None, then this replaces
             the default title
-        alpha : float
+        alpha : float, optional
             significance level for the confidence intervals
         Returns
         -------
@@ -2338,15 +2339,15 @@ class GEEResults(GLMResults):
 
         Parameters
         ----------
-        ax : AxesSubplot
+        ax : AxesSubplot, optional
             An axes on which to draw the graph.  If None, new
             figure and axes objects are created
-        xpoints : scalar or array_like
+        xpoints : int or array_like, optional
             If scalar, the number of points equally spaced points on
             the time difference axis used to define bins for
             calculating local means.  If an array, the specific points
             that define the bins.
-        min_n : int
+        min_n : int, optional
             The minimum sample size in a bin for the mean residual
             product to be included on the plot.
         """
@@ -2414,7 +2415,7 @@ class GEEResults(GLMResults):
 
         Returns
         -------
-        results : array_like
+        results : list of GEEResultsWrapper
             The GEEResults objects resulting from the fits.
         """
 
@@ -2653,10 +2654,10 @@ class OrdinalGEEResults(GEEResults):
 
         Parameters
         ----------
-        ax : AxesSubplot
+        ax : AxesSubplot, optional
             An axes on which to draw the graph.  If None, new
             figure and axes objects are created
-        exog_values : array_like
+        exog_values : list of dict, optional
             A list of dictionaries, with each dictionary mapping
             variable names to values at which the variable is held
             fixed.  The values P(endog=y | exog) are plotted for all
@@ -2748,10 +2749,10 @@ def _score_test_submodel(par, sub):
 
     Returns
     -------
-    qm : array_like
+    qm : ndarray
         Matrix mapping the design matrix of the parent to the design matrix
         for the sub-model.
-    qc : array_like
+    qc : ndarray
         Matrix mapping the design matrix of the parent to the orthogonal
         complement of the columnspace of the submodel in the columnspace
         of the parent.
@@ -3092,10 +3093,10 @@ class NominalGEEResults(GEEResults):
 
         Parameters
         ----------
-        ax : AxesSubplot
+        ax : AxesSubplot, optional
             An axes on which to draw the graph.  If None, new
             figure and axes objects are created
-        exog_values : array_like
+        exog_values : list of dict, optional
             A list of dictionaries, with each dictionary mapping
             variable names to values at which the variable is held
             fixed.  The values P(endog=y | exog) are plotted for all
@@ -3201,8 +3202,8 @@ class _MultinomialLogit(Link):
 
         Parameters
         ----------
-        lpr : array_like (length must be divisible by `ncut`)
-            The linear predictors
+        lpr : array_like
+            The linear predictors.  Length must be divisible by `ncut`.
 
         Returns
         -------
@@ -3241,7 +3242,7 @@ class _Multinomial(families.Family):
         nlevels : int
             The number of distinct categories for the multinomial
             distribution.
-        check_link : bool
+        check_link : bool, optional
             If True (default), then an exception is raised if the link is
             invalid for the family.
             If False, then the link is not checked.
@@ -3265,7 +3266,7 @@ class GEEMargins:
     args : tuple
         Args are passed to `get_margeff`. This is the same as
         results.get_margeff. See there for more information.
-    kwargs : dict
+    kwargs : dict, optional
         Keyword args are passed to `get_margeff`. This is the same as
         results.get_margeff. See there for more information.
     """
@@ -3290,13 +3291,13 @@ class GEEMargins:
 
         Parameters
         ----------
-        alpha : float
+        alpha : float, optional
             Number between 0 and 1. The confidence intervals have the
             probability 1-alpha.
 
         Returns
         -------
-        frame : DataFrames
+        frame : DataFrame
             A DataFrame summarizing the marginal effects.
         """
         _check_at_is_all(self.margeff_options)
@@ -3335,7 +3336,7 @@ class GEEMargins:
 
         Parameters
         ----------
-        alpha : float
+        alpha : float, optional
             Number between 0 and 1. The confidence intervals have the
             probability 1-alpha.
 
@@ -3358,14 +3359,14 @@ class GEEMargins:
 
         Parameters
         ----------
-        alpha : float
+        alpha : float, optional
             Number between 0 and 1. The confidence intervals have the
             probability 1-alpha.
 
         Returns
         -------
-        Summary : SummaryTable
-            A SummaryTable instance
+        smry : Summary
+            A Summary instance.
         """
         _check_at_is_all(self.margeff_options)
         results = self.results

--- a/statsmodels/genmod/generalized_linear_model.py
+++ b/statsmodels/genmod/generalized_linear_model.py
@@ -80,25 +80,25 @@ class GLM(base.LikelihoodModel):
         is the number of regressors. An intercept is not included by default
         and should be added by the user (models specified using a formula
         include an intercept by default). See `statsmodels.tools.add_constant`.
-    family : family class instance
+    family : family class instance, optional
         The default is Gaussian.  To specify the binomial distribution, use
         family = sm.families.Binomial().
         Each family can take a link instance as an argument.  See
         sm.families.family for more information.
-    offset : array_like or None
+    offset : array_like, optional
         An offset to be included in the model.  If provided, must be
         an array whose length is the number of rows in exog.
-    exposure : array_like or None
+    exposure : array_like, optional
         Log(exposure) will be added to the linear prediction in the model.
         Exposure is only valid if the log link is used. If provided, it must be
         an array with the same length as endog.
-    freq_weights : array_like
+    freq_weights : array_like, optional
         1d array of frequency weights. The default is None. If None is selected
         or a blank value, then the algorithm will replace with an array of 1's
         with length equal to the endog.
         WARNING: Using weights is not verified yet for all possible options
         and results, see Notes.
-    var_weights : array_like
+    var_weights : array_like, optional
         1d array of variance (analytic) weights. The default is None. If None
         is selected or a blank value, then the algorithm will replace with an
         array of 1's with length equal to the endog.
@@ -119,7 +119,7 @@ class GLM(base.LikelihoodModel):
         See Notes.  Note that `endog` is a reference to the data so that if
         data is already an array and it is changed, then `endog` changes
         as well.
-    exposure : array_like
+    exposure : ndarray or None
         Include ln(exposure) in model with coefficient constrained to 1. Can
         only be used if the link is the logarithm function.
     exog : ndarray
@@ -155,13 +155,13 @@ class GLM(base.LikelihoodModel):
     normalized_cov_params : ndarray
         The p x p normalized covariance of the design / exogenous data.
         This is approximately equal to (X.T X)^(-1)
-    offset : array_like
+    offset : ndarray or None
         Include offset in model with coefficient constrained to 1.
     scale : float
         The estimate of the scale / dispersion of the model fit.  Only
         available after fit is called.  See GLM.fit and GLM.estimate_scale
         for more information.
-    scaletype : str
+    scaletype : str, float, or None
         The scaling used for fitting the model.  This is only available after
         fit is called.  The default is None.  See GLM.fit for more information.
     weights : ndarray
@@ -495,7 +495,7 @@ class GLM(base.LikelihoodModel):
         ----------
         params : ndarray
             Parameter at which score is evaluated.
-        scale : None or float
+        scale : float, optional
             If scale is None, then the default scale will be calculated.
             Default scale is defined by `self.scaletype` and set in fit.
             If scale is not None, then it is used as a fixed scale.
@@ -518,14 +518,14 @@ class GLM(base.LikelihoodModel):
         ----------
         params : ndarray
             Parameter at which score is evaluated.
-        scale : None or float
+        scale : float, optional
             If scale is None, then the default scale will be calculated.
             Default scale is defined by `self.scaletype` and set in fit.
             If scale is not None, then it is used as a fixed scale.
 
         Returns
         -------
-        score : ndarray_1d
+        score : ndarray, 1d
             The first derivative of the log-likelihood function calculated as
             the sum of `score_obs`
         """
@@ -543,14 +543,14 @@ class GLM(base.LikelihoodModel):
         ----------
         params : ndarray
             parameter at which score is evaluated
-        scale : None or float
+        scale : float, optional
             If scale is None, then the default scale will be calculated.
             Default scale is defined by `self.scaletype` and set in fit.
             If scale is not None, then it is used as a fixed scale.
 
         Returns
         -------
-        score_factor : ndarray_1d
+        score_factor : ndarray, 1d
             A 1d weight vector used in the calculation of the score_obs.
             The score_obs are obtained by `score_factor[:, None] * exog`
         """
@@ -576,11 +576,11 @@ class GLM(base.LikelihoodModel):
         ----------
         params : ndarray
             parameter at which Hessian is evaluated
-        scale : None or float
+        scale : float, optional
             If scale is None, then the default scale will be calculated.
             Default scale is defined by `self.scaletype` and set in fit.
             If scale is not None, then it is used as a fixed scale.
-        observed : bool
+        observed : bool, optional
             If True, then the observed Hessian is returned. If false then the
             expected information matrix is returned.
 
@@ -634,11 +634,11 @@ class GLM(base.LikelihoodModel):
         ----------
         params : ndarray
             parameter at which Hessian is evaluated
-        scale : None or float
+        scale : float, optional
             If scale is None, then the default scale will be calculated.
             Default scale is defined by `self.scaletype` and set in fit.
             If scale is not None, then it is used as a fixed scale.
-        observed : bool
+        observed : bool, optional
             If True, then the observed Hessian is returned (default).
             If False, then the expected information matrix is returned.
 
@@ -734,10 +734,10 @@ class GLM(base.LikelihoodModel):
         ----------
         params : ndarray
             parameter at which score is evaluated
-        exog : ndarray or None
+        exog : ndarray, optional
             Explanatory variables at which derivative are computed.
             If None, then the estimation exog is used.
-        transform : str
+        transform : str, optional
             The marginal effects transformation.
         offset, exposure : None
             Not yet implemented.
@@ -794,14 +794,14 @@ class GLM(base.LikelihoodModel):
         ----------
         params : ndarray
             parameter at which score is evaluated
-        scale : None or float
+        scale : float, optional
             If scale is None, then the default scale will be calculated.
             Default scale is defined by `self.scaletype` and set in fit.
             If scale is not None, then it is used as a fixed scale.
 
         Returns
         -------
-        derivative : ndarray_2d
+        derivative : ndarray, 2d
             The derivative of the score_obs with respect to endog. This
             can is given by `score_factor0[:, None] * exog` where
             `score_factor0` is the score_factor without the residual.
@@ -836,15 +836,15 @@ class GLM(base.LikelihoodModel):
             estimated parameter of the restricted model. This can be the
             parameter estimate for the current when testing for omitted
             variables.
-        k_constraints : int or None
+        k_constraints : int, optional
             Number of constraints that were used in the estimation of params
             restricted relative to the number of exog in the model.
             This must be provided if no exog_extra are given. If exog_extra is
             not None, then k_constraints is assumed to be zero if it is None.
-        exog_extra : None or array_like
+        exog_extra : array_like, optional
             Explanatory variables that are jointly tested for inclusion in the
             model, i.e., omitted variables.
-        observed : bool
+        observed : bool, optional
             If True, then the observed Hessian is used in calculating the
             covariance matrix of the score. If false then the expected
             information matrix is used.
@@ -973,9 +973,9 @@ class GLM(base.LikelihoodModel):
         ----------
         mu : array_like
             Fitted mean response variable
-        method : str, defaults to 'brentq'
+        method : str, optional
             Scipy optimizer used to solve the Pearson equation. Only brentq
-            currently supported.
+            currently supported. The default is 'brentq'.
         low : float, optional
             Low end of the bracketing interval [a,b] to be used in the search
             for the power. Defaults to 1.01.
@@ -1026,7 +1026,7 @@ class GLM(base.LikelihoodModel):
             function.  See notes for details.
         offset : array_like, optional
             Offset values.  See notes for details.
-        which : 'mean', 'linear', 'var'(optional)
+        which : {'mean', 'linear', 'var_unscaled'}, optional
             Statistic to predict. Default is 'mean'.
 
             - 'mean' returns the conditional expectation of endog E(y | x),
@@ -1037,7 +1037,8 @@ class GLM(base.LikelihoodModel):
 
         Returns
         -------
-        An array of fitted values
+        ndarray
+            An array of fitted values
 
         Notes
         -----
@@ -1101,17 +1102,17 @@ class GLM(base.LikelihoodModel):
         ----------
         params : array_like
             The model parameters.
-        scale : scalar
+        scale : scalar, optional
             The scale parameter.
-        exog : array_like
+        exog : array_like, optional
             The predictor variable matrix.
-        offset : array_like or None
+        offset : array_like, optional
             Offset variable for predicted mean.
-        exposure : array_like or None
+        exposure : array_like, optional
             Log(exposure) will be added to the linear prediction.
-        var_weights : array_like
-            1d array of variance (analytic) weights. The default is None.
-        n_trials : int
+        var_weights : array_like, optional
+            1d array of variance (analytic) weights. The default is 1.
+        n_trials : int, optional
             Number of trials for the binomial distribution. The default is 1
             which corresponds to a Bernoulli random variable.
 
@@ -1186,24 +1187,24 @@ class GLM(base.LikelihoodModel):
             initial mean will be calculated as ``np.dot(exog, start_params)``.
         maxiter : int, optional
             Default is 100.
-        method : str
+        method : str, optional
             Default is 'IRLS' for iteratively reweighted least squares.
             Otherwise gradient optimization is used.
-        tol : float
+        tol : float, optional
             Convergence tolerance.  Default is 1e-8.
-        scale : str or float, optional
+        scale : {'X2', 'dev'} or float, optional
             `scale` can be 'X2', 'dev', or a float
             The default value is None, which uses `X2` for Gamma, Gaussian,
             and Inverse Gaussian.
             `X2` is Pearson's chi-square divided by `df_resid`.
             The default is 1 for the Binomial and Poisson families.
             `dev` is the deviance divided by df_resid
-        cov_type : str
+        cov_type : str, optional
             The type of parameter estimate covariance matrix to compute.
-        cov_kwds : dict-like
+        cov_kwds : dict-like, optional
             Extra arguments for calculating the covariance of the parameter
             estimates.
-        use_t : bool
+        use_t : bool, optional
             If True, the Student t-distribution is used for inference.
         full_output : bool, optional
             Set to True to have all available output in the Results object's
@@ -1213,7 +1214,7 @@ class GLM(base.LikelihoodModel):
         disp : bool, optional
             Set to True to print convergence messages.  Not used if method is
             IRLS.
-        max_start_irls : int
+        max_start_irls : int, optional
             The number of IRLS iterations used to obtain starting
             values for gradient optimization.  Only relevant if
             `method` is set to something other than 'IRLS'.
@@ -1520,24 +1521,24 @@ class GLM(base.LikelihoodModel):
 
         Parameters
         ----------
-        method : {'elastic_net', 'l1_slsqp'}
+        method : {'elastic_net', 'l1_slsqp'}, optional
             'elastic_net' uses coordinate descent and supports the full
             elastic net penalty.  'l1_slsqp' solves a smooth constrained
             reformulation of the L1 problem with slsqp, an interior
             point style method, and only supports the lasso penalty
             (L1_wt must be 1).
-        alpha : scalar or array_like
+        alpha : scalar or array_like, optional
             The penalty weight.  If a scalar, the same penalty weight
             applies to all variables in the model.  If a vector, it
             must have the same length as `params`, and contains a
             penalty weight for each coefficient.
-        start_params : array_like
+        start_params : array_like, optional
             Starting values for `params`.
-        refit : bool
+        refit : bool, optional
             If True, the model is refit using only the variables that
             have non-zero coefficients in the regularized fit.  The
             refitted model is not regularized.
-        opt_method : string
+        opt_method : str, optional
             The method used for numerical optimization.
         **kwargs
             Additional keyword arguments used when fitting the model.
@@ -1705,7 +1706,7 @@ class GLM(base.LikelihoodModel):
             Otherwise, the constraints can be given as strings or list of
             strings.
             see t_test for details
-        start_params : None or array_like
+        start_params : array_like, optional
             starting values for the optimization. `start_params` needs to be
             given in the original parameter space and are internally
             transformed.
@@ -1801,7 +1802,7 @@ class GLMResults(base.LikelihoodModelResults):
     df_resid : float
         See GLM.df_resid
     fit_history : dict
-        Contains information about the iterations. Its keys are `iterations`,
+        Contains information about the iterations. Its keys are `iteration`,
         `deviance` and `params`.
     model : class instance
         Pointer to GLM model instance that called fit.
@@ -1818,8 +1819,8 @@ class GLMResults(base.LikelihoodModelResults):
     scale : float
         The estimate of the scale / dispersion for the model fit.
         See GLM.fit and GLM.estimate_scale for more information.
-    stand_errors : ndarray
-        The standard errors of the fitted GLM.   # TODO still named bse
+    bse : ndarray
+        The standard errors of the fitted GLM.
 
     See Also
     --------
@@ -2133,7 +2134,7 @@ class GLMResults(base.LikelihoodModelResults):
 
         Parameters
         ----------
-        kind : P"cs", "mcf"}
+        kind : {'cs', 'mcf'}, optional
             Type of pseudo R-square to return
 
         Returns
@@ -2201,12 +2202,12 @@ class GLMResults(base.LikelihoodModelResults):
 
         Parameters
         ----------
-        crit : string
+        crit : str
             One of 'aic', 'bic', or 'qaic'.
-        scale : float
+        scale : float, optional
             The scale parameter estimated using the parent model,
             used only for qaic.
-        dk_params : int or float
+        dk_params : int or float, optional
             Correction to the number of parameters used in the information
             criterion. By default, only mean parameters are included, the
             scale parameter is not included in the parameter count.
@@ -2214,7 +2215,8 @@ class GLMResults(base.LikelihoodModelResults):
 
         Returns
         -------
-        Value of information criterion.
+        float
+            Value of information criterion.
 
         Notes
         -----
@@ -2286,7 +2288,7 @@ class GLMResults(base.LikelihoodModelResults):
             you can pass a data structure that contains x1 and x2 in
             their original form. Otherwise, you'd need to log the data
             first.
-        which : 'mean', 'linear', 'var'(optional)
+        which : None or {'mean', 'linear', 'var_unscaled'}, optional
             Statistic to predict. Default is 'mean'.
             If which is None, then the pre-0.14 backwards compatible
             prediction results class is returned.
@@ -2300,7 +2302,7 @@ class GLMResults(base.LikelihoodModelResults):
             - 'var_unscaled' variance of endog implied by the likelihood model.
               This does not include scale or var_weights.
 
-        average : bool
+        average : bool, optional
             Keyword is only used if ``which`` is not None.
             If average is True, then the mean prediction is computed, that is,
             predictions are computed for individual exog and then the average
@@ -2310,7 +2312,7 @@ class GLMResults(base.LikelihoodModelResults):
         agg_weights : ndarray, optional
             Keyword is only used if ``which`` is not None.
             Aggregation weights, only used if average is True.
-        row_labels : list of str or None
+        row_labels : list of str, optional
             If row_labels are provided, then they will replace the generated
             labels.
 
@@ -2445,7 +2447,7 @@ class GLMResults(base.LikelihoodModelResults):
 
         Parameters
         ----------
-        observed : bool
+        observed : bool, optional
             If true, then observed hessian is used in the hat matrix
             computation. If false, then the expected hessian is used.
             In the case of a canonical link function both are the same.
@@ -2468,7 +2470,7 @@ class GLMResults(base.LikelihoodModelResults):
 
         Parameters
         ----------
-        observed : bool
+        observed : bool, optional
             If true, then observed hessian is used in the hat matrix
             computation. If false, then the expected hessian is used.
             In the case of a canonical link function both are the same.
@@ -2509,15 +2511,15 @@ class GLMResults(base.LikelihoodModelResults):
 
         Parameters
         ----------
-        exog : array_like
+        exog : array_like, optional
             The predictor variable matrix.
-        offset : array_like or None
+        offset : array_like, optional
             Offset variable for predicted mean.
-        exposure : array_like or None
+        exposure : array_like, optional
             Log(exposure) will be added to the linear prediction.
-        var_weights : array_like
+        var_weights : array_like, optional
             1d array of variance (analytic) weights. The default is 1.
-        n_trials : int
+        n_trials : int, optional
             Number of trials for the binomial distribution. The default is 1
             which corresponds to a Bernoulli random variable.
 
@@ -2712,14 +2714,14 @@ class GLMResults(base.LikelihoodModelResults):
         ----------
         yname : str, optional
             Default is `y`
-        xname : list[str], optional
+        xname : list of str, optional
             Names for the exogenous variables, default is `var_#` for ## in
             the number of regressors. Must match the number of parameters in
             the model
         title : str, optional
             Title for the top table. If not None, then this replaces the
             default title
-        alpha : float
+        alpha : float, optional
             significance level for the confidence intervals
 
         Returns
@@ -2803,18 +2805,18 @@ class GLMResults(base.LikelihoodModelResults):
 
         Parameters
         ----------
-        yname : str
-            Name of the dependent variable (optional)
-        xname : list[str], optional
+        yname : str, optional
+            Name of the dependent variable
+        xname : list of str, optional
             Names for the exogenous variables, default is `var_#` for ## in
             the number of regressors. Must match the number of parameters in
             the model
         title : str, optional
             Title for the top table. If not None, then this replaces the
             default title
-        alpha : float
+        alpha : float, optional
             significance level for the confidence intervals
-        float_format : str
+        float_format : str, optional
             print format for floats in parameters summary
 
         Returns

--- a/statsmodels/genmod/qif.py
+++ b/statsmodels/genmod/qif.py
@@ -29,6 +29,20 @@ class QIFCovariance:
         """
         Returns the term'th basis matrix, which is a dim x dim
         matrix.
+
+        Parameters
+        ----------
+        dim : int
+            The dimension of the basis matrix.
+        term : int
+            The index of the basis matrix to return, ranging from 0
+            to `num_terms` - 1.
+
+        Returns
+        -------
+        ndarray or None
+            The dim x dim basis matrix for `term`, or None if `term`
+            is greater than or equal to `num_terms`.
         """
         raise NotImplementedError
 
@@ -116,11 +130,12 @@ class QIF(base.Model):
     groups : array_like
         Labels indicating which group each observation belongs to.
         Observations in different groups should be independent.
-    family : genmod family
-        An instance of a GLM family.
-    cov_struct : QIFCovariance instance
-        An instance of a QIFCovariance.
-    missing : str
+    family : genmod family, optional
+        An instance of a GLM family. The default is Gaussian.
+    cov_struct : QIFCovariance instance, optional
+        An instance of a QIFCovariance. The default is
+        QIFIndependence.
+    missing : str, optional
         Available options are 'none', 'drop', and 'raise'. If 'none', no nan
         checking is done. If 'drop', any observations with nans are dropped.
         If 'raise', an error is raised.
@@ -193,15 +208,15 @@ class QIF(base.Model):
         -------
         qif : float
             The value of the QIF objective function.
-        grad : array_like
+        grad : ndarray
             The gradient vector of the QIF objective function.
-        cmat : array_like
+        cmat : ndarray
             The estimated covariance matrix of the estimating
             equations.
-        gn : array_like
+        gn : ndarray
             The moment vector, i.e., the average of the estimating
             equations over the groups.
-        gn_deriv : array_like
+        gn_deriv : ndarray
             The gradients of each estimating equation with
             respect to the parameter.
         """
@@ -336,14 +351,14 @@ class QIF(base.Model):
         ----------
         formula : str or generic Formula object
             The formula specifying the model
-        groups : array_like or string
+        groups : array_like or str
             Array of grouping labels.  If a string, this is the name
             of a variable in `data` that contains the grouping labels.
         data : array_like
             The data for the model.
-        subset : array_like
+        subset : array_like, optional
             An array_like object of booleans, integers, or index
-            values that indicate the subset of the data to used when
+            values that indicate the subset of the data to use when
             fitting the model.
 
         Returns
@@ -367,14 +382,14 @@ class QIF(base.Model):
 
         Parameters
         ----------
-        maxiter : int
+        maxiter : int, optional
             Maximum number of iterations.
         start_params : array_like, optional
             Starting values
-        tol : float
+        tol : float, optional
             Convergence threshold for difference of successive
             estimates.
-        gtol : float
+        gtol : float, optional
             Convergence threshold for gradient.
         ddof_scale : int, optional
             Degrees of freedom for the scale parameter
@@ -428,7 +443,15 @@ class QIF(base.Model):
 
 
 class QIFResults(base.LikelihoodModelResults):
-    """Results class for QIF Regression"""
+    """
+    Results class for QIF Regression
+
+    Attributes
+    ----------
+    qif : float
+        The value of the QIF objective function at the estimated
+        parameters.
+    """
     def __init__(self, model, params, cov_params, scale,
                  use_t=False, **kwds):
 
@@ -476,14 +499,14 @@ class QIFResults(base.LikelihoodModelResults):
         ----------
         yname : str, optional
             Default is `y`
-        xname : list[str], optional
+        xname : list of str, optional
             Names for the exogenous variables, default is `var_#` where `#`
             is the 0-based index of the regressor. Must match the number of
             parameters in the model
         title : str, optional
             Title for the top table. If not None, then this replaces
             the default title
-        alpha : float
+        alpha : float, optional
             significance level for the confidence intervals
 
         Returns


### PR DESCRIPTION
- [x] code/documentation is well formatted.
- [x] properly formatted commit message. See
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message).

#### AI Disclosure

Contributions must comply with the statsmodels [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html).

If using AI tools, edit the second option to explain which tool was selected and
how the tool's output was used.

Please complete **one** of the following:

- [ ] No AI tools were used to develop this pull request.
- [x] AI tools were used.
      Tool(s): Claude
      Used for: Docstring cleaning
      I have personally read, understood, and can explain every line of this diff, and
      have verified the statistical/numerical correctness of the change.

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows
  using the Windows System for Linux once `flake8` is installed in the
  local Linux environment. While passing this test is not required, it is good practice and it help
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.
* If AI tools were used to help write this PR, see the
  [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html) for what disclosure
  and review is expected of you before submitting.

</details>
