### PR TITLE
DOC: Clean docstrings in statespace

### DIFF
--- a/statsmodels/tsa/statespace/_pykalman_smoother.py
+++ b/statsmodels/tsa/statespace/_pykalman_smoother.py
@@ -23,11 +23,11 @@ class _KalmanSmoother:
 
     Parameters
     ----------
-    model : Representation
+    model : KalmanFilter
         The state space model.
-    kfilter : KalmanFilter
-        The Cython Kalman filter object with which filtering has already
-        been performed.
+    kfilter : FilterResults
+        The Cython Kalman filter results object with which filtering has
+        already been performed.
     smoother_output : int
         Bitmask value to indicate what smoother output to compute. See
         `SMOOTHER_STATE`, `SMOOTHER_STATE_COV`, `SMOOTHER_DISTURBANCE`,

--- a/statsmodels/tsa/statespace/_quarterly_ar1.py
+++ b/statsmodels/tsa/statespace/_quarterly_ar1.py
@@ -115,7 +115,7 @@ class QuarterlyAR1(mlemodel.MLEModel):
             The `cov_type` keyword governs the method for calculating the
             covariance matrix of parameter estimates. Default is 'none', in
             which case no covariance matrix is estimated.
-        cov_kwds : dict or None, optional
+        cov_kwds : dict, optional
             A dictionary of arguments affecting covariance matrix computation.
         maxiter : int, optional
             The maximum number of EM iterations to perform. Default is 500.

--- a/statsmodels/tsa/statespace/cfa_simulation_smoother.py
+++ b/statsmodels/tsa/statespace/cfa_simulation_smoother.py
@@ -165,11 +165,11 @@ class CFASimulationSmoother:
 
         Parameters
         ----------
-        variates : array_like, optional
+        variates : ndarray, optional
             Random variates, distributed standard Normal. Usually only
             specified if results are to be replicated (e.g., to enforce a seed)
             or for testing. If not specified, random variates are drawn. Must
