### PR TITLE
BUG: Fix out-of-bounds write and dropped observations in fast_linbin

### DIFF
--- a/statsmodels/nonparametric/linbin.pyx
+++ b/statsmodels/nonparametric/linbin.pyx
@@ -15,6 +15,12 @@ ctypedef np.int64_t INT
 def fast_linbin(np.ndarray[DOUBLE] X, double a, double b, int M, int trunc=1):
     """
     Linear Binning as described in Fan and Marron (1994)
+
+    Each observation in [a, b] is split linearly between the two grid points
+    of the equally spaced grid ``linspace(a, b, M)`` that enclose it, so that
+    the bin counts sum to the number of observations in [a, b]. Observations
+    outside [a, b] are dropped if ``trunc`` is nonzero and are otherwise
+    assigned to the nearest end point of the grid.
     """
     cdef:
         Py_ssize_t i, li_i
@@ -27,10 +33,20 @@ def fast_linbin(np.ndarray[DOUBLE] X, double a, double b, int M, int trunc=1):
 
 
     for i in range(nobs):
+        if not (a <= X[i] <= b):
+            # outside [a, b] (or nan): drop, or move to the nearest end point
+            if trunc == 0:
+                if X[i] < a:
+                    gcnts[0] = gcnts[0] + 1
+                elif X[i] > b:
+                    gcnts[M-1] = gcnts[M-1] + 1
+            continue
         li_i = li[i]
-        if li_i > 1 and li_i < M:
+        if li_i >= M - 1:
+            # X[i] == b, up to rounding in lxi; all of the weight belongs to
+            # the last grid point and gcnts[M] is out of bounds
+            gcnts[M-1] = gcnts[M-1] + 1
+        else:
             gcnts[li_i] = gcnts[li_i] + 1 - rem[i]
             gcnts[li_i+1] = gcnts[li_i+1] + rem[i]
-        if li_i > M and trunc == 0:
-            gcnts[M] = gcnts[M] + 1
     return gcnts

--- a/statsmodels/nonparametric/tests/test_kde.py
+++ b/statsmodels/nonparametric/tests/test_kde.py
@@ -15,6 +15,7 @@ from statsmodels.nonparametric.kde import (
     kdensity,
     kdensityfft,
 )
+from statsmodels.nonparametric.linbin import fast_linbin
 from statsmodels.sandbox.nonparametric import kernels
 
 # get results from Stata
@@ -406,6 +407,43 @@ def test_kde_bw_positive():
     kde = KDE(x)
     kde.fit()
     assert kde.bw > 0
+
+
+def test_fast_linbin_boundary_observations():
+    # GH 9556: an observation at the upper grid boundary (li == M - 1) was
+    # split onto gcnts[M], one past the end of the array, and observations
+    # in the first two bins were dropped, so the counts did not sum to nobs.
+    x = np.array([0.0, 0.3, 1.0])
+    counts = fast_linbin(x, 0.0, 1.0, 5)
+    npt.assert_allclose(counts, [1.0, 0.8, 0.2, 0.0, 1.0])
+
+    rs = np.random.RandomState(12345)
+    x = rs.standard_normal(200)
+    counts = fast_linbin(x, x.min(), x.max(), 512)
+    assert counts.shape == (512,)
+    npt.assert_allclose(counts.sum(), 200)
+    # linear binning preserves the first moment
+    grid = np.linspace(x.min(), x.max(), 512)
+    npt.assert_allclose(counts @ grid, x.sum())
+
+    # observations outside [a, b] are dropped, or moved to the end points
+    x = np.array([-1.0, 0.5, 2.0])
+    npt.assert_allclose(fast_linbin(x, 0.0, 1.0, 5), [0.0, 0.0, 1.0, 0.0, 0.0])
+    npt.assert_allclose(
+        fast_linbin(x, 0.0, 1.0, 5, trunc=0), [1.0, 0.0, 1.0, 0.0, 1.0]
+    )
+
+
+def test_kde_fft_cut_zero():
+    # GH 9556: with cut=0 the largest observation sits exactly on the last
+    # grid point; the FFT path wrote past the end of the bin counts and
+    # dropped the smallest observation, so the density integrated to 5/6.
+    x = [24.0, 43.0, 27.0, 15.0, 37.0, 8.82]
+    kde = KDE(x)
+    kde.fit(fft=True, cut=0)
+    density, support = kde.density, kde.support
+    integral = np.sum(0.5 * (density[1:] + density[:-1]) * np.diff(support))
+    npt.assert_allclose(integral, 1.0, atol=0.01)
 
 
 def test_fit_self():


