### PR TITLE
TST: Cover dead computational methods on live estimators

### DIFF
--- a/statsmodels/discrete/tests/test_discrete.py
+++ b/statsmodels/discrete/tests/test_discrete.py
@@ -3891,3 +3891,60 @@ def test_im_ratio_nonrobust_and_robust():
     res_robust = sm.Poisson(endog, exog).fit(disp=0, cov_type="HC0")
     expected_robust = res_robust.cov_params() @ (-hess)
     assert_allclose(res_robust.im_ratio, expected_robust, rtol=1e-10)
+
+
+def test_generalized_poisson_score_p_var_prob_nonzero():
+    rng = np.random.RandomState(74123)
+    n = 300
+    exog = sm.add_constant(rng.standard_normal((n, 2)))
+    lin = exog @ [0.5, 0.2, -0.1]
+    endog = rng.poisson(np.exp(lin))
+
+    mod = GeneralizedPoisson(endog, exog, p=2)
+    res = mod.fit(disp=0)
+
+    # _score_p is d(loglike)/dp holding the fitted params fixed, where
+    # "p" here is the parameterization exponent (mod.parameterization =
+    # p_ctor - 1), not one of the fitted params. Check it against a
+    # central finite difference over models built with perturbed p.
+    eps = 1e-6
+    mod_hi = GeneralizedPoisson(endog, exog, p=2 + eps)
+    mod_lo = GeneralizedPoisson(endog, exog, p=2 - eps)
+    numeric = (mod_hi.loglike(res.params) - mod_lo.loglike(res.params)) / (2 * eps)
+    assert_allclose(mod._score_p(res.params), numeric, rtol=1e-4)
+
+    # _var and _prob_nonzero: GP2 closed forms (p=2 -> pm1 = 1 in the
+    # variance formula), cross-checked against direct evaluation.
+    mu = mod.predict(res.params)
+    alpha = res.params[-1]
+    expected_var = mu * (1 + alpha * mu) ** 2
+    assert_allclose(mod._var(mu, res.params), expected_var, rtol=1e-12)
+
+    expected_prob_nz = 1 - np.exp(-mu / (1 + alpha * mu))
+    assert_allclose(mod._prob_nonzero(mu, res.params), expected_prob_nz,
+                    rtol=1e-12)
+    # a genuine probability
+    assert np.all(mod._prob_nonzero(mu, res.params) > 0)
+    assert np.all(mod._prob_nonzero(mu, res.params) < 1)
+
+
+def test_poisson_cdf_pdf_match_scipy():
+    rng = np.random.RandomState(999)
+    n = 50
+    endog = rng.poisson(4, size=n)
+    exog = sm.add_constant(rng.standard_normal((n, 1)))
+    mod = sm.Poisson(endog, exog)
+
+    X = rng.standard_normal(n)
+    lam = np.exp(X)
+    assert_allclose(mod.cdf(X), stats.poisson.cdf(endog, lam), rtol=1e-12)
+    assert_allclose(mod.pdf(X), stats.poisson.pmf(endog, lam), rtol=1e-12)
+
+
+def test_logit_family_is_binomial():
+    rng = np.random.RandomState(998)
+    n = 50
+    exog = sm.add_constant(rng.standard_normal((n, 1)))
+    endog = rng.binomial(1, 0.5, n)
+    mod = Logit(endog, exog)
+    assert isinstance(mod.family, sm.families.Binomial)

--- a/statsmodels/discrete/tests/test_truncated_model.py
+++ b/statsmodels/discrete/tests/test_truncated_model.py
@@ -601,3 +601,47 @@ def test_summary_after_remove_data(fit_func):
     assert isinstance(res.summary(), Summary)
     res.remove_data()
     assert isinstance(res.summary(), Summary)
+
+
+def test_truncated_poisson_dispersion_factor():
+    rs = np.random.RandomState(462)
+    n = 300
+    exog = np.column_stack([np.ones(n), rs.standard_normal(n)])
+    lam = np.exp(exog @ [0.5, 0.3])
+    endog = rs.poisson(lam)
+    endog[endog == 0] = 1  # zero-truncated sample
+
+    mod = TruncatedLFPoisson(endog, exog, truncation=0)
+    res = mod.fit(disp=0)
+
+    mu = np.exp(res.predict(which="linear"))
+    expected = 1 - mu / (np.exp(mu) - 1)
+    assert_allclose(res._dispersion_factor, expected)
+
+    # the NotImplementedError guard is checked before any computation, so
+    # a single non-converged iteration is enough to exercise it
+    mod_trunc5 = TruncatedLFPoisson(endog, exog, truncation=5)
+    res_trunc5 = mod_trunc5.fit(disp=0, start_params=res.params, maxiter=1,
+                                skip_hessian=True)
+    with pytest.raises(NotImplementedError, match="zero-truncation"):
+        res_trunc5._dispersion_factor
+
+
+def test_truncated_negative_binomial_dispersion_factor():
+    rs = np.random.RandomState(463)
+    n = 300
+    exog = np.column_stack([np.ones(n), rs.standard_normal(n)])
+    mu = np.exp(exog @ [0.5, 0.3])
+    alpha = 0.3
+    endog = rs.negative_binomial(1 / alpha, 1 / (1 + alpha * mu))
+    endog[endog == 0] = 1
+
+    mod = TruncatedLFNegativeBinomialP(endog, exog, truncation=0, p=2)
+    res = mod.fit(disp=0)
+
+    alpha_hat = res.params[-1]
+    p = mod.model_main.parameterization
+    mu_hat = np.exp(res.predict(which="linear"))
+    expected = 1 - alpha_hat * mu_hat ** (p - 1) / (
+        np.exp(mu_hat ** (p - 1)) - 1)
+    assert_allclose(res._dispersion_factor, expected)

