### PR TITLE
fix: fix Unkown/occured typos in user-visible exception messages

### DIFF
--- a/statsmodels/tsa/ardl/model.py
+++ b/statsmodels/tsa/ardl/model.py
@@ -1216,7 +1216,7 @@ class ARDLResults(AutoRegResults):
             )
         except Exception as exc:
             error = (
-                "An exception occured during the creation of the cloned "
+                "An exception occurred during the creation of the cloned "
                 "ARDL instance when applying the existing model "
                 "specification to the new data. The original traceback appears below"
             )

--- a/statsmodels/tsa/vector_ar/util.py
+++ b/statsmodels/tsa/vector_ar/util.py
@@ -94,7 +94,7 @@ def get_trendorder(trend="c"):
     elif trend == "ctt":
         trendorder = 3
     else:
-        raise ValueError(f"Unkown trend: {trend}")
+        raise ValueError(f"Unknown trend: {trend}")
     return trendorder
 
 


### PR DESCRIPTION
Two user-visible exception strings carried typos:

- `tsa/vector_ar/util.py`: `ValueError("Unkown trend: {trend}")` → "Unknown trend"
- `tsa/ardl/model.py`: "An exception **occured** during the creation of the cloned…" → "occurred"

#### AI Disclosure

Contributions must comply with the statsmodels [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html).

- [ ] No AI tools were used to develop this pull request.
- [x] AI tools were used.
      Tool(s): `Claude`.
      Used for: `identifying the typos and drafting the one-line string fixes`.
      I have personally read, understood, and can explain every line of this diff, and
      have verified the statistical/numerical correctness of the change.
