### PR TITLE
BUG: Validate exog before reconstructing the model in ARDLResults.apply

### DIFF
--- a/statsmodels/tsa/ardl/model.py
+++ b/statsmodels/tsa/ardl/model.py
@@ -1149,6 +1149,41 @@ class ARDLResults(AutoRegResults):
         """
 
         existing = self.model
+
+        # These two checks must run before the ARDL(...) reconstruction
+        # below, not after it: existing._order is a dict keyed by the
+        # original exog's column names (DataFrame) or positions (ndarray),
+        # so almost any exog mismatch -- missing entirely, wrong number of
+        # columns, different column names -- makes _format_order raise its
+        # own "extra keys"/"array_like" error first, while trying to apply
+        # that stale order to the new exog. That error gets caught by the
+        # try/except below and wrapped into a generic message, so the
+        # specific, actionable errors here were previously unreachable for
+        # most of the mismatches they exist to describe.
+        if (exog is None) != (existing.exog is None):
+            if existing.exog is not None:
+                raise ValueError(
+                    "exog must be provided when the original model contained "
+                    "exog variables"
+                )
+            raise ValueError(
+                "exog must be None when the original model did not contain "
+                "exog variables"
+            )
+        if existing.exog is not None:
+            # Mirrors _format_order's own type check: a DataFrame's column
+            # count is read directly, anything else goes through the same
+            # array_like coercion _format_order itself uses.
+            if isinstance(exog, pd.DataFrame):
+                n_exog = exog.shape[1]
+            else:
+                n_exog = array_like(exog, "exog", ndim=2, maxdim=2).shape[1]
+            if existing.exog.shape[1] != n_exog:
+                raise ValueError(
+                    "The number of exog variables passed must match the "
+                    f"original Number of exog values ({existing.exog.shape[1]})"
+                )
+
         try:
             deterministic = existing.deterministic
             if deterministic is not None:
@@ -1181,21 +1216,6 @@ class ARDLResults(AutoRegResults):
             exc.args = (error, ) + exc.args
             raise exc.with_traceback(exc.__traceback__) from exc
 
-        if (mod.exog is None) != (existing.exog is None):
-            if existing.exog is not None:
-                raise ValueError(
-                    "exog must be provided when the original model contained "
-                    "exog variables"
-                )
-            raise ValueError(
-                "exog must be None when the original model did not contain "
-                "exog variables"
-            )
-        if existing.exog is not None and existing.exog.shape[1] != mod.exog.shape[1]:
-            raise ValueError(
-                "The number of exog variables passed must match the original "
-                f"Number of exog values ({existing.exog.shape[1]})"
-            )
         if refit:
             fit_kwargs = {} if fit_kwargs is None else fit_kwargs
             return mod.fit(**fit_kwargs)

--- a/statsmodels/tsa/ardl/model.py
+++ b/statsmodels/tsa/ardl/model.py
@@ -141,7 +141,15 @@ def _format_order(
 ) -> dict[Hashable, list[int]]:
     keys: list[Hashable]
     exog_order: dict[Hashable, int | Sequence[int] | None]
-    if exog is None and order in (0, None):
+    if exog is None and (order in (0, None) or not order):
+        # order is `{}`, the resolved (already-formatted) empty order that
+        # a no-exog model's own _order attribute holds -- ARDLResults.apply
+        # and .append round-trip _order back through this function when
+        # cloning a fitted model onto new data, so `order in (0, None)`
+        # alone isn't enough: an empty dict is truthy-equal to neither `0`
+        # nor `None`, so without this it falls through to the array_like
+        # call below and raises on the None exog that's completely
+        # legitimate for a model that never had exog to begin with.
         return {}
     if not isinstance(exog, pd.DataFrame):
         exog = array_like(exog, "exog", ndim=2, maxdim=2)

--- a/statsmodels/tsa/ardl/tests/test_ardl.py
+++ b/statsmodels/tsa/ardl/tests/test_ardl.py
@@ -667,6 +667,28 @@ def test_apply_unexpected_exog_raises():
         res_no_exog.apply(endog=y.iloc[:50], exog=x.iloc[:50])
 
 
+def test_apply_no_exog_roundtrip():
+    """
+    apply()ing a no-exog model with exog=None -- the ordinary, documented
+    case for such a model -- used to crash. ARDLResults.apply reconstructs
+    the clone with order=existing._order, and _order for a no-exog model is
+    `{}` (the *resolved* empty order, not the raw None the user originally
+    passed), which _format_order's `order in (0, None)` guard does not
+    match; it fell through to array_like(None, ...) and raised. append()
+    delegates to apply() and hit the identical crash.
+    """
+    y = dane_data.lrm
+    res_no_exog = ARDL(y.iloc[:45], 3, trend="c").fit()
+
+    applied = res_no_exog.apply(endog=y.iloc[:50], exog=None)
+    assert applied.model.exog is None
+    assert np.all(np.isfinite(applied.params))
+
+    appended = res_no_exog.append(endog=y.iloc[45:50], exog=None)
+    assert appended.model.exog is None
+    assert_allclose(applied.model._x, appended.model._x)
+
+
 def test_apply_missing_exog_raises():
     """
     apply()'s own explicit check for this case ("exog must be provided

