### PR TITLE
BUG: Enable percentile in _select_sigma

### DIFF
--- a/statsmodels/nonparametric/bandwidths.py
+++ b/statsmodels/nonparametric/bandwidths.py
@@ -1,9 +1,10 @@
 from statsmodels.compat.pandas import Substitution
 
 import numpy as np
-from scipy.stats import scoreatpercentile
+from scipy.stats import norm, scoreatpercentile
 
 from statsmodels.sandbox.nonparametric import kernels
+from statsmodels.tools.validation import float_like
 
 
 def _select_sigma(x, percentile=25):
@@ -14,23 +15,37 @@ def _select_sigma(x, percentile=25):
     ----------
     x : array_like
         Array for which to get the dispersion estimate.
-    percentile : int, optional
-        Unused.
+    percentile : float, optional
+        The lower percentile of the inter-percentile range, in percent. The
+        upper percentile is ``100 - percentile``. The range is normalized by
+        the same range of the standard normal distribution, so that the
+        result estimates the standard deviation when the data are normal.
+        The default, 25, gives the interquartile range and uses Silverman's
+        rounded normalizing constant of 1.349.  percentile must be strictly
+        between 0 and 50.
 
     Returns
     -------
     float
         The smaller of the sample standard deviation and the normalized
-        interquartile range.
+        inter-percentile range.
 
     References
     ----------
     Silverman (1986) p.47
     """
-    # normalize = norm.ppf(.75) - norm.ppf(.25)
-    # TODO: Make percentile work for other values than 75/25
-    normalize = 1.349
-    IQR = (scoreatpercentile(x, 100 - percentile) - scoreatpercentile(x, percentile)) / normalize
+    percentile = float_like(percentile, "percentile")
+    if not 0 < percentile < 50:
+        raise ValueError("percentile must be between 0 and 50")
+    if percentile == 25:
+        # Silverman (1986) p.47 rounds the normal interquartile range to
+        # four digits. The rounded value is retained for the default so
+        # that the bandwidths it produces are unchanged.
+        normalize = 1.349
+    else:
+        normalize = norm.ppf(1 - percentile / 100.0) - norm.ppf(percentile / 100.0)
+    iqr = scoreatpercentile(x, 100 - percentile) - scoreatpercentile(x, percentile)
+    IQR = iqr / normalize
     std_dev = np.std(x, axis=0, ddof=1)
     if IQR > 0:
         return np.minimum(std_dev, IQR)

--- a/statsmodels/nonparametric/tests/test_bandwidths.py
+++ b/statsmodels/nonparametric/tests/test_bandwidths.py
@@ -11,7 +11,11 @@ import pytest
 from scipy import stats
 
 from statsmodels.distributions.mixture_rvs import mixture_rvs
-from statsmodels.nonparametric.bandwidths import bw_normal_reference, select_bandwidth
+from statsmodels.nonparametric.bandwidths import (
+    _select_sigma,
+    bw_normal_reference,
+    select_bandwidth,
+)
 from statsmodels.sandbox.nonparametric import kernels
 
 # setup test data
@@ -44,6 +48,28 @@ class TestBandwidthCalculation:
         bw_expected = 0.29781147113698891
         bw = bw_normal_reference(Xi)
         assert_allclose(bw, bw_expected)
+
+
+@pytest.mark.parametrize("percentile", [40, 45])
+def test_select_sigma_percentile(percentile):
+    # the inter-percentile range must be normalized by the same range of the
+    # standard normal, otherwise a non-default percentile badly understates
+    # the dispersion of normal data
+    rs = np.random.RandomState(12345)
+    x = rs.standard_normal(50000)
+    assert_allclose(
+        _select_sigma(x, percentile=percentile), np.std(x, ddof=1), rtol=0.02
+    )
+
+
+def test_select_sigma_default_normalization():
+    # the default keeps Silverman's rounded constant, so bandwidths that
+    # depend on it are unchanged
+    rs = np.random.RandomState(12345)
+    x = rs.standard_normal(500)
+    iqr = stats.scoreatpercentile(x, 75) - stats.scoreatpercentile(x, 25)
+    expected = np.minimum(np.std(x, ddof=1), iqr / 1.349)
+    assert_allclose(_select_sigma(x), expected, rtol=0, atol=0)
 
 
 class CheckNormalReferenceConstant:


### PR DESCRIPTION
Enable previously disabled sigma and protext against errors

- [X] tests added / passed.
- [X] code/documentation is well formatted.
- [X] properly formatted commit message. See
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message).

#### AI Disclosure

Contributions must comply with the statsmodels [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html).

If using AI tools, edit the second option to explain which tool was selected and
how the tool's output was used.

Please complete **one** of the following:

- [ ] No AI tools were used to develop this pull request.
- [X] AI tools were used.
      Tool(s): Claude
      Used for: test wiriting
      I have personally read, understood, and can explain every line of this diff, and
      have verified the statistical/numerical correctness of the change.

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows
  using the Windows System for Linux once `flake8` is installed in the
  local Linux environment. While passing this test is not required, it is good practice and it help
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.
* If AI tools were used to help write this PR, see the
  [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html) for what disclosure
  and review is expected of you before submitting.

</details>
