### PR TITLE
Fix/mixedlm singular cov re fe params

### DIFF
--- a/statsmodels/regression/mixed_linear_model.py
+++ b/statsmodels/regression/mixed_linear_model.py
@@ -1444,13 +1444,18 @@ class MixedLM(base.LikelihoodModel):
         xtxy = 0.0
         for group_ix, _group in enumerate(self.group_labels):
             vc_var = self._expand_vcomp(vcomp, group_ix)
+            vc_project = False
             if vc_var.size > 0:
                 if vc_var.min() < tol:
-                    # Pseudo-inverse
+                    # Same reasoning as for cov_re above: a variance
+                    # component whose variance has collapsed to
+                    # (numerically) zero should be dropped from the design
+                    # entirely, not given zero precision while its column
+                    # is still passed through the Woodbury solver.
                     sing = True
-                    ii = np.flatnonzero(vc_var >= tol)
-                    vc_vari = np.zeros_like(vc_var)
-                    vc_vari[ii] = 1 / vc_var[ii]
+                    vc_project = True
+                    vc_ii = np.flatnonzero(vc_var >= tol)
+                    vc_vari = 1 / vc_var[vc_ii]
                 else:
                     vc_vari = 1 / vc_var
             else:
@@ -1467,6 +1472,17 @@ class MixedLM(base.LikelihoodModel):
                 cov_re_inv = np.diag(1 / wi_good)
             else:
                 ex_r, ex2_r = self._aex_r[group_ix], self._aex_r2[group_ix]
+
+            if vc_project:
+                # ex_r's trailing vc_var.size columns are always the full,
+                # untrimmed variance-component design (re_project only
+                # ever touches the columns before them), so drop the
+                # degenerate ones and recompute ex2_r to match -- same
+                # drop-don't-zero-fill fix as re_project above.
+                re_width = ex_r.shape[1] - vc_var.size
+                good = np.concatenate((np.arange(re_width), re_width + vc_ii))
+                ex_r = ex_r[:, good]
+                ex2_r = np.dot(ex_r.T, ex_r)
 
             if ex_r.shape[1] == 0:
                 # No random effects (or variance components) survive for

--- a/statsmodels/regression/mixed_linear_model.py
+++ b/statsmodels/regression/mixed_linear_model.py
@@ -1389,8 +1389,10 @@ class MixedLM(base.LikelihoodModel):
         vcomp : array_like (1d)
             The variance components.
         tol : float, optional
-            A tolerance parameter to determine when covariances
-            are singular.
+            Eigenvalues (of `cov_re`) or variances (of `vcomp`) below
+            this value are treated as zero: the corresponding random
+            effects directions are dropped from the GLS fit entirely,
+            rather than approximated by an inverse of zero.
 
         Returns
         -------
@@ -1404,21 +1406,29 @@ class MixedLM(base.LikelihoodModel):
             return np.array([]), False
 
         sing = False
+        re_project = False
 
         if self.k_re == 0:
             cov_re_inv = np.empty((0, 0))
         else:
             w, v = np.linalg.eigh(cov_re)
             if w.min() < tol:
-                # Singular, use pseudo-inverse
+                # cov_re is (numerically) singular along one or more
+                # eigendirections. Using a zero-filled pseudo-inverse here
+                # and passing the *full* random effects design through the
+                # Woodbury solver below would implicitly take the cov_re ->
+                # infinity limit along those directions (a within-group fixed
+                # effects fit), not the cov_re -> 0 limit (OLS) that
+                # a vanishing random effect variance actually corresponds
+                # to. So instead, drop the degenerate eigendirections from
+                # the random effects design entirely (see re_project below),
+                # and keep the true inverse variance for the eigendirections
+                # that remain well-conditioned.
                 sing = True
+                re_project = True
                 ii = np.flatnonzero(w >= tol)
-                if len(ii) == 0:
-                    cov_re_inv = np.zeros_like(cov_re)
-                else:
-                    vi = v[:, ii]
-                    wi = w[ii]
-                    cov_re_inv = np.dot(vi / wi, vi.T)
+                v_good = v[:, ii]
+                wi_good = w[ii]
             else:
                 cov_re_inv = np.linalg.inv(cov_re)
 