--- a/statsmodels/discrete/tests/test_truncated_model.py
+++ b/statsmodels/discrete/tests/test_truncated_model.py
@@ -624,7 +624,7 @@ def test_truncated_poisson_dispersion_factor():
     res_trunc5 = mod_trunc5.fit(disp=0, start_params=res.params, maxiter=1,
                                 skip_hessian=True)
     with pytest.raises(NotImplementedError, match="zero-truncation"):
-        res_trunc5._dispersion_factor
+        _ = res_trunc5._dispersion_factor
 
 
 def test_truncated_negative_binomial_dispersion_factor():

--- a/statsmodels/gam/tests/test_gam.py
+++ b/statsmodels/gam/tests/test_gam.py
@@ -839,3 +839,38 @@ def test_cov_params():
     assert_allclose(
         res_glm.cov_params(), res_glm_gam.cov_params(), rtol=1e-4, atol=1e-8
     )
+
+
+def test_glmgam_results_hat_matrix_cv_gcv_test_significance():
+    from statsmodels.gam.smooth_basis import CubicSplines
+
+    rs = np.random.RandomState(0)
+    n = 200
+    x1 = np.linspace(-3, 3, n)
+    x2 = np.linspace(0, 1, n) ** 2
+    x = np.vstack([x1, x2]).T
+    y = np.sin(x1) / x1 + x2 * x2 + rs.normal(0, 0.2, n)
+
+    cs = CubicSplines(x, df=[6, 6], constraints="center")
+    gam = GLMGam(y, exog=np.ones((n, 1)), smoother=cs, alpha=[1e-2, 1e-2])
+    res = gam.fit(method="pirls")
+
+    # hat_matrix_trace/diag and gcv/cv are simple closed forms over
+    # get_hat_matrix_diag() -- recompute independently
+    hd = res.get_hat_matrix_diag(observed=True)
+    assert_allclose(res.hat_matrix_diag, hd)
+    assert_allclose(res.hat_matrix_trace, hd.sum())
+    assert_allclose(res.gcv, res.scale / (1.0 - hd.sum() / res.nobs) ** 2)
+    expected_cv = ((res.resid_pearson / (1.0 - hd)) ** 2).sum() / res.nobs
+    assert_allclose(res.cv, expected_cv)
+
+    # test_significance(i) is a wald_test restricted to smooth term i's
+    # columns, using that term's effective degrees of freedom
+    for i in range(2):
+        wt = res.test_significance(i)
+        assert 0 <= wt.pvalue <= 1
+        mask = cs.mask[i]
+        start = gam.k_exog_linear
+        idx = start + np.nonzero(mask)[0][0]
+        k_constraints = mask.sum()
+        assert_allclose(wt.df_denom, res.edf[idx:idx + k_constraints].sum())

--- a/statsmodels/genmod/tests/test_gee.py
+++ b/statsmodels/genmod/tests/test_gee.py
@@ -2445,12 +2445,12 @@ def test_gee_results_resid_split():
 
     split = res.resid_split
     assert len(split) == n_groups
-    for v, part in zip(mod.group_labels, split):
+    for v, part in zip(mod.group_labels, split, strict=True):
         assert_allclose(part, res.resid[mod.group_indices[v]])
 
     centered_split = res.resid_centered_split
     assert len(centered_split) == n_groups
-    for v, part in zip(mod.group_labels, centered_split):
+    for v, part in zip(mod.group_labels, centered_split, strict=True):
         assert_allclose(part, res.centered_resid[mod.group_indices[v]])
         assert_allclose(part.mean(), 0, atol=1e-10)
 

--- a/statsmodels/genmod/tests/test_gee.py
+++ b/statsmodels/genmod/tests/test_gee.py
@@ -2431,6 +2431,30 @@ def test_ex_covsolve():
             assert_allclose(z1, z2[0], rtol=1e-5, atol=1e-5)
 
 
+def test_gee_results_resid_split():
+    rs = np.random.RandomState(872341)
+    n_groups, n_per_group = 15, 6
+    n = n_groups * n_per_group
+    groups = np.repeat(np.arange(n_groups), n_per_group)
+    exog = np.column_stack([np.ones(n), rs.standard_normal(n)])
+    endog = exog @ [0.5, 1.0] + rs.standard_normal(n)
+
+    mod = gee.GEE(endog, exog, groups=groups,
+                  cov_struct=cov_struct.Independence())
+    res = mod.fit()
+
+    split = res.resid_split
+    assert len(split) == n_groups
+    for v, part in zip(mod.group_labels, split):
+        assert_allclose(part, res.resid[mod.group_indices[v]])
+
+    centered_split = res.resid_centered_split
+    assert len(centered_split) == n_groups
+    for v, part in zip(mod.group_labels, centered_split):
+        assert_allclose(part, res.centered_resid[mod.group_indices[v]])
+        assert_allclose(part.mean(), 0, atol=1e-10)
+
+
 def test_stationary_covsolve():
 
     rs = np.random.RandomState(123)

--- a/statsmodels/genmod/tests/test_glm.py
+++ b/statsmodels/genmod/tests/test_glm.py
@@ -3460,3 +3460,50 @@ def test_glm_get_margeff():
         res_log.fittedvalues[:, None] * res_log.params[1:], axis=0
     )
     assert_allclose(me_log.margeff, manual, rtol=1e-10)
