### PR TITLE
DOC: Docstring clean in dist, emplike, iolib and mismodel

### DIFF
--- a/statsmodels/distributions/bernstein.py
+++ b/statsmodels/distributions/bernstein.py
@@ -35,12 +35,18 @@ class BernsteinDistribution:
 
     Attributes
     ----------
-    cdf_grid : grid of cdf values
-    prob_grid : grid of cell or bin probabilities
-    k_dim : (int) number of components, dimension of random variable
-    k_grid : (tuple) shape of cdf_grid
-    k_grid_product : (int) total number of bins in grid
-    _grid : Grid instance with helper methods and attributes
+    cdf_grid : ndarray
+        Grid of cdf values.
+    prob_grid : ndarray
+        Grid of cell or bin probabilities.
+    k_dim : int
+        Number of components, dimension of the random variable.
+    k_grid : tuple of int
+        Shape of `cdf_grid`.
+    k_grid_product : int
+        Total number of bins in the grid.
+    _grid : _Grid
+        Instance with grid helper methods and attributes.
     """
 
     def __init__(self, cdf_grid):
@@ -61,14 +67,15 @@ class BernsteinDistribution:
         data : array_like
             Data with observation in rows and random variables in columns.
             Data can be 1-dimensional in the univariate case.
-        k_bins : int or list
-            Number or edges of bins to be used in numpy histogramdd.
-            If k_bins is a scalar int, then the number of bins of each
-            component will be equal to it.
+        k_bins : int or list of int
+            Number of bins to be used in numpy histogramdd for each
+            component. If k_bins is a scalar int, then the number of bins
+            of each component will be equal to it.
 
         Returns
         -------
-        Instance of a Bernstein distribution
+        BernsteinDistribution
+            Instance of a Bernstein distribution.
         """
         data = np.asarray(data)
         if np.any(data < 0) or np.any(data > 1):
@@ -109,7 +116,8 @@ class BernsteinDistribution:
 
         Returns
         -------
-        pdf values
+        ndarray
+            Cdf values evaluated at `x`.
 
         Notes
         -----
@@ -138,7 +146,8 @@ class BernsteinDistribution:
 
         Returns
         -------
-        cdf values
+        ndarray
+            Pdf values evaluated at `x`.
 
         Notes
         -----
@@ -164,7 +173,8 @@ class BernsteinDistribution:
 
         Returns
         -------
-        BernsteinDistribution instance for the marginal distribution.
+        BernsteinDistribution
+            Instance for the marginal distribution.
         """
 
         # univariate
@@ -188,17 +198,23 @@ class BernsteinDistribution:
         ----------
         nobs : int
             Number of random observations to generate.
-        rng : int, array_like of int, numpy.random.Generator, numpy.random.RandomState, optional
+        rng : int, array_like of int, numpy.random.Generator, or numpy.random.RandomState, optional
             If `rng` is None, a new ``Generator`` is created using fresh
             entropy from the operating system. If `rng` is an int or array
             of ints, a new ``Generator`` is created, seeded with `rng`. If
             `rng` is already a ``Generator`` or ``RandomState`` instance,
             that instance is used.
-        rng : int, array_like of int, numpy.random.Generator, numpy.random.RandomState, optional
+        rng : int, array_like of int, numpy.random.Generator, or numpy.random.RandomState, optional
             .. deprecated:: 0.15
 
                random_state has been deprecated. In-line with SPEC-007, use
                rng for passing a random number generator or seed.
+
+        Returns
+        -------
+        ndarray
+            Random samples from the Bernstein polynomial distribution, with
+            `nobs` rows and `k_dim` columns.
         """
         rng = check_random_state(rng)
         rvs_mnl = rng.multinomial(nobs, self.prob_grid.flatten())
@@ -228,25 +244,96 @@ class BernsteinDistribution:
 
 
 class BernsteinDistributionBV(BernsteinDistribution):
+    """Bivariate distribution based on Bernstein polynomials.
+
+    Parameters
+    ----------
+    cdf_grid : array_like
+        cdf values on a equal spaced grid of the unit square [0, 1]^2.
+    """
 
     def cdf(self, x):
+        """cdf values evaluated at x.
+
+        Parameters
+        ----------
+        x : array_like
+            Points at which the bivariate cdf is evaluated. Can be a
+            single point with two coordinates, or two dimensional with
+            points (observations) in rows and the two variables in
+            columns.
+
+        Returns
+        -------
+        ndarray
+            Cdf values evaluated at `x`.
+        """
         cdf_ = _eval_bernstein_2d(x, self.cdf_grid)
         return cdf_
 
     def pdf(self, x):
+        """pdf values evaluated at x.
+
+        Parameters
+        ----------
+        x : array_like
+            Points at which the bivariate pdf is evaluated. Can be a
+            single point with two coordinates, or two dimensional with
+            points (observations) in rows and the two variables in
+            columns.
+
+        Returns
+        -------
+        ndarray
+            Pdf values evaluated at `x`.
+        """
         # TODO: check usage of k_grid_product. Should this go into eval?
         pdf_ = self.k_grid_product * _eval_bernstein_2d(x, self.prob_grid)
         return pdf_
 
 
 class BernsteinDistributionUV(BernsteinDistribution):
+    """Univariate distribution based on Bernstein polynomials.
+
+    Parameters
+    ----------
+    cdf_grid : array_like
+        cdf values on a equal spaced grid of the unit interval [0, 1].
+    """
 
     def cdf(self, x, method="binom"):
+        """cdf values evaluated at x.
 
+        Parameters
+        ----------
+        x : array_like
+            Points at which the univariate cdf is evaluated.
+        method : {"binom", "beta", "bpoly"}, optional
+            Method used to construct the Bernstein polynomial basis.
+
+        Returns
+        -------
+        ndarray
+            Cdf values evaluated at `x`.
+        """
         cdf_ = _eval_bernstein_1d(x, self.cdf_grid, method=method)
         return cdf_
 
     def pdf(self, x, method="binom"):
+        """pdf values evaluated at x.
+
+        Parameters
+        ----------
+        x : array_like
+            Points at which the univariate pdf is evaluated.
+        method : {"binom", "beta", "bpoly"}, optional
+            Method used to construct the Bernstein polynomial basis.
+
+        Returns
+        -------
+        ndarray
+            Pdf values evaluated at `x`.
+        """
         # TODO: check usage of k_grid_product. Should this go into eval?
         pdf_ = self.k_grid_product * _eval_bernstein_1d(
             x, self.prob_grid, method=method

--- a/statsmodels/distributions/copula/_special.py
+++ b/statsmodels/distributions/copula/_special.py
@@ -81,6 +81,16 @@ def li3(z):
     """Polylogarithm for negative integer order -3
 
     Li(-3, z)
+
+    Parameters
+    ----------
+    z : array_like
+        Value(s) at which the polylogarithm is evaluated.
+
+    Returns
+    -------
+    ndarray or float
+        Value(s) of the polylogarithm Li(-3, z).
     """
     return z * (1 + 4 * z + z**2) / (1 - z)**4
 
@@ -89,6 +99,16 @@ def li4(z):
     """Polylogarithm for negative integer order -4
 
     Li(-4, z)
+
+    Parameters
+    ----------
+    z : array_like
+        Value(s) at which the polylogarithm is evaluated.
+
+    Returns
+    -------
+    ndarray or float
+        Value(s) of the polylogarithm Li(-4, z).
     """
     return z * (1 + z) * (1 + 10 * z + z**2) / (1 - z)**5
 
@@ -99,6 +119,18 @@ def lin(n, z):
     Li(-n, z)
 
     https://en.wikipedia.org/wiki/Polylogarithm#Particular_values
+
+    Parameters
+    ----------
+    n : int
+        Order of the polylogarithm, evaluated at -n.
+    z : array_like
+        Value(s) at which the polylogarithm is evaluated.
+
+    Returns
+    -------
+    ndarray
+        Value(s) of the polylogarithm Li(-n, z).
     """
     if np.size(z) > 1:
         z = np.array(z)[..., None]

--- a/statsmodels/distributions/copula/archimedean.py
+++ b/statsmodels/distributions/copula/archimedean.py
@@ -62,7 +62,8 @@ def tau_frank(theta):
 
     Returns
     -------
-    tau : float, tau for given theta
+    tau : float
+        Kendall's tau for given theta.
     """
 
     if theta <= 1:
@@ -97,10 +98,10 @@ class ArchimedeanCopula(Copula):
     transform : instance of transformation class
         Archimedean generator with required methods including first and second
         derivatives
-    args : tuple
-        Optional copula parameters. Copula parameters can be either provided
+    args : tuple, optional
+        Copula parameters. Copula parameters can be either provided
         when creating the instance or as arguments when calling methods.
-    k_dim : int
+    k_dim : int, optional
         Dimension, number of components in the multivariate random variable.
         Currently only bivariate copulas are verified. Support for more than
         2 dimension is incomplete.
@@ -141,7 +142,25 @@ class ArchimedeanCopula(Copula):
         return u
 
     def cdf(self, u, args=()):
-        """Evaluate cdf of Archimedean copula."""
+        """Evaluate cdf of Archimedean copula.
+
+        Parameters
+        ----------
+        u : array_like
+            Values of random bivariate random variable, each defined on
+            [0, 1], for which cdf is computed. The second (or last)
+            dimension should be the same as the dimension of the random
+            variable, e.g., 2 for bivariate copula.
+        args : tuple, optional
+            Copula parameters. If empty, then the copula parameters will be
+            taken from the ``args`` attribute created when initializing the
+            instance.
+
+        Returns
+        -------
+        ndarray
+            Copula cdf evaluated at points ``u``.
+        """
         args = self._handle_args(args)
         u = self._handle_u(u)
         axis = -1
@@ -154,7 +173,25 @@ class ArchimedeanCopula(Copula):
         return cdfv
 
     def pdf(self, u, args=()):
-        """Evaluate pdf of Archimedean copula."""
+        """Evaluate pdf of Archimedean copula.
+
+        Parameters
+        ----------
+        u : array_like
+            Values of random bivariate random variable, each defined on
+            [0, 1], for which pdf is computed. The second (or last)
+            dimension should be the same as the dimension of the random
+            variable, e.g., 2 for bivariate copula.
+        args : tuple, optional
+            Copula parameters. If empty, then the copula parameters will be
+            taken from the ``args`` attribute created when initializing the
+            instance.
+
+        Returns
+        -------
+        ndarray
+            Copula pdf evaluated at points ``u``.
+        """
         u = self._handle_u(u)
         args = self._handle_args(args)
         axis = -1
@@ -182,7 +219,25 @@ class ArchimedeanCopula(Copula):
         return np.abs(pdfv)
 
     def logpdf(self, u, args=()):
-        """Evaluate log pdf of multivariate Archimedean copula."""
+        """Evaluate log pdf of multivariate Archimedean copula.
+
+        Parameters
+        ----------
+        u : array_like
+            Values of random bivariate random variable, each defined on
+            [0, 1], for which log-pdf is computed. The second (or last)
+            dimension should be the same as the dimension of the random
+            variable, e.g., 2 for bivariate copula.
+        args : tuple, optional
+            Copula parameters. If empty, then the copula parameters will be
+            taken from the ``args`` attribute created when initializing the
+            instance.
+
+        Returns
+        -------
+        ndarray
+            Copula log-pdf evaluated at points ``u``.
+        """
 
         u = self._handle_u(u)
         args = self._handle_args(args)
@@ -228,6 +283,16 @@ class ClaytonCopula(ArchimedeanCopula):
 
     with :math:`\theta\in[-1,\infty)\backslash\{0\}`.
 
+    Parameters
+    ----------
+    theta : float, optional
+        Parameter of the copula, must be > -1 and != 0. If not provided,
+        then the copula parameter must be provided as ``args`` when calling
+        methods.
+    k_dim : int, optional
+        Dimension, number of components in the multivariate random
+        variable.
+
     """
 
     def __init__(self, theta=None, k_dim=2):
@@ -250,16 +315,16 @@ class ClaytonCopula(ArchimedeanCopula):
         ----------
         nobs : int, optional
             Number of samples to generate from the copula. Default is 1.
-        args : tuple
+        args : tuple, optional
             Arguments for copula parameters. The number of arguments depends
             on the copula.
-        rng : int, array_like of int, numpy.random.Generator, numpy.random.RandomState, optional
+        rng : int, array_like of int, numpy.random.Generator, or numpy.random.RandomState, optional
             If `rng` is None, a new ``Generator`` is created using fresh
             entropy from the operating system. If `rng` is an int or array
             of ints, a new ``Generator`` is created, seeded with `rng`. If
             `rng` is already a ``Generator`` or ``RandomState`` instance,
             that instance is used.
-        rng : int, array_like of int, numpy.random.Generator, numpy.random.RandomState, optional
+        rng : int, array_like of int, numpy.random.Generator, or numpy.random.RandomState, optional
             .. deprecated:: 0.15
 
                random_state has been deprecated. In-line with SPEC-007, use
@@ -267,7 +332,7 @@ class ClaytonCopula(ArchimedeanCopula):
 
         Returns
         -------
-        sample : array_like (nobs, k_dim)
+        sample : ndarray of shape (nobs, k_dim)
             Sample from the copula.
         """
         rng = check_random_state(rng)
@@ -281,6 +346,25 @@ class ClaytonCopula(ArchimedeanCopula):
         return rv
 
     def pdf(self, u, args=()):
+        """Evaluate pdf of the Clayton copula.
+
+        Parameters
+        ----------
+        u : array_like
+            Values of random bivariate random variable, each defined on
+            [0, 1], for which pdf is computed. Bivariate case uses a
+            closed-form expression; for higher dimensions the generic
+            Archimedean pdf is used.
+        args : tuple, optional
+            Copula parameters. If empty, then the copula parameters will be
+            taken from the ``args`` attribute created when initializing the
+            instance.
+
+        Returns
+        -------
+        ndarray
+            Copula pdf evaluated at points ``u``.
+        """
         u = self._handle_u(u)
         (th,) = self._handle_args(args)
         if u.shape[-1] == 2:
@@ -292,16 +376,64 @@ class ClaytonCopula(ArchimedeanCopula):
             return super().pdf(u, args)
 
     def logpdf(self, u, args=()):
+        """Evaluate log-pdf of the Clayton copula.
+
+        Parameters
+        ----------
+        u : array_like
+            Values of random bivariate random variable, each defined on
+            [0, 1], for which log-pdf is computed.
+        args : tuple, optional
+            Copula parameters. If empty, then the copula parameters will be
+            taken from the ``args`` attribute created when initializing the
+            instance.
+
+        Returns
+        -------
+        ndarray
+            Copula log-pdf evaluated at points ``u``.
+        """
         # we skip Archimedean logpdf, that uses numdiff
         return super().logpdf(u, args=args)
 
     def cdf(self, u, args=()):
+        """Evaluate cdf of the Clayton copula.
+
+        Parameters
+        ----------
+        u : array_like
+            Values of random bivariate random variable, each defined on
+            [0, 1], for which cdf is computed.
+        args : tuple, optional
+            Copula parameters. If empty, then the copula parameters will be
+            taken from the ``args`` attribute created when initializing the
+            instance.
+
+        Returns
+        -------
+        ndarray
+            Copula cdf evaluated at points ``u``.
+        """
         u = self._handle_u(u)
         (th,) = self._handle_args(args)
         d = u.shape[-1]  # self.k_dim
         return (np.sum(u ** (-th), axis=-1) - d + 1) ** (-1.0 / th)
 
     def tau(self, theta=None):
+        """Kendall's tau as a function of the copula parameter theta.
+
+        Joe (2014), p. 168.
+
+        Parameters
+        ----------
+        theta : float, optional
+            Copula parameter. If not given, then ``self.theta`` is used.
+
+        Returns
+        -------
+        float
+            Kendall's tau corresponding to `theta`.
+        """
         # Joe 2014 p. 168
         if theta is None:
             theta = self.theta
@@ -309,6 +441,18 @@ class ClaytonCopula(ArchimedeanCopula):
         return theta / (theta + 2)
 
     def theta_from_tau(self, tau):
+        """Compute the copula parameter theta from Kendall's tau.
+
+        Parameters
+        ----------
+        tau : float
+            Kendall's tau.
+
+        Returns
+        -------
+        float
+            Copula parameter theta corresponding to `tau`.
+        """
         return 2 * tau / (1 - tau)
 
 
@@ -324,6 +468,15 @@ class FrankCopula(ArchimedeanCopula):
         1} } \right]
 
     with :math:`\theta\in \mathbb{R}\backslash\{0\}, \mathbf{u} \in [0, 1]^d`.
+
+    Parameters
+    ----------
+    theta : float, optional
+        Parameter of the copula, must be != 0. If not provided, then the
+        copula parameter must be provided as ``args`` when calling methods.
+    k_dim : int, optional
+        Dimension, number of components in the multivariate random
+        variable.
 
     """
 
@@ -347,16 +500,16 @@ class FrankCopula(ArchimedeanCopula):
         ----------
         nobs : int, optional
             Number of samples to generate from the copula. Default is 1.
-        args : tuple
+        args : tuple, optional
             Arguments for copula parameters. The number of arguments depends
             on the copula.
-        rng : int, array_like of int, numpy.random.Generator, numpy.random.RandomState, optional
+        rng : int, array_like of int, numpy.random.Generator, or numpy.random.RandomState, optional
             If `rng` is None, a new ``Generator`` is created using fresh
             entropy from the operating system. If `rng` is an int or array
             of ints, a new ``Generator`` is created, seeded with `rng`. If
             `rng` is already a ``Generator`` or ``RandomState`` instance,
             that instance is used.
-        rng : int, array_like of int, numpy.random.Generator, numpy.random.RandomState, optional
+        rng : int, array_like of int, numpy.random.Generator, or numpy.random.RandomState, optional
             .. deprecated:: 0.15
 
                random_state has been deprecated. In-line with SPEC-007, use
@@ -364,7 +517,7 @@ class FrankCopula(ArchimedeanCopula):
 
         Returns
         -------
-        sample : array_like (nobs, k_dim)
+        sample : ndarray of shape (nobs, k_dim)
             Sample from the copula.
         """
         rng = check_random_state(rng)
