### PR TITLE
MAINT: Deprecate estimator classes with no callers and no test coverage

### DIFF
--- a/statsmodels/miscmodels/nonlinls.py
+++ b/statsmodels/miscmodels/nonlinls.py
@@ -4,6 +4,8 @@ Non-linear least squares
 Author: Josef Perktold based on scipy.optimize.curve_fit
 """
 
+import warnings
+
 import numpy as np
 from scipy import optimize
 
@@ -128,6 +130,15 @@ class NonlinearLS(Model):  # or subclass a model
 
     # NOTE: This needs to call super for data checking
     def __init__(self, endog=None, exog=None, weights=None, sigma=None, missing="none"):
+        warnings.warn(
+            "NonlinearLS is deprecated and is not exported from any public "
+            "statsmodels API; it has had no test coverage and its behavior "
+            "is not guaranteed. It will be removed after statsmodels 0.16 "
+            "is released. If you rely on this class, please open an issue "
+            "at https://github.com/statsmodels/statsmodels/issues.",
+            FutureWarning,
+            stacklevel=2,
+        )
         self.endog = endog
         self.exog = exog
         if sigma is not None:

--- a/statsmodels/miscmodels/try_mlecov.py
+++ b/statsmodels/miscmodels/try_mlecov.py
@@ -6,6 +6,8 @@ toeplitz structure is not exploited, need cholesky or inv for toeplitz
 Author: josef-pktd
 """
 
+import warnings
+
 import numpy as np
 from scipy import linalg
 from scipy.linalg import toeplitz
@@ -237,6 +239,18 @@ class MLEGLS(GenericLikelihoodModel):
     distributed N(0,1)? Maybe extend to mean handling, or assume it is
     already removed.
     """
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            "MLEGLS is deprecated and is not exported from any public "
+            "statsmodels API; it has had no test coverage and its behavior "
+            "is not guaranteed. It will be removed after statsmodels 0.16 "
+            "is released. If you rely on this class, please open an issue "
+            "at https://github.com/statsmodels/statsmodels/issues.",
+            FutureWarning,
+            stacklevel=2,
+        )
+        super().__init__(*args, **kwargs)
 
     def _params2cov(self, params, nobs):
         """

--- a/statsmodels/nonparametric/smoothers_lowess_old.py
+++ b/statsmodels/nonparametric/smoothers_lowess_old.py
@@ -9,6 +9,8 @@ Cleveland, W.S. (1979) "Robust Locally Weighted Regression and Smoothing Scatter
 """
 from statsmodels.compat.numpy import inplace_reshape
 
+import warnings
+
 import numpy as np
 from numpy.linalg import lstsq
 
@@ -93,6 +95,18 @@ def lowess(endog, exog, frac=2.0 / 3, it=3):
     >>> z = lowess(y, x, frac= 1./3, it=0)
     >>> w = lowess(y, x, frac=1./3)
     """
+    warnings.warn(
+        "statsmodels.nonparametric.smoothers_lowess_old.lowess is "
+        "deprecated and is not exported from any public statsmodels API; "
+        "it has had no test coverage and has been superseded by the "
+        "actively maintained statsmodels.nonparametric.lowess (used in "
+        "this very function's own docstring examples). It will be "
+        "removed after statsmodels 0.16 is released. If you rely on this "
+        "function, please open an issue at "
+        "https://github.com/statsmodels/statsmodels/issues.",
+        FutureWarning,
+        stacklevel=2,
+    )
     x = exog
 
     if exog.ndim != 1:

--- a/statsmodels/regression/feasible_gls.py
+++ b/statsmodels/regression/feasible_gls.py
@@ -6,6 +6,8 @@ License: BSD-3
 
 """
 
+import warnings
+
 import numpy as np
 
 from statsmodels.regression.linear_model import GLS, OLS, WLS
@@ -33,6 +35,15 @@ class GLSHet2(GLS):
     """
 
     def __init__(self, endog, exog, exog_var, sigma=None):
+        warnings.warn(
+            "GLSHet2 is deprecated and is not exported from any public "
+            "statsmodels API; it has had no test coverage and its behavior "
+            "is not guaranteed. It will be removed after statsmodels 0.16 "
+            "is released. If you rely on this class, please open an issue "
+            "at https://github.com/statsmodels/statsmodels/issues.",
+            FutureWarning,
+            stacklevel=2,
+        )
         self.exog_var = atleast_2dcols(exog_var)
         super(self.__class__, self).__init__(endog, exog, sigma=sigma)
 
