### PR TITLE
ENH: effect_group (ATET/ATC) for TreatmentEffect.aipw and aipw_wls

### DIFF
--- a/statsmodels/treatment/tests/results/results_teffects.py
+++ b/statsmodels/treatment/tests/results/results_teffects.py
@@ -359,14 +359,12 @@ results_ipwra = Bunch(
                 )
 
 
-# ATET and ATC for aipw and aipw_wls from DoubleML 0.11.4
-# (DoubleMLIRM, score="ATTE", trimming_threshold=0.01, scikit-learn 1.9.0).
-# Nuisance models are fit on the full sample (no cross-fitting):
-#   propensity: logit on prenatal1_ mmarried_ mage mage2 fbaby_ medu
-#   outcome:    OLS on the same covariates, by treatment group
-# ATC is obtained by relabeling the treatment as 1 - d.
-# For aipw_wls the DoubleML score is evaluated with external_predictions
-# equal to the weighted outcome regressions of TreatmentEffect.aipw_wls.
+# Effects on the treated (att) and on the controls (atc) were obtained from
+# DoubleML 0.11.4, DoubleMLIRM with score="ATTE" and trimming at 0.01.
+# Logit propensity score and OLS outcome models are fit on the full sample
+# without cross-fitting; atc uses the relabeled treatment 1 - d.
+# For aipw_wls, DoubleML's score is evaluated at the WLS outcome predictions
+# of TreatmentEffect.aipw_wls (external_predictions).
 results_aipw_atet_dml = Bunch(
                 aipw_att=-226.178244689,
                 aipw_atc=-230.764615449,

--- a/statsmodels/treatment/tests/results/results_teffects.py
+++ b/statsmodels/treatment/tests/results/results_teffects.py
@@ -357,3 +357,19 @@ results_ipwra = Bunch(
                 table_t_colnames=table_t_colnames,
                 table_t_rownames=table_t_rownames,
                 )
+
+
+# ATET and ATC for aipw and aipw_wls from DoubleML 0.11.4
+# (DoubleMLIRM, score="ATTE", trimming_threshold=0.01, scikit-learn 1.9.0).
+# Nuisance models are fit on the full sample (no cross-fitting):
+#   propensity: logit on prenatal1_ mmarried_ mage mage2 fbaby_ medu
+#   outcome:    OLS on the same covariates, by treatment group
+# ATC is obtained by relabeling the treatment as 1 - d.
+# For aipw_wls the DoubleML score is evaluated with external_predictions
+# equal to the weighted outcome regressions of TreatmentEffect.aipw_wls.
+results_aipw_atet_dml = Bunch(
+                aipw_att=-226.178244689,
+                aipw_atc=-230.764615449,
+                aipw_wls_att=-223.448320722,
+                aipw_wls_atc=-223.602248802,
+                )

--- a/statsmodels/treatment/tests/results/results_teffects.py
+++ b/statsmodels/treatment/tests/results/results_teffects.py
@@ -362,12 +362,13 @@ results_ipwra = Bunch(
 # Effects on the treated (att) and on the controls (atc) were obtained from
 # DoubleML 0.11.4, DoubleMLIRM with score="ATTE" and trimming at 0.01.
 # Logit propensity score and OLS outcome models are fit on the full sample
-# without cross-fitting; atc uses the relabeled treatment 1 - d.
+# without cross-fitting; atc negates the effect for relabeled treatment 1 - d.
 # For aipw_wls, DoubleML's score is evaluated at the WLS outcome predictions
 # of TreatmentEffect.aipw_wls (external_predictions).
+# Reproduce the comparison with teffects_doubleml.py in this directory.
 results_aipw_atet_dml = Bunch(
-                aipw_att=-226.178244689,
-                aipw_atc=-230.764615449,
+                aipw_att=-226.178244783,
+                aipw_atc=-230.764613267,
                 aipw_wls_att=-223.448320722,
                 aipw_wls_atc=-223.602248802,
                 )

--- a/statsmodels/treatment/tests/results/teffects_doubleml.py
+++ b/statsmodels/treatment/tests/results/teffects_doubleml.py
@@ -1,0 +1,91 @@
+"""Reproduce the AIPW ATET/ATC point-estimate comparison with DoubleML 0.11.4.
+
+Requires DoubleML and scikit-learn in addition to statsmodels. Run from the
+repository root with::
+
+    python -m statsmodels.treatment.tests.results.teffects_doubleml
+
+This is a reference-generation script, not a test dependency. The WLS comparison
+uses statsmodels outcome predictions and therefore checks only the AIPW score.
+"""
+
+from pathlib import Path
+
+import doubleml
+import numpy as np
+from numpy.testing import assert_allclose
+import pandas as pd
+import sklearn
+from sklearn.linear_model import LinearRegression, LogisticRegression
+from sklearn.pipeline import make_pipeline
+from sklearn.preprocessing import StandardScaler
+
+from statsmodels.discrete.discrete_model import Logit
+from statsmodels.regression.linear_model import OLS
+from statsmodels.treatment.treatment_effects import TreatmentEffect
+
+from .results_teffects import results_aipw_atet_dml
+
+
+def main():
+    data = pd.read_csv(Path(__file__).with_name("cataneo2.csv"))
+    names = "prenatal1_ mmarried_ mage mage2 fbaby_ medu".split()
+    x = data[names].to_numpy()
+    y = data["bweight"].to_numpy()
+    d = data["mbsmoke_"].to_numpy()
+    formula = " + ".join(names)
+    selection = Logit.from_formula("mbsmoke_ ~ " + formula, data).fit(disp=0)
+    model = OLS.from_formula("bweight ~ " + formula, data)
+    teff = TreatmentEffect(model, d, results_select=selection, ps_bounds=(0.01, 0.99))
+    sample = np.arange(len(d))
+    print(f"DoubleML {doubleml.__version__}; scikit-learn {sklearn.__version__}")
+    print("method target DoubleML statsmodels relative_difference")
+    for method in ["aipw", "aipw_wls"]:
+        for group, target in [(1, "att"), (0, "atc")]:
+            estimate = getattr(teff, method)(return_results=False, effect_group=group)[
+                0
+            ]
+            treatment = d if group == 1 else 1 - d
+            dml_data = doubleml.DoubleMLData.from_arrays(x, y, treatment)
+            propensity = make_pipeline(
+                StandardScaler(),
+                LogisticRegression(C=np.inf, solver="lbfgs", tol=1e-12, max_iter=10000),
+            )
+            fit = doubleml.DoubleMLIRM(
+                dml_data,
+                LinearRegression(),
+                propensity,
+                score="ATTE",
+                n_folds=1,
+                draw_sample_splitting=False,
+                normalize_ipw=False,
+                trimming_rule="truncate",
+                trimming_threshold=0.01,
+            )
+            fit.set_sample_splitting((sample, sample))
+            external = None
+            if method == "aipw_wls":
+                g0 = teff.results_ipwwls0.predict(model.exog)
+                g1 = teff.results_ipwwls1.predict(model.exog)
+                p = selection.predict()
+                if group == 0:
+                    g0, g1, p = g1, g0, 1 - p
+                external = {
+                    dml_data.d_cols[0]: {
+                        "ml_g0": g0[:, None],
+                        "ml_g1": g1[:, None],
+                        "ml_m": p[:, None],
+                    }
+                }
+            fit.fit(external_predictions=external)
+            reference = fit.coef[0] if group == 1 else -fit.coef[0]
+            assert_allclose(
+                reference, results_aipw_atet_dml[method + "_" + target], rtol=1e-7
+            )
+            assert_allclose(estimate, reference, rtol=1e-7)
+            relative = abs((estimate - reference) / reference)
+            print(f"{method} {target} {reference:.9f} {estimate:.9f} {relative:.2g}")
+
+
+if __name__ == "__main__":
+    main()

--- a/statsmodels/treatment/tests/test_teffects.py
+++ b/statsmodels/treatment/tests/test_teffects.py
@@ -11,7 +11,7 @@ from numpy.testing import assert_allclose
 import pandas as pd
 import pytest
 
-from statsmodels.discrete.discrete_model import Probit
+from statsmodels.discrete.discrete_model import Logit, Probit
 from statsmodels.regression.linear_model import OLS
 from statsmodels.treatment.treatment_effects import TreatmentEffect
 
@@ -171,6 +171,21 @@ class TestTEffects:
         if effect_group == 0:
             pom_t, pom_c = pom_c, pom_t
         assert_allclose(res1, [pom_t - pom_c, pom_c, pom_t], rtol=1e-12)
+
+
+@pytest.mark.parametrize("meth", ["aipw", "aipw_wls"])
+@pytest.mark.parametrize("effect_group", [1, 0])
+def test_aipw_effect_group_doubleml(meth, effect_group):
+    # reference values from DoubleML, see results_teffects.py
+    xnames = "prenatal1_ + mmarried_ + mage + mage2 + fbaby_ + medu"
+    res_logit = Logit.from_formula("mbsmoke_ ~ " + xnames, dta_cat).fit(disp=0)
+    mod = OLS.from_formula("bweight ~ " + xnames, dta_cat)
+    tind = np.asarray(dta_cat["mbsmoke_"])
+    teff = TreatmentEffect(mod, tind, results_select=res_logit,
+                           ps_bounds=(0.01, 0.99))
+    res = getattr(teff, meth)(return_results=False, effect_group=effect_group)
+    key = meth + ("_att" if effect_group == 1 else "_atc")
+    assert_allclose(res[0], res_st.results_aipw_atet_dml[key], rtol=1e-7)
 
 
 @pytest.mark.parametrize("meth", ["ipw_ra", "aipw_wls"])

--- a/statsmodels/treatment/tests/test_teffects.py
+++ b/statsmodels/treatment/tests/test_teffects.py
@@ -106,7 +106,7 @@ class TestTEffects:
         assert_allclose(res1.params, res2.table[idx, 0], rtol=1e-4)
         assert_allclose(res1.bse, res2.table[idx, 1], rtol=0.05)
 
-        # test effects on the treated, not available for aipw
+        # test effects on the treated, no Stata reference values for aipw
         if not meth.startswith("aipw"):
             table = res2.table_t
 
@@ -134,6 +134,43 @@ class TestTEffects:
             assert_allclose(res1, res0.effect, rtol=1e-12)
             assert_allclose(res0.start_params, res0.results_gmm.params,
                             rtol=1e-12)
+
+    @pytest.mark.parametrize("meth", ["aipw", "aipw_wls"])
+    @pytest.mark.parametrize("effect_group", [1, 0])
+    def test_aipw_effect_group(self, meth, effect_group):
+        # no Stata reference values, check against direct computation
+        teff = self.teff
+        res1 = getattr(teff, meth)(return_results=False,
+                                   effect_group=effect_group)
+        res0 = getattr(teff, meth)(return_results=True,
+                                   effect_group=effect_group)
+        assert_allclose(res1, res0.effect, rtol=1e-12)
+        assert_allclose(res0.start_params, res0.results_gmm.params,
+                        rtol=1e-12)
+        assert res0.effect_group == effect_group
+
+        tind = teff.treatment
+        endog = teff.model_pool.endog
+        exog = teff.model_pool.exog
+        prob = res_probit.predict()
+        if meth == "aipw":
+            fit0 = teff.results0.predict(exog)
+            fit1 = teff.results1.predict(exog)
+        else:
+            fit0 = teff.results_ipwwls0.predict(exog)
+            fit1 = teff.results_ipwwls1.predict(exog)
+        if effect_group == 0:
+            # ATC by symmetry: swap treatment and control
+            tind, prob = 1 - tind, 1 - prob
+            fit0, fit1 = fit1, fit0
+        treated = tind == 1
+        odds = prob / (1 - prob)
+        pom_t = endog[treated].mean()
+        pom_c = (fit0[treated].sum()
+                 + (odds * (endog - fit0))[~treated].sum()) / treated.sum()
+        if effect_group == 0:
+            pom_t, pom_c = pom_c, pom_t
+        assert_allclose(res1, [pom_t - pom_c, pom_c, pom_t], rtol=1e-12)
 
 
 @pytest.mark.parametrize("meth", ["ipw_ra", "aipw_wls"])

--- a/statsmodels/treatment/tests/test_teffects.py
+++ b/statsmodels/treatment/tests/test_teffects.py
@@ -136,6 +136,13 @@ class TestTEffects:
                             rtol=1e-12)
 
     @pytest.mark.parametrize("meth", ["aipw", "aipw_wls"])
+    @pytest.mark.parametrize("disp", [False, True])
+    def test_aipw_positional_disp(self, meth, disp):
+        estimate = getattr(self.teff, meth)
+        assert_allclose(estimate(False, disp), estimate(return_results=False),
+                        rtol=1e-12)
+
+    @pytest.mark.parametrize("meth", ["aipw", "aipw_wls"])
     @pytest.mark.parametrize("effect_group", [1, 0])
     def test_aipw_effect_group(self, meth, effect_group):
         # no Stata reference values, check against direct computation

--- a/statsmodels/treatment/treatment_effects.py
+++ b/statsmodels/treatment/treatment_effects.py
@@ -1027,7 +1027,7 @@ class TreatmentEffect:
         return res
 
     @Substitution(params_returns=indent(doc_params_returns, " " * 8))
-    def aipw(self, return_results=True, effect_group="all", disp=False):
+    def aipw(self, return_results=True, disp=False, *, effect_group="all"):
         """
         ATE and POM from double robust augmented inverse probability weighting
         \n%(params_returns)s
@@ -1071,7 +1071,7 @@ class TreatmentEffect:
         return res
 
     @Substitution(params_returns=indent(doc_params_returns, " " * 8))
-    def aipw_wls(self, return_results=True, effect_group="all", disp=False):
+    def aipw_wls(self, return_results=True, disp=False, *, effect_group="all"):
         """
         ATE and POM from double robust augmented inverse probability weighting.
 

--- a/statsmodels/treatment/treatment_effects.py
+++ b/statsmodels/treatment/treatment_effects.py
@@ -260,6 +260,41 @@ def ate_ipw(endog, tind, prob, weighted=True, probt=None):
     return (endog * wdiff).mean(), (endog * w0).mean(), (endog * w1).mean()
 
 
+def _aipw_pom_terms(endog, tind, prob, fitted0, fitted1, effect_group):
+    """Observation terms of AIPW potential outcome means for a target group
+
+    Returns (tmean0, tmean1, sind) where sind is the indicator of the target
+    population. POM_t is sum(tmean_t) / sum(sind).
+    """
+    if effect_group == "all":
+        sind = np.ones_like(prob)
+        c0 = 1 / (1 - prob)
+        c1 = 1 / prob
+    elif effect_group == 1:
+        sind = tind
+        c0 = prob / (1 - prob)
+        c1 = 1.
+    elif effect_group == 0:
+        sind = 1 - tind
+        c0 = 1.
+        c1 = (1 - prob) / prob
+    else:
+        raise ValueError("incorrect option for effect_group")
+    tmean0 = sind * fitted0 + (1 - tind) * c0 * (endog - fitted0)
+    tmean1 = sind * fitted1 + tind * c1 * (endog - fitted1)
+    return tmean0, tmean1, sind
+
+
+def _standardize_effect_group(effect_group):
+    if effect_group in [1, "treated"]:
+        return 1
+    if effect_group in [0, "untreated", "control"]:
+        return 0
+    if effect_group == "all":
+        return "all"
+    raise ValueError("incorrect option for effect_group")
+
+
 class _TEGMMGeneric1(GMM):
     """
     GMM class to get cov_params for treatment effects
@@ -477,15 +512,10 @@ class _AIPWGMM(_TEGMMGeneric1):
         # moments for target statistics, ATE and POM
         tind = ra.treatment
         tind = np.concatenate((tind[~treat_mask], tind[treat_mask]))
-        correct0 = (endog - fitted0) / (1 - prob) * (1 - tind)
-        correct1 = (endog - fitted1) / prob * tind
-
-        tmean0 = fitted0 + correct0
-        tmean1 = fitted1 + correct1
-        ate = tmean1 - tmean0
-
-        mm = ate - pm
-        mpom = tmean0 - ppom
+        tmean0, tmean1, sind = _aipw_pom_terms(
+            endog, tind, prob, fitted0, fitted1, self.effect_group)
+        mm = (tmean1 - tmean0 - sind * pm) / sind.mean()
+        mpom = (tmean0 - sind * ppom) / sind.mean()
         mm = np.column_stack((mm, mpom))
 
         # Note: res_select has original data order,
@@ -554,15 +584,10 @@ class _AIPWWLSGMM(_TEGMMGeneric1):
         tind = ra.treatment
         tind = np.concatenate((tind[~treat_mask], tind[treat_mask]))
 
-        correct0 = (endog - fitted0) / (1 - prob) * (1 - tind)
-        correct1 = (endog - fitted1) / prob * tind
-
-        tmean0 = fitted0 + correct0
-        tmean1 = fitted1 + correct1
-        ate = tmean1 - tmean0
-
-        mm = ate - pm
-        mpom = tmean0 - ppom
+        tmean0, tmean1, sind = _aipw_pom_terms(
+            endog, tind, prob, fitted0, fitted1, self.effect_group)
+        mm = (tmean1 - tmean0 - sind * pm) / sind.mean()
+        mpom = (tmean0 - sind * ppom) / sind.mean()
         mm = np.column_stack((mm, mpom))
 
         # Note: res_select has original data order,
@@ -749,23 +774,6 @@ effect_group : {"all", 0, 1}
     returned.
     If effect_group is 0, "untreated" or "control", then effects on
     untreated, i.e., control group, are returned.
-disp : bool, optional
-    Indicates whether the scipy optimizer should display the
-    optimization results
-
-Returns
--------
-TreatmentEffectResults or tuple
-    Results instance if `return_results` is True, otherwise the tuple
-    (ATE, POM0, POM1).
-"""
-
-doc_params_returns2 = """\
-Parameters
-----------
-return_results : bool, optional
-    If True, then a results instance is returned.
-    If False, just ATE, POM0 and POM1 are returned.
 disp : bool, optional
     Indicates whether the scipy optimizer should display the
     optimization results
@@ -1018,8 +1026,8 @@ class TreatmentEffect:
                                      )
         return res
 
-    @Substitution(params_returns=indent(doc_params_returns2, " " * 8))
-    def aipw(self, return_results=True, disp=False):
+    @Substitution(params_returns=indent(doc_params_returns, " " * 8))
+    def aipw(self, return_results=True, effect_group="all", disp=False):
         """
         ATE and POM from double robust augmented inverse probability weighting
         \n%(params_returns)s
@@ -1027,22 +1035,24 @@ class TreatmentEffect:
         --------
         TreatmentEffectResults
         """
-        nobs = self.nobs
+        effect_group = _standardize_effect_group(effect_group)
         prob = self.prob_select
         tind = self.treatment
+        endog = self.model_pool.endog
         exog = self.model_pool.exog  # in original order
-        correct0 = (self.results0.resid / (1 - prob[tind == 0])).sum() / nobs
-        correct1 = (self.results1.resid / (prob[tind == 1])).sum() / nobs
-        tmean0 = self.results0.predict(exog).mean() + correct0
-        tmean1 = self.results1.predict(exog).mean() + correct1
+        tmean0, tmean1, sind = _aipw_pom_terms(
+            endog, tind, prob, self.results0.predict(exog),
+            self.results1.predict(exog), effect_group)
+        tmean0 = tmean0.sum() / sind.sum()
+        tmean1 = tmean1.sum() / sind.sum()
         ate = tmean1 - tmean0
         if not return_results:
             return ate, tmean0, tmean1
 
-        endog = self.model_pool.endog
         p2_aipw = np.asarray([ate, tmean0])
 
-        mag_aipw1 = _AIPWGMM(endog, self.results_select, None, teff=self)
+        mag_aipw1 = _AIPWGMM(endog, self.results_select, None, teff=self,
+                             effect_group=effect_group)
         start_params = np.concatenate((
             p2_aipw,
             self.results0.params, self.results1.params,
@@ -1056,24 +1066,23 @@ class TreatmentEffect:
 
         res = TreatmentEffectResults(self, res_gmm, "AIPW",
                                      start_params=start_params,
-                                     effect_group="all",
+                                     effect_group=effect_group,
                                      )
         return res
 
-    @Substitution(params_returns=indent(doc_params_returns2, " " * 8))
-    def aipw_wls(self, return_results=True, disp=False):
+    @Substitution(params_returns=indent(doc_params_returns, " " * 8))
+    def aipw_wls(self, return_results=True, effect_group="all", disp=False):
         """
-        ATE and POM from double robust augmented inverse probability weighting
+        ATE and POM from double robust augmented inverse probability weighting.
 
         This uses weighted outcome regression, while `aipw` uses unweighted
         outcome regression.
-        Option for effect on treated or on untreated is not available.
         \n%(params_returns)s
         See Also
         --------
         TreatmentEffectResults
         """
-        nobs = self.nobs
+        effect_group = _standardize_effect_group(effect_group)
         prob = self.prob_select
 
         endog = self.model_pool.endog
@@ -1085,21 +1094,20 @@ class TreatmentEffect:
         mod1 = WLS(endog[treat_mask], exog[treat_mask],
                    weights=ww1[treat_mask])
         result1 = mod1.fit(cov_type="HC1")
-        mean1_ipw2 = result1.predict(exog).mean()
 
         ww0 = (1 - tind) / (1 - prob) * ((1 - tind) / (1 - prob) - 1)
         mod0 = WLS(endog[~treat_mask], exog[~treat_mask],
                    weights=ww0[~treat_mask])
         result0 = mod0.fit(cov_type="HC1")
-        mean0_ipw2 = result0.predict(exog).mean()
 
         self.results_ipwwls0 = result0
         self.results_ipwwls1 = result1
 
-        correct0 = (result0.resid / (1 - prob[tind == 0])).sum() / nobs
-        correct1 = (result1.resid / (prob[tind == 1])).sum() / nobs
-        tmean0 = mean0_ipw2 + correct0
-        tmean1 = mean1_ipw2 + correct1
+        tmean0, tmean1, sind = _aipw_pom_terms(
+            endog, tind, prob, result0.predict(exog), result1.predict(exog),
+            effect_group)
+        tmean0 = tmean0.sum() / sind.sum()
+        tmean1 = tmean1.sum() / sind.sum()
         ate = tmean1 - tmean0
 
         if not return_results:
@@ -1109,7 +1117,7 @@ class TreatmentEffect:
 
         # GMM
         mod_gmm = _AIPWWLSGMM(endog, self.results_select, None,
-                              teff=self)
+                              teff=self, effect_group=effect_group)
         start_params = np.concatenate((
             p2_aipw_wls,
             result0.params,
@@ -1123,7 +1131,7 @@ class TreatmentEffect:
             maxiter=1)
         res = TreatmentEffectResults(self, res_gmm, "AIPW-WLS",
                                      start_params=start_params,
-                                     effect_group="all",
+                                     effect_group=effect_group,
                                      )
         return res
 


### PR DESCRIPTION
Adds `effect_group` to `TreatmentEffect.aipw` and `aipw_wls`, supporting effects on the treated (ATET) and controls (ATC). The default remains the overall ATE. Both point estimates and joint GMM inference support the new targets. Existing positional calls retain their meaning; `effect_group` is keyword-only.

Stata 18 added `atet` to `teffects aipw`, but I don't have access to it. I verified the point estimates against DoubleML 0.11.4 instead, using `DoubleMLIRM(score="ATTE")`, which solves the same ATT estimating equation.

The comparison uses full-sample fitting without cross-fitting, the same unpenalized logit propensity specification, and propensity scores clipped to `[0.01, 0.99]`. ATC is obtained by reversing treatment labels and negating the estimate.

| Estimator | Target | DoubleML | statsmodels (this PR) | rel. diff |
|---|---|---:|---:|---:|
| `aipw` | ATET | -226.178244783 | -226.178244812 | 1.3e-10 |
| `aipw` | ATC | -230.764613267 | -230.764613251 | 7.1e-11 |
| `aipw_wls` | ATET | -223.448320722 | -223.448320722 | < 1e-12 |
| `aipw_wls` | ATC | -223.602248802 | -223.602248802 | < 1e-12 |

For `aipw`, DoubleML fits its own propensity and OLS outcome models. For `aipw_wls`, DoubleML evaluates its score using the statsmodels WLS predictions, so that comparison validates the score calculation rather than independently validating the WLS fit.

The reference tests cover point estimates only. Standard errors use the existing statsmodels joint GMM approach and are not benchmarked against DoubleML.

The reference values are stored in `results_teffects.py` and tested in `test_aipw_effect_group_doubleml`. The comparison can be reproduced with DoubleML 0.11.4 and scikit-learn 1.9.0 by running:

```bash
python -m statsmodels.treatment.tests.results.teffects_doubleml
```

The script specifies the solver, tolerance, sample splitting, and weight normalization settings. If a reviewer can produce Stata 18 output, I'm happy to add it as an additional independent reference.

- [x] closes #10226
- [x] tests added / passed.
- [x] code/documentation is well formatted.
- [x] properly formatted commit message.

#### AI Disclosure

- [x] AI tools were used.
      Tool(s): Claude, Codex.
      Used for: Claude drafted the implementation and tests. Codex reviewed the mathematics and API compatibility, fixed positional-argument compatibility, added regression tests and a reference-generation script, and edited the PR description.
      I have personally read, understood, and can explain every line of this diff, and
      have verified the statistical/numerical correctness of the change.
