### PR TITLE
ENH: Add explicit target for removal of string aliases

### DIFF
--- a/statsmodels/base/_prediction_inference.py
+++ b/statsmodels/base/_prediction_inference.py
@@ -84,6 +84,7 @@ class PredictionResultsBase:
                 "l": "larger",
                 "s": "smaller",
             },
+            removed_after="0.16",
         )
         # assumes symmetric distribution
         stat = (self.predicted - value) / self.se

--- a/statsmodels/stats/_lilliefors.py
+++ b/statsmodels/stats/_lilliefors.py
@@ -122,6 +122,7 @@ def ksstat(x, cdf, alternative="two-sided", args=()):
         "alternative",
         options=("two-sided", "lower", "upper"),
         deprecated={"two_sided": "two-sided", "less": "lower", "greater": "upper"},
+        removed_after="0.16",
     )
     nobs = float(len(x))
 

--- a/statsmodels/stats/diagnostic.py
+++ b/statsmodels/stats/diagnostic.py
@@ -1407,6 +1407,7 @@ def het_goldfeldquandt(
             "2": "two-sided",
             "2-sided": "two-sided",
         },
+        removed_after="0.16",
     )
     resols1 = OLS(y[:split], x[:split]).fit()
     resols2 = OLS(y[start2:], x[start2:]).fit()

--- a/statsmodels/stats/meta_analysis.py
+++ b/statsmodels/stats/meta_analysis.py
@@ -513,6 +513,7 @@ def effectsize_2proportions(
             "arcsine": "arcsin",
             "as": "arcsin",
         },
+        removed_after="0.16",
     )
     if zero_correction is None:
         cc1 = cc2 = 0

--- a/statsmodels/stats/oneway.py
+++ b/statsmodels/stats/oneway.py
@@ -465,6 +465,7 @@ def confint_noncentrality(f_stat, df, alpha=0.05, alternative="two-sided"):
         options=("two-sided",),
         lower=False,
         deprecated={"2s": "two-sided", "ts": "two-sided"},
+        removed_after="0.16",
     )
     alpha1s = alpha / 2
     ci = ncfdtrinc(df1, df2, [1 - alpha1s, alpha1s], f_stat)

--- a/statsmodels/stats/power.py
+++ b/statsmodels/stats/power.py
@@ -105,6 +105,7 @@ def ttest_power(effect_size, nobs, alpha, df=None, alternative="two-sided"):
         options=("two-sided", "larger", "smaller"),
         lower=False,
         deprecated=_ALTERNATIVE_ALIASES,
+        removed_after="0.16",
     )
     if alternative == "two-sided":
         alpha_ = alpha / 2.0  # no inplace changes, does not work
@@ -171,6 +172,7 @@ def normal_power(effect_size, nobs, alpha, alternative="two-sided", sigma=1.0):
         options=("two-sided", "larger", "smaller"),
         lower=False,
         deprecated=_ALTERNATIVE_ALIASES,
+        removed_after="0.16",
     )
     if alternative == "two-sided":
         alpha_ = alpha / 2.0  # no inplace changes, does not work
@@ -235,6 +237,7 @@ def normal_power_het(
         options=("two-sided", "larger", "smaller"),
         lower=False,
         deprecated=_ALTERNATIVE_ALIASES,
+        removed_after="0.16",
     )
     if alternative == "two-sided":
         alpha_ = alpha / 2.0  # no inplace changes, does not work

--- a/statsmodels/stats/proportion.py
+++ b/statsmodels/stats/proportion.py
@@ -859,6 +859,7 @@ def binom_test_reject_interval(value, nobs, alpha=0.05, alternative="two-sided")
         options=("two-sided", "larger", "smaller"),
         lower=False,
         deprecated={"2s": "two-sided"},
+        removed_after="0.16",
     )
     if alternative == "two-sided":
         alpha = alpha / 2
@@ -914,6 +915,7 @@ def binom_test(count, nobs, prop=0.5, alternative="two-sided"):
         options=("two-sided", "larger", "smaller"),
         lower=False,
         deprecated={"2s": "two-sided", "l": "larger", "s": "smaller"},
+        removed_after="0.16",
     )
     if alternative == "two-sided":
         pval = stats.binomtest(count, n=nobs, p=prop).pvalue