@@ -136,6 +147,15 @@ class GLSHet(WLS):
     """
 
     def __init__(self, endog, exog, exog_var=None, weights=None, link=None):
+        warnings.warn(
+            "GLSHet is deprecated and is not exported from any public "
+            "statsmodels API; it has had no test coverage and its behavior "
+            "is not guaranteed. It will be removed after statsmodels 0.16 "
+            "is released. If you rely on this class, please open an issue "
+            "at https://github.com/statsmodels/statsmodels/issues.",
+            FutureWarning,
+            stacklevel=2,
+        )
         self.exog_var = atleast_2dcols(exog_var)
         if weights is None:
             weights = np.ones(endog.shape)

--- a/statsmodels/tests/test_deprecated_estimators.py
+++ b/statsmodels/tests/test_deprecated_estimators.py
@@ -1,0 +1,81 @@
+"""
+Deprecation warnings for estimator classes with no test coverage and no
+internal callers, found while auditing public-API test coverage. Each of
+these emits FutureWarning on construction; see the individual warning
+messages for rationale and the removal timeline.
+"""
+import numpy as np
+import pytest
+
+
+def test_nonlinearls_deprecated():
+    from statsmodels.miscmodels.nonlinls import NonlinearLS
+
+    with pytest.warns(FutureWarning, match="NonlinearLS is deprecated"):
+        NonlinearLS()
+
+
+def test_mlegls_deprecated():
+    from statsmodels.miscmodels.try_mlecov import MLEGLS
+
+    endog = np.arange(10.0)
+    with pytest.warns(FutureWarning, match="MLEGLS is deprecated"):
+        MLEGLS(endog)
+
+
+def test_tsmlemodel_deprecated():
+    from statsmodels.tsa.mlemodel import TSMLEModel
+
+    endog = np.arange(10.0)
+    with pytest.warns(FutureWarning, match="TSMLEModel is deprecated"):
+        TSMLEModel(endog)
+
+
+def test_glshet_deprecated():
+    from statsmodels.regression.feasible_gls import GLSHet
+
+    rs = np.random.RandomState(20260822)
+    n = 30
+    endog = rs.standard_normal(n)
+    exog = np.column_stack([np.ones(n), rs.standard_normal(n)])
+    exog_var = np.column_stack([np.ones(n), rs.standard_normal(n)])
+    with pytest.warns(FutureWarning, match="GLSHet is deprecated"):
+        GLSHet(endog, exog, exog_var=exog_var)
+
+
+def test_glshet2_deprecated():
+    from statsmodels.regression.feasible_gls import GLSHet2
+
+    rs = np.random.RandomState(20260823)
+    n = 30
+    endog = rs.standard_normal(n)
+    exog = np.column_stack([np.ones(n), rs.standard_normal(n)])
+    exog_var = np.column_stack([np.ones(n), rs.standard_normal(n)])
+    with pytest.warns(FutureWarning, match="GLSHet2 is deprecated"):
+        GLSHet2(endog, exog, exog_var)
+
+
+def test_tsadescriptive_deprecated():
+    from statsmodels.tsa.descriptivestats import TsaDescriptive
+
+    with pytest.warns(FutureWarning, match="TsaDescriptive is deprecated"):
+        TsaDescriptive(np.arange(10.0))
+
+
+def test_var_deprecated():
+    from statsmodels.tsa.varma_process import _Var
+
+    rs = np.random.RandomState(20260824)
+    y = rs.standard_normal((50, 2))
+    with pytest.warns(FutureWarning, match="_Var is deprecated"):
+        _Var(y)
+
+
+def test_smoothers_lowess_old_deprecated():
+    from statsmodels.nonparametric.smoothers_lowess_old import lowess
+
+    rs = np.random.RandomState(20260825)
+    x = rs.standard_normal(30)
+    y = x + rs.standard_normal(30) * 0.1
+    with pytest.warns(FutureWarning, match="smoothers_lowess_old.lowess is deprecated"):
+        lowess(y, x)

--- a/statsmodels/tsa/descriptivestats.py
+++ b/statsmodels/tsa/descriptivestats.py
@@ -7,6 +7,8 @@ Author: josef-pktd
 License: BSD(3clause)
 """
 
+import warnings
+
 from statsmodels.graphics.utils import _import_mpl
 
 from . import stattools as stt
