### PR TITLE
BUG: compute Probit loglike, score and hessian in log space

### DIFF
--- a/statsmodels/discrete/discrete_model.py
+++ b/statsmodels/discrete/discrete_model.py
@@ -2568,6 +2568,27 @@ class GeneralizedPoisson(CountModel):
         return distr
 
 
+def _norm_logcdf(z):
+    """Compute log(Phi(z)) without underflow.
+
+    ``log(norm.cdf(z))`` underflows to ``log(0)`` for ``z`` below about
+    -38 and loses precision well before that; ``log_ndtr`` is exact for
+    arbitrarily large ``|z|`` and supports complex inputs, so complex-step
+    differentiation keeps working.
+    """
+    return special.log_ndtr(z)
+
+
+def _norm_mills(z):
+    """Compute the inverse Mills ratio phi(z) / Phi(z) without underflow.
+
+    Evaluated in log space so that the ratio stays finite and accurate
+    where ``norm.cdf(z)`` underflows to zero (``z`` below about -38); the
+    ratio behaves like ``-z`` there.
+    """
+    return np.exp(stats.norm._logpdf(z) - special.log_ndtr(z))
+
+
 def _log_1pexp(w):
     """Compute log(1 + exp(w)) without overflow.
 
@@ -2991,7 +3012,9 @@ class Probit(BinaryModel):
 
         q = 2 * self.endog - 1
         linpred = self.predict(params, which="linear")
-        return np.sum(np.log(np.clip(self.cdf(q * linpred), FLOAT_EPS, 1)))
+        # log Phi(z) evaluated in log space so that large |z| neither
+        # underflows to log(0) nor gets clipped to a constant
+        return np.sum(_norm_logcdf(q * linpred))
 
     def loglikeobs(self, params):
         """
@@ -3020,7 +3043,7 @@ class Probit(BinaryModel):
 
         q = 2 * self.endog - 1
         linpred = self.predict(params, which="linear")
-        return np.log(np.clip(self.cdf(q * linpred), FLOAT_EPS, 1))
+        return _norm_logcdf(q * linpred)
 
     def score(self, params):
         """
@@ -3048,8 +3071,7 @@ class Probit(BinaryModel):
         X = self.exog
         XB = self.predict(params, which="linear")
         q = 2 * y - 1
-        # clip to get rid of invalid divide complaint
-        L = q * self.pdf(q * XB) / np.clip(self.cdf(q * XB), FLOAT_EPS, 1 - FLOAT_EPS)
+        L = q * _norm_mills(q * XB)
         return np.dot(L, X)
 
     def score_obs(self, params):
@@ -3080,8 +3102,7 @@ class Probit(BinaryModel):
         X = self.exog
         XB = self.predict(params, which="linear")
         q = 2 * y - 1
-        # clip to get rid of invalid divide complaint
-        L = q * self.pdf(q * XB) / np.clip(self.cdf(q * XB), FLOAT_EPS, 1 - FLOAT_EPS)
+        L = q * _norm_mills(q * XB)
         return L[:, None] * X
 
     def score_factor(self, params):
@@ -3111,8 +3132,7 @@ class Probit(BinaryModel):
         y = self.endog
         XB = self.predict(params, which="linear")
         q = 2 * y - 1
-        # clip to get rid of invalid divide complaint
-        L = q * self.pdf(q * XB) / np.clip(self.cdf(q * XB), FLOAT_EPS, 1 - FLOAT_EPS)
+        L = q * _norm_mills(q * XB)
         return L
 
     def hessian(self, params):
@@ -3143,7 +3163,7 @@ class Probit(BinaryModel):
         X = self.exog
         XB = self.predict(params, which="linear")
         q = 2 * self.endog - 1
-        L = q * self.pdf(q * XB) / self.cdf(q * XB)
+        L = q * _norm_mills(q * XB)
         return np.dot(-L * (L + XB) * X.T, X)
 
     def hessian_factor(self, params):
@@ -3173,7 +3193,7 @@ class Probit(BinaryModel):
         """
         XB = self.predict(params, which="linear")
         q = 2 * self.endog - 1
