### PR TITLE
MAINT: Fix the sign when using Newton's method

### DIFF
--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -581,7 +581,6 @@ class LikelihoodModel(Model):
         # args in most (any?) of the optimize function
 
         nobs = self.endog.shape[0]
-        # f = lambda params, *args: -self.loglike(params, *args) / nobs
 
         def f(params, *args):
             return -self.loglike(params, *args) / nobs
@@ -638,8 +637,8 @@ class LikelihoodModel(Model):
         cov_params_func = kwargs.setdefault("cov_params_func", None)
         if cov_params_func:
             Hinv = cov_params_func(self, xopt, retvals)
-        elif method == "newton" and full_output:
-            Hinv = np.linalg.inv(-retvals["Hessian"]) / nobs
+        elif method == 'newton' and full_output:
+            Hinv = np.linalg.inv(retvals['Hessian']) / nobs
         elif not skip_hessian:
             H = -1 * self.hessian(xopt)
             invertible = False

--- a/statsmodels/base/model.py
+++ b/statsmodels/base/model.py
@@ -585,21 +585,11 @@ class LikelihoodModel(Model):
         def f(params, *args):
             return -self.loglike(params, *args) / nobs
 
-        if method == "newton":
-            # TODO: why are score and hess positive?
-            def score(params, *args):
-                return self.score(params, *args) / nobs
+        def score(params, *args):
+            return -self.score(params, *args) / nobs
 
-            def hess(params, *args):
-                return self.hessian(params, *args) / nobs
-
-        else:
-
-            def score(params, *args):
-                return -self.score(params, *args) / nobs
-
-            def hess(params, *args):
-                return -self.hessian(params, *args) / nobs
+        def hess(params, *args):
+            return -self.hessian(params, *args) / nobs
 
         warn_convergence = kwargs.pop("warn_convergence", True)
 

--- a/statsmodels/base/optimizer.py
+++ b/statsmodels/base/optimizer.py
@@ -500,7 +500,8 @@ def _fit_newton(
         mle_retvals attribute. The output is dependent on the solver.
         See LikelihoodModelResults notes section for more information.
     hess : callable, optional
-        Method for computing the Hessian matrix, if applicable.
+        Returns Hessian matrix of negative log likelihood with respect to
+        params.
     ridge_factor : float, optional
         Regularization factor for Hessian matrix.
 

--- a/statsmodels/base/optimizer.py
+++ b/statsmodels/base/optimizer.py
@@ -500,8 +500,8 @@ def _fit_newton(
         mle_retvals attribute. The output is dependent on the solver.
         See LikelihoodModelResults notes section for more information.
     hess : callable, optional
-        Returns Hessian matrix of negative log likelihood with respect to
-        params.
+        Method for computing the Hessian matrix of negative log likelihood
+        with respect to params.
     ridge_factor : float, optional
         Regularization factor for Hessian matrix.
 

--- a/statsmodels/genmod/tests/test_glm.py
+++ b/statsmodels/genmod/tests/test_glm.py
@@ -1698,6 +1698,8 @@ def test_gradient_irls_eim(family_and_link, binom_version):
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
             mod_gradient = sm.GLM(endog, exog, family=family_class(link=link()))
+        if isinstance(mod_gradient.family, fam.InverseGaussian):
+            max_start_irls = 25
         rslt_gradient = mod_gradient.fit(
             max_start_irls=max_start_irls,
             start_params=start_params,

--- a/statsmodels/stats/libqsturng/tests/test_qsturng.py
+++ b/statsmodels/stats/libqsturng/tests/test_qsturng.py
@@ -167,20 +167,10 @@ class TestPsturng:
         # 1 <= v < 2 and q < qstrung(0.9, r, v), e.g. p < 0.9
         # test both v == 1 and 1 < v < 2 as both are changes from
         # original code
-        msg_v_1 = (
-            "v must be >= 2 when p < 0.9 and the q passed 1 is less "
-            "than 16.361992909976326 which is the q corresponding "
-            "to p = 0.9, r = 4 and v = 1."
-        )
-        with pytest.raises(ValueError, match=msg_v_1):
+        with pytest.raises(ValueError, match=r"q passed 1 is less than 16.36"):
             psturng(1, 4, 1)
 
-        msg_v_15 = (
-            "v must be >= 2 when p < 0.9 and the q passed 1 is less "
-            "than 8.965056833713536 which is the q corresponding "
-            "to p = 0.9, r = 4 and v = 1.5."
-        )
-        with pytest.raises(ValueError, match=msg_v_15):
+        with pytest.raises(ValueError, match=r" q passed 1 is less than 8.96"):
             psturng(1, 4, 1.5)
 
     def test_invalid_parameters(self):


### PR DESCRIPTION
- [X] closes #9466 
- [X] tests added / passed.
- [X] code/documentation is well formatted.
- [X] properly formatted commit message. See
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message).

#### AI Disclosure

Contributions must comply with the statsmodels [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html).

If using AI tools, edit the second option to explain which tool was selected and
how the tool's output was used.

Please complete **one** of the following:

- [X] No AI tools were used to develop this pull request.
- [ ] AI tools were used.
      Tool(s): `<name(s), e.g. Copilot, Claude, ChatGPT>`.
      Used for: `<e.g. drafting an implementation, writing tests, debugging, editing docstrings>`.
      I have personally read, understood, and can explain every line of this diff, and
      have verified the statistical/numerical correctness of the change.

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows
  using the Windows System for Linux once `flake8` is installed in the
  local Linux environment. While passing this test is not required, it is good practice and it help
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.
* If AI tools were used to help write this PR, see the
  [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html) for what disclosure
  and review is expected of you before submitting.

</details>
