### PR TITLE
ENH: Enforce string like validation

### DIFF
--- a/statsmodels/base/_parameter_inference.py
+++ b/statsmodels/base/_parameter_inference.py
@@ -11,6 +11,7 @@ import numpy as np
 from scipy import stats
 
 from statsmodels.stats.base import LimitedIterationMixin
+from statsmodels.tools.validation import string_like
 
 
 @dataclass(frozen=True, slots=True)
@@ -241,6 +242,9 @@ def score_test(
     The covariance matrix of the score is the simple empirical covariance of
     score_obs without degrees of freedom correction.
     """
+    hypothesis = string_like(
+        hypothesis, "hypothesis", options=("joint", "separate"), lower=False
+    )
     # TODO: we are computing unnecessary things for cov_type nonrobust
     if hasattr(self, "_results"):
         # use numpy if we have wrapper, not relevant if method
@@ -369,8 +373,6 @@ def score_test(
             pvalue=pval,
             distribution="norm",
         )
-    else:
-        raise NotImplementedError('only hypothesis "joint" is available')
 
 
 def _scorehess_extra(

--- a/statsmodels/base/_parameter_inference.py
+++ b/statsmodels/base/_parameter_inference.py
@@ -363,7 +363,7 @@ def score_test(
             k_constraint=k_constraints,
             distribution="chi2",
         )
-    elif hypothesis == "separate":
+    else:  # hypothesis == "separate"
         diff = score
         bse = np.sqrt(np.diag(cov_score_test))
         stat = diff / bse

--- a/statsmodels/base/_prediction_inference.py
+++ b/statsmodels/base/_prediction_inference.py
@@ -10,6 +10,8 @@ import numpy as np
 import pandas as pd
 from scipy import stats
 
+from statsmodels.tools.validation import string_like
+
 
 # this is similar to ContrastResults after t_test, partially copied, adjusted
 class PredictionResultsBase:
@@ -224,6 +226,9 @@ class PredictionResultsMonotonic(PredictionResultsBase):
             The array has the lower and the upper limit of the confidence
             interval in the columns.
         """
+        method = string_like(
+            method, "method", options=("endpoint", "delta"), lower=False
+        )
         tmp = np.linspace(0, 1, 6)
         # TODO: drop check?
         is_linear = (self.func(tmp) == tmp).all()
@@ -331,6 +336,9 @@ class PredictionResultsMean(PredictionResultsBase):
             The array has the lower and the upper limit of the confidence
             interval in the columns.
         """
+        method = string_like(
+            method, "method", options=("endpoint", "delta"), lower=False
+        )
         tmp = np.linspace(0, 1, 6)
         is_linear = (self.link.inverse(tmp) == tmp).all()
         if method == "endpoint" and not is_linear:

--- a/statsmodels/base/distributed_estimation.py
+++ b/statsmodels/base/distributed_estimation.py
@@ -8,6 +8,7 @@ from statsmodels.stats.regularized_covariance import (
     _calc_nodewise_row,
     _calc_nodewise_weight,
 )
+from statsmodels.tools.validation import string_like
 
 """
 Distributed estimation routines. Currently, we support several
@@ -547,6 +548,12 @@ class DistributedModel:
         if fit_kwds is None:
             fit_kwds = {}
 
+        parallel_method = string_like(
+            parallel_method,
+            "parallel_method",
+            options=("sequential", "joblib"),
+            lower=False,
+        )
         if parallel_method == "sequential":
             results_l = self.fit_sequential(
                 data_generator, fit_kwds, init_kwds_generator
@@ -555,11 +562,6 @@ class DistributedModel:
         elif parallel_method == "joblib":
             results_l = self.fit_joblib(
                 data_generator, fit_kwds, parallel_backend, init_kwds_generator
-            )
-
-        else:
-            raise ValueError(
-                f"parallel_method: {parallel_method} is currently not supported"
             )
 
         params = self.join_method(results_l, **self.join_kwds)

--- a/statsmodels/base/distributed_estimation.py
+++ b/statsmodels/base/distributed_estimation.py
@@ -559,7 +559,7 @@ class DistributedModel:
                 data_generator, fit_kwds, init_kwds_generator
             )
 
-        elif parallel_method == "joblib":
+        else:  # parallel_method == "joblib"
             results_l = self.fit_joblib(
                 data_generator, fit_kwds, parallel_backend, init_kwds_generator
             )

--- a/statsmodels/base/elastic_net.py
+++ b/statsmodels/base/elastic_net.py
@@ -352,7 +352,7 @@ def fit_elasticnet(model, method="coord_descent", maxiter=100,
         params, itr, converged = _coord_descent(
             model, alpha, L1_wt, start_params, maxiter, cnvrg_tol,
             zero_tol, check_step, loglike_kwds, score_kwds, hess_kwds)
-    elif method == "l1_slsqp":
+    else:  # method == "l1_slsqp"
         if L1_wt != 1.:
             raise ValueError("L1_wt must be 1 when method is 'l1_slsqp'")
         params, itr, converged = _l1_slsqp(

--- a/statsmodels/base/elastic_net.py
+++ b/statsmodels/base/elastic_net.py
@@ -4,6 +4,7 @@ from statsmodels.base.l1_slsqp import fit_l1_slsqp
 from statsmodels.base.model import Results
 import statsmodels.base.wrapper as wrap
 from statsmodels.tools._decorators import cache_readonly
+from statsmodels.tools.validation import string_like
 
 """
 Elastic net regularization.
@@ -341,6 +342,12 @@ def fit_elasticnet(model, method="coord_descent", maxiter=100,
     if np.isscalar(alpha):
         alpha = alpha * np.ones(k_exog)
 
+    method = string_like(
+        method,
+        "method",
+        options=("coord_descent", "elastic_net", "l1_slsqp"),
+        lower=False,
+    )
     if method in ("coord_descent", "elastic_net"):
         params, itr, converged = _coord_descent(
             model, alpha, L1_wt, start_params, maxiter, cnvrg_tol,
@@ -353,9 +360,6 @@ def fit_elasticnet(model, method="coord_descent", maxiter=100,
             trim_mode=trim_mode, auto_trim_tol=auto_trim_tol,
             size_trim_tol=size_trim_tol, qc_tol=qc_tol,
             qc_verbose=qc_verbose, acc=acc)
-    else:
-        raise ValueError(
-            "method must be 'coord_descent' or 'l1_slsqp'")
 
     if not refit:
         results = RegularizedResults(model, params)

--- a/statsmodels/base/l1_solvers_common.py
+++ b/statsmodels/base/l1_solvers_common.py
@@ -5,6 +5,7 @@ Holds common functions for l1 solvers.
 import numpy as np
 
 from statsmodels.tools.sm_exceptions import ConvergenceWarning
+from statsmodels.tools.validation import string_like
 
 
 def qc_results(params, alpha, score, qc_tol, qc_verbose=False):
@@ -129,6 +130,9 @@ def do_trim_params(
     trimmed : ndarray of bool
         trimmed[i] == True if the ith parameter was trimmed.
     """
+    trim_mode = string_like(
+        trim_mode, "trim_mode", options=("auto", "size", "off"), lower=False
+    )
     # Trim the small params
     trimmed = [False] * k_params
 
@@ -156,7 +160,5 @@ def do_trim_params(
                 if abs(params[i]) < size_trim_tol:
                     params[i] = 0.0
                     trimmed[i] = True
-    else:
-        raise ValueError(f"trim_mode == {trim_mode}, which is not recognized")
 
     return params, np.asarray(trimmed)

--- a/statsmodels/base/l1_solvers_common.py
+++ b/statsmodels/base/l1_solvers_common.py
@@ -154,7 +154,7 @@ def do_trim_params(
                 if (alpha[i] - abs(fprime[i])) / alpha[i] > auto_trim_tol:
                     params[i] = 0.0
                     trimmed[i] = True
-    elif trim_mode == "size":
+    else:  # trim_mode == "size"
         for i in range(k_params):
             if alpha[i] != 0:
                 if abs(params[i]) < size_trim_tol:

--- a/statsmodels/base/optimizer.py
+++ b/statsmodels/base/optimizer.py
@@ -13,6 +13,8 @@ import warnings
 import numpy as np
 from scipy import optimize
 
+from statsmodels.tools.validation import string_like
+
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
@@ -29,12 +31,6 @@ def check_kwargs(kwargs: dict[str, Any], allowed: Sequence[str], method: str):
             FutureWarning,
             stacklevel=2,
         )
-
-
-def _check_method(method, methods):
-    if method not in methods:
-        message = f"Unknown fit method {method}"
-        raise ValueError(message)
 
 
 class Optimizer:
@@ -245,8 +241,7 @@ class Optimizer:
             "minimize",
         ]
         methods += extra_fit_funcs.keys()
-        method = method.lower()
-        _check_method(method, methods)
+        method = string_like(method, "method", options=methods)
 
         fit_funcs = {
             "newton": _fit_newton,

--- a/statsmodels/base/tests/test_distributed_estimation.py
+++ b/statsmodels/base/tests/test_distributed_estimation.py
@@ -297,6 +297,16 @@ def test_fit_sequential():
     )
 
 
+def test_fit_invalid_parallel_method_raises():
+    rs = np.random.RandomState(435265)
+    X = rs.normal(size=(50, 3))
+    y = rs.randint(0, 2, size=50)
+
+    mod = DistributedModel(1, model_class=OLS)
+    with pytest.raises(ValueError, match="parallel_method"):
+        mod.fit(_data_gen(y, X, 1), parallel_method="not-a-method")
+
+
 @pytest.mark.joblib
 @pytest.mark.slow
 @pytest.mark.thread_unsafe(reason="Uses joblib")

--- a/statsmodels/base/tests/test_optimize.py
+++ b/statsmodels/base/tests/test_optimize.py
@@ -210,6 +210,22 @@ def test_minimize_no_hess_method(min_method):
     assert_allclose(res.params, res_default.params, rtol=1e-4)
 
 
+def test_fit_invalid_method_raises():
+    from statsmodels.discrete.discrete_model import Poisson
+
+    exog = np.column_stack((np.ones(10), np.arange(10) / 10.0))
+    endog = np.array([1, 2, 1, 3, 2, 4, 3, 5, 4, 6])
+    mod = Poisson(endog, exog)
+
+    with pytest.raises(ValueError, match="method"):
+        mod.fit(method="not-a-method", disp=0)
+
+    # case-insensitive, matching the previous manual `method.lower()`
+    res_upper = mod.fit(method="BFGS", disp=0)
+    res_lower = mod.fit(method="bfgs", disp=0)
+    assert_allclose(res_upper.params, res_lower.params)
+
+
 def test_lbfgs_disp_false_no_output(capsys):
     xopt, _ = _fit_lbfgs(
         dummy_func,

--- a/statsmodels/base/transform.py
+++ b/statsmodels/base/transform.py
@@ -2,6 +2,7 @@ import numpy as np
 from scipy.optimize import minimize_scalar
 
 from statsmodels.robust import mad
+from statsmodels.tools.validation import string_like
 
 
 class BoxCox:
@@ -91,7 +92,7 @@ class BoxCox:
         y : ndarray
             The untransformed series.
         """
-        method = method.lower()
+        method = string_like(method, "method", options=("naive",))
         x = np.asarray(x)
 
         if method == "naive":
@@ -99,8 +100,6 @@ class BoxCox:
                 y = np.exp(x)
             else:
                 y = np.power(lmbda * x + 1, 1.0 / lmbda)
-        else:
-            raise ValueError(f"Method '{method}' not understood.")
 
         return y
 
@@ -131,7 +130,7 @@ class BoxCox:
         lmbda : float
             The lambda parameter.
         """
-        method = method.lower()
+        method = string_like(method, "method", options=("guerrero", "loglik"))
 
         if len(bounds) != 2:
             raise ValueError(f"Bounds of length {len(bounds)} not understood.")
@@ -142,8 +141,6 @@ class BoxCox:
             lmbda = self._guerrero_cv(x, bounds=bounds, **kwargs)
         elif method == "loglik":
             lmbda = self._loglik_boxcox(x, bounds=bounds, **kwargs)
-        else:
-            raise ValueError(f"Method '{method}' not understood.")
 
         return lmbda
 
@@ -188,13 +185,11 @@ class BoxCox:
         )
         mean = np.mean(grouped_data, 1)
 
-        scale = scale.lower()
+        scale = string_like(scale, "scale", options=("sd", "mad"))
         if scale == "sd":
             dispersion = np.std(grouped_data, 1, ddof=1)
         elif scale == "mad":
             dispersion = mad(grouped_data, axis=1)
-        else:
-            raise ValueError(f"Scale '{scale}' not understood.")
 
         def optim(lmbda):
             rat = np.divide(dispersion, np.power(mean, 1 - lmbda))  # eq 6, p 40

--- a/statsmodels/base/transform.py
+++ b/statsmodels/base/transform.py
@@ -139,7 +139,7 @@ class BoxCox:
 
         if method == "guerrero":
             lmbda = self._guerrero_cv(x, bounds=bounds, **kwargs)
-        elif method == "loglik":
+        else:  # method == "loglik"
             lmbda = self._loglik_boxcox(x, bounds=bounds, **kwargs)
 
         return lmbda
@@ -188,7 +188,7 @@ class BoxCox:
         scale = string_like(scale, "scale", options=("sd", "mad"))
         if scale == "sd":
             dispersion = np.std(grouped_data, 1, ddof=1)
-        elif scale == "mad":
+        else:  # scale == "mad"
             dispersion = mad(grouped_data, axis=1)
 
         def optim(lmbda):

--- a/statsmodels/discrete/conditional_models.py
+++ b/statsmodels/discrete/conditional_models.py
@@ -18,8 +18,8 @@ from statsmodels.discrete.discrete_model import (
 from statsmodels.formula.formulatools import advance_eval_env
 import statsmodels.regression.linear_model as lm
 from statsmodels.tools.rng_qrng import check_random_state
-from statsmodels.tools.validation import string_like
 from statsmodels.tools.sm_exceptions import ModelWarning
+from statsmodels.tools.validation import string_like
 
 
 class _ConditionalModel(base.LikelihoodModel):

--- a/statsmodels/discrete/conditional_models.py
+++ b/statsmodels/discrete/conditional_models.py
@@ -18,6 +18,7 @@ from statsmodels.discrete.discrete_model import (
 from statsmodels.formula.formulatools import advance_eval_env
 import statsmodels.regression.linear_model as lm
 from statsmodels.tools.rng_qrng import check_random_state
+from statsmodels.tools.validation import string_like
 from statsmodels.tools.sm_exceptions import ModelWarning
 
 
@@ -235,8 +236,7 @@ class _ConditionalModel(base.LikelihoodModel):
 
         from statsmodels.base.elastic_net import fit_elasticnet
 
-        if method != "elastic_net":
-            raise ValueError("method for fit_regularized must be elastic_net")
+        method = string_like(method, "method", options=("elastic_net",), lower=False)
 
         defaults = {"maxiter": 50, "L1_wt": 1, "cnvrg_tol": 1e-10, "zero_tol": 1e-10}
         defaults.update(kwargs)

--- a/statsmodels/discrete/discrete_model.py
+++ b/statsmodels/discrete/discrete_model.py
@@ -56,6 +56,7 @@ from statsmodels.tools.sm_exceptions import (
     PerfectSeparationWarning,
     SpecificationWarning,
 )
+from statsmodels.tools.validation import string_like
 
 try:
     import cvxopt  # noqa:F401
@@ -179,11 +180,7 @@ def _validate_l1_method(method):
     ------
     ValueError
     """
-    if method not in ["l1", "l1_cvxopt_cp"]:
-        raise ValueError(
-            f"`method` = {method} is not supported, use either "
-            '"l1" or "l1_cvxopt_cp"'
-        )
+    string_like(method, "method", options=("l1", "l1_cvxopt_cp"), lower=False)
 
 
 # Private Model Classes
@@ -5094,7 +5091,7 @@ class DiscreteResults(base.LikelihoodModelResults):
         .. [BurnhamAnderson2002] Burnham KP, Anderson KR (2002). Model Selection
            and Multimodel Inference; Springer New York.
         """
-        crit = crit.lower()
+        crit = string_like(crit, "crit", options=("aic", "bic", "tic", "gbic"))
         k_extra = getattr(self.model, "k_extra", 0)
         k_params = self.df_model + 1 + k_extra + dk_params
 
@@ -5108,8 +5105,6 @@ class DiscreteResults(base.LikelihoodModelResults):
             return pinfer.tic(self)
         elif crit == "gbic":
             return pinfer.gbic(self)
-        else:
-            raise ValueError("Name of information criterion not recognized.")
 
     def score_test(
         self,

--- a/statsmodels/discrete/discrete_model.py
+++ b/statsmodels/discrete/discrete_model.py
@@ -5103,7 +5103,7 @@ class DiscreteResults(base.LikelihoodModelResults):
             return bic
         elif crit == "tic":
             return pinfer.tic(self)
-        elif crit == "gbic":
+        else:  # crit == "gbic"
             return pinfer.gbic(self)
 
     def score_test(

--- a/statsmodels/discrete/tests/test_conditional.py
+++ b/statsmodels/discrete/tests/test_conditional.py
@@ -288,6 +288,18 @@ def test_lasso_poisson():
     assert_allclose(result2.params, result3.params)
 
 
+def test_fit_regularized_invalid_method():
+    rs = np.random.RandomState(3423948)
+    n = 200
+    groups = np.kron(np.arange(10), np.ones(n // 10))
+    x = rs.normal(size=(n, 2))
+    y = (rs.uniform(size=n) < 0.5).astype(int)
+
+    model = ConditionalLogit(y, x, groups=groups)
+    with pytest.raises(ValueError, match="method"):
+        model.fit_regularized(method="not-a-method")
+
+
 def gen_mnlogit(n):
 
     rs = np.random.RandomState(235)

--- a/statsmodels/discrete/tests/test_discrete.py
+++ b/statsmodels/discrete/tests/test_discrete.py
@@ -156,7 +156,7 @@ class CheckModelMixin:
         # GH#5224 check we get ValueError when passing invalid "method" arg
         model = self.res1.model
 
-        with pytest.raises(ValueError, match=r"is not supported, use either"):
+        with pytest.raises(ValueError, match=r"method"):
             model.fit_regularized(method="foo")
 
 
@@ -3871,7 +3871,7 @@ def test_binary_results_info_criteria():
     expected_bic = -2 * res.llf + k_params * np.log(nobs)
     assert_allclose(res.info_criteria("bic", dk_params=2), expected_bic)
 
-    with pytest.raises(ValueError, match="not recognized"):
+    with pytest.raises(ValueError, match="crit"):
         res.info_criteria("not-a-real-criterion")
 
 

--- a/statsmodels/discrete/tests/test_predict.py
+++ b/statsmodels/discrete/tests/test_predict.py
@@ -422,3 +422,18 @@ def test_distr(case, close_figures):
             # ZI models warn about missing hat_matrix_diag
             warnings.simplefilter("ignore", category=UserWarning)
             influ.plot_influence()
+
+
+def test_prediction_results_monotonic_conf_int_invalid_method():
+    rs = np.random.RandomState(918273)
+    n = 100
+    exog = np.column_stack([np.ones(n), rs.standard_normal((n, 2))])
+    endog = (rs.standard_normal(n) + exog[:, 1] > 0).astype(float)
+    res = Logit(endog, exog).fit(disp=False)
+    pred = res.get_prediction()
+    assert isinstance(pred, PredictionResultsMonotonic)
+
+    assert pred.conf_int(method="endpoint") is not None
+    assert pred.conf_int(method="delta") is not None
+    with pytest.raises(ValueError, match="method"):
+        pred.conf_int(method="not-a-method")

--- a/statsmodels/distributions/tests/test_tools.py
+++ b/statsmodels/distributions/tests/test_tools.py
@@ -8,6 +8,7 @@ License: BSD-3
 
 import numpy as np
 from numpy.testing import assert_allclose, assert_equal
+import pytest
 from scipy import stats
 
 import statsmodels.distributions.tools as dt
@@ -63,6 +64,9 @@ def test_average_grid():
     assert_allclose(res0, res1 / x1.max() / x2.max(), rtol=1e-13)
     res0 = dt.average_grid(y, coords=[x1 / x1.max(), x2 / x2.max()], _method="convolve")
     assert_allclose(res0, res1 / x1.max() / x2.max(), rtol=1e-13)
+
+    with pytest.raises(ValueError, match="_method"):
+        dt.average_grid(y, coords=[x1, x2], _method="not-a-method")
 
 
 def test_grid_class():
@@ -231,6 +235,9 @@ def test_bernstein_1d():
 
     res_bp = dt._eval_bernstein_1d(xg2, xg1, method="bpoly")
     assert_allclose(res_bp, xg2, atol=1e-12)
+
+    with pytest.raises(ValueError, match="method"):
+        dt._eval_bernstein_1d(xg2, xg1, method="not-a-method")
 
 
 def test_bernstein_2d():

--- a/statsmodels/distributions/tools.py
+++ b/statsmodels/distributions/tools.py
@@ -12,6 +12,7 @@ import numpy as np
 from scipy import interpolate, stats
 
 from statsmodels.tools.rng_qrng import check_random_state
+from statsmodels.tools.validation import string_like
 
 # helper functions to work on a grid of cdf and pdf, histogram
 
@@ -134,6 +135,7 @@ def average_grid(values, coords=None, _method="slicing"):
     ndarray
         Grid with averaged cell values.
     """
+    _method = string_like(_method, "_method", options=("slicing", "convolve"))
     k_dim = values.ndim
     if _method == "slicing":
         p = values.copy()
@@ -396,28 +398,27 @@ def _eval_bernstein_1d(x, fvals, method="binom"):
         Bernstein polynomial at evaluation points, weighted sum of Bernstein
         polynomial basis.
     """
+    method = string_like(method, "method", options=("binom", "beta", "bpoly"))
     k_terms = fvals.shape[-1]
     xx = np.asarray(x)
     k = np.arange(k_terms).astype(float)
     n = k_terms - 1.0
 
-    if method.lower() == "binom":
+    if method == "binom":
         # Divide by 0 RuntimeWarning here
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", RuntimeWarning)
             poly_base = stats.binom.pmf(k, n, xx[..., None])
         bp_values = (fvals * poly_base).sum(-1)
-    elif method.lower() == "bpoly":
+    elif method == "bpoly":
         bpb = interpolate.BPoly(fvals[:, None], [0.0, 1])
         bp_values = bpb(x)
-    elif method.lower() == "beta":
+    elif method == "beta":
         # Divide by 0 RuntimeWarning here
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", RuntimeWarning)
             poly_base = stats.beta.pdf(xx[..., None], k + 1, n - k + 1) / (n + 1)
         bp_values = (fvals * poly_base).sum(-1)
-    else:
-        raise ValueError("method not recogized")
 
     return bp_values
 

--- a/statsmodels/distributions/tools.py
+++ b/statsmodels/distributions/tools.py
@@ -135,7 +135,9 @@ def average_grid(values, coords=None, _method="slicing"):
     ndarray
         Grid with averaged cell values.
     """
-    _method = string_like(_method, "_method", options=("slicing", "convolve"))
+    _method = string_like(
+        _method, "_method", options=("slicing", "convolve"), lower=False
+    )
     k_dim = values.ndim
     if _method == "slicing":
         p = values.copy()

--- a/statsmodels/distributions/tools.py
+++ b/statsmodels/distributions/tools.py
@@ -153,7 +153,7 @@ def average_grid(values, coords=None, _method="slicing"):
 
             p = (p[sl1] + p[sl2]) / 2
 
-    elif _method == "convolve":
+    else:  # _method == "convolve"
         from scipy import signal
 
         p = signal.convolve(values, 0.5**k_dim * np.ones([2] * k_dim), mode="valid")
@@ -415,7 +415,7 @@ def _eval_bernstein_1d(x, fvals, method="binom"):
     elif method == "bpoly":
         bpb = interpolate.BPoly(fvals[:, None], [0.0, 1])
         bp_values = bpb(x)
-    elif method == "beta":
+    else:  # method == "beta"
         # Divide by 0 RuntimeWarning here
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", RuntimeWarning)

--- a/statsmodels/duration/hazard_regression.py
+++ b/statsmodels/duration/hazard_regression.py
@@ -26,6 +26,7 @@ from statsmodels.tools._decorators import cache_readonly
 from statsmodels.tools.docstring_helpers import Appender
 from statsmodels.tools.rng_qrng import check_random_state
 from statsmodels.tools.sm_exceptions import SpecificationWarning
+from statsmodels.tools.validation import string_like
 
 _predict_docstring = """
     Returns predicted values from the proportional hazards
@@ -368,9 +369,7 @@ class PHReg(model.LikelihoodModel):
         self.df_resid = float(self.exog.shape[0] - np.linalg.matrix_rank(self.exog))
         self.df_model = float(np.linalg.matrix_rank(self.exog))
 
-        ties = ties.lower()
-        if ties not in ("efron", "breslow"):
-            raise ValueError("`ties` must be either `efron` or " + "`breslow`")
+        ties = string_like(ties, "ties", options=("efron", "breslow"))
 
         self.ties = ties
 
@@ -581,8 +580,7 @@ class PHReg(model.LikelihoodModel):
 
         from statsmodels.base.elastic_net import fit_elasticnet
 
-        if method != "elastic_net":
-            raise ValueError("method for fit_regularized must be elastic_net")
+        method = string_like(method, "method", options=("elastic_net",), lower=False)
 
         defaults = {"maxiter": 50, "L1_wt": 1, "cnvrg_tol": 1e-10, "zero_tol": 1e-10}
         defaults.update(kwargs)

--- a/statsmodels/duration/survfunc.py
+++ b/statsmodels/duration/survfunc.py
@@ -3,6 +3,7 @@ import pandas as pd
 from scipy.stats.distributions import chi2, norm
 
 from statsmodels.graphics import utils
+from statsmodels.tools.validation import string_like
 
 
 def _calc_survfunc_right(time, status, weights=None, entry=None, compress=True,
@@ -544,7 +545,11 @@ class SurvfuncRight:
 
         tr = norm.ppf(1 - alpha / 2)
 
-        method = method.lower()
+        method = string_like(
+            method,
+            "method",
+            options=("cloglog", "linear", "log", "logit", "asinsqrt"),
+        )
         if method == "cloglog":
 
             def g(x):
@@ -578,8 +583,6 @@ class SurvfuncRight:
 
             def gprime(x):
                 return 1 / (2 * np.sqrt(x) * np.sqrt(1 - x))
-        else:
-            raise ValueError("unknown method")
 
         r = g(self.surv_prob) - g(1 - p)
         r /= (gprime(self.surv_prob) * self.surv_prob_se)
@@ -649,15 +652,12 @@ class SurvfuncRight:
             in `surv_times`.
         """
 
-        method = method.lower()
-        if method != "hw":
-            msg = "only the Hall-Wellner (hw) method is implemented"
-            raise ValueError(msg)
+        method = string_like(method, "method", options=("hw",))
 
         if alpha != 0.05:
             raise ValueError("alpha must be set to 0.05")
 
-        transform = transform.lower()
+        transform = string_like(transform, "transform", options=("log", "arcsin"))
         s2 = self.surv_prob_se**2 / self.surv_prob**2
         nn = self.n_risk
         if transform == "log":
@@ -675,8 +675,6 @@ class SurvfuncRight:
             lcb = np.sin(v)**2
             v = np.clip(f + k, -np.inf, np.pi/2)
             ucb = np.sin(v)**2
-        else:
-            raise ValueError("Unknown transform")
 
         return lcb, ucb
 

--- a/statsmodels/duration/survfunc.py
+++ b/statsmodels/duration/survfunc.py
@@ -652,7 +652,7 @@ class SurvfuncRight:
             in `surv_times`.
         """
 
-        method = string_like(method, "method", options=("hw",))
+        _ = string_like(method, "method", options=("hw",))
 
         if alpha != 0.05:
             raise ValueError("alpha must be set to 0.05")

--- a/statsmodels/duration/survfunc.py
+++ b/statsmodels/duration/survfunc.py
@@ -576,7 +576,7 @@ class SurvfuncRight:
 
             def gprime(x):
                 return 1 / (x * (1 - x))
-        elif method == "asinsqrt":
+        else:  # method == "asinsqrt"
 
             def g(x):
                 return np.arcsin(np.sqrt(x))
@@ -666,7 +666,7 @@ class SurvfuncRight:
             theta = np.exp(theta)
             lcb = self.surv_prob**(1/theta)
             ucb = self.surv_prob**theta
-        elif transform == "arcsin":
+        else:  # transform == "arcsin"
             k = 1.3581
             k *= (1 + nn * s2) / (2 * np.sqrt(nn))
             k *= np.sqrt(self.surv_prob / (1 - self.surv_prob))

--- a/statsmodels/duration/tests/test_phreg.py
+++ b/statsmodels/duration/tests/test_phreg.py
@@ -453,6 +453,17 @@ class TestPHReg:
                 llf_sm = plf(sm_result.params, model, time, s)
                 assert_equal(np.sign(llf_sm - llf_r), 1)
 
+    def test_invalid_ties_raises(self):
+        time, status, entry, exog = self.load_file("survival_data_50_2.csv")
+        with pytest.raises(ValueError, match="ties"):
+            PHReg(time, exog, status=status, ties="not-a-tie-method")
+
+    def test_fit_regularized_invalid_method_raises(self):
+        time, status, entry, exog = self.load_file("survival_data_50_2.csv")
+        model = PHReg(time, exog, status=status, ties="breslow")
+        with pytest.raises(ValueError, match="method"):
+            model.fit_regularized(method="not-a-method")
+
 
 cur_dir = Path(__file__).resolve().parent
 rdir = Path(cur_dir).joinpath("results")

--- a/statsmodels/duration/tests/test_survfunc.py
+++ b/statsmodels/duration/tests/test_survfunc.py
@@ -129,6 +129,11 @@ def test_simultaneous_cb():
     assert_allclose(lcb2[ix], np.r_[0.52115708, 0.48079378, 0.45595321, 0.43341115])
     assert_allclose(ucb2[ix], np.r_[0.96465636, 0.92745068, 0.90885428, 0.88796708])
 
+    with pytest.raises(ValueError, match="method"):
+        sf.simultaneous_cb(method="not-a-method")
+    with pytest.raises(ValueError, match="transform"):
+        sf.simultaneous_cb(transform="not-a-transform")
+
 
 def test_bmt():
     # All tests against SAS
@@ -160,6 +165,9 @@ def test_bmt():
     for method in "linear", "cloglog", "log", "logit", "asinsqrt":
         lcb, ucb = sf.quantile_ci(0.25, method=method)
         assert_allclose(cb[method], np.r_[lcb, ucb])
+
+    with pytest.raises(ValueError, match="method"):
+        sf.quantile_ci(0.25, method="not-a-method")
 
 
 def test_survdiff():

--- a/statsmodels/formula/_manager.py
+++ b/statsmodels/formula/_manager.py
@@ -13,6 +13,7 @@ import numpy as np
 import pandas as pd
 
 from statsmodels.tools.data import _to_pandas
+from statsmodels.tools.validation import string_like
 
 HAVE_PATSY = False
 HAVE_FORMULAIC = False
@@ -288,10 +289,9 @@ class FormulaManager:
             _engine = statsmodels.formula.options.formula_engine
 
         assert _engine is not None
-        if _engine not in ("patsy", "formulaic"):
-            raise ValueError(
-                f"Unknown engine: {_engine}. Only patsy and formulaic are supported."
-            )
+        _engine = string_like(
+            _engine, "engine", options=("patsy", "formulaic"), lower=False
+        )
         # Ensure selected engine is available
         msg = f"{_engine} is not available. Please install {_engine}."
         if (

--- a/statsmodels/gam/smooth_basis.py
+++ b/statsmodels/gam/smooth_basis.py
@@ -19,6 +19,7 @@ import pandas as pd
 
 from statsmodels.formula._manager import FormulaManager
 from statsmodels.tools.linalg import transf_constraints
+from statsmodels.tools.validation import string_like
 
 # Obtain b splines from patsy
 
@@ -278,6 +279,8 @@ def get_knots_bsplines(x=None, df=None, knots=None, degree=3,
     if all_knots is not None:
         return all_knots
 
+    spacing = string_like(spacing, "spacing", options=("quantile", "equal"))
+
     x_min = x.min()
     x_max = x.max()
 
@@ -311,8 +314,6 @@ def get_knots_bsplines(x=None, df=None, knots=None, degree=3,
             grid = np.linspace(0, 1, n_inner_knots + 2)[1:-1]
             inner_knots = x_min + grid * (x_max - x_min)
             diff_knots = inner_knots[1] - inner_knots[0]
-        else:
-            raise ValueError("incorrect option for spacing")
     if knots is not None:
         inner_knots = knots
     if lower_bound is None:

--- a/statsmodels/gam/smooth_basis.py
+++ b/statsmodels/gam/smooth_basis.py
@@ -279,7 +279,9 @@ def get_knots_bsplines(x=None, df=None, knots=None, degree=3,
     if all_knots is not None:
         return all_knots
 
-    spacing = string_like(spacing, "spacing", options=("quantile", "equal"))
+    spacing = string_like(
+        spacing, "spacing", options=("quantile", "equal"), lower=False
+    )
 
     x_min = x.min()
     x_max = x.max()

--- a/statsmodels/gam/smooth_basis.py
+++ b/statsmodels/gam/smooth_basis.py
@@ -311,7 +311,7 @@ def get_knots_bsplines(x=None, df=None, knots=None, degree=3,
             # Need to compute inner knots
             knot_quantiles = np.linspace(0, 1, n_inner_knots + 2)[1:-1]
             inner_knots = _R_compat_quantile(x, knot_quantiles)
-        elif spacing == "equal":
+        else:  # spacing == "equal"
             # Need to compute inner knots
             grid = np.linspace(0, 1, n_inner_knots + 2)[1:-1]
             inner_knots = x_min + grid * (x_max - x_min)

--- a/statsmodels/gam/tests/test_smooth_basis.py
+++ b/statsmodels/gam/tests/test_smooth_basis.py
@@ -14,7 +14,30 @@ from statsmodels.gam.smooth_basis import (
     CubicSplines,
     PolynomialSmoother,
     UnivariatePolynomialSmoother,
+    get_knots_bsplines,
 )
+
+
+def test_get_knots_bsplines_spacing():
+    rs = np.random.RandomState(0)
+    x = rs.uniform(size=100)
+
+    # df=8, degree=3 -> n_inner_knots=4, avoiding the pre-existing,
+    # unrelated IndexError that spacing="equal" hits when there is only
+    # 1 inner knot (e.g. df=5, degree=3)
+    knots_q = get_knots_bsplines(x, df=8, degree=3, spacing="quantile")
+    knots_e = get_knots_bsplines(x, df=8, degree=3, spacing="equal")
+    assert knots_q.ndim == 1
+    assert knots_e.ndim == 1
+
+    with pytest.raises(ValueError, match="spacing"):
+        get_knots_bsplines(x, df=8, degree=3, spacing="not-a-spacing")
+
+    # previously silent: an invalid `spacing` was never checked at all when
+    # `knots` was given directly instead of `df`, so this used to succeed
+    # (identically to spacing="quantile") instead of raising.
+    with pytest.raises(ValueError, match="spacing"):
+        get_knots_bsplines(x, knots=[0.25, 0.5, 0.75], degree=3, spacing="bogus")
 
 
 def test_univariate_polynomial_smoother():

--- a/statsmodels/genmod/generalized_linear_model.py
+++ b/statsmodels/genmod/generalized_linear_model.py
@@ -1067,7 +1067,7 @@ class GLM(base.LikelihoodModel):
             exposure = np.log(np.asarray(exposure))
 
         which = string_like(
-            which, "which", options=("mean", "linear", "var_unscaled")
+            which, "which", options=("mean", "linear", "var_unscaled"), lower=False
         )
         if exog is None:
             exog = self.exog

--- a/statsmodels/genmod/generalized_linear_model.py
+++ b/statsmodels/genmod/generalized_linear_model.py
@@ -49,7 +49,7 @@ from statsmodels.tools.sm_exceptions import (
     HessianInversionWarning,
     PerfectSeparationWarning,
 )
-from statsmodels.tools.validation import float_like
+from statsmodels.tools.validation import float_like, string_like
 
 # need import in module instead of lazily to copy `__doc__`
 from . import families
@@ -945,16 +945,13 @@ class GLM(base.LikelihoodModel):
             return np.array(self.scaletype)
 
         if isinstance(self.scaletype, str):
-            if self.scaletype.lower() == "x2":
+            scaletype = string_like(self.scaletype, "scaletype", options=("x2", "dev"))
+            if scaletype == "x2":
                 return self._estimate_x2_scale(mu)
-            elif self.scaletype.lower() == "dev":
+            elif scaletype == "dev":
                 return self.family.deviance(
                     self.endog, mu, self.var_weights, self.freq_weights, 1.0
                 ) / (self.df_resid)
-            else:
-                raise ValueError(
-                    f"Scale {self.scaletype} with type {type(self.scaletype)} not understood"
-                )
         else:
             raise ValueError(
                 f"Scale {self.scaletype} with type {type(self.scaletype)} not understood"
@@ -1069,6 +1066,9 @@ class GLM(base.LikelihoodModel):
         else:
             exposure = np.log(np.asarray(exposure))
 
+        which = string_like(
+            which, "which", options=("mean", "linear", "var_unscaled")
+        )
         if exog is None:
             exog = self.exog
 
@@ -1082,8 +1082,6 @@ class GLM(base.LikelihoodModel):
             mean = self.family.fitted(linpred)
             var_ = self.family.variance(mean)
             return var_
-        else:
-            raise ValueError(f'The which value "{which}" is not recognized')
 
     def get_distribution(
         self,
@@ -1254,9 +1252,7 @@ class GLM(base.LikelihoodModel):
         as `results_wls` attribute.
         """
         if isinstance(scale, str):
-            scale = scale.lower()
-            if scale not in ("x2", "dev"):
-                raise ValueError("scale must be either X2 or dev when a string.")
+            scale = string_like(scale, "scale", options=("x2", "dev"))
         elif scale is not None:
             # GH-6627
             try:
@@ -1600,10 +1596,9 @@ class GLM(base.LikelihoodModel):
             Requested accuracy as used by slsqp (default 1e-10).
         """
 
-        if method not in ("elastic_net", "l1_slsqp"):
-            raise ValueError(
-                "method for fit_regularized must be elastic_net or l1_slsqp"
-            )
+        method = string_like(
+            method, "method", options=("elastic_net", "l1_slsqp"), lower=False
+        )
 
         if method == "elastic_net" and kwargs.get("L1_wt", 1) == 0:
             return self._fit_ridge(alpha, start_params, opt_method)

--- a/statsmodels/genmod/generalized_linear_model.py
+++ b/statsmodels/genmod/generalized_linear_model.py
@@ -948,7 +948,7 @@ class GLM(base.LikelihoodModel):
             scaletype = string_like(self.scaletype, "scaletype", options=("x2", "dev"))
             if scaletype == "x2":
                 return self._estimate_x2_scale(mu)
-            elif scaletype == "dev":
+            else:  # scaletype == "dev"
                 return self.family.deviance(
                     self.endog, mu, self.var_weights, self.freq_weights, 1.0
                 ) / (self.df_resid)
@@ -1078,7 +1078,7 @@ class GLM(base.LikelihoodModel):
             return self.family.fitted(linpred)
         elif which == "linear":
             return linpred
-        elif which == "var_unscaled":
+        else:  # which == "var_unscaled"
             mean = self.family.fitted(linpred)
             var_ = self.family.variance(mean)
             return var_

--- a/statsmodels/genmod/tests/test_glm.py
+++ b/statsmodels/genmod/tests/test_glm.py
@@ -2985,7 +2985,7 @@ class TestRegularized:
         endog, exog = self._load_enet_data("binomial")
 
         model = GLM(endog, exog, family=sm.families.Binomial())
-        with pytest.raises(ValueError, match="method for fit_regularized"):
+        with pytest.raises(ValueError, match="method"):
             model.fit_regularized(method="l1", alpha=0.1)
         with pytest.raises(ValueError, match="L1_wt must be 1"):
             model.fit_regularized(method="l1_slsqp", L1_wt=0.5, alpha=0.1)
@@ -2993,7 +2993,7 @@ class TestRegularized:
         # An invalid method must be rejected even when L1_wt == 0, i.e.
         # the method must be validated before the L1_wt == 0 shortcut to
         # ridge regression is taken.
-        with pytest.raises(ValueError, match="method for fit_regularized"):
+        with pytest.raises(ValueError, match="method"):
             model.fit_regularized(method="l1", L1_wt=0, alpha=0.1)
 
         # l1_slsqp only supports the lasso penalty, so L1_wt=0 must not
@@ -3220,6 +3220,36 @@ def test_int_scale():
     res = mod.fit(scale=1)
     assert isinstance(res.params, pd.Series)
     assert res.scale.dtype == np.float64
+
+
+def test_invalid_scale_string_raises():
+    # scale may be a float/int, None, or one of the strings "X2"/"dev"
+    # (case-insensitively); anything else must be rejected. Numeric scale
+    # is unaffected, see test_int_scale above.
+    data = longley.load()
+    mod = GLM(data.endog, data.exog, family=sm.families.Gaussian())
+    with pytest.raises(ValueError, match="scale"):
+        mod.fit(scale="not-a-scale")
+
+
+def test_predict_invalid_which_raises():
+    data = longley.load()
+    mod = GLM(data.endog, data.exog, family=sm.families.Gaussian())
+    res = mod.fit()
+    with pytest.raises(ValueError, match="which"):
+        res.predict(which="not-a-real-option")
+
+
+def test_estimate_scale_invalid_scaletype_raises():
+    # scaletype is a public, documented attribute that can be set directly
+    # (not only through fit's validated `scale` argument), so
+    # estimate_scale must independently validate it.
+    data = longley.load()
+    mod = GLM(data.endog, data.exog, family=sm.families.Gaussian())
+    res = mod.fit()
+    mod.scaletype = "not-a-scale"
+    with pytest.raises(ValueError, match="scaletype"):
+        mod.estimate_scale(res.fittedvalues)
 
 
 @pytest.mark.parametrize("dtype", [np.int8, np.int16, np.int32, np.int64])

--- a/statsmodels/genmod/tests/test_score_test.py
+++ b/statsmodels/genmod/tests/test_score_test.py
@@ -6,6 +6,7 @@ Author: Josef Perktold
 
 import numpy as np
 from numpy.testing import assert_allclose
+import pytest
 
 from statsmodels.base._parameter_inference import score_test
 import statsmodels.discrete._diagnostics_count as diac
@@ -13,6 +14,13 @@ from statsmodels.discrete.discrete_model import Poisson
 from statsmodels.genmod import families
 from statsmodels.genmod.generalized_linear_model import GLM
 import statsmodels.stats._diagnostic_other as diao
+
+
+def test_score_test_invalid_hypothesis_raises():
+    # hypothesis is validated before any use of `self`/`model`, so this
+    # is cheap to check without a fitted model.
+    with pytest.raises(ValueError, match="hypothesis"):
+        score_test(None, hypothesis="not-a-hypothesis")
 
 
 class CheckScoreTest:

--- a/statsmodels/graphics/boxplots.py
+++ b/statsmodels/graphics/boxplots.py
@@ -133,7 +133,7 @@ def violinplot(
 
     .. plot:: plots/graphics_boxplot_violinplot.py
     """
-    side = string_like(side, "side", options=("both", "left", "right"))
+    side = string_like(side, "side", options=("both", "left", "right"), lower=False)
     plot_opts = {} if plot_opts is None else plot_opts
     if max([np.size(arr) for arr in data]) == 0:
         msg = "No Data to make Violin: Try again!"
@@ -359,7 +359,7 @@ def beanplot(
 
     .. plot:: plots/graphics_boxplot_beanplot.py
     """
-    side = string_like(side, "side", options=("both", "left", "right"))
+    side = string_like(side, "side", options=("both", "left", "right"), lower=False)
     plot_opts = {} if plot_opts is None else plot_opts
     fig, ax = utils.create_mpl_ax(ax)
 

--- a/statsmodels/graphics/boxplots.py
+++ b/statsmodels/graphics/boxplots.py
@@ -7,6 +7,7 @@ import numpy as np
 from scipy.stats import gaussian_kde
 
 from statsmodels.tools.rng_qrng import check_random_state
+from statsmodels.tools.validation import string_like
 
 from . import utils
 
@@ -132,6 +133,7 @@ def violinplot(
 
     .. plot:: plots/graphics_boxplot_violinplot.py
     """
+    side = string_like(side, "side", options=("both", "left", "right"))
     plot_opts = {} if plot_opts is None else plot_opts
     if max([np.size(arr) for arr in data]) == 0:
         msg = "No Data to make Violin: Try again!"
@@ -202,9 +204,6 @@ def _single_violin(ax, pos, pos_data, width, side, plot_opts):
         envelope_l, envelope_r = (pos, violin + pos)
     elif side == "left":
         envelope_l, envelope_r = (-violin + pos, pos)
-    else:
-        msg = "`side` parameter should be one of {'left', 'right', 'both'}."
-        raise ValueError(msg)
 
     # Draw the violin.
     ax.fill_betweenx(
@@ -360,6 +359,7 @@ def beanplot(
 
     .. plot:: plots/graphics_boxplot_beanplot.py
     """
+    side = string_like(side, "side", options=("both", "left", "right"))
     plot_opts = {} if plot_opts is None else plot_opts
     fig, ax = utils.create_mpl_ax(ax)
 
@@ -448,8 +448,6 @@ def _jitter_envelope(pos_data, xvals, violin, side, rng):
         low, high = (0, 1.0)
     elif side == "left":
         low, high = (-1.0, 0)
-    else:
-        raise ValueError(f"`side` input incorrect: {side}")
 
     jitter_envelope = np.interp(pos_data, xvals, violin)
     jitter_coord = jitter_envelope * rng.uniform(low=low, high=high, size=pos_data.size)

--- a/statsmodels/graphics/boxplots.py
+++ b/statsmodels/graphics/boxplots.py
@@ -202,7 +202,7 @@ def _single_violin(ax, pos, pos_data, width, side, plot_opts):
         envelope_l, envelope_r = (-violin + pos, violin + pos)
     elif side == "right":
         envelope_l, envelope_r = (pos, violin + pos)
-    elif side == "left":
+    else:  # side == "left"
         envelope_l, envelope_r = (-violin + pos, pos)
 
     # Draw the violin.
@@ -446,7 +446,7 @@ def _jitter_envelope(pos_data, xvals, violin, side, rng):
         low, high = (-1.0, 1.0)
     elif side == "right":
         low, high = (0, 1.0)
-    elif side == "left":
+    else:  # side == "left"
         low, high = (-1.0, 0)
 
     jitter_envelope = np.interp(pos_data, xvals, violin)

--- a/statsmodels/graphics/dotplots.py
+++ b/statsmodels/graphics/dotplots.py
@@ -1,5 +1,7 @@
 import numpy as np
 
+from statsmodels.tools.validation import string_like
+
 from . import utils
 
 
@@ -136,6 +138,8 @@ def dot_plot(points, intervals=None, lines=None, sections=None,
     lines = asarray_or_none(lines)
     sections = asarray_or_none(sections)
     styles = asarray_or_none(styles)
+
+    show_names = string_like(show_names, "show_names", options=("both", "left", "right"))
 
     # Total number of points
     npoint = len(points)
@@ -380,7 +384,7 @@ def dot_plot(points, intervals=None, lines=None, sections=None,
             jrow += 1
 
             # Draw the left margin label
-            if show_names.lower() in ("left", "both"):
+            if show_names in ("left", "both"):
                 if horizontal:
                     ax.text(-0.1/awidth, pos, left_label,
                             horizontalalignment="right",
@@ -395,7 +399,7 @@ def dot_plot(points, intervals=None, lines=None, sections=None,
                             family="monospace")
 
             # Draw the right margin label
-            if show_names.lower() in ("right", "both"):
+            if show_names in ("right", "both"):
                 if right_label is not None:
                     if horizontal:
                         ax.text(1 + 0.1/awidth, pos, right_label,

--- a/statsmodels/graphics/factorplots.py
+++ b/statsmodels/graphics/factorplots.py
@@ -175,7 +175,7 @@ def interaction_plot(
                 linestyle=linestyles[i],
                 **kwargs,
             )
-    elif plottype == "scatter" or plottype == "s":
+    else:  # plottype == "scatter" or plottype == "s"
         for i, (_, group) in enumerate(plot_data.groupby("trace")):
             # trace label
             label = str(group["trace"].values[0])

--- a/statsmodels/graphics/factorplots.py
+++ b/statsmodels/graphics/factorplots.py
@@ -8,6 +8,7 @@ import numpy as np
 
 from statsmodels.graphics import utils
 from statsmodels.graphics.plottools import rainbow
+from statsmodels.tools.validation import string_like
 
 
 def interaction_plot(
@@ -108,6 +109,9 @@ def interaction_plot(
 
     from pandas import DataFrame
 
+    plottype = string_like(
+        plottype, "plottype", options=("b", "both", "l", "line", "s", "scatter")
+    )
     fig, ax = utils.create_mpl_ax(ax)
 
     response_name = ylabel or getattr(response, "name", "response")
@@ -181,8 +185,6 @@ def interaction_plot(
                 **kwargs,
             )
 
-    else:
-        raise ValueError(f"Plot type {plottype} not understood")
     ax.legend(loc=legendloc, title=legendtitle)
     ax.margins(0.1)
 

--- a/statsmodels/graphics/factorplots.py
+++ b/statsmodels/graphics/factorplots.py
@@ -110,7 +110,10 @@ def interaction_plot(
     from pandas import DataFrame
 
     plottype = string_like(
-        plottype, "plottype", options=("b", "both", "l", "line", "s", "scatter")
+        plottype,
+        "plottype",
+        options=("b", "both", "l", "line", "s", "scatter"),
+        lower=False,
     )
     fig, ax = utils.create_mpl_ax(ax)
 

--- a/statsmodels/graphics/functional.py
+++ b/statsmodels/graphics/functional.py
@@ -942,7 +942,7 @@ def banddepth(data, method="MBD"):
     method = string_like(method, "method", options=("MBD", "BD2"), lower=False)
     if method == "BD2":
         depth = _fbd2()
-    elif method == "MBD":
+    else:  # method == "MBD"
         depth = _fmbd()
 
     return depth

--- a/statsmodels/graphics/functional.py
+++ b/statsmodels/graphics/functional.py
@@ -13,6 +13,7 @@ from statsmodels.graphics.utils import _import_mpl
 from statsmodels.multivariate.pca import PCA
 from statsmodels.nonparametric.kernel_density import KDEMultivariate
 from statsmodels.tools.rng_qrng import check_random_state
+from statsmodels.tools.validation import string_like
 
 from . import utils
 
@@ -686,8 +687,9 @@ def fboxplot(
 
     # Calculate band depth if required.
     if depth is None:
-        if method not in ["MBD", "BD2"]:
-            raise ValueError("Unknown value for parameter `method`.")
+        method = string_like(
+            method, "method", options=("MBD", "BD2"), lower=False
+        )
 
         depth = banddepth(data, method=method)
     elif depth.size != data.shape[0]:
@@ -845,8 +847,9 @@ def rainbowplot(data, xdata=None, depth=None, method="MBD", ax=None, cmap=None):
 
     # Calculate band depth if required.
     if depth is None:
-        if method not in ["MBD", "BD2"]:
-            raise ValueError("Unknown value for parameter `method`.")
+        method = string_like(
+            method, "method", options=("MBD", "BD2"), lower=False
+        )
 
         depth = banddepth(data, method=method)
     elif depth.size != data.shape[0]:
@@ -936,11 +939,10 @@ def banddepth(data, method="MBD"):
         up = n - rmat
         return ((np.sum(up * down, axis=1) / p) + n - 1) / comb(n, 2)
 
+    method = string_like(method, "method", options=("MBD", "BD2"), lower=False)
     if method == "BD2":
         depth = _fbd2()
     elif method == "MBD":
         depth = _fmbd()
-    else:
-        raise ValueError("Unknown input value for parameter `method`.")
 
     return depth

--- a/statsmodels/graphics/gofplots.py
+++ b/statsmodels/graphics/gofplots.py
@@ -7,6 +7,7 @@ from statsmodels.distributions import ECDF
 from statsmodels.regression.linear_model import OLS
 from statsmodels.tools._decorators import cache_readonly
 from statsmodels.tools.tools import add_constant
+from statsmodels.tools.validation import string_like
 
 from . import utils
 
@@ -859,6 +860,7 @@ def qqline(ax, line, x=None, y=None, dist=None, fmt="r-", **lineoptions):
 
     .. plot:: plots/graphics_gofplots_qqplot_qqline.py
     """
+    line = string_like(line, "line", options=("45", "r", "s", "q"), lower=False)
     lineoptions = lineoptions.copy()
     for ls in ("-", "--", "-.", ":"):
         if ls in fmt:

--- a/statsmodels/graphics/gofplots.py
+++ b/statsmodels/graphics/gofplots.py
@@ -922,7 +922,7 @@ def qqline(ax, line, x=None, y=None, dist=None, fmt="r-", **lineoptions):
         m, b = np.std(y), np.mean(y)
         ref_line = x * m + b
         ax.plot(x, ref_line, **lineoptions)
-    elif line == "q":
+    else:  # line == "q"
         _check_for(dist, "ppf")
         q25 = stats.scoreatpercentile(y, 25)
         q75 = stats.scoreatpercentile(y, 75)

--- a/statsmodels/graphics/tests/test_boxplots.py
+++ b/statsmodels/graphics/tests/test_boxplots.py
@@ -158,6 +158,18 @@ def test_beanplot_side_left(age_and_labels, close_figures):
     )
 
 
+def test_violinplot_invalid_side_raises(age_and_labels):
+    age, labels = age_and_labels
+    with pytest.raises(ValueError, match="side"):
+        violinplot(age, labels=labels, side="not-a-side")
+
+
+def test_beanplot_invalid_side_raises(age_and_labels):
+    age, labels = age_and_labels
+    with pytest.raises(ValueError, match="side"):
+        beanplot(age, labels=labels, side="not-a-side")
+
+
 @pytest.mark.thread_unsafe(reason="Uses matplotlib")
 @pytest.mark.matplotlib
 def test_beanplot_legend_text(age_and_labels, close_figures):

--- a/statsmodels/graphics/tests/test_dotplot.py
+++ b/statsmodels/graphics/tests/test_dotplot.py
@@ -488,3 +488,11 @@ def test_all(close_figures):
     leg.draw_frame(False)
     ax.set_title("Dotplot with different numbers of points per line")
     plt.close(fig)
+
+
+@pytest.mark.thread_unsafe(reason="Uses matplotlib")
+@pytest.mark.matplotlib
+def test_invalid_show_names_raises(close_figures):
+    points = range(5)
+    with pytest.raises(ValueError, match="show_names"):
+        dot_plot(points, show_names="not-a-side")

--- a/statsmodels/graphics/tests/test_functional.py
+++ b/statsmodels/graphics/tests/test_functional.py
@@ -474,6 +474,22 @@ def test_banddepth_MBD(close_figures):
     assert_almost_equal(depth, expected_depth, decimal=4)
 
 
+def test_banddepth_invalid_method_raises():
+    data = np.asarray([np.arange(10), np.arange(10) + 1.0])
+    with pytest.raises(ValueError, match="method"):
+        banddepth(data, method="not-a-method")
+
+
+@pytest.mark.thread_unsafe(reason="Uses matplotlib")
+@pytest.mark.matplotlib
+def test_fboxplot_rainbowplot_invalid_method_raises(close_figures):
+    data = np.asarray([np.arange(10), np.arange(10) + 1.0, np.arange(10) - 1.0])
+    with pytest.raises(ValueError, match="method"):
+        fboxplot(data, method="not-a-method")
+    with pytest.raises(ValueError, match="method"):
+        rainbowplot(data, method="not-a-method")
+
+
 @pytest.mark.thread_unsafe(reason="Uses matplotlib")
 @pytest.mark.matplotlib
 def test_fboxplot_rainbowplot(close_figures):

--- a/statsmodels/graphics/tests/test_gofplots.py
+++ b/statsmodels/graphics/tests/test_gofplots.py
@@ -526,6 +526,15 @@ class TestQQLine:
 
     @pytest.mark.thread_unsafe(reason="Uses matplotlib")
     @pytest.mark.matplotlib
+    def test_badline_with_x_y(self, close_figures):
+        # Previously, an unrecognized `line` with valid x/y silently did
+        # nothing instead of raising (test_badline above only happened to
+        # raise because x and y were both left as None).
+        with pytest.raises(ValueError, match="line"):
+            qqline(self.ax, "junk", x=self.x, y=self.y)
+
+    @pytest.mark.thread_unsafe(reason="Uses matplotlib")
+    @pytest.mark.matplotlib
     def test_non45_no_x(self, close_figures):
         with pytest.raises(ValueError):
             qqline(self.ax, "s", y=self.y)

--- a/statsmodels/miscmodels/ordinal_model.py
+++ b/statsmodels/miscmodels/ordinal_model.py
@@ -453,7 +453,7 @@ class OrderedModel(GenericLikelihoodModel):
         if which == "prob":
             prob = self.prob(low, upp)
             return prob
-        elif which in ["cum", "cumprob"]:
+        else:  # which in ("cum", "cumprob")
             cumprob = self.cdf(upp)
             return cumprob
 

--- a/statsmodels/miscmodels/ordinal_model.py
+++ b/statsmodels/miscmodels/ordinal_model.py
@@ -28,6 +28,7 @@ import statsmodels.regression.linear_model as lm
 from statsmodels.tools._decorators import cache_readonly
 from statsmodels.tools.docstring_helpers import Appender
 from statsmodels.tools.sm_exceptions import SpecificationWarning
+from statsmodels.tools.validation import string_like
 
 
 class OrderedModel(GenericLikelihoodModel):
@@ -437,6 +438,10 @@ class OrderedModel(GenericLikelihoodModel):
             one-dimensional.
         """
         # note, exog and offset handling is in linpred
+        which = string_like(
+            which, "which", options=("prob", "linpred", "cum", "cumprob"),
+            lower=False,
+        )
 
         thresh = self.transform_threshold_params(params)
         xb = self._linpred(params, exog=exog, offset=offset)
@@ -451,8 +456,6 @@ class OrderedModel(GenericLikelihoodModel):
         elif which in ["cum", "cumprob"]:
             cumprob = self.cdf(upp)
             return cumprob
-        else:
-            raise ValueError("`which` is not available")
 
     def _linpred(self, params, exog=None, offset=None):
         """

--- a/statsmodels/miscmodels/tests/test_ordinal_model.py
+++ b/statsmodels/miscmodels/tests/test_ordinal_model.py
@@ -587,3 +587,25 @@ def test_summary_after_remove_data():
     assert isinstance(res.summary(), Summary)
     res.remove_data()
     assert isinstance(res.summary(), Summary)
+
+
+def test_predict_which():
+    data = ds.df
+    mod = OrderedModel(
+        data["apply"].values.codes,
+        np.asarray(data[["pared", "public", "gpa"]], float),
+        distr="logit",
+    )
+    res = mod.fit(method="bfgs", disp=False)
+
+    prob = res.predict(which="prob")
+    cum = res.predict(which="cum")
+    cumprob = res.predict(which="cumprob")
+    linpred = res.predict(which="linpred")
+
+    assert_allclose(cum, cumprob)
+    assert_allclose(np.cumsum(prob, axis=1), cumprob, atol=1e-10)
+    assert linpred.ndim == 1
+
+    with pytest.raises(ValueError, match="which"):
+        res.predict(which="not-a-real-option")

--- a/statsmodels/multivariate/factor.py
+++ b/statsmodels/multivariate/factor.py
@@ -15,6 +15,7 @@ from statsmodels.tools.sm_exceptions import (
     EstimationWarning,
     SpecificationWarning,
 )
+from statsmodels.tools.validation import string_like
 
 from .factor_rotation import promax, rotate_factors
 
@@ -1026,9 +1027,9 @@ class FactorResults:
             index=self.endog_names,
         )
 
-        if style not in ["raw", "display", "strings"]:
-            msg = "style has to be one of 'raw', 'display', 'strings'"
-            raise ValueError(msg)
+        style = string_like(
+            style, "style", options=("raw", "display", "strings"), lower=False
+        )
 
         if style == "raw":
             return loadings_df

--- a/statsmodels/multivariate/factor_rotation/_gpa_rotation.py
+++ b/statsmodels/multivariate/factor_rotation/_gpa_rotation.py
@@ -23,6 +23,8 @@ Psychometrika, 67, 7-19.
 
 import numpy as np
 
+from statsmodels.tools.validation import string_like
+
 
 def GPA(A, ff=None, vgQ=None, T=None, max_tries=501,
         rotation_method="orthogonal", tol=1e-5):
@@ -75,9 +77,12 @@ def GPA(A, ff=None, vgQ=None, T=None, max_tries=501,
         step size for each iteration, used for monitoring convergence
     """
     # pre processing
-    if rotation_method not in ["orthogonal", "oblique"]:
-        raise ValueError("rotation_method should be one of "
-                         "{orthogonal, oblique}")
+    rotation_method = string_like(
+        rotation_method,
+        "rotation_method",
+        options=("orthogonal", "oblique"),
+        lower=False,
+    )
     if vgQ is None:
         if ff is None:
             raise ValueError("ff should be provided if vgQ is not")

--- a/statsmodels/multivariate/factor_rotation/_gpa_rotation.py
+++ b/statsmodels/multivariate/factor_rotation/_gpa_rotation.py
@@ -217,13 +217,16 @@ def rotateA(A, T, rotation_method="orthogonal"):
     ndarray
         The rotated factors :math:`L`.
     """
+    rotation_method = string_like(
+        rotation_method,
+        "rotation_method",
+        options=("orthogonal", "oblique"),
+        lower=False,
+    )
     if rotation_method == "orthogonal":
         L = A.dot(T)
-    elif rotation_method == "oblique":
+    else:  # rotation_method == "oblique"
         L = A.dot(np.linalg.inv(T.T))
-    else:  # i.e., if rotation_method == 'oblique':
-        raise ValueError("rotation_method should be one of "
-                         "{orthogonal, oblique}")
     return L
 
 

--- a/statsmodels/multivariate/factor_rotation/tests/test_rotation.py
+++ b/statsmodels/multivariate/factor_rotation/tests/test_rotation.py
@@ -12,10 +12,22 @@ from statsmodels.multivariate.factor_rotation._gpa_rotation import (
     ff_target,
     oblimin_objective,
     orthomax_objective,
+    rotateA,
     vgQ_partial_target,
     vgQ_target,
 )
 from statsmodels.multivariate.factor_rotation._wrappers import rotate_factors
+
+
+def test_rotateA_invalid_rotation_method_raises():
+    import pytest
+
+    A = np.eye(3)
+    T = np.eye(3)
+    with pytest.raises(ValueError, match="rotation_method"):
+        rotateA(A, T, rotation_method="not-a-rotation-method")
+    with pytest.raises(ValueError, match="rotation_method"):
+        GPA(A, ff=lambda L: 0.0, rotation_method="not-a-rotation-method")
 
 
 class TestAnalyticRotation(unittest.TestCase):

--- a/statsmodels/multivariate/multivariate_ols.py
+++ b/statsmodels/multivariate/multivariate_ols.py
@@ -14,6 +14,7 @@ import statsmodels.base.wrapper as wrap
 from statsmodels.formula._manager import FormulaManager
 from statsmodels.iolib import summary2
 from statsmodels.regression.linear_model import RegressionResultsWrapper
+from statsmodels.tools.validation import string_like
 from statsmodels.tools._decorators import cache_readonly
 
 __docformat__ = "restructuredtext en"
@@ -100,6 +101,8 @@ def _multivariate_ols_fit(endog, exog, method="svd", tolerance=1e-8):
         raise ValueError(f"x(n={nobs1:d}) and y(n={nobs:d}) should have the same number of "
                          "rows!")
 
+    method = string_like(method, "method", options=("svd", "pinv"), lower=False)
+
     # Calculate the matrices necessary for hypotheses testing
     df_resid = nobs - k_exog
     if method == "pinv":
@@ -128,8 +131,6 @@ def _multivariate_ols_fit(endog, exog, method="svd", tolerance=1e-8):
         t = np.diag(s).dot(v).dot(params)
         sscpr = np.subtract(y.T.dot(y), t.T.dot(t))
         return (params, df_resid, inv_cov, sscpr)
-    else:
-        raise ValueError(f"{method} is not a supported method!")
 
 
 def multivariate_stats(eigenvals,

--- a/statsmodels/multivariate/multivariate_ols.py
+++ b/statsmodels/multivariate/multivariate_ols.py
@@ -120,7 +120,7 @@ def _multivariate_ols_fit(endog, exog, method="svd", tolerance=1e-8):
         t = x.dot(params)
         sscpr = np.subtract(y.T.dot(y), t.T.dot(t))
         return (params, df_resid, inv_cov, sscpr)
-    elif method == "svd":
+    else:  # method == "svd"
         u, s, v = svd(x, 0)
         if (s > tolerance).sum() < len(s):
             raise ValueError("Covariance of x singular!")

--- a/statsmodels/multivariate/multivariate_ols.py
+++ b/statsmodels/multivariate/multivariate_ols.py
@@ -14,8 +14,8 @@ import statsmodels.base.wrapper as wrap
 from statsmodels.formula._manager import FormulaManager
 from statsmodels.iolib import summary2
 from statsmodels.regression.linear_model import RegressionResultsWrapper
-from statsmodels.tools.validation import string_like
 from statsmodels.tools._decorators import cache_readonly
+from statsmodels.tools.validation import string_like
 
 __docformat__ = "restructuredtext en"
 

--- a/statsmodels/multivariate/pca.py
+++ b/statsmodels/multivariate/pca.py
@@ -273,10 +273,10 @@ class PCA:
             warnings.warn(warn, ValueWarning, stacklevel=2)
             self._ncomp = min_dim
 
-        self._method = method
         # Workaround to avoid instance methods in __dict__
-        if self._method not in ("eig", "svd", "nipals"):
-            raise ValueError(f"method {method} is not known.")
+        self._method = string_like(
+            method, "method", options=("eig", "svd", "nipals"), lower=False
+        )
 
         self.rows = np.arange(self._nobs)
         self.cols = np.arange(self._nvar)

--- a/statsmodels/multivariate/tests/test_multivariate_ols.py
+++ b/statsmodels/multivariate/tests/test_multivariate_ols.py
@@ -109,6 +109,15 @@ def test_glm_dogs_example(model):
 
 
 @pytest.mark.parametrize("model", models)
+def test_invalid_fit_method_raises(model):
+    mod = model.from_formula(
+        "Histamine0 + Histamine1 + Histamine3 + Histamine5 ~ Drug * Depleted", data
+    )
+    with pytest.raises(ValueError, match="method"):
+        mod.fit(method="not-a-method")
+
+
+@pytest.mark.parametrize("model", models)
 def test_specify_L_M_by_string(model):
     mod = model.from_formula(
         "Histamine0 + Histamine1 + Histamine3 + Histamine5 ~ Drug * Depleted", data

--- a/statsmodels/regression/linear_model.py
+++ b/statsmodels/regression/linear_model.py
@@ -379,6 +379,7 @@ class RegressionModel(base.LikelihoodModel):
         # cached based on whether they already exist) so that the model's
         # state after fit() depends only on the current data, never on
         # which `method` a previous fit() call happened to use.
+        method = string_like(method, "method", options=("pinv", "qr"), lower=False)
         if method == "pinv":
             pinv_wexog, singular_values = pinv_extended(self.wexog)
             self.pinv_wexog = pinv_wexog
@@ -408,8 +409,6 @@ class RegressionModel(base.LikelihoodModel):
             # used in ANOVA
             self.effects = effects = np.dot(Q.T, self.wendog)
             beta = np.linalg.solve(R, effects)
-        else:
-            raise ValueError('method has to be "pinv" or "qr"')
 
         if self._df_model is None:
             self._df_model = float(self.rank - self.k_constant)
@@ -2141,7 +2140,7 @@ class RegressionResults(base.LikelihoodModelResults):
         .. [BurnhamAnderson2002] Burnham KP, Anderson KR (2002). Model Selection
            and Multimodel Inference; Springer New York.
         """
-        crit = crit.lower()
+        crit = string_like(crit, "crit", options=("aic", "bic", "aicc", "hqic"))
         k_params = self.df_model + self.k_constant + dk_params
 
         if crit == "aic":

--- a/statsmodels/regression/linear_model.py
+++ b/statsmodels/regression/linear_model.py
@@ -1191,9 +1191,9 @@ class OLS(WLS):
     ):
 
         # In the future we could add support for other penalties, e.g., SCAD.
-        if method not in ("elastic_net", "sqrt_lasso"):
-            msg = f"Unknown method '{method}' for fit_regularized"
-            raise ValueError(msg)
+        method = string_like(
+            method, "method", options=("elastic_net", "sqrt_lasso"), lower=False
+        )
 
         # Set default parameters.
         defaults = {"maxiter": 50, "cnvrg_tol": 1e-10, "zero_tol": 1e-8}

--- a/statsmodels/regression/linear_model.py
+++ b/statsmodels/regression/linear_model.py
@@ -399,7 +399,7 @@ class RegressionModel(base.LikelihoodModel):
 
             beta = np.dot(self.pinv_wexog, self.wendog)
 
-        elif method == "qr":
+        else:  # method == "qr"
             Q, R = np.linalg.qr(self.wexog)
             self.normalized_cov_params = np.linalg.inv(np.dot(R.T, R))
             self.wexog_singular_values = np.linalg.svd(R, 0, 0)
@@ -2152,7 +2152,7 @@ class RegressionResults(base.LikelihoodModelResults):
             from statsmodels.tools.eval_measures import aicc
 
             return aicc(self.llf, self.nobs, k_params)
-        elif crit == "hqic":
+        else:  # crit == "hqic"
             from statsmodels.tools.eval_measures import hqic
 
             return hqic(self.llf, self.nobs, k_params)

--- a/statsmodels/regression/mixed_linear_model.py
+++ b/statsmodels/regression/mixed_linear_model.py
@@ -3090,7 +3090,7 @@ class MixedLMResults(base.LikelihoodModelResults, base.ResultMixin):
             low = (cov_re[0, 0] - dist_low) / self.scale
             high = (cov_re[0, 0] + dist_high) / self.scale
 
-        elif vtype == "vc":
+        else:  # vtype == "vc"
             re_ix = self.model.exog_vc.names.index(re_ix)
             params = self.params_object.copy()
             vcomp = self.vcomp

--- a/statsmodels/regression/mixed_linear_model.py
+++ b/statsmodels/regression/mixed_linear_model.py
@@ -166,6 +166,7 @@ from statsmodels.tools.sm_exceptions import (
     SingularMatrixWarning,
     ValueWarning,
 )
+from statsmodels.tools.validation import string_like
 
 _warn_cov_sing = "The random effects covariance matrix is singular."
 
@@ -3060,6 +3061,7 @@ class MixedLMResults(base.LikelihoodModelResults, base.ResultMixin):
         Only variance parameters can be profiled.
 
         """
+        vtype = string_like(vtype, "vtype", options=("re", "vc"), lower=False)
         pmodel = self.model
         k_fe = pmodel.k_fe
         k_re = pmodel.k_re

--- a/statsmodels/regression/quantile_regression.py
+++ b/statsmodels/regression/quantile_regression.py
@@ -161,7 +161,7 @@ class QuantReg(RegressionModel):
             bandwidth = hall_sheather
         elif bandwidth == "bofinger":
             bandwidth = bofinger
-        elif bandwidth == "chamberlain":
+        else:  # bandwidth == "chamberlain"
             bandwidth = chamberlain
 
         endog = self.endog
@@ -243,7 +243,7 @@ class QuantReg(RegressionModel):
             xtxi = pinv(np.dot(exog.T, exog))
             xtdx = np.dot(exog.T * d[np.newaxis, :], exog)
             vcov = xtxi @ xtdx @ xtxi
-        elif vcov == "iid":
+        else:  # vcov == "iid"
             vcov = (1.0 / fhat0) ** 2 * q * (1 - q) * pinv(np.dot(exog.T, exog))
 
         lfit = QuantRegResults(self, beta, normalized_cov_params=vcov)

--- a/statsmodels/regression/quantile_regression.py
+++ b/statsmodels/regression/quantile_regression.py
@@ -29,6 +29,7 @@ from statsmodels.regression.linear_model import (
 )
 from statsmodels.tools._decorators import cache_readonly, cache_writable
 from statsmodels.tools.sm_exceptions import ConvergenceWarning, IterationLimitWarning
+from statsmodels.tools.validation import string_like
 
 
 class QuantReg(RegressionModel):
@@ -146,22 +147,22 @@ class QuantReg(RegressionModel):
         if q <= 0 or q >= 1:
             raise ValueError("q must be strictly between 0 and 1")
 
-        kern_names = ["biw", "cos", "epa", "gau", "par"]
-        if kernel not in kern_names:
-            raise ValueError("kernel must be one of " + ", ".join(kern_names))
-        else:
-            kernel = kernels[kernel]
+        kernel = string_like(
+            kernel, "kernel", options=("biw", "cos", "epa", "gau", "par"),
+            lower=False,
+        )
+        kernel = kernels[kernel]
 
+        bandwidth = string_like(
+            bandwidth, "bandwidth",
+            options=("hsheather", "bofinger", "chamberlain"), lower=False,
+        )
         if bandwidth == "hsheather":
             bandwidth = hall_sheather
         elif bandwidth == "bofinger":
             bandwidth = bofinger
         elif bandwidth == "chamberlain":
             bandwidth = chamberlain
-        else:
-            raise ValueError(
-                "bandwidth must be in 'hsheather', 'bofinger', 'chamberlain'"
-            )
 
         endog = self.endog
         exog = self.exog
@@ -236,6 +237,7 @@ class QuantReg(RegressionModel):
 
         fhat0 = 1.0 / (nobs * h) * np.sum(kernel(e / h))
 
+        vcov = string_like(vcov, "vcov", options=("robust", "iid"), lower=False)
         if vcov == "robust":
             d = np.where(e > 0, (q / fhat0) ** 2, ((1 - q) / fhat0) ** 2)
             xtxi = pinv(np.dot(exog.T, exog))
@@ -243,8 +245,6 @@ class QuantReg(RegressionModel):
             vcov = xtxi @ xtdx @ xtxi
         elif vcov == "iid":
             vcov = (1.0 / fhat0) ** 2 * q * (1 - q) * pinv(np.dot(exog.T, exog))
-        else:
-            raise ValueError("vcov must be 'robust' or 'iid'")
 
         lfit = QuantRegResults(self, beta, normalized_cov_params=vcov)
 

--- a/statsmodels/regression/tests/test_lme.py
+++ b/statsmodels/regression/tests/test_lme.py
@@ -237,6 +237,8 @@ class TestMixedLM:
         rslt.profile_re(
             "b", vtype="vc", dist_low=0.5, num_low=3, dist_high=0.5, num_high=3
         )
+        with pytest.raises(ValueError, match="vtype"):
+            rslt.profile_re(0, vtype="not-a-vtype")
 
     def test_vcomp_1(self):
         # Fit the same model using constrained random effects and

--- a/statsmodels/regression/tests/test_predict.py
+++ b/statsmodels/regression/tests/test_predict.py
@@ -329,3 +329,19 @@ def test_prediction_results_t_test():
     pred_t = res_t.get_prediction()
     assert pred_t.dist is sp_stats.t
     assert pred_t.dist_args == (pred_t.df,)
+
+
+def test_prediction_results_mean_conf_int_invalid_method():
+    from statsmodels.genmod.generalized_linear_model import GLM
+
+    rs = np.random.RandomState(918273)
+    n = 40
+    exog = np.column_stack([np.ones(n), rs.standard_normal((n, 2))])
+    endog = exog @ [1.0, 0.5, -0.5] + rs.standard_normal(n)
+    res = GLM(endog, exog).fit()
+    pred = res.get_prediction()
+
+    assert pred.conf_int(method="endpoint") is not None
+    assert pred.conf_int(method="delta") is not None
+    with pytest.raises(ValueError, match="method"):
+        pred.conf_int(method="not-a-method")

--- a/statsmodels/regression/tests/test_quantile_regression.py
+++ b/statsmodels/regression/tests/test_quantile_regression.py
@@ -2,6 +2,7 @@
 
 import numpy as np
 from numpy.testing import assert_allclose, assert_almost_equal, assert_equal
+import pytest
 import scipy.stats
 
 import statsmodels.api as sm
@@ -409,3 +410,21 @@ def test_prsquared_improves_with_informative_regressors():
     res_full = QuantReg(y, exog_full).fit(0.5)
     assert 0 < res_full.prsquared <= 1
     assert res_full.prsquared > res_null.prsquared
+
+
+def test_fit_invalid_options_raise():
+    X = np.array([[1, 0], [0, 1], [0, 2.1], [0, 3.1]], dtype=np.float64)
+    y = np.array([0, 1, 2, 3], dtype=np.float64)
+    mod = QuantReg(y, X)
+
+    with pytest.raises(ValueError, match="kernel"):
+        mod.fit(0.5, kernel="not-a-kernel")
+    with pytest.raises(ValueError, match="bandwidth"):
+        mod.fit(0.5, bandwidth="not-a-bandwidth")
+    with pytest.raises(ValueError, match="vcov"):
+        mod.fit(0.5, vcov="not-a-vcov")
+
+    # case is not folded: this file's existing validation never was, and
+    # string_like(..., lower=False) preserves that
+    with pytest.raises(ValueError, match="vcov"):
+        mod.fit(0.5, vcov="ROBUST")

--- a/statsmodels/regression/tests/test_regression.py
+++ b/statsmodels/regression/tests/test_regression.py
@@ -1297,6 +1297,28 @@ Notes: \\newline
 
 class TestRegularizedFit:
 
+    def test_invalid_method_raises(self):
+        from statsmodels.base.elastic_net import fit_elasticnet
+
+        rs = np.random.RandomState(742)
+        n = 100
+        endog = rs.normal(size=n)
+        exog = rs.normal(size=(n, 3))
+        model = OLS(endog, exog)
+
+        # OLS.fit_regularized only exposes "elastic_net"/"sqrt_lasso"
+        with pytest.raises(ValueError, match="method"):
+            model.fit_regularized(method="not-a-method")
+
+        # fit_elasticnet itself also accepts "coord_descent"/"l1_slsqp"
+        with pytest.raises(ValueError, match="method"):
+            fit_elasticnet(model, method="not-a-method")
+
+        with pytest.raises(ValueError, match="trim_mode"):
+            fit_elasticnet(
+                model, method="l1_slsqp", L1_wt=1.0, trim_mode="not-a-trim-mode"
+            )
+
     # Make sure there are no problems when no variables are selected.
     def test_empty_model(self):
 

--- a/statsmodels/regression/tests/test_regression.py
+++ b/statsmodels/regression/tests/test_regression.py
@@ -172,6 +172,11 @@ class CheckRegressionResults:
         hqic1 = self.res1.info_criteria("hqic")
         hqic2 = (self.res1.aic - 2 * k) + 2 * np.log(np.log(nobs)) * k
         assert_allclose(hqic1, hqic2, rtol=1e-10)
+        assert_allclose(self.res1.info_criteria("aic"), self.res1.aic, rtol=1e-10)
+        assert_allclose(self.res1.info_criteria("AIC"), self.res1.aic, rtol=1e-10)
+        assert_allclose(self.res1.info_criteria("bic"), self.res1.bic, rtol=1e-10)
+        with pytest.raises(ValueError, match="crit"):
+            self.res1.info_criteria("not-a-real-criterion")
 
     decimal_bic = DECIMAL_4
 
@@ -1519,6 +1524,14 @@ def test_fvalue_only_constant():
     assert_(np.isnan(res.fvalue))
     assert_(np.isnan(res.f_pvalue))
     res.summary()
+
+
+def test_fit_invalid_method_raises():
+    rs = np.random.RandomState(89432)
+    exog = add_constant(rs.normal(size=(50, 2)))
+    endog = exog @ [1.0, 0.5, -0.5] + rs.normal(size=50)
+    with pytest.raises(ValueError, match="method"):
+        OLS(endog, exog).fit(method="not-a-method")
 
 
 def test_ridge():

--- a/statsmodels/robust/covariance.py
+++ b/statsmodels/robust/covariance.py
@@ -1591,7 +1591,7 @@ def _get_detcov_startidx(z, h, options_start=None, methods_cov="all"):
         a string label identifying the method used to obtain it.
     """
 
-    methods_cov = string_like(
+    _ = string_like(
         methods_cov, "methods_cov", options=("all",), lower=False
     )
 

--- a/statsmodels/robust/covariance.py
+++ b/statsmodels/robust/covariance.py
@@ -35,6 +35,7 @@ import statsmodels.robust.norms as rnorms
 import statsmodels.robust.scale as rscale
 import statsmodels.robust.tools as rtools
 from statsmodels.stats.covariance import corr_normal_scores, corr_rank
+from statsmodels.tools.validation import string_like
 
 from .scale import mad
 
@@ -1302,13 +1303,12 @@ def _cov_iter(
     # recompute maha distance at final estimate
     dist = mahalanobis(data, cov=cov)
 
+    rescale = string_like(rescale, "rescale", options=("med", "none"), lower=False)
     if rescale == "none":
         s = 1
     elif rescale == "med":
         s = np.median(dist) / stats.chi2.ppf(0.5, k_vars)
         cov *= s
-    else:
-        raise NotImplementedError('only rescale="med" is currently available')
 
     res = CovIterResult(
         cov=cov,
@@ -1590,6 +1590,10 @@ def _get_detcov_startidx(z, h, options_start=None, methods_cov="all"):
         Each tuple contains an array of indices for a starting subset and
         a string label identifying the method used to obtain it.
     """
+
+    methods_cov = string_like(
+        methods_cov, "methods_cov", options=("all",), lower=False
+    )
 
     if options_start is None:
         options_start = {}

--- a/statsmodels/robust/covariance.py
+++ b/statsmodels/robust/covariance.py
@@ -1306,7 +1306,7 @@ def _cov_iter(
     rescale = string_like(rescale, "rescale", options=("med", "none"), lower=False)
     if rescale == "none":
         s = 1
-    elif rescale == "med":
+    else:  # rescale == "med"
         s = np.median(dist) / stats.chi2.ppf(0.5, k_vars)
         cov *= s
 

--- a/statsmodels/robust/robust_linear_model.py
+++ b/statsmodels/robust/robust_linear_model.py
@@ -24,6 +24,7 @@ import statsmodels.regression.linear_model as lm
 from statsmodels.robust import norms, scale
 from statsmodels.tools._decorators import cache_readonly
 from statsmodels.tools.sm_exceptions import ConvergenceWarning
+from statsmodels.tools.validation import string_like
 
 __all__ = ["RLM"]
 
@@ -209,12 +210,8 @@ class RLM(base.LikelihoodModel):
             The estimated scale.
         """
         if isinstance(scale_est, str):
-            if scale_est.lower() == "mad":
-                return scale.mad(resid, center=0)
-            else:
-                raise ValueError(
-                    f"Option {scale_est} for scale_est not understood"
-                )
+            scale_est = string_like(scale_est, "scale_est", options=("mad",))
+            return scale.mad(resid, center=0)
         elif isinstance(scale_est, scale.HuberScale):
             return scale_est(self.df_resid, self.nobs, resid)
         else:
@@ -280,12 +277,10 @@ class RLM(base.LikelihoodModel):
         results : statsmodels.robust.robust_linear_model.RLMResults
             Results instance
         """
-        if cov.upper() not in ["H1", "H2", "H3"]:
-            raise ValueError(f"Covariance matrix {cov} not understood")
-        cov = cov.upper()
-        conv = conv.lower()
-        if conv not in ["weights", "coefs", "dev", "sresid"]:
-            raise ValueError(f"Convergence argument {conv} not understood")
+        # options are upper-cased for display/storage, unlike most other
+        # string options in this codebase which are lower-cased
+        cov = string_like(cov, "cov", options=("h1", "h2", "h3")).upper()
+        conv = string_like(conv, "conv", options=("weights", "coefs", "dev", "sresid"))
 
         if start_params is None:
             wls_results = lm.WLS(self.endog, self.exog).fit()

--- a/statsmodels/robust/robust_linear_model.py
+++ b/statsmodels/robust/robust_linear_model.py
@@ -210,7 +210,7 @@ class RLM(base.LikelihoodModel):
             The estimated scale.
         """
         if isinstance(scale_est, str):
-            scale_est = string_like(scale_est, "scale_est", options=("mad",))
+            _ = string_like(scale_est, "scale_est", options=("mad",))
             return scale.mad(resid, center=0)
         elif isinstance(scale_est, scale.HuberScale):
             return scale_est(self.df_resid, self.nobs, resid)

--- a/statsmodels/robust/robust_linear_model.py
+++ b/statsmodels/robust/robust_linear_model.py
@@ -316,7 +316,7 @@ class RLM(base.LikelihoodModel):
         elif conv == "sresid":
             history.update(dict(sresid=[np.inf]))
             criterion = history["sresid"]
-        elif conv == "weights":
+        else:  # conv == "weights"
             history.update(dict(weights=[np.inf]))
             criterion = history["weights"]
 
@@ -455,7 +455,9 @@ class RLMResults(base.LikelihoodModelResults):
         self.df_model = model.df_model
         self.df_resid = model.df_resid
         self.nobs = model.nobs
-        self.cov = cov
+        # cov is a public constructor argument (not only reachable through
+        # the already-validated RLM.fit), so it needs its own validation
+        self.cov = string_like(cov, "cov", options=("h1", "h2", "h3")).upper()
         # Snapshot the final IRLS weights now, rather than deferring to
         # model.weights, so this result is unaffected by any later fit()
         # call on the same model instance.
@@ -519,7 +521,7 @@ class RLMResults(base.LikelihoodModelResults):
                     / ((1 / self.nobs) * np.sum(model.M.psi_deriv(self.sresid)))
                     * W_inv
                 )
-            elif self.cov == "H3":
+            else:  # self.cov == "H3"
                 return (
                     k**-1
                     * 1

--- a/statsmodels/robust/scale.py
+++ b/statsmodels/robust/scale.py
@@ -19,7 +19,7 @@ from scipy import stats
 from scipy.stats import norm as Gaussian
 
 from statsmodels.tools import tools
-from statsmodels.tools.validation import array_like, float_like
+from statsmodels.tools.validation import array_like, float_like, string_like
 
 from . import norms
 from ._qn import _qn
@@ -648,6 +648,13 @@ def scale_trimmed(data, alpha, center="median", axis=0, distr=None, distargs=Non
     x_trimmed = x[tuple(sl)]
 
     center_type = center
+    if isinstance(center, str):
+        center = string_like(
+            center,
+            "center",
+            options=("med", "median", "mean", "tmean"),
+            lower=False,
+        )
     if center in ["med", "median"]:
         center = np.median(x, axis=axis)
     elif center == "mean":

--- a/statsmodels/robust/tests/test_covariance.py
+++ b/statsmodels/robust/tests/test_covariance.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import numpy as np
 from numpy.testing import assert_allclose, assert_equal
 import pandas as pd
+import pytest
 from scipy import linalg
 
 from statsmodels import robust
@@ -418,3 +419,19 @@ def test_robcov_SMOKE():
             assert_allclose(c1, cov, rtol=0.4)
             assert_allclose(c1, cov_clean, rtol=1e-8)  # oracle, w/o outliers
             assert_allclose(m1, mean, rtol=0.5, atol=0.2)
+
+
+def test_cov_iter_invalid_rescale_raises():
+    rs = np.random.RandomState(28345)
+    x = rs.standard_normal((50, 3))
+    with pytest.raises(ValueError, match="rescale"):
+        robcov._cov_iter(
+            x, robcov.weights_quantile, weights_args=(0.50,), rescale="not-a-rescale"
+        )
+
+
+def test_get_detcov_startidx_invalid_methods_cov_raises():
+    rs = np.random.RandomState(28346)
+    z = rs.standard_normal((50, 3))
+    with pytest.raises(ValueError, match="methods_cov"):
+        robcov._get_detcov_startidx(z, 30, methods_cov="not-all")

--- a/statsmodels/robust/tests/test_rlm.py
+++ b/statsmodels/robust/tests/test_rlm.py
@@ -468,3 +468,24 @@ def test_fit_invalid_options_raise():
     res_mad = mod.fit(scale_est="mad")
     res_default = mod.fit()
     assert_allclose(res_mad.params, res_default.params)
+
+
+def test_rlm_results_direct_construction_validates_cov():
+    # RLMResults.cov is a public constructor argument, independently
+    # reachable without going through RLM.fit's validation
+    from statsmodels.robust.robust_linear_model import RLMResults
+
+    data = load_stackloss()
+    data.exog = sm.add_constant(data.exog, prepend=False)
+    mod = RLM(data.endog, data.exog, M=norms.HuberT())
+    res = mod.fit()
+
+    # lower-case input is accepted and stored upper-cased, same as fit()
+    direct = RLMResults(
+        mod, res.params, res.normalized_cov_params, res.scale, cov="h2"
+    )
+    assert direct.cov == "H2"
+    assert_allclose(direct.bcov_scaled, mod.fit(cov="H2").bcov_scaled)
+
+    with pytest.raises(ValueError, match="cov"):
+        RLMResults(mod, res.params, res.normalized_cov_params, res.scale, cov="H4")

--- a/statsmodels/robust/tests/test_rlm.py
+++ b/statsmodels/robust/tests/test_rlm.py
@@ -386,7 +386,7 @@ def test_bad_criterion():
     data.endog = np.asarray(data.endog)
     data.exog = sm.add_constant(data.exog, prepend=False)
     mod = RLM(data.endog, data.exog, M=norms.HuberT())
-    with pytest.raises(ValueError, match="Convergence argument unknown"):
+    with pytest.raises(ValueError, match="conv"):
         mod.fit(conv="unknown")
 
 
@@ -444,3 +444,27 @@ def test_summary_title():
     smry = res.summary(title=custom_title)
     assert custom_title in str(smry)
     assert default_title not in str(smry)
+
+
+def test_fit_invalid_options_raise():
+    data = load_stackloss()
+    data.exog = sm.add_constant(data.exog, prepend=False)
+    mod = RLM(data.endog, data.exog, M=norms.HuberT())
+
+    with pytest.raises(ValueError, match="cov"):
+        mod.fit(cov="not-a-cov")
+    with pytest.raises(ValueError, match="conv"):
+        mod.fit(conv="not-a-conv")
+    with pytest.raises(ValueError, match="scale_est"):
+        mod.fit(scale_est="not-a-scale-est")
+
+    # cov is upper-cased regardless of input case, unlike most other
+    # string options in this codebase, which are lower-cased
+    res_lower = mod.fit(cov="h2")
+    res_upper = mod.fit(cov="H2")
+    assert res_lower.cov == res_upper.cov == "H2"
+
+    # scale_est="mad" (string form) matches the HuberScale-free default
+    res_mad = mod.fit(scale_est="mad")
+    res_default = mod.fit()
+    assert_allclose(res_mad.params, res_default.params)

--- a/statsmodels/robust/tests/test_scale.py
+++ b/statsmodels/robust/tests/test_scale.py
@@ -463,6 +463,18 @@ def test_scale_trimmed_approx():
     s = scale_trimmed(x, alpha, distr=stats.t, distargs=(100,)).scale
     assert_allclose(s, [2], rtol=1e-1)
 
+    # "med" is a documented alias for "median"
+    res_med = scale_trimmed(x, alpha, center="med")
+    res_median = scale_trimmed(x, alpha, center="median")
+    assert_allclose(res_med.scale, res_median.scale)
+
+    # center may also be array_like, not just one of the 4 string options
+    res_num = scale_trimmed(x, alpha, center=0.0)
+    assert res_num.center_type == "user"
+
+    with pytest.raises(ValueError, match="center"):
+        scale_trimmed(x, alpha, center="not-a-center")
+
 
 def test_scale_trimmed_distarge():
     nobs = 500

--- a/statsmodels/sandbox/stats/multicomp.py
+++ b/statsmodels/sandbox/stats/multicomp.py
@@ -74,6 +74,7 @@ from scipy import interpolate, stats
 from statsmodels.graphics import utils
 from statsmodels.iolib.table import SimpleTable
 from statsmodels.tools.sm_exceptions import ValueWarning
+from statsmodels.tools.validation import string_like
 
 try:
     # Studentized Range in SciPy 1.7+
@@ -1181,14 +1182,15 @@ class MultiComparison:
             np.column_stack([self.data, self.groupintlab]), useranks=False
         )
 
+        use_var = string_like(
+            use_var, "use_var", options=("unequal", "equal"), lower=False
+        )
         gmeans = self.groupstats.groupmean
         gnobs = self.groupstats.groupnobs
         if use_var == "unequal":
             var_ = self.groupstats.groupvarwithin()
         elif use_var == "equal":
             var_ = np.var(self.groupstats.groupdemean(), ddof=len(gmeans))
-        else:
-            raise ValueError('use_var should be "unequal" or "equal"')
 
         # res contains: 0:(idx1, idx2), 1:reject, 2:meandiffs, 3: std_pairs,
         # 4:confint, 5:q_crit, 6:df_total, 7:reject2, 8: pvals

--- a/statsmodels/sandbox/stats/multicomp.py
+++ b/statsmodels/sandbox/stats/multicomp.py
@@ -1189,7 +1189,7 @@ class MultiComparison:
         gnobs = self.groupstats.groupnobs
         if use_var == "unequal":
             var_ = self.groupstats.groupvarwithin()
-        elif use_var == "equal":
+        else:  # use_var == "equal"
             var_ = np.var(self.groupstats.groupdemean(), ddof=len(gmeans))
 
         # res contains: 0:(idx1, idx2), 1:reject, 2:meandiffs, 3: std_pairs,

--- a/statsmodels/sandbox/stats/runs.py
+++ b/statsmodels/sandbox/stats/runs.py
@@ -25,7 +25,7 @@ import numpy as np
 from scipy import stats
 from scipy.special import comb
 
-from statsmodels.tools.validation import array_like
+from statsmodels.tools.validation import array_like, string_like
 
 
 class Runs:
@@ -138,6 +138,8 @@ def runstest_1samp(x, cutoff="mean", correction=True):
     """
 
     x = array_like(x, "x")
+    if isinstance(cutoff, str):
+        cutoff = string_like(cutoff, "cutoff", options=("mean", "median"), lower=False)
     if cutoff == "mean":
         cutoff = np.mean(x)
     elif cutoff == "median":

--- a/statsmodels/sandbox/stats/tests/test_runs.py
+++ b/statsmodels/sandbox/stats/tests/test_runs.py
@@ -45,6 +45,12 @@ def test_numeric_cutoff():
     assert_almost_equal(expected, results)
 
 
+def test_invalid_string_cutoff_raises():
+    x = [1] * 5 + [2] * 6 + [3] * 8
+    with pytest.raises(ValueError, match="cutoff"):
+        runstest_1samp(x, cutoff="not-a-cutoff")
+
+
 def test_single_run():
     x = [1] * 10
     expected = (-2.8856349, 0.0039062)

--- a/statsmodels/stats/_diagnostic_other.py
+++ b/statsmodels/stats/_diagnostic_other.py
@@ -732,7 +732,7 @@ def conditional_moment_test_generic(
     Wooldridge ???
     Pagan and Vella 1989
     """
-    cov_type = string_like(cov_type, "cov_type", options=("OPG",), lower=False)
+    _ = string_like(cov_type, "cov_type", options=("OPG",), lower=False)
 
     k_constraints = mom_test.shape[1]
 

--- a/statsmodels/stats/_diagnostic_other.py
+++ b/statsmodels/stats/_diagnostic_other.py
@@ -155,6 +155,7 @@ from scipy import stats
 
 from statsmodels.regression.linear_model import OLS
 from statsmodels.tools._decorators import cache_readonly
+from statsmodels.tools.validation import string_like
 
 
 class ResultsGeneric:
@@ -731,8 +732,7 @@ def conditional_moment_test_generic(
     Wooldridge ???
     Pagan and Vella 1989
     """
-    if cov_type != "OPG":
-        raise NotImplementedError
+    cov_type = string_like(cov_type, "cov_type", options=("OPG",), lower=False)
 
     k_constraints = mom_test.shape[1]
 

--- a/statsmodels/stats/_inference_tools.py
+++ b/statsmodels/stats/_inference_tools.py
@@ -72,7 +72,7 @@ def _mover_confint(stat1, stat2, ci1, ci2, contrast="diff"):
         upp_half = np.sqrt((stat1 - ci1[1])**2 + (stat2 - ci2[1])**2)
         ci = (stat - low_half, stat + upp_half)
 
-    elif contrast == "ratio":
+    else:  # contrast == "ratio"
         # stat = stat1 / stat2
         prod = stat1 * stat2
         term1 = stat2**2 - (ci2[1] - stat2)**2

--- a/statsmodels/stats/_inference_tools.py
+++ b/statsmodels/stats/_inference_tools.py
@@ -8,6 +8,8 @@ License: BSD-3
 import numpy as np
 from numpy.testing import assert_allclose
 
+from statsmodels.tools.validation import string_like
+
 
 def _mover_confint(stat1, stat2, ci1, ci2, contrast="diff"):
     """
@@ -54,6 +56,9 @@ def _mover_confint(stat1, stat2, ci1, ci2, contrast="diff"):
        about Effect Measures: A General Approach.” Statistics in Medicine 27
        (10): 1693-1702. https://doi.org/10.1002/sim.3095.
     """
+    contrast = string_like(
+        contrast, "contrast", options=("diff", "sum", "ratio"), lower=False
+    )
 
     if contrast == "diff":
         stat = stat1 - stat2

--- a/statsmodels/stats/_lilliefors.py
+++ b/statsmodels/stats/_lilliefors.py
@@ -295,7 +295,7 @@ def kstest_fit(x, dist="norm", pvalmethod="table"):
     if dist == "norm":
         z = (x - x.mean()) / x.std(ddof=1)
         test_d = stats.norm.cdf
-    elif dist == "exp":
+    else:  # dist == "exp"
         z = x / x.mean()
         test_d = stats.expon.cdf
         pvalmethod = "table"

--- a/statsmodels/stats/_lilliefors.py
+++ b/statsmodels/stats/_lilliefors.py
@@ -291,6 +291,7 @@ def kstest_fit(x, dist="norm", pvalmethod="table"):
 
     nobs = len(x)
 
+    dist = string_like(dist, "dist", options=("norm", "exp"), lower=False)
     if dist == "norm":
         z = (x - x.mean()) / x.std(ddof=1)
         test_d = stats.norm.cdf
@@ -298,8 +299,6 @@ def kstest_fit(x, dist="norm", pvalmethod="table"):
         z = x / x.mean()
         test_d = stats.expon.cdf
         pvalmethod = "table"
-    else:
-        raise ValueError("Invalid dist parameter, must be 'norm' or 'exp'")
     # deferred/cached: only builds (and imports) the critical-value table
     # for the distribution actually requested
     lilliefors_table = get_lilliefors_table(dist=dist)

--- a/statsmodels/stats/contrast.py
+++ b/statsmodels/stats/contrast.py
@@ -693,7 +693,7 @@ def _constraints_factor(
 
     import statsmodels.sandbox.stats.multicomp as mc
 
-    comparison = string_like(
+    _ = string_like(
         comparison, "comparison", options=("pairwise", "pw", "pairs"), lower=False
     )
     c_all = -mc.contrast_allpairs(k_level)

--- a/statsmodels/stats/contrast.py
+++ b/statsmodels/stats/contrast.py
@@ -7,6 +7,7 @@ from scipy.stats import f as fdist, t as student_t
 from statsmodels.formula._manager import FormulaManager
 from statsmodels.stats.multitest import multipletests
 from statsmodels.tools.tools import clean0, fullrank
+from statsmodels.tools.validation import string_like
 
 
 # TODO: should this be public if it's just a container?
@@ -692,10 +693,10 @@ def _constraints_factor(
 
     import statsmodels.sandbox.stats.multicomp as mc
 
-    if comparison in ["pairwise", "pw", "pairs"]:
-        c_all = -mc.contrast_allpairs(k_level)
-    else:
-        raise NotImplementedError("currentlyonly pairwise comparison")
+    comparison = string_like(
+        comparison, "comparison", options=("pairwise", "pw", "pairs"), lower=False
+    )
+    c_all = -mc.contrast_allpairs(k_level)
 
     contrasts = c_all.dot(cm)
     if k_params is not None:

--- a/statsmodels/stats/dist_dependence_measures.py
+++ b/statsmodels/stats/dist_dependence_measures.py
@@ -24,6 +24,7 @@ from scipy.stats import norm
 
 from statsmodels.tools.rng_qrng import check_random_state
 from statsmodels.tools.sm_exceptions import HypothesisTestWarning
+from statsmodels.tools.validation import string_like
 
 
 class DistDependStat(NamedTuple):
@@ -147,6 +148,10 @@ def distance_covariance_test(x, y, B=None, method="auto", rng=None):
     """
     x, y = _validate_and_tranform_x_and_y(x, y)
 
+    method = string_like(
+        method, "method", options=("auto", "emp", "asym"), lower=False
+    )
+
     n = x.shape[0]
     stats = distance_statistics(x, y)
 
@@ -158,9 +163,6 @@ def distance_covariance_test(x, y, B=None, method="auto", rng=None):
     elif (method == "auto" and n > 500) or method == "asym":
         chosen_method = "asym"
         test_statistic, pval = _asymptotic_pvalue(stats)
-
-    else:
-        raise ValueError(f"Unknown 'method' parameter: {method}")
 
     # In case we got an extreme p-value (0 or 1) when using the empirical
     # distribution of the test statistic under the null, we fall back

--- a/statsmodels/stats/dist_dependence_measures.py
+++ b/statsmodels/stats/dist_dependence_measures.py
@@ -160,7 +160,7 @@ def distance_covariance_test(x, y, B=None, method="auto", rng=None):
         rng = check_random_state(rng)
         test_statistic, pval = _empirical_pvalue(x, y, B, n, stats, rng)
 
-    elif (method == "auto" and n > 500) or method == "asym":
+    else:  # method == "asym", or method == "auto" and n > 500
         chosen_method = "asym"
         test_statistic, pval = _asymptotic_pvalue(stats)
 

--- a/statsmodels/stats/gof.py
+++ b/statsmodels/stats/gof.py
@@ -143,7 +143,7 @@ def powerdiscrepancy(observed, expected, lambd=0.0, axis=0, ddof=0):
         a = 1
     elif lambd == "modified_loglikeratio":
         a = -1
-    elif lambd == "cressie_read":
+    else:  # lambd == "cressie_read"
         a = 2/3.0
 
     n = np.sum(o, axis=axis)

--- a/statsmodels/stats/gof.py
+++ b/statsmodels/stats/gof.py
@@ -25,6 +25,8 @@ from typing import NamedTuple
 import numpy as np
 from scipy import stats
 
+from statsmodels.tools.validation import string_like
+
 
 # copied from regression/stats.utils
 def powerdiscrepancy(observed, expected, lambd=0.0, axis=0, ddof=0):
@@ -120,6 +122,17 @@ def powerdiscrepancy(observed, expected, lambd=0.0, axis=0, ddof=0):
     o = np.array(observed)
     e = np.array(expected)
 
+    if isinstance(lambd, str):
+        lambd = string_like(
+            lambd,
+            "lambd",
+            options=(
+                "loglikeratio", "freeman_tukey", "pearson",
+                "modified_loglikeratio", "cressie_read",
+            ),
+            lower=False,
+        )
+
     if not isinstance(lambd, str):
         a = lambd
     elif lambd == "loglikeratio":
@@ -132,10 +145,6 @@ def powerdiscrepancy(observed, expected, lambd=0.0, axis=0, ddof=0):
         a = -1
     elif lambd == "cressie_read":
         a = 2/3.0
-    else:
-        raise ValueError("lambd has to be a number or one of "
-                         "loglikeratio, freeman_tukey, pearson, "
-                         "modified_loglikeratio or cressie_read")
 
     n = np.sum(o, axis=axis)
     nt = n

--- a/statsmodels/stats/multitest.py
+++ b/statsmodels/stats/multitest.py
@@ -25,7 +25,12 @@ __all__ = [
     "multipletests",
 ]
 
-from statsmodels.tools.validation import array_like, bool_like, float_like
+from statsmodels.tools.validation import (
+    array_like,
+    bool_like,
+    float_like,
+    string_like,
+)
 
 # ==============================================
 #
@@ -401,6 +406,12 @@ def fdrcorrection(pvals, alpha=0.05, method="indep", is_sorted=False):
     else:
         pvals_sorted = pvals  # alias
 
+    method = string_like(
+        method,
+        "method",
+        options=("i", "indep", "p", "poscorr", "n", "negcorr"),
+        lower=False,
+    )
     if method in ["i", "indep", "p", "poscorr"]:
         ecdffactor = _ecdf(pvals_sorted)
     elif method in ["n", "negcorr"]:
@@ -409,8 +420,6 @@ def fdrcorrection(pvals, alpha=0.05, method="indep", is_sorted=False):
     #    elif method in ['n', 'negcorr']:
     #        cm = np.sum(np.arange(len(pvals)))
     #        ecdffactor = ecdf(pvals_sorted)/cm
-    else:
-        raise ValueError("only indep and negcorr implemented")
     reject = pvals_sorted <= ecdffactor * alpha
     if reject.any():
         rejectmax = max(np.nonzero(reject)[0])
@@ -685,6 +694,7 @@ def fdrcorrection_twostage(
         pvals_sortind = np.argsort(pvals)
         pvals = np.take(pvals, pvals_sortind)
 
+    method = string_like(method, "method", options=("bky", "bh"), lower=False)
     ntests = len(pvals)
     if method == "bky":
         fact = 1.0 + alpha
@@ -692,8 +702,6 @@ def fdrcorrection_twostage(
     elif method == "bh":
         fact = 1.0
         alpha_prime = alpha
-    else:
-        raise ValueError("only 'bky' and 'bh' are available as method")
 
     alpha_stages = [alpha_prime]
     rej, pvalscorr = fdrcorrection(

--- a/statsmodels/stats/multitest.py
+++ b/statsmodels/stats/multitest.py
@@ -414,7 +414,7 @@ def fdrcorrection(pvals, alpha=0.05, method="indep", is_sorted=False):
     )
     if method in ["i", "indep", "p", "poscorr"]:
         ecdffactor = _ecdf(pvals_sorted)
-    elif method in ["n", "negcorr"]:
+    else:  # method in ("n", "negcorr")
         cm = np.sum(1.0 / np.arange(1, len(pvals_sorted) + 1))  # corrected this
         ecdffactor = _ecdf(pvals_sorted) / cm
     #    elif method in ['n', 'negcorr']:
@@ -699,7 +699,7 @@ def fdrcorrection_twostage(
     if method == "bky":
         fact = 1.0 + alpha
         alpha_prime = alpha / fact
-    elif method == "bh":
+    else:  # method == "bh"
         fact = 1.0
         alpha_prime = alpha
 

--- a/statsmodels/stats/nonparametric.py
+++ b/statsmodels/stats/nonparametric.py
@@ -23,6 +23,7 @@ from statsmodels.stats.weightstats import (
     _zconfint_generic,
     _zstat_generic,
 )
+from statsmodels.tools.validation import string_like
 
 
 def rankdata_2samp(x1, x2):
@@ -862,10 +863,12 @@ def jonckheere_terpstra(samples, alternative="larger"):
     samples = list(samples)
     if len(samples) < 2:
         raise ValueError("`samples` must contain at least two ordered samples.")
-    if alternative not in ("two-sided", "larger", "smaller"):
-        raise ValueError(
-            "alternative must be one of 'two-sided', 'larger', or 'smaller'."
-        )
+    alternative = string_like(
+        alternative,
+        "alternative",
+        options=("two-sided", "larger", "smaller"),
+        lower=False,
+    )
 
     arrays = []
     for idx, sample in enumerate(samples):
@@ -1308,10 +1311,12 @@ def samplesize_rank_compare_onetail(
             "Ratio of reference group to treatment group must be"
             " strictly positive."
         )
-    if alternative not in ("two-sided", "larger", "smaller"):
-        raise ValueError(
-            "Alternative must be one of `two-sided`, `larger`, or `smaller`."
-        )
+    alternative = string_like(
+        alternative,
+        "alternative",
+        options=("two-sided", "larger", "smaller"),
+        lower=False,
+    )
 
     # Group 1 is the treatment group, Group 2 is the reference group
     rank_place = _compute_rank_placements(

--- a/statsmodels/stats/proportion.py
+++ b/statsmodels/stats/proportion.py
@@ -20,7 +20,7 @@ from scipy import optimize, stats
 from statsmodels.stats.base import AllPairsResults, LimitedIterationMixin
 from statsmodels.stats.weightstats import _zstat_generic2
 from statsmodels.tools.sm_exceptions import HypothesisTestWarning
-from statsmodels.tools.validation import array_like
+from statsmodels.tools.validation import array_like, string_like
 
 FLOAT_INFO = np.finfo(float)
 
@@ -201,11 +201,13 @@ def proportion_confint(
 
     q_ = count_a / nobs_a
 
+    alternative = string_like(
+        alternative, "alternative", options=("two-sided", "larger", "smaller"),
+        lower=False,
+    )
     if alternative == "two-sided":
         if method != "binom_test":
             alpha = alpha / 2.0
-    elif alternative not in ["larger", "smaller"]:
-        raise NotImplementedError(f"alternative {alternative} is not available")
 
     if method == "normal":
         std_ = np.sqrt(q_ * (1 - q_) / nobs_a)

--- a/statsmodels/stats/rates.py
+++ b/statsmodels/stats/rates.py
@@ -951,6 +951,7 @@ def test_poisson_2indep(
     rate1, rate2 = y1 / n1, y2 / n2
     rates_cmle = None
 
+    compare = string_like(compare, "compare", options=("diff", "ratio"), lower=False)
     if compare == "ratio":
         if method is None:
             # default method
@@ -1018,7 +1019,7 @@ def test_poisson_2indep(
         else:
             raise ValueError(f'method "{method}" not recognized')
 
-    elif compare == "diff":
+    else:  # compare == "diff"
         if value is None:
             value = 0
         if method == "wald":
@@ -1066,8 +1067,6 @@ def test_poisson_2indep(
             dist = "poisson"
         else:
             raise ValueError(f'method "{method}" not recognized')
-    else:
-        raise NotImplementedError('"compare" needs to be ratio or diff')
 
     if dist == "normal":
         stat, pvalue = _zstat_generic2(stat, 1, alternative)
@@ -1228,6 +1227,7 @@ def etest_poisson_2indep(
 
     eps = 1e-20  # avoid zero division in stat_func
 
+    compare = string_like(compare, "compare", options=("diff", "ratio"), lower=False)
     if compare == "ratio":
         if value is None:
             # default value
@@ -1260,7 +1260,7 @@ def etest_poisson_2indep(
         else:
             raise ValueError("method not recognized")
 
-    elif compare == "diff":
+    else:  # compare == "diff"
         if value is None:
             value = 0
         tmp = _score_diff(y1, n1, y2, n2, value=value, return_cmle=True)
@@ -1720,6 +1720,7 @@ def confint_poisson_2indep(
     rate1, rate2 = y1 / n1, y2 / n2
     alpha = alpha / 2  # two-sided only
 
+    compare = string_like(compare, "compare", options=("diff", "ratio"), lower=False)
     if compare == "ratio":
 
         if method == "score":
@@ -1787,7 +1788,7 @@ def confint_poisson_2indep(
 
         ci = (np.maximum(ci[0], 0), ci[1])
 
-    elif compare == "diff":
+    else:  # compare == "diff"
 
         if method == "wald":
             crit = stats.norm.isf(alpha)
@@ -1823,8 +1824,6 @@ def confint_poisson_2indep(
             ci = _mover_confint(rate1, rate2, ci1, ci2, contrast="diff")
         else:
             raise ValueError(f'method "{method}" not recognized')
-    else:
-        raise NotImplementedError('"compare" needs to be ratio or diff')
 
     return ci
 

--- a/statsmodels/stats/rates.py
+++ b/statsmodels/stats/rates.py
@@ -15,6 +15,7 @@ from scipy import optimize, stats
 from statsmodels.stats._inference_tools import _mover_confint
 from statsmodels.stats.base import LimitedIterationMixin
 from statsmodels.stats.weightstats import _zstat_generic2
+from statsmodels.tools.validation import string_like
 
 # shorthand
 norm = stats.norm
@@ -324,10 +325,12 @@ def confint_poisson(count, exposure, method=None, alpha=0.05, alternative="two-s
     n = exposure  # short hand
     rate = count / exposure
 
+    alternative = string_like(
+        alternative, "alternative", options=("two-sided", "larger", "smaller"),
+        lower=False,
+    )
     if alternative == "two-sided":
         alpha = alpha / 2
-    elif alternative not in ["larger", "smaller"]:
-        raise NotImplementedError(f"alternative {alternative} is not available")
 
     if method is None:
         msg = "method needs to be specified, currently no default method"
@@ -500,6 +503,10 @@ def tolerance_int_poisson(
        Poisson and Binomial Variables.” Journal of Quality Technology 13 (2):
        100-110. https://doi.org/10.1080/00224065.1981.11980998.
     """
+    alternative = string_like(
+        alternative, "alternative", options=("two-sided", "larger", "smaller"),
+        lower=False,
+    )
     prob_tail = 1 - prob
     alpha_ = alpha
     if alternative != "two-sided":
@@ -517,7 +524,7 @@ def tolerance_int_poisson(
     elif alternative == "larger":
         low_pred = 0
         upp_pred = stats.poisson.ppf(1 - prob_tail, upp)
-    elif alternative == "smaller":
+    else:  # alternative == "smaller"
         low_pred = stats.poisson.ppf(prob_tail, low)
         upp_pred = np.inf
 
@@ -579,6 +586,10 @@ def confint_quantile_poisson(
     Hahn, Gerald J, and William Q Meeker. 2010. Statistical Intervals: A Guide
     for Practitioners.
     """
+    alternative = string_like(
+        alternative, "alternative", options=("two-sided", "larger", "smaller"),
+        lower=False,
+    )
     alpha_ = alpha
     if alternative != "two-sided":
         # confint_poisson does not have one-sided alternatives
@@ -594,7 +605,7 @@ def confint_quantile_poisson(
     elif alternative == "larger":
         low_pred = 0
         upp_pred = stats.poisson.ppf(prob, upp)
-    elif alternative == "smaller":
+    else:  # alternative == "smaller"
         low_pred = stats.poisson.ppf(prob, low)
         upp_pred = np.inf
 

--- a/statsmodels/stats/rates.py
+++ b/statsmodels/stats/rates.py
@@ -1996,14 +1996,15 @@ def power_poisson_ratio_2indep(
 
     nobs2 = nobs_ratio * nobs1
     v1 = dispersion / exposure * (1 / rate1 + 1 / (nobs_ratio * rate2))
+    method_var = string_like(
+        method_var, "method_var", options=("score", "alt"), lower=False
+    )
     if method_var == "alt":
         v0 = v1
-    elif method_var == "score":
+    else:  # method_var == "score"
         # nobs_ratio = 1 / nobs_ratio
         v0 = dispersion / exposure * (1 + value / nobs_ratio) ** 2
         v0 /= value / nobs_ratio * (rate1 + (nobs_ratio * rate2))
-    else:
-        raise NotImplementedError(f"method_var {method_var} not recognized")
 
     std_null = np.sqrt(v0)
     std_alt = np.sqrt(v1)
@@ -2161,15 +2162,16 @@ def power_equivalence_poisson_2indep(
     nobs2 = nobs_ratio * nobs1
     v1 = dispersion / exposure * (1 / rate1 + 1 / (nobs_ratio * rate2))
 
+    method_var = string_like(
+        method_var, "method_var", options=("score", "alt"), lower=False
+    )
     if method_var == "alt":
         v0_low = v0_upp = v1
-    elif method_var == "score":
+    else:  # method_var == "score"
         v0_low = dispersion / exposure * (1 + low * nobs_ratio) ** 2
         v0_low /= low * nobs_ratio * (rate1 + (nobs_ratio * rate2))
         v0_upp = dispersion / exposure * (1 + upp * nobs_ratio) ** 2
         v0_upp /= upp * nobs_ratio * (rate1 + (nobs_ratio * rate2))
-    else:
-        raise NotImplementedError(f"method_var {method_var} not recognized")
 
     es_low = np.log(rate1 / rate2) - np.log(low)
     es_upp = np.log(rate1 / rate2) - np.log(upp)
@@ -2652,6 +2654,9 @@ def power_negbin_ratio_2indep(
     v1 = (1 / rate1 + 1 / (nobs_ratio * rate2)) / exposure + (
         1 + nobs_ratio
     ) / nobs_ratio * dispersion
+    method_var = string_like(
+        method_var, "method_var", options=("score", "alt", "ftotal"), lower=False
+    )
     if method_var == "alt":
         v0 = v1
     elif method_var == "ftotal":
@@ -2659,7 +2664,7 @@ def power_negbin_ratio_2indep(
             exposure * nobs_ratio * value * (rate1 + nobs_ratio * rate2)
         )
         v0 += (1 + nobs_ratio) / nobs_ratio * dispersion
-    elif method_var == "score":
+    else:  # method_var == "score"
         v0 = _var_cmle_negbin(
             rate1,
             rate2,
@@ -2668,8 +2673,6 @@ def power_negbin_ratio_2indep(
             value=value,
             dispersion=dispersion,
         )[0]
-    else:
-        raise NotImplementedError(f"method_var {method_var} not recognized")
 
     std_null = np.sqrt(v0)
     std_alt = np.sqrt(v1)
@@ -2778,6 +2781,9 @@ def power_equivalence_neginb_2indep(
     v1 = (1 / rate2 + 1 / (nobs_ratio * rate1)) / exposure + (
         1 + nobs_ratio
     ) / nobs_ratio * dispersion
+    method_var = string_like(
+        method_var, "method_var", options=("score", "alt", "ftotal"), lower=False
+    )
     if method_var == "alt":
         v0_low = v0_upp = v1
     elif method_var == "ftotal":
@@ -2789,7 +2795,7 @@ def power_equivalence_neginb_2indep(
             exposure * nobs_ratio * upp * (rate1 + nobs_ratio * rate2)
         )
         v0_upp += (1 + nobs_ratio) / nobs_ratio * dispersion
-    elif method_var == "score":
+    else:  # method_var == "score"
         v0_low = _var_cmle_negbin(
             rate1,
             rate2,
@@ -2806,8 +2812,6 @@ def power_equivalence_neginb_2indep(
             value=upp,
             dispersion=dispersion,
         )[0]
-    else:
-        raise NotImplementedError(f"method_var {method_var} not recognized")
 
     es_low = np.log(rate1 / rate2) - np.log(low)
     es_upp = np.log(rate1 / rate2) - np.log(upp)

--- a/statsmodels/stats/rates.py
+++ b/statsmodels/stats/rates.py
@@ -1788,7 +1788,7 @@ def confint_poisson_2indep(
 
         ci = (np.maximum(ci[0], 0), ci[1])
 
-    else:  # compare == "diff"
+    else:  # noqa: PLR5501, compare == "diff" path
 
         if method == "wald":
             crit = stats.norm.isf(alpha)

--- a/statsmodels/stats/robust_compare.py
+++ b/statsmodels/stats/robust_compare.py
@@ -236,7 +236,7 @@ class TrimmedMean:
         if transform == "trimmed":
             mean_ = self.mean_trimmed
             std_ = self.std_mean_trimmed
-        elif transform == "winsorized":
+        else:  # transform == "winsorized"
             mean_ = self.mean_winsorized
             std_ = self.std_mean_winsorized
 

--- a/statsmodels/stats/robust_compare.py
+++ b/statsmodels/stats/robust_compare.py
@@ -10,6 +10,8 @@ import numbers
 
 import numpy as np
 
+from statsmodels.tools.validation import string_like
+
 # the trimboth and trim_mean are taken from scipy.stats.stats
 # and enhanced by axis
 
@@ -228,14 +230,15 @@ class TrimmedMean:
         import statsmodels.stats.weightstats as smws
 
         df = self.nobs_reduced - 1
+        transform = string_like(
+            transform, "transform", options=("trimmed", "winsorized"), lower=False
+        )
         if transform == "trimmed":
             mean_ = self.mean_trimmed
             std_ = self.std_mean_trimmed
         elif transform == "winsorized":
             mean_ = self.mean_winsorized
             std_ = self.std_mean_winsorized
-        else:
-            raise ValueError("transform can only be 'trimmed' or 'winsorized'")
 
         res = smws._tstat_generic(
             mean_, 0, std_, df, alternative=alternative, diff=value
@@ -292,6 +295,11 @@ def scale_transform(data, center="median", transform="abs", trim_frac=0.2, axis=
     """
     x = np.asarray(data)  # x is shorthand from earlier code
 
+    if isinstance(transform, str):
+        transform = string_like(
+            transform, "transform", options=("abs", "square", "identity"),
+            lower=False,
+        )
     if transform == "abs":
         tfunc = np.abs
     elif transform == "square":
@@ -309,6 +317,10 @@ def scale_transform(data, center="median", transform="abs", trim_frac=0.2, axis=
     else:
         raise ValueError("transform should be abs, square or exp")
 
+    if isinstance(center, str):
+        center = string_like(
+            center, "center", options=("median", "mean", "trimmed"), lower=False
+        )
     if center == "median":
         res = tfunc(x - np.expand_dims(np.median(x, axis=axis), axis))
     elif center == "mean":

--- a/statsmodels/stats/sandwich_covariance.py
+++ b/statsmodels/stats/sandwich_covariance.py
@@ -108,6 +108,7 @@ import numpy as np
 
 from statsmodels.stats.moment_helpers import se_cov
 from statsmodels.tools.grouputils import combine_indices, group_sums
+from statsmodels.tools.validation import string_like
 
 __all__ = [
     "cov_cluster",
@@ -750,11 +751,12 @@ def cov_cluster(results, group, use_correction=True, crv_type="cluster"):
     same result as Stata in UCLA example and same as Peterson
 
     """
-    if crv_type not in ("cluster", "cluster-crv3", "cluster-jk"):
-        raise ValueError(
-            "crv_type must be one of 'cluster', 'cluster-crv3' or "
-            f"'cluster-jk', got {crv_type!r}"
-        )
+    crv_type = string_like(
+        crv_type,
+        "crv_type",
+        options=("cluster", "cluster-crv3", "cluster-jk"),
+        lower=False,
+    )
     # TODO: currently used version of groupsums requires 2d resid
 
     xu, hessian_inv = _get_sandwich_arrays(results, cov_type="clu")
@@ -816,7 +818,7 @@ def cov_cluster_2groups(
     crv_type : {"cluster"}, optional
        Only 'cluster' (default), computing the additive two-way CRV1
        combination ``cov0 + cov1 - cov01``, is supported here. Passing
-       'cluster-crv3' or 'cluster-jk' raises ``NotImplementedError``; use
+       'cluster-crv3' or 'cluster-jk' raises ``ValueError``; use
        :func:`cov_cluster` directly with one-way clustering for those
        options.
 
@@ -838,17 +840,7 @@ def cov_cluster_2groups(
 
     verified against Peterson's table, (4 decimal print precision)
     """
-    if crv_type != "cluster":
-        raise NotImplementedError(
-            "Two-way clustering is only supported for crv_type='cluster' "
-            f"(CRV1); got crv_type={crv_type!r}. The additive two-way "
-            "combination cov0 + cov1 - cov01 (Cameron, Gelbach and Miller, "
-            "2011) is only valid for the CRV1 sandwich estimator -- "
-            "applying it to the CRV3/cluster-jackknife estimator does not "
-            "generally produce a positive semi-definite covariance matrix. "
-            "Use one-way clustering (a single `groups` array) with "
-            "crv_type='cluster-crv3' or 'cluster-jk'."
-        )
+    crv_type = string_like(crv_type, "crv_type", options=("cluster",), lower=False)
     if group2 is None:
         if group.ndim != 2 or group.shape[1] != 2:
             raise ValueError(

--- a/statsmodels/stats/sandwich_covariance.py
+++ b/statsmodels/stats/sandwich_covariance.py
@@ -840,7 +840,17 @@ def cov_cluster_2groups(
 
     verified against Peterson's table, (4 decimal print precision)
     """
-    crv_type = string_like(crv_type, "crv_type", options=("cluster",), lower=False)
+    if crv_type != "cluster":
+        raise NotImplementedError(
+            "Two-way clustering is only supported for crv_type='cluster' "
+            f"(CRV1); got crv_type={crv_type!r}. The additive two-way "
+            "combination cov0 + cov1 - cov01 (Cameron, Gelbach and Miller, "
+            "2011) is only valid for the CRV1 sandwich estimator -- "
+            "applying it to the CRV3/cluster-jackknife estimator does not "
+            "generally produce a positive semi-definite covariance matrix. "
+            "Use one-way clustering (a single `groups` array) with "
+            "crv_type='cluster-crv3' or 'cluster-jk'."
+        )
     if group2 is None:
         if group.ndim != 2 or group.shape[1] != 2:
             raise ValueError(

--- a/statsmodels/stats/tests/test_contrast.py
+++ b/statsmodels/stats/tests/test_contrast.py
@@ -78,6 +78,15 @@ def test_constraints():
     c1 = smc._contrast_pairs(6, 4, 1)  # k_params, k_level, idx_start
     assert_equal(c1, cpairs2)
 
+    # "pw" and "pairs" are documented aliases for "pairwise"
+    assert_equal(smc._constraints_factor(cm_, comparison="pw"), cpairs)
+    assert_equal(smc._constraints_factor(cm_, comparison="pairs"), cpairs)
+
+    import pytest
+
+    with pytest.raises(ValueError, match="comparison"):
+        smc._constraints_factor(cm_, comparison="not-a-comparison")
+
 
 def test_contrast_results_str_repr():
     import statsmodels.api as sm

--- a/statsmodels/stats/tests/test_diagnostic_other.py
+++ b/statsmodels/stats/tests/test_diagnostic_other.py
@@ -9,6 +9,7 @@ License: BSD-3
 
 import numpy as np
 from numpy.testing import assert_allclose
+import pytest
 
 from statsmodels.regression.linear_model import OLS
 import statsmodels.stats._diagnostic_other as diao
@@ -290,3 +291,12 @@ class TestCMTOLS(CheckCMT):
         res_all.append(("score reparam QMLE", tres))
 
         return res_all
+
+
+def test_conditional_moment_test_generic_invalid_cov_type_raises():
+    mom_test = np.eye(2)
+    mom_test_deriv = np.eye(2)
+    with pytest.raises(ValueError, match="cov_type"):
+        diao.conditional_moment_test_generic(
+            mom_test, mom_test_deriv, None, None, cov_type="not-a-cov-type"
+        )

--- a/statsmodels/stats/tests/test_dist_dependant_measures.py
+++ b/statsmodels/stats/tests/test_dist_dependant_measures.py
@@ -63,7 +63,7 @@ class TestDistDependenceMeasures:
 
     def test_input_validation_unknown_method(self):
         rs = np.random.RandomState(34784729)
-        with pytest.raises(ValueError, match="Unknown 'method' parameter"):
+        with pytest.raises(ValueError, match="method"):
             ddm.distance_covariance_test(self.x, self.y, method="wrong_name", rng=rs)
 
     def test_statistic_value_asym_method(self):

--- a/statsmodels/stats/tests/test_gof.py
+++ b/statsmodels/stats/tests/test_gof.py
@@ -6,9 +6,36 @@ Author: Josef Perktold
 """
 import numpy as np
 from numpy.testing import assert_almost_equal, assert_equal
+import pytest
 
-from statsmodels.stats.gof import chisquare, chisquare_effectsize, chisquare_power
+from statsmodels.stats.gof import (
+    chisquare,
+    chisquare_effectsize,
+    chisquare_power,
+    powerdiscrepancy,
+)
 from statsmodels.tools.testing import Holder
+
+
+def test_powerdiscrepancy_lambd_aliases():
+    observed = np.array([2.0, 4.0, 2.0, 1.0, 1.0])
+    expected = np.array([0.2, 0.2, 0.2, 0.2, 0.2])
+
+    lambd_and_a = [
+        ("loglikeratio", 0),
+        ("freeman_tukey", -0.5),
+        ("pearson", 1),
+        ("modified_loglikeratio", -1),
+        ("cressie_read", 2 / 3.0),
+    ]
+    for lambd, a in lambd_and_a:
+        d_str, p_str = powerdiscrepancy(observed, expected, lambd=lambd)
+        d_num, p_num = powerdiscrepancy(observed, expected, lambd=a)
+        assert_almost_equal(d_str, d_num, decimal=13)
+        assert_almost_equal(p_str, p_num, decimal=13)
+
+    with pytest.raises(ValueError, match="lambd"):
+        powerdiscrepancy(observed, expected, lambd="not-a-lambd")
 
 
 def test_chisquare_power():

--- a/statsmodels/stats/tests/test_inference_tools.py
+++ b/statsmodels/stats/tests/test_inference_tools.py
@@ -1,0 +1,22 @@
+import pytest
+
+from statsmodels.stats._inference_tools import _mover_confint
+
+
+def test_mover_confint_invalid_contrast_raises():
+    with pytest.raises(ValueError, match="contrast"):
+        _mover_confint(1.0, 2.0, (0.5, 1.5), (1.5, 2.5), contrast="not-a-contrast")
+
+
+def test_mover_confint_contrasts():
+    stat1, stat2 = 3.0, 5.0
+    ci1, ci2 = (2.0, 4.0), (4.0, 6.0)
+
+    low_diff, upp_diff = _mover_confint(stat1, stat2, ci1, ci2, contrast="diff")
+    assert low_diff < stat1 - stat2 < upp_diff
+
+    low_sum, upp_sum = _mover_confint(stat1, stat2, ci1, ci2, contrast="sum")
+    assert low_sum < stat1 + stat2 < upp_sum
+
+    low_ratio, upp_ratio = _mover_confint(stat1, stat2, ci1, ci2, contrast="ratio")
+    assert low_ratio < stat1 / stat2 < upp_ratio

--- a/statsmodels/stats/tests/test_multi.py
+++ b/statsmodels/stats/tests/test_multi.py
@@ -533,6 +533,14 @@ def test_fdr_twostage():
     assert_allclose(res3[1], res1[1])  # check default maxiter
 
 
+def test_fdrcorrection_invalid_method_raises():
+    pvals = np.array([0.01, 0.02, 0.3, 0.04, 0.5])
+    with pytest.raises(ValueError, match="method"):
+        fdrcorrection(pvals, method="not-a-method")
+    with pytest.raises(ValueError, match="method"):
+        fdrcorrection_twostage(pvals, method="not-a-method")
+
+
 @pytest.mark.parametrize("method", sorted(multitest_methods_names))
 def test_issorted(method):
     # test that is_sorted keyword works correctly

--- a/statsmodels/stats/tests/test_nonparametric.py
+++ b/statsmodels/stats/tests/test_nonparametric.py
@@ -967,8 +967,8 @@ def test_samplesize_rank_compare_onetail(reference_implementation_results):
             0.8,
             0.5,
             False,
-            ValueError,
-            "Alternative must be one of `two-sided`, `larger`, or `smaller`.",
+            TypeError,
+            "alternative must be a string",
         ),
         # Invalid alternative value
         (
@@ -979,7 +979,7 @@ def test_samplesize_rank_compare_onetail(reference_implementation_results):
             0.5,
             "invalid-alternative",
             ValueError,
-            "Alternative must be one of `two-sided`, `larger`, or `smaller`.",
+            "alternative",
         ),
         # Relative effect > 0.5 but alternative is smaller
         (

--- a/statsmodels/stats/tests/test_oneway.py
+++ b/statsmodels/stats/tests/test_oneway.py
@@ -166,6 +166,26 @@ def test_scale_transform(center):
     assert_allclose(xt0, xtt[0, :], rtol=1e-13)
 
 
+@pytest.mark.parametrize("transform", ["abs", "square", "identity"])
+def test_scale_transform_transform_options(transform):
+    rs = np.random.RandomState(32832188)
+    x = rs.randn(20)
+    xt = scale_transform(x, center="median", transform=transform)
+    assert xt.shape == x.shape
+
+    # center may be a plain number, transform may be a callable
+    xt_num = scale_transform(x, center=0.0, transform=transform)
+    assert xt_num.shape == x.shape
+
+    xt_callable = scale_transform(x, center="median", transform=np.abs)
+    assert_allclose(xt_callable, scale_transform(x, center="median", transform="abs"))
+
+    with pytest.raises(ValueError, match="transform"):
+        scale_transform(x, center="median", transform="not-a-transform")
+    with pytest.raises(ValueError, match="center"):
+        scale_transform(x, center="not-a-center", transform="abs")
+
+
 class TestOnewayEquivalenc:
 
     @classmethod

--- a/statsmodels/stats/tests/test_pairwise.py
+++ b/statsmodels/stats/tests/test_pairwise.py
@@ -741,3 +741,11 @@ def test_plot(close_figures):
     resgh = mc.tukeyhsd(alpha=alpha, use_var="unequal")
     resth.plot_simultaneous()
     resgh.plot_simultaneous()
+
+
+def test_tukeyhsd_invalid_use_var_raises():
+    cylinders_adj = cylinders.astype(float)
+    cylinders_adj[[10, 28]] += 0.05
+    mc = MultiComparison(cylinders_adj, cyl_labels)
+    with pytest.raises(ValueError, match="use_var"):
+        mc.tukeyhsd(use_var="not-a-use-var")

--- a/statsmodels/stats/tests/test_panel_robustcov.py
+++ b/statsmodels/stats/tests/test_panel_robustcov.py
@@ -71,3 +71,21 @@ def test_panel_robust_cov():
 
     rcov = sw.cov_nw_groupsum(res, 4, time)  # check default
     assert_almost_equal(rcov, res_stata.cov_dk4_stata, decimal=4)
+
+
+def test_cov_cluster_invalid_crv_type_raises():
+    import pytest
+
+    rs = np.random.RandomState(89012)
+    exog = add_constant(rs.standard_normal((60, 2)))
+    endog = exog @ [1.0, 0.5, -0.5] + rs.standard_normal(60)
+    res = OLS(endog, exog).fit()
+    group = np.repeat(np.arange(10), 6)
+
+    with pytest.raises(ValueError, match="crv_type"):
+        sw.cov_cluster(res, group, crv_type="not-a-crv-type")
+    with pytest.raises(ValueError, match="crv_type"):
+        sw.cov_cluster_2groups(res, group, group2=group, crv_type="not-a-crv-type")
+    # cov_cluster_2groups only supports "cluster", not "cluster-crv3"/"cluster-jk"
+    with pytest.raises(ValueError, match="crv_type"):
+        sw.cov_cluster_2groups(res, group, group2=group, crv_type="cluster-crv3")

--- a/statsmodels/stats/tests/test_panel_robustcov.py
+++ b/statsmodels/stats/tests/test_panel_robustcov.py
@@ -84,8 +84,8 @@ def test_cov_cluster_invalid_crv_type_raises():
 
     with pytest.raises(ValueError, match="crv_type"):
         sw.cov_cluster(res, group, crv_type="not-a-crv-type")
-    with pytest.raises(ValueError, match="crv_type"):
+    with pytest.raises(NotImplementedError, match="Two-way clustering"):
         sw.cov_cluster_2groups(res, group, group2=group, crv_type="not-a-crv-type")
     # cov_cluster_2groups only supports "cluster", not "cluster-crv3"/"cluster-jk"
-    with pytest.raises(ValueError, match="crv_type"):
+    with pytest.raises(NotImplementedError, match="Two-way clustering"):
         sw.cov_cluster_2groups(res, group, group2=group, crv_type="cluster-crv3")

--- a/statsmodels/stats/tests/test_proportion.py
+++ b/statsmodels/stats/tests/test_proportion.py
@@ -1389,6 +1389,11 @@ def test_proportion_confint(count, nobs, method, alpha, alternative, expected):
     assert_allclose(np.array([ci_low, ci_upp]), np.array(expected))
 
 
+def test_proportion_confint_invalid_alternative_raises():
+    with pytest.raises(ValueError, match="alternative"):
+        proportion_confint(50, 100, alternative="not-a-real-alternative")
+
+
 @pytest.mark.parametrize("count", [100])
 @pytest.mark.parametrize("nobs", [200])
 @pytest.mark.parametrize(

--- a/statsmodels/stats/tests/test_rates_poisson.py
+++ b/statsmodels/stats/tests/test_rates_poisson.py
@@ -1478,3 +1478,12 @@ def test_poisson_invalid_alternative_raises():
         confint_quantile_poisson(
             5, 10, prob=0.9, method="wald", alternative="not-a-real-alternative"
         )
+
+
+def test_poisson_2indep_invalid_compare_raises():
+    with pytest.raises(ValueError, match="compare"):
+        smr.test_poisson_2indep(5, 10, 8, 10, method="wald", compare="not-a-compare")
+    with pytest.raises(ValueError, match="compare"):
+        etest_poisson_2indep(5, 10, 8, 10, method="score", compare="not-a-compare")
+    with pytest.raises(ValueError, match="compare"):
+        confint_poisson_2indep(5, 10, 8, 10, method="score", compare="not-a-compare")

--- a/statsmodels/stats/tests/test_rates_poisson.py
+++ b/statsmodels/stats/tests/test_rates_poisson.py
@@ -1487,3 +1487,24 @@ def test_poisson_2indep_invalid_compare_raises():
         etest_poisson_2indep(5, 10, 8, 10, method="score", compare="not-a-compare")
     with pytest.raises(ValueError, match="compare"):
         confint_poisson_2indep(5, 10, 8, 10, method="score", compare="not-a-compare")
+
+
+def test_power_2indep_invalid_method_var_raises():
+    with pytest.raises(ValueError, match="method_var"):
+        power_poisson_ratio_2indep(
+            rate1=2, rate2=1, nobs1=20, method_var="not-a-method-var"
+        )
+    with pytest.raises(ValueError, match="method_var"):
+        power_equivalence_poisson_2indep(
+            rate1=2, rate2=1, nobs1=20, low=0.5, upp=2,
+            method_var="not-a-method-var",
+        )
+    with pytest.raises(ValueError, match="method_var"):
+        power_negbin_ratio_2indep(
+            rate1=2, rate2=1, nobs1=20, method_var="not-a-method-var"
+        )
+    with pytest.raises(ValueError, match="method_var"):
+        power_equivalence_neginb_2indep(
+            rate1=2, rate2=1, nobs1=20, low=0.5, upp=2,
+            method_var="not-a-method-var",
+        )

--- a/statsmodels/stats/tests/test_rates_poisson.py
+++ b/statsmodels/stats/tests/test_rates_poisson.py
@@ -1465,3 +1465,16 @@ def test_confint_poisson_alternative(count, exposure, method, alpha, alternative
     elif alternative == "smaller":
         two_sided_ci = (two_sided_ci[0], np.inf)
         assert_allclose(one_sided_ci, two_sided_ci, rtol=1e-12)
+
+
+def test_poisson_invalid_alternative_raises():
+    with pytest.raises(ValueError, match="alternative"):
+        confint_poisson(5, 10, method="wald", alternative="not-a-real-alternative")
+    with pytest.raises(ValueError, match="alternative"):
+        tolerance_int_poisson(
+            5, 10, method="wald", alternative="not-a-real-alternative"
+        )
+    with pytest.raises(ValueError, match="alternative"):
+        confint_quantile_poisson(
+            5, 10, prob=0.9, method="wald", alternative="not-a-real-alternative"
+        )

--- a/statsmodels/stats/tests/test_robust_compare.py
+++ b/statsmodels/stats/tests/test_robust_compare.py
@@ -193,6 +193,9 @@ class TestTrimmedR1:
         assert_allclose(ttw[1], ttw_pvalue, rtol=1e-13)
         assert_equal(ttw[2], tt_w_df)
 
+        with pytest.raises(ValueError, match="transform"):
+            tm.ttest_mean(transform="not-a-transform")
+
     def test_other(self):
         tm = self.tm
         tm2 = tm.reset_fraction(0.0)

--- a/statsmodels/stats/tests/test_weightstats.py
+++ b/statsmodels/stats/tests/test_weightstats.py
@@ -18,6 +18,7 @@ License: BSD (3-clause)
 import numpy as np
 from numpy.testing import assert_, assert_allclose, assert_almost_equal
 import pandas as pd
+import pytest
 from scipy import stats
 
 from statsmodels.stats.weightstats import (
@@ -852,3 +853,26 @@ def test_weightstats_2d_w2():
     w1 = [[1]]
     d1 = DescrStatsW(x1, w1)
     assert (d1.quantile([0, 0.5, 1.0]) == 1).all().all()
+
+
+def test_invalid_usevar_raises():
+    rs = np.random.RandomState(90210)
+    x1 = rs.standard_normal(20)
+    x2 = rs.standard_normal(20) + 0.5
+    cm = CompareMeans(DescrStatsW(x1), DescrStatsW(x2))
+
+    with pytest.raises(ValueError, match="usevar"):
+        cm.ttest_ind(usevar="not-a-usevar")
+    with pytest.raises(ValueError, match="usevar"):
+        cm.ztest_ind(usevar="not-a-usevar")
+    with pytest.raises(ValueError, match="usevar"):
+        cm.tconfint_diff(usevar="not-a-usevar")
+    with pytest.raises(ValueError, match="usevar"):
+        cm.zconfint_diff(usevar="not-a-usevar")
+    with pytest.raises(ValueError, match="usevar"):
+        ttest_ind(x1, x2, usevar="not-a-usevar")
+    with pytest.raises(ValueError, match="usevar"):
+        ztest(x1, x2, usevar="not-a-usevar")
+    # zconfint only implements "pooled", unlike the other five
+    with pytest.raises(ValueError, match="usevar"):
+        zconfint(x1, x2, usevar="unequal")

--- a/statsmodels/stats/weightstats.py
+++ b/statsmodels/stats/weightstats.py
@@ -33,6 +33,7 @@ import numpy as np
 from scipy import stats
 
 from statsmodels.tools._decorators import cache_readonly
+from statsmodels.tools.validation import string_like
 
 
 class DescrStatsW:
@@ -1059,14 +1060,15 @@ class CompareMeans:
         d1 = self.d1
         d2 = self.d2
 
+        usevar = string_like(
+            usevar, "usevar", options=("pooled", "unequal"), lower=False
+        )
         if usevar == "pooled":
             stdm = self.std_meandiff_pooledvar
             dof = d1.nobs - 1 + d2.nobs - 1
-        elif usevar == "unequal":
+        else:  # usevar == "unequal"
             stdm = self.std_meandiff_separatevar
             dof = self.dof_satt()
-        else:
-            raise ValueError('usevar can only be "pooled" or "unequal"')
 
         tstat, pval = _tstat_generic(
             d1.mean, d2.mean, stdm, dof, alternative, diff=value
@@ -1104,12 +1106,13 @@ class CompareMeans:
         d1 = self.d1
         d2 = self.d2
 
+        usevar = string_like(
+            usevar, "usevar", options=("pooled", "unequal"), lower=False
+        )
         if usevar == "pooled":
             stdm = self.std_meandiff_pooledvar
-        elif usevar == "unequal":
+        else:  # usevar == "unequal"
             stdm = self.std_meandiff_separatevar
-        else:
-            raise ValueError('usevar can only be "pooled" or "unequal"')
 
         tstat, pval = _zstat_generic(
             d1.mean, d2.mean, stdm, alternative, diff=value
@@ -1154,14 +1157,15 @@ class CompareMeans:
         d1 = self.d1
         d2 = self.d2
         diff = d1.mean - d2.mean
+        usevar = string_like(
+            usevar, "usevar", options=("pooled", "unequal"), lower=False
+        )
         if usevar == "pooled":
             std_diff = self.std_meandiff_pooledvar
             dof = d1.nobs - 1 + d2.nobs - 1
-        elif usevar == "unequal":
+        else:  # usevar == "unequal"
             std_diff = self.std_meandiff_separatevar
             dof = self.dof_satt()
-        else:
-            raise ValueError('usevar can only be "pooled" or "unequal"')
 
         res = _tconfint_generic(
             diff, std_diff, dof, alpha=alpha, alternative=alternative
@@ -1205,12 +1209,13 @@ class CompareMeans:
         d1 = self.d1
         d2 = self.d2
         diff = d1.mean - d2.mean
+        usevar = string_like(
+            usevar, "usevar", options=("pooled", "unequal"), lower=False
+        )
         if usevar == "pooled":
             std_diff = self.std_meandiff_pooledvar
-        elif usevar == "unequal":
+        else:  # usevar == "unequal"
             std_diff = self.std_meandiff_separatevar
-        else:
-            raise ValueError('usevar can only be "pooled" or "unequal"')
 
         res = _zconfint_generic(
             diff, std_diff, alpha=alpha, alternative=alternative
@@ -1540,8 +1545,9 @@ def ztest(
 
     # usevar can be pooled or unequal
 
-    if usevar not in {"pooled", "unequal"}:
-        raise NotImplementedError('usevar can only be "pooled" or "unequal"')
+    usevar = string_like(
+        usevar, "usevar", options=("pooled", "unequal"), lower=False
+    )
 
     x1 = np.asarray(x1)
     nobs1 = x1.shape[0]
@@ -1557,7 +1563,7 @@ def ztest(
             var = nobs1 * x1_var + nobs2 * x2_var
             var /= nobs1 + nobs2 - 2 * ddof
             var *= 1.0 / nobs1 + 1.0 / nobs2
-        elif usevar == "unequal":
+        else:  # usevar == "unequal"
             var = x1_var / (nobs1 - ddof) + x2_var / (nobs2 - ddof)
     else:
         var = x1_var / (nobs1 - ddof)
@@ -1631,8 +1637,7 @@ def zconfint(
     # usevar is not used, always pooled
     # mostly duplicate code from ztest
 
-    if usevar != "pooled":
-        raise NotImplementedError('only usevar="pooled" is implemented')
+    usevar = string_like(usevar, "usevar", options=("pooled",), lower=False)
     x1 = np.asarray(x1)
     nobs1 = x1.shape[0]
     x1_mean = x1.mean(0)

--- a/statsmodels/stats/weightstats.py
+++ b/statsmodels/stats/weightstats.py
@@ -1637,7 +1637,7 @@ def zconfint(
     # usevar is not used, always pooled
     # mostly duplicate code from ztest
 
-    usevar = string_like(usevar, "usevar", options=("pooled",), lower=False)
+    _ = string_like(usevar, "usevar", options=("pooled",), lower=False)
     x1 = np.asarray(x1)
     nobs1 = x1.shape[0]
     x1_mean = x1.mean(0)

--- a/statsmodels/tsa/adfvalues.py
+++ b/statsmodels/tsa/adfvalues.py
@@ -1,6 +1,8 @@
 from numpy import array, asarray, inf, polyval
 from scipy.stats import norm
 
+from statsmodels.tools.validation import string_like
+
 __all__ = ["mackinnoncrit", "mackinnonp"]
 
 # These are the cut-off values for the left-tail vs. the rest of the
@@ -255,6 +257,9 @@ def mackinnonp(teststat, regression="c", N=1, lags=None):
         for Unit-Root and Cointegration Tests." Journal of Business & Economics
         Statistics, 12.2, 167-76.
     """
+    regression = string_like(
+        regression, "regression", options=("c", "n", "ct", "ctt"), lower=False
+    )
     maxstat = _tau_maxs[regression]
     minstat = _tau_mins[regression]
     starstat = _tau_stars[regression]
@@ -446,9 +451,9 @@ def mackinnoncrit(N=1, regression="c", nobs=inf):
         Queen's University, Dept of Economics Working Papers 1227.
         http://ideas.repec.org/p/qed/wpaper/1227.html
     """
-    reg = regression
-    if reg not in ["c", "ct", "n", "ctt"]:
-        raise ValueError(f"regression keyword {reg} not understood")
+    reg = string_like(
+        regression, "regression", options=("c", "ct", "n", "ctt"), lower=False
+    )
     tau = tau_2010s[reg]
     if nobs is inf:
         return tau[N-1, :, 0]

--- a/statsmodels/tsa/ar_model.py
+++ b/statsmodels/tsa/ar_model.py
@@ -2125,6 +2125,7 @@ def ar_select_order(
     >>> mod.ar_lags
     array([1, 2, 9])
     """
+    ic = string_like(ic, "ic", options=("aic", "hqic", "bic"))
     full_mod = AutoReg(
         endog,
         maxlag,

--- a/statsmodels/tsa/ardl/model.py
+++ b/statsmodels/tsa/ardl/model.py
@@ -28,6 +28,7 @@ from statsmodels.tools.validation import (
     bool_like,
     float_like,
     int_like,
+    string_like,
 )
 from statsmodels.tsa.ar_model import (
     AROrderSelectionResults,
@@ -1562,6 +1563,7 @@ def ardl_select_order(
         of information criteria for all models fit.
     """
     orig_hold_back = int_like(hold_back, "hold_back", optional=True)
+    ic = string_like(ic, "ic", options=("aic", "bic", "hqic"))
 
     def compute_ics(y, x, df):
         if x.shape[1]:

--- a/statsmodels/tsa/ardl/tests/test_ardl.py
+++ b/statsmodels/tsa/ardl/tests/test_ardl.py
@@ -297,6 +297,11 @@ def test_ardl_select_order(
     assert res.ar_lags is None or isinstance(res.ar_lags, list)
 
 
+def test_ardl_select_order_invalid_ic_raises(data):
+    with pytest.raises(ValueError, match="ic"):
+        ardl_select_order(data.y, 2, data.x, 2, ic="not-a-real-ic")
+
+
 def test_ardl_no_regressors(data):
     res = ARDL(
         data.y,

--- a/statsmodels/tsa/arima/specification.py
+++ b/statsmodels/tsa/arima/specification.py
@@ -8,6 +8,7 @@ import numpy as np
 import pandas as pd
 
 from statsmodels.tools.data import _is_using_pandas
+from statsmodels.tools.validation import string_like
 from statsmodels.tsa.arima.tools import standardize_lag_order, validate_basic
 from statsmodels.tsa.base.tsa_model import TimeSeriesModel
 from statsmodels.tsa.statespace.tools import (
@@ -684,8 +685,22 @@ class SARIMAXSpecification:
         >>> spec.validate_estimator('statespace')       # returns None
 
         >>> spec.validate_estimator('not_an_estimator')
-        ValueError: "not_an_estimator" is not a valid estimator.
+        ValueError: estimator must be one of: 'yule_walker', 'burg', \
+'innovations', 'hannan_rissanen', 'innovations_mle', 'statespace'
         """
+        estimator = string_like(
+            estimator,
+            "estimator",
+            options=(
+                "yule_walker",
+                "burg",
+                "innovations",
+                "hannan_rissanen",
+                "innovations_mle",
+                "statespace",
+            ),
+            lower=False,
+        )
         has_ar = self.max_ar_order != 0
         has_ma = self.max_ma_order != 0
         has_missing = self._has_missing
@@ -752,11 +767,9 @@ class SARIMAXSpecification:
                 raise ValueError("Innovations MLE estimator does not support"
                                  " concentrating the scale out of the"
                                  " log-likelihood function")
-        elif estimator == "statespace":
+        else:  # estimator == "statespace"
             # State space form supports all variations of SARIMAX.
             pass
-        else:
-            raise ValueError(f'"{estimator}" is not a valid estimator.')
 
     def split_params(self, params, allow_infnan=False):
         """

--- a/statsmodels/tsa/exponential_smoothing/base.py
+++ b/statsmodels/tsa/exponential_smoothing/base.py
@@ -17,6 +17,7 @@ from statsmodels.tools.numdiff import (
 )
 from statsmodels.tools.sm_exceptions import PrecisionWarning
 from statsmodels.tools.tools import pinv_extended
+from statsmodels.tools.validation import string_like
 import statsmodels.tsa.base.tsa_model as tsbase
 from statsmodels.tsa.statespace.tools import _safe_cond
 
@@ -551,48 +552,47 @@ class StateSpaceMLEResults(tsbase.TimeSeriesModelResults):
         """
         if method is None:
             method = "ljungbox"
+        method = string_like(
+            method, "method", options=("ljungbox", "boxpierce")
+        )
 
         if self.standardized_forecasts_error is None:
             raise ValueError("Cannot compute test statistic when standardized"
                              " forecast errors have not been computed.")
 
-        if method == "ljungbox" or method == "boxpierce":
-            from statsmodels.stats.diagnostic import acorr_ljungbox
-            if hasattr(self, "loglikelihood_burn"):
-                d = np.maximum(self.loglikelihood_burn, self.nobs_diffuse)
-                # This differs from self.nobs_effective because here we want to
-                # exclude exact diffuse periods, whereas self.nobs_effective
-                # only excludes explicitly burned (usually approximate diffuse)
-                # periods.
-                nobs_effective = self.nobs - d
-            else:
-                nobs_effective = self.nobs_effective
-            output = []
-
-            # Default lags for acorr_ljungbox is 40, but may not always have
-            # that many observations
-            if lags is None:
-                seasonal_periods = getattr(self.model, "seasonal_periods", 0)
-                if seasonal_periods:
-                    lags = min(2 * seasonal_periods, nobs_effective // 5)
-                else:
-                    lags = min(10, nobs_effective // 5)
-
-            cols = [2, 3] if method == "boxpierce" else [0, 1]
-            for i in range(self.model.k_endog):
-                if hasattr(self, "filter_results"):
-                    x = self.filter_results.standardized_forecasts_error[i][d:]
-                else:
-                    x = self.standardized_forecasts_error
-                results = acorr_ljungbox(
-                    x, lags=lags, boxpierce=(method == "boxpierce")
-                )
-                output.append(np.asarray(results)[:, cols].T)
-
-            output = np.c_[output]
+        from statsmodels.stats.diagnostic import acorr_ljungbox
+        if hasattr(self, "loglikelihood_burn"):
+            d = np.maximum(self.loglikelihood_burn, self.nobs_diffuse)
+            # This differs from self.nobs_effective because here we want to
+            # exclude exact diffuse periods, whereas self.nobs_effective
+            # only excludes explicitly burned (usually approximate diffuse)
+            # periods.
+            nobs_effective = self.nobs - d
         else:
-            raise NotImplementedError("Invalid serial correlation test"
-                                      " method.")
+            nobs_effective = self.nobs_effective
+        output = []
+
+        # Default lags for acorr_ljungbox is 40, but may not always have
+        # that many observations
+        if lags is None:
+            seasonal_periods = getattr(self.model, "seasonal_periods", 0)
+            if seasonal_periods:
+                lags = min(2 * seasonal_periods, nobs_effective // 5)
+            else:
+                lags = min(10, nobs_effective // 5)
+
+        cols = [2, 3] if method == "boxpierce" else [0, 1]
+        for i in range(self.model.k_endog):
+            if hasattr(self, "filter_results"):
+                x = self.filter_results.standardized_forecasts_error[i][d:]
+            else:
+                x = self.standardized_forecasts_error
+            results = acorr_ljungbox(
+                x, lags=lags, boxpierce=(method == "boxpierce")
+            )
+            output.append(np.asarray(results)[:, cols].T)
+
+        output = np.c_[output]
         return output
 
     def test_heteroskedasticity(self, method, alternative="two-sided",
@@ -679,101 +679,98 @@ class StateSpaceMLEResults(tsbase.TimeSeriesModelResults):
         """
         if method is None:
             method = "breakvar"
+        method = string_like(method, "method", options=("breakvar",))
 
         if self.standardized_forecasts_error is None:
             raise ValueError("Cannot compute test statistic when standardized"
                              " forecast errors have not been computed.")
 
-        if method == "breakvar":
-            # Store some values
-            if hasattr(self, "filter_results"):
-                squared_resid = (
-                    self.filter_results.standardized_forecasts_error**2
-                )
-                d = np.maximum(self.loglikelihood_burn, self.nobs_diffuse)
-                # This differs from self.nobs_effective because here we want to
-                # exclude exact diffuse periods, whereas self.nobs_effective
-                # only excludes explicitly burned (usually approximate diffuse)
-                # periods.
-                nobs_effective = self.nobs - d
-            else:
-                squared_resid = self.standardized_forecasts_error**2
-                if squared_resid.ndim == 1:
-                    squared_resid = np.asarray(squared_resid)
-                    squared_resid = squared_resid[np.newaxis, :]
-                nobs_effective = self.nobs_effective
-                d = 0
-            squared_resid = np.asarray(squared_resid)
-
-            test_statistics = []
-            p_values = []
-            for i in range(self.model.k_endog):
-                h = int(np.round(nobs_effective / 3))
-                numer_resid = squared_resid[i, -h:]
-                numer_resid = numer_resid[~np.isnan(numer_resid)]
-                numer_dof = len(numer_resid)
-
-                denom_resid = squared_resid[i, d:d + h]
-                denom_resid = denom_resid[~np.isnan(denom_resid)]
-                denom_dof = len(denom_resid)
-
-                if numer_dof < 2:
-                    warnings.warn(f"Early subset of data for variable {i:d}"
-                                  "  has too few non-missing observations to"
-                                  " calculate test statistic.",
-                                  stacklevel=2,
-                                  )
-                    numer_resid = np.nan
-                if denom_dof < 2:
-                    warnings.warn(f"Later subset of data for variable {i:d}"
-                                  "  has too few non-missing observations to"
-                                  " calculate test statistic.",
-                                  stacklevel=2,
-                                  )
-                    denom_resid = np.nan
-
-                test_statistic = np.sum(numer_resid) / np.sum(denom_resid)
-
-                # Setup functions to calculate the p-values
-                if use_f:
-                    from scipy.stats import f
-
-                    def pval_lower(test_statistics, numer_dof, denom_dof):
-                        return f.cdf(test_statistics, numer_dof, denom_dof)
-
-                    def pval_upper(test_statistics, numer_dof, denom_dof):
-                        return f.sf(test_statistics, numer_dof, denom_dof)
-
-                else:
-                    from scipy.stats import chi2
-
-                    def pval_lower(test_statistics, numer_dof, denom_dof):
-                        return chi2.cdf(numer_dof * test_statistics, denom_dof)
-
-                    def pval_upper(test_statistics, numer_dof, denom_dof):
-                        return chi2.sf(numer_dof * test_statistics, denom_dof)
-                # Calculate the one- or two-sided p-values
-                alternative = alternative.lower()
-                if alternative in ["i", "inc", "increasing"]:
-                    p_value = pval_upper(test_statistic)
-                elif alternative in ["d", "dec", "decreasing"]:
-                    test_statistic = 1. / test_statistic
-                    p_value = pval_upper(test_statistic)
-                elif alternative in ["2", "2-sided", "two-sided"]:
-                    p_value = 2 * np.minimum(
-                        pval_lower(test_statistic, numer_dof, denom_dof),
-                        pval_upper(test_statistic, numer_dof, denom_dof)
-                    )
-                else:
-                    raise ValueError("Invalid alternative.")
-
-                test_statistics.append(test_statistic)
-                p_values.append(p_value)
-
-            output = np.c_[test_statistics, p_values]
+        # Store some values
+        if hasattr(self, "filter_results"):
+            squared_resid = (
+                self.filter_results.standardized_forecasts_error**2
+            )
+            d = np.maximum(self.loglikelihood_burn, self.nobs_diffuse)
+            # This differs from self.nobs_effective because here we want to
+            # exclude exact diffuse periods, whereas self.nobs_effective
+            # only excludes explicitly burned (usually approximate diffuse)
+            # periods.
+            nobs_effective = self.nobs - d
         else:
-            raise NotImplementedError("Invalid heteroskedasticity test"
-                                      " method.")
+            squared_resid = self.standardized_forecasts_error**2
+            if squared_resid.ndim == 1:
+                squared_resid = np.asarray(squared_resid)
+                squared_resid = squared_resid[np.newaxis, :]
+            nobs_effective = self.nobs_effective
+            d = 0
+        squared_resid = np.asarray(squared_resid)
+
+        test_statistics = []
+        p_values = []
+        for i in range(self.model.k_endog):
+            h = int(np.round(nobs_effective / 3))
+            numer_resid = squared_resid[i, -h:]
+            numer_resid = numer_resid[~np.isnan(numer_resid)]
+            numer_dof = len(numer_resid)
+
+            denom_resid = squared_resid[i, d:d + h]
+            denom_resid = denom_resid[~np.isnan(denom_resid)]
+            denom_dof = len(denom_resid)
+
+            if numer_dof < 2:
+                warnings.warn(f"Early subset of data for variable {i:d}"
+                              "  has too few non-missing observations to"
+                              " calculate test statistic.",
+                              stacklevel=2,
+                              )
+                numer_resid = np.nan
+            if denom_dof < 2:
+                warnings.warn(f"Later subset of data for variable {i:d}"
+                              "  has too few non-missing observations to"
+                              " calculate test statistic.",
+                              stacklevel=2,
+                              )
+                denom_resid = np.nan
+
+            test_statistic = np.sum(numer_resid) / np.sum(denom_resid)
+
+            # Setup functions to calculate the p-values
+            if use_f:
+                from scipy.stats import f
+
+                def pval_lower(test_statistics, numer_dof, denom_dof):
+                    return f.cdf(test_statistics, numer_dof, denom_dof)
+
+                def pval_upper(test_statistics, numer_dof, denom_dof):
+                    return f.sf(test_statistics, numer_dof, denom_dof)
+
+            else:
+                from scipy.stats import chi2
+
+                def pval_lower(test_statistics, numer_dof, denom_dof):
+                    return chi2.cdf(numer_dof * test_statistics, denom_dof)
+
+                def pval_upper(test_statistics, numer_dof, denom_dof):
+                    return chi2.sf(numer_dof * test_statistics, denom_dof)
+            # Calculate the one- or two-sided p-values
+            alternative = alternative.lower()
+            if alternative in ["i", "inc", "increasing"]:
+                p_value = pval_upper(test_statistic)
+            elif alternative in ["d", "dec", "decreasing"]:
+                test_statistic = 1. / test_statistic
+                p_value = pval_upper(test_statistic)
+            elif alternative in ["2", "2-sided", "two-sided"]:
+                p_value = 2 * np.minimum(
+                    pval_lower(test_statistic, numer_dof, denom_dof),
+                    pval_upper(test_statistic, numer_dof, denom_dof)
+                )
+            else:
+                raise ValueError("Invalid alternative.")
+
+            test_statistics.append(test_statistic)
+            p_values.append(p_value)
+
+        output = np.c_[test_statistics, p_values]
 
         return output
 
@@ -813,29 +810,27 @@ class StateSpaceMLEResults(tsbase.TimeSeriesModelResults):
         """
         if method is None:
             method = "jarquebera"
+        method = string_like(method, "method", options=("jarquebera",))
 
         if self.standardized_forecasts_error is None:
             raise ValueError("Cannot compute test statistic when standardized"
                              " forecast errors have not been computed.")
 
-        if method == "jarquebera":
-            from statsmodels.stats.stattools import jarque_bera
-            if hasattr(self, "loglikelihood_burn"):
-                d = np.maximum(self.loglikelihood_burn, self.nobs_diffuse)
-            else:
-                d = 0
-            output = []
-            for i in range(self.model.k_endog):
-                if hasattr(self, "filter_results"):
-                    resid = self.filter_results.standardized_forecasts_error[
-                        i, d:
-                    ]
-                else:
-                    resid = self.standardized_forecasts_error
-                mask = ~np.isnan(resid)
-                output.append(jarque_bera(resid[mask]))
+        from statsmodels.stats.stattools import jarque_bera
+        if hasattr(self, "loglikelihood_burn"):
+            d = np.maximum(self.loglikelihood_burn, self.nobs_diffuse)
         else:
-            raise NotImplementedError("Invalid normality test method.")
+            d = 0
+        output = []
+        for i in range(self.model.k_endog):
+            if hasattr(self, "filter_results"):
+                resid = self.filter_results.standardized_forecasts_error[
+                    i, d:
+                ]
+            else:
+                resid = self.standardized_forecasts_error
+            mask = ~np.isnan(resid)
+            output.append(jarque_bera(resid[mask]))
 
         return np.array(output)
 

--- a/statsmodels/tsa/exponential_smoothing/base.py
+++ b/statsmodels/tsa/exponential_smoothing/base.py
@@ -679,7 +679,7 @@ class StateSpaceMLEResults(tsbase.TimeSeriesModelResults):
         """
         if method is None:
             method = "breakvar"
-        method = string_like(method, "method", options=("breakvar",))
+        _ = string_like(method, "method", options=("breakvar",))
 
         if self.standardized_forecasts_error is None:
             raise ValueError("Cannot compute test statistic when standardized"

--- a/statsmodels/tsa/exponential_smoothing/base.py
+++ b/statsmodels/tsa/exponential_smoothing/base.py
@@ -810,7 +810,7 @@ class StateSpaceMLEResults(tsbase.TimeSeriesModelResults):
         """
         if method is None:
             method = "jarquebera"
-        method = string_like(method, "method", options=("jarquebera",))
+        _ = string_like(method, "method", options=("jarquebera",))
 
         if self.standardized_forecasts_error is None:
             raise ValueError("Cannot compute test statistic when standardized"

--- a/statsmodels/tsa/holtwinters/results.py
+++ b/statsmodels/tsa/holtwinters/results.py
@@ -14,6 +14,7 @@ from statsmodels.base.wrapper import (
     union_dicts,
 )
 from statsmodels.tools.rng_qrng import check_random_state
+from statsmodels.tools.validation import string_like
 
 
 class HoltWintersResults(Results):
@@ -541,10 +542,10 @@ class HoltWintersResults(Results):
         """
 
         # check inputs
-        if error in ["additive", "multiplicative"]:
-            error = {"additive": "add", "multiplicative": "mul"}[error]
-        if error not in ["add", "mul"]:
-            raise ValueError("error must be 'add' or 'mul'!")
+        error = string_like(
+            error, "error", options=("add", "mul", "additive", "multiplicative")
+        )
+        error = {"additive": "add", "multiplicative": "mul"}.get(error, error)
 
         # Get the starting location
         if anchor is None or anchor == "end":
@@ -651,6 +652,10 @@ class HoltWintersResults(Results):
             eps = random_errors
         else:
             rng = check_random_state(rng, deprecated=True)
+            if isinstance(random_errors, str):
+                random_errors = string_like(
+                    random_errors, "random_errors", options=("bootstrap",)
+                )
             if random_errors == "bootstrap":
                 eps = rng.choice(resid, size=(nsimulations, repetitions), replace=True)
             elif random_errors is None:

--- a/statsmodels/tsa/holtwinters/tests/test_holtwinters.py
+++ b/statsmodels/tsa/holtwinters/tests/test_holtwinters.py
@@ -1983,9 +1983,26 @@ def test_simulate(ses):
         TypeError, match="When creating a random number generator from a"
     ):
         res.simulate(10, error="additive", anchor=100, rng="bad_value")
-    with pytest.raises(ValueError, match="Argument random_errors has unexpected value"):
+    with pytest.raises(ValueError, match="random_errors must be"):
         with pytest.warns(FutureWarning, match="After statsmodels 0.15 is released"):
             res.simulate(10, error="additive", random_errors="bad_values", rng=0)
+
+
+def test_simulate_error_aliases(ses):
+    # "additive"/"multiplicative" are documented aliases for "add"/"mul"
+    mod = ExponentialSmoothing(np.asarray(ses), initialization_method="heuristic")
+    res = mod.fit()
+    innov = np.arange(1, 41, dtype=float).reshape(10, 4)
+    add_sim = res.simulate(10, repetitions=4, error="add", random_errors=innov)
+    additive_sim = res.simulate(
+        10, repetitions=4, error="additive", random_errors=innov
+    )
+    assert_almost_equal(np.asarray(add_sim), np.asarray(additive_sim))
+    mul_sim = res.simulate(10, repetitions=4, error="mul", random_errors=innov)
+    multiplicative_sim = res.simulate(
+        10, repetitions=4, error="multiplicative", random_errors=innov
+    )
+    assert_almost_equal(np.asarray(mul_sim), np.asarray(multiplicative_sim))
 
 
 @pytest.mark.parametrize("index_typ", ["date_range", "period", "range"])

--- a/statsmodels/tsa/interp/denton.py
+++ b/statsmodels/tsa/interp/denton.py
@@ -2,6 +2,8 @@ import numpy as np
 from numpy import asarray, diag, diag_indices, dot, ones, r_, zeros
 from numpy.linalg import solve
 
+from statsmodels.tools.validation import string_like
+
 # def denton(indicator, benchmark, freq="aq", **kwarg):
 #    """
 #    Denton's method to convert low-frequency to high frequency data.
@@ -174,16 +176,15 @@ def dentonm(indicator, benchmark, freq="aq", **kwargs):
 
     # number of low-freq observations for aggregate measure
     # 4 for annual to quarter and 3 for quarter to monthly
+    freq = string_like(freq, "freq", options=("aq", "qm", "other"), lower=False)
     if freq == "aq":
         k = 4
     elif freq == "qm":
         k = 3
-    elif freq == "other":
+    else:  # freq == "other"
         k = kwargs.get("k")
         if not k:
             raise ValueError('k must be supplied with freq="other"')
-    else:
-        raise ValueError(f"freq {freq} not understood")
 
     n = k*m  # number of indicator series with a benchmark for back-series
     # if k*m != n, then we are going to extrapolate q observations

--- a/statsmodels/tsa/interp/tests/test_denton.py
+++ b/statsmodels/tsa/interp/tests/test_denton.py
@@ -1,4 +1,6 @@
 import numpy as np
+from numpy.testing import assert_allclose
+import pytest
 
 from statsmodels.tsa.interp import dentonm
 
@@ -30,3 +32,35 @@ def test_denton_quarterly2():
         109.67405, 58.290761, 122.62556, 190.41409, 128.66959
     ])
     np.testing.assert_almost_equal(x_denton, x_stata, 5)
+
+
+def test_denton_freq_qm_matches_benchmark_sums():
+    # Denton benchmarking preserves the low-frequency totals: each block of
+    # k consecutive high-frequency values must sum to its benchmark value.
+    indicator = np.array([10.0, 12.0, 11.0, 9.0, 13.0, 14.0])
+    benchmark = np.array([300.0, 360.0])
+    x = dentonm(indicator, benchmark, freq="qm")
+    assert_allclose(x[0:3].sum(), benchmark[0])
+    assert_allclose(x[3:6].sum(), benchmark[1])
+
+
+def test_denton_freq_other_matches_benchmark_sums():
+    indicator = np.array([10.0, 12.0, 11.0, 9.0, 13.0, 14.0, 15.0, 16.0])
+    benchmark = np.array([300.0, 360.0])
+    x = dentonm(indicator, benchmark, freq="other", k=4)
+    assert_allclose(x[0:4].sum(), benchmark[0])
+    assert_allclose(x[4:8].sum(), benchmark[1])
+
+
+def test_denton_freq_other_requires_k():
+    indicator = np.array([10.0, 12.0, 11.0, 9.0])
+    benchmark = np.array([50.0])
+    with pytest.raises(ValueError, match='k must be supplied'):
+        dentonm(indicator, benchmark, freq="other")
+
+
+def test_denton_invalid_freq_raises():
+    indicator = np.array([10.0, 12.0, 11.0, 9.0])
+    benchmark = np.array([50.0])
+    with pytest.raises(ValueError, match="freq"):
+        dentonm(indicator, benchmark, freq="not-a-freq")

--- a/statsmodels/tsa/seasonal/_seasonal.py
+++ b/statsmodels/tsa/seasonal/_seasonal.py
@@ -7,7 +7,7 @@ import numpy as np
 import pandas as pd
 from pandas.core.nanops import nanmean as pd_nanmean
 
-from statsmodels.tools.validation import PandasWrapper, array_like
+from statsmodels.tools.validation import PandasWrapper, array_like, string_like
 from statsmodels.tsa.filters.filtertools import convolution_filter
 from statsmodels.tsa.tsatools import freq_to_period
 
@@ -212,6 +212,14 @@ def seasonal_decompose(
 
     nsides = int(two_sided) + 1
     trend = convolution_filter(x, filt, nsides)
+
+    if isinstance(extrapolate_trend, str):
+        extrapolate_trend = string_like(
+            extrapolate_trend,
+            "extrapolate_trend",
+            options=("period", "freq"),
+            lower=False,
+        )
 
     if extrapolate_trend == "freq":
         warnings.warn(

--- a/statsmodels/tsa/statespace/dynamic_factor.py
+++ b/statsmodels/tsa/statespace/dynamic_factor.py
@@ -14,6 +14,7 @@ from statsmodels.tools._decorators import cache_readonly
 from statsmodels.tools.data import _is_using_pandas
 from statsmodels.tools.docstring_helpers import Appender
 from statsmodels.tools.tools import Bunch
+from statsmodels.tools.validation import string_like
 from statsmodels.tsa.arima.model import ARIMA
 from statsmodels.tsa.tsatools import lagmat
 from statsmodels.tsa.vector_ar.var_model import VAR
@@ -201,9 +202,12 @@ class DynamicFactor(MLEModel):
                              " of endogenous variables.")
 
         # Test for invalid error_cov_type
-        if self.error_cov_type not in ["scalar", "diagonal", "unstructured"]:
-            raise ValueError("Invalid error covariance matrix type"
-                             " specification.")
+        self.error_cov_type = string_like(
+            self.error_cov_type,
+            "error_cov_type",
+            options=("scalar", "diagonal", "unstructured"),
+            lower=False,
+        )
 
         # By default, initialize as stationary
         kwargs.setdefault("initialization", "stationary")

--- a/statsmodels/tsa/statespace/dynamic_factor_mq.py
+++ b/statsmodels/tsa/statespace/dynamic_factor_mq.py
@@ -2817,17 +2817,17 @@ class DynamicFactorMQ(mlemodel.MLEModel):
         has_missing = np.any(res.nmissing)
         if mstep_method is None:
             mstep_method = "missing" if has_missing else "nonmissing"
-        mstep_method = mstep_method.lower()
+        mstep_method = string_like(
+            mstep_method, "mstep_method", options=("missing", "nonmissing")
+        )
         if mstep_method == "nonmissing" and has_missing:
             raise ValueError('Cannot use EM algorithm option'
                              ' `mstep_method="nonmissing"` with missing data.')
 
         if mstep_method == "nonmissing":
             func = self._em_maximization_obs_nonmissing
-        elif mstep_method == "missing":
+        else:  # mstep_method == "missing"
             func = self._em_maximization_obs_missing
-        else:
-            raise ValueError(f'Invalid maximization step method: "{mstep_method}".')
         # TODO: compute H is pretty slow
         Lambda, H = func(res, Eaa, a, compute_H=(not self.idiosyncratic_ar1))
 
@@ -3473,6 +3473,7 @@ class DynamicFactorMQResults(mlemodel.MLEResults):
                                                         "cumulative"])
         if which is None:
             which = "filtered" if self.smoothed_state is None else "smoothed"
+        which = string_like(which, "which", options=("filtered", "smoothed"))
 
         k_endog = self.model.k_endog
         k_factors = self.model.k_factors

--- a/statsmodels/tsa/statespace/exponential_smoothing.py
+++ b/statsmodels/tsa/statespace/exponential_smoothing.py
@@ -164,7 +164,9 @@ class ExponentialSmoothing(MLEModel):
         self.seasonal_periods = int_like(seasonal, "seasonal", optional=True)
         self.seasonal = self.seasonal_periods is not None
         self.initialization_method = string_like(
-            initialization_method, "initialization_method").lower()
+            initialization_method, "initialization_method",
+            options=("concentrated", "estimated", "simple", "heuristic", "known"),
+        )
         self.concentrate_scale = bool_like(concentrate_scale,
                                            "concentrate_scale")
 
@@ -182,10 +184,6 @@ class ExponentialSmoothing(MLEModel):
         if self.seasonal and self.seasonal_periods is None:
             raise NotImplementedError("Unable to detect season automatically;"
                                       " please specify `seasonal_periods`.")
-
-        if self.initialization_method not in ["concentrated", "estimated",
-                                              "simple", "heuristic", "known"]:
-            raise ValueError(f'Invalid initialization method "{initialization_method}".')
 
         if self.initialization_method == "known":
             if initial_level is None:

--- a/statsmodels/tsa/statespace/kalman_smoother.py
+++ b/statsmodels/tsa/statespace/kalman_smoother.py
@@ -9,6 +9,7 @@ from types import SimpleNamespace
 
 import numpy as np
 
+from statsmodels.tools.validation import string_like
 from statsmodels.tsa.statespace import initialization, tools
 from statsmodels.tsa.statespace.kalman_filter import FilterResults, KalmanFilter
 from statsmodels.tsa.statespace.representation import OptionWrapper
@@ -1860,9 +1861,12 @@ class SmootherResults(FilterResults):
         the smoothed signal is :math:`Z_t \alpha_t`, where :math:`Z_t` is the
         design matrix operative at time :math:`t`.
         """
-        if decomposition_of not in ["smoothed_state", "smoothed_signal"]:
-            raise ValueError('Invalid value for `decomposition_of`. Must be'
-                             ' one of "smoothed_state" or "smoothed_signal".')
+        decomposition_of = string_like(
+            decomposition_of,
+            "decomposition_of",
+            options=("smoothed_state", "smoothed_signal"),
+            lower=False,
+        )
 
         weights, state_intercept_weights, prior_weights = (
             tools._compute_smoothed_state_weights(

--- a/statsmodels/tsa/statespace/mlemodel.py
+++ b/statsmodels/tsa/statespace/mlemodel.py
@@ -3539,7 +3539,7 @@ class MLEResults(tsbase.TimeSeriesModelResults):
         """
         if method is None:
             method = "jarquebera"
-        method = string_like(method, "method", options=("jarquebera",))
+        _ = string_like(method, "method", options=("jarquebera",))
 
         if self.standardized_forecasts_error is None:
             raise ValueError(
@@ -3628,9 +3628,8 @@ class MLEResults(tsbase.TimeSeriesModelResults):
         .. [1] Harvey, Andrew C. 1990. *Forecasting, Structural Time Series*
                *Models and the Kalman Filter.* Cambridge University Press.
         """
-        if method is None:
-            method = "breakvar"
-        method = string_like(method, "method", options=("breakvar",))
+        method = "breakvar" if method is None else method
+        _ = string_like(method, "method", options=("breakvar",))
 
         if self.standardized_forecasts_error is None:
             raise ValueError(

--- a/statsmodels/tsa/statespace/mlemodel.py
+++ b/statsmodels/tsa/statespace/mlemodel.py
@@ -30,6 +30,7 @@ from statsmodels.tools.numdiff import (
 from statsmodels.tools.rng_qrng import check_random_state
 from statsmodels.tools.sm_exceptions import ModelWarning, PrecisionWarning, ValueWarning
 from statsmodels.tools.tools import Bunch, pinv_extended
+from statsmodels.tools.validation import string_like
 import statsmodels.tsa.base.prediction as pred
 import statsmodels.tsa.base.tsa_model as tsbase
 from statsmodels.tsa.stattools._stattools import breakvar_heteroskedasticity_test
@@ -1635,6 +1636,7 @@ class MLEModel(tsbase.TimeSeriesModel):
         # will just be called 'method'
         if "method" in kwargs:
             method = kwargs.pop("method")
+        method = string_like(method, "method", options=("harvey", "approx"))
 
         if approx_complex_step is None:
             approx_complex_step = not self.ssm._complex_endog
@@ -1663,13 +1665,11 @@ class MLEModel(tsbase.TimeSeriesModel):
         elif method == "approx" and approx_complex_step:
             kwargs["includes_fixed"] = True
             score = self._score_complex_step(params, **kwargs)
-        elif method == "approx":
+        else:  # method == "approx"
             kwargs["includes_fixed"] = True
             score = self._score_finite_difference(
                 params, approx_centered=approx_centered, **kwargs
             )
-        else:
-            raise NotImplementedError("Invalid score method.")
 
         if not transformed:
             score = np.dot(transform_score, score)
@@ -1725,6 +1725,8 @@ class MLEModel(tsbase.TimeSeriesModel):
         This is a numerical approximation, calculated using first-order complex
         step differentiation on the `loglikeobs` method.
         """
+        method = string_like(method, "method", options=("approx", "harvey"))
+
         if not transformed and approx_complex_step:
             raise ValueError(
                 "Cannot use complex-step approximations to"
@@ -1757,12 +1759,10 @@ class MLEModel(tsbase.TimeSeriesModel):
             score = approx_fprime_cs(
                 params, self.loglikeobs, epsilon=epsilon, kwargs=kwargs
             )
-        elif method == "approx":
+        else:  # method == "approx"
             score = approx_fprime(
                 params, self.loglikeobs, kwargs=kwargs, centered=approx_centered
             )
-        else:
-            raise NotImplementedError("Invalid scoreobs method.")
 
         return score
 
@@ -1814,6 +1814,7 @@ class MLEModel(tsbase.TimeSeriesModel):
         # the method will just be called 'method'
         if "method" in kwargs:
             method = kwargs.pop("method")
+        method = string_like(method, "method", options=("oim", "opg", "approx"))
 
         if not transformed and approx_complex_step:
             raise ValueError(
@@ -1850,15 +1851,13 @@ class MLEModel(tsbase.TimeSeriesModel):
             hessian = self._hessian_complex_step(
                 params, transformed=transformed, **kwargs
             )
-        elif method == "approx":
+        else:  # method == "approx"
             hessian = self._hessian_finite_difference(
                 params,
                 transformed=transformed,
                 approx_centered=approx_centered,
                 **kwargs,
             )
-        else:
-            raise NotImplementedError("Invalid Hessian calculation method.")
         return hessian
 
     def _hessian_oim(self, params, **kwargs):
@@ -3362,12 +3361,12 @@ class MLEResults(tsbase.TimeSeriesModelResults):
         .. [Lütkepohl2007] Lütkepohl, Helmut. 2005. New Introduction to Multiple Time
            Series Analysis. Berlin: Springer.
         """
-        criteria = criteria.lower()
-        method = method.lower()
+        criteria = string_like(criteria, "criteria", options=("aic", "bic", "hqic"))
+        method = string_like(method, "method", options=("standard", "lutkepohl"))
 
         if method == "standard":
             out = getattr(self, criteria)
-        elif method == "lutkepohl":
+        else:  # method == "lutkepohl"
             if self.filter_results.state_cov.shape[-1] > 1:
                 raise ValueError(
                     "Cannot compute Lütkepohl statistics for"
@@ -3385,7 +3384,7 @@ class MLEResults(tsbase.TimeSeriesModelResults):
                     np.linalg.slogdet(cov)[1]
                     + self.df_model * np.log(self.nobs_effective) / self.nobs_effective
                 )
-            elif criteria == "hqic":
+            else:  # criteria == "hqic"
                 out = np.squeeze(
                     np.linalg.slogdet(cov)[1]
                     + 2
@@ -3393,11 +3392,6 @@ class MLEResults(tsbase.TimeSeriesModelResults):
                     * np.log(np.log(self.nobs_effective))
                     / self.nobs_effective
                 )
-            else:
-                raise ValueError("Invalid information criteria")
-
-        else:
-            raise ValueError("Invalid information criteria computation method")
 
         return out
 
@@ -3545,6 +3539,7 @@ class MLEResults(tsbase.TimeSeriesModelResults):
         """
         if method is None:
             method = "jarquebera"
+        method = string_like(method, "method", options=("jarquebera",))
 
         if self.standardized_forecasts_error is None:
             raise ValueError(
@@ -3552,17 +3547,14 @@ class MLEResults(tsbase.TimeSeriesModelResults):
                 " forecast errors have not been computed."
             )
 
-        if method == "jarquebera":
-            from statsmodels.stats.stattools import jarque_bera
+        from statsmodels.stats.stattools import jarque_bera
 
-            d = np.maximum(self.loglikelihood_burn, self.nobs_diffuse)
-            output = []
-            for i in range(self.model.k_endog):
-                resid = self.filter_results.standardized_forecasts_error[i, d:]
-                mask = ~np.isnan(resid)
-                output.append(jarque_bera(resid[mask]))
-        else:
-            raise NotImplementedError("Invalid normality test method.")
+        d = np.maximum(self.loglikelihood_burn, self.nobs_diffuse)
+        output = []
+        for i in range(self.model.k_endog):
+            resid = self.filter_results.standardized_forecasts_error[i, d:]
+            mask = ~np.isnan(resid)
+            output.append(jarque_bera(resid[mask]))
 
         return np.array(output)
 
@@ -3638,6 +3630,7 @@ class MLEResults(tsbase.TimeSeriesModelResults):
         """
         if method is None:
             method = "breakvar"
+        method = string_like(method, "method", options=("breakvar",))
 
         if self.standardized_forecasts_error is None:
             raise ValueError(
@@ -3645,29 +3638,25 @@ class MLEResults(tsbase.TimeSeriesModelResults):
                 " forecast errors have not been computed."
             )
 
-        if method == "breakvar":
-            # Store some values
-            resid = self.filter_results.standardized_forecasts_error
-            d = np.maximum(self.loglikelihood_burn, self.nobs_diffuse)
-            # This differs from self.nobs_effective because here we want to
-            # exclude exact diffuse periods, whereas self.nobs_effective only
-            # excludes explicitly burned (usually approximate diffuse) periods.
-            nobs_effective = self.nobs - d
-            h = int(np.round(nobs_effective / 3))
+        # Store some values
+        resid = self.filter_results.standardized_forecasts_error
+        d = np.maximum(self.loglikelihood_burn, self.nobs_diffuse)
+        # This differs from self.nobs_effective because here we want to
+        # exclude exact diffuse periods, whereas self.nobs_effective only
+        # excludes explicitly burned (usually approximate diffuse) periods.
+        nobs_effective = self.nobs - d
+        h = int(np.round(nobs_effective / 3))
 
-            test_statistics = []
-            p_values = []
-            for i in range(self.model.k_endog):
-                _het_result = breakvar_heteroskedasticity_test(
-                    resid[i, d:], subset_length=h, alternative=alternative, use_f=use_f
-                )
-                test_statistics.append(_het_result.statistic)
-                p_values.append(_het_result.pvalue)
+        test_statistics = []
+        p_values = []
+        for i in range(self.model.k_endog):
+            _het_result = breakvar_heteroskedasticity_test(
+                resid[i, d:], subset_length=h, alternative=alternative, use_f=use_f
+            )
+            test_statistics.append(_het_result.statistic)
+            p_values.append(_het_result.pvalue)
 
-            output = np.c_[test_statistics, p_values]
-        else:
-            raise NotImplementedError("Invalid heteroskedasticity test method.")
-
+        output = np.c_[test_statistics, p_values]
         return output
 
     def test_serial_correlation(self, method, df_adjust=False, lags=None):
@@ -3724,6 +3713,9 @@ class MLEResults(tsbase.TimeSeriesModelResults):
         """
         if method is None:
             method = "ljungbox"
+        method = string_like(
+            method, "method", options=("ljungbox", "boxpierce")
+        )
 
         if self.standardized_forecasts_error is None:
             raise ValueError(
@@ -3731,42 +3723,39 @@ class MLEResults(tsbase.TimeSeriesModelResults):
                 " forecast errors have not been computed."
             )
 
-        if method == "ljungbox" or method == "boxpierce":
-            from statsmodels.stats.diagnostic import acorr_ljungbox
+        from statsmodels.stats.diagnostic import acorr_ljungbox
 
-            d = np.maximum(self.loglikelihood_burn, self.nobs_diffuse)
-            # This differs from self.nobs_effective because here we want to
-            # exclude exact diffuse periods, whereas self.nobs_effective only
-            # excludes explicitly burned (usually approximate diffuse) periods.
-            nobs_effective = self.nobs - d
-            output = []
+        d = np.maximum(self.loglikelihood_burn, self.nobs_diffuse)
+        # This differs from self.nobs_effective because here we want to
+        # exclude exact diffuse periods, whereas self.nobs_effective only
+        # excludes explicitly burned (usually approximate diffuse) periods.
+        nobs_effective = self.nobs - d
+        output = []
 
-            # Default lags for acorr_ljungbox is 40, but may not always have
-            # that many observations
-            if lags is None:
-                seasonal_periods = getattr(self.model, "seasonal_periods", 0)
-                if seasonal_periods:
-                    lags = min(2 * seasonal_periods, nobs_effective // 5)
-                else:
-                    lags = min(10, nobs_effective // 5)
+        # Default lags for acorr_ljungbox is 40, but may not always have
+        # that many observations
+        if lags is None:
+            seasonal_periods = getattr(self.model, "seasonal_periods", 0)
+            if seasonal_periods:
+                lags = min(2 * seasonal_periods, nobs_effective // 5)
+            else:
+                lags = min(10, nobs_effective // 5)
 
-            model_df = 0
-            if df_adjust:
-                model_df = max(0, self.df_model - self.k_diffuse_states - 1)
+        model_df = 0
+        if df_adjust:
+            model_df = max(0, self.df_model - self.k_diffuse_states - 1)
 
-            cols = [2, 3] if method == "boxpierce" else [0, 1]
-            for i in range(self.model.k_endog):
-                results = acorr_ljungbox(
-                    self.filter_results.standardized_forecasts_error[i][d:],
-                    lags=lags,
-                    boxpierce=(method == "boxpierce"),
-                    model_df=model_df,
-                )
-                output.append(np.asarray(results)[:, cols].T)
+        cols = [2, 3] if method == "boxpierce" else [0, 1]
+        for i in range(self.model.k_endog):
+            results = acorr_ljungbox(
+                self.filter_results.standardized_forecasts_error[i][d:],
+                lags=lags,
+                boxpierce=(method == "boxpierce"),
+                model_df=model_df,
+            )
+            output.append(np.asarray(results)[:, cols].T)
 
-            output = np.c_[output]
-        else:
-            raise NotImplementedError("Invalid serial correlation test method.")
+        output = np.c_[output]
         return output
 
     def get_prediction(
@@ -4389,6 +4378,13 @@ class MLEResults(tsbase.TimeSeriesModelResults):
     def _get_previous_updated(
         self, comparison, exog=None, comparison_type=None, **kwargs
     ):
+        comparison_type = string_like(
+            comparison_type,
+            "comparison_type",
+            options=("previous", "updated"),
+            optional=True,
+            lower=False,
+        )
         # If we were given data, create a new results object
         comparison_dataset = not isinstance(comparison, (MLEResults, MLEResultsWrapper))
         if comparison_dataset:
@@ -5745,7 +5741,13 @@ class PredictionResults(pred.PredictionResults):
         )
         self.prediction_results = prediction_results
 
-        self.information_set = information_set
+        self.information_set = string_like(
+            information_set,
+            "information_set",
+            options=("predicted", "filtered", "smoothed"),
+            lower=False,
+        )
+        information_set = self.information_set
         self.signal_only = signal_only
 
         # Get required values

--- a/statsmodels/tsa/statespace/news.py
+++ b/statsmodels/tsa/statespace/news.py
@@ -12,6 +12,7 @@ import pandas as pd
 from statsmodels.iolib.summary import Summary
 from statsmodels.iolib.table import SimpleTable
 from statsmodels.iolib.tableformatting import fmt_params
+from statsmodels.tools.validation import string_like
 
 
 class NewsResults:
@@ -1086,6 +1087,7 @@ class NewsResults:
             s[3] = np.s_[updated_variable]
         s = tuple(s)
 
+        source = string_like(source, "source", options=("news", "revisions"))
         if source == "news":
             details = self.details_by_impact.loc[s, :]
             columns = {
@@ -1095,7 +1097,7 @@ class NewsResults:
                 "updated variable": "updated variable",
                 "news": "news",
             }
-        elif source == "revisions":
+        else:  # source == "revisions"
             details = self.revision_details_by_impact.loc[s, :]
             columns = {
                 "current": "revised",
@@ -1104,9 +1106,6 @@ class NewsResults:
                 "updated variable": "revised variable",
                 "news": "revision",
             }
-        else:
-            raise ValueError(f'Invalid `source`: {source}. Must be "news" or'
-                             ' "revisions".')
 
         # Make the first index level the groupby level
         groupby = groupby.lower().replace("_", " ")

--- a/statsmodels/tsa/statespace/simulation_smoother.py
+++ b/statsmodels/tsa/statespace/simulation_smoother.py
@@ -9,6 +9,7 @@ from statsmodels.compat.pandas import deprecate_kwarg
 import numpy as np
 
 from statsmodels.tools.rng_qrng import check_random_state
+from statsmodels.tools.validation import string_like
 
 from . import tools
 from .cfa_simulation_smoother import CFASimulationSmoother
@@ -277,7 +278,7 @@ class SimulationSmoother(KalmanSmoother):
         SimulationSmoothResults
             Object holding the output of the simulation smoother.
         """
-        method = method.lower()
+        method = string_like(method, "method", options=("kfs", "cfa"))
 
         # Short-circuit for CFA
         if method == "cfa":
@@ -287,11 +288,6 @@ class SimulationSmoother(KalmanSmoother):
                     " vector using the CFA simulation smoother."
                 )
             return CFASimulationSmoother(self)
-        elif method != "kfs":
-            raise ValueError(
-                f'Invalid simulation smoother method "{method}". Valid'
-                ' methods are "kfs" or "cfa".'
-            )
 
         # Set the class to be the default results class, if None provided
         if results_class is None:

--- a/statsmodels/tsa/statespace/structural.py
+++ b/statsmodels/tsa/statespace/structural.py
@@ -16,6 +16,7 @@ import statsmodels.base.wrapper as wrap
 from statsmodels.tools.docstring_helpers import Appender
 from statsmodels.tools.sm_exceptions import OutputWarning, SpecificationWarning
 from statsmodels.tools.tools import Bunch
+from statsmodels.tools.validation import string_like
 from statsmodels.tsa.filters.hp_filter import hpfilter
 from statsmodels.tsa.tsatools import lagmat
 
@@ -1704,6 +1705,7 @@ class UnobservedComponentsResults(MLEResults):
         # Determine which results we have
         if which is None:
             which = "filtered" if self.smoothed_state is None else "smoothed"
+        which = string_like(which, "which", options=("filtered", "smoothed"))
 
         # Determine which plots we have
         spec = self.specification
@@ -1798,10 +1800,6 @@ class UnobservedComponentsResults(MLEResults):
                     title = component_bunch.pretty_name
                 else:
                     raise
-
-            # Check for a valid estimation type
-            if which not in component_bunch:
-                raise ValueError("Invalid type of state estimate.")
 
             # Get the predicted values
             value = component_bunch[which]

--- a/statsmodels/tsa/statespace/tests/test_dynamic_factor_mq.py
+++ b/statsmodels/tsa/statespace/tests/test_dynamic_factor_mq.py
@@ -1746,6 +1746,12 @@ def test_coefficient_of_determination(close_figures):
                 desired.iloc[i, j] = res_ols.rsquared
     assert_allclose(actual, desired)
 
+    # Invalid method / which raise clear errors
+    with pytest.raises(ValueError, match="method"):
+        res.get_coefficients_of_determination(method="invalid")
+    with pytest.raises(ValueError, match="which"):
+        res.get_coefficients_of_determination(which="invalid")
+
     # Optional smoke test for plot_coefficient_of_determination
     try:
         import matplotlib.pyplot as plt
@@ -1763,6 +1769,15 @@ def test_coefficient_of_determination(close_figures):
         res.plot_coefficients_of_determination(which="filtered", fig=fig4)
     except ImportError:
         pass
+
+
+def test_em_invalid_mstep_method():
+    endog, _, _, _, _, _ = gen_dfm_data(k_endog=2, nobs=100)
+    mod = dynamic_factor_mq.DynamicFactorMQ(
+        endog, factors=1, standardize=False, idiosyncratic_ar1=False
+    )
+    with pytest.raises(ValueError, match="mstep_method"):
+        mod.fit_em(maxiter=1, mstep_method="invalid")
 
 
 @pytest.mark.filterwarnings("ignore:Log-likelihood decreased")

--- a/statsmodels/tsa/statespace/tests/test_exponential_smoothing.py
+++ b/statsmodels/tsa/statespace/tests/test_exponential_smoothing.py
@@ -932,7 +932,7 @@ def test_invalid():
     ):
         ExponentialSmoothing(aust, seasonal=True)
 
-    with pytest.raises(ValueError, match=r'Invalid initialization method "invalid".'):
+    with pytest.raises(ValueError, match="initialization_method"):
         ExponentialSmoothing(aust, initialization_method="invalid")
 
     with pytest.raises(

--- a/statsmodels/tsa/statespace/tests/test_mlemodel.py
+++ b/statsmodels/tsa/statespace/tests/test_mlemodel.py
@@ -318,6 +318,40 @@ def test_score_misc():
     mod.score(res.params)
 
 
+def test_score_hessian_invalid_method_raises():
+    mod, res = get_dummy_mod()
+
+    with pytest.raises(ValueError, match="method"):
+        mod.score(res.params, method="invalid")
+    with pytest.raises(ValueError, match="method"):
+        mod.score_obs(res.params, method="invalid")
+    with pytest.raises(ValueError, match="method"):
+        mod.hessian(res.params, method="invalid")
+
+
+def test_info_criteria_invalid_raises():
+    mod, res = get_dummy_mod()
+
+    with pytest.raises(ValueError, match="criteria"):
+        res.info_criteria("invalid")
+    with pytest.raises(ValueError, match="method"):
+        res.info_criteria("aic", method="invalid")
+
+
+def test_get_prediction_invalid_information_set_raises():
+    mod, res = get_dummy_mod()
+
+    with pytest.raises(ValueError, match="information_set"):
+        res.get_prediction(information_set="invalid")
+
+
+def test_get_smoothed_decomposition_invalid_raises():
+    mod, res = get_dummy_mod()
+
+    with pytest.raises(ValueError, match="decomposition_of"):
+        res.get_smoothed_decomposition(decomposition_of="invalid")
+
+
 def test_from_formula():
     with pytest.raises(NotImplementedError):
         MLEModel.from_formula(1, 2, 3)
@@ -927,7 +961,7 @@ def test_diagnostics():
     desired = res.test_normality(method="jarquebera")
     assert_allclose(actual, desired)
 
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(ValueError, match="method"):
         res.test_normality(method="invalid")
 
     actual = res.test_heteroskedasticity(method=None)
@@ -936,14 +970,14 @@ def test_diagnostics():
 
     with pytest.raises(ValueError):
         res.test_heteroskedasticity(method=None, alternative="invalid")
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(ValueError, match="method"):
         res.test_heteroskedasticity(method="invalid")
 
     actual = res.test_serial_correlation(method=None)
     desired = res.test_serial_correlation(method="ljungbox")
     assert_allclose(actual, desired)
 
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(ValueError, match="method"):
         res.test_serial_correlation(method="invalid")
 
     # Smoke tests for other options

--- a/statsmodels/tsa/statespace/tests/test_news.py
+++ b/statsmodels/tsa/statespace/tests/test_news.py
@@ -824,6 +824,14 @@ def test_comparison_types():
     assert_allclose(news.total_impacts, 0)
 
 
+def test_invalid_comparison_type():
+    endog = dta["infl"].copy()
+    mod = sarimax.SARIMAX(endog)
+    res = mod.smooth([0.5, 1.0])
+    with pytest.raises(ValueError, match="comparison_type"):
+        res.news(endog, comparison_type="not-a-comparison-type")
+
+
 @pytest.mark.parametrize("use_periods", [True, False])
 def test_start_end_dates(use_periods):
     endog = dta["infl"].copy()
@@ -1406,6 +1414,12 @@ def test_news_summary_methods():
     for variable in news.total_impacts.columns:
         total_impact = news.total_impacts.loc["2009Q3", variable]
         assert_(f"{total_impact:.2f}" in full_text)
+
+    # summary_details' source parameter: "news" is the default (already
+    # exercised above); "revisions" is a separate code path.
+    assert_(str(news.summary_details(source="revisions")).strip() != "")
+    with pytest.raises(ValueError, match="source"):
+        news.summary_details(source="invalid")
 
     # revision_details_by_impact aggregates by (impact date, impacted
     # variable): the two cpi revisions (2009Q2 and 2009Q3) both land on the

--- a/statsmodels/tsa/statespace/tests/test_simulation_smoothing.py
+++ b/statsmodels/tsa/statespace/tests/test_simulation_smoothing.py
@@ -695,6 +695,16 @@ def test_misc():
     assert_equal(sim.simulation_output, 0)
 
 
+def test_simulation_smoother_invalid_method_raises():
+    dta = datasets.macrodata.load_pandas().data
+    dta.index = pd.date_range(start="1959-01-01", end="2009-7-01", freq="QS")
+    obs = np.log(dta[["realgdp"]]).diff().iloc[1:]
+
+    mod = sarimax.SARIMAX(obs["realgdp"], order=(1, 0, 0))
+    with pytest.raises(ValueError, match="method"):
+        mod.simulation_smoother(method="invalid")
+
+
 def test_simulation_smoothing_obs_intercept():
     nobs = 10
     intercept = 100

--- a/statsmodels/tsa/statespace/tests/test_structural.py
+++ b/statsmodels/tsa/statespace/tests/test_structural.py
@@ -166,11 +166,9 @@ def test_random_walk(close_figures):
     run_ucm("random_walk", use_exact_diffuse=True)
 
 
+@pytest.mark.matplotlib
 def test_plot_components_invalid_which_raises(close_figures):
-    try:
-        import matplotlib.pyplot as plt
-    except ImportError:
-        pytest.skip("matplotlib not available")
+    import matplotlib.pyplot as plt
 
     mod = UnobservedComponents(np.arange(20) * 1.0, "local level")
     res = mod.smooth([1.0, 1.0])

--- a/statsmodels/tsa/statespace/tests/test_structural.py
+++ b/statsmodels/tsa/statespace/tests/test_structural.py
@@ -166,6 +166,19 @@ def test_random_walk(close_figures):
     run_ucm("random_walk", use_exact_diffuse=True)
 
 
+def test_plot_components_invalid_which_raises(close_figures):
+    try:
+        import matplotlib.pyplot as plt
+    except ImportError:
+        pytest.skip("matplotlib not available")
+
+    mod = UnobservedComponents(np.arange(20) * 1.0, "local level")
+    res = mod.smooth([1.0, 1.0])
+    fig = plt.figure()
+    with pytest.raises(ValueError, match="which"):
+        res.plot_components(which="invalid", fig=fig)
+
+
 def test_local_level(close_figures):
     run_ucm("local_level")
     run_ucm("local_level", use_exact_diffuse=True)

--- a/statsmodels/tsa/statespace/varmax.py
+++ b/statsmodels/tsa/statespace/varmax.py
@@ -154,7 +154,7 @@ class VARMAX(MLEModel):
         self.k_ma = int(order[1])
 
         # Check for valid model
-        self.error_cov_type = error_cov_type = string_like(
+        self.error_cov_type = string_like(
             error_cov_type,
             "error_cov_type",
             options=("diagonal", "unstructured"),

--- a/statsmodels/tsa/statespace/varmax.py
+++ b/statsmodels/tsa/statespace/varmax.py
@@ -17,6 +17,7 @@ from statsmodels.tools.data import _is_using_pandas
 from statsmodels.tools.docstring_helpers import Appender
 from statsmodels.tools.sm_exceptions import EstimationWarning
 from statsmodels.tools.tools import Bunch
+from statsmodels.tools.validation import string_like
 from statsmodels.tsa.vector_ar import var_model
 
 from .initialization import Initialization
@@ -153,9 +154,12 @@ class VARMAX(MLEModel):
         self.k_ma = int(order[1])
 
         # Check for valid model
-        if error_cov_type not in ["diagonal", "unstructured"]:
-            raise ValueError("Invalid error covariance matrix type"
-                             " specification.")
+        self.error_cov_type = error_cov_type = string_like(
+            error_cov_type,
+            "error_cov_type",
+            options=("diagonal", "unstructured"),
+            lower=False,
+        )
         if self.k_ar == 0 and self.k_ma == 0:
             raise ValueError("Invalid VARMAX(p,q) specification; at least one"
                              " p,q must be greater than zero.")

--- a/statsmodels/tsa/stattools/_leybourne.py
+++ b/statsmodels/tsa/stattools/_leybourne.py
@@ -2,6 +2,7 @@ import numpy as np
 
 from statsmodels.regression.linear_model import OLS
 from statsmodels.tools.tools import add_constant
+from statsmodels.tools.validation import string_like
 import statsmodels.tsa._leybourne
 from statsmodels.tsa.stattools._stattools import lagmat, pacf
 
@@ -218,12 +219,13 @@ class LeybourneMcCabeStationarity:
         Schwert, G W. (1987). Effects of model specification on tests for unit
         roots in macroeconomic data. Journal of Monetary Economics, 20: 73-103.
         """
-        if regression not in ["c", "ct"]:
-            raise ValueError(f"LM: regression option '{regression}' not understood")
-        if method not in ["mle", "ols"]:
-            raise ValueError(f"LM: method option '{method}' not understood")
-        if varest not in ["var94", "var99"]:
-            raise ValueError(f"LM: varest option '{varest}' not understood")
+        regression = string_like(
+            regression, "regression", options=("c", "ct"), lower=False
+        )
+        method = string_like(method, "method", options=("mle", "ols"), lower=False)
+        varest = string_like(
+            varest, "varest", options=("var94", "var99"), lower=False
+        )
         x = np.asarray(x)
         if x.ndim > 2 or (x.ndim == 2 and x.shape[1] != 1):
             raise ValueError(

--- a/statsmodels/tsa/stattools/_stattools.py
+++ b/statsmodels/tsa/stattools/_stattools.py
@@ -142,8 +142,8 @@ def _autolag(
     # TODO: This could be changed to laggedRHS and exog keyword arguments if
     #    this will be more general.
 
+    method = string_like(method, "method", options=("aic", "bic", "t-stat"))
     results = {}
-    method = method.lower()
     for lag in range(startlag, startlag + maxlag + 1):
         mod_instance = mod(endog, exog[:, :lag], *modargs)
         results[lag] = mod_instance.fit()
@@ -152,7 +152,7 @@ def _autolag(
         icbest, bestlag = min((v.aic, k) for k, v in results.items())
     elif method == "bic":
         icbest, bestlag = min((v.bic, k) for k, v in results.items())
-    elif method == "t-stat":
+    else:  # method == "t-stat"
         # stop = stats.norm.ppf(.95)
         stop = 1.6448536269514722
         # Default values to ensure that always set
@@ -164,8 +164,6 @@ def _autolag(
             if np.abs(icbest) >= stop:
                 # Break for first lag with a significant t-stat
                 break
-    else:
-        raise ValueError(f"Information Criterion {method} not understood.")
 
     if not regresults:
         return icbest, bestlag
@@ -367,10 +365,6 @@ def adfuller(
     if regresults:
         store = True
 
-    trenddict = {None: "n", 0: "c", 1: "ct", 2: "ctt"}
-    if regression is None or isinstance(regression, int):
-        regression = trenddict[regression]
-    regression = regression.lower()
     nobs = x.shape[0]
 
     ntrend = len(regression) if regression != "n" else 0
@@ -543,7 +537,6 @@ def acovf(x, adjusted=False, demean=True, fft=True, missing="none", nlag=None):
 
     x = array_like(x, "x", ndim=1)
 
-    missing = missing.lower()
     if missing == "none":
         deal_with_masked = False
     else:
@@ -3172,6 +3165,8 @@ def kpss(
             "None is not a valid value for nlags. nlags must be an integer, 'auto' "
             "or 'legacy'."
         )
+    if isinstance(nlags, str):
+        nlags = string_like(nlags, "nlags", options=("auto", "legacy"))
     if nlags == "legacy":
         nlags = int(np.ceil(12.0 * np.power(nobs / 100.0, 1 / 4.0)))
         nlags = min(nlags, nobs - 1)
@@ -3179,8 +3174,6 @@ def kpss(
         # autolag method of Hobijn et al. (1998)
         nlags = _kpss_autolag(resids, nobs)
         nlags = min(nlags, nobs - 1)
-    elif isinstance(nlags, str):
-        raise ValueError("nvals must be 'auto' or 'legacy' when not an int")
     else:
         nlags = int_like(nlags, "nlags", optional=False)
 

--- a/statsmodels/tsa/tests/test_adfvalues.py
+++ b/statsmodels/tsa/tests/test_adfvalues.py
@@ -1,0 +1,27 @@
+import numpy as np
+import pytest
+
+from statsmodels.tsa.adfvalues import mackinnoncrit, mackinnonp
+
+
+@pytest.mark.parametrize("regression", ["c", "n", "ct", "ctt"])
+def test_mackinnonp_valid_regression(regression):
+    # smoke test: must not raise, and returns a probability
+    pvalue = mackinnonp(-2.5, regression=regression)
+    assert 0 <= pvalue <= 1
+
+
+def test_mackinnonp_invalid_regression_raises():
+    with pytest.raises(ValueError, match="regression"):
+        mackinnonp(-2.5, regression="not-a-regression")
+
+
+@pytest.mark.parametrize("regression", ["c", "n", "ct", "ctt"])
+def test_mackinnoncrit_valid_regression(regression):
+    crit = mackinnoncrit(regression=regression)
+    assert np.asarray(crit).shape == (3,)
+
+
+def test_mackinnoncrit_invalid_regression_raises():
+    with pytest.raises(ValueError, match="regression"):
+        mackinnoncrit(regression="not-a-regression")

--- a/statsmodels/tsa/tests/test_ar.py
+++ b/statsmodels/tsa/tests/test_ar.py
@@ -749,6 +749,13 @@ def test_ar_order_select():
     assert res.period is None
 
 
+def test_ar_select_order_invalid_ic_raises():
+    rs = np.random.RandomState(12345)
+    y = arma_generate_sample([1, -0.75, 0.3], [1], 100, distrvs=rs.standard_normal)
+    with pytest.raises(ValueError, match="ic"):
+        ar_select_order(y, maxlag=4, ic="not-a-real-ic")
+
+
 def test_autoreg_constant_column_trend():
     sample = np.array(
         [

--- a/statsmodels/tsa/tests/test_exponential_smoothing.py
+++ b/statsmodels/tsa/tests/test_exponential_smoothing.py
@@ -738,6 +738,18 @@ def test_hessian(austourists_model_fit):
     )
 
 
+def test_diagnostics_invalid_method_raises(austourists_model_fit):
+    model_class, model_args, model_kwargs = austourists_model_fit
+    fit = model_class(*model_args, **model_kwargs).fit(disp=False)
+
+    with pytest.raises(ValueError, match="method"):
+        fit.test_serial_correlation(method="not-a-method")
+    with pytest.raises(ValueError, match="method"):
+        fit.test_heteroskedasticity(method="not-a-method")
+    with pytest.raises(ValueError, match="method"):
+        fit.test_normality(method="not-a-method")
+
+
 def test_prediction_results(austourists_model_fit):
     # simple test case starting at 0
     model_class, model_args, model_kwargs = austourists_model_fit

--- a/statsmodels/tsa/tests/test_seasonal.py
+++ b/statsmodels/tsa/tests/test_seasonal.py
@@ -816,6 +816,23 @@ class TestDecompose:
         trend = seasonal_decompose(x, period=period, extrapolate_trend="period").trend
         assert_almost_equal(trend, x)
 
+    def test_extrapolate_trend_freq_deprecated(self):
+        x = np.arange(12)
+        period = 4
+        with pytest.warns(FutureWarning, match="extrapolate_trend='freq'"):
+            trend_freq = seasonal_decompose(
+                x, period=period, extrapolate_trend="freq"
+            ).trend
+        trend_period = seasonal_decompose(
+            x, period=period, extrapolate_trend="period"
+        ).trend
+        assert_almost_equal(trend_freq, trend_period)
+
+    def test_extrapolate_trend_invalid_string_raises(self):
+        x = np.arange(12)
+        with pytest.raises(ValueError, match="extrapolate_trend"):
+            seasonal_decompose(x, period=4, extrapolate_trend="not-a-value")
+
     def test_raises(self):
         with pytest.raises(ValueError):
             seasonal_decompose(self.data.values)

--- a/statsmodels/tsa/tests/test_stattools.py
+++ b/statsmodels/tsa/tests/test_stattools.py
@@ -1432,6 +1432,10 @@ class TestKPSS:
         with pytest.raises(ValueError):
             kpss(x)
 
+    def test_fail_invalid_nlags_string(self):
+        with pytest.raises(ValueError, match="nlags"):
+            kpss(self.x, nlags="invalid", result_object=False)
+
     def test_fail_unclear_hypothesis(self):
         # these should be fine,
         with pytest.warns(InterpolationWarning):

--- a/statsmodels/tsa/tests/test_varma_process.py
+++ b/statsmodels/tsa/tests/test_varma_process.py
@@ -41,6 +41,22 @@ def test_vstack_hstack_are_reshapes_of_the_source_array():
     assert_array_equal(vp.vstack(), ar23.reshape(-1, 2))
     assert_array_equal(vp.hstack(name="ma"), ma22.transpose(1, 0, 2).reshape(2, -1))
 
+    # An explicit `a` is used as-is; `name` is only consulted when `a` is
+    # None, so an invalid `name` alongside an explicit `a` must not raise.
+    assert_array_equal(vp.vstack(a=ma22, name="invalid"), ma22.reshape(-1, 2))
+
+
+def test_vstack_hstack_stacksquare_invalid_name_raises():
+    import pytest
+
+    vp = VarmaPoly(ar23, ma22)
+    with pytest.raises(ValueError, match="name"):
+        vp.vstack(name="invalid")
+    with pytest.raises(ValueError, match="name"):
+        vp.hstack(name="invalid")
+    with pytest.raises(ValueError, match="name"):
+        vp.stacksquare(name="invalid")
+
 
 def test_stacksquare_is_companion_form():
     # stacksquare builds a companion matrix: the first `nvars` columns hold

--- a/statsmodels/tsa/varma_process.py
+++ b/statsmodels/tsa/varma_process.py
@@ -34,6 +34,7 @@ import warnings
 import numpy as np
 from scipy import signal
 
+from statsmodels.tools.validation import string_like
 from statsmodels.tsa.tsatools import lagmat
 
 
@@ -600,12 +601,9 @@ class VarmaPoly:
         """
         if a is not None:
             _a = a
-        elif name == "ar":
-            _a = self.ar
-        elif name == "ma":
-            _a = self.ma
         else:
-            raise ValueError("no array or name given")
+            name = string_like(name, "name", options=("ar", "ma"))
+            _a = self.ar if name == "ar" else self.ma
         return _a.reshape(-1, self.nvarall)
 
     # @property
@@ -628,12 +626,9 @@ class VarmaPoly:
         """
         if a is not None:
             _a = a
-        elif name == "ar":
-            _a = self.ar
-        elif name == "ma":
-            _a = self.ma
         else:
-            raise ValueError("no array or name given")
+            name = string_like(name, "name", options=("ar", "ma"))
+            _a = self.ar if name == "ar" else self.ma
         return _a.swapaxes(1, 2).reshape(-1, self.nvarall).T
 
     # @property
@@ -659,12 +654,9 @@ class VarmaPoly:
         """
         if a is not None:
             _a = a
-        elif name == "ar":
-            _a = self.ar
-        elif name == "ma":
-            _a = self.ma
         else:
-            raise ValueError("no array or name given")
+            name = string_like(name, "name", options=("ar", "ma"))
+            _a = self.ar if name == "ar" else self.ma
         astacked = _a.reshape(-1, self.nvarall)
         lenpk, nvars = astacked.shape  # [0]
         amat = np.eye(lenpk, k=nvars)

--- a/statsmodels/tsa/vector_ar/irf.py
+++ b/statsmodels/tsa/vector_ar/irf.py
@@ -7,6 +7,7 @@ import numpy.linalg as la
 import scipy.linalg as L
 
 from statsmodels.tools._decorators import cache_readonly
+from statsmodels.tools.validation import string_like
 import statsmodels.tsa.tsatools as tsa
 from statsmodels.tsa.vector_ar import plotting, util
 from statsmodels.tsa.vector_ar.hypothesis_test_results import ErrorBand
@@ -197,10 +198,12 @@ class BaseIRAnalysis:
         else:
             title = "Impulse responses"
 
-        if stderr_type not in ["asym", "mc", "sz1", "sz2", "sz3"]:
-            raise ValueError(
-                "Error type must be either 'asym', 'mc','sz1','sz2', or 'sz3'"
-            )
+        stderr_type = string_like(
+            stderr_type,
+            "stderr_type",
+            options=("asym", "mc", "sz1", "sz2", "sz3"),
+            lower=False,
+        )
 
         if plot_stderr is False:
             stderr = None
@@ -359,15 +362,17 @@ class BaseIRAnalysis:
                     f"{expected_shape} (2, periods+1, neqs, neqs)."
                 )
             stderr = err_bands
-        elif stderr_type not in ["asym", "mc"]:
-            raise ValueError("`stderr_type` must be one of 'asym', 'mc'")
-        elif stderr_type == "asym":
-            stderr = self.cum_effect_cov(orth=orth)
-        else:  # stderr_type == "mc"
-            _err_band = self.cum_errband_mc(
-                orth=orth, repl=repl, signif=signif, rng=rng
+        else:
+            stderr_type = string_like(
+                stderr_type, "stderr_type", options=("asym", "mc"), lower=False
             )
-            stderr = (_err_band.lower, _err_band.upper)
+            if stderr_type == "asym":
+                stderr = self.cum_effect_cov(orth=orth)
+            else:  # stderr_type == "mc"
+                _err_band = self.cum_errband_mc(
+                    orth=orth, repl=repl, signif=signif, rng=rng
+                )
+                stderr = (_err_band.lower, _err_band.upper)
 
         fig = plotting.irf_grid_plot(
             cum_effects,

--- a/statsmodels/tsa/vector_ar/svar_model.py
+++ b/statsmodels/tsa/vector_ar/svar_model.py
@@ -14,6 +14,7 @@ from numpy.linalg import slogdet
 
 from statsmodels.tools.numdiff import approx_fprime, approx_hess
 from statsmodels.tools.rng_qrng import check_random_state
+from statsmodels.tools.validation import string_like
 import statsmodels.tsa.base.tsa_model as tsbase
 from statsmodels.tsa.vector_ar import util
 from statsmodels.tsa.vector_ar.hypothesis_test_results import ErrorBand
@@ -71,9 +72,9 @@ class SVAR(tsbase.TimeSeriesModel):
 
         self.neqs = self.endog.shape[1]
 
-        types = ["A", "B", "AB"]
-        if svar_type not in types:
-            raise ValueError("SVAR type not recognized, must be in " + str(types))
+        svar_type = string_like(
+            svar_type, "svar_type", options=("A", "B", "AB"), lower=False
+        )
         self.svar_type = svar_type
 
         svar_ckerr(svar_type, A, B)

--- a/statsmodels/tsa/vector_ar/tests/test_svar.py
+++ b/statsmodels/tsa/vector_ar/tests/test_svar.py
@@ -159,6 +159,13 @@ def test_oneparam():
     assert_allclose(results.A[0, 1], -0.075818, atol=1e-5)
 
 
+def test_invalid_svar_type_raises():
+    rs = np.random.RandomState(0)
+    y = rs.randn(50, 2)
+    with pytest.raises(ValueError, match="svar_type"):
+        SVAR(y, svar_type="invalid")
+
+
 def test_summary_no_user_exog():
     rs = np.random.RandomState(0)
     data = rs.randn(200, 3)

--- a/statsmodels/tsa/vector_ar/tests/test_var.py
+++ b/statsmodels/tsa/vector_ar/tests/test_var.py
@@ -1111,6 +1111,14 @@ def test_irf_plot_err_bands_kwarg(close_figures):
     assert fig2 is not None
 
 
+def test_irf_invalid_stderr_type_raises(bivariate_var_result):
+    irf = bivariate_var_result.irf()
+    with pytest.raises(ValueError, match="stderr_type"):
+        irf.plot(stderr_type="invalid")
+    with pytest.raises(ValueError, match="stderr_type"):
+        irf.plot_cum_effects(stderr_type="invalid")
+
+
 def test_0_lag():
     # GH 9412
     rs = np.random.RandomState(20260112)

--- a/statsmodels/tsa/vector_ar/tests/test_var.py
+++ b/statsmodels/tsa/vector_ar/tests/test_var.py
@@ -704,6 +704,21 @@ def test_var_trend():
         model.fit(4, trend="t")
 
 
+@pytest.mark.parametrize(
+    "trend,k_trend", [("c", 1), ("ct", 2), ("ctt", 3), ("n", 0)]
+)
+def test_var_fit_valid_trend(trend, k_trend):
+    data = get_macrodata().view((float, 3), type=np.ndarray)
+    results = VAR(data).fit(2, trend=trend)
+    assert results.k_trend == k_trend
+
+
+def test_var_fit_invalid_trend_raises():
+    data = get_macrodata().view((float, 3), type=np.ndarray)
+    with pytest.raises(ValueError, match="trend"):
+        VAR(data).fit(2, trend="not-a-trend")
+
+
 def test_irf_trend():
     # test for irf with different trend see #1636
     # this is a rough comparison by adding trend or subtracting mean to data

--- a/statsmodels/tsa/vector_ar/tests/test_vecm.py
+++ b/statsmodels/tsa/vector_ar/tests/test_vecm.py
@@ -1482,6 +1482,10 @@ def test_exceptions():
     with pytest.raises(ValueError):
         select_coint_rank(endog, 0, 3, "trace", 0.025)
 
+    # VECM.fit: method argument cannot be anything other than "ml"
+    with pytest.raises(ValueError, match="method"):
+        VECM(endog).fit(method="not-ml")
+
     # Granger_causality:
     # # 0<signif<1
     # this means signif=0

--- a/statsmodels/tsa/vector_ar/var_model.py
+++ b/statsmodels/tsa/vector_ar/var_model.py
@@ -25,7 +25,7 @@ from statsmodels.tools._decorators import cache_readonly
 from statsmodels.tools.linalg import logdet_symm
 from statsmodels.tools.rng_qrng import check_random_state
 from statsmodels.tools.sm_exceptions import OutputWarning
-from statsmodels.tools.validation import array_like
+from statsmodels.tools.validation import array_like, string_like
 from statsmodels.tsa.base.tsa_model import (
     TimeSeriesModel,
     TimeSeriesResultsWrapper,
@@ -723,8 +723,9 @@ class VAR(TimeSeriesModel):
         See Lütkepohl pp. 146-153 for implementation details.
         """
         lags = maxlags
-        if trend not in ["c", "ct", "ctt", "n"]:
-            raise ValueError(f"trend '{trend}' not supported for VAR")
+        trend = string_like(
+            trend, "trend", options=("c", "ct", "ctt", "n"), lower=False
+        )
 
         if ic is not None:
             selections = self.select_order(maxlags=maxlags)

--- a/statsmodels/tsa/vector_ar/vecm.py
+++ b/statsmodels/tsa/vector_ar/vecm.py
@@ -975,7 +975,7 @@ class VECM(tsbase.TimeSeriesModel):
         ----------
         .. [1] Lütkepohl, H. 2005. *New Introduction to Multiple Time Series Analysis*. Springer.
         """
-        method = string_like(method, "method", options=("ml",), lower=False)
+        _ = string_like(method, "method", options=("ml",), lower=False)
         return self._estimate_vecm_ml()
 
     def _estimate_vecm_ml(self):

--- a/statsmodels/tsa/vector_ar/vecm.py
+++ b/statsmodels/tsa/vector_ar/vecm.py
@@ -555,10 +555,7 @@ def select_coint_rank(endog, det_order, k_ar_diff, method="trace", signif=0.05):
         A :class:`CointRankResults` object containing the cointegration rank suggested
         by the test and allowing a summary to be printed.
     """
-    if method not in ["trace", "maxeig"]:
-        raise ValueError(
-            "The method argument has to be either 'trace' or'maximum eigenvalue'."
-        )
+    method = string_like(method, "method", options=("trace", "maxeig"), lower=False)
 
     if det_order not in [-1, 0, 1]:
         if type(det_order) is int and det_order > 1:
@@ -978,10 +975,8 @@ class VECM(tsbase.TimeSeriesModel):
         ----------
         .. [1] Lütkepohl, H. 2005. *New Introduction to Multiple Time Series Analysis*. Springer.
         """
-        if method == "ml":
-            return self._estimate_vecm_ml()
-        else:
-            raise ValueError("{} not recognized, must be among {}".format(method, "ml"))
+        method = string_like(method, "method", options=("ml",), lower=False)
+        return self._estimate_vecm_ml()
 
     def _estimate_vecm_ml(self):
         y_1_T, delta_y_1_T, y_lag1, delta_x = _endog_matrices(


### PR DESCRIPTION
- [X] tests added / passed.
- [x] code/documentation is well formatted.
- [x] properly formatted commit message. See
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message).

#### AI Disclosure

Contributions must comply with the statsmodels [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html).

If using AI tools, edit the second option to explain which tool was selected and
how the tool's output was used.

Please complete **one** of the following:

- [ ] No AI tools were used to develop this pull request.
- [X] AI tools were used.
      Tool(s): Claude
      Used for: Bulk checking for string literals
      I have personally read, understood, and can explain every line of this diff, and
      have verified the statistical/numerical correctness of the change.

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows
  using the Windows System for Linux once `flake8` is installed in the
  local Linux environment. While passing this test is not required, it is good practice and it help
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.
* If AI tools were used to help write this PR, see the
  [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html) for what disclosure
  and review is expected of you before submitting.

</details>
