### PR TITLE
BUG: Remove cache_readonly the presented parameter

### DIFF
--- a/statsmodels/multivariate/factor.py
+++ b/statsmodels/multivariate/factor.py
@@ -1172,7 +1172,6 @@ class FactorResults:
         c.flat[:: c.shape[0] + 1] += self.uniqueness
         return c
 
-    @cache_readonly
     def uniq_stderr(self, kurt=0):
         """
         The standard errors of the uniquenesses
@@ -1181,6 +1180,11 @@ class FactorResults:
         ----------
         kurt : float, optional
             Excess kurtosis
+
+        Returns
+        -------
+        ndarray
+            The standard errors of the uniquenesses
 
         Notes
         -----

--- a/statsmodels/multivariate/tests/test_ml_factor.py
+++ b/statsmodels/multivariate/tests/test_ml_factor.py
@@ -207,7 +207,7 @@ def test_2factor():
     e = np.asarray(
         [0.11056836, 0.05191071, 0.09836349, 0.09836349, 0.05191071, 0.11056836]
     )
-    assert_allclose(rslt.uniq_stderr, e, atol=1e-4)
+    assert_allclose(rslt.uniq_stderr(), e, atol=1e-4)
     e = np.asarray(
         [
             [0.08842151, 0.08842151],


### PR DESCRIPTION
Remove cache_readonly decorator that prevented a parameter from being set in a method

- [X] tests added / passed.
- [X] code/documentation is well formatted.
- [X] properly formatted commit message. See
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message).

#### AI Disclosure

Contributions must comply with the statsmodels [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html).

If using AI tools, edit the second option to explain which tool was selected and
how the tool's output was used.

Please complete **one** of the following:

- [X] No AI tools were used to develop this pull request.
- [ ] AI tools were used.
      Tool(s): `<name(s), e.g. Copilot, Claude, ChatGPT>`.
      Used for: `<e.g. drafting an implementation, writing tests, debugging, editing docstrings>`.
      I have personally read, understood, and can explain every line of this diff, and
      have verified the statistical/numerical correctness of the change.

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows
  using the Windows System for Linux once `flake8` is installed in the
  local Linux environment. While passing this test is not required, it is good practice and it help
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.
* If AI tools were used to help write this PR, see the
  [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html) for what disclosure
  and review is expected of you before submitting.

</details>
