### PR TITLE
DOC: Replace broken OECD glossary links in endog_exog docs

### DIFF
--- a/docs/source/endog_exog.rst
+++ b/docs/source/endog_exog.rst
@@ -40,11 +40,11 @@ Some informal definitions of the terms are
 
 *Endogenous variables designates variables in an economic/econometric model
 that are explained, or predicted, by that model.*
-http://stats.oecd.org/glossary/detail.asp?ID=794
+`Endogenous and exogenous variables <https://en.wikipedia.org/wiki/Endogenous_and_exogenous_variables>`_
 
 *Exogenous variables designates variables that appear in an
 economic/econometric model, but are not explained by that model (i.e. they are
-taken as given by the model).*  http://stats.oecd.org/glossary/detail.asp?ID=890
+taken as given by the model).*  See `Endogenous and exogenous variables <https://en.wikipedia.org/wiki/Endogenous_and_exogenous_variables>`_.
 
 In econometrics and statistics the terms are defined more formally, and
 different definitions of exogeneity (weak, strong, strict) are used depending


### PR DESCRIPTION
Fixes #10109

## Summary

Both OECD glossary links in `docs/source/endog_exog.rst` are dead: they redirect to
`https://stats.oecd.org/glossary/detail.asp?ID=794` / `...ID=890` and end in HTTP 404.
The glossary is no longer served by the OECD.

Replace both with the Wikipedia article "Endogenous and exogenous variables", which
defines the same concepts that the surrounding text refers to.

## Verification

- Both original URLs: HTTP 302 -> HTTPS -> 404 (checked 2026-08-18).
- Replacement target: HTTP 200.
- RST markup verified against the surrounding document style.

- [x] closes #10109
- [ ] tests added / passed. (not applicable: documentation-only change)
- [x] code/documentation is well formatted.
- [x] properly formatted commit message. See
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message).

#### AI Disclosure

- [ ] No AI tools were used to develop this pull request.
- [x] AI tools were used.
      Tool(s): Codex (OpenAI).
      Used for: drafting the documentation link replacement and verifying the replacement target.
      I have personally read, understood, and can explain every line of this diff, and
      have verified the statistical/numerical correctness of the change.