### PR TITLE
ENH: Simplify aliases

### DIFF
--- a/statsmodels/base/_prediction_inference.py
+++ b/statsmodels/base/_prediction_inference.py
@@ -73,17 +73,27 @@ class PredictionResultsBase:
             the attribute of the instance, specified in `__init__`. Default
             if not specified is the normal distribution.
         """
+        alternative = string_like(
+            alternative,
+            "alternative",
+            options=("two-sided", "larger", "smaller"),
+            lower=False,
+            deprecated={
+                "2-sided": "two-sided",
+                "2s": "two-sided",
+                "l": "larger",
+                "s": "smaller",
+            },
+        )
         # assumes symmetric distribution
         stat = (self.predicted - value) / self.se
 
-        if alternative in ["two-sided", "2-sided", "2s"]:
+        if alternative == "two-sided":
             pvalue = self.dist.sf(np.abs(stat), *self.dist_args) * 2
-        elif alternative in ["larger", "l"]:
+        elif alternative == "larger":
             pvalue = self.dist.sf(stat, *self.dist_args)
-        elif alternative in ["smaller", "s"]:
+        elif alternative == "smaller":
             pvalue = self.dist.cdf(stat, *self.dist_args)
-        else:
-            raise ValueError("invalid alternative")
         return stat, pvalue
 
     def _conf_int_generic(self, center, se, alpha, dist_args=None):

--- a/statsmodels/regression/tests/test_predict.py
+++ b/statsmodels/regression/tests/test_predict.py
@@ -318,8 +318,16 @@ def test_prediction_results_t_test():
     # statistic, by definition
     assert_allclose(pvalue_s, 1 - pvalue_l, atol=1e-10)
 
-    with pytest.raises(ValueError, match="invalid alternative"):
+    with pytest.raises(ValueError, match="alternative must be one of"):
         pred.t_test(alternative="not-a-real-option")
+
+    # undocumented short forms still work but warn, and are equivalent to
+    # spelling out the documented alternative
+    for alias, canonical in [("2s", "two-sided"), ("l", "larger"), ("s", "smaller")]:
+        with pytest.warns(FutureWarning, match="is a deprecated alias"):
+            alias_result = pred.t_test(value=1.0, alternative=alias)
+        canonical_result = pred.t_test(value=1.0, alternative=canonical)
+        assert_allclose(alias_result, canonical_result)
 
     # GLM defaults to use_t=False -> normal reference distribution
     assert pred.dist is sp_stats.norm

--- a/statsmodels/stats/diagnostic.py
+++ b/statsmodels/stats/diagnostic.py
@@ -1394,23 +1394,35 @@ def het_goldfeldquandt(
         y = y[xsortind]
         x = x[xsortind, :]
 
+    alternative = string_like(
+        alternative,
+        "alternative",
+        options=("increasing", "decreasing", "two-sided"),
+        lower=True,
+        deprecated={
+            "i": "increasing",
+            "inc": "increasing",
+            "d": "decreasing",
+            "dec": "decreasing",
+            "2": "two-sided",
+            "2-sided": "two-sided",
+        },
+    )
     resols1 = OLS(y[:split], x[:split]).fit()
     resols2 = OLS(y[start2:], x[start2:]).fit()
     fval = resols2.mse_resid / resols1.mse_resid
     # if fval>1:
-    if alternative.lower() in ["i", "inc", "increasing"]:
+    if alternative == "increasing":
         fpval = stats.f.sf(fval, resols1.df_resid, resols2.df_resid)
         ordering = "increasing"
-    elif alternative.lower() in ["d", "dec", "decreasing"]:
+    elif alternative == "decreasing":
         fpval = stats.f.sf(1.0 / fval, resols2.df_resid, resols1.df_resid)
         ordering = "decreasing"
-    elif alternative.lower() in ["2", "2-sided", "two-sided"]:
+    elif alternative == "two-sided":
         fpval_sm = stats.f.cdf(fval, resols2.df_resid, resols1.df_resid)
         fpval_la = stats.f.sf(fval, resols2.df_resid, resols1.df_resid)
         fpval = 2 * min(fpval_sm, fpval_la)
         ordering = "two-sided"
-    else:
-        raise ValueError("invalid alternative")
 
     if store:
         res = ResultsStore()

--- a/statsmodels/stats/oneway.py
+++ b/statsmodels/stats/oneway.py
@@ -459,11 +459,15 @@ def confint_noncentrality(f_stat, df, alpha=0.05, alternative="two-sided"):
     """
 
     df1, df2 = df
-    if alternative in ["two-sided", "2s", "ts"]:
-        alpha1s = alpha / 2
-        ci = ncfdtrinc(df1, df2, [1 - alpha1s, alpha1s], f_stat)
-    else:
-        raise NotImplementedError
+    alternative = string_like(
+        alternative,
+        "alternative",
+        options=("two-sided",),
+        lower=False,
+        deprecated={"2s": "two-sided", "ts": "two-sided"},
+    )
+    alpha1s = alpha / 2
+    ci = ncfdtrinc(df1, df2, [1 - alpha1s, alpha1s], f_stat)
 
     return ci
 

--- a/statsmodels/stats/power.py
+++ b/statsmodels/stats/power.py
@@ -39,6 +39,12 @@ from scipy import optimize, special, stats
 
 from statsmodels.graphics.utils import _import_mpl
 from statsmodels.tools.rootfinding import brentq_expanding
+from statsmodels.tools.validation import string_like
+
+# Undocumented short form accepted for backwards compatibility by
+# ttest_power, normal_power and normal_power_het. Deprecated in favor of
+# the documented spelling.
+_ALTERNATIVE_ALIASES = {"2s": "two-sided"}
 
 
 def nct_cdf(x, df, nc):
@@ -93,17 +99,20 @@ def ttest_power(effect_size, nobs, alpha, df=None, alternative="two-sided"):
     if df is None:
         df = nobs - 1
 
-    if alternative in ["two-sided", "2s"]:
+    alternative = string_like(
+        alternative,
+        "alternative",
+        options=("two-sided", "larger", "smaller"),
+        lower=False,
+        deprecated=_ALTERNATIVE_ALIASES,
+    )
+    if alternative == "two-sided":
         alpha_ = alpha / 2.0  # no inplace changes, does not work
-    elif alternative in ["smaller", "larger"]:
-        alpha_ = alpha
     else:
