### PR TITLE
BUG: Fix bug in line-style application

### DIFF
--- a/statsmodels/graphics/agreement.py
+++ b/statsmodels/graphics/agreement.py
@@ -52,10 +52,12 @@ def mean_diff_plot(
         matplotlib Axes.scatter plotting method.
     mean_line_kwds : dict, optional
         Options to style the mean difference line. Accepts any keywords for
-        the matplotlib Axes.axhline plotting method.
+        the matplotlib Axes.axhline plotting method. Keys that are not
+        supplied default to a gray dashed line of width 1.
     limit_lines_kwds : dict, optional
         Options to style the limit-of-agreement lines. Accepts any keywords
-        for the matplotlib Axes.axhline plotting method.
+        for the matplotlib Axes.axhline plotting method. Keys that are not
+        supplied default to gray dotted lines of width 1.
 
     Returns
     -------
@@ -112,9 +114,9 @@ def mean_diff_plot(
         if "linewidth" not in kwds:
             kwds["linewidth"] = 1
     if "linestyle" not in mean_line_kwds:
-        kwds["linestyle"] = "--"
+        mean_line_kwds["linestyle"] = "--"
     if "linestyle" not in limit_lines_kwds:
-        kwds["linestyle"] = ":"
+        limit_lines_kwds["linestyle"] = ":"
     ax.scatter(means, diffs, **scatter_kwds)  # Plot the means against the diffs.
     ax.axhline(mean_diff, **mean_line_kwds)  # draw mean line.
 

--- a/statsmodels/graphics/tests/test_agreement.py
+++ b/statsmodels/graphics/tests/test_agreement.py
@@ -39,3 +39,35 @@ def test_mean_diff_plot(close_figures):
     mean_diff_plot(m1, m2, mean_line_kwds={"color": "green", "lw": 5})
 
     mean_diff_plot(m1, m2, limit_lines_kwds={"color": "green", "lw": 5, "ls": "dotted"})
+
+
+@pytest.mark.thread_unsafe(reason="Uses matplotlib")
+@pytest.mark.matplotlib
+def test_mean_diff_plot_linestyles(close_figures):
+    import matplotlib.pyplot as plt
+
+    rs = np.random.RandomState(11111)
+    m1 = rs.random(20)
+    m2 = rs.random(20)
+
+    # The mean line defaults to dashed and the limit lines to dotted
+    fig, ax = plt.subplots()
+    mean_diff_plot(m1, m2, ax=ax)
+    mean_line, lower, upper = ax.lines
+    assert mean_line.get_linestyle() == "--"
+    assert lower.get_linestyle() == ":"
+    assert upper.get_linestyle() == ":"
+
+    # An explicit linestyle is used for the line it was supplied for
+    fig, ax = plt.subplots()
+    mean_diff_plot(
+        m1,
+        m2,
+        ax=ax,
+        mean_line_kwds={"linestyle": "-."},
+        limit_lines_kwds={"linestyle": "-"},
+    )
+    mean_line, lower, upper = ax.lines
+    assert mean_line.get_linestyle() == "-."
+    assert lower.get_linestyle() == "-"
+    assert upper.get_linestyle() == "-"


### PR DESCRIPTION
Ensure that the line style is set in the correct keyword arguments

- [X} tests added
- [X] code/documentation is well formatted.
- [X] properly formatted commit message. See
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message).

#### AI Disclosure

Contributions must comply with the statsmodels [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html).

If using AI tools, edit the second option to explain which tool was selected and
how the tool's output was used.

Please complete **one** of the following:

- [ ] No AI tools were used to develop this pull request.
- [X] AI tools were used.
      Tool(s): Claude
      Used for: Test writing
      I have personally read, understood, and can explain every line of this diff, and
      have verified the statistical/numerical correctness of the change.

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows
  using the Windows System for Linux once `flake8` is installed in the
  local Linux environment. While passing this test is not required, it is good practice and it help
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.
* If AI tools were used to help write this PR, see the
  [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html) for what disclosure
  and review is expected of you before submitting.

</details>
