### PR TITLE
TST: Cover results-class surface gaps

### DIFF
--- a/statsmodels/discrete/tests/test_discrete.py
+++ b/statsmodels/discrete/tests/test_discrete.py
@@ -3873,3 +3873,21 @@ def test_binary_results_info_criteria():
 
     with pytest.raises(ValueError, match="not recognized"):
         res.info_criteria("not-a-real-criterion")
+
+
+def test_im_ratio_nonrobust_and_robust():
+    rng = np.random.RandomState(74125)
+    n = 200
+    exog = sm.add_constant(rng.standard_normal((n, 2)))
+    endog = rng.poisson(np.exp(exog @ [0.2, 0.3, -0.1]))
+
+    res = sm.Poisson(endog, exog).fit(disp=0)
+    hess = res.model.hessian(res.params)
+    score_obs = res.model.score_obs(res.params)
+    cov_score = score_obs.T @ score_obs
+    expected = np.linalg.inv(-hess) @ cov_score
+    assert_allclose(res.im_ratio, expected, rtol=1e-10)
+
+    res_robust = sm.Poisson(endog, exog).fit(disp=0, cov_type="HC0")
+    expected_robust = res_robust.cov_params() @ (-hess)
+    assert_allclose(res_robust.im_ratio, expected_robust, rtol=1e-10)

--- a/statsmodels/regression/tests/test_predict.py
+++ b/statsmodels/regression/tests/test_predict.py
@@ -283,3 +283,49 @@ def test_predict_remove_data():
 
     series = model.get_prediction(pd.Series([1])).predicted_mean
     assert_allclose(scalar, series)
+
+
+def test_prediction_results_t_test():
+    from scipy import stats as sp_stats
+
+    from statsmodels.genmod.generalized_linear_model import GLM
+
+    rs = np.random.RandomState(918273)
+    n = 40
+    exog = np.column_stack([np.ones(n), rs.standard_normal((n, 2))])
+    endog = exog @ [1.0, 0.5, -0.5] + rs.standard_normal(n)
+    # GLM.get_prediction returns PredictionResultsMean, the class that
+    # actually implements t_test; OLS's get_prediction is a different,
+    # unrelated PredictionResults class of the same name.
+    res = GLM(endog, exog).fit()
+    pred = res.get_prediction()
+
+    stat, pvalue = pred.t_test(value=0, alternative="two-sided")
+    expected_stat = pred.predicted / pred.se
+    assert_allclose(stat, expected_stat)
+    assert_allclose(pvalue, pred.dist.sf(np.abs(expected_stat), *pred.dist_args) * 2)
+
+    stat_l, pvalue_l = pred.t_test(value=1.0, alternative="larger")
+    expected_stat_l = (pred.predicted - 1.0) / pred.se
+    assert_allclose(stat_l, expected_stat_l)
+    assert_allclose(pvalue_l, pred.dist.sf(expected_stat_l, *pred.dist_args))
+
+    stat_s, pvalue_s = pred.t_test(value=1.0, alternative="smaller")
+    assert_allclose(stat_s, expected_stat_l)
+    assert_allclose(pvalue_s, pred.dist.cdf(expected_stat_l, *pred.dist_args))
+
+    # smaller-side p-value is 1 minus the larger-side p-value for the same
+    # statistic, by definition
+    assert_allclose(pvalue_s, 1 - pvalue_l, atol=1e-10)
+
+    with pytest.raises(ValueError, match="invalid alternative"):
+        pred.t_test(alternative="not-a-real-option")
+
+    # GLM defaults to use_t=False -> normal reference distribution
+    assert pred.dist is sp_stats.norm
+    assert pred.dist_args == ()
+
+    res_t = GLM(endog, exog).fit(use_t=True)
+    pred_t = res_t.get_prediction()
+    assert pred_t.dist is sp_stats.t
+    assert pred_t.dist_args == (pred_t.df,)

