### PR TITLE
docs(tools): fix 'defualts' typo in nbgenerate docstring

### DIFF
--- a/tools/nbgenerate.py
+++ b/tools/nbgenerate.py
@@ -53,7 +53,7 @@ def execute_nb(src, dst, allow_errors=False, timeout=1000, kernel_name=None):
     allow_errors: bool
     timeout: int
     kernel_name: str
-        defualts to value set in notebook metadata
+        defaults to value set in notebook metadata
 
     Returns
     -------


### PR DESCRIPTION
`tools/nbgenerate.py`: "**defualts** to value set in notebook metadata" → "defaults". Docs-only.

**AI Generation Disclosure**: found and prepared with AI assistance (Claude); reviewed and submitted by @simpleqt.