+
+
+def test_loglike_mu_matches_loglike():
+    # loglike_mu(mu, scale) must equal loglike(params, scale) when mu is
+    # the model's own predicted mean at those params: same likelihood,
+    # computed two different ways.
+    rs = np.random.RandomState(987456)
+    n = 200
+    exog = sm.add_constant(rs.standard_normal((n, 2)))
+    lin = exog @ [0.2, 0.5, -0.3]
+    endog = rs.poisson(np.exp(lin))
+    mod = GLM(endog, exog, family=sm.families.Poisson())
+    res = mod.fit()
+
+    mu = mod.predict(res.params)
+    assert_allclose(mod.loglike_mu(mu, scale=1.0),
+                    mod.loglike(res.params, scale=1.0), rtol=1e-12)
+
+
+def test_information_is_expected_hessian():
+    rs = np.random.RandomState(1)
+    n = 150
+    exog = sm.add_constant(rs.standard_normal((n, 2)))
+    endog = rs.poisson(np.exp(exog @ [0.1, 0.3, -0.2]))
+    mod = GLM(endog, exog, family=sm.families.Poisson())
+    res = mod.fit()
+    assert_allclose(mod.information(res.params),
+                    mod.hessian(res.params, observed=False), rtol=1e-12)
+
+
+def test_derivative_predict_matches_numerical_derivative():
+    from statsmodels.tools.numdiff import approx_fprime
+
+    rs = np.random.RandomState(2468)
+    n = 300
+    exog = sm.add_constant(rs.standard_normal((n, 2)))
+    lin = exog @ [0.1, 0.4, -0.25]
+    endog = rs.binomial(1, 1 / (1 + np.exp(-lin)))
+    mod = GLM(endog, exog, family=sm.families.Binomial())
+    res = mod.fit()
+
+    analytic = mod._derivative_predict(res.params)
+    numeric = approx_fprime(res.params, mod.predict, centered=True)
+    assert_allclose(analytic, numeric, rtol=1e-4, atol=1e-6)
+    # exog=None must default to the estimation exog and agree with the
+    # lower-level helper margins/score computations use internally
+    assert_allclose(analytic, mod._deriv_mean_dparams(res.params), rtol=1e-12)

--- a/statsmodels/multivariate/tests/test_cancorr.py
+++ b/statsmodels/multivariate/tests/test_cancorr.py
@@ -87,3 +87,13 @@ def test_cancorr():
     assert_almost_equal(r.stats.loc[0, "Pr > F"], 0.0635, decimal=4)
     assert_almost_equal(r.stats.loc[1, "Pr > F"], 0.9491, decimal=4)
     assert_almost_equal(r.stats.loc[2, "Pr > F"], 0.7748, decimal=4)
+
+    text = r.summary().as_text()
+    assert str(r) == text
+    assert "Cancorr results" in text
+    assert "Multivariate Statistics and F Approximations" in text
+    # every value from both underlying tables actually appears rendered
+    for df in (r.stats, r.stats_mv):
+        for col in df.columns:
+            for val in df[col]:
+                assert f"{val:.4f}" in text

--- a/statsmodels/multivariate/tests/test_multivariate_ols.py
+++ b/statsmodels/multivariate/tests/test_multivariate_ols.py
@@ -347,3 +347,29 @@ def test_multivariate_ls_results_summary():
 
     custom = res.summary(title="Custom Title")
     assert "Custom Title" in str(custom)
+
+
+def test_resid_distance_and_hat_matrix_diag():
+    rs = np.random.RandomState(20260821)
+    n, k_endog, k_exog = 40, 3, 2
+    exog = np.column_stack([np.ones(n), rs.standard_normal((n, k_exog))])
+    beta = rs.standard_normal((k_exog + 1, k_endog))
+    endog = exog @ beta + rs.standard_normal((n, k_endog))
+
+    mod = MultivariateLS(endog, exog)
+    res = mod.fit(method="svd")
+
+    resid = res.resid
+    cov = res.cov_resid
+    expected_dist = (resid * np.linalg.solve(cov, resid.T).T).sum(1)
+    assert_allclose(res.resid_distance, expected_dist)
+    assert np.all(res.resid_distance >= 0)
+
+    pinv_exog = np.linalg.pinv(exog)
+    expected_hd = (exog * pinv_exog.T).sum(1)
+    assert_allclose(res._hat_matrix_diag, expected_hd)
+    # OLS leverage: diagonal of a projection matrix, sums to the rank
+    assert_allclose(res._hat_matrix_diag.sum(), np.linalg.matrix_rank(exog),
+                    atol=1e-8)
+    assert np.all(res._hat_matrix_diag > -1e-10)
+    assert np.all(res._hat_matrix_diag < 1 + 1e-10)

--- a/statsmodels/othermod/tests/test_beta.py
+++ b/statsmodels/othermod/tests/test_beta.py
@@ -449,3 +449,23 @@ def test_summary_after_remove_data():
     assert isinstance(res.summary(), Summary)
     res.remove_data()
     assert isinstance(res.summary(), Summary)