@@ -1446,9 +1456,25 @@ class MixedLM(base.LikelihoodModel):
             else:
                 vc_vari = np.empty(0)
             exog = self.exog_li[group_ix]
-            ex_r, ex2_r = self._aex_r[group_ix], self._aex_r2[group_ix]
-            solver = _smw_solver(1.0, ex_r, ex2_r, cov_re_inv, vc_vari)
-            u = solver(self._endex_li[group_ix])
+
+            if re_project:
+                ex_r_full = self._aex_r[group_ix]
+                re_cols = ex_r_full[:, : self.k_re]
+                vc_cols = ex_r_full[:, self.k_re :]
+                re_proj = np.dot(re_cols, v_good)
+                ex_r = np.concatenate((re_proj, vc_cols), axis=1)
+                ex2_r = np.dot(ex_r.T, ex_r)
+                cov_re_inv = np.diag(1 / wi_good)
+            else:
+                ex_r, ex2_r = self._aex_r[group_ix], self._aex_r2[group_ix]
+
+            if ex_r.shape[1] == 0:
+                # No random effects (or variance components) survive for
+                # this group -- the Woodbury correction is the identity.
+                u = self._endex_li[group_ix]
+            else:
+                solver = _smw_solver(1.0, ex_r, ex2_r, cov_re_inv, vc_vari)
+                u = solver(self._endex_li[group_ix])
             xtxy += np.dot(exog.T, u)
 
         if sing:

--- a/statsmodels/regression/tests/test_lme.py
+++ b/statsmodels/regression/tests/test_lme.py
@@ -18,6 +18,7 @@ from scipy import sparse
 
 from statsmodels.base import _penalties as penalties
 from statsmodels.iolib.summary2 import Summary
