### PR TITLE
BUG: Add array_like for offset

### DIFF
--- a/statsmodels/miscmodels/count.py
+++ b/statsmodels/miscmodels/count.py
@@ -201,7 +201,7 @@ class PoissonZiGMLE(GenericLikelihoodModel):
         A nobs x k array where `nobs` is the number of observations and
         `k` is the number of regressors. If None, a column of ones is
         used.
-    offset : ndarray, optional
+    offset : array_like, optional
         Offset added to the linear predictor before computing the mean.
     missing : str, optional
         Available options are 'none', 'drop', and 'raise'. If 'none', no
@@ -217,6 +217,7 @@ class PoissonZiGMLE(GenericLikelihoodModel):
         super().__init__(
             endog, exog, missing=missing, extra_params_names=["zi"], **kwds
         )
+        offset = array_like(offset, "offset", optional=True, ndim=1)
         if offset is not None:
             if offset.ndim == 1:
                 offset = offset[:, None]  # need column

--- a/statsmodels/miscmodels/tests/test_poisson.py
+++ b/statsmodels/miscmodels/tests/test_poisson.py
@@ -198,7 +198,8 @@ class TestPoissonZi(CompareMixin):
         )
 
         # Note : ZI has one extra parameter
-        cls.res = PoissonZiGMLE(data_endog, data_exog[:, 1:], offset=offset).fit(
+        cls.mod = PoissonZiGMLE(data_endog, data_exog[:, 1:], offset=offset)
+        cls.res = cls.mod.fit(
             start_params=np.r_[0.9 * cls.res_discrete.params, 10], method="bfgs", disp=0
         )
 
@@ -227,3 +228,13 @@ class TestPoissonZi(CompareMixin):
         mod1.data.xnames = mod1.data.xnames * 2
         with pytest.warns(ValueWarning):
             mod1.fit(disp=0)
+
+    def test_offset_array_like(self):
+        offset = list(self.mod.offset)
+        # Check that like works for offset
+        _ = PoissonZiGMLE(self.mod.endog, self.mod.endog, offset=offset)
+        # Check that like works for offset
+        rng = np.random.default_rng(12121)
+        offset = rng.standard_normal((self.mod.endog.shape[0], 2)).tolist()
+        with pytest.raises(ValueError, match="offset is required to have ndim 1"):
+            _ = PoissonZiGMLE(self.mod.endog, self.mod.endog, offset=offset)


### PR DESCRIPTION
- [x] tests added / passed.
- [x] code/documentation is well formatted.
- [x] properly formatted commit message. See
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message).

#### AI Disclosure

Contributions must comply with the statsmodels [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html).

If using AI tools, edit the second option to explain which tool was selected and
how the tool's output was used.

Please complete **one** of the following:

- [x] No AI tools were used to develop this pull request.
- [ ] AI tools were used.
      Tool(s): `<name(s), e.g. Copilot, Claude, ChatGPT>`.
      Used for: `<e.g. drafting an implementation, writing tests, debugging, editing docstrings>`.
      I have personally read, understood, and can explain every line of this diff, and
      have verified the statistical/numerical correctness of the change.

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows
  using the Windows System for Linux once `flake8` is installed in the
  local Linux environment. While passing this test is not required, it is good practice and it help
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.
* If AI tools were used to help write this PR, see the
  [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html) for what disclosure
  and review is expected of you before submitting.

</details>
