### PR TITLE
BUG: Fix TreatmentEffectResults mislabeling every method as IPW

### DIFF
--- a/statsmodels/treatment/tests/test_teffects.py
+++ b/statsmodels/treatment/tests/test_teffects.py
@@ -35,6 +35,14 @@ methods = [
     ("ipw_ra", res_st.results_ipwra),
     ]
 
+method_labels = [
+    ("ra", "RA"),
+    ("ipw", "IPW"),
+    ("aipw", "AIPW"),
+    ("aipw_wls", "AIPW-WLS"),
+    ("ipw_ra", "IPW-RA"),
+    ]
+
 
 class TestTEffects:
 
@@ -48,6 +56,13 @@ class TestTEffects:
     def test_aux(self):
         prob = res_probit.predict()
         assert prob.shape == (4642,)
+
+    @pytest.mark.parametrize("case", method_labels)
+    def test_method_label(self, case):
+        # each estimator must label its own results, not report "IPW"
+        meth, label = case
+        res = getattr(self.teff, meth)(return_results=True)
+        assert res.method == label
 
     @pytest.mark.parametrize("case", methods)
     def test_effects(self, case):

--- a/statsmodels/treatment/treatment_effects.py
+++ b/statsmodels/treatment/treatment_effects.py
@@ -702,8 +702,9 @@ class TreatmentEffectResults(ContrastResults):
     results_gmm : instance of GMMResults class
         The GMM results instance used to compute the treatment effect
         parameters and their covariance.
-    method : str
-        Method and estimator of treatment effect.
+    method : {"IPW", "RA", "AIPW", "AIPW-WLS", "IPW-RA"}
+        Method and estimator of treatment effect, corresponding to the
+        ``TreatmentEffect`` method that produced the results.
     **kwds
         Other keywords with additional information.
 
@@ -999,7 +1000,7 @@ class TreatmentEffect:
                               optim_args={"maxiter": 5000, "disp": disp},
                               maxiter=1,
                               )
-        res = TreatmentEffectResults(self, res_gmm, "IPW",
+        res = TreatmentEffectResults(self, res_gmm, "RA",
                                      start_params=start_params,
                                      effect_group=effect_group,
                                      )
@@ -1041,7 +1042,7 @@ class TreatmentEffect:
             optim_args={"maxiter": 5000, "disp": disp},
             maxiter=1)
 
-        res = TreatmentEffectResults(self, res_gmm, "IPW",
+        res = TreatmentEffectResults(self, res_gmm, "AIPW",
                                      start_params=start_params,
                                      effect_group="all",
                                      )
@@ -1108,7 +1109,7 @@ class TreatmentEffect:
             optim_method="nm",
             optim_args={"maxiter": 5000, "disp": disp},
             maxiter=1)
-        res = TreatmentEffectResults(self, res_gmm, "IPW",
+        res = TreatmentEffectResults(self, res_gmm, "AIPW-WLS",
                                      start_params=start_params,
                                      effect_group="all",
                                      )
@@ -1180,7 +1181,7 @@ class TreatmentEffect:
             maxiter=1
             )
 
-        res = TreatmentEffectResults(self, res_gmm, "IPW",
+        res = TreatmentEffectResults(self, res_gmm, "IPW-RA",
                                      start_params=start_params,
                                      effect_group=effect_group,
                                      )


### PR DESCRIPTION
ra, aipw, and aipw_wls all hardcoded "IPW" as the results method label instead of their own name, so res.method was wrong for three of the five estimators.

- [X] tests added / passed.
- [X] code/documentation is well formatted.
- [X] properly formatted commit message. See
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message).

#### AI Disclosure

Contributions must comply with the statsmodels [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html).

If using AI tools, edit the second option to explain which tool was selected and
how the tool's output was used.

Please complete **one** of the following:

- [ ] No AI tools were used to develop this pull request.
- [X] AI tools were used.
      Tool(s): Claude
      Used for: test writing
      I have personally read, understood, and can explain every line of this diff, and
      have verified the statistical/numerical correctness of the change.

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows
  using the Windows System for Linux once `flake8` is installed in the
  local Linux environment. While passing this test is not required, it is good practice and it help
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.
* If AI tools were used to help write this PR, see the
  [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html) for what disclosure
  and review is expected of you before submitting.

</details>
