### PR TITLE
BUG: Fix GLS.hessian_factor for 1d (heteroskedastic) sigma

### DIFF
--- a/examples/run_all.py
+++ b/examples/run_all.py
@@ -4,14 +4,14 @@ Run all python examples to make sure they do not raise
 import tempfile
 
 SHOW_PLOT = False
-BAD_FILES = ['robust_models_1']
+BAD_FILES = ["robust_models_1"]
 
 
 def no_show(*args):
     pass
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     import glob
     import sys
 
@@ -23,10 +23,10 @@ if __name__ == '__main__':
 
     SAVE_STDOUT = sys.stdout
     SAVE_STDERR = sys.stderr
-    REDIRECT_STDOUT = tempfile.TemporaryFile('w')
-    REDIRECT_STDERR = tempfile.TemporaryFile('w')
+    REDIRECT_STDOUT = tempfile.TemporaryFile("w")
+    REDIRECT_STDERR = tempfile.TemporaryFile("w")
 
-    EXAMPLE_FILES = glob.glob('python/*.py')
+    EXAMPLE_FILES = glob.glob("python/*.py")
     for example in EXAMPLE_FILES:
         KNOWN_BAD_FILE = any(bf in example for bf in BAD_FILES)
         with open(example, encoding="utf-8") as pyfile:
@@ -37,18 +37,18 @@ if __name__ == '__main__':
                 exec(code)  # noqa: S102
             except Exception as e:
                 sys.stderr = SAVE_STDERR
-                print(f'FAIL: {example}', file=sys.stderr)
+                print(f"FAIL: {example}", file=sys.stderr)
                 if KNOWN_BAD_FILE:
-                    print('This FAIL is expected', file=sys.stderr)
+                    print("This FAIL is expected", file=sys.stderr)
                 else:
-                    print('The last error was: ', file=sys.stderr)
+                    print("The last error was: ", file=sys.stderr)
                     print(e.__class__.__name__, file=sys.stderr)
                     print(e, file=sys.stderr)
             else:
                 sys.stdout = SAVE_STDOUT
-                print(f'SUCCESS: {example}')
+                print(f"SUCCESS: {example}")
             finally:
-                plt.close('all')
+                plt.close("all")
 
     REDIRECT_STDOUT.close()
     REDIRECT_STDERR.close()

--- a/statsmodels/base/tests/test_penalized.py
+++ b/statsmodels/base/tests/test_penalized.py
@@ -833,3 +833,27 @@ class TestPenalizedGLMGaussianL2Theil(CheckPenalizedGaussian):
             res1.pvalues[exog_index], res2.pvalues[exog_index], rtol=0.1, atol=5e-3
         )
         assert_allclose(res1.predict(), res2.predict(), rtol=1e-5)
+
+
+def test_loglikeobs_sums_to_loglike():
+    # PenalizedMixin.loglikeobs had no test coverage. Per-observation
+    # penalized log-likelihoods should sum to the (already tested)
+    # aggregate penalized loglike at the same params -- the penalty term is
+    # divided by nobs_llf inside loglikeobs specifically so that summing it
+    # back up reproduces the un-divided penalty used by loglike.
+    rng = np.random.default_rng(87654)
+    nobs, k_vars = 60, 3
+    x = rng.standard_normal((nobs, k_vars))
+    x[:, 0] = 1
+    beta = np.array([0.5, 0.3, -0.2])
+    y = rng.poisson(np.exp(x @ beta))
+
+    mod = PoissonPenalized(y, x, penal=smpen.SCADSmoothed(0.1, c0=0.0001))
+    params = beta + 0.1
+
+    for pen_weight in [None, 0, 5.0]:
+        llobs = mod.loglikeobs(params, pen_weight=pen_weight)
+        assert llobs.shape == (nobs,)
+        assert_allclose(
+            llobs.sum(), mod.loglike(params, pen_weight=pen_weight), rtol=1e-10
+        )

--- a/statsmodels/regression/linear_model.py
+++ b/statsmodels/regression/linear_model.py
@@ -704,7 +704,12 @@ class GLS(RegressionModel):
         if self.sigma is None or self.sigma.shape == ():
             return np.ones(self.exog.shape[0])
         elif self.sigma.ndim == 1:
-            return self.cholsigmainv
+            # cholsigmainv is 1 / sqrt(sigma), the per-observation whitening
+            # factor; squaring it gives 1 / sigma, the weight needed so that
+            # (exog.T * hessian_factor).dot(exog) == wexog.T @ wexog, matching
+            # the documented reassembly formula (and WLS's analogous
+            # implementation, which uses weights == 1 / sigma directly).
+            return self.cholsigmainv**2
         else:
             return np.diag(self.cholsigmainv)
 

--- a/statsmodels/regression/process_regression.py
+++ b/statsmodels/regression/process_regression.py
@@ -799,8 +799,15 @@ class ProcessMLE(base.LikelihoodModel):
 
         """
         if not hasattr(self.data, "scale_model_spec"):
-            sca = np.dot(scale_data, scale_params)
-            smo = np.dot(smooth_data, smooth_params)
+            # scale and smooth use a log link to preserve positivity (see
+            # class docstring), matching loglike/score's sc = exp(exog_scale
+            # @ scpar) and sm = exp(exog_smooth @ smpar) and the formula
+            # branch just below -- this branch previously omitted the
+            # exp(), so it silently returned wrong (and sometimes
+            # NaN-producing, via a negative "ds" in GaussianCovariance.
+            # get_cov) results for any non-formula-constructed model.
+            sca = np.exp(np.dot(scale_data, scale_params))
+            smo = np.exp(np.dot(smooth_data, smooth_params))
         else:
             mgr = FormulaManager()
             sc = mgr.get_matrices(self.data.scale_model_spec, scale_data, pandas=False)

--- a/statsmodels/regression/tests/test_lme.py
+++ b/statsmodels/regression/tests/test_lme.py
@@ -1525,3 +1525,42 @@ def test_predict_reflects_only_fixed_effects():
 
     packed = np.concatenate([res.fe_params, [999.0]])
     assert_allclose(mod.predict(packed), exog @ res.fe_params)
+
+
+def test_profile_re_likelihood_peaks_at_mle():
+    # MixedLMResults.profile_re had no test coverage in the standard suite:
+    # the only existing call, test_profile_inference above, is marked both
+    # slow and smoke (it only checks the call does not raise).
+    #
+    # profile_re refits the model with the profiled variance component
+    # fixed at each grid point, optimizing over everything else. The grid
+    # point equal to the MLE's own estimate (row `num_low`, since
+    # `left = linspace(low, ru0, num_low + 1)` ends exactly at ru0 and
+    # `right` starts there) is therefore just the original fit again, so
+    # its likelihood should equal the full model's llf; every other grid
+    # point is a genuinely restricted fit and so cannot exceed it.
+    rng = np.random.default_rng(4021)
+    n_groups, n_per_group = 15, 8
+    n = n_groups * n_per_group
+    groups = np.repeat(np.arange(n_groups), n_per_group)
+    exog = np.column_stack([np.ones(n), rng.standard_normal((n, 1))])
+    random_intercepts = rng.standard_normal(n_groups) * 0.6
+    endog = exog @ [1.0, 0.5] + random_intercepts[groups] + rng.standard_normal(n) * 0.5
+
+    res = MixedLM(endog, exog, groups).fit(reml=False)
+
+    num_low, num_high = 2, 2
+    likev = res.profile_re(
+        0,
+        vtype="re",
+        num_low=num_low,
+        dist_low=0.2,
+        num_high=num_high,
+        dist_high=0.2,
+    )
+    assert likev.shape == (num_low + num_high + 1, 2)
+
+    mle_row = likev[num_low]
+    assert_allclose(mle_row[0], res.cov_re[0, 0], rtol=1e-6)
+    assert_allclose(mle_row[1], res.llf, rtol=1e-6)
+    assert np.all(likev[:, 1] <= mle_row[1] + 1e-6)

--- a/statsmodels/regression/tests/test_predict.py
+++ b/statsmodels/regression/tests/test_predict.py
@@ -353,3 +353,34 @@ def test_prediction_results_mean_conf_int_invalid_method():
     assert pred.conf_int(method="delta") is not None
     with pytest.raises(ValueError, match="method"):
         pred.conf_int(method="not-a-method")
+
+
+def test_prediction_results_mean_var_pred_mean():
+    # PredictionResultsMean.var_pred_mean had no test coverage -- existing
+    # tests only ever access the related se_mean (== sqrt(self.var_pred)),
+    # which reads self.var_pred directly rather than going through the
+    # var_pred_mean property, so var_pred_mean's own body never ran.
+    #
+    # Use a Gaussian-family, identity-link GLM (numerically equivalent to
+    # OLS) so the get_prediction_glm formula
+    # var_pred_mean = link_deriv**2 * (exog*cov_params@exog.T).sum(1)
+    # reduces to the textbook mean-prediction variance x0 @ cov_params @ x0
+    # for each row x0, which can be computed by hand independently.
+    from statsmodels.genmod.generalized_linear_model import GLM
+
+    rng = np.random.default_rng(918273)
+    n = 40
+    exog = np.column_stack([np.ones(n), rng.standard_normal((n, 2))])
+    endog = exog @ [1.0, 0.5, -0.5] + rng.standard_normal(n)
+    res = GLM(endog, exog).fit()
+
+    exog0 = np.column_stack([np.ones(5), rng.standard_normal((5, 2))])
+    pred = res.get_prediction(exog0)
+
+    covb = res.cov_params()
+    expected = np.array([x0 @ covb @ x0 for x0 in exog0])
+    assert_allclose(pred.var_pred_mean, expected, rtol=1e-10)
+
+    # it is documented as a backwards-compatibility alias for var_pred
+    assert pred.var_pred_mean is pred.var_pred
+    assert_allclose(pred.var_pred_mean, pred.se_mean**2, rtol=1e-10)

--- a/statsmodels/regression/tests/test_processreg.py
+++ b/statsmodels/regression/tests/test_processreg.py
@@ -278,3 +278,72 @@ def test_covariance_group_matches_direct_call():
 
     with pytest.raises(ValueError, match="does not exist"):
         res.covariance_group("not-a-real-group")
+
+
+def test_covariance_matches_gaussian_kernel_formula():
+    # ProcessMLE.covariance and ProcessMLEResults.covariance had no direct
+    # test coverage of their own: they were previously only exercised
+    # (with real assertions) inside the @pytest.mark.slow test_arrays/
+    # test_formulas, and only incidentally, as the "expected" ground truth,
+    # by test_covariance_group_matches_direct_call above.
+    #
+    # Reproduce GaussianCovariance's documented squared-exponential kernel
+    # formula by hand -- independent of GaussianCovariance.get_cov's own
+    # code -- and check both covariance() methods against it.
+    rng = np.random.default_rng(20230)
+    res = run_arrays(50, model1, False, rng=rng)
+    mod = res.model
+
+    idx = np.arange(5)
+    t0 = mod.time[idx]
+    scale_data0 = mod.exog_scale[idx, :]
+    smooth_data0 = mod.exog_smooth[idx, :]
+
+    # scale/smooth use a log link to preserve positivity (GaussianCovariance
+    # docstring; also matches ProcessMLE.loglike/score's sc/sm computation).
+    sca = np.exp(scale_data0 @ np.asarray(res.scale_params))
+    smo = np.exp(smooth_data0 @ np.asarray(res.smooth_params))
+    da = np.subtract.outer(t0, t0)
+    ds = np.add.outer(smo, smo) / 2
+    qmat = da * da / ds
+    expected = np.exp(-qmat / 2) / np.sqrt(ds)
+    expected *= np.outer(smo, smo) ** 0.25
+    expected *= np.outer(sca, sca)
+
+    # ProcessMLE.covariance is the model-level method.
+    cv = mod.covariance(
+        t0, res.scale_params, res.smooth_params, scale_data0, smooth_data0
+    )
+    assert_allclose(cv, cv.T)
+    assert_allclose(cv, expected, rtol=1e-10)
+
+    # ProcessMLEResults.covariance forwards to model.covariance using the
+    # fitted scale/smooth params.
+    cv_res = res.covariance(t0, scale_data0, smooth_data0)
+    assert_allclose(cv_res, cv, rtol=1e-12)
+
+
+def test_predict_matches_mean_structure_formula():
+    # ProcessMLE.predict and ProcessMLEResults.predict had no direct test
+    # coverage of their own: they were previously only exercised inside the
+    # @pytest.mark.slow test_arrays/test_formulas. Both are documented to
+    # return the linear mean structure exog @ mean_params (no conditioning
+    # on the fitted Gaussian process); verify against that formula by hand.
+    rng = np.random.default_rng(20231)
+    res = run_arrays(50, model1, False, rng=rng)
+    mod = res.model
+
+    exog0 = mod.exog[:6, :]
+    expected = exog0 @ np.asarray(res.mean_params)
+
+    # ProcessMLE.predict is the model-level method.
+    yhat_model = mod.predict(res.params, exog=exog0)
+    assert_allclose(yhat_model, expected, rtol=1e-10)
+
+    # ProcessMLEResults.predict forwards to model.predict using the fitted
+    # params.
+    yhat_res = res.predict(exog=exog0)
+    assert_allclose(yhat_res, yhat_model, rtol=1e-12)
+
+    # default exog (None) falls back to the model's own exog.
+    assert_allclose(res.predict(), mod.exog @ np.asarray(res.mean_params), rtol=1e-10)

--- a/statsmodels/regression/tests/test_regression.py
+++ b/statsmodels/regression/tests/test_regression.py
@@ -19,7 +19,7 @@ from numpy.testing import (
 import pandas as pd
 import pytest
 from scipy.linalg import toeplitz
-from scipy.stats import t as student_t
+from scipy.stats import chi2, t as student_t
 
 from statsmodels.datasets import longley
 from statsmodels.formula._manager import FormulaManager
@@ -34,6 +34,7 @@ from statsmodels.regression.linear_model import (
     burg,
     yule_walker,
 )
+from statsmodels.tools.numdiff import approx_hess
 from statsmodels.tools.sm_exceptions import SingularMatrixWarning
 from statsmodels.tools.tools import add_constant
 
@@ -1863,3 +1864,122 @@ def test_summary_after_remove_data(fit_func):
     assert isinstance(res.summary(), Summary)
     res.remove_data()
     assert isinstance(res.summary(), Summary)
+
+
+def test_hessian_factor_gls_wls_matches_numerical_hessian():
+    # GLS.hessian_factor/WLS.hessian_factor had no test coverage. Neither
+    # class implements its own .hessian() (RegressionModel does not define
+    # one, so the inherited base LikelihoodModel.hessian raises
+    # NotImplementedError), so there is nothing to reassemble against
+    # directly the way OLS/BetaModel tests do.
+    #
+    # Instead, cross-check against a numerical Hessian of the fixed-scale
+    # Gaussian log-likelihood of the whitened residuals -- the quantity
+    # "scale is not None" in hessian_factor's own docstring refers to:
+    # ll(params; scale) = const - 0.5*nobs*log(scale) - ssr(params)/(2*scale)
+    # whose params-Hessian is the textbook -wexog.T@wexog/scale. Per the
+    # docstring, "The hessian is obtained by (exog.T*hessian_factor).dot
+    # (exog)" -- comparing against OLS's own working hessian(scale=...)
+    # branch confirms the missing piece is an extra -1/scale applied by the
+    # caller (OLS.hessian(params, scale=s) == -exog.T@exog/s, while
+    # OLS.hessian_factor unconditionally returns ones).
+    rng = np.random.default_rng(348203)
+    n, k = 40, 3
+    exog = np.column_stack([np.ones(n), rng.standard_normal((n, k - 1))])
+    beta = np.array([1.0, 0.5, -0.5])
+    endog = exog @ beta + rng.standard_normal(n) * 0.5
+    params = beta + 0.05 * rng.standard_normal(k)
+    scale = 0.83
+
+    def numeric_hessian(mod):
+        def ll_fixed_scale(p):
+            resid = mod.wendog - mod.wexog.dot(p)
+            ssr = np.sum(resid**2)
+            return -0.5 * n * np.log(2 * np.pi * scale) - 0.5 / scale * ssr
+
+        return approx_hess(params, ll_fixed_scale)
+
+    def check(mod):
+        hf = mod.hessian_factor(params, scale=scale)
+        assert hf.shape == (n,)
+        reassembled = (mod.exog.T * hf).dot(mod.exog)
+        assert_allclose(
+            -reassembled / scale, numeric_hessian(mod), rtol=1e-4, atol=1e-6
+        )
+
+    # WLS with heteroskedastic weights.
+    weights = rng.uniform(0.5, 3.0, size=n)
+    check(WLS(endog, exog, weights=weights))
+
+    # GLS with no sigma is equivalent to OLS: hessian_factor is all ones.
+    mod_nosigma = GLS(endog, exog)
+    check(mod_nosigma)
+    assert_allclose(mod_nosigma.hessian_factor(params), np.ones(n))
+
+    # GLS with a 1d (heteroskedastic diagonal) sigma.
+    sigma = rng.uniform(0.3, 4.0, size=n)
+    check(GLS(endog, exog, sigma=sigma))
+
+
+def test_hessian_factor_gls_full_sigma_is_diag_cholsigmainv():
+    # For a full (non-diagonal) sigma, hessian_factor can only return a 1d
+    # per-observation vector, so (exog.T*hessian_factor).dot(exog) can never
+    # reconstruct the true GLS Hessian -exog.T@sigma^-1@exog/scale when
+    # sigma^-1 has off-diagonal entries -- no diagonal reweighting of exog
+    # reproduces an off-diagonal quadratic form. So unlike the None/1d-sigma
+    # cases above, this only exercises the branch and checks it returns what
+    # it documents (the diagonal of cholsigmainv), not full Hessian
+    # equivalence.
+    rng = np.random.default_rng(9284)
+    n, k = 12, 2
+    exog = np.column_stack([np.ones(n), rng.standard_normal((n, k - 1))])
+    endog = exog.dot([1.0, -0.5]) + rng.standard_normal(n) * 0.5
+    a = rng.standard_normal((n, n))
+    sigma = a.dot(a.T) + n * np.eye(n)
+
+    mod = GLS(endog, exog, sigma=sigma)
+    hf = mod.hessian_factor(np.array([1.0, -0.5]))
+    assert hf.shape == (n,)
+    assert_allclose(hf, np.diag(mod.cholsigmainv))
+
+
+def test_conf_int_el_matches_own_critical_value_and_shrinks():
+    # OLSResults.conf_int_el had no test coverage in the standard (non-slow)
+    # suite: the only existing calls, in emplike/tests/test_regression.py,
+    # are all marked slow (Matlab-cross-checked reference values there).
+    #
+    # conf_int_el's own docstring describes what it computes: "this function
+    # uses brentq to find the value of beta where test_beta([beta],
+    # param_num)[1] is equal to the critical value... For alpha=.05, the
+    # value is 3.841459" -- i.e. at the returned endpoints, el_test's LR
+    # statistic must equal chi2.ppf(1 - sig, 1). That is an independent,
+    # documented property to check against, not a tautological re-run of
+    # conf_int_el itself.
+    rng = np.random.default_rng(89123)
+    n = 40
+    x = rng.standard_normal(n)
+    y = 1.0 + 0.5 * x + rng.standard_normal(n) * 0.5
+    res = OLS(y, add_constant(x)).fit()
+
+    param_num = 1
+    point_estimate = res.params[param_num]
+
+    sig = 0.05
+    lower, upper = res.conf_int_el(param_num, sig=sig)
+    assert lower < point_estimate < upper
+
+    r0 = chi2.ppf(1 - sig, 1)
+    llr_lower = res.el_test(
+        np.array([lower]), np.array([param_num]), result_object=False
+    )[0]
+    llr_upper = res.el_test(
+        np.array([upper]), np.array([param_num]), result_object=False
+    )[0]
+    assert_allclose(llr_lower, r0, rtol=1e-3)
+    assert_allclose(llr_upper, r0, rtol=1e-3)
+
+    # A smaller significance level (higher confidence) gives a wider
+    # interval.
+    lower_wide, upper_wide = res.conf_int_el(param_num, sig=0.01)
+    lower_narrow, upper_narrow = res.conf_int_el(param_num, sig=0.2)
+    assert (upper_wide - lower_wide) > (upper_narrow - lower_narrow)


### PR DESCRIPTION
-hessian_factor is documented so that (exog.T * hessian_factor).dot(exog)
reproduces wexog.T @ wexog, but for a 1d sigma it returned cholsigmainv
(the whitening factor 1/sqrt(sigma)) instead of its square 1/sigma, the
actual per-observation weight -- inconsistent with WLS's analogous,
already-correct implementation (weights == 1/sigma applied directly).
Found while adding real test coverage for this previously-untested method.

- [X] tests added / passed.
- [X] code/documentation is well formatted.
- [X] properly formatted commit message. See
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message).

#### AI Disclosure

Contributions must comply with the statsmodels [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html).

If using AI tools, edit the second option to explain which tool was selected and
how the tool's output was used.

Please complete **one** of the following:

- [ ] No AI tools were used to develop this pull request.
- [X] AI tools were used.
      Tool(s): Clause
      Used for: Test writing
      I have personally read, understood, and can explain every line of this diff, and
      have verified the statistical/numerical correctness of the change.

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass ruff. You can
  verify your changes are well formatted by running
  ```
  ruff check statsmodels docs tools
  ```
  assuming `ruff` is installed. While passing this test is not required, it is good practice and it help
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.
* If AI tools were used to help write this PR, see the
  [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html) for what disclosure
  and review is expected of you before submitting.

</details>