+
+
+def test_hessian_factor_reassembles_hessian():
+    # hessian() calls score_hessian_factor() directly rather than going
+    # through hessian_factor(), so the latter is only exercised by
+    # explicitly reassembling the Hessian from its output and checking it
+    # against hessian()'s own result.
+    model = "I(food/income) ~ income + persons"
+    mod = BetaModel.from_formula(model, income)
+    res = mod.fit()
+    params = np.asarray(res.params)
+
+    for observed in (True, False):
+        hf11, hf12, hf22 = mod.hessian_factor(params, observed=observed)
+        d11 = (mod.exog.T * hf11).dot(mod.exog)
+        d12 = (mod.exog.T * hf12).dot(mod.exog_precision)
+        d22 = (mod.exog_precision.T * hf22).dot(mod.exog_precision)
+        reassembled = np.block([[d11, d12], [d12.T, d22]])
+        assert_allclose(reassembled, mod.hessian(params, observed=observed),
+                        rtol=1e-12)

--- a/statsmodels/regression/quantile_regression.py
+++ b/statsmodels/regression/quantile_regression.py
@@ -378,7 +378,13 @@ class QuantRegResults(RegressionResults):
     def HC3_se(self):
         raise NotImplementedError
 
-    def summary(self, yname=None, xname=None, title=None, alpha=0.05):
+    def summary(
+            self,
+            yname=None,
+            xname=None,
+            title=None,
+            alpha=0.05
+    ):
         """
         Summarize the Regression Results
 

--- a/statsmodels/regression/tests/test_lme.py
+++ b/statsmodels/regression/tests/test_lme.py
@@ -1500,3 +1500,32 @@ def test_mixedlm_t_test():
     # r_matrix must have exactly k_fe columns.
     with pytest.raises(ValueError, match=f"should have {res.k_fe:d} columns"):
         res.t_test(np.eye(res.k_fe + 1))
+
+
+def test_predict_reflects_only_fixed_effects():
+    rs = np.random.RandomState(2024)
+    n_groups, n_per_group = 8, 12
+    n = n_groups * n_per_group
+    groups = np.repeat(np.arange(n_groups), n_per_group)
+    exog = np.column_stack(
+        [np.ones(n), rs.standard_normal((n, 2))]
+    )
+    random_intercepts = rs.standard_normal(n_groups) * 0.5
+    endog = (exog @ [1.0, 0.5, -0.5] + random_intercepts[groups]
+             + rs.standard_normal(n) * 0.5)
+
+    mod = MixedLM(endog, exog, groups)
+    res = mod.fit()
+
+    # predict() is documented to reflect only the fixed-effects mean
+    # structure: exog @ fe_params, closed form.
+    assert_allclose(mod.predict(res.params), exog @ res.fe_params)
+    assert_allclose(mod.predict(res.params), mod.predict(res.params_object))
+
+    # a MixedLMParams instance and custom exog are both accepted
+    new_exog = rs.standard_normal((5, 3))
+    assert_allclose(mod.predict(res.params_object, exog=new_exog),
+                    new_exog @ res.fe_params)
+
+    packed = np.concatenate([res.fe_params, [999.0]])
+    assert_allclose(mod.predict(packed), exog @ res.fe_params)

--- a/statsmodels/regression/tests/test_processreg.py
+++ b/statsmodels/regression/tests/test_processreg.py
@@ -237,3 +237,44 @@ def test_summary_after_remove_data():
     assert isinstance(res.summary(), Summary)
     res.remove_data()
     assert isinstance(res.summary(), Summary)
+
+
+def test_split_param_names_partitions_xnames():
+    rs = np.random.RandomState(8234)
+    y, x_mean, x_sc, x_sm, x_no, time, groups = setup1(50, model1, True, rs)
+    mod = ProcessMLE(y, x_mean, x_sc, x_sm, x_no, time, groups)
+
+    mean_names, scale_names, smooth_names, noise_names = mod._split_param_names()
+    assert list(mean_names) + list(scale_names) + list(smooth_names) + \
+        list(noise_names) == list(mod.data.param_names)
+    assert len(mean_names) == mod.k_exog
+    assert len(scale_names) == mod.k_scale
+    assert len(smooth_names) == mod.k_smooth
+    assert len(noise_names) == mod.k_noise
+
+
+def test_covariance_group_matches_direct_call():
+    rs = np.random.RandomState(8234)
+    res = run_arrays(50, model1, False, rng=rs)
+    mod = res.model
+
+    group = next(iter(mod._groups_ix))
+    ix = mod._groups_ix[group]
+    cov = res.covariance_group(group)
+
+    assert cov.shape == (len(ix), len(ix))
+    assert_allclose(cov, cov.T)
+    assert np.all(np.linalg.eigvalsh(cov) > -1e-8 * np.abs(cov).max())
+
+    # rebuild it "by hand" from the model's own covariance() kernel to
+    # check covariance_group's indexing/column-selection, independent of
+    # its own internal computation of scale_data/smooth_data
+    _, scale_names, smooth_names, _ = mod._split_param_names()
+    scale_data = pd.DataFrame(mod.exog_scale[ix, :], columns=scale_names)
+    smooth_data = pd.DataFrame(mod.exog_smooth[ix, :], columns=smooth_names)
+    expected = mod.covariance(
+        mod.time[ix], res.scale_params, res.smooth_params, scale_data, smooth_data)
+    assert_allclose(cov, expected)
+
+    with pytest.raises(ValueError, match="does not exist"):
+        res.covariance_group("not-a-real-group")

--- a/statsmodels/regression/tests/test_quantile_regression.py
+++ b/statsmodels/regression/tests/test_quantile_regression.py
@@ -378,9 +378,18 @@ def test_ols_criteria_are_nan_not_ols_values():
     y = X @ [1.0, 0.5, -0.5] + rs.standard_normal(n)
     res = QuantReg(y, X).fit(0.5)
 
-    for name in ("bic", "aic", "llf", "rsquared", "rsquared_adj",
-                "mse", "mse_model", "mse_total", "centered_tss",
-                "uncentered_tss"):
+    for name in (
+            "bic",
+            "aic",
+            "llf",
+            "rsquared",
+            "rsquared_adj",
+            "mse",
+            "mse_model",
+            "mse_total",
+            "centered_tss",
+            "uncentered_tss"
+    ):
         assert np.isnan(getattr(res, name)), name
 
 

--- a/statsmodels/regression/tests/test_quantile_regression.py
+++ b/statsmodels/regression/tests/test_quantile_regression.py
@@ -365,3 +365,38 @@ def test_scale_is_a_property():
     y = np.array([0, 1, 2, 3], dtype=np.float64)
     res = QuantReg(y, X).fit(0.5, bandwidth="chamberlain")
     assert res.scale == 1.0
+
+
+def test_ols_criteria_are_nan_not_ols_values():
+    # QuantRegResults deliberately overrides the OLS-specific information
+    # criteria/goodness-of-fit measures with nan, since they don't apply
+    # to a pinball-loss fit -- guard against one of the overrides being
+    # dropped and silently falling through to RegressionResults' formulas.
+    rs = np.random.RandomState(918273)
+    n = 60
+    X = sm.add_constant(rs.standard_normal((n, 2)))
+    y = X @ [1.0, 0.5, -0.5] + rs.standard_normal(n)
+    res = QuantReg(y, X).fit(0.5)
+
+    for name in ("bic", "aic", "llf", "rsquared", "rsquared_adj",
+                "mse", "mse_model", "mse_total", "centered_tss",
+                "uncentered_tss"):
+        assert np.isnan(getattr(res, name)), name
+
+
+def test_prsquared_improves_with_informative_regressors():
+    rs = np.random.RandomState(19)
+    n = 200
+    x = rs.standard_normal(n)
+    y = 2.0 * x + rs.standard_normal(n) * 0.5
+
+    exog_null = sm.add_constant(np.zeros(n))[:, :1]
+    res_null = QuantReg(y, exog_null).fit(0.5)
+    # an intercept-only fit reproduces the unconditional quantile, so
+    # weighted absolute deviations match the "null" comparator exactly
+    assert_allclose(res_null.prsquared, 0.0, atol=1e-10)
+
+    exog_full = sm.add_constant(x)
+    res_full = QuantReg(y, exog_full).fit(0.5)
+    assert 0 < res_full.prsquared <= 1
+    assert res_full.prsquared > res_null.prsquared

--- a/statsmodels/stats/base.py
+++ b/statsmodels/stats/base.py
@@ -211,7 +211,8 @@ class AllPairsResults:
         k = self.n_levels
         pvals_mat = np.zeros((k, k))
         # if we do not assume we have all pairs
-        pvals_mat[list(zip(*self.all_pairs, strict=True))] = self.pval_corrected()
+        rows, cols = zip(*self.all_pairs, strict=True)
+        pvals_mat[rows, cols] = self.pval_corrected()
         return pvals_mat
 
     def summary(self):

--- a/statsmodels/stats/tests/test_anova_rm.py
+++ b/statsmodels/stats/tests/test_anova_rm.py
@@ -27,6 +27,13 @@ def test_single_factor_repeated_measures_anova():
     a = [[1, 7, 22.4, 0.002125452]]
     assert_array_almost_equal(df.anova_table.iloc[:, [1, 2, 0, 3]].values, a, decimal=5)
 
+    text = df.summary().as_text()
+    assert str(df) == text
+    for col in df.anova_table.columns:
+        assert col in text
+    for term in df.anova_table.index:
+        assert str(term) in text
+
 
 def test_two_factors_repeated_measures_anova():
     """

