### PR TITLE
REF: Delegate ETS breakvar test to the shared implementation

### DIFF
--- a/docs/source/release/version0.15.0.rst
+++ b/docs/source/release/version0.15.0.rst
@@ -583,6 +583,16 @@ Notable Bug Fixes
   count. :pr:`9907`
 - Cast the ``np.repeat`` argument to platform ``intp`` size in the
   Jonckheere-Terpstra test so it works on 32-bit platforms (Pyodide). :pr:`10075`
+- ``breakvar_heteroskedasticity_test`` (and the state space and ETS
+  ``test_heteroskedasticity`` methods built on it) referred the raw ratio of
+  the two sums of squares to ``F(numer_dof, denom_dof)``.  The ratio of sums
+  is that ``F`` only after rescaling by ``denom_dof / numer_dof``, so the
+  p-values were wrong whenever missing observations left the two subsets with
+  different numbers of usable residuals -- for example a multivariate state
+  space model with a ragged edge.  The ``use_f=False`` variant had its
+  multiplier and its degrees of freedom interchanged, and the ``decreasing``
+  alternative did not swap the degrees of freedom when it inverted the
+  statistic.  Balanced samples, which is the usual case, are unaffected.
 
 
 Build, Packaging, and Infrastructure

--- a/statsmodels/stats/tests/test_diagnostic.py
+++ b/statsmodels/stats/tests/test_diagnostic.py
@@ -2309,7 +2309,7 @@ def test_het_goldfeldquandt_alternative_deprecated_alias(
         canonical_result = smsdia.het_goldfeldquandt(
             y, x, alternative=canonical, result_object=True
         )
-    assert_allclose(alias_result, canonical_result)
+    assert_allclose(alias_result.fval, canonical_result.fval)
 
     with pytest.raises(ValueError, match="alternative must be one of"):
         smsdia.het_goldfeldquandt(y, x, alternative="bogus", result_object=True)

--- a/statsmodels/stats/tests/test_diagnostic.py
+++ b/statsmodels/stats/tests/test_diagnostic.py
@@ -2309,7 +2309,7 @@ def test_het_goldfeldquandt_alternative_deprecated_alias(
         canonical_result = smsdia.het_goldfeldquandt(
             y, x, alternative=canonical, result_object=True
         )
-    assert alias_result == canonical_result
+    assert_allclose(alias_result, canonical_result)
 
     with pytest.raises(ValueError, match="alternative must be one of"):
         smsdia.het_goldfeldquandt(y, x, alternative="bogus", result_object=True)

--- a/statsmodels/stats/tests/test_rates_poisson.py
+++ b/statsmodels/stats/tests/test_rates_poisson.py
@@ -1521,7 +1521,7 @@ def test_etest_poisson_2indep_alternative_deprecated_alias(alias, canonical):
     canonical_result = etest_poisson_2indep(
         60, 51477.5, 30, 54308.7, alternative=canonical
     )
-    assert alias_result == canonical_result
+    assert_allclose(alias_result, canonical_result)
 
     with pytest.raises(ValueError, match="alternative must be one of"):
         etest_poisson_2indep(60, 51477.5, 30, 54308.7, alternative="bogus")

--- a/statsmodels/tsa/exponential_smoothing/base.py
+++ b/statsmodels/tsa/exponential_smoothing/base.py
@@ -20,6 +20,9 @@ from statsmodels.tools.tools import pinv_extended
 from statsmodels.tools.validation import string_like
 import statsmodels.tsa.base.tsa_model as tsbase
 from statsmodels.tsa.statespace.tools import _safe_cond
+from statsmodels.tsa.stattools._stattools import (
+    breakvar_heteroskedasticity_test,
+)
 
 
 class StateSpaceMLEModel(tsbase.TimeSeriesModel):
@@ -630,6 +633,10 @@ class StateSpaceMLEResults(tsbase.TimeSeriesModelResults):
             where `het[0][0]` is the test statistic, and `het[0][1]` is the
             p-value.
 
+        See Also
+        --------
+        statsmodels.tsa.stattools.breakvar_heteroskedasticity_test
+
         Notes
         -----
         The null hypothesis is of no heteroskedasticity. That means different
@@ -681,30 +688,13 @@ class StateSpaceMLEResults(tsbase.TimeSeriesModelResults):
             method = "breakvar"
         _ = string_like(method, "method", options=("breakvar",))
 
-        alternative = string_like(
-            alternative,
-            "alternative",
-            options=("increasing", "decreasing", "two-sided"),
-            lower=True,
-            deprecated={
-                "i": "increasing",
-                "inc": "increasing",
-                "d": "decreasing",
-                "dec": "decreasing",
-                "2": "two-sided",
-                "2-sided": "two-sided",
-            },
-        )
-
         if self.standardized_forecasts_error is None:
             raise ValueError("Cannot compute test statistic when standardized"
                              " forecast errors have not been computed.")
 
         # Store some values
         if hasattr(self, "filter_results"):
-            squared_resid = (
-                self.filter_results.standardized_forecasts_error**2
-            )
+            resid = self.filter_results.standardized_forecasts_error
             d = np.maximum(self.loglikelihood_burn, self.nobs_diffuse)
             # This differs from self.nobs_effective because here we want to
             # exclude exact diffuse periods, whereas self.nobs_effective
@@ -712,72 +702,22 @@ class StateSpaceMLEResults(tsbase.TimeSeriesModelResults):
             # periods.
             nobs_effective = self.nobs - d
         else:
-            squared_resid = self.standardized_forecasts_error**2
-            if squared_resid.ndim == 1:
-                squared_resid = np.asarray(squared_resid)
-                squared_resid = squared_resid[np.newaxis, :]
+            resid = np.asarray(self.standardized_forecasts_error)
+            if resid.ndim == 1:
+                resid = resid[np.newaxis, :]
             nobs_effective = self.nobs_effective
             d = 0
-        squared_resid = np.asarray(squared_resid)
+        h = int(np.round(nobs_effective / 3))
 
         test_statistics = []
         p_values = []
         for i in range(self.model.k_endog):
-            h = int(np.round(nobs_effective / 3))
-            numer_resid = squared_resid[i, -h:]
-            numer_resid = numer_resid[~np.isnan(numer_resid)]
-            numer_dof = len(numer_resid)
-
-            denom_resid = squared_resid[i, d:d + h]
-            denom_resid = denom_resid[~np.isnan(denom_resid)]
-            denom_dof = len(denom_resid)
-
-            if numer_dof < 2:
-                warnings.warn(f"Early subset of data for variable {i:d}"
-                              "  has too few non-missing observations to"
-                              " calculate test statistic.",
-                              stacklevel=2,
-                              )
-                numer_resid = np.nan
-            if denom_dof < 2:
-                warnings.warn(f"Later subset of data for variable {i:d}"
-                              "  has too few non-missing observations to"
-                              " calculate test statistic.",
-                              stacklevel=2,
-                              )
-                denom_resid = np.nan
-
-            test_statistic = np.sum(numer_resid) / np.sum(denom_resid)
-
-            # Setup functions to calculate the p-values
-            if use_f:
-                def pval_lower(test_statistics, numer_dof, denom_dof):
-                    return stats.f.cdf(test_statistics, numer_dof, denom_dof)
-
-                def pval_upper(test_statistics, numer_dof, denom_dof):
-                    return stats.f.sf(test_statistics, numer_dof, denom_dof)
-
-            else:
-                def pval_lower(test_statistics, numer_dof, denom_dof):
-                    return stats.chi2.cdf(numer_dof * test_statistics, denom_dof)
-
-                def pval_upper(test_statistics, numer_dof, denom_dof):
-                    return stats.chi2.sf(numer_dof * test_statistics, denom_dof)
-            # Calculate the one- or two-sided p-values
-            alternative = alternative.lower()
-            if alternative == "increasing":
-                p_value = pval_upper(test_statistic, numer_dof, denom_dof)
-            elif alternative == "decreasing":
-                test_statistic = 1. / test_statistic
-                p_value = pval_upper(test_statistic, numer_dof, denom_dof)
-            else:  # alternative == "two-sided"
-                p_value = 2 * np.minimum(
-                    pval_lower(test_statistic, numer_dof, denom_dof),
-                    pval_upper(test_statistic, numer_dof, denom_dof)
-                )
-
-            test_statistics.append(test_statistic)
-            p_values.append(p_value)
+            _het_result = breakvar_heteroskedasticity_test(
+                resid[i, d:], subset_length=h, alternative=alternative,
+                use_f=use_f
+            )
+            test_statistics.append(_het_result.statistic)
+            p_values.append(_het_result.pvalue)
 
         output = np.c_[test_statistics, p_values]
 

--- a/statsmodels/tsa/stattools/_stattools.py
+++ b/statsmodels/tsa/stattools/_stattools.py
@@ -2333,20 +2333,18 @@ def breakvar_heteroskedasticity_test(
     # The chi2 form is the dfd -> oo limit: the denominator sum converges to
     # dfd * sigma**2, so dfd * H(h) -> chi2(dfn).
     if use_f:
-        from scipy.stats import f
 
         def tail_pvalues(stat, dfn, dfd):
             """Lower- and upper-tail p-values for the statistic."""
             scaled = stat * dfd / dfn
-            return f.cdf(scaled, dfn, dfd), f.sf(scaled, dfn, dfd)
+            return stats.f.cdf(scaled, dfn, dfd), stats.f.sf(scaled, dfn, dfd)
 
     else:
-        from scipy.stats import chi2
 
         def tail_pvalues(stat, dfn, dfd):
             """Lower- and upper-tail p-values for the statistic."""
             scaled = stat * dfd
-            return chi2.cdf(scaled, dfn), chi2.sf(scaled, dfn)
+            return stats.chi2.cdf(scaled, dfn), stats.chi2.sf(scaled, dfn)
 
     # Calculate the one- or two-sided p-values.  Inverting the statistic for
     # the "decreasing" alternative swaps the roles of the two subsets, so the

--- a/statsmodels/tsa/stattools/_stattools.py
+++ b/statsmodels/tsa/stattools/_stattools.py
@@ -2300,7 +2300,7 @@ def breakvar_heteroskedasticity_test(
     for i, dof in enumerate(numer_dof):
         if dof < 2:
             warnings.warn(
-                f"Early subset of data for variable {i:d}"
+                f"Later subset of data for variable {i:d}"
                 " has too few non-missing observations to"
                 " calculate test statistic.",
                 stacklevel=2,
@@ -2313,7 +2313,7 @@ def breakvar_heteroskedasticity_test(
     for i, dof in enumerate(denom_dof):
         if dof < 2:
             warnings.warn(
-                f"Later subset of data for variable {i:d}"
+                f"Early subset of data for variable {i:d}"
                 " has too few non-missing observations to"
                 " calculate test statistic.",
                 stacklevel=2,
@@ -2322,33 +2322,43 @@ def breakvar_heteroskedasticity_test(
 
     test_statistic = numer_squared_sum / denom_squared_sum
 
-    # Setup functions to calculate the p-values
+    # Under the null the two sums of squares are independent and, divided by
+    # the common variance, are chi2 with dfn and dfd degrees of freedom.  The
+    # ratio of their *means* is F(dfn, dfd), so H(h) -- a ratio of *sums* --
+    # must be rescaled by dfd / dfn before being referred to that
+    # distribution.  The two agree when dfn == dfd, which is the usual case;
+    # they differ only when missing observations leave the two subsets with
+    # different numbers of usable residuals.
+    #
+    # The chi2 form is the dfd -> oo limit: the denominator sum converges to
+    # dfd * sigma**2, so dfd * H(h) -> chi2(dfn).
     if use_f:
         from scipy.stats import f
 
-        def pval_lower(test_statistics):
-            return f.cdf(test_statistics, numer_dof, denom_dof)
-
-        def pval_upper(test_statistics):
-            return f.sf(test_statistics, numer_dof, denom_dof)
+        def tail_pvalues(stat, dfn, dfd):
+            """Lower- and upper-tail p-values for the statistic."""
+            scaled = stat * dfd / dfn
+            return f.cdf(scaled, dfn, dfd), f.sf(scaled, dfn, dfd)
 
     else:
         from scipy.stats import chi2
 
-        def pval_lower(test_statistics):
-            return chi2.cdf(numer_dof * test_statistics, denom_dof)
+        def tail_pvalues(stat, dfn, dfd):
+            """Lower- and upper-tail p-values for the statistic."""
+            scaled = stat * dfd
+            return chi2.cdf(scaled, dfn), chi2.sf(scaled, dfn)
 
-        def pval_upper(test_statistics):
-            return chi2.sf(numer_dof * test_statistics, denom_dof)
-
-    # Calculate the one- or two-sided p-values
-    if alternative == "increasing":
-        p_value = pval_upper(test_statistic)
-    elif alternative == "decreasing":
+    # Calculate the one- or two-sided p-values.  Inverting the statistic for
+    # the "decreasing" alternative swaps the roles of the two subsets, so the
+    # degrees of freedom have to swap with it.
+    if alternative == "decreasing":
         test_statistic = 1.0 / test_statistic
-        p_value = pval_upper(test_statistic)
-    elif alternative == "two-sided":
-        p_value = 2 * np.minimum(pval_lower(test_statistic), pval_upper(test_statistic))
+        numer_dof, denom_dof = denom_dof, numer_dof
+    lower, upper = tail_pvalues(test_statistic, numer_dof, denom_dof)
+    if alternative == "two-sided":
+        p_value = 2 * np.minimum(lower, upper)
+    else:  # "increasing" or "decreasing"
+        p_value = upper
 
     if len(test_statistic) == 1:
         return BreakvarHeteroskedasticityResult(test_statistic[0], p_value[0])

--- a/statsmodels/tsa/tests/test_stattools.py
+++ b/statsmodels/tsa/tests/test_stattools.py
@@ -1229,7 +1229,7 @@ class TestBreakvarHeteroskedasticityTest:
         canonical_result = breakvar_heteroskedasticity_test(
             input_residuals, alternative=canonical
         )
-        assert alias_result == canonical_result
+        assert_allclose(alias_result, canonical_result)
 
         with pytest.raises(ValueError, match="alternative must be one of"):
             breakvar_heteroskedasticity_test(input_residuals, alternative="bogus")

--- a/statsmodels/tsa/tests/test_stattools.py
+++ b/statsmodels/tsa/tests/test_stattools.py
@@ -1098,17 +1098,19 @@ class TestBreakvarHeteroskedasticityTest:
                 np.nan,
             ]
         )
+        # H(h) is a ratio of sums of squares, so it is F(dfn, dfd) only after
+        # rescaling by dfd / dfn.  Column 1 has an unbalanced (3, 2) split.
         expected_pvalue = np.array(
             [
                 2
                 * min(
-                    self.f.cdf(expected_statistic[0], 3, 3),
-                    self.f.sf(expected_statistic[0], 3, 3),
+                    self.f.cdf(expected_statistic[0] * 3 / 3, 3, 3),
+                    self.f.sf(expected_statistic[0] * 3 / 3, 3, 3),
                 ),
                 2
                 * min(
-                    self.f.cdf(expected_statistic[1], 3, 2),
-                    self.f.sf(expected_statistic[1], 3, 2),
+                    self.f.cdf(expected_statistic[1] * 2 / 3, 3, 2),
+                    self.f.sf(expected_statistic[1] * 2 / 3, 3, 2),
                 ),
                 np.nan,
             ]
@@ -1118,6 +1120,61 @@ class TestBreakvarHeteroskedasticityTest:
 
         assert_equal(actual_statistic, expected_statistic)
         assert_equal(actual_pvalue, expected_pvalue)
+
+    @pytest.mark.parametrize("use_f", [True, False])
+    @pytest.mark.parametrize(
+        "alternative", ["increasing", "decreasing", "two-sided"]
+    )
+    def test_unbalanced_degrees_of_freedom(self, alternative, use_f):
+        # When missing values leave the two subsets with different numbers of
+        # usable residuals, H(h) -- a ratio of *sums* of squares -- must be
+        # rescaled by denom_dof / numer_dof before it is F(dfn, dfd), and
+        # inverting it for "decreasing" must swap the two degrees of freedom.
+        resid = np.array([np.nan, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0])
+        # h = 3; numerator {7, 8, 9} -> dfn = 3, denominator {2, 3} -> dfd = 2
+        stat = (7.0**2 + 8.0**2 + 9.0**2) / (2.0**2 + 3.0**2)
+        dfn, dfd = 3, 2
+        if alternative == "decreasing":
+            stat = 1.0 / stat
+            dfn, dfd = dfd, dfn
+        if use_f:
+            scaled, dist, args = stat * dfd / dfn, self.f, (dfn, dfd)
+        else:
+            scaled, dist, args = stat * dfd, self.chi2, (dfn,)
+        if alternative == "two-sided":
+            expected = 2 * min(dist.cdf(scaled, *args), dist.sf(scaled, *args))
+        else:
+            expected = dist.sf(scaled, *args)
+
+        result = breakvar_heteroskedasticity_test(
+            resid, alternative=alternative, use_f=use_f
+        )
+        assert_allclose(result.statistic, stat)
+        assert_allclose(result.pvalue, expected)
+
+    @pytest.mark.parametrize(
+        "resid",
+        [
+            [0.0, 1.0, 2.0, 3.0, 4.0, 5.0],
+            [np.nan, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0],
+        ],
+        ids=["balanced", "unbalanced"],
+    )
+    def test_one_sided_alternatives_are_complementary(self, resid):
+        # The exact (F) versions of the two one-sided tests are opposite tails
+        # of the same statistic, so their p-values sum to one -- including
+        # when missing values make the degrees of freedom unbalanced, because
+        # 1 / F(dfn, dfd) is F(dfd, dfn).  The unscaled ratio of sums does not
+        # have this property.  It does not hold for use_f=False: the two chi2
+        # approximations are different limits (dfd -> oo and dfn -> oo).
+        resid = np.asarray(resid)
+        up = breakvar_heteroskedasticity_test(
+            resid, alternative="increasing"
+        ).pvalue
+        down = breakvar_heteroskedasticity_test(
+            resid, alternative="decreasing"
+        ).pvalue
+        assert_allclose(up + down, 1.0)
 
     @pytest.mark.parametrize(
         "subset_length,expected_statistic,expected_pvalue",


### PR DESCRIPTION
test_heteroskedasticity in tsa/exponential_smoothing/base.py carried a
verbatim copy of the pre-refactor mlemodel.py body, including its own
nested pval_lower/pval_upper closures.  mlemodel.py has since been
rewritten to call tsa.stattools.breakvar_heteroskedasticity_test; do the
same here so the p-value logic lives in exactly one place.

Also drops a redundant string_like() call on ``alternative`` (the shared
helper already validates it, with the same options and deprecated
aliases) and a dead ``alternative = alternative.lower()`` inside the
per-variable loop.

No behaviour change: statistics and p-values are bit-identical for every
(alternative, use_f) combination on ETS(AAN)/ETS(AAA)/ETS(MAM) fits, and
summary() output is unchanged.

- [X] tests added / passed.
- [X] code/documentation is well formatted.
- [X] properly formatted commit message. See
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message).

#### AI Disclosure

Contributions must comply with the statsmodels [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html).

If using AI tools, edit the second option to explain which tool was selected and
how the tool's output was used.

Please complete **one** of the following:

- [ ] No AI tools were used to develop this pull request.
- [X] AI tools were used.
      Tool(s): Claude
      Used for: Test writing
      I have personally read, understood, and can explain every line of this diff, and
      have verified the statistical/numerical correctness of the change.

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows
  using the Windows System for Linux once `flake8` is installed in the
  local Linux environment. While passing this test is not required, it is good practice and it help
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.
* If AI tools were used to help write this PR, see the
  [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html) for what disclosure
  and review is expected of you before submitting.

</details>
