### PR TITLE
BUG: Ensure not implemented options raise

### DIFF
--- a/statsmodels/tsa/vector_ar/svar_model.py
+++ b/statsmodels/tsa/vector_ar/svar_model.py
@@ -739,12 +739,23 @@ class SVARResults(SVARProcess, VARResults):
         ----------
         periods : int, optional
         var_order : sequence, optional
-            Alternate variable order for Cholesky decomposition
+            Alternate variable order for the structural impulse matrix. Not
+            implemented, and so must be None.
 
         Returns
         -------
         irf : IRAnalysis
+
+        Raises
+        ------
+        NotImplementedError
+            If `var_order` is not None.
         """
+        if var_order is not None:
+            raise NotImplementedError(
+                "alternate variable order not implemented (yet)"
+            )
+
         A = self.A
         B = self.B
         P = np.dot(npl.inv(A), B)

--- a/statsmodels/tsa/vector_ar/tests/test_svar.py
+++ b/statsmodels/tsa/vector_ar/tests/test_svar.py
@@ -82,6 +82,12 @@ class TestSVAR:
         assert_allclose(errband1.lower, errband2.lower, rtol=1e-8, atol=atol)
         assert_allclose(errband1.upper, errband2.upper, rtol=1e-8, atol=atol)
 
+    def test_irf_var_order_not_implemented(self):
+        # var_order is not supported and must not be silently ignored,
+        # matching VARResults.irf
+        with pytest.raises(NotImplementedError, match="variable order"):
+            self.res1.irf(var_order=[2, 0, 1])
+
 
 def test_oneparam():
     # regression test, one parameter in A, B, issue #9302


### PR DESCRIPTION
- [X] tests added / passed.
- [X] code/documentation is well formatted.
- [X] properly formatted commit message. See
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message).

#### AI Disclosure

Contributions must comply with the statsmodels [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html).

If using AI tools, edit the second option to explain which tool was selected and
how the tool's output was used.

Please complete **one** of the following:

- [ ] No AI tools were used to develop this pull request.
- [X] AI tools were used.
      Tool(s): Claude
      Used for: test writing
      I have personally read, understood, and can explain every line of this diff, and
      have verified the statistical/numerical correctness of the change.

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows
  using the Windows System for Linux once `flake8` is installed in the
  local Linux environment. While passing this test is not required, it is good practice and it help
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.
* If AI tools were used to help write this PR, see the
  [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html) for what disclosure
  and review is expected of you before submitting.

</details>