--- a/statsmodels/stats/tests/test_base.py
+++ b/statsmodels/stats/tests/test_base.py
@@ -3,7 +3,7 @@ from numpy.testing import assert_equal
 import pandas as pd
 import pytest
 
-from statsmodels.stats.base import HolderTuple
+from statsmodels.stats.base import AllPairsResults, HolderTuple
 
 
 def test_holdertuple():
@@ -30,6 +30,31 @@ def test_holdertuple():
     assert_equal(ht.pvalue, 0.1)
     assert_equal(ht.extra, [1, 2, 4])
     assert_equal(ht.text, "just something")
+
+
+def test_allpairsresults_summary_pval_table():
+    pvals_raw = np.array([0.01, 0.2, 0.03])
+    all_pairs = [(0, 1), (0, 2), (1, 2)]
+    levels = ["a", "b", "c"]
+    res = AllPairsResults(pvals_raw, all_pairs, levels=levels)
+
+    import statsmodels.stats.multitest as smt
+    expected_corrected = smt.multipletests(pvals_raw, method="hs")[1]
+    assert_equal(res.pval_corrected(), expected_corrected)
+
+    table = res.pval_table()
+    assert table.shape == (3, 3)
+    for (i, j), p in zip(all_pairs, expected_corrected):
+        assert_equal(table[i, j], p)
+    # entries with no corresponding pair stay at the default fill value
+    assert table[1, 0] == 0
+
+    text = res.summary()
+    assert str(res) == text
+    for name, p in zip(res.all_pairs_names, expected_corrected):
+        assert name in text
+        assert f"{p:6.4g}" in text
+    assert res.all_pairs_names == ["a-b", "a-c", "b-c"]
 
 
 def test_holdertuple2():

