### PR TITLE
TST: Add skip on WASM for linalg error

### DIFF
--- a/statsmodels/tsa/tests/test_varma_process.py
+++ b/statsmodels/tsa/tests/test_varma_process.py
@@ -6,8 +6,12 @@ references anywhere else in the repository. These tests independently
 verify its stationarity/invertibility checks against textbook AR/MA root
 conditions rather than merely asserting the methods run.
 """
+
+from statsmodels.compat.python import PYTHON_IMPL_WASM
+
 import numpy as np
 from numpy.testing import assert_allclose, assert_array_equal
+import pytest
 
 from statsmodels.tsa.varma_process import VarmaPoly
 
@@ -69,7 +73,7 @@ def test_stacksquare_is_companion_form():
 
     assert sq.shape == (lenpk, lenpk)
     assert_array_equal(sq[:, : vp.nvars], vp.vstack())
-    assert_array_equal(sq[:, vp.nvars:], np.eye(lenpk, k=vp.nvars)[:, vp.nvars:])
+    assert_array_equal(sq[:, vp.nvars :], np.eye(lenpk, k=vp.nvars)[:, vp.nvars :])
 
 
 def test_getisstationary_matches_ar1_boundary():
@@ -93,9 +97,7 @@ def test_getisstationary_matches_independent_root_computation():
     is_stationary = vp.getisstationary()
 
     assert is_stationary == bool((np.abs(roots) > 1).all())
-    assert_allclose(
-        np.sort(1 / vp.areigenvalues), np.sort(roots), rtol=1e-10
-    )
+    assert_allclose(np.sort(1 / vp.areigenvalues), np.sort(roots), rtol=1e-10)
 
 
 def test_getisinvertible_matches_ma1_boundary():
@@ -158,11 +160,14 @@ def test_reduceform_normalizes_lag_zero_to_identity():
 
 
 def test_reduceform_errors():
-    import pytest
-
     vp = VarmaPoly(ar23, ma22)
     with pytest.raises(ValueError, match="apoly needs to be 3d"):
         vp.reduceform(np.eye(2))
+
+
+@pytest.mark.skipif(PYTHON_IMPL_WASM, reason="linalg error not raised on WASM")
+def test_reduceform_linalg_error():
+    vp = VarmaPoly(ar23, ma22)
 
     singular = np.array([[[0.0, 0.0], [0.0, 0.0]], [[1.0, 2.0], [3.0, 4.0]]])
     with pytest.raises(ValueError, match="matrix not invertible"):


### PR DESCRIPTION
WASM does nto correctly raise LinAlgError on numpy so skip

- [X] tests added / passed.
- [X] code/documentation is well formatted.
- [X] properly formatted commit message. See
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message).

#### AI Disclosure

Contributions must comply with the statsmodels [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html).

If using AI tools, edit the second option to explain which tool was selected and
how the tool's output was used.

Please complete **one** of the following:

- [X] No AI tools were used to develop this pull request.
- [ ] AI tools were used.
      Tool(s): `<name(s), e.g. Copilot, Claude, ChatGPT>`.
      Used for: `<e.g. drafting an implementation, writing tests, debugging, editing docstrings>`.
      I have personally read, understood, and can explain every line of this diff, and
      have verified the statistical/numerical correctness of the change.

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass ruff. You can
  verify your changes are well formatted by running
  ```
  ruff check . --fix
  ```
  assuming `ruff` is installed. While passing this test is not required, it is good practice and it help
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.
* If AI tools were used to help write this PR, see the
  [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html) for what disclosure
  and review is expected of you before submitting.

</details>