-        L = q * self.pdf(q * XB) / self.cdf(q * XB)
+        L = q * _norm_mills(q * XB)
         return -L * (L + XB)
 
     @Appender(DiscreteModel.fit.__doc__)
@@ -3218,10 +3238,12 @@ class Probit(BinaryModel):
 
         linpred = self.predict(params, which="linear")
 
-        pdf_ = self.pdf(linpred)
-        # clip to get rid of invalid divide complaint
-        cdf_ = np.clip(self.cdf(linpred), FLOAT_EPS, 1 - FLOAT_EPS)
-        deriv = pdf_ / cdf_ / (1 - cdf_)  # deriv factor
+        # phi / (Phi * (1 - Phi)) in log space, using 1 - Phi(z) = Phi(-z)
+        deriv = np.exp(
+            stats.norm._logpdf(linpred)
+            - special.log_ndtr(linpred)
+            - special.log_ndtr(-linpred)
+        )
         return deriv[:, None] * self.exog
 
 

--- a/statsmodels/discrete/tests/test_discrete.py
+++ b/statsmodels/discrete/tests/test_discrete.py
@@ -4187,3 +4187,73 @@ def test_logit_loglikeobs_extreme_linpred():
     assert np.all(np.isfinite(loglike))
     assert_allclose(loglikeobs, log_expit(z), rtol=1e-14)
     assert_allclose(loglike, loglikeobs.sum(), rtol=1e-14)
+
+
+def test_probit_loglikeobs_extreme_linpred():
+    # log(clip(cdf(z), eps, 1)) was flat at log(eps) for z below about -8
+    # and log(cdf(z)) underflows to -inf below about -38.  The log_ndtr
+    # based computation is exact and agrees with the stable reference.
+    from scipy import stats
+
+    n = 50
+    z = np.linspace(-1e4, 1e4, n)
+    X = np.column_stack([np.ones(n), z])
+    y = np.ones(n, dtype=int)
+    params = np.array([0.0, 1.0])
+
+    model = sm.Probit(y, X)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        loglikeobs = model.loglikeobs(params)
+        loglike = model.loglike(params)
+        score_obs = model.score_obs(params)
+        hessian = model.hessian(params)
+
+    assert np.all(np.isfinite(loglikeobs))
+    assert np.all(np.isfinite(score_obs))
+    assert np.all(np.isfinite(hessian))
+    assert_allclose(loglikeobs, stats.norm.logcdf(z), rtol=1e-14)
+    assert_allclose(loglike, loglikeobs.sum(), rtol=1e-14)
+    # score factor is the inverse Mills ratio phi(z) / Phi(z)
+    mills = np.exp(stats.norm.logpdf(z) - stats.norm.logcdf(z))
+    assert_allclose(score_obs, mills[:, None] * X, rtol=1e-12)
+
+
+def test_probit_extreme_observation_fit():
+    # One extreme, misclassified observation drives q * XB to -60 at
+    # reasonable params.  The clipped loglike and score were far from the
+    # exact values there, the unclipped hessian was nan, and bfgs stopped
+    # at a spurious optimum with nan standard errors.
+    from scipy import optimize, stats
+
+    from statsmodels.tools.numdiff import approx_fprime_cs, approx_hess
+
+    rng = np.random.default_rng(1)
+    n = 300
+    x = rng.standard_normal(n)
+    y = (1.5 * x + rng.standard_normal(n) > 0).astype(int)
+    x = np.append(x, 40.0)
+    y = np.append(y, 0)
+    X = np.column_stack([np.ones(n + 1), x])
+    q = 2 * y - 1
+    model = sm.Probit(y, X)
+
+    params = np.array([0.0, 1.5])
+    z = q * (X @ params)
+    assert z.min() < -50
+    assert_allclose(model.loglike(params), stats.norm.logcdf(z).sum(), rtol=1e-12)
+    mills = np.exp(stats.norm.logpdf(z) - stats.norm.logcdf(z))
+    assert_allclose(model.score(params), X.T @ (q * mills), rtol=1e-12)
+    assert_allclose(model.score(params), approx_fprime_cs(params, model.loglike), rtol=1e-8)
+    assert_allclose(model.hessian(params), approx_hess(params, model.loglike), rtol=1e-4)
+
+    # both optimizers agree with a direct minimization of the exact loglike
+    ref = optimize.minimize(
+        lambda b: -stats.norm.logcdf(q * (X @ b)).sum(), params, method="BFGS"
+    )
+    for method in ["newton", "bfgs"]:
+        res = model.fit(method=method, disp=0, maxiter=200)
+        assert res.mle_retvals["converged"]
+        assert_allclose(res.params, ref.x, rtol=1e-4)
+        assert_allclose(res.llf, -ref.fun, rtol=1e-8)
+        assert np.all(np.isfinite(res.bse))


