### PR TITLE
BUG: Fix OLSInfluence._ols_xnoti crashing on every call

### DIFF
--- a/statsmodels/duration/tests/test_survfunc.py
+++ b/statsmodels/duration/tests/test_survfunc.py
@@ -62,6 +62,31 @@ def test_survfunc1():
     assert_allclose(sr.n_risk, n_risk1)
     assert_allclose(sr.n_events, n_events1)
 
+    df = sr.summary()
+    assert list(df.index) == list(sr.surv_times)
+    assert_allclose(df["Surv prob"].values, sr.surv_prob)
+    assert_allclose(df["Surv prob SE"].values, sr.surv_prob_se)
+    assert_allclose(df["num at risk"].values, sr.n_risk)
+    assert_allclose(df["num events"].values, sr.n_events)
+
+    # quantile(p): first time where the survival curve drops below 1-p,
+    # i.e. the smallest t with P(T > t) < 1-p
+    for p in (0.1, 0.5, 0.9):
+        q = sr.quantile(p)
+        ii = np.flatnonzero(sr.surv_prob < 1 - p)
+        expected = np.nan if len(ii) == 0 else sr.surv_times[ii[0]]
+        if np.isnan(expected):
+            assert np.isnan(q)
+        else:
+            assert q == expected
+            # the survival probability at (just before) the quantile has
+            # indeed just dropped below 1-p
+            assert sr.surv_prob[sr.surv_times == q][0] < 1 - p
+
+    # p beyond the lowest observed survival probability: no such time
+    p_beyond = 1 - sr.surv_prob.min() + 0.01
+    assert np.isnan(sr.quantile(p_beyond))
+
 
 def test_survfunc2():
     # Test where some times have no events.

--- a/statsmodels/genmod/tests/test_gee.py
+++ b/statsmodels/genmod/tests/test_gee.py
@@ -2458,3 +2458,34 @@ def test_stationary_covsolve():
             )
 
             assert_allclose(z1, z2[0], rtol=1e-5, atol=1e-5)
+
+
+def test_autoregressive_covariance_matrix_and_summary():
+    rs = np.random.RandomState(20260821)
+    c = cov_struct.Autoregressive(grid=False)
+    c.dep_params = 0.6
+    d = 5
+    index = np.arange(d, dtype=int)
+
+    cmat, is_cor = c.covariance_matrix(np.zeros(d), index)
+    assert is_cor is True
+    expected = 0.6 ** np.abs(np.subtract.outer(index, index))
+    assert_allclose(cmat, expected)
+
+    # covariance_matrix agrees with the already-tested fast tridiagonal
+    # solve: applying the explicit matrix inverse must give the same
+    # answer as covariance_matrix_solve for the same (dep_params, stdev)
+    sd = rs.uniform(0.5, 2, d)
+    z = rs.normal(size=d)
+    scaled_cov = np.diag(sd) @ cmat @ np.diag(sd)
+    z1 = np.linalg.solve(scaled_cov, z)
+    z2 = c.covariance_matrix_solve(np.zeros(d), index, sd, [z])
+    assert_allclose(z1, z2[0], rtol=1e-8)
+
+    # dep_params == 0 special-cases to the identity
+    c0 = cov_struct.Autoregressive(grid=False)
+    c0.dep_params = 0
+    cmat0, _ = c0.covariance_matrix(np.zeros(d), index)
+    assert_allclose(cmat0, np.eye(d))
+
+    assert c.summary() == "Autoregressive(1) dependence parameter: 0.600\n"

--- a/statsmodels/othermod/tests/test_beta.py
+++ b/statsmodels/othermod/tests/test_beta.py
@@ -449,3 +449,30 @@ def test_summary_after_remove_data():
     assert isinstance(res.summary(), Summary)
     res.remove_data()
     assert isinstance(res.summary(), Summary)
