### PR TITLE
BUG: Ensure gap size is correct in mosaic_plot

### DIFF
--- a/statsmodels/graphics/mosaicplot.py
+++ b/statsmodels/graphics/mosaicplot.py
@@ -318,7 +318,8 @@ def _hierarchical_split(count_dict, horizontal=True, gap=0.05):
 
     if len(gap) < L:
         last = gap[-1]
-        gap = list(*gap) + [last / 1.5**idx for idx in range(L)]
+        n_extra = L - len(gap)
+        gap = list(gap) + [last / 1.5**idx for idx in range(1, n_extra + 1)]
     # trim if it's too long
 
     gap = gap[:L]

--- a/statsmodels/graphics/tests/test_mosaicplot.py
+++ b/statsmodels/graphics/tests/test_mosaicplot.py
@@ -313,6 +313,24 @@ def test_recursive_split():
     res[("f", "o")] = (0.5, 2 / 3, 0.5, 1 / 3)
 
 
+def test_recursive_split_short_gap_sequence():
+    # a gap sequence shorter than the number of levels is extended with
+    # exponentially decreasing gaps rather than raising
+    keys = list(product("mf", "yao"))
+    data = dict(zip(keys, [1] * len(keys), strict=True))
+
+    res = _hierarchical_split(data, gap=[0.05])
+    assert_(list(res.keys()) == keys)
+
+    # extending continues the decay of the last supplied gap, which makes
+    # the one-element sequence equivalent to the equivalent scalar
+    assert_(res == _hierarchical_split(data, gap=[0.05, 0.05 / 1.5]))
+    assert_(res == _hierarchical_split(data, gap=0.05))
+
+    # a gap sequence longer than the number of levels is still trimmed
+    assert_(res == _hierarchical_split(data, gap=[0.05, 0.05 / 1.5, 1.0]))
+
+
 def test__reduce_dict():
     data = dict(zip(list(product("mf", "oy", "wn")), [1] * 8, strict=True))
     eq(_reduce_dict(data, ("m",)), 4)


### PR DESCRIPTION
- [X] tests added / passed.
- [X] code/documentation is well formatted.
- [X] properly formatted commit message. See
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message).

#### AI Disclosure

Contributions must comply with the statsmodels [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html).

If using AI tools, edit the second option to explain which tool was selected and
how the tool's output was used.

Please complete **one** of the following:

- [ ] No AI tools were used to develop this pull request.
- [X] AI tools were used.
      Tool(s): Claude
      Used for: test writing
      I have personally read, understood, and can explain every line of this diff, and
      have verified the statistical/numerical correctness of the change.

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows
  using the Windows System for Linux once `flake8` is installed in the
  local Linux environment. While passing this test is not required, it is good practice and it help
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.
* If AI tools were used to help write this PR, see the
  [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html) for what disclosure
  and review is expected of you before submitting.

</details>