@@ -378,6 +531,25 @@ class FrankCopula(ArchimedeanCopula):
     # todo: check expm1 and log1p for improved numerical precision
 
     def pdf(self, u, args=()):
+        """Evaluate pdf of the Frank copula.
+
+        Parameters
+        ----------
+        u : array_like
+            Values of random bivariate random variable, each defined on
+            [0, 1], for which pdf is computed. Bivariate case uses a
+            closed-form expression; for higher dimensions the generic
+            Archimedean pdf is used.
+        args : tuple, optional
+            Copula parameters. If empty, then the copula parameters will be
+            taken from the ``args`` attribute created when initializing the
+            instance.
+
+        Returns
+        -------
+        ndarray
+            Copula pdf evaluated at points ``u``.
+        """
         u = self._handle_u(u)
         (th,) = self._handle_args(args)
         if u.shape[-1] != 2:
@@ -392,6 +564,23 @@ class FrankCopula(ArchimedeanCopula):
         return num / den
 
     def cdf(self, u, args=()):
+        """Evaluate cdf of the Frank copula.
+
+        Parameters
+        ----------
+        u : array_like
+            Values of random bivariate random variable, each defined on
+            [0, 1], for which cdf is computed.
+        args : tuple, optional
+            Copula parameters. If empty, then the copula parameters will be
+            taken from the ``args`` attribute created when initializing the
+            instance.
+
+        Returns
+        -------
+        ndarray
+            Copula cdf evaluated at points ``u``.
+        """
         u = self._handle_u(u)
         (th,) = self._handle_args(args)
         dim = u.shape[-1]
@@ -402,6 +591,25 @@ class FrankCopula(ArchimedeanCopula):
         return -1.0 / th * np.log(1 - num / den)
 
     def logpdf(self, u, args=()):
+        """Evaluate log-pdf of the Frank copula.
+
+        Parameters
+        ----------
+        u : array_like
+            Values of random bivariate random variable, each defined on
+            [0, 1], for which log-pdf is computed. Bivariate case uses a
+            closed-form expression; for higher dimensions the generic
+            Copula log-pdf, ``log(self.pdf(...))``, is used.
+        args : tuple, optional
+            Copula parameters. If empty, then the copula parameters will be
+            taken from the ``args`` attribute created when initializing the
+            instance.
+
+        Returns
+        -------
+        ndarray
+            Copula log-pdf evaluated at points ``u``.
+        """
         u = self._handle_u(u)
         (th,) = self._handle_args(args)
         if u.shape[-1] == 2:
@@ -417,7 +625,24 @@ class FrankCopula(ArchimedeanCopula):
             return super().logpdf(u, args)
 
     def cdfcond_2g1(self, u, args=()):
-        """Conditional cdf of second component given the value of first."""
+        """Conditional cdf of second component given the value of first.
+
+        Parameters
+        ----------
+        u : array_like
+            Values of bivariate random variable, each defined on [0, 1],
+            at which the conditional cdf is evaluated.
+        args : tuple, optional
+            Copula parameters. If empty, then the copula parameters will be
+            taken from the ``args`` attribute created when initializing the
+            instance.
+
+        Returns
+        -------
+        ndarray
+            Conditional cdf of the second component given the first,
+            evaluated at ``u``.
+        """
         u = self._handle_u(u)
         (th,) = self._handle_args(args)
         if u.shape[-1] == 2:
@@ -430,7 +655,27 @@ class FrankCopula(ArchimedeanCopula):
             raise NotImplementedError("u needs to be bivariate (2 columns)")
 
     def ppfcond_2g1(self, q, u1, args=()):
-        """Conditional pdf of second component given the value of first."""
+        """Conditional ppf (quantile) of second component given first.
+
+        Parameters
+        ----------
+        q : array_like
+            Values of the conditional cdf, in [0, 1], for which the
+            conditional ppf (quantile) is computed.
+        u1 : array_like
+            Values of the first component on which the second component is
+            conditioned.
+        args : tuple, optional
+            Copula parameters. If empty, then the copula parameters will be
+            taken from the ``args`` attribute created when initializing the
+            instance.
+
+        Returns
+        -------
+        ndarray
+            Conditional ppf of the second component given the first,
+            evaluated at ``q``.
+        """
         u1 = np.asarray(u1)
         (th,) = self._handle_args(args)
         if u1.shape[-1] == 1:
@@ -444,6 +689,20 @@ class FrankCopula(ArchimedeanCopula):
             raise NotImplementedError("u needs to be bivariate (2 columns)")
 
     def tau(self, theta=None):
+        """Kendall's tau as a function of the copula parameter theta.
+
+        Joe (2014), p. 166.
+
+        Parameters
+        ----------
+        theta : float, optional
+            Copula parameter. If not given, then ``self.theta`` is used.
+
+        Returns
+        -------
+        float
+            Kendall's tau corresponding to `theta`.
+        """
         # Joe 2014 p. 166
         if theta is None:
             theta = self.theta
@@ -451,6 +710,19 @@ class FrankCopula(ArchimedeanCopula):
         return tau_frank(theta)
 
     def theta_from_tau(self, tau):
+        """Compute the copula parameter theta from Kendall's tau.
+
+        Parameters
+        ----------
+        tau : float
+            Kendall's tau.
+
+        Returns
+        -------
+        float
+            Copula parameter theta corresponding to `tau`, found
+            numerically by least squares.
+        """
         MIN_FLOAT_LOG = np.log(sys.float_info.min)
         MAX_FLOAT_LOG = np.log(sys.float_info.max)
 
@@ -479,6 +751,15 @@ class GumbelCopula(ArchimedeanCopula):
 
     with :math:`\theta\in[1,\infty)`.
 
+    Parameters
+    ----------
+    theta : float, optional
+        Parameter of the copula, must be > 1. If not provided, then the
+        copula parameter must be provided as ``args`` when calling methods.
+    k_dim : int, optional
+        Dimension, number of components in the multivariate random
+        variable.
+
     """
 
     def __init__(self, theta=None, k_dim=2):
@@ -501,16 +782,16 @@ class GumbelCopula(ArchimedeanCopula):
         ----------
         nobs : int, optional
             Number of samples to generate from the copula. Default is 1.
-        args : tuple
+        args : tuple, optional
             Arguments for copula parameters. The number of arguments depends
             on the copula.
-        rng : int, array_like of int, numpy.random.Generator, numpy.random.RandomState, optional
+        rng : int, array_like of int, numpy.random.Generator, or numpy.random.RandomState, optional
             If `rng` is None, a new ``Generator`` is created using fresh
             entropy from the operating system. If `rng` is an int or array
             of ints, a new ``Generator`` is created, seeded with `rng`. If
             `rng` is already a ``Generator`` or ``RandomState`` instance,
             that instance is used.
-        rng : int, array_like of int, numpy.random.Generator, numpy.random.RandomState, optional
+        rng : int, array_like of int, numpy.random.Generator, or numpy.random.RandomState, optional
             .. deprecated:: 0.15
 
                random_state has been deprecated. In-line with SPEC-007, use
@@ -518,7 +799,7 @@ class GumbelCopula(ArchimedeanCopula):
 
         Returns
         -------
-        sample : array_like (nobs, k_dim)
+        sample : ndarray of shape (nobs, k_dim)
             Sample from the copula.
         """
         rng = check_random_state(rng)
@@ -540,6 +821,25 @@ class GumbelCopula(ArchimedeanCopula):
         return rv
 
     def pdf(self, u, args=()):
+        """Evaluate pdf of the Gumbel copula.
+
+        Parameters
+        ----------
+        u : array_like
+            Values of random bivariate random variable, each defined on
+            [0, 1], for which pdf is computed. Bivariate case uses a
+            closed-form expression; for higher dimensions the generic
+            Archimedean pdf is used.
+        args : tuple, optional
+            Copula parameters. If empty, then the copula parameters will be
+            taken from the ``args`` attribute created when initializing the
+            instance.
+
+        Returns
+        -------
+        ndarray
+            Copula pdf evaluated at points ``u``.
+        """
         u = self._handle_u(u)
         (th,) = self._handle_args(args)
         if u.shape[-1] == 2:
@@ -560,6 +860,23 @@ class GumbelCopula(ArchimedeanCopula):
             return super().pdf(u, args)
 
     def cdf(self, u, args=()):
+        """Evaluate cdf of the Gumbel copula.
+
+        Parameters
+        ----------
+        u : array_like
+            Values of random bivariate random variable, each defined on
+            [0, 1], for which cdf is computed.
+        args : tuple, optional
+            Copula parameters. If empty, then the copula parameters will be
+            taken from the ``args`` attribute created when initializing the
+            instance.
+
+        Returns
+        -------
+        ndarray
+            Copula cdf evaluated at points ``u``.
+        """
         u = self._handle_u(u)
         (th,) = self._handle_args(args)
         h = np.sum((-np.log(u)) ** th, axis=-1)
@@ -567,10 +884,41 @@ class GumbelCopula(ArchimedeanCopula):
         return cdf
 
     def logpdf(self, u, args=()):
+        """Evaluate log-pdf of the Gumbel copula.
+
+        Parameters
+        ----------
+        u : array_like
+            Values of random bivariate random variable, each defined on
+            [0, 1], for which log-pdf is computed.
+        args : tuple, optional
+            Copula parameters. If empty, then the copula parameters will be
+            taken from the ``args`` attribute created when initializing the
+            instance.
+
+        Returns
+        -------
+        ndarray
+            Copula log-pdf evaluated at points ``u``.
+        """
         # we skip Archimedean logpdf, that uses numdiff
         return super().logpdf(u, args=args)
 
     def tau(self, theta=None):
+        """Kendall's tau as a function of the copula parameter theta.
+
+        Joe (2014), p. 172.
+
+        Parameters
+        ----------
+        theta : float, optional
+            Copula parameter. If not given, then ``self.theta`` is used.
+
+        Returns
+        -------
+        float
+            Kendall's tau corresponding to `theta`.
+        """
         # Joe 2014 p. 172
         if theta is None:
             theta = self.theta
@@ -578,4 +926,16 @@ class GumbelCopula(ArchimedeanCopula):
         return (theta - 1) / theta
 
     def theta_from_tau(self, tau):
+        """Compute the copula parameter theta from Kendall's tau.
+
+        Parameters
+        ----------
+        tau : float
+            Kendall's tau.
+
+        Returns
+        -------
+        float
+            Copula parameter theta corresponding to `tau`.
+        """
         return 1 / (1 - tau)

--- a/statsmodels/distributions/copula/copulas.py
+++ b/statsmodels/distributions/copula/copulas.py
@@ -32,8 +32,8 @@ class CopulaDistribution:
         :class:`FrankCopula`, etc.
     marginals : list of distribution instances
         Marginal distributions.
-    copargs : tuple
-        Parameters for copula
+    cop_args : tuple, optional
+        Parameters for the copula.
 
     Notes
     -----
@@ -52,32 +52,30 @@ class CopulaDistribution:
 
     @deprecate_kwarg("random_state", "rng")
     def rvs(self, nobs=1, cop_args=None, marg_args=None, rng=None):
-        """Draw `n` in the half-open interval ``[0, 1)``.
-
-        Sample the joint distribution.
+        """Draw random samples from the joint (copula) distribution.
 
         Parameters
         ----------
         nobs : int, optional
             Number of samples to generate in the parameter space.
             Default is 1.
-        cop_args : tuple
+        cop_args : tuple, optional
             Copula parameters. If None, then the copula parameters will be
             taken from the ``cop_args`` attribute created when initiializing
             the instance.
-        marg_args : list of tuples
+        marg_args : list of tuples, optional
             Parameters for the marginal distributions. It can be None if none
             of the marginal distributions have parameters, otherwise it needs
             to be a list of tuples with the same length has the number of
             marginal distributions. The list can contain empty tuples for
             marginal distributions that do not take parameter arguments.
-        rng : int, array_like of int, numpy.random.Generator, numpy.random.RandomState, optional
+        rng : int, array_like of int, numpy.random.Generator, or numpy.random.RandomState, optional
             If `rng` is None, a new ``Generator`` is created using fresh
             entropy from the operating system. If `rng` is an int or array
             of ints, a new ``Generator`` is created, seeded with `rng`. If
             `rng` is already a ``Generator`` or ``RandomState`` instance,
             that instance is used.
-        rng : int, array_like of int, numpy.random.Generator, numpy.random.RandomState, optional
+        rng : int, array_like of int, numpy.random.Generator, or numpy.random.RandomState, optional
             .. deprecated:: 0.15
 
                random_state has been deprecated. In-line with SPEC-007, use
@@ -85,8 +83,9 @@ class CopulaDistribution:
 
         Returns
         -------
-        sample : array_like (n, d)
-            Sample from the joint distribution.
+        sample : ndarray of shape (nobs, k_vars)
+            Sample from the joint distribution, with marginals transformed
+            to the distributions in ``self.marginals``.
 
         Notes
         -----
@@ -120,11 +119,11 @@ class CopulaDistribution:
             Values of random variable at which to evaluate cdf.
             If 2-dimensional, then components of multivariate random variable
             need to be in columns
-        cop_args : tuple
+        cop_args : tuple, optional
             Copula parameters. If None, then the copula parameters will be
             taken from the ``cop_args`` attribute created when initiializing
             the instance.
-        marg_args : list of tuples
+        marg_args : list of tuples, optional
             Parameters for the marginal distributions. It can be None if none
             of the marginal distributions have parameters, otherwise it needs
             to be a list of tuples with the same length has the number of
@@ -133,7 +132,8 @@ class CopulaDistribution:
 
         Returns
         -------
-        cdf values
+        ndarray
+            CDF values evaluated at ``y``.
 
         """
         y = np.asarray(y)
@@ -157,14 +157,14 @@ class CopulaDistribution:
         Parameters
         ----------
         y : array_like
-            Values of random variable at which to evaluate cdf.
+            Values of random variable at which to evaluate pdf.
             If 2-dimensional, then components of multivariate random variable
             need to be in columns
-        cop_args : tuple
+        cop_args : tuple, optional
             Copula parameters. If None, then the copula parameters will be
             taken from the ``cop_args`` attribute created when initiializing
             the instance.
-        marg_args : list of tuples
+        marg_args : list of tuples, optional
             Parameters for the marginal distributions. It can be None if none
             of the marginal distributions have parameters, otherwise it needs
             to be a list of tuples with the same length has the number of
@@ -173,7 +173,8 @@ class CopulaDistribution:
 
         Returns
         -------
-        pdf values
+        ndarray
+            PDF values evaluated at ``y``.
         """
         return np.exp(self.logpdf(y, cop_args=cop_args, marg_args=marg_args))
 
@@ -183,14 +184,14 @@ class CopulaDistribution:
         Parameters
         ----------
         y : array_like
-            Values of random variable at which to evaluate cdf.
+            Values of random variable at which to evaluate log-pdf.
             If 2-dimensional, then components of multivariate random variable
             need to be in columns
-        cop_args : tuple
+        cop_args : tuple, optional
             Copula parameters. If None, then the copula parameters will be
-            taken from the ``cop_args`` attribute creating when initiializing
+            taken from the ``cop_args`` attribute created when initiializing
             the instance.
-        marg_args : list of tuples
+        marg_args : list of tuples, optional
             Parameters for the marginal distributions. It can be None if none
             of the marginal distributions have parameters, otherwise it needs
             to be a list of tuples with the same length has the number of
@@ -199,7 +200,8 @@ class CopulaDistribution:
 
         Returns
         -------
-        log-pdf values
+        ndarray
+            Log-pdf values evaluated at ``y``.
 
         """
         y = np.asarray(y)
@@ -266,7 +268,7 @@ class Copula(ABC):
       Journal of the American Statistical Association, 83, 834-841, 1988.
     .. [2] Marius Hofert. "Sampling Archimedean copulas",
       Universität Ulm, 2008.
-    .. rvs[3] Harry Joe. "Dependence Modeling with Copulas", Monographs on
+    .. [3] Harry Joe. "Dependence Modeling with Copulas", Monographs on
       Statistics and Applied Probability 134, 2015.
 
     """
@@ -284,16 +286,16 @@ class Copula(ABC):
         ----------
         nobs : int, optional
             Number of samples to generate from the copula. Default is 1.
-        args : tuple
+        args : tuple, optional
             Arguments for copula parameters. The number of arguments depends
             on the copula.
-        rng : int, array_like of int, numpy.random.Generator, numpy.random.RandomState, optional
+        rng : int, array_like of int, numpy.random.Generator, or numpy.random.RandomState, optional
             If `rng` is None, a new ``Generator`` is created using fresh
             entropy from the operating system. If `rng` is an int or array
             of ints, a new ``Generator`` is created, seeded with `rng`. If
             `rng` is already a ``Generator`` or ``RandomState`` instance,
             that instance is used.
-        rng : int, array_like of int, numpy.random.Generator, numpy.random.RandomState, optional
+        rng : int, array_like of int, numpy.random.Generator, or numpy.random.RandomState, optional
             .. deprecated:: 0.15
 
                random_state has been deprecated. In-line with SPEC-007, use
@@ -301,7 +303,7 @@ class Copula(ABC):
 
         Returns
         -------