### PR DESCRIPTION
- [x] closes #9556
- [x] tests added / passed.
- [x] code/documentation is well formatted.
- [x] properly formatted commit message. See
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message).

#### AI Disclosure

Contributions must comply with the statsmodels [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html).

- [ ] No AI tools were used to develop this pull request.
- [x] AI tools were used.
      Tool(s): Claude Code (Claude).
      Used for: drafting the fix and tests, writing the reference implementation used for verification, debugging.
      I have personally read, understood, and can explain every line of this diff, and
      have verified the statistical/numerical correctness of the change.

<details>

#### What was wrong

`fast_linbin` (the linear binning behind `kdensityfft` / `KDEUnivariate.fit(fft=True)`) has two problems in its 8-line loop:

1. **Out-of-bounds write.** For an observation in the last bin (`li == M - 1`) the split `gcnts[li + 1] += rem` writes to `gcnts[M]`, one element past the end of the array, and the `trunc == 0` tail case writes to `gcnts[M]` directly. The module is compiled with `boundscheck=False`, so this silently corrupts the heap. With `cut=0` the largest observation always maps to `li == M - 1`, and whether `rem` is exactly 0 or a few ulp depends on rounding in `(X - a) / delta`, which is why `8.82` crashes for the reporter and `8.8` does not. Compiling the *unchanged* module with `boundscheck=True` raises `IndexError: Out of bounds on buffer access (axis 0)` for the data in #9556:

   ```python
   x = np.array([24.0, 43.0, 27.0, 15.0, 37.0, 8.82]); a, b = x.min(), x.max()   # cut=0
   lxi = (x - a) / ((b - a) / 511)
   # lxi[1] = 511.00000000000006  ->  li = 511 = M - 1, rem = 5.7e-14  ->  gcnts[512] += 5.7e-14
   ```

2. **Dropped observations.** The loop only counts observations with `li > 1`, so anything in the first two bins is dropped; with `cut=0` that is always the minimum. The counts then no longer sum to `nobs`, but `kdensityfft` divides by `delta * nobs`, so the density is under-normalized. For the #9556 data the bin counts sum to `4.99999999999994` instead of `6`, and the FFT density integrates to `0.8317` (5/6 from the dropped minimum, minus the mass leaked past the array).

#### Fix

Rewrite the loop to follow linear binning as in Wand & Jones / KernSmooth's `linbin`: observations in `[a, b]` are split between the two enclosing grid points; an observation on the upper boundary (`li >= M - 1`, i.e. `X == b` up to rounding) gets all of its weight at the last grid point; observations outside `[a, b]` (or nan) are dropped, or moved to the nearest end point when `trunc == 0`. No index can exceed `M - 1`: the split branch only runs for `li < M - 1`.

Results with the default `cut=3` are unchanged (the first two and last bins are empty by construction, which is why the existing R/Stata-referenced KDE tests never saw this).

#### Verification

- The compiled fixed module agrees with a pure-Python reference implementation of KernSmooth's `linbin` on 200 random cases (`M` in {2, 3, 8, 64, 512}, observations exactly on `a` and `b`, outside `[a, b]`, and nan; both `trunc` values) to a max abs difference of `1.1e-13`, and the counts sum to the number of in-range observations in every case.
- #9556 data: bin counts sum to 6 (was 4.99999999999994); `KDEUnivariate(x).fit(fft=True, cut=0)` density integrates to `0.9979` (was `0.8317`).
- `x = [0, 0.3, 1.0]`, `a=0, b=1, M=5`: `[1, 0.8, 0.2, 0, 1]` (was `[0, 0, 0, 0, 1]`).

#### Tests

`test_fast_linbin_boundary_observations` checks the hand-computable case above, that counts sum to `nobs` and preserve the first moment (`counts @ grid == x.sum()`) for 200 normal draws binned on `[min, max]`, and truncation with `trunc=1`/`trunc=0`. `test_kde_fft_cut_zero` is the #9556 example and asserts the density integrates to 1 within 0.01. Both fail against `main` (`[0, 0, 0, 0, 1]` and `0.8317`) and pass with the fix.

```
python -m pytest statsmodels/nonparametric -n 4
188 passed, 1 skipped, 8 xfailed
ruff check statsmodels/nonparametric   # clean
```

(macOS arm64 / Apple M3, Python 3.12, numpy 2.5.2, Cython 3.3.0; the `.pyx` was compiled standalone with `cython -3` + clang and run against the 0.15.0 wheel. CPU only.)

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