+
+
+def test_llrmixin_set_null_options():
+    # BetaResults is the only class in the codebase that mixes in
+    # _LLRMixin without overriding set_null_options (discrete_model.py's
+    # DiscreteResults defines its own, shadowing the mixin's version for
+    # every discrete model) -- so this is the only place its actual body
+    # can be exercised at all.
+    model = "I(food/income) ~ income + persons"
+    res = BetaModel.from_formula(model, income).fit()
+
+    llnull0 = res.llnull
+    assert not hasattr(res, "res_null")
+
+    res.set_null_options(attach_results=True)
+    lln = res.llnull
+    assert_allclose(lln, llnull0)
+    assert hasattr(res, "res_null")
+    assert_allclose(res.res_null.llf, lln)
+
+    # llr/llr_pvalue/pseudo_rsquared derive from llnull and must move
+    # together with it when the cache is reset via a direct override
+    res.set_null_options(llnull=res.llf - 5)
+    assert "prsquared" not in res._cache
+    assert_allclose(res._cache["llnull"], res.llf - 5)
+    assert_allclose(res.llr, -2 * (res.llnull - res.llf))
+    assert_allclose(res.pseudo_rsquared(), 1 - res.llf / res.llnull)

--- a/statsmodels/stats/outliers_influence.py
+++ b/statsmodels/stats/outliers_influence.py
@@ -1155,23 +1155,17 @@ class OLSInfluence(_BaseInfluenceMixin):
         This needs more thought, memory versus speed.
         Not yet used in any other parts, not sufficiently tested.
         """
-        # reverse the structure, access store, if fail calculate ?
-        # this creates keys in store even if store = false ! bug
         if endog_idx == "endog":
             stored = self.aux_regression_endog
-            if hasattr(stored, drop_idx):
+            if drop_idx in stored:
                 return stored[drop_idx]
             x_i = self.results.model.endog
 
         else:
-            # nested dictionary
-            try:
-                self.aux_regression_exog[endog_idx][drop_idx]
-            except KeyError:
-                pass
-
-            stored = self.aux_regression_exog[endog_idx]
-            stored = {}
+            # nested dictionary, one per endog_idx
+            stored = self.aux_regression_exog.setdefault(endog_idx, {})
+            if drop_idx in stored:
+                return stored[drop_idx]
 
             x_i = self.exog[:, endog_idx]
 

--- a/statsmodels/stats/tests/test_influence.py
+++ b/statsmodels/stats/tests/test_influence.py
@@ -410,3 +410,63 @@ def test_vif_instability():
     vif_true = variance_inflation_factor(clean_exog, 1, standardize=True)
     vif_false = variance_inflation_factor(clean_exog, 1, standardize=False)
     assert_allclose(vif_true, vif_false, rtol=1e-7)
+
+
+def test_olsinfluence_closed_form_measures():
+    from statsmodels.stats.outliers_influence import OLSInfluence
+
+    rs = np.random.RandomState(20260821)
+    n = 60
+    exog = np.column_stack([np.ones(n), rs.standard_normal((n, 2))])
+    endog = exog @ [1.0, 0.5, -0.5] + rs.standard_normal(n)
+    res = OLS(endog, exog).fit()
+    infl = OLSInfluence(res)
+
+    hii = infl.hat_matrix_diag
+    assert_allclose(infl.resid_press, infl.resid / (1 - hii))
+    assert_allclose(infl.hat_diag_factor, hii / (1 - hii))
+    assert_allclose(infl.ess_press, np.dot(infl.resid_press, infl.resid_press))
+    assert_allclose(infl.resid_var, infl.scale * (1 - hii))
+    assert_allclose(infl.resid_std, np.sqrt(infl.resid_var))
+
+
+def test_olsinfluence_ols_xnoti_and_get_drop_vari():
+    from statsmodels.stats.outliers_influence import OLSInfluence
+
+    rs = np.random.RandomState(20260822)
+    n = 50
+    exog = np.column_stack([np.ones(n), rs.standard_normal((n, 3))])
+    endog = exog @ [1.0, 0.5, -0.5, 0.2] + rs.standard_normal(n)
+    res = OLS(endog, exog).fit()
+    infl = OLSInfluence(res)
+
+    # _ols_xnoti: exog[:, endog_idx] regressed on the other exog columns
+    drop_idx, endog_idx = 1, 2
+    aux = infl._ols_xnoti(drop_idx, endog_idx=endog_idx)
+    mask = np.arange(exog.shape[1]) != drop_idx
+    expected = OLS(exog[:, endog_idx], exog[:, mask]).fit()
+    assert_allclose(aux.params, expected.params)
+
+    # cached on repeated calls with store=True, and the cache actually
+    # persists on the instance (this used to silently discard it: see the
+    # BUG commit removing a stray `stored = {}` and a broken `hasattr`
+    # check that made this method crash on every call)
+    assert infl.aux_regression_exog[endog_idx][drop_idx] is aux
+    aux2 = infl._ols_xnoti(drop_idx, endog_idx=endog_idx)
+    assert aux2 is aux
+
+    # endog_idx="endog": original endog regressed on exog minus drop_idx
+    aux_endog = infl._ols_xnoti(drop_idx)
+    expected_endog = OLS(endog, exog[:, mask]).fit()
+    assert_allclose(aux_endog.params, expected_endog.params)
+    assert infl.aux_regression_endog[drop_idx] is aux_endog
+    assert infl._ols_xnoti(drop_idx) is aux_endog
+
+    # _get_drop_vari: leave-one-*variable*-out loop, collecting the
+    # requested attribute from each k_vars-1 auxiliary fit
+    res_loo = infl._get_drop_vari(["params"])
+    assert len(res_loo["params"]) == infl.k_vars
+    for j, params_j in enumerate(res_loo["params"]):
+        mask_j = np.arange(infl.k_vars) != j
+        expected_j = OLS(endog, exog[:, mask_j]).fit().params
+        assert_allclose(params_j, expected_j)

--- a/statsmodels/tools/tests/test_grouputils.py
+++ b/statsmodels/tools/tests/test_grouputils.py
@@ -27,6 +27,16 @@ class CheckGrouping:
         self.grouping.count_categories(level=0)
         np.testing.assert_equal(self.grouping.counts, self.expected_counts)
 
+    def test_levels(self):
+        levels = self.grouping.levels
+        if hasattr(self.grouping.index, "levels"):
+            assert levels is self.grouping.index.levels
+        else:
+            assert_equal(
+                np.asarray(levels),
+                np.asarray(pd.Categorical(self.grouping.index).categories),
+            )
+
     def test_check_index(self):
         # GH: check_index used `if not index:`, which raises for a
         # multi-element pandas Index/MultiIndex, and called the long-removed
@@ -158,6 +168,12 @@ class CheckGrouping:
                 pd.Series(values, dtype="category"), drop_first=False
             )
             np.testing.assert_equal(self.grouping._dummies.toarray(), expected)
+
+            # dummies_time() is a thin convenience wrapper: dummy_sparse(1)
+            # then return _dummies
+            np.testing.assert_equal(
+                self.grouping.dummies_time().toarray(), expected
+            )
 
 
 class TestMultiIndexGrouping(CheckGrouping):


### PR DESCRIPTION
Both branches were broken. The endog_idx="endog" branch called
hasattr(stored, drop_idx) where stored is a dict and drop_idx an int --
hasattr requires a string name, so this always raised TypeError. The
endog_idx=<int> branch read self.aux_regression_exog[endog_idx] (a plain
dict, not a defaultdict) inside a try/except that swallowed the KeyError
for a never-seen endog_idx, then immediately repeated the same lookup
outside the try with nothing to catch it -- and even when that lookup
somehow succeeded, the very next line `stored = {}` threw the result away
and rebound `stored` to a fresh local dict, so the cache was never
actually read from or written back to. The method's own docstring said
"Not yet used in any other parts, not sufficiently tested" -- accurate:
every call, in both branches, was reaching one of these crashes.

Fixed by checking dict membership directly and using setdefault() for the
nested-dict case, matching the caching behavior the docstring describes.


- [X] tests added / passed.
- [X] code/documentation is well formatted.
- [X] properly formatted commit message. See
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message).

#### AI Disclosure

Contributions must comply with the statsmodels [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html).

If using AI tools, edit the second option to explain which tool was selected and
how the tool's output was used.

Please complete **one** of the following:

- [ ] No AI tools were used to develop this pull request.
- [X] AI tools were used.
      Tool(s): Claude
      Used for: Writing tests
      I have personally read, understood, and can explain every line of this diff, and
      have verified the statistical/numerical correctness of the change.

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows
  using the Windows System for Linux once `flake8` is installed in the
  local Linux environment. While passing this test is not required, it is good practice and it help
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.
* If AI tools were used to help write this PR, see the
  [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html) for what disclosure
  and review is expected of you before submitting.

</details>
