### PR TITLE
ENH: add TreatmentEffect overlap and balance diagnostics

### DIFF
--- a/docs/source/release/version0.15.0.rst
+++ b/docs/source/release/version0.15.0.rst
@@ -37,6 +37,16 @@ Release Statistics
 The Highlights
 ===============
 
+Treatment effect diagnostics
+----------------------------
+
+``TreatmentEffect.overlap_summary`` reports unclipped propensity-score
+summaries and clipping counts by treatment group. ``TreatmentEffect.balance_table``
+reports covariate means and standardized mean differences before and after
+inverse probability weighting for ATE, ATET, or ATC. These methods do not trim
+observations. This partially addresses :issue:`10224`.
+
+
 SPEC-007: consistent use of ``rng`` for randomness
 ---------------------------------------------------
 

--- a/docs/source/treatment.rst
+++ b/docs/source/treatment.rst
@@ -32,3 +32,31 @@ See also overview notebook in
 
    treatment_effects.TreatmentEffect
    treatment_effects.TreatmentEffectResults
+
+Overlap and covariate balance
+-----------------------------
+
+After constructing a ``TreatmentEffect`` with a fitted selection model, inspect
+its numerical diagnostics before interpreting weighted estimates::
+
+    teff.overlap_summary()
+    teff.balance_table()
+    teff.balance_table(effect_group="treated")
+
+The overlap summary describes original, unclipped propensity scores by treatment
+group, including counts outside the clipping bounds. The balance table reports
+selection-model covariate means and standardized mean differences before and
+after weighting, using the estimator's clipped propensity scores. Supply ``exog``
+to examine other numeric covariates in the same observation order.
+
+Standardization uses a fixed pooled unweighted sample standard deviation for all
+weighting targets and numeric columns, including binary columns. Constant
+columns have undefined (NaN) standardized differences. These are descriptive
+diagnostics; they neither establish overlap nor rule out unmeasured confounding.
+Neither method drops observations or refits the models.
+
+.. autosummary::
+   :toctree: generated/
+
+   treatment_effects.TreatmentEffect.overlap_summary
+   treatment_effects.TreatmentEffect.balance_table