### PR DESCRIPTION
- [x] closes #10228
- [x] tests added / passed.
- [x] code/documentation is well formatted.
- [x] properly formatted commit message. See
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message).

#### AI Disclosure

Contributions must comply with the statsmodels [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html).

- [ ] No AI tools were used to develop this pull request.
- [x] AI tools were used.
      Tool(s): Claude (Claude Code).
      Used for: locating the bug (probing Probit against scipy references after the Logit gh-3923 fix), drafting the implementation and the two regression tests, running the verification (scipy references, complex-step and finite-difference derivative checks, min-version scipy 1.8.1 check), and drafting this description and the linked issue.
      I have personally read, understood, and can explain every line of this diff, and
      have verified the statistical/numerical correctness of the change.

#### Summary

`Probit` evaluated its log-likelihood as `log(clip(cdf(z), FLOAT_EPS, 1))`, which is flat at `log(eps) = -36.04` for `q * XB` below about -8 while the true `log(Phi(z))` keeps falling (-53 at z = -10, -805 at z = -40). The score used the same clipped `cdf` in the Mills ratio `pdf / cdf`, where `pdf` underflows first, so extreme observations contributed ~0 score instead of a value growing like `|z|`; `hessian` and `hessian_factor` did not clip at all and returned nan below z = -38. With a single extreme misclassified observation in the sample this gave a wrong `llf`, a wrong-signed score, a nan Hessian, and `fit(method="bfgs")` stopping at a spurious optimum with nan `bse` (details and repro in #10228). This is the Probit counterpart of the `Logit` overflow fixed in gh-3923.

The fix computes everything in log space with the exact scipy pieces:

- `_norm_logcdf(z) = log_ndtr(z)` replaces `log(clip(cdf))` in `loglike` and `loglikeobs`.
- `_norm_mills(z) = exp(norm._logpdf(z) - log_ndtr(z))` replaces the clipped `pdf / cdf` in `score`, `score_obs`, `score_factor`, `hessian` and `hessian_factor`, so the inverse Mills ratio stays finite and accurate where `cdf` underflows (it behaves like `-z` there).
- `_deriv_score_obs_dendog` uses `exp(logpdf - log_ndtr(z) - log_ndtr(-z))` for `pdf / (cdf * (1 - cdf))`, via `1 - Phi(z) = Phi(-z)`.

`log_ndtr` accepts complex input (checked on scipy 1.8.1, the minimum supported version), so complex-step differentiation of the new `loglike` still works and agrees with the analytic score. In the normal range the new values agree with the old ones to ~1e-14, and all existing Probit tests pass unchanged.

#### Tests

`test_probit_loglikeobs_extreme_linpred` mirrors the gh-3923 Logit test (z from -1e4 to 1e4: finite `loglikeobs`, `score_obs`, `hessian`; agreement with `scipy.stats.norm.logcdf` at 1e-14 and with the Mills ratio reference at 1e-12). `test_probit_extreme_observation_fit` uses the outlier sample: exact `loglike`/`score`/`hessian` against scipy references, complex-step and finite-difference derivative checks, and both `newton` and `bfgs` converging to the same optimum as a direct `scipy.optimize.minimize` of the exact log-likelihood with finite `bse`. Both tests fail on main and pass with the fix. The reference values are scipy's `log_ndtr`/`norm.logcdf` and `norm.logpdf`, which are the same quantities R's `pnorm(log.p = TRUE)` and `dnorm(log = TRUE)` compute.

`pytest statsmodels/discrete/tests` and `statsmodels/tools/tests/test_numdiff.py` pass; `ruff check` is clean. No release note added since the recent BUG merges did not touch `docs/source/release/`; happy to add one wherever you want it.