--- a/statsmodels/stats/tests/test_contrast.py
+++ b/statsmodels/stats/tests/test_contrast.py
@@ -77,3 +77,66 @@ def test_constraints():
 
     c1 = smc._contrast_pairs(6, 4, 1)  # k_params, k_level, idx_start
     assert_equal(c1, cpairs2)
+
+
+def test_contrast_results_str_repr():
+    import statsmodels.api as sm
+
+    rs = numpy.random.RandomState(918273)
+    n = 60
+    exog = sm.add_constant(rs.standard_normal((n, 2)))
+    endog = exog @ [1.0, 0.5, -0.5] + rs.standard_normal(n)
+    res = sm.OLS(endog, exog).fit()
+
+    tt = res.t_test(np.eye(3))
+    text = str(tt)
+    assert repr(tt) == str(type(tt)) + "\n" + text
+    for val in tt.effect:
+        assert f"{val:0.4f}"[:6] in text
+
+    ft = res.f_test(np.eye(3)[1:])
+    text_f = str(ft)
+    assert repr(ft) == str(type(ft)) + "\n" + text_f
+    assert "F test" in text_f
+
+
+def test_wald_test_results_summary_frame_str_repr():
+    import statsmodels.api as sm
+
+    rs = numpy.random.RandomState(918274)
+    n = 80
+    exog = sm.add_constant(rs.standard_normal((n, 4)))
+    endog = exog @ [1.0, 0.5, -0.5, 0.2, 0.1] + rs.standard_normal(n)
+    res = sm.OLS(endog, exog).fit()
+
+    wa = res.wald_test_terms(skip_single=False, scalar=True)
+    assert isinstance(wa, smc.WaldTestResults)
+
+    frame = wa.summary_frame()
+    assert wa.dframe is frame
+    assert wa.summary_frame() is frame  # cached, not recomputed
+
+    text = str(wa)
+    assert text == frame.to_string()
+    assert repr(wa) == str(type(wa)) + "\n" + text
+    for col in wa.col_names:
+        assert col in frame.columns
+
+
+def test_wald_test_results_direct_construction():
+    import pytest
+    from scipy import stats as sp_stats
+
+    stat_chi2 = np.array([3.5, 8.2, 1.1])
+    wa_chi2 = smc.WaldTestResults(stat_chi2, "chi2", dist_args=(4,))
+    assert_almost_equal(wa_chi2.df_constraints, 4)
+    assert_almost_equal(wa_chi2.pvalues, sp_stats.chi2.sf(stat_chi2, 4))
+
+    stat_f = np.array([2.1, 5.4])
+    wa_f = smc.WaldTestResults(stat_f, "F", dist_args=(3, 40))
+    assert_almost_equal(wa_f.df_constraints, 3)
+    assert_almost_equal(wa_f.df_denom, 40)
+    assert_almost_equal(wa_f.pvalues, sp_stats.f.sf(stat_f, 3, 40))
+
+    with pytest.raises(ValueError, match="only F and chi2"):
+        smc.WaldTestResults(stat_chi2, "t", dist_args=(4,))

--- a/statsmodels/stats/tests/test_meta.py
+++ b/statsmodels/stats/tests/test_meta.py
@@ -426,3 +426,47 @@ class TestMetaBinOR:
         assert fig_out is fig
         with pytest.raises(TypeError, match="unexpected keyword"):
             res1.plot_forest(junk=5, use_t=False)