--- a/statsmodels/treatment/tests/test_diagnostics.py
+++ b/statsmodels/treatment/tests/test_diagnostics.py
@@ -1,0 +1,134 @@
+"""Numerical references use small samples with hand-calculated moments."""
+
+from types import SimpleNamespace
+
+import numpy as np
+from numpy.testing import assert_allclose
+import pandas as pd
+import pytest
+
+from statsmodels.regression.linear_model import OLS
+from statsmodels.treatment.treatment_effects import TreatmentEffect
+
+
+@pytest.fixture
+def teff():
+    # Control x=(0, 2), treated x=(2, 4): both sample variances are 2.
+    x = np.array([0.0, 2.0, 2.0, 4.0])
+    exog = np.column_stack([np.ones(4), x])
+    selection = SimpleNamespace(
+        predict=lambda: np.array([0.2, 0.4, 0.5, 0.8]),
+        model=SimpleNamespace(exog=exog, exog_names=["const", "x"]),
+    )
+    return TreatmentEffect(
+        OLS([0.0, 1.0, 3.0, 2.0], np.ones((4, 1))),
+        np.array([0, 0, 1, 1]),
+        results_select=selection,
+    )
+
+
+def test_overlap_unclipped(teff):
+    teff.results_select.predict = lambda: np.array([0.0, 0.2, 0.8, 1.0])
+    teff.ps_bounds = np.array([0.2, 0.8])
+    result = teff.overlap_summary()
+    assert list(result.index) == ["control", "treated"]
+    assert_allclose(
+        result[["min", "q25", "median", "q75", "max"]],
+        [[0, 0.05, 0.1, 0.15, 0.2], [0.8, 0.85, 0.9, 0.95, 1]],
+    )
+    assert_allclose(result[["nobs", "n_below", "n_above"]], [[2, 1, 0], [2, 0, 1]])
+    assert result.nobs.dtype.kind == "i"
+
+
+@pytest.mark.parametrize(
+    "target,means",
+    [
+        ("all", [8 / 7, 36 / 13]),
+        (1, [16 / 11, 3]),
+        (0, [1, 12 / 5]),
+        ("treated", [16 / 11, 3]),
+        ("control", [1, 12 / 5]),
+        ("untreated", [1, 12 / 5]),
+    ],
+)
+def test_balance_hand_calculated(teff, target, means):
+    # ATE control weights=(5/4,5/3), treated=(2,5/4).
+    # ATET control weights=(1/4,2/3), treated=(1,1).
+    # ATC control weights=(1,1), treated=(1,1/4).
+    table = teff.balance_table(effect_group=target)
+    row = table.loc["x"]
+    assert_allclose(row[["mean_control", "mean_treated"]], [1, 3])
+    assert_allclose(row[["mean_control_weighted", "mean_treated_weighted"]], means)
+    assert_allclose(row.smd, np.sqrt(2))
+    assert_allclose(row.smd_weighted, (means[1] - means[0]) / np.sqrt(2))
+    assert table.loc["const", ["smd", "smd_weighted"]].isna().all()
+
+
+def test_balance_uses_clipped_scores(teff):
+    teff.results_select.predict = lambda: np.array([0.0, 0.2, 0.8, 1.0])
+    teff.prob_select = np.clip(teff.results_select.predict(), 0.2, 0.8)
+    before = teff.prob_select.copy()
+    result = teff.balance_table()
+    assert_allclose(result.loc["x", ["smd", "smd_weighted"]], np.sqrt(2))
+    assert_allclose(teff.prob_select, before)
+
+
+def test_custom_exog_and_binary(teff):
+    x = pd.DataFrame({"binary": [0, 1, 1, 1], "separated": [0, 0, 1, 1]})
+    result = teff.balance_table(x)
+    # Sample variances are 1/2 and 0: pooled SD=1/2.
+    assert_allclose(result.loc["binary", "smd"], 1)
+    assert_allclose(result.loc["binary", "smd_weighted"], 6 / 7)
+    assert result.loc["separated", ["smd", "smd_weighted"]].isna().all()
+    assert list(teff.balance_table(x.to_numpy()).index) == ["x0", "x1"]
+
+
+@pytest.mark.parametrize(
+    "exog",
+    [
+        np.ones(4),
+        np.ones((3, 2)),
+        np.empty((4, 0)),
+        np.full((4, 1), np.nan),
+        np.full((4, 1), np.inf),
+    ],
+)
+def test_invalid_exog(teff, exog):
+    with pytest.raises(ValueError, match="exog must"):
+        teff.balance_table(exog)
+
+
+@pytest.mark.parametrize(
+    "prob",
+    [[0.2, 0.5], [0.2, np.nan, 0.5, 0.8], [-0.1, 0.2, 0.5, 0.8], [0.1, 0.2, 0.5, 1.1]],
+)
+def test_invalid_predictions(teff, prob):
+    teff.results_select.predict = lambda: prob
+    with pytest.raises(ValueError, match="selection predictions"):
+        teff.overlap_summary()
+
+
+@pytest.mark.parametrize("method", ["overlap_summary", "balance_table"])
+def test_missing_selection(teff, method):
+    del teff.results_select
+    with pytest.raises(ValueError, match="require results_select"):
+        getattr(teff, method)()
+
+
+@pytest.mark.parametrize("treatment", [[0, 0, 0, 0], [0, 0, 1, 2], [[0, 0, 1, 1]]])
+def test_invalid_treatment(teff, treatment):
+    teff.treatment = np.array(treatment)
+    with pytest.raises(ValueError, match="treatment"):
+        teff.overlap_summary()
+
+
+def test_small_arm(teff):
+    teff.treatment = np.array([0, 0, 0, 1])
+    assert teff.overlap_summary().loc["treated", "nobs"] == 1
+    with pytest.raises(ValueError, match="at least two"):
+        teff.balance_table()
+
+
+def test_invalid_target(teff):
+    with pytest.raises(ValueError, match="effect_group"):
+        teff.balance_table(effect_group="invalid")

--- a/statsmodels/treatment/tests/test_diagnostics.py
+++ b/statsmodels/treatment/tests/test_diagnostics.py
@@ -83,6 +83,20 @@ def test_custom_exog_and_binary(teff):
     assert list(teff.balance_table(x.to_numpy()).index) == ["x0", "x1"]
 
 