+from statsmodels.regression.linear_model import OLS
 from statsmodels.regression.mixed_linear_model import (
     MixedLM,
     MixedLMParams,
@@ -1333,6 +1334,102 @@ def test_singular():
     with pytest.warns(SingularMatrixWarning, match=r"effects"):
         mdf = md.fit()
     mdf.summary()
+
+
+def _dense_gls(model, cov_re):
+    # Reference solution with no eigen-splitting shortcuts at all: build
+    # V = Z cov_re Z' + I densely per group and solve GLS directly.
+    n = int(model.nobs)
+    vdense = np.eye(n)
+    row = 0
+    for zg in model.exog_re_li:
+        ng = zg.shape[0]
+        vdense[row:row + ng, row:row + ng] += zg @ cov_re @ zg.T
+        row += ng
+    vinv = np.linalg.inv(vdense)
+    exog, endog = model.exog, model.endog
+    return np.linalg.solve(exog.T @ vinv @ exog, exog.T @ vinv @ endog)
+
+
+def test_get_fe_params_singular_cov_re_matches_ols():
+    # GH 10239: when every eigenvalue of cov_re collapses below get_fe_params'
+    # tol, the fixed effects should smoothly approach the OLS solution (the
+    # cov_re -> 0 limit), not jump to a within-group fixed-effects fit (the
+    # cov_re -> infinity limit) with between-group coefficients zeroed out.
+    rng = np.random.default_rng(0)
+    n_groups, n_per_group = 30, 3
+    n = n_groups * n_per_group
+    groups = np.repeat(np.arange(n_groups), n_per_group)
+    between = np.where(groups % 2 == 0, 0.0, 1.0)  # constant within each group
+    within = np.tile(np.arange(n_per_group, dtype=float), n_groups)
+    exog = np.column_stack([np.ones(n), between, within])
+    endog = (10.0 + 5.0 * between + 2.0 * within
+             + rng.standard_normal(n))
+
+    model = MixedLM(endog, exog, groups)
+    ols_params = OLS(endog, exog).fit().params
+
+    for v in [1e-9, 1e-10, 9.9e-11, 1e-12, 0.0]:
+        fe_params, singular = model.get_fe_params(np.array([[v]]), np.array([]))
+        assert_allclose(fe_params, ols_params, atol=1e-8)
+        assert singular == (v < 1e-10)
+
+
+def test_get_fe_params_partial_singular_cov_re():
+    # GH 10239 follow-up: with two random effects (intercept and a slope),
+    # only one eigendirection of cov_re needs to collapse to trigger the
+    # bug -- the other, perfectly well-conditioned direction does not
+    # protect the fixed effects from being zeroed out.
+    rng = np.random.default_rng(1)
+    n_groups, n_per_group = 40, 4
+    n = n_groups * n_per_group
+    groups = np.repeat(np.arange(n_groups), n_per_group)
+    x = rng.standard_normal(n)
+    between = np.where(groups % 2 == 0, 0.0, 1.0)
+    endog = 10.0 + 3.0 * between + 2.0 * x + rng.standard_normal(n) * 0.5
+    exog = np.column_stack([np.ones(n), between, x])
+    exog_re = np.column_stack([np.ones(n), x])
+
+    model = MixedLM(endog, exog, groups, exog_re=exog_re)
+
+    # Only the intercept direction (variance v0) is pushed below tol; the
+    # slope direction (variance 2.0) stays perfectly well-conditioned.
+    for v0 in [1e-9, 9.9e-11, 1e-15, 0.0]:
+        cov_re = np.diag([v0, 2.0])
+        fe_params, singular = model.get_fe_params(cov_re, np.array([]))
+        gold = _dense_gls(model, np.diag([max(v0, 1e-12), 2.0]))
+        assert_allclose(fe_params, gold, atol=1e-4)
+        assert singular == (v0 < 1e-10)
+
+
+def test_get_fe_params_correlated_singular_cov_re():
+    # GH 10239 follow-up: a *correlated* near-singular cov_re (as a real
+    # optimizer would produce for dependent random effects, rather than a
+    # clean diagonal with an exact 0.0) previously could make get_fe_params
+    # feed enormous, ill-conditioned values into the Woodbury solver and
+    # crash with LinAlgError. It should instead drop the degenerate
+    # eigendirection and match the dense GLS solution without raising.
+    rng = np.random.default_rng(1)
+    n_groups, n_per_group = 40, 4
+    n = n_groups * n_per_group
+    groups = np.repeat(np.arange(n_groups), n_per_group)
+    x = rng.standard_normal(n)
+    between = np.where(groups % 2 == 0, 0.0, 1.0)
+    endog = 10.0 + 3.0 * between + 2.0 * x + rng.standard_normal(n) * 0.5
+    exog = np.column_stack([np.ones(n), between, x])
+    exog_re = np.column_stack([np.ones(n), x])
+
+    model = MixedLM(endog, exog, groups, exog_re=exog_re)
+
+    a = np.random.default_rng(1).standard_normal((2, 1)) * np.sqrt(2.0)
+    cov_re_good = a @ a.T
+    for noise_scale in [1e-6, 1e-8, 1e-11, 1e-15]:
+        noise = np.random.default_rng(2).standard_normal((2, 2)) * noise_scale
+        cov_re = cov_re_good + noise @ noise.T
+
+        fe_params, singular = model.get_fe_params(cov_re, np.array([]))
+        gold = _dense_gls(model, cov_re)
+        assert_allclose(fe_params, gold, atol=1e-4)
 
 
 def test_get_distribution():

--- a/statsmodels/regression/tests/test_lme.py
+++ b/statsmodels/regression/tests/test_lme.py
@@ -22,6 +22,7 @@ from statsmodels.regression.linear_model import OLS
 from statsmodels.regression.mixed_linear_model import (
     MixedLM,
     MixedLMParams,
+    VCSpec,
     _smw_logdet,
     _smw_solver,
 )
@@ -1430,6 +1431,126 @@ def test_get_fe_params_correlated_singular_cov_re():
         fe_params, singular = model.get_fe_params(cov_re, np.array([]))
         gold = _dense_gls(model, cov_re)
         assert_allclose(fe_params, gold, atol=1e-4)
+
+
+def _dense_gls_vc(model, cov_re, vcomp):
+    # Reference solution with no eigen-splitting shortcuts at all: build
+    # V = Z_re cov_re Z_re' + Z_vc diag(vcomp) Z_vc' + I densely per group
+    # and solve GLS directly. Generalizes _dense_gls to also cover
+    # variance components.
+    n = int(model.nobs)
+    vdense = np.eye(n)
+    row = 0
+    for group_ix, _ in enumerate(model.group_labels):
+        ng = model.exog_li[group_ix].shape[0]
+        block = np.zeros((ng, ng))
+        if model.k_re > 0:
+            zg = model.exog_re_li[group_ix]
+            block += zg @ cov_re @ zg.T
+        for j in range(len(model.exog_vc.names)):
+            mat = np.asarray(model.exog_vc.mats[j][group_ix])
+            block += vcomp[j] * (mat @ mat.T)
+        vdense[row:row + ng, row:row + ng] += block
+        row += ng
+    vinv = np.linalg.inv(vdense)
+    exog, endog = model.exog, model.endog
+    return np.linalg.solve(exog.T @ vinv @ exog, exog.T @ vinv @ endog)
+
+
+def test_get_fe_params_singular_vcomp_matches_ols():
+    # GH 10239 follow-up: the same zero-fills-the-inverse bug that affected
+    # cov_re also affected variance components (vcomp). When a variance
+    # component's variance collapses below get_fe_params' tol, the fixed
+    # effects should smoothly approach the OLS solution (the vcomp -> 0
+    # limit), not jump to a within-group fixed-effects fit with
+    # between-group coefficients zeroed out.
+    rng = np.random.default_rng(0)
+    n_groups, n_per_group = 30, 3
+    n = n_groups * n_per_group
+    groups = np.repeat(np.arange(n_groups), n_per_group)
+    between = np.where(groups % 2 == 0, 0.0, 1.0)  # constant within each group
+    within = np.tile(np.arange(n_per_group, dtype=float), n_groups)
+    exog = np.column_stack([np.ones(n), between, within])
+    endog = (10.0 + 5.0 * between + 2.0 * within
+             + rng.standard_normal(n))
+
+    vc_mats = [np.ones((n_per_group, 1)) for _ in range(n_groups)]
+    vc_colnames = [["vc0"] for _ in range(n_groups)]
+    exog_vc = VCSpec(["vc0"], [vc_colnames], [vc_mats])
+
+    model = MixedLM(endog, exog, groups, exog_vc=exog_vc)
+    ols_params = OLS(endog, exog).fit().params
+
+    for v in [1e-9, 1e-10, 9.9e-11, 1e-12, 0.0]:
+        fe_params, singular = model.get_fe_params(np.empty((0, 0)), np.array([v]))
+        assert_allclose(fe_params, ols_params, atol=1e-8)
+        assert singular == (v < 1e-10)
+
+
+def test_get_fe_params_partial_singular_vcomp():
+    # GH 10239 follow-up: with two variance components, only one needs to
+    # collapse to trigger the bug -- the other, well-conditioned component
+    # does not protect the fixed effects from being zeroed out.
+    rng = np.random.default_rng(1)
+    n_groups, n_per_group = 40, 4
+    n = n_groups * n_per_group
+    groups = np.repeat(np.arange(n_groups), n_per_group)
+    x = rng.standard_normal(n)
+    between = np.where(groups % 2 == 0, 0.0, 1.0)
+    endog = 10.0 + 3.0 * between + 2.0 * x + rng.standard_normal(n) * 0.5
+    exog = np.column_stack([np.ones(n), between, x])
+
+    vc0_mats = [np.ones((n_per_group, 1)) for _ in range(n_groups)]
+    vc1_mats = [x[groups == g][:, None] for g in range(n_groups)]
+    exog_vc = VCSpec(
+        ["vc0", "vc1"],
+        [[["vc0"] for _ in range(n_groups)], [["vc1"] for _ in range(n_groups)]],
+        [vc0_mats, vc1_mats],
+    )
+
+    model = MixedLM(endog, exog, groups, exog_vc=exog_vc)
+
+    # Only vc0 (variance v0) is pushed below tol; vc1 (variance 2.0)
+    # stays perfectly well-conditioned.
+    for v0 in [1e-9, 9.9e-11, 1e-15, 0.0]:
+        vcomp = np.array([v0, 2.0])
+        fe_params, singular = model.get_fe_params(np.empty((0, 0)), vcomp)
+        gold = _dense_gls_vc(
+            model, np.empty((0, 0)), np.array([max(v0, 1e-12), 2.0])
+        )
+        assert_allclose(fe_params, gold, atol=1e-4)
+        assert singular == (v0 < 1e-10)
+
+
+def test_get_fe_params_mixed_singular_cov_re_and_vcomp():
+    # GH 10239 follow-up: cov_re and vcomp can collapse simultaneously.
+    # Exercises re_project and vc_project both firing in the same call, so
+    # the vc_project trimming step must correctly locate the vc columns in
+    # ex_r even though re_project already shrank the re part of ex_r.
+    rng = np.random.default_rng(2)
+    n_groups, n_per_group = 40, 4
+    n = n_groups * n_per_group
+    groups = np.repeat(np.arange(n_groups), n_per_group)
+    x = rng.standard_normal(n)
+    between = np.where(groups % 2 == 0, 0.0, 1.0)
+    endog = 10.0 + 3.0 * between + 2.0 * x + rng.standard_normal(n) * 0.5
+    exog = np.column_stack([np.ones(n), between, x])
+    exog_re = np.column_stack([np.ones(n), x])
+
+    vc_mats = [np.ones((n_per_group, 1)) for _ in range(n_groups)]
+    exog_vc = VCSpec(["vc0"], [[["vc0"] for _ in range(n_groups)]], [vc_mats])
+
+    model = MixedLM(endog, exog, groups, exog_re=exog_re, exog_vc=exog_vc)
+
+    for v0 in [1e-9, 9.9e-11, 1e-15, 0.0]:
+        cov_re = np.diag([v0, 2.0])
+        vcomp = np.array([v0])
+        fe_params, singular = model.get_fe_params(cov_re, vcomp)
+        gold = _dense_gls_vc(
+            model, np.diag([max(v0, 1e-12), 2.0]), np.array([max(v0, 1e-12)])
+        )
+        assert_allclose(fe_params, gold, atol=1e-4)
+        assert singular == (v0 < 1e-10)
 
 
 def test_get_distribution():


### PR DESCRIPTION
- [x] closes #10239 
- [x] tests added / passed.
- [x] code/documentation is well formatted.
- [x] properly formatted commit message. See
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message).

