### PR TITLE
DOC: explain D./L. coefficient naming in UECM docs

### DIFF
--- a/examples/notebooks/autoregressive_distributed_lag.ipynb
+++ b/examples/notebooks/autoregressive_distributed_lag.ipynb
@@ -343,6 +343,19 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The coefficient names in the summary follow the lag-operator notation used throughout the ARDL family of models. Each name maps to a mathematical term as follows\n",
+    "\n",
+    "* `lrm.L1`: the level of `lrm` lagged by one period, $lrm_{t-1}$\n",
+    "* `D.lrm.L1`: the first difference of `lrm` lagged by one period, $\\Delta lrm_{t-1} = lrm_{t-1} - lrm_{t-2}$\n",
+    "* `D.lry.L0`: the first difference of `lry`, $\\Delta lry_t = lry_t - lry_{t-1}$\n",
+    "\n",
+    "In general, `<name>.L<k>` denotes the level of a variable lagged by $k$ periods, $\\text{name}_{t-k}$, `D.<name>` denotes its first difference, $\\Delta \\text{name}_t = \\text{name}_t - \\text{name}_{t-1}$, and `D.<name>.L<k>` denotes the first difference lagged by $k$ periods, $\\Delta \\text{name}_{t-k} = \\text{name}_{t-k} - \\text{name}_{t-k-1}$. In a UECM the lagged levels are the long-run (error-correction) terms, while the differences capture the short-run dynamics."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "9ecf6cab-9477-4492-b83a-40fe92665697",
    "metadata": {},
    "source": [

--- a/statsmodels/tsa/ardl/model.py
+++ b/statsmodels/tsa/ardl/model.py
@@ -1856,6 +1856,18 @@ class UECM(ARDL):
     then the 0-th lag of the exogenous variables is not included and the
     sum starts at ``m=1``.
 
+    The coefficient names used in the summary follow the lag-operator
+    notation
+
+    * ``<name>.L<k>`` : the level of variable ``<name>`` lagged by ``k``
+      periods, i.e. ``name[t-k]``. In a UECM, these are the long-run
+      (error-correction) terms.
+    * ``D.<name>`` : the first difference of ``<name>``, i.e.
+      ``name[t] - name[t-1]``
+    * ``D.<name>.L<k>`` : the first difference lagged by ``k`` periods,
+      i.e. ``name[t-k] - name[t-k-1]``, so that ``D.lry.L1`` is
+      ``lry[t-1] - lry[t-2]``
+
     Examples
     --------
     >>> from statsmodels.tsa.api import UECM
@@ -1883,6 +1895,13 @@ class UECM(ARDL):
     >>> lrma = np.asarray(lrm)
     >>> exoga = np.asarray(exog)
     >>> UECM(lrma, 3, exoga, {0: 1, 1: 3, 2: 2})
+
+    The estimated coefficient names use the ``D.`` and ``.Lk`` notation
+    described in the Notes section
+
+    >>> res = UECM(data.lrm, 2, data[["lry"]], 2).fit()
+    >>> res.params.index.tolist()
+    ['const', 'lrm.L1', 'lry.L1', 'D.lrm.L1', 'D.lry.L0', 'D.lry.L1']
     """
 
     def __init__(


### PR DESCRIPTION
- [x] closes #9743
- [ ] tests added / passed. Docs-only change (no test needed per template); `pytest statsmodels/tsa/ardl/tests` passes (1636 passed).
- [x] code/documentation is well formatted — `ruff check statsmodels/tsa/ardl/model.py` passes.
- [x] properly formatted commit message.

#### AI Disclosure

- [ ] No AI tools were used to develop this pull request.
- [x] AI tools were used.
      Tool(s): a CLI-based coding assistant.
      Used for: drafting the docstring wording and verifying the example output.
      I have personally read, understood, and can explain every line of this diff, and have verified the statistical/numerical correctness of the change.

The summary of a UECM reports coefficient names such as `lrm.L1`, `D.lry.L0` and `D.lry.L1` without the notation being explained anywhere (#9743). This PR adds to the `UECM` docstring:

1. A Notes-section legend for the lag-operator notation:
   - `<name>.L<k>` — the level lagged `k` periods (in a UECM these are the long-run / error-correction terms)
   - `D.<name>` — the first difference
   - `D.<name>.L<k>` — the lagged first difference (so `D.lry.L1` is `lry[t-1] - lry[t-2]`)
2. A worked example on the danish data whose output shows exactly which names a `UECM(y, 2, exog, 2)` fit produces: `['const', 'lrm.L1', 'lry.L1', 'D.lrm.L1', 'D.lry.L0', 'D.lry.L1']` (verified verbatim against actual output).

Note: v0.15.0 was just released and there is no release-notes file for the next cycle yet — happy to add an entry to whichever file the maintainers set up (e.g. `version0.16.0.rst`).