+def test_constant_column_unequal_groups():
+    # Rounding makes group means of 0.1 differ, so variances are not exactly 0.
+    selection = SimpleNamespace(
+        predict=lambda: np.full(9, 0.5),
+        model=SimpleNamespace(exog=np.full((9, 1), 0.1), exog_names=["c"]),
+    )
+    teff = TreatmentEffect(
+        OLS(np.zeros(9), np.ones((9, 1))),
+        np.array([0, 0, 0, 1, 1, 1, 1, 1, 1]),
+        results_select=selection,
+    )
+    assert teff.balance_table().loc["c", ["smd", "smd_weighted"]].isna().all()
+
+
 @pytest.mark.parametrize(
     "exog",
     [

--- a/statsmodels/treatment/treatment_effects.py
+++ b/statsmodels/treatment/treatment_effects.py
@@ -31,6 +31,7 @@ could be loaded with webuse
 from statsmodels.compat.pandas import Substitution
 
 import numpy as np
+import pandas as pd
 from scipy.linalg import block_diag
 
 from statsmodels.regression.linear_model import WLS
@@ -856,6 +857,150 @@ class TreatmentEffect:
 
         self.exog_grouped = np.concatenate((mod0.exog, mod1.exog), axis=0)
         self.endog_grouped = np.concatenate((mod0.endog, mod1.endog), axis=0)
+
+    def _diagnostic_sample(self):
+        if not hasattr(self, "results_select"):
+            raise ValueError("diagnostics require results_select")
+        treatment = np.asarray(self.treatment)
+        if (treatment.shape != (self.nobs,)
+                or not np.isin(treatment, [0, 1]).all()):
+            raise ValueError("treatment must be a one-dimensional 0/1 array")
+        mask = treatment == 1
+        if not mask.any() or mask.all():
+            raise ValueError("diagnostics require both treatment groups")
+        return mask
+
+    def overlap_summary(self):
+        """
+        Summarize unclipped propensity scores by treatment group.
+
+        Returns
+        -------
+        DataFrame
+            Rows ``control`` and ``treated`` contain the observation count
+            (``nobs``), minimum, 25th percentile, median, 75th percentile,
+            maximum, and counts strictly below and above ``ps_bounds``
+            (``n_below`` and ``n_above``).
+
+        Notes
+        -----
+        Uses predictions from the selection model before clipping. Extreme
+        scores can indicate poor practical overlap; these summaries do not
+        establish the population overlap assumption. No observations are
+        dropped and no model is refitted.
+        """
+        mask = self._diagnostic_sample()
+        prob = np.asarray(self.results_select.predict(), dtype=float)
+        if (prob.shape != (self.nobs,) or not np.isfinite(prob).all()
+                or np.any((prob < 0) | (prob > 1))):
+            raise ValueError("selection predictions must be finite probabilities "
+                             "with one value per observation")
+        rows = []
+        for group in [~mask, mask]:
+            values = prob[group]
+            quantiles = np.quantile(values, [0, 0.25, 0.5, 0.75, 1])
+            rows.append(dict(zip(
+                ["min", "q25", "median", "q75", "max"], quantiles,
+                strict=True)))
+            rows[-1].update(
+                nobs=values.size,
+                n_below=int(np.sum(values < self.ps_bounds[0])),
+                n_above=int(np.sum(values > self.ps_bounds[1])),
+            )
+        return pd.DataFrame(rows, index=["control", "treated"])[
+            ["nobs", "min", "q25", "median", "q75", "max", "n_below",
+             "n_above"]]
+
+    def balance_table(self, exog=None, effect_group="all"):
+        """
+        Compare covariate means before and after inverse probability weighting.
+
+        Parameters
+        ----------
+        exog : array_like, optional
+            Two-dimensional finite numeric covariates in the original sample
+            order, with one row per observation. The default is the selection
+            model's design matrix. DataFrame column names are retained.
+            Categorical covariates must first be encoded numerically.
+        effect_group : {"all", 0, 1, "treated", "untreated", "control"}, optional
+            Weighting target: ``"all"`` for ATE, 1 or ``"treated"`` for ATET,
+            and 0, ``"untreated"`` or ``"control"`` for ATC.
+
+        Returns
+        -------
+        DataFrame
+            One row per covariate, with ``mean_control``, ``mean_treated``,
+            ``mean_control_weighted``, ``mean_treated_weighted``, ``smd`` and
+            ``smd_weighted``. Selection-model covariate names are used by
+            default; unnamed supplied columns are labelled x0, x1, etc.
+
+        Notes
+        -----
+        Weights use the clipped ``prob_select`` used by the estimators.
+        Means are normalized separately within each treatment group.
+        SMD is treated minus control mean divided by
+        ``sqrt((var_treated + var_control) / 2)``, using unweighted sample
+        variances (ddof=1). This same denominator is held fixed before and
+        after weighting, for all weighting targets. Binary columns use this
+        same numeric convention rather than population Bernoulli variances.
+        This follows the fixed-scale approach in [1]_, but does not adopt
+        its target-specific or binary-covariate defaults.
+
+        Columns with zero pooled variance, including intercepts, have NaN
+        SMDs. At least two observations are required in each treatment group.
+        These descriptive statistics do not certify absence of confounding.
+
+        References
+        ----------
+        .. [1] Greifer, N. cobalt: Frequently Asked Questions, "How are
+           standardized mean differences computed in cobalt?"
+           https://ngreifer.github.io/cobalt/articles/faq.html
+        """
+        mask = self._diagnostic_sample()
+        if min(mask.sum(), (~mask).sum()) < 2:
+            raise ValueError("balance requires at least two observations per group")
+        if exog is None:
+            exog = self.results_select.model.exog
+            names = self.results_select.model.exog_names
+        else:
+            names = getattr(exog, "columns", None)
+        exog = np.asarray(exog, dtype=float)
+        if (exog.ndim != 2 or exog.shape[0] != self.nobs
+                or exog.shape[1] == 0 or not np.isfinite(exog).all()):
+            raise ValueError("exog must be a finite nonempty two-dimensional "
+                             "array with one row per observation")
+        if names is None:
+            names = [f"x{i}" for i in range(exog.shape[1])]
+        prob = np.asarray(self.prob_select)
+        if (prob.shape != (self.nobs,) or not np.isfinite(prob).all()
+                or np.any((prob <= 0) | (prob >= 1))):
+            raise ValueError("prob_select must contain finite probabilities "
+                             "strictly between 0 and 1")
+        if effect_group == "all":
+            target = np.ones(self.nobs)
+        elif effect_group in [1, "treated"]:
+            target = prob
+        elif effect_group in [0, "untreated", "control"]:
+            target = 1 - prob
+        else:
+            raise ValueError("incorrect option for effect_group")
+        w0 = target[~mask] / (1 - prob[~mask])
+        w1 = target[mask] / prob[mask]
+        x0, x1 = exog[~mask], exog[mask]
+        mean0, mean1 = x0.mean(axis=0), x1.mean(axis=0)
+        weighted0 = np.average(x0, axis=0, weights=w0)
+        weighted1 = np.average(x1, axis=0, weights=w1)
+        scale = np.sqrt((x0.var(axis=0, ddof=1)
+                         + x1.var(axis=0, ddof=1)) / 2)
+        scale[scale == 0] = np.nan
+        return pd.DataFrame({
+            "mean_control": mean0,
+            "mean_treated": mean1,
+            "mean_control_weighted": weighted0,
+            "mean_treated_weighted": weighted1,
+            "smd": (mean1 - mean0) / scale,
+            "smd_weighted": (weighted1 - weighted0) / scale,
+        }, index=names)
 
     @classmethod
     def from_data(cls, endog, exog, treatment, model="ols", **kwds):

--- a/statsmodels/treatment/treatment_effects.py
+++ b/statsmodels/treatment/treatment_effects.py
@@ -992,7 +992,7 @@ class TreatmentEffect:
         weighted1 = np.average(x1, axis=0, weights=w1)
         scale = np.sqrt((x0.var(axis=0, ddof=1)
                          + x1.var(axis=0, ddof=1)) / 2)
-        scale[scale == 0] = np.nan
+        scale[(np.ptp(x0, axis=0) == 0) & (np.ptp(x1, axis=0) == 0)] = np.nan
         return pd.DataFrame({
             "mean_control": mean0,
             "mean_treated": mean1,


### PR DESCRIPTION
Adds numerical overlap summaries and covariate balance tables to TreatmentEffect, including standardized mean differences before and after ATE, ATET, or ATC weighting. Plots and trimming are left for later work.
- [x] closes #10234 
- [x] tests added / passed.
- [x] code/documentation is well formatted.
- [x] properly formatted commit message. See
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message).

#### AI Disclosure

Contributions must comply with the statsmodels [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html).

If using AI tools, edit the second option to explain which tool was selected and
how the tool's output was used.

Please complete **one** of the following:

- [ ] No AI tools were used to develop this pull request.
- [x] AI tools were used.
      Tool(s): Codex
      Used for: drafting an implementation
      I have personally read, understood, and can explain every line of this diff, and
      have verified the statistical/numerical correctness of the change.
