### PR TITLE
BUG: fix SARIMAX time-varying regression with differencing in the state vector

### DIFF
--- a/statsmodels/tsa/statespace/sarimax.py
+++ b/statsmodels/tsa/statespace/sarimax.py
@@ -721,7 +721,12 @@ class SARIMAX(MLEModel):
         # then the exogenous data is incorporated as a time-varying component
         # of the design matrix
         if self.state_regression:
-            if self._k_order > 0:
+            # The first block of the design vector (differencing and ARMA
+            # states) is only empty when simple differencing removes the
+            # differencing states from the state vector and there are no ARMA
+            # states (e.g. time-varying regression with order=(0, 0, 0) and
+            # simple_differencing=True)
+            if self._k_order > 0 or self._k_states_diff > 0:
                 design = np.c_[
                     np.reshape(
                         np.repeat(design, self.nobs),
@@ -788,7 +793,11 @@ class SARIMAX(MLEModel):
                     transition[start, end + self.seasonal_periods - 1] = 1
 
                 # \iota
-                transition[start, self._k_states_diff] = 1
+                # (the seasonal differencing states accumulate the
+                # stationary component at column _k_states_diff, which only
+                # exists if there are ARMA states)
+                if self._k_order > 0:
+                    transition[start, self._k_states_diff] = 1
 
         # Differencing component
         if self._k_diff > 0:
@@ -803,8 +812,12 @@ class SARIMAX(MLEModel):
                     ([0] * (self.seasonal_periods - 1) + [1]) *
                     self._k_seasonal_diff)
             # [1 0]
-            column = self._k_states_diff
-            transition[:self._k_diff, column] = 1
+            # (the differencing states accumulate the stationary component
+            # at column _k_states_diff, which only exists if there are ARMA
+            # states)
+            if self._k_order > 0:
+                column = self._k_states_diff
+                transition[:self._k_diff, column] = 1
 
         return transition
 

--- a/statsmodels/tsa/statespace/tests/test_sarimax.py
+++ b/statsmodels/tsa/statespace/tests/test_sarimax.py
@@ -2018,6 +2018,77 @@ def test_invalid_time_varying():
         )
 
 
+def test_time_varying_regression_differencing():
+    # GH 8725: with time-varying regression and differencing integrated in
+    # the state vector (so that there are no ARMA states), the design matrix
+    # was missing the differencing-state columns and the differencing states
+    # were incorrectly coupled into the regression state
+    nobs = 100
+    rng = np.random.default_rng(1234)
+    exog = rng.normal(size=nobs)
+    endog = 0.7 * exog + rng.normal(size=nobs)
+
+    mod = sarimax.SARIMAX(
+        endog,
+        exog=exog,
+        order=(0, 1, 0),
+        time_varying_regression=True,
+        mle_regression=False,
+    )
+
+    # The design matrix must contain the differencing state column along
+    # with the time-varying exogenous column
+    design = mod.ssm["design"]
+    assert_equal(design.shape, (1, 2, nobs))
+    assert_almost_equal(design[0, 0], np.ones(nobs))
+    assert_almost_equal(design[0, 1], exog)
+
+    # The differencing state must not feed into the regression state
+    assert_almost_equal(mod.ssm["transition"], np.eye(2))
+
+    # The model can now be fit, and the time-varying coefficient should
+    # estimate the static regression slope of the differenced data
+    d_endog = np.diff(endog)
+    d_exog = np.diff(exog)
+    slope = np.dot(d_exog, d_endog) / np.dot(d_exog, d_exog)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        res = mod.fit(disp=-1)
+    assert_allclose(res.smoothed_state[1].mean(), slope, atol=0.2)
+
+
+def test_time_varying_regression_seasonal_differencing():
+    # GH 8725: same failure mode as test_time_varying_regression_differencing
+    # but with seasonal differencing states
+    nobs = 80
+    rng = np.random.default_rng(1234)
+    exog = rng.normal(size=nobs)
+    endog = 0.5 * exog + rng.normal(size=nobs)
+
+    mod = sarimax.SARIMAX(
+        endog,
+        exog=exog,
+        order=(0, 0, 0),
+        seasonal_order=(0, 1, 0, 4),
+        time_varying_regression=True,
+        mle_regression=False,
+    )
+
+    design = mod.ssm["design"]
+    assert_equal(design.shape, (1, 5, nobs))
+    assert_almost_equal(design[0, -1], exog)
+
+    # The seasonal differencing states must not feed into the regression
+    # state
+    transition = mod.ssm["transition"]
+    assert_almost_equal(transition[-1], [0, 0, 0, 0, 1])
+    assert_(np.all(transition[:4, 4] == 0))
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        mod.fit(disp=-1)
+
+
 def test_manual_stationary_initialization():
     endog = results_sarimax.wpi1_data
 


