### PR TITLE
BUG: Correct bug in knot centereing

### DIFF
--- a/statsmodels/gam/smooth_basis.py
+++ b/statsmodels/gam/smooth_basis.py
@@ -315,7 +315,13 @@ def get_knots_bsplines(x=None, df=None, knots=None, degree=3,
             # Need to compute inner knots
             grid = np.linspace(0, 1, n_inner_knots + 2)[1:-1]
             inner_knots = x_min + grid * (x_max - x_min)
-            diff_knots = inner_knots[1] - inner_knots[0]
+            # The n_inner_knots + 1 segments spanning [x_min, x_max] all
+            # have this width by construction of the uniform grid above, so
+            # this is equivalent to inner_knots[1] - inner_knots[0]) whenever
+            # that difference exists, and (unlike that difference) remains
+            # well-defined for n_inner_knots in (0, 1), where there are too
+            # few inner knots to take a difference between two of them.
+            diff_knots = (x_max - x_min) / (n_inner_knots + 1)
     if knots is not None:
         inner_knots = knots
     if lower_bound is None:
@@ -337,8 +343,12 @@ def get_knots_bsplines(x=None, df=None, knots=None, degree=3,
 
     if spacing == "equal":
         diffs = np.arange(1, order + 1) * diff_knots
-        lower_knots = inner_knots[0] - diffs[::-1]
-        upper_knots = inner_knots[-1] + diffs
+        # Anchor on x_min/x_max + / - diff_knots rather than inner_knots[0]
+        # and inner_knots[-1]: equal to those when there is at least one
+        # inner knot (by construction of the grid above), but also
+        # well-defined when n_inner_knots == 0 and inner_knots is empty.
+        lower_knots = (x_min + diff_knots) - diffs[::-1]
+        upper_knots = (x_max - diff_knots) + diffs
         all_knots = np.concatenate((lower_knots, inner_knots, upper_knots))
     else:
         all_knots = np.concatenate(([lower_bound, upper_bound] * order,

--- a/statsmodels/gam/tests/test_smooth_basis.py
+++ b/statsmodels/gam/tests/test_smooth_basis.py
@@ -22,9 +22,7 @@ def test_get_knots_bsplines_spacing():
     rs = np.random.RandomState(0)
     x = rs.uniform(size=100)
 
-    # df=8, degree=3 -> n_inner_knots=4, avoiding the pre-existing,
-    # unrelated IndexError that spacing="equal" hits when there is only
-    # 1 inner knot (e.g. df=5, degree=3)
+    # df=8, degree=3 -> n_inner_knots=4
     knots_q = get_knots_bsplines(x, df=8, degree=3, spacing="quantile")
     knots_e = get_knots_bsplines(x, df=8, degree=3, spacing="equal")
     assert knots_q.ndim == 1
@@ -38,6 +36,64 @@ def test_get_knots_bsplines_spacing():
     # (identically to spacing="quantile") instead of raising.
     with pytest.raises(ValueError, match="spacing"):
         get_knots_bsplines(x, knots=[0.25, 0.5, 0.75], degree=3, spacing="bogus")
+
+
+@pytest.mark.parametrize(
+    "df,degree,n_inner_knots",
+    [
+        (4, 3, 0),  # cubic spline, no inner knots at all
+        (5, 3, 1),  # cubic spline, exactly one inner knot
+        (3, 2, 0),  # quadratic spline, no inner knots
+        (4, 2, 1),  # quadratic spline, exactly one inner knot
+    ],
+)
+def test_get_knots_bsplines_spacing_equal_few_inner_knots(df, degree, n_inner_knots):
+    # GH: spacing="equal" raised IndexError ("index 1 is out of bounds")
+    # whenever n_inner_knots = df - (degree + 1) was 0 or 1, because
+    # diff_knots was computed as inner_knots[1] - inner_knots[0], which
+    # needs at least 2 inner knots to exist.
+    rs = np.random.RandomState(0)
+    x = rs.uniform(size=100)
+    x_min, x_max = x.min(), x.max()
+    order = degree + 1
+
+    all_knots = get_knots_bsplines(x, df=df, degree=degree, spacing="equal")
+
+    assert all_knots.ndim == 1
+    assert len(all_knots) == n_inner_knots + 2 * order
+    assert np.all(np.diff(all_knots) > 0)
+
+    # Independent check, not just "it didn't raise": spacing="equal" means
+    # every gap between consecutive knots equals the width of one of the
+    # n_inner_knots + 1 equal segments spanning [x_min, x_max].
+    expected_step = (x_max - x_min) / (n_inner_knots + 1)
+    assert_allclose(np.diff(all_knots), expected_step)
+
+    expected_inner = x_min + expected_step * np.arange(1, n_inner_knots + 1)
+    assert_allclose(all_knots[order:order + n_inner_knots], expected_inner)
+
+
+def test_get_knots_bsplines_spacing_equal_unchanged_for_multiple_inner_knots():
+    # regression check for the fix above: n_inner_knots >= 2 must still
+    # match the pre-fix inner_knots[1] - inner_knots[0] formula, since that
+    # difference is well-defined there and was never broken.
+    rs = np.random.RandomState(0)
+    x = rs.uniform(size=100)
+    x_min, x_max = x.min(), x.max()
+
+    for df, degree in [(6, 3), (12, 3), (9, 2)]:
+        order = degree + 1
+        n_inner_knots = df - order
+        grid = np.linspace(0, 1, n_inner_knots + 2)[1:-1]
+        inner_knots = x_min + grid * (x_max - x_min)
+        diff_knots = inner_knots[1] - inner_knots[0]
+        diffs = np.arange(1, order + 1) * diff_knots
+        expected = np.sort(np.concatenate((
+            inner_knots[0] - diffs[::-1], inner_knots, inner_knots[-1] + diffs,
+        )))
+
+        actual = get_knots_bsplines(x, df=df, degree=degree, spacing="equal")
+        assert_allclose(actual, expected)
 
 
 def test_univariate_polynomial_smoother():


### PR DESCRIPTION
If thre are insufficient knots the array can be too small resulting in IndexError

- [X] tests added / passed.
- [X] code/documentation is well formatted.
- [X] properly formatted commit message. See
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message).

#### AI Disclosure

Contributions must comply with the statsmodels [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html).

If using AI tools, edit the second option to explain which tool was selected and
how the tool's output was used.

Please complete **one** of the following:

- [ ] No AI tools were used to develop this pull request.
- [X] AI tools were used.
      Tool(s): Claude
      Used for: Test writing
      I have personally read, understood, and can explain every line of this diff, and
      have verified the statistical/numerical correctness of the change.

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows
  using the Windows System for Linux once `flake8` is installed in the
  local Linux environment. While passing this test is not required, it is good practice and it help
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.
* If AI tools were used to help write this PR, see the
  [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html) for what disclosure
  and review is expected of you before submitting.

</details>
