### PR TITLE
BUG: place fixed_effects rows before the info_dict rows in summary_col

### DIFF
--- a/statsmodels/iolib/summary2.py
+++ b/statsmodels/iolib/summary2.py
@@ -701,13 +701,13 @@ def summary_col(results, float_format="%.4f", model_names=(), stars=False,
             idx.append(index[i + 1])
     summ.index = idx
 
-    # add fixed effects info
+    # add fixed effects info.  The fixed-effects indicator rows belong
+    # with the parameters and are placed before the other model info
+    # rows (gh-9282), so they are built separately from info_dict.
+    fe_dict = {}
     if fixed_effects:
-        if not info_dict:
-            info_dict = {}
-
         for fe in fixed_effects:
-            info_dict[fe + " FE"] = (
+            fe_dict[fe + " FE"] = (
                 lambda x, fe=fe, fe_present=fe_present, fe_absent=fe_absent:
                     fe_present
                     if any((f"C({fe})" in param) for param in x.params.index)
@@ -718,22 +718,47 @@ def summary_col(results, float_format="%.4f", model_names=(), stars=False,
     if info_dict:
         cols = [_col_info(x, info_dict.get(x.model.__class__.__name__,
                                            info_dict)) for x in results]
-    else:
+    elif not fixed_effects:
         cols = [_col_info(x, getattr(x, "default_model_infos", None)) for x in
                 results]
+    else:
+        # fixed_effects without info_dict: no user info rows are added,
+        # matching the historical output of this combination
+        cols = [_col_info(x, {}) for x in results]
     # use unique column names, otherwise the merge will not succeed
     for df, name in zip(cols, _make_unique([df.columns[0] for df in cols]), strict=True):
         df.columns = [name]
 
     info = reduce(merg, cols)
-    dat = pd.DataFrame(np.vstack([summ, info]))  # pd.concat better, but error
+
+    if fe_dict:
+        fe_cols = [_col_info(x, fe_dict) for x in results]
+        for df, name in zip(fe_cols,
+                            _make_unique([df.columns[0] for df in fe_cols]),
+                            strict=True):
+            df.columns = [name]
+        fe_info = reduce(merg, fe_cols)
+
+        # the R-squared rows end the params block; place them after the
+        # fixed-effects indicators and before the other model info rows
+        r_squared_rows = [ix for ix in summ.index if "R-squared" in str(ix)]
+        r_squared_section = summ.loc[r_squared_rows]
+        summ = summ.drop(index=r_squared_rows)
+
+        dat = pd.DataFrame(np.vstack([summ, fe_info, r_squared_section, info]))
+        dat.index = pd.Index(summ.index.tolist() + fe_info.index.tolist()
+                             + r_squared_section.index.tolist()
+                             + info.index.tolist())
+    else:
+        dat = pd.DataFrame(np.vstack([summ, info]))  # pd.concat better, but error
+        dat.index = pd.Index(summ.index.tolist() + info.index.tolist())
     dat.columns = summ.columns
-    dat.index = pd.Index(summ.index.tolist() + info.index.tolist())
     summ = dat
 
     summ = summ.fillna("")
 
-    # fixed effects processing
+    # fixed effects processing: drop the C(fe) coefficient rows, the
+    # fixed-effects indicator rows convey their presence
     if fixed_effects:
         index_series = pd.Series(summ.index, index=summ.index)
         skip_flag = index_series.apply(
@@ -742,11 +767,6 @@ def summary_col(results, float_format="%.4f", model_names=(), stars=False,
         skip_next_flag = skip_flag.shift(fill_value=False)
         final_skip = skip_flag | skip_next_flag
         summ = summ[~final_skip]
-
-        r_squared_rows = summ.index[summ.index.str.contains("R-squared")]
-        r_squared_section = summ.loc[r_squared_rows]
-        summ = summ.drop(index=r_squared_rows)
-        summ = pd.concat([summ, r_squared_section])
 
     smry = Summary()
     smry._merge_latex = True

--- a/statsmodels/iolib/tests/test_summary2.py
+++ b/statsmodels/iolib/tests/test_summary2.py
@@ -300,3 +300,34 @@ class TestSummaryLabels:
         table = summary_col(results=self.mod, include_r2=False)
         assert "R-squared" not in str(table)
         assert "R-squared Adj." not in str(table)
+
+
+def test_summarycol_fixed_effects_before_info_dict():
+    # gh-9282: the fixed-effects indicator rows belong with the
+    # parameters, i.e. before the rows generated from info_dict
+    from statsmodels.datasets.fair import load_pandas
+
+    df_fair = load_pandas().data
+
+    res0 = OLS.from_formula("affairs ~ yrs_married", df_fair).fit()
+    form1 = "affairs ~ yrs_married + C(occupation)"
+    res1 = OLS.from_formula(form1, df_fair).fit()
+
+    summary = summary_col(
+        [res0, res1],
+        model_names=["ols0", "ols1"],
+        float_format="%0.2f",
+        info_dict={"N": lambda x: f"{int(x.nobs):d}"},
+        fixed_effects=["occupation"],
+    )
+
+    assert list(summary.tables[0].index) == [
+        "Intercept",
+        "",
+        "yrs_married",
+        "",
+        "occupation FE",
+        "R-squared",
+        "R-squared Adj.",
+        "N",
+    ]


### PR DESCRIPTION
## Summary

`summary_col` implemented the `fixed_effects` indicators as entries injected into `info_dict`, so the `"<fe> FE"` rows were stacked **after** the user's info rows (e.g. pseudo-R2, llf) instead of appearing with the parameters. In addition, the R-squared rows were explicitly relocated to the very end of the table to compensate for that placement.

Fixes #9282.

## The fix

- The fixed-effects indicator rows are now built in a separate dict (the caller's `info_dict` is no longer mutated) and are stacked **directly after the parameters**, followed by the R-squared rows and then the user's info rows.
- The R-squared relocation is removed — it existed only to force R² below the misplaced FE rows. With the new order (params → FE rows → R-squared → info rows) it is unnecessary.
- For `fixed_effects` passed without `info_dict`, the info section stays empty as before, so the historical output of that combination is unchanged.

Resulting order with `fixed_effects=["occupation"]` and `info_dict`:

```
Intercept        ...
yrs_married      ...
occupation FE    Yes
R-squared        ...
R-squared Adj.   ...
N                ...
```

Output only changes when `info_dict` is passed together with `fixed_effects`; the existing baseline in `test_summarycol_fixed_effects` (no `info_dict`) is unchanged and still passes.

## Testing

- New `test_summarycol_fixed_effects_before_info_dict`: asserts the exact row order `params → FE → R-squared → R-squared Adj. → info rows`.
- Existing `test_summarycol_fixed_effects` (both baselines, no `info_dict`) passes unchanged.
- Full `test_summary2.py`: 11 passed.
- `ruff check` passes on the changed files.

## AI Disclosure

- [ ] No AI tools were used to develop this pull request.
- [x] AI tools were used.
      Tool(s): `GLM coding agent (Z.ai), operating under the direction of the account owner`.
      Used for: `tracing the row-assembly flow reported in gh-9282, drafting the reordering implementation and the regression test, and running the verification (existing baselines unchanged, new order assertions, ruff)`.
      I have personally read, understood, and can explain every line of this diff, and
      have verified the statistical/numerical correctness of the change.
