### PR TITLE
BUG: Print seasonal MA order as an integer in SARIMAX summary

### DIFF
--- a/statsmodels/tsa/statespace/sarimax.py
+++ b/statsmodels/tsa/statespace/sarimax.py
@@ -2073,7 +2073,7 @@ class SARIMAXResults(MLEResults):
             else:
                 order_seasonal_ar = list(self.model._spec.seasonal_ar_lags)
             tmp = int(self.model.k_seasonal_ma / self.model.seasonal_periods)
-            if tmp == self.model.k_ma_params:
+            if tmp == self.model.k_seasonal_ma_params:
                 order_seasonal_ma = tmp
             else:
                 order_seasonal_ma = list(self.model._spec.seasonal_ma_lags)

--- a/statsmodels/tsa/statespace/tests/test_sarimax.py
+++ b/statsmodels/tsa/statespace/tests/test_sarimax.py
@@ -3142,6 +3142,28 @@ def test_summary_after_remove_data():
     assert isinstance(res.summary(), Summary)
 
 
+@pytest.mark.parametrize(
+    "order, seasonal_order, expected",
+    [
+        ((1, 0, 1), (1, 0, 2, 4), "SARIMAX(1, 0, 1)x(1, 0, 2, 4)"),
+        ((1, 0, 0), (0, 0, 1, 4), "SARIMAX(1, 0, 0)x(0, 0, 1, 4)"),
+        ((0, 0, 2), (2, 0, 1, 12), "SARIMAX(0, 0, 2)x(2, 0, 1, 12)"),
+        ((1, 0, 1), (1, 0, [2], 4), "SARIMAX(1, 0, 1)x(1, 0, [2], 4)"),
+    ],
+)
+def test_summary_seasonal_ma_order(order, seasonal_order, expected):
+    # GH 9490: the seasonal MA order was compared against the number of
+    # non-seasonal MA parameters, so whenever q != Q the summary printed Q
+    # as the list of seasonal MA lags, e.g. "x(1, 0, [1, 2], 4)".
+    endog = np.arange(40, dtype=float) % 4
+    mod = sarimax.SARIMAX(endog, order=order, seasonal_order=seasonal_order)
+    params = np.zeros(mod.k_params)
+    params[-1] = 1.0
+    res = mod.filter(params)
+
+    assert expected in res.summary().tables[0].as_text()
+
+
 def test_model_latex_names_matches_model_names_structure():
     rs = np.random.RandomState(19)
     endog = rs.standard_normal(60).cumsum()


### PR DESCRIPTION
- [x] closes #9490
- [x] tests added / passed.
- [x] code/documentation is well formatted.
- [x] properly formatted commit message. See
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message).

#### AI Disclosure

Contributions must comply with the statsmodels [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html).

- [ ] No AI tools were used to develop this pull request.
- [x] AI tools were used.
      Tool(s): Claude Code (Claude).
      Used for: drafting the regression test, running the test suite.
      I have personally read, understood, and can explain every line of this diff, and
      have verified the statistical/numerical correctness of the change.

<details>

#### What was wrong

`SARIMAXResults.summary()` prints the seasonal MA order as a list of lags whenever it differs from the non-seasonal MA order:

| `order`, `seasonal_order` | printed on `main` | expected |
| --- | --- | --- |
| `(1, 0, 1)`, `(1, 0, 2, 4)` | `SARIMAX(1, 0, 1)x(1, 0, [1, 2], 4)` | `SARIMAX(1, 0, 1)x(1, 0, 2, 4)` |
| `(1, 0, 0)`, `(0, 0, 1, 4)` | `SARIMAX(1, 0, 0)x(0, 0, [1], 4)` | `SARIMAX(1, 0, 0)x(0, 0, 1, 4)` |
| `(0, 0, 2)`, `(2, 0, 1, 12)` | `SARIMAX(0, 0, 2)x(2, 0, [1], 12)` | `SARIMAX(0, 0, 2)x(2, 0, 1, 12)` |
| `(2, 1, 2)`, `(2, 1, 2, 12)` | `SARIMAX(2, 1, 2)x(2, 1, 2, 12)` | (unchanged, q == Q) |

#### Root cause

In `summary`, the seasonal MA branch compares `int(k_seasonal_ma / seasonal_periods)` with `self.model.k_ma_params` (the number of non-seasonal MA parameters) instead of `self.model.k_seasonal_ma_params`; the seasonal AR branch directly above correctly uses `k_seasonal_ar_params`. The comparison therefore only succeeds when q == Q.

#### Fix

One-token change: compare with `k_seasonal_ma_params`. Genuinely sparse seasonal MA lags (e.g. `seasonal_order=(1, 0, [2], 4)`) still print as a list, which the new test also checks.

#### Tests

`test_summary_seasonal_ma_order` builds the model name from `res.summary()` for the four cases above (using `mod.filter` with zero AR/MA coefficients so no fit is needed). Three of the four cases fail on `main`; all pass with the fix.

```
python -m pytest statsmodels/tsa/statespace/tests/test_sarimax.py -n 4
495 passed, 61 skipped
ruff check statsmodels/tsa/statespace   # clean
```

(run against the 0.15.0 wheel with the patched `sarimax.py` and test file; CPU only.)

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