-        sample : array_like (nobs, d)
+        sample : ndarray of shape (nobs, k_dim)
             Sample from the copula.
 
         See Also
@@ -321,7 +323,7 @@ class Copula(ABC):
             evaluated.
             The second (or last) dimension should be the same as the dimension
             of the random variable, e.g., 2 for bivariate copula.
-        args : tuple
+        args : tuple, optional
             Arguments for copula parameters. The number of arguments depends
             on the copula.
 
@@ -341,13 +343,13 @@ class Copula(ABC):
             evaluated.
             The second (or last) dimension should be the same as the dimension
             of the random variable, e.g., 2 for bivariate copula.
-        args : tuple
+        args : tuple, optional
             Arguments for copula parameters. The number of arguments depends
             on the copula.
 
         Returns
         -------
-        cdf : ndarray, (nobs, k_dim)
+        logpdf : ndarray, (nobs, k_dim)
             Copula log-pdf evaluated at points ``u``.
         """
         return np.log(self.pdf(u, *args))
@@ -363,7 +365,7 @@ class Copula(ABC):
             evaluated.
             The second (or last) dimension should be the same as the dimension
             of the random variable, e.g., 2 for bivariate copula.
-        args : tuple
+        args : tuple, optional
             Arguments for copula parameters. The number of arguments depends
             on the copula.
 
@@ -378,12 +380,12 @@ class Copula(ABC):
 
         Parameters
         ----------
-        sample : array-like, optional
+        sample : array_like, optional
             The sample to plot.  If not provided (the default), a sample
             is generated.
         nobs : int, optional
             Number of samples to generate from the copula.
-        rng : int, array_like of int, numpy.random.Generator, numpy.random.RandomState, optional
+        rng : int, array_like of int, numpy.random.Generator, or numpy.random.RandomState, optional
             If `rng` is None, a new ``Generator`` is created using fresh
             entropy from the operating system. If `rng` is an int or array
             of ints, a new ``Generator`` is created, seeded with `rng`. If
@@ -398,7 +400,7 @@ class Copula(ABC):
         fig : Figure
             If `ax` is None, the created figure.  Otherwise the figure to which
             `ax` is connected.
-        sample : array_like (n, d)
+        sample : ndarray of shape (nobs, k_dim)
             Sample from the copula.
 
         See Also
@@ -489,7 +491,7 @@ class Copula(ABC):
         ----------
         nobs : int, optional
             Number of samples to generate from the copula.
-        rng : int, array_like of int, numpy.random.Generator, numpy.random.RandomState, optional
+        rng : int, array_like of int, numpy.random.Generator, or numpy.random.RandomState, optional
             If `rng` is None, a new ``Generator`` is created using fresh
             entropy from the operating system. If `rng` is an int or array
             of ints, a new ``Generator`` is created, seeded with `rng`. If

--- a/statsmodels/distributions/copula/depfunc_ev.py
+++ b/statsmodels/distributions/copula/depfunc_ev.py
@@ -15,11 +15,33 @@ from statsmodels.tools.numdiff import _approx_fprime_cs_scalar, approx_hess
 
 
 class PickandDependence:
+    """Base class for Pickands dependence functions for EV-copulas.
+
+    Subclasses implement ``evaluate`` (the dependence function itself) and
+    may override ``deriv`` and ``deriv2`` with closed-form derivatives;
+    otherwise these fall back to numerical differentiation.
+    """
 
     def __call__(self, *args, **kwargs):
         return self.evaluate(*args, **kwargs)
 
     def evaluate(self, t, *args):
+        """Evaluate the Pickands dependence function.
+
+        Parameters
+        ----------
+        t : array_like
+            Value(s) in [0, 1] at which the dependence function is
+            evaluated.
+        *args
+            Shape parameters of the dependence function. The number and
+            meaning of these depends on the specific dependence function.
+
+        Returns
+        -------
+        ndarray or float
+            Value(s) of the Pickands dependence function at `t`.
+        """
         raise NotImplementedError
 
     def deriv(self, t, *args):
@@ -61,6 +83,25 @@ class AsymLogistic(PickandDependence):
         return condth and conda1 and conda2
 
     def evaluate(self, t, a1, a2, theta):
+        """Evaluate the asymmetric logistic Pickands dependence function.
+
+        Parameters
+        ----------
+        t : array_like
+            Value(s) in [0, 1] at which the dependence function is
+            evaluated.
+        a1 : float
+            Asymmetry parameter, restricted to [0, 1].
+        a2 : float
+            Asymmetry parameter, restricted to [0, 1].
+        theta : float
+            Dependence parameter, restricted to (0, 1].
+
+        Returns
+        -------
+        ndarray or float
+            Value(s) of the Pickands dependence function at `t`.
+        """
 
         # if not np.all(_check_args(a1, a2, theta)):
         #    raise ValueError('invalid args')
@@ -107,6 +148,25 @@ class AsymNegLogistic(PickandDependence):
         return condth and conda1 and conda2
 
     def evaluate(self, t, a1, a2, theta):
+        """Evaluate the asymmetric negative logistic dependence function.
+
+        Parameters
+        ----------
+        t : array_like
+            Value(s) in [0, 1] at which the dependence function is
+            evaluated.
+        a1 : float
+            Asymmetry parameter, restricted to (0, 1].
+        a2 : float
+            Asymmetry parameter, restricted to (0, 1].
+        theta : float
+            Dependence parameter, restricted to (0, inf).
+
+        Returns
+        -------
+        ndarray or float
+            Value(s) of the Pickands dependence function at `t`.
+        """
         # if not np.all(self._check_args(a1, a2, theta)):
         #     raise ValueError('invalid args')
 
@@ -164,6 +224,25 @@ class AsymMixed(PickandDependence):
         return condth & cond1
 
     def evaluate(self, t, theta, k):
+        """Evaluate the asymmetric mixed Pickands dependence function.
+
+        Parameters
+        ----------
+        t : array_like
+            Value(s) in [0, 1] at which the dependence function is
+            evaluated.
+        theta : float
+            Dependence parameter, restricted to theta > 0 (jointly with
+            `k`, see class restrictions).
+        k : float
+            Shape parameter, restricted jointly with `theta`, see class
+            restrictions.
+
+        Returns
+        -------
+        ndarray or float
+            Value(s) of the Pickands dependence function at `t`.
+        """
         transf = 1 - (theta + k) * t + theta * t*t + k * t**3
         return transf
 
@@ -197,6 +276,26 @@ class AsymBiLogistic(PickandDependence):
         return cond1 | cond2
 
     def evaluate(self, t, beta, delta):
+        """Evaluate the bilogistic Pickands dependence function.
+
+        Not vectorized in `t` because of the numerical integration.
+
+        Parameters
+        ----------
+        t : float
+            Value in [0, 1] at which the dependence function is evaluated.
+        beta : float
+            Shape parameter, jointly restricted with `delta` to either
+            (0, 1) or (-inf, 0).
+        delta : float
+            Shape parameter, jointly restricted with `beta` to either
+            (0, 1) or (-inf, 0).
+
+        Returns
+        -------
+        float
+            Value of the Pickands dependence function at `t`.
+        """
         # if not np.all(_check_args(beta, delta)):
         #    raise ValueError('invalid args')
 
@@ -228,6 +327,21 @@ class HR(PickandDependence):
         return cond
 
     def evaluate(self, t, lamda):
+        """Evaluate the Huesler-Reiss Pickands dependence function.
+
+        Parameters
+        ----------
+        t : array_like
+            Value(s) in [0, 1] at which the dependence function is
+            evaluated.
+        lamda : float
+            Dependence parameter, restricted to (0, inf).
+
+        Returns
+        -------
+        ndarray or float
+            Value(s) of the Pickands dependence function at `t`.
+        """
         # if not np.all(self._check_args(lamda)):
         #    raise ValueError('invalid args')
 
@@ -311,6 +425,24 @@ class TEV(PickandDependence):
         return cond1 and cond2
 
     def evaluate(self, t, rho, df):
+        """Evaluate the t-EV Pickands dependence function.
+
+        Parameters
+        ----------
+        t : array_like
+            Value(s) in [0, 1] at which the dependence function is
+            evaluated.
+        rho : float
+            Correlation parameter, restricted to (-1, 1).
+        df : float
+            Degrees of freedom parameter (denoted ``x`` or ``chi`` in
+            some references), restricted to > 0.
+
+        Returns
+        -------
+        ndarray or float
+            Value(s) of the Pickands dependence function at `t`.
+        """
         x = df  # alias, Genest and Segers use chi, copual package uses df
         # if not np.all(self, _check_args(rho, x)):
         #    raise ValueError('invalid args')

--- a/statsmodels/distributions/copula/elliptical.py
+++ b/statsmodels/distributions/copula/elliptical.py
@@ -50,17 +50,17 @@ class EllipticalCopula(Copula):
         ----------
         nobs : int, optional
             Number of samples to generate from the copula. Default is 1.
-        args : tuple
+        args : tuple, optional
             Arguments for copula parameters. Not used by elliptical copulas,
             which take their parameters as attributes.
-        rng : int, array_like of int, numpy.random.Generator, numpy.random.RandomState, optional
+        rng : int, array_like of int, numpy.random.Generator, or numpy.random.RandomState, optional
             Passed directly to the underlying SciPy distribution as its
             ``random_state`` argument. If `rng` is None, the global NumPy
             singleton random state is used. If `rng` is an int or array of
             ints, a new ``RandomState`` is created, seeded with `rng`. If
             `rng` is already a ``Generator`` or ``RandomState`` instance,
             that instance is used.
-        rng : int, array_like of int, numpy.random.Generator, numpy.random.RandomState, optional
+        rng : int, array_like of int, numpy.random.Generator, or numpy.random.RandomState, optional
             .. deprecated:: 0.15
 
                random_state has been deprecated. In-line with SPEC-007, use
@@ -68,7 +68,7 @@ class EllipticalCopula(Copula):
 
         Returns
         -------
-        sample : array_like (nobs, k_dim)
+        sample : ndarray of shape (nobs, k_dim)
             Sample from the copula.
         """
         self._handle_args(args)
@@ -76,6 +76,22 @@ class EllipticalCopula(Copula):
         return self.distr_uv.cdf(x)
 
     def pdf(self, u, args=()):
+        """Evaluate the pdf of the copula.
+
+        Parameters
+        ----------
+        u : array_like, 2-D
+            Points of random variables in unit hypercube at which method is
+            evaluated.
+        args : tuple, optional
+            Arguments for copula parameters. Not used by elliptical copulas,
+            which take their parameters as attributes.
+
+        Returns
+        -------
+        ndarray
+            Copula pdf evaluated at points ``u``.
+        """
         self._handle_args(args)
         ppf = self.distr_uv.ppf(u)
         mv_pdf_ppf = self.distr_mv.pdf(ppf)
@@ -91,17 +107,17 @@ class EllipticalCopula(Copula):
         u : array_like, 2-D
             Points of random variables in unit hypercube at which method is
             evaluated.
-        args : tuple
+        args : tuple, optional
             Arguments for copula parameters. Not used by elliptical copulas,
             which take their parameters as attributes.
-        rng : int, array_like of int, numpy.random.Generator, numpy.random.RandomState, optional
+        rng : int, array_like of int, numpy.random.Generator, or numpy.random.RandomState, optional
             Passed directly to the underlying SciPy distribution as its
             ``random_state``/``rng`` argument, if supported. If `rng` is
             None, the global NumPy singleton random state is used. If `rng`
             is an int or array of ints, a new ``RandomState`` is created,
             seeded with `rng`. If `rng` is already a ``Generator`` or
             ``RandomState`` instance, that instance is used.
-        rng : int, array_like of int, numpy.random.Generator, numpy.random.RandomState, optional
+        rng : int, array_like of int, numpy.random.Generator, or numpy.random.RandomState, optional
             .. deprecated:: 0.15
 
                random_state has been deprecated. In-line with SPEC-007, use
@@ -125,14 +141,15 @@ class EllipticalCopula(Copula):
 
         Parameters
         ----------
-        corr : None or float
+        corr : float, optional
             Pearson correlation. If corr is None, then the correlation will be
             taken from the copula attribute.
 
         Returns
         -------
-        Kendall's tau that corresponds to pearson correlation in the
-        elliptical copula.
+        float or ndarray
+            Kendall's tau that corresponds to pearson correlation in the
+            elliptical copula.
         """
         if corr is None:
             corr = self.corr
@@ -151,8 +168,9 @@ class EllipticalCopula(Copula):
 
         Returns
         -------
-        Pearson correlation coefficient for given tau in elliptical
-        copula. This can be used as parameter for an elliptical copula.
+        float or ndarray
+            Pearson correlation coefficient for given tau in elliptical
+            copula. This can be used as parameter for an elliptical copula.
         """
         corr = np.sin(tau * np.pi / 2)
         return corr
@@ -167,10 +185,11 @@ class EllipticalCopula(Copula):
 
         Returns
         -------
-        corr_param : float
+        corr_param : float or ndarray
             Correlation parameter of the copula, ``theta`` in Archimedean and
-            pearson correlation in elliptical.
-            If k_dim > 2, then average tau is used.
+            pearson correlation in elliptical. For the bivariate case
+            (k_dim == 2) this is a scalar; if k_dim > 2, then the full
+            k_dim x k_dim matrix of pairwise correlations is returned.
         """
         x = np.asarray(data)
 
@@ -210,14 +229,14 @@ class GaussianCopula(EllipticalCopula):
 
     Parameters
     ----------
-    corr : scalar or array_like
+    corr : float or array_like, optional
         Correlation or scatter matrix for the elliptical copula. In the
         bivariate case, ``corr`` can be a scalar and is then considered as
         the correlation coefficient. If ``corr`` is None, then the scatter
         matrix is the identity matrix.
-    k_dim : int
+    k_dim : int, optional
         Dimension, number of components in the multivariate random variable.
-    allow_singular : bool
+    allow_singular : bool, optional
         Allow singular correlation matrix.
         The behavior when the correlation matrix is singular is determined by
         ``scipy.stats.multivariate_normal`` and might not be appropriate for
@@ -262,14 +281,18 @@ class GaussianCopula(EllipticalCopula):
 
         Parameters
         ----------
-        corr : any
+        corr : float, optional
             Tail dependence for Gaussian copulas is always zero.
             Argument will be ignored
 
         Returns
         -------
-        Lower and upper tail dependence coefficients of the copula with given
-        Pearson correlation coefficient.
+        lower : float
+            Lower tail dependence coefficient, always 0 for the Gaussian
+            copula.
+        upper : float
+            Upper tail dependence coefficient, always 0 for the Gaussian
+            copula.
         """
 
         return 0, 0
@@ -284,14 +307,14 @@ class StudentTCopula(EllipticalCopula):
 
     Parameters
     ----------
-    corr : scalar or array_like
+    corr : float or array_like, optional
         Correlation or scatter matrix for the elliptical copula. In the
         bivariate case, ``corr`` can be a scalar and is then considered as
         the correlation coefficient. If ``corr`` is None, then the scatter
         matrix is the identity matrix.
-    df : float (optional)
+    df : float, optional
         Degrees of freedom of the multivariate t distribution.
-    k_dim : int
+    k_dim : int, optional
         Dimension, number of components in the multivariate random variable.
 
     Notes
@@ -324,6 +347,25 @@ class StudentTCopula(EllipticalCopula):
         self.distr_mv = stats.multivariate_t(shape=corr, df=df)
 
     def cdf(self, u, args=()):
+        """Evaluate the cdf of the copula.
+
+        Not implemented for the Student t copula.
+
+        Parameters
+        ----------
+        u : array_like, 2-D
+            Points of random variables in unit hypercube at which method
+            would be evaluated.
+        args : tuple, optional
+            Arguments for copula parameters. Not used by elliptical copulas,
+            which take their parameters as attributes.
+
+        Raises
+        ------
+        NotImplementedError
+            The cdf of the Student t copula is not available in closed
+            form.
+        """
         raise NotImplementedError("CDF not available in closed form.")
         # ppf = self.distr_uv.ppf(u)
         # mvt = MVT([0, 0], self.corr, self.df)
@@ -337,14 +379,15 @@ class StudentTCopula(EllipticalCopula):
 
         Parameters
         ----------
-        corr : None or float
+        corr : float, optional
             Pearson correlation. If corr is None, then the correlation will be
             taken from the copula attribute.
 
         Returns
         -------
-        Spearman's rho that corresponds to pearson correlation in the
-        elliptical copula.
+        float or ndarray
+            Spearman's rho that corresponds to pearson correlation in the
+            elliptical copula.
         """
         if corr is None:
             corr = self.corr
@@ -362,14 +405,18 @@ class StudentTCopula(EllipticalCopula):
 
         Parameters
         ----------
-        corr : None or float
+        corr : float, optional
             Pearson correlation. If corr is None, then the correlation will be
             taken from the copula attribute.
 
         Returns
         -------
-        Lower and upper tail dependence coefficients of the copula with given
-        Pearson correlation coefficient.
+        lower : float or ndarray
+            Lower tail dependence coefficient of the copula with given
+            Pearson correlation coefficient.
+        upper : float or ndarray
+            Upper tail dependence coefficient of the copula with given
+            Pearson correlation coefficient.
         """
         if corr is None:
             corr = self.corr

--- a/statsmodels/distributions/copula/extreme_value.py
+++ b/statsmodels/distributions/copula/extreme_value.py
@@ -13,6 +13,22 @@ from .copulas import Copula
 
 def copula_bv_ev(u, transform, args=()):
     """generic bivariate extreme value copula
+
+    Parameters
+    ----------
+    u : tuple
+        Pair ``(u, v)`` of values in [0, 1] at which the copula is
+        evaluated.
+    transform : instance of transformation class
+        Pickand's dependence function with required methods including
+        first and second derivatives.
+    args : tuple, optional
+        Optional copula parameters, passed to `transform`.
+
+    Returns
+    -------
+    ndarray
+        CDF values at evaluation points.
     """
     u, v = u
     return np.exp(np.log(u * v) * (transform(np.log(u)/np.log(u*v), *args)))