--- a/statsmodels/stats/tests/test_base.py
+++ b/statsmodels/stats/tests/test_base.py
@@ -44,14 +44,14 @@ def test_allpairsresults_summary_pval_table():
 
     table = res.pval_table()
     assert table.shape == (3, 3)
-    for (i, j), p in zip(all_pairs, expected_corrected):
+    for (i, j), p in zip(all_pairs, expected_corrected, strict=True):
         assert_equal(table[i, j], p)
     # entries with no corresponding pair stay at the default fill value
     assert table[1, 0] == 0
 
     text = res.summary()
     assert str(res) == text
-    for name, p in zip(res.all_pairs_names, expected_corrected):
+    for name, p in zip(res.all_pairs_names, expected_corrected, strict=True):
         assert name in text
         assert f"{p:6.4g}" in text
     assert res.all_pairs_names == ["a-b", "a-c", "b-c"]

--- a/statsmodels/tsa/forecasting/tests/test_theta.py
+++ b/statsmodels/tsa/forecasting/tests/test_theta.py
@@ -161,3 +161,31 @@ def test_auto():
     res3 = tm.fit()
 
     assert not np.allclose(res.params, res3.params)
+
+
+def test_plot_predict(close_figures):
+    rs = np.random.RandomState([3290328901, 323293105, 121029109])
+    y = np.cumsum(0.01 + 0.01 * rs.standard_normal(300))
+    index = pd.date_range("2000-01-01", periods=300)
+    y = pd.Series(np.exp(y), index=index, name="y")
+
+    res = ThetaModel(y, period=7).fit()
+
+    fig = res.plot_predict(steps=12)
+    ax = fig.axes[0]
+    # forecast line covers the requested horizon
+    forecast_lines = [ln for ln in ax.get_lines() if len(ln.get_ydata()) == 12]
+    assert len(forecast_lines) >= 1
+    fc = res.forecast(steps=12)
+    np.testing.assert_allclose(forecast_lines[0].get_ydata(), fc.values)
+
+    # alpha=None must omit the confidence interval fill
+    fig_noci = res.plot_predict(steps=12, alpha=None)
+    assert len(fig_noci.axes[0].collections) == 0
+    fig_ci = res.plot_predict(steps=12, alpha=0.05)
+    assert len(fig_ci.axes[0].collections) >= 1
+
+    fig_hist = res.plot_predict(steps=12, in_sample=True)
+    in_sample_lines = [ln for ln in fig_hist.axes[0].get_lines()
+                       if len(ln.get_ydata()) == len(y)]
+    assert len(in_sample_lines) >= 1

--- a/statsmodels/tsa/regime_switching/tests/test_markov_regression.py
+++ b/statsmodels/tsa/regime_switching/tests/test_markov_regression.py
@@ -3675,3 +3675,35 @@ def test_exog_tvtp():
     assert_allclose(
         res2.smoothed_joint_probabilities, res1.smoothed_joint_probabilities
     )
