### PR TITLE
BUG: support model-aware RLM scale callbacks

### DIFF
--- a/statsmodels/robust/robust_linear_model.py
+++ b/statsmodels/robust/robust_linear_model.py
@@ -14,6 +14,8 @@ R Venables, B Ripley. 'Modern Applied Statistics in S'  Springer, New York,
     2002.
 """
 
+import inspect
+
 import numpy as np
 from scipy import stats
 
@@ -215,6 +217,20 @@ class RLM(base.LikelihoodModel):
         elif isinstance(scale_est, scale.HuberScale):
             return scale_est(self.df_resid, self.nobs, resid)
         else:
+            try:
+                parameters = inspect.signature(self.scale_est).parameters.values()
+            except (TypeError, ValueError):
+                parameters = ()
+            n_args = sum(
+                parameter.kind
+                in (
+                    inspect.Parameter.POSITIONAL_ONLY,
+                    inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                )
+                for parameter in parameters
+            )
+            if n_args > 1:
+                return self.scale_est(self, resid)
             # use df correction to match HuberScale
             return scale_est(resid) * np.sqrt(self.nobs / self.df_resid)
 
@@ -248,14 +264,16 @@ class RLM(base.LikelihoodModel):
             See rlm.RLMResults for more information.
         maxiter : int, optional
             The maximum number of iterations to try. Default is 50.
-        scale_est : {"mad"} or callable, optional
+        scale_est : {'mad'}, HuberScale or callable, optional
             Indicates the estimate to use for scaling the weights in the IRLS.
-            The default is 'mad' (median absolute deviation).  Other options
-            are a `HuberScale` instance for Huber's proposal 2, or any other
-            callable that takes the residuals and returns a scale estimate.
-            Huber's proposal 2 has optional keyword arguments d, tol, and
-            maxiter for specifying the tuning constant, the convergence
-            tolerance, and the maximum number of iterations. See
+            The default is 'mad' (median absolute deviation).  Other options are
+            'HuberScale' for Huber's proposal 2. Huber's proposal 2 has
+            optional keyword arguments d, tol, and maxiter for specifying the
+            tuning constant, the convergence tolerance, and the maximum number
+            of iterations. Custom callables can accept either ``resid`` or
+            ``(model, resid)`` and must return the scale estimate. Single-
+            argument callables use the same degrees-of-freedom correction as
+            the built-in non-Huber scale estimators. See
             statsmodels.robust.scale for more information.
         tol : float, optional
             The convergence tolerance of the estimate.  Default is 1e-8.

--- a/statsmodels/robust/robust_linear_model.py
+++ b/statsmodels/robust/robust_linear_model.py
@@ -14,8 +14,6 @@ R Venables, B Ripley. 'Modern Applied Statistics in S'  Springer, New York,
     2002.
 """
 
-import inspect
-
 import numpy as np
 from scipy import stats
 
@@ -218,21 +216,9 @@ class RLM(base.LikelihoodModel):
             return scale_est(self.df_resid, self.nobs, resid)
         else:
             try:
-                parameters = inspect.signature(self.scale_est).parameters.values()
-            except (TypeError, ValueError):
-                parameters = ()
-            n_args = sum(
-                parameter.kind
-                in (
-                    inspect.Parameter.POSITIONAL_ONLY,
-                    inspect.Parameter.POSITIONAL_OR_KEYWORD,
-                )
-                for parameter in parameters
-            )
-            if n_args > 1:
-                return self.scale_est(self, resid)
-            # use df correction to match HuberScale
-            return scale_est(resid) * np.sqrt(self.nobs / self.df_resid)
+                return scale_est(self, resid)
+            except TypeError:
+                return scale_est(resid) * np.sqrt(self.nobs / self.df_resid)
 
     def fit(
         self,
@@ -264,17 +250,21 @@ class RLM(base.LikelihoodModel):
             See rlm.RLMResults for more information.
         maxiter : int, optional
             The maximum number of iterations to try. Default is 50.
-        scale_est : {'mad'}, HuberScale or callable, optional
+        scale_est : {"mad"}, HuberScale or callable, optional
             Indicates the estimate to use for scaling the weights in the IRLS.
             The default is 'mad' (median absolute deviation).  Other options are
             'HuberScale' for Huber's proposal 2. Huber's proposal 2 has
             optional keyword arguments d, tol, and maxiter for specifying the
             tuning constant, the convergence tolerance, and the maximum number
             of iterations. Custom callables can accept either ``resid`` or
-            ``(model, resid)`` and must return the scale estimate. Single-
-            argument callables use the same degrees-of-freedom correction as
-            the built-in non-Huber scale estimators. See
-            statsmodels.robust.scale for more information.
+            ``(model, resid)`` and must return the scale estimate. The ``model``
+            object provides useful afftributes like ``nobs`` and ``df_reside``
+            that may be needed in scale estimation. Due to backward compatability
+            issues, single- argument callables use the same degrees-of-freedom
+            correction as the built-in non-Huber scale estimators (nobs/df_resid).
+            Scale estimates from two argument functions are used without
+            modification. See statsmodels.robust.scale for more information or
+            the examples below.
         tol : float, optional
             The convergence tolerance of the estimate.  Default is 1e-8.
         update_scale : bool, optional
@@ -294,6 +284,46 @@ class RLM(base.LikelihoodModel):
         -------
         results : statsmodels.robust.robust_linear_model.RLMResults
             Results instance
+
+        Examples
+        --------
+        >>> import statsmodels.api as sm
+        >>> data = sm.datasets.stackloss.load()
+        >>> data.exog = sm.add_constant(data.exog)
+        >>> rlm_model = sm.RLM(data.endog, data.exog, M=sm.robust.norms.HuberT())
+        >>> rlm_results_mad = rlm_model.fit(scale_est="mad")
+
+        >>> from statsmodels.robust import HuberScale
+        >>> hs = HuberScale(d=1.345, tol=1e-6, maxiter=100)
+        >>> rlm_results_mad = rlm_model.fit(scale_est=hs)
+
+        Next we use a custom callable to estimate the scale. The callable can
+        either accept a single argument (the residuals) or two arguments (the
+        model and the residuals). In this example, we use a callable that computes
+        the average absolute deviation of the residuals. Note that the scale
+        estimate from this one-input callable is adjusted for degrees of freedom,
+        so it will be different than the two-input callable version below.
+
+        >>> import numpy as np
+        >>> def avg_abs_deviation(resid):
+        ...     median = np.median(resid)
+        ...     c = np.sqrt(np.pi / 2)
+        ...     return c * np.mean(np.abs(resid - median))
+        >>> rlm_results_custom = rlm_model.fit(scale_est=avg_abs_deviation)
+        >>> print(f"{rlm_results_custom.scale:.4f}")
+        3.0997
+
+        This second version accepts two versions. While the function value is the same
+        it will behave differently in practice since the scale estimate is not adjusted
+        for degrees of freedom.
+
+        >>> def avg_abs_deviation_with_model(model, resid):
+        ...     median = np.median(resid)
+        ...     c = np.sqrt(np.pi / 2)
+        ...     return c * np.mean(np.abs(resid - median))
+        >>> rlm_results_custom_2 = rlm_model.fit(scale_est=avg_abs_deviation_with_model)
+        >>> print(f"{rlm_results_custom_2.scale:.4f}")
+        2.7686
         """
         # options are upper-cased for display/storage, unlike most other
         # string options in this codebase which are lower-cased

--- a/statsmodels/robust/tests/test_rlm.py
+++ b/statsmodels/robust/tests/test_rlm.py
@@ -339,6 +339,38 @@ def test_rlm_start_values_errors():
         model.fit(start_params=start_params)
 
 
+def test_rlm_scale_est_callback_receives_model():
+    data = sm.datasets.stackloss.load_pandas()
+    exog = sm.add_constant(data.exog, prepend=False)
+    model = RLM(data.endog, exog, M=norms.HuberT())
+
+    class ScaleEstimator:
+        def __init__(self):
+            self.calls = []
+
+        def __call__(self, rlm_model, resid):
+            self.calls.append((rlm_model, resid.copy()))
+            return mad(resid, center=0)
+
+    scale_est = ScaleEstimator()
+    result = model.fit(scale_est=scale_est)
+
+    assert scale_est.calls
+    assert all(call[0] is model for call in scale_est.calls)
+    assert_allclose(result.scale, mad(result.resid, center=0))
+
+
+def test_rlm_scale_est_resid_callable_df_correction():
+    data = sm.datasets.stackloss.load_pandas()
+    exog = sm.add_constant(data.exog, prepend=False)
+    model = RLM(data.endog, exog, M=norms.HuberT())
+
+    result = model.fit(scale_est=lambda resid: mad(resid, center=0))
+
+    expected = mad(result.resid, center=0) * np.sqrt(model.nobs / model.df_resid)
+    assert_allclose(result.scale, expected)
+
+
 @pytest.fixture(scope="module",
                 params=[norms.AndrewWave, norms.LeastSquares, norms.HuberT,
                         norms.TrimmedMean, norms.TukeyBiweight, norms.Hampel,

--- a/statsmodels/robust/tests/test_rlm.py
+++ b/statsmodels/robust/tests/test_rlm.py
@@ -360,6 +360,26 @@ def test_rlm_scale_est_callback_receives_model():
     assert_allclose(result.scale, mad(result.resid, center=0))
 
 
+def test_rlm_scale_est_one_and_two_inputs():
+    data = sm.datasets.stackloss.load_pandas()
+    exog = sm.add_constant(data.exog, prepend=False)
+    model = RLM(data.endog, exog, M=norms.HuberT())
+
+    def one_input(resid):
+        median = np.median(resid)
+        c = np.sqrt(np.pi / 2)
+        return c * np.mean(np.abs(resid - median))
+
+    def two_inputs(model, resid):
+        median = np.median(resid)
+        c = np.sqrt(np.pi / 2)
+        return c * np.mean(np.abs(resid - median)) * np.sqrt(model.nobs / model.df_resid)
+
+    result_1 = model.fit(scale_est=one_input)
+    result_2 = model.fit(scale_est=two_inputs)
+    assert_allclose(result_1.scale, result_2.scale)
+
+
 def test_rlm_scale_est_resid_callable_df_correction():
     data = sm.datasets.stackloss.load_pandas()
     exog = sm.add_constant(data.exog, prepend=False)


### PR DESCRIPTION
Allow callable scale estimators to accept the fitted model and residuals while preserving existing single-argument callback behavior.

Closes #9171

- [X] closes #9171
- [X] closes #9968 
- [X] tests added / passed.
- [X] code/documentation is well formatted.
- [X] properly formatted commit message. See
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message).

#### AI Disclosure

Contributions must comply with the statsmodels [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html).

If using AI tools, edit the second option to explain which tool was selected and
how the tool's output was used.

Please complete **one** of the following:

- [ ] No AI tools were used to develop this pull request.
- [X] AI tools were used.
      Tool(s): Copilot?
      Used for: Based on another PR, looks like critten using copilot
      I have personally read, understood, and can explain every line of this diff, and
      have verified the statistical/numerical correctness of the change.

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass flake8. If on Linux or OSX, you can
  verify you changes are well formatted by running
  ```
  git diff upstream/main -u -- "*.py" | flake8 --diff --isolated
  ```
  assuming `flake8` is installed. This command is also available on Windows
  using the Windows System for Linux once `flake8` is installed in the
  local Linux environment. While passing this test is not required, it is good practice and it help
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.
* If AI tools were used to help write this PR, see the
  [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html) for what disclosure
  and review is expected of you before submitting.

</details>