@@ -25,13 +41,13 @@ class ExtremeValueCopula(Copula):
 
     Parameters
     ----------
-    transform: instance of transformation class
+    transform : instance of transformation class
         Pickand's dependence function with required methods including first
         and second derivatives
-    args : tuple
+    args : tuple, optional
         Optional copula parameters. Copula parameters can be either provided
         when creating the instance or as arguments when calling methods.
-    k_dim : int
+    k_dim : int, optional
         Currently only bivariate extreme value copulas are supported.
 
     Notes
@@ -77,17 +93,18 @@ class ExtremeValueCopula(Copula):
         Parameters
         ----------
         u : array_like
-            Values of random bivariate random variable, each defined on [0, 1],
+            Values of the bivariate random variable, each defined on [0, 1],
             for which cdf is computed.
             Can be two dimensional with multivariate components in columns and
             observation in rows.
-        args : tuple
+        args : tuple, optional
             Required parameters for the copula. The meaning and number of
             parameters in the tuple depends on the specific copula.
 
         Returns
         -------
-        CDF values at evaluation points.
+        ndarray
+            CDF values at evaluation points.
         """
         # currently only Bivariate
         u, v = np.asarray(u).T
@@ -102,17 +119,18 @@ class ExtremeValueCopula(Copula):
         Parameters
         ----------
         u : array_like
-            Values of random bivariate random variable, each defined on [0, 1],
-            for which cdf is computed.
+            Values of the bivariate random variable, each defined on [0, 1],
+            for which pdf is computed.
             Can be two dimensional with multivariate components in columns and
             observation in rows.
-        args : tuple
+        args : tuple, optional
             Required parameters for the copula. The meaning and number of
             parameters in the tuple depends on the specific copula.
 
         Returns
         -------
-        PDF values at evaluation points.
+        ndarray
+            PDF values at evaluation points.
         """
         tr = self.transform
         u1, u2 = np.asarray(u).T
@@ -135,17 +153,18 @@ class ExtremeValueCopula(Copula):
         Parameters
         ----------
         u : array_like
-            Values of random bivariate random variable, each defined on [0, 1],
-            for which cdf is computed.
+            Values of the bivariate random variable, each defined on [0, 1],
+            for which log-pdf is computed.
             Can be two dimensional with multivariate components in columns and
             observation in rows.
-        args : tuple
+        args : tuple, optional
             Required parameters for the copula. The meaning and number of
             parameters in the tuple depends on the specific copula.
 
         Returns
         -------
-        Log-pdf values at evaluation points.
+        ndarray
+            Log-pdf values at evaluation points.
         """
         return np.log(self.pdf(u, args=args))
 

--- a/statsmodels/distributions/copula/other_copulas.py
+++ b/statsmodels/distributions/copula/other_copulas.py
@@ -16,7 +16,7 @@ from statsmodels.tools.rng_qrng import check_random_state
 
 
 class IndependenceCopula(Copula):
-    """Independence copula.
+    r"""Independence copula.
 
     Copula with independent random variables.
 
@@ -26,7 +26,7 @@ class IndependenceCopula(Copula):
 
     Parameters
     ----------
-    k_dim : int
+    k_dim : int, optional
         Dimension, number of components in the multivariate random variable.
 
     Notes
@@ -56,15 +56,15 @@ class IndependenceCopula(Copula):
         ----------
         nobs : int, optional
             Number of samples to generate from the copula. Default is 1.
-        args : tuple
+        args : tuple, optional
             Arguments for copula parameters. Not used by ``IndependenceCopula``.
-        rng : int, array_like of int, numpy.random.Generator, numpy.random.RandomState, optional
+        rng : int, array_like of int, numpy.random.Generator, or numpy.random.RandomState, optional
             If `rng` is None, a new ``Generator`` is created using fresh
             entropy from the operating system. If `rng` is an int or array
             of ints, a new ``Generator`` is created, seeded with `rng`. If
             `rng` is already a ``Generator`` or ``RandomState`` instance,
             that instance is used.
-        rng : int, array_like of int, numpy.random.Generator, numpy.random.RandomState, optional
+        rng : int, array_like of int, numpy.random.Generator, or numpy.random.RandomState, optional
             .. deprecated:: 0.15
 
                random_state has been deprecated. In-line with SPEC-007, use
@@ -81,16 +81,66 @@ class IndependenceCopula(Copula):
         return x
 
     def pdf(self, u, args=()):
+        """Probability density function of the independence copula.
+
+        Parameters
+        ----------
+        u : array_like, 2-D
+            Points of random variables in unit hypercube at which method is
+            evaluated.
+            The second (or last) dimension should be the same as the
+            dimension of the random variable, e.g., 2 for bivariate copula.
+        args : tuple, optional
+            Not used by ``IndependenceCopula``.
+
+        Returns
+        -------
+        ndarray
+            Copula pdf evaluated at points ``u``. Constant equal to 1.
+        """
         u = np.asarray(u)
         return np.ones(u.shape[:-1])
 
     def cdf(self, u, args=()):
+        """Cumulative distribution function of the independence copula.
+
+        Parameters
+        ----------
+        u : array_like, 2-D
+            Points of random variables in unit hypercube at which method is
+            evaluated.
+            The second (or last) dimension should be the same as the
+            dimension of the random variable, e.g., 2 for bivariate copula.
+        args : tuple, optional
+            Not used by ``IndependenceCopula``.
+
+        Returns
+        -------
+        ndarray
+            Copula cdf evaluated at points ``u``, i.e., the product of the
+            components of ``u``.
+        """
         return np.prod(u, axis=-1)
 
     def tau(self):
+        """Kendall's tau of the independence copula.
+
+        Returns
+        -------
+        float
+            Kendall's tau, which is always 0 for the independence copula.
+        """
         return 0
 
     def plot_pdf(self, *args):
+        """Not implemented.
+
+        Raises
+        ------
+        NotImplementedError
+            The independence copula's pdf is constant over the domain and
+            is not plotted.
+        """
         raise NotImplementedError("PDF is constant over the domain.")
 
 
@@ -100,23 +150,23 @@ def rvs_kernel(sample, size, bw=1, k_func=None, return_extras=False, rng=None):
     Parameters
     ----------
     sample : ndarray
-        Sample of multivariate observations in (o, 1) interval.
+        Sample of multivariate observations in (0, 1) interval.
     size : int
         Number of observations to simulate.
-    bw : float
+    bw : float, optional
         Bandwidth for Beta sampling. The beta copula corresponds to a kernel
         estimate of the distribution. bw=1 corresponds to the empirical beta
         copula. A small bandwidth like bw=0.001 corresponds to small noise
         added to the empirical distribution. Larger bw, e.g., bw=10 corresponds
         to kernel estimate with more smoothing.
-    k_func : None or callable
+    k_func : callable, optional
         The default kernel function is currently a beta function with 1 added
         to the first beta parameter.
-    return_extras : bool
+    return_extras : bool, optional
         If this is False, then only the random sample will be returned.
         If true, then extra information is returned that is mainly of interest
         for verification.
-    rng : int, array_like of int, numpy.random.Generator, numpy.random.RandomState, optional
+    rng : int, array_like of int, numpy.random.Generator, or numpy.random.RandomState, optional
         If `rng` is None, a new ``Generator`` is created using fresh
         entropy from the operating system. If `rng` is an int or array
         of ints, a new ``Generator`` is created, seeded with `rng`. If

--- a/statsmodels/distributions/copula/transforms.py
+++ b/statsmodels/distributions/copula/transforms.py
@@ -14,23 +14,80 @@ from scipy.special import expm1, gamma
 
 
 class Transforms:
+    """Base class for transformation (generator) functions of Archimedean
+    copulas.
+
+    Subclasses implement ``evaluate`` (the generator function) and
+    ``inverse`` (its inverse), and may override ``deriv``, ``deriv2`` and
+    the higher order derivatives of the inverse with closed-form
+    expressions.
+    """
 
     def __init__(self):
         pass
 
     def deriv2_inverse(self, phi, args):
+        """Second derivative of the inverse transformation function.
+
+        Generic implementation based on the derivatives of the direct
+        transformation function evaluated at the inverse.
+
+        Parameters
+        ----------
+        phi : array_like
+            Value(s) at which the derivative is evaluated.
+        args : tuple or float
+            Copula parameter(s), passed through to `inverse`, `deriv` and
+            `deriv2`.
+
+        Returns
+        -------
+        ndarray or float
+            Value(s) of the second derivative of the inverse transformation
+            function.
+        """
         t = self.inverse(phi, args)
         phi_d1 = self.deriv(t, args)
         phi_d2 = self.deriv2(t, args)
         return np.abs(phi_d2 / phi_d1**3)
 
     def derivk_inverse(self, k, phi, theta):
+        """k-th derivative of the inverse transformation function.
+
+        Not implemented in the base class.
+
+        Parameters
+        ----------
+        k : int
+            Order of the derivative.
+        phi : array_like
+            Value(s) at which the derivative is evaluated.
+        theta : array_like
+            Copula parameter.
+        """
         raise NotImplementedError("not yet implemented")
 
 
 class TransfFrank(Transforms):
+    """Transformation (generator) function of the Frank copula.
+    """
 
     def evaluate(self, t, theta):
+        """Evaluate the Frank copula generator function.
+
+        Parameters
+        ----------
+        t : array_like
+            Value(s) in [0, 1] at which the generator function is
+            evaluated.
+        theta : float
+            Copula dependence parameter.
+
+        Returns
+        -------
+        ndarray
+            Value(s) of the generator function at `t`.
+        """
         t = np.asarray(t)
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", RuntimeWarning)
@@ -39,6 +96,20 @@ class TransfFrank(Transforms):
         # return - np.log(expm1(-theta*t) / expm1(-theta))
 
     def inverse(self, phi, theta):
+        """Evaluate the inverse of the Frank copula generator function.
+
+        Parameters
+        ----------
+        phi : array_like
+            Value(s) at which the inverse generator function is evaluated.
+        theta : float
+            Copula dependence parameter.
+
+        Returns
+        -------
+        ndarray
+            Value(s) of the inverse generator function at `phi`.
+        """
         phi = np.asarray(phi)
         return -np.log1p(np.exp(-phi) * expm1(-theta)) / theta
 
@@ -85,14 +156,45 @@ class TransfFrank(Transforms):
 
 
 class TransfClayton(Transforms):
+    """Transformation (generator) function of the Clayton copula.
+    """
 
     def _checkargs(self, theta):
         return theta > 0
 
     def evaluate(self, t, theta):
+        """Evaluate the Clayton copula generator function.
+
+        Parameters
+        ----------
+        t : array_like
+            Value(s) in [0, 1] at which the generator function is
+            evaluated.
+        theta : float
+            Copula dependence parameter, restricted to > 0.
+
+        Returns
+        -------
+        ndarray
+            Value(s) of the generator function at `t`.
+        """
         return np.power(t, -theta) - 1.
 
     def inverse(self, phi, theta):
+        """Evaluate the inverse of the Clayton copula generator function.
+
+        Parameters
+        ----------
+        phi : array_like
+            Value(s) at which the inverse generator function is evaluated.
+        theta : float
+            Copula dependence parameter, restricted to > 0.
+
+        Returns
+        -------
+        ndarray
+            Value(s) of the inverse generator function at `phi`.
+        """
         return np.power(1 + phi, -1/theta)
 
     def deriv(self, t, theta):
@@ -128,17 +230,47 @@ class TransfClayton(Transforms):
 
 
 class TransfGumbel(Transforms):
-    """
-    requires theta >=1
+    """Transformation (generator) function of the Gumbel copula.
+
+    Requires theta >= 1.
     """
 
     def _checkargs(self, theta):
         return theta >= 1
 
     def evaluate(self, t, theta):
+        """Evaluate the Gumbel copula generator function.
+
+        Parameters
+        ----------
+        t : array_like
+            Value(s) in [0, 1] at which the generator function is
+            evaluated.
+        theta : float
+            Copula dependence parameter, restricted to >= 1.
+
+        Returns
+        -------
+        ndarray
+            Value(s) of the generator function at `t`.
+        """
         return np.power(-np.log(t), theta)
 
     def inverse(self, phi, theta):
+        """Evaluate the inverse of the Gumbel copula generator function.
+
+        Parameters
+        ----------
+        phi : array_like
+            Value(s) at which the inverse generator function is evaluated.
+        theta : float
+            Copula dependence parameter, restricted to >= 1.
+
+        Returns
+        -------
+        ndarray
+            Value(s) of the inverse generator function at `phi`.
+        """
         return np.exp(-np.power(phi, 1. / theta))
 
     def deriv(self, t, theta):
@@ -185,12 +317,46 @@ class TransfGumbel(Transforms):
 
 
 class TransfIndep(Transforms):
+    """Transformation (generator) function of the independence copula.
+    """
 
     def evaluate(self, t, *args):
+        """Evaluate the independence copula generator function.
+
+        Parameters
+        ----------
+        t : array_like
+            Value(s) in [0, 1] at which the generator function is
+            evaluated.
+        *args
+            Not used. Present for a consistent interface across
+            transforms.
+
+        Returns
+        -------
+        ndarray
+            Value(s) of the generator function at `t`.
+        """
         t = np.asarray(t)
         return -np.log(t)
 
     def inverse(self, phi, *args):
+        """Evaluate the inverse of the independence copula generator
+        function.
+
+        Parameters
+        ----------
+        phi : array_like
+            Value(s) at which the inverse generator function is evaluated.
+        *args
+            Not used. Present for a consistent interface across
+            transforms.
+
+        Returns
+        -------
+        ndarray
+            Value(s) of the inverse generator function at `phi`.
+        """
         phi = np.asarray(phi)
         return np.exp(-phi)
 
@@ -218,12 +384,39 @@ class _TransfPower(Transforms):
     Nelson p.144, equ. 4.5.2
 
     experimental, not yet tested and used
+
+    Parameters
+    ----------
+    transform : instance of transformation class
+        The base transformation (generator) function to which the power
+        transform is applied.
     """
 
     def __init__(self, transform):
         self.transform = transform
 
     def evaluate(self, t, alpha, beta, *tr_args):
+        """Evaluate the power-transformed generator function.
+
+        Parameters
+        ----------
+        t : array_like
+            Value(s) in [0, 1] at which the generator function is
+            evaluated.
+        alpha : float
+            Power parameter applied to `t` before evaluating the base
+            transform.
+        beta : float
+            Power parameter applied to the output of the base transform.
+        *tr_args
+            Additional arguments passed to the base transform's
+            ``evaluate`` method.
+
+        Returns
+        -------
+        ndarray
+            Value(s) of the power-transformed generator function at `t`.
+        """
         t = np.asarray(t)
 
         phi = np.power(self.transform.evaluate(np.power(t, alpha), *tr_args),
@@ -231,6 +424,27 @@ class _TransfPower(Transforms):
         return phi
 
     def inverse(self, phi, alpha, beta, *tr_args):
+        """Evaluate the inverse of the power-transformed generator function.
+
+        Parameters
+        ----------
+        phi : array_like
+            Value(s) at which the inverse generator function is evaluated.
+        alpha : float
+            Power parameter applied to the output of the base transform.
+        beta : float
+            Power parameter applied to `phi` before evaluating the base
+            transform.
+        *tr_args
+            Additional arguments passed to the base transform's
+            ``evaluate`` method.
+
+        Returns
+        -------
+        ndarray
+            Value(s) of the inverse power-transformed generator function at
+            `phi`.
+        """
         phi = np.asarray(phi)
         transf = self.transform
         phi_inv = np.power(transf.evaluate(np.power(phi, 1. / beta), *tr_args),

--- a/statsmodels/distributions/discrete.py
+++ b/statsmodels/distributions/discrete.py
@@ -261,12 +261,12 @@ class DiscretizedCount(rv_discrete):
     Parameters
     ----------
     distr : distribution instance
-    d_offset : float
+    d_offset : float, optional
         Offset for integer interval, default is zero.
         The discrete random variable is ``y = floor(x + offset)`` where x is
         the continuous random variable.
         Warning: not verified for all methods.
-    add_scale : bool
+    add_scale : bool, optional
         If True (default), then the scale of the base distribution is added
         as parameter for the discrete distribution. The scale parameter is in
         the last position.
@@ -351,14 +351,14 @@ class DiscretizedCount(rv_discrete):
             continuous distribution.
         size : int or tuple of ints, optional
             Number of random variates to generate.
-        rng : int, array_like of int, numpy.random.Generator, numpy.random.RandomState, optional
+        rng : int, array_like of int, numpy.random.Generator, or numpy.random.RandomState, optional
             Passed directly to the underlying SciPy distribution as its
             ``random_state`` argument. If `rng` is None, the global NumPy
             singleton random state is used. If `rng` is an int or array of
             ints, a new ``RandomState`` is created, seeded with `rng`. If
             `rng` is already a ``Generator`` or ``RandomState`` instance,
             that instance is used.
-        rng : int, array_like of int, numpy.random.Generator, numpy.random.RandomState, optional
+        rng : int, array_like of int, numpy.random.Generator, or numpy.random.RandomState, optional
             .. deprecated:: 0.15
 
                random_state has been deprecated. In-line with SPEC-007, use
@@ -450,7 +450,7 @@ class DiscretizedModel(GenericLikelihoodModel):
     --------
     >>> from scipy import stats
     >>> from statsmodels.distributions.discrete import (
-            DiscretizedCount, DiscretizedModel)
+    ...     DiscretizedCount, DiscretizedModel)
 
     >>> dd = DiscretizedCount(stats.gamma)
     >>> mod = DiscretizedModel(y, distr=dd)
@@ -473,7 +473,20 @@ class DiscretizedModel(GenericLikelihoodModel):
         self.start_params = 0.5 * np.ones(self.nparams)
 
     def loglike(self, params):
+        """
+        Log-likelihood of the discretized distribution.
 
