### PR TITLE
BUG: Return NotImplementedError rather then wrong

### DIFF
--- a/statsmodels/regression/linear_model.py
+++ b/statsmodels/regression/linear_model.py
@@ -700,6 +700,16 @@ class GLS(RegressionModel):
             A 1d weight vector used in the calculation of the Hessian.
             The hessian is obtained by `(exog.T * hessian_factor).dot(exog)`.
 
+        Raises
+        ------
+        NotImplementedError
+            If `sigma` is a full (non-diagonal) covariance matrix. A 1d
+            per-observation weight vector cannot represent the
+            off-diagonal correlation terms, so no choice of
+            `hessian_factor` can satisfy the reassembly formula above in
+            this case; `fit`, `predict`, and other core results are
+            unaffected; only this diagnostic is unavailable.
+
         """
         if self.sigma is None or self.sigma.shape == ():
             return np.ones(self.exog.shape[0])
@@ -711,7 +721,16 @@ class GLS(RegressionModel):
             # implementation, which uses weights == 1 / sigma directly).
             return self.cholsigmainv**2
         else:
-            return np.diag(self.cholsigmainv)
+            raise NotImplementedError(
+                "hessian_factor is not available for GLS with a full "
+                "(non-diagonal) sigma: a 1d per-observation weight vector "
+                "cannot represent sigma's off-diagonal correlation terms, "
+                "so (exog.T * hessian_factor).dot(exog) can never equal "
+                "the true GLS Hessian in this case. This affects only "
+                "diagnostics built on hessian_factor (e.g. score_test, "
+                "MLEInfluence.resid_score_factor); fit(), predict(), and "
+                "other core results are unaffected."
+            )
 
     @Appender(_fit_regularized_doc)
     def fit_regularized(

--- a/statsmodels/regression/tests/test_regression.py
+++ b/statsmodels/regression/tests/test_regression.py
@@ -1921,15 +1921,16 @@ def test_hessian_factor_gls_wls_matches_numerical_hessian():
     check(GLS(endog, exog, sigma=sigma))
 
 
-def test_hessian_factor_gls_full_sigma_is_diag_cholsigmainv():
+def test_hessian_factor_gls_full_sigma_raises():
     # For a full (non-diagonal) sigma, hessian_factor can only return a 1d
     # per-observation vector, so (exog.T*hessian_factor).dot(exog) can never
     # reconstruct the true GLS Hessian -exog.T@sigma^-1@exog/scale when
     # sigma^-1 has off-diagonal entries -- no diagonal reweighting of exog
-    # reproduces an off-diagonal quadratic form. So unlike the None/1d-sigma
-    # cases above, this only exercises the branch and checks it returns what
-    # it documents (the diagonal of cholsigmainv), not full Hessian
-    # equivalence.
+    # reproduces an off-diagonal quadratic form. This used to silently
+    # return the diagonal of cholsigmainv (a genuinely wrong Hessian, not
+    # just an unnormalized one -- see GH real-bugs.md); it now raises
+    # instead of returning a value nothing could use correctly. fit() uses
+    # the full cholsigmainv matrix, not hessian_factor, so it's unaffected.
     rng = np.random.default_rng(9284)
     n, k = 12, 2
     exog = np.column_stack([np.ones(n), rng.standard_normal((n, k - 1))])
@@ -1938,9 +1939,13 @@ def test_hessian_factor_gls_full_sigma_is_diag_cholsigmainv():
     sigma = a.dot(a.T) + n * np.eye(n)
 
     mod = GLS(endog, exog, sigma=sigma)
-    hf = mod.hessian_factor(np.array([1.0, -0.5]))
-    assert hf.shape == (n,)
-    assert_allclose(hf, np.diag(mod.cholsigmainv))
+    with pytest.raises(NotImplementedError, match="hessian_factor"):
+        mod.hessian_factor(np.array([1.0, -0.5]))
+
+    # fit() itself is unaffected -- it whitens with the full cholsigmainv
+    # matrix, never going through hessian_factor.
+    res = mod.fit()
+    assert np.isfinite(res.params).all()
 
 
 def test_conf_int_el_matches_own_critical_value_and_shrinks():


### PR DESCRIPTION
GLS.hessian_factor is not correct in the non-diagonal case so return NotImplementedError to stops its incorrect result

- [X] tests added / passed.
- [X] code/documentation is well formatted.
- [X] properly formatted commit message. See
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message).

#### AI Disclosure

Contributions must comply with the statsmodels [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html).

If using AI tools, edit the second option to explain which tool was selected and
how the tool's output was used.

Please complete **one** of the following:

- [ ] No AI tools were used to develop this pull request.
- [X] AI tools were used.
      Tool(s): Bug detection
      Used for: `<e.g. drafting an implementation, writing tests, debugging, editing docstrings>`.
      I have personally read, understood, and can explain every line of this diff, and
      have verified the statistical/numerical correctness of the change.

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass ruff. You can
  verify your changes are well formatted by running
  ```
  ruff check . --fix
  ```
  assuming `ruff` is installed. While passing this test is not required, it is good practice and it help
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.
* If AI tools were used to help write this PR, see the
  [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html) for what disclosure
  and review is expected of you before submitting.

</details>
