### PR TITLE
BUG: pass transformed through to MarkovSwitching.hessian

### DIFF
--- a/docs/source/release/version0.15.0.rst
+++ b/docs/source/release/version0.15.0.rst
@@ -757,6 +757,8 @@ Notable Bug Fixes
 - Correct the knot-centering computation in ``get_knots_bsplines`` for
   splines with few interior knots, where it previously produced
   incorrect (non-equally-spaced) knots or raised. :pr:`10177`
+- Pass ``transformed`` through to the likelihood when computing the
+  ``MarkovSwitching`` Hessian, matching ``score``. :issue:`10148`
 
 
 Build, Packaging, and Infrastructure

--- a/statsmodels/tsa/regime_switching/markov_switching.py
+++ b/statsmodels/tsa/regime_switching/markov_switching.py
@@ -1174,7 +1174,7 @@ class MarkovSwitching(tsbase.TimeSeriesModel):
         """
         params = np.array(params, ndmin=1)
 
-        return approx_hess_cs(params, self.loglike)
+        return approx_hess_cs(params, self.loglike, args=(transformed,))
 
     def fit(
         self,

--- a/statsmodels/tsa/regime_switching/tests/test_markov_regression.py
+++ b/statsmodels/tsa/regime_switching/tests/test_markov_regression.py
@@ -3707,3 +3707,23 @@ def test_results_fittedvalues_resid_joint_likelihoods_cov_params_robust():
     hess = mod.hessian(res.params, transformed=True)
     expected, _ = pinv_extended(hess.dot(cov_opg).dot(hess))
     assert_allclose(cov_robust, expected, rtol=1e-8)
+
+
+def test_hessian_respects_transformed():
+    # GH#10148: hessian previously ignored transformed, unlike score().
+    rng = np.random.default_rng(0)
+    y = np.concatenate([rng.normal(0, 1, 80), rng.normal(4, 1, 80)])
+    mod = markov_regression.MarkovRegression(y, k_regimes=2)
+    params = mod.start_params
+
+    hess_transformed = mod.hessian(params, transformed=True)
+    hess_untransformed = mod.hessian(params, transformed=False)
+
+    k = len(params)
+    assert hess_transformed.shape == (k, k)
+    assert hess_untransformed.shape == (k, k)
+    assert np.all(np.isfinite(hess_transformed))
+    assert np.all(np.isfinite(hess_untransformed))
+    # transform_params is not the identity for this model, so the two
+    # Hessians must differ if the flag is forwarded to loglike.
+    assert np.max(np.abs(hess_transformed - hess_untransformed)) > 1e-8


### PR DESCRIPTION
- [x] closes #10148
- [x] tests added / passed.
- [x] code/documentation is well formatted.
- [x] properly formatted commit message. See
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message).

#### AI Disclosure

- [ ] No AI tools were used to develop this pull request.
- [x] AI tools were used.
      Tool(s): `Cursor`.
      Used for: locating the unclaimed issue, drafting the one-line implementation and regression test, and editing the release note.
      I have personally read, understood, and can explain every line of this diff, and
      have verified the statistical/numerical correctness of the change.

### Summary

`MarkovSwitching.hessian` accepts `transformed` but never forwards it to `loglike`, so `hessian(params, transformed=False)` silently returns the `transformed=True` Hessian. `score` on the same class already passes the flag.

### Problem

`loglike` defaults to `transformed=True`. `approx_hess_cs` was called as `approx_hess_cs(params, self.loglike)` with no `args`, so the likelihood was always differentiated in the transformed parameterisation.

`fit()` is unaffected: internal call sites already pass `transformed=True`. The bug only hits callers who evaluate the Hessian in the unconstrained parameter space.

### Solution

Pass `args=(transformed,)` to `approx_hess_cs`, matching `score` / `score_obs`.

### Testing

- Reproduced on installed statsmodels 0.14.6 and current `main` source: `hessian(p, True)` and `hessian(p, False)` were identical while `score` and `loglike` were not.
- Added `test_hessian_respects_transformed`, which fails on the unfixed method and passes after the change.
- Existing `test_results_fittedvalues_resid_joint_likelihoods_cov_params_robust` still passes (covers the `transformed=True` path).
- `ruff check` on the changed Python files passed.

### Related Issue

Closes #10148

Made with [Cursor](https://cursor.com)