### PR TITLE
BUG: Correct hess choice in betareg

### DIFF
--- a/statsmodels/othermod/betareg.py
+++ b/statsmodels/othermod/betareg.py
@@ -595,18 +595,19 @@ class BetaModel(GenericLikelihoodModel):
         params : ndarray
             Parameter at which Hessian is evaluated.
         observed : bool, optional
-            If True, then the observed Hessian is returned (default).
+            If True, then the observed Hessian is returned.
             If False, then the expected information matrix is returned.
+            If None, the default, then the choice is made by the model's
+            ``hess_type`` attribute, which is "oim", i.e. observed, unless
+            ``fit`` was called with ``cov_type="eim"``.
 
         Returns
         -------
         hessian : ndarray
             Hessian, i.e., observed information, or expected information matrix.
         """
-        if self.hess_type == "eim":
-            observed = False
-        else:
-            observed = True
+        if observed is None:
+            observed = self.hess_type != "eim"
         _, hf = self.score_hessian_factor(
             params, return_hessian=True, observed=observed
         )

--- a/statsmodels/othermod/tests/test_beta.py
+++ b/statsmodels/othermod/tests/test_beta.py
@@ -416,6 +416,31 @@ class TestBetaIncome:
         assert_allclose(frame, frame0, rtol=1e-13, atol=1e-13)
 
 
+def test_hessian_observed_argument():
+    # `observed` must be honored when supplied, and only fall back to
+    # hess_type when it is None
+    formula = "methylation ~ gender + CpG"
+    mod = BetaModel.from_formula(formula, methylation,
+                                 exog_precision_formula="~ age",
+                                 link_precision=links.Log())
+    res = mod.fit()
+    params = res.params
+
+    hess_obs = mod.hessian(params, observed=True)
+    hess_eim = mod.hessian(params, observed=False)
+    assert not np.allclose(hess_obs, hess_eim)
+
+    # the default follows hess_type, which fit sets to "oim"
+    assert mod.hess_type == "oim"
+    assert_allclose(mod.hessian(params), hess_obs, rtol=1e-13)
+
+    mod.hess_type = "eim"
+    assert_allclose(mod.hessian(params), hess_eim, rtol=1e-13)
+
+    # an explicit argument still wins over hess_type
+    assert_allclose(mod.hessian(params, observed=True), hess_obs, rtol=1e-13)
+
+
 def test_summary_after_remove_data():
     # summary() must still work after remove_data() has been called
     model = "I(food/income) ~ income + persons"


### PR DESCRIPTION
- [X] tests added / passed.
- [X] code/documentation is well formatted.
- [X] properly formatted commit message. See
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message).

#### AI Disclosure

Contributions must comply with the statsmodels [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html).

If using AI tools, edit the second option to explain which tool was selected and
how the tool's output was used.

Please complete **one** of the following:

- [ ] No AI tools were used to develop this pull request.
- [X] AI tools were used.
      Tool(s): Claude
      Used for: test writing
      I have personally read, understood, and can explain every line of this diff, and
      have verified the statistical/numerical correctness of the change.

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows
  using the Windows System for Linux once `flake8` is installed in the
  local Linux environment. While passing this test is not required, it is good practice and it help
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.
* If AI tools were used to help write this PR, see the
  [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html) for what disclosure
  and review is expected of you before submitting.

</details>
