### PR TITLE
ENH: make MICEData iterable, yielding successive imputed datasets

### DIFF
--- a/docs/source/release/version0.15.0.rst
+++ b/docs/source/release/version0.15.0.rst
@@ -672,6 +672,8 @@ New Features and Enhancements
 Notable Bug Fixes
 ====================
 
+- Make ``MICEData`` iterable; each iteration step advances the MICE chain by
+  one update cycle and yields the current imputed dataset. :issue:`7110`
 - Fix a typo in the ``InfeasibleTestError`` exception string. :pr:`8878`
 - Correct diagnostics for changes in pandas. :pr:`8887`
 - MNLogit Wald tests: fix ``ravel``, string ``cov_names``. :pr:`8907`

--- a/statsmodels/imputation/mice.py
+++ b/statsmodels/imputation/mice.py
@@ -288,6 +288,25 @@ class MICEData:
         self.update_all(1)
         return self.data
 
+    def __iter__(self):
+        """
+        Return the iterator object; iterating yields imputed datasets
+
+        Each step of the iteration performs one full MICE update cycle
+        (equivalent to calling ``update_all(1)``) and yields the current
+        imputed dataset. Iteration is infinite; use ``itertools.islice``
+        or break in the caller to stop.
+
+        Notes
+        -----
+        As with ``next_sample``, each yielded value is a reference to the
+        ``data`` attribute and should be copied before making any changes.
+        """
+        return self
+
+    def __next__(self):
+        return self.next_sample()
+
     def _initial_imputation(self):
         """
         Use a PMM-like procedure for initial imputed values

--- a/statsmodels/imputation/tests/test_mice.py
+++ b/statsmodels/imputation/tests/test_mice.py
@@ -1,3 +1,4 @@
+import itertools
 import warnings
 
 import numpy as np
@@ -446,3 +447,23 @@ def test_micedata_miss1():
 
     for key, val in ix_miss.items():
         assert_equal(data_imp.ix_miss[key], val)
+
+
+def test_mice_data_iterable():
+    # gh-7110: iterating over MICEData should yield successive
+    # imputed datasets, one update cycle per step.
+    rs = np.random.RandomState(986431)
+    df = gendat()
+    imp_data = mice.MICEData(df, rng=rs)
+
+    it = iter(imp_data)
+    assert iter(imp_data) is imp_data
+
+    first = next(it)
+    assert isinstance(first, pd.DataFrame)
+    assert first.shape == df.shape
+    assert not first.isna().any().any()
+
+    datasets = list(itertools.islice(it, 3))
+    assert len(datasets) == 3
+    assert all(isinstance(d, pd.DataFrame) for d in datasets)


### PR DESCRIPTION
- closes #7110

#### What
Adds `__iter__`/`__next__` to `MICEData`, wrapping the existing `next_sample()`. Iterating yields successive imputed datasets, one full update cycle per step; iteration is infinite so callers use `itertools.islice` or break.

```python
imp = sm.imputation.mice.MICEData(df)
for imputed in itertools.islice(imp, 5):
    process(imputed.copy())   # yielded value is a reference, copy before mutating
```

This implements what kshedden described as planned-but-never-implemented in the issue thread. Docs-only alternative was discussed there, but the iterator primitive already existed as `next_sample`, so this is a thin wrapper with no behavior change for existing users.

#### Tests
New `test_mice_data_iterable` in `statsmodels/imputation/tests/test_mice.py`; full module suite passes locally (17 passed). Uses seeded RandomState, no global RNG.

#### AI disclosure
- [x] AI tools were used. I have used AI assistance for this change and reviewed, tested, and take full responsibility for every line. Claude was used for documentation and identification of issue.  Every line was reviewed, tested locally, and is fully understood by me.