@@ -1398,6 +1400,7 @@ def proportions_chisquare_pairscontrol(
         options=("two-sided",),
         lower=False,
         deprecated={"2s": "two-sided"},
+        removed_after="0.16",
     )
     if value is not None:
         raise NotImplementedError
@@ -2641,6 +2644,7 @@ def samplesize_proportions_2indep_onetail(
         options=("two-sided", "larger", "smaller"),
         lower=False,
         deprecated={"2s": "two-sided"},
+        removed_after="0.16",
     )
     if alternative == "two-sided":
         alpha = alpha / 2

--- a/statsmodels/stats/rates.py
+++ b/statsmodels/stats/rates.py
@@ -1228,6 +1228,7 @@ def etest_poisson_2indep(
             "l": "larger",
             "s": "smaller",
         },
+        removed_after="0.16",
     )
     y1, n1, y2, n2 = (
         np.asarray(count1),

--- a/statsmodels/stats/tests/test_weightstats.py
+++ b/statsmodels/stats/tests/test_weightstats.py
@@ -888,7 +888,11 @@ def test_alternative_deprecated_alias(alias, canonical):
     # spelling out the documented alternative
     x1 = [1, 2, 3, 4, 5, 6, 2, 4, 6, 8]
 
-    with pytest.warns(FutureWarning, match="is a deprecated alias"):
+    # the version-scoped message wiring is a real call site, not just a
+    # string_like-level unit test: "removed after statsmodels 0.16"
+    with pytest.warns(
+        FutureWarning, match=r"removed after statsmodels 0\.16 is released"
+    ):
         stat_alias, pval_alias = ztest(x1, value=3, alternative=alias)
     stat, pval = ztest(x1, value=3, alternative=canonical)
     assert stat_alias == stat

--- a/statsmodels/stats/weightstats.py
+++ b/statsmodels/stats/weightstats.py
@@ -673,6 +673,7 @@ def _tstat_generic(value1, value2, std_diff, dof, alternative, diff=0):
         options=("two-sided", "larger", "smaller"),
         lower=False,
         deprecated=_ALTERNATIVE_ALIASES,
+        removed_after="0.16",
     )
     tstat = (value1 - value2 - diff) / std_diff
     if alternative == "two-sided":
@@ -723,6 +724,7 @@ def _tconfint_generic(mean, std_mean, dof, alpha, alternative):
         options=("two-sided", "larger", "smaller"),
         lower=False,
         deprecated=_ALTERNATIVE_ALIASES,
+        removed_after="0.16",
     )
     if alternative == "two-sided":
         tcrit = stats.t.ppf(1 - alpha / 2.0, dof)
@@ -782,6 +784,7 @@ def _zstat_generic(value1, value2, std_diff, alternative, diff=0):
         options=("two-sided", "larger", "smaller"),
         lower=False,
         deprecated=_ALTERNATIVE_ALIASES,
+        removed_after="0.16",
     )
     zstat = (value1 - value2 - diff) / std_diff
     if alternative == "two-sided":
@@ -830,6 +833,7 @@ def _zstat_generic2(value, std, alternative):
         options=("two-sided", "larger", "smaller"),
         lower=False,
         deprecated=_ALTERNATIVE_ALIASES,
+        removed_after="0.16",
     )
     zstat = value / std
     if alternative == "two-sided":
@@ -878,6 +882,7 @@ def _zconfint_generic(mean, std_mean, alpha, alternative):
         options=("two-sided", "larger", "smaller"),
         lower=False,
         deprecated=_ALTERNATIVE_ALIASES,
+        removed_after="0.16",
     )
     if alternative == "two-sided":
         zcrit = stats.norm.ppf(1 - alpha / 2.0)

--- a/statsmodels/tools/validation/tests/test_validation.py
+++ b/statsmodels/tools/validation/tests/test_validation.py
@@ -388,6 +388,43 @@ def test_string_deprecated_alias():
     assert out == "new"
 
 
