### PR TITLE
BUG/ENH: apply consistent propensity score clipping in TreatmentEffect

### DIFF
--- a/statsmodels/treatment/treatment_effects.py
+++ b/statsmodels/treatment/treatment_effects.py
@@ -37,6 +37,7 @@ from statsmodels.regression.linear_model import WLS
 from statsmodels.sandbox.regression.gmm import GMM
 from statsmodels.stats.contrast import ContrastResults
 from statsmodels.tools.docstring import indent
+from statsmodels.tools.validation import array_like
 
 
 def _mom_ate(params, endog, tind, prob, weighted=True):
@@ -799,7 +800,7 @@ class TreatmentEffect:
     _cov_type : str, optional
         Internal keyword. The keyword does not affect GMMResults which always
         corresponds to HC0 standard errors.
-    ps_bounds : tuple of float, optional
+    ps_bounds : array_like of float, optional
         Lower and upper bounds for clipping the propensity score, i.e. the
         predicted probabilities of the selection model. The same bounds are
         used for point estimates and for the GMM moment conditions of all
@@ -826,6 +827,11 @@ class TreatmentEffect:
         self.__dict__.update(kwds)  # currently not used
         self.treatment = np.asarray(treatment)
         self.treat_mask = treat_mask = (treatment == 1)
+        ps_bounds = array_like(ps_bounds, "ps_bounds", shape=(2,))
+        if not 0 < ps_bounds[0] < ps_bounds[1] < 1:
+            raise ValueError(
+                "ps_bounds values must satisfy 0 < lower < upper < 1"
+                )
         self.ps_bounds = ps_bounds
 
         if results_select is not None:

--- a/statsmodels/treatment/treatment_effects.py
+++ b/statsmodels/treatment/treatment_effects.py
@@ -399,7 +399,7 @@ class _IPWGMM(_TEGMMGeneric1):
         ps = params[2:]
 
         prob_sel = np.asarray(res_select.model.predict(ps))
-        prob_sel = np.clip(prob_sel, 0.01, 0.99)
+        prob_sel = np.clip(prob_sel, *ra.ps_bounds)
         prob = prob_sel
 
         if effect_group == "all":
@@ -458,7 +458,7 @@ class _AIPWGMM(_TEGMMGeneric1):
         endog = ra.endog_grouped
 
         prob_sel = np.asarray(res_select.model.predict(ps))
-        prob_sel = np.clip(prob_sel, 0.01, 0.99)
+        prob_sel = np.clip(prob_sel, *ra.ps_bounds)
 
         prob0 = prob_sel[~treat_mask]
         prob1 = prob_sel[treat_mask]
@@ -529,7 +529,7 @@ class _AIPWWLSGMM(_TEGMMGeneric1):
         # todo: need weights in outcome models
         prob_sel = np.asarray(res_select.model.predict(ps))
 
-        prob_sel = np.clip(prob_sel, 0.001, 0.999)
+        prob_sel = np.clip(prob_sel, *ra.ps_bounds)
 
         prob0 = prob_sel[~treat_mask]
         prob1 = prob_sel[treat_mask]
@@ -644,7 +644,7 @@ class _IPWRAGMM(_TEGMMGeneric1):
 
         # selection probability by group, propensity score
         prob_sel = np.asarray(res_select.model.predict(ps))
-        prob_sel = np.clip(prob_sel, 0.001, 0.999)
+        prob_sel = np.clip(prob_sel, *ra.ps_bounds)
         prob0 = prob_sel[~treat_mask]
         prob1 = prob_sel[treat_mask]
 
@@ -799,6 +799,11 @@ class TreatmentEffect:
     _cov_type : str, optional
         Internal keyword. The keyword does not affect GMMResults which always
         corresponds to HC0 standard errors.
+    ps_bounds : tuple of float, optional
+        Lower and upper bounds for clipping the propensity score, i.e. the
+        predicted probabilities of the selection model. The same bounds are
+        used for point estimates and for the GMM moment conditions of all
+        estimation methods. Default is (0.001, 0.999).
     **kwds
         Currently not used.
 
@@ -815,16 +820,17 @@ class TreatmentEffect:
     """
 
     def __init__(self, model, treatment, results_select=None, _cov_type="HC0",
-                 **kwds):
+                 ps_bounds=(0.001, 0.999), **kwds):
         # Note _cov_type is only for preliminary estimators,
         # cov in GMM always corresponds to HC0
         self.__dict__.update(kwds)  # currently not used
         self.treatment = np.asarray(treatment)
         self.treat_mask = treat_mask = (treatment == 1)
+        self.ps_bounds = ps_bounds
 
         if results_select is not None:
             self.results_select = results_select
-            self.prob_select = results_select.predict()
+            self.prob_select = np.clip(results_select.predict(), *ps_bounds)
 
         self.model_pool = model
         endog = model.endog


### PR DESCRIPTION
Closes #10222 
Point estimates used unclipped predicted probabilities while the GMM moment conditions clipped them, with different bounds across estimators (0.01/0.99 in _IPWGMM and _AIPWGMM, 0.001/0.999 in _AIPWWLSGMM and _IPWRAGMM). With poor overlap this made results depend on return_results and on the chosen method's hidden bounds.

Before (issue repr):

ipw ATE, return_results=False: -0.3404   # unclipped
ipw ATE, return_results=True :  1.1391   # GMM re-solves with clipped probs

After:
 Both return -0.15

Clip prob_select once in TreatmentEffect.__init__ and use the same bounds, exposed as the ps_bounds keyword (default (0.001, 0.999)), in all GMM moment conditions. The default (0.001, 0.999) matches the previous aipw_wls/ipw_ra behavior. Users can pass ps_bounds=(0.01, 0.99) to reproduce the previous ipw/aipw GMM behavior.

Note on scope: this PR fixes internal consistency, not correctness under poor overlap. In the repro the true ATE is 1.0 
after the fix both code paths agree on −0.15, but that estimate is still badly biased because 550+ observations have propensity scores outside the bounds and clipping merely caps their weights

#### AI Disclosure

- [ ] No AI tools were used to develop this pull request.
- [x] AI tools were used.
      Tool(s): Claude
      Used for: drafting an implementation
      I have personally read, understood, and can explain every line of this diff, and
      have verified the statistical/numerical correctness of the change.