### PR TITLE
BUG: Fix MICEData using observed-row index for predict_miss_kwds

### DIFF
--- a/statsmodels/imputation/mice.py
+++ b/statsmodels/imputation/mice.py
@@ -484,7 +484,7 @@ class MICEData:
         predict_miss_kwds = {}
         if vname in self.predict_kwds:
             kwds = self.predict_kwds[vname]
-            predict_miss_kwds = self._process_kwds(kwds, ixo)
+            predict_miss_kwds = self._process_kwds(kwds, ixm)
 
         return (endog_obs, exog_obs, exog_miss, predict_obs_kwds, predict_miss_kwds)
 

--- a/statsmodels/imputation/tests/test_mice.py
+++ b/statsmodels/imputation/tests/test_mice.py
@@ -101,6 +101,31 @@ class TestMICEData:
         assert_equal(exog_obs.shape, [190, 6])
         assert_equal(exog_miss.shape, [10, 6])
 
+    def test_split_data_predict_kwds_use_missing_rows(self):
+        # predict_miss_kwds must be subset to the rows where the variable
+        # being imputed is missing, not to the observed rows.
+        rs = np.random.RandomState(3927)
+        df = gendat()
+        imp_data = mice.MICEData(df, rng=rs)
+        imp_data.set_imputer(
+            "x3",
+            formula="x1 + x2 + x4 + x5 + y",
+            predict_kwds={"offset": mice.PatsyFormula("x5")},
+        )
+
+        ixo = imp_data.ix_obs["x3"]
+        ixm = imp_data.ix_miss["x3"]
+        x5 = np.asarray(imp_data.data["x5"])
+
+        _, exog_obs, exog_miss, predict_obs_kwds, predict_miss_kwds = (
+            imp_data.get_split_data("x3")
+        )
+
+        assert_equal(predict_obs_kwds["offset"].shape[0], exog_obs.shape[0])
+        assert_equal(predict_miss_kwds["offset"].shape[0], exog_miss.shape[0])
+        assert_allclose(predict_obs_kwds["offset"], x5[ixo])
+        assert_allclose(predict_miss_kwds["offset"], x5[ixm])
+
     def test_settingwithcopywarning(self):
         "Test that MICEData does not throw a SettingWithCopyWarning when imputing (https://github.com/statsmodels/statsmodels/issues/5430)"
         rs = np.random.RandomState(8214223)


### PR DESCRIPTION
get_split_data() subset predict_miss_kwds with ixo (observed rows) instead of ixm (missing rows), so the kwargs passed alongside the missing-row prediction were misaligned.

- [X] tests added / passed.
- [X] code/documentation is well formatted.
- [X] properly formatted commit message. See
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message).

#### AI Disclosure

Contributions must comply with the statsmodels [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html).

If using AI tools, edit the second option to explain which tool was selected and
how the tool's output was used.

Please complete **one** of the following:

- [ ] No AI tools were used to develop this pull request.
- [X] AI tools were used.
      Tool(s): Claude
      Used for: test writing
      I have personally read, understood, and can explain every line of this diff, and
      have verified the statistical/numerical correctness of the change.

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows
  using the Windows System for Linux once `flake8` is installed in the
  local Linux environment. While passing this test is not required, it is good practice and it help
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.
* If AI tools were used to help write this PR, see the
  [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html) for what disclosure
  and review is expected of you before submitting.

</details>