--- a/statsmodels/tsa/ardl/tests/test_ardl.py
+++ b/statsmodels/tsa/ardl/tests/test_ardl.py
@@ -667,6 +667,40 @@ def test_apply_unexpected_exog_raises():
         res_no_exog.apply(endog=y.iloc[:50], exog=x.iloc[:50])
 
 
+def test_apply_missing_exog_raises():
+    """
+    apply()'s own explicit check for this case ("exog must be provided
+    when the original model contained exog variables") used to be
+    unreachable: order=existing._order is keyed by the original exog's
+    columns, so reconstructing with exog=None made _format_order raise its
+    own array_like error first, wrapped into a generic message that never
+    mentioned exog at all.
+    """
+    y = dane_data.lrm
+    x = dane_data[["lry", "ibo", "ide"]]
+    res = ARDL(y.iloc[:45], 3, x.iloc[:45], order=3, trend="c").fit()
+
+    with pytest.raises(ValueError, match="exog must be provided"):
+        res.apply(endog=y.iloc[:50], exog=None)
+
+
+def test_apply_wrong_number_of_exog_columns_raises():
+    """
+    apply()'s own explicit check for a column-count mismatch used to be
+    reachable only when the new exog's columns were a superset of the
+    original order dict's keys (e.g. more columns, same names/positions
+    reused) -- the much more common case, fewer or renamed columns, made
+    _format_order raise its own "extra keys" error first, about the order
+    dict rather than about exog itself.
+    """
+    y = dane_data.lrm
+    x = dane_data[["lry", "ibo", "ide"]]
+    res = ARDL(y.iloc[:45], 3, x.iloc[:45], order=3, trend="c").fit()
+
+    with pytest.raises(ValueError, match="number of exog variables"):
+        res.apply(endog=y.iloc[:50], exog=x.iloc[:50, :2])
+
+
 @pytest.mark.thread_unsafe(reason="Uses matplotlib")
 @pytest.mark.matplotlib
 @pytest.mark.smoke


### PR DESCRIPTION
ARDLResults.apply's two explicit exog-mismatch ValueErrors ("exog must be
provided when...", "The number of exog variables passed must match...")
ran after the ARDL(...) reconstruction inside a broad try/except. existing
._order is a dict keyed by the original exog's column names or positions,
so almost any real mismatch -- exog=None when the original had exog,
fewer or renamed columns -- made _format_order raise its own "extra
keys"/array_like error first while trying to apply that stale order to
the new exog. That error was caught and wrapped into a generic message
that never mentioned exog at all, so the two specific, actionable
ValueErrors below were unreachable for most of the cases they exist to
describe (confirmed empirically, not just by reading the code: only a
narrow case, new exog whose columns are a superset of the original
order's keys, ever reached the second check).

Move both checks before the try block, using only `exog` and `existing`
so they no longer need the reconstructed model. The exog-column-count
check mirrors _format_order's own DataFrame/array_like branching so its
behavior stays consistent with what construction would do anyway.

- [X] tests added / passed.
- [X] code/documentation is well formatted.
- [X] properly formatted commit message. See
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message).

#### AI Disclosure

Contributions must comply with the statsmodels [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html).

If using AI tools, edit the second option to explain which tool was selected and
how the tool's output was used.

Please complete **one** of the following:

- [ ] No AI tools were used to develop this pull request.
- [X] AI tools were used.
      Tool(s): Claude
      Used for: Reordering checks and test writing
      I have personally read, understood, and can explain every line of this diff, and
      have verified the statistical/numerical correctness of the change.

<details>


**Notes**:

* It is essential that you add a test when making code changes. Tests are not
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass ruff. You can
  verify your changes are well formatted by running
  ```
  ruff check . --fix
  ```
  assuming `ruff` is installed. While passing this test is not required, it is good practice and it help
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.
* If AI tools were used to help write this PR, see the
  [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html) for what disclosure
  and review is expected of you before submitting.

</details>