+        Parameters
+        ----------
+        params : array_like
+            Shape (and scale) parameters of the underlying continuous
+            distribution.
+
+        Returns
+        -------
+        float
+            Sum of the log-probabilities of `endog` given `params`.
+        """
         # this does not allow exog yet,
         # model `params` are also distribution `args`
         # For regression model this needs to be replaced by a conversion method
@@ -482,7 +495,32 @@ class DiscretizedModel(GenericLikelihoodModel):
         return ll.sum()
 
     def predict(self, params, exog=None, which=None, k_max=20):
+        """
+        Predict values for the discretized distribution.
 
+        Parameters
+        ----------
+        params : array_like
+            Shape (and scale) parameters of the underlying continuous
+            distribution.
+        exog : None
+            Explanatory variables are not supported. The ``exog`` argument
+            is only included for consistency in the signature across
+            models.
+        which : str, optional
+            Statistic to predict. The only currently implemented value is
+            "probs", which returns the probability mass function evaluated
+            at ``0, 1, ..., k_max - 1``. Any other value, including the
+            default of None, raises a ``ValueError``.
+        k_max : int, optional
+            Number of support points, starting at zero, for which
+            probabilities are returned.
+
+        Returns
+        -------
+        ndarray
+            Probability mass function evaluated at ``0, 1, ..., k_max - 1``.
+        """
         if exog is not None:
             raise ValueError("exog is not supported")
 
@@ -494,7 +532,21 @@ class DiscretizedModel(GenericLikelihoodModel):
             raise ValueError('only which="probs" is currently implemented')
 
     def get_distr(self, params):
-        """frozen distribution instance of the discrete distribution."""
+        """
+        Frozen distribution instance of the discrete distribution.
+
+        Parameters
+        ----------
+        params : array_like
+            Shape (and scale) parameters of the underlying continuous
+            distribution.
+
+        Returns
+        -------
+        rv_discrete_frozen
+            Frozen distribution instance of the discretized distribution
+            with `params` substituted for the shape parameters.
+        """
         args = params
         distr = self.distr(*args)
         return distr

--- a/statsmodels/distributions/edgeworth.py
+++ b/statsmodels/distributions/edgeworth.py
@@ -59,12 +59,12 @@ def cumulant_from_moments(momt, n):
 
     Parameters
     ----------
-    momt : array_like
+    momt : sequence of float
         `momt[j]` contains `(j+1)`-th moment.
         These can be raw moments around zero, or central moments
         (in which case, `momt[0]` == 0).
     n : int
-        which cumulant to calculate (must be >1)
+        which cumulant to calculate (must be >= 1)
 
     Returns
     -------

--- a/statsmodels/distributions/empirical_distribution.py
+++ b/statsmodels/distributions/empirical_distribution.py
@@ -13,7 +13,7 @@ def _conf_set(F, alpha=.05):
     ----------
     F : array_like
         The empirical distributions
-    alpha : float
+    alpha : float, optional
         Set alpha for a (1 - alpha) % confidence band.
 
     Notes
@@ -45,12 +45,15 @@ class StepFunction:
     Parameters
     ----------
     x : array_like
+        The x-values of the step function.
     y : array_like
-    ival : float
+        The y-values of the step function, one for each value in `x`.
+    ival : float, optional
         ival is the value given to the values to the left of x[0]. Default
         is 0.
-    sorted : bool
-        Default is False.
+    sorted : bool, optional
+        Set to True if `x` is already sorted to skip sorting. Default is
+        False.
     side : {'left', 'right'}, optional
         Default is 'left'. Defines the shape of the intervals constituting the
         steps. 'right' correspond to [a, b) intervals and 'left' to (a, b].
@@ -162,7 +165,7 @@ class ECDFDiscrete(StepFunction):
         If freq_weights is not None, then x will be taken as the support of the
         mass point distribution with freq_weights as counts for x values.
         The x values can be arbitrary sortable values and need not be integers.
-    freq_weights : array_like
+    freq_weights : array_like, optional
         Weights of the observations.  sum(freq_weights) is interpreted as nobs
         for confint.
         If freq_weights is None, then the frequency counts for unique values
@@ -219,6 +222,27 @@ def monotone_fn_inverter(fn, x, vectorized=True, **keywords):
     Given a monotone function fn (no checking is done to verify monotonicity)
     and a set of x values, return an linearly interpolated approximation
     to its inverse from its values on x.
+
+    Parameters
+    ----------
+    fn : callable
+        Monotone function to invert. No check is performed to verify
+        monotonicity.
+    x : array_like
+        Grid of values on which `fn` is evaluated to construct the
+        approximate inverse.
+    vectorized : bool, optional
+        If True, `fn` is called on the whole array `x` at once. If False,
+        `fn` is called separately for each element of `x`. Default is
+        True.
+    **keywords
+        Additional keyword arguments passed to `fn`.
+
+    Returns
+    -------
+    callable
+        Linearly interpolated approximation to the inverse of `fn`,
+        constructed with `scipy.interpolate.interp1d`.
     """
     x = np.asarray(x)
     if vectorized:

--- a/statsmodels/distributions/mixture_rvs.py
+++ b/statsmodels/distributions/mixture_rvs.py
@@ -15,10 +15,12 @@ def _make_index(prob, size, rng=None):
         Probability of sampling from each distribution in dist.
     size : int
         The length of the returned sample.
-    rng : {None, numpy.random.Generator, numpy.random.RandomState}, optional
-        If `rng` is None, the global (legacy) NumPy random state is
-        used. If `rng` is already a ``Generator`` or ``RandomState``
-        instance, that instance is used.
+    rng : int, array_like of int, numpy.random.Generator, or numpy.random.RandomState, optional
+        If `rng` is None, a new ``Generator`` is created using fresh
+        entropy from the operating system. If `rng` is an int or array
+        of ints, a new ``Generator`` is created, seeded with `rng`. If
+        `rng` is already a ``Generator`` or ``RandomState`` instance,
+        that instance is used.
 
     Notes
     -----
@@ -48,10 +50,17 @@ def mixture_rvs(prob, size, dist, kwargs=None, rng=None):
         A tuple of dicts.  Each dict in kwargs can have keys loc, scale, and
         args to be passed to the respective distribution in dist.  If not
         provided, the distribution defaults are used.
-    rng : {None, numpy.random.Generator, numpy.random.RandomState}, optional
+    rng : int, array_like of int, numpy.random.Generator, or numpy.random.RandomState, optional
         If `rng` is None, the global (legacy) NumPy random state is
-        used. If `rng` is already a ``Generator`` or ``RandomState``
-        instance, that instance is used.
+        used. If `rng` is an int or array of ints, a new ``RandomState``
+        instance is created, seeded with `rng`. If `rng` is already a
+        ``Generator`` or ``RandomState`` instance, that instance is
+        used.
+
+    Returns
+    -------
+    ndarray
+        Sample from the mixture distribution, with length `size`.
 
     Examples
     --------
@@ -115,11 +124,13 @@ class MixtureDistribution:
             A tuple of dicts.  Each dict in kwargs can have keys loc, scale, and
             args to be passed to the respective distribution in dist.  If not
             provided, the distribution defaults are used.
-        rng : {None, numpy.random.Generator, numpy.random.RandomState}, optional
+        rng : int, array_like of int, numpy.random.Generator, or numpy.random.RandomState, optional
             If `rng` is None, the global (legacy) NumPy random state is
-            used. If `rng` is already a ``Generator`` or ``RandomState``
-            instance, that instance is used.
-        rng : int, array_like of int, numpy.random.Generator, numpy.random.RandomState, optional
+            used. If `rng` is an int or array of ints, a new
+            ``RandomState`` instance is created, seeded with `rng`. If
+            `rng` is already a ``Generator`` or ``RandomState`` instance,
+            that instance is used.
+        rng : int, array_like of int, numpy.random.Generator, or numpy.random.RandomState, optional
             .. deprecated:: 0.15
 
                random_state has been deprecated. In-line with SPEC-007, use
@@ -148,6 +159,11 @@ class MixtureDistribution:
             A tuple of dicts.  Each dict in kwargs can have keys loc, scale, and
             args to be passed to the respective distribution in dist.  If not
             provided, the distribution defaults are used.
+
+        Returns
+        -------
+        ndarray
+            Pdf of the mixture distribution evaluated at `x`.
 
         Examples
         --------
@@ -199,6 +215,11 @@ class MixtureDistribution:
             args to be passed to the respective distribution in dist.  If not
             provided, the distribution defaults are used.
 
+        Returns
+        -------
+        ndarray
+            Cdf of the mixture distribution evaluated at `x`.
+
         Examples
         --------
         Say we want 5000 random variables from mixture of normals with two
@@ -247,12 +268,20 @@ def mv_mixture_rvs(prob, size, dist, nvars, rng=None, **kwargs):
         An iterable of distributions instances with callable method rvs.
     nvars : int
         dimension of the multivariate distribution, could be inferred instead
-    rng : {None, numpy.random.Generator, numpy.random.RandomState}, optional
+    rng : int, array_like of int, numpy.random.Generator, or numpy.random.RandomState, optional
         If `rng` is None, the global (legacy) NumPy random state is
-        used. If `rng` is already a ``Generator`` or ``RandomState``
-        instance, that instance is used.
-    kwargs : tuple of dicts, optional
-        ignored
+        used. If `rng` is an int or array of ints, a new ``RandomState``
+        instance is created, seeded with `rng`. If `rng` is already a
+        ``Generator`` or ``RandomState`` instance, that instance is
+        used.
+    **kwargs
+        Ignored.
+
+    Returns
+    -------
+    ndarray
+        Sample from the mixture of multivariate distributions, with shape
+        (`size`, `nvars`).
 
     Examples
     --------

--- a/statsmodels/distributions/tools.py
+++ b/statsmodels/distributions/tools.py
@@ -26,22 +26,25 @@ class _Grid:
 
     Parameters
     ----------
-    k_grid : tuple or array_like
-        number of elements for axes, this defines k_grid - 1 equal sized
+    k_grid : sequence of int
+        Number of elements for axes, this defines k_grid - 1 equal sized
         intervals of [0, 1] for each axis.
-    eps : float
+    eps : float, optional
         If eps is not zero, then x values will be clipped to [eps, 1 - eps],
         i.e., to the interior of the unit interval or hyper cube.
 
-
     Attributes
     ----------
-    k_grid : list of number of grid points
-    x_marginal: list of 1-dimensional marginal values
-    idx_flat: integer array with indices
-    x_flat: flattened grid values,
-        rows are grid points, columns represent variables or axis.
-        ``x_flat`` is currently also 2-dim in the univariate 1-dim grid case.
+    k_grid : sequence of int
+        Number of grid points along each axis.
+    x_marginal : list of ndarray
+        List of 1-dimensional marginal grid values, one array per axis.
+    idx_flat : ndarray
+        Integer array with indices.
+    x_flat : ndarray
+        Flattened grid values, rows are grid points, columns represent
+        variables or axis. ``x_flat`` is currently also 2-dim in the
+        univariate 1-dim grid case.
 
     """
 
@@ -64,7 +67,7 @@ class _Grid:
 
 
 def prob2cdf_grid(probs):
-    """Cumulative probabilities from cell provabilites on a grid
+    """Cumulative probabilities from cell probabilities on a grid
 
     Parameters
     ----------
@@ -91,7 +94,7 @@ def cdf2prob_grid(cdf, prepend=0):
     ----------
     cdf : array_like
         Grid of cumulative probabilities with same shape as probs.
-    prepend : int, float or None
+    prepend : int, float, or None, optional
         Value to prepend to the difference along each axis before taking
         ``np.diff``. If None, then no value is prepended (i.e., the length
         along each axis decreases by 1 relative to ``cdf``).
@@ -117,18 +120,19 @@ def average_grid(values, coords=None, _method="slicing"):
 
     Parameters
     ----------
-    values : array_like
+    values : ndarray
         Values on a grid that will average over corner points of each cell.
-    coords : None or list of array_like
-        Grid coordinates for each axis use to compute volumne of cell.
+    coords : None or list of array_like, optional
+        Grid coordinates for each axis used to compute the volume of cell.
         If None, then averaged values are not rescaled.
-    _method : {"slicing", "convolve"}
+    _method : {"slicing", "convolve"}, optional
         Grid averaging is implemented using numpy "slicing" or using
         scipy.signal "convolve".
 
     Returns
     -------
-    Grid with averaged cell values.
+    ndarray
+        Grid with averaged cell values.
     """
     k_dim = values.ndim
     if _method == "slicing":
@@ -165,18 +169,18 @@ def nearest_matrix_margins(mat, maxiter=100, tol=1e-8):
 
     Parameters
     ----------
-    mat : array_like, 2-D
+    mat : array_like
         Matrix that will be converted to have uniform margins.
-        Currently, `mat` has to be two dimensional.
-    maxiter : in
+    maxiter : int, optional
         Maximum number of iterations.
-    tol : float
+    tol : float, optional
         Tolerance for convergence, defined for difference between largest and
         smallest margin in each dimension.
 
     Returns
     -------
-    ndarray, nearest matrix with uniform margins.
+    ndarray
+        Nearest matrix with uniform margins.
 
     Notes
     -----
@@ -225,6 +229,16 @@ def _rankdata_no_ties(x):
     This is a simplified version for ranking data if there are no ties.
     Works vectorized across columns.
 
+    Parameters
+    ----------
+    x : ndarray
+        2-D array with observations in rows and variables in columns.
+
+    Returns
+    -------
+    ndarray
+        Ranks of `x`, computed separately for each column.
+
     See Also
     --------
     scipy.stats.rankdata
@@ -250,7 +264,7 @@ def frequencies_fromdata(data, k_bins, use_ranks=True):
         in unit interval.
     k_bins : int
         Number of bins along each dimension in the histogram
-    use_ranks : bool
+    use_ranks : bool, optional
         If use_rank is True, then data will be converted to ranks without
         tie handling.
 
