### PR TITLE
BUG: Ensure array_like covnull is coerced

### DIFF
--- a/statsmodels/stats/multivariate.py
+++ b/statsmodels/stats/multivariate.py
@@ -13,7 +13,7 @@ from scipy import stats
 
 from statsmodels.stats.base import LimitedIterationMixin
 from statsmodels.stats.moment_helpers import cov2corr
-from statsmodels.tools.validation import array_like
+from statsmodels.tools.validation import array_like, int_like
 
 
 # shortcut function
@@ -385,9 +385,12 @@ def test_cov(cov, nobs, cov_null):
     """
     # using Stata formulas where cov_sample use nobs in denominator
     # Bartlett 1954 has fewer terms
+    cov = array_like(cov, "cov", ndim=2)
+    nobs = int_like(nobs, "nobs")
+    cov_null = array_like(cov_null, "cov_null", ndim=2)
 
-    S = np.asarray(cov) * (nobs - 1) / nobs
-    S0 = np.asarray(cov_null)
+    S = cov * (nobs - 1) / nobs
+    S0 = cov_null
     k = cov.shape[0]
     n = nobs
 

--- a/statsmodels/stats/tests/test_multivariate.py
+++ b/statsmodels/stats/tests/test_multivariate.py
@@ -272,6 +272,10 @@ class TestCovStructure:
         assert_allclose(stat, chi2, rtol=1e-7)
         assert_allclose(pv, p_chi2, rtol=1e-6)
 
+        stat_2, pv_2 = smmv.test_cov(cov.tolist(), nobs, cov_null.tolist())
+        assert_allclose(stat, stat_2, rtol=1e-7)
+        assert_allclose(pv, pv_2, rtol=1e-6)
+
 
 def test_cov_oneway():
     # from Stata 14


### PR DESCRIPTION
Add an array_like around cov_null

- [X] tests added / passed.
- [X] code/documentation is well formatted.
- [X] properly formatted commit message. See
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message).

#### AI Disclosure

Contributions must comply with the statsmodels [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html).

If using AI tools, edit the second option to explain which tool was selected and
how the tool's output was used.

Please complete **one** of the following:

- [X] No AI tools were used to develop this pull request.
- [ ] AI tools were used.
      Tool(s): `<name(s), e.g. Copilot, Claude, ChatGPT>`.
      Used for: `<e.g. drafting an implementation, writing tests, debugging, editing docstrings>`.
      I have personally read, understood, and can explain every line of this diff, and
      have verified the statistical/numerical correctness of the change.

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows
  using the Windows System for Linux once `flake8` is installed in the
  local Linux environment. While passing this test is not required, it is good practice and it help
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.
* If AI tools were used to help write this PR, see the
  [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html) for what disclosure
  and review is expected of you before submitting.

</details>
