### PR TITLE
TST: Add tests for rng selector

### DIFF
--- a/statsmodels/tools/tests/test_rng_qrng.py
+++ b/statsmodels/tools/tests/test_rng_qrng.py
@@ -1,0 +1,98 @@
+import contextlib
+import warnings
+
+import numpy as np
+from numpy.testing import assert_equal
+import pytest
+from scipy import stats
+
+from statsmodels.tools.rng_qrng import check_random_state
+
+
+@contextlib.contextmanager
+def warnings_as_errors():
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        yield
+
+
+def test_none_returns_fresh_generator():
+    rng1 = check_random_state(None)
+    rng2 = check_random_state(None)
+    assert isinstance(rng1, np.random.Generator)
+    assert isinstance(rng2, np.random.Generator)
+    # Two fresh, OS-entropy-seeded generators should not produce the
+    # same stream.
+    assert not np.allclose(rng1.standard_normal(10), rng2.standard_normal(10))
+
+
+def test_int_returns_generator_by_default():
+    rng = check_random_state(0)
+    assert isinstance(rng, np.random.Generator)
+
+
+def test_int_reproducible():
+    rng1 = check_random_state(123)
+    rng2 = check_random_state(123)
+    assert_equal(rng1.standard_normal(10), rng2.standard_normal(10))
+
+
+def test_array_like_int_seed():
+    rng1 = check_random_state([1, 2, 3])
+    rng2 = check_random_state([1, 2, 3])
+    assert isinstance(rng1, np.random.Generator)
+    assert_equal(rng1.standard_normal(10), rng2.standard_normal(10))
+
+
+def test_non_integer_array_raises():
+    with pytest.raises(TypeError):
+        check_random_state([1.5, 2.5])
+
+
+def test_randomstate_instance_passthrough():
+    rs = np.random.RandomState(0)
+    out = check_random_state(rs)
+    assert out is rs
+
+
+def test_generator_instance_passthrough():
+    gen = np.random.default_rng(0)
+    out = check_random_state(gen)
+    assert out is gen
+
+
+def test_qmc_engine_passthrough():
+    if not hasattr(stats, "qmc"):
+        pytest.skip("scipy.stats.qmc not available")
+    engine = stats.qmc.Sobol(d=2, seed=0)
+    out = check_random_state(engine)
+    assert out is engine
+
+
+def test_deprecated_int_warns_and_returns_randomstate():
+    with pytest.warns(FutureWarning, match="After statsmodels 0.15"):
+        rng = check_random_state(0, deprecated=True)
+    assert isinstance(rng, np.random.RandomState)
+
+
+def test_deprecated_int_warn_false_suppresses_warning():
+    with warnings_as_errors():
+        rng = check_random_state(0, deprecated=True, warn=False)
+    assert isinstance(rng, np.random.RandomState)
+
+
+def test_deprecated_none_does_not_warn_and_returns_generator():
+    # None should never trigger the legacy-seed FutureWarning: there is
+    # no "value" being reinterpreted, so the deprecated flag should have
+    # no effect and callers should always get a fresh Generator.
+    with warnings_as_errors():
+        rng = check_random_state(None, deprecated=True)
+    assert isinstance(rng, np.random.Generator)
+
+
+def test_deprecated_instance_passthrough_does_not_warn():
+    rs = np.random.RandomState(0)
+    gen = np.random.default_rng(0)
+    with warnings_as_errors():
+        assert check_random_state(rs, deprecated=True) is rs
+        assert check_random_state(gen, deprecated=True) is gen


### PR DESCRIPTION
- [X] code/documentation is well formatted.
- [X] properly formatted commit message. See
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message).

#### AI Disclosure

Contributions must comply with the statsmodels [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html).

If using AI tools, edit the second option to explain which tool was selected and
how the tool's output was used.

Please complete **one** of the following:

- [ ] No AI tools were used to develop this pull request.
- [X] AI tools were used.
      Tool(s): Claude
      Used for: Writing test only
      I have personally read, understood, and can explain every line of this diff, and
      have verified the statistical/numerical correctness of the change.

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows
  using the Windows System for Linux once `flake8` is installed in the
  local Linux environment. While passing this test is not required, it is good practice and it help
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.
* If AI tools were used to help write this PR, see the
  [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html) for what disclosure
  and review is expected of you before submitting.

</details>
