### PR TITLE
BUG: Fix factor reverse intent

### DIFF
--- a/statsmodels/multivariate/factor.py
+++ b/statsmodels/multivariate/factor.py
@@ -35,13 +35,28 @@ def _check_args_1(endog, n_factor, corr, nobs):
         Directly specified correlation matrix.
     nobs : int or None
         The number of observations.
+
+    Raises
+    ------
+    ValueError
+        If neither `endog` nor `corr` is provided, or if `n_factor` is not
+        positive.
+
+    Warns
+    -----
+    SpecificationWarning
+        If both `endog` and `corr` are provided, since `corr` is then
+        ignored.
+    UserWarning
+        If `nobs` is provided together with `endog`, since `nobs` is then
+        taken from `endog`.
     """
-    msg = "Either endog or corr must be provided."
-    if endog is not None and corr is not None:
-        raise ValueError(msg)
     if endog is None and corr is None:
+        raise ValueError("Either endog or corr must be provided.")
+    if endog is not None and corr is not None:
         warnings.warn(
-            "Both endog and corr are provided, corr will be used for factor analysis.",
+            "Both endog and corr are provided, endog will be used for factor "
+            "analysis.",
             SpecificationWarning,
             stacklevel=2,
         )
@@ -99,8 +114,10 @@ class Factor(Model):
         The number of factors to extract
     corr : array_like, optional
         Directly specify the correlation matrix instead of estimating
-        it from `endog`.  If provided, `endog` is not used for the
-        factor analysis, it may be used in post-estimation.
+        it from `endog`.  Exactly one of `endog` and `corr` is required.
+        If both are provided a ``SpecificationWarning`` is raised and
+        `corr` is ignored in favor of the correlation matrix computed
+        from `endog`.
     method : {'pa', 'ml'}, optional
         The method to extract factors, currently must be either 'pa'
         for principal axis factor analysis or 'ml' for maximum

--- a/statsmodels/multivariate/tests/test_factor.py
+++ b/statsmodels/multivariate/tests/test_factor.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import warnings
 
 import numpy as np
 from numpy.testing import (
@@ -13,6 +14,7 @@ import pandas as pd
 import pytest
 
 from statsmodels.multivariate.factor import Factor
+from statsmodels.tools.sm_exceptions import SpecificationWarning
 
 try:
     import matplotlib.pyplot as plt
@@ -87,6 +89,24 @@ def test_direct_corr_matrix():
     # Test set endog_names with the wrong number of elements
     with pytest.raises(ValueError):
         mod.endog_names = X.iloc[:, :1].columns
+
+
+def test_no_endog_no_corr_raises():
+    # Providing neither endog nor corr must raise, and must not first emit
+    # a warning claiming that both were provided
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        with pytest.raises(ValueError, match="Either endog or corr"):
+            Factor(None, 2, corr=None)
+
+
+def test_both_endog_and_corr_warns():
+    # Providing both must warn and fall back to endog, not raise
+    endog = X.iloc[:, 1:-1]
+    corr = np.eye(endog.shape[1])
+    with pytest.warns(SpecificationWarning, match="endog will be used"):
+        mod = Factor(endog, 2, corr=corr, smc=False)
+    assert_allclose(mod.corr, np.corrcoef(endog, rowvar=0))
 
 
 def test_unknown_fa_method_error():


### PR DESCRIPTION
- [X] tests added / passed.
- [X] code/documentation is well formatted.
- [X] properly formatted commit message. See
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message).

#### AI Disclosure

Contributions must comply with the statsmodels [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html).

If using AI tools, edit the second option to explain which tool was selected and
how the tool's output was used.

Please complete **one** of the following:

- [ ] No AI tools were used to develop this pull request.
- [X] AI tools were used.
      Tool(s): Claude
      Used for: test writing
      I have personally read, understood, and can explain every line of this diff, and
      have verified the statistical/numerical correctness of the change.

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows
  using the Windows System for Linux once `flake8` is installed in the
  local Linux environment. While passing this test is not required, it is good practice and it help
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.
* If AI tools were used to help write this PR, see the
  [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html) for what disclosure
  and review is expected of you before submitting.

</details>
