### PR TITLE
BUG: Fix MNLogit score_test crash with exog_extra (GH#9273)

### DIFF
--- a/statsmodels/base/_parameter_inference.py
+++ b/statsmodels/base/_parameter_inference.py
@@ -305,16 +305,11 @@ def score_test(
             score = score_obs.sum(0)
         else:
             exog_extra = np.asarray(exog_extra)
-            k_extra = 0
+            k_extra = exog_extra.shape[1]
             ex = np.column_stack((model.exog, exog_extra))
-            # this uses shape not matrix rank to determine k_constraints
-            # requires nonsingular (no added perfect collinearity)
-
-            k_extra += ex.shape[1] - model.exog.shape[1]
 
             score_factor = model.score_factor(params_constrained)
-            hessian_factor = model.hessian_factor(params_constrained,
-                                                  **hess_kwd)
+            hessian_factor = model.hessian_factor(params_constrained, **hess_kwd)
             # see #4714
             from statsmodels.genmod.generalized_linear_model import GLM
 

--- a/statsmodels/base/_parameter_inference.py
+++ b/statsmodels/base/_parameter_inference.py
@@ -305,28 +305,63 @@ def score_test(
             score = score_obs.sum(0)
         else:
             exog_extra = np.asarray(exog_extra)
-            k_constraints = 0
+            k_extra = 0
             ex = np.column_stack((model.exog, exog_extra))
             # this uses shape not matrix rank to determine k_constraints
             # requires nonsingular (no added perfect collinearity)
-            k_constraints += ex.shape[1] - model.exog.shape[1]
-            # TODO use diag instead of full np.eye
-            r_matrix = np.eye(len(self.params) + k_constraints)[-k_constraints:]
+
+            k_extra += ex.shape[1] - model.exog.shape[1]
 
             score_factor = model.score_factor(params_constrained)
-            if score_factor.ndim == 1:
-                score_obs = score_factor[:, None] * ex
-            else:
-                sf = score_factor
-                score_obs = np.column_stack((sf[:, :1] * ex, sf[:, 1:]))
-            score = score_obs.sum(0)
-            hessian_factor = model.hessian_factor(params_constrained, **hess_kwd)
+            hessian_factor = model.hessian_factor(params_constrained,
+                                                  **hess_kwd)
             # see #4714
             from statsmodels.genmod.generalized_linear_model import GLM
 
             if isinstance(model, GLM):
                 hessian_factor *= -1
-            hessian = np.dot(ex.T * hessian_factor, ex)
+
+            if hessian_factor.ndim == 3:
+                # Multinomial-type model: score_factor is (n, J-1),
+                # hessian_factor is (n, J-1, J-1).
+                # Each extra exog column adds J-1 parameters.
+                n_eq = score_factor.shape[1]  # J-1
+                k_constraints = k_extra * n_eq
+                # r_matrix selects the last k_constraints parameters
+                # in the extended parameter vector of length
+                # (K + k_extra) * n_eq
+                n_params_ext = ex.shape[1] * n_eq
+                r_matrix = np.eye(n_params_ext)[-k_constraints:]
+                # score_obs: Kronecker product per observation
+                # (n, J-1, K_ext) -> (n, (J-1)*K_ext)
+                score_obs = (score_factor[:, :, None]
+                             * ex[:, None, :]).reshape(nobs, -1)
+                # Hessian: block matrix ((J-1)*K_ext, (J-1)*K_ext)
+                # H[(j*K_ext):((j+1)*K_ext), (l*K_ext):((l+1)*K_ext)]
+                #   = ex.T @ diag(hf[:, j, l]) @ ex
+                K_ext = ex.shape[1]
+                hessian = np.empty((n_eq * K_ext, n_eq * K_ext))
+                for j in range(n_eq):
+                    for l in range(n_eq):
+                        hessian[j*K_ext:(j+1)*K_ext,
+                                l*K_ext:(l+1)*K_ext] = (
+                            (ex.T * hessian_factor[:, j, l]) @ ex
+                        )
+            else:
+                # Scalar or two-parameter models
+                k_constraints = k_extra
+                # TODO use diag instead of full np.eye
+                r_matrix = np.eye(len(self.params) + k_constraints
+                                  )[-k_constraints:]
+                if score_factor.ndim == 1:
+                    score_obs = (score_factor[:, None] * ex)
+                else:
+                    sf = score_factor
+                    score_obs = np.column_stack(
+                        (sf[:, :1] * ex, sf[:, 1:]))
+                hessian = np.dot(ex.T * hessian_factor, ex)
+
+            score = score_obs.sum(0)
 
     if cov_type == "nonrobust":
         cov_score_test = -hessian

--- a/statsmodels/base/_parameter_inference.py
+++ b/statsmodels/base/_parameter_inference.py
@@ -342,10 +342,10 @@ def score_test(
                 K_ext = ex.shape[1]
                 hessian = np.empty((n_eq * K_ext, n_eq * K_ext))
                 for j in range(n_eq):
-                    for l in range(n_eq):
+                    for ll in range(n_eq):
                         hessian[j*K_ext:(j+1)*K_ext,
-                                l*K_ext:(l+1)*K_ext] = (
-                            (ex.T * hessian_factor[:, j, l]) @ ex
+                                ll*K_ext:(ll+1)*K_ext] = (
+                            (ex.T * hessian_factor[:, j, ll]) @ ex
                         )
             else:
                 # Scalar or two-parameter models

--- a/statsmodels/discrete/discrete_model.py
+++ b/statsmodels/discrete/discrete_model.py
@@ -3460,6 +3460,65 @@ class MNLogit(MultinomialModel):
         )
         return H
 
+    def score_factor(self, params):
+        """
+        Multinomial logit score factor for each observation.
+
+        The score factor is the residual (observed minus predicted probability)
+        for each non-reference category. It has shape (nobs, J-1) where J is
+        the number of outcome categories.
+
+        The full per-observation score is computed from the score factor as:
+            score_obs[i] = kron(score_factor[i], exog[i])
+        which produces a vector of length K * (J-1) per observation.
+
+        Parameters
+        ----------
+        params : array_like
+            The parameters of the model, flattened in column-major order
+            with shape (K * (J-1),).
+
+        Returns
+        -------
+        score_factor : ndarray, shape (nobs, J-1)
+            The residual for each observation and non-reference category.
+        """
+        params = np.asarray(params).reshape(self.K, -1, order="F")
+        pr = self.cdf(np.dot(self.exog, params))
+        return self.wendog[:, 1:] - pr[:, 1:]
+
+    def hessian_factor(self, params):
+        """
+        Multinomial logit Hessian weights for each observation.
+
+        For MNLogit the Hessian has a block structure that cannot be reduced
+        to a single scalar weight per observation. Instead, each observation
+        contributes a (J-1, J-1) weight matrix, so the full Hessian for
+        design matrix X is:
+            H[j,l] = sum_i w[i,j,l] * X[i] @ X[i].T
+
+        The weight for observation i is:
+            w[i,j,l] = -pr[i,j] * (1(j==l) - pr[i,l])
+
+        Parameters
+        ----------
+        params : array_like
+            The parameters of the model, flattened in column-major order
+            with shape (K * (J-1),).
+
+        Returns
+        -------
+        hessian_factor : ndarray, shape (nobs, J-1, J-1)
+            The per-observation weight matrix for the Hessian.
+        """
+        params = np.asarray(params).reshape(self.K, -1, order="F")
+        pr = self.cdf(np.dot(self.exog, params))
+        pr_nr = pr[:, 1:]  # (nobs, J-1)
+        # w[i,j,l] = -pr_j*(delta_jl - pr_l) = pr_j*pr_l - delta_jl*pr_j
+        hf = np.einsum("ij,ik->ijk", pr_nr, pr_nr)
+        hf -= np.einsum("ij,jk->ijk", pr_nr, np.eye(self.J - 1))
+        return hf
+
 
 # TODO: Weibull can replaced by a survival analsysis function
 # like stat's streg (The cox model as well)

--- a/statsmodels/discrete/tests/test_discrete.py
+++ b/statsmodels/discrete/tests/test_discrete.py
@@ -3948,3 +3948,138 @@ def test_logit_family_is_binomial():
     endog = rng.binomial(1, 0.5, n)
     mod = Logit(endog, exog)
     assert isinstance(mod.family, sm.families.Binomial)
+
+
+class TestMNLogitScoreTest:
+    """Tests for MNLogit score_test with exog_extra (GH#9273).
+
+    The score_test variable addition test previously crashed because MNLogit
+    did not implement score_factor or hessian_factor. This test class verifies
+    that the fix works correctly.
+    """
+
+    @classmethod
+    def setup_class(cls):
+        np.random.seed(789)
+        n = 500
+        X = np.random.randn(n, 3)
+        X = sm.add_constant(X)
+        x_extra = np.random.randn(n, 2)
+        X_full = np.column_stack((X, x_extra))
+
+        # Generate y from the restricted model (no effect of extra vars)
+        beta = np.array([[0.5, -0.3], [0.2, 0.1], [-0.1, 0.4], [0.3, -0.2]])
+        linpred = X @ beta
+        pr = np.exp(np.column_stack((np.zeros(n), linpred)))
+        pr = pr / pr.sum(axis=1, keepdims=True)
+        y = np.array([np.random.choice(3, p=p) for p in pr])
+
+        cls.model_drop = sm.MNLogit(y, X)
+        cls.model_full = sm.MNLogit(y, X_full)
+        cls.exog_extra = x_extra
+        cls.nobs = n
+
+    def test_score_test_smoke(self):
+        """score_test with exog_extra should not crash (GH#9273)."""
+        res_drop = self.model_drop.fit(disp=0)
+        stat, pval, df = res_drop.score_test(exog_extra=self.exog_extra)
+        assert np.isfinite(stat.item())
+        assert 0 <= pval.item() <= 1
+        # 2 extra columns * (J-1=2) equations = 4 constraints
+        assert df == 4
+
+    def test_score_test_df(self):
+        """k_constraints should equal k_extra * (J-1)."""
+        res_drop = self.model_drop.fit(disp=0)
+        # Single extra column
+        _, _, df1 = res_drop.score_test(
+            exog_extra=self.exog_extra[:, :1])
+        assert df1 == 2
+        # Two extra columns
+        _, _, df2 = res_drop.score_test(exog_extra=self.exog_extra)
+        assert df2 == 4
+
+    def test_score_wald_equivalence(self):
+        """Score test should be close to Wald test from the full model."""
+        res_drop = self.model_drop.fit(disp=0)
+        res_full = self.model_full.fit(disp=0)
+
+        lm_stat, lm_pval, lm_df = res_drop.score_test(
+            exog_extra=self.exog_extra)
+
+        # Build restriction matrix for Wald test on full model
+        K_full = self.model_full.exog.shape[1]  # 6
+        n_eq = self.model_full.J - 1  # 2
+        k_extra = self.exog_extra.shape[1]  # 2
+        r_matrix = np.zeros((k_extra * n_eq, K_full * n_eq))
+        for eq in range(n_eq):
+            for k in range(k_extra):
+                row = eq * k_extra + k
+                col = eq * K_full + (K_full - k_extra + k)
+                r_matrix[row, col] = 1.0
+
+        wald = res_full.wald_test(r_matrix, scalar=True)
+        wald_stat = float(wald.statistic)
+
+        # Under correct specification, LM and Wald should be close
+        assert_allclose(lm_stat.item(), wald_stat, rtol=0.3)
+
+    def test_score_test_hc0(self):
+        """HC0 robust covariance should work for MNLogit score_test."""
+        res_drop = self.model_drop.fit(disp=0)
+        res = res_drop.score_test(
+            exog_extra=self.exog_extra, cov_type="HC0")
+        stat, pval, df = res
+        assert np.isfinite(np.asarray(stat).item())
+        assert 0 <= np.asarray(pval).item() <= 1
+        assert df == 4
+
+    def test_score_factor_consistency(self):
+        """score_factor should reproduce score_obs via Kronecker product."""
+        res = self.model_drop.fit(disp=0)
+        params = np.asarray(res.params).ravel("F")
+        model = res.model
+
+        sf = model.score_factor(params)
+        score_obs_from_factor = (
+            sf[:, :, None] * model.exog[:, None, :]
+        ).reshape(self.nobs, -1)
+        score_obs = model.score_obs(params)
+        assert_allclose(score_obs_from_factor, score_obs, rtol=1e-10)
+
+    def test_hessian_factor_consistency(self):
+        """hessian_factor should reproduce hessian via block structure."""
+        res = self.model_drop.fit(disp=0)
+        params = np.asarray(res.params).ravel("F")
+        model = res.model
+
+        hf = model.hessian_factor(params)
+        K = model.K
+        n_eq = model.J - 1
+        hessian_from_factor = np.empty((n_eq * K, n_eq * K))
+        for j in range(n_eq):
+            for l in range(n_eq):
+                hessian_from_factor[j*K:(j+1)*K, l*K:(l+1)*K] = (
+                    (model.exog.T * hf[:, j, l]) @ model.exog
+                )
+        hessian = model.hessian(params)
+        assert_allclose(hessian_from_factor, hessian, rtol=1e-10)
+
+    def test_score_test_4_categories(self):
+        """score_test should work with J=4 categories."""
+        np.random.seed(456)
+        n = 300
+        X = np.random.randn(n, 2)
+        X = sm.add_constant(X)
+        y_probs = np.random.dirichlet([1, 1, 1, 1], size=n)
+        y = np.array([np.random.choice(4, p=p) for p in y_probs])
+
+        model = sm.MNLogit(y, X)
+        result = model.fit(disp=0)
+
+        exog_extra = np.random.randn(n, 1)
+        stat, pval, df = result.score_test(exog_extra=exog_extra)
+        assert np.isfinite(stat.item())
+        assert 0 <= pval.item() <= 1
+        # 1 extra column * (J-1=3) equations = 3 constraints
+        assert df == 3

--- a/statsmodels/discrete/tests/test_discrete.py
+++ b/statsmodels/discrete/tests/test_discrete.py
@@ -4058,9 +4058,9 @@ class TestMNLogitScoreTest:
         n_eq = model.J - 1
         hessian_from_factor = np.empty((n_eq * K, n_eq * K))
         for j in range(n_eq):
-            for l in range(n_eq):
-                hessian_from_factor[j*K:(j+1)*K, l*K:(l+1)*K] = (
-                    (model.exog.T * hf[:, j, l]) @ model.exog
+            for ll in range(n_eq):
+                hessian_from_factor[j*K:(j+1)*K, ll*K:(ll+1)*K] = (
+                    (model.exog.T * hf[:, j, ll]) @ model.exog
                 )
         hessian = model.hessian(params)
         assert_allclose(hessian_from_factor, hessian, rtol=1e-10)

--- a/statsmodels/discrete/tests/test_discrete.py
+++ b/statsmodels/discrete/tests/test_discrete.py
@@ -4065,6 +4065,7 @@ class TestMNLogitScoreTest:
         hessian = model.hessian(params)
         assert_allclose(hessian_from_factor, hessian, rtol=1e-10)
 
+    @pytest.mark.singleton_randomstate
     def test_score_test_4_categories(self):
         """score_test should work with J=4 categories."""
         np.random.seed(456)

--- a/statsmodels/discrete/tests/test_discrete.py
+++ b/statsmodels/discrete/tests/test_discrete.py
@@ -3982,30 +3982,30 @@ class TestMNLogitScoreTest:
     def test_score_test_smoke(self):
         """score_test with exog_extra should not crash (GH#9273)."""
         res_drop = self.model_drop.fit(disp=0)
-        stat, pval, df = res_drop.score_test(exog_extra=self.exog_extra)
-        assert np.isfinite(stat.item())
-        assert 0 <= pval.item() <= 1
+        test_result = res_drop.score_test(exog_extra=self.exog_extra)
+        assert np.isfinite(test_result.statistic.item())
+        assert 0 <= test_result.pvalue.item() <= 1
         # 2 extra columns * (J-1=2) equations = 4 constraints
-        assert df == 4
+        assert test_result.k_constraint == 4
 
     def test_score_test_df(self):
         """k_constraints should equal k_extra * (J-1)."""
         res_drop = self.model_drop.fit(disp=0)
         # Single extra column
-        _, _, df1 = res_drop.score_test(
-            exog_extra=self.exog_extra[:, :1])
-        assert df1 == 2
+        test_result = res_drop.score_test(exog_extra=self.exog_extra[:, :1])
+        assert test_result.k_constraint == 2
         # Two extra columns
-        _, _, df2 = res_drop.score_test(exog_extra=self.exog_extra)
-        assert df2 == 4
+        test_result = res_drop.score_test(exog_extra=self.exog_extra)
+        assert test_result.k_constraint == 4
 
     def test_score_wald_equivalence(self):
         """Score test should be close to Wald test from the full model."""
         res_drop = self.model_drop.fit(disp=0)
         res_full = self.model_full.fit(disp=0)
 
-        lm_stat, lm_pval, lm_df = res_drop.score_test(
-            exog_extra=self.exog_extra)
+        test_result = res_drop.score_test(exog_extra=self.exog_extra)
+        lm_stat, lm_pval = test_result
+        lm_df = test_result.k_constraint
 
         # Build restriction matrix for Wald test on full model
         K_full = self.model_full.exog.shape[1]  # 6
@@ -4027,12 +4027,10 @@ class TestMNLogitScoreTest:
     def test_score_test_hc0(self):
         """HC0 robust covariance should work for MNLogit score_test."""
         res_drop = self.model_drop.fit(disp=0)
-        res = res_drop.score_test(
-            exog_extra=self.exog_extra, cov_type="HC0")
-        stat, pval, df = res
-        assert np.isfinite(np.asarray(stat).item())
-        assert 0 <= np.asarray(pval).item() <= 1
-        assert df == 4
+        res = res_drop.score_test(exog_extra=self.exog_extra, cov_type="HC0")
+        assert np.isfinite(res.statistic.item())
+        assert 0 <= res.pvalue.item() <= 1
+        assert res.k_constraint == 4
 
     def test_score_factor_consistency(self):
         """score_factor should reproduce score_obs via Kronecker product."""
@@ -4079,8 +4077,8 @@ class TestMNLogitScoreTest:
         result = model.fit(disp=0)
 
         exog_extra = np.random.randn(n, 1)
-        stat, pval, df = result.score_test(exog_extra=exog_extra)
-        assert np.isfinite(stat.item())
-        assert 0 <= pval.item() <= 1
+        test_result = result.score_test(exog_extra=exog_extra)
+        assert np.isfinite(test_result.statistic.item())
+        assert 0 <= test_result.pvalue.item() <= 1
         # 1 extra column * (J-1=3) equations = 3 constraints
-        assert df == 3
+        assert test_result.k_constraint == 3

--- a/statsmodels/discrete/tests/test_discrete.py
+++ b/statsmodels/discrete/tests/test_discrete.py
@@ -4005,7 +4005,6 @@ class TestMNLogitScoreTest:
 
         test_result = res_drop.score_test(exog_extra=self.exog_extra)
         lm_stat, lm_pval = test_result
-        lm_df = test_result.k_constraint
 
         # Build restriction matrix for Wald test on full model
         K_full = self.model_full.exog.shape[1]  # 6

--- a/statsmodels/stats/libqsturng/tests/test_qsturng.py
+++ b/statsmodels/stats/libqsturng/tests/test_qsturng.py
@@ -167,20 +167,11 @@ class TestPsturng:
         # 1 <= v < 2 and q < qstrung(0.9, r, v), e.g. p < 0.9
         # test both v == 1 and 1 < v < 2 as both are changes from
         # original code
-        msg_v_1 = (
-            "v must be >= 2 when p < 0.9 and the q passed 1 is less "
-            "than 16.361992909976326 which is the q corresponding "
-            "to p = 0.9, r = 4 and v = 1."
-        )
-        with pytest.raises(ValueError, match=msg_v_1):
+
+        with pytest.raises(ValueError, match=r"q passed 1 is less than 16.36"):
             psturng(1, 4, 1)
 
-        msg_v_15 = (
-            "v must be >= 2 when p < 0.9 and the q passed 1 is less "
-            "than 8.965056833713536 which is the q corresponding "
-            "to p = 0.9, r = 4 and v = 1.5."
-        )
-        with pytest.raises(ValueError, match=msg_v_15):
+        with pytest.raises(ValueError, match=r"q passed 1 is less than 8.96"):
             psturng(1, 4, 1.5)
 
     def test_invalid_parameters(self):


### PR DESCRIPTION
MNLogit.score_test(exog_extra=...) crashed with AttributeError because
score_factor and hessian_factor were not implemented for MNLogit.

Changes:
- Add MNLogit.score_factor(params) returning (nobs, J-1) residuals
- Add MNLogit.hessian_factor(params) returning (nobs, J-1, J-1) weights
- Update _parameter_inference.score_test to handle 3D hessian_factor
  (multinomial block structure) in the exog_extra code path
- Add TestMNLogitScoreTest with 7 regression tests

The variable addition score test for multinomial models requires special
handling because each extra exog column contributes J-1 parameters (one
per non-reference category). The score_obs is computed as a Kronecker
product of score_factor and extended exog, and the Hessian uses the
block structure from hessian_factor.

- [X] closes #9889 
- [X] closes #9273
- [X] tests added / passed.
- [X] code/documentation is well formatted.
- [X] properly formatted commit message. See
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message).

#### AI Disclosure

Contributions must comply with the statsmodels [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html).

If using AI tools, edit the second option to explain which tool was selected and
how the tool's output was used.

Please complete **one** of the following:

- [X] No AI tools were used to develop this pull request.
- [ ] AI tools were used.
      Tool(s): `<name(s), e.g. Copilot, Claude, ChatGPT>`.
      Used for: `<e.g. drafting an implementation, writing tests, debugging, editing docstrings>`.
      I have personally read, understood, and can explain every line of this diff, and
      have verified the statistical/numerical correctness of the change.

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows
  using the Windows System for Linux once `flake8` is installed in the
  local Linux environment. While passing this test is not required, it is good practice and it help
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.
* If AI tools were used to help write this PR, see the
  [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html) for what disclosure
  and review is expected of you before submitting.

</details>
