### PR TITLE
TST: Avoid test where log_write_bessel is not available

### DIFF
--- a/statsmodels/genmod/families/tests/test_family.py
+++ b/statsmodels/genmod/families/tests/test_family.py
@@ -11,6 +11,7 @@ import pytest
 from scipy import integrate
 
 import statsmodels.genmod.families as F
+from statsmodels.compat.scipy import SP_LT_114
 from statsmodels.genmod.families.family import Binomial, Tweedie
 import statsmodels.genmod.families.links as L
 from statsmodels.tools.sm_exceptions import ValueWarning
@@ -174,10 +175,10 @@ def test_binomial_varfunc_deriv():
 
 
 @pytest.mark.skipif(
-    PLATFORM_32,
+    PLATFORM_32 or SP_LT_114,
     reason=(
             "scipy.special.log_wright_bessel does not have sufficient accuracy on "
-            "32-bit platforms"
+            "32-bit platforms and is only available in SciPy 1.14.0 and later"
     )
 )
 def test_tweedie_log_wright_bessel():


### PR DESCRIPTION
Avoid test where the increased accuracy of log_wright_bessel is required by skipping for SciPy < 1.14

- [X] tests added / passed.
- [X] code/documentation is well formatted.
- [X] properly formatted commit message. See
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message).

#### AI Disclosure

Contributions must comply with the statsmodels [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html).

If using AI tools, edit the second option to explain which tool was selected and
how the tool's output was used.

Please complete **one** of the following:

- [X] No AI tools were used to develop this pull request.
- [ ] AI tools were used.
      Tool(s): `<name(s), e.g. Copilot, Claude, ChatGPT>`.
      Used for: `<e.g. drafting an implementation, writing tests, debugging, editing docstrings>`.
      I have personally read, understood, and can explain every line of this diff, and
      have verified the statistical/numerical correctness of the change.

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows
  using the Windows System for Linux once `flake8` is installed in the
  local Linux environment. While passing this test is not required, it is good practice and it help
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.
* If AI tools were used to help write this PR, see the
  [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html) for what disclosure
  and review is expected of you before submitting.

</details>