+
+
+def test_conf_int_samples():
+    from scipy import stats as sp_stats
+
+    from statsmodels.tools.sm_exceptions import InvalidTestWarning
+
+    rs = np.random.RandomState(918273)
+    k = 8
+    eff = rs.standard_normal(k)
+    var_eff = rs.uniform(0.5, 1.5, k)
+    res = combine_effects(eff, var_eff, method_re="dl")
+
+    ci_low, ci_upp = res.conf_int_samples(alpha=0.05, use_t=False)
+    crit = sp_stats.norm.isf(0.025)
+    assert_allclose(ci_low, res.eff - crit * res.sd_eff)
+    assert_allclose(ci_upp, res.eff + crit * res.sd_eff)
+    assert res.ci_sample_distr == "normal"
+
+    # cached: a second call with the same (alpha, use_t) returns the
+    # exact cached arrays rather than recomputing
+    ci_low2, ci_upp2 = res.conf_int_samples(alpha=0.05, use_t=False)
+    assert ci_low2 is ci_low
+    assert ci_upp2 is ci_upp
+
+    # use_t=True with nobs given uses the t distribution
+    nobs = 12
+    ci_low_t, ci_upp_t = res.conf_int_samples(alpha=0.05, use_t=True, nobs=nobs)
+    crit_t = sp_stats.t.isf(0.025, nobs - 1)
+    assert_allclose(ci_low_t, res.eff - crit_t * res.sd_eff)
+    assert res.ci_sample_distr == "t"
+
+    # use_t=True without nobs or ci_func falls back to normal with a warning
+    with pytest.warns(InvalidTestWarning, match="requires `nobs`"):
+        ci_low_fb, _ = res.conf_int_samples(alpha=0.1, use_t=True)
+    crit_fb = sp_stats.norm.isf(0.05)
+    assert_allclose(ci_low_fb, res.eff - crit_fb * res.sd_eff)
+    assert res.ci_sample_distr == "normal"
+
+    # a user-provided ci_func is used directly
+    sentinel = (np.zeros(k), np.ones(k))
+    ci_custom = res.conf_int_samples(alpha=0.2, ci_func=lambda alpha, **kw: sentinel)
+    assert ci_custom is sentinel
+    assert res.ci_sample_distr == "ci_func"

--- a/statsmodels/tsa/ardl/tests/test_ardl.py
+++ b/statsmodels/tsa/ardl/tests/test_ardl.py
@@ -636,6 +636,32 @@ def test_append_matches_apply():
     )
 
 
+def test_apply_refit_reestimates_params():
+    y = dane_data.lrm
+    x = dane_data[["lry", "ibo", "ide"]]
+    res = ARDL(y.iloc[:45], 3, x.iloc[:45], order=3, trend="c").fit()
+
+    y_apply, x_apply = y.iloc[:50], x.iloc[:50]
+    applied_fixed = res.apply(endog=y_apply, exog=x_apply, refit=False)
+    applied_refit = res.apply(endog=y_apply, exog=x_apply, refit=True)
+
+    # refit=False just carries the original params over unchanged
+    assert_allclose(applied_fixed.params, res.params)
+    # refit=True re-estimates on the new data, matching a fresh fit
+    fresh = ARDL(y_apply, 3, x_apply, order=res.model._order, trend="c").fit()
+    assert_allclose(applied_refit.params, fresh.params)
+    assert not np.allclose(applied_refit.params, res.params)
+
+
+def test_apply_unexpected_exog_raises():
+    y = dane_data.lrm
+    x = dane_data[["lry", "ibo", "ide"]]
+    res_no_exog = ARDL(y.iloc[:45], 3, trend="c").fit()
+
+    with pytest.raises(ValueError, match="exog must be None"):
+        res_no_exog.apply(endog=y.iloc[:50], exog=x.iloc[:50])
+
+
 @pytest.mark.thread_unsafe(reason="Uses matplotlib")
 @pytest.mark.matplotlib
 @pytest.mark.smoke


### PR DESCRIPTION
Expand testign in results classes 

- [X] tests added / passed.
- [X] code/documentation is well formatted.
- [X] properly formatted commit message. See
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message).

#### AI Disclosure

Contributions must comply with the statsmodels [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html).

If using AI tools, edit the second option to explain which tool was selected and
how the tool's output was used.

Please complete **one** of the following:

- [ ] No AI tools were used to develop this pull request.
- [X] AI tools were used.
      Tool(s): Claude
      Used for: Test writing
      I have personally read, understood, and can explain every line of this diff, and
      have verified the statistical/numerical correctness of the change.

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows
  using the Windows System for Linux once `flake8` is installed in the
  local Linux environment. While passing this test is not required, it is good practice and it help
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.
* If AI tools were used to help write this PR, see the
  [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html) for what disclosure
  and review is expected of you before submitting.

</details>
