### PR TITLE
BUG: Correct distargs usage in scale_trimmed

### DIFF
--- a/statsmodels/robust/scale.py
+++ b/statsmodels/robust/scale.py
@@ -622,10 +622,10 @@ def scale_trimmed(data, alpha, center="median", axis=0, distr=None, distargs=Non
 
     if distr is None:
         distr = stats.norm
-        if distargs is None:
-            distargs = ()
+    if distargs is None:
+        distargs = ()
 
-    x = np.array(data)  # make copy for inplace sort
+    x = np.array(data, copy=True)  # make copy for inplace sort
     if axis is None:
         x = x.ravel()
         axis = 0

--- a/statsmodels/robust/tests/test_scale.py
+++ b/statsmodels/robust/tests/test_scale.py
@@ -462,3 +462,19 @@ def test_scale_trimmed_approx():
     assert_allclose(s2, s, rtol=1e-1)
     s = scale_trimmed(x, alpha, distr=stats.t, distargs=(100,)).scale
     assert_allclose(s, [2], rtol=1e-1)
+
+
+def test_scale_trimmed_distarge():
+    nobs = 500
+    rs = np.random.RandomState(965578)
+    x = 2 * rs.randn(nobs)
+    x[:10] = 60
+
+    alpha = 0.2
+    res = scale.scale_trimmed(x, alpha)
+    assert_allclose(res.scale, 2, rtol=1e-1)
+    distr = stats.norm
+    res_distr = scale.scale_trimmed(x, alpha, distr=distr)
+    assert_allclose(res_distr.scale, res.scale)
+    res_distargs = scale.scale_trimmed(x, alpha, distargs=())
+    assert_allclose(res_distargs.scale, res.scale)


### PR DESCRIPTION
Ensure it is not None anytime it may be used

- [x] tests added / passed.
- [x] code/documentation is well formatted.
- [x] properly formatted commit message. See
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message).

#### AI Disclosure

Contributions must comply with the statsmodels [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html).

If using AI tools, edit the second option to explain which tool was selected and
how the tool's output was used.

Please complete **one** of the following:

- [x] No AI tools were used to develop this pull request.
- [ ] AI tools were used.
      Tool(s): `<name(s), e.g. Copilot, Claude, ChatGPT>`.
      Used for: `<e.g. drafting an implementation, writing tests, debugging, editing docstrings>`.
      I have personally read, understood, and can explain every line of this diff, and
      have verified the statistical/numerical correctness of the change.

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows
  using the Windows System for Linux once `flake8` is installed in the
  local Linux environment. While passing this test is not required, it is good practice and it help
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.
* If AI tools were used to help write this PR, see the
  [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html) for what disclosure
  and review is expected of you before submitting.

</details>