+def test_string_deprecated_alias_removed_after():
+    # without removed_after, the message only promises "a future version"
+    with pytest.warns(
+        FutureWarning,
+        match=r"will be removed in a future version",
+    ) as rec:
+        string_like(
+            "old", "value", options=("new",), deprecated={"old": "new"}
+        )
+    assert "statsmodels" not in str(rec[0].message)
+
+    # removed_after names a concrete release in the same message
+    with pytest.warns(
+        FutureWarning,
+        match=r"will be removed after statsmodels 0\.16 is released",
+    ):
+        out = string_like(
+            "old",
+            "value",
+            options=("new",),
+            deprecated={"old": "new"},
+            removed_after="0.16",
+        )
+    assert out == "new"
+
+    # removed_after is ignored (no warning at all) for values that are
+    # not deprecated aliases, canonical or otherwise
+    out = string_like(
+        "new",
+        "value",
+        options=("new",),
+        deprecated={"old": "new"},
+        removed_after="0.16",
+    )
+    assert out == "new"
+
+
 @pytest.fixture(params=(1.0, 1.1, np.float32(1.2), np.array([1.2]), 1.2 + 0j))
 def floating(request):
     return request.param

--- a/statsmodels/tools/validation/validation.py
+++ b/statsmodels/tools/validation/validation.py
@@ -423,7 +423,13 @@ def float_like(value, name, optional=False, strict=False):
 
 
 def string_like(
-    value, name, optional=False, options=None, lower=True, deprecated=None
+    value,
+    name,
+    optional=False,
+    options=None,
+    lower=True,
+    deprecated=None,
+    removed_after=None,
 ):
     """
     Check if object is string-like and raise if not
@@ -446,6 +452,13 @@ def string_like(
         matching one of these deprecated spellings is still accepted and
         normalized to its replacement, but raises a ``FutureWarning``.
         Ignored if `options` is None.
+    removed_after : str, optional
+        statsmodels version after which the spellings in `deprecated` will
+        stop being accepted, e.g. ``"0.16"``. Included in the
+        ``FutureWarning`` message when `deprecated` triggers. Ignored if
+        `deprecated` is None; if `deprecated` is set but `removed_after` is
+        not, the message says only that the alias will be removed "in a
+        future version".
 
     Returns
     -------
@@ -479,9 +492,16 @@ def string_like(
         raise ValueError(msg)
     if deprecated is not None and value in deprecated:
         replacement = deprecated[value]
+        if removed_after is not None:
+            removal_text = (
+                f"and will be removed after statsmodels {removed_after} "
+                "is released."
+            )
+        else:
+            removal_text = "and will be removed in a future version."
         warnings.warn(
             f"{name}={value!r} is a deprecated alias for {name}={replacement!r} "
-            "and will be removed in a future version.",
+            f"{removal_text}",
             FutureWarning,
             stacklevel=2,
         )

--- a/statsmodels/tsa/base/prediction.py
+++ b/statsmodels/tsa/base/prediction.py
@@ -132,6 +132,7 @@ class PredictionResults:
                 "l": "larger",
                 "s": "smaller",
             },
+            removed_after="0.16",
         )
         # assumes symmetric distribution
         stat = (self.predicted_mean - value) / self.se_mean

--- a/statsmodels/tsa/stattools/_stattools.py
+++ b/statsmodels/tsa/stattools/_stattools.py
@@ -2283,6 +2283,7 @@ def breakvar_heteroskedasticity_test(
             "2": "two-sided",
             "2-sided": "two-sided",
         },
+        removed_after="0.16",
     )
     squared_resid = np.asarray(resid, dtype=float) ** 2
     if squared_resid.ndim == 1:


### PR DESCRIPTION
- [X] tests added / passed.
- [X] code/documentation is well formatted.
- [X] properly formatted commit message. See
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message).

#### AI Disclosure

Contributions must comply with the statsmodels [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html).

If using AI tools, edit the second option to explain which tool was selected and
how the tool's output was used.

Please complete **one** of the following:

- [ ] No AI tools were used to develop this pull request.
- [X] AI tools were used.
      Tool(s): Claude
      Used for: Automated insertion of removal target
      I have personally read, understood, and can explain every line of this diff, and
      have verified the statistical/numerical correctness of the change.

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows
  using the Windows System for Linux once `flake8` is installed in the
  local Linux environment. While passing this test is not required, it is good practice and it help
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.
* If AI tools were used to help write this PR, see the
  [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html) for what disclosure
  and review is expected of you before submitting.

</details>
