### PR TITLE
Handle high-dimensional robust covariance starts

### DIFF
--- a/statsmodels/robust/covariance.py
+++ b/statsmodels/robust/covariance.py
@@ -1395,10 +1395,12 @@ def _cov_starting(data, standardize=False, quantile=0.5, retransform=False):
 
     cov_all = []
     d = mahalanobis(xs, cov=None, cov_inv=np.eye(k_vars))
-    percentiles = [(k_vars + 2) / nobs * 100 * 2, 25, 50, 85]
+    # Use the full sample when the deterministic starting subset is too large.
+    first_percentile = min((k_vars + 2) / nobs * 100 * 2, 100)
+    percentiles = [first_percentile, 25, 50, 85]
     cutoffs = np.percentile(d, percentiles)
     for p, cutoff in zip(percentiles, cutoffs, strict=True):
-        xsp = xs[d < cutoff]
+        xsp = xs[d <= cutoff] if p == 100 else xs[d < cutoff]
         c = np.cov(xsp.T)
         corr_factor = coef_normalize_cov_truncated(p / 100, k_vars)
         c0 = CovStartingResult(

--- a/statsmodels/robust/tests/test_covariance.py
+++ b/statsmodels/robust/tests/test_covariance.py
@@ -291,6 +291,15 @@ def test_covdetmcd():
     assert_allclose(shape, shape_r, rtol=1e-5)
 
 
+def test_cov_starting_handles_more_than_half_as_many_variables_as_observations():
+    rs = np.random.RandomState(10241)
+    x = rs.standard_normal((8, 4))
+
+    results = robcov._cov_starting(x)
+
+    assert_allclose(results[0].mean, x.mean(axis=0))
+
+
 def test_covdetmm():
 
     # results from rrcov


### PR DESCRIPTION
## What changed

The deterministic robust covariance starting set now caps its first percentile at 100 when the requested starting subset is larger than the sample. At the cap, the full sample is included so `CovDetMCD`, `CovDetS`, and `CovDetMM` can handle the documented high-dimensional edge case.

Adds a regression test for the failure boundary described in #10241.

Fixes #10241.

## Validation

- `python -m py_compile statsmodels/robust/covariance.py statsmodels/robust/tests/test_covariance.py`
- `uv run --no-project --with ruff ruff check statsmodels/robust/covariance.py statsmodels/robust/tests/test_covariance.py`
- `git diff --check`

The numerical test run could not start on this Windows host because Application Control blocked the Meson build executable and the SciPy DLLs used by the source environment.