### PR TITLE
CI: Reduce Linux jobs to speed up completion

### DIFF
--- a/tools/ci/azure/azure_template_posix.yml
+++ b/tools/ci/azure/azure_template_posix.yml
@@ -29,9 +29,6 @@ jobs:
           python.version: '3.14'
           python.architecture: 'x64-freethreaded'
           PANDAS_VERSION: 3
-        python_312_latest:
-          python.version: '3.12'
-          python.architecture: 'x64'
           coverage: true
           PYTEST_PATTERN: '(not slow or slow) and not joblib'
         python_311_wheel:
@@ -67,18 +64,18 @@ jobs:
           SM_TEST_COPY_ON_WRITE: 1
           coverage: true
           test.x13: true
-        python_312_pre:
-          python.version: '3.12'
+        python_313_pre:
+          python.version: '3.13'
           python.architecture: 'x64'
           pip.pre: true
-        python_312_formulaic_no_patsy:
-          python.version: '3.12'
+        python_313_formulaic_no_patsy:
+          python.version: '3.13'
           python.architecture: 'x64'
           SM_FORMULA_ENGINE: "formulaic"
           PIP_UNINSTALL: "patsy matplotlib joblib"
           USE_MATPLOTLIB: false
-        python_312_no_formulaic:
-          python.version: '3.12'
+        python_314_no_formulaic:
+          python.version: '3.14'
           python.architecture: 'x64'
           PIP_UNINSTALL: "formulaic"
       ${{ if eq(parameters.name, 'macOS') }}:
@@ -87,8 +84,8 @@ jobs:
         python310_macos_compat:
           python.version: '3.10'
           python.architecture: 'x64'
-        python313_macos_latest_install:
-          python.version: '3.13'
+        python314_macos_latest_install:
+          python.version: '3.14'
           python.architecture: 'x64'
           test.install: true
     maxParallel: 20


### PR DESCRIPTION
- [X] code/documentation is well formatted.
- [X] properly formatted commit message. See
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message).

#### AI Disclosure

Contributions must comply with the statsmodels [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html).

If using AI tools, edit the second option to explain which tool was selected and
how the tool's output was used.

Please complete **one** of the following:

- [X] No AI tools were used to develop this pull request.
- [ ] AI tools were used.
      Tool(s): `<name(s), e.g. Copilot, Claude, ChatGPT>`.
      Used for: `<e.g. drafting an implementation, writing tests, debugging, editing docstrings>`.
      I have personally read, understood, and can explain every line of this diff, and
      have verified the statistical/numerical correctness of the change.

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows
  using the Windows System for Linux once `flake8` is installed in the
  local Linux environment. While passing this test is not required, it is good practice and it help
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.
* If AI tools were used to help write this PR, see the
  [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html) for what disclosure
  and review is expected of you before submitting.

</details>
