### PR TITLE
TST: Cover margins and diagnostics gaps

### DIFF
--- a/statsmodels/discrete/tests/test_margins.py
+++ b/statsmodels/discrete/tests/test_margins.py
@@ -131,3 +131,47 @@ class TestNegBinPMargin(CheckMarginMixin):
         cls.res1 = res_stata.results_negbin_margins_cont
         cls.rtol_fac = 5e1
         # negbin has lower agreement with Stata in this case
+
+
+def test_discrete_margins_summary_single_equation():
+    rs = np.random.RandomState(20260822)
+    n = 200
+    x = rs.standard_normal(n)
+    exog = add_constant(np.column_stack([x, rs.standard_normal(n)]))
+    endog = rs.poisson(np.exp(exog @ [0.2, 0.3, -0.1]))
+
+    res = Poisson(endog, exog).fit(disp=0)
+    marge = res.get_margeff()
+    text = str(marge.summary())
+
+    assert "Poisson Marginal Effects" in text
+    assert res.model.endog_names in text
+    for val, se in zip(marge.margeff, marge.margeff_se, strict=True):
+        assert f"{val:.4f}" in text
+        assert f"{se:.3f}" in text
+
+
+def test_discrete_margins_summary_multi_equation():
+    from statsmodels.discrete.discrete_model import MNLogit
+
+    rs = np.random.RandomState(20260823)
+    n = 300
+    x = rs.standard_normal((n, 2))
+    exog = add_constant(x)
+    lin0 = exog @ [0.0, 0.0, 0.0]
+    lin1 = exog @ [0.5, 0.8, -0.4]
+    lin2 = exog @ [-0.3, -0.2, 0.6]
+    p = np.exp(np.column_stack([lin0, lin1, lin2]))
+    p /= p.sum(1, keepdims=True)
+    endog = np.array([rs.choice(3, p=row) for row in p])
+
+    res = MNLogit(endog, exog).fit(disp=0)
+    marge = res.get_margeff()
+    text = str(marge.summary())
+
+    assert "MNLogit Marginal Effects" in text
+    # one sub-table per outcome category
+    assert marge.margeff.shape[1] == 3
+    for eq in range(marge.margeff.shape[1]):
+        for val in marge.margeff[:, eq]:
+            assert f"{val:.4f}" in text

--- a/statsmodels/genmod/tests/test_gee.py
+++ b/statsmodels/genmod/tests/test_gee.py
@@ -98,6 +98,17 @@ class TestGEE:
         # smoke test
         marg.summary()
 
+        # summary_frame: its columns must reproduce the marginal-effects
+        # arrays exactly, in the documented column order
+        frame = marg.summary_frame()
+        assert_allclose(frame.iloc[:, 0].values, marg.margeff)
+        assert_allclose(frame.iloc[:, 1].values, marg.margeff_se)
+        assert_allclose(frame.iloc[:, 2].values, marg.tvalues)
+        assert_allclose(frame.iloc[:, 3].values, marg.pvalues)
+        assert_allclose(frame.iloc[:, 4:6].values, marg.conf_int())
+        # only non-constant exog columns are included
+        assert list(frame.index) == ["x1", "x2"]
+
     def test_summary_after_remove_data(self):
         # summary() must still work after remove_data() has been called
         n = 40

--- a/statsmodels/stats/tests/test_deltacov.py
+++ b/statsmodels/stats/tests/test_deltacov.py
@@ -89,6 +89,39 @@ class TestDeltacovOLS:
         assert_allclose(nl.predicted(), res.params[0], rtol=1e-12)
         assert_allclose(nl.se_vectorized(), res.bse[0], rtol=1e-12)
 
+    def test_wald_test(self):
+        # fun = identity: predicted() = params, cov() = cov_params exactly,
+        # so wald_test(value) must reduce to the ordinary multivariate Wald
+        # statistic for H0: params = value, cross-checked against the
+        # already-tested Results.wald_test on an identity restriction.
+        res = self.res
+        k = len(res.params)
+
+        def fun(params):
+            return params
+
+        nl = NonlinearDeltaCov(fun, res.params, res.cov_params(), deriv=lambda p: np.eye(k))
+        value = res.params + 0.1
+
+        stat, pvalue = nl.wald_test(value)
+
+        diff = res.params - value
+        expected_stat = diff @ np.linalg.inv(res.cov_params()) @ diff
+        assert_allclose(stat, expected_stat, rtol=1e-10)
+
+        # NonlinearDeltaCov.wald_test always reports a raw chi2 statistic;
+        # Results.wald_test defaults to an F-statistic (chi2 / df_constraints)
+        # when the model uses t-distributed inference, so force use_f=False
+        # for a like-for-like comparison.
+        wt = res.wald_test((np.eye(k), value), use_f=False, scalar=True)
+        assert_allclose(stat, wt.statistic, rtol=1e-8)
+        assert_allclose(pvalue, wt.pvalue, rtol=1e-8)
+
+        # H0 exactly true at value=params: statistic must be ~0
+        stat0, pvalue0 = nl.wald_test(res.params)
+        assert_allclose(stat0, 0, atol=1e-8)
+        assert_allclose(pvalue0, 1, atol=1e-6)
+
 
 def test_deltacov_margeff():
     # compare with discrete margins


### PR DESCRIPTION
DiscreteMargins.summary (both the J==1 single-equation branch and the J>1 multi-equation branch used by MNLogit, previously entirely untested), GEEMargins.summary_frame (checked column-by-column against margeff/margeff_se/tvalues/pvalues/conf_int, plus that only non-constant exog columns appear), and NonlinearDeltaCov.wald_test.

wald_test is checked two ways: recomputing the chi-square statistic directly from predicted()/cov(), and cross-checking against the already-tested Results.wald_test using an identity function (so NonlinearDeltaCov reduces to an ordinary multivariate Wald test of H0: params = value). That cross-check surfaced a statistic-convention mismatch worth noting for later: Results.wald_test defaults to an F-statistic (chi2 / df_constraints) when the model uses t-distributed inference, while NonlinearDeltaCov.wald_test always reports the raw chi2 statistic -- not a bug in either (both are internally consistent and documented), but a real trap for anyone comparing the two without passing use_f=False.

PoissonDiagnostic._chisquare_binned (a multi-parameter Hosmer-Lemeshow style test) and the separate 0%-covered Margins class in discrete_margins.py were identified but not reached this phase -- deferred rather than rushed.

- [X] tests added / passed.
- [X] code/documentation is well formatted.
- [X] properly formatted commit message. See
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message).

#### AI Disclosure

Contributions must comply with the statsmodels [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html).

If using AI tools, edit the second option to explain which tool was selected and
how the tool's output was used.

Please complete **one** of the following:

- [ ] No AI tools were used to develop this pull request.
- [X] AI tools were used.
      Tool(s): Claude
      Used for: Test writing
      I have personally read, understood, and can explain every line of this diff, and
      have verified the statistical/numerical correctness of the change.

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows
  using the Windows System for Linux once `flake8` is installed in the
  local Linux environment. While passing this test is not required, it is good practice and it help
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.
* If AI tools were used to help write this PR, see the
  [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html) for what disclosure
  and review is expected of you before submitting.

</details>