-            be shaped (nobs, k_states).
+            be shaped (k_states, nobs).
         update_posterior : bool, optional
             Whether to update the posterior mean and covariance matrix (held
             in the `posterior_mean` and `posterior_cov_inv_chol_sparse`

--- a/statsmodels/tsa/statespace/dynamic_factor.py
+++ b/statsmodels/tsa/statespace/dynamic_factor.py
@@ -52,7 +52,7 @@ class DynamicFactor(MLEModel):
         is "diagonal".
     error_order : int, optional
         The order of the vector autoregression followed by the observation
-        error component. Default is None, corresponding to white noise errors.
+        error component. Default is 0, corresponding to white noise errors.
     error_var : bool, optional
         Whether or not to model the errors jointly via a vector autoregression,
         rather than as individual autoregressions. Has no effect unless

--- a/statsmodels/tsa/statespace/dynamic_factor_mq.py
+++ b/statsmodels/tsa/statespace/dynamic_factor_mq.py
@@ -152,9 +152,9 @@ class DynamicFactorMQStates(dict):
         Number of monthly (or non-time-specific, if k_endog_Q=0) variables.
     k_endog_Q : int
         Number of quarterly variables.
-    endog_names : list
+    endog_names : list of str
         Names of the endogenous variables.
-    factors : int, list, or dict
+    factors : int, list of str, or dict
         Integer giving the number of (global) factors, a list with the names of
         (global) factors, or a dictionary with:
 
@@ -728,7 +728,7 @@ class DynamicFactorMQ(mlemodel.MLEModel):
         the columns with quarterly variables should come afterwards. See the
         "Notes" section for details on how to set up a model with
         monthly/quarterly mixed frequency data.
-    factors : int, list, or dict, optional
+    factors : int, list of str, or dict, optional
         Integer giving the number of (global) factors, a list with the names of
         (global) factors, or a dictionary with:
 
@@ -2317,7 +2317,7 @@ class DynamicFactorMQ(mlemodel.MLEModel):
 
             Default is 'none', since computing this matrix can be very slow
             when there are a large number of parameters.
-        cov_kwds : dict or None, optional
+        cov_kwds : dict, optional
             A dictionary of arguments affecting covariance matrix computation.
 
             **opg, oim, approx, robust, robust_approx**
@@ -2488,7 +2488,7 @@ class DynamicFactorMQ(mlemodel.MLEModel):
 
             Default is 'none', since computing this matrix can be very slow
             when there are a large number of parameters.
-        cov_kwds : dict or None, optional
+        cov_kwds : dict, optional
             A dictionary of arguments affecting covariance matrix computation.
 
             **opg, oim, approx, robust, robust_approx**
@@ -3079,7 +3079,7 @@ class DynamicFactorMQ(mlemodel.MLEModel):
         cov_type : str, optional
             See `MLEResults.fit` for a description of covariance matrix types
             for results object. Default is None.
-        cov_kwds : dict or None, optional
+        cov_kwds : dict, optional
             See `MLEResults.get_robustcov_results` for a description of required
             keywords for alternative covariance estimators
         results_class : type, optional
@@ -3126,7 +3126,7 @@ class DynamicFactorMQ(mlemodel.MLEModel):
         cov_type : str, optional
             See `MLEResults.fit` for a description of covariance matrix types
             for results object. Default is 'none'.
-        cov_kwds : dict or None, optional
+        cov_kwds : dict, optional
             See `MLEResults.get_robustcov_results` for a description of required
             keywords for alternative covariance estimators
         results_class : type, optional
@@ -3293,10 +3293,10 @@ class DynamicFactorMQ(mlemodel.MLEModel):
             Default is 1. Note that for time-invariant models, the initial
             impulse is not counted as a step, so if `steps=1`, the output will
             have 2 entries.
-        impulse : int or array_like
+        impulse : int or array_like, optional
             If an integer, the state innovation to pulse; must be between 0
             and `k_posdef-1`. Alternatively, a custom impulse vector may be
-            provided; must be shaped `k_posdef x 1`.
+            provided; must be shaped `k_posdef x 1`. Default is 0.
         orthogonalized : bool, optional
             Whether or not to perform impulse using orthogonalized innovations.
             Note that this will also affect custum `impulse` vectors. Default
@@ -3447,7 +3447,7 @@ class DynamicFactorMQResults(mlemodel.MLEResults):
             "cumulative" plots the successive R-squared values as each
             additional factor is added to the regression, for each variable.
             Default is 'individual'.
-        which: {None, 'filtered', 'smoothed'}, optional
+        which : {None, 'filtered', 'smoothed'}, optional
             Whether to compute R-squared values based on filtered or smoothed
             estimates of the factors. Default is 'smoothed' if smoothed results
             are available and 'filtered' otherwise.
@@ -3563,7 +3563,7 @@ class DynamicFactorMQResults(mlemodel.MLEResults):
             "cumulative" plots the successive R-squared values as each
             additional factor is added to the regression, for each variable.
             Default is 'individual'.
-        which: {None, 'filtered', 'smoothed'}, optional
+        which : {None, 'filtered', 'smoothed'}, optional
             Whether to compute R-squared values based on filtered or smoothed
             estimates of the factors. Default is 'smoothed' if smoothed results
             are available and 'filtered' otherwise.
@@ -3772,7 +3772,7 @@ class DynamicFactorMQResults(mlemodel.MLEResults):
         exog : array_like, optional
             Array of exogenous regressors for the out-of-sample period, if
             applicable.
-        comparison_type : {None, 'previous', 'updated'}
+        comparison_type : {None, 'previous', 'updated'}, optional
             This denotes whether the `comparison` argument represents a
             *previous* results object or dataset or an *updated* results object
             or dataset. If not specified, then an attempt is made to determine
@@ -3913,7 +3913,7 @@ class DynamicFactorMQResults(mlemodel.MLEResults):
 
         Parameters
         ----------
-        decomposition_of : {"smoothed_state", "smoothed_signal"}
+        decomposition_of : {"smoothed_state", "smoothed_signal"}, optional
             The object to perform a decomposition of. If it is set to
             "smoothed_state", then the elements of the smoothed state vector
             are decomposed into the contributions of each observation. If it

--- a/statsmodels/tsa/statespace/exponential_smoothing.py
+++ b/statsmodels/tsa/statespace/exponential_smoothing.py
@@ -67,14 +67,14 @@ class ExponentialSmoothing(MLEModel):
         or length `seasonal - 1` (in which case the last initial value
         is computed to make the average effect zero). Only used if
         initialization is 'known'.
-    bounds : iterable[tuple], optional
+    bounds : iterable of tuple, optional
         An iterable containing bounds for the parameters. Must contain four
         elements, where each element is a tuple of the form (lower, upper).
         Default is (0.0001, 0.9999) for the level, trend, and seasonal
         smoothing parameters and (0.8, 0.98) for the trend damping parameter.
     concentrate_scale : bool, optional
         Whether or not to concentrate the scale (variance of the error term)
-        out of the likelihood.
+        out of the likelihood. Default is True.
     dates : array_like of datetime, optional
         An array-like object of datetime objects. If a Pandas object is given
         for endog, it is assumed to have a DateIndex.

--- a/statsmodels/tsa/statespace/initialization.py
+++ b/statsmodels/tsa/statespace/initialization.py
@@ -27,7 +27,7 @@ class Initialization:
         be one of 'known', 'diffuse', 'approximate_diffuse', or 'stationary'.
         If not specified, no global initialization is performed and blocks of
         states must instead be initialized using the `set` method.
-    initialization_classes : dict, optional
+    initialization_classes : dict of str to type, optional
         Dictionary with BLAS prefixes as keys and the associated Cython
         initialization classes as values. If not specified, the default
         mapping is used.
@@ -288,7 +288,7 @@ class Initialization:
 
         Returns
         -------
-        initialization
+        Initialization
             Initialization object.
 
         Notes
@@ -385,6 +385,20 @@ class Initialization:
 
     @classmethod
     def from_results(cls, filter_results):
+        """
+        Construct initialization object from filter results
+
+        Parameters
+        ----------
+        filter_results : FilterResults
+            Filter results object from which to take the initial state and
+            initial state covariance matrices.
+
+        Returns
+        -------
+        Initialization
+            Initialization object.
+        """
         a = filter_results.initial_state
         Pstar = filter_results.initial_state_cov
         Pinf = filter_results.initial_diffuse_state_cov
@@ -452,10 +466,13 @@ class Initialization:
             `(start, stop)` (note that for `slice`, stop is not inclusive), or
             an integer (to select a specific state), or None (to select all the
             states).
-        initialization_type : str
+        initialization_type : str or Initialization
             The type of initialization used for the states selected by `index`.
-            Must be one of 'known', 'diffuse', 'approximate_diffuse', or
-            'stationary'.
+            If a string, must be one of 'known', 'diffuse',
+            'approximate_diffuse', or 'stationary'. Alternatively, a
+            previously created `Initialization` object may be given, in which
+            case it is used directly as the initialization for the selected
+            block of states.
         constant : array_like, optional
             A vector of constant values, denoted :math:`a`. Most often used
             with 'known' initialization, but may also be used with
@@ -705,13 +722,13 @@ class Initialization:
 
         Parameters
         ----------
-        index : ndarray, optional
+        index : array_like of int, optional
             The base index of the block of states being initialized within the
             full state vector. If not specified, all states are used.
         model : Representation, optional
-            A state space model representation object, optional if 'stationary'
-            initialization is used and ignored otherwise. See notes for
-            details in the stationary initialization case.
+            A state space model representation object. Required if
+            'stationary' initialization is used (either globally or for any
+            block of states); ignored otherwise. See Notes for details.
         initial_state_mean : ndarray, optional
             An array (or more usually view) in which to place the initial state
             mean.
@@ -740,8 +757,7 @@ class Initialization:
         Notes
         -----
         If stationary initialization is used either globally or for any block
-        of states, then either `model` or all of `state_intercept`,
-        `transition`, `selection`, and `state_cov` must be provided.
+        of states, then `model` must be provided.
         """
         # Check that all states are initialized somehow
         if self.initialization_type is None and np.any(

--- a/statsmodels/tsa/statespace/kalman_filter.py
+++ b/statsmodels/tsa/statespace/kalman_filter.py
@@ -67,7 +67,7 @@ class KalmanFilter(Representation):
 
     Parameters
     ----------
-    k_endog : {array_like, int}
+    k_endog : ndarray or int
         The observed time-series process :math:`y` if array like or the
         number of variables in the process if an integer.
     k_states : int
@@ -82,7 +82,7 @@ class KalmanFilter(Representation):
     tolerance : float, optional
         The tolerance at which the Kalman filter determines convergence to
         steady-state. Default is 1e-19.
-    results_class : class, optional
+    results_class : type, optional
         Default results class to use to save filtering output. Default is
         `FilterResults`. If specified, class must extend from `FilterResults`.
     kalman_filter_classes : dict, optional
@@ -750,7 +750,7 @@ class KalmanFilter(Representation):
         Examples
         --------
         >>> mod = sm.tsa.statespace.SARIMAX(range(10))
-        >>> mod.ssm..conserve_memory
+        >>> mod.ssm.conserve_memory
         0
         >>> mod.ssm.memory_no_predicted
         False
@@ -800,7 +800,7 @@ class KalmanFilter(Representation):
 
         Parameters
         ----------
-        scale : numeric
+        scale : float or None
             Scale of the model.
 
         Notes
@@ -984,7 +984,7 @@ class KalmanFilter(Representation):
 
         Returns
         -------
-        loglike : array of float
+        loglike : ndarray of float
             Array of loglikelihood values for each observation.
         """
         if self.memory_no_likelihood:
@@ -1105,12 +1105,12 @@ class KalmanFilter(Representation):
             Whether or not to return the simulator object. Typically used to
             improve performance when performing repeated sampling. Default is
             False.
-        rng : int, array_like of int, numpy.random.Generator, numpy.random.RandomState, optional
+        rng : int, array_like of int, numpy.random.Generator, or numpy.random.RandomState, optional
             If `rng` is None or an int, a new ``Generator`` is created
             (seeded with `rng` if an int is given). If `rng` is already a
             ``Generator`` or ``RandomState`` instance, that instance is
             used.
-        rng : int, array_like of int, numpy.random.Generator, numpy.random.RandomState, optional
+        rng : int, array_like of int, numpy.random.Generator, or numpy.random.RandomState, optional
             .. deprecated:: 0.15
 
                random_state has been deprecated. In-line with SPEC-007, use
@@ -1163,11 +1163,12 @@ class KalmanFilter(Representation):
             The number of steps for which impulse responses are calculated.
             Default is 10. Note that the initial impulse is not counted as a
             step, so if `steps=1`, the output will have 2 entries.
-        impulse : int or array_like
+        impulse : int or array_like, optional
             If an integer, the state innovation to pulse; must be between 0
             and `k_posdef-1` where `k_posdef` is the same as in the state
             space model. Alternatively, a custom impulse vector may be
             provided; must be a column vector with shape `(k_posdef, 1)`.
+            Default is 0.
         orthogonalized : bool, optional
             Whether or not to perform impulse using orthogonalized innovations.
             Note that this will also affect custum `impulse` vectors. Default
@@ -1306,7 +1307,7 @@ class FilterResults(FrozenRepresentation):
         Datatype of representation matrices
     prefix : str
         BLAS prefix of representation matrices
-    shapes : dictionary of name,tuple
+    shapes : dict of str to tuple
         A dictionary recording the shapes of each of the
         representation matrices as tuples.
     endog : ndarray
@@ -1325,12 +1326,12 @@ class FilterResults(FrozenRepresentation):
         The selection matrix, :math:`R`.
     state_cov : ndarray
         The covariance matrix for the state equation :math:`Q`.
-    missing : array of bool
+    missing : ndarray of bool
         An array of the same size as `endog`, filled
         with boolean values that are True if the
         corresponding entry in `endog` is NaN and False
         otherwise.
-    nmissing : array of int
+    nmissing : ndarray of int
         An array of size `nobs`, where the ith entry
         is the number (between 0 and `k_endog`) of NaNs in
         the ith row of the `endog` array.
@@ -1338,11 +1339,11 @@ class FilterResults(FrozenRepresentation):
         Whether or not the representation matrices are time-invariant
     initialization : str
         Kalman filter initialization method.
-    initial_state : array_like
+    initial_state : ndarray
         The state vector used to initialize the Kalman filter.
-    initial_state_cov : array_like
+    initial_state_cov : ndarray
         The state covariance matrix used to initialize the Kalman filter.
-    initial_diffuse_state_cov : array_like
+    initial_diffuse_state_cov : ndarray
         Diffuse state covariance matrix used to initialize the Kalman filter.
     filter_method : int
         Bitmask representing the Kalman filtering method
@@ -1375,7 +1376,7 @@ class FilterResults(FrozenRepresentation):
         The predicted state vector at each time period.
     predicted_state_cov : ndarray
         The predicted state covariance matrix at each time period.
-    forecast_error_diffuse_cov : ndarray
+    forecasts_error_diffuse_cov : ndarray
         Diffuse forecast error covariance matrix at each time period.
     predicted_diffuse_state_cov : ndarray
         The predicted diffuse state covariance matrix at each time period.
@@ -1876,7 +1877,7 @@ class FilterResults(FrozenRepresentation):
         end : int, optional
             Zero-indexed observation number at which to end prediction, i.e.,
             the last prediction will be at end.
-        dynamic : int, optional
+        dynamic : bool or int, optional
             Offset relative to `start` at which to begin dynamic prediction.
             Prior to this observation, true endogenous values will be used for
             prediction; starting with this observation and continuing through
@@ -2061,6 +2062,9 @@ class PredictionResults(FilterResults):
     nforecast : int
         Number of in-sample forecasts (these always follow the dynamic
         predictions directly).
+    oos_results : FilterResults, optional
+        Filtering output associated with the out-of-sample forecasting
+        period, if any. Default is None.
 
     Attributes
     ----------
@@ -2370,7 +2374,7 @@ def _check_dynamic(dynamic, start, end, nobs):
 
     Parameters
     ----------
-    dynamic : {int, None}
+    dynamic : int or None
         The offset relative to start of the dynamic forecasts. None if no
         dynamic forecasts are required.
     start : int
@@ -2382,7 +2386,7 @@ def _check_dynamic(dynamic, start, end, nobs):
 
     Returns
     -------
-    dynamic : {int, None}
+    dynamic : int or None
         The start location of the first dynamic forecast. None if there
         are no in-sample dynamic forecasts.
     ndynamic : int

--- a/statsmodels/tsa/statespace/kalman_smoother.py
+++ b/statsmodels/tsa/statespace/kalman_smoother.py
@@ -41,7 +41,7 @@ class KalmanSmoother(KalmanFilter):
 
     Parameters
     ----------
-    k_endog : {array_like, int}
+    k_endog : ndarray or int
         The observed time-series process :math:`y` if array like or the
         number of variables in the process if an integer.
     k_states : int
@@ -50,7 +50,7 @@ class KalmanSmoother(KalmanFilter):
         The dimension of a guaranteed positive definite covariance matrix
         describing the shocks in the measurement equation. Must be less than
         or equal to `k_states`. Default is `k_states`.
-    results_class : class, optional
+    results_class : type, optional
         Default results class to use to save filtering output. Default is
         `SmootherResults`. If specified, class must extend from
         `SmootherResults`.
@@ -384,8 +384,8 @@ class KalmanSmoother(KalmanFilter):
             Determines which Kalman smoothing approach to use. Default is
             the smoother method specified by `smooth_method` in the current
             state space model.
-        results : class or object, optional
-            If a class, then that class is instantiated and returned with the
+        results : type or object, optional
+            If a type, then that type is instantiated and returned with the
             result of both filtering and smoothing.
             If an object, then that object is updated with the smoothing data.
             If None, then a SmootherResults object is returned with both
@@ -467,7 +467,7 @@ class SmootherResults(FilterResults):
         Datatype of representation matrices
     prefix : str
         BLAS prefix of representation matrices
-    shapes : dictionary of name:tuple
+    shapes : dict of str to tuple
         A dictionary recording the shapes of each of the representation
         matrices as tuples.
     endog : ndarray
@@ -486,20 +486,20 @@ class SmootherResults(FilterResults):
         The selection matrix, :math:`R`.
     state_cov : ndarray
         The covariance matrix for the state equation :math:`Q`.
-    missing : array of bool
+    missing : ndarray of bool
         An array of the same size as `endog`, filled with boolean values that
         are True if the corresponding entry in `endog` is NaN and False
         otherwise.
-    nmissing : array of int
+    nmissing : ndarray of int
         An array of size `nobs`, where the ith entry is the number (between 0
         and k_endog) of NaNs in the ith row of the `endog` array.
     time_invariant : bool
         Whether or not the representation matrices are time-invariant
     initialization : str
         Kalman filter initialization method.
-    initial_state : array_like
+    initial_state : ndarray
         The state vector used to initialize the Kalman filter.
-    initial_state_cov : array_like
+    initial_state_cov : ndarray
         The state covariance matrix used to initialize the Kalman filter.
     filter_method : int
         Bitmask representing the Kalman filtering method
@@ -1111,7 +1111,7 @@ class SmootherResults(FilterResults):
             revisions are grouped together. Default is True. Note that for
             large models, setting this to be near the beginning of the sample
             can cause this function to be slow.
-        design : array, optional
+        design : ndarray, optional
             Design matrix for the period `t` in time-varying models. If this
             model has a time-varying design matrix, and the argument `t` is out
             of this model's sample, then a new design matrix for period `t`
@@ -1614,7 +1614,7 @@ class SmootherResults(FilterResults):
 
         Parameters
         ----------
-        updates_ix : list
+        updates_ix : list of tuple
             List of indices `(t, i)`, where `t` denotes a zero-indexed time
             location and `i` denotes a zero-indexed endog variable.
         t : int, optional
@@ -1809,7 +1809,7 @@ class SmootherResults(FilterResults):
 
         Returns
         -------
-        data_contributions : array
+        data_contributions : ndarray
             Contributions of observations to the decomposed object. If the
             smoothed state is being decomposed, then `data_contributions` are
             shaped `(nobs, k_states, nobs, k_endog)`, where the
@@ -1820,7 +1820,7 @@ class SmootherResults(FilterResults):
             `(t, k, j, p)`-th element is the contribution of the `p`-th
             observation at time `j` to the smoothed prediction of the `k`-th
             observation at time `t`.
-        obs_intercept_contributions : array
+        obs_intercept_contributions : ndarray
             Contributions of the observation intercept to the decomposed
             object. If the smoothed state is being decomposed, then
             `obs_intercept_contributions` are shaped
@@ -1831,7 +1831,7 @@ class SmootherResults(FilterResults):
             `(nobs, k_endog, nobs, k_endog)`, where the `(t, k, j, p)`-th
             element is the contribution of the `p`-th observation at time `j`
             to the smoothed prediction of the `k`-th observation at time `t`.
-        state_intercept_contributions : array
+        state_intercept_contributions : ndarray
             Contributions of the state intercept to the decomposed object. If
             the smoothed state is being decomposed, then
             `state_intercept_contributions` are shaped
@@ -1843,7 +1843,7 @@ class SmootherResults(FilterResults):
             `(t, k, j, l)`-th element is the contribution of the `l`-th
             state intercept at time `j` to the smoothed prediction of the
             `k`-th observation at time `t`.
-        prior_contributions : array
+        prior_contributions : ndarray
             Contributions of the prior to the decomposed object. If the
             smoothed state is being decomposed, then `prior_contributions` are
             shaped `(nobs, k_states, k_states)`, where the `(t, m, l)`-th

--- a/statsmodels/tsa/statespace/mlemodel.py
+++ b/statsmodels/tsa/statespace/mlemodel.py
@@ -584,7 +584,7 @@ class MLEModel(tsbase.TimeSeriesModel):
             Default is 'opg' unless memory conservation is used to avoid
             computing the loglikelihood values for each observation, in which
             case the default is 'approx'.
-        cov_kwds : dict or None, optional
+        cov_kwds : dict, optional
             A dictionary of arguments affecting covariance matrix computation.
 
             **opg, oim, approx, robust, robust_approx**
@@ -877,13 +877,13 @@ class MLEModel(tsbase.TimeSeriesModel):
         complex_step : bool, optional
             Whether or not to compute the filtered output using complex step
             differentiation. Default is False.
-        return_ssm : bool,optional
+        return_ssm : bool, optional
             Whether or not to return only the state space output or a full
             results object. Default is to return a full results object.
         cov_type : str, optional
             See `MLEResults.fit` for a description of covariance matrix types
             for results object.
-        cov_kwds : dict or None, optional
+        cov_kwds : dict, optional
             See `MLEResults.get_robustcov_results` for a description required
             keywords for alternative covariance estimators
         results_class : type, optional
@@ -963,13 +963,13 @@ class MLEModel(tsbase.TimeSeriesModel):
         complex_step : bool, optional
             Whether or not to compute the smoothed output using complex step
             differentiation. Default is False.
-        return_ssm : bool,optional
+        return_ssm : bool, optional
             Whether or not to return only the state space output or a full
             results object. Default is to return a full results object.
         cov_type : str, optional
             See `MLEResults.fit` for a description of covariance matrix types
             for results object.
-        cov_kwds : dict or None, optional
+        cov_kwds : dict, optional
             See `MLEResults.get_robustcov_results` for a description required
             keywords for alternative covariance estimators
         results_class : type, optional
@@ -1292,7 +1292,7 @@ class MLEModel(tsbase.TimeSeriesModel):
 
         Parameters
         ----------
-        params : array_like, optional
+        params : array_like
             Array of parameters at which to evaluate the loglikelihood
             function.
         transformed : bool, optional
@@ -1416,7 +1416,7 @@ class MLEModel(tsbase.TimeSeriesModel):
 
         Parameters
         ----------
-        params : array_like, optional
+        params : array_like
             Array of parameters at which to evaluate the loglikelihood
             function.
         transformed : bool, optional
@@ -1494,7 +1494,7 @@ class MLEModel(tsbase.TimeSeriesModel):
 
         Parameters
         ----------
-        params : array_like, optional
+        params : array_like
             Array of parameters at which to evaluate the loglikelihood
             function.
         approx_complex_step : bool, optional
@@ -1989,7 +1989,7 @@ class MLEModel(tsbase.TimeSeriesModel):
 
         Returns
         -------
-        constrained : array_like
+        constrained : ndarray
             Array of constrained parameters which may be used in likelihood
             evaluation.
 
@@ -2013,7 +2013,7 @@ class MLEModel(tsbase.TimeSeriesModel):
 
         Returns
         -------
-        unconstrained : array_like
+        unconstrained : ndarray
             Array of unconstrained parameters used by the optimizer.
 
         Notes
@@ -2082,7 +2082,7 @@ class MLEModel(tsbase.TimeSeriesModel):
 
         Returns
         -------
-        params : array_like
+        params : ndarray
             Array of parameters.
 
         Notes
@@ -2317,12 +2317,12 @@ class MLEModel(tsbase.TimeSeriesModel):
             assumed to contain draws from the standard Normal distribution that
             must be transformed using the `initial_state_cov` covariance
             matrix. Default is True.
-        rng : int, array_like of int, numpy.random.Generator, numpy.random.RandomState, optional
+        rng : int, array_like of int, numpy.random.Generator, or numpy.random.RandomState, optional
             If `rng` is None or an int, a new ``Generator`` is created
             (seeded with `rng` if an int is given). If `rng` is already a
             ``Generator`` or ``RandomState`` instance, that instance is
             used.
-        rng : int, array_like of int, numpy.random.Generator, numpy.random.RandomState, optional
+        rng : int, array_like of int, numpy.random.Generator, or numpy.random.RandomState, optional
             .. deprecated:: 0.15
 
                random_state has been deprecated. In-line with SPEC-007, use
@@ -2483,12 +2483,12 @@ class MLEModel(tsbase.TimeSeriesModel):
             Default is 1. Note that for time-invariant models, the initial
             impulse is not counted as a step, so if `steps=1`, the output will
             have 2 entries.
-        impulse : int, str or array_like
+        impulse : int, str, or array_like, optional
             If an integer, the state innovation to pulse; must be between 0
             and `k_posdef-1`. If a str, it indicates which column of df
             the unit (1) impulse is given.
             Alternatively, a custom impulse vector may be provided; must be
-            shaped `k_posdef x 1`.
+            shaped `k_posdef x 1`. Default is 0.
         orthogonalized : bool, optional
             Whether or not to perform impulse using orthogonalized innovations.
             Note that this will also affect custom `impulse` vectors. Default
@@ -2700,7 +2700,7 @@ class MLEResults(tsbase.TimeSeriesModelResults):
         description of available options. Default is None, in which case the
         `cov_type` is chosen based on whether or not `memory_no_likelihood`
         is set on `results`.
-    cov_kwds : dict or None, optional
+    cov_kwds : dict, optional
         A dictionary of arguments affecting covariance matrix computation.
         See `MLEModel.fit` for details. Default is None.
     **kwargs
@@ -2969,11 +2969,11 @@ class MLEResults(tsbase.TimeSeriesModelResults):
 
         Parameters
         ----------
-        cov_type : str
+        cov_type : str, optional
             the type of covariance matrix estimator to use. See Notes below
-        kwargs : depends on cov_type
-            Required or optional arguments for covariance calculation.
-            See Notes below.
+        **kwargs
+            Required or optional arguments for covariance calculation,
+            depending on `cov_type`. See Notes below.
 
         Returns
         -------
@@ -3321,7 +3321,7 @@ class MLEResults(tsbase.TimeSeriesModelResults):
         ----------
         criteria : {'aic', 'bic', 'hqic'}
             The information criteria to compute.
-        method : {'standard', 'lutkepohl'}
+        method : {'standard', 'lutkepohl'}, optional
             The method for information criteria computation. Default is
             'standard' method; 'lutkepohl' computes the information criteria
             as in Lütkepohl (2007). See Notes for formulas.
@@ -3580,7 +3580,7 @@ class MLEResults(tsbase.TimeSeriesModelResults):
             The statistical test for heteroskedasticity. Must be 'breakvar'
             for test of a break in the variance. If None, an attempt is
             made to select an appropriate test.
-        alternative : str, 'increasing', 'decreasing' or 'two-sided'
+        alternative : {'increasing', 'decreasing', 'two-sided'}, optional
             This specifies the alternative for the p-value calculation. Default
             is two-sided.
         use_f : bool, optional
@@ -3680,7 +3680,7 @@ class MLEResults(tsbase.TimeSeriesModelResults):
         method : {'ljungbox', 'boxpierce', None}
             The statistical test for serial correlation. If None, an attempt is
             made to select an appropriate test.
-        lags : None, int or array_like
+        lags : int, array_like, or None, optional
             If lags is an integer then this is taken to be the largest lag
             that is included, the test result is reported for all smaller lag
             length.
@@ -3972,18 +3972,18 @@ class MLEResults(tsbase.TimeSeriesModelResults):
 
         Parameters
         ----------
-        start : {int, str,datetime}, optional
+        start : int, str, or datetime, optional
             Zero-indexed observation number at which to start forecasting,
             i.e., the first forecast is start. Can also be a date string to
             parse or a datetime type. Default is the zeroth observation.
-        end : {int, str,datetime}, optional
+        end : int, str, or datetime, optional
             Zero-indexed observation number at which to end forecasting, i.e.,
             the last forecast is end. Can also be a date string to
             parse or a datetime type. However, if the dates index does not
             have a fixed frequency, end must be an integer index if you
             want out of sample prediction. Default is the last observation in
             the sample.
-        dynamic : {bool, int, str,datetime}, optional
+        dynamic : bool, int, str, or datetime, optional
             Integer offset relative to `start` at which to begin dynamic
             prediction. Can also be an absolute date string to parse or a
             datetime type (these are not interpreted as offsets).
@@ -4016,7 +4016,7 @@ class MLEResults(tsbase.TimeSeriesModelResults):
 
         Returns
         -------
-        predictions : array_like
+        predictions : ndarray, Series, or DataFrame
             In-sample predictions / Out-of-sample forecasts. (Numpy array or
             Pandas Series or DataFrame, depending on input and dimensions).
             Dimensions are `(npredict x k_endog)`.
@@ -4068,7 +4068,7 @@ class MLEResults(tsbase.TimeSeriesModelResults):
 
         Returns
         -------
-        forecast : array_like
+        forecast : ndarray, Series, or DataFrame
             Out-of-sample forecasts (Numpy array or Pandas Series or DataFrame,
             depending on input and dimensions).
             Dimensions are `(steps x k_endog)`.
@@ -4174,7 +4174,7 @@ class MLEResults(tsbase.TimeSeriesModelResults):
             assumed to contain draws from the standard Normal distribution that
             must be transformed using the `initial_state_cov` covariance
             matrix. Default is True.
-        rng : int, array_like of int, numpy.random.Generator, numpy.random.RandomState, optional
+        rng : int, array_like of int, numpy.random.Generator, or numpy.random.RandomState, optional
             If `rng` is None or an int, a new ``Generator`` is created
             (seeded with `rng` if an int is given). If `rng` is already a
             ``Generator`` or ``RandomState`` instance, that instance is
@@ -4265,12 +4265,12 @@ class MLEResults(tsbase.TimeSeriesModelResults):
             Default is 1. Note that for time-invariant models, the initial
             impulse is not counted as a step, so if `steps=1`, the output will
             have 2 entries.
-        impulse : int, str or array_like
+        impulse : int, str, or array_like, optional
             If an integer, the state innovation to pulse; must be between 0
             and `k_posdef-1`. If a str, it indicates which column of df
             the unit (1) impulse is given.
             Alternatively, a custom impulse vector may be provided; must be
-            shaped `k_posdef x 1`.
+            shaped `k_posdef x 1`. Default is 0.
         orthogonalized : bool, optional
             Whether or not to perform impulse using orthogonalized innovations.
             Note that this will also affect custom `impulse` vectors. Default
@@ -4594,7 +4594,7 @@ class MLEResults(tsbase.TimeSeriesModelResults):
         exog : array_like, optional
             Array of exogenous regressors for the out-of-sample period, if
             applicable.
-        comparison_type : {None, 'previous', 'updated'}
+        comparison_type : {None, 'previous', 'updated'}, optional
             This denotes whether the `comparison` argument represents a
             *previous* results object or dataset or an *updated* results object
             or dataset. If not specified, then an attempt is made to determine
@@ -4766,7 +4766,7 @@ class MLEResults(tsbase.TimeSeriesModelResults):
 
         Parameters
         ----------
-        decomposition_of : {"smoothed_state", "smoothed_signal"}
+        decomposition_of : {"smoothed_state", "smoothed_signal"}, optional
             The object to perform a decomposition of. If it is set to
             "smoothed_state", then the elements of the smoothed state vector
             are decomposed into the contributions of each observation. If it
@@ -5273,9 +5273,9 @@ class MLEResults(tsbase.TimeSeriesModelResults):
 
         Parameters
         ----------
-        variable : int, optional
-            Index of the endogenous variable for which the diagnostic plots
-            should be created. Default is 0.
+        variable : int or str, optional
+            Index or name of the endogenous variable for which the diagnostic
+            plots should be created. Default is 0.
         lags : int, optional
             Number of lags to include in the correlogram. Default is 10.
         fig : Figure, optional
@@ -5290,7 +5290,7 @@ class MLEResults(tsbase.TimeSeriesModelResults):
             endogenous variable when used in plot titles. Default is 24.
         auto_ylims : bool, optional
             If True, adjusts automatically the y-axis limits to ACF values.
-        bartlett_confint : bool, default False
+        bartlett_confint : bool, optional
             Confidence intervals for ACF values are generally placed at 2
             standard errors around r_k. The formula used for standard error
             depends upon the situation. If the autocorrelations are being used
@@ -5446,7 +5446,7 @@ class MLEResults(tsbase.TimeSeriesModelResults):
         title : str, optional
             The title used for the summary table. Default is "Statespace
             Model Results".
-        model_name : str
+        model_name : str or list of str, optional
             The name of the model used. Default is to use model class name.
         display_params : bool, optional
             Whether or not to display the table of estimated parameters.
@@ -5704,11 +5704,11 @@ class PredictionResults(pred.PredictionResults):
     prediction_results : kalman_filter.PredictionResults instance
         Results object from prediction after fitting or filtering a state space
         model.
-    row_labels : iterable
+    row_labels : iterable, optional
         Row labels for the predicted data.
-    information_set : str
+    information_set : {"predicted", "filtered", "smoothed"}, optional
         Name of information set
-    signal_only : bool
+    signal_only : bool, optional
         Whether the prediction is for the signal only
 
     Attributes

--- a/statsmodels/tsa/statespace/news.py
+++ b/statsmodels/tsa/statespace/news.py
@@ -40,7 +40,7 @@ class NewsResults:
     tolerance : float, optional
         The numerical threshold for determining zero impact. Default is that
         any impact less than 1e-10 is assumed to be zero.
-    row_labels : iterable
+    row_labels : array_like, optional
         Row labels (often dates) for the impacts of the revisions and news.
 
     Attributes
@@ -55,15 +55,15 @@ class NewsResults:
     revision_impacts : DataFrame
         Updates to forecasts of impacted variables from all data revisions,
         E[y^i | revisions] - E[y^i | previous].
-    news : DataFrame
+    news : Series
         The unexpected component of the updated data,
         E[y^u | post] - E[y^u | revisions] where y^u are the updated variables.
     weights : DataFrame
         Weights describing the effect of news on variables of interest.
-    revisions : DataFrame
+    revisions : Series
         The revisions between the current and previously observed data, for
         revisions for which detailed impacts were computed.
-    revisions_all : DataFrame
+    revisions_all : Series
         The revisions between the current and previously observed data,
         y^r_{revised} - y^r_{previous} where y^r are the revised variables.
     revision_weights : DataFrame
@@ -73,10 +73,10 @@ class NewsResults:
         Weights describing the effect of revisions on variables of interest,
         with a new entry that includes NaNs for the revisions for which
         detailed impacts were not computed.
-    update_forecasts : DataFrame
+    update_forecasts : Series
         Forecasts based on the previous dataset of the variables that were
         updated, E[y^u | previous].
-    update_realized : DataFrame
+    update_realized : Series
         Actual observed data associated with the variables that were
         updated, y^u
     revisions_details_start : int
@@ -88,16 +88,16 @@ class NewsResults:
     revision_grouped_impacts : DataFrame
         Updates to forecasts of impacted variables from data revisions that
         were grouped together, E[y^i | grouped revisions] - E[y^i | previous].
-    revised_prev : DataFrame
+    revised_prev : Series
         Previously observed data associated with the variables that were
         revised, for revisions for which detailed impacts were computed.
-    revised_prev_all : DataFrame
+    revised_prev_all : Series
         Previously observed data associated with the variables that were
         revised, y^r_{previous}
-    revised : DataFrame
+    revised : Series
         Currently observed data associated with the variables that were
         revised, for revisions for which detailed impacts were computed.
-    revised_all : DataFrame
+    revised_all : Series
         Currently observed data associated with the variables that were
         revised, y^r_{revised}
     prev_impacted_forecasts : DataFrame
@@ -119,7 +119,7 @@ class NewsResults:
         The integer locations of the updated data points.
     updates_ix : DataFrame
         The label-based locations of updated data points.
-    state_index : array_like
+    state_index : ndarray or None
         Index of state variables used to compute impacts.
 
     References
@@ -855,7 +855,7 @@ class NewsResults:
             the variables that were *affected* by the news. If you do not know
             the labels for the variables, check the `endog_names` attribute of
             the model instance.
-        groupby : {impact date, impacted variable}
+        groupby : {"impact date", "impacted variable"}, optional
             The primary variable for grouping results in the impacts table. The
             default is to group by impact date.
         show_revisions_columns : bool, optional
@@ -863,9 +863,9 @@ class NewsResults:
             data revisions or the total impacts. Default is to show the
             revisions and totals columns if any revisions were made and
             otherwise to hide them.
-        sparsify : bool, optional, default True
+        sparsify : bool, optional
             Set to False for the table to include every one of the multiindex
-            keys at each row.
+            keys at each row. Default is True.
         float_format : str, optional
             Formatter format string syntax for converting numbers to strings.
             Default is '%.2f'.
@@ -978,7 +978,7 @@ class NewsResults:
 
         Parameters
         ----------
-        source : {news, revisions}
+        source : {"news", "revisions"}, optional
             The source of impacts to summarize. Default is "news".
         impact_date : int, str, datetime, list, array, or slice, optional
             Observation index label or slice of labels specifying particular
@@ -1007,12 +1007,13 @@ class NewsResults:
             variables that were *affected* by the news. If you do not know the
             labels for the variables, check the `endog_names` attribute of the
             model instance.
-        groupby : {update date, updated variable, impact date, impacted variable}
+        groupby : {"update date", "updated variable", "impact date",
+            "impacted variable"}, optional
             The primary variable for grouping results in the details table. The
             default is to group by update date.
-        sparsify : bool, optional, default True
+        sparsify : bool, optional
             Set to False for the table to include every one of the multiindex
-            keys at each row.
+            keys at each row. Default is True.
         float_format : str, optional
             Formatter format string syntax for converting numbers to strings.
             Default is '%.2f'.
@@ -1245,9 +1246,9 @@ class NewsResults:
 
         Parameters
         ----------
-        sparsify : bool, optional, default True
+        sparsify : bool, optional
             Set to False for the table to include every one of the multiindex
-            keys at each row.
+            keys at each row. Default is True.
 
         Returns
         -------
@@ -1303,9 +1304,9 @@ class NewsResults:
 
         Parameters
         ----------
-        sparsify : bool, optional, default True
+        sparsify : bool, optional
             Set to False for the table to include every one of the multiindex
-            keys at each row.
+            keys at each row. Default is True.
 
         Returns
         -------
@@ -1407,22 +1408,22 @@ class NewsResults:
             variables that were *revised*. If you do not know the labels for
             the variables, check the `endog_names` attribute of the model
             instance.
-        impacts_groupby : {impact date, impacted variable}
+        impacts_groupby : {"impact date", "impacted variable"}, optional
             The primary variable for grouping results in the impacts table. The
             default is to group by impact date.
-        details_groupby : str
-            One of "update date", "updated variable", "impact date", or
-            "impacted variable". The primary variable for grouping results in
-            the details table. Only used if the details tables are included.
-            The default is to group by update date.
+        details_groupby : {"update date", "updated variable", "impact date",
+            "impacted variable"}, optional
+            The primary variable for grouping results in the details table.
+            Only used if the details tables are included. The default is to
+            group by update date.
         show_revisions_columns : bool, optional
             If set to False, the impacts table will not show the impacts from
             data revisions or the total impacts. Default is to show the
             revisions and totals columns if any revisions were made and
             otherwise to hide them.
-        sparsify : bool, optional, default True
+        sparsify : bool, optional
             Set to False for the table to include every one of the multiindex
-            keys at each row.
+            keys at each row. Default is True.
         include_details_tables : bool, optional
             If set to True, the summary will show tables describing the details
             of how news from specific updates translate into specific impacts.
@@ -1614,7 +1615,7 @@ class NewsResults:
 
         Parameters
         ----------
-        groupby : str, list of str, or function, optional
+        groupby : str, list of str, or callable, optional
             Argument passed to the `groupby` method of the combined details
             table (see `get_details`) to group impacts by, e.g., by the
             update date. If not specified, no grouping is performed.

--- a/statsmodels/tsa/statespace/representation.py
+++ b/statsmodels/tsa/statespace/representation.py
@@ -89,7 +89,7 @@ class Representation:
 
     Parameters
     ----------
-    k_endog : {array_like, int}
+    k_endog : ndarray or int
         The observed time-series process :math:`y` if array like or the
         number of variables in the process if an integer.
     k_states : int
@@ -101,7 +101,7 @@ class Representation:
     initial_variance : float, optional
         Initial variance used when approximate diffuse initialization is
         specified. Default is 1e6.
-    initialization : Initialization object or str, optional
+    initialization : Initialization or str, optional
         Initialization method for the initial state. If a string, must be one
         of {'diffuse', 'approximate_diffuse', 'stationary', 'known'}.
     initial_state : array_like, optional
@@ -155,11 +155,11 @@ class Representation:
         The dimension of a guaranteed positive
         definite covariance matrix describing
         the shocks in the measurement equation.
-    shapes : dictionary of name:tuple
+    shapes : dict of str to tuple
         A dictionary recording the initial shapes
         of each of the representation matrices as
         tuples.
-    initialization : str
+    initialization : Initialization
         Kalman filter initialization method. Default is unset.
     initial_variance : float
         Initial variance for approximate diffuse
@@ -998,7 +998,7 @@ class Representation:
         ----------
         variance : float, optional
             The variance for approximating diffuse initial conditions. Default
-            is 1e6.
+            is `self.initial_variance`.
         """
         if variance is None:
             variance = self.initial_variance
@@ -1188,7 +1188,7 @@ class FrozenRepresentation:
         Datatype of representation matrices
     prefix : str
         BLAS prefix of representation matrices
-    shapes : dictionary of name:tuple
+    shapes : dict of str to tuple
         A dictionary recording the shapes of each of
         the representation matrices as tuples.
     endog : ndarray
@@ -1207,24 +1207,24 @@ class FrozenRepresentation:
         The selection matrix, :math:`R`.
     state_cov : ndarray
         The covariance matrix for the state equation :math:`Q`.
-    missing : array of bool
+    missing : ndarray of bool
         An array of the same size as `endog`, filled
         with boolean values that are True if the
         corresponding entry in `endog` is NaN and False
         otherwise.
-    nmissing : array of int
+    nmissing : ndarray of int
         An array of size `nobs`, where the ith entry
         is the number (between 0 and `k_endog`) of NaNs in
         the ith row of the `endog` array.
     time_invariant : bool
         Whether or not the representation matrices are time-invariant
-    initialization : Initialization object
+    initialization : Initialization
         Kalman filter initialization method.
-    initial_state : array_like
+    initial_state : ndarray
         The state vector used to initialize the Kalman filter.
-    initial_state_cov : array_like
+    initial_state_cov : ndarray
         The state covariance matrix used to initialize the Kalman filter.
-    initial_diffuse_state_cov : array_like
+    initial_diffuse_state_cov : ndarray
         The diffuse part of the state covariance matrix used to initialize
         the Kalman filter.
     initial_variance : float

--- a/statsmodels/tsa/statespace/sarimax.py
+++ b/statsmodels/tsa/statespace/sarimax.py
@@ -63,7 +63,7 @@ class SARIMAX(MLEModel):
         integer giving the periodicity (number of periods in season), often it
         is 4 for quarterly data or 12 for monthly data. Default is no seasonal
         effect.
-    trend : str{'n','c','t','ct'} or iterable, optional
+    trend : {'n', 'c', 't', 'ct'} or iterable, optional
         Parameter controlling the deterministic trend polynomial :math:`A(t)`.
         Can be specified as a string where 'c' indicates a constant (i.e., a
         degree zero component of the trend polynomial), 't' indicates a
@@ -167,7 +167,7 @@ class SARIMAX(MLEModel):
         component of the model.
     hamilton_representation : bool
         Whether or not to use the Hamilton representation of an ARMA process.
-    trend : str{'n','c','t','ct'} or iterable
+    trend : {'n', 'c', 't', 'ct'} or iterable
         Parameter controlling the deterministic
         trend polynomial :math:`A(t)`. See the class
         parameter documentation for more information.

--- a/statsmodels/tsa/statespace/simulation_smoother.py
+++ b/statsmodels/tsa/statespace/simulation_smoother.py
@@ -26,7 +26,7 @@ class SimulationSmoother(KalmanSmoother):
 
     Parameters
     ----------
-    k_endog : {array_like, int}
+    k_endog : ndarray or int
         The observed time-series process :math:`y` if array like or the
         number of variables in the process if an integer.
     k_states : int
@@ -35,7 +35,7 @@ class SimulationSmoother(KalmanSmoother):
         The dimension of a guaranteed positive definite covariance matrix
         describing the shocks in the measurement equation. Must be less than
         or equal to `k_states`. Default is `k_states`.
-    simulation_smooth_results_class : class, optional
+    simulation_smooth_results_class : type, optional
         Default results class to use to save output of simulation smoothing.
         Default is `SimulationSmoothResults`. If specified, class must extend
         from `SimulationSmoothResults`.
@@ -162,7 +162,7 @@ class SimulationSmoother(KalmanSmoother):
         simulator : SimulationSmoothResults, optional
             An existing simulator to reuse. If not specified, a new
             simulator is created using `rng`.
-        rng : int, array_like of int, numpy.random.Generator, numpy.random.RandomState, optional
+        rng : int, array_like of int, numpy.random.Generator, or numpy.random.RandomState, optional
             If `rng` is None or an int, a new ``Generator`` is created
             (seeded with `rng` if an int is given). If `rng` is already a
             ``Generator`` or ``RandomState`` instance, that instance is
@@ -198,7 +198,7 @@ class SimulationSmoother(KalmanSmoother):
         ----------
         nsimulations : int
             The number of observations to simulate.
-        rng : int, array_like of int, numpy.random.Generator, numpy.random.RandomState, optional
+        rng : int, array_like of int, numpy.random.Generator, or numpy.random.RandomState, optional
             If `rng` is None or an int, a new ``Generator`` is created
             (seeded with `rng` if an int is given). If `rng` is already a
             ``Generator`` or ``RandomState`` instance, that instance is
@@ -242,7 +242,7 @@ class SimulationSmoother(KalmanSmoother):
             based on the Cholesky Factor Algorithm (CFA) approach. The CFA
             approach is not applicable to all state space models, but can be
             faster for the cases in which it is supported.
-        results_class : class, optional
+        results_class : type, optional
             Default results class to use to save output of simulation
             smoothing. Default is `SimulationSmoothResults`. If specified,
             class must extend from `SimulationSmoothResults`.
@@ -254,12 +254,12 @@ class SimulationSmoother(KalmanSmoother):
             smoothing will not be performed), so that only the `generated_obs`
             and `generated_state` attributes will be available. Default is -1,
             which uses the number of observations in the model.
-        rng : int, array_like of int, numpy.random.Generator, numpy.random.RandomState, optional
+        rng : int, array_like of int, numpy.random.Generator, or numpy.random.RandomState, optional
             If `rng` is None or an int, a new ``Generator`` is created
             (seeded with `rng` if an int is given). If `rng` is already a
             ``Generator`` or ``RandomState`` instance, that instance is
             used.
-        rng : int, array_like of int, numpy.random.Generator, numpy.random.RandomState, optional
+        rng : int, array_like of int, numpy.random.Generator, or numpy.random.RandomState, optional
             .. deprecated:: 0.15
 
                random_state has been deprecated. In-line with SPEC-007, use
@@ -350,12 +350,12 @@ class SimulationSmoothResults:
         A Statespace representation
     simulation_smoother : {{prefix}}SimulationSmoother object
         The Cython simulation smoother object with which to simulation smooth.
-    rng : int, array_like of int, numpy.random.Generator, numpy.random.RandomState, optional
+    rng : int, array_like of int, numpy.random.Generator, or numpy.random.RandomState, optional
         If `rng` is None or an int, a new ``Generator`` is created
         (seeded with `rng` if an int is given). If `rng` is already a
         ``Generator`` or ``RandomState`` instance, that instance is
         used.
-    rng : int, array_like of int, numpy.random.Generator, numpy.random.RandomState, optional
+    rng : int, array_like of int, numpy.random.Generator, or numpy.random.RandomState, optional
         .. deprecated:: 0.15
 
            random_state has been deprecated. In-line with SPEC-007, use
@@ -636,12 +636,12 @@ class SimulationSmoothResults:
             then it is assumed to contain draws from the standard Normal
             distribution that must be transformed using the `initial_state_cov`
             covariance matrix. Default is False.
-        rng : int, array_like of int, numpy.random.Generator, numpy.random.RandomState, optional
+        rng : int, array_like of int, numpy.random.Generator, or numpy.random.RandomState, optional
             If `rng` is None or an int, a new ``Generator`` is created
             (seeded with `rng` if an int is given). If `rng` is already a
             ``Generator`` or ``RandomState`` instance, that instance is
             used.
-        rng : int, array_like of int, numpy.random.Generator, numpy.random.RandomState, optional
+        rng : int, array_like of int, numpy.random.Generator, or numpy.random.RandomState, optional
             .. deprecated:: 0.15
 
                random_state has been deprecated. In-line with SPEC-007, use

--- a/statsmodels/tsa/statespace/structural.py
+++ b/statsmodels/tsa/statespace/structural.py
@@ -56,16 +56,16 @@ class UnobservedComponents(MLEModel):
     ----------
     endog : array_like
         The observed time-series process :math:`y`
-    level : {bool, str}, optional
+    level : bool or str, optional
         Whether or not to include a level component. Default is False. Can also
         be a string specification of the level / trend component; see Notes
         for available model specification strings.
     trend : bool, optional
         Whether or not to include a trend component. Default is False. If True,
         `level` must also be True.
-    seasonal : {int, None}, optional
+    seasonal : int, optional
         The period of the seasonal component, if any. Default is None.
-    freq_seasonal : {list[dict], None}, optional.
+    freq_seasonal : list of dict, optional
         Whether (and how) to model seasonal component(s) with trig. functions.
         If specified, there is one dictionary for each frequency-domain
         seasonal component.  Each dictionary must have the key, value pair for
@@ -74,9 +74,9 @@ class UnobservedComponents(MLEModel):
         dictionaries, it defaults to the floor of period/2.
     cycle : bool, optional
         Whether or not to include a cycle component. Default is False.
-    autoregressive : {int, None}, optional
+    autoregressive : int, optional
         The order of the autoregressive component. Default is None.
-    exog : {array_like, None}, optional
+    exog : array_like, optional
         Exogenous variables.
     irregular : bool, optional
         Whether or not to include an irregular component. Default is False.
@@ -86,7 +86,7 @@ class UnobservedComponents(MLEModel):
         Whether or not any trend component is stochastic. Default is False.
     stochastic_seasonal : bool, optional
         Whether or not any seasonal component is stochastic. Default is True.
-    stochastic_freq_seasonal : list[bool], optional
+    stochastic_freq_seasonal : list of bool, optional
         Whether or not each seasonal component(s) is (are) stochastic.  Default
         is True for each component.  The list should be of the same length as
         freq_seasonal.
@@ -1637,7 +1637,7 @@ class UnobservedComponentsResults(MLEResults):
 
         Parameters
         ----------
-        which : {'filtered', 'smoothed'}, or None, optional
+        which : {'filtered', 'smoothed'}, optional
             Type of state estimate to plot. Default is 'smoothed' if smoothed
             results are available otherwise 'filtered'.
         alpha : float, optional

--- a/statsmodels/tsa/statespace/tools.py
+++ b/statsmodels/tsa/statespace/tools.py
@@ -145,7 +145,7 @@ def companion_matrix(polynomial):
 
     Parameters
     ----------
-    polynomial : array_like or list
+    polynomial : array_like or int
         If an iterable, interpreted as the coefficients of the polynomial from
         which to form the companion matrix. Polynomial coefficients are in
         order of increasing degree, and may be either scalars (as in an AR(p)
@@ -280,7 +280,7 @@ def diff(series, k_diff=1, k_seasonal_diff=None, seasonal_periods=1):
         The series to be differenced.
     k_diff : int, optional
         The number of simple differences to perform. Default is 1.
-    k_seasonal_diff : int or None, optional
+    k_seasonal_diff : int, optional
         The number of seasonal differences to perform. Default is no seasonal
         differencing.
     seasonal_periods : int, optional
@@ -322,11 +322,11 @@ def concat(series, axis=0, allow_mix=False):
 
     Parameters
     ----------
-    series : iterable
-        An iterable of series to be concatenated
+    series : sequence of array_like
+        A sequence of series to be concatenated
     axis : int, optional
         The axis along which to concatenate. Default is 0 (rows).
-    allow_mix : bool
+    allow_mix : bool, optional
         Whether or not to allow a mix of pandas and non-pandas objects. Default
         is False. If true, the returned object is an ndarray, and additional
         pandas metadata (e.g., column names, indices, etc) is lost.
@@ -403,13 +403,13 @@ def is_invertible(polynomial, threshold=1 - 1e-10):
 
     Parameters
     ----------
-    polynomial : array_like or tuple, list
+    polynomial : array_like or list of array_like
         Coefficients of a polynomial, in order of increasing degree.
         For example, `polynomial=[1, -0.5]` corresponds to the polynomial
         :math:`1 - 0.5x` which has root :math:`2`. If it is a matrix
         polynomial (in which case the coefficients are coefficient matrices),
         a tuple or list of matrices should be passed.
-    threshold : number
+    threshold : float, optional
         Allowed threshold for `is_invertible` to return True. Default is 1.
 
     See Also
@@ -812,7 +812,7 @@ def constrain_stationary_multivariate_python(unconstrained, error_variance,
 
     Parameters
     ----------
-    unconstrained : array or list
+    unconstrained : ndarray or list of ndarray
         Arbitrary matrices to be transformed to stationary coefficient matrices
         of the VAR. If a list, should be a list of length `order`, where each
         element is an array sized `k_endog` x `k_endog`. If an array, should be
@@ -835,7 +835,7 @@ def constrain_stationary_multivariate_python(unconstrained, error_variance,
 
     Returns
     -------
-    constrained : array or list
+    constrained : ndarray or list of ndarray
         Transformed coefficient matrices leading to a stationary VAR
         representation. Will match the type of the passed `unconstrained`
         variable (so if a list was passed, a list will be returned).
@@ -1070,7 +1070,7 @@ def _compute_multivariate_acovf_from_coefficients(
 
     Parameters
     ----------
-    coefficients : array or list
+    coefficients : ndarray or list of ndarray
         The coefficients matrices. If a list, should be a list of length
         `order`, where each element is an array sized `k_endog` x `k_endog`. If
         an array, should be the coefficient matrices horizontally concatenated
@@ -1361,7 +1361,7 @@ def _compute_multivariate_pacf_from_coefficients(constrained, error_variance,
 
     Parameters
     ----------
-    constrained : array or list
+    constrained : ndarray or list of ndarray
         The coefficients matrices. If a list, should be a list of length
         `order`, where each element is an array sized `k_endog` x `k_endog`. If
         an array, should be the coefficient matrices horizontally concatenated
@@ -1422,7 +1422,7 @@ def unconstrain_stationary_multivariate(constrained, error_variance):
 
     Parameters
     ----------
-    constrained : array or list
+    constrained : ndarray or list of ndarray
         Constrained parameters of, e.g., an autoregressive or moving average
         component, to be transformed to arbitrary parameters used by the
         optimizer. If a list, should be a list of length `order`, where each
@@ -1436,7 +1436,7 @@ def unconstrain_stationary_multivariate(constrained, error_variance):
 
     Returns
     -------
-    unconstrained : ndarray
+    unconstrained : ndarray or list of ndarray
         Unconstrained parameters used by the optimizer. Will match the type
         of the passed `constrained` variable (so if a list was passed, a
         list will be returned).
@@ -1494,7 +1494,7 @@ def validate_matrix_shape(name, shape, nrows, ncols, nobs):
     ----------
     name : str
         The name of the matrix being validated (used in exception messages)
-    shape : array_like
+    shape : sequence of int
         The shape of the matrix to be validated. May be of size 2 or (if
         the matrix is time-varying) 3.
     nrows : int
@@ -1545,7 +1545,7 @@ def validate_vector_shape(name, shape, nrows, nobs):
     ----------
     name : str
         The name of the vector being validated (used in exception messages)
-    shape : array_like
+    shape : sequence of int
         The shape of the vector to be validated. May be of size 1 or (if
         the vector is time-varying) 2.
     nrows : int
@@ -1613,7 +1613,7 @@ def reorder_missing_matrix(matrix, missing, reorder_rows=False,
 
     Returns
     -------
-    reordered_matrix : array_like
+    reordered_matrix : ndarray
         The reordered matrix.
     """
     if prefix is None:
@@ -1648,7 +1648,7 @@ def reorder_missing_vector(vector, missing, inplace=False, prefix=None):
 
     Returns
     -------
-    reordered_vector : array_like
+    reordered_vector : ndarray
         The reordered vector.
     """
     if prefix is None:
@@ -1696,7 +1696,7 @@ def copy_missing_matrix(A, B, missing, missing_rows=False, missing_cols=False,
 
     Returns
     -------
-    copied_matrix : array_like
+    copied_matrix : ndarray
         The matrix B with the non-missing submatrix of A copied onto it.
     """
     if prefix is None:
@@ -1741,7 +1741,7 @@ def copy_missing_vector(a, b, missing, inplace=False, prefix=None):
 
     Returns
     -------
-    copied_vector : array_like
+    copied_vector : ndarray
         The vector b with the non-missing subvector of a copied onto it.
     """
     if prefix is None:
@@ -1797,7 +1797,7 @@ def copy_index_matrix(A, B, index, index_rows=False, index_cols=False,
 
     Returns
     -------
-    copied_matrix : array_like
+    copied_matrix : ndarray
         The matrix B with the non-index submatrix of A copied onto it.
     """
     if prefix is None:
@@ -1842,7 +1842,7 @@ def copy_index_vector(a, b, index, inplace=False, prefix=None):
 
     Returns
     -------
-    copied_vector : array_like
+    copied_vector : ndarray
         The vector b with the non-index subvector of a copied onto it.
     """
     if prefix is None:
@@ -1880,7 +1880,7 @@ def prepare_exog(exog):
     k_exog : int
         The number of exogenous regressors (columns of `exog`). Zero if
         `exog` is None.
-    exog : array_like or None
+    exog : ndarray, DataFrame, or None
         The `exog` array, coerced to a two-dimensional array (or
         `pandas.DataFrame`, if `exog` was a pandas object) if it was not
         already. None if `exog` is None.
@@ -1908,7 +1908,7 @@ def prepare_trend_spec(trend):
 
     Parameters
     ----------
-    trend : {str, array_like, None}
+    trend : str, array_like, or None
         The trend specification. Can be a string, in which case it must be
         one of 'n' (no trend), 'c' (constant), 't' (linear trend in time),
         'ct' (both constant and linear trend), or 'ctt' (constant, linear
@@ -2157,7 +2157,7 @@ def compute_smoothed_state_weights(results, compute_t=None, compute_j=None,
 
     Returns
     -------
-    weights : array_like
+    weights : ndarray
         Weight matrices that can be used to construct the smoothed state from
         the observations. The returned matrix is always shaped
         `(nobs, nobs, k_states, k_endog)`, and entries that are not computed
@@ -2168,11 +2168,11 @@ def compute_smoothed_state_weights(results, compute_t=None, compute_j=None,
         this matrix contains the weight of the `p`-th element of the
         observation vector at time `j` in constructing the `m`-th element of
         the smoothed state vector at time `t`.
-    state_intercept_weights : array_like
+    state_intercept_weights : ndarray
         Weight matrices describing the impact of the state intercept on the
         smoothed state vector. The returned matrix is always shaped
         `(nobs, nobs, k_states, k_states)`.
-    prior_weights : array_like
+    prior_weights : ndarray
         Weight matrices that describe the impact of the prior (also called the
         initialization) on the smoothed state vector. The returned matrix is
         always shaped `(nobs, k_states, k_states)`. If prior weights are not
@@ -2267,15 +2267,15 @@ def get_impact_dates(previous_model, updated_model, impact_date=None,
         Model used to compute the index. In the case of computing impacts of
         data updates, this would be the model estimated with the updated
         dataset. Otherwise, can be the same as `previous_model`.
-    impact_date : {int, str, datetime}, optional
+    impact_date : int, str, or datetime, optional
         Specific individual impact date. Cannot be used in combination with
         `start`, `end`, or `periods`.
-    start : {int, str, datetime}, optional
+    start : int, str, or datetime, optional
         Starting point of the impact dates. If given, one of `end` or `periods`
         must also be given. If a negative integer, will be computed relative to
         the dates in the `updated_model` index. Cannot be used in combination
         with `impact_date`.
-    end : {int, str, datetime}, optional
+    end : int, str, or datetime, optional
         Ending point of the impact dates. If given, one of `start` or `periods`
         must also be given. If a negative integer, will be computed relative to
         the dates in the `updated_model` index. Cannot be used in combination

--- a/statsmodels/tsa/statespace/varmax.py
+++ b/statsmodels/tsa/statespace/varmax.py
@@ -46,7 +46,7 @@ class VARMAX(MLEModel):
     order : iterable
         The (p,q) order of the model for the number of AR and MA parameters to
         use.
-    trend : str{'n','c','t','ct'} or iterable, optional
+    trend : {'n', 'c', 't', 'ct'} or iterable, optional
         Parameter controlling the deterministic trend polynomial :math:`A(t)`.
         Can be specified as a string where 'c' indicates a constant (i.e., a
         degree zero component of the trend polynomial), 't' indicates a
@@ -82,7 +82,7 @@ class VARMAX(MLEModel):
     order : iterable
         The (p,q) order of the model for the number of AR and MA parameters to
         use.
-    trend : str{'n','c','t','ct'} or iterable
+    trend : {'n', 'c', 't', 'ct'} or iterable
         Parameter controlling the deterministic trend polynomial :math:`A(t)`.
         Can be specified as a string where 'c' indicates a constant (i.e., a
         degree zero component of the trend polynomial), 't' indicates a


### PR DESCRIPTION
- [X] code/documentation is well formatted.
- [X] properly formatted commit message. See
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message).

#### AI Disclosure

Contributions must comply with the statsmodels [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html).

If using AI tools, edit the second option to explain which tool was selected and
how the tool's output was used.

Please complete **one** of the following:

- [ ] No AI tools were used to develop this pull request.
- [X] AI tools were used.
      Tool(s): Claude
      Used for: docstrign cleaning
      I have personally read, understood, and can explain every line of this diff, and
      have verified the statistical/numerical correctness of the change.

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows
  using the Windows System for Linux once `flake8` is installed in the
  local Linux environment. While passing this test is not required, it is good practice and it help
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.
* If AI tools were used to help write this PR, see the
  [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html) for what disclosure
  and review is expected of you before submitting.

</details>
