### PR TITLE
BUG: Only initialize trend when required

### DIFF
--- a/statsmodels/tsa/exponential_smoothing/initialization.py
+++ b/statsmodels/tsa/exponential_smoothing/initialization.py
@@ -74,7 +74,7 @@ def _initialization_simple(endog, trend=False, seasonal=False,
         initial_level = np.mean(endog[:seasonal_periods])
         m = seasonal_periods
 
-        if trend is not None:
+        if trend in ("add", "mul"):
             initial_trend = (pd.Series(endog).diff(m)[m:2 * m] / m).mean()
 
         if seasonal == "add":

--- a/statsmodels/tsa/tests/test_exponential_smoothing.py
+++ b/statsmodels/tsa/tests/test_exponential_smoothing.py
@@ -18,6 +18,9 @@ import scipy.stats
 from statsmodels.iolib.summary import Summary
 from statsmodels.tsa import holtwinters
 from statsmodels.tsa.exponential_smoothing.ets import ETSModel
+from statsmodels.tsa.exponential_smoothing.initialization import (
+    _initialization_simple,
+)
 import statsmodels.tsa.statespace.exponential_smoothing as statespace
 
 # This contains tests for the exponential smoothing implementation in
@@ -541,6 +544,28 @@ def test_initialization_known(austourists):
     assert initial_level == internal_params[4]
     assert initial_trend == internal_params[5]
     assert internal_params[6] == 0
+
+
+@pytest.mark.parametrize("trend", [False, None])
+def test_initialization_simple_seasonal_no_trend(trend):
+    # `False` is the no-trend sentinel used by ExponentialSmoothing, so a
+    # seasonal model without a trend must not get an initial trend value
+    y = np.arange(1.0, 25.0) + np.tile([1.0, 2.0, 3.0, 0.0], 6)
+    level, initial_trend, seasonal = _initialization_simple(
+        y, trend=trend, seasonal="add", seasonal_periods=4
+    )
+    assert initial_trend is None
+    assert level is not None
+    assert seasonal is not None
+
+
+@pytest.mark.parametrize("trend", ["add", "mul"])
+def test_initialization_simple_seasonal_with_trend(trend):
+    y = np.arange(1.0, 25.0) + np.tile([1.0, 2.0, 3.0, 0.0], 6)
+    _, initial_trend, _ = _initialization_simple(
+        y, trend=trend, seasonal="add", seasonal_periods=4
+    )
+    assert_allclose(initial_trend, 1.0)
 
 
 def test_initialization_heuristic(oildata):


### PR DESCRIPTION
- [X] tests added / passed.
- [X] code/documentation is well formatted.
- [X] properly formatted commit message. See
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message).

#### AI Disclosure

Contributions must comply with the statsmodels [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html).

If using AI tools, edit the second option to explain which tool was selected and
how the tool's output was used.

Please complete **one** of the following:

- [ ] No AI tools were used to develop this pull request.
- [X] AI tools were used.
      Tool(s): Claude
      Used for: test writing
      I have personally read, understood, and can explain every line of this diff, and
      have verified the statistical/numerical correctness of the change.

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows
  using the Windows System for Linux once `flake8` is installed in the
  local Linux environment. While passing this test is not required, it is good practice and it help
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.
* If AI tools were used to help write this PR, see the
  [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html) for what disclosure
  and review is expected of you before submitting.

</details>
