### PR TITLE
DOC: Update agents to improve docstrings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,83 @@ if the source `.pyx` file is newer than the compiled `.so` or `.dll` file.
 - If it's a substantial new feature, an example notebook is strongly encouraged.
   (see the "Add an example" step in `CONTRIBUTING.md`).
 
+### Docstring type conventions
+
+Distilled from a repo-wide numpydoc type-correctness pass (2026-08). These
+govern the `Parameters`/`Returns`/`Attributes` *type* field specifically —
+apply them whenever writing or reviewing a docstring, not just during a
+dedicated cleanup:
+
+- **Verify against the actual code, don't pattern-match.** The most common
+  real bug in this codebase's docstrings is a type that describes what
+  "sounds right" for the parameter's name rather than what the
+  implementation actually does with it (coercion, indexing, arithmetic).
+  Read the function body before writing or trusting a type string.
+- **`array_like` vs `ndarray` vs `sequence of X`:**
+  - `array_like` — the value is coerced (`np.asarray`/`np.array(...)`) and
+    then used with real array semantics (arithmetic, broadcasting,
+    `.shape`/`.ndim`, or passed into another `array_like`-typed call).
+  - `ndarray` — genuinely restricted to an already-constructed numpy array
+    (no coercion happens; `.shape`/`.ndim`/fancy-indexing used directly on
+    the raw parameter, or a plain list would raise).
+  - `sequence of X` (or `list of X` if genuinely list-only) — the value is
+    only ever iterated, indexed, or `len()`'d, never given real array
+    treatment. Don't default to `array_like` just because a parameter
+    accepts "more than a bare `ndarray`" — check which of the three is
+    actually true.
+  - `Returns`/`Attributes` describe the concrete output/stored type, never
+    the `Parameters`-side acceptance convention — a value that's always a
+    real `ndarray`/`Series`/`DataFrame` by the time it's returned should
+    say so, even if the same name accepts `array_like` as an input.
+- **No bracket-subscript container types.** `list[int]`, `array_like[int]`,
+  `dict[str, int]`, `tuple[float]` are all wrong — use prose:
+  `list of int`, `array_like of int`, `dict of str to int`,
+  `tuple of float`.
+- **`, optional` is the only default marker.** Every parameter with a
+  default ends its type string with `, optional`; don't also write
+  `, default: X` or restate the default value in the type field — the
+  default belongs in prose, in the description below the type line.
+- **Don't write `None or X, optional`** when `None` is just the ordinary
+  default sentinel — `, optional` already conveys that `None` is accepted.
+  Write plain `X, optional`. Keep the explicit `None or X` form only when
+  `None` triggers genuinely different downstream behavior (a distinct code
+  path, not just "the code checks `is None`" — check whether it *branches*
+  meaningfully).
+- **Curly braces `{...}` are for literal value enumerations only**, never
+  for type unions — `{int, str}` should be `int or str`. A real string-enum
+  parameter (validated with `raise ValueError` against exact literal
+  values, e.g. `trend`, `method`) should list the actual accepted values,
+  not an approximation. Inside the braces, use plain quoted values with no
+  backtick markup: `{"n", "co"}` is correct, `` {``"n"``, ``"co"``} `` is
+  wrong (redundant RST markup once the value is already quoted inside
+  braces).
+- `bool` not `boolean`; `str` not `string`; `callable` not
+  `function`/`class`.
+- The canonical type string for an RNG-seeding parameter (after the
+  `seed`→`rng` migration) is exactly:
+  `rng : int, array_like of int, numpy.random.Generator, or numpy.random.RandomState, optional`
+  — no `None` in the list (redundant with `, optional`), no curly braces.
+  If the parameter actually flows into something narrower (e.g. a legacy
+  `scipy` `seed=` kwarg that rejects `array_like of int`), use the
+  narrower, verified form instead of the full canonical one.
+- Standard numpydoc section headers only: `Parameters`, `Returns`,
+  `Yields`, `Raises`, `Warns`, `Other Parameters`, `Attributes`, `Methods`,
+  `See Also`, `Notes`, `References`, `Examples`, `Warnings`. Don't invent
+  new section names (`Restrictions`, `Column order`, etc.) — fold that
+  content into `Notes`. Section-underline length must match the header
+  text length exactly (this repo's own docstring tooling expects an exact
+  match, not just RST's "underline ≥ header length" minimum).
+- Every documented parameter/attribute/return must actually exist in the
+  current signature/implementation, and every real parameter should be
+  documented — check both directions, since signatures drift out of sync
+  with docstrings over time (a stale copy-pasted name from a sibling
+  method is a very common real bug, not just a style nit).
+- A real, non-docstring bug found while auditing docstrings (dead
+  parameters, unused kwargs, wrong operator precedence, etc.) belongs in
+  its own `BUG:` commit — don't fold a behavior fix into a `DOC:` commit,
+  and don't silently "fix" the docstring to match buggy behavior without
+  flagging the underlying bug.
+
 ## Testing conventions
 
 - Tests live in a `tests/` subpackage next to the code


### PR DESCRIPTION
- [X] code/documentation is well formatted.
- [X] properly formatted commit message. See
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message).

#### AI Disclosure

Contributions must comply with the statsmodels [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html).

If using AI tools, edit the second option to explain which tool was selected and
how the tool's output was used.

Please complete **one** of the following:

- [X] No AI tools were used to develop this pull request.
- [ ] AI tools were used.
      Tool(s): `<name(s), e.g. Copilot, Claude, ChatGPT>`.
      Used for: `<e.g. drafting an implementation, writing tests, debugging, editing docstrings>`.
      I have personally read, understood, and can explain every line of this diff, and
      have verified the statistical/numerical correctness of the change.

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows
  using the Windows System for Linux once `flake8` is installed in the
  local Linux environment. While passing this test is not required, it is good practice and it help
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.
* If AI tools were used to help write this PR, see the
  [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html) for what disclosure
  and review is expected of you before submitting.

</details>