#### AI Disclosure

Contributions must comply with the statsmodels [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html).

If using AI tools, edit the second option to explain which tool was selected and
how the tool's output was used.

Please complete **one** of the following:

- [ ] No AI tools were used to develop this pull request.
- [x] AI tools were used.
      Tool(s): `claude code`
      Used for: `exploring the problem, drafting a fix, finding the same problem with the variance, drafting tests`.
      I have personally read, understood, and can explain every line of this diff, and
      have verified the statistical/numerical correctness of the change.

When random-effect variance or the variance component variance becomes degenerate, any fixed effect that is constant in a group was returned as 0.0. This would be fine, only the solver used the inverse of this number (which was zero filled in the inverse matrix) and would therefore output the limit $D\rightarrow \infty$, while the correct limit would be $D \rightarrow 0$. Instead we now drop the 0 direction entirely, which results in the correct limit. This is solved for both  the random effect variance as well as the variance component variance. This therefore fixes #10239 , although there might still be another lbfgs hessian bug that was also mentioned in that issue.

All commits are made by Claude. All code and commits have been checked by me line for line and all correspondence is and will be written by me. 


**Notes**:

* It is essential that you add a test when making code changes. Tests are not
  needed for doc changes.
* When adding a new function, test values should usually be verified in another package (e.g., R/SAS/Stata).
* When fixing a bug, you must add a test that would produce the bug in main and
  then show that it is fixed with the new code.
* New code additions must be well formatted. Changes should pass ruff. You can
  verify your changes are well formatted by running
  ```
  ruff check . --fix
  ```
  assuming `ruff` is installed. While passing this test is not required, it is good practice and it help
  improve code quality in `statsmodels`.
* Docstring additions must render correctly, including escapes and LaTeX.
* If AI tools were used to help write this PR, see the
  [AI Policy](https://www.statsmodels.org/devel/dev/ai-policy.html) for what disclosure
  and review is expected of you before submitting.

</details>
