### PR TITLE
BUG: acorr_ljungbox auto_lag selects the wrong lag

### DIFF
--- a/statsmodels/stats/diagnostic.py
+++ b/statsmodels/stats/diagnostic.py
@@ -719,7 +719,12 @@ def acorr_ljungbox(
         # obtain thresholds
         q = 2.4
         threshold = np.sqrt(q * np.log(nobs))
-        threshold_metric = np.abs(sacf).max() * np.sqrt(nobs)
+        # The threshold maximises over lags 1..maxlag. sacf[0] is the lag-0
+        # autocorrelation, which is identically 1, so including it fixed
+        # threshold_metric at sqrt(nobs) for every input and made the
+        # comparison below equivalent to nobs <= q * log(nobs), which has no
+        # solution. The penalty on the first branch was therefore never used.
+        threshold_metric = np.abs(sacf[1:]).max() * np.sqrt(nobs)
 
         # compute penalized sum of squared autocorrelations
         if threshold_metric <= threshold:
@@ -727,8 +732,11 @@ def acorr_ljungbox(
         else:
             q_sacf = q_sacf - (2 * np.arange(1, nobs))
 
+        # q_sacf is built from sacf[1:] and penalised with np.arange(1, nobs),
+        # so q_sacf[j] is the criterion for lag j + 1. Convert the index of the
+        # maximum into a lag rather than using it directly.
         # note: np.argmax returns first (i.e., smallest) index of largest value
-        lags = np.argmax(q_sacf)
+        lags = np.argmax(q_sacf) + 1
         lags = max(1, lags)  # optimal lag has to be at least 1
         lags = int_like(lags, "lags")
         lags = np.arange(1, lags + 1)

--- a/statsmodels/stats/tests/test_diagnostic.py
+++ b/statsmodels/stats/tests/test_diagnostic.py
@@ -34,6 +34,7 @@ import statsmodels.stats.sandwich_covariance as sw
 from statsmodels.tools.tools import Bunch, add_constant
 from statsmodels.tsa.ar_model import AutoReg
 from statsmodels.tsa.arima.model import ARIMA
+from statsmodels.tsa.stattools import acf
 
 cur_dir = Path(__file__).parent.resolve()
 
@@ -1806,6 +1807,40 @@ def test_ljungbox_auto_lag_whitenoise():
     # TODO: compare selected lags with Stata/ R to confirm
     # that correct auto_lag is selected
     assert res.shape[0] >= 1  # auto lag selected must be at least 1
+
+
+def test_ljungbox_auto_lag_selects_the_lag_not_the_index():
+    # q_sacf[j] is the penalised criterion for lag j + 1, so the index of the
+    # maximum must be converted to a lag. On an MA(7) the only autocorrelation
+    # is at lag 7, so the automatic rule has to select 7.
+    rs = np.random.RandomState(20090151)
+    e = rs.standard_normal(307)
+    y = e[7:] + 0.6 * e[:-7]
+    res = smsdia.acorr_ljungbox(y, auto_lag=True)
+    assert res.shape[0] == 7
+    assert res["lb_pvalue"].iloc[-1] < 1e-6
+    # the same series scored at the lag one below is not significant at 5%,
+    # so the off-by-one changed the conclusion of the test, not just the lag
+    assert smsdia.acorr_ljungbox(y, lags=[6])["lb_pvalue"].iloc[0] > 0.05
+
+
+def test_ljungbox_auto_lag_threshold_excludes_lag_zero():
+    # The threshold metric maximises |rho_j| over j >= 1. sacf[0] is identically
+    # 1, so including it pinned the metric at sqrt(nobs) and the comparison
+    # became nobs <= 2.4 * log(nobs), which is false for every nobs. The first
+    # penalty branch was therefore unreachable and the rule always used 2 * p.
+    rs = np.random.RandomState(21)
+    data = rs.standard_normal(500)
+
+    sacf = acf(data, nlags=len(data) - 1, fft=False)
+    assert np.abs(sacf).max() == sacf[0] == 1.0
+    threshold = np.sqrt(2.4 * np.log(len(data)))
+    assert np.abs(sacf[1:]).max() * np.sqrt(len(data)) <= threshold
+    assert np.abs(sacf).max() * np.sqrt(len(data)) > threshold
+
+    # This is white noise, so the heavier penalty applies and the rule should
+    # collapse to a single lag. Under the 2 * p penalty it selected ten.
+    assert smsdia.acorr_ljungbox(data, auto_lag=True).shape[0] == 1
 
 
 def test_ljungbox_errors_warnings():


### PR DESCRIPTION
Two independent defects in the automatic lag-selection block of `acorr_ljungbox` (`statsmodels/stats/diagnostic.py`, L702-734). Both are silent: the function returns a lag, a statistic and a p-value that look ordinary.

Both are checkable from the code alone, without reference to the Escanciano & Lobato paper, which matters because the two `TODO`s already in `test_diagnostic.py` note that the selected lag has never been compared against R or Stata.

## 1. The threshold metric includes the lag-0 autocorrelation

```python
sacf = acf(x, nlags=maxlag, fft=False)
...
threshold = np.sqrt(q * np.log(nobs))
threshold_metric = np.abs(sacf).max() * np.sqrt(nobs)

if threshold_metric <= threshold:
    q_sacf = q_sacf - (np.arange(1, nobs) * np.log(nobs))
else:
    q_sacf = q_sacf - (2 * np.arange(1, nobs))
```

`sacf[0]` is the lag-0 autocorrelation, which is identically `1.0` and is therefore always the maximum. So `threshold_metric` is `sqrt(nobs)` for **every** input, and the condition reduces to

```
nobs <= 2.4 * log(nobs)
```

which has no solution for `nobs >= 1`. The `p * log(n)` penalty is unreachable code and the `2 * p` penalty is always used. Every other line in the block indexes from lag 1, and the rule cited in the docstring maximises over `j >= 1`.

Checked directly:

```
     n   max|acf| incl lag0   threshold_metric   threshold   BIC branch taken?
    50             1.000000             7.0711      3.1284   False
   300             1.000000            17.3205      3.7434   False
  2000             1.000000            44.7214      4.4022   False
```

## 2. The argmax index is used as the lag

```python
lags = np.argmax(q_sacf)
lags = max(1, lags)
```

`q_sacf` is built from `sacf[1:maxlag+1]` and penalised with `np.arange(1, nobs)`, so `q_sacf[j]` is the criterion for lag `j + 1`. Using the index directly selects a lag one too low.

This is verifiable without any external reference: `q_sacf[0]` equals `acorr_ljungbox(x, lags=[1]).lb_stat` exactly. The `max(1, lags)` clamp masks the error whenever the argmax index is 0 or 1, which is why the existing white-noise test still passes.

## Effect

On an MA(7) with `theta = 0.6`, `n = 300` — a series whose only autocorrelation is at lag 7:

```
statsmodels auto_lag picked lag: 6
  lb_stat  5.8737   p 0.437489
at the true lag 7:
  lb_stat 58.7766   p 2.6479e-10
```

The conclusion at any conventional level flips from "no serial correlation" to "serial correlation".

## Fix

```diff
-        threshold_metric = np.abs(sacf).max() * np.sqrt(nobs)
+        threshold_metric = np.abs(sacf[1:]).max() * np.sqrt(nobs)
...
-        lags = np.argmax(q_sacf)
+        lags = np.argmax(q_sacf) + 1
```

## Tests

Two regression tests added. On unpatched `main` they fail with `assert 6 == 7` and `assert 10 == 1`; with the fix, `test_diagnostic.py` is 165 passed. The existing `test_ljungbox_auto_lag_whitenoise` still passes, so the `ValueError` fixed in #8339 does not come back.

## What I have not verified, and one caveat

- **No cross-check against R or Stata.** I did not have the source paper. Both defects are argued from the code's own indexing and from the rule as described in the docstring reference, not from a reference implementation. If a maintainer has access to `vrtest`/`portes` output, that would be the right confirmation, and I would rather it be checked than taken on my word.
- **The fix does not restore nominal size.** Under an iid-normal null at nominal 5%, 500 replications, I measured 0.096 before and 0.084 after at n=200, and 0.098 before and 0.068 after at n=500. Better, but still over-rejecting, and the improvement is noisy across seeds. I suspect the remaining gap is that the automatic statistic has a chi-squared(1) limiting distribution rather than chi-squared(p), which is what `acorr_ljungbox` reports. That is a separate and larger change and I have not touched it. I mention it so the numbers above are not read as a claim that this makes the automatic test correctly sized.
- I did not run the full statsmodels suite, only `statsmodels/stats/tests/test_diagnostic.py`.

## Related

#6785 introduced `auto_lag`; #8338/#8339 fixed a crash and the initialisation and introduced the current vectorised `argmax` form. #8339's own description says "Need additional test to compare to R results." Neither of these two defects is mentioned in any open or closed issue or PR that I could find.
- [x] No AI tools were used