### PR TITLE
ENH: Allow string type for groups in NominalGEE

### DIFF
--- a/statsmodels/genmod/generalized_estimating_equations.py
+++ b/statsmodels/genmod/generalized_estimating_equations.py
@@ -2896,7 +2896,7 @@ class NominalGEE(GEE):
         ncols = len(endog_cuts) * exog.shape[1]
         exog_out = np.zeros((nrows, ncols), dtype=np.float64)
         endog_out = np.zeros(nrows, dtype=np.float64)
-        groups_out = np.zeros(nrows, dtype=np.float64)
+        groups_out = np.zeros(nrows, dtype=groups.dtype)
         time_out = np.zeros((nrows, time.shape[1]), dtype=np.float64)
         offset_out = np.zeros(nrows, dtype=np.float64)
 

--- a/statsmodels/genmod/tests/test_gee.py
+++ b/statsmodels/genmod/tests/test_gee.py
@@ -236,7 +236,8 @@ class TestGEE:
         assert_allclose(marg.margeff, np.r_[11.0928], rtol=1e-6)
         assert_allclose(marg.margeff_se, np.r_[3.269015], rtol=1e-6)
 
-    def test_multinomial(self):
+    @pytest.mark.parametrize("dtype", [int, str])
+    def test_multinomial_input_type(self, dtype):
         """
         Check the 2-class multinomial (nominal) GEE fit against
         logistic regression.
@@ -251,8 +252,11 @@ class TestGEE:
         model = gee.NominalGEE(endog, exog, groups)
         results = model.fit(cov_type="naive", start_params=[3.295837, -2.197225])
 
+        # Ensure the correct type is used
+        groups = groups.astype(dtype)
+        # Check that groups can be strings
         logit_model = gee.GEE(endog, exog, groups, family=families.Binomial())
-        logit_results = logit_model.fit(cov_type="naive")
+        logit_results = logit_model.fit(cov_type='naive')
 
         assert_allclose(results.params, -logit_results.params, rtol=1e-5)
         assert_allclose(results.bse, logit_results.bse, rtol=1e-5)


### PR DESCRIPTION
- [X] closes #8796 
- [X] tests added / passed.
- [X] code/documentation is well formatted.
- [X] properly formatted commit message. See
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message).

#### AI Disclosure

Contributions must comply with the statsmodels [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html).

If using AI tools, edit the second option to explain which tool was selected and
how the tool's output was used.

Please complete **one** of the following:

- [X] No AI tools were used to develop this pull request.
- [ ] AI tools were used.
      Tool(s): `<name(s), e.g. Copilot, Claude, ChatGPT>`.
      Used for: `<e.g. drafting an implementation, writing tests, debugging, editing docstrings>`.
      I have personally read, understood, and can explain every line of this diff, and
      have verified the statistical/numerical correctness of the change.

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows
  using the Windows System for Linux once `flake8` is installed in the
  local Linux environment. While passing this test is not required, it is good practice and it help
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.
* If AI tools were used to help write this PR, see the
  [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html) for what disclosure
  and review is expected of you before submitting.

</details>
