### PR TITLE
BUG: Use final seasonal factor in Holt-Winters forecasts

### DIFF
--- a/statsmodels/tsa/holtwinters/model.py
+++ b/statsmodels/tsa/holtwinters/model.py
@@ -1286,7 +1286,7 @@ class ExponentialSmoothing(TimeSeriesModel):
                 b[:nobs] = dampen(b[:nobs], phi)
                 b[nobs:] = dampen(b[nobs], phi_h)
             trend = trended(lvls, b)
-            s[nobs + m - 1 :] = [s[(nobs - 1) + j % m] for j in range(h + 1 + 1)]
+            s[nobs + m :] = [s[nobs + j % m] for j in range(h + 1)]
             fitted = trend * s[:-m]
         elif seasonal == "add":
             for i in range(1, nobs + 1):
@@ -1311,7 +1311,7 @@ class ExponentialSmoothing(TimeSeriesModel):
                 b[:nobs] = dampen(b[:nobs], phi)
                 b[nobs:] = dampen(b[nobs], phi_h)
             trend = trended(lvls, b)
-            s[nobs + m - 1 :] = [s[(nobs - 1) + j % m] for j in range(h + 1 + 1)]
+            s[nobs + m :] = [s[nobs + j % m] for j in range(h + 1)]
             fitted = trend + s[:-m]
         else:
             for i in range(1, nobs + 1):

--- a/statsmodels/tsa/holtwinters/tests/test_holtwinters.py
+++ b/statsmodels/tsa/holtwinters/tests/test_holtwinters.py
@@ -18,6 +18,7 @@ import pytest
 import scipy.stats
 
 from statsmodels.tools.sm_exceptions import ValueWarning
+from statsmodels.tsa.exponential_smoothing.ets import ETSModel
 from statsmodels.tsa.holtwinters import (
     PY_SMOOTHERS,
     SMOOTHERS,
@@ -745,11 +746,11 @@ class TestHoltWinters:
                 59.487190,
                 35.758854,
                 44.600641,
-                47.751384,
+                47.913736,
                 59.487190,
                 35.758854,
                 44.600641,
-                47.751384,
+                47.913736,
             ],
             2,
         )
@@ -2164,3 +2165,83 @@ def test_all_initial_values():
     assert_allclose(fit2.params["initial_level"], lvl)
     assert_allclose(fit2.params["initial_trend"], trend)
     assert_allclose(fit2.params["initial_seasons"], seas)
+
+
+@pytest.mark.parametrize("trend", [None, "add"])
+@pytest.mark.parametrize("seasonal", ["add", "mul"])
+def test_seasonal_forecast_uses_final_season(trend, seasonal):
+    # GH 9538: forecasts at horizons h = m, 2m, ... used the seasonal factor
+    # from one full period before the end of the sample, s[T - m], instead
+    # of the final in-sample factor s[T].
+    m = 4
+    nobs = 32
+    rs = np.random.RandomState(12345)
+    y = 10 + 0.1 * np.arange(nobs) + np.tile([1.0, -1.0, 2.0, -2.0], nobs // m)
+    y += 0.3 * rs.standard_normal(nobs)
+    alpha, beta, gamma = 0.3, 0.1, 0.4
+    if seasonal == "add":
+        initial_seasonal = [0.9, -1.1, 2.2, -2.0]
+    else:
+        initial_seasonal = [1.09, 0.91, 1.19, 0.81]
+    has_trend = trend is not None
+    mod = ExponentialSmoothing(
+        y,
+        trend=trend,
+        seasonal=seasonal,
+        seasonal_periods=m,
+        initialization_method="known",
+        initial_level=10.0,
+        initial_trend=0.1 if has_trend else None,
+        initial_seasonal=initial_seasonal,
+    )
+    res = mod.fit(
+        smoothing_level=alpha,
+        smoothing_trend=beta if has_trend else None,
+        smoothing_seasonal=gamma,
+        optimized=False,
+    )
+    h = 2 * m + 1
+    fcast = res.forecast(h)
+
+    # Hyndman & Athanasopoulos, FPP, Holt-Winters' method:
+    # y[T+h|T] = (l[T] + h * b[T]) (+ or *) s[T + h - m * (k + 1)]
+    level = res.level[-1]
+    slope = res.trend[-1] if has_trend else 0.0
+    season = np.asarray(res.season)[-m:]
+    expected = []
+    for step in range(1, h + 1):
+        s_t = season[(step - 1) % m]
+        base = level + step * slope
+        expected.append(base + s_t if seasonal == "add" else base * s_t)
+    assert_allclose(fcast, expected, rtol=1e-12)
+
+    if seasonal == "mul":
+        # ETSModel's multiplicative-seasonal update differs from the
+        # Holt-Winters recursion, so only the additive case is cross-checked.
+        return
+
+    # ETSModel is an independent implementation of the same recursions.
+    # Its smoothing_trend is beta* = alpha * beta in Holt-Winters notation.
+    ets = ETSModel(
+        y,
+        error="add",
+        trend=trend,
+        seasonal="add",
+        seasonal_periods=m,
+        initialization_method="known",
+        initial_level=10.0,
+        initial_trend=0.1 if has_trend else None,
+        initial_seasonal=initial_seasonal,
+    )
+    ets_params = {
+        "smoothing_level": alpha,
+        "smoothing_trend": alpha * beta,
+        "smoothing_seasonal": gamma,
+        "initial_level": 10.0,
+        "initial_trend": 0.1,
+    }
+    for i, value in enumerate(initial_seasonal):
+        ets_params[f"initial_seasonal.{i}"] = value
+    ets_res = ets.smooth([ets_params[name] for name in ets.param_names])
+    assert_allclose(res.fittedvalues, ets_res.fittedvalues, rtol=1e-10)
+    assert_allclose(fcast, ets_res.forecast(h), rtol=1e-10)


### PR DESCRIPTION
- [x] closes #9538
- [x] tests added / passed.
- [x] code/documentation is well formatted.
- [x] properly formatted commit message. See
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message).

