### PR TITLE
BUG: Fix Representation.initialize_components missing k_states arg

### DIFF
--- a/statsmodels/tsa/statespace/representation.py
+++ b/statsmodels/tsa/statespace/representation.py
@@ -933,7 +933,7 @@ class Representation:
             )
         elif initialization == "components":
             initialization = Initialization.from_components(
-                a=a, Pstar=Pstar, Pinf=Pinf, A=A, R0=R0, Q0=Q0
+                self.k_states, a=a, Pstar=Pstar, Pinf=Pinf, A=A, R0=R0, Q0=Q0
             )
         elif initialization == "approximate_diffuse":
             if approximate_diffuse_variance is None:

--- a/statsmodels/tsa/statespace/tests/test_kalman.py
+++ b/statsmodels/tsa/statespace/tests/test_kalman.py
@@ -852,3 +852,43 @@ def test_stationary_initialization():
     check_stationary_initialization_2dim(np.float64)
     check_stationary_initialization_2dim(np.complex64)
     check_stationary_initialization_2dim(np.complex128)
+
+
+def test_prediction_results_clear():
+    # `PredictionResults.clear()` deletes the cached `_<attr>` values for
+    # `endog` plus the `representation_attributes` and `filter_attributes`
+    # lists (see the method body), forcing them to be recomputed via
+    # `__getattr__` on next access. It deliberately leaves other caches
+    # (e.g. smoother_attributes) untouched.
+    endog = np.arange(10, dtype=float)
+    mod = MLEModel(endog, k_states=1, k_posdef=1)
+    mod.ssm.initialize_known(np.array([0.0]), np.array([[1.0]]))
+    mod["design", 0, 0] = 1.0
+    mod["obs_cov", 0, 0] = 1.0
+    mod["transition", 0, 0] = 0.5
+    mod["selection", 0, 0] = 1.0
+    mod["state_cov", 0, 0] = 1.0
+
+    res = mod.ssm.filter()
+    pred = res.predict()
+
+    cached_attrs = ["endog"] + pred.representation_attributes + pred.filter_attributes
+
+    # Access each attribute once so that it gets cached as `_<attr>`
+    values_before = {}
+    for attr in cached_attrs:
+        values_before[attr] = np.array(getattr(pred, attr), copy=True)
+        assert hasattr(pred, "_" + attr)
+
+    pred.clear()
+
+    # Every cache that `clear()` is documented to reset is actually gone
+    for attr in cached_attrs:
+        assert not hasattr(pred, "_" + attr)
+
+    # Re-accessing reproduces identical values and re-populates the cache
+    # (clear() only drops the cache; it cannot change the underlying,
+    # already-computed filter output)
+    for attr in cached_attrs:
+        assert_allclose(getattr(pred, attr), values_before[attr])
+        assert hasattr(pred, "_" + attr)

--- a/statsmodels/tsa/statespace/tests/test_representation.py
+++ b/statsmodels/tsa/statespace/tests/test_representation.py
@@ -1457,3 +1457,69 @@ def test_missing():
     llf_inject_na = mod.loglikeobs()
 
     assert_allclose(llf_inject_na, llf)
+
+
+def test_initialize_components():
+    # `initialize_components` builds an Initialization from the component
+    # matrices (a, Pstar, Pinf/A) as documented in `Initialization.
+    # from_components` (Durbin and Koopman (2012), Sec. 5.2): the resulting
+    # initialization, evaluated via `__call__`, must reproduce `a` as the
+    # initial state mean, `Pinf = A @ A.T` as the diffuse covariance, and
+    # `Pstar` as the stationary covariance.
+    mod = Representation(1, k_states=3)
+
+    a = np.array([1.0, 2.0, 0.0])
+    Pstar = np.diag([4.0, 9.0, 0.0])
+    A = np.zeros((3, 1))
+    A[2, 0] = 1.0
+
+    mod.initialize_components(a=a, Pstar=Pstar, A=A)
+
+    assert mod.initialization.initialized
+    mean, diffuse_cov, stationary_cov = mod.initialization()
+    assert_allclose(mean, a)
+    assert_allclose(diffuse_cov, A.dot(A.T))
+    assert_allclose(stationary_cov, Pstar)
+
+
+def test_initialize_components_r0_q0_equivalent_to_pstar():
+    # Per the documented contract, `Pstar = R0 @ Q0 @ R0.T`, so specifying
+    # R0/Q0 must give identical results to specifying the equivalent Pstar
+    # directly.
+    Pstar = np.array([[2.0, 0.5], [0.5, 3.0]])
+
+    mod1 = Representation(1, k_states=2)
+    mod1.initialize_components(a=[0.0, 0.0], Pstar=Pstar)
+
+    mod2 = Representation(1, k_states=2)
+    R0 = np.eye(2)
+    Q0 = Pstar
+    mod2.initialize_components(a=[0.0, 0.0], R0=R0, Q0=Q0)
+
+    mean1, diffuse_cov1, stationary_cov1 = mod1.initialization()
+    mean2, diffuse_cov2, stationary_cov2 = mod2.initialization()
+
+    assert_allclose(stationary_cov1, Pstar)
+    assert_allclose(stationary_cov1, stationary_cov2)
+    assert_allclose(mean1, mean2)
+    assert_allclose(diffuse_cov1, diffuse_cov2)
+
+
+def test_initialize_components_default_a_is_zero():
+    # `a` defaults to a zero vector when not specified
+    mod = Representation(1, k_states=2)
+    mod.initialize_components(Pstar=np.eye(2))
+
+    mean, _, stationary_cov = mod.initialization()
+    assert_allclose(mean, np.zeros(2))
+    assert_allclose(stationary_cov, np.eye(2))
+
+
+def test_initialize_components_pstar_and_r0q0_raises():
+    # Cannot specify both Pstar and R0/Q0 (they are documented as mutually
+    # exclusive parameterizations of the same stationary covariance)
+    mod = Representation(1, k_states=2)
+    with pytest.raises(ValueError):
+        mod.initialize_components(
+            a=[0.0, 0.0], Pstar=np.eye(2), R0=np.eye(2), Q0=np.eye(2)
+        )

