### PR TITLE
BUG: expose DynamicFactorMQ EM convergence status

### DIFF
--- a/statsmodels/tsa/statespace/dynamic_factor_mq.py
+++ b/statsmodels/tsa/statespace/dynamic_factor_mq.py
@@ -2523,7 +2523,8 @@ class DynamicFactorMQ(mlemodel.MLEModel):
             "nonmissing" if there are no NaN values or "missing" if there are.
         full_output : bool, optional
             Set to True to have all available output from EM iterations in
-            the Results object's mle_retvals attribute.
+            the Results object's mle_retvals attribute, including whether the
+            iterations converged.
         return_params : bool, optional
             Whether or not to return only the array of maximizing parameters.
             Default is False.
@@ -2713,6 +2714,7 @@ class DynamicFactorMQ(mlemodel.MLEModel):
 
         # Check for convergence
         not_converged = (i == maxiter and delta > tolerance)
+        converged = bool(not terminate and delta <= tolerance)
 
         # If no convergence without explicit termination, warn users
         if not_converged:
@@ -2758,7 +2760,9 @@ class DynamicFactorMQ(mlemodel.MLEModel):
             # Save the output
             if full_output:
                 llf.append(result.llf)
-                em_retvals = Bunch(params=np.array(params), llf=np.array(llf), iter=i, inits=inits)
+                em_retvals = Bunch(
+                    params=np.array(params), llf=np.array(llf), iter=i,
+                    converged=converged, inits=inits)
                 em_settings = Bunch(method="em", tolerance=tolerance, maxiter=maxiter)
             else:
                 em_retvals = None

--- a/statsmodels/tsa/statespace/tests/test_dynamic_factor_mq.py
+++ b/statsmodels/tsa/statespace/tests/test_dynamic_factor_mq.py
@@ -20,6 +20,7 @@ import pytest
 from statsmodels.iolib.summary import Summary
 from statsmodels.regression.linear_model import OLS
 from statsmodels.tools import add_constant
+from statsmodels.tools.sm_exceptions import ConvergenceWarning, EstimationWarning
 from statsmodels.tsa.statespace import (
     dynamic_factor,
     dynamic_factor_mq,
@@ -1778,6 +1779,59 @@ def test_em_invalid_mstep_method():
     )
     with pytest.raises(ValueError, match="mstep_method"):
         mod.fit_em(maxiter=1, mstep_method="invalid")
+
+
+def _get_small_em_model():
+    rng = np.random.default_rng(0)
+    nobs, k_endog = 30, 2
+    factor = np.cumsum(rng.standard_normal(nobs)) * 0.3
+    endog = factor[:, None] * rng.uniform(0.6, 1.4, k_endog)
+    endog += rng.standard_normal((nobs, k_endog)) * 0.5
+    return dynamic_factor_mq.DynamicFactorMQ(
+        endog, factors=1, factor_orders=1, idiosyncratic_ar1=False
+    )
+
+
+@pytest.mark.parametrize(
+    ("maxiter", "converged"), [(1, False), (500, True)]
+)
+def test_em_convergence_flag(maxiter, converged):
+    mod = _get_small_em_model()
+    if converged:
+        res = mod.fit_em(maxiter=maxiter, tolerance=1e-6, disp=False)
+    else:
+        with pytest.warns(ConvergenceWarning, match="maximum number of iterations"):
+            res = mod.fit_em(maxiter=maxiter, tolerance=1e-6, disp=False)
+
+    assert res.mle_retvals.converged is converged
+
+
+def test_em_convergence_flag_after_revert(monkeypatch):
+    mod = _get_small_em_model()
+    original_iteration = mod._em_iteration
+    previous_llf = None
+    iteration = 0
+
+    def decrease_second_iteration(params0, init=None, mstep_method=None):
+        nonlocal iteration, previous_llf
+        result, params1 = original_iteration(
+            params0, init=init, mstep_method=mstep_method
+        )
+        iteration += 1
+        current_llf = result.llf_obs.sum()
+        if iteration == 2:
+            result.llf_obs += (
+                previous_llf - 1.0 - current_llf
+            ) / result.llf_obs.size
+        previous_llf = result.llf_obs.sum()
+        return result, params1
+
+    monkeypatch.setattr(mod, "_em_iteration", decrease_second_iteration)
+    with pytest.warns(EstimationWarning, match="Log-likelihood decreased"):
+        res = mod.fit_em(maxiter=10, tolerance=1e-10, disp=False)
+
+    assert res.mle_retvals.iter < 10
+    assert res.mle_retvals.converged is False
 
 
 @pytest.mark.filterwarnings("ignore:Log-likelihood decreased")


### PR DESCRIPTION
- [x] closes #10157
- [x] tests added / passed.
- [x] code/documentation is well formatted.
- [x] properly formatted commit message. See
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message).

#### AI Disclosure

Contributions must comply with the statsmodels [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html).

- [ ] No AI tools were used to develop this pull request.
- [x] AI tools were used.
      Disclosure: AI was used to understand the codebase and review the fix.
      I have personally read, understood, and can explain every line of this diff, and
      have verified the statistical/numerical correctness of the change.

## Summary

Add a boolean `converged` entry to the `mle_retvals` output from `DynamicFactorMQ.fit_em`. The value is `True` only when the EM convergence criterion satisfies the requested tolerance. It is `False` when fitting reaches `maxiter` or reverts after a log-likelihood decrease.

This preserves the existing iteration count and warning behavior while allowing callers to distinguish a reverted fit from genuine convergence without parsing warning text.

The separate `llf_decrease_action="raise"` proposal and changes to the convergence criterion are intentionally outside the scope of this pull request.

## Tests

- `pytest -q statsmodels/tsa/statespace/tests/test_dynamic_factor_mq.py`
- `pytest -q -m "not slow" statsmodels/tsa/statespace/tests`
- `ruff check statsmodels`