### PR TITLE
BUG: use k_select in AIPW-WLS and IPW-RA GMM moment conditions

### DIFF
--- a/statsmodels/treatment/tests/test_teffects.py
+++ b/statsmodels/treatment/tests/test_teffects.py
@@ -134,3 +134,19 @@ class TestTEffects:
             assert_allclose(res1, res0.effect, rtol=1e-12)
             assert_allclose(res0.start_params, res0.results_gmm.params,
                             rtol=1e-12)
+
+
+@pytest.mark.parametrize("meth", ["ipw_ra", "aipw_wls"])
+def test_select_params_not_six(meth):
+    # GMM moment conditions used to hardcode 6 selection parameters
+    formula_sel = "mbsmoke_ ~ mmarried_ + mage + fbaby_"
+    res_sel = Probit.from_formula(formula_sel, dta_cat).fit(disp=0)
+    formula_outcome = "bweight ~ prenatal1_ + mmarried_ + mage + fbaby_"
+    mod = OLS.from_formula(formula_outcome, dta_cat)
+    tind = np.asarray(dta_cat["mbsmoke_"])
+    teff = TreatmentEffect(mod, tind, results_select=res_sel)
+
+    res1 = getattr(teff, meth)(return_results=False)
+    res0 = getattr(teff, meth)(return_results=True)
+    assert_allclose(res1, res0.effect, rtol=1e-12)
+    assert_allclose(res0.start_params, res0.results_gmm.params, rtol=1e-12)

--- a/statsmodels/treatment/treatment_effects.py
+++ b/statsmodels/treatment/treatment_effects.py
@@ -519,7 +519,7 @@ class _AIPWWLSGMM(_TEGMMGeneric1):
         pm = params[0]  # ATE parameter
         p0 = params[1:k+1]
         p1 = params[k+1:2*k+1]
-        ps = params[-6:]
+        ps = params[-self.k_select:]
         mod0 = ra.results0.model
         mod1 = ra.results1.model
         # use reordered exog, endog so it matches sub models by group
@@ -633,7 +633,7 @@ class _IPWRAGMM(_TEGMMGeneric1):
         pm = params[0]  # ATE parameter
         p0 = params[1:k+1]
         p1 = params[k+1:2*k+1]
-        ps = params[-6:]
+        ps = params[-self.k_select:]
         mod0 = ra.results0.model
         mod1 = ra.results1.model
 


### PR DESCRIPTION
#### Summary

`_AIPWWLSGMM.momcond` and `_IPWRAGMM.momcond` slice the selection-model parameters as `params[-6:]`. This was hardcoded to match the Cattaneo example which has 6 coefficients.  If number of parameters is not 6 `TreatmentEffect.ipw_ra()` and `TreatmentEffect.aipw_wls()` will fail with `return_results=True` (the default):

```
ValueError: shapes (4642,4) and (6,) not aligned: 4 (dim 1) != 6 (dim 0)
```

`return_results=False` works, because it skips the GMM step.

This PR replaces the hardcoded slice with `params[-self.k_select:]`, which `_TEGMMGeneric1.__init__` already computes from the selection results. The other GMM classes (`_IPWGMM`, `_AIPWGMM`, `_RAGMM`) already slice by model size and are unaffected.

#### How to reproduce (0.14.6 and 0.15.0)

```python
import numpy as np, statsmodels.api as sm
from statsmodels.treatment.treatment_effects import TreatmentEffect

rng = np.random.default_rng(0); n = 5000
x = rng.normal(size=n)
t = (rng.uniform(size=n) < 1 / (1 + np.exp(-x))).astype(int)
y = 1 + x + 2 * t + rng.normal(size=n)
exog = sm.add_constant(x)  # 2 selection parameters, not 6
te = TreatmentEffect(sm.OLS(y, exog), t, results_select=sm.Probit(t, exog).fit(disp=0))
te.ipw_ra()    # ValueError before this fix
te.aipw_wls()  # ValueError before this fix
```

#### Tests

Added `test_select_params_not_six`, parametrized over `ipw_ra` and `aipw_wls`, using a four-parameter Probit selection model on the existing data. It fails on `main` with the error above and passes with this change.

## AI Disclosure

- [ ] No AI tools were used to develop this pull request.
- [x] AI tools were used.
      Tool(s): claude code
      Used for: drafting implementation
I have read and understand every line of the diff as well as how it interacts with the surrounding code