### PR TITLE
docs(duration): repoint the dead statsmodels-examples ref

### DIFF
--- a/docs/source/duration.rst
+++ b/docs/source/duration.rst
@@ -181,7 +181,7 @@ depending on the value of the covariates.
    print(rslt.summary())
 
 
-See :ref:`statsmodels-examples` for more detailed examples.
+See the `examples <https://www.statsmodels.org/stable/examples/index.html>`_ for more detailed examples.
 
 
 There are some notebook examples on the Wiki:


### PR DESCRIPTION
`docs/source/duration.rst` references `:ref:`statsmodels-examples`` — the label is defined nowhere in the repo (verified repo-wide; `autosectionlabel_prefix_document = True` also rules out title-based resolution), so it renders as a broken reference. Now points at the stable examples index URL.

#### AI Disclosure

Contributions must comply with the statsmodels [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html).

- [ ] No AI tools were used to develop this pull request.
- [x] AI tools were used.
      Tool(s): `Claude`.
      Used for: `identifying the broken reference and drafting the repoint`.
      I have personally read, understood, and can explain every line of this diff, and
      have verified the correctness of the change.