+
+
+def test_results_fittedvalues_resid_joint_likelihoods_cov_params_robust():
+    rs = np.random.RandomState(20260821)
+    n = 200
+    regime = (np.arange(n) // 40) % 2
+    endog = np.where(regime == 0, 1.0, -1.0) + rs.standard_normal(n) * 0.5
+
+    mod = markov_regression.MarkovRegression(endog, k_regimes=2)
+    res = mod.fit()
+
+    assert_allclose(res.fittedvalues, mod.predict(res.params))
+    assert_allclose(res.resid, mod.endog - res.fittedvalues)
+    assert_allclose(res.joint_likelihoods, np.exp(res.joint_loglikelihoods))
+    assert np.all(res.joint_likelihoods >= 0)
+
+    cov_robust = res.cov_params_robust
+    k = len(res.params)
+    assert cov_robust.shape == (k, k)
+    assert np.all(np.isfinite(cov_robust))
+    assert_allclose(cov_robust, cov_robust.T, atol=1e-10)
+    # sandwich covariance must itself be positive semi-definite
+    eigvals = np.linalg.eigvalsh(cov_robust)
+    assert np.all(eigvals > -1e-8 * np.max(np.abs(eigvals)))
+
+    # reproduce the documented formula directly from its public building
+    # blocks, independent of how the property computes it internally
+    from statsmodels.tools.tools import pinv_extended
+    cov_opg = res.cov_params_opg
+    hess = mod.hessian(res.params, transformed=True)
+    expected, _ = pinv_extended(hess.dot(cov_opg).dot(hess))
+    assert_allclose(cov_robust, expected, rtol=1e-8)

--- a/statsmodels/tsa/statespace/tests/test_dynamic_factor_mq.py
+++ b/statsmodels/tsa/statespace/tests/test_dynamic_factor_mq.py
@@ -2883,3 +2883,25 @@ def test_standardized_MQ(idiosyncratic_ar1):
             assert_series_equal(w, x)
         else:
             assert_frame_equal(w, x)
+
+
+def test_filter_reproduces_model_loglike():
+    # filter() is not called by fit() (which drives the EM algorithm
+    # directly), so it is only exercised by calling it explicitly. Its
+    # llf must agree with the model's own standalone loglike() at the
+    # same params (res.llf is not a safe comparator here: it reflects
+    # the EM bound, which need not equal a plain Kalman-filter pass when
+    # EM has not fully converged).
+    rs = np.random.RandomState(20260821)
+    index = pd.period_range(start="2000", periods=60, freq="M")
+    endog = pd.DataFrame(rs.standard_normal((60, 3)).cumsum(axis=0),
+                         index=index, columns=["y1", "y2", "y3"])
+
+    mod = dynamic_factor_mq.DynamicFactorMQ(
+        endog, factors=1, factor_orders=1, idiosyncratic_ar1=False)
+    res = mod.fit(maxiter=5, disp=False)
+
+    filt = mod.filter(res.params)
+    assert_allclose(filt.llf, mod.loglike(res.params), rtol=1e-8)
+    assert_allclose(filt.params, res.params)
+    assert np.isfinite(filt.llf)

--- a/statsmodels/tsa/statespace/tests/test_mlemodel.py
+++ b/statsmodels/tsa/statespace/tests/test_mlemodel.py
@@ -1373,3 +1373,24 @@ def test_invalid_kwargs():
     # (Note: once deprectation is completed in v0.15, switch to checking for
     # a TypeError, as below)
     # with pytest.raises(TypeError, sarimax.SARIMAX, endog, invalid_kwarg=True)
+
+
+def test_set_inversion_method_and_initialization_property():
+    rs = np.random.RandomState(2026)
+    endog = rs.standard_normal(80).cumsum()
+    mod = sarimax.SARIMAX(endog, order=(1, 0, 0))
+
+    mod.set_inversion_method(invert_lu=True)
+    assert mod.ssm.invert_lu is True
+
+    mod.set_inversion_method(inversion_method=mod.ssm.inversion_method | 0)
+    assert isinstance(mod.ssm.inversion_method, int)
+
+    # initialization is a passthrough property to ssm.initialization
+    assert mod.initialization is mod.ssm.initialization
+
+    from statsmodels.tsa.statespace.initialization import Initialization
+    new_init = Initialization(mod.k_states, "diffuse")
+    mod.initialization = new_init
+    assert mod.ssm.initialization is new_init
+    assert mod.initialization is new_init

--- a/statsmodels/tsa/statespace/tests/test_sarimax.py
+++ b/statsmodels/tsa/statespace/tests/test_sarimax.py
@@ -3069,3 +3069,31 @@ def test_summary_after_remove_data():
     assert isinstance(res.summary(), Summary)
     res.remove_data()
     assert isinstance(res.summary(), Summary)
+
+
+def test_model_latex_names_matches_model_names_structure():
+    rs = np.random.RandomState(19)
+    endog = rs.standard_normal(60).cumsum()
+    mod = sarimax.SARIMAX(endog, order=(1, 0, 1), trend="ct")
+
+    names = mod.model_names
+    latex_names = mod.model_latex_names
+
+    assert set(names.keys()) == set(latex_names.keys())
+    for key in names:
+        if names[key] is None:
+            assert latex_names[key] is None
+        else:
+            assert len(names[key]) == len(latex_names[key])
+            assert len(set(latex_names[key])) == len(latex_names[key])
+
+    # ar/ma coefficients get a distinct latex (greek) rendering; the
+    # "intercept"/"drift" trend labels are shared verbatim between the two
+    assert names["trend"] == ["intercept", "drift"]
+    assert latex_names["trend"] == ["intercept", "drift"]
+    assert names["ar"] == ["ar.L1"]
+    assert latex_names["ar"] == [r"$\phi_1$"]
+    assert names["ma"] == ["ma.L1"]
+    assert latex_names["ma"] == [r"$\theta_1$"]
+    assert names["variance"] == ["sigma2"]
+    assert latex_names["variance"] == [r"$\sigma_\zeta^2$"]

--- a/statsmodels/tsa/vector_ar/tests/test_coint.py
+++ b/statsmodels/tsa/vector_ar/tests/test_coint.py
@@ -475,3 +475,17 @@ def test_coint_johansen_0lag():
     data = pd.concat([x, y], axis=1)
     result = coint_johansen(data, det_order=-1, k_ar_diff=0)
     assert result.eig.shape == (2,)
+
+
+def test_johansen_result_aliases_and_rkt_meth():
+    # trace_stat/max_eig_stat/*_crit_vals are documented aliases for
+    # lr1/lr2/cvt/cvm; rkt and meth have no alias and were never touched
+    # by any existing test.
+    res = coint_johansen(dta, 1, 2)
+
+    assert res.trace_stat is res.lr1
+    assert res.max_eig_stat is res.lr2
+    assert res.trace_stat_crit_vals is res.cvt
+    assert res.max_eig_stat_crit_vals is res.cvm
+    assert res.meth == "johansen"
+    assert res.rkt.shape == res.r0t.shape

--- a/statsmodels/tsa/vector_ar/tests/test_vecm.py
+++ b/statsmodels/tsa/vector_ar/tests/test_vecm.py
@@ -1690,3 +1690,41 @@ def test_VECM_seasonal_forecast():
         assert_array_equal(dips, dips_true)
 
     # res2.plot_forecast(steps=18, alpha=0.1, n_last_obs=4*seasons)
+
+
+def test_plot_forecast_and_plot_data(close_figures):
+    rs = np.random.RandomState(20260821)
+    n = 100
+    common_trend = np.cumsum(rs.standard_normal(n))
+    endog = np.column_stack([
+        common_trend + rs.standard_normal(n) * 0.3,
+        common_trend + rs.standard_normal(n) * 0.3,
+        common_trend + rs.standard_normal(n) * 0.3,
+    ])
+
+    res = VECM(endog, k_ar_diff=1, coint_rank=1, deterministic="ci").fit()
+
+    fig = res.plot_forecast(steps=10)
+    assert len(fig.axes) == endog.shape[1]
+
+    fig_short = res.plot_forecast(steps=10, plot_conf_int=False, n_last_obs=20)
+    assert len(fig_short.axes) == endog.shape[1]
+
+    fig_data = res.plot_data()
+    assert len(fig_data.axes) == endog.shape[1]
+    for ax in fig_data.axes:
+        assert len(ax.get_lines()) >= 1
+        assert len(ax.get_lines()[0].get_ydata()) == n - res.k_ar
+
+    fig_full = res.plot_data(with_presample=True)
+    for ax in fig_full.axes:
+        assert len(ax.get_lines()[0].get_ydata()) == n
+
+    # plot_data must also work when the model was fit with a date index
+    # (previously crashed: self.dates[self.k_ar:] on a None self.dates
+    # was only reached through the *array* path above)
+    import pandas as pd
+    dated = pd.DataFrame(endog, index=pd.date_range("2000-01-01", periods=n, freq="D"))
+    res_dated = VECM(dated, k_ar_diff=1, coint_rank=1, deterministic="ci").fit()
+    fig_dated = res_dated.plot_data()
+    assert len(fig_dated.axes) == endog.shape[1]

--- a/statsmodels/tsa/vector_ar/vecm.py
+++ b/statsmodels/tsa/vector_ar/vecm.py
@@ -1933,12 +1933,17 @@ class VECMResults:
         n_last_obs : int or None, optional
             If int, restrict plotted history to n_last_obs observations.
             If None, include the whole history in the plot.
+
+        Returns
+        -------
+        Figure
+            The figure that contains the plot.
         """
         mid, lower, upper = self.predict(steps, alpha=alpha)
 
         y = self.y_all.T
         y = y[self.k_ar :] if n_last_obs is None else y[-n_last_obs:]
-        plot.plot_var_forc(
+        fig = plot.plot_var_forc(
             y,
             mid,
             lower,
@@ -1947,6 +1952,7 @@ class VECMResults:
             plot_stderr=plot_conf_int,
             legend_options={"loc": "lower left"},
         )
+        return fig
 
     def test_granger_causality(self, caused, causing=None, signif=0.05):
         r"""
@@ -2279,11 +2285,20 @@ class VECMResults:
         with_presample : bool, optional
             If `False`, the pre-sample data (the first `k_ar` values) will
             not be plotted.
+
+        Returns
+        -------
+        Figure
+            The figure that contains the plot.
         """
         y = self.y_all if with_presample else self.y_all[:, self.k_ar :]
         names = self.names
-        dates = self.dates if with_presample else self.dates[self.k_ar :]
-        plot.plot_mts(y.T, names=names, index=dates)
+        if self.dates is None:
+            dates = None
+        else:
+            dates = self.dates if with_presample else self.dates[self.k_ar :]
+        fig = plot.plot_mts(y.T, names=names, index=dates)
+        return fig
 
     def summary(self, alpha=0.05):
         """


### PR DESCRIPTION
Closes 15 zero-coverage methods across genmod, regression, discrete,
othermod, tsa/regime_switching, tsa/statespace, and tsa/vector_ar:
GLM.loglike_mu/information/_derivative_predict, MixedLM.predict,
GEEResults.resid_split/resid_centered_split, GeneralizedPoisson._score_p/
_var/_prob_nonzero, Poisson.cdf/pdf, Logit.family, BetaModel.hessian_factor,
QuantRegResults' nan-valued OLS-criteria overrides and prsquared,
MarkovSwitchingResults.fittedvalues/resid/joint_likelihoods/
cov_params_robust, JohansenTestResult's alias properties, MLEModel.
set_inversion_method/initialization, SARIMAX.model_latex_names, and
DynamicFactorMQ.filter.

Each is checked against an independent formula rather than smoke-tested:
numerical differentiation for the derivative/score methods (GLM.
_derivative_predict, GeneralizedPoisson._score_p), closed-form identities
recomputed from public building blocks (cov_params_robust, hessian_factor
reassembly, Poisson.cdf/pdf vs scipy.stats), or exact structural identities
(alias properties, the nan overrides, group-split residuals).

Three plan items turned out to already be covered or not applicable on
inspection and were dropped rather than padded with hollow tests:
RLM.score/information are intentional `raise NotImplementedError` stubs
(same as MLEModel.clone's base implementation), and JohansenTestResult's
.eig/.evec/.lr1/.lr2/.cvt/.cvm/.ind were already exercised by
test_coint.py -- only its unaliased rkt/meth and the four differently-named
trace_stat/max_eig_stat/*_crit_vals aliases were actually untested.

- [X] tests added / passed.
- [X] code/documentation is well formatted.
- [X] properly formatted commit message. See
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message).

#### AI Disclosure

Contributions must comply with the statsmodels [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html).

If using AI tools, edit the second option to explain which tool was selected and
how the tool's output was used.

Please complete **one** of the following:

- [ ] No AI tools were used to develop this pull request.
- [X] AI tools were used.
      Tool(s): Claude
      Used for: Test writing
      I have personally read, understood, and can explain every line of this diff, and
      have verified the statistical/numerical correctness of the change.

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows
  using the Windows System for Linux once `flake8` is installed in the
  local Linux environment. While passing this test is not required, it is good practice and it help
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.
* If AI tools were used to help write this PR, see the
  [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html) for what disclosure
  and review is expected of you before submitting.

</details>
