### PR TITLE
BUG: Guard against None zero_kwds in effectsize_2proportions

### DIFF
--- a/statsmodels/stats/meta_analysis.py
+++ b/statsmodels/stats/meta_analysis.py
@@ -512,6 +512,7 @@ def effectsize_2proportions(
         cc1 = nobs2 / nobs_t
         cc2 = nobs1 / nobs_t
     elif zero_correction == "clip":
+        zero_kwds = {} if zero_kwds is None else zero_kwds
         clip_bounds = zero_kwds.get("clip_bounds", (1e-6, 1 - 1e-6))
         cc1 = cc2 = 0
     else:

--- a/statsmodels/stats/tests/test_meta.py
+++ b/statsmodels/stats/tests/test_meta.py
@@ -79,6 +79,33 @@ class TestEffectsizeBinom:
         assert_allclose(var_eff, res2.v_as, rtol=1e-13)
 
 
+def test_effectsize_2proportions_clip_default_zero_kwds():
+    # zero_correction="clip" must use the documented default clip bounds
+    # when zero_kwds is not provided
+    count1 = np.array([0, 5, 10])
+    nobs1 = np.array([20, 20, 20])
+    count2 = np.array([3, 20, 8])
+    nobs2 = np.array([20, 20, 20])
+
+    eff, var_eff = effectsize_2proportions(
+        count1, nobs1, count2, nobs2, statistic="or", zero_correction="clip"
+    )
+    assert np.all(np.isfinite(eff))
+    assert np.all(np.isfinite(var_eff))
+
+    eff2, var_eff2 = effectsize_2proportions(
+        count1,
+        nobs1,
+        count2,
+        nobs2,
+        statistic="or",
+        zero_correction="clip",
+        zero_kwds={"clip_bounds": (1e-6, 1 - 1e-6)},
+    )
+    assert_allclose(eff, eff2, rtol=1e-13)
+    assert_allclose(var_eff, var_eff2, rtol=1e-13)
+
+
 class TestEffSmdMeta:
 
     @classmethod


### PR DESCRIPTION
zero_correction="clip" called zero_kwds.get(...) without defaulting zero_kwds to {} first, raising AttributeError when it was left at its None default.


- [X] tests added / passed.
- [X] code/documentation is well formatted.
- [X] properly formatted commit message. See
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message).

#### AI Disclosure

Contributions must comply with the statsmodels [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html).

If using AI tools, edit the second option to explain which tool was selected and
how the tool's output was used.

Please complete **one** of the following:

- [ ] No AI tools were used to develop this pull request.
- [X] AI tools were used.
      Tool(s): Claude
      Used for: test writing
      I have personally read, understood, and can explain every line of this diff, and
      have verified the statistical/numerical correctness of the change.

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows
  using the Windows System for Linux once `flake8` is installed in the
  local Linux environment. While passing this test is not required, it is good practice and it help
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.
* If AI tools were used to help write this PR, see the
  [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html) for what disclosure
  and review is expected of you before submitting.

</details>