### PR DESCRIPTION
## Summary

`SARIMAX(..., time_varying_regression=True, mle_regression=False)` raised `ValueError: Invalid dimensions for design matrix` whenever differencing was integrated in the state vector and the model had no ARMA states (e.g. `order=(0, 1, 0)`, or `seasonal_order=(0, 1, 0, s)`). Fixing the crash exposed a second, silent mis-specification in the transition matrix. Both are fixed here.

Fixes #8725.

## Root cause 1: design matrix missing the differencing-state columns

`initial_design` built the time-varying design from the exog data only when `_k_order == 0` (`design = self.exog.T[None, :, :]`). But `_k_order == 0` with state regression also happens for `order=(0, 1, 0)` + `time_varying_regression=True` (the special case in `__init__` sets `_k_order = 0` to drop the then-redundant error state). In that case `k_states = _k_states_diff + _k_exog`, so dropping the `[1] * _k_diff` columns produces a design with too few columns and `Representation.__setitem__` raises. The example from #8725:

```python
mod = sm.tsa.SARIMAX(endog=endog, exog=exog, order=(0, 1, 0), trend='n',
                     time_varying_regression=True, mle_regression=False)
# ValueError: Invalid dimensions for design matrix: requires 2 columns, got 1
```

The exog-only branch is only correct when there are no non-exog states at all (simple differencing already removed the differencing states, e.g. `order=(0, 0, 0)` on pre-differenced data), so the condition is now `_k_order > 0 or _k_states_diff > 0`.

## Root cause 2: differencing states coupled into the regression state

`initial_transition` unconditionally sets `transition[:_k_diff, _k_states_diff] = 1` (and the seasonal `\iota` equivalent): the differencing states accumulate the stationary component, which starts at column `_k_states_diff`. Without ARMA states that column holds a **time-varying regression coefficient**, so the model became

```
d_{t+1} = d_t + beta_t        (intended: d_{t+1} = d_t + u_{t+1})
y_t     = d_t + x_t beta_t
```

i.e. beta was silently respecified as a drift rate. With only the design fix the model fits without error but the smoothed coefficient ignores the exogenous data (mean ≈ 0 against a static OLS slope of 0.68); with the transition coupling gated on `_k_order > 0` as well, the smoothed coefficient tracks the static OLS slope of the differenced data (0.65 vs 0.68 in the regression test added here). Both couplings are now only applied when ARMA states exist.

## Testing

- `test_time_varying_regression_differencing`: the #8725 reproducer — asserts the design matrix is `[1 | exog]`, the transition is the identity, the model fits, and the smoothed time-varying coefficient estimates the static OLS slope of the differenced data.
- `test_time_varying_regression_seasonal_differencing`: the seasonal variant of the same failure mode, with structural assertions on design/transition.
- Full existing `test_sarimax.py` run against a patched 0.14.6 install: 488 passed; the 1 failure + 61 errors present are pre-existing (the failure also fails on the pristine wheel — it uses post-0.14.6 API — and the errors are a missing matplotlib test fixture in that ad-hoc setup), verified identical with and without this patch.
- Configurations with ARMA states (`order=(1, 1, 0)`, `(0, 1, 1)`, ...) produce bit-identical results before and after the change: the new guards only alter the `_k_order == 0` paths that previously crashed or mis-specified the model.
- `ruff check` and `flake8` clean on the changed files.

## AI Disclosure

- [ ] No AI tools were used to develop this pull request.
- [x] AI tools were used.
      Tool(s): `GLM coding agent (Z.ai), operating under the direction of the account owner`.
      Used for: `root cause analysis of issue #8725, drafting the implementation, writing the regression tests, and running the verification (patched-wheel test runs, ruff/flake8)`.
      I have personally read, understood, and can explain every line of this diff, and
      have verified the statistical/numerical correctness of the change.
