### PR TITLE
BUG: Correct size of cancorr returns

### DIFF
--- a/docs/source/stats.rst
+++ b/docs/source/stats.rst
@@ -646,6 +646,20 @@ Status: experimental, API might change, added in 0.12
    test_cov_spherical
    CovTestResult
 
+.. module:: statsmodels.stats.multivariate_tools
+   :synopsis: Tools for multivariate analysis
+
+.. currentmodule:: statsmodels.stats.multivariate_tools
+
+.. autosummary::
+   :toctree: generated
+
+   cancorr
+   cc_ranktest
+   CCRankTestResult
+   cc_stats
+   CCStatsResult
+
 
 .. _oneway_stats:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -477,7 +477,7 @@ markers = [
 [tool.coverage.run]
 source = ["statsmodels"]
 branch = true
-# plugins = ["Cython.Coverage"]
+plugins = ["Cython.Coverage"]
 omit = [
     # print_version is untestable
     "*/print_version.py",
@@ -500,6 +500,7 @@ omit = [
     "*/tests/r*",
     "*/tests/s*",
     "*/_version.py",
+    "*/_pss_critical_values/*",
 ]
 
 [tool.coverage.report]

--- a/statsmodels/stats/multivariate_tools.py
+++ b/statsmodels/stats/multivariate_tools.py
@@ -9,9 +9,32 @@ TODO:
 - names of functions, currently just "working titles"
 
 '''
+from dataclasses import dataclass
+
 import numpy as np
 
-from statsmodels.tools.tools import Bunch
+from statsmodels.tools.validation import array_like
+
+
+@dataclass(frozen=True, slots=True)
+class PartialProjectResult:
+    """
+    Result of :func:`partial_project`.
+
+    Parameters
+    ----------
+    params : ndarray
+        OLS parameter estimates from the projection of endog on exog.
+    fittedvalues : ndarray
+        Predicted values of endog given exog.
+    resid : ndarray
+        Residuals of the regression, i.e. the values of endog with the
+        effect of exog partialled out.
+    """
+
+    params: np.ndarray
+    fittedvalues: np.ndarray
+    resid: np.ndarray
 
 
 def partial_project(endog, exog):
@@ -22,35 +45,31 @@ def partial_project(endog, exog):
 
     Parameters
     ----------
-    endog : ndarray
+    endog : array_like
         Array of variables where the effect of exog is partialled out.
-    exog : ndarray
+    exog : array_like
         Array of variables on which the endog variables are projected.
 
     Returns
     -------
-    res : Bunch
-        Instance of ``Bunch`` with
-
-        - params : OLS parameter estimates from projection of endog on exog
-        - fittedvalues : predicted values of endog given exog
-        - resid : residual of the regression, values of endog with effect of
-          exog partialled out
+    PartialProjectResult
+        Result instance with attributes ``params``, ``fittedvalues`` and
+        ``resid``. See :class:`PartialProjectResult` for details.
 
     Notes
     -----
-    This is no-frills mainly for internal calculations, no error checking or
-    array conversion is performed, at least for now.
+    This is no-frills mainly for internal calculations. ``endog`` and
+    ``exog`` are converted to ndarrays, but no other error
+    checking, such as verifying that both arrays have the same number of
+    observations, is performed.
     """
-    x1, x2 = endog, exog
+    x1 = array_like(endog, "endog", ndim=2)
+    x2 = array_like(exog, "exog", ndim=2)
     params = np.linalg.pinv(x2).dot(x1)
     predicted = x2.dot(params)
     residual = x1 - predicted
-    res = Bunch(params=params,
-                fittedvalues=predicted,
-                resid=residual)
 
-    return res
+    return PartialProjectResult(params=params, fittedvalues=predicted, resid=residual)
 
 
 def cancorr(x1, x2, demean=True, standardize=False):
@@ -59,7 +78,7 @@ def cancorr(x1, x2, demean=True, standardize=False):
 
     Parameters
     ----------
-    x1, x2 : ndarray, 2-D
+    x1, x2 : array_like, 2-D
         Two 2-dimensional data arrays, observations in rows, variables in
         columns.
     demean : bool, optional
@@ -75,6 +94,15 @@ def cancorr(x1, x2, demean=True, standardize=False):
         Canonical correlation coefficients, sorted from largest to smallest.
         Note, that these are the square root of the eigenvalues.
 
+    See Also
+    --------
+    cc_ranktest
+        Rank tests based on the smallest canonical correlations.
+    cc_stats
+        MANOVA statistics based on the canonical correlations.
+    CCA
+        Not yet implemented.
+
     Notes
     -----
     This is a helper function for other statistical functions. It only
@@ -85,31 +113,79 @@ def cancorr(x1, x2, demean=True, standardize=False):
     matrix inverse and does not raise an exception if one of the data arrays
     have less than full column rank.
 
-    See Also
-    --------
-    cc_ranktest
-    cc_stats
-    CCA : not yet implemented
+    The eigenvalues underlying the canonical correlations are mathematically
+    guaranteed to be real and non-negative, but the generalized eigenvalue
+    problem is solved numerically and can return eigenvalues with a small
+    spurious complex part or a small negative real part. Such numerical noise
+    is clipped to zero before taking the square root, so ``ccorr`` is always
+    real-valued.
     """
-    # x, y = x1, x2
+    x1 = array_like(x1, "x1", ndim=2)
+    x2 = array_like(x2, "x2", ndim=2)
+
     if demean or standardize:
-        x1 = (x1 - x1.mean(0))
-        x2 = (x2 - x2.mean(0))
+        x1 = x1 - x1.mean(0)
+        x2 = x2 - x2.mean(0)
 
     if standardize:
         # std does not make a difference to canonical correlation coefficients
-        x1 /= x1.std(0)
-        x2 /= x2.std(0)
+        x1 = x1 / x1.std(0)
+        x2 = x2 / x2.std(0)
 
     t1 = np.linalg.pinv(x1).dot(x2)
     t2 = np.linalg.pinv(x2).dot(x1)
     m = t1.dot(t2)
-    cc = np.sqrt(np.linalg.eigvals(m))
-    cc.sort()
-    return cc[::-1]
+    # eigvals of m are theoretically real and non-negative (they equal the
+    # squared canonical correlations), but the generalized eigenvalue
+    # solver can return a complex dtype with a negligible imaginary part,
+    # or a tiny negative real part from floating point noise. ``.real``
+    # is a no-op when the dtype is already real, so this is safe either way.
+    eigval = np.clip(np.linalg.eigvals(m).real, 0, None)
+    cc = np.sqrt(eigval)
+    cc = np.sort(cc)[::-1]
+    cc = cc[:min(x1.shape[1], x2.shape[1])]
+
+    return cc
 
 
-def cc_ranktest(x1, x2, demean=True, fullrank=False):
+@dataclass(frozen=True, slots=True)
+class CCRankTestResult:
+    """
+    Result of :func:`cc_ranktest`.
+
+    Only returned if ``return_object=True`` is used, otherwise
+    :func:`cc_ranktest` returns the equivalent plain tuple
+    ``(statistic, pvalue, df, ccorr, wald_statistic, wald_pvalue)``.
+
+    Parameters
+    ----------
+    statistic : float or ndarray
+        Value of the LM (Anderson canonical correlations) test statistic.
+    pvalue : float or ndarray
+        P-value for the LM test statistic, based on the chi-square
+        distribution.
+    df : int or ndarray
+        Degrees of freedom for the chi-square distribution in the
+        hypothesis test.
+    ccorr : ndarray, 1-D
+        All canonical correlation coefficients sorted from largest to
+        smallest.
+    wald_statistic : float or ndarray
+        Value of the Wald (Cragg-Donald) test statistic.
+    wald_pvalue : float or ndarray
+        P-value for the Wald test statistic, based on the chi-square
+        distribution.
+    """
+
+    statistic: float | np.ndarray
+    pvalue: float | np.ndarray
+    df: int | np.ndarray
+    ccorr: np.ndarray
+    wald_statistic: float | np.ndarray
+    wald_pvalue: float | np.ndarray
+
+
+def cc_ranktest(x1, x2, demean=True, fullrank=False, return_object=False):
     """
     Rank tests based on smallest canonical correlation coefficients
 
@@ -123,7 +199,7 @@ def cc_ranktest(x1, x2, demean=True, fullrank=False):
 
     Parameters
     ----------
-    x1, x2 : ndarray, 2-D
+    x1, x2 : array_like, 2-D
         Two 2-dimensional data arrays, observations in rows, variables in
         columns.
     demean : bool, optional
@@ -132,25 +208,27 @@ def cc_ranktest(x1, x2, demean=True, fullrank=False):
         If true, then only the test that the matrix has full rank is returned.
         If false, the test for all possible ranks are returned. However,
         the p-values are not corrected for the multiplicity of tests.
+    return_object : bool, optional
+        If False (default), the results are returned as a plain tuple
+        ``(statistic, pvalue, df, ccorr, wald_statistic, wald_pvalue)``, the
+        legacy return format of this function. If True, a
+        :class:`CCRankTestResult` instance is returned instead, which
+        exposes the same values as named attributes and still unpacks as the
+        same 6-tuple.
 
     Returns
     -------
-    value : float or ndarray
-        Value of the LM (Anderson canonical correlations) test statistic.
-    p-value : float or ndarray
-        P-value for the LM test statistic, for the null hypothesis that
-        the smallest canonical correlation coefficient is zero, based on
-        the chi-square distribution.
-    df : int or ndarray
-        Degrees of freedom for the chi-square distribution in the
-        hypothesis test.
-    ccorr : ndarray, 1-D
-        All canonical correlation coefficients sorted from largest to smallest.
-    wald_value : float or ndarray
-        Value of the Wald (Cragg-Donald) test statistic.
-    wald_pvalue : float or ndarray
-        P-value for the Wald test statistic, based on the chi-square
-        distribution.
+    tuple or CCRankTestResult
+        By default, the tuple ``(statistic, pvalue, df, ccorr,
+        wald_statistic, wald_pvalue)``. If ``return_object`` is True, a
+        :class:`CCRankTestResult` with the same values as attributes.
+
+    See Also
+    --------
+    cancorr
+        Canonical correlation coefficients used by this test.
+    cc_stats
+        MANOVA statistics based on the canonical correlations.
 
     Notes
     -----
@@ -159,14 +237,21 @@ def cc_ranktest(x1, x2, demean=True, fullrank=False):
     (I'm not sure yet what the interpretation of the test is if x1 or x2 are of
     reduced rank.)
 
-    See Also
-    --------
-    cancorr
-    cc_stats
+    References
+    ----------
+    Anderson, T. W. 1951. "Estimating Linear Restrictions on Regression
+    Coefficients for Multivariate Normal Distributions." The Annals of
+    Mathematical Statistics 22 (3): 327-51.
+
+    Cragg, John G., and Stephen G. Donald. 1993. "Testing Identifiability
+    and Specification in Instrumental Variable Models." Econometric Theory
+    9 (2): 222-40.
     """
 
     from scipy import stats
 
+    x1 = array_like(x1, "x1", ndim=2)
+    x2 = array_like(x2, "x2", ndim=2)
     nobs1, k1 = x1.shape
     nobs2, k2 = x2.shape
 
@@ -176,16 +261,67 @@ def cc_ranktest(x1, x2, demean=True, fullrank=False):
         df = np.abs(k1 - k2) + 1
         value = nobs1 * cc2[-1]
         w_value = nobs1 * (cc2[-1] / (1. - cc2[-1]))
-        return value, stats.chi2.sf(value, df), df, cc, w_value, stats.chi2.sf(w_value, df)
+        pvalue = stats.chi2.sf(value, df)
+        w_pvalue = stats.chi2.sf(w_value, df)
     else:
         r = np.arange(min(k1, k2))[::-1]
         df = (k1 - r) * (k2 - r)
-        values = nobs1 * cc2[::-1].cumsum()
-        w_values = nobs1 * (cc2 / (1. - cc2))[::-1].cumsum()
-        return values, stats.chi2.sf(values, df), df, cc, w_values, stats.chi2.sf(w_values, df)
+        value = nobs1 * cc2[::-1].cumsum()
+        w_value = nobs1 * (cc2 / (1. - cc2))[::-1].cumsum()
+        pvalue = stats.chi2.sf(value, df)
+        w_pvalue = stats.chi2.sf(w_value, df)
+
+    if return_object:
+        return CCRankTestResult(
+            statistic=value,
+            pvalue=pvalue,
+            df=df,
+            ccorr=cc,
+            wald_statistic=w_value,
+            wald_pvalue=w_pvalue,
+        )
+    return value, pvalue, df, cc, w_value, w_pvalue
 
 
-def cc_stats(x1, x2, demean=True):
+@dataclass(frozen=True, slots=True)
+class CCStatsResult:
+    """
+    Result of :func:`cc_stats`.
+
+    Only returned if ``return_object=True`` is used, otherwise
+    :func:`cc_stats` returns the equivalent legacy dict.
+
+    Parameters
+    ----------
+    ccorr : ndarray, 1-D
+        Canonical correlation coefficients, sorted from largest to smallest.
+    eigenvalues : ndarray, 1-D
+        Eigenvalues corresponding to ``ccorr ** 2 / (1 - ccorr ** 2)``.
+    pillai_trace : float
+        Pillai's Trace statistic.
+    wilks_lambda : float
+        Wilk's Lambda statistic.
+    hotelling_trace : float
+        Hotelling's Trace statistic.
+    roys_largest_root : float
+        Roy's Largest Root statistic.
+    df_resid : float
+        Residual degrees of freedom.
+    df_model : float
+        Model (hypothesis) degrees of freedom.
+    """
+
+    ccorr: np.ndarray
+    eigenvalues: np.ndarray
+    pillai_trace: float
+    wilks_lambda: float
+    hotelling_trace: float
+    roys_largest_root: float
+    df_resid: float
+    df_model: float
+
+
+def cc_stats(x1, x2, demean=True, return_object=False):
     """
     MANOVA statistics based on canonical correlation coefficient
 
@@ -194,16 +330,30 @@ def cc_stats(x1, x2, demean=True):
 
     Parameters
     ----------
-    x1, x2 : ndarray, 2-D
+    x1, x2 : array_like, 2-D
         Two 2-dimensional data arrays, observations in rows, variables in
         columns.
     demean : bool, optional
         If demean is true, then the mean is subtracted from each variable.
+    return_object : bool, optional
+        If False (default), the results are returned as a dict with the
+        legacy keys used by this function ("canonical correlation
+        coefficient", "eigenvalues", "Pillai's Trace", "Wilk's Lambda",
+        "Hotelling's Trace", "Roy's Largest Root", "df_resid", "df_m"). If
+        True, a :class:`CCStatsResult` instance is returned instead, which
+        exposes the same values as named attributes.
 
     Returns
     -------
-    res : dict
-        Dictionary containing the test statistics.
+    dict or CCStatsResult
+        By default, a dict with the legacy keys described above. If
+        ``return_object`` is True, a :class:`CCStatsResult` with the same
+        values as attributes.
+
+    See Also
+    --------
+    cancorr : Canonical correlation coefficients used by these statistics.
+    cc_ranktest : Rank tests based on the smallest canonical correlations.
 
     Notes
     -----
@@ -211,16 +361,17 @@ def cc_stats(x1, x2, demean=True):
 
     Missing: F-statistics and p-values.
 
-    TODO: should return a results class instead
-    produces nans sometimes, singular, perfect correlation of x1, x2 ?
+    Can produce nans, for example, if x1 and x2 are (numerically) singular or
+    perfectly correlated, in which case a canonical correlation equals one
+    and ``Hotelling's Trace`` and the underlying ``eigenvalues`` are
+    infinite or not a number.
     """
-
+    x1 = array_like(x1, "x1", ndim=2)
+    x2 = array_like(x2, "x2", ndim=2)
     nobs1, k1 = x1.shape  # endogenous ?
     nobs2, k2 = x2.shape
     cc = cancorr(x1, x2, demean=demean)
     cc2 = cc**2
-    if np.issubdtype(cc2.dtype, np.complexfloating):
-        cc2 = np.real(cc2)
     lam = (cc2 / (1 - cc2))  # what if max cc2 is 1 ?
     # Problem: ccr might not care if x1 or x2 are reduced rank,
     #          but df will depend on rank
@@ -234,6 +385,17 @@ def cc_stats(x1, x2, demean=True):
     rm_value = lam.max()    # Roy's largest root
     # from scipy import stats
     # what's the distribution, the test statistic ?
+    if return_object:
+        return CCStatsResult(
+            ccorr=cc,
+            eigenvalues=lam,
+            pillai_trace=pt_value,
+            wilks_lambda=wl_value,
+            hotelling_trace=ht_value,
+            roys_largest_root=rm_value,
+            df_resid=df_resid,
+            df_model=m,
+        )
     res = {}
     res["canonical correlation coefficient"] = cc
     res["eigenvalues"] = lam

--- a/statsmodels/stats/tests/test_multivariate_tools.py
+++ b/statsmodels/stats/tests/test_multivariate_tools.py
@@ -2,13 +2,26 @@
 Tests for statsmodels.stats.multivariate_tools
 
 Regression tests: cc_stats had no test coverage and raised AttributeError on
-numpy >= 2.0 because it used the removed alias ``np.product``.
+numpy >= 2.0 because it used the removed alias ``np.product``. cc_ranktest
+had no test coverage at all, and could raise TypeError whenever cancorr's
+underlying eigenvalue solver returned a complex dtype (which happens for
+some inputs even though the canonical correlations are mathematically real).
 """
 import numpy as np
 from numpy.testing import assert_allclose
+import pandas as pd
 import pytest
+from scipy import stats as sp_stats
 
-from statsmodels.stats.multivariate_tools import cancorr, cc_stats
+from statsmodels.stats.multivariate_tools import (
+    CCRankTestResult,
+    CCStatsResult,
+    PartialProjectResult,
+    cancorr,
+    cc_ranktest,
+    cc_stats,
+    partial_project,
+)
 
 
 @pytest.fixture
@@ -18,6 +31,191 @@ def data():
     x2 = rs.standard_normal((200, 2))
     return x1, x2
 
+
+@pytest.fixture
+def data_r():
+    # Same data used to generate the reference values below with R 4.6.1:
+    #
+    #   cc <- cancor(x1, x2, xcenter = TRUE, ycenter = TRUE)
+    #   fit <- lm(x1 ~ x2)
+    #   summary(manova(fit))$stats["x2", "Pillai"]
+    #   summary(manova(fit), test = "Wilks")$stats["x2", "Wilks"]
+    #   summary(manova(fit), test = "Hotelling-Lawley")$stats["x2", "Hotelling-Lawley"]
+    #   summary(manova(fit), test = "Roy")$stats["x2", "Roy"]
+    rs = np.random.RandomState(20260821)
+    x1 = rs.standard_normal((40, 3))
+    x2 = x1[:, :2] * 0.5 + rs.standard_normal((40, 2))
+    x2 = np.hstack([x2, rs.standard_normal((40, 1))])
+    return x1, x2
+
+
+# ---------------------------------------------------------------------
+# cancorr
+# ---------------------------------------------------------------------
+
+def test_cancorr_perfect_correlation():
+    # x with itself has all canonical correlations equal to one, so
+    # Wilks' Lambda collapses to zero.
+    rs = np.random.RandomState(12345)
+    x1 = rs.standard_normal((50, 2))
+    assert_allclose(cancorr(x1, x1), np.ones(2), atol=1e-8)
+
+
+def test_cancorr_shape():
+    rs = np.random.RandomState(12345)
+    x1 = rs.standard_normal((50, 2))
+    _x2 = x1 * 0.7 + rs.standard_normal((50, 2))
+    x2 = np.hstack([_x2, rs.standard_normal((50, 1))])
+    cc = cancorr(x1, x2)
+    assert len(cc) == 2
+
+
+def test_cancorr_against_r(data_r):
+    # Reference values from R's base `cancor` function.
+    x1, x2 = data_r
+    cc = cancorr(x1, x2)
+    cc_expected = [0.532338026574400, 0.344170637520608, 0.114617183600323]
+    assert_allclose(np.real(cc), cc_expected, rtol=1e-7)
+
+
+def test_cancorr_returns_real_dtype(data_r):
+    # Regression test: eigvals of the (generally non-symmetric) auxiliary
+    # matrix can come back with complex dtype even though the underlying
+    # canonical correlations are mathematically real. cancorr must not leak
+    # that dtype since cc_ranktest feeds the squared values straight into
+    # scipy.stats.chi2.sf, which raises TypeError on complex input.
+    x1, x2 = data_r
+    cc = cancorr(x1, x2)
+    assert not np.iscomplexobj(cc)
+    # cc_ranktest must not raise despite this.
+    cc_ranktest(x1, x2)
+
+
+def test_cancorr_standardize_same_as_demean():
+    # Rescaling by the standard deviation should not change the canonical
+    # correlation coefficients (see docstring).
+    rs = np.random.RandomState(7)
+    x1 = rs.standard_normal((80, 2)) * 3 + 1
+    x2 = rs.standard_normal((80, 2)) * 0.2 - 4
+    cc_demean = cancorr(x1, x2, demean=True, standardize=False)
+    cc_std = cancorr(x1, x2, demean=True, standardize=True)
+    assert_allclose(cc_demean, cc_std, rtol=1e-10)
+
+
+def test_cancorr_demean_false_differs():
+    # Without demeaning, the location of the data enters the projection and
+    # generally changes the canonical correlations.
+    rs = np.random.RandomState(10)
+    x1 = rs.standard_normal((80, 2)) + 5
+    x2 = rs.standard_normal((80, 2)) + 3
+    cc_demean = cancorr(x1, x2, demean=True)
+    cc_raw = cancorr(x1, x2, demean=False)
+    assert not np.allclose(cc_demean, cc_raw)
+
+
+def test_cancorr_accepts_array_like():
+    rs = np.random.RandomState(9)
+    x1 = rs.standard_normal((40, 2))
+    x2 = rs.standard_normal((40, 2))
+    cc_ndarray = cancorr(x1, x2)
+    cc_list = cancorr(x1.tolist(), x2.tolist())
+    cc_df = cancorr(pd.DataFrame(x1), pd.DataFrame(x2))
+    assert_allclose(cc_list, cc_ndarray, rtol=1e-12)
+    assert_allclose(cc_df, cc_ndarray, rtol=1e-12)
+
+
+# ---------------------------------------------------------------------
+# cc_ranktest
+# ---------------------------------------------------------------------
+
+def test_cc_ranktest_fullrank_univariate_matches_formula():
+    # With one variable on each side, the canonical correlation is the
+    # Pearson correlation (an independent computation via np.corrcoef), and
+    # the fullrank LM/Wald statistics reduce to simple closed-form
+    # expressions in that correlation.
+    rs = np.random.RandomState(11)
+    x1 = rs.standard_normal((120, 1))
+    x2 = x1 * 0.6 + rs.standard_normal((120, 1))
+
+    r = np.corrcoef(x1.ravel(), x2.ravel())[0, 1]
+    nobs = x1.shape[0]
+    expected_lm = nobs * r**2
+    expected_wald = nobs * r**2 / (1 - r**2)
+    expected_df = 1
+
+    value, pvalue, df, cc, w_value, w_pvalue = cc_ranktest(x1, x2, fullrank=True)
+    assert_allclose(value, expected_lm, rtol=1e-10)
+    assert_allclose(w_value, expected_wald, rtol=1e-10)
+    assert df == expected_df
+    assert_allclose(pvalue, sp_stats.chi2.sf(expected_lm, expected_df), rtol=1e-10)
+    assert_allclose(w_pvalue, sp_stats.chi2.sf(expected_wald, expected_df), rtol=1e-10)
+    assert_allclose(cc, [abs(r)], rtol=1e-10)
+
+
+def test_cc_ranktest_fullrank_matches_smallest_cc(data):
+    x1, x2 = data
+    nobs = x1.shape[0]
+    cc = cancorr(x1, x2)
+    cc2_min = cc[-1] ** 2
+
+    value, pvalue, df, cc_out, w_value, w_pvalue = cc_ranktest(x1, x2, fullrank=True)
+    assert_allclose(value, nobs * cc2_min, rtol=1e-12)
+    assert_allclose(w_value, nobs * cc2_min / (1 - cc2_min), rtol=1e-12)
+    assert_allclose(cc_out, cc, rtol=1e-12)
+
+
+def test_cc_ranktest_not_fullrank_matches_cumulative_formula(data):
+    x1, x2 = data
+    nobs, k1 = x1.shape
+    _, k2 = x2.shape
+    cc = cancorr(x1, x2)
+    cc2 = cc ** 2
+    r = np.arange(min(k1, k2))[::-1]
+    expected_df = (k1 - r) * (k2 - r)
+    expected_value = nobs * cc2[::-1].cumsum()
+    expected_wald = nobs * (cc2 / (1 - cc2))[::-1].cumsum()
+
+    value, pvalue, df, cc_out, w_value, w_pvalue = cc_ranktest(x1, x2, fullrank=False)
+    assert_allclose(value, expected_value, rtol=1e-12)
+    assert_allclose(w_value, expected_wald, rtol=1e-12)
+    assert_allclose(df, expected_df)
+    assert len(value) == min(k1, k2)
+
+
+@pytest.mark.parametrize("fullrank", [True, False])
+def test_cc_ranktest_return_object(data, fullrank):
+    x1, x2 = data
+    legacy = cc_ranktest(x1, x2, fullrank=fullrank)
+    obj = cc_ranktest(x1, x2, fullrank=fullrank, return_object=True)
+
+    assert isinstance(obj, CCRankTestResult)
+    slots = obj.__slots__
+    for slot, b in zip(slots, legacy, strict=True):
+        a = getattr(obj, slot)
+        assert_allclose(a, b, rtol=1e-12)
+
+    assert_allclose(obj.statistic, legacy[0], rtol=1e-12)
+    assert_allclose(obj.pvalue, legacy[1], rtol=1e-12)
+    assert_allclose(obj.df, legacy[2], rtol=1e-12)
+    assert_allclose(obj.ccorr, legacy[3], rtol=1e-12)
+    assert_allclose(obj.wald_statistic, legacy[4], rtol=1e-12)
+    assert_allclose(obj.wald_pvalue, legacy[5], rtol=1e-12)
+
+
+def test_cc_ranktest_accepts_array_like(data):
+    x1, x2 = data
+    legacy = cc_ranktest(x1, x2)
+    from_list = cc_ranktest(x1.tolist(), x2.tolist())
+    from_df = cc_ranktest(pd.DataFrame(x1), pd.DataFrame(x2))
+    for a, b in zip(legacy, from_list, strict=True):
+        assert_allclose(a, b, rtol=1e-10)
+    for a, b in zip(legacy, from_df, strict=True):
+        assert_allclose(a, b, rtol=1e-10)
+
+
+# ---------------------------------------------------------------------
+# cc_stats
+# ---------------------------------------------------------------------
 
 def test_cc_stats_runs(data):
     x1, x2 = data
@@ -65,9 +263,108 @@ def test_cc_stats_univariate_equals_correlation():
     assert_allclose(res["Pillai's Trace"], r**2, rtol=1e-10)
 
 
-def test_cancorr_perfect_correlation():
-    # x with itself has all canonical correlations equal to one, so
-    # Wilks' Lambda collapses to zero.
-    rs = np.random.RandomState(12345)
-    x1 = rs.standard_normal((50, 2))
-    assert_allclose(cancorr(x1, x1), np.ones(2), atol=1e-8)
+def test_cc_stats_against_r(data_r):
+    # Reference values from R's `summary(manova(lm(x1 ~ x2)))` for the four
+    # classical MANOVA test statistics, which are equivalent to cc_stats
+    # with demean=True (the default).
+    x1, x2 = data_r
+    res = cc_stats(x1, x2)
+    assert_allclose(res["Pillai's Trace"], 0.414974301044939, rtol=1e-7)
+    assert_allclose(res["Wilk's Lambda"], 0.623431470196253, rtol=1e-7)
+    assert_allclose(res["Hotelling's Trace"], 0.543129049437308, rtol=1e-7)
+    assert_allclose(res["Roy's Largest Root"], 0.395447053063982, rtol=1e-7)
+
+
+def test_cc_stats_demean_false():
+    # Not demeaning changes the projection (the mean is no longer
+    # partialled out), so the results generally differ from demean=True,
+    # but the returned statistics must still be exact functions of
+    # cancorr(..., demean=False).
+    rs = np.random.RandomState(4)
+    x1 = rs.standard_normal((60, 2)) + 5
+    x2 = rs.standard_normal((60, 2)) + 3
+    res_demean = cc_stats(x1, x2, demean=True)
+    res_raw = cc_stats(x1, x2, demean=False)
+    assert not np.allclose(res_demean["Wilk's Lambda"], res_raw["Wilk's Lambda"])
+
+    cc2 = cancorr(x1, x2, demean=False) ** 2
+    assert_allclose(res_raw["Pillai's Trace"], cc2.sum(), rtol=1e-12)
+
+
+def test_cc_stats_return_object(data):
+    x1, x2 = data
+    res_dict = cc_stats(x1, x2)
+    res_obj = cc_stats(x1, x2, return_object=True)
+
+    assert isinstance(res_obj, CCStatsResult)
+    assert_allclose(res_obj.ccorr, res_dict["canonical correlation coefficient"])
+    assert_allclose(res_obj.eigenvalues, res_dict["eigenvalues"])
+    assert_allclose(res_obj.pillai_trace, res_dict["Pillai's Trace"])
+    assert_allclose(res_obj.wilks_lambda, res_dict["Wilk's Lambda"])
+    assert_allclose(res_obj.hotelling_trace, res_dict["Hotelling's Trace"])
+    assert_allclose(res_obj.roys_largest_root, res_dict["Roy's Largest Root"])
+    assert res_obj.df_resid == res_dict["df_resid"]
+    assert res_obj.df_model == res_dict["df_m"]
+
+
+def test_cc_stats_accepts_array_like(data):
+    x1, x2 = data
+    res_ndarray = cc_stats(x1, x2)
+    res_list = cc_stats(x1.tolist(), x2.tolist())
+    res_df = cc_stats(pd.DataFrame(x1), pd.DataFrame(x2))
+    for key in res_ndarray:
+        assert_allclose(res_list[key], res_ndarray[key], rtol=1e-12)
+        assert_allclose(res_df[key], res_ndarray[key], rtol=1e-12)
+
+
+# ---------------------------------------------------------------------
+# partial_project
+# ---------------------------------------------------------------------
+
+def test_partial_project_matches_lstsq():
+    # Cross-check against numpy's lstsq, an independent least-squares
+    # implementation, rather than only checking internal consistency.
+    rs = np.random.RandomState(3)
+    endog = rs.standard_normal((50, 2))
+    exog = np.column_stack([np.ones(50), rs.standard_normal((50, 2))])
+    res = partial_project(endog, exog)
+    assert isinstance(res, PartialProjectResult)
+
+    expected_params = np.linalg.lstsq(exog, endog, rcond=None)[0]
+    assert_allclose(res.params, expected_params, rtol=1e-10)
+    assert_allclose(res.fittedvalues, exog.dot(expected_params), rtol=1e-10)
+    assert_allclose(res.resid, endog - exog.dot(expected_params), rtol=1e-10)
+
+
+def test_partial_project_orthogonality():
+    # The projected residual must be orthogonal to every column of exog:
+    # the defining property of an OLS projection, verified independently of
+    # the pinv-based implementation.
+    rs = np.random.RandomState(5)
+    endog = rs.standard_normal((60, 3))
+    exog = np.column_stack([np.ones(60), rs.standard_normal((60, 2))])
+    res = partial_project(endog, exog)
+    cross = exog.T.dot(res.resid)
+    assert_allclose(cross, np.zeros_like(cross), atol=1e-8)
+
+
+def test_partial_project_accepts_array_like():
+    rs = np.random.RandomState(6)
+    endog = rs.standard_normal((30, 2))
+    exog = rs.standard_normal((30, 2))
+    res_ndarray = partial_project(endog, exog)
+    res_list = partial_project(endog.tolist(), exog.tolist())
+    res_df = partial_project(pd.DataFrame(endog), pd.DataFrame(exog))
+    assert_allclose(res_list.resid, res_ndarray.resid, rtol=1e-10)
+    assert_allclose(res_df.resid, res_ndarray.resid, rtol=1e-10)
+
+
+def test_partial_project_1d_input():
+    # array_like inserts a trailing axis for 1-D input, so a single-column
+    # endog/exog specified as a plain 1-D array must still work.
+    rs = np.random.RandomState(8)
+    endog = rs.standard_normal(40)
+    exog = rs.standard_normal(40)
+    res = partial_project(endog, exog)
+    assert res.params.shape == (1, 1)
+    assert res.resid.shape == (40, 1)


### PR DESCRIPTION
Change tests and print values

- [x] tests added / passed.
- [x] code/documentation is well formatted.
- [ ] properly formatted commit message. See
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message).

#### AI Disclosure

Contributions must comply with the statsmodels [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html).

If using AI tools, edit the second option to explain which tool was selected and
how the tool's output was used.

Please complete **one** of the following:

- [ ] No AI tools were used to develop this pull request.
- [X] AI tools were used.
      Tool(s): Claude
      Used for: Reference testing from R
      I have personally read, understood, and can explain every line of this diff, and
      have verified the statistical/numerical correctness of the change.

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows
  using the Windows System for Linux once `flake8` is installed in the
  local Linux environment. While passing this test is not required, it is good practice and it help
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.
* If AI tools were used to help write this PR, see the
  [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html) for what disclosure
  and review is expected of you before submitting.

</details>
