### PR TITLE
BUG: FIx bad merge

### DIFF
--- a/statsmodels/genmod/families/tests/test_family.py
+++ b/statsmodels/genmod/families/tests/test_family.py
@@ -2,6 +2,7 @@
 Test functions for genmod.families.family
 """
 from statsmodels.compat.platform import PLATFORM_32
+from statsmodels.compat.scipy import SP_LT_114
 
 import warnings
 
@@ -11,7 +12,6 @@ import pytest
 from scipy import integrate
 
 import statsmodels.genmod.families as F
-from statsmodels.compat.scipy import SP_LT_114
 from statsmodels.genmod.families.family import Binomial, Tweedie
 import statsmodels.genmod.families.links as L
 from statsmodels.tools.sm_exceptions import ValueWarning

--- a/statsmodels/regression/mixed_linear_model.py
+++ b/statsmodels/regression/mixed_linear_model.py
@@ -2305,10 +2305,7 @@ class MixedLM(base.LikelihoodModel):
         -------
         MixedLMResults
             The model instance containing the fitted results.
-
-        if "cov_type" in fit_kwargs:
-            raise NotImplementedError("cov_type is not supported in MixedLM.fit")
-
+        """
         _allowed_kwargs = [
             "gtol",
             "maxiter",
@@ -2318,13 +2315,15 @@ class MixedLM(base.LikelihoodModel):
             "tol",
             "disp",
             "maxls",
-            "cov_type",
         ]
         disallowed_kwargs = sorted(set(fit_kwargs).difference(_allowed_kwargs))
         if disallowed_kwargs:
+            disallowed = ", ".join(disallowed_kwargs)
+            ending = "s" if len(disallowed_kwargs) > 1 else ""
             warnings.warn(
-                "Argument(s) {} not used by MixedLM.fit".format(", ".join(disallowed_kwargs)),
-                RuntimeWarning,
+                f"Argument{ending} {disallowed} not used by MixedLM.fit. Future versions will raise "
+                "on these arguments.",
+                FutureWarning,
                 stacklevel=2,
             )
             fit_kwargs = {k: v for k, v in fit_kwargs.items()

--- a/statsmodels/regression/tests/test_lme.py
+++ b/statsmodels/regression/tests/test_lme.py
@@ -1420,8 +1420,7 @@ def test_fit_unsupported_kwargs_ignored():
 
     model = MixedLM.from_formula("y ~ x", groups="g", data=df)
 
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
+    with pytest.warns(FutureWarning, match="Argument cov_type"):
         result = model.fit(cov_type="hc1")
 
     # Should complete without AttributeError and return valid results
@@ -1440,13 +1439,8 @@ def test_fit_unsupported_kwargs_warns():
 
     model = MixedLM.from_formula("y ~ x", groups="g", data=df)
 
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter("always")
+    with pytest.warns(FutureWarning, match="Argument cov_type"):
         model.fit(cov_type="hc1")
-
-    runtime_warnings = [x for x in w if issubclass(x.category, RuntimeWarning)]
-    assert len(runtime_warnings) == 1
-    assert "not used by MixedLM.fit" in str(runtime_warnings[0].message)
 
 
 def test_summary_after_remove_data():


### PR DESCRIPTION
Fix ending quotes, remove exception and correct error

- [X] code/documentation is well formatted.
- [X] properly formatted commit message. See
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message).

#### AI Disclosure

Contributions must comply with the statsmodels [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html).

If using AI tools, edit the second option to explain which tool was selected and
how the tool's output was used.

Please complete **one** of the following:

- [X] No AI tools were used to develop this pull request.
- [ ] AI tools were used.
      Tool(s): `<name(s), e.g. Copilot, Claude, ChatGPT>`.
      Used for: `<e.g. drafting an implementation, writing tests, debugging, editing docstrings>`.
      I have personally read, understood, and can explain every line of this diff, and
      have verified the statistical/numerical correctness of the change.

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows
  using the Windows System for Linux once `flake8` is installed in the
  local Linux environment. While passing this test is not required, it is good practice and it help
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.
* If AI tools were used to help write this PR, see the
  [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html) for what disclosure
  and review is expected of you before submitting.

</details>