#### AI Disclosure

Contributions must comply with the statsmodels [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html).

- [ ] No AI tools were used to develop this pull request.
- [x] AI tools were used.
      Tool(s): Claude Code (Claude).
      Used for: drafting the fix and the regression test, running the test suite, debugging.
      I have personally read, understood, and can explain every line of this diff, and
      have verified the statistical/numerical correctness of the change.

<details>

#### What was wrong

`ExponentialSmoothing` forecasts at horizons that are a multiple of the seasonal period use the wrong seasonal factor. With the example from #9538 (m = 3, known initialization, fixed `smoothing_level=0.5`, `smoothing_seasonal=0.5`), the level and season components are `l_T = -0.0875`, `s = [1.05, 3.075, 2.0875]`, and

```
h   forecast(h)   l_T + s_{T+h-m(k+1)}
1   0.9625        0.9625
2   2.9875        2.9875
3   2.0125        2.0000      <- uses s_{T-3} = 2.1 instead of s_T = 2.0875
4   0.9625        0.9625
5   2.9875        2.9875
6   2.0125        2.0000
```

Horizons that are not multiples of m are unaffected; every horizon h = m, 2m, ... is off by `s_T - s_{T-m}`.

#### Root cause

In `ExponentialSmoothing._predict` the seasonal state is extended into the forecast period with

```python
s[nobs + m - 1 :] = [s[(nobs - 1) + j % m] for j in range(h + 1 + 1)]
```

The slice starts one position too early: `s[nobs + m - 1]` is where the loop stored the final in-sample factor `s_T`, and the assignment overwrites it with `s[nobs - 1] = s_{T-m}`. The same line appears in the multiplicative branch.

#### Fix

Start the periodic extension at `s[nobs + m]` and read from the final m in-sample factors `s[nobs:nobs + m]`:

```python
s[nobs + m :] = [s[nobs + j % m] for j in range(h + 1)]
```

Slice length and list length are both `h + 1`, and the values read are never overwritten, so the RHS is well defined for any `h >= 0`. In-sample fitted values, SSE and therefore parameter estimates are unchanged (`fitted[:nobs]` only reads `s[:nobs]`).

#### Tests

`test_seasonal_forecast_uses_final_season` fits models with known initialization and fixed parameters for `(trend, seasonal)` in `{None, add} x {add, mul}`, and checks `forecast(2m + 1)` against `(l_T + h b_T) (+|*) s_{T+h-m(k+1)}` built from `res.level`, `res.trend`, `res.season` (Hyndman & Athanasopoulos, FPP, Holt-Winters' method), `rtol=1e-12`. For additive seasonality it also cross-checks fitted values and forecasts against `ETSModel` (independent implementation; `smoothing_trend_ets = alpha * beta`), `rtol=1e-10`. All four cases fail on `main` and pass with the fix.

`TestHoltWinters.test_hw_seasonal_buggy` needed one expected value changed: its step-4/step-8 forecast `47.751384` is `inv_boxcox(l_T + s_{T-4}, lambda)` from the fitted components, i.e. it encoded the bug; the corrected value `47.913736 = inv_boxcox(l_T + s_T, lambda)`. The multiplicative case in the same test is unchanged (its fitted gamma is ~0, so `s_T == s_{T-4}`). All other Holt-Winters tests, including the R-derived reference values in `test_hw_seasonal` and `test_hw_seasonal_add_mul`, pass unchanged.

```
python -m pytest statsmodels/tsa/holtwinters -n 4
164 passed, 2 xfailed
ruff check statsmodels/tsa/holtwinters   # clean
```

(run against the 0.15.0 wheel with the patched `model.py` and test file; CPU only.)

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