@@ -286,20 +300,20 @@ def approx_copula_pdf(copula, k_bins=10, force_uniform=True, use_pdf=False, rng=
     ----------
     copula : instance
         Instance of a copula class. Only the ``pdf`` method is used.
-    k_bins : int
+    k_bins : int, optional
         Number of bins along each dimension in the approximating histogram.
-    force_uniform : bool
+    force_uniform : bool, optional
         If true, then the pdf grid will be adjusted to have uniform margins
         using `nearest_matrix_margin`.
         If false, then no adjustment is done and the margins may not be exactly
         uniform.
-    use_pdf : bool
+    use_pdf : bool, optional
         If false, then the grid cell probabilities will be computed from the
         copula cdf.
         If true, then the density, ``pdf``, is used and cell probabilities
         are approximated by averaging the pdf of the cell corners. This is
         only useful if the cdf is not available.
-    rng : int, array_like of int, numpy.random.Generator, numpy.random.RandomState, optional
+    rng : int, array_like of int, numpy.random.Generator, or numpy.random.RandomState, optional
         The source of the random variables to use in cdf calculation, if
         needed. If `rng` is None, a new ``Generator`` is created using
         fresh entropy from the operating system. If `rng` is an int or
@@ -309,12 +323,12 @@ def approx_copula_pdf(copula, k_bins=10, force_uniform=True, use_pdf=False, rng=
 
     Returns
     -------
-    bin probabilites : ndarray
+    ndarray
         Probability that random variable falls in given bin. This corresponds
         to a discrete distribution, and is not scaled to bin size to form a
         piecewise uniform, histogram density.
         Bin probabilities are a k-dim array with k_bins segments in each
-        dimensionrows.
+        dimension.
 
     Notes
     -----
@@ -368,7 +382,7 @@ def _eval_bernstein_1d(x, fvals, method="binom"):
     fvals : ndarray
         Grid values of coefficients for Bernstein polynomial basis in the
         weighted sum.
-    method: "binom", "beta" or "bpoly"
+    method : {"binom", "beta", "bpoly"}, optional
         Method to construct Bernstein polynomial basis, used for comparison
         of parameterizations.
 
@@ -378,8 +392,9 @@ def _eval_bernstein_1d(x, fvals, method="binom"):
 
     Returns
     -------
-    Bernstein polynomial at evaluation points, weighted sum of Bernstein
-    polynomial basis.
+    ndarray
+        Bernstein polynomial at evaluation points, weighted sum of Bernstein
+        polynomial basis.
     """
     k_terms = fvals.shape[-1]
     xx = np.asarray(x)
@@ -422,8 +437,9 @@ def _eval_bernstein_2d(x, fvals):
 
     Returns
     -------
-    Bernstein polynomial at evaluation points, weighted sum of Bernstein
-    polynomial basis.
+    ndarray
+        Bernstein polynomial at evaluation points, weighted sum of Bernstein
+        polynomial basis.
     """
     k_terms = fvals.shape
     k_dim = fvals.ndim
@@ -448,7 +464,7 @@ def _eval_bernstein_2d(x, fvals):
 
 
 def _eval_bernstein_dd(x, fvals):
-    """Evaluate d-dimensional bernstein polynomial given grid of valuesv
+    """Evaluate d-dimensional bernstein polynomial given grid of values
 
     experimental
 
@@ -462,8 +478,9 @@ def _eval_bernstein_dd(x, fvals):
 
     Returns
     -------
-    Bernstein polynomial at evaluation points, weighted sum of Bernstein
-    polynomial basis.
+    ndarray
+        Bernstein polynomial at evaluation points, weighted sum of Bernstein
+        polynomial basis.
     """
     k_terms = fvals.shape
     k_dim = fvals.ndim
@@ -493,8 +510,26 @@ def _eval_bernstein_dd(x, fvals):
 
 def _ecdf_mv(data, method="seq", use_ranks=True):
     """
-    Multivariate empiricial distribution function, empirical copula
+    Multivariate empirical distribution function, empirical copula
 
+    Parameters
+    ----------
+    data : array_like
+        Multivariate data with observations in rows and variables in
+        columns.
+    method : {"seq", "brute"}, optional
+        Method used to compute the empirical distribution function.
+    use_ranks : bool, optional
+        If True, then data is converted to ranks, without tie handling,
+        before computing the empirical distribution function.
+
+    Returns
+    -------
+    count : ndarray
+        Empirical distribution function counts for each observation.
+    x : ndarray
+        Data converted to ranks if `use_ranks` is True, otherwise the
+        original data as an array.
 
     Notes
     -----

--- a/statsmodels/emplike/aft_el.py
+++ b/statsmodels/emplike/aft_el.py
@@ -62,9 +62,9 @@ class OptAFT(_OptFuncts):
 
         Parameters
         ----------
-        test_vals : 1d array
-            The regression coefficients of the model.  This includes the
-            nuisance and parameters of interest.
+        test_vals : ndarray
+            The regression coefficients of the model, as a 1d array.  This
+            includes the nuisance and parameters of interest.
 
         Returns
         -------
@@ -201,7 +201,7 @@ class OptAFT(_OptFuncts):
         ----------
         b0 : float
             Value of a regression parameter
-        param_num : int
+        param_num : int, optional
             Parameter index of b0
 
         Returns
@@ -219,29 +219,29 @@ class emplikeAFT:
 
     Parameters
     ----------
-    endog : nx1 array
+    endog : ndarray
         Response variables that are subject to random censoring
 
-    exog : nxk array
+    exog : ndarray
         Matrix of covariates
 
-    censors : nx1 array
+    censors : array_like
         Array with entries 0 or 1.  0 indicates a response was
         censored.
 
     Attributes
     ----------
-    nobs : float
+    nobs : int
         Number of observations
     endog : ndarray
         Endog array
     exog : ndarray
         Exogenous variable matrix
-    censors
+    censors : ndarray
         Censors array but sets the max(endog) to uncensored
-    nvar : float
+    nvar : int
         Number of exogenous variables
-    uncens_nobs : float
+    uncens_nobs : int
         Number of uncensored observations
     uncens_endog : ndarray
         Uncensored response variables
@@ -314,9 +314,9 @@ class emplikeAFT:
 
         Parameters
         ----------
-        tie_indic : 1d array
+        tie_indic : ndarray
             Indicates if the i'th observation is the same as the ith +1
-        untied_km : 1d array
+        untied_km : ndarray
             Km estimates at each observation assuming no ties.
 
         Returns
@@ -348,9 +348,9 @@ class emplikeAFT:
 
         Parameters
         ----------
-        endog : nx1 array
+        endog : ndarray
             Array of response variables
-        censors : nx1 array
+        censors : ndarray
             Censor-indicating variable
 
         Returns
@@ -414,6 +414,21 @@ class emplikeAFT:
 
 
 class AFTResults(OptAFT):
+    """
+    Results class for an accelerated failure time model fit via
+    empirical likelihood.
+
+    Parameters
+    ----------
+    model : emplikeAFT
+        The fitted AFT model.
+
+    Attributes
+    ----------
+    model : emplikeAFT
+        The AFT model used to compute the results.
+    """
+
     def __init__(self, model):
         self.model = model
 
@@ -444,9 +459,9 @@ class AFTResults(OptAFT):
 
         Parameters
         ----------
-        b0_vals : list
+        b0_vals : list of float
             The value of parameters to be tested
-        param_nums : list
+        param_nums : list of int
             Which parameters to be tested
         maxiter : int, optional
             How many iterations to use in the EM algorithm.  Default is 30
@@ -456,7 +471,7 @@ class AFTResults(OptAFT):
 
         Returns
         -------
-        test_results : tuple
+        test_results : tuple of float
             The log-likelihood and p-value of the test.
 
         Notes
@@ -578,7 +593,7 @@ class AFTResults(OptAFT):
 
         Returns
         -------
-        Interval : tuple
+        Interval : tuple of float
             Lower and upper confidence limit
 
         Notes

--- a/statsmodels/emplike/descriptive.py
+++ b/statsmodels/emplike/descriptive.py
@@ -76,12 +76,12 @@ def DescStat(endog):
 
     Parameters
     ----------
-    endog : ndarray
-         Array of data
+    endog : array_like
+        Array of data
 
     Returns
     -------
-    DescStat
+    DescStatUV or DescStatMV
         If k=1, the function returns a univariate instance, DescStatUV.
         If k>1, the function returns a multivariate instance, DescStatMV.
     """
@@ -131,13 +131,13 @@ class _OptFuncts:
 
         Parameters
         ----------
-        eta : float
-            Lagrange multiplier
+        eta : ndarray, (1,m)
+            Lagrange multiplier in the profile likelihood maximization
 
         est_vect : ndarray (n,k)
             Estimating equations vector
 
-        weights : nx1 array
+        weights : 1darray
             Observation weights
 
         nobs : int
@@ -333,7 +333,7 @@ class _OptFuncts:
         nuisance_mu : float
             Value of a nuisance mean parameter
 
-        pval : bool
+        pval : bool, optional
             If True, return the p-value for the likelihood ratio instead
             of the -2 x log-likelihood ratio.  Used for contour plotting.
             Default is False.
@@ -389,7 +389,7 @@ class _OptFuncts:
         Parameters
         ----------
         nuis_params : 1darray
-            An array with a  nuisance mean and variance parameter
+            An array with a nuisance mean and variance parameter
 
         Returns
         -------
@@ -604,7 +604,7 @@ class DescStatUV(_OptFuncts):
     endog : 1darray
         Data to be analyzed
 
-    nobs : float
+    nobs : int
         Number of observations
     """
 
@@ -622,7 +622,7 @@ class DescStatUV(_OptFuncts):
         mu0 : float
             Mean value to be tested
 
-        return_weights : bool
+        return_weights : bool, optional
             If return_weights is True the function returns
             the weights of the observations under the null hypothesis.
             Default is False
@@ -682,10 +682,10 @@ class DescStatUV(_OptFuncts):
 
         Parameters
         ----------
-        sig : float
+        sig : float, optional
             Significance level. Default is .05
 
-        method : str
+        method : str, optional
             Root finding method,  Can be 'nested-brent' or
             'gamma'.  Default is 'gamma'
 
@@ -700,17 +700,17 @@ class DescStatUV(_OptFuncts):
             converge, try expanding the gamma_high and gamma_low
             variables.
 
-        gamma_low : float
+        gamma_low : float, optional
             Lower bound for gamma when finding lower limit.
             If function returns f(a) and f(b) must have different signs,
             consider lowering gamma_low.
 
-        gamma_high : float
+        gamma_high : float, optional
             Upper bound for gamma when finding upper limit.
             If function returns f(a) and f(b) must have different signs,
             consider raising gamma_high.
 
-        epsilon : float
+        epsilon : float, optional
             When using 'nested-brent', amount to decrease (increase)
             from the maximum (minimum) of the data when
             starting the search.  This is to protect against the
@@ -725,7 +725,7 @@ class DescStatUV(_OptFuncts):
 
         Returns
         -------
-        Interval : tuple
+        Interval : tuple of float
             Confidence interval for the mean
         """
         endog = self.endog
@@ -767,7 +767,7 @@ class DescStatUV(_OptFuncts):
         sig2_0 : float
             Hypothesized variance to be tested
 
-        return_weights : bool
+        return_weights : bool, optional
             If True, returns the weights that maximize the
             likelihood of observing sig2_0. Default is False
         result_object : bool, optional
@@ -823,24 +823,24 @@ class DescStatUV(_OptFuncts):
 
         Parameters
         ----------
-        lower_bound : float
+        lower_bound : float, optional
             The minimum value the lower confidence interval can
             take. The p-value from test_var(lower_bound) must be lower
             than 1 - significance level. Default is .99 confidence
             limit assuming normality
 
-        upper_bound : float
+        upper_bound : float, optional
             The maximum value the upper confidence interval
             can take. The p-value from test_var(upper_bound) must be lower
             than 1 - significance level.  Default is .99 confidence
             limit assuming normality
 
-        sig : float
+        sig : float, optional
             The significance level. Default is .05
 
         Returns
         -------
-        Interval : tuple
+        Interval : tuple of float
             Confidence interval for the variance
 
         Examples
@@ -908,9 +908,9 @@ class DescStatUV(_OptFuncts):
         var_step : float
             Increments to evaluate the mean
 
-        levs : list
+        levs : sequence of float, optional
             Which values of significance the contour lines will be drawn.
-            Default is [.2, .1, .05, .01, .001]
+            Default is (.2, .1, .05, .01, .001)
 
         Returns
         -------
@@ -941,7 +941,7 @@ class DescStatUV(_OptFuncts):
         skew0 : float
             Skewness value to be tested
 
-        return_weights : bool
+        return_weights : bool, optional
             If True, function also returns the weights that
             maximize the likelihood ratio. Default is False.
         result_object : bool, optional
@@ -995,7 +995,7 @@ class DescStatUV(_OptFuncts):
         kurt0 : float
             Kurtosis value to be tested
 
-        return_weights : bool
+        return_weights : bool, optional
             If True, function also returns the weights that
             maximize the likelihood ratio. Default is False.
         result_object : bool, optional
@@ -1053,7 +1053,7 @@ class DescStatUV(_OptFuncts):
         kurt0 : float
             Kurtosis value to be tested
 
-        return_weights : bool
+        return_weights : bool, optional
             If True, function also returns the weights that
             maximize the likelihood ratio. Default is False.
         result_object : bool, optional
@@ -1104,20 +1104,20 @@ class DescStatUV(_OptFuncts):
 
         Parameters
         ----------
-        sig : float
+        sig : float, optional
             The significance level.  Default is .05
 
-        upper_bound : float
+        upper_bound : float, optional
             Maximum value of skewness the upper limit can be.
             Default is .99 confidence limit assuming normality.
 
-        lower_bound : float
+        lower_bound : float, optional
             Minimum value of skewness the lower limit can be.
             Default is .99 confidence level assuming normality.
 
         Returns
         -------
-        Interval : tuple
+        Interval : tuple of float
             Confidence interval for the skewness
 
         Notes
@@ -1158,20 +1158,20 @@ class DescStatUV(_OptFuncts):
 
         Parameters
         ----------
-        sig : float
+        sig : float, optional
             The significance level.  Default is .05
 
-        upper_bound : float
+        upper_bound : float, optional
             Maximum value of kurtosis the upper limit can be.
             Default is .99 confidence limit assuming normality.
 
-        lower_bound : float
+        lower_bound : float, optional
             Minimum value of kurtosis the lower limit can be.
             Default is .99 confidence limit assuming normality.
 
         Returns
         -------
-        Interval : tuple
+        Interval : tuple of float
             Lower and upper confidence limit
 
         Notes
@@ -1231,7 +1231,7 @@ class DescStatMV(_OptFuncts):
     endog : ndarray
         Data to be analyzed
 
-    nobs : float
+    nobs : int
         Number of observations
     """
 
@@ -1250,7 +1250,7 @@ class DescStatMV(_OptFuncts):
             Hypothesized values for the mean.  Must have same number of
             elements as columns in endog
 
-        return_weights : bool
+        return_weights : bool, optional
             If True, returns the weights that maximize the
             likelihood of mu_array. Default is False.
         result_object : bool, optional
@@ -1336,15 +1336,15 @@ class DescStatMV(_OptFuncts):
             Increment of evaluations for variable 1
         step2 : float
             Increment of evaluations for variable 2
-        levs : list
+        levs : sequence of float, optional
             Levels to be drawn on the contour plot.
             Default =  (.001, .01, .05, .1, .2)
-        plot_dta : bool
+        plot_dta : bool, optional
             If True, makes a scatter plot of the data on
             top of the contour plot. Default is False.
-        var1_name : str
+        var1_name : str, optional
             Name of variable 1 to be plotted on the x-axis
-        var2_name : str
+        var2_name : str, optional
             Name of variable 2 to be plotted on the y-axis
 
         Notes
@@ -1398,8 +1398,8 @@ class DescStatMV(_OptFuncts):
         corr0 : float
             Hypothesized value to be tested
 
-        return_weights : bool
-            If true, returns the weights that maximize
+        return_weights : bool, optional
+            If True, returns the weights that maximize
             the log-likelihood at the hypothesized value
         result_object : bool, optional
             Flag indicating whether to return the results as an
@@ -1461,20 +1461,20 @@ class DescStatMV(_OptFuncts):
 
         Parameters
         ----------
-        sig : float
+        sig : float, optional
             The significance level.  Default is .05
 
-        upper_bound : float
+        upper_bound : float, optional
             Maximum value the upper confidence limit can be.
             Default is  99% confidence limit assuming normality.
 
-        lower_bound : float
+        lower_bound : float, optional
             Minimum value the lower confidence limit can be.
             Default is 99% confidence limit assuming normality.
 
         Returns
         -------
-        interval : tuple
+        Interval : tuple of float
             Confidence interval for the correlation
         """
         endog = self.endog

--- a/statsmodels/emplike/elanova.py
+++ b/statsmodels/emplike/elanova.py
@@ -90,9 +90,18 @@ class ANOVA(_ANOVAOpt):
 
     Parameters
     ----------
-    endog : list of arrays
+    endog : list of array_like
         endog should be a list containing 1 dimensional arrays.  Each array
         is the data collected from a certain group.
+
+    Attributes
+    ----------
+    endog : list of array_like
+        The data passed by the caller.
+    num_groups : int
+        The number of groups.
+    nobs : int
+        The total number of observations across all groups.
     """
 
     def __init__(self, endog):
@@ -111,17 +120,17 @@ class ANOVA(_ANOVAOpt):
 
         Parameters
         ----------
-        mu : float
+        mu : float, optional
             If a mu is specified, ANOVA is conducted with mu as the
             common mean.  Otherwise, the common mean is the maximum
             empirical likelihood estimate of the common mean.
             Default is None.
-        mu_start : float
+        mu_start : float, optional
             Starting value for common mean if specific mu is not specified.
-            Default = 0.
-        return_weights : bool
-            if TRUE, returns the weights on observations that maximize the
-            likelihood.  Default is FALSE.
+            Default is 0.
+        return_weights : bool, optional
+            if True, returns the weights on observations that maximize the
+            likelihood.  Default is False.
         result_object : bool, optional
             Flag indicating whether to return the results as an
             ``ANOVAResult`` NamedTuple instead of a plain tuple. When

--- a/statsmodels/emplike/elregress.py
+++ b/statsmodels/emplike/elregress.py
@@ -50,24 +50,24 @@ class _ELRegOpts(_OptFuncts):
         ----------
         nuisance_params : 1darray
             Parameters to be optimized over.
-        param_nums : 1darray
+        param_nums : 1darray, optional
             The index locations of the parameters of interest in
             `params`.
-        endog : ndarray
+        endog : ndarray, optional
             The endogenous (response) variable.
-        exog : ndarray
+        exog : ndarray, optional
             The exogenous (regressor) variables.
-        nobs : int
+        nobs : int, optional
             The number of observations.
-        nvar : int
+        nvar : int, optional
             The number of exogenous regressors.
-        params : ndarray
+        params : ndarray, optional
             The full parameter vector, with the parameters of
             interest set to their hypothesized values and the
             remaining entries filled in with `nuisance_params`.
-        b0_vals : 1darray
+        b0_vals : 1darray, optional
             The hypothesized values for the parameters of interest.
-        stochastic_exog : bool
+        stochastic_exog : bool, optional
             If True, the exogenous variables are assumed to be
             stochastic and moment conditions are not placed on them.
 

--- a/statsmodels/emplike/originregress.py
+++ b/statsmodels/emplike/originregress.py
@@ -38,16 +38,16 @@ class ELOriginRegress:
 
     Parameters
     ----------
-    endog : nx1 array
+    endog : array_like
         Array of response variables.
-    exog : nxk array
+    exog : array_like
         Array of exogenous variables.  Assumes no array of ones
 
     Attributes
     ----------
-    endog : nx1 array
+    endog : array_like
         Array of response variables
-    exog : nxk array
+    exog : array_like
         Array of exogenous variables.  Assumes no array of ones.
     nobs : int
         Number of observations.
@@ -92,7 +92,7 @@ class ELOriginRegress:
         params : ndarray
             Parameters, including the (fixed at 0) intercept term,
             as returned by `fit`.
-        exog : ndarray, optional
+        exog : array_like, optional
             Exogenous variables to use for the prediction.  If None,
             the exog attached to the model is used.
 
@@ -112,7 +112,7 @@ class OriginResults(RegressionResults):
 
     Parameters
     ----------
-    model : class
+    model : OLS
         An OLS model with an intercept.
     params : 1darray
         Fitted parameters.
@@ -125,7 +125,7 @@ class OriginResults(RegressionResults):
 
     Attributes
     ----------
-    model : class
+    model : OLS
         An OLS model with an intercept.
     params : 1darray
         Fitted parameter.
@@ -194,17 +194,17 @@ class OriginResults(RegressionResults):
             Which parameters to test.  Note this uses python
             indexing but the '0' parameter refers to the intercept term,
             which is assumed 0.  Therefore, param_num should be > 0.
-        method : str
+        method : str, optional
             Can either be 'nm' for Nelder-Mead or 'powell' for Powell.  The
             optimization method that optimizes over nuisance parameters.
             Default is 'nm'.
-        stochastic_exog : bool
-            When TRUE, the exogenous variables are assumed to be stochastic.
+        stochastic_exog : bool, optional
+            When True, the exogenous variables are assumed to be stochastic.
             When the regressors are nonstochastic, moment conditions are
             placed on the exogenous variables.  Confidence intervals for
             stochastic regressors are at least as large as non-stochastic
-            regressors.  Default is TRUE.
-        return_weights : bool
+            regressors.  Default is True.
+        return_weights : bool, optional
             If true, returns the weights that optimize the likelihood
             ratio at b0_vals.  Default is False.
         result_object : bool, optional

--- a/statsmodels/iolib/foreign.py
+++ b/statsmodels/iolib/foreign.py
@@ -19,15 +19,15 @@ def savetxt(fname, X, names=None, fmt="%.18e", delimiter=" "):
 
     Parameters
     ----------
-    fname : filename or file handle
+    fname : str, path object or file-like object
         If the filename ends in ``.gz``, the file is automatically saved in
         compressed gzip format.  `loadtxt` understands gzipped files
         transparently.
     X : array_like
         Data to be saved to a text file.
-    names : list, optional
+    names : sequence of str, optional
         If given names will be the column header in the text file.
-    fmt : str or sequence of strs, optional
+    fmt : str or sequence of str, optional
         A single format (%10.5f), a sequence of formats, or a
         multi-format string, e.g., 'Iteration %d -- %10.5f', in which
         case `delimiter` is ignored.

--- a/statsmodels/iolib/smpickle.py
+++ b/statsmodels/iolib/smpickle.py
@@ -13,7 +13,7 @@ def save_pickle(obj, fname):
     ----------
     obj : object
         Any object that can be pickled
-    fname : {str, pathlib.Path}
+    fname : str or pathlib.Path
         Filename to pickle to
     """
     with get_file_obj(fname, "wb") as fout:
@@ -51,7 +51,7 @@ def load_pickle(fname):
 
     Parameters
     ----------
-    fname : {str, pathlib.Path}
+    fname : str or pathlib.Path
         Filename to unpickle
 
     Notes

--- a/statsmodels/iolib/summary.py
+++ b/statsmodels/iolib/summary.py
@@ -26,7 +26,7 @@ def forg(x, prec=3):
     x : array_like
         The value to format. Must be a scalar or an array that squeezes
         to a scalar.
-    prec : int
+    prec : int, optional
         The precision to use, either 3 or 4.
 
     Returns
@@ -62,7 +62,7 @@ def d_or_f(x, width=6):
     ----------
     x : int or float
         The value to format.
-    width : int
+    width : int, optional
         Only used if x is nan.
 
     Returns
@@ -91,7 +91,7 @@ def summary(self, yname=None, xname=None, title=0, alpha=.05,
         instance.
     yname : str, optional
         Default is `Y`.
-    xname : list[str], optional
+    xname : list of str, optional
         Default is `X.#` for # in p the number of regressors.
     title : str or int, optional
         Title for the summary. If 0 (the default), the title is derived
@@ -279,7 +279,7 @@ def _getnames(self, yname=None, xname=None):
     yname : str, optional
         Name for the endogenous variable. If None, taken from the model
         or defaults to "y".
-    xname : list[str], optional
+    xname : list of str, optional
         Names for the exogenous variables. If None, taken from the model
         or defaults to "var_%d".
 
@@ -287,7 +287,7 @@ def _getnames(self, yname=None, xname=None):
     -------
     yname : str
         Name for the endogenous variable.
-    xname : list[str]
+    xname : list of str
         Names for the exogenous variables.
     """
     if yname is None:
@@ -317,14 +317,14 @@ def summary_top(results, title=None, gleft=None, gright=None, yname=None, xname=
     title : str, optional
         Title for the table(s). If None, a default title is constructed
         from the model class name.
-    gleft : list[tuple], optional
+    gleft : list of tuple, optional
         Elements for the left table, tuples are (name, value) pairs. If
         None, a default table is created.
-    gright : list[tuple], optional
+    gright : list of tuple, optional
         Elements for the right table, tuples are (name, value) pairs.
     yname : str, optional
         Name for the endogenous variable, default is "y".
-    xname : list[str], optional
+    xname : list of str, optional
         Names for the exogenous variables, default is "var_xx".
 
     Returns
@@ -456,16 +456,16 @@ def summary_params(results, yname=None, xname=None, alpha=.05, use_t=True,
         instance. May also be a tuple of
         (results, params, std_err, tvalues, pvalues, conf_int) for
         multivariate endog.
-    yname : {str, None}
-        optional name for the endogenous variable, default is "y"
-    xname : {list[str], None}
-        optional names for the exogenous variables, default is "var_xx"
-    alpha : float
-        significance level for the confidence intervals
-    use_t : bool
-        indicator whether the p-values are based on the Student-t
-        distribution (if True) or on the normal distribution (if False)
-    skip_header : bool
+    yname : str, optional
+        Name for the endogenous variable, default is "y".
+    xname : list of str, optional
+        Names for the exogenous variables, default is "var_xx".
+    alpha : float, optional
+        Significance level for the confidence intervals.
+    use_t : bool, optional
+        Indicator whether the p-values are based on the Student-t
+        distribution (if True) or on the normal distribution (if False).
+    skip_header : bool, optional
         If false (default), then the header row is added. If true, then no
         header row is added.
     title : str, optional
@@ -547,15 +547,15 @@ def summary_params_frame(results, yname=None, xname=None, alpha=.05,
         instance. May also be a tuple of
         (results, params, std_err, tvalues, pvalues, conf_int) for
         multivariate endog.
-    yname : {str, None}
-        optional name for the endogenous variable, default is "y"
-    xname : {list[str], None}
-        optional names for the exogenous variables, default is "var_xx"
-    alpha : float
-        significance level for the confidence intervals
-    use_t : bool
-        indicator whether the p-values are based on the Student-t
-        distribution (if True) or on the normal distribution (if False)
+    yname : str, optional
+        Name for the endogenous variable, default is "y".
+    xname : list of str, optional
+        Names for the exogenous variables, default is "var_xx".
+    alpha : float, optional
+        Significance level for the confidence intervals.
+    use_t : bool, optional
+        Indicator whether the p-values are based on the Student-t
+        distribution (if True) or on the normal distribution (if False).
 
     Returns
     -------
@@ -609,14 +609,15 @@ def summary_params_2d(result, extras=None, endog_names=None, exog_names=None,
     ----------
     result : result instance
         the result instance with params and attributes in extras
-    extras : list[str]
-        additional attributes to add below a parameter row, e.g., bse or tvalues
-    endog_names : {list[str], None}
-        names for rows of the parameter array (multivariate endog)
-    exog_names : {list[str], None}
-        names for columns of the parameter array (exog)
-    title : None or str
-        title for the table
+    extras : list of str, optional
+        Additional attributes to add below a parameter row, e.g., bse or
+        tvalues.
+    endog_names : list of str, optional
+        Names for rows of the parameter array (multivariate endog).
+    exog_names : list of str, optional
+        Names for columns of the parameter array (exog).
+    title : str, optional
+        Title for the table.
 
     Returns
     -------
@@ -664,19 +665,19 @@ def summary_params_2dflat(result, endog_names=None, exog_names=None, alpha=0.05,
     ----------
     result : result instance
         the result instance with params, bse, tvalues and conf_int
-    endog_names : {list[str], None}
-        names for rows of the parameter array (multivariate endog)
-    exog_names : {list[str], None}
-        names for columns of the parameter array (exog)
-    alpha : float
-        level for confidence intervals, default 0.05
-    use_t : bool
-        indicator whether the p-values are based on the Student-t
-        distribution (if True) or on the normal distribution (if False)
-    keep_headers : bool
+    endog_names : list of str, optional
+        Names for rows of the parameter array (multivariate endog).
+    exog_names : list of str, optional
+        Names for columns of the parameter array (exog).
+    alpha : float, optional
+        Level for confidence intervals, default 0.05.
+    use_t : bool, optional
+        Indicator whether the p-values are based on the Student-t
+        distribution (if True) or on the normal distribution (if False).
+    keep_headers : bool, optional
         If true (default), then sub-tables keep their headers. If false, then
-        only the first headers are kept, the other headers are blanked out
-    endog_cols : bool
+        only the first headers are kept, the other headers are blanked out.
+    endog_cols : bool, optional
         If false (default) then params and other result statistics have
         equations by rows. If true, then equations are assumed to be in columns.
         Not implemented yet.
@@ -742,7 +743,7 @@ def table_extend(tables, keep_headers=True):
     ----------
     tables : list of SimpleTable instances
         The tables to merge.
-    keep_headers : bool
+    keep_headers : bool, optional
         If true, then all headers are kept. If false, then the headers of
         subtables are blanked out.
 
@@ -785,7 +786,7 @@ def summary_return(tables, return_fmt="text"):
     ----------
     tables : list of SimpleTable
         The tables to join.
-    return_fmt : str
+    return_fmt : str, optional
         One of "text", "tables", "csv", "latex" or "html".
 
     Returns
@@ -864,14 +865,14 @@ class Summary:
             instance
         title : str, optional
             if None, then a default title is used.
-        gleft : list[tuple], optional
+        gleft : list of tuple, optional
             elements for the left table, tuples are (name, value) pairs
             If gleft is None, then a default table is created
-        gright : list[tuple], optional
+        gright : list of tuple, optional
             elements for the right table, tuples are (name, value) pairs
         yname : str, optional
             optional name for the endogenous variable, default is "y"
-        xname : list[str], optional
+        xname : list of str, optional
             optional names for the exogenous variables, default is "var_xx".
             Must match the number of parameters in the model.
         """
@@ -890,13 +891,13 @@ class Summary:
         res : results instance
             some required information is directly taken from the result
             instance
-        yname : {str, None}
+        yname : str, optional
             optional name for the endogenous variable, default is "y"
-        xname : {list[str], None}
+        xname : list of str, optional
             optional names for the exogenous variables, default is "var_xx"
-        alpha : float
+        alpha : float, optional
             significance level for the confidence intervals
-        use_t : bool
+        use_t : bool, optional
             indicator whether the p-values are based on the Student-t
             distribution (if True) or on the normal distribution (if False)
 
@@ -922,7 +923,7 @@ class Summary:
 
         Parameters
         ----------
-        etext : list[str]
+        etext : list of str
             string with lines that are added to the text output.
         """
         self.extra_txt = "\n".join(etext)

--- a/statsmodels/iolib/summary2.py
+++ b/statsmodels/iolib/summary2.py
@@ -61,13 +61,13 @@ class Summary:
         ----------
         df : DataFrame
             The DataFrame to add to the summary table.
-        index : bool
+        index : bool, optional
             Reproduce the DataFrame row labels in summary table
-        header : bool
+        header : bool, optional
             Reproduce the DataFrame column labels in summary table
-        float_format : str
+        float_format : str, optional
             Formatting to float data columns
-        align : str
+        align : str, optional
             Data alignment (l/c/r)
         """
 
@@ -82,11 +82,11 @@ class Summary:
 
         Parameters
         ----------
-        array : ndarray
-            A 2D numpy array.
-        align : str
+        array : array_like
+            A 2D array of values.
+        align : str, optional
             Data alignment (l/c/r)
-        float_format : str
+        float_format : str, optional
             Formatting to array if type is float
         """
 
@@ -103,11 +103,11 @@ class Summary:
         d : dict
             Keys and values are automatically coerced to strings with str().
             Users are encouraged to format them before using add_dict.
-        ncols : int
+        ncols : int, optional
             Number of columns of the output table
-        align : str
+        align : str, optional
             Data alignment (l/c/r)
-        float_format : str
+        float_format : str, optional
             Formatting to float data columns
         """
 
@@ -170,16 +170,18 @@ class Summary:
         Parameters
         ----------
         results : Model results instance
-        alpha : float
-            significance level for the confidence intervals (optional)
-        float_format: str
-            Float formatting for summary of parameters (optional)
-        title : str
-            Title of the summary table (optional)
-        xname : list[str] of length equal to the number of parameters
-            Names of the independent variables (optional)
-        yname : str
-            Name of the dependent variable (optional)
+            The result instance to summarize.
+        alpha : float, optional
+            Significance level for the confidence intervals.
+        float_format : str, optional
+            Float formatting for summary of parameters.
+        title : str, optional
+            Title of the summary table.
+        xname : list of str, optional
+            Names of the independent variables. Must have length equal to
+            the number of parameters.
+        yname : str, optional
+            Name of the dependent variable.
         """
 
         param = summary_params(results, alpha=alpha, use_t=results.use_t)
@@ -250,9 +252,9 @@ class Summary:
 
         Parameters
         ----------
-        label : str
+        label : str, optional
             Label of the summary table that can be referenced
-            in a latex document (optional)
+            in a latex document.
         """
         tables = self.tables
         settings = self.settings
@@ -414,19 +416,19 @@ def summary_params(results, yname=None, xname=None, alpha=.05, use_t=True,
         instance. May also be a tuple of
         (results, params, bse, tvalues, pvalues, conf_int) for
         multivariate endog.
-    yname : {str, None}
+    yname : str, optional
         optional name for the endogenous variable, default is "y"
-    xname : {list[str], None}
+    xname : list of str, optional
         optional names for the exogenous variables, default is "var_xx"
-    alpha : float
+    alpha : float, optional
         significance level for the confidence intervals
-    use_t : bool
+    use_t : bool, optional
         indicator whether the p-values are based on the Student-t
         distribution (if True) or on the normal distribution (if False)
-    skip_header : bool
+    skip_header : bool, optional
         If false (default), then the header row is added. If true, then no
         header row is added.
-    float_format : str
+    float_format : str, optional
         float formatting options (e.g., ".3g")
 
     Returns
@@ -476,11 +478,11 @@ def _col_params(result, float_format="%.4f", stars=True, include_r2=False):
     ----------
     result : Model results instance
         The result instance to summarize.
-    float_format : str
+    float_format : str, optional
         Formatting to apply to coefficients and standard errors.
-    stars : bool
+    stars : bool, optional
         If True, append significance stars to the coefficients.
-    include_r2 : bool
+    include_r2 : bool, optional
         If True, include R-squared and adjusted R-squared in the column.
 
     Returns
@@ -567,12 +569,12 @@ def _make_unique(list_of_names):
 
     Parameters
     ----------
-    list_of_names : list[str]
+    list_of_names : list of str
         The candidate names.
 
     Returns
     -------
-    list[str]
+    list of str
         `list_of_names` unchanged if all entries are already unique.
         Otherwise, a list of the same length where repeated names have
         had roman-numeral-like "I" suffixes appended to disambiguate them
@@ -600,15 +602,16 @@ def summary_col(results, float_format="%.4f", model_names=(), stars=False,
     Parameters
     ----------
     results : statsmodels results instance or list of result instances
+        The results to summarize side-by-side.
     float_format : str, optional
         float format for coefficients and standard errors
         Default : '%.4f'
-    model_names : list[str], optional
+    model_names : list of str, optional
         Must have same length as the number of results. If the names are not
         unique, a roman number will be appended to all model names
-    stars : bool
+    stars : bool, optional
         print significance stars
-    info_dict : dict, default None
+    info_dict : dict, optional
         dict of functions to be applied to results instances to retrieve
         model info. To use specific information for different models, add a
         (nested) info_dict with model name as the key.
@@ -617,7 +620,7 @@ def summary_col(results, float_format="%.4f", model_names=(), stars=False,
         additionally `N` for all other results.
         Default : None (use the info_dict specified in
         result.default_model_infos, if this property exists)
-    regressor_order : list[str], optional
+    regressor_order : list of str, optional
         list of names of the regressors in the desired order. All regressors
         not specified will be appended to the end of the list.
     drop_omitted : bool, optional
@@ -626,7 +629,7 @@ def summary_col(results, float_format="%.4f", model_names=(), stars=False,
         If True, only regressors in regressor_order will be included.
     include_r2 : bool, optional
         Includes R2 and adjusted R2 in the summary table.
-    fixed_effects : list[str], optional
+    fixed_effects : list of str, optional
         List of categorical variables for which to indicate presence of
         fixed effects.
     fe_present : str, optional
@@ -764,7 +767,7 @@ def _formatter(element, float_format="%.4f"):
     element : object
         The value to format. Formatted as a float if possible, otherwise
         converted to a string.
-    float_format : str
+    float_format : str, optional
         The format string to apply if `element` can be formatted as a
         float.
 
@@ -790,23 +793,23 @@ def _df_to_simpletable(df, align="r", float_format="%.4f", header=True,
     ----------
     df : DataFrame
         The DataFrame to convert.
-    align : str
+    align : str, optional
         Data alignment (l/c/r).
-    float_format : str
+    float_format : str, optional
         Formatting to apply to float data columns.
-    header : bool
+    header : bool, optional
         If True, use the DataFrame column labels as the table header.
-    index : bool
+    index : bool, optional
         If True, use the DataFrame row labels as the table stubs.
-    table_dec_above : str
+    table_dec_above : str, optional
         Character used for the decoration line above the table.
-    table_dec_below : str
+    table_dec_below : str, optional
         Character used for the decoration line below the table.
-    header_dec_below : str
+    header_dec_below : str, optional
         Character used for the decoration line below the header.
-    pad_col : int
+    pad_col : int, optional
         Extra spaces to add to the column separator.
-    pad_index : int
+    pad_index : int, optional
         Extra spaces to add after each stub.
 
     Returns

--- a/statsmodels/iolib/table.py
+++ b/statsmodels/iolib/table.py
@@ -96,10 +96,10 @@ def csv2st(csvfile, headers=False, stubs=False, title=None):
     ----------
     csvfile : str
         Path to a file containing comma separated values.
-    headers : bool or tuple of str
+    headers : bool or tuple of str, optional
         The first row may contain headers: set headers=True. Can also
         supply headers directly as a tuple of strings.
-    stubs : bool or tuple of str
+    stubs : bool or tuple of str, optional
         The first column may contain stubs: set stubs=True. Can also
         supply stubs directly as a tuple of strings.
     title : str, optional
@@ -168,25 +168,25 @@ class SimpleTable(list):
         ----------
         data : list of lists or 2d array (not matrix!)
             R rows by K columns of table elements
-        headers : list (or tuple) of str
+        headers : sequence of str, optional
             sequence of K strings, one per header
-        stubs : list (or tuple) of str
+        stubs : sequence of str, optional
             sequence of R strings, one per stub
-        title : str
+        title : str, optional
             title of the table
-        datatypes : list of int
+        datatypes : list of int, optional
             indexes to `data_fmts`
-        txt_fmt : dict
+        txt_fmt : dict, optional
             text formatting options
-        ltx_fmt : dict
+        ltx_fmt : dict, optional
             latex formatting options
-        csv_fmt : dict
+        csv_fmt : dict, optional
             csv formatting options
-        html_fmt : dict
+        html_fmt : dict, optional
             html formatting options
-        celltype : class
+        celltype : class, optional
             the cell class for the table (default: Cell)
-        rowtype : class
+        rowtype : class, optional
             the row class for the table (default: Row)
         fmt_dict : dict
             general formatting options
@@ -242,9 +242,9 @@ class SimpleTable(list):
 
         Parameters
         ----------
-        headers : list[str]
+        headers : sequence of str
             K strings, where K is number of columns
-        stubs : list[str]
+        stubs : sequence of str
             R strings, where R is number of non-header rows
 
         Notes
@@ -289,7 +289,7 @@ class SimpleTable(list):
         headers : sequence of str
             The header strings, one per column. The strings may contain
             newlines, to indicate multiline headers.
-        dec_below : str
+        dec_below : str, optional
             The decoration tag to use below the header row.
         """
         header_rows = [header.split("\n") for header in headers]
@@ -566,7 +566,7 @@ class SimpleTable(list):
 
         Parameters
         ----------
-        center : bool
+        center : bool, optional
             If True, wrap the tabular environment in a center environment.
         **fmt_dict
             Additional formatting options that override the table's LaTeX
@@ -710,14 +710,14 @@ class Row(list):
     ----------
     seq : sequence of data or cells
         The contents of the row.
-    datatype : str
+    datatype : str, optional
         One of 'data' or 'header'.
     table : SimpleTable, optional
         The table the row belongs to, if any.
     celltype : class, optional
         The cell class used to wrap the values in `seq`. If None, uses
         `table._Cell` if `table` is not None, otherwise `Cell`.
-    dec_below : str
+    dec_below : str, optional
         (e.g., 'header_dec_below' or 'row_dec_below')
         decoration tag, identifies the decoration to go below the row.
         (Decoration is repeated as needed for text formats.)
@@ -843,7 +843,7 @@ class Row(list):
 
         Parameters
         ----------
-        output_format : str
+        output_format : str, optional
             One of 'txt', 'csv', 'html' or 'latex'.
         **fmt_dict
             Additional formatting options that override the row's
@@ -928,7 +928,7 @@ class Cell:
 
     Parameters
     ----------
-    data : object or Cell
+    data : object or Cell, optional
         The cell's data. If a Cell instance is passed, its data,
         datatype and formatting are copied.
     datatype : object, optional
@@ -1069,7 +1069,7 @@ class Cell:
         ----------
         width : int
             The width, in characters, to pad the formatted cell to.
-        output_format : str
+        output_format : str, optional
             One of 'txt', 'csv', 'html' or 'latex'.
         **fmt_dict
             Additional formatting options that override the cell's

--- a/statsmodels/miscmodels/count.py
+++ b/statsmodels/miscmodels/count.py
@@ -126,9 +126,9 @@ class PoissonOffsetGMLE(GenericLikelihoodModel):
     exog : array_like, optional
         A nobs x k array where `nobs` is the number of observations and
         `k` is the number of regressors.
-    offset : array_like, optional
+    offset : ndarray, optional
         Offset added to the linear predictor before computing the mean.
-    missing : str
+    missing : str, optional
         Available options are 'none', 'drop', and 'raise'. If 'none', no
         nan checking is done. If 'drop', any observations with nans are
         dropped. If 'raise', an error is raised. Default is 'none'.
@@ -199,9 +199,9 @@ class PoissonZiGMLE(GenericLikelihoodModel):
         A nobs x k array where `nobs` is the number of observations and
         `k` is the number of regressors. If None, a column of ones is
         used.
-    offset : array_like, optional
+    offset : ndarray, optional
         Offset added to the linear predictor before computing the mean.
-    missing : str
+    missing : str, optional
         Available options are 'none', 'drop', and 'raise'. If 'none', no
         nan checking is done. If 'drop', any observations with nans are
         dropped. If 'raise', an error is raised. Default is 'none'.

--- a/statsmodels/miscmodels/nonlinls.py
+++ b/statsmodels/miscmodels/nonlinls.py
@@ -94,7 +94,7 @@ class NonlinearLS(Model):  # or subclass a model
     sigma : array_like, optional
         1-d array of standard deviations used to construct `weights` as
         ``1 / sigma``. Correlated errors (2-d `sigma`) are not supported.
-    missing : str
+    missing : str, optional
         Available options are 'none', 'drop', and 'raise'. Currently not
         used in `__init__`.
 
@@ -340,7 +340,7 @@ class NonlinearLS(Model):  # or subclass a model
 
         Parameters
         ----------
-        ntries : int
+        ntries : int, optional
             Number of random starting values to try.
         rvs_generator : callable, optional
             Function to generate random starting values given a `size`

--- a/statsmodels/miscmodels/ordinal_model.py
+++ b/statsmodels/miscmodels/ordinal_model.py
@@ -75,11 +75,11 @@ class OrderedModel(GenericLikelihoodModel):
         sorted in lexicographic order (by numpy.unique).
     exog : array_like
         Exogenous, explanatory variables. This should not include an intercept.
-        A DataFrame is  also accepted.
-        see Notes about constant when using formulas
+        A DataFrame is also accepted.
+        See Notes about constant when using formulas.
     offset : array_like, optional
         Offset is added to the linear prediction with coefficient equal to 1.
-    distr : string 'probit' or 'logit', or a distribution instance
+    distr : {"probit", "logit"} or distribution instance, optional
         The default is currently 'probit' which uses the normal distribution
         and corresponds to an ordered Probit model. The distribution is
         assumed to have the main methods of scipy.stats distributions, mainly
@@ -237,7 +237,7 @@ class OrderedModel(GenericLikelihoodModel):
 
         Parameters
         ----------
-        labels : array_like
+        labels : sequence
             The category labels of the ordered endogenous variable.
         k_levels : int, optional
             The number of levels/categories. If None, it is inferred from
@@ -415,7 +415,7 @@ class OrderedModel(GenericLikelihoodModel):
             equal to 1. If offset is not provided and exog
             is None, uses the model's offset if present.  If not, uses
             0 as the default value.
-        which : {"prob", "linpred", "cum", "cumprob"}
+        which : {"prob", "linpred", "cum", "cumprob"}, optional
             Determines which statistic is predicted.
 
             - prob : predicted probabilities to be in each choice. 2-dim.

--- a/statsmodels/miscmodels/tmodel.py
+++ b/statsmodels/miscmodels/tmodel.py
@@ -95,7 +95,7 @@ class TLinearModel(GenericLikelihoodModel):
         start_params : array_like, optional
             Starting values to use directly. If None, starting values are
             constructed from an OLS fit of `endog` on `exog`.
-        use_kurtosis : bool
+        use_kurtosis : bool, optional
             If True and `start_params` is None and `df` is not fixed, use
             the kurtosis of the OLS residuals to construct a starting
             value for the degrees of freedom parameter. Otherwise a

--- a/statsmodels/miscmodels/try_mlecov.py
+++ b/statsmodels/miscmodels/try_mlecov.py
@@ -104,7 +104,7 @@ def mvn_loglike_chol(x, sigma):
         The log likelihood.
     logdetsigma : float
         The log of the determinant of `sigma`.
-    float
+    logdet_cholsigmainv : float
         Twice the sum of the log of the diagonal of the Cholesky factor
         of the inverse of `sigma`.
     """

--- a/statsmodels/nonparametric/_kernel_base.py
+++ b/statsmodels/nonparametric/_kernel_base.py
@@ -91,8 +91,9 @@ def _compute_subset(
         subset of data.
     data : ndarray
         The full data array from which the subset is drawn.
-    bw : ndarray
-        The bandwidth values used to fit the sub-sample model.
+    bw : str
+        The bandwidth selection method (e.g. "cv_ml", "cv_ls" or
+        "normal_reference") used to fit the sub-sample model.
     co : float
         Twice the order of the continuous kernel, used in the scaling
         factor exponent.
@@ -117,7 +118,7 @@ def _compute_subset(
     bound : tuple of int
         The (start, stop) indices used to slice `data` when `randomize`
         is False.
-    generator : {RandomState, Generator}
+    generator : numpy.random.Generator or numpy.random.RandomState
         The random number generator used when `randomize` is True.
 
     Returns
@@ -210,7 +211,7 @@ class GenericKDE:
 
         Parameters
         ----------
-        bw : {array_like, str}
+        bw : array_like or str
             If array_like: user-specified bandwidth.
             If a string, should be one of:
 
@@ -292,7 +293,7 @@ class GenericKDE:
 
         Parameters
         ----------
-        bw : {array_like, str, None}
+        bw : array_like, str, or None
             If a string, the bandwidth selection method, used to set
             ``self._bw_method``. Otherwise `bw` is returned unchanged.
 
@@ -716,7 +717,7 @@ def gpke(
     ----------
     bw : 1-D ndarray
         The user-specified bandwidth parameters.
-    data : 1D or 2-D ndarray
+    data : 2-D ndarray
         The training data.
     data_predict : 1-D ndarray
         The evaluation points at which the kernel estimation is performed.
@@ -734,8 +735,10 @@ def gpke(
 
     Returns
     -------
-    dens : array_like
-        The generalized product kernel density estimator.
+    dens : float or ndarray
+        The generalized product kernel density estimator, summed over
+        observations if `tosum` is True, otherwise the per-observation
+        array of kernel values.
 
     Notes
     -----
@@ -780,7 +783,7 @@ def initialize_generator(
 
     Parameters
     ----------
-    entropy : int, array_like of int, np.random.Generator, np.random.RandomState, optional
+    entropy : int, array_like of int, numpy.random.Generator, or numpy.random.RandomState, optional
         If an initialized NumPy random Generator or an initialized RandomState,
         the object is returned unchanged. If it is an integer or array_like of
         integers, the value is used to seed a new numpy.random.default_rng. If
@@ -795,7 +798,7 @@ def initialize_generator(
 
     Returns
     -------
-    generator: {Generator, RandomState}
+    generator : numpy.random.Generator or numpy.random.RandomState
         The object that is used for random number generation.
     """
     if entropy is None:

--- a/statsmodels/nonparametric/kernel_density.py
+++ b/statsmodels/nonparametric/kernel_density.py
@@ -81,7 +81,7 @@ class KDEMultivariate(GenericKDE):
 
     defaults : EstimatorSettings instance, optional
         The default values for (efficient) bandwidth estimation.
-    rng : {int, Generator, RandomState}, optional
+    rng : int, array_like of int, numpy.random.Generator, or numpy.random.RandomState, optional
         A seed to use. If None, will use the global RandomState.
 
         .. deprecated:: 0.15.0

--- a/statsmodels/nonparametric/kernel_regression.py
+++ b/statsmodels/nonparametric/kernel_regression.py
@@ -95,7 +95,7 @@ class KernelReg(GenericKDE):
         The kernel used for the unordered discrete variables.
     defaults : EstimatorSettings instance, optional
         The default values for the efficient bandwidth estimation.
-    rng : {int, numpy.random.Generator, numpy.random.RandomState}, optional
+    rng : int, array_like of int, numpy.random.Generator, or numpy.random.RandomState, optional
         A seed to use. If None, will use the global RandomState.
 
         .. deprecated:: 0.15.0
@@ -106,7 +106,7 @@ class KernelReg(GenericKDE):
 
     Attributes
     ----------
-    bw : array_like
+    bw : ndarray
         The bandwidth parameters.
     """
 
@@ -313,15 +313,15 @@ class KernelReg(GenericKDE):
 
         Parameters
         ----------
-        bw : str or array_like
-            See the ``bw`` parameter of `KernelReg` for details.
-        func : None, optional
+        bw : array_like
+            Vector of bandwidth value(s) at which to evaluate the criterion.
+        func : callable, optional
             Unused here, needed in signature because it's used in `cv_loo`.
 
         Returns
         -------
         aic : ndarray
-            The AIC Hurvich criteria, one element for each variable.
+            The value of the AIC Hurvich criterion.
 
         References
         ----------
@@ -370,7 +370,7 @@ class KernelReg(GenericKDE):
         ----------
         bw : array_like
             Vector of bandwidth values.
-        func : callable function
+        func : callable
             Returns the estimator of g(x).  Can be either ``_est_loc_constant``
             (local constant) or ``_est_loc_linear`` (local_linear).
 
@@ -472,7 +472,7 @@ class KernelReg(GenericKDE):
 
         Parameters
         ----------
-        var_pos : sequence
+        var_pos : array_like of int
             The position of the variable in exog to be tested.
         nboot : int, optional
             Number of bootstrap samples used to determine the distribution
@@ -562,9 +562,9 @@ class KernelCensoredReg(KernelReg):
 
     Parameters
     ----------
-    endog : list with one element which is array_like
+    endog : array_like
         This is the dependent variable.
-    exog : list
+    exog : array_like
         The training data for the independent variable(s)
         Each element in the list is a separate variable
     var_type : str
@@ -597,7 +597,7 @@ class KernelCensoredReg(KernelReg):
         Value at which the dependent variable is censored. Default is 0.
     defaults : EstimatorSettings instance, optional
         The default values for the efficient bandwidth estimation
-    rng : {int, Generator, RandomState}, optional
+    rng : int, array_like of int, numpy.random.Generator, or numpy.random.RandomState, optional
         A seed to use. If None, will use the global RandomState.
 
         .. deprecated:: 0.15.0
@@ -608,7 +608,7 @@ class KernelCensoredReg(KernelReg):
 
     Attributes
     ----------
-    bw : array_like
+    bw : ndarray
         The bandwidth parameters
     """
 
@@ -713,9 +713,9 @@ class KernelCensoredReg(KernelReg):
 
         Returns
         -------
-        mean : array_like
+        mean : ndarray
             The value of the conditional mean at data_predict
-        mfx : array_like
+        mfx : ndarray
             The marginal effects.
 
         Notes
@@ -768,7 +768,7 @@ class KernelCensoredReg(KernelReg):
         ----------
         bw : array_like
             Vector of bandwidth values
-        func : callable function
+        func : callable
             Returns the estimator of g(x).
             Can be either ``_est_loc_constant`` (local constant) or
             ``_est_loc_linear`` (local_linear).
@@ -857,7 +857,7 @@ class TestRegCoefC:
     model : KernelReg instance
         This is the nonparametric regression model whose elements
         are tested for significance.
-    test_vars : tuple, list of integers, array_like
+    test_vars : sequence of int
         index of position of the continuous variables to be tested
         for significance. e.g., (1,3,5) jointly tests variables at
         position 1,3 and 5 for significance.
@@ -872,7 +872,7 @@ class TestRegCoefC:
         Significantly increases computational time. But pivot statistics
         have more desirable properties
         (See references). Default is False.
-    rng : {int, Generator, RandomState}, optional
+    rng : int, array_like of int, numpy.random.Generator, or numpy.random.RandomState, optional
         A seed to use. If None, will use the global RandomState.
 
         .. deprecated:: 0.15.0
@@ -1060,14 +1060,14 @@ class TestRegCoefD(TestRegCoefC):
     model : Instance of KernelReg class
         This is the nonparametric regression model whose elements
         are tested for significance.
-    test_vars : tuple, list of one element
+    test_vars : sequence of int
         index of position of the discrete variable to be tested
         for significance. e.g., (3) tests variable at
         position 3 for significance.
     nboot : int, optional
         Number of bootstrap samples used to determine the distribution
         of the test statistic in a finite sample. Default is 400
-    rng : {int, Generator, RandomState}, optional
+    rng : int, array_like of int, numpy.random.Generator, or numpy.random.RandomState, optional
         A seed to use. If None, will use the global RandomState.
 
         .. deprecated:: 0.15.0


### PR DESCRIPTION
- [X] code/documentation is well formatted.
- [x] properly formatted commit message. See
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message).

#### AI Disclosure

Contributions must comply with the statsmodels [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html).

If using AI tools, edit the second option to explain which tool was selected and
how the tool's output was used.

Please complete **one** of the following:

- [ ] No AI tools were used to develop this pull request.
- [x] AI tools were used.
      Tool(s): Claude
      Used for: docstring cleaning
      I have personally read, understood, and can explain every line of this diff, and
      have verified the statistical/numerical correctness of the change.

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows
  using the Windows System for Linux once `flake8` is installed in the
  local Linux environment. While passing this test is not required, it is good practice and it help
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.
* If AI tools were used to help write this PR, see the
  [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html) for what disclosure
  and review is expected of you before submitting.

</details>