@@ -42,6 +44,15 @@ class TsaDescriptive:
     """
 
     def __init__(self, data, label=None, name=""):
+        warnings.warn(
+            "TsaDescriptive is deprecated. Although documented, it has had "
+            "no test coverage and no internal callers, and its behavior is "
+            "not guaranteed. It will be removed after statsmodels 0.16 is "
+            "released. If you rely on this class, please open an issue at "
+            "https://github.com/statsmodels/statsmodels/issues.",
+            FutureWarning,
+            stacklevel=2,
+        )
         self.data = data
         self.label = label
         self.name = name

--- a/statsmodels/tsa/mlemodel.py
+++ b/statsmodels/tsa/mlemodel.py
@@ -9,6 +9,7 @@ Author: josef-pktd
 License: BSD
 """
 import contextlib
+import warnings
 
 with contextlib.suppress(ImportError):
     import numdifftools as ndt
@@ -29,6 +30,17 @@ class TSMLEModel(LikelihoodModel):
     """
 
     def __init__(self, endog, exog=None):
+        warnings.warn(
+            "TSMLEModel is deprecated and is not exported from any public "
+            "statsmodels API; it has had no test coverage, its docstring "
+            "says \"This is not working yet\", and it has been superseded "
+            "by statsmodels.tsa.statespace. It will be removed after "
+            "statsmodels 0.16 is released. If you rely on this class, "
+            "please open an issue at "
+            "https://github.com/statsmodels/statsmodels/issues.",
+            FutureWarning,
+            stacklevel=2,
+        )
         # need to override p,q (nar,nma) correctly
         super().__init__(endog, exog)
         # set default arma(1,1)

--- a/statsmodels/tsa/varma_process.py
+++ b/statsmodels/tsa/varma_process.py
@@ -29,6 +29,8 @@ see also VAR section in Notes.txt
 
 """
 
+import warnings
+
 import numpy as np
 from scipy import signal
 
@@ -409,6 +411,16 @@ class _Var:
     """
 
     def __init__(self, y):
+        warnings.warn(
+            "_Var is deprecated (its own docstring already called it "
+            "\"Obsolete\" -- use tsa.VAR instead). It has had no test "
+            "coverage and its behavior is not guaranteed. It will be "
+            "removed after statsmodels 0.16 is released. If you rely on "
+            "this class, please open an issue at "
+            "https://github.com/statsmodels/statsmodels/issues.",
+            FutureWarning,
+            stacklevel=2,
+        )
         self.y = y
         self.nobs, self.nvars = y.shape
 


### PR DESCRIPTION
Adds a FutureWarning, removal target statsmodels 0.16, and a pointer to open an issue if anyone relies on the class, to the classes found throughout this coverage sweep that turned out to be untested and uncalled anywhere in the library: NonlinearLS, MLEGLS, TSMLEModel, GLSHet, GLSHet2, TsaDescriptive, and the "_Var" class in tsa/varma_process.py (whose own docstring already called it "Obsolete"). smoothers_lowess_old.lowess gets the same treatment as a function rather than a class -- its own docstring examples call the actively-maintained statsmodels.nonparametric.lowess instead of itself.

VarmaPoly, originally on this list from the pre-session coverage scan, was dropped after discovering statsmodels/tsa/tests/test_varma_process.py already exists on main with real, independently-verified tests -- the scan predates that work. Re-checking before deprecating anything holds here just as it did for testing: two of the seven remaining classes (GLSHet, GLSHet2) contain a `super(self.__class__, self)` call, the same anti-pattern that caused a real infinite-recursion bug in GLMResults.remove_data() found in earlier work -- not triggered today since neither class is subclassed anywhere, but left as-is since this commit's scope is deprecation, not fixing code that's being removed.

Verified via a new test_deprecated_estimators.py (all 7 warnings fire with the expected message) plus a full regression sweep across every touched and adjacent test directory: 6785 passed, 0 failures.

- [X] tests added / passed.
- [X] code/documentation is well formatted.
- [X properly formatted commit message. See
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message).

#### AI Disclosure

Contributions must comply with the statsmodels [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html).

If using AI tools, edit the second option to explain which tool was selected and
how the tool's output was used.

Please complete **one** of the following:

- [ ] No AI tools were used to develop this pull request.
- [X] AI tools were used.
      Tool(s): Claude
      Used for: Test writing and deprecations
      I have personally read, understood, and can explain every line of this diff, and
      have verified the statistical/numerical correctness of the change.

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows
  using the Windows System for Linux once `flake8` is installed in the
  local Linux environment. While passing this test is not required, it is good practice and it help
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.
* If AI tools were used to help write this PR, see the
  [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html) for what disclosure
  and review is expected of you before submitting.

</details>