-        raise ValueError(
-            "alternative has to be 'two-sided', 'larger' " + "or 'smaller'"
-        )
+        alpha_ = alpha
 
     pow_ = 0
-    if alternative in ["two-sided", "2s", "larger"]:
+    if alternative in ["two-sided", "larger"]:
         crit_upp = stats.t.isf(alpha_, df)
         # print crit_upp, df, d*np.sqrt(nobs)
         # use private methods, generic methods return nan with negative d
@@ -114,7 +123,7 @@ def ttest_power(effect_size, nobs, alpha, df=None, alternative="two-sided"):
             # pow_ = stats.nct._sf(crit_upp, df, d*np.sqrt(nobs))
             # use scipy.special
             pow_ = nct_sf(crit_upp, df, d * np.sqrt(nobs))
-    if alternative in ["two-sided", "2s", "smaller"]:
+    if alternative in ["two-sided", "smaller"]:
         crit_low = stats.t.ppf(alpha_, df)
         # print crit_low, df, d*np.sqrt(nobs)
         if np.any(np.isnan(crit_low)):
@@ -156,20 +165,23 @@ def normal_power(effect_size, nobs, alpha, alternative="two-sided", sigma=1.0):
 
     d = effect_size
 
-    if alternative in ["two-sided", "2s"]:
+    alternative = string_like(
+        alternative,
+        "alternative",
+        options=("two-sided", "larger", "smaller"),
+        lower=False,
+        deprecated=_ALTERNATIVE_ALIASES,
+    )
+    if alternative == "two-sided":
         alpha_ = alpha / 2.0  # no inplace changes, does not work
-    elif alternative in ["smaller", "larger"]:
-        alpha_ = alpha
     else:
-        raise ValueError(
-            "alternative has to be 'two-sided', 'larger' " + "or 'smaller'"
-        )
+        alpha_ = alpha
 
     pow_ = 0
-    if alternative in ["two-sided", "2s", "larger"]:
+    if alternative in ["two-sided", "larger"]:
         crit = stats.norm.isf(alpha_)
         pow_ = stats.norm.sf(crit - d * np.sqrt(nobs) / sigma)
-    if alternative in ["two-sided", "2s", "smaller"]:
+    if alternative in ["two-sided", "smaller"]:
         crit = stats.norm.ppf(alpha_)
         pow_ += stats.norm.cdf(crit - d * np.sqrt(nobs) / sigma)
     return pow_