--- a/statsmodels/tsa/statespace/tests/test_simulation_smoothing.py
+++ b/statsmodels/tsa/statespace/tests/test_simulation_smoothing.py
@@ -695,6 +695,56 @@ def test_misc():
     assert_equal(sim.simulation_output, 0)
 
 
+def test_simulation_smooth_results_output_flag_properties():
+    # `simulate_state`, `simulate_disturbance`, and `simulate_all` are
+    # boolean flag properties backed by the `simulation_output` bitmask
+    # (the same OptionWrapper-style pattern used elsewhere in
+    # tsa.statespace, e.g. `smoother_state`/`smoother_all` in
+    # kalman_smoother.py). `test_misc` above exercises the *setters*
+    # indirectly (by checking `simulation_output` afterwards) but never
+    # calls the getters, so check the getters directly here against
+    # independently-computed bitmask values.
+    endog = np.arange(10) * 1.0
+    mod = sarimax.SARIMAX(endog, order=(1, 0, 0))
+    mod.update([0.5, 1.0])
+    sim = mod.simulation_smoother()
+
+    sim.simulation_output = 0
+    assert sim.simulate_state is False
+    assert sim.simulate_disturbance is False
+    assert sim.simulate_all is False
+
+    sim.simulation_output = SIMULATION_STATE
+    assert sim.simulate_state is True
+    assert sim.simulate_disturbance is False
+    # SIMULATION_ALL = SIMULATION_STATE | SIMULATION_DISTURBANCE, so
+    # `simulate_all` reads True whenever *either* component bit is set
+    # (matching the analogous `smoother_all`/OptionWrapper "any-bit"
+    # semantics used throughout this subpackage), not only when both are.
+    assert sim.simulate_all is True
+
+    sim.simulation_output = SIMULATION_DISTURBANCE
+    assert sim.simulate_state is False
+    assert sim.simulate_disturbance is True
+    assert sim.simulate_all is True
+
+    sim.simulation_output = SIMULATION_ALL
+    assert sim.simulate_state is True
+    assert sim.simulate_disturbance is True
+    assert sim.simulate_all is True
+
+    # Setters round-trip through the same bitmask; verify by re-reading the
+    # flag itself (not just `simulation_output`).
+    sim.simulate_state = False
+    assert sim.simulation_output == SIMULATION_DISTURBANCE
+    assert sim.simulate_state is False
+    assert sim.simulate_disturbance is True
+
+    sim.simulate_disturbance = False
+    assert sim.simulation_output == 0
+    assert sim.simulate_all is False
+
+
 def test_simulation_smoother_invalid_method_raises():
     dta = datasets.macrodata.load_pandas().data
     dta.index = pd.date_range(start="1959-01-01", end="2009-7-01", freq="QS")


### PR DESCRIPTION
`Representation.initialize("components", ...)` called
`Initialization.from_components(a=a, Pstar=Pstar, Pinf=Pinf, A=A, R0=R0,
Q0=Q0)` without the required `k_states` positional argument, so every
call to the public `initialize_components()` wrapper raised:

    TypeError: from_components() missing 1 required positional
    argument: 'k_states'

`initialize_components` is not called anywhere else in the codebase
(hence zero test coverage), so this had gone unnoticed.
`Initialization.from_results`, a few lines below, already uses the
correct calling convention
(`cls.from_components(filter_results.model.k_states, ...)`). Fix by
passing `self.k_states` through, matching that convention.

- [X] tests added / passed.
- [X] code/documentation is well formatted.
- [X] properly formatted commit message. See
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message).

#### AI Disclosure

Contributions must comply with the statsmodels [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html).

If using AI tools, edit the second option to explain which tool was selected and
how the tool's output was used.

Please complete **one** of the following:

- [ ] No AI tools were used to develop this pull request.
- [X] AI tools were used.
      Tool(s): Claude
      Used for: Test writing
      I have personally read, understood, and can explain every line of this diff, and
      have verified the statistical/numerical correctness of the change.

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass ruff. You can
  verify your changes are well formatted by running
  ```
  ruff check . --fix
  ```
  assuming `ruff` is installed. While passing this test is not required, it is good practice and it help
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.
* If AI tools were used to help write this PR, see the
  [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html) for what disclosure
  and review is expected of you before submitting.

</details>