@@ -217,21 +229,24 @@ def normal_power_het(
     if std_alternative is None:
         std_alternative = std_null
 
-    if alternative in ["two-sided", "2s"]:
+    alternative = string_like(
+        alternative,
+        "alternative",
+        options=("two-sided", "larger", "smaller"),
+        lower=False,
+        deprecated=_ALTERNATIVE_ALIASES,
+    )
+    if alternative == "two-sided":
         alpha_ = alpha / 2.0  # no inplace changes, does not work
-    elif alternative in ["smaller", "larger"]:
-        alpha_ = alpha
     else:
-        raise ValueError(
-            "alternative has to be 'two-sided', 'larger' " + "or 'smaller'"
-        )
+        alpha_ = alpha
 
     std_ratio = std_null / std_alternative
     pow_ = 0
-    if alternative in ["two-sided", "2s", "larger"]:
+    if alternative in ["two-sided", "larger"]:
         crit = stats.norm.isf(alpha_)
         pow_ = stats.norm.sf(crit * std_ratio - d * np.sqrt(nobs) / std_alternative)
-    if alternative in ["two-sided", "2s", "smaller"]:
+    if alternative in ["two-sided", "smaller"]:
         crit = stats.norm.ppf(alpha_)
         pow_ += stats.norm.cdf(crit * std_ratio - d * np.sqrt(nobs) / std_alternative)
     return pow_

--- a/statsmodels/stats/proportion.py
+++ b/statsmodels/stats/proportion.py
@@ -844,7 +844,7 @@ def binom_test_reject_interval(value, nobs, alpha=0.05, alternative="two-sided")
         the number of trials or observations.
     alpha : float, optional
         Significance level of the test, default 0.05.
-    alternative : str in ['two-sided', 'smaller', 'larger'], optional
+    alternative : {'two-sided', 'smaller', 'larger'}, optional
         alternative hypothesis, which can be two-sided or either one of the
         one-sided tests.
 
@@ -853,15 +853,21 @@ def binom_test_reject_interval(value, nobs, alpha=0.05, alternative="two-sided")
     x_low, x_upp : int
         lower and upper bound of rejection region
     """
-    if alternative in ["2s", "two-sided"]:
-        alternative = "2s"  # normalize alternative name
+    alternative = string_like(
+        alternative,
+        "alternative",
+        options=("two-sided", "larger", "smaller"),
+        lower=False,
+        deprecated={"2s": "two-sided"},
+    )
+    if alternative == "two-sided":
         alpha = alpha / 2
 
-    if alternative in ["2s", "smaller"]:
+    if alternative in ["two-sided", "smaller"]:
         x_low = stats.binom.ppf(alpha, nobs, value) - 1
     else:
         x_low = 0
-    if alternative in ["2s", "larger"]:
+    if alternative in ["two-sided", "larger"]:
         x_upp = stats.binom.isf(alpha, nobs, value) + 1
     else:
         x_upp = nobs
@@ -886,7 +892,7 @@ def binom_test(count, nobs, prop=0.5, alternative="two-sided"):
     prop : float, optional
         The probability of success under the null hypothesis,
         `0 <= prop <= 1`. The default value is `prop = 0.5`
-    alternative : str in ['two-sided', 'smaller', 'larger'], optional
+    alternative : {'two-sided', 'smaller', 'larger'}, optional
         alternative hypothesis, which can be two-sided or either one of the
         one-sided tests.
 
@@ -902,16 +908,19 @@ def binom_test(count, nobs, prop=0.5, alternative="two-sided"):
 
     if np.any(prop > 1.0) or np.any(prop < 0.0):
         raise ValueError("p must be in range [0,1]")
-    if alternative in ["2s", "two-sided"]:
+    alternative = string_like(
+        alternative,
+        "alternative",
+        options=("two-sided", "larger", "smaller"),
+        lower=False,
+        deprecated={"2s": "two-sided", "l": "larger", "s": "smaller"},
+    )
+    if alternative == "two-sided":
         pval = stats.binomtest(count, n=nobs, p=prop).pvalue
-    elif alternative in ["l", "larger"]:
+    elif alternative == "larger":
         pval = stats.binom.sf(count - 1, nobs, prop)
-    elif alternative in ["s", "smaller"]:
+    elif alternative == "smaller":
         pval = stats.binom.cdf(count, nobs, prop)
-    else:
-        raise ValueError(
-            "alternative not recognized\nshould be two-sided, larger or smaller"
-        )
     return pval
 
 
@@ -1102,7 +1111,7 @@ def proportions_ztest(count, nobs, value=None, alternative="two-sided", prop_var
         null hypothesis is that prop[0] - prop[1] = value, where prop is the
         proportion in the two samples. If not provided value = 0 and the null
         is prop[0] = prop[1]
-    alternative : str in ['two-sided', 'smaller', 'larger'], optional
+    alternative : {'two-sided', 'smaller', 'larger'}, optional
         The alternative hypothesis can be either two-sided or one of the one-
         sided tests, smaller means that the alternative hypothesis is
         ``prop < value`` and larger means ``prop > value``. In the two sample
@@ -1366,7 +1375,7 @@ def proportions_chisquare_pairscontrol(
         that is used as default in the results.
         It can be any method that is available in  ``multipletesting``.
         The default is Holm-Sidak 'hs'.
-    alternative : str in ['two-sided', 'smaller', 'larger'], optional
+    alternative : {'two-sided', 'smaller', 'larger'}, optional
         alternative hypothesis, which can be two-sided or either one of the
         one-sided tests.
 
@@ -1383,7 +1392,14 @@ def proportions_chisquare_pairscontrol(
 
     ``value`` and ``alternative`` options are not yet implemented.
     """
-    if (value is not None) or (alternative not in ["two-sided", "2s"]):
+    _ = string_like(
+        alternative,
+        "alternative",
+        options=("two-sided",),
+        lower=False,
+        deprecated={"2s": "two-sided"},
+    )
+    if value is not None:
         raise NotImplementedError
     # all_pairs = lmap(list, lzip(*np.triu_indices(4, 1)))
     all_pairs = [(0, k) for k in range(1, len(count))]
@@ -1683,7 +1699,7 @@ class ScoreTestProportionsResult(LimitedIterationMixin[float]):
         Method used to compute the test, always ``"score"``.
     variance : float
         Estimated variance of the test statistic under the null hypothesis.
-    alternative : str
+    alternative : {'two-sided', 'smaller', 'larger'}
         The alternative hypothesis used for the test.
     prop1_null : float
         Constrained estimate of the first proportion under the null
@@ -1897,7 +1913,7 @@ class Proportions2indepTestResult(LimitedIterationMixin[float]):
         Observed odds ratio.
     variance : float
         Estimated variance of the test statistic under the null hypothesis.
-    alternative : str
+    alternative : {'two-sided', 'smaller', 'larger'}
         The alternative hypothesis used for the test.
     value : float
         Value of the difference, risk ratio or odds ratio under the null
@@ -2619,7 +2635,14 @@ def samplesize_proportions_2indep_onetail(
     # TODO: avoid possible circular import, check if needed
     from statsmodels.stats.power import normal_sample_size_one_tail
 
-    if alternative in ["two-sided", "2s"]:
+    alternative = string_like(
+        alternative,
+        "alternative",
+        options=("two-sided", "larger", "smaller"),
+        lower=False,
+        deprecated={"2s": "two-sided"},
+    )
+    if alternative == "two-sided":
         alpha = alpha / 2
 
     _, std_null, std_alt = _std_2prop_power(

--- a/statsmodels/stats/rates.py
+++ b/statsmodels/stats/rates.py
@@ -1217,6 +1217,18 @@ def etest_poisson_2indep(
     for the Difference of Two Poisson Means.” Computational Statistics & Data
     Analysis 51 (6): 3085-99. https://doi.org/10.1016/j.csda.2006.02.004.
     """
+    alternative = string_like(
+        alternative,
+        "alternative",
+        options=("two-sided", "larger", "smaller"),
+        lower=False,
+        deprecated={
+            "2-sided": "two-sided",
+            "2s": "two-sided",
+            "l": "larger",
+            "s": "smaller",
+        },
+    )
     y1, n1, y2, n2 = (
         np.asarray(count1),
         np.asarray(exposure1),
@@ -1310,14 +1322,12 @@ def etest_poisson_2indep(
     stat_space = stat_func(y_grid[:, None], y_grid[None, :])  # broadcasting
     eps = 1e-15  # correction for strict inequality check
 
-    if alternative in ["two-sided", "2-sided", "2s"]:
+    if alternative == "two-sided":
         mask = np.abs(stat_space) >= (np.abs(stat_sample) - eps)
-    elif alternative in ["larger", "l"]:
+    elif alternative == "larger":
         mask = stat_space >= (stat_sample - eps)
-    elif alternative in ["smaller", "s"]:
+    elif alternative == "smaller":
         mask = stat_space <= (stat_sample + eps)
-    else:
-        raise ValueError("invalid alternative")
 
     pvalue = ((pdf1[:, None] * pdf2[None, :])[mask]).sum()
     return stat_sample, pvalue

--- a/statsmodels/stats/tests/test_diagnostic.py
+++ b/statsmodels/stats/tests/test_diagnostic.py
@@ -2286,3 +2286,30 @@ def test_het_goldfeldquandt_result_object(diagnostic_namedtuple_data):
         result = smsdia.het_goldfeldquandt(y, x, store=True, result_object=True)
     assert isinstance(result, smsdia.GoldfeldQuandtResult)
     assert isinstance(result.res_store, smsdia.ResultsStore)
+
+
+@pytest.mark.parametrize(
+    "alias,canonical", [("i", "increasing"), ("d", "decreasing"), ("2", "two-sided")]
+)
+def test_het_goldfeldquandt_alternative_deprecated_alias(
+    diagnostic_namedtuple_data, alias, canonical
+):
+    # undocumented short forms still work but warn, and are equivalent to
+    # spelling out the documented alternative
+    res = diagnostic_namedtuple_data.res
+    y = res.model.endog
+    x = res.model.exog
+
+    with pytest.warns(FutureWarning, match="is a deprecated alias"):
+        alias_result = smsdia.het_goldfeldquandt(
+            y, x, alternative=alias, result_object=True
+        )
+    with warnings.catch_warnings():
+        warnings.filterwarnings("error", category=FutureWarning)
+        canonical_result = smsdia.het_goldfeldquandt(
+            y, x, alternative=canonical, result_object=True
+        )
+    assert alias_result == canonical_result
+
+    with pytest.raises(ValueError, match="alternative must be one of"):
+        smsdia.het_goldfeldquandt(y, x, alternative="bogus", result_object=True)

--- a/statsmodels/stats/tests/test_oneway.py
+++ b/statsmodels/stats/tests/test_oneway.py
@@ -827,3 +827,19 @@ def test_simulate_equivalence():
     ]
     # regression test numbers
     assert_allclose(pow_, [0.147749, 0.173358, 0.177412], atol=0.007)
+
+
+def test_confint_noncentrality_alternative():
+    f_stat, df = 5.0, (2, 30)
+    # undocumented "2s"/"ts" aliases still work but warn
+    for alias in ("2s", "ts"):
+        with pytest.warns(FutureWarning, match="is a deprecated alias"):
+            ci_alias = confint_noncentrality(f_stat, df, alternative=alias)
+        ci = confint_noncentrality(f_stat, df, alternative="two-sided")
+        assert_allclose(ci_alias, ci)
+
+    # only "two-sided" is implemented; "larger"/"smaller" must still raise,
+    # now as a ValueError from the shared alternative validation rather
+    # than a NotImplementedError
+    with pytest.raises(ValueError, match="alternative must be one of"):
+        confint_noncentrality(f_stat, df, alternative="larger")

--- a/statsmodels/stats/tests/test_power.py
+++ b/statsmodels/stats/tests/test_power.py
@@ -1111,3 +1111,24 @@ def test_normal_sample_size_one_tail():
     nobs_with_zeros = smp.normal_sample_size_one_tail(5, powers, alphas, 2, 2)
     # check_nans = np.isnan(zero_mask) == np.isnan(nobs_with_nans)
     assert_array_equal(nobs_with_zeros[powers <= alphas], 0)
+
+
+@pytest.mark.parametrize(
+    "power_func",
+    [
+        lambda alternative: smp.ttest_power(0.5, 20, 0.05, alternative=alternative),
+        lambda alternative: smp.normal_power(0.5, 20, 0.05, alternative=alternative),
+        lambda alternative: smp.normal_power_het(0.5, 20, 0.05, alternative=alternative),
+    ],
+    ids=["ttest_power", "normal_power", "normal_power_het"],
+)
+def test_alternative_deprecated_alias(power_func):
+    # the undocumented "2s" short form still works but warns, and is
+    # equivalent to spelling out "two-sided"
+    with pytest.warns(FutureWarning, match="is a deprecated alias"):
+        power_alias = power_func("2s")
+    power_canonical = power_func("two-sided")
+    assert power_alias == power_canonical
+
+    with pytest.raises(ValueError, match="alternative must be one of"):
+        power_func("bogus")

--- a/statsmodels/stats/tests/test_proportion.py
+++ b/statsmodels/stats/tests/test_proportion.py
@@ -1417,3 +1417,59 @@ def test_proportion_confint_binom_test(count, nobs, alpha, alternative, expected
         count, nobs, alpha=alpha, method="binom_test", alternative=alternative
     )
     assert_allclose(np.array([ci_low, ci_upp]), np.array(expected), rtol=rtol)
+
+
+def test_binom_test_alternative_deprecated_alias():
+    # undocumented short forms still work but warn, and are equivalent to
+    # spelling out the documented alternative
+    with pytest.warns(FutureWarning, match="is a deprecated alias"):
+        pval_alias = smprop.binom_test(5, 10, prop=0.3, alternative="2s")
+    pval = smprop.binom_test(5, 10, prop=0.3, alternative="two-sided")
+    assert pval_alias == pval
+
+    with pytest.warns(FutureWarning, match="is a deprecated alias"):
+        pval_alias = smprop.binom_test(5, 10, prop=0.3, alternative="l")
+    pval = smprop.binom_test(5, 10, prop=0.3, alternative="larger")
+    assert pval_alias == pval
+
+    with pytest.raises(ValueError, match="alternative must be one of"):
+        smprop.binom_test(5, 10, prop=0.3, alternative="bogus")
+
+
+def test_binom_test_reject_interval_alternative():
+    # undocumented "2s" alias still works but warns
+    with pytest.warns(FutureWarning, match="is a deprecated alias"):
+        alias_interval = smprop.binom_test_reject_interval(0.3, 10, alternative="2s")
+    interval = smprop.binom_test_reject_interval(0.3, 10, alternative="two-sided")
+    assert alias_interval == interval
+
+    # previously a garbage value silently behaved like an unbounded,
+    # always-reject interval instead of raising
+    with pytest.raises(ValueError, match="alternative must be one of"):
+        smprop.binom_test_reject_interval(0.3, 10, alternative="bogus")
+
+
+def test_samplesize_proportions_2indep_onetail_alternative():
+    with pytest.warns(FutureWarning, match="is a deprecated alias"):
+        nobs_alias = samplesize_proportions_2indep_onetail(
+            0.1, 0.3, 0.8, alternative="2s"
+        )
+    nobs = samplesize_proportions_2indep_onetail(0.1, 0.3, 0.8, alternative="two-sided")
+    assert nobs_alias == nobs
+
+    # previously a garbage value was silently treated as one-sided instead
+    # of raising
+    with pytest.raises(ValueError, match="alternative must be one of"):
+        samplesize_proportions_2indep_onetail(0.1, 0.3, 0.8, alternative="bogus")
+
+
+def test_proportions_chisquare_pairscontrol_alternative():
+    count = np.array([20, 18, 15, 12])
+    nobs = np.array([50, 50, 50, 50])
+    with pytest.warns(FutureWarning, match="is a deprecated alias"):
+        smprop.proportions_chisquare_pairscontrol(count, nobs, alternative="2s")
+
+    # "larger"/"smaller" are not implemented for this function and must
+    # continue to raise, now via the shared alternative validation
+    with pytest.raises(ValueError, match="alternative must be one of"):
+        smprop.proportions_chisquare_pairscontrol(count, nobs, alternative="larger")

--- a/statsmodels/stats/tests/test_rates_poisson.py
+++ b/statsmodels/stats/tests/test_rates_poisson.py
@@ -1508,3 +1508,20 @@ def test_power_2indep_invalid_method_var_raises():
             rate1=2, rate2=1, nobs1=20, low=0.5, upp=2,
             method_var="not-a-method-var",
         )
+
+
+@pytest.mark.parametrize(
+    "alias,canonical", [("2s", "two-sided"), ("l", "larger"), ("s", "smaller")]
+)
+def test_etest_poisson_2indep_alternative_deprecated_alias(alias, canonical):
+    # undocumented short forms still work but warn, and are equivalent to
+    # spelling out the documented alternative
+    with pytest.warns(FutureWarning, match="is a deprecated alias"):
+        alias_result = etest_poisson_2indep(60, 51477.5, 30, 54308.7, alternative=alias)
+    canonical_result = etest_poisson_2indep(
+        60, 51477.5, 30, 54308.7, alternative=canonical
+    )
+    assert alias_result == canonical_result
+
+    with pytest.raises(ValueError, match="alternative must be one of"):
+        etest_poisson_2indep(60, 51477.5, 30, 54308.7, alternative="bogus")

--- a/statsmodels/stats/tests/test_weightstats.py
+++ b/statsmodels/stats/tests/test_weightstats.py
@@ -876,3 +876,32 @@ def test_invalid_usevar_raises():
     # zconfint only implements "pooled", unlike the other five
     with pytest.raises(ValueError, match="usevar"):
         zconfint(x1, x2, usevar="unequal")
+
+
+@pytest.mark.parametrize(
+    "alias,canonical",
+    [("2-sided", "two-sided"), ("2s", "two-sided"), ("l", "larger"), ("s", "smaller")],
+)
+def test_alternative_deprecated_alias(alias, canonical):
+    # undocumented short forms accepted by the shared _*stat_generic /
+    # _*confint_generic helpers still work but warn, and are equivalent to
+    # spelling out the documented alternative
+    x1 = [1, 2, 3, 4, 5, 6, 2, 4, 6, 8]
+
+    with pytest.warns(FutureWarning, match="is a deprecated alias"):
+        stat_alias, pval_alias = ztest(x1, value=3, alternative=alias)
+    stat, pval = ztest(x1, value=3, alternative=canonical)
+    assert stat_alias == stat
+    assert pval_alias == pval
+
+    with pytest.warns(FutureWarning, match="is a deprecated alias"):
+        low_alias, upp_alias = zconfint(x1, alternative=alias)
+    low, upp = zconfint(x1, alternative=canonical)
+    assert low_alias == low
+    assert upp_alias == upp
+
+
+def test_alternative_invalid():
+    x1 = [1, 2, 3, 4, 5, 6, 2, 4, 6, 8]
+    with pytest.raises(ValueError, match="alternative must be one of"):
+        ztest(x1, value=3, alternative="bogus")

--- a/statsmodels/stats/weightstats.py
+++ b/statsmodels/stats/weightstats.py
@@ -35,6 +35,16 @@ from scipy import stats
 from statsmodels.tools._decorators import cache_readonly
 from statsmodels.tools.validation import string_like
 
+# Undocumented short forms accepted for backwards compatibility by
+# _tstat_generic, _tconfint_generic, _zstat_generic, _zstat_generic2 and
+# _zconfint_generic. Deprecated in favor of the documented spellings.
+_ALTERNATIVE_ALIASES = {
+    "2-sided": "two-sided",
+    "2s": "two-sided",
+    "l": "larger",
+    "s": "smaller",
+}
+
 
 class DescrStatsW:
     """
@@ -657,15 +667,20 @@ def _tstat_generic(value1, value2, std_diff, dof, alternative, diff=0):
         t-distributed with ``df`` degrees of freedom.
     """
 
+    alternative = string_like(
+        alternative,
+        "alternative",
+        options=("two-sided", "larger", "smaller"),
+        lower=False,
+        deprecated=_ALTERNATIVE_ALIASES,
+    )
     tstat = (value1 - value2 - diff) / std_diff
-    if alternative in ["two-sided", "2-sided", "2s"]:
+    if alternative == "two-sided":
         pvalue = stats.t.sf(np.abs(tstat), dof) * 2
-    elif alternative in ["larger", "l"]:
+    elif alternative == "larger":
         pvalue = stats.t.sf(tstat, dof)
-    elif alternative in ["smaller", "s"]:
+    elif alternative == "smaller":
         pvalue = stats.t.cdf(tstat, dof)
-    else:
-        raise ValueError("invalid alternative")
     return tstat, pvalue
 
 
@@ -702,20 +717,25 @@ def _tconfint_generic(mean, std_mean, dof, alpha, alternative):
         "larger".
     """
 
-    if alternative in ["two-sided", "2-sided", "2s"]:
+    alternative = string_like(
+        alternative,
+        "alternative",
+        options=("two-sided", "larger", "smaller"),
+        lower=False,
+        deprecated=_ALTERNATIVE_ALIASES,
+    )
+    if alternative == "two-sided":
         tcrit = stats.t.ppf(1 - alpha / 2.0, dof)
         lower = mean - tcrit * std_mean
         upper = mean + tcrit * std_mean
-    elif alternative in ["larger", "l"]:
+    elif alternative == "larger":
         tcrit = stats.t.ppf(alpha, dof)
         lower = mean + tcrit * std_mean
         upper = np.inf
-    elif alternative in ["smaller", "s"]:
+    elif alternative == "smaller":
         tcrit = stats.t.ppf(1 - alpha, dof)
         lower = -np.inf
         upper = mean + tcrit * std_mean
-    else:
-        raise ValueError("invalid alternative")
 
     return lower, upper
 
@@ -756,15 +776,20 @@ def _zstat_generic(value1, value2, std_diff, alternative, diff=0):
         t-distributed with ``df`` degrees of freedom.
     """
 
+    alternative = string_like(
+        alternative,
+        "alternative",
+        options=("two-sided", "larger", "smaller"),
+        lower=False,
+        deprecated=_ALTERNATIVE_ALIASES,
+    )
     zstat = (value1 - value2 - diff) / std_diff
-    if alternative in ["two-sided", "2-sided", "2s"]:
+    if alternative == "two-sided":
         pvalue = stats.norm.sf(np.abs(zstat)) * 2
-    elif alternative in ["larger", "l"]:
+    elif alternative == "larger":
         pvalue = stats.norm.sf(zstat)
-    elif alternative in ["smaller", "s"]:
+    elif alternative == "smaller":
         pvalue = stats.norm.cdf(zstat)
-    else:
-        raise ValueError("invalid alternative")
     return zstat, pvalue
 
 
@@ -799,15 +824,20 @@ def _zstat_generic2(value, std, alternative):
         normally distributed.
     """
 
+    alternative = string_like(
+        alternative,
+        "alternative",
+        options=("two-sided", "larger", "smaller"),
+        lower=False,
+        deprecated=_ALTERNATIVE_ALIASES,
+    )
     zstat = value / std
-    if alternative in ["two-sided", "2-sided", "2s"]:
+    if alternative == "two-sided":
         pvalue = stats.norm.sf(np.abs(zstat)) * 2
-    elif alternative in ["larger", "l"]:
+    elif alternative == "larger":
         pvalue = stats.norm.sf(zstat)
-    elif alternative in ["smaller", "s"]:
+    elif alternative == "smaller":
         pvalue = stats.norm.cdf(zstat)
-    else:
-        raise ValueError("invalid alternative")
     return zstat, pvalue
 
 
@@ -842,20 +872,25 @@ def _zconfint_generic(mean, std_mean, alpha, alternative):
         "larger".
     """
 
-    if alternative in ["two-sided", "2-sided", "2s"]:
+    alternative = string_like(
+        alternative,
+        "alternative",
+        options=("two-sided", "larger", "smaller"),
+        lower=False,
+        deprecated=_ALTERNATIVE_ALIASES,
+    )
+    if alternative == "two-sided":
         zcrit = stats.norm.ppf(1 - alpha / 2.0)
         lower = mean - zcrit * std_mean
         upper = mean + zcrit * std_mean
-    elif alternative in ["larger", "l"]:
+    elif alternative == "larger":
         zcrit = stats.norm.ppf(alpha)
         lower = mean + zcrit * std_mean
         upper = np.inf
-    elif alternative in ["smaller", "s"]:
+    elif alternative == "smaller":
         zcrit = stats.norm.ppf(1 - alpha)
         lower = -np.inf
         upper = mean + zcrit * std_mean
-    else:
-        raise ValueError("invalid alternative")
 
     return lower, upper
 

--- a/statsmodels/tools/validation/tests/test_validation.py
+++ b/statsmodels/tools/validation/tests/test_validation.py
@@ -348,6 +348,46 @@ def test_optional_string():
         string_like(b"4", "value", optional=True)
 
 
+def test_string_deprecated_alias():
+    # a value matching a key of `deprecated` is accepted and normalized to
+    # its replacement, but warns
+    with pytest.warns(
+        FutureWarning,
+        match=r"value='old' is a deprecated alias for value='new'",
+    ):
+        out = string_like(
+            "old", "value", options=("new", "other"), deprecated={"old": "new"}
+        )
+    assert out == "new"
+
+    # documented options are unaffected and never warn
+    out = string_like(
+        "new", "value", options=("new", "other"), deprecated={"old": "new"}
+    )
+    assert out == "new"
+
+    # a value that is neither a documented option nor a deprecated alias
+    # still raises, and the message lists both
+    with pytest.raises(
+        ValueError,
+        match=r"value must be one of: 'new', 'other', 'old'",
+    ):
+        string_like(
+            "bogus", "value", options=("new", "other"), deprecated={"old": "new"}
+        )
+
+    # lower= still applies before matching against options and deprecated
+    with pytest.warns(FutureWarning, match="is a deprecated alias"):
+        out = string_like(
+            "OLD",
+            "value",
+            options=("new", "other"),
+            lower=True,
+            deprecated={"old": "new"},
+        )
+    assert out == "new"
+
+
 @pytest.fixture(params=(1.0, 1.1, np.float32(1.2), np.array([1.2]), 1.2 + 0j))
 def floating(request):
     return request.param

--- a/statsmodels/tools/validation/validation.py
+++ b/statsmodels/tools/validation/validation.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from typing import Any
+import warnings
 
 import numpy as np
 import pandas as pd
@@ -421,7 +422,9 @@ def float_like(value, name, optional=False, strict=False):
     )
 
 
-def string_like(value, name, optional=False, options=None, lower=True):
+def string_like(
+    value, name, optional=False, options=None, lower=True, deprecated=None
+):
     """
     Check if object is string-like and raise if not
 
@@ -437,18 +440,26 @@ def string_like(value, name, optional=False, options=None, lower=True):
         Allowed values for input parameter `value`.
     lower : bool, optional
         Convert all case-based characters in `value` into lowercase.
+    deprecated : dict[str, str], optional
+        Mapping from a deprecated, undocumented spelling of an option to
+        the documented value in `options` it stands for. A `value`
+        matching one of these deprecated spellings is still accepted and
+        normalized to its replacement, but raises a ``FutureWarning``.
+        Ignored if `options` is None.
 
     Returns
     -------
     str
-        The validated input
+        The validated input, normalized to its replacement in `options`
+        if it matched a key of `deprecated`.
 
     Raises
     ------
     TypeError
         If the value is not a string or None when optional is True.
     ValueError
-        If the input is not in ``options`` when ``options`` is set.
+        If the input is not in ``options`` (or a key of ``deprecated``,
+        if provided) when ``options`` is set.
 
     """
     if optional and value is None:
@@ -458,11 +469,23 @@ def string_like(value, name, optional=False, options=None, lower=True):
         raise TypeError(f"{name} must be a string{extra_text}")
     if lower:
         value = value.lower()
-    if options is not None and value not in options:
+    all_options = options
+    if options is not None and deprecated is not None:
+        all_options = tuple(options) + tuple(deprecated)
+    if all_options is not None and value not in all_options:
         extra_text = "If not None, " if optional else ""
-        options_text = "'" + "', '".join(options) + "'"
+        options_text = "'" + "', '".join(all_options) + "'"
         msg = f"{extra_text}{name} must be one of: {options_text}"
         raise ValueError(msg)
+    if deprecated is not None and value in deprecated:
+        replacement = deprecated[value]
+        warnings.warn(
+            f"{name}={value!r} is a deprecated alias for {name}={replacement!r} "
+            "and will be removed in a future version.",
+            FutureWarning,
+            stacklevel=2,
+        )
+        value = replacement
     return value
 
 

--- a/statsmodels/tsa/base/prediction.py
+++ b/statsmodels/tsa/base/prediction.py
@@ -2,6 +2,8 @@ import numpy as np
 import pandas as pd
 from scipy import stats
 
+from statsmodels.tools.validation import string_like
+
 
 class PredictionResults:
     """
@@ -119,17 +121,27 @@ class PredictionResults:
             given by the attribute of the instance specified in `__init__`.
             The default, if not specified, is the normal distribution.
         """
+        alternative = string_like(
+            alternative,
+            "alternative",
+            options=("two-sided", "larger", "smaller"),
+            lower=False,
+            deprecated={
+                "2-sided": "two-sided",
+                "2s": "two-sided",
+                "l": "larger",
+                "s": "smaller",
+            },
+        )
         # assumes symmetric distribution
         stat = (self.predicted_mean - value) / self.se_mean
 
-        if alternative in ["two-sided", "2-sided", "2s"]:
+        if alternative == "two-sided":
             pvalue = self.dist.sf(np.abs(stat), *self.dist_args) * 2
-        elif alternative in ["larger", "l"]:
+        elif alternative == "larger":
             pvalue = self.dist.sf(stat, *self.dist_args)
-        elif alternative in ["smaller", "s"]:
+        elif alternative == "smaller":
             pvalue = self.dist.cdf(stat, *self.dist_args)
-        else:
-            raise ValueError("invalid alternative")
         return stat, pvalue
 
     def conf_int(self, alpha=0.05):

--- a/statsmodels/tsa/base/tests/test_prediction.py
+++ b/statsmodels/tsa/base/tests/test_prediction.py
@@ -83,5 +83,19 @@ def test_t_test(data, alternative):
 
 def test_t_test_invalid_alternative(data):
     pred = PredictionResults(data[0], data[1])
-    with pytest.raises(ValueError, match="invalid alternative"):
+    with pytest.raises(ValueError, match="alternative must be one of"):
         pred.t_test(alternative="not-a-real-alternative")
+
+
+@pytest.mark.parametrize(
+    "alias,canonical",
+    [("2-sided", "two-sided"), ("2s", "two-sided"), ("l", "larger"), ("s", "smaller")],
+)
+def test_t_test_alternative_deprecated_alias(data, alias, canonical):
+    # undocumented short forms still work but warn, and are equivalent to
+    # spelling out the documented alternative
+    pred = PredictionResults(data[0], data[1])
+    with pytest.warns(FutureWarning, match="is a deprecated alias"):
+        alias_result = pred.t_test(value=1.0, alternative=alias)
+    canonical_result = pred.t_test(value=1.0, alternative=canonical)
+    np.testing.assert_allclose(alias_result, canonical_result)

--- a/statsmodels/tsa/exponential_smoothing/base.py
+++ b/statsmodels/tsa/exponential_smoothing/base.py
@@ -4,7 +4,7 @@ import warnings
 
 import numpy as np
 import pandas as pd
-from scipy.stats import norm
+from scipy import stats
 
 from statsmodels.base.data import PandasData
 from statsmodels.tools._decorators import cache_readonly
@@ -429,7 +429,7 @@ class StateSpaceMLEResults(tsbase.TimeSeriesModelResults):
         mask = np.ones_like(pvalues, dtype=bool)
         mask[self._free_params_index] = True
         mask &= ~np.isnan(self.zvalues)
-        pvalues[mask] = norm.sf(np.abs(self.zvalues[mask])) * 2
+        pvalues[mask] = stats.norm.sf(np.abs(self.zvalues[mask])) * 2
         return pvalues
 
     @cache_readonly
@@ -681,6 +681,21 @@ class StateSpaceMLEResults(tsbase.TimeSeriesModelResults):
             method = "breakvar"
         _ = string_like(method, "method", options=("breakvar",))
 
+        alternative = string_like(
+            alternative,
+            "alternative",
+            options=("increasing", "decreasing", "two-sided"),
+            lower=True,
+            deprecated={
+                "i": "increasing",
+                "inc": "increasing",
+                "d": "decreasing",
+                "dec": "decreasing",
+                "2": "two-sided",
+                "2-sided": "two-sided",
+            },
+        )
+
         if self.standardized_forecasts_error is None:
             raise ValueError("Cannot compute test statistic when standardized"
                              " forecast errors have not been computed.")
@@ -736,36 +751,30 @@ class StateSpaceMLEResults(tsbase.TimeSeriesModelResults):
 
             # Setup functions to calculate the p-values
             if use_f:
-                from scipy.stats import f
-
                 def pval_lower(test_statistics, numer_dof, denom_dof):
-                    return f.cdf(test_statistics, numer_dof, denom_dof)
+                    return stats.f.cdf(test_statistics, numer_dof, denom_dof)
 
                 def pval_upper(test_statistics, numer_dof, denom_dof):
-                    return f.sf(test_statistics, numer_dof, denom_dof)
+                    return stats.f.sf(test_statistics, numer_dof, denom_dof)
 
             else:
-                from scipy.stats import chi2
-
                 def pval_lower(test_statistics, numer_dof, denom_dof):
-                    return chi2.cdf(numer_dof * test_statistics, denom_dof)
+                    return stats.chi2.cdf(numer_dof * test_statistics, denom_dof)
 
                 def pval_upper(test_statistics, numer_dof, denom_dof):
-                    return chi2.sf(numer_dof * test_statistics, denom_dof)
+                    return stats.chi2.sf(numer_dof * test_statistics, denom_dof)
             # Calculate the one- or two-sided p-values
             alternative = alternative.lower()
-            if alternative in ["i", "inc", "increasing"]:
-                p_value = pval_upper(test_statistic)
-            elif alternative in ["d", "dec", "decreasing"]:
+            if alternative == "increasing":
+                p_value = pval_upper(test_statistic, numer_dof, denom_dof)
+            elif alternative == "decreasing":
                 test_statistic = 1. / test_statistic
-                p_value = pval_upper(test_statistic)
-            elif alternative in ["2", "2-sided", "two-sided"]:
+                p_value = pval_upper(test_statistic, numer_dof, denom_dof)
+            else:  # alternative == "two-sided"
                 p_value = 2 * np.minimum(
                     pval_lower(test_statistic, numer_dof, denom_dof),
                     pval_upper(test_statistic, numer_dof, denom_dof)
                 )
-            else:
-                raise ValueError("Invalid alternative.")
 
             test_statistics.append(test_statistic)
             p_values.append(p_value)

--- a/statsmodels/tsa/statespace/tests/test_mlemodel.py
+++ b/statsmodels/tsa/statespace/tests/test_mlemodel.py
@@ -981,7 +981,7 @@ def test_diagnostics():
         res.test_serial_correlation(method="invalid")
 
     # Smoke tests for other options
-    res.test_heteroskedasticity(method=None, alternative="d", use_f=False)
+    res.test_heteroskedasticity(method=None, alternative="decreasing", use_f=False)
     res.test_serial_correlation(method="boxpierce")
 
 

--- a/statsmodels/tsa/stattools/_stattools.py
+++ b/statsmodels/tsa/stattools/_stattools.py
@@ -2270,6 +2270,20 @@ def breakvar_heteroskedasticity_test(
     .. [1] Harvey, Andrew C. 1990. *Forecasting, Structural Time Series*
             *Models and the Kalman Filter.* Cambridge University Press.
     """
+    alternative = string_like(
+        alternative,
+        "alternative",
+        options=("increasing", "decreasing", "two-sided"),
+        lower=True,
+        deprecated={
+            "i": "increasing",
+            "inc": "increasing",
+            "d": "decreasing",
+            "dec": "decreasing",
+            "2": "two-sided",
+            "2-sided": "two-sided",
+        },
+    )
     squared_resid = np.asarray(resid, dtype=float) ** 2
     if squared_resid.ndim == 1:
         squared_resid = squared_resid.reshape(-1, 1)
@@ -2328,16 +2342,13 @@ def breakvar_heteroskedasticity_test(
             return chi2.sf(numer_dof * test_statistics, denom_dof)
 
     # Calculate the one- or two-sided p-values
-    alternative = alternative.lower()
-    if alternative in ["i", "inc", "increasing"]:
+    if alternative == "increasing":
         p_value = pval_upper(test_statistic)
-    elif alternative in ["d", "dec", "decreasing"]:
+    elif alternative == "decreasing":
         test_statistic = 1.0 / test_statistic
         p_value = pval_upper(test_statistic)
-    elif alternative in ["2", "2-sided", "two-sided"]:
+    elif alternative == "two-sided":
         p_value = 2 * np.minimum(pval_lower(test_statistic), pval_upper(test_statistic))
-    else:
-        raise ValueError("Invalid alternative.")
 
     if len(test_statistic) == 1:
         return BreakvarHeteroskedasticityResult(test_statistic[0], p_value[0])

--- a/statsmodels/tsa/tests/test_exponential_smoothing.py
+++ b/statsmodels/tsa/tests/test_exponential_smoothing.py
@@ -873,6 +873,20 @@ def test_results_vs_statespace(statespace_comparison):
         assert_allclose(ets_het[0], statespace_het[0], rtol=0.2)
         assert_allclose(ets_het[1], statespace_het[1], rtol=0.7)
 
+    # the undocumented "d" alias for "decreasing" still works but warns,
+    # and is equivalent to spelling out "decreasing"
+    with pytest.warns(FutureWarning, match="is a deprecated alias"):
+        ets_het_alias = ets_results.test_heteroskedasticity(
+            method="breakvar", alternative="d"
+        )
+    ets_het_canonical = ets_results.test_heteroskedasticity(
+        method="breakvar", alternative="decreasing"
+    )
+    assert_allclose(ets_het_alias, ets_het_canonical)
+
+    with pytest.raises(ValueError, match="alternative must be one of"):
+        ets_results.test_heteroskedasticity(method="breakvar", alternative="bogus")
+
 
 def test_prediction_results_vs_statespace(statespace_comparison):
     ets_results, statespace_results = statespace_comparison

--- a/statsmodels/tsa/tests/test_stattools.py
+++ b/statsmodels/tsa/tests/test_stattools.py
@@ -1157,6 +1157,26 @@ class TestBreakvarHeteroskedasticityTest:
         assert actual_statistic == expected_statistic
         assert actual_pvalue == expected_pvalue
 
+    @pytest.mark.parametrize(
+        "alias,canonical",
+        [("2", "two-sided"), ("d", "decreasing"), ("i", "increasing")],
+    )
+    def test_alternative_deprecated_alias(self, alias, canonical):
+        # undocumented short forms still work but warn, and are equivalent
+        # to spelling out the documented alternative (case-insensitively)
+        input_residuals = [0.0, 1.0, 2.0, 3.0, 4.0, 5.0]
+        with pytest.warns(FutureWarning, match="is a deprecated alias"):
+            alias_result = breakvar_heteroskedasticity_test(
+                input_residuals, alternative=alias.upper()
+            )
+        canonical_result = breakvar_heteroskedasticity_test(
+            input_residuals, alternative=canonical
+        )
+        assert alias_result == canonical_result
+
+        with pytest.raises(ValueError, match="alternative must be one of"):
+            breakvar_heteroskedasticity_test(input_residuals, alternative="bogus")
+
     def test_use_chi2(self):
 
         input_residuals = [0.0, 1.0, 2.0, 3.0, 4.0, 5.0]


### PR DESCRIPTION
Reduce alias space to be mroe explicit

- [X] tests added / passed.
- [X] code/documentation is well formatted.
- [X] properly formatted commit message. See
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message).

#### AI Disclosure

Contributions must comply with the statsmodels [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html).

If using AI tools, edit the second option to explain which tool was selected and
how the tool's output was used.

Please complete **one** of the following:

- [ ] No AI tools were used to develop this pull request.
- [X] AI tools were used.
      Tool(s): Claude
      Used for: Repeated replacing aliases
      I have personally read, understood, and can explain every line of this diff, and
      have verified the statistical/numerical correctness of the change.

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows
  using the Windows System for Linux once `flake8` is installed in the
  local Linux environment. While passing this test is not required, it is good practice and it help
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.
* If AI tools were used to help write this PR, see the
  [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html) for what disclosure
  and review is expected of you before submitting.

</details